### PR TITLE
test: convert unit tests to integration tests with real database

### DIFF
--- a/turbo/apps/web/src/lib/api/__tests__/agent-configs.test.ts
+++ b/turbo/apps/web/src/lib/api/__tests__/agent-configs.test.ts
@@ -1,0 +1,260 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { createHash } from "crypto";
+import { initServices } from "../../init-services";
+import { apiKeys } from "../../../db/schema/api-key";
+import { agentConfigs } from "../../../db/schema/agent-config";
+import { eq } from "drizzle-orm";
+import { POST } from "../../../../app/api/agent-configs/route";
+import { GET } from "../../../../app/api/agent-configs/[id]/route";
+
+function hashApiKey(key: string): string {
+  return createHash("sha256").update(key).digest("hex");
+}
+
+describe("Agent Configs API - integration tests", () => {
+  const testApiKey = "test-api-key-123";
+  let testApiKeyId: string;
+  let testAgentConfigId: string;
+
+  beforeEach(async () => {
+    // Initialize services
+    initServices();
+
+    // Clean up test data
+    if (testApiKeyId) {
+      await globalThis.services.db
+        .delete(agentConfigs)
+        .where(eq(agentConfigs.apiKeyId, testApiKeyId))
+        .execute();
+    }
+    await globalThis.services.db
+      .delete(apiKeys)
+      .where(eq(apiKeys.name, "Test API Key"))
+      .execute();
+
+    // Create test API key
+    const [insertedKey] = await globalThis.services.db
+      .insert(apiKeys)
+      .values({
+        keyHash: hashApiKey(testApiKey),
+        name: "Test API Key",
+      })
+      .returning({ id: apiKeys.id });
+
+    testApiKeyId = insertedKey?.id ?? "";
+  });
+
+  afterEach(async () => {
+    // Clean up test data
+    if (testAgentConfigId) {
+      await globalThis.services.db
+        .delete(agentConfigs)
+        .where(eq(agentConfigs.id, testAgentConfigId))
+        .execute();
+    }
+    await globalThis.services.db
+      .delete(agentConfigs)
+      .where(eq(agentConfigs.apiKeyId, testApiKeyId))
+      .execute();
+    await globalThis.services.db
+      .delete(apiKeys)
+      .where(eq(apiKeys.id, testApiKeyId))
+      .execute();
+  });
+
+  describe("POST /api/agent-configs", () => {
+    it("should return 401 when API key is missing", async () => {
+      const request = new NextRequest("http://localhost/api/agent-configs", {
+        method: "POST",
+        body: JSON.stringify({
+          config: { name: "test-agent" },
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(401);
+
+      const data = await response.json();
+      expect(data.error.code).toBe("UNAUTHORIZED");
+      expect(data.error.message).toBe("Missing API key");
+    });
+
+    it("should return 401 when API key is invalid", async () => {
+      const request = new NextRequest("http://localhost/api/agent-configs", {
+        method: "POST",
+        headers: { "x-api-key": "invalid-key" },
+        body: JSON.stringify({
+          config: { name: "test-agent" },
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(401);
+
+      const data = await response.json();
+      expect(data.error.code).toBe("UNAUTHORIZED");
+      expect(data.error.message).toBe("Invalid API key");
+    });
+
+    it("should return 400 when config is missing", async () => {
+      const request = new NextRequest("http://localhost/api/agent-configs", {
+        method: "POST",
+        headers: { "x-api-key": testApiKey },
+        body: JSON.stringify({}),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+
+      const data = await response.json();
+      expect(data.error.code).toBe("BAD_REQUEST");
+      expect(data.error.message).toBe("Missing config");
+    });
+
+    it("should create agent config and return 201", async () => {
+      const configData = {
+        version: "1.0.0",
+        agent: {
+          name: "test-agent",
+          description: "Test agent config",
+        },
+      };
+
+      const request = new NextRequest("http://localhost/api/agent-configs", {
+        method: "POST",
+        headers: { "x-api-key": testApiKey },
+        body: JSON.stringify({
+          config: configData,
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(201);
+
+      const data = await response.json();
+      expect(data.agentConfigId).toBeDefined();
+      expect(data.createdAt).toBeDefined();
+
+      // Store for cleanup
+      testAgentConfigId = data.agentConfigId;
+
+      // Verify in database
+      const [dbConfig] = await globalThis.services.db
+        .select()
+        .from(agentConfigs)
+        .where(eq(agentConfigs.id, data.agentConfigId))
+        .limit(1);
+
+      expect(dbConfig).toBeDefined();
+      expect(dbConfig?.apiKeyId).toBe(testApiKeyId);
+      expect(dbConfig?.config).toEqual(configData);
+    });
+  });
+
+  describe("GET /api/agent-configs/:id", () => {
+    beforeEach(async () => {
+      // Create a test agent config for GET tests
+      const [inserted] = await globalThis.services.db
+        .insert(agentConfigs)
+        .values({
+          apiKeyId: testApiKeyId,
+          config: {
+            version: "1.0.0",
+            agent: {
+              name: "test-agent",
+            },
+          },
+        })
+        .returning({ id: agentConfigs.id });
+
+      testAgentConfigId = inserted?.id ?? "";
+    });
+
+    it("should return 401 when API key is missing", async () => {
+      const request = new NextRequest(
+        `http://localhost/api/agent-configs/${testAgentConfigId}`,
+        {
+          method: "GET",
+        },
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ id: testAgentConfigId }),
+      });
+      expect(response.status).toBe(401);
+
+      const data = await response.json();
+      expect(data.error.code).toBe("UNAUTHORIZED");
+      expect(data.error.message).toBe("Missing API key");
+    });
+
+    it("should return 401 when API key is invalid", async () => {
+      const request = new NextRequest(
+        `http://localhost/api/agent-configs/${testAgentConfigId}`,
+        {
+          method: "GET",
+          headers: { "x-api-key": "invalid-key" },
+        },
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ id: testAgentConfigId }),
+      });
+      expect(response.status).toBe(401);
+
+      const data = await response.json();
+      expect(data.error.code).toBe("UNAUTHORIZED");
+      expect(data.error.message).toBe("Invalid API key");
+    });
+
+    it("should return 404 when agent config not found", async () => {
+      const nonExistentId = "00000000-0000-0000-0000-000000000000";
+      const request = new NextRequest(
+        `http://localhost/api/agent-configs/${nonExistentId}`,
+        {
+          method: "GET",
+          headers: { "x-api-key": testApiKey },
+        },
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ id: nonExistentId }),
+      });
+      expect(response.status).toBe(404);
+
+      const data = await response.json();
+      expect(data.error.code).toBe("NOT_FOUND");
+      expect(data.error.message).toBe("Agent config not found");
+    });
+
+    it("should return agent config when found", async () => {
+      const request = new NextRequest(
+        `http://localhost/api/agent-configs/${testAgentConfigId}`,
+        {
+          method: "GET",
+          headers: { "x-api-key": testApiKey },
+        },
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ id: testAgentConfigId }),
+      });
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.id).toBe(testAgentConfigId);
+      expect(data.config).toEqual({
+        version: "1.0.0",
+        agent: {
+          name: "test-agent",
+        },
+      });
+      expect(data.createdAt).toBeDefined();
+      expect(data.updatedAt).toBeDefined();
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/middleware/__tests__/auth.test.ts
+++ b/turbo/apps/web/src/lib/middleware/__tests__/auth.test.ts
@@ -1,29 +1,47 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 import { authenticate } from "../auth";
 import { UnauthorizedError } from "../../errors";
 import { createHash } from "crypto";
-
-// Mock globalThis.services
-const mockDb = {
-  select: vi.fn(),
-  update: vi.fn(),
-};
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  // Setup globalThis.services mock
-  Object.defineProperty(globalThis, "services", {
-    value: { db: mockDb },
-    configurable: true,
-  });
-});
+import { initServices } from "../../init-services";
+import { apiKeys } from "../../../db/schema/api-key";
+import { eq } from "drizzle-orm";
 
 function hashApiKey(key: string): string {
   return createHash("sha256").update(key).digest("hex");
 }
 
-describe("authenticate", () => {
+describe("authenticate - integration tests", () => {
+  beforeEach(async () => {
+    // Initialize services to connect to real database
+    initServices();
+
+    // Clean up test data
+    await globalThis.services.db
+      .delete(apiKeys)
+      .where(eq(apiKeys.name, "Test Key"))
+      .execute();
+    await globalThis.services.db
+      .delete(apiKeys)
+      .where(eq(apiKeys.name, "Test Key 2"))
+      .execute();
+  });
+
+  afterEach(async () => {
+    // Clean up test data after each test
+    await globalThis.services.db
+      .delete(apiKeys)
+      .where(eq(apiKeys.name, "Test Key"))
+      .execute();
+    await globalThis.services.db
+      .delete(apiKeys)
+      .where(eq(apiKeys.name, "Test Key 2"))
+      .execute();
+  });
+
   it("should throw UnauthorizedError when API key is missing", async () => {
     const request = new NextRequest("http://localhost/api/test");
 
@@ -36,90 +54,83 @@ describe("authenticate", () => {
       headers: { "x-api-key": "invalid-key" },
     });
 
-    mockDb.select.mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([]),
-        }),
-      }),
-    });
-
     await expect(authenticate(request)).rejects.toThrow(UnauthorizedError);
     await expect(authenticate(request)).rejects.toThrow("Invalid API key");
   });
 
   it("should return API key ID when authentication succeeds", async () => {
     const apiKey = "valid-key-123";
-    const apiKeyId = "api-key-id-123";
+
+    // Insert test API key into database
+    const [insertedKey] = await globalThis.services.db
+      .insert(apiKeys)
+      .values({
+        keyHash: hashApiKey(apiKey),
+        name: "Test Key",
+      })
+      .returning({ id: apiKeys.id });
+
     const request = new NextRequest("http://localhost/api/test", {
       headers: { "x-api-key": apiKey },
-    });
-
-    const mockApiKeyRecord = {
-      id: apiKeyId,
-      keyHash: hashApiKey(apiKey),
-      name: "Test Key",
-      createdAt: new Date(),
-      lastUsedAt: null,
-    };
-
-    mockDb.select.mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([mockApiKeyRecord]),
-        }),
-      }),
-    });
-
-    mockDb.update.mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(undefined),
-      }),
     });
 
     const result = await authenticate(request);
 
