### PR TITLE
fix: reset neon preview branches to sync with main before migrations

### DIFF
--- a/.github/actions/neon-branch/action.yml
+++ b/.github/actions/neon-branch/action.yml
@@ -58,8 +58,11 @@ runs:
 
         if neonctl branches list --project-id $NEON_PROJECT_ID --output json | jq -e ".[] | select(.name == \"$BRANCH_NAME\")" > /dev/null 2>&1; then
           echo "Branch $BRANCH_NAME already exists"
+          echo "Resetting branch to sync with parent (main)..."
+          neonctl branches reset $BRANCH_NAME --project-id $NEON_PROJECT_ID --parent
+          echo "Branch reset complete"
         else
-          echo "Create branch $BRANCH_NAME"
+          echo "Creating branch $BRANCH_NAME"
           neonctl branches create --name $BRANCH_NAME --project-id $NEON_PROJECT_ID
         fi
 
@@ -87,7 +90,9 @@ runs:
       run: |
         if [ -n "$DATABASE_URL" ]; then
           echo "Running database migrations..."
-          cd turbo && pnpm -F web db:migrate
+          echo "Migration output:"
+          cd turbo && pnpm -F web db:migrate 2>&1
+          echo "Migration complete"
         else
           echo "No database URL provided, skipping migrations"
         fi


### PR DESCRIPTION
## Summary

- Reset existing Neon preview branches to sync with main before running migrations
- Use `neonctl branches reset --parent` to ensure branches have latest schema from main
- Add improved migration logging for better visibility

## Problem

When a PR adds new database migrations, the Neon preview branch may not have the new table/schema because:
1. The branch was created from `main` at an earlier point in time
2. Subsequent CI runs find the branch already exists (no recreation)
3. Migrations fail silently because branch schema is stale

## Solution

Use `neonctl branches reset <branch> --parent` to sync existing preview branches with main before running migrations. This ensures new migrations in the PR can apply correctly on top of main's schema.

## Test plan

- [ ] Verify CI pipeline passes on this PR
- [ ] Test with a PR that adds a new migration to confirm branch reset works

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)