### PR TITLE
feat(web): add structured logging system

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -206,6 +206,7 @@ jobs:
             AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
             S3_USER_STORAGES_NAME=${{ secrets.CI_S3_USER_STORAGES_NAME }}
             USE_MOCK_CLAUDE=true
+            DEBUG=*
           meta-branch: ${{ github.head_ref }}
           meta-pr: ${{ github.event.pull_request.number }}
 

--- a/turbo/apps/web/src/lib/__tests__/logger.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { logger, clearLoggerCache } from "../logger";
+
+// Helper to set NODE_ENV (readonly in TypeScript)
+const setNodeEnv = (value: string) => {
+  (process.env as Record<string, string>).NODE_ENV = value;
+};
+
+describe("logger", () => {
+  const originalDebug = process.env.DEBUG;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    clearLoggerCache();
+    // Reset to production-like environment for consistent tests
+    delete process.env.DEBUG;
+    setNodeEnv("production");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env.DEBUG = originalDebug;
+    if (originalNodeEnv) setNodeEnv(originalNodeEnv);
+    vi.restoreAllMocks();
+  });
+
+  describe("logger creation", () => {
+    it("creates a logger with the given name", () => {
+      const log = logger("test:module");
+      expect(log).toBeDefined();
+      expect(log.debug).toBeTypeOf("function");
+      expect(log.info).toBeTypeOf("function");
+      expect(log.warn).toBeTypeOf("function");
+      expect(log.error).toBeTypeOf("function");
+    });
+
+    it("returns cached logger for same name", () => {
+      const log1 = logger("test:module");
+      const log2 = logger("test:module");
+      expect(log1).toBe(log2);
+    });
+
+    it("returns different logger for different name", () => {
+      const log1 = logger("test:module1");
+      const log2 = logger("test:module2");
+      expect(log1).not.toBe(log2);
+    });
+  });
+
+  describe("output format", () => {
+    it("formats output as [LEVEL] [name] message", () => {
+      process.env.DEBUG = "*";
+      clearLoggerCache();
+      const log = logger("service:e2b");
+
+      log.debug("test message");
+      expect(console.log).toHaveBeenCalledWith(
+        "[DEBUG] [service:e2b] test message",
+      );
+
+      log.warn("warning message");
+      expect(console.warn).toHaveBeenCalledWith(
+        "[WARN] [service:e2b] warning message",
+      );
+
+      log.error("error message");
+      expect(console.error).toHaveBeenCalledWith(
+        "[ERROR] [service:e2b] error message",
+      );
+    });
+
+    it("handles multiple arguments", () => {
+      process.env.DEBUG = "*";
+      clearLoggerCache();
+      const log = logger("service:e2b");
+
+      log.debug("message", { id: "123" });
+      expect(console.log).toHaveBeenCalledWith(
+        "[DEBUG] [service:e2b] message",
+        { id: "123" },
+      );
+    });
+
+    it("handles non-string first argument", () => {
+      process.env.DEBUG = "*";
+      clearLoggerCache();
+      const log = logger("service:e2b");
+
+      log.debug({ id: "123" });
+      expect(console.log).toHaveBeenCalledWith("[DEBUG] [service:e2b]", {
+        id: "123",
+      });
+    });
+
+    it("handles no arguments", () => {
+      process.env.DEBUG = "*";
+      clearLoggerCache();
+      const log = logger("service:e2b");
+
+      log.debug();
+      expect(console.log).toHaveBeenCalledWith("[DEBUG] [service:e2b]");
+    });
+  });
+
+  describe("DEBUG environment variable", () => {
+    it("suppresses debug when DEBUG is not set", () => {
+      delete process.env.DEBUG;
+      clearLoggerCache();
+      const log = logger("service:e2b");
+
+      log.debug("should not appear");
+      expect(console.log).not.toHaveBeenCalled();
+    });
+
+    it("enables debug when DEBUG matches exactly", () => {
+      process.env.DEBUG = "service:e2b";
+      clearLoggerCache();
+      const log = logger("service:e2b");
+
+      log.debug("should appear");
+      expect(console.log).toHaveBeenCalled();
+    });
+
+    it("enables debug when DEBUG=*", () => {
+      process.env.DEBUG = "*";
+      clearLoggerCache();
+      const log = logger("service:e2b");
+
+      log.debug("should appear");
+      expect(console.log).toHaveBeenCalled();
+    });
+
+    it("enables debug with wildcard prefix match", () => {
+      process.env.DEBUG = "service:*";
+      clearLoggerCache();
+      const log = logger("service:e2b");
+
+      log.debug("should appear");
+      expect(console.log).toHaveBeenCalled();
+    });
+
+    it("does not match different prefix with wildcard", () => {
+      process.env.DEBUG = "api:*";
+      clearLoggerCache();
+      const log = logger("service:e2b");
+
+      log.debug("should not appear");
+      expect(console.log).not.toHaveBeenCalled();
+    });
+
+    it("supports multiple patterns separated by comma", () => {
+      process.env.DEBUG = "api:runs,service:e2b";
+      clearLoggerCache();
+
+      const log1 = logger("service:e2b");
+      const log2 = logger("api:runs");
+      const log3 = logger("service:other");
+
+      log1.debug("should appear");
+      log2.debug("should appear");
+      log3.debug("should not appear");
+
+      expect(console.log).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("warn and error always output", () => {
+    it("outputs warn regardless of DEBUG", () => {
+      delete process.env.DEBUG;
+      clearLoggerCache();
+      const log = logger("service:e2b");
+
+      log.warn("warning");
+      expect(console.warn).toHaveBeenCalledWith("[WARN] [service:e2b] warning");
+    });
+
+    it("outputs error regardless of DEBUG", () => {
+      delete process.env.DEBUG;
+      clearLoggerCache();
+      const log = logger("service:e2b");
+
+      log.error("error");
+      expect(console.error).toHaveBeenCalledWith("[ERROR] [service:e2b] error");
+    });
+  });
+
+  describe("info level", () => {
+    it("outputs info regardless of DEBUG", () => {
+      delete process.env.DEBUG;
+      clearLoggerCache();
+      const log = logger("service:e2b");
+
+      log.info("info message");
+      expect(console.info).toHaveBeenCalledWith(
+        "[INFO] [service:e2b] info message",
+      );
+    });
+  });
+
+  describe("auto-enable debug", () => {
+    it("auto-enables debug in development environment", () => {
+      delete process.env.DEBUG;
+      setNodeEnv("development");
+      clearLoggerCache();
+      const log = logger("service:e2b");
+
+      log.debug("should appear in dev");
+      expect(console.log).toHaveBeenCalled();
+    });
+
+    it("does not auto-enable debug in production", () => {
+      delete process.env.DEBUG;
+      setNodeEnv("production");
+      clearLoggerCache();
+      const log = logger("service:e2b");
+
+      log.debug("should not appear in production");
+      expect(console.log).not.toHaveBeenCalled();
+    });
+
+    it("explicit DEBUG overrides auto-enable", () => {
+      process.env.DEBUG = "other:logger";
+      setNodeEnv("development");
+      clearLoggerCache();
+      const log = logger("service:e2b");
+
+      log.debug("should not appear - explicit DEBUG set");
+      expect(console.log).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -21,6 +21,9 @@ import {
 import type { ExecutionContext } from "../run/types";
 import { calculateSessionHistoryPath } from "../run/run-service";
 import { sendVm0ErrorEvent } from "../events";
+import { logger } from "../logger";
+
+const log = logger("service:e2b");
 
 /**
  * E2B Service
@@ -39,8 +42,8 @@ export class E2BService {
     const startTime = Date.now();
     const isResume = !!context.resumeSession;
 
-    console.log(
-      `[E2B] ${isResume ? "Resuming" : "Creating"} run ${context.runId} for agent ${context.agentConfigId}...`,
+    log.debug(
+      `${isResume ? "Resuming" : "Creating"} run ${context.runId} for agent ${context.agentConfigId}...`,
     );
 
     let sandbox: Sandbox | null = null;
@@ -133,11 +136,11 @@ export class E2BService {
 
       const webhookEndpoint = `${apiUrl}/api/webhooks/agent/events`;
 
-      console.log(
-        `[E2B] Environment - VERCEL_ENV: ${vercelEnv}, VERCEL_URL: ${vercelUrl}, VM0_API_URL: ${apiUrl}`,
+      log.debug(
+        `Environment - VERCEL_ENV: ${vercelEnv}, VERCEL_URL: ${vercelUrl}, VM0_API_URL: ${apiUrl}`,
       );
-      console.log(`[E2B] Computed API URL: ${apiUrl}`);
-      console.log(`[E2B] Webhook: ${webhookEndpoint}`);
+      log.debug(`Computed API URL: ${apiUrl}`);
+      log.debug(`Webhook: ${webhookEndpoint}`);
 
       // Create E2B sandbox with environment variables
       const sandboxEnvVars: Record<string, string> = {
@@ -150,16 +153,14 @@ export class E2BService {
       const vercelBypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
       if (vercelBypassSecret) {
         sandboxEnvVars.VERCEL_PROTECTION_BYPASS = vercelBypassSecret;
-        console.log(
-          `[E2B] Added Vercel protection bypass for preview deployment`,
-        );
+        log.debug(`Added Vercel protection bypass for preview deployment`);
       }
 
       sandbox = await this.createSandbox(
         sandboxEnvVars,
         agentConfig as AgentConfigYaml | undefined,
       );
-      console.log(`[E2B] Sandbox created: ${sandbox.sandboxId}`);
+      log.debug(`Sandbox created: ${sandbox.sandboxId}`);
 
       // Mount storages and artifact to sandbox
       await storageService.mountStorages(
@@ -192,9 +193,7 @@ export class E2BService {
       const executionTimeMs = Date.now() - startTime;
       const completedAt = new Date();
 
-      console.log(
-        `[E2B] Run ${context.runId} completed in ${executionTimeMs}ms`,
-      );
+      log.debug(`Run ${context.runId} completed in ${executionTimeMs}ms`);
 
       // If sandbox script failed, send vm0_error event
       // This ensures CLI doesn't timeout waiting for events
@@ -205,8 +204,8 @@ export class E2BService {
             error: result.stderr || "Agent execution failed",
           });
         } catch (e) {
-          console.error(
-            `[E2B] Failed to send vm0_error event for run ${context.runId}:`,
+          log.error(
+            `Failed to send vm0_error event for run ${context.runId}:`,
             e,
           );
         }
@@ -228,7 +227,7 @@ export class E2BService {
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error";
 
-      console.error(`[E2B] Run ${context.runId} failed:`, error);
+      log.error(`Run ${context.runId} failed:`, error);
 
       // Send vm0_error event so CLI doesn't timeout
       try {
@@ -237,8 +236,8 @@ export class E2BService {
           error: errorMessage,
         });
       } catch (e) {
-        console.error(
-          `[E2B] Failed to send vm0_error event for run ${context.runId}:`,
+        log.error(
+          `Failed to send vm0_error event for run ${context.runId}:`,
           e,
         );
       }
@@ -279,7 +278,7 @@ export class E2BService {
     sessionHistory: string,
     workingDir: string,
   ): Promise<void> {
-    console.log(`[E2B] Restoring session history for ${sessionId}...`);
+    log.debug(`Restoring session history for ${sessionId}...`);
 
     // Calculate session history path using same logic as run-agent-script
     const sessionHistoryPath = calculateSessionHistoryPath(
@@ -287,7 +286,7 @@ export class E2BService {
       sessionId,
     );
 
-    console.log(`[E2B] Session history path: ${sessionHistoryPath}`);
+    log.debug(`Session history path: ${sessionHistoryPath}`);
 
     // Create directory structure
     const dirPath = sessionHistoryPath.substring(
@@ -305,8 +304,8 @@ export class E2BService {
 
     await sandbox.files.write(sessionHistoryPath, arrayBuffer);
 
-    console.log(
-      `[E2B] Session history restored (${sessionHistory.split("\n").length} lines)`,
+    log.debug(
+      `Session history restored (${sessionHistory.split("\n").length} lines)`,
     );
   }
 
@@ -334,11 +333,11 @@ export class E2BService {
       );
     }
 
-    console.log(`[E2B] Using template: ${templateName}`);
-    console.log(
-      `[E2B] Template source: ${agentConfig?.agents?.[0]?.image ? "agents[0].image" : "E2B_TEMPLATE_NAME"}`,
+    log.debug(`Using template: ${templateName}`);
+    log.debug(
+      `Template source: ${agentConfig?.agents?.[0]?.image ? "agents[0].image" : "E2B_TEMPLATE_NAME"}`,
     );
-    console.log(`[E2B] Sandbox env vars:`, Object.keys(envVars));
+    log.debug(`Sandbox env vars:`, Object.keys(envVars));
 
     const sandbox = await Sandbox.create(templateName, sandboxOptions);
     return sandbox;
@@ -387,8 +386,8 @@ export class E2BService {
       );
     }
 
-    console.log(
-      `[E2B] Uploaded ${scripts.length} agent scripts to sandbox: ${SCRIPT_PATHS.baseDir}`,
+    log.debug(
+      `Uploaded ${scripts.length} agent scripts to sandbox: ${SCRIPT_PATHS.baseDir}`,
     );
     return SCRIPT_PATHS.runAgent;
   }
@@ -411,7 +410,7 @@ export class E2BService {
     // This allows script changes without rebuilding the E2B template
     const scriptPath = await this.uploadRunAgentScript(sandbox);
 
-    console.log(`[E2B] Executing run-agent.sh for run ${runId}...`);
+    log.debug(`Executing run-agent.sh for run ${runId}...`);
 
     // Extract working_dir from agent config
     const config = agentConfig as AgentConfigYaml | undefined;
@@ -427,41 +426,38 @@ export class E2BService {
     // Add working directory if configured
     if (workingDir) {
       envs.VM0_WORKING_DIR = workingDir;
-      console.log(`[E2B] Working directory configured: ${workingDir}`);
+      log.debug(`Working directory configured: ${workingDir}`);
     }
 
     // Add resume session ID if provided
     if (resumeSessionId) {
       envs.VM0_RESUME_SESSION_ID = resumeSessionId;
-      console.log(`[E2B] Resume session ID configured: ${resumeSessionId}`);
+      log.debug(`Resume session ID configured: ${resumeSessionId}`);
     }
 
     // Pass USE_MOCK_CLAUDE for testing (executes prompt as bash instead of calling LLM)
     if (process.env.USE_MOCK_CLAUDE === "true") {
       envs.USE_MOCK_CLAUDE = "true";
-      console.log(`[E2B] Using mock-claude for testing`);
+      log.debug(`Using mock-claude for testing`);
     }
 
     // Add artifact information for checkpoint
     // Only artifact creates new versions after agent runs
     if (preparedArtifact) {
-      console.log(
-        `[E2B] Prepared artifact for checkpoint:`,
-        JSON.stringify({
-          driver: preparedArtifact.driver,
-          mountPath: preparedArtifact.mountPath,
-          vasStorageName: preparedArtifact.vasStorageName,
-        }),
-      );
+      log.debug(`Prepared artifact for checkpoint:`, {
+        driver: preparedArtifact.driver,
+        mountPath: preparedArtifact.mountPath,
+        vasStorageName: preparedArtifact.vasStorageName,
+      });
 
       // VAS artifact - pass info for vas snapshot
       envs.VM0_ARTIFACT_DRIVER = "vas";
       envs.VM0_ARTIFACT_MOUNT_PATH = preparedArtifact.mountPath;
       envs.VM0_ARTIFACT_VOLUME_NAME = preparedArtifact.vasStorageName;
       envs.VM0_ARTIFACT_VERSION_ID = preparedArtifact.vasVersionId;
-      console.log(`[E2B] Configured VAS artifact for checkpoint`);
+      log.debug(`Configured VAS artifact for checkpoint`);
     } else {
-      console.log(`[E2B] No artifact configured for checkpoint`);
+      log.debug(`No artifact configured for checkpoint`);
     }
 
     // Add Minimax API configuration if available
@@ -478,7 +474,7 @@ export class E2BService {
       envs.ANTHROPIC_DEFAULT_SONNET_MODEL = "MiniMax-M2";
       envs.ANTHROPIC_DEFAULT_OPUS_MODEL = "MiniMax-M2";
       envs.ANTHROPIC_DEFAULT_HAIKU_MODEL = "MiniMax-M2";
-      console.log(`[E2B] Using Minimax API (${minimaxBaseUrl})`);
+      log.debug(`Using Minimax API (${minimaxBaseUrl})`);
     }
 
     const result = await sandbox.commands.run(scriptPath, {
@@ -489,14 +485,12 @@ export class E2BService {
     const executionTimeMs = Date.now() - execStart;
 
     // Always log stderr to capture [VM0] checkpoint logs (even on success)
-    console.log(`[E2B] stderr (${result.stderr.length} chars):`, result.stderr);
+    log.debug(`stderr (${result.stderr.length} chars):`, result.stderr);
 
     if (result.exitCode === 0) {
-      console.log(`[E2B] Run ${runId} completed successfully`);
+      log.debug(`Run ${runId} completed successfully`);
     } else {
-      console.error(
-        `[E2B] Run ${runId} failed with exit code ${result.exitCode}`,
-      );
+      log.error(`Run ${runId} failed with exit code ${result.exitCode}`);
     }
 
     return {
@@ -512,14 +506,11 @@ export class E2BService {
    */
   private async cleanupSandbox(sandbox: Sandbox): Promise<void> {
     try {
-      console.log(`[E2B] Cleaning up sandbox ${sandbox.sandboxId}...`);
+      log.debug(`Cleaning up sandbox ${sandbox.sandboxId}...`);
       await sandbox.kill();
-      console.log(`[E2B] Sandbox ${sandbox.sandboxId} cleaned up`);
+      log.debug(`Sandbox ${sandbox.sandboxId} cleaned up`);
     } catch (error) {
-      console.error(
-        `[E2B] Failed to cleanup sandbox ${sandbox.sandboxId}:`,
-        error,
-      );
+      log.error(`Failed to cleanup sandbox ${sandbox.sandboxId}:`, error);
     }
   }
 }

--- a/turbo/apps/web/src/lib/logger.ts
+++ b/turbo/apps/web/src/lib/logger.ts
@@ -1,0 +1,116 @@
+/**
+ * Lightweight structured logging system with DEBUG environment variable support.
+ *
+ * Usage:
+ *   const log = logger('service:e2b')
+ *   log.debug('sandbox created', { id: '123' })  // Only when DEBUG matches
+ *   log.warn('slow response')                     // Always output
+ *   log.error('failed', error)                    // Always output
+ *
+ * Environment:
+ *   DEBUG=service:e2b     - Enable specific logger
+ *   DEBUG=service:*       - Enable all service loggers (wildcard)
+ *   DEBUG=*               - Enable all debug output
+ *   DEBUG=a,b,c           - Enable multiple loggers
+ *
+ * Auto-enabled:
+ *   - Local development (NODE_ENV=development) automatically enables DEBUG=*
+ *
+ * Production/Preview:
+ *   - DEBUG must be explicitly set via environment variables
+ *   - Preview deployments: DEBUG=* is set via GitHub Actions workflow
+ */
+
+type LogMethod = (...args: unknown[]) => void;
+
+interface Logger {
+  debug: LogMethod;
+  info: LogMethod;
+  warn: LogMethod;
+  error: LogMethod;
+}
+
+const loggerCache: Map<string, Logger> = new Map();
+
+function isAutoDebugEnabled(): boolean {
+  // Auto-enable debug in local development
+  return process.env.NODE_ENV === "development";
+}
+
+function getDebugPatterns(): string[] {
+  const debug = process.env.DEBUG;
+
+  // If DEBUG is explicitly set, use it
+  if (debug) {
+    return debug.split(",").map((p) => p.trim());
+  }
+
+  // Auto-enable all debug in development/preview
+  if (isAutoDebugEnabled()) {
+    return ["*"];
+  }
+
+  return [];
+}
+
+function matchesDebug(name: string): boolean {
+  const patterns = getDebugPatterns();
+  if (patterns.length === 0) return false;
+
+  return patterns.some((pattern) => {
+    if (pattern === "*") return true;
+    if (pattern.endsWith(":*")) {
+      const prefix = pattern.slice(0, -1);
+      return name.startsWith(prefix);
+    }
+    return name === pattern;
+  });
+}
+
+function formatArgs(
+  level: string,
+  name: string,
+  args: unknown[],
+): [string, ...unknown[]] {
+  const prefix = `[${level}] [${name}]`;
+  if (args.length === 0) {
+    return [prefix];
+  }
+  if (typeof args[0] === "string") {
+    return [`${prefix} ${args[0]}`, ...args.slice(1)];
+  }
+  return [prefix, ...args];
+}
+
+function createLogger(name: string): Logger {
+  const isDebugEnabled = matchesDebug(name);
+
+  return {
+    debug: (...args: unknown[]) => {
+      if (!isDebugEnabled) return;
+      console.log(...formatArgs("DEBUG", name, args));
+    },
+    info: (...args: unknown[]) => {
+      console.info(...formatArgs("INFO", name, args));
+    },
+    warn: (...args: unknown[]) => {
+      console.warn(...formatArgs("WARN", name, args));
+    },
+    error: (...args: unknown[]) => {
+      console.error(...formatArgs("ERROR", name, args));
+    },
+  };
+}
+
+export function logger(name: string): Logger {
+  const cached = loggerCache.get(name);
+  if (cached) return cached;
+
+  const newLogger = createLogger(name);
+  loggerCache.set(name, newLogger);
+  return newLogger;
+}
+
+export function clearLoggerCache(): void {
+  loggerCache.clear();
+}

--- a/turbo/packages/eslint-config/next.js
+++ b/turbo/packages/eslint-config/next.js
@@ -46,4 +46,26 @@ export const nextJsConfig = [
       "react/react-in-jsx-scope": "off",
     },
   },
+  {
+    // Prevent log.info() from being committed - it's for development only
+    // Exclude test files since they need to test info() functionality
+    ignores: [
+      "**/__tests__/**",
+      "**/*.test.ts",
+      "**/*.test.tsx",
+      "**/*.spec.ts",
+      "**/*.spec.tsx",
+    ],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            'CallExpression[callee.property.name="info"][callee.object.name="log"]',
+          message:
+            "log.info() is for development only. Use log.debug(), log.warn(), or log.error() instead.",
+        },
+      ],
+    },
+  },
 ];

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -3,6 +3,7 @@
   "ui": "tui",
   "globalEnv": [
     "DATABASE_URL",
+    "DEBUG",
     "NODE_ENV",
     "SKIP_ENV_VALIDATION",
     "VERCEL",


### PR DESCRIPTION
## Summary

- Add lightweight logger module with named loggers (`logger('service:e2b')`)
- Support DEBUG env var with wildcard matching (`DEBUG=*`, `DEBUG=service:*`)
- Auto-enable debug in local development (`NODE_ENV=development`)
- Add ESLint rule to prevent `log.info()` commits (dev-only method)
- Migrate `e2b-service.ts` console.log calls to demonstrate usage
- Configure `DEBUG=*` for Vercel preview deployments via workflow

## Test plan

- [x] Logger tests pass (19 tests)
- [x] Type checks pass
- [x] Lint passes
- [ ] CI pipeline passes
- [ ] Verify debug output in preview deployment

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)