### PR TITLE
fix(proxy): update domain from vm0.dev to vm7.ai and fix certificate paths

### DIFF
--- a/turbo/packages/proxy/Caddyfile
+++ b/turbo/packages/proxy/Caddyfile
@@ -5,19 +5,19 @@
 
 # Main domain redirect to www
 vm7.ai:8443 {
-  tls ../../.certs/vm7.ai.pem ../../.certs/vm7.ai-key.pem
+  tls ../../../.certs/vm7.ai.pem ../../../.certs/vm7.ai-key.pem
   redir https://www.vm7.ai:8443{uri} permanent
 }
 
 # Web application
 www.vm7.ai:8443 {
-  tls ../../.certs/www.vm7.ai.pem ../../.certs/www.vm7.ai-key.pem
+  tls ../../../.certs/www.vm7.ai.pem ../../../.certs/www.vm7.ai-key.pem
   reverse_proxy localhost:3000
 }
 
 # Docs application
 docs.vm7.ai:8443 {
-  tls ../../.certs/docs.vm7.ai.pem ../../.certs/docs.vm7.ai-key.pem
+  tls ../../../.certs/docs.vm7.ai.pem ../../../.certs/docs.vm7.ai-key.pem
   reverse_proxy localhost:3001
 }
 

--- a/turbo/packages/proxy/README.md
+++ b/turbo/packages/proxy/README.md
@@ -93,11 +93,11 @@ The `Caddyfile` defines:
 
 ### Domain Mapping
 
-| Domain            | Port | Backend                       |
-| ----------------- | ---- | ----------------------------- |
-| www.vm7.ai:8443   | 8443 | localhost:3000 (Next.js web)  |
-| docs.vm7.ai:8443  | 8443 | localhost:3001 (Next.js docs) |
-| vm7.ai:8443       | 8443 | Redirect to www.vm7.ai:8443   |
+| Domain           | Port | Backend                       |
+| ---------------- | ---- | ----------------------------- |
+| www.vm7.ai:8443  | 8443 | localhost:3000 (Next.js web)  |
+| docs.vm7.ai:8443 | 8443 | localhost:3001 (Next.js docs) |
+| vm7.ai:8443      | 8443 | Redirect to www.vm7.ai:8443   |
 
 ## Scripts
 

--- a/turbo/packages/proxy/README.md
+++ b/turbo/packages/proxy/README.md
@@ -9,7 +9,7 @@ This package provides a Caddy-based reverse proxy that enables HTTPS for local d
 ## Features
 
 - **HTTPS support** for all local development servers
-- **Multiple domains**: www.vm0.dev, docs.vm0.dev
+- **Multiple domains**: www.vm7.ai, docs.vm7.ai
 - **Automatic HTTP to HTTPS redirect**
 - **WebSocket support** for hot module replacement
 
@@ -41,9 +41,9 @@ This will:
 
 - Install mkcert CA to your system trust store
 - Generate SSL certificates for:
-  - vm0.dev
-  - www.vm0.dev
-  - docs.vm0.dev
+  - vm7.ai
+  - www.vm7.ai
+  - docs.vm7.ai
 
 ### 2. Verify Certificates
 
@@ -72,8 +72,8 @@ pnpm dev
 
 With HTTPS (via Caddy):
 
-- Web: https://www.vm0.dev:8443
-- Docs: https://docs.vm0.dev:8443
+- Web: https://www.vm7.ai:8443
+- Docs: https://docs.vm7.ai:8443
 
 Direct access (HTTP only):
 
@@ -95,9 +95,9 @@ The `Caddyfile` defines:
 
 | Domain            | Port | Backend                       |
 | ----------------- | ---- | ----------------------------- |
-| www.vm0.dev:8443  | 8443 | localhost:3000 (Next.js web)  |
-| docs.vm0.dev:8443 | 8443 | localhost:3001 (Next.js docs) |
-| vm0.dev:8443      | 8443 | Redirect to www.vm0.dev:8443  |
+| www.vm7.ai:8443   | 8443 | localhost:3000 (Next.js web)  |
+| docs.vm7.ai:8443  | 8443 | localhost:3001 (Next.js docs) |
+| vm7.ai:8443       | 8443 | Redirect to www.vm7.ai:8443   |
 
 ## Scripts
 
@@ -109,7 +109,7 @@ The `Caddyfile` defines:
 
 The DevContainer automatically:
 
-- Adds vm0.dev domains to `/etc/hosts`
+- Adds vm7.ai domains to `/etc/hosts`
 - Installs mkcert CA to system trust store
 - Installs CA to NSS database (for Chrome/Firefox)
 - Persists mkcert state across container rebuilds
@@ -159,7 +159,7 @@ Then restart your browser.
 In DevContainer, this should be automatic. If not:
 
 ```bash
-echo "127.0.0.1 vm0.dev www.vm0.dev docs.vm0.dev" | sudo tee -a /etc/hosts
+echo "127.0.0.1 vm7.ai www.vm7.ai docs.vm7.ai" | sudo tee -a /etc/hosts
 ```
 
 ## File Structure

--- a/turbo/packages/proxy/scripts/check-certs.js
+++ b/turbo/packages/proxy/scripts/check-certs.js
@@ -3,15 +3,15 @@
 const fs = require("fs");
 const path = require("path");
 
-const CERTS_DIR = path.join(__dirname, "../../../.certs");
+const CERTS_DIR = path.join(__dirname, "../../../../.certs");
 
 const requiredCerts = [
-  "vm0.dev.pem",
-  "vm0.dev-key.pem",
-  "www.vm0.dev.pem",
-  "www.vm0.dev-key.pem",
-  "docs.vm0.dev.pem",
-  "docs.vm0.dev-key.pem",
+  "vm7.ai.pem",
+  "vm7.ai-key.pem",
+  "www.vm7.ai.pem",
+  "www.vm7.ai-key.pem",
+  "docs.vm7.ai.pem",
+  "docs.vm7.ai-key.pem",
 ];
 
 console.log("🔍 Checking SSL certificates...\n");

--- a/turbo/packages/proxy/scripts/start-caddy.js
+++ b/turbo/packages/proxy/scripts/start-caddy.js
@@ -54,8 +54,8 @@ caddy.on("exit", (code) => {
 setTimeout(() => {
   console.log("\n✅ Caddy is running!");
   console.log("\n📱 Available at:");
-  console.log("   Web:  https://www.vm0.dev:8443");
-  console.log("   Docs: https://docs.vm0.dev:8443");
+  console.log("   Web:  https://www.vm7.ai:8443");
+  console.log("   Docs: https://docs.vm7.ai:8443");
   console.log("\n💡 Make sure your applications are running:");
   console.log("   Web:  pnpm --filter web dev (port 3000)");
   console.log("   Docs: pnpm --filter docs dev (port 3001)");


### PR DESCRIPTION
## Summary
- Update all proxy configuration to use vm7.ai instead of vm0.dev
- Fix certificate path in check-certs.js to correctly point to git root (.certs directory)
- Fix certificate path in Caddyfile to correctly point to git root (.certs directory)  
- Update README documentation with new vm7.ai domain references

## Test plan
- [x] Generate SSL certificates for vm7.ai
- [x] Start development server successfully
- [x] Verify Caddy proxy starts without errors
- [x] Verify all services are accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)