### PR TITLE
feat: add aws cli feature to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,8 @@
       "version": "17"
     },
     "ghcr.io/devcontainers-extra/features/caddy:1": {},
-    "ghcr.io/joedmck/devcontainer-features/cloudflared:1": {}
+    "ghcr.io/joedmck/devcontainer-features/cloudflared:1": {},
+    "ghcr.io/devcontainers/features/aws-cli:1": {}
   },
   "remoteUser": "vscode",
   "forwardPorts": [8443],


### PR DESCRIPTION
## Summary
- Add AWS CLI feature to devcontainer configuration
- Enables AWS CLI support in the development environment

## Changes
- Added `ghcr.io/devcontainers/features/aws-cli:1` to `.devcontainer/devcontainer.json`

## Test plan
- [ ] Rebuild devcontainer to verify AWS CLI is installed
- [ ] Verify `aws --version` works in the devcontainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)