### PR TITLE
feat: add git volume driver support for repository mounting

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -301,3 +301,4 @@ jobs:
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/e2e/fixtures/configs/vm0-git-volume-test.yaml
+++ b/e2e/fixtures/configs/vm0-git-volume-test.yaml
@@ -1,0 +1,26 @@
+version: "1.0"
+
+agent:
+  name: vm0-git-volume-test
+  description: "Test agent with git volume"
+  image: vm0-claude-code-dev
+  provider: claude-code
+  working_dir: /home/user/workspace
+  volumes:
+    - claude-system:/home/user/.claude
+    - user-workspace:/home/user/workspace
+
+volumes:
+  claude-system:
+    driver: s3fs
+    driver_opts:
+      uri: s3://vm0-s3-demo-bucket-public/claude-files
+      region: us-west-2
+
+dynamic_volumes:
+  user-workspace:
+    driver: git
+    driver_opts:
+      uri: https://github.com/{{user}}/question.git
+      branch: main
+      token: "${CI_GITHUB_TOKEN}"

--- a/e2e/tests/02-commands/t04-git-volume-mounting.bats
+++ b/e2e/tests/02-commands/t04-git-volume-mounting.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+
+setup() {
+    # Set config paths for git volume mounting tests
+    export TEST_GIT_VOLUME_CONFIG="${TEST_ROOT}/fixtures/configs/vm0-git-volume-test.yaml"
+}
+
+@test "Build agent with git volume configuration" {
+    run $CLI_COMMAND build "$TEST_GIT_VOLUME_CONFIG"
+    assert_success
+    assert_output --partial "vm0-git-volume-test"
+}
+
+@test "Run agent with git volume - read file from cloned repository" {
+    # Skip if CI_GITHUB_TOKEN is not set
+    if [ -z "$CI_GITHUB_TOKEN" ]; then
+        skip "CI_GITHUB_TOKEN not set, skipping git volume test"
+    fi
+
+    run $CLI_COMMAND run vm0-git-volume-test -e user=key "List all files in the current directory (pwd and ls -la), then read the README.md file if it exists"
+    assert_success
+    assert_output --partial "README"
+}

--- a/e2e/tests/02-commands/t04-git-volume-mounting.bats
+++ b/e2e/tests/02-commands/t04-git-volume-mounting.bats
@@ -19,7 +19,7 @@ setup() {
         skip "CI_GITHUB_TOKEN not set, skipping git volume test"
     fi
 
-    run $CLI_COMMAND run vm0-git-volume-test -e user=key "List all files in the current directory (pwd and ls -la), then read the question.md file and tell me what it says"
+    run $CLI_COMMAND run vm0-git-volume-test -e user=lancy "List all files in the current directory (pwd and ls -la), then read the question.md file and tell me what it says"
     assert_success
     assert_output --partial "1+1"
 }

--- a/e2e/tests/02-commands/t04-git-volume-mounting.bats
+++ b/e2e/tests/02-commands/t04-git-volume-mounting.bats
@@ -19,7 +19,7 @@ setup() {
         skip "CI_GITHUB_TOKEN not set, skipping git volume test"
     fi
 
-    run $CLI_COMMAND run vm0-git-volume-test -e user=key "List all files in the current directory (pwd and ls -la), then read the README.md file if it exists"
+    run $CLI_COMMAND run vm0-git-volume-test -e user=key "List all files in the current directory (pwd and ls -la), then read the question.md file and tell me what it says"
     assert_success
-    assert_output --partial "README"
+    assert_output --partial "1+1"
 }

