### PR TITLE
feat: use content-based sha-256 hash for storage version ids

### DIFF
--- a/.github/actions/neon-branch/action.yml
+++ b/.github/actions/neon-branch/action.yml
@@ -56,14 +56,44 @@ runs:
       run: |
         BRANCH_NAME="preview/${{ inputs.branch-name }}"
 
+        # Function to wait for branch to be ready
+        wait_for_branch_ready() {
+          local branch_name=$1
+          local max_attempts=30
+          local attempt=0
+
+          echo "Waiting for branch to be ready..."
+          while [ $attempt -lt $max_attempts ]; do
+            STATUS=$(neonctl branches list --project-id $NEON_PROJECT_ID --output json | jq -r ".[] | select(.name == \"$branch_name\") | .current_state")
+            echo "Branch status: $STATUS (attempt $((attempt + 1))/$max_attempts)"
+
+            if [ "$STATUS" = "ready" ] || [ "$STATUS" = "idle" ] || [ -z "$STATUS" ]; then
+              echo "Branch is ready"
+              return 0
+            fi
+
+            sleep 2
+            attempt=$((attempt + 1))
+          done
+
+          echo "Warning: Branch may not be ready after $max_attempts attempts"
+          return 0
+        }
+
         if neonctl branches list --project-id $NEON_PROJECT_ID --output json | jq -e ".[] | select(.name == \"$BRANCH_NAME\")" > /dev/null 2>&1; then
           echo "Branch $BRANCH_NAME already exists"
           echo "Resetting branch to sync with parent (main)..."
           neonctl branches reset $BRANCH_NAME --project-id $NEON_PROJECT_ID --parent
+
+          # Wait for reset to complete
+          wait_for_branch_ready "$BRANCH_NAME"
           echo "Branch reset complete"
         else
           echo "Creating branch $BRANCH_NAME"
           neonctl branches create --name $BRANCH_NAME --project-id $NEON_PROJECT_ID
+
+          # Wait for branch creation to complete
+          wait_for_branch_ready "$BRANCH_NAME"
         fi
 
         DATABASE_URL=$(neonctl connection-string $BRANCH_NAME --project-id $NEON_PROJECT_ID --database-name ${{ inputs.database-name }} --pooled)

--- a/.github/actions/neon-branch/action.yml
+++ b/.github/actions/neon-branch/action.yml
@@ -56,44 +56,14 @@ runs:
       run: |
         BRANCH_NAME="preview/${{ inputs.branch-name }}"
 
-        # Function to wait for branch to be ready
-        wait_for_branch_ready() {
-          local branch_name=$1
-          local max_attempts=30
-          local attempt=0
-
-          echo "Waiting for branch to be ready..."
-          while [ $attempt -lt $max_attempts ]; do
-            STATUS=$(neonctl branches list --project-id $NEON_PROJECT_ID --output json | jq -r ".[] | select(.name == \"$branch_name\") | .current_state")
-            echo "Branch status: $STATUS (attempt $((attempt + 1))/$max_attempts)"
-
-            if [ "$STATUS" = "ready" ] || [ "$STATUS" = "idle" ] || [ -z "$STATUS" ]; then
-              echo "Branch is ready"
-              return 0
-            fi
-
-            sleep 2
-            attempt=$((attempt + 1))
-          done
-
-          echo "Warning: Branch may not be ready after $max_attempts attempts"
-          return 0
-        }
-
         if neonctl branches list --project-id $NEON_PROJECT_ID --output json | jq -e ".[] | select(.name == \"$BRANCH_NAME\")" > /dev/null 2>&1; then
           echo "Branch $BRANCH_NAME already exists"
           echo "Resetting branch to sync with parent (main)..."
           neonctl branches reset $BRANCH_NAME --project-id $NEON_PROJECT_ID --parent
-
-          # Wait for reset to complete
-          wait_for_branch_ready "$BRANCH_NAME"
           echo "Branch reset complete"
         else
           echo "Creating branch $BRANCH_NAME"
           neonctl branches create --name $BRANCH_NAME --project-id $NEON_PROJECT_ID
-
-          # Wait for branch creation to complete
-          wait_for_branch_ready "$BRANCH_NAME"
         fi
 
         DATABASE_URL=$(neonctl connection-string $BRANCH_NAME --project-id $NEON_PROJECT_ID --database-name ${{ inputs.database-name }} --pooled)

