### PR TITLE
feat(e2e): add --abort flag to stop tests on first failure

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -287,7 +287,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run CLI E2E Tests
-        run: ./e2e/test/libs/bats/bin/bats ./e2e/tests/**/*.bats
+        run: ./e2e/test/libs/bats/bin/bats --abort ./e2e/tests/**/*.bats
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -12,5 +12,5 @@ init:
 	
 # Run all tests
 test:
-	@$(BATS) $(TESTS_DIR)/**/*.bats
+	@$(BATS) --abort $(TESTS_DIR)/**/*.bats
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -36,8 +36,8 @@ echo -e "${GREEN}Running BATS tests...${NC}"
 
 # Default: run all tests
 if [[ $# -eq 0 ]]; then
-    "$BATS_BIN" "$SCRIPT_DIR"/tests/**/*.bats
+    "$BATS_BIN" --abort "$SCRIPT_DIR"/tests/**/*.bats
 else
     # Run specific tests passed as arguments
-    "$BATS_BIN" "$@"
+    "$BATS_BIN" --abort "$@"
 fi


### PR DESCRIPTION
## Summary
- Add bats `--abort` option to CI workflow, run.sh, and Makefile
- Tests will now stop immediately on first failure instead of running all remaining tests
- Saves CI time and provides faster feedback when tests fail

## Test plan
- [ ] Verify CI workflow runs with the new flag
- [ ] Confirm tests abort on first failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)