### PR TITLE
feat: add mock-claude for faster e2e testing

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -203,6 +203,7 @@ jobs:
             AWS_REGION=${{ secrets.AWS_REGION }}
             AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            USE_MOCK_CLAUDE=true
           meta-branch: ${{ github.head_ref }}
           meta-pr: ${{ github.event.pull_request.number }}
 
@@ -292,3 +293,4 @@ jobs:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+          USE_MOCK_CLAUDE: "true"

--- a/e2e/tests/02-commands/t01-validation.bats
+++ b/e2e/tests/02-commands/t01-validation.bats
@@ -24,7 +24,7 @@ setup() {
     assert_success
 
     # Then try to run without providing template vars
-    run $CLI_COMMAND run vm0-vars-test-with-token "answer my question."
+    run $CLI_COMMAND run vm0-vars-test-with-token "echo hello"
     assert_failure
     assert_output --partial "Missing required template variables"
     assert_output --partial "user"

--- a/e2e/tests/02-commands/t02-checkpoint.bats
+++ b/e2e/tests/02-commands/t02-checkpoint.bats
@@ -14,9 +14,9 @@ setup() {
 
 @test "Execute initial run, resume from checkpoint, and verify git volume access" {
     # Step 1: Run initial task that creates a checkpoint
-    # Using bash command to read files from git volume (lancy/question.git contains message.txt and answer.md)
+    # Using bash command to read files from git volume (lancy/question.git contains question.md)
     echo "# Step 1: Running initial task to read files from git volume..."
-    run $CLI_COMMAND run vm0-checkpoint-resume-test -e user=lancy "cat message.txt && cat answer.md"
+    run $CLI_COMMAND run vm0-checkpoint-resume-test -e user=lancy "cat question.md"
     assert_success
 
     # Verify we got a checkpoint created
@@ -41,8 +41,8 @@ setup() {
     # Verify the run started and resumed from checkpoint
     assert_output --partial "[vm0_start]"
 
-    # Step 3: Verify git volume is accessible and answer.md exists
+    # Step 3: Verify git volume is accessible and question.md exists
     echo "# Step 3: Verifying git volume access..."
-    # The agent should be able to see answer.md from the question.git repository
-    assert_output --partial "answer.md"
+    # The agent should be able to see question.md from the question.git repository
+    assert_output --partial "question.md"
 }

--- a/e2e/tests/02-commands/t02-checkpoint.bats
+++ b/e2e/tests/02-commands/t02-checkpoint.bats
@@ -14,8 +14,9 @@ setup() {
 
 @test "Execute initial run, resume from checkpoint, and verify git volume access" {
     # Step 1: Run initial task that creates a checkpoint
-    echo "# Step 1: Running initial task 'answer my question'..."
-    run $CLI_COMMAND run vm0-checkpoint-resume-test -e user=lancy "answer my question"
+    # Using bash command to read files from git volume (lancy/question.git contains message.txt and answer.md)
+    echo "# Step 1: Running initial task to read files from git volume..."
+    run $CLI_COMMAND run vm0-checkpoint-resume-test -e user=lancy "cat message.txt && cat answer.md"
     assert_success
 
     # Verify we got a checkpoint created
@@ -32,8 +33,9 @@ setup() {
     }
 
     # Step 2: Resume from checkpoint with new prompt
-    echo "# Step 2: Resuming from checkpoint with prompt 'List all files in the current directory'..."
-    run $CLI_COMMAND run resume "$CHECKPOINT_ID" "List all files in the current directory"
+    # Using ls command to list files in current directory
+    echo "# Step 2: Resuming from checkpoint to list files..."
+    run $CLI_COMMAND run resume "$CHECKPOINT_ID" "ls -la"
     assert_success
 
     # Verify the run started and resumed from checkpoint

--- a/e2e/tests/02-commands/t02-checkpoint.bats
+++ b/e2e/tests/02-commands/t02-checkpoint.bats
@@ -19,6 +19,12 @@ setup() {
     run $CLI_COMMAND run vm0-checkpoint-resume-test -e user=lancy "cat question.md"
     assert_success
 
+    # Verify mock-claude execution events (deterministic with mock-claude)
+    assert_output --partial "[tool_use] Bash"
+    assert_output --partial "cat question.md"
+    assert_output --partial "[tool_result]"
+    assert_output --partial "[result]"
+
     # Verify we got a checkpoint created
     assert_output --partial "Checkpoint:"
 
@@ -44,5 +50,8 @@ setup() {
     # Step 3: Verify git volume is accessible and question.md exists
     echo "# Step 3: Verifying git volume access..."
     # The agent should be able to see question.md from the question.git repository
+    # With mock-claude, the ls -la output is deterministic
+    assert_output --partial "[tool_use] Bash"
+    assert_output --partial "ls -la"
     assert_output --partial "question.md"
 }

--- a/e2e/tests/02-commands/t03-volumes.bats
+++ b/e2e/tests/02-commands/t03-volumes.bats
@@ -175,9 +175,20 @@ EOF
         "cat /workspace/message.txt && cat /workspace/answer.txt"
 
     assert_success
+
+    # Verify mock-claude execution events (deterministic with mock-claude)
+    assert_output --partial "[tool_use] Bash"
+    assert_output --partial "cat /workspace/message.txt"
+    assert_output --partial "[tool_result]"
+    assert_output --partial "[result]"
+
     # Verify HEAD version content (not old content)
+    # With mock-claude, the actual file content appears in tool_result
     assert_output --partial "Hello from HEAD version"
     assert_output --partial "42"
+
+    # Verify we did NOT get old content
+    refute_output --partial "old content - should not see this"
 
     rm -rf "$CONFIG_DIR"
 }

--- a/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
+++ b/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
@@ -135,8 +135,8 @@ describe("E2B Service - mocked unit tests", () => {
       expect(result.error).toBeUndefined();
 
       // Verify sandbox methods were called
-      // commands.run called: 1 (mkdir) + 6 (mv/chmod for each script) + 1 (execute) = 8 times
-      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(8);
+      // commands.run called: 1 (mkdir) + 7 (mv/chmod for each script) + 1 (execute) = 9 times
+      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(9);
       expect(mockSandbox.kill).toHaveBeenCalledTimes(1);
     });
 
@@ -186,9 +186,9 @@ describe("E2B Service - mocked unit tests", () => {
 
       // Verify both sandboxes were created and cleaned up
       expect(Sandbox.create).toHaveBeenCalledTimes(2);
-      // Each sandbox: 1 (mkdir) + 6 (mv/chmod for each script) + 1 (execute) = 8 times
-      expect(mockSandbox1.commands.run).toHaveBeenCalledTimes(8);
-      expect(mockSandbox2.commands.run).toHaveBeenCalledTimes(8);
+      // Each sandbox: 1 (mkdir) + 7 (mv/chmod for each script) + 1 (execute) = 9 times
+      expect(mockSandbox1.commands.run).toHaveBeenCalledTimes(9);
+      expect(mockSandbox2.commands.run).toHaveBeenCalledTimes(9);
       expect(mockSandbox1.kill).toHaveBeenCalledTimes(1);
       expect(mockSandbox2.kill).toHaveBeenCalledTimes(1);
     });
@@ -218,8 +218,8 @@ describe("E2B Service - mocked unit tests", () => {
 
       // Verify sandbox was created and cleaned up
       expect(Sandbox.create).toHaveBeenCalledTimes(1);
-      // 1 (mkdir) + 6 (mv/chmod for each script) + 1 (execute) = 8 times
-      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(8);
+      // 1 (mkdir) + 7 (mv/chmod for each script) + 1 (execute) = 9 times
+      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(9);
       expect(mockSandbox.kill).toHaveBeenCalledTimes(1);
     });
 
@@ -252,8 +252,8 @@ describe("E2B Service - mocked unit tests", () => {
 
       // Verify sandbox was created and cleaned up
       expect(Sandbox.create).toHaveBeenCalledTimes(1);
-      // 1 (mkdir) + 6 (mv/chmod for each script) + 1 (execute) = 8 times
-      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(8);
+      // 1 (mkdir) + 7 (mv/chmod for each script) + 1 (execute) = 9 times
+      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(9);
       expect(mockSandbox.kill).toHaveBeenCalledTimes(1);
     });
 

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -12,6 +12,7 @@ import {
   VM0_SNAPSHOT_SCRIPT,
   CREATE_CHECKPOINT_SCRIPT,
   RUN_AGENT_SCRIPT,
+  MOCK_CLAUDE_SCRIPT,
   SCRIPT_PATHS,
 } from "./scripts";
 import type { ExecutionContext } from "../run/types";
@@ -315,6 +316,7 @@ export class E2BService {
         path: SCRIPT_PATHS.createCheckpoint,
       },
       { content: RUN_AGENT_SCRIPT, path: SCRIPT_PATHS.runAgent },
+      { content: MOCK_CLAUDE_SCRIPT, path: SCRIPT_PATHS.mockClaude },
     ];
 
     // Upload each script
@@ -384,6 +386,12 @@ export class E2BService {
     if (resumeSessionId) {
       envs.VM0_RESUME_SESSION_ID = resumeSessionId;
       console.log(`[E2B] Resume session ID configured: ${resumeSessionId}`);
+    }
+
+    // Pass USE_MOCK_CLAUDE for testing (executes prompt as bash instead of calling LLM)
+    if (process.env.USE_MOCK_CLAUDE === "true") {
+      envs.USE_MOCK_CLAUDE = "true";
+      console.log(`[E2B] Using mock-claude for testing`);
     }
 
     // Add volume information for checkpoint

--- a/turbo/apps/web/src/lib/e2b/scripts/index.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/index.ts
@@ -8,6 +8,7 @@ export { GIT_SNAPSHOT_SCRIPT } from "./git-snapshot";
 export { VM0_SNAPSHOT_SCRIPT } from "./vm0-snapshot";
 export { CREATE_CHECKPOINT_SCRIPT } from "./create-checkpoint";
 export { RUN_AGENT_SCRIPT } from "./run-agent";
+export { MOCK_CLAUDE_SCRIPT } from "./mock-claude";
 
 /**
  * Script paths in the E2B sandbox
@@ -21,4 +22,5 @@ export const SCRIPT_PATHS = {
   gitSnapshot: "/usr/local/bin/vm0-agent/lib/git-snapshot.sh",
   vm0Snapshot: "/usr/local/bin/vm0-agent/lib/vm0-snapshot.sh",
   createCheckpoint: "/usr/local/bin/vm0-agent/lib/create-checkpoint.sh",
+  mockClaude: "/usr/local/bin/vm0-agent/lib/mock-claude.sh",
 } as const;

--- a/turbo/apps/web/src/lib/e2b/scripts/mock-claude.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/mock-claude.ts
@@ -1,0 +1,91 @@
+/**
+ * Mock Claude CLI script for testing
+ * Executes the prompt as a bash command and outputs Claude-compatible JSONL
+ * This allows e2e tests to run without calling the real Claude LLM API
+ */
+export const MOCK_CLAUDE_SCRIPT = `#!/bin/bash
+# mock-claude - Executes prompt as bash and outputs Claude-compatible JSONL
+# Usage: mock-claude [options] <prompt>
+# The prompt is executed as a bash command
+
+set -o pipefail
+
+SESSION_ID="mock-$(date +%s%N)"
+PROMPT=""
+OUTPUT_FORMAT="text"
+
+# Parse arguments (same as real claude CLI)
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --output-format)
+      OUTPUT_FORMAT="$2"
+      shift 2
+      ;;
+    --print|--verbose|--dangerously-skip-permissions)
+      # These flags are accepted but ignored
+      shift
+      ;;
+    --resume)
+      # Skip resume session id (not supported in mock)
+      shift 2
+      ;;
+    -*)
+      # Unknown option, skip
+      shift
+      ;;
+    *)
+      # Positional argument is the prompt
+      PROMPT="$1"
+      shift
+      ;;
+  esac
+done
+
+# Function to escape string for JSON
+json_escape() {
+  printf '%s' "$1" | jq -Rs .
+}
+
+# Get current working directory
+CWD="$(pwd)"
+
+if [[ "$OUTPUT_FORMAT" == "stream-json" ]]; then
+  # Output JSONL events in Claude format
+
+  # 1. System init event
+  echo '{"type":"system","subtype":"init","cwd":"'"$CWD"'","session_id":"'"$SESSION_ID"'","tools":["Bash"],"model":"mock-claude"}'
+
+  # 2. Assistant text event
+  echo '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Executing command..."}]},"session_id":"'"$SESSION_ID"'"}'
+
+  # 3. Assistant tool_use event
+  ESCAPED_PROMPT=$(json_escape "$PROMPT")
+  echo '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_mock_001","name":"Bash","input":{"command":'$ESCAPED_PROMPT'}}]},"session_id":"'"$SESSION_ID"'"}'
+
+  # 4. Execute prompt as bash and capture output
+  OUTPUT=$(bash -c "$PROMPT" 2>&1)
+  EXIT_CODE=$?
+  ESCAPED_OUTPUT=$(json_escape "$OUTPUT")
+
+  # 5. User tool_result event
+  if [[ $EXIT_CODE -eq 0 ]]; then
+    IS_ERROR="false"
+  else
+    IS_ERROR="true"
+  fi
+  echo '{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_mock_001","content":'$ESCAPED_OUTPUT',"is_error":'$IS_ERROR'}]},"session_id":"'"$SESSION_ID"'"}'
+
+  # 6. Result event
+  if [[ $EXIT_CODE -eq 0 ]]; then
+    echo '{"type":"result","subtype":"success","is_error":false,"duration_ms":100,"num_turns":1,"result":'$ESCAPED_OUTPUT',"session_id":"'"$SESSION_ID"'","total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0}}'
+  else
+    echo '{"type":"result","subtype":"error","is_error":true,"duration_ms":100,"num_turns":1,"result":'$ESCAPED_OUTPUT',"session_id":"'"$SESSION_ID"'","total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0}}'
+  fi
+
+  exit $EXIT_CODE
+else
+  # Plain text output - just execute the prompt
+  bash -c "$PROMPT"
+  exit $?
+fi
+`;

--- a/turbo/apps/web/src/lib/e2b/scripts/mock-claude.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/mock-claude.ts
@@ -49,18 +49,38 @@ json_escape() {
 # Get current working directory
 CWD="$(pwd)"
 
+# Create session history file for checkpoint compatibility
+# Claude Code stores session history at: ~/.config/claude/projects/-{path}/{session_id}.jsonl
+create_session_history() {
+  local session_dir
+  local project_name
+  project_name=$(echo "$CWD" | sed 's|^/||' | sed 's|/|-|g')
+  session_dir="$HOME/.config/claude/projects/-\${project_name}"
+  mkdir -p "$session_dir"
+  echo "$session_dir/\${SESSION_ID}.jsonl"
+}
+
 if [[ "$OUTPUT_FORMAT" == "stream-json" ]]; then
-  # Output JSONL events in Claude format
+  # Create session history file path
+  SESSION_HISTORY_FILE=$(create_session_history)
+
+  # Output JSONL events in Claude format and write to session history
 
   # 1. System init event
-  echo '{"type":"system","subtype":"init","cwd":"'"$CWD"'","session_id":"'"$SESSION_ID"'","tools":["Bash"],"model":"mock-claude"}'
+  INIT_EVENT='{"type":"system","subtype":"init","cwd":"'"$CWD"'","session_id":"'"$SESSION_ID"'","tools":["Bash"],"model":"mock-claude"}'
+  echo "$INIT_EVENT"
+  echo "$INIT_EVENT" >> "$SESSION_HISTORY_FILE"
 
   # 2. Assistant text event
-  echo '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Executing command..."}]},"session_id":"'"$SESSION_ID"'"}'
+  TEXT_EVENT='{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Executing command..."}]},"session_id":"'"$SESSION_ID"'"}'
+  echo "$TEXT_EVENT"
+  echo "$TEXT_EVENT" >> "$SESSION_HISTORY_FILE"
 
   # 3. Assistant tool_use event
   ESCAPED_PROMPT=$(json_escape "$PROMPT")
-  echo '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_mock_001","name":"Bash","input":{"command":'$ESCAPED_PROMPT'}}]},"session_id":"'"$SESSION_ID"'"}'
+  TOOL_USE_EVENT='{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_mock_001","name":"Bash","input":{"command":'$ESCAPED_PROMPT'}}]},"session_id":"'"$SESSION_ID"'"}'
+  echo "$TOOL_USE_EVENT"
+  echo "$TOOL_USE_EVENT" >> "$SESSION_HISTORY_FILE"
 
   # 4. Execute prompt as bash and capture output
   OUTPUT=$(bash -c "$PROMPT" 2>&1)
@@ -73,14 +93,18 @@ if [[ "$OUTPUT_FORMAT" == "stream-json" ]]; then
   else
     IS_ERROR="true"
   fi
-  echo '{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_mock_001","content":'$ESCAPED_OUTPUT',"is_error":'$IS_ERROR'}]},"session_id":"'"$SESSION_ID"'"}'
+  TOOL_RESULT_EVENT='{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_mock_001","content":'$ESCAPED_OUTPUT',"is_error":'$IS_ERROR'}]},"session_id":"'"$SESSION_ID"'"}'
+  echo "$TOOL_RESULT_EVENT"
+  echo "$TOOL_RESULT_EVENT" >> "$SESSION_HISTORY_FILE"
 
   # 6. Result event
   if [[ $EXIT_CODE -eq 0 ]]; then
-    echo '{"type":"result","subtype":"success","is_error":false,"duration_ms":100,"num_turns":1,"result":'$ESCAPED_OUTPUT',"session_id":"'"$SESSION_ID"'","total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0}}'
+    RESULT_EVENT='{"type":"result","subtype":"success","is_error":false,"duration_ms":100,"num_turns":1,"result":'$ESCAPED_OUTPUT',"session_id":"'"$SESSION_ID"'","total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0}}'
   else
-    echo '{"type":"result","subtype":"error","is_error":true,"duration_ms":100,"num_turns":1,"result":'$ESCAPED_OUTPUT',"session_id":"'"$SESSION_ID"'","total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0}}'
+    RESULT_EVENT='{"type":"result","subtype":"error","is_error":true,"duration_ms":100,"num_turns":1,"result":'$ESCAPED_OUTPUT',"session_id":"'"$SESSION_ID"'","total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0}}'
   fi
+  echo "$RESULT_EVENT"
+  echo "$RESULT_EVENT" >> "$SESSION_HISTORY_FILE"
 
   exit $EXIT_CODE
 else

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.ts
@@ -40,8 +40,16 @@ else
   echo "[VM0] Starting new session" >&2
 fi
 
+# Select Claude binary - use mock-claude for testing if USE_MOCK_CLAUDE is set
+if [ "$USE_MOCK_CLAUDE" = "true" ]; then
+  CLAUDE_BIN="/usr/local/bin/vm0-agent/lib/mock-claude.sh"
+  echo "[VM0] Using mock-claude for testing" >&2
+else
+  CLAUDE_BIN="claude"
+fi
+
 # Execute Claude and process output stream
-/usr/local/bin/claude $CLAUDE_ARGS "$PROMPT" 2>&1 | while IFS= read -r line; do
+"$CLAUDE_BIN" $CLAUDE_ARGS "$PROMPT" 2>&1 | while IFS= read -r line; do
   # Skip empty lines
   if [ -z "$line" ]; then
     continue

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -19,7 +19,8 @@
     "MINIMAX_API_KEY",
     "AWS_REGION",
     "AWS_ACCESS_KEY_ID",
-    "AWS_SECRET_ACCESS_KEY"
+    "AWS_SECRET_ACCESS_KEY",
+    "USE_MOCK_CLAUDE"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary

Add a mock-claude script that allows e2e tests to run without calling the real Claude LLM API, significantly speeding up test execution.

- Add `mock-claude.ts` script that outputs Claude-compatible JSONL events
- Modify `run-agent.ts` to conditionally use mock-claude when `USE_MOCK_CLAUDE=true`
- Pass `USE_MOCK_CLAUDE` env var from e2b-service to sandbox
- Add `USE_MOCK_CLAUDE` to turbo.json globalEnv

### How it works

When `USE_MOCK_CLAUDE=true` is set:
1. The prompt is executed directly as a bash command (instead of being sent to Claude LLM)
2. mock-claude outputs JSONL events in the exact Claude format:
   - `system` (init) → `assistant` (text) → `assistant` (tool_use) → `user` (tool_result) → `result`
3. Tests can verify the infrastructure without waiting for LLM responses

### Usage

```bash
# Run e2e tests with mock-claude (fast)
USE_MOCK_CLAUDE=true make test

# Run with real claude (default)
make test
```

## Test plan

- [ ] Verify lint passes
- [ ] Verify type check passes
- [ ] Manual test with `USE_MOCK_CLAUDE=true` to verify JSONL output format
- [ ] Run e2e tests with mock-claude enabled

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)