-    expect(result).toBe(apiKeyId);
-    expect(mockDb.update).toHaveBeenCalled();
+    expect(result).toBe(insertedKey?.id);
+
+    // Verify lastUsedAt was updated
+    const [updatedKey] = await globalThis.services.db
+      .select()
+      .from(apiKeys)
+      .where(eq(apiKeys.id, result))
+      .limit(1);
+
+    expect(updatedKey?.lastUsedAt).toBeDefined();
   });
 
   it("should update lastUsedAt timestamp on successful authentication", async () => {
     const apiKey = "valid-key-456";
-    const apiKeyId = "api-key-id-456";
+
+    // Insert test API key into database
+    const [insertedKey] = await globalThis.services.db
+      .insert(apiKeys)
+      .values({
+        keyHash: hashApiKey(apiKey),
+        name: "Test Key 2",
+      })
+      .returning({ id: apiKeys.id });
+
     const request = new NextRequest("http://localhost/api/test", {
       headers: { "x-api-key": apiKey },
     });
 
-    const mockApiKeyRecord = {
-      id: apiKeyId,
-      keyHash: hashApiKey(apiKey),
-      name: "Test Key 2",
-      createdAt: new Date(),
-      lastUsedAt: null,
-    };
+    // First authentication
+    await authenticate(request);
 
-    const mockSet = vi.fn().mockReturnValue({
-      where: vi.fn().mockResolvedValue(undefined),
-    });
+    const [firstCheck] = await globalThis.services.db
+      .select()
+      .from(apiKeys)
+      .where(eq(apiKeys.id, insertedKey?.id ?? ""))
+      .limit(1);
 
-    mockDb.select.mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([mockApiKeyRecord]),
-        }),
-      }),
-    });
+    const firstLastUsedAt = firstCheck?.lastUsedAt;
+    expect(firstLastUsedAt).toBeDefined();
 
