### PR TITLE
refactor(web): migrate console.log calls to structured logger

### DIFF
--- a/turbo/apps/web/src/lib/api-response.ts
+++ b/turbo/apps/web/src/lib/api-response.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
 import { ApiError } from "./errors";
+import { logger } from "./logger";
+
+const log = logger("api:response");
 
 /**
  * Standard success response
@@ -25,7 +28,7 @@ export function errorResponse(error: unknown) {
   }
 
   // Unexpected error
-  console.error("Unexpected error:", error);
+  log.error("Unexpected error:", error);
   return NextResponse.json(
     {
       error: {

--- a/turbo/apps/web/src/lib/auth/get-user-id.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-id.ts
@@ -3,6 +3,9 @@ import { headers } from "next/headers";
 import { eq, and, gt } from "drizzle-orm";
 import { initServices } from "../init-services";
 import { cliTokens } from "../../db/schema/cli-tokens";
+import { logger } from "../logger";
+
+const log = logger("auth:user");
 
 /**
  * Get the current user ID from CLI token or Clerk session
@@ -31,7 +34,7 @@ export async function getUserId(): Promise<string | null> {
         .update(cliTokens)
         .set({ lastUsedAt: new Date() })
         .where(eq(cliTokens.token, token))
-        .catch(console.error);
+        .catch((err) => log.error("Failed to update token lastUsedAt:", err));
 
       return tokenRecord.userId;
     }

--- a/turbo/apps/web/src/lib/auth/sandbox-token.ts
+++ b/turbo/apps/web/src/lib/auth/sandbox-token.ts
@@ -2,6 +2,9 @@ import { randomBytes } from "crypto";
 import { initServices } from "../init-services";
 import { cliTokens } from "../../db/schema/cli-tokens";
 import { eq, and, lt } from "drizzle-orm";
+import { logger } from "../logger";
+
+const log = logger("auth:sandbox");
 
 /**
  * Generate a temporary CLI token for E2B sandbox
@@ -32,7 +35,7 @@ export async function generateSandboxToken(
     createdAt: now,
   });
 
-  console.log(`Generated sandbox token for run ${runId}`);
+  log.debug(`Generated sandbox token for run ${runId}`);
   return token;
 }
 
@@ -48,5 +51,5 @@ async function cleanupExpiredSandboxTokens(userId: string): Promise<void> {
       and(eq(cliTokens.userId, userId), lt(cliTokens.expiresAt, new Date())),
     );
 
-  console.log(`Cleaned up expired sandbox tokens for user ${userId}`);
+  log.debug(`Cleaned up expired sandbox tokens for user ${userId}`);
 }

--- a/turbo/apps/web/src/lib/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/checkpoint/checkpoint-service.ts
@@ -5,6 +5,7 @@ import { conversations } from "../../db/schema/conversation";
 import { checkpoints } from "../../db/schema/checkpoint";
 import { NotFoundError } from "../errors";
 import { agentSessionService } from "../agent-session";
+import { logger } from "../logger";
 import type {
   CheckpointRequest,
   CheckpointResponse,
@@ -12,6 +13,8 @@ import type {
   ArtifactSnapshot,
 } from "./types";
 import type { AgentConfigYaml } from "../../types/agent-config";
+
+const log = logger("service:checkpoint");
 
 /**
  * Checkpoint Service
@@ -28,7 +31,7 @@ export class CheckpointService {
   async createCheckpoint(
     request: CheckpointRequest,
   ): Promise<CheckpointResponse> {
-    console.log(`[Checkpoint] Creating checkpoint for run ${request.runId}`);
+    log.debug(`Creating checkpoint for run ${request.runId}`);
 
     // Fetch agent run from database
     const [run] = await globalThis.services.db
@@ -52,8 +55,8 @@ export class CheckpointService {
       throw new NotFoundError("Agent config");
     }
 
-    console.log(
-      `[Checkpoint] Creating conversation record for CLI agent: ${request.cliAgentType}`,
+    log.debug(
+      `Creating conversation record for CLI agent: ${request.cliAgentType}`,
     );
 
     // Create conversation record first
@@ -71,8 +74,8 @@ export class CheckpointService {
       throw new Error("Failed to create conversation record");
     }
 
-    console.log(
-      `[Checkpoint] Conversation created: ${conversation.id}, storing checkpoint...`,
+    log.debug(
+      `Conversation created: ${conversation.id}, storing checkpoint...`,
     );
 
     // Build agent config snapshot
@@ -108,9 +111,7 @@ export class CheckpointService {
       throw new Error("Failed to create checkpoint record");
     }
 
-    console.log(
-      `[Checkpoint] Checkpoint created successfully: ${checkpoint.id}`,
-    );
+    log.debug(`Checkpoint created successfully: ${checkpoint.id}`);
 
     // Find or create agent session
     const artifactSnapshot = request.artifactSnapshot as ArtifactSnapshot;
@@ -124,9 +125,7 @@ export class CheckpointService {
       templateVars,
     );
 
-    console.log(
-      `[Checkpoint] Agent session updated/created: ${agentSession.id}`,
-    );
+    log.debug(`Agent session updated/created: ${agentSession.id}`);
 
     return {
       checkpointId: checkpoint.id,

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -47,8 +47,8 @@ export class E2BService {
     log.debug(
       `${isResume ? "Resuming" : "Creating"} run ${context.runId} for agent ${context.agentConfigId}...`,
     );
-    console.log(
-      `[E2B] context.volumeVersions=${JSON.stringify(context.volumeVersions)}`,
+    log.debug(
+      `context.volumeVersions=${JSON.stringify(context.volumeVersions)}`,
     );
 
     let sandbox: Sandbox | null = null;

--- a/turbo/apps/web/src/lib/events/vm0-events.ts
+++ b/turbo/apps/web/src/lib/events/vm0-events.ts
@@ -5,6 +5,9 @@
 
 import { agentRunEvents } from "../../db/schema/agent-run-event";
 import type { Vm0StartEvent, Vm0ResultEvent, Vm0ErrorEvent } from "./types";
+import { logger } from "../logger";
+
+const log = logger("events:vm0");
 
 /**
  * Send a VM0 start event
@@ -77,5 +80,5 @@ async function sendVm0Event(
     eventData: event,
   });
 
-  console.log(`[VM0 Events] Sent ${event.type} event for run ${runId}`);
+  log.debug(`Sent ${event.type} event for run ${runId}`);
 }


### PR DESCRIPTION
## Summary
- Migrate all `console.log/warn/error` calls in web app source files to use the structured logger system
- 8 files migrated with ~50 console calls replaced
- Each file uses appropriately named loggers following the colon-separated hierarchy convention

## Files Changed
| File | Logger Name | Changes |
|------|-------------|---------|
| `api-response.ts` | `api:response` | 1 error log |
| `get-user-id.ts` | `auth:user` | 1 error callback |
| `sandbox-token.ts` | `auth:sandbox` | 2 debug logs |
| `vm0-events.ts` | `events:vm0` | 1 debug log |
| `checkpoint-service.ts` | `service:checkpoint` | 5 debug logs |
| `storage-service.ts` | `service:storage` | 18 logs |
| `run-service.ts` | `service:run` | 20 logs |
| `e2b-service.ts` | `service:e2b` | 1 remaining log |

## Test plan
- [x] ESLint passes with no errors
- [x] TypeScript type check passes for web app
- [x] Logger unit tests pass (19/19)
- [x] No remaining `console.log` calls in source files (only in `logger.ts` and test files)

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)