### PR TITLE
fix: update webhook sequence numbers to use integer type

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent-events/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent-events/route.ts
@@ -62,12 +62,12 @@ export async function POST(request: NextRequest) {
       .from(agentRuntimeEvents)
       .where(eq(agentRuntimeEvents.runtimeId, body.runtimeId));
 
-    const lastSequence = lastEvent?.maxSeq ? parseInt(lastEvent.maxSeq, 10) : 0;
+    const lastSequence = lastEvent?.maxSeq ?? 0;
 
     // Prepare events for insertion
     const eventsToInsert = body.events.map((event, index) => ({
       runtimeId: body.runtimeId,
-      sequenceNumber: String(lastSequence + index + 1),
+      sequenceNumber: lastSequence + index + 1,
       eventType: event.type,
       eventData: event,
     }));

--- a/turbo/apps/web/src/lib/api/__tests__/webhooks.test.ts
+++ b/turbo/apps/web/src/lib/api/__tests__/webhooks.test.ts
@@ -143,9 +143,9 @@ describe("POST /api/webhooks/agent-events", () => {
 
     expect(events).toHaveLength(2);
     expect(events[0]?.eventType).toBe("init");
-    expect(events[0]?.sequenceNumber).toBe("1");
+    expect(events[0]?.sequenceNumber).toBe(1);
     expect(events[1]?.eventType).toBe("text");
-    expect(events[1]?.sequenceNumber).toBe("2");
+    expect(events[1]?.sequenceNumber).toBe(2);
   });
 
   it("should reject invalid token", async () => {

--- a/turbo/apps/web/vitest.config.ts
+++ b/turbo/apps/web/vitest.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: "./src/test/setup.ts",
     // Don't override env vars, let them pass through from system
+    // Run tests sequentially to avoid database race conditions
+    fileParallelism: false,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Update webhook endpoint to use integer type for sequenceNumber
- Fix test expectations to match integer type  
- Fix database race conditions in tests

## Context
PR #55 changed the `sequenceNumber` field from varchar to integer in the database schema. This PR updates the webhook endpoint and tests to align with that change.

## Changes
1. **Webhook endpoint**: Remove string conversion for sequenceNumber
2. **Tests**: Update expectations from string "1", "2" to integer 1, 2
3. **Test config**: Disable file parallelism to prevent database race conditions

## Test Results
All 14 webhook tests pass:
- ✓ 7 webhook authentication tests
- ✓ 7 webhook integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)