### PR TITLE
feat: add UTF-8 locale support to devcontainer setup

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -9,6 +9,12 @@ echo "🚀 Setting up dev container..."
 sudo chown -R postgres:postgres /var/lib/postgresql 2>/dev/null || true
 sudo service postgresql start 2>/dev/null || true
 
+# Generate locale for UTF-8 support
+echo "🌐 Setting up locale..."
+sudo locale-gen en_US.UTF-8 2>/dev/null || true
+sudo update-locale LANG=en_US.UTF-8 2>/dev/null || true
+echo "✓ Locale configured"
+
 # Setup directories - fix ownership for all mounted volumes
 # This is the key difference - uspark fixes all directories at once
 sudo mkdir -p /home/vscode/.local/bin


### PR DESCRIPTION
## Summary
- Add UTF-8 locale generation and configuration to devcontainer setup script
- Configure en_US.UTF-8 locale during container initialization
- Ensure proper UTF-8 support for international characters and text processing

## Test plan
- [ ] Rebuild devcontainer and verify locale is configured correctly
- [ ] Check that `locale` command shows en_US.UTF-8 as LANG
- [ ] Verify UTF-8 characters display correctly in terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)