### PR TITLE
test: simplify volume mount paths to workspace root

### DIFF
--- a/e2e/fixtures/configs/vm0-test-volume-dynamic.yaml
+++ b/e2e/fixtures/configs/vm0-test-volume-dynamic.yaml
@@ -7,7 +7,7 @@ agent:
   provider: claude-code
   working_dir: /home/user/workspace
   volumes:
-    - "user-data:/home/user/workspace/user-files"
+    - "user-data:/home/user/workspace"
 
 dynamic_volumes:
   user-data:

--- a/e2e/fixtures/configs/vm0-test-volume-static.yaml
+++ b/e2e/fixtures/configs/vm0-test-volume-static.yaml
@@ -7,7 +7,7 @@ agent:
   provider: claude-code
   working_dir: /home/user/workspace
   volumes:
-    - "test-data:/home/user/workspace/data"
+    - "test-data:/home/user/workspace"
 
 volumes:
   test-data:

--- a/e2e/tests/02-commands/t03-volume-mounting.bats
+++ b/e2e/tests/02-commands/t03-volume-mounting.bats
@@ -15,7 +15,7 @@ setup() {
 }
 
 @test "Run agent with static volume - read file from S3 volume" {
-    run $CLI_COMMAND run vm0-test-volume-static "Read the file at /home/user/workspace/data/message.txt and output exactly what it says"
+    run $CLI_COMMAND run vm0-test-volume-static "Read the file at /home/user/workspace/message.txt and output exactly what it says"
     assert_success
     assert_output --partial "Hello from S3 volume"
 }
@@ -27,7 +27,7 @@ setup() {
 }
 
 @test "Run agent with dynamic volume - read file with template variable" {
-    run $CLI_COMMAND run vm0-test-volume-dynamic -e userId=test-user-123 "Read the file at /home/user/workspace/user-files/message.txt and output exactly what it says"
+    run $CLI_COMMAND run vm0-test-volume-dynamic -e userId=test-user-123 "Read the file at /home/user/workspace/message.txt and output exactly what it says"
     assert_success
     assert_output --partial "Hello from test-user-123"
 }


### PR DESCRIPTION
## Summary

- Simplified volume mount paths by mounting directly to `/home/user/workspace` instead of subdirectories
- Updated test assertions to use simplified paths (`/home/user/workspace/message.txt` instead of nested subdirectories)
- Reduces path complexity and makes volume mounting configuration more straightforward

## Test plan

- [ ] Verify e2e tests pass with new volume mount paths
- [ ] Confirm static volume test reads from `/home/user/workspace/message.txt`
- [ ] Confirm dynamic volume test reads from `/home/user/workspace/message.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)