### PR TITLE
fix: align docs dev port with caddy proxy configuration

### DIFF
--- a/turbo/apps/docs/package.json
+++ b/turbo/apps/docs/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "next dev --turbo",
+    "dev": "next dev --turbo --port 3001",
     "start": "next start",
     "lint": "next lint --max-warnings 0",
     "check-types": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- Fixed docs app dev server port to match Caddy reverse proxy configuration
- Changed from default port 3000 to port 3001 to avoid conflict with web app

## Problem
The docs application dev script was using Next.js default port (3000), which:
- Conflicts with the web app that also runs on port 3000
- Doesn't match Caddy proxy configuration expecting docs on port 3001

## Solution
Updated `turbo/apps/docs/package.json` dev script to explicitly specify port 3001:
```json
"dev": "next dev --turbo --port 3001"
```

## Test plan
- [x] Verify docs app starts on port 3001
- [x] Confirm no port conflict with web app (port 3000)
- [x] Test docs.vm0.dev:8443 routes correctly through Caddy proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)