### PR TITLE
fix: remove duplicate result event emission in agent execution

### DIFF
--- a/turbo/apps/web/src/lib/e2b/run-agent-script.ts
+++ b/turbo/apps/web/src/lib/e2b/run-agent-script.ts
@@ -365,10 +365,9 @@ set -e
 # Print newline after output
 echo ""
 
-# Send final result event
+# Handle completion
 if [ $CLAUDE_EXIT_CODE -eq 0 ]; then
   echo "[VM0] Claude Code completed successfully" >&2
-  send_event '{"type": "result", "data": {"status": "success", "exitCode": 0}}'
 
   # Create checkpoint - this is mandatory for successful runs
   if ! create_checkpoint; then
@@ -379,7 +378,6 @@ if [ $CLAUDE_EXIT_CODE -eq 0 ]; then
   fi
 else
   echo "[VM0] Claude Code failed with exit code $CLAUDE_EXIT_CODE" >&2
-  send_event "{\\"type\\": \\"result\\", \\"data\\": {\\"status\\": \\"failed\\", \\"exitCode\\": $CLAUDE_EXIT_CODE}}"
 fi
 
 # Cleanup temp files


### PR DESCRIPTION
## Summary

Fixes #159 - Remove duplicate result event emissions during agent execution.

### Problem
Agent execution was emitting two result events:
1. First result event from Claude Code's JSONL output (with complete statistics)
2. Second result event manually sent by the bash script (with zero statistics)

### Solution
Remove the manual result event emissions at lines 371 and 382 in `run-agent-script.ts`. Claude Code already emits complete result events through its JSONL output stream, which are properly forwarded by the event processing loop.

### Changes
- Remove manual `send_event` call for success case
- Remove manual `send_event` call for failure case  
- Keep logging messages and checkpoint creation workflow intact
- Result events now come exclusively from Claude Code's output

### Result
Only one result event with complete execution statistics (duration, cost, turns, tokens) is now emitted per agent run.

## Test Plan

- [x] Verify code changes follow project guidelines
- [ ] Test successful agent execution shows single result event
- [ ] Test failed agent execution shows single result event  
- [ ] Verify checkpoint creation still works correctly
- [ ] Verify CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)