### PR TITLE
refactor: remove container_start event and send agent events immediately

### DIFF
--- a/e2b/run-agent.sh
+++ b/e2b/run-agent.sh
@@ -7,46 +7,14 @@ WEBHOOK_URL="${VM0_WEBHOOK_URL}"
 WEBHOOK_TOKEN="${VM0_WEBHOOK_TOKEN}"
 PROMPT="${VM0_PROMPT}"
 
-# Batch configuration
-BATCH_SIZE=10
-BATCH_INTERVAL=1  # seconds
-
-# Event accumulator
-events_json="[]"
-event_count=0
-
-# Send events to webhook
-send_events() {
-  if [ "$event_count" -eq 0 ]; then
-    return
-  fi
-
-  local payload=$(jq -n \
-    --arg rid "$RUN_ID" \
-    --argjson events "$events_json" \
-    '{runId: $rid, events: $events}')
-
-  curl -X POST "$WEBHOOK_URL" \
-    -H "Content-Type: application/json" \
-    -H "Authorization: Bearer $WEBHOOK_TOKEN" \
-    -d "$payload" \
-    --silent --fail || echo "[ERROR] Failed to send events" >&2
-
-  # Reset batch
-  events_json="[]"
-  event_count=0
-}
-
 # Send single event immediately
 send_event() {
-  local event_type="$1"
-  local event_data="$2"
+  local event_json="$1"
 
   local payload=$(jq -n \
     --arg rid "$RUN_ID" \
-    --arg type "$event_type" \
-    --argjson data "$event_data" \
-    '{runId: $rid, events: [{type: $type, data: $data}]}')
+    --argjson event "$event_json" \
+    '{runId: $rid, events: [$event]}')
 
   curl -X POST "$WEBHOOK_URL" \
     -H "Content-Type: application/json" \
@@ -54,23 +22,6 @@ send_event() {
     -d "$payload" \
     --silent --fail || echo "[ERROR] Failed to send event" >&2
 }
-
-# Add event to batch
-add_event() {
-  local event_json="$1"
-
-  events_json=$(echo "$events_json" | jq --argjson event "$event_json" '. + [$event]')
-  event_count=$((event_count + 1))
-
-  # Send batch if full
-  if [ "$event_count" -ge "$BATCH_SIZE" ]; then
-    send_events
-  fi
-}
-
-# Send container start event
-echo "[VM0] Sending container_start event..." >&2
-send_event "container_start" '{"timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}'
 
 # Execute Claude Code with JSONL output
 echo "[VM0] Starting Claude Code execution..." >&2
@@ -91,8 +42,8 @@ set +e  # Don't exit on Claude error
 
   # Check if line is valid JSON
   if echo "$line" | jq empty 2>/dev/null; then
-    # Valid JSONL - add to batch
-    add_event "$line"
+    # Valid JSONL - send immediately
+    send_event "$line"
 
     # Extract result from "result" event for stdout
     event_type=$(echo "$line" | jq -r '.type // empty' 2>/dev/null)
@@ -114,16 +65,13 @@ set -e
 # Print newline after output
 echo ""
 
-# Send any remaining events
-send_events
-
 # Send final result event
 if [ $CLAUDE_EXIT_CODE -eq 0 ]; then
   echo "[VM0] Claude Code completed successfully" >&2
-  send_event "result" '{"status": "success", "exitCode": 0}'
+  send_event '{"type": "result", "data": {"status": "success", "exitCode": 0}}'
 else
   echo "[VM0] Claude Code failed with exit code $CLAUDE_EXIT_CODE" >&2
-  send_event "result" "{\"status\": \"failed\", \"exitCode\": $CLAUDE_EXIT_CODE}"
+  send_event "{\"type\": \"result\", \"data\": {\"status\": \"failed\", \"exitCode\": $CLAUDE_EXIT_CODE}}"
 fi
 
 exit $CLAUDE_EXIT_CODE


### PR DESCRIPTION
## Summary

Fixes #82

This PR refactors the agent event handling system to:
- Remove the infrastructure-level `container_start` event
- Send events immediately instead of batching them
- Simplify the codebase by removing ~52 lines of batching logic

## Changes

### Removed
- `container_start` event sent before Claude Code execution
- Batching configuration variables (`BATCH_SIZE`, `BATCH_INTERVAL`)
- Batch state variables (`events_json`, `event_count`)
- `send_events()` batch function
- `add_event()` batch accumulator function
- Final `send_events()` call after execution

### Modified
- Simplified `send_event()` to accept single JSON event and send immediately
- Updated event processing loop to call `send_event()` directly for each Claude Code event
- Updated final result event calls to use new `send_event()` signature

## Impact

**Before:**
- Events were batched in groups of 10 before sending
- First event was `container_start` (infrastructure-level)
- Artificial latency from batching delays
- 130 lines of code

**After:**
- Events sent immediately when received from Claude Code
- First event is `system` (Claude Code initialization)
- Zero batching latency for real-time visibility
- 78 lines of code (40% reduction)

## Testing

The refactored script maintains the same webhook integration:
- Events are still sent as arrays to maintain API compatibility
- Error handling preserved (`--silent --fail` with stderr logging)
- Exit code handling unchanged
- Result extraction for stdout still works

## Test Plan

- [ ] Run agent execution and verify events are sent immediately
- [ ] Confirm first event is `system` (not `container_start`)
- [ ] Check webhook logs to ensure proper event flow
- [ ] Verify exit code handling works correctly for both success and failure cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)