### PR TITLE
feat: add CI pipeline verification and auto-fix to issue-continue workflow

### DIFF
--- a/.claude/commands/issue-continue.md
+++ b/.claude/commands/issue-continue.md
@@ -38,9 +38,28 @@ Your job is to continue working on the GitHub issue from the current conversatio
    - **If work complete**: Create PR and go to step 8
    - **If blocked or need clarification**: Post comment explaining the situation, add "pending" label, and exit
    - **If intermediate checkpoint**: Post progress update comment, add "pending" label, and exit (optional)
-8. **Create PR and finalize**:
+8. **Create PR and verify CI pipeline**:
    - Push branch and create Pull Request
-   - Post comment to issue: `gh issue comment <issue_id> --body "Work completed. PR created: <PR_URL>"`
+   - Wait 60 seconds for CI workflows to start
+   - Check and fix pipeline issues:
+     - Use `gh pr checks` to check pipeline status
+     - **If checks still running**: Wait 30 seconds and retry (up to 10 times total)
+     - **If checks failing**: Attempt automatic fixes:
+       - **Lint failures** (if output contains "lint" and "fail"):
+         1. Run `cd turbo && pnpm format`
+         2. If changes detected: `git add -A && git commit -m "fix: auto-format code" && git push`
+         3. Wait 60 seconds and re-check pipeline
+       - **Type check failures** (if output contains "type" or "check-types" and "fail"):
+         1. Run `cd turbo && pnpm check-types`
+         2. Report errors (manual fix required)
+       - **Test failures** (if output contains "test" and "fail"):
+         1. Run `cd turbo && pnpm vitest`
+         2. Report failures (manual fix required)
+       - After pushing fixes, wait 60 seconds and re-check pipeline
+       - Retry fix attempts up to 2 times
+     - **If checks pass** (after fixes or initially): Post success comment to issue
+     - **If unable to fix after retries**: Post comment with failure details and add "pending" label, then exit
+   - Post comment to issue: `gh issue comment <issue_id> --body "Work completed. PR created: <PR_URL>\n\n✅ All CI checks passing"`
    - Add "pending" label for user to review PR
    - Keep issue open (user will close it after merging PR)
 


### PR DESCRIPTION
## Summary

Enhanced the `issue-continue` slash command to automatically verify and fix CI pipeline issues after PR creation.

**Changes:**
- Wait for CI workflows to complete (up to 10 retries with 30s intervals)
- Auto-fix lint failures by running `pnpm format` and committing changes
- Report type check and test failures for manual resolution
- Only post success comment when all CI checks pass
- Add pending label and exit if unable to fix after retries

**Benefits:**
- Ensures PRs have passing CI checks before user review
- Reduces manual intervention for common fixable issues (lint)
- Provides clear feedback when manual fixes are needed
- Maintains clean workflow with proper pending label management

## Test plan

- [ ] Test with PR that has lint failures (should auto-fix)
- [ ] Test with PR that has type check failures (should report)
- [ ] Test with PR that has test failures (should report)
- [ ] Test with PR where CI takes long time (should wait up to 10 retries)
- [ ] Test with PR where all CI passes initially

🤖 Generated with [Claude Code](https://claude.com/claude-code)