### PR TITLE
chore: remove unused CI_GITHUB_TOKEN references

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -297,5 +297,4 @@ jobs:
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
           USE_MOCK_CLAUDE: "true"

--- a/e2e/.env.local.tpl
+++ b/e2e/.env.local.tpl
@@ -2,6 +2,3 @@
 # Use 1Password CLI to inject secrets: npm run sync:env
 CLERK_PUBLISHABLE_KEY=op://Development/vm0-env-local/clerk_publishable_key
 CLERK_SECRET_KEY=op://Development/vm0-env-local/clerk_secret_key
-
-# GitHub token for git volume tests
-CI_GITHUB_TOKEN=op://Development/vm0-env-local/ci_github_token


### PR DESCRIPTION
## Summary
- Remove `CI_GITHUB_TOKEN` from `.github/workflows/turbo.yml` (e2e test env)
- Remove `CI_GITHUB_TOKEN` from `e2e/.env.local.tpl` (local env template)

This token was previously used for git volume tests, which are no longer needed after removing git driver support in #230.

## Test plan
- [ ] Verify CI workflow passes without this token
- [ ] Confirm no e2e tests depend on this environment variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)