### PR TITLE
fix: fail agent run when vm0 volume preparation fails

### DIFF
--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -48,6 +48,12 @@ export class E2BService {
         );
 
     try {
+      // Fail fast if any volumes failed to prepare
+      if (volumeResult.errors.length > 0) {
+        throw new Error(
+          `Volume preparation failed: ${volumeResult.errors.join("; ")}`,
+        );
+      }
       // Get API configuration with dynamic fallback logic
       // Priority: explicit VM0_API_URL > VERCEL_URL (for preview) > production URL > localhost
       const envVars = globalThis.services?.env;

--- a/turbo/apps/web/src/lib/volume/volume-service.ts
+++ b/turbo/apps/web/src/lib/volume/volume-service.ts
@@ -137,13 +137,9 @@ export class VolumeService {
           }
 
           if (!dbVolume.headVersionId) {
-            console.warn(
-              `[Volume] VM0 volume "${volume.vm0VolumeName}" has no HEAD version, skipping`,
+            throw new Error(
+              `VM0 volume "${volume.vm0VolumeName}" has no HEAD version`,
             );
-            errors.push(
-              `${volume.name}: Volume "${volume.vm0VolumeName}" has no versions`,
-            );
-            continue;
           }
 
           // Get HEAD version details


### PR DESCRIPTION
## Summary
- Fail agent run when VM0 volume has no HEAD version (instead of logging warning and continuing)
- Add error check in e2bService.execute() to fail fast when any volume preparation errors occur
- Send descriptive error to CLI via vm0_error event

## Changes
- `volume-service.ts`: Changed warning + continue to throw Error when VM0 volume has no HEAD version
- `e2b-service.ts`: Added check for `volumeResult.errors` and fail fast if any errors exist
- Added test coverage for both error scenarios

## Test plan
- [x] Test that VM0 volume with no HEAD version returns error in errors array
- [x] Test that VM0 volume not found in database returns error in errors array
- [x] Test that e2bService.execute() fails when volumeResult.errors has entries
- [x] Run existing tests to ensure no regressions

Fixes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)