### PR TITLE
fix: add aws environment variables to production deployment

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -100,6 +100,9 @@ jobs:
             E2B_TEMPLATE_NAME=${{ secrets.E2B_TEMPLATE_NAME }}
             MINIMAX_ANTHROPIC_BASE_URL=${{ secrets.MINIMAX_ANTHROPIC_BASE_URL }}
             MINIMAX_API_KEY=${{ secrets.MINIMAX_API_KEY }}
+            AWS_REGION=${{ secrets.AWS_REGION }}
+            AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   # Deploy docs app to production
   deploy-docs-production:


### PR DESCRIPTION
## Summary

- Adds missing AWS environment variables (AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY) to production deployment configuration
- Fixes S3 region mismatch errors in production environment

## Problem

Production environment was experiencing S3 download failures with this error:
```
PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint.
Endpoint: 'vm0-s3-demo-bucket-public.s3-us-west-2.amazonaws.com'
```

Root cause: The release-please.yml workflow was missing AWS environment variables in the production deployment step, causing the S3 client to use default/incorrect region configuration instead of the actual bucket region (us-west-2).

## Solution

Added AWS environment variables to the production deployment configuration in `.github/workflows/release-please.yml` to match the preview deployment setup that already had these variables configured.

## Test plan

- [x] Verify the workflow file syntax is correct
- [ ] Deploy to production and verify S3 operations succeed
- [ ] Confirm no S3 region mismatch errors in production logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)