### PR TITLE
fix: improve sandbox script error handling with retry and unified logging

### DIFF
--- a/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
+++ b/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
@@ -137,8 +137,8 @@ describe("E2B Service - mocked unit tests", () => {
       expect(result.error).toBeUndefined();
 
       // Verify sandbox methods were called
-      // commands.run called: 1 (mkdir) + 6 (mv/chmod for each script) + 1 (execute) = 8 times
-      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(8);
+      // commands.run called: 1 (mkdir) + 8 (mv/chmod for each script) + 1 (execute) = 10 times
+      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(10);
       expect(mockSandbox.kill).toHaveBeenCalledTimes(1);
     });
 
@@ -188,9 +188,9 @@ describe("E2B Service - mocked unit tests", () => {
 
       // Verify both sandboxes were created and cleaned up
       expect(Sandbox.create).toHaveBeenCalledTimes(2);
-      // Each sandbox: 1 (mkdir) + 6 (mv/chmod for each script) + 1 (execute) = 8 times
-      expect(mockSandbox1.commands.run).toHaveBeenCalledTimes(8);
-      expect(mockSandbox2.commands.run).toHaveBeenCalledTimes(8);
+      // Each sandbox: 1 (mkdir) + 8 (mv/chmod for each script) + 1 (execute) = 10 times
+      expect(mockSandbox1.commands.run).toHaveBeenCalledTimes(10);
+      expect(mockSandbox2.commands.run).toHaveBeenCalledTimes(10);
       expect(mockSandbox1.kill).toHaveBeenCalledTimes(1);
       expect(mockSandbox2.kill).toHaveBeenCalledTimes(1);
     });
@@ -220,8 +220,8 @@ describe("E2B Service - mocked unit tests", () => {
 
       // Verify sandbox was created and cleaned up
       expect(Sandbox.create).toHaveBeenCalledTimes(1);
-      // 1 (mkdir) + 6 (mv/chmod for each script) + 1 (execute) = 8 times
-      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(8);
+      // 1 (mkdir) + 8 (mv/chmod for each script) + 1 (execute) = 10 times
+      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(10);
       expect(mockSandbox.kill).toHaveBeenCalledTimes(1);
     });
 