--- a/e2e/tests/02-commands/t03-artifacts.bats
+++ b/e2e/tests/02-commands/t03-artifacts.bats
@@ -60,9 +60,9 @@ teardown() {
     assert_success
     assert_output --partial "Uploading"
     assert_output --partial "$ARTIFACT_NAME"
-    # Verify versionId is returned (UUID format)
+    # Verify versionId is returned (SHA-256 format - 64 hex chars, displayed as 8 char short version)
     assert_output --partial "Version:"
-    assert_output --regexp "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    assert_output --regexp "[0-9a-f]{8}"
 }
 
 @test "Multiple pushes create different versions" {
@@ -74,13 +74,13 @@ teardown() {
     echo "version 1" > data.txt
     run $CLI_COMMAND artifact push
     assert_success
-    VERSION1=$(echo "$output" | grep -oP 'Version: \K[0-9a-f-]+')
+    VERSION1=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
 
     # Second push with different content
     echo "version 2" > data.txt
     run $CLI_COMMAND artifact push
     assert_success
-    VERSION2=$(echo "$output" | grep -oP 'Version: \K[0-9a-f-]+')
+    VERSION2=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
 
     # Versions should be different
     [ "$VERSION1" != "$VERSION2" ]
@@ -135,7 +135,7 @@ EOF
     echo "content from version 1" > data.txt
     run $CLI_COMMAND artifact push
     assert_success
-    VERSION1=$(echo "$output" | grep -oP 'Version: \K[0-9a-f-]+')
+    VERSION1=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
 
     # Push version 2
     echo "content from version 2" > data.txt
@@ -185,7 +185,8 @@ name: $ARTIFACT_NAME
 type: artifact
 EOF
 
-    FAKE_VERSION="00000000-0000-0000-0000-000000000000"
+    # Use a valid-looking SHA-256 hash that doesn't exist (minimum 8 chars for short version)
+    FAKE_VERSION="00000000"
     run $CLI_COMMAND artifact pull "$FAKE_VERSION"
     assert_failure
     assert_output --partial "not found"

--- a/e2e/tests/02-commands/t03-volumes.bats
+++ b/e2e/tests/02-commands/t03-volumes.bats
@@ -58,9 +58,9 @@ teardown() {
     assert_success
     assert_output --partial "Uploading"
     assert_output --partial "$VOLUME_NAME"
-    # Verify versionId is returned (UUID format)
+    # Verify versionId is returned (SHA-256 format - 64 hex chars, displayed as 8 char short version)
     assert_output --partial "Version:"
-    assert_output --regexp "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    assert_output --regexp "[0-9a-f]{8}"
 }
 
 @test "Multiple pushes create different versions" {
@@ -72,13 +72,13 @@ teardown() {
     echo "version 1" > data.txt
     run $CLI_COMMAND volume push
     assert_success
-    VERSION1=$(echo "$output" | grep -oP 'Version: \K[0-9a-f-]+')
+    VERSION1=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
 
     # Second push with different content
     echo "version 2" > data.txt
     run $CLI_COMMAND volume push
     assert_success
-    VERSION2=$(echo "$output" | grep -oP 'Version: \K[0-9a-f-]+')
+    VERSION2=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
 
     # Versions should be different
     [ "$VERSION1" != "$VERSION2" ]
@@ -132,7 +132,7 @@ EOF
     echo "content from version 1" > data.txt
     run $CLI_COMMAND volume push
     assert_success
-    VERSION1=$(echo "$output" | grep -oP 'Version: \K[0-9a-f-]+')
+    VERSION1=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
 
     # Push version 2
     echo "content from version 2" > data.txt
@@ -180,7 +180,8 @@ EOF
 name: $VOLUME_NAME
 EOF
 
-    FAKE_VERSION="00000000-0000-0000-0000-000000000000"
+    # Use a valid-looking SHA-256 hash that doesn't exist (minimum 8 chars for short version)
+    FAKE_VERSION="00000000"
     run $CLI_COMMAND volume pull "$FAKE_VERSION"
     assert_failure
     assert_output --partial "not found"

--- a/e2e/tests/02-commands/t07-vm0-volume-version-override.bats
+++ b/e2e/tests/02-commands/t07-vm0-volume-version-override.bats
@@ -72,7 +72,7 @@ EOF
     echo "version-1" > data.txt
     run $CLI_COMMAND volume push
     assert_success
-    VERSION1=$(echo "$output" | grep -oP 'Version: \K[0-9a-f-]+')
+    VERSION1=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
     echo "# Version 1 ID: $VERSION1"
     [ -n "$VERSION1" ]
 
@@ -80,7 +80,7 @@ EOF
     echo "version-2" > data.txt
     run $CLI_COMMAND volume push
     assert_success
-    VERSION2=$(echo "$output" | grep -oP 'Version: \K[0-9a-f-]+')
+    VERSION2=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
     echo "# Version 2 ID: $VERSION2"
     [ -n "$VERSION2" ]
 
@@ -132,7 +132,7 @@ EOF
     echo "checkpoint-version" > data.txt
     run $CLI_COMMAND volume push
     assert_success
-    CHECKPOINT_VERSION=$(echo "$output" | grep -oP 'Version: \K[0-9a-f-]+')
+    CHECKPOINT_VERSION=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
     echo "# Checkpoint version ID: $CHECKPOINT_VERSION"
     [ -n "$CHECKPOINT_VERSION" ]
 
@@ -162,7 +162,7 @@ EOF
     echo "override-version" > data.txt
     run $CLI_COMMAND volume push
     assert_success
-    OVERRIDE_VERSION=$(echo "$output" | grep -oP 'Version: \K[0-9a-f-]+')
+    OVERRIDE_VERSION=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
     echo "# Override version ID: $OVERRIDE_VERSION"
     [ -n "$OVERRIDE_VERSION" ]
 
@@ -199,7 +199,7 @@ EOF
     echo "initial-volume-content" > data.txt
     run $CLI_COMMAND volume push
     assert_success
-    INITIAL_VERSION=$(echo "$output" | grep -oP 'Version: \K[0-9a-f-]+')
+    INITIAL_VERSION=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
     echo "# Initial version ID: $INITIAL_VERSION"
     [ -n "$INITIAL_VERSION" ]
 
@@ -229,7 +229,7 @@ EOF
     echo "new-volume-content" > data.txt
     run $CLI_COMMAND volume push
     assert_success
-    NEW_VERSION=$(echo "$output" | grep -oP 'Version: \K[0-9a-f-]+')
+    NEW_VERSION=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
     echo "# New version ID: $NEW_VERSION"
     [ -n "$NEW_VERSION" ]
 

--- a/turbo/apps/cli/src/commands/artifact/push.ts
+++ b/turbo/apps/cli/src/commands/artifact/push.ts
@@ -134,10 +134,18 @@ export const pushCommand = new Command()
         versionId: string;
         size: number;
         fileCount: number;
+        deduplicated?: boolean;
       };
 
-      console.log(chalk.green("✓ Upload complete"));
-      console.log(chalk.gray(`  Version: ${result.versionId}`));
+      // Display short version (8 characters) by default
+      const shortVersion = result.versionId.slice(0, 8);
+
+      if (result.deduplicated) {
+        console.log(chalk.green("✓ Content unchanged (deduplicated)"));
+      } else {
+        console.log(chalk.green("✓ Upload complete"));
+      }
+      console.log(chalk.gray(`  Version: ${shortVersion}`));
       console.log(chalk.gray(`  Files: ${result.fileCount.toLocaleString()}`));
       console.log(chalk.gray(`  Size: ${formatBytes(result.size)}`));
     } catch (error) {

--- a/turbo/apps/cli/src/commands/volume/push.ts
+++ b/turbo/apps/cli/src/commands/volume/push.ts
@@ -124,10 +124,18 @@ export const pushCommand = new Command()
         versionId: string;
         size: number;
         fileCount: number;
+        deduplicated?: boolean;
       };
 
-      console.log(chalk.green("✓ Upload complete"));
-      console.log(chalk.gray(`  Version: ${result.versionId}`));
+      // Display short version (8 characters) by default
+      const shortVersion = result.versionId.slice(0, 8);
+
+      if (result.deduplicated) {
+        console.log(chalk.green("✓ Content unchanged (deduplicated)"));
+      } else {
+        console.log(chalk.green("✓ Upload complete"));
+      }
+      console.log(chalk.gray(`  Version: ${shortVersion}`));
       console.log(chalk.gray(`  Files: ${result.fileCount.toLocaleString()}`));
       console.log(chalk.gray(`  Size: ${formatBytes(result.size)}`));
     } catch (error) {

--- a/turbo/apps/cli/src/lib/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/event-renderer.ts
@@ -155,6 +155,18 @@ export class EventRenderer {
   }
 
   /**
+   * Format version ID for display (show short 8-character prefix)
+   */
+  private static formatVersion(version: string): string {
+    // SHA-256 hashes are 64 characters, show first 8
+    if (version.length === 64 && /^[a-f0-9]+$/i.test(version)) {
+      return version.slice(0, 8);
+    }
+    // For "latest" or other formats, show as-is
+    return version;
+  }
+
+  /**
    * Render artifact and volumes info
    * Used by both vm0_start and vm0_result events
    */
@@ -163,7 +175,7 @@ export class EventRenderer {
     if (artifact && Object.keys(artifact).length > 0) {
       console.log(`  Artifact:`);
       for (const [name, version] of Object.entries(artifact)) {
-        console.log(`    ${name}: ${chalk.gray(version)}`);
+        console.log(`    ${name}: ${chalk.gray(this.formatVersion(version))}`);
       }
     }
 
@@ -171,7 +183,7 @@ export class EventRenderer {
     if (volumes && Object.keys(volumes).length > 0) {
       console.log(`  Volumes:`);
       for (const [name, version] of Object.entries(volumes)) {
-        console.log(`    ${name}: ${chalk.gray(version)}`);
+        console.log(`    ${name}: ${chalk.gray(this.formatVersion(version))}`);
       }
     }
   }

--- a/turbo/apps/web/app/api/storages/route.ts
+++ b/turbo/apps/web/app/api/storages/route.ts
@@ -125,10 +125,6 @@ export async function POST(request: NextRequest) {
       fileEntries.push({ path: relativePath, content });
     }
 
-    // Compute content-addressable hash for version ID
-    const contentHash = computeContentHash(fileEntries);
-    log.debug(`Computed content hash: ${contentHash}`);
-
     // Check if storage already exists (outside transaction for read)
     const existingStorages = await globalThis.services.db
       .select()
@@ -162,6 +158,10 @@ export async function POST(request: NextRequest) {
         }
         log.debug(`Created new storage record: ${storage.id}`);
       }
+
+      // Compute content-addressable hash for version ID (includes storageId for uniqueness per storage)
+      const contentHash = computeContentHash(storage.id, fileEntries);
+      log.debug(`Computed content hash: ${contentHash}`);
 
       // Check if version with same content hash already exists (deduplication)
       const [existingVersion] = await tx

--- a/turbo/apps/web/app/api/storages/route.ts
+++ b/turbo/apps/web/app/api/storages/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { initServices } from "../../../src/lib/init-services";
 import { getUserId } from "../../../src/lib/auth/get-user-id";
 import { storages, storageVersions } from "../../../src/db/schema/storage";
-import { eq, and } from "drizzle-orm";
+import { eq, and, like } from "drizzle-orm";
 import {
   uploadS3Directory,
   downloadS3Directory,
@@ -12,6 +12,15 @@ import * as path from "node:path";
 import * as os from "node:os";
 import AdmZip from "adm-zip";
 import { env } from "../../../src/env";
+import {
+  computeContentHash,
+  isValidVersionPrefix,
+  MIN_VERSION_PREFIX_LENGTH,
+  type FileEntry,
+} from "../../../src/lib/storage/content-hash";
+import { logger } from "../../../src/lib/logger";
+
+const log = logger("api:storages");
 
 /**
  * Validate storage name format
@@ -80,8 +89,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log(
-      `[Storage] Uploading storage "${storageName}" (type: ${storageType}) for user ${userId}`,
+    log.debug(
+      `Uploading storage "${storageName}" (type: ${storageType}) for user ${userId}`,
     );
 
     // Create temp directory for extraction
@@ -98,16 +107,27 @@ export async function POST(request: NextRequest) {
     const extractPath = path.join(tempDir, "extracted");
     zip.extractAllTo(extractPath, true);
 
-    console.log(`[Storage] Extracted zip to ${extractPath}`);
+    log.debug(`Extracted zip to ${extractPath}`);
 
-    // Calculate file count and size
-    const files = await getAllFiles(extractPath);
-    const fileCount = files.length;
+    // Calculate file count, size, and collect file entries for hashing
+    const filePaths = await getAllFiles(extractPath);
+    const fileCount = filePaths.length;
     let totalSize = 0;
-    for (const filePath of files) {
+    const fileEntries: FileEntry[] = [];
+
+    for (const filePath of filePaths) {
       const stats = await fs.promises.stat(filePath);
       totalSize += stats.size;
+
+      // Read file content for hash computation
+      const content = await fs.promises.readFile(filePath);
+      const relativePath = path.relative(extractPath, filePath);
+      fileEntries.push({ path: relativePath, content });
     }
+
+    // Compute content-addressable hash for version ID
+    const contentHash = computeContentHash(fileEntries);
+    log.debug(`Computed content hash: ${contentHash}`);
 
     // Check if storage already exists (outside transaction for read)
     const existingStorages = await globalThis.services.db
@@ -140,15 +160,55 @@ export async function POST(request: NextRequest) {
         if (!storage) {
           throw new Error("Failed to create storage");
         }
-        console.log(`[Storage] Created new storage record: ${storage.id}`);
+        log.debug(`Created new storage record: ${storage.id}`);
       }
 
-      // Create new version record within transaction
+      // Check if version with same content hash already exists (deduplication)
+      const [existingVersion] = await tx
+        .select()
+        .from(storageVersions)
+        .where(
+          and(
+            eq(storageVersions.storageId, storage.id),
+            eq(storageVersions.id, contentHash),
+          ),
+        )
+        .limit(1);
+
+      if (existingVersion) {
+        // Content already exists, return existing version (deduplication)
+        log.debug(
+          `Version with same content already exists: ${existingVersion.id}`,
+        );
+
+        // Update HEAD pointer to existing version if needed
+        if (storage.headVersionId !== existingVersion.id) {
+          await tx
+            .update(storages)
+            .set({
+              headVersionId: existingVersion.id,
+              updatedAt: new Date(),
+            })
+            .where(eq(storages.id, storage.id));
+        }
+
+        return {
+          name: storageName,
+          versionId: existingVersion.id,
+          size: Number(existingVersion.size),
+          fileCount: existingVersion.fileCount,
+          type: storageType,
+          deduplicated: true,
+        };
+      }
+
+      // Create new version record with content hash as ID
       const createdVersions = await tx
         .insert(storageVersions)
         .values({
+          id: contentHash,
           storageId: storage.id,
-          s3Key: `${userId}/${storageName}/${crypto.randomUUID()}`,
+          s3Key: `${userId}/${storageName}/${contentHash}`,
           size: totalSize,
           fileCount,
           message: null,
@@ -162,7 +222,7 @@ export async function POST(request: NextRequest) {
         throw new Error("Failed to create storage version");
       }
 
-      console.log(`[Storage] Created version: ${version.id}`);
+      log.debug(`Created version: ${version.id}`);
 
       // Upload files to versioned S3 path
       // If this fails, the transaction will be rolled back
@@ -173,7 +233,7 @@ export async function POST(request: NextRequest) {
         );
       }
       const s3Uri = `s3://${bucketName}/${version.s3Key}`;
-      console.log(`[Storage] Uploading ${fileCount} files to ${s3Uri}...`);
+      log.debug(`Uploading ${fileCount} files to ${s3Uri}...`);
       await uploadS3Directory(extractPath, s3Uri);
 
       // Update storage's HEAD pointer and metadata within transaction
@@ -187,8 +247,8 @@ export async function POST(request: NextRequest) {
         })
         .where(eq(storages.id, storage.id));
 
-      console.log(
-        `[Storage] Successfully uploaded storage "${storageName}" version ${version.id}`,
+      log.debug(
+        `Successfully uploaded storage "${storageName}" version ${version.id}`,
       );
 
       return {
@@ -197,6 +257,7 @@ export async function POST(request: NextRequest) {
         size: totalSize,
         fileCount,
         type: storageType,
+        deduplicated: false,
       };
     });
 
@@ -255,8 +316,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    console.log(
-      `[Storage] Downloading storage "${storageName}"${versionId ? ` version ${versionId}` : ""} for user ${userId}`,
+    log.debug(
+      `Downloading storage "${storageName}"${versionId ? ` version ${versionId}` : ""} for user ${userId}`,
     );
 
     // Check if storage exists and belongs to user
@@ -274,10 +335,17 @@ export async function GET(request: NextRequest) {
     }
 
     // Determine which version to download
-    let targetVersionId: string;
+    let version;
     if (versionId) {
-      // Use specified version
-      targetVersionId = versionId;
+      // Resolve version (supports short prefix)
+      const resolveResult = await resolveVersionById(storage.id, versionId);
+      if ("error" in resolveResult) {
+        return NextResponse.json(
+          { error: resolveResult.error },
+          { status: resolveResult.status },
+        );
+      }
+      version = resolveResult.version;
     } else {
       // Use HEAD version
       if (!storage.headVersionId) {
@@ -286,39 +354,24 @@ export async function GET(request: NextRequest) {
           { status: 404 },
         );
       }
-      targetVersionId = storage.headVersionId;
-    }
 
-    // Get version details
-    const [version] = await globalThis.services.db
-      .select()
-      .from(storageVersions)
-      .where(
-        and(
-          eq(storageVersions.id, targetVersionId),
-          eq(storageVersions.storageId, storage.id),
-        ),
-      )
-      .limit(1);
+      // Get HEAD version details
+      const [headVersion] = await globalThis.services.db
+        .select()
+        .from(storageVersions)
+        .where(eq(storageVersions.id, storage.headVersionId))
+        .limit(1);
 
-    if (!version) {
-      if (versionId) {
+      if (!headVersion) {
         return NextResponse.json(
-          {
-            error: `Version "${versionId}" not found for storage "${storageName}"`,
-          },
+          { error: `Storage "${storageName}" HEAD version not found` },
           { status: 404 },
         );
       }
-      return NextResponse.json(
-        { error: `Storage "${storageName}" HEAD version not found` },
-        { status: 404 },
-      );
+      version = headVersion;
     }
 
-    console.log(
-      `[Storage] Downloading version ${version.id} (${version.fileCount} files)`,
-    );
+    log.debug(`Downloading version ${version.id} (${version.fileCount} files)`);
 
     // Create temp directory for download
     tempDir = path.join(os.tmpdir(), `vm0-storage-${Date.now()}`);
@@ -397,4 +450,82 @@ async function getAllFiles(dirPath: string): Promise<string[]> {
   }
 
   return files;
+}
+
+/**
+ * Resolve version ID by exact match or prefix match
+ * Supports short version prefixes (minimum 8 characters)
+ */
+type StorageVersion = typeof storageVersions.$inferSelect;
+
+async function resolveVersionById(
+  storageId: string,
+  versionIdOrPrefix: string,
+): Promise<{ version: StorageVersion } | { error: string; status: number }> {
+  // First, try exact match
+  const [exactMatch] = await globalThis.services.db
+    .select()
+    .from(storageVersions)
+    .where(
+      and(
+        eq(storageVersions.storageId, storageId),
+        eq(storageVersions.id, versionIdOrPrefix),
+      ),
+    )
+    .limit(1);
+
+  if (exactMatch) {
+    return { version: exactMatch };
+  }
+
+  // If not exact match, try prefix match (for short version IDs)
+  if (!isValidVersionPrefix(versionIdOrPrefix)) {
+    // Too short or invalid format
+    if (versionIdOrPrefix.length < MIN_VERSION_PREFIX_LENGTH) {
+      return {
+        error: `Version prefix too short. Minimum ${MIN_VERSION_PREFIX_LENGTH} characters required.`,
+        status: 400,
+      };
+    }
+    return {
+      error: `Version "${versionIdOrPrefix}" not found`,
+      status: 404,
+    };
+  }
+
+  // Search by prefix using LIKE
+  const prefixMatches = await globalThis.services.db
+    .select()
+    .from(storageVersions)
+    .where(
+      and(
+        eq(storageVersions.storageId, storageId),
+        like(storageVersions.id, `${versionIdOrPrefix.toLowerCase()}%`),
+      ),
+    )
+    .limit(2); // Only need to know if there's more than one
+
+  if (prefixMatches.length === 0) {
+    return {
+      error: `Version "${versionIdOrPrefix}" not found`,
+      status: 404,
+    };
+  }
+
+  if (prefixMatches.length > 1) {
+    return {
+      error: `Ambiguous version prefix "${versionIdOrPrefix}". Please use more characters.`,
+      status: 400,
+    };
+  }
+
+  const matchedVersion = prefixMatches[0];
+  if (!matchedVersion) {
+    return {
+      error: `Version "${versionIdOrPrefix}" not found`,
+      status: 404,
+    };
+  }
+
+  return { version: matchedVersion };
 }

--- a/turbo/apps/web/app/api/storages/route.ts
+++ b/turbo/apps/web/app/api/storages/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { initServices } from "../../../src/lib/init-services";
 import { getUserId } from "../../../src/lib/auth/get-user-id";
 import { storages, storageVersions } from "../../../src/db/schema/storage";
-import { eq, and, like } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import {
   uploadS3Directory,
   downloadS3Directory,
@@ -14,10 +14,9 @@ import AdmZip from "adm-zip";
 import { env } from "../../../src/env";
 import {
   computeContentHash,
-  isValidVersionPrefix,
-  MIN_VERSION_PREFIX_LENGTH,
   type FileEntry,
 } from "../../../src/lib/storage/content-hash";
+import { resolveVersionByPrefix } from "../../../src/lib/storage/version-resolver";
 import { logger } from "../../../src/lib/logger";
 
 const log = logger("api:storages");
@@ -338,7 +337,7 @@ export async function GET(request: NextRequest) {
     let version;
     if (versionId) {
       // Resolve version (supports short prefix)
-      const resolveResult = await resolveVersionById(storage.id, versionId);
+      const resolveResult = await resolveVersionByPrefix(storage.id, versionId);
       if ("error" in resolveResult) {
         return NextResponse.json(
           { error: resolveResult.error },
@@ -450,82 +449,4 @@ async function getAllFiles(dirPath: string): Promise<string[]> {
   }
 
   return files;
-}
-
-/**
- * Resolve version ID by exact match or prefix match
- * Supports short version prefixes (minimum 8 characters)
- */
-type StorageVersion = typeof storageVersions.$inferSelect;
-
-async function resolveVersionById(
-  storageId: string,
-  versionIdOrPrefix: string,
-): Promise<{ version: StorageVersion } | { error: string; status: number }> {
-  // First, try exact match
-  const [exactMatch] = await globalThis.services.db
-    .select()
-    .from(storageVersions)
-    .where(
-      and(
-        eq(storageVersions.storageId, storageId),
-        eq(storageVersions.id, versionIdOrPrefix),
-      ),
-    )
-    .limit(1);
-
-  if (exactMatch) {
-    return { version: exactMatch };
-  }
-
-  // If not exact match, try prefix match (for short version IDs)
-  if (!isValidVersionPrefix(versionIdOrPrefix)) {
-    // Too short or invalid format
-    if (versionIdOrPrefix.length < MIN_VERSION_PREFIX_LENGTH) {
-      return {
-        error: `Version prefix too short. Minimum ${MIN_VERSION_PREFIX_LENGTH} characters required.`,
-        status: 400,
-      };
-    }
-    return {
-      error: `Version "${versionIdOrPrefix}" not found`,
-      status: 404,
-    };
-  }
-
-  // Search by prefix using LIKE
-  const prefixMatches = await globalThis.services.db
-    .select()
-    .from(storageVersions)
-    .where(
-      and(
-        eq(storageVersions.storageId, storageId),
-        like(storageVersions.id, `${versionIdOrPrefix.toLowerCase()}%`),
-      ),
-    )
-    .limit(2); // Only need to know if there's more than one
-
-  if (prefixMatches.length === 0) {
-    return {
-      error: `Version "${versionIdOrPrefix}" not found`,
-      status: 404,
-    };
-  }
-
-  if (prefixMatches.length > 1) {
-    return {
-      error: `Ambiguous version prefix "${versionIdOrPrefix}". Please use more characters.`,
-      status: 400,
-    };
-  }
-
-  const matchedVersion = prefixMatches[0];
-  if (!matchedVersion) {
-    return {
-      error: `Version "${versionIdOrPrefix}" not found`,
-      status: 404,
-    };
-  }
-
-  return { version: matchedVersion };
 }

--- a/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
@@ -22,6 +22,13 @@ import * as path from "node:path";
 import * as os from "node:os";
 import AdmZip from "adm-zip";
 import { env } from "../../../../../src/env";
+import {
+  computeContentHash,
+  type FileEntry,
+} from "../../../../../src/lib/storage/content-hash";
+import { logger } from "../../../../../src/lib/logger";
+
+const log = logger("webhook:storages");
 
 interface StorageVersionResponse {
   versionId: string;
@@ -68,8 +75,8 @@ export async function POST(request: NextRequest) {
       throw new BadRequestError("Missing file");
     }
 
-    console.log(
-      `[Storage Webhook] Received storage version request for "${storageName}" from run ${runId}`,
+    log.debug(
+      `Received storage version request for "${storageName}" from run ${runId}`,
     );
 
     // Verify run exists and belongs to the authenticated user
@@ -108,64 +115,100 @@ export async function POST(request: NextRequest) {
     const extractPath = path.join(tempDir, "extracted");
     zip.extractAllTo(extractPath, true);
 
-    console.log(`[Storage Webhook] Extracted zip to ${extractPath}`);
+    log.debug(`Extracted zip to ${extractPath}`);
 
-    // Calculate file count and size
-    const files = await getAllFiles(extractPath);
-    const fileCount = files.length;
+    // Calculate file count, size, and collect file entries for hashing
+    const filePaths = await getAllFiles(extractPath);
+    const fileCount = filePaths.length;
     let totalSize = 0;
-    for (const filePath of files) {
+    const fileEntries: FileEntry[] = [];
+
+    for (const filePath of filePaths) {
       const stats = await fs.promises.stat(filePath);
       totalSize += stats.size;
+
+      // Read file content for hash computation
+      const content = await fs.promises.readFile(filePath);
+      const relativePath = path.relative(extractPath, filePath);
+      fileEntries.push({ path: relativePath, content });
     }
 
-    // Create new version record
-    const versionId = crypto.randomUUID();
-    const s3Key = `${userId}/${storageName}/${versionId}`;
+    // Compute content-addressable hash for version ID
+    const contentHash = computeContentHash(fileEntries);
+    log.debug(`Computed content hash: ${contentHash}`);
 
-    const [version] = await globalThis.services.db
-      .insert(storageVersions)
-      .values({
-        id: versionId,
-        storageId: storage.id,
-        s3Key,
-        size: totalSize,
-        fileCount,
-        message: message || `Checkpoint from run ${runId}`,
-        createdBy: "agent",
-      })
-      .returning();
+    // Check if version with same content hash already exists (deduplication)
+    const [existingVersion] = await globalThis.services.db
+      .select()
+      .from(storageVersions)
+      .where(
+        and(
+          eq(storageVersions.storageId, storage.id),
+          eq(storageVersions.id, contentHash),
+        ),
+      )
+      .limit(1);
 
-    if (!version) {
-      throw new Error("Failed to create storage version");
+    let versionId: string;
+    let deduplicated = false;
+
+    if (existingVersion) {
+      // Content already exists, use existing version (deduplication)
+      log.debug(
+        `Version with same content already exists: ${existingVersion.id}`,
+      );
+      versionId = existingVersion.id;
+      deduplicated = true;
+    } else {
+      // Create new version record with content hash as ID
+      const s3Key = `${userId}/${storageName}/${contentHash}`;
+
+      const [version] = await globalThis.services.db
+        .insert(storageVersions)
+        .values({
+          id: contentHash,
+          storageId: storage.id,
+          s3Key,
+          size: totalSize,
+          fileCount,
+          message: message || `Checkpoint from run ${runId}`,
+          createdBy: "agent",
+        })
+        .returning();
+
+      if (!version) {
+        throw new Error("Failed to create storage version");
+      }
+
+      log.debug(`Created version: ${version.id}`);
+
+      // Upload files to versioned S3 path
+      const bucketName = env().S3_USER_STORAGES_NAME;
+      if (!bucketName) {
+        throw new Error(
+          "S3_USER_STORAGES_NAME environment variable is not set",
+        );
+      }
+      const s3Uri = `s3://${bucketName}/${s3Key}`;
+      log.debug(`Uploading ${fileCount} files to ${s3Uri}...`);
+      await uploadS3Directory(extractPath, s3Uri);
+
+      versionId = version.id;
     }
-
-    console.log(`[Storage Webhook] Created version: ${version.id}`);
-
-    // Upload files to versioned S3 path
-    const bucketName = env().S3_USER_STORAGES_NAME;
-    if (!bucketName) {
-      throw new Error("S3_USER_STORAGES_NAME environment variable is not set");
-    }
-    const s3Uri = `s3://${bucketName}/${s3Key}`;
-    console.log(
-      `[Storage Webhook] Uploading ${fileCount} files to ${s3Uri}...`,
-    );
-    await uploadS3Directory(extractPath, s3Uri);
 
     // Update storage's HEAD pointer and metadata
     await globalThis.services.db
       .update(storages)
       .set({
-        headVersionId: version.id,
+        headVersionId: versionId,
         size: totalSize,
         fileCount,
         updatedAt: new Date(),
       })
       .where(eq(storages.id, storage.id));
 
-    console.log(
-      `[Storage Webhook] Successfully created version ${version.id} for storage "${storageName}"`,
+    log.debug(
+      `Successfully ${deduplicated ? "reused" : "created"} version ${versionId} for storage "${storageName}"`,
     );
 
     // Clean up temp directory
@@ -174,7 +217,7 @@ export async function POST(request: NextRequest) {
 
     // Return response
     const response: StorageVersionResponse = {
-      versionId: version.id,
+      versionId,
       storageName,
       size: totalSize,
       fileCount,
@@ -182,7 +225,7 @@ export async function POST(request: NextRequest) {
 
     return successResponse(response, 200);
   } catch (error) {
-    console.error("[Storage Webhook] Error:", error);
+    log.error("Error:", error);
 
     // Clean up temp directory if exists
     if (tempDir) {

--- a/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
@@ -133,8 +133,8 @@ export async function POST(request: NextRequest) {
       fileEntries.push({ path: relativePath, content });
     }
 
-    // Compute content-addressable hash for version ID
-    const contentHash = computeContentHash(fileEntries);
+    // Compute content-addressable hash for version ID (includes storageId for uniqueness per storage)
+    const contentHash = computeContentHash(storage.id, fileEntries);
     log.debug(`Computed content hash: ${contentHash}`);
 
     // Check if version with same content hash already exists (deduplication)

--- a/turbo/apps/web/src/db/migrations/0024_storage_version_sha256.sql
+++ b/turbo/apps/web/src/db/migrations/0024_storage_version_sha256.sql
@@ -1,0 +1,28 @@
+-- Migration: Change storage version IDs from UUID to SHA-256 content hash
+-- This enables content-addressable storage with automatic deduplication
+
+-- Step 1: Drop existing foreign key constraint
+ALTER TABLE "storages" DROP CONSTRAINT IF EXISTS "storages_head_version_id_storage_versions_id_fk";
+
+-- Step 2: Alter storage_versions.id from uuid to varchar(64)
+-- First, drop the primary key constraint
+ALTER TABLE "storage_versions" DROP CONSTRAINT IF EXISTS "storage_versions_pkey";
+
+-- Change the column type (this will fail if there's existing data with incompatible format)
+ALTER TABLE "storage_versions" ALTER COLUMN "id" TYPE varchar(64) USING id::text;
+
+-- Re-add primary key constraint
+ALTER TABLE "storage_versions" ADD PRIMARY KEY ("id");
+
+-- Step 3: Alter storages.head_version_id from uuid to varchar(64)
+ALTER TABLE "storages" ALTER COLUMN "head_version_id" TYPE varchar(64) USING head_version_id::text;
+
+-- Step 4: Re-add foreign key constraint
+ALTER TABLE "storages"
+  ADD CONSTRAINT "storages_head_version_id_storage_versions_id_fk"
+  FOREIGN KEY ("head_version_id")
+  REFERENCES "public"."storage_versions"("id")
+  ON DELETE no action ON UPDATE no action;
+
+-- Step 5: Alter storage_versions.storage_id reference (this column stays as uuid, just referencing storages.id)
+-- No change needed here as storages.id remains uuid

--- a/turbo/apps/web/src/db/migrations/0024_storage_version_sha256.sql
+++ b/turbo/apps/web/src/db/migrations/0024_storage_version_sha256.sql
@@ -5,14 +5,12 @@
 ALTER TABLE "storages" DROP CONSTRAINT IF EXISTS "storages_head_version_id_storage_versions_id_fk";
 
 -- Step 2: Alter storage_versions.id from uuid to varchar(64)
--- First, drop the primary key constraint
-ALTER TABLE "storage_versions" DROP CONSTRAINT IF EXISTS "storage_versions_pkey";
+-- Drop the primary key constraint (named volume_versions_pkey from original table creation)
+ALTER TABLE "storage_versions" DROP CONSTRAINT IF EXISTS "volume_versions_pkey";
 
--- Change the column type (this will fail if there's existing data with incompatible format)
+-- Change the column type and re-add primary key in one step
 ALTER TABLE "storage_versions" ALTER COLUMN "id" TYPE varchar(64) USING id::text;
-
--- Re-add primary key constraint
-ALTER TABLE "storage_versions" ADD PRIMARY KEY ("id");
+ALTER TABLE "storage_versions" ADD CONSTRAINT "storage_versions_pkey" PRIMARY KEY ("id");
 
 -- Step 3: Alter storages.head_version_id from uuid to varchar(64)
 ALTER TABLE "storages" ALTER COLUMN "head_version_id" TYPE varchar(64) USING head_version_id::text;

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1764800000000,
       "tag": "0023_add_volume_versions_to_checkpoints",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1764900000000,
+      "tag": "0024_storage_version_sha256",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/storage.ts
+++ b/turbo/apps/web/src/db/schema/storage.ts
@@ -30,7 +30,7 @@ export const storages = pgTable(
     s3Prefix: text("s3_prefix").notNull(),
     size: bigint("size", { mode: "number" }).notNull().default(0),
     fileCount: integer("file_count").notNull().default(0),
-    headVersionId: uuid("head_version_id"),
+    headVersionId: varchar("head_version_id", { length: 64 }),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
@@ -44,10 +44,11 @@ export const storages = pgTable(
 
 /**
  * Storage versions table
- * Stores individual versions of each storage with versioned S3 paths
+ * Stores individual versions of each storage with content-addressable SHA-256 hash IDs
+ * Version ID is computed from the content itself, enabling deduplication and verification
  */
 export const storageVersions = pgTable("storage_versions", {
-  id: uuid("id").defaultRandom().primaryKey(),
+  id: varchar("id", { length: 64 }).primaryKey(),
   storageId: uuid("storage_id")
     .notNull()
     .references(() => storages.id, { onDelete: "cascade" }),

--- a/turbo/apps/web/src/lib/storage/__tests__/content-hash.test.ts
+++ b/turbo/apps/web/src/lib/storage/__tests__/content-hash.test.ts
@@ -8,23 +8,27 @@ import {
   FULL_VERSION_LENGTH,
 } from "../content-hash";
 
+// Test storage IDs (UUIDs)
+const STORAGE_ID_1 = "11111111-1111-1111-1111-111111111111";
+const STORAGE_ID_2 = "22222222-2222-2222-2222-222222222222";
+
 describe("computeContentHash", () => {
   it("should return 64-character hex string", () => {
     const files = [{ path: "test.txt", content: Buffer.from("hello") }];
-    const hash = computeContentHash(files);
+    const hash = computeContentHash(STORAGE_ID_1, files);
 
     expect(hash).toHaveLength(FULL_VERSION_LENGTH);
     expect(hash).toMatch(/^[a-f0-9]{64}$/);
   });
 
-  it("should be deterministic - same content produces same hash", () => {
+  it("should be deterministic - same storageId and content produces same hash", () => {
     const files = [
       { path: "a.txt", content: Buffer.from("content a") },
       { path: "b.txt", content: Buffer.from("content b") },
     ];
 
-    const hash1 = computeContentHash(files);
-    const hash2 = computeContentHash(files);
+    const hash1 = computeContentHash(STORAGE_ID_1, files);
+    const hash2 = computeContentHash(STORAGE_ID_1, files);
 
     expect(hash1).toBe(hash2);
   });
@@ -40,8 +44,8 @@ describe("computeContentHash", () => {
       { path: "a.txt", content: Buffer.from("content a") },
     ];
 
-    const hash1 = computeContentHash(filesOrder1);
-    const hash2 = computeContentHash(filesOrder2);
+    const hash1 = computeContentHash(STORAGE_ID_1, filesOrder1);
+    const hash2 = computeContentHash(STORAGE_ID_1, filesOrder2);
 
     expect(hash1).toBe(hash2);
   });
@@ -50,8 +54,8 @@ describe("computeContentHash", () => {
     const files1 = [{ path: "test.txt", content: Buffer.from("hello") }];
     const files2 = [{ path: "test.txt", content: Buffer.from("world") }];
 
-    const hash1 = computeContentHash(files1);
-    const hash2 = computeContentHash(files2);
+    const hash1 = computeContentHash(STORAGE_ID_1, files1);
+    const hash2 = computeContentHash(STORAGE_ID_1, files2);
 
     expect(hash1).not.toBe(hash2);
   });
@@ -60,22 +64,38 @@ describe("computeContentHash", () => {
     const files1 = [{ path: "a.txt", content: Buffer.from("content") }];
     const files2 = [{ path: "b.txt", content: Buffer.from("content") }];
 
-    const hash1 = computeContentHash(files1);
-    const hash2 = computeContentHash(files2);
+    const hash1 = computeContentHash(STORAGE_ID_1, files1);
+    const hash2 = computeContentHash(STORAGE_ID_1, files2);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it("should produce different hash for different storageId (same content)", () => {
+    const files = [{ path: "test.txt", content: Buffer.from("same content") }];
+
+    const hash1 = computeContentHash(STORAGE_ID_1, files);
+    const hash2 = computeContentHash(STORAGE_ID_2, files);
 
     expect(hash1).not.toBe(hash2);
   });
 
   it("should handle empty file list", () => {
-    const hash = computeContentHash([]);
+    const hash = computeContentHash(STORAGE_ID_1, []);
 
     expect(hash).toHaveLength(FULL_VERSION_LENGTH);
     expect(hash).toMatch(/^[a-f0-9]{64}$/);
   });
 
+  it("should produce different hash for empty file list with different storageId", () => {
+    const hash1 = computeContentHash(STORAGE_ID_1, []);
+    const hash2 = computeContentHash(STORAGE_ID_2, []);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
   it("should handle files with empty content", () => {
     const files = [{ path: "empty.txt", content: Buffer.from("") }];
-    const hash = computeContentHash(files);
+    const hash = computeContentHash(STORAGE_ID_1, files);
 
     expect(hash).toHaveLength(FULL_VERSION_LENGTH);
   });
@@ -86,7 +106,7 @@ describe("computeContentHash", () => {
       { path: "root.txt", content: Buffer.from("root") },
     ];
 
-    const hash = computeContentHash(files);
+    const hash = computeContentHash(STORAGE_ID_1, files);
     expect(hash).toHaveLength(FULL_VERSION_LENGTH);
   });
 
@@ -94,7 +114,7 @@ describe("computeContentHash", () => {
     const binaryContent = Buffer.from([0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd]);
     const files = [{ path: "binary.bin", content: binaryContent }];
 
-    const hash = computeContentHash(files);
+    const hash = computeContentHash(STORAGE_ID_1, files);
     expect(hash).toHaveLength(FULL_VERSION_LENGTH);
   });
 });

--- a/turbo/apps/web/src/lib/storage/__tests__/content-hash.test.ts
+++ b/turbo/apps/web/src/lib/storage/__tests__/content-hash.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeContentHash,
+  formatShortVersion,
+  isValidVersionId,
+  isValidVersionPrefix,
+  MIN_VERSION_PREFIX_LENGTH,
+  FULL_VERSION_LENGTH,
+} from "../content-hash";
+
+describe("computeContentHash", () => {
+  it("should return 64-character hex string", () => {
+    const files = [{ path: "test.txt", content: Buffer.from("hello") }];
+    const hash = computeContentHash(files);
+
+    expect(hash).toHaveLength(FULL_VERSION_LENGTH);
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("should be deterministic - same content produces same hash", () => {
+    const files = [
+      { path: "a.txt", content: Buffer.from("content a") },
+      { path: "b.txt", content: Buffer.from("content b") },
+    ];
+
+    const hash1 = computeContentHash(files);
+    const hash2 = computeContentHash(files);
+
+    expect(hash1).toBe(hash2);
+  });
+
+  it("should produce same hash regardless of file order", () => {
+    const filesOrder1 = [
+      { path: "a.txt", content: Buffer.from("content a") },
+      { path: "b.txt", content: Buffer.from("content b") },
+    ];
+
+    const filesOrder2 = [
+      { path: "b.txt", content: Buffer.from("content b") },
+      { path: "a.txt", content: Buffer.from("content a") },
+    ];
+
+    const hash1 = computeContentHash(filesOrder1);
+    const hash2 = computeContentHash(filesOrder2);
+
+    expect(hash1).toBe(hash2);
+  });
+
+  it("should produce different hash for different content", () => {
+    const files1 = [{ path: "test.txt", content: Buffer.from("hello") }];
+    const files2 = [{ path: "test.txt", content: Buffer.from("world") }];
+
+    const hash1 = computeContentHash(files1);
+    const hash2 = computeContentHash(files2);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it("should produce different hash for different paths", () => {
+    const files1 = [{ path: "a.txt", content: Buffer.from("content") }];
+    const files2 = [{ path: "b.txt", content: Buffer.from("content") }];
+
+    const hash1 = computeContentHash(files1);
+    const hash2 = computeContentHash(files2);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it("should handle empty file list", () => {
+    const hash = computeContentHash([]);
+
+    expect(hash).toHaveLength(FULL_VERSION_LENGTH);
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("should handle files with empty content", () => {
+    const files = [{ path: "empty.txt", content: Buffer.from("") }];
+    const hash = computeContentHash(files);
+
+    expect(hash).toHaveLength(FULL_VERSION_LENGTH);
+  });
+
+  it("should handle nested paths", () => {
+    const files = [
+      { path: "dir/subdir/file.txt", content: Buffer.from("nested") },
+      { path: "root.txt", content: Buffer.from("root") },
+    ];
+
+    const hash = computeContentHash(files);
+    expect(hash).toHaveLength(FULL_VERSION_LENGTH);
+  });
+
+  it("should handle binary content", () => {
+    const binaryContent = Buffer.from([0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd]);
+    const files = [{ path: "binary.bin", content: binaryContent }];
+
+    const hash = computeContentHash(files);
+    expect(hash).toHaveLength(FULL_VERSION_LENGTH);
+  });
+});
+
+describe("formatShortVersion", () => {
+  it("should return first 8 characters", () => {
+    const fullVersion =
+      "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2";
+    const short = formatShortVersion(fullVersion);
+
+    expect(short).toBe("a1b2c3d4");
+    expect(short).toHaveLength(8);
+  });
+});
+
+describe("isValidVersionId", () => {
+  it("should accept valid 64-char hex string", () => {
+    const validHash =
+      "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2";
+    expect(isValidVersionId(validHash)).toBe(true);
+  });
+
+  it("should accept uppercase hex", () => {
+    const validHash =
+      "A1B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9B0C1D2E3F4A5B6C7D8E9F0A1B2";
+    expect(isValidVersionId(validHash)).toBe(true);
+  });
+
+  it("should reject too short strings", () => {
+    expect(isValidVersionId("a1b2c3d4")).toBe(false);
+  });
+
+  it("should reject too long strings", () => {
+    const tooLong =
+      "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2extra";
+    expect(isValidVersionId(tooLong)).toBe(false);
+  });
+
+  it("should reject non-hex characters", () => {
+    const invalid =
+      "g1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2";
+    expect(isValidVersionId(invalid)).toBe(false);
+  });
+
+  it("should reject UUID format", () => {
+    const uuid = "a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6";
+    expect(isValidVersionId(uuid)).toBe(false);
+  });
+});
+
+describe("isValidVersionPrefix", () => {
+  it("should accept 8-character prefix", () => {
+    expect(isValidVersionPrefix("a1b2c3d4")).toBe(true);
+  });
+
+  it("should accept longer prefixes", () => {
+    expect(isValidVersionPrefix("a1b2c3d4e5f6")).toBe(true);
+  });
+
+  it("should accept full 64-character hash", () => {
+    const fullHash =
+      "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2";
+    expect(isValidVersionPrefix(fullHash)).toBe(true);
+  });
+
+  it("should reject prefix shorter than minimum", () => {
+    expect(isValidVersionPrefix("a1b2c3")).toBe(false);
+    expect(isValidVersionPrefix("a1b2c3d")).toBe(false);
+  });
+
+  it("should reject non-hex characters", () => {
+    expect(isValidVersionPrefix("a1b2c3g4")).toBe(false);
+  });
+
+  it("should accept uppercase", () => {
+    expect(isValidVersionPrefix("A1B2C3D4")).toBe(true);
+  });
+
+  it("should have correct minimum length constant", () => {
+    expect(MIN_VERSION_PREFIX_LENGTH).toBe(8);
+  });
+});

--- a/turbo/apps/web/src/lib/storage/content-hash.ts
+++ b/turbo/apps/web/src/lib/storage/content-hash.ts
@@ -1,0 +1,101 @@
+/**
+ * Content-addressable storage hash utilities
+ * Computes SHA-256 hash of storage content for version identification
+ */
+
+import { createHash } from "crypto";
+
+/**
+ * File entry for hash computation
+ */
+export interface FileEntry {
+  /** Relative path within the storage */
+  path: string;
+  /** File content as Buffer */
+  content: Buffer;
+}
+
+/**
+ * Compute SHA-256 hash of a single file's content
+ */
+function hashFileContent(content: Buffer): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+/**
+ * Compute content-addressable hash for a collection of files
+ *
+ * The hash is computed using a merkle-tree-like approach:
+ * 1. For each file, compute: "relativePath:sha256(content)"
+ * 2. Sort all entries alphabetically by path
+ * 3. Join with newlines
+ * 4. Compute SHA-256 of the combined string
+ *
+ * This ensures:
+ * - Same content always produces same hash (deterministic)
+ * - Different content produces different hash
+ * - File order doesn't affect the result (sorted)
+ * - Both path and content contribute to the hash
+ *
+ * @param files Array of file entries with path and content
+ * @returns 64-character lowercase hexadecimal SHA-256 hash
+ */
+export function computeContentHash(files: FileEntry[]): string {
+  // Handle empty storage case
+  if (files.length === 0) {
+    // Hash of empty string for empty storage
+    return createHash("sha256").update("").digest("hex");
+  }
+
+  // Create sorted list of "path:hash" entries
+  const entries = files
+    .map((file) => {
+      const contentHash = hashFileContent(file.content);
+      return `${file.path}:${contentHash}`;
+    })
+    .sort();
+
+  // Combine and hash
+  const combined = entries.join("\n");
+  return createHash("sha256").update(combined).digest("hex");
+}
+
+/**
+ * Minimum length for short version ID prefix
+ */
+export const MIN_VERSION_PREFIX_LENGTH = 8;
+
+/**
+ * Default display length for version IDs
+ */
+export const DEFAULT_VERSION_DISPLAY_LENGTH = 8;
+
+/**
+ * Full SHA-256 hash length
+ */
+export const FULL_VERSION_LENGTH = 64;
+
+/**
+ * Format a full version ID for display (short form)
+ * @param versionId Full 64-character version ID
+ * @returns 8-character short version ID
+ */
+export function formatShortVersion(versionId: string): string {
+  return versionId.slice(0, DEFAULT_VERSION_DISPLAY_LENGTH);
+}
+
+/**
+ * Check if a string is a valid SHA-256 hash (64 hex characters)
+ */
+export function isValidVersionId(versionId: string): boolean {
+  return /^[a-f0-9]{64}$/i.test(versionId);
+}
+
+/**
+ * Check if a string is a valid version prefix (8+ hex characters)
+ */
+export function isValidVersionPrefix(prefix: string): boolean {
+  return (
+    /^[a-f0-9]+$/i.test(prefix) && prefix.length >= MIN_VERSION_PREFIX_LENGTH
+  );
+}

--- a/turbo/apps/web/src/lib/storage/content-hash.ts
+++ b/turbo/apps/web/src/lib/storage/content-hash.ts
@@ -26,25 +26,30 @@ function hashFileContent(content: Buffer): string {
  * Compute content-addressable hash for a collection of files
  *
  * The hash is computed using a merkle-tree-like approach:
- * 1. For each file, compute: "relativePath:sha256(content)"
- * 2. Sort all entries alphabetically by path
- * 3. Join with newlines
- * 4. Compute SHA-256 of the combined string
+ * 1. Include storage ID as prefix (to ensure uniqueness per storage)
+ * 2. For each file, compute: "relativePath:sha256(content)"
+ * 3. Sort all entries alphabetically by path
+ * 4. Join with newlines
+ * 5. Compute SHA-256 of the combined string
  *
  * This ensures:
- * - Same content always produces same hash (deterministic)
+ * - Same content in same storage produces same hash (deterministic)
+ * - Same content in different storages produces different hashes
  * - Different content produces different hash
  * - File order doesn't affect the result (sorted)
  * - Both path and content contribute to the hash
  *
+ * @param storageId The storage UUID to include in the hash
  * @param files Array of file entries with path and content
  * @returns 64-character lowercase hexadecimal SHA-256 hash
  */
-export function computeContentHash(files: FileEntry[]): string {
-  // Handle empty storage case
+export function computeContentHash(
+  storageId: string,
+  files: FileEntry[],
+): string {
+  // Handle empty storage case - still include storageId for uniqueness
   if (files.length === 0) {
-    // Hash of empty string for empty storage
-    return createHash("sha256").update("").digest("hex");
+    return createHash("sha256").update(`storage:${storageId}\n`).digest("hex");
   }
 
   // Create sorted list of "path:hash" entries
@@ -55,8 +60,8 @@ export function computeContentHash(files: FileEntry[]): string {
     })
     .sort();
 
-  // Combine and hash
-  const combined = entries.join("\n");
+  // Include storageId prefix and combine with file entries
+  const combined = `storage:${storageId}\n${entries.join("\n")}`;
   return createHash("sha256").update(combined).digest("hex");
 }
 

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -14,12 +14,9 @@ import type {
 } from "./types";
 import type { ArtifactSnapshot } from "../checkpoint/types";
 import { storages, storageVersions } from "../../db/schema/storage";
-import { eq, and, like } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { env } from "../../env";
-import {
-  isValidVersionPrefix,
-  MIN_VERSION_PREFIX_LENGTH,
-} from "./content-hash";
+import { resolveVersionByPrefix, isResolutionError } from "./version-resolver";
 
 const log = logger("service:storage");
 
@@ -70,67 +67,25 @@ export class StorageService {
       return { versionId: headVersion.id, s3Key: headVersion.s3Key };
     }
 
-    // First, try exact match for specific version by ID (full hash)
-    const [exactMatch] = await globalThis.services.db
-      .select()
-      .from(storageVersions)
-      .where(
-        and(
-          eq(storageVersions.storageId, dbStorage.id),
-          eq(storageVersions.id, version),
-        ),
-      )
-      .limit(1);
+    // Use shared version resolver for exact match and prefix match
+    const result = await resolveVersionByPrefix(dbStorage.id, version);
 
-    if (exactMatch) {
-      return { versionId: exactMatch.id, s3Key: exactMatch.s3Key };
-    }
-
-    // If not exact match, try prefix match (for short version IDs)
-    if (!isValidVersionPrefix(version)) {
-      // Too short or invalid format
-      if (version.length < MIN_VERSION_PREFIX_LENGTH) {
+    if (isResolutionError(result)) {
+      // Add storage name context to error message
+      if (result.error.includes("not found")) {
         throw new Error(
-          `Version prefix too short. Minimum ${MIN_VERSION_PREFIX_LENGTH} characters required.`,
+          `Storage "${storageName}" version "${version}" not found`,
         );
       }
-      throw new Error(
-        `Storage "${storageName}" version "${version}" not found`,
-      );
+      if (result.error.includes("Ambiguous")) {
+        throw new Error(
+          `Ambiguous version prefix "${version}" for storage "${storageName}". Please use more characters.`,
+        );
+      }
+      throw new Error(result.error);
     }
 
-    // Search by prefix using LIKE
-    const prefixMatches = await globalThis.services.db
-      .select()
-      .from(storageVersions)
-      .where(
-        and(
-          eq(storageVersions.storageId, dbStorage.id),
-          like(storageVersions.id, `${version.toLowerCase()}%`),
-        ),
-      )
-      .limit(2); // Only need to know if there's more than one
-
-    if (prefixMatches.length === 0) {
-      throw new Error(
-        `Storage "${storageName}" version "${version}" not found`,
-      );
-    }
-
-    if (prefixMatches.length > 1) {
-      throw new Error(
-        `Ambiguous version prefix "${version}" for storage "${storageName}". Please use more characters.`,
-      );
-    }
-
-    const matchedVersion = prefixMatches[0];
-    if (!matchedVersion) {
-      throw new Error(
-        `Storage "${storageName}" version "${version}" not found`,
-      );
-    }
-
-    return { versionId: matchedVersion.id, s3Key: matchedVersion.s3Key };
+    return { versionId: result.version.id, s3Key: result.version.s3Key };
   }
 
   /**

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -14,8 +14,12 @@ import type {
 } from "./types";
 import type { ArtifactSnapshot } from "../checkpoint/types";
 import { storages, storageVersions } from "../../db/schema/storage";
-import { eq, and } from "drizzle-orm";
+import { eq, and, like } from "drizzle-orm";
 import { env } from "../../env";
+import {
+  isValidVersionPrefix,
+  MIN_VERSION_PREFIX_LENGTH,
+} from "./content-hash";
 
 const log = logger("service:storage");
 
@@ -66,8 +70,8 @@ export class StorageService {
       return { versionId: headVersion.id, s3Key: headVersion.s3Key };
     }
 
-    // Query for specific version by ID (hash)
-    const [specificVersion] = await globalThis.services.db
+    // First, try exact match for specific version by ID (full hash)
+    const [exactMatch] = await globalThis.services.db
       .select()
       .from(storageVersions)
       .where(
@@ -78,13 +82,55 @@ export class StorageService {
       )
       .limit(1);
 
-    if (!specificVersion) {
+    if (exactMatch) {
+      return { versionId: exactMatch.id, s3Key: exactMatch.s3Key };
+    }
+
+    // If not exact match, try prefix match (for short version IDs)
+    if (!isValidVersionPrefix(version)) {
+      // Too short or invalid format
+      if (version.length < MIN_VERSION_PREFIX_LENGTH) {
+        throw new Error(
+          `Version prefix too short. Minimum ${MIN_VERSION_PREFIX_LENGTH} characters required.`,
+        );
+      }
       throw new Error(
         `Storage "${storageName}" version "${version}" not found`,
       );
     }
 
-    return { versionId: specificVersion.id, s3Key: specificVersion.s3Key };
+    // Search by prefix using LIKE
+    const prefixMatches = await globalThis.services.db
+      .select()
+      .from(storageVersions)
+      .where(
+        and(
+          eq(storageVersions.storageId, dbStorage.id),
+          like(storageVersions.id, `${version.toLowerCase()}%`),
+        ),
+      )
+      .limit(2); // Only need to know if there's more than one
+
+    if (prefixMatches.length === 0) {
+      throw new Error(
+        `Storage "${storageName}" version "${version}" not found`,
+      );
+    }
+
+    if (prefixMatches.length > 1) {
+      throw new Error(
+        `Ambiguous version prefix "${version}" for storage "${storageName}". Please use more characters.`,
+      );
+    }
+
+    const matchedVersion = prefixMatches[0];
+    if (!matchedVersion) {
+      throw new Error(
+        `Storage "${storageName}" version "${version}" not found`,
+      );
+    }
+
+    return { versionId: matchedVersion.id, s3Key: matchedVersion.s3Key };
   }
 
   /**

--- a/turbo/apps/web/src/lib/storage/version-resolver.ts
+++ b/turbo/apps/web/src/lib/storage/version-resolver.ts
@@ -1,0 +1,115 @@
+/**
+ * Version resolution utilities for storage versions
+ * Supports exact match and short prefix matching (like Git)
+ */
+
+import { storageVersions } from "../../db/schema/storage";
+import { eq, and, like } from "drizzle-orm";
+import {
+  isValidVersionPrefix,
+  MIN_VERSION_PREFIX_LENGTH,
+} from "./content-hash";
+
+/**
+ * Storage version record type
+ */
+export type StorageVersion = typeof storageVersions.$inferSelect;
+
+/**
+ * Result of version resolution - either success with version or error with details
+ */
+export type VersionResolutionResult =
+  | { version: StorageVersion }
+  | { error: string; status: number };
+
+/**
+ * Resolve a version by ID or prefix within a storage
+ *
+ * Resolution order:
+ * 1. Try exact match (full 64-char hash)
+ * 2. Try prefix match (minimum 8 characters)
+ *
+ * @param storageId - UUID of the storage
+ * @param versionIdOrPrefix - Full version ID or short prefix (8+ chars)
+ * @returns Resolved version or error with HTTP status code
+ */
+export async function resolveVersionByPrefix(
+  storageId: string,
+  versionIdOrPrefix: string,
+): Promise<VersionResolutionResult> {
+  // First, try exact match
+  const [exactMatch] = await globalThis.services.db
+    .select()
+    .from(storageVersions)
+    .where(
+      and(
+        eq(storageVersions.storageId, storageId),
+        eq(storageVersions.id, versionIdOrPrefix),
+      ),
+    )
+    .limit(1);
+
+  if (exactMatch) {
+    return { version: exactMatch };
+  }
+
+  // If not exact match, try prefix match (for short version IDs)
+  if (!isValidVersionPrefix(versionIdOrPrefix)) {
+    // Too short or invalid format
+    if (versionIdOrPrefix.length < MIN_VERSION_PREFIX_LENGTH) {
+      return {
+        error: `Version prefix too short. Minimum ${MIN_VERSION_PREFIX_LENGTH} characters required.`,
+        status: 400,
+      };
+    }
+    return {
+      error: `Version "${versionIdOrPrefix}" not found`,
+      status: 404,
+    };
+  }
+
+  // Search by prefix using LIKE
+  const prefixMatches = await globalThis.services.db
+    .select()
+    .from(storageVersions)
+    .where(
+      and(
+        eq(storageVersions.storageId, storageId),
+        like(storageVersions.id, `${versionIdOrPrefix.toLowerCase()}%`),
+      ),
+    )
+    .limit(2); // Only need to know if there's more than one
+
+  if (prefixMatches.length === 0) {
+    return {
+      error: `Version "${versionIdOrPrefix}" not found`,
+      status: 404,
+    };
+  }
+
+  if (prefixMatches.length > 1) {
+    return {
+      error: `Ambiguous version prefix "${versionIdOrPrefix}". Please use more characters.`,
+      status: 400,
+    };
+  }
+
+  const matchedVersion = prefixMatches[0];
+  if (!matchedVersion) {
+    return {
+      error: `Version "${versionIdOrPrefix}" not found`,
+      status: 404,
+    };
+  }
+
+  return { version: matchedVersion };
+}
+
+/**
+ * Check if a resolution result is an error
+ */
+export function isResolutionError(
+  result: VersionResolutionResult,
+): result is { error: string; status: number } {
+  return "error" in result;
+}


### PR DESCRIPTION
## Summary

Implements content-addressable storage for volume/artifact versions using SHA-256 hashes instead of random UUIDs.

**Key changes:**
- Storage version IDs are now derived from content using SHA-256 hash (64 hex characters)
- Automatic deduplication: uploading identical content returns existing version
- Short version prefix support: users can reference versions with 8+ character prefixes
- CLI displays 8-character short versions by default

## Test plan

- [x] Unit tests for `computeContentHash()` - deterministic hashing, file order independence
- [x] Unit tests for version prefix validation
- [x] Existing storage tests pass
- [ ] Manual test: upload same content twice, verify same version ID returned
- [ ] Manual test: reference version with 8-character prefix

## Implementation Details

### Content Hash Algorithm
- Files sorted by path, each entry: `path:sha256(content)`
- Final hash: SHA-256 of joined entries

### Database Changes
- `storageVersions.id`: `uuid` → `varchar(64)`
- `storages.headVersionId`: `uuid` → `varchar(64)`

### Short Version Resolution
- Minimum prefix: 8 characters
- Exact match tried first
- Prefix match with `LIKE 'prefix%'`
- Error on ambiguous prefix (multiple matches)

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)