### PR TITLE
fix: push git branch to remote even when no changes to commit

### DIFF
--- a/turbo/apps/web/src/lib/checkpoint/git-snapshot.ts
+++ b/turbo/apps/web/src/lib/checkpoint/git-snapshot.ts
@@ -70,7 +70,13 @@ export async function createGitSnapshot(
       console.log(
         `[Checkpoint] No changes to commit in volume "${volumeName}"`,
       );
-      // Still return snapshot with current HEAD commit
+      // Push the branch even without new commits so resume can find it
+      console.log(`[Checkpoint] Pushing branch ${branchName} to remote`);
+      await executeGitCommand(
+        sandbox,
+        mountPath,
+        `git push origin ${branchName}`,
+      );
       const commitId = await getCommitId(sandbox, mountPath);
       return { branch: branchName, commitId };
     }


### PR DESCRIPTION
## Summary

- Fix checkpoint resume failing with git exit code 128 when no file changes occurred during the run
- Push the snapshot branch to remote even when there are no changes to commit, so resume can find it

## Root Cause

When creating a git snapshot with no file changes:
1. Code created local branch `run-<runId>` with `git checkout -b`
2. Detected no changes via `git status --porcelain`
3. Returned early **without pushing** the branch to remote
4. On resume, `git clone --branch run-<runId>` failed because branch didn't exist on remote

## Test plan

- [ ] Run agent with git volume that doesn't modify files
- [ ] Verify checkpoint is created with volume snapshot
- [ ] Resume from checkpoint and verify git clone succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)