### PR TITLE
chore: auto-configure git credential helper in devcontainer

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -14,6 +14,10 @@ sudo service postgresql start 2>/dev/null || true
 sudo mkdir -p /home/vscode/.local/bin
 sudo chown -R vscode:vscode /home/vscode/.config /home/vscode/.cache /home/vscode/.local
 
+# Setup Git to use GitHub CLI for authentication
+echo "Configuring Git credential helper..."
+gh auth setup-git 2>/dev/null || true
+
 # Install dependencies
 echo "Installing dependencies..."
 cd /workspaces/vm0/turbo && pnpm install


### PR DESCRIPTION
## Summary
- Automatically configure GitHub CLI as Git credential helper during devcontainer initialization
- Prevents password prompts for git operations (pull, push, fetch)
- Ensures seamless git authentication using mounted GitHub CLI config

## Test plan
- [ ] Rebuild devcontainer and verify `git pull` works without password prompt
- [ ] Verify `gh auth setup-git` runs successfully during container setup
- [ ] Confirm git operations work normally after container restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)