### PR TITLE
fix(web): capitalize 'Code' in 'Claude Code' on landing page

### DIFF
--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -365,7 +365,7 @@ export default function LandingPage() {
                     className="cli-icon-img"
                   />
                 </div>
-                <h3 className="cli-tool-name">Claude code</h3>
+                <h3 className="cli-tool-name">Claude Code</h3>
               </div>
               <div className="cli-tool-item">
                 <div className="cli-icon-wrapper">


### PR DESCRIPTION
## Summary
- Fix capitalization: "Claude code" → "Claude Code"

## Test plan
- [x] Verify text is correctly capitalized

🤖 Generated with [Claude Code](https://claude.com/claude-code)