### PR TITLE
feat(cli): add version selection support for volume and artifact pull

### DIFF
--- a/turbo/apps/cli/src/commands/artifact/pull.ts
+++ b/turbo/apps/cli/src/commands/artifact/pull.ts
@@ -20,7 +20,8 @@ function formatBytes(bytes: number): string {
 export const pullCommand = new Command()
   .name("pull")
   .description("Pull cloud artifact to local directory")
-  .action(async () => {
+  .argument("[versionId]", "Version ID to pull (default: latest)")
+  .action(async (versionId?: string) => {
     try {
       const cwd = process.cwd();
 
@@ -42,14 +43,25 @@ export const pullCommand = new Command()
         process.exit(1);
       }
 
-      console.log(chalk.cyan(`Pulling artifact: ${config.name}`));
+      if (versionId) {
+        console.log(
+          chalk.cyan(
+            `Pulling artifact: ${config.name} (version: ${versionId})`,
+          ),
+        );
+      } else {
+        console.log(chalk.cyan(`Pulling artifact: ${config.name}`));
+      }
 
       // Download from API
       console.log(chalk.gray("Downloading..."));
 
-      const response = await apiClient.get(
-        `/api/storages?name=${encodeURIComponent(config.name)}`,
-      );
+      let url = `/api/storages?name=${encodeURIComponent(config.name)}`;
+      if (versionId) {
+        url += `&version=${encodeURIComponent(versionId)}`;
+      }
+
+      const response = await apiClient.get(url);
 
       if (!response.ok) {
         if (response.status === 404) {

--- a/turbo/apps/cli/src/commands/volume/pull.ts
+++ b/turbo/apps/cli/src/commands/volume/pull.ts
@@ -20,7 +20,8 @@ function formatBytes(bytes: number): string {
 export const pullCommand = new Command()
   .name("pull")
   .description("Pull cloud files to local directory")
-  .action(async () => {
+  .argument("[versionId]", "Version ID to pull (default: latest)")
+  .action(async (versionId?: string) => {
     try {
       const cwd = process.cwd();
 
@@ -32,14 +33,23 @@ export const pullCommand = new Command()
         process.exit(1);
       }
 
-      console.log(chalk.cyan(`Pulling volume: ${config.name}`));
+      if (versionId) {
+        console.log(
+          chalk.cyan(`Pulling volume: ${config.name} (version: ${versionId})`),
+        );
+      } else {
+        console.log(chalk.cyan(`Pulling volume: ${config.name}`));
+      }
 
       // Download from API
       console.log(chalk.gray("Downloading..."));
 
-      const response = await apiClient.get(
-        `/api/storages?name=${encodeURIComponent(config.name)}`,
-      );
+      let url = `/api/storages?name=${encodeURIComponent(config.name)}`;
+      if (versionId) {
+        url += `&version=${encodeURIComponent(versionId)}`;
+      }
+
+      const response = await apiClient.get(url);
 
       if (!response.ok) {
         if (response.status === 404) {


### PR DESCRIPTION
## Summary

- Add optional `[versionId]` argument to `vm0 volume pull` and `vm0 artifact pull` commands
- Update API endpoint to support `version` query parameter
- When version is specified, pull that specific version; otherwise pull latest (HEAD)
- Add security check to ensure version belongs to the requested storage

## Usage

```bash
# Pull latest (current behavior, unchanged)
vm0 volume pull
vm0 artifact pull

# Pull specific version
vm0 volume pull 550e8400-e29b-41d4-a716-446655440000
vm0 artifact pull 550e8400-e29b-41d4-a716-446655440000
```

## Test plan

- [x] CLI tests pass
- [x] Web type checking passes
- [x] Linting passes
- [ ] Manual testing with real volume/artifact versions

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)