### PR TITLE
chore: initialize all package versions to 0.0.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"turbo/apps/cli":"0.1.0","turbo/packages/core":"0.1.0","turbo/apps/web":"0.1.0","turbo/apps/docs":"1.0.0"}
+{"turbo/apps/cli":"0.0.1","turbo/packages/core":"0.0.1","turbo/apps/web":"0.0.1","turbo/apps/docs":"0.0.1"}

--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vm0-cli",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "private": true,
   "description": "CLI application",
   "type": "module",

--- a/turbo/apps/docs/package.json
+++ b/turbo/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "type": "module",
   "private": true,
   "scripts": {

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "type": "module",
   "private": true,
   "scripts": {

--- a/turbo/packages/core/package.json
+++ b/turbo/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vm0/core",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Initialize all package versions to 0.0.1 for release-please to properly manage versioning.

## Changes

Updated versions in both manifest and package.json files:

| Package | Before | After |
|---------|--------|-------|
| turbo/apps/cli | 0.1.0 | **0.0.1** |
| turbo/packages/core | 0.1.0 | **0.0.1** |
| turbo/apps/web | 0.1.0 | **0.0.1** |
| turbo/apps/docs | 1.0.0 | **0.0.1** |

## Modified Files

- `.release-please-manifest.json` - Release Please version manifest
- `turbo/apps/cli/package.json`
- `turbo/packages/core/package.json`
- `turbo/apps/web/package.json`
- `turbo/apps/docs/package.json`

## Why 0.0.1?

Starting with 0.0.1 allows release-please to:
- Track version changes from the beginning
- Automatically increment versions based on conventional commits
- Create proper release tags and changelogs

## Next Steps

Once merged, release-please will:
1. Create release PRs when conventional commits are detected
2. Automatically bump versions (patch/minor/major)
3. Generate changelogs and GitHub releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)