### PR TITLE
fix: extract stderr from E2B CommandExitError for better error reporting

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -240,13 +240,23 @@ export async function POST(request: NextRequest) {
         console.log(`[API] Run ${run.id} completed successfully`);
       })
       .catch(async (error) => {
+        // Extract error message - E2B CommandExitError includes result with stderr
+        let errorMessage =
+          error instanceof Error ? error.message : "Unknown error";
+
+        // Check if error has result property (E2B CommandExitError)
+        const errorWithResult = error as { result?: { stderr?: string } };
+        if (errorWithResult.result?.stderr) {
+          errorMessage = errorWithResult.result.stderr;
+        }
+
         // Update run with error on failure
-        console.error(`[API] Run ${run.id} failed:`, error);
+        console.error(`[API] Run ${run.id} failed:`, errorMessage);
         await globalThis.services.db
           .update(agentRuns)
           .set({
             status: "failed",
-            error: error instanceof Error ? error.message : "Unknown error",
+            error: errorMessage,
             completedAt: new Date(),
           })
           .where(eq(agentRuns.id, run.id));
@@ -254,7 +264,7 @@ export async function POST(request: NextRequest) {
         // Send vm0_error event
         await sendVm0ErrorEvent({
           runId: run.id,
-          error: error instanceof Error ? error.message : "Unknown error",
+          error: errorMessage,
           errorType: "sandbox_error",
         });
       });


### PR DESCRIPTION
## Summary

- Extract `stderr` from E2B `CommandExitError.result` instead of just using `error.message`
- Send full stderr content in `vm0_error` event so CLI displays actual error details
- Log stderr at error level when sandbox script fails

## Problem

When agent runs fail, the CLI only showed `Error: exit status 1` instead of the actual error from the sandbox script (e.g., checkpoint creation failed, VAS snapshot failed, etc.).

**Root cause:** E2B SDK throws `CommandExitError` when commands exit with non-zero code. The error object has `result.stderr` with the actual error, but we only extracted `error.message`.

## Changes

- `e2b-service.ts`: Extract stderr from CommandExitError in catch block, log stderr on failure
- `runs/route.ts`: Extract stderr from CommandExitError in catch block

## Test plan

- [ ] Run an agent that fails during checkpoint creation
- [ ] Verify CLI shows the actual error message from sandbox stderr
- [ ] Verify server logs contain the full stderr output

Fixes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)