### PR TITLE
feat: add working_dir support for agent execution

### DIFF
--- a/e2b/run-agent.sh
+++ b/e2b/run-agent.sh
@@ -6,6 +6,7 @@ RUN_ID="${VM0_RUN_ID}"
 WEBHOOK_URL="${VM0_WEBHOOK_URL}"
 WEBHOOK_TOKEN="${VM0_WEBHOOK_TOKEN}"
 PROMPT="${VM0_PROMPT}"
+WORKING_DIR="${VM0_WORKING_DIR:-/home/user}"
 
 # Send single event immediately
 send_event() {
@@ -21,6 +22,13 @@ send_event() {
     -H "Authorization: Bearer $WEBHOOK_TOKEN" \
     -d "$payload" \
     --silent --fail || echo "[ERROR] Failed to send event" >&2
+}
+
+# Change to working directory
+echo "[VM0] Working directory: $WORKING_DIR" >&2
+cd "$WORKING_DIR" || {
+  echo "[ERROR] Failed to change to working directory: $WORKING_DIR" >&2
+  exit 1
 }
 
 # Execute Claude Code with JSONL output


### PR DESCRIPTION
## Summary
Implements working directory configuration for agents running in E2B sandbox. This resolves the issue where agents always started in `/home/user` instead of the configured `working_dir`.

## Changes
- **e2b-service.ts**: Extract `working_dir` from agent config and pass as `VM0_WORKING_DIR` environment variable
- **run-agent.sh**: Change to working directory before executing Claude Code CLI
- **Tests**: Add test coverage for working_dir configuration (both with and without working_dir)
- **Dependencies**: Add missing `@aws-sdk/client-s3` dependency

## Testing
- Added 2 new test cases for working_dir support
- All new tests passing successfully
- Verified environment variable is correctly passed to sandbox

## Fixes
Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)