### PR TITLE
feat: use agent.image for E2B template selection

### DIFF
--- a/.env.local.tpl
+++ b/.env.local.tpl
@@ -1,7 +1,7 @@
 CLERK_SECRET_KEY=op://Development/vm0-env-local/clerk_secret_key
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=op://Development/vm0-env-local/clerk_publishable_key
 E2B_API_KEY=op://Development/vm0-env-local/e2b_api_key
-E2B_TEMPLATE_NAME=vm0-claude-code
+E2B_TEMPLATE_NAME=vm0-claude-code-dev
 MINIMAX_ANTHROPIC_BASE_URL=op://Development/vm0-env-local/minimax_anthropic_base_url
 MINIMAX_API_KEY=op://Development/vm0-env-local/minimax_api_key
 

--- a/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
+++ b/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
@@ -321,4 +321,44 @@ describe("E2B Service - mocked unit tests", () => {
       expect(Sandbox.create).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("template selection", () => {
+    it("should use agent.image when provided", async () => {
+      // Arrange
+      const mockSandbox = createMockSandbox();
+      vi.mocked(Sandbox.create).mockResolvedValue(
+        mockSandbox as unknown as Sandbox,
+      );
+
+      const runId = "run-test-template-001";
+      const options: CreateRunOptions = {
+        agentConfigId: "test-agent-template-001",
+        sandboxToken: "vm0_live_test_token",
+        prompt: "Test with custom image",
+        agentConfig: {
+          version: "1.0",
+          agent: {
+            name: "test-agent",
+            description: "Test agent with custom image",
+            image: "custom-template-name",
+            provider: "claude-code",
+            working_dir: "/workspace",
+            volumes: [],
+          },
+        },
+      };
+
+      // Act
+      const result = await e2bService.createRun(runId, options);
+
+      // Assert
+      expect(result.status).toBe("completed");
+      expect(Sandbox.create).toHaveBeenCalledTimes(1);
+
+      // Verify that agent.image was used
+      const createCall = vi.mocked(Sandbox.create).mock.calls[0];
+      expect(createCall).toBeDefined();
+      expect(createCall?.[0]).toBe("custom-template-name");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Implement per-agent E2B template selection using `agent.image` field from `vm0.config.yaml`. 

Template priority: `agent.image` > `E2B_TEMPLATE_NAME` > error

Throws error if neither is set (no default fallback to E2B's default image).

## Changes
- Update `createSandbox()` to accept `agentConfig` parameter
- Implement template priority logic with error on missing template
- Update `createRun()` to pass `agentConfig` to `createSandbox()`
- Add test case for template selection

## Test plan
- ✅ All existing tests pass
- ✅ New test verifies `agent.image` is used when provided
- ✅ Logs show correct template source (agent.image vs E2B_TEMPLATE_NAME)

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)