### PR TITLE
chore: update devcontainer image to b9e1383

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:f3e500a",
+  "image": "ghcr.io/vm0-ai/vm0-dev:b9e1383",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"


### PR DESCRIPTION
## Summary
- Update devcontainer to use new Docker image with Vercel CLI 48.11.0

## Test plan
- [ ] Rebuild devcontainer uses new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)