### PR TITLE
feat: add codex volume mount to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,6 +25,7 @@
     "source=vercel,target=/home/vscode/.local/share/com.vercel.cli",
     "source=pnpm,target=/home/vscode/.local/share/pnpm",
     "source=mkcert,target=/home/vscode/.local/share/mkcert",
+    "source=codex,target=/home/vscode/.codex",
     "source=pki,target=/home/vscode/.pki"
   ],
   "postCreateCommand": "bash .devcontainer/setup.sh",


### PR DESCRIPTION
## Summary

- Add codex volume mount to devcontainer configuration
- Mounts codex data at `/home/vscode/.codex` to persist across container rebuilds
- Follows the same pattern as existing tool volumes (vercel, pnpm, mkcert, pki)

## Test plan

- [ ] Rebuild devcontainer and verify codex volume is mounted correctly
- [ ] Verify codex data persists after container rebuild
- [ ] Confirm no conflicts with existing volume mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)