### PR TITLE
feat: add playwright e2e web tests with github actions integration

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -17,6 +17,7 @@ jobs:
     outputs:
       web-changed: ${{ steps.detect.outputs.web-changed }}
       docs-changed: ${{ steps.detect.outputs.docs-changed }}
+      web-e2e-changed: ${{ steps.detect.outputs.web-e2e-changed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -33,6 +34,7 @@ jobs:
             echo "Not a PR, assuming all apps changed"
             echo "web-changed=true" >> $GITHUB_OUTPUT
             echo "docs-changed=true" >> $GITHUB_OUTPUT
+            echo "web-e2e-changed=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -57,6 +59,16 @@ jobs:
           else
             echo "Changes detected in docs app"
             echo "docs-changed=true" >> $GITHUB_OUTPUT
+          fi
+
+          # Check e2e/web tests
+          cd ../../../e2e/web
+          if git diff --quiet HEAD^ HEAD .; then
+            echo "No changes detected in web e2e tests"
+            echo "web-e2e-changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected in web e2e tests"
+            echo "web-e2e-changed=true" >> $GITHUB_OUTPUT
           fi
 
   lint:
@@ -103,8 +115,8 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:829341a
     needs: [change-detection]
-    # Deploy if it's a PR and web changed
-    if: github.event_name == 'pull_request' && needs.change-detection.outputs.web-changed == 'true'
+    # Deploy if it's a PR and web or web e2e changed (e2e tests need web deployment)
+    if: github.event_name == 'pull_request' && (needs.change-detection.outputs.web-changed == 'true' || needs.change-detection.outputs.web-e2e-changed == 'true')
     outputs:
       preview-url: ${{ steps.deploy.outputs.url }}
     permissions:
@@ -169,3 +181,55 @@ jobs:
           deployment-env: docs
           meta-branch: ${{ github.head_ref }}
           meta-pr: ${{ github.event.pull_request.number }}
+
+  # Run Web E2E tests with Playwright
+  web-e2e:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:829341a
+    needs: [change-detection, deploy-web]
+    # Run if web or web e2e tests changed and deployment succeeded
+    if: github.event_name == 'pull_request' && (needs.change-detection.outputs.web-changed == 'true' || needs.change-detection.outputs.web-e2e-changed == 'true') && needs.deploy-web.outputs.preview-url != ''
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Install npm dependencies for e2e tests
+        run: |
+          cd e2e/web
+          npm ci
+
+      - name: Install Playwright browser
+        run: |
+          cd e2e/web
+          npx playwright install chromium
+
+      - name: Wait for deployment to be ready
+        run: |
+          echo "Checking deployment readiness at ${{ needs.deploy-web.outputs.preview-url }}"
+          HEALTH_URL="${{ needs.deploy-web.outputs.preview-url }}/api/health"
+          MAX_ATTEMPTS=30
+          INTERVAL=2
+
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            echo "Attempt $i/$MAX_ATTEMPTS: Checking $HEALTH_URL"
+            if curl -sf "$HEALTH_URL" | grep -q '"status":"ready"'; then
+              echo "✅ Deployment is ready!"
+              exit 0
+            fi
+            if [ $i -lt $MAX_ATTEMPTS ]; then
+              echo "⏳ Deployment not ready yet, waiting ${INTERVAL}s before next attempt..."
+              sleep $INTERVAL
+            fi
+          done
+
+          echo "❌ Deployment not ready after $MAX_ATTEMPTS attempts"
+          exit 1
+
+      - name: Run Playwright E2E Tests
+        run: |
+          echo "Testing web app at: ${{ needs.deploy-web.outputs.preview-url }}"
+          cd e2e/web
+          npx playwright test --reporter=list
+        env:
+          BASE_URL: ${{ needs.deploy-web.outputs.preview-url }}

--- a/e2e/web/.env.local.example
+++ b/e2e/web/.env.local.example
@@ -1,0 +1,1 @@
+BASE_URL=http://localhost:3000

--- a/e2e/web/.gitignore
+++ b/e2e/web/.gitignore
@@ -3,4 +3,3 @@ test-results/
 playwright-report/
 playwright/.cache/
 .env.local
-package-lock.json

--- a/e2e/web/.gitignore
+++ b/e2e/web/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+test-results/
+playwright-report/
+playwright/.cache/
+.env.local
+package-lock.json

--- a/e2e/web/README.md
+++ b/e2e/web/README.md
@@ -1,0 +1,53 @@
+# Web E2E Tests
+
+End-to-end tests for the VM0 web application using Playwright.
+
+## Setup
+
+Install dependencies:
+
+```bash
+cd e2e/web
+npm install
+npx playwright install chromium
+```
+
+## Running Tests Locally
+
+Create a `.env.local` file with the base URL:
+
+```bash
+BASE_URL=http://localhost:3000
+```
+
+Then run the tests:
+
+```bash
+npm test
+```
+
+## Running Tests in CI
+
+The tests are automatically run in GitHub Actions when a PR is created. The workflow:
+
+1. Deploys the web app to a preview URL on Vercel
+2. Waits for the deployment to be ready by checking the health endpoint
+3. Passes the preview URL as `BASE_URL` environment variable
+4. Runs the Playwright tests against the preview deployment
+
+## Writing Tests
+
+Tests are located in the `tests/` directory. Each test file should follow the pattern `*.spec.ts`.
+
+Example test:
+
+```typescript
+import { test, expect } from "@playwright/test";
+
+test("homepage loads", async ({ page }) => {
+  await page.goto("/");
+  await expect(page).toHaveTitle(/VM0/i);
+});
+```
+
+The `baseURL` is configured in `playwright.config.ts` from the `BASE_URL` environment variable, so tests can use relative paths like `page.goto("/")`.

--- a/e2e/web/package-lock.json
+++ b/e2e/web/package-lock.json
@@ -1,0 +1,125 @@
+{
+  "name": "@vm0/e2e-web",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@vm0/e2e-web",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.55.1",
+        "@types/node": "^22.10.2",
+        "dotenv": "^17.2.2",
+        "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/e2e/web/package.json
+++ b/e2e/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@vm0/e2e-web",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.55.1",
+    "@types/node": "^22.10.2",
+    "dotenv": "^17.2.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/e2e/web/playwright.config.ts
+++ b/e2e/web/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+import dotenv from "dotenv";
+dotenv.config({ path: "./.env.local" });
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 4,
+  reporter: "list",
+  timeout: 30000,
+  use: {
+    baseURL: process.env.BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+  ],
+});

--- a/e2e/web/tests/basic-smoke.spec.ts
+++ b/e2e/web/tests/basic-smoke.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Basic Smoke Tests", () => {
+  test("homepage loads successfully", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page).toHaveTitle(/VM0/i);
+
+    const mainContent = page.locator('main, [role="main"], body').first();
+    await expect(mainContent).toBeVisible();
+  });
+
+  test("API health check endpoint works", async ({ request }) => {
+    const response = await request.get("/api/health");
+
+    expect(response.status()).toBe(200);
+  });
+
+  test("navigation elements exist", async ({ page }) => {
+    await page.goto("/");
+
+    // Check for common navigation elements
+    const navElements = await page.locator("nav, header, a[href], div").count();
+
+    expect(navElements).toBeGreaterThan(0);
+  });
+});

