### PR TITLE
feat: add slash commands for github issue workflow automation

### DIFF
--- a/.claude/commands/issue-continue.md
+++ b/.claude/commands/issue-continue.md
@@ -1,0 +1,60 @@
+# Continue Working on GitHub Issue
+
+Your job is to continue working on the GitHub issue from the current conversation context. This continues from where `/issue-todo` left off.
+
+## Important Notes
+- This command does NOT accept issue ID parameter - it automatically uses the issue from current conversation
+- Follow software engineering best practices: work on existing feature branch or create new one if needed
+- Commit messages must follow Conventional Commits specification (feat / fix / docs / refactor / test / chore)
+- Follow the small iteration principle: implement small, focused changes with corresponding test cases
+- After each change, run relevant tests to verify functionality before proceeding
+- When fixing bugs: reproduce via tests first, then fix, then verify tests pass
+- In regression testing: fix failed tests one at a time, verify each individually
+- Never fix multiple failed tests simultaneously unless you're certain they're related
+- Core principle: propose and verify hypotheses at fine granularity through continuous iteration
+
+## Workflow
+1. **Retrieve issue ID from context**:
+   - Look through the current conversation history to find the issue ID from previous `/issue-todo` or `/issue-continue` calls
+   - If no issue ID found in context: Ask user "Which issue would you like to continue working on? Please provide the issue ID."
+   - Exit and wait for user response if issue ID not found
+2. **Fetch latest updates**: Use `gh issue view <issue_id> --json title,body,comments,labels` to get all comments since last interaction
+3. **Remove pending label**: Use `gh issue edit <issue_id> --remove-label pending` to indicate work has resumed
+4. **Analyze feedback**: Review new comments for:
+   - Plan approval/rejection
+   - Modification requests
+   - Additional requirements
+   - Questions or clarifications
+5. **Take action based on feedback**:
+   - **If plan approved**: Proceed with implementation
+   - **If changes requested**: Update plan and post revised plan as comment, then add "pending" label and exit
+   - **If questions asked**: Answer questions in comment, then add "pending" label and exit
+6. **Implementation**:
+   - Create/switch to feature branch
+   - Implement changes following the approved plan
+   - Write and run tests after each change
+   - Commit with conventional commit messages
+7. **Check completion status**:
+   - **If work complete**: Create PR and go to step 8
+   - **If blocked or need clarification**: Post comment explaining the situation, add "pending" label, and exit
+   - **If intermediate checkpoint**: Post progress update comment, add "pending" label, and exit (optional)
+8. **Create PR and finalize**:
+   - Push branch and create Pull Request
+   - Post comment to issue: `gh issue comment <issue_id> --body "Work completed. PR created: <PR_URL>"`
+   - Add "pending" label for user to review PR
+   - Keep issue open (user will close it after merging PR)
+
+## Label Management
+- **Remove "pending" label** when resuming work (step 3)
+- **Add "pending" label** when:
+  - Waiting for plan approval (revised plan)
+  - Blocked and need user input
+  - Work completed and PR ready for review
+  - Optional: intermediate progress checkpoints
+
+## Error Handling
+- If issue ID cannot be found in conversation context: ask user to provide issue ID and exit
+- If "pending" label doesn't exist: create it first with `gh label create pending --description "Waiting for human input" --color FFA500`
+- If tests fail during implementation: report failures, add "pending" label, and ask for guidance
+
+Let's continue working!

--- a/.claude/commands/issue-todo.md
+++ b/.claude/commands/issue-todo.md
@@ -1,0 +1,35 @@
+# Start Working on GitHub Issue
+
+Your job is to start working on GitHub issue {{ISSUE_ID}} for the current project. This is the initial workflow for a new issue.
+
+## Important Notes
+- Follow software engineering best practices: create independent feature branches (git checkout -b feature/issue-{{ISSUE_ID}}-xxx)
+- Commit messages must follow Conventional Commits specification (feat / fix / docs / refactor / test / chore)
+- Follow the small iteration principle: implement small, focused changes with corresponding test cases
+- After each change, run relevant tests to verify functionality before proceeding
+- When fixing bugs: reproduce via tests first, then fix, then verify tests pass
+- In regression testing: fix failed tests one at a time, verify each individually
+- Never fix multiple failed tests simultaneously unless you're certain they're related
+- Core principle: propose and verify hypotheses at fine granularity through continuous iteration
+
+## Workflow
+1. **Fetch issue details**: Use `gh issue view {{ISSUE_ID}} --json title,body,comments,labels` to read complete issue information
+2. **Remove pending label**: Use `gh issue edit {{ISSUE_ID}} --remove-label pending` to indicate work has started
+3. **Analyze and plan**:
+   - Review issue description and all comments for requirements, suggestions, and context
+   - Create detailed work plan with specific implementation steps
+   - Post plan as issue comment: `gh issue comment {{ISSUE_ID}} --body "..."`
+4. **Add pending label**: Use `gh issue edit {{ISSUE_ID}} --add-label pending` to wait for user approval
+5. **Remember issue ID**: Store {{ISSUE_ID}} in context for future `/issue-continue` calls
+6. **Exit and wait**: Stop here and wait for user to review the plan and call `/issue-continue`
+
+## Label Management
+- **Remove "pending" label** when starting work (step 2)
+- **Add "pending" label** when waiting for user input (step 4)
+
+## Error Handling
+- If issue doesn't exist or is inaccessible: report error and exit
+- If "pending" label doesn't exist: create it first with `gh label create pending --description "Waiting for human input" --color FFA500`
+- If feature branch already exists: ask user whether to reuse or create new branch
+
+Let's get started!


### PR DESCRIPTION
## Summary

Add two new slash commands to automate GitHub issue handling workflow:

- `/issue-todo {ISSUE_ID}` - Start working on a new issue
  - Fetches issue details from GitHub
  - Analyzes requirements and creates detailed work plan
  - Posts plan as issue comment for user approval
  - Manages "pending" label to indicate waiting for human input

- `/issue-continue` - Continue working on current issue
  - Automatically retrieves issue ID from conversation context
  - Fetches latest comments and user feedback
  - Implements approved changes with tests
  - Creates PR when work is complete
  - Manages "pending" label throughout workflow

## Key Features

- **Label management**: Removes "pending" when working, adds "pending" when waiting for user input
- **Contextual continuation**: `/issue-continue` automatically finds issue from conversation history
- **Best practices enforcement**: Conventional commits, small iterations, test-driven development
- **PR automation**: Creates pull request with proper formatting when work is complete

## Test plan

- [x] Create command files in `.claude/commands/`
- [x] Follow conventional commit format
- [ ] Manual testing with actual GitHub issue workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)