@@ -254,8 +254,8 @@ describe("E2B Service - mocked unit tests", () => {
 
       // Verify sandbox was created and cleaned up
       expect(Sandbox.create).toHaveBeenCalledTimes(1);
-      // 1 (mkdir) + 6 (mv/chmod for each script) + 1 (execute) = 8 times
-      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(8);
+      // 1 (mkdir) + 8 (mv/chmod for each script) + 1 (execute) = 10 times
+      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(10);
       expect(mockSandbox.kill).toHaveBeenCalledTimes(1);
     });
 

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -11,6 +11,8 @@ import type {
 import type { AgentConfigYaml } from "../../types/agent-config";
 import {
   COMMON_SCRIPT,
+  LOG_SCRIPT,
+  REQUEST_SCRIPT,
   SEND_EVENT_SCRIPT,
   VAS_SNAPSHOT_SCRIPT,
   CREATE_CHECKPOINT_SCRIPT,
@@ -365,6 +367,8 @@ export class E2BService {
     // Define scripts to upload
     const scripts: Array<{ content: string; path: string }> = [
       { content: COMMON_SCRIPT, path: SCRIPT_PATHS.common },
+      { content: LOG_SCRIPT, path: SCRIPT_PATHS.log },
+      { content: REQUEST_SCRIPT, path: SCRIPT_PATHS.request },
       { content: SEND_EVENT_SCRIPT, path: SCRIPT_PATHS.sendEvent },
       { content: VAS_SNAPSHOT_SCRIPT, path: SCRIPT_PATHS.vasSnapshot },
       {

--- a/turbo/apps/web/src/lib/e2b/scripts/common.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/common.ts
@@ -28,4 +28,13 @@ STORAGE_WEBHOOK_URL="\${API_URL}/api/webhooks/agent/storages"
 # Variables for checkpoint (use temp files to persist across subshells)
 SESSION_ID_FILE="/tmp/vm0-session-$RUN_ID.txt"
 SESSION_HISTORY_PATH_FILE="/tmp/vm0-session-history-$RUN_ID.txt"
+
+# HTTP request configuration
+HTTP_CONNECT_TIMEOUT=10
+HTTP_MAX_TIME=30
+HTTP_MAX_TIME_UPLOAD=60
+HTTP_MAX_RETRIES=3
+
+# Event error flag file - used to track if any events failed to send
+EVENT_ERROR_FLAG="/tmp/vm0-event-error-$RUN_ID"
 `;

--- a/turbo/apps/web/src/lib/e2b/scripts/create-checkpoint.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/create-checkpoint.ts
@@ -3,71 +3,71 @@
  * Creates checkpoints with conversation history and artifact snapshot (VAS only)
  */
 export const CREATE_CHECKPOINT_SCRIPT = `# Create checkpoint after successful run
-# Requires: COMMON_SCRIPT, VAS_SNAPSHOT_SCRIPT to be sourced first
+# Requires: COMMON_SCRIPT, LOG_SCRIPT, REQUEST_SCRIPT, VAS_SNAPSHOT_SCRIPT to be sourced first
 
 create_checkpoint() {
-  echo "[VM0] Creating checkpoint..." >&2
+  log_info "Creating checkpoint..."
 
   # Read session ID from temp file
   if [ ! -f "$SESSION_ID_FILE" ]; then
-    echo "[ERROR] No session ID found, checkpoint creation failed" >&2
+    log_error "No session ID found, checkpoint creation failed"
     return 1
   fi
   local CLI_AGENT_SESSION_ID=$(cat "$SESSION_ID_FILE")
 
   # Read session history path from temp file
   if [ ! -f "$SESSION_HISTORY_PATH_FILE" ]; then
-    echo "[ERROR] No session history path found, checkpoint creation failed" >&2
+    log_error "No session history path found, checkpoint creation failed"
     return 1
   fi
   local SESSION_HISTORY_PATH=$(cat "$SESSION_HISTORY_PATH_FILE")
 
   # Check if session history file exists
   if [ ! -f "$SESSION_HISTORY_PATH" ]; then
-    echo "[ERROR] Session history file not found at $SESSION_HISTORY_PATH, checkpoint creation failed" >&2
+    log_error "Session history file not found at $SESSION_HISTORY_PATH, checkpoint creation failed"
     return 1
   fi
 
   # Read session history
   CLI_AGENT_SESSION_HISTORY=$(cat "$SESSION_HISTORY_PATH" 2>/dev/null || echo "")
   if [ -z "$CLI_AGENT_SESSION_HISTORY" ]; then
-    echo "[ERROR] Session history is empty, checkpoint creation failed" >&2
+    log_error "Session history is empty, checkpoint creation failed"
     return 1
   fi
 
-  echo "[VM0] Session history loaded ($(echo "$CLI_AGENT_SESSION_HISTORY" | wc -l) lines)" >&2
+  log_info "Session history loaded ($(echo "$CLI_AGENT_SESSION_HISTORY" | wc -l) lines)"
 
   # CLI agent type (default to claude-code)
   local CLI_AGENT_TYPE="\${CLI_AGENT_TYPE:-claude-code}"
 
   # Create artifact snapshot (VAS only, required)
   if [ -z "$ARTIFACT_DRIVER" ] || [ -z "$ARTIFACT_VOLUME_NAME" ]; then
-    echo "[ERROR] Artifact is required but not configured" >&2
+    log_error "Artifact is required but not configured"
     return 1
   fi
 
-  echo "[VM0] Processing artifact with driver: $ARTIFACT_DRIVER" >&2
+  log_info "Processing artifact with driver: $ARTIFACT_DRIVER"
 
   if [ "$ARTIFACT_DRIVER" != "vas" ]; then
-    echo "[ERROR] Unknown artifact driver: $ARTIFACT_DRIVER (only 'vas' is supported)" >&2
+    log_error "Unknown artifact driver: $ARTIFACT_DRIVER (only 'vas' is supported)"
     return 1
   fi
 
   # VAS artifact: create vas snapshot
-  echo "[VM0] Creating VAS snapshot for artifact '$ARTIFACT_VOLUME_NAME' at $ARTIFACT_MOUNT_PATH" >&2
+  log_info "Creating VAS snapshot for artifact '$ARTIFACT_VOLUME_NAME' at $ARTIFACT_MOUNT_PATH"
 
   # Create VAS snapshot
   SNAPSHOT=$(create_vas_snapshot "$ARTIFACT_MOUNT_PATH" "artifact" "$ARTIFACT_VOLUME_NAME")
 
   if [ $? -ne 0 ] || [ -z "$SNAPSHOT" ]; then
-    echo "[ERROR] Failed to create VAS snapshot for artifact" >&2
+    log_error "Failed to create VAS snapshot for artifact"
     return 1
   fi
 
   # Extract versionId from snapshot response
   local ARTIFACT_VERSION=$(echo "$SNAPSHOT" | jq -r '.versionId // empty')
   if [ -z "$ARTIFACT_VERSION" ]; then
-    echo "[ERROR] Failed to extract versionId from snapshot" >&2
+    log_error "Failed to extract versionId from snapshot"
     return 1
   fi
 
@@ -77,9 +77,9 @@ create_checkpoint() {
     --arg artifactVersion "$ARTIFACT_VERSION" \\
     '{artifactName: $artifactName, artifactVersion: $artifactVersion}')
 
-  echo "[VM0] VAS artifact snapshot created: $ARTIFACT_VOLUME_NAME@$ARTIFACT_VERSION" >&2
+  log_info "VAS artifact snapshot created: $ARTIFACT_VOLUME_NAME@$ARTIFACT_VERSION"
 
-  echo "[VM0] Calling checkpoint API..." >&2
+  log_info "Calling checkpoint API..."
 
   # Build checkpoint payload with new schema
   local checkpoint_payload=$(jq -n \\
@@ -96,36 +96,13 @@ create_checkpoint() {
       artifactSnapshot: $artifactSnapshot
     }')
 
-  # Call checkpoint API directly (avoid eval) with timeout to prevent hanging
-  if [ -n "$VERCEL_BYPASS" ]; then
-    if curl -X POST "$CHECKPOINT_URL" \\
-      -H "Content-Type: application/json" \\
-      -H "Authorization: Bearer $API_TOKEN" \\
-      -H "x-vercel-protection-bypass: $VERCEL_BYPASS" \\
-      -d "$checkpoint_payload" \\
-      --connect-timeout 10 \\
-      --max-time 60 \\
-      --silent --fail; then
-      echo "[VM0] Checkpoint created successfully" >&2
-      return 0
-    else
-      echo "[ERROR] Failed to create checkpoint" >&2
-      return 1
-    fi
+  # Call checkpoint API using unified HTTP request function
+  if http_post_json "$CHECKPOINT_URL" "$checkpoint_payload" >/dev/null; then
+    log_info "Checkpoint created successfully"
+    return 0
   else
-    if curl -X POST "$CHECKPOINT_URL" \\
-      -H "Content-Type: application/json" \\
-      -H "Authorization: Bearer $API_TOKEN" \\
-      -d "$checkpoint_payload" \\
-      --connect-timeout 10 \\
-      --max-time 60 \\
-      --silent --fail; then
-      echo "[VM0] Checkpoint created successfully" >&2
-      return 0
-    else
-      echo "[ERROR] Failed to create checkpoint" >&2
-      return 1
-    fi
+    log_error "Failed to create checkpoint"
+    return 1
   fi
 }
 `;

--- a/turbo/apps/web/src/lib/e2b/scripts/index.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/index.ts
@@ -3,6 +3,8 @@
  * Re-exports all script constants for use by e2b-service
  */
 export { COMMON_SCRIPT } from "./common";
+export { LOG_SCRIPT } from "./log";
+export { REQUEST_SCRIPT } from "./request";
 export { SEND_EVENT_SCRIPT } from "./send-event";
 export { VAS_SNAPSHOT_SCRIPT } from "./vas-snapshot";
 export { CREATE_CHECKPOINT_SCRIPT } from "./create-checkpoint";
@@ -17,6 +19,8 @@ export const SCRIPT_PATHS = {
   libDir: "/usr/local/bin/vm0-agent/lib",
   runAgent: "/usr/local/bin/vm0-agent/run-agent.sh",
   common: "/usr/local/bin/vm0-agent/lib/common.sh",
+  log: "/usr/local/bin/vm0-agent/lib/log.sh",
+  request: "/usr/local/bin/vm0-agent/lib/request.sh",
   sendEvent: "/usr/local/bin/vm0-agent/lib/send-event.sh",
   vasSnapshot: "/usr/local/bin/vm0-agent/lib/vas-snapshot.sh",
   createCheckpoint: "/usr/local/bin/vm0-agent/lib/create-checkpoint.sh",

--- a/turbo/apps/web/src/lib/e2b/scripts/log.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/log.ts
@@ -1,0 +1,25 @@
+/**
+ * Unified logging functions for agent scripts
+ * Provides consistent log format across all sandbox scripts
+ */
+export const LOG_SCRIPT = `# Unified logging functions
+# Format: [VM0][LEVEL] message
+
+log_info() {
+  echo "[VM0][INFO] $*" >&2
+}
+
+log_warn() {
+  echo "[VM0][WARN] $*" >&2
+}
+
+log_error() {
+  echo "[VM0][ERROR] $*" >&2
+}
+
+log_debug() {
+  if [ "$VM0_DEBUG" = "1" ]; then
+    echo "[VM0][DEBUG] $*" >&2
+  fi
+}
+`;

--- a/turbo/apps/web/src/lib/e2b/scripts/request.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/request.ts
@@ -1,0 +1,114 @@
+/**
+ * Unified HTTP request functions for agent scripts
+ * Provides curl wrapper with retry logic and Vercel bypass support
+ */
+export const REQUEST_SCRIPT = `# Unified HTTP request functions
+# Requires: LOG_SCRIPT to be sourced first
+
+# HTTP POST with JSON body and retry logic
+# Usage: http_post_json <url> <json_data> [max_retries]
+# Returns: 0 on success, 1 on failure
+# Outputs: Response body on stdout
+http_post_json() {
+  local url="$1"
+  local data="$2"
+  local max_retries="\${3:-$HTTP_MAX_RETRIES}"
+  local attempt=1
+  local response
+  local curl_exit
+
+  while [ $attempt -le $max_retries ]; do
+    log_debug "HTTP POST attempt $attempt/$max_retries to $url"
+
+    if [ -n "$VERCEL_BYPASS" ]; then
+      response=$(curl -X POST "$url" \\
+        -H "Content-Type: application/json" \\
+        -H "Authorization: Bearer $API_TOKEN" \\
+        -H "x-vercel-protection-bypass: $VERCEL_BYPASS" \\
+        -d "$data" \\
+        --connect-timeout "$HTTP_CONNECT_TIMEOUT" \\
+        --max-time "$HTTP_MAX_TIME" \\
+        --silent --fail 2>&1)
+      curl_exit=$?
+    else
+      response=$(curl -X POST "$url" \\
+        -H "Content-Type: application/json" \\
+        -H "Authorization: Bearer $API_TOKEN" \\
+        -d "$data" \\
+        --connect-timeout "$HTTP_CONNECT_TIMEOUT" \\
+        --max-time "$HTTP_MAX_TIME" \\
+        --silent --fail 2>&1)
+      curl_exit=$?
+    fi
+
+    if [ $curl_exit -eq 0 ]; then
+      echo "$response"
+      return 0
+    fi
+
+    log_warn "HTTP POST failed (attempt $attempt/$max_retries): exit code $curl_exit"
+
+    if [ $attempt -lt $max_retries ]; then
+      sleep 1
+    fi
+
+    attempt=$((attempt + 1))
+  done
+
+  log_error "HTTP POST failed after $max_retries attempts to $url"
+  return 1
+}
+
+# HTTP POST with form data and retry logic
+# Usage: http_post_form <url> [max_retries] -F "field=value" ...
+# Returns: 0 on success, 1 on failure
+# Outputs: Response body on stdout
+http_post_form() {
+  local url="$1"
+  local max_retries="\${2:-$HTTP_MAX_RETRIES}"
+  shift 2
+
+  local attempt=1
+  local response
+  local curl_exit
+
+  while [ $attempt -le $max_retries ]; do
+    log_debug "HTTP POST form attempt $attempt/$max_retries to $url"
+
+    if [ -n "$VERCEL_BYPASS" ]; then
+      response=$(curl -X POST "$url" \\
+        -H "Authorization: Bearer $API_TOKEN" \\
+        -H "x-vercel-protection-bypass: $VERCEL_BYPASS" \\
+        "$@" \\
+        --connect-timeout "$HTTP_CONNECT_TIMEOUT" \\
+        --max-time "$HTTP_MAX_TIME_UPLOAD" \\
+        --silent 2>&1)
+      curl_exit=$?
+    else
+      response=$(curl -X POST "$url" \\
+        -H "Authorization: Bearer $API_TOKEN" \\
+        "$@" \\
+        --connect-timeout "$HTTP_CONNECT_TIMEOUT" \\
+        --max-time "$HTTP_MAX_TIME_UPLOAD" \\
+        --silent 2>&1)
+      curl_exit=$?
+    fi
+
+    if [ $curl_exit -eq 0 ]; then
+      echo "$response"
+      return 0
+    fi
+
+    log_warn "HTTP POST form failed (attempt $attempt/$max_retries): exit code $curl_exit"
+
+    if [ $attempt -lt $max_retries ]; then
+      sleep 1
+    fi
+
+    attempt=$((attempt + 1))
+  done
+
+  log_error "HTTP POST form failed after $max_retries attempts to $url"
+  return 1
+}
+`;


### PR DESCRIPTION
## Summary

- Add unified logging functions with `[VM0][LEVEL]` format for consistent log output
- Add HTTP request functions with configurable retry logic and Vercel bypass support
- Refactor `send_event()` to return error codes and set error flag on failure
- Update `run-agent.sh` to check error flag and fail properly when events can't be sent
- This prevents the CLI from timing out waiting for events that were never sent due to silent failures

## Root Cause

The flaky E2E test `VM0 agent session: session persists across runs with same config and artifact` was failing because `send_event()` in sandbox scripts failed silently (only printed error message), causing the CLI to timeout waiting for events that were never sent.

## Changes

### New Scripts
- `log.ts` - Unified logging functions (`log_info`, `log_warn`, `log_error`, `log_debug`)
- `request.ts` - HTTP request functions with retry (`http_post_json`, `http_post_form`)

### Modified Scripts
- `send-event.ts` - Use `http_post_json`, return error codes, set `EVENT_ERROR_FLAG`
- `vas-snapshot.ts` - Use `http_post_form` with retry
- `create-checkpoint.ts` - Use `http_post_json` with retry
- `common.ts` - Add HTTP config constants and error flag path
- `run-agent.ts` - Check `EVENT_ERROR_FLAG` before exit
- `index.ts` - Export new scripts
- `e2b-service.ts` - Upload new scripts to sandbox

## Test Plan

- [x] All unit tests pass (156 passed)
- [x] Type checking passes
- [x] Linting passes
- [ ] E2E tests pass in CI

Fixes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)