--- a/e2e/web/tsconfig.json
+++ b/e2e/web/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node", "@playwright/test"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/turbo/apps/web/app/api/health/route.ts
+++ b/turbo/apps/web/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({ status: "ready" }, { status: 200 });
+}


### PR DESCRIPTION
## Summary

- Migrate e2e web testing setup from uspark-hq/uspark project
- Add Playwright test framework with TypeScript configuration
- Implement basic smoke tests for homepage and API endpoints
- Integrate e2e tests with GitHub Actions workflow
- Add health endpoint for deployment readiness checks
- Configure change detection to trigger deployments when e2e tests change

## Key Changes

**E2E Test Infrastructure:**
- `e2e/web/` - New directory with Playwright test setup
- `e2e/web/tests/basic-smoke.spec.ts` - Homepage, health check, and navigation tests
- `e2e/web/playwright.config.ts` - Playwright configuration with BASE_URL from env
- `e2e/web/package.json` - Playwright dependencies (^1.55.1)

**GitHub Actions Workflow:**
- Added `web-e2e` job that runs after `deploy-web`
- Receives preview URL from Vercel deployment
- Waits for health endpoint readiness before running tests
- Passes preview URL as `BASE_URL` environment variable to Playwright
- Triggers deployment when either web app or e2e tests change

**API Endpoint:**
- `turbo/apps/web/app/api/health/route.ts` - New health check endpoint returning `{"status":"ready"}`

## How It Works

1. PR created with web or e2e test changes
2. GitHub Actions detects changes and deploys to Vercel preview
3. Web e2e job receives preview URL from deploy job
4. Health endpoint polling waits for deployment readiness (max 60s)
5. Playwright tests run against live preview deployment
6. Tests use relative URLs (e.g., `page.goto("/")`) with baseURL configured

## Test Plan

- [ ] Verify e2e tests pass in CI when this PR is created
- [ ] Check that health endpoint returns proper status
- [ ] Confirm tests run against preview URL not localhost
- [ ] Validate change detection triggers deployment correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)