--- a/turbo/apps/web/src/lib/git/__tests__/git-client.test.ts
+++ b/turbo/apps/web/src/lib/git/__tests__/git-client.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateGitUrl,
+  normalizeGitUrl,
+  buildAuthenticatedUrl,
+  sanitizeGitUrlForLogging,
+  buildGitCloneCommand,
+} from "../git-client";
+
+describe("git-client", () => {
+  describe("validateGitUrl", () => {
+    it("should validate HTTPS Git URLs", () => {
+      expect(validateGitUrl("https://github.com/user/repo.git")).toBe(true);
+      expect(validateGitUrl("https://gitlab.com/user/repo.git")).toBe(true);
+    });
+
+    it("should reject non-HTTPS URLs", () => {
+      expect(validateGitUrl("http://github.com/user/repo.git")).toBe(false);
+      expect(validateGitUrl("git@github.com:user/repo.git")).toBe(false);
+      expect(validateGitUrl("ssh://git@github.com/user/repo.git")).toBe(false);
+    });
+
+    it("should reject URLs without .git suffix", () => {
+      expect(validateGitUrl("https://github.com/user/repo")).toBe(false);
+    });
+  });
+
+  describe("normalizeGitUrl", () => {
+    it("should normalize GitHub short format to full URL", () => {
+      expect(normalizeGitUrl("user/repo")).toBe(
+        "https://github.com/user/repo.git",
+      );
+      expect(normalizeGitUrl("org/project")).toBe(
+        "https://github.com/org/project.git",
+      );
+    });
+
+    it("should handle full URLs with .git suffix", () => {
+      expect(normalizeGitUrl("https://github.com/user/repo.git")).toBe(
+        "https://github.com/user/repo.git",
+      );
+    });
+
+    it("should add .git suffix to full URLs without it", () => {
+      expect(normalizeGitUrl("https://github.com/user/repo")).toBe(
+        "https://github.com/user/repo.git",
+      );
+    });
+
+    it("should handle URLs with leading/trailing slashes", () => {
+      expect(normalizeGitUrl("/user/repo/")).toBe(
+        "https://github.com/user/repo.git",
+      );
+    });
+  });
+
+  describe("buildAuthenticatedUrl", () => {
+    it("should add token to URL", () => {
+      const url = "https://github.com/user/repo.git";
+      const token = "ghp_test123";
+      const result = buildAuthenticatedUrl(url, token);
+      expect(result).toBe("https://ghp_test123@github.com/user/repo.git");
+    });
+
+    it("should return original URL when no token provided", () => {
+      const url = "https://github.com/user/repo.git";
+      const result = buildAuthenticatedUrl(url);
+      expect(result).toBe(url);
+    });
+
+    it("should return original URL when token is undefined", () => {
+      const url = "https://github.com/user/repo.git";
+      const result = buildAuthenticatedUrl(url, undefined);
+      expect(result).toBe(url);
+    });
+  });
+
+  describe("sanitizeGitUrlForLogging", () => {
+    it("should mask token in authenticated URL", () => {
+      const url = "https://ghp_test123@github.com/user/repo.git";
+      const result = sanitizeGitUrlForLogging(url);
+      expect(result).toBe("https://***@github.com/user/repo.git");
+    });
+
+    it("should mask both username and password", () => {
+      const url = "https://user:password@github.com/user/repo.git";
+      const result = sanitizeGitUrlForLogging(url);
+      expect(result).toBe("https://***:***@github.com/user/repo.git");
+    });
+
+    it("should return original URL if no credentials", () => {
+      const url = "https://github.com/user/repo.git";
+      const result = sanitizeGitUrlForLogging(url);
+      expect(result).toBe(url);
+    });
+
+    it("should handle invalid URLs gracefully", () => {
+      const url = "not-a-url";
+      const result = sanitizeGitUrlForLogging(url);
+      expect(result).toBe(url);
+    });
+  });
+
+  describe("buildGitCloneCommand", () => {
+    it("should build clone command with all parameters", () => {
+      const url = "https://github.com/user/repo.git";
+      const branch = "main";
+      const mountPath = "/workspace/repo";
+      const result = buildGitCloneCommand(url, branch, mountPath);
+      expect(result).toBe(
+        `git clone --single-branch --branch "main" --depth 1 "https://github.com/user/repo.git" "/workspace/repo"`,
+      );
+    });
+
+    it("should handle different branches", () => {
+      const url = "https://github.com/user/repo.git";
+      const branch = "develop";
+      const mountPath = "/workspace/repo";
+      const result = buildGitCloneCommand(url, branch, mountPath);
+      expect(result).toContain('--branch "develop"');
+    });
+
+    it("should properly quote paths", () => {
+      const url = "https://github.com/user/repo.git";
+      const branch = "main";
+      const mountPath = "/workspace/my repo";
+      const result = buildGitCloneCommand(url, branch, mountPath);
+      expect(result).toContain('"/workspace/my repo"');
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/git/git-client.ts
+++ b/turbo/apps/web/src/lib/git/git-client.ts
@@ -1,0 +1,95 @@
+/**
+ * Git Client
+ * Handles Git repository operations for volume mounting
+ */
+
+/**
+ * Validate Git URL format
+ * @param url - Git repository URL
+ * @returns True if valid HTTPS Git URL
+ */
+export function validateGitUrl(url: string): boolean {
+  // Support HTTPS URLs only for MVP
+  const httpsPattern = /^https:\/\/.+\/.+\.git$/;
+  return httpsPattern.test(url);
+}
+
+/**
+ * Normalize Git URL to full HTTPS format
+ * @param uri - Git repository URI (can be full URL or short format)
+ * @returns Normalized HTTPS URL ending in .git
+ */
+export function normalizeGitUrl(uri: string): string {
+  // If already a valid URL (https/http), return with .git suffix
+  if (uri.startsWith("https://") || uri.startsWith("http://")) {
+    return uri.endsWith(".git") ? uri : `${uri}.git`;
+  }
+
+  // If it's an SSH or git protocol URL, return as-is (will be rejected by validation)
+  if (
+    uri.startsWith("git@") ||
+    uri.startsWith("ssh://") ||
+    uri.startsWith("git://")
+  ) {
+    return uri;
+  }
+
+  // Otherwise treat as GitHub short format (e.g., "owner/repo")
+  // Remove any leading/trailing slashes
+  const cleaned = uri.replace(/^\/+|\/+$/g, "");
+  return `https://github.com/${cleaned}.git`;
+}
+
+/**
+ * Build authenticated Git URL with token
+ * @param url - Base Git URL
+ * @param token - Authentication token (optional)
+ * @returns URL with embedded token for authentication
+ */
+export function buildAuthenticatedUrl(url: string, token?: string): string {
+  if (!token) {
+    return url;
+  }
+
+  // Parse URL and inject token
+  // https://github.com/user/repo.git -> https://token@github.com/user/repo.git
+  const urlObj = new URL(url);
+  urlObj.username = token;
+  return urlObj.toString();
+}
+
+/**
+ * Sanitize Git URL for logging (hide token)
+ * @param url - Git URL that may contain token
+ * @returns Sanitized URL with token masked
+ */
+export function sanitizeGitUrlForLogging(url: string): string {
+  try {
+    const urlObj = new URL(url);
+    if (urlObj.username) {
+      urlObj.username = "***";
+    }
+    if (urlObj.password) {
+      urlObj.password = "***";
+    }
+    return urlObj.toString();
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Build Git clone command
+ * @param url - Git repository URL (with auth if needed)
+ * @param branch - Branch to clone
+ * @param mountPath - Target directory path
+ * @returns Git clone command string
+ */
+export function buildGitCloneCommand(
+  url: string,
+  branch: string,
+  mountPath: string,
+): string {
+  // Use single-branch clone for efficiency
+  return `git clone --single-branch --branch "${branch}" --depth 1 "${url}" "${mountPath}"`;
+}

--- a/turbo/apps/web/src/lib/volume/__tests__/volume-service.test.ts
+++ b/turbo/apps/web/src/lib/volume/__tests__/volume-service.test.ts
@@ -12,16 +12,6 @@ vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return {
     ...actual,
-    default: {
-      ...actual.default,
-      promises: {
-        mkdir: vi.fn(),
-        readdir: vi.fn(),
-        readFile: vi.fn(),
-        stat: vi.fn(),
-        rm: vi.fn(),
-      },
-    },
     promises: {
       mkdir: vi.fn(),
       readdir: vi.fn(),
@@ -100,6 +90,7 @@ describe("VolumeService", () => {
         volumes: [
           {
             name: "data",
+            driver: "s3fs",
             s3Uri: "s3://test-bucket/data",
             mountPath: "/workspace/data",
             region: "us-east-1",
@@ -123,6 +114,7 @@ describe("VolumeService", () => {
       expect(result.preparedVolumes).toHaveLength(1);
       expect(result.preparedVolumes[0]).toEqual({
         name: "data",
+        driver: "s3fs",
         localPath: "/tmp/vm0-run-test-run-id/data",
         mountPath: "/workspace/data",
         s3Uri: "s3://test-bucket/data",
@@ -185,6 +177,7 @@ describe("VolumeService", () => {
         volumes: [
           {
             name: "data",
+            driver: "s3fs",
             s3Uri: "s3://test-bucket/data",
             mountPath: "/workspace/data",
             region: "us-east-1",
@@ -232,6 +225,7 @@ describe("VolumeService", () => {
       const preparedVolumes: PreparedVolume[] = [
         {
           name: "data",
+          driver: "s3fs",
           localPath: "/tmp/vm0-run-test/data",
           mountPath: "/workspace/data",
           s3Uri: "s3://test-bucket/data",

--- a/turbo/apps/web/src/lib/volume/__tests__/volume-service.test.ts
+++ b/turbo/apps/web/src/lib/volume/__tests__/volume-service.test.ts
@@ -198,7 +198,7 @@ describe("VolumeService", () => {
 
       expect(result.preparedVolumes).toHaveLength(0);
       expect(result.errors).toHaveLength(1);
-      expect(result.errors[0]).toContain("data: Failed to download");
+      expect(result.errors[0]).toContain("data: Failed to prepare");
     });
   });
 

--- a/turbo/apps/web/src/lib/volume/types.ts
+++ b/turbo/apps/web/src/lib/volume/types.ts
@@ -5,7 +5,9 @@ export interface VolumeConfig {
   driver: string;
   driver_opts: {
     uri: string;
-    region: string;
+    region?: string;
+    branch?: string;
+    token?: string;
   };
 }
 
@@ -14,9 +16,13 @@ export interface VolumeConfig {
  */
 export interface ResolvedVolume {
   name: string;
-  s3Uri: string;
+  driver: string;
   mountPath: string;
-  region: string;
+  s3Uri?: string;
+  region?: string;
+  gitUri?: string;
+  gitBranch?: string;
+  gitToken?: string;
 }
 
 /**
@@ -52,9 +58,13 @@ export interface AgentVolumeConfig {
  */
 export interface PreparedVolume {
   name: string;
-  localPath: string;
+  driver: string;
+  localPath?: string;
   mountPath: string;
-  s3Uri: string;
+  s3Uri?: string;
+  gitUri?: string;
+  gitBranch?: string;
+  gitToken?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements Git repository mounting as dynamic volumes in agent configurations (#149), enabling agents to work directly with code from Git repositories.

### Key Features
- **Git Driver Support**: Add new `git` driver alongside existing `s3fs` driver
- **HTTPS Git URLs**: Support HTTPS Git URLs with token-based authentication  
- **Template Variables**: Enable `{{user}}` style template variables in Git URIs
- **Sandbox Cloning**: Clone repositories directly in E2B sandbox (not on web server)
- **Environment Variables**: Preserve `${ENV_VAR}` patterns for runtime resolution

### Technical Changes

**Type Definitions** (`volume/types.ts`):
- Extend `VolumeConfig.driver_opts` to support Git options: `uri`, `branch`, `token`
- Add Git fields to `ResolvedVolume`: `gitUri`, `gitBranch`, `gitToken`
- Update `PreparedVolume` to handle both S3 and Git volumes

**Git Client** (`git/git-client.ts`):
- `normalizeGitUrl()`: Convert short format (`user/repo`) to full HTTPS URLs
- `validateGitUrl()`: Validate HTTPS URLs (reject SSH/git protocols)
- `buildAuthenticatedUrl()`: Inject token into URL for private repos
- `sanitizeGitUrlForLogging()`: Mask tokens in logs
- `buildGitCloneCommand()`: Generate optimized clone command

**Volume Resolver** (`volume/volume-resolver.ts`):
- Support both `s3fs` and `git` drivers
- Apply template variable replacement to Git URIs and branches
- Validate Git URLs and reject unsupported protocols
- Default branch to `main` if not specified

**Volume Service** (`volume/volume-service.ts`):
- `prepareVolumes()`: Handle Git volumes (store metadata only, no download)
- `mountVolumes()`: Clone Git repos in sandbox via `sandbox.commands.run()`
- `cloneGitRepo()`: Execute git clone with proper error handling

### Testing

**Unit Tests** (42 tests total):
- 17 tests for Git client (URL validation, normalization, authentication)
- 9 tests for Git volume resolver (template variables, error handling)
- Updated existing volume service tests for driver field

**E2E Tests**:
- Config: `vm0-git-volume-test.yaml` with `{{user}}` template variable
- Test: Clone repository and verify file access in sandbox
- Uses `CI_GITHUB_TOKEN` from GitHub Actions secrets

### Test Plan

**Configuration Example**:
```yaml
dynamic_volumes:
  user-workspace:
    driver: git
    driver_opts:
      uri: https://github.com/{{user}}/question.git
      branch: main
      token: "${CI_GITHUB_TOKEN}"
```

**Test Steps**:
1. Build agent: `vm0 build vm0-git-volume-test.yaml`
2. Run agent: `vm0 run vm0-git-volume-test -e user=key "list files"`
3. Verify repository files are accessible in `/home/user/workspace`

### Architecture Decisions

**Why clone in sandbox?**
- Vercel web server doesn't have Git installed
- More efficient: avoid download → upload cycle
- Sandboxes have Git pre-installed

**Why HTTPS only (no SSH)?**
- Token-based auth is simpler for CI/CD
- Easier to inject credentials programmatically
- SSH support can be added later if needed

**Why preserve `${ENV_VAR}` patterns?**
- Tokens shouldn't be resolved on web server (security)
- Environment variables available in sandbox at runtime
- Follows principle of least privilege

### Acceptance Criteria

- [x] Git driver type supported in YAML configuration
- [x] HTTPS Git URLs validated and normalized
- [x] Template variables (`{{user}}`) work in URIs
- [x] Environment variables (`${TOKEN}`) preserved
- [x] Repositories cloned directly in E2B sandbox
- [x] Clear error messages for clone failures
- [x] Full read-write access to mounted Git volumes
- [x] Unit tests for Git client and resolver
- [x] E2E test with example configuration
- [x] All pre-commit checks pass (lint, types, format, tests)

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)