### PR TITLE
fix(cli): add repository field for npm provenance verification

### DIFF
--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -3,6 +3,11 @@
   "version": "1.8.0",
   "private": true,
   "description": "CLI application",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vm0-ai/vm0",
+    "directory": "turbo/apps/cli"
+  },
   "type": "module",
   "bin": {
     "vm0": "./dist/index.js"


### PR DESCRIPTION
## Summary
- Add `repository` field to CLI `package.json` to fix npm publish provenance verification failure

## Root Cause
The npm publish job in release-please workflow was failing with error:
```
Error verifying sigstore provenance bundle: Failed to validate repository information: 
package.json: "repository.url" is "", expected to match "https://github.com/vm0-ai/vm0" from provenance
```

This was blocking CLI v1.8.0 from being published to npm (current published version is v1.6.0).

## Test plan
- [ ] Verify PR CI passes
- [ ] After merge, verify release-please creates a new release
- [ ] Verify publish-npm job succeeds and new version is available on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)