### PR TITLE
fix(docs): correct dev server url to include port 8443

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ To run the web application locally with HTTPS:
    ```
 
 4. **Access the application**:
-   Open https://vm7.ai in your browser.
+   Open https://vm7.ai:8443/ in your browser.
 
 ## Pull Request Process
 


### PR DESCRIPTION
## Summary
- Fix dev server URL in CONTRIBUTING.md from `https://vm7.ai` to `https://vm7.ai:8443/`

## Test plan
- [x] URL corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)