### PR TITLE
chore(e2e): add ci_github_token to env template

### DIFF
--- a/e2e/.env.local.tpl
+++ b/e2e/.env.local.tpl
@@ -2,3 +2,6 @@
 # Use 1Password CLI to inject secrets: npm run sync:env
 CLERK_PUBLISHABLE_KEY=op://Development/vm0-env-local/clerk_publishable_key
 CLERK_SECRET_KEY=op://Development/vm0-env-local/clerk_secret_key
+
+# GitHub token for git volume tests
+CI_GITHUB_TOKEN=op://Development/vm0-env-local/ci_github_token


### PR DESCRIPTION
## Summary
- Add `CI_GITHUB_TOKEN` variable to `e2e/.env.local.tpl` for git volume tests
- Token is sourced from 1Password vault (`op://Development/vm0-env-local/ci_github_token`)

## Test plan
- [ ] Run `./scripts/sync-env.sh` to verify token injection works
- [ ] Run e2e tests with git volume tests enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)