### PR TITLE
fix: require authentication for cli device authorization page

### DIFF
--- a/turbo/apps/web/middleware.ts
+++ b/turbo/apps/web/middleware.ts
@@ -8,7 +8,6 @@ const isPublicRoute = createRouteMatcher([
   "/api/hello(.*)",
   "/api/cli/auth/device",
   "/api/cli/auth/token",
-  "/cli-auth(.*)",
 ]);
 
 export default clerkMiddleware(async (auth, request) => {


### PR DESCRIPTION
## Summary

Fixes a security vulnerability where the CLI device authorization page (`/cli-auth`) was publicly accessible without authentication.

## Problem

The `/cli-auth` page allows users to authorize CLI access to their account by entering a device code. Previously, this page was marked as a public route in the middleware, allowing **anyone** to access it without signing in.

### Security Risks

1. ❌ **Unauthorized Access**: Any visitor could see the authorization form
2. ❌ **Brute Force Risk**: Attackers could attempt to guess device codes
3. ❌ **Poor UX**: Unauthenticated users could fill the form, then get "Not authenticated" error

## Solution

Remove `/cli-auth(.*)` from the public routes list in middleware, requiring Clerk authentication before accessing the page.

### Changes

- **File**: `turbo/apps/web/middleware.ts`
- **Change**: Removed `/cli-auth(.*)` from `isPublicRoute` matcher
- **Effect**: Clerk middleware now calls `auth.protect()` for `/cli-auth` routes

### OAuth Device Flow Preserved

The OAuth 2.0 Device Authorization Flow (RFC 8628) API endpoints remain public as required:
- ✅ `/api/cli/auth/device` - CLI requests device code (public)
- ✅ `/api/cli/auth/token` - CLI polls for token (public)

### Flow After Fix

```
1. User runs: vm0 auth login
2. CLI calls /api/cli/auth/device → gets device code
3. CLI shows: "Visit https://vm0.ai/cli-auth and enter: ABCD-1234"
4. User visits /cli-auth → **Redirected to sign-in if not authenticated** ✅
5. After sign-in → User enters code → CLI authorized
6. CLI polls /api/cli/auth/token → gets access token
```

## Testing

- [x] Unauthenticated users are redirected to sign-in page
- [x] Authenticated users can access `/cli-auth` page
- [x] Device authorization flow works end-to-end
- [x] API endpoints remain publicly accessible for CLI

## Security Impact

- ✅ Prevents unauthorized access to device authorization
- ✅ Reduces attack surface for brute-forcing device codes
- ✅ Ensures only authenticated users can authorize devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)