### PR TITLE
test(e2e): add e2e tests for vm0 artifact commands

### DIFF
--- a/e2e/tests/02-commands/t03-artifacts.bats
+++ b/e2e/tests/02-commands/t03-artifacts.bats
@@ -1,0 +1,194 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+
+setup() {
+    # Create temporary test directory
+    export TEST_ARTIFACT_DIR="$(mktemp -d)"
+    # Use unique test artifact name with timestamp to avoid conflicts
+    export ARTIFACT_NAME="e2e-test-artifact-$(date +%s)"
+}
+
+teardown() {
+    # Clean up temporary directory
+    if [ -n "$TEST_ARTIFACT_DIR" ] && [ -d "$TEST_ARTIFACT_DIR" ]; then
+        rm -rf "$TEST_ARTIFACT_DIR"
+    fi
+}
+
+@test "Initialize artifact in directory" {
+    mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+
+    run $CLI_COMMAND artifact init
+    assert_success
+    assert_output --partial "$ARTIFACT_NAME"
+
+    # Verify .vm0/storage.yaml file is created with type: artifact
+    [ -f ".vm0/storage.yaml" ]
+    run cat .vm0/storage.yaml
+    assert_output --partial "type: artifact"
+}
+
+@test "Initialize artifact with auto-detected name" {
+    mkdir -p "$TEST_ARTIFACT_DIR/my-project"
+    cd "$TEST_ARTIFACT_DIR/my-project"
+    run $CLI_COMMAND artifact init
+    assert_success
+    assert_output --partial "my-project"
+}
+
+@test "artifact init rejects invalid artifact name" {
+    mkdir -p "$TEST_ARTIFACT_DIR/INVALID_NAME"
+    cd "$TEST_ARTIFACT_DIR/INVALID_NAME"
+
+    run $CLI_COMMAND artifact init
+    assert_failure
+    assert_output --partial "Invalid artifact name"
+}
+
+@test "Push artifact to cloud and returns versionId" {
+    mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+
+    echo "Hello from E2E test" > test-file.txt
+    mkdir -p src
+    echo "console.log('hello')" > src/index.js
+
+    run $CLI_COMMAND artifact push
+    assert_success
+    assert_output --partial "Uploading"
+    assert_output --partial "$ARTIFACT_NAME"
+    # Verify versionId is returned (UUID format)
+    assert_output --partial "Version:"
+    assert_output --regexp "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+}
+
+@test "Multiple pushes create different versions" {
+    mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+
+    # First push
+    echo "version 1" > data.txt
+    run $CLI_COMMAND artifact push
+    assert_success
+    VERSION1=$(echo "$output" | grep -oP 'Version: \K[0-9a-f-]+')
+
+    # Second push with different content
+    echo "version 2" > data.txt
+    run $CLI_COMMAND artifact push
+    assert_success
+    VERSION2=$(echo "$output" | grep -oP 'Version: \K[0-9a-f-]+')
+
+    # Versions should be different
+    [ "$VERSION1" != "$VERSION2" ]
+}
+
+@test "Pull artifact from cloud gets HEAD version" {
+    # First push multiple versions
+    mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+
+    echo "version 1" > data.txt
+    $CLI_COMMAND artifact push >/dev/null
+
+    echo "version 2" > data.txt
+    $CLI_COMMAND artifact push >/dev/null
+
+    echo "version 3 - HEAD" > data.txt
+    mkdir -p subdir
+    echo "nested file" > subdir/nested.txt
+    $CLI_COMMAND artifact push >/dev/null
+
+    # Pull in a different directory
+    NEW_DIR="$(mktemp -d)"
+    cd "$NEW_DIR"
+    mkdir -p .vm0
+    cat > .vm0/storage.yaml <<EOF
+name: $ARTIFACT_NAME
+type: artifact
+EOF
+
+    run $CLI_COMMAND artifact pull
+    assert_success
+    assert_output --partial "Downloading"
+
+    # Verify we got HEAD version (version 3)
+    [ -f "data.txt" ]
+    [ -f "subdir/nested.txt" ]
+    run cat data.txt
+    assert_output "version 3 - HEAD"
+
+    rm -rf "$NEW_DIR"
+}
+
+@test "Pull specific version by versionId" {
+    # Push multiple versions and capture their IDs
+    mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+
+    # Push version 1
+    echo "content from version 1" > data.txt
+    run $CLI_COMMAND artifact push
+    assert_success
+    VERSION1=$(echo "$output" | grep -oP 'Version: \K[0-9a-f-]+')
+
+    # Push version 2
+    echo "content from version 2" > data.txt
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    # Push version 3 (HEAD)
+    echo "content from version 3 - HEAD" > data.txt
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    # Pull version 1 specifically (not HEAD)
+    NEW_DIR="$(mktemp -d)"
+    cd "$NEW_DIR"
+    mkdir -p .vm0
+    cat > .vm0/storage.yaml <<EOF
+name: $ARTIFACT_NAME
+type: artifact
+EOF
+
+    run $CLI_COMMAND artifact pull "$VERSION1"
+    assert_success
+    assert_output --partial "version: $VERSION1"
+
+    # Verify we got version 1 content (not HEAD)
+    [ -f "data.txt" ]
+    run cat data.txt
+    assert_output "content from version 1"
+
+    rm -rf "$NEW_DIR"
+}
+
+@test "Pull non-existent version fails with error" {
+    mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+
+    echo "some content" > data.txt
+    $CLI_COMMAND artifact push >/dev/null
+
+    # Try to pull a non-existent version
+    NEW_DIR="$(mktemp -d)"
+    cd "$NEW_DIR"
+    mkdir -p .vm0
+    cat > .vm0/storage.yaml <<EOF
+name: $ARTIFACT_NAME
+type: artifact
+EOF
+
+    FAKE_VERSION="00000000-0000-0000-0000-000000000000"
+    run $CLI_COMMAND artifact pull "$FAKE_VERSION"
+    assert_failure
+    assert_output --partial "not found"
+
+    rm -rf "$NEW_DIR"
+}


### PR DESCRIPTION
## Summary

Add dedicated e2e test file for `vm0 artifact` CLI commands, matching the existing test coverage for `vm0 volume` commands.

## Test Cases

| # | Test | Description |
|---|------|-------------|
| 1 | Initialize artifact in directory | `vm0 artifact init` creates `.vm0/storage.yaml` with `type: artifact` |
| 2 | Initialize artifact with auto-detected name | Uses directory name as artifact name |
| 3 | artifact init rejects invalid artifact name | Invalid names (uppercase, special chars) are rejected |
| 4 | Push artifact to cloud and returns versionId | Successful push returns UUID versionId |
| 5 | Multiple pushes create different versions | Each push creates a new unique version |
| 6 | Pull artifact from cloud gets HEAD version | Default pull gets latest version |
| 7 | Pull specific version by versionId | Can pull older versions by specifying versionId |
| 8 | Pull non-existent version fails with error | Returns "not found" error for invalid versionId |

## Test plan

- [ ] All 8 test cases pass in CI e2e pipeline

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)