### PR TITLE
fix: remove timeout limitation for e2b sandbox command execution

### DIFF
--- a/turbo/apps/web/src/lib/e2b/config.ts
+++ b/turbo/apps/web/src/lib/e2b/config.ts
@@ -5,7 +5,7 @@ import { env } from "../../env";
  */
 
 export const e2bConfig = {
-  defaultTimeout: 600000, // 10 minutes (600 seconds)
+  defaultTimeout: 0, // No timeout - allows indefinite execution
   // Template name for E2B sandbox with Claude Code CLI
   // See E2B_SETUP.md for instructions on building and pushing the template
   // Leave undefined to use default E2B image (Claude Code must be installed manually)

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -286,6 +286,7 @@ export class E2BService {
 
     const result = await sandbox.commands.run(scriptPath, {
       envs,
+      timeoutMs: 0, // No timeout - allows indefinite execution
     });
 
     const executionTimeMs = Date.now() - execStart;


### PR DESCRIPTION
## Summary
- Removes 10-minute timeout limit for E2B sandbox operations
- Allows agent operations to run indefinitely without being terminated
- Prevents `TimeoutError` failures for long-running operations

## Changes Made
1. **Updated `apps/web/src/lib/e2b/config.ts`**:
   - Changed `defaultTimeout` from `600000` (10 minutes) to `0` (no timeout)
   - Updated comment to reflect the change

2. **Updated `apps/web/src/lib/e2b/e2b-service.ts:287`**:
   - Added explicit `timeoutMs: 0` parameter to `sandbox.commands.run()` call
   - Ensures command execution has no timeout independent of sandbox creation timeout

## Test Plan
- ✅ Lint checks passed
- ✅ Pre-commit hooks passed (prettier, lint, commitlint)
- Existing short operations remain unaffected
- Long-running operations no longer fail with timeout errors

## Related Issue
Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)