### PR TITLE
fix(devcontainer): use dynamic port mapping for CLI compatibility

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,10 @@
     "ghcr.io/devcontainers-extra/features/caddy:1": {}
   },
   "remoteUser": "vscode",
-  "forwardPorts": [3000, 3001, 4983, 5432, 8080, 8443],
+  "forwardPorts": [8443],
+  "runArgs": [
+    "-p", "8443"
+  ],
   "remoteEnv": {
     "CLAUDE_CONFIG_DIR": "/home/vscode/.config/claude",
     "HISTFILE": "/home/vscode/.cache/.zsh_history",


### PR DESCRIPTION
## Summary

- Simplified port forwarding configuration to only expose port 8443
- Enabled dynamic host port mapping using `runArgs` with `-p 8443`
- Removed unused port forwards (3000, 3001, 4983, 5432, 8080) that don't work with `@devcontainers/cli`

## Context

The `forwardPorts` configuration in `devcontainer.json` is a VS Code-specific feature that doesn't work when using `@devcontainers/cli up`. This causes issues when trying to access services from the host machine in CLI-based workflows.

## Changes

- **forwardPorts**: Reduced from 6 ports to only port 8443
- **runArgs**: Added Docker `-p` flag for dynamic port mapping
- This allows Docker to automatically assign an available host port, preventing conflicts when running multiple devcontainers

## Benefits

- Multiple devcontainers can run simultaneously without port conflicts
- Works consistently with both VS Code and CLI workflows
- Simpler configuration focused on the primary service port (8443)

## Test plan

- [ ] Start devcontainer using `@devcontainers/cli up`
- [ ] Run `docker port <container-id> 8443` on host to verify dynamic port mapping
- [ ] Access the service via the mapped host port
- [ ] Verify no port conflicts when running multiple devcontainers

🤖 Generated with [Claude Code](https://claude.com/claude-code)