### PR TITLE
feat(cli): increase default timeout from 60 to 120 seconds

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/run.test.ts
@@ -596,7 +596,7 @@ describe("run command", () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it("should use default timeout (60 seconds) when not specified", async () => {
+    it("should use default timeout (120 seconds) when not specified", async () => {
       await runCommand.parseAsync([
         "node",
         "cli",

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -22,7 +22,7 @@ function isUUID(str: string): boolean {
   return /^[0-9a-f-]{36}$/i.test(str);
 }
 
-const DEFAULT_TIMEOUT_SECONDS = 60;
+const DEFAULT_TIMEOUT_SECONDS = 120;
 
 async function pollEvents(
   runId: string,
@@ -95,7 +95,7 @@ const runCmd = new Command()
   )
   .option(
     "-t, --timeout <seconds>",
-    "Polling timeout in seconds (default: 60)",
+    "Polling timeout in seconds (default: 120)",
     String(DEFAULT_TIMEOUT_SECONDS),
   )
   .action(
@@ -220,7 +220,7 @@ runCmd
   .argument("<prompt>", "Prompt for the resumed agent")
   .option(
     "-t, --timeout <seconds>",
-    "Polling timeout in seconds (default: 60)",
+    "Polling timeout in seconds (default: 120)",
     String(DEFAULT_TIMEOUT_SECONDS),
   )
   .action(
@@ -292,7 +292,7 @@ runCmd
   .argument("<prompt>", "Prompt for the continued agent")
   .option(
     "-t, --timeout <seconds>",
-    "Polling timeout in seconds (default: 60)",
+    "Polling timeout in seconds (default: 120)",
     String(DEFAULT_TIMEOUT_SECONDS),
   )
   .action(


### PR DESCRIPTION
## Summary
- Increase the default polling timeout for agent execution from 1 minute to 2 minutes
- Update help text documentation to reflect the new default value
- Update test description to match the new default

## Test plan
- [x] CLI lint passes
- [x] CLI type check passes
- [x] CLI tests pass (215 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)