### PR TITLE
fix(web): make landing page cube respond to window-wide mouse movement

### DIFF
--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -72,25 +72,15 @@ export default function LandingPage() {
       };
 
       const handlePointerMove = (event: PointerEvent) => {
-        const rect = sandboxContainer.getBoundingClientRect();
-        const x = (event.clientX - rect.left) / rect.width;
-        const y = (event.clientY - rect.top) / rect.height;
-        const clampedX = Math.max(0, Math.min(1, x)) - 0.5;
-        const clampedY = Math.max(0, Math.min(1, y)) - 0.5;
-        setTilt(clampedX * 2, clampedY * 2);
+        const x = event.clientX / window.innerWidth - 0.5;
+        const y = event.clientY / window.innerHeight - 0.5;
+        setTilt(x * 2, y * 2);
       };
 
-      const resetTilt = () => {
-        sandboxContainer.style.setProperty("--tiltX", "0deg");
-        sandboxContainer.style.setProperty("--tiltY", "0deg");
-      };
-
-      sandboxContainer.addEventListener("pointermove", handlePointerMove);
-      sandboxContainer.addEventListener("pointerleave", resetTilt);
+      window.addEventListener("pointermove", handlePointerMove);
 
       return () => {
-        sandboxContainer.removeEventListener("pointermove", handlePointerMove);
-        sandboxContainer.removeEventListener("pointerleave", resetTilt);
+        window.removeEventListener("pointermove", handlePointerMove);
       };
     }
 


### PR DESCRIPTION
## Summary
- Change cube tilt effect to respond to mouse movement across the entire window
- Previously only responded within the sandbox container area, causing jumpy behavior

## Test plan
- [x] Move mouse across the window and verify cube tilts smoothly
- [x] No more jumping when cursor crosses container boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)