### PR TITLE
feat(ci): add environment variables injection for e2b and minimax

### DIFF
--- a/.github/DEPLOYMENT_SETUP.md
+++ b/.github/DEPLOYMENT_SETUP.md
@@ -24,14 +24,28 @@ Configure these in your GitHub repository settings (Settings → Secrets and var
   - Generate at: https://vercel.com/account/tokens
 - `NEON_API_KEY`: Your Neon API key (Optional but Recommended)
   - Generate at: https://console.neon.tech/app/settings/api-keys
+- `CLERK_SECRET_KEY`: Your Clerk secret key (Required)
+  - Get from: https://dashboard.clerk.com
+- `E2B_API_KEY`: Your E2B API key (Optional)
+  - Get from: https://e2b.dev/dashboard
+- `E2B_TEMPLATE_NAME`: Custom E2B template name (Optional)
+  - Generate by running `cd turbo && pnpm e2b:build`
+- `MINIMAX_ANTHROPIC_BASE_URL`: Minimax API base URL (Optional)
+  - For using Minimax as an alternative LLM provider
+- `MINIMAX_API_KEY`: Minimax API key (Optional)
+  - Required if using Minimax API
 
 ### Variables (Store as Repository Variables)
 - `VERCEL_TEAM_ID`: Your Vercel team/organization ID
   - Find in Vercel project settings → General → Team ID
-- `VERCEL_PROJECT_ID`: Your Vercel project ID
+- `VERCEL_PROJECT_ID_WEB`: Your Vercel project ID for web app
+  - Find in Vercel project settings → General → Project ID
+- `VERCEL_PROJECT_ID_DOCS`: Your Vercel project ID for docs app
   - Find in Vercel project settings → General → Project ID
 - `NEON_PROJECT_ID`: Your Neon project ID (Optional but Recommended)
   - Find in Neon console → Project Settings → General
+- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`: Your Clerk publishable key (Required)
+  - Get from: https://dashboard.clerk.com
 
 **Note**: If Neon secrets are not configured, the deployment will still work but without database branching.
 
@@ -58,3 +72,40 @@ pnpm db:push
 ```
 
 This uses Drizzle Kit to push your schema defined in `turbo/apps/web/src/db/schema/` to the Neon database branch.
+
+## Environment Variables Details
+
+### Required Variables
+These must be configured for the application to work:
+- **CLERK_SECRET_KEY**: Required for user authentication
+- **NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY**: Required for Clerk client-side SDK
+- **DATABASE_URL**: Automatically injected by the workflow from Neon
+
+### Optional E2B Configuration
+For running agent code in sandboxes:
+- **E2B_API_KEY**: Your E2B API key for creating sandboxes
+- **E2B_TEMPLATE_NAME**: Custom template with Claude Code CLI pre-installed
+  - Build template: `cd turbo && pnpm e2b:build`
+  - Without this, the default E2B image is used (Claude Code must be manually installed)
+
+### Optional Minimax Configuration
+For using Minimax as an alternative LLM provider:
+- **MINIMAX_ANTHROPIC_BASE_URL**: Base URL for Minimax API
+- **MINIMAX_API_KEY**: API key for Minimax
+- Both must be set to enable Minimax integration
+
+### How Environment Variables are Injected
+
+The workflow uses two methods to inject environment variables into Vercel deployments:
+
+1. **GitHub Actions → Vercel CLI** (Recommended for sensitive values)
+   - Secrets are stored in GitHub and passed to Vercel during deployment
+   - Used for: `CLERK_SECRET_KEY`, `E2B_API_KEY`, etc.
+   - See `.github/workflows/release-please.yml` and `.github/workflows/turbo.yml`
+
+2. **Vercel Dashboard** (Alternative method)
+   - Environment variables can also be set directly in Vercel project settings
+   - Go to: Project Settings → Environment Variables
+   - Useful for overriding values or configuring additional environments
+
+**Note**: GitHub Actions method takes precedence and is recommended for security and consistency across deployments.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -96,6 +96,10 @@ jobs:
             DATABASE_URL=${{ steps.get-db-url.outputs.database-url }}
             NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
             CLERK_SECRET_KEY=${{ secrets.CLERK_SECRET_KEY }}
+            E2B_API_KEY=${{ secrets.E2B_API_KEY }}
+            E2B_TEMPLATE_NAME=${{ secrets.E2B_TEMPLATE_NAME }}
+            MINIMAX_ANTHROPIC_BASE_URL=${{ secrets.MINIMAX_ANTHROPIC_BASE_URL }}
+            MINIMAX_API_KEY=${{ secrets.MINIMAX_API_KEY }}
 
   # Deploy docs app to production
   deploy-docs-production:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -161,6 +161,10 @@ jobs:
             DATABASE_URL=${{ steps.branch.outputs.database-url }}
             NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
             CLERK_SECRET_KEY=${{ secrets.CLERK_SECRET_KEY }}
+            E2B_API_KEY=${{ secrets.E2B_API_KEY }}
+            E2B_TEMPLATE_NAME=${{ secrets.E2B_TEMPLATE_NAME }}
+            MINIMAX_ANTHROPIC_BASE_URL=${{ secrets.MINIMAX_ANTHROPIC_BASE_URL }}
+            MINIMAX_API_KEY=${{ secrets.MINIMAX_API_KEY }}
           meta-branch: ${{ github.head_ref }}
           meta-pr: ${{ github.event.pull_request.number }}
 

--- a/turbo/apps/web/src/env.ts
+++ b/turbo/apps/web/src/env.ts
@@ -13,7 +13,10 @@ function initEnv() {
         .default("development"),
       CLERK_SECRET_KEY: z.string().min(1),
       E2B_API_KEY: z.string().min(1).optional(),
+      E2B_TEMPLATE_NAME: z.string().min(1).optional(),
       VM0_API_URL: z.string().url().optional().default("http://localhost:3000"),
+      MINIMAX_ANTHROPIC_BASE_URL: z.string().url().optional(),
+      MINIMAX_API_KEY: z.string().min(1).optional(),
     },
     client: {
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),
@@ -23,7 +26,10 @@ function initEnv() {
       NODE_ENV: process.env.NODE_ENV,
       CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
       E2B_API_KEY: process.env.E2B_API_KEY,
+      E2B_TEMPLATE_NAME: process.env.E2B_TEMPLATE_NAME,
       VM0_API_URL: process.env.VM0_API_URL,
+      MINIMAX_ANTHROPIC_BASE_URL: process.env.MINIMAX_ANTHROPIC_BASE_URL,
+      MINIMAX_API_KEY: process.env.MINIMAX_API_KEY,
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
         process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
     },

--- a/turbo/apps/web/src/lib/e2b/config.ts
+++ b/turbo/apps/web/src/lib/e2b/config.ts
@@ -1,3 +1,5 @@
+import { env } from "../../env";
+
 /**
  * E2B configuration
  */
@@ -7,5 +9,5 @@ export const e2bConfig = {
   // Template name for E2B sandbox with Claude Code CLI
   // See E2B_SETUP.md for instructions on building and pushing the template
   // Leave undefined to use default E2B image (Claude Code must be installed manually)
-  defaultTemplate: process.env.E2B_TEMPLATE_NAME, // Optional: Custom template name (alias)
+  defaultTemplate: env().E2B_TEMPLATE_NAME, // Optional: Custom template name (alias)
 } as const;

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -1,4 +1,5 @@
 import { Sandbox } from "@e2b/code-interpreter";
+import { env } from "../../env";
 import { e2bConfig } from "./config";
 import type {
   CreateRunOptions,
@@ -153,8 +154,8 @@ export class E2BService {
     };
 
     // Add Minimax API configuration if available
-    const minimaxBaseUrl = process.env.MINIMAX_ANTHROPIC_BASE_URL;
-    const minimaxApiKey = process.env.MINIMAX_API_KEY;
+    const minimaxBaseUrl = env().MINIMAX_ANTHROPIC_BASE_URL;
+    const minimaxApiKey = env().MINIMAX_API_KEY;
 
     if (minimaxBaseUrl && minimaxApiKey) {
       envs.ANTHROPIC_BASE_URL = minimaxBaseUrl;


### PR DESCRIPTION
## Summary

Add support for automatically injecting E2B and Minimax environment variables during deployment, following the same pattern as CLERK_SECRET_KEY.

### Changes

- **Environment Variables Schema**: Added type-safe validation for E2B_API_KEY, E2B_TEMPLATE_NAME, MINIMAX_ANTHROPIC_BASE_URL, and MINIMAX_API_KEY in env.ts
- **Code Updates**: Updated e2b-service.ts and config.ts to use type-safe env() function instead of direct process.env access
- **CI/CD Workflows**: Updated both production (release-please.yml) and preview (turbo.yml) deployment workflows to inject environment variables via Vercel CLI
- **Documentation**: Enhanced DEPLOYMENT_SETUP.md with detailed configuration instructions for all environment variables

### Environment Variables Added

**E2B Configuration (Optional)**:
- `E2B_API_KEY` - API key for E2B sandbox creation
- `E2B_TEMPLATE_NAME` - Custom E2B template with Claude Code CLI

**Minimax Configuration (Optional)**:
- `MINIMAX_ANTHROPIC_BASE_URL` - Base URL for Minimax API
- `MINIMAX_API_KEY` - API key for Minimax as alternative LLM provider

### Configuration Required

All secrets have been configured in GitHub repository settings. No additional action required for deployment.

## Test plan

- [x] TypeScript type checking passes (`pnpm check-types`)
- [x] Linting passes (`pnpm lint`)
- [ ] Verify preview deployment includes new environment variables
- [ ] Verify production deployment after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)