-    mockDb.update.mockReturnValue({
-      set: mockSet,
-    });
+    // Wait a bit and authenticate again
+    await new Promise((resolve) => setTimeout(resolve, 100));
 
     await authenticate(request);
 
-    expect(mockSet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        lastUsedAt: expect.any(Date),
-      }),
+    const [secondCheck] = await globalThis.services.db
+      .select()
+      .from(apiKeys)
+      .where(eq(apiKeys.id, insertedKey?.id ?? ""))
+      .limit(1);
+
+    const secondLastUsedAt = secondCheck?.lastUsedAt;
+    expect(secondLastUsedAt).toBeDefined();
+    expect(secondLastUsedAt?.getTime()).toBeGreaterThan(
+      firstLastUsedAt?.getTime() ?? 0,
     );
   });
 });

--- a/turbo/apps/web/src/test/setup.ts
+++ b/turbo/apps/web/src/test/setup.ts
@@ -1,5 +1,9 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
+import { config } from "dotenv";
+
+// Load environment variables from .env file
+config({ path: "./.env" });
 
 // Mock Clerk authentication
 vi.mock("@clerk/nextjs/server", () => ({


### PR DESCRIPTION
## Summary

Convert all unit tests to integration tests that connect to real database instead of using mocks.

## Changes

### Authentication Tests (`src/lib/middleware/__tests__/auth.test.ts`)
- Removed all mock objects (`vi.fn()`)
- Added `@vitest-environment node` to run in Node.js environment
- Connect to real database using `initServices()`
- Insert and cleanup test data in database
- Verify actual database operations

### API Integration Tests (NEW: `src/lib/api/__tests__/agent-configs.test.ts`)
- Complete integration tests for POST `/api/agent-configs`
  - 401 when API key is missing
  - 401 when API key is invalid
  - 400 when config is missing
  - 201 successful creation with database verification
- Complete integration tests for GET `/api/agent-configs/:id`
  - 401 when API key is missing
  - 401 when API key is invalid
  - 404 when agent config not found
  - 200 successful retrieval

### Test Setup (`src/test/setup.ts`)
- Load environment variables from `.env` file using dotenv
- Ensure `DATABASE_URL` is available for integration tests

## Test Results

✅ **All 19 tests passing**
- 12 integration tests (with real database)
- 7 existing unit tests

```bash
Test Files  6 passed (6)
     Tests  19 passed (19)
  Duration  679ms
```

## Test Plan

- [x] Run all tests: `pnpm vitest run`
- [x] Verify database connections work
- [x] Verify test data cleanup (beforeEach/afterEach)
- [x] Verify all authentication flows
- [x] Verify all API endpoint behaviors

🤖 Generated with [Claude Code](https://claude.com/claude-code)