### PR TITLE
fix(cli): read version from package.json instead of hardcoded value

### DIFF
--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -10,10 +10,12 @@ import { artifactCommand } from "./commands/artifact";
 
 const program = new Command();
 
+declare const __CLI_VERSION__: string;
+
 program
   .name("vm0")
   .description("VM0 CLI - A modern build tool")
-  .version("0.1.0");
+  .version(__CLI_VERSION__);
 
 program
   .command("hello")

--- a/turbo/apps/cli/tsup.config.ts
+++ b/turbo/apps/cli/tsup.config.ts
@@ -1,4 +1,9 @@
 import { defineConfig } from "tsup";
+import { readFileSync } from "fs";
+
+const pkg = JSON.parse(readFileSync("./package.json", "utf-8")) as {
+  version: string;
+};
 
 export default defineConfig({
   entry: ["src/index.ts"],
@@ -12,4 +17,8 @@ export default defineConfig({
   },
   // Bundle workspace packages
   noExternal: [/@vm0\/.*/],
+  // Inject version from package.json at build time
+  define: {
+    __CLI_VERSION__: JSON.stringify(pkg.version),
+  },
 });


### PR DESCRIPTION
## Summary
- CLI `--version` was hardcoded to `0.1.0` instead of reading from `package.json`
- Version is now injected at build time via tsup's `define` option
- This ensures the CLI version stays in sync with release-please updates

## Test plan
- [x] Verified `node dist/index.js --version` outputs `1.8.0`
- [x] Lint and type check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)