### PR TITLE
chore: upgrade vercel cli to 48.11.0

### DIFF
--- a/.docker/toolchain/Dockerfile
+++ b/.docker/toolchain/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -sL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-am
     && chmod +x /usr/local/bin/jq
 
 # Install global npm packages for CI/CD
-RUN npm install -g pnpm@10.15.0 lefthook@1.12.3 vercel@46.1.1 neonctl@2.15.0
+RUN npm install -g pnpm@10.15.0 lefthook@1.12.3 vercel@48.11.0 neonctl@2.15.0
 
 # Install Playwright system dependencies for Chromium
 # This is needed for e2e tests in CI


### PR DESCRIPTION
## Summary
- Upgrade Vercel CLI from 46.1.1 to 48.11.0 in the Docker toolchain

## Test plan
- [ ] CI Docker build completes successfully
- [ ] New `ghcr.io/vm0-ai/vm0-dev` image is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)