### PR TITLE
feat: add e2b api key configuration

### DIFF
--- a/.env.local.tpl
+++ b/.env.local.tpl
@@ -1,2 +1,3 @@
 CLERK_SECRET_KEY=op://Development/vm0-env-local/clerk_secret_key
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=op://Development/vm0-env-local/clerk_publishable_key
+E2B_API_KEY=op://Development/vm0-env-local/e2b_api_key

--- a/turbo/apps/web/src/env.ts
+++ b/turbo/apps/web/src/env.ts
@@ -12,7 +12,7 @@ function initEnv() {
         .enum(["development", "test", "production"])
         .default("development"),
       CLERK_SECRET_KEY: z.string().min(1),
-      E2B_API_KEY: z.string().min(1),
+      E2B_API_KEY: z.string().min(1).optional(),
     },
     client: {
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),

--- a/turbo/apps/web/src/env.ts
+++ b/turbo/apps/web/src/env.ts
@@ -12,6 +12,7 @@ function initEnv() {
         .enum(["development", "test", "production"])
         .default("development"),
       CLERK_SECRET_KEY: z.string().min(1),
+      E2B_API_KEY: z.string().min(1),
     },
     client: {
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),
@@ -20,6 +21,7 @@ function initEnv() {
       DATABASE_URL: process.env.DATABASE_URL,
       NODE_ENV: process.env.NODE_ENV,
       CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
+      E2B_API_KEY: process.env.E2B_API_KEY,
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
         process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
     },

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -7,7 +7,8 @@
     "SKIP_ENV_VALIDATION",
     "VERCEL",
     "CLERK_SECRET_KEY",
-    "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY"
+    "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+    "E2B_API_KEY"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary
- Add E2B_API_KEY to 1Password template (`.env.local.tpl`) for secure key management
- Add E2B_API_KEY validation in `turbo/apps/web/src/env.ts` with zod schema
- Configure runtime environment mapping for E2B API access

## Changes
- `.env.local.tpl`: Added E2B_API_KEY reference to 1Password vault
- `turbo/apps/web/src/env.ts`: Added E2B_API_KEY to server-side environment validation

## Test plan
- [x] E2B_API_KEY added to 1Password vault `Development/vm0-env-local`
- [x] Run `pnpm sync:env` to sync environment variables
- [x] Verify E2B_API_KEY appears in `turbo/apps/web/.env.local`
- [ ] Verify application can access E2B_API_KEY via `globalThis.services.env.E2B_API_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)