### PR TITLE
refactor: standardize webhook endpoint path and API configuration naming

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
@@ -4,11 +4,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { POST } from "../route";
 import { NextRequest } from "next/server";
-import { initServices } from "../../../../../src/lib/init-services";
-import { agentRuns } from "../../../../../src/db/schema/agent-run";
-import { agentRunEvents } from "../../../../../src/db/schema/agent-run-event";
-import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
-import { agentConfigs } from "../../../../../src/db/schema/agent-config";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import { agentRunEvents } from "../../../../../../src/db/schema/agent-run-event";
+import { cliTokens } from "../../../../../../src/db/schema/cli-tokens";
+import { agentConfigs } from "../../../../../../src/db/schema/agent-config";
 import { eq } from "drizzle-orm";
 import { randomUUID } from "crypto";
 

--- a/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
@@ -28,7 +28,7 @@ import { auth } from "@clerk/nextjs/server";
 const mockHeaders = vi.mocked(headers);
 const mockAuth = vi.mocked(auth);
 
-describe("POST /api/webhooks/agent-events", () => {
+describe("POST /api/webhooks/agent/events", () => {
   // Generate unique IDs for this test run to avoid conflicts
   const testUserId = `test-user-${Date.now()}-${process.pid}`;
   const testRunId = randomUUID(); // UUID for agent run
@@ -112,7 +112,7 @@ describe("POST /api/webhooks/agent-events", () => {
   describe("Authentication", () => {
     it("should reject webhook without authentication", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent-events",
+        "http://localhost:3000/api/webhooks/agent/events",
         {
           method: "POST",
           headers: {
@@ -135,7 +135,7 @@ describe("POST /api/webhooks/agent-events", () => {
 
     it("should reject webhook with invalid token", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent-events",
+        "http://localhost:3000/api/webhooks/agent/events",
         {
           method: "POST",
           headers: {
@@ -174,7 +174,7 @@ describe("POST /api/webhooks/agent-events", () => {
       });
 
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent-events",
+        "http://localhost:3000/api/webhooks/agent/events",
         {
           method: "POST",
           headers: {
@@ -222,7 +222,7 @@ describe("POST /api/webhooks/agent-events", () => {
 
     it("should reject webhook without runId", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent-events",
+        "http://localhost:3000/api/webhooks/agent/events",
         {
           method: "POST",
           headers: {
@@ -245,7 +245,7 @@ describe("POST /api/webhooks/agent-events", () => {
 
     it("should reject webhook without events array", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent-events",
+        "http://localhost:3000/api/webhooks/agent/events",
         {
           method: "POST",
           headers: {
@@ -268,7 +268,7 @@ describe("POST /api/webhooks/agent-events", () => {
 
     it("should reject webhook with empty events array", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent-events",
+        "http://localhost:3000/api/webhooks/agent/events",
         {
           method: "POST",
           headers: {
@@ -315,7 +315,7 @@ describe("POST /api/webhooks/agent-events", () => {
       const nonExistentRunId = randomUUID(); // Use a valid UUID that doesn't exist
 
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent-events",
+        "http://localhost:3000/api/webhooks/agent/events",
         {
           method: "POST",
           headers: {
@@ -350,7 +350,7 @@ describe("POST /api/webhooks/agent-events", () => {
       });
 
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent-events",
+        "http://localhost:3000/api/webhooks/agent/events",
         {
           method: "POST",
           headers: {
@@ -403,7 +403,7 @@ describe("POST /api/webhooks/agent-events", () => {
       });
 
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent-events",
+        "http://localhost:3000/api/webhooks/agent/events",
         {
           method: "POST",
           headers: {
@@ -484,7 +484,7 @@ describe("POST /api/webhooks/agent-events", () => {
 
       // First webhook - 2 events
       const request1 = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent-events",
+        "http://localhost:3000/api/webhooks/agent/events",
         {
           method: "POST",
           headers: {
@@ -510,7 +510,7 @@ describe("POST /api/webhooks/agent-events", () => {
 
       // Second webhook - 3 events
       const request2 = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent-events",
+        "http://localhost:3000/api/webhooks/agent/events",
         {
           method: "POST",
           headers: {
@@ -607,7 +607,7 @@ describe("POST /api/webhooks/agent-events", () => {
       ];
 
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent-events",
+        "http://localhost:3000/api/webhooks/agent/events",
         {
           method: "POST",
           headers: {
@@ -682,7 +682,7 @@ describe("POST /api/webhooks/agent-events", () => {
       }));
 
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent-events",
+        "http://localhost:3000/api/webhooks/agent/events",
         {
           method: "POST",
           headers: {

--- a/turbo/apps/web/app/api/webhooks/agent/events/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/route.ts
@@ -19,7 +19,7 @@ import type {
 } from "../../../../src/types/webhook";
 
 /**
- * POST /api/webhooks/agent-events
+ * POST /api/webhooks/agent/events
  * Receive agent events from E2B sandbox
  */
 export async function POST(request: NextRequest) {

--- a/turbo/apps/web/app/api/webhooks/agent/events/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/route.ts
@@ -1,22 +1,22 @@
 import { NextRequest } from "next/server";
-import { initServices } from "../../../../src/lib/init-services";
-import { agentRuns } from "../../../../src/db/schema/agent-run";
-import { agentRunEvents } from "../../../../src/db/schema/agent-run-event";
+import { initServices } from "../../../../../src/lib/init-services";
+import { agentRuns } from "../../../../../src/db/schema/agent-run";
+import { agentRunEvents } from "../../../../../src/db/schema/agent-run-event";
 import { eq, max, and } from "drizzle-orm";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getUserId } from "../../../../../src/lib/auth/get-user-id";
 import {
   successResponse,
   errorResponse,
-} from "../../../../src/lib/api-response";
+} from "../../../../../src/lib/api-response";
 import {
   BadRequestError,
   NotFoundError,
   UnauthorizedError,
-} from "../../../../src/lib/errors";
+} from "../../../../../src/lib/errors";
 import type {
   WebhookRequest,
   WebhookResponse,
-} from "../../../../src/types/webhook";
+} from "../../../../../src/types/webhook";
 
 /**
  * POST /api/webhooks/agent/events

--- a/turbo/apps/web/src/lib/e2b/E2B_SETUP.md
+++ b/turbo/apps/web/src/lib/e2b/E2B_SETUP.md
@@ -201,8 +201,8 @@ E2B_API_KEY=your-api-key
 ### Passed to Sandbox (Automatically)
 
 - `VM0_RUN_ID` - Run UUID
-- `VM0_WEBHOOK_URL` - Webhook endpoint URL
-- `VM0_WEBHOOK_TOKEN` - Webhook auth token
+- `VM0_API_URL` - API base URL (sandbox constructs webhook endpoint internally)
+- `VM0_API_TOKEN` - Temporary webhook auth token
 - `VM0_PROMPT` - User prompt for Claude
 
 ## CI/CD Setup

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -64,7 +64,7 @@ export class E2BService {
         }
       }
 
-      const webhookEndpoint = `${apiUrl}/api/webhooks/agent-events`;
+      const webhookEndpoint = `${apiUrl}/api/webhooks/agent/events`;
 
       console.log(
         `[E2B] Environment - VERCEL_ENV: ${vercelEnv}, VERCEL_URL: ${vercelUrl}, VM0_API_URL: ${apiUrl}`,
@@ -75,9 +75,8 @@ export class E2BService {
       // Create E2B sandbox with environment variables
       const sandboxEnvVars: Record<string, string> = {
         VM0_API_URL: apiUrl,
-        VM0_WEBHOOK_URL: webhookEndpoint,
         VM0_RUN_ID: runId,
-        VM0_WEBHOOK_TOKEN: options.sandboxToken, // Temporary bearer token for webhook authentication
+        VM0_API_TOKEN: options.sandboxToken, // Temporary bearer token for webhook authentication
       };
 
       // Add Vercel protection bypass secret if available (for preview deployments)
@@ -103,7 +102,6 @@ export class E2BService {
         sandbox,
         runId,
         options.prompt,
-        webhookEndpoint,
         options.sandboxToken,
         options.agentConfig,
       );
@@ -224,7 +222,6 @@ export class E2BService {
     sandbox: Sandbox,
     runId: string,
     prompt: string,
-    webhookUrl: string,
     sandboxToken: string,
     agentConfig?: unknown,
   ): Promise<SandboxExecutionResult> {
@@ -243,8 +240,7 @@ export class E2BService {
     // Set environment variables and execute script
     const envs: Record<string, string> = {
       VM0_RUN_ID: runId,
-      VM0_WEBHOOK_URL: webhookUrl,
-      VM0_WEBHOOK_TOKEN: sandboxToken,
+      VM0_API_TOKEN: sandboxToken,
       VM0_PROMPT: prompt,
     };
 

--- a/turbo/apps/web/src/lib/e2b/run-agent-script.ts
+++ b/turbo/apps/web/src/lib/e2b/run-agent-script.ts
@@ -7,11 +7,14 @@ set -e
 
 # Get environment variables
 RUN_ID="\${VM0_RUN_ID}"
-WEBHOOK_URL="\${VM0_WEBHOOK_URL}"
-WEBHOOK_TOKEN="\${VM0_WEBHOOK_TOKEN}"
+API_URL="\${VM0_API_URL}"
+API_TOKEN="\${VM0_API_TOKEN}"
 PROMPT="\${VM0_PROMPT}"
 WORKING_DIR="\${VM0_WORKING_DIR:-/home/user}"
 VERCEL_BYPASS="\${VERCEL_PROTECTION_BYPASS:-}"
+
+# Construct webhook endpoint URL
+WEBHOOK_URL="\${API_URL}/api/webhooks/agent/events"
 
 # Send single event immediately
 send_event() {
@@ -25,7 +28,7 @@ send_event() {
   # Build curl command with optional Vercel bypass header
   local curl_cmd="curl -X POST \\"$WEBHOOK_URL\\" \\
     -H \\"Content-Type: application/json\\" \\
-    -H \\"Authorization: Bearer $WEBHOOK_TOKEN\\""
+    -H \\"Authorization: Bearer $API_TOKEN\\""
 
   # Add Vercel protection bypass header if available (for preview deployments)
   if [ -n "$VERCEL_BYPASS" ]; then

--- a/turbo/docs/LOCAL_WEBHOOK_TESTING.md
+++ b/turbo/docs/LOCAL_WEBHOOK_TESTING.md
@@ -69,7 +69,8 @@ You'll see webhook events streaming in real-time! 🎉
 3. **Environment Setup**: `VM0_API_URL` is set to the tunnel URL
 4. **Dev Server Start**: Next.js starts with the tunnel URL configured
 5. **Webhook Flow**:
-   - E2B sandbox receives `VM0_WEBHOOK_URL=https://tunnel-url.trycloudflare.com/api/webhooks/agent-events`
+   - E2B sandbox receives `VM0_API_URL=https://tunnel-url.trycloudflare.com`
+   - Sandbox constructs webhook URL: `${VM0_API_URL}/api/webhooks/agent/events`
    - Sandbox sends webhook events through the tunnel
    - Events reach your local dev server
    - Events are authenticated and stored in local database
@@ -91,7 +92,7 @@ When you run `pnpm dev:tunnel`, you'll see:
   Tunnel:  https://example-name-random.trycloudflare.com
 
 E2B webhooks will be sent to:
-  https://example-name-random.trycloudflare.com/api/webhooks/agent-events
+  https://example-name-random.trycloudflare.com/api/webhooks/agent/events
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -180,7 +181,7 @@ lsof -ti:3000 | xargs kill -9
 4. **Test webhook endpoint manually**:
    ```bash
    # Replace with your tunnel URL
-   curl -X POST https://your-tunnel.trycloudflare.com/api/webhooks/agent-events \
+   curl -X POST https://your-tunnel.trycloudflare.com/api/webhooks/agent/events \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer test-token" \
      -d '{"runId": "test", "events": [{"type": "init"}]}'

--- a/turbo/packages/agent/src/event-handler.ts
+++ b/turbo/packages/agent/src/event-handler.ts
@@ -38,7 +38,7 @@ export function getEventHandlerConfig(): EventHandlerConfig {
     // Local dev with ngrok or production with real URL
     return {
       mode: "webhook",
-      webhookUrl: `${webhookUrl}/api/webhooks/agent-events`,
+      webhookUrl: `${webhookUrl}/api/webhooks/agent/events`,
     };
   }
 


### PR DESCRIPTION
## Summary
Refactors webhook endpoint path and API configuration naming for better consistency and future extensibility.

### Changes
- **Webhook endpoint path**: `/api/webhooks/agent-events` → `/api/webhooks/agent/events`
- **Environment variables**: 
  - `VM0_WEBHOOK_URL` → `VM0_API_URL` (stores base URL only)
  - `VM0_WEBHOOK_TOKEN` → `VM0_API_TOKEN`
- **Architecture improvement**: Base URL and endpoint path are now decoupled. The system constructs the full webhook URL internally by combining `VM0_API_URL` with the endpoint path.

### Files Modified
- Webhook endpoint: Moved `/app/api/webhooks/agent-events/` → `/app/api/webhooks/agent/events/`
- Updated import paths to reflect new directory structure
- `run-agent-script.ts`: Updated bash script to construct full webhook URL from base URL
- `e2b-service.ts`: Simplified environment variable handling, removed redundant parameters
- `event-handler.ts`: Updated endpoint path construction
- Documentation: Updated `LOCAL_WEBHOOK_TESTING.md` and `E2B_SETUP.md`

## Test Plan
- ✅ All webhook endpoint tests passing
- ✅ Import paths corrected and verified
- ✅ Documentation updated

## Breaking Changes
⚠️ **Configuration update required**: Users must update their configuration to use `VM0_API_URL` (base URL) instead of `VM0_WEBHOOK_URL` (full URL with path).

## Related Issue
Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)