### PR TITLE
fix: set explicit 1-hour timeout for e2b sandbox lifecycle

### DIFF
--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -219,7 +219,7 @@ export class E2BService {
     envVars: Record<string, string>,
   ): Promise<Sandbox> {
     const sandboxOptions = {
-      timeoutMs: e2bConfig.defaultTimeout,
+      timeoutMs: 3_600_000, // 1 hour timeout to allow for long-running operations
       envs: envVars, // Pass environment variables to sandbox
     };
 


### PR DESCRIPTION
## Summary

Fixes E2B sandbox timeout issue that was causing sandboxes to be destroyed during file upload operations.

### Problem
- Previously used `e2bConfig.defaultTimeout` (value: 0) when creating sandboxes
- E2B SDK interpreted 0 as "use default" and applied 5-minute default timeout
- Sandboxes were being destroyed mid-operation during volume uploads
- Error: `TimeoutError: The sandbox was not found: This error is likely due to sandbox timeout`

### Solution
- Set explicit `timeoutMs: 3_600_000` (1 hour) for sandbox lifecycle
- Aligns with E2B's maximum timeout for Hobby tier users
- Provides sufficient time for volume uploads and long-running agent operations
- Command execution timeout remains at 0 (unlimited) as recommended by E2B docs

### Changes
- `turbo/apps/web/src/lib/e2b/e2b-service.ts:222` - Changed from `e2bConfig.defaultTimeout` to explicit `3_600_000`

### References
- [E2B Sandbox Timeout Documentation](https://e2b.dev/docs/sdk-reference/js-sdk/v1.2.0/sandbox)
- [E2B Claude Code Guide](https://e2b.dev/blog/javascript-guide-run-claude-code-in-an-e2b-sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)