### PR TITLE
feat(e2e): enable parallel test file execution with 4 workers

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -267,6 +267,9 @@ jobs:
       - name: Setup CLI globally
         run: cd turbo/apps/cli && pnpm link --global
 
+      - name: Install GNU parallel for bats
+        run: sudo apt-get update && sudo apt-get install -y parallel
+
       - name: Install E2E dependencies
         run: cd e2e && npm install
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -268,7 +268,7 @@ jobs:
         run: cd turbo/apps/cli && pnpm link --global
 
       - name: Install GNU parallel for bats
-        run: sudo apt-get update && sudo apt-get install -y parallel
+        run: apt-get update && apt-get install -y parallel
 
       - name: Install E2E dependencies
         run: cd e2e && npm install

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -290,7 +290,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run CLI E2E Tests
-        run: ./e2e/test/libs/bats/bin/bats --abort ./e2e/tests/**/*.bats
+        run: ./e2e/test/libs/bats/bin/bats --abort -j 4 --no-parallelize-within-files ./e2e/tests/**/*.bats
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -11,6 +11,8 @@ init:
 	@git submodule update --init --recursive
 	
 # Run all tests
+# -j 4: run up to 4 files in parallel
+# --no-parallelize-within-files: run tests sequentially within each file
 test:
-	@$(BATS) --abort $(TESTS_DIR)/**/*.bats
+	@$(BATS) --abort -j 4 --no-parallelize-within-files $(TESTS_DIR)/**/*.bats
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -35,9 +35,11 @@ echo -e "${YELLOW}Linking CLI globally...${NC}"
 echo -e "${GREEN}Running BATS tests...${NC}"
 
 # Default: run all tests
+# -j 4: run up to 4 files in parallel
+# --no-parallelize-within-files: run tests sequentially within each file
 if [[ $# -eq 0 ]]; then
-    "$BATS_BIN" --abort "$SCRIPT_DIR"/tests/**/*.bats
+    "$BATS_BIN" --abort -j 4 --no-parallelize-within-files "$SCRIPT_DIR"/tests/**/*.bats
 else
     # Run specific tests passed as arguments
-    "$BATS_BIN" --abort "$@"
+    "$BATS_BIN" --abort -j 4 --no-parallelize-within-files "$@"
 fi


### PR DESCRIPTION
## Summary
- Add `-j 4` flag to run up to 4 test files in parallel
- Add `--no-parallelize-within-files` to keep tests sequential within each file
- This balances speed improvement with e2b sandbox concurrency limits (max 10)

## Changes
- `e2e/run.sh`
- `e2e/Makefile`
- `.github/workflows/turbo.yml`

## Test plan
- [ ] Verify CI runs tests in parallel across files
- [ ] Confirm tests within each file run sequentially

🤖 Generated with [Claude Code](https://claude.com/claude-code)