### PR TITLE
fix: extract result field from claude code jsonl output

### DIFF
--- a/e2b/run-agent.sh
+++ b/e2b/run-agent.sh
@@ -76,9 +76,6 @@ send_event "container_start" '{"timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}'
 echo "[VM0] Starting Claude Code execution..." >&2
 echo "[VM0] Prompt: $PROMPT" >&2
 
-# Accumulator for final output
-output_text=""
-
 # Run Claude Code and capture output
 set +e  # Don't exit on Claude error
 /usr/local/bin/claude --print \
@@ -97,13 +94,12 @@ set +e  # Don't exit on Claude error
     # Valid JSONL - add to batch
     add_event "$line"
 
-    # Extract text content from JSONL event for stdout
+    # Extract result from "result" event for stdout
     event_type=$(echo "$line" | jq -r '.type // empty' 2>/dev/null)
-    if [ "$event_type" = "content" ]; then
-      text_content=$(echo "$line" | jq -r '.data.text // empty' 2>/dev/null)
-      if [ -n "$text_content" ]; then
-        echo -n "$text_content"
-        output_text="${output_text}${text_content}"
+    if [ "$event_type" = "result" ]; then
+      result_content=$(echo "$line" | jq -r '.result // empty' 2>/dev/null)
+      if [ -n "$result_content" ]; then
+        echo "$result_content"
       fi
     fi
   else


### PR DESCRIPTION
## Summary
- Fix empty output issue in `vm0 run` command by correctly parsing Claude Code's JSONL output format
- Extract the `result` field from `type: "result"` events instead of looking for non-existent `type: "content"` events
- Remove unused `output_text` accumulator variable to simplify the script

## Problem
When running `vm0 run <config-id> "prompt"`, the output was always empty because:
1. The `run-agent.sh` script was looking for `type: "content"` events
2. Claude Code's `--output-format stream-json` doesn't produce `content` type events
3. The actual result is in the `result` field of `type: "result"` events

## Solution
Updated `/e2b/run-agent.sh` to:
- Extract the `result` field from `type: "result"` JSONL events
- Output the result to stdout so it's captured by E2B and returned to the CLI
- Simplified the code by removing the unused `output_text` variable
- All other event types (`system`, `assistant`) are still sent via webhook for future processing

## Test Plan
- [x] Build E2B template with updated script
- [ ] Test `vm0 build` and `vm0 run` commands end-to-end
- [ ] Verify output is correctly displayed in CLI
- [ ] Confirm webhook events are still being sent

## Related
Fixes the issue where `vm0 run` would complete successfully but show empty output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)