### PR TITLE
fix(docs): correct ci badge url from .yaml to .yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 ![NPM Type Definitions](https://img.shields.io/npm/types/@vm0/cli)
 ![NPM Version](https://img.shields.io/npm/v/@vm0/cli)
 ![npm package minimized gzipped size](https://img.shields.io/bundlejs/size/@vm0/cli)
-[![CI](https://github.com/vm0-ai/vm0/actions/workflows/turbo.yaml/badge.svg)](https://github.com/vm0-ai/vm0/actions/workflows/turbo.yaml)
+[![CI](https://github.com/vm0-ai/vm0/actions/workflows/turbo.yml/badge.svg)](https://github.com/vm0-ai/vm0/actions/workflows/turbo.yml)
 
 The modern runtime for agent-native development. Infrastructure for AI agents, not workflows. VM0's built-in sandbox gives you everything you need to design, run, and iterate on modern agents.


### PR DESCRIPTION
## Summary
- Fix CI badge URL in README.md from `.yaml` to `.yml` extension
- The workflow file is actually named `turbo.yml`, not `turbo.yaml`

## Test plan
- [x] Badge URL now points to correct workflow file

🤖 Generated with [Claude Code](https://claude.com/claude-code)