### PR TITLE
fix: resolve and display volumes in vm0_start and vm0_result events

### DIFF
--- a/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
+++ b/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Sandbox } from "@e2b/code-interpreter";
 import { e2bService } from "../e2b-service";
+import { sendVm0StartEvent } from "../../events";
 import type { ExecutionContext } from "../../run/types";
 
 // Mock the E2B SDK module
@@ -36,6 +37,12 @@ const mockStorageService = vi.hoisted(() => ({
 
 vi.mock("../../storage/storage-service", () => ({
   storageService: mockStorageService,
+}));
+
+// Mock events module
+vi.mock("../../events", () => ({
+  sendVm0StartEvent: vi.fn().mockResolvedValue(undefined),
+  sendVm0ErrorEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock fs module
@@ -140,6 +147,106 @@ describe("E2B Service - mocked unit tests", () => {
       // commands.run called: 1 (mkdir) + 8 (mv/chmod for each script) + 1 (execute) = 10 times
       expect(mockSandbox.commands.run).toHaveBeenCalledTimes(10);
       expect(mockSandbox.kill).toHaveBeenCalledTimes(1);
+    });
+
+    it("should send vm0_start event with correct parameters", async () => {
+      // Arrange
+      const mockSandbox = createMockSandbox();
+      vi.mocked(Sandbox.create).mockResolvedValue(
+        mockSandbox as unknown as Sandbox,
+      );
+
+      const context: ExecutionContext = {
+        runId: "run-test-event",
+        agentConfigId: "test-agent-event",
+        agentConfig: {},
+        sandboxToken: "vm0_live_test_token",
+        prompt: "Test prompt",
+        templateVars: { key: "value" },
+        agentName: "My Agent",
+        resumedFromCheckpointId: "checkpoint-123",
+        continuedFromSessionId: undefined,
+      };
+
+      // Act
+      await e2bService.execute(context);
+
+      // Assert - Verify vm0_start event was sent with correct parameters
+      expect(sendVm0StartEvent).toHaveBeenCalledTimes(1);
+      expect(sendVm0StartEvent).toHaveBeenCalledWith({
+        runId: "run-test-event",
+        agentConfigId: "test-agent-event",
+        agentName: "My Agent",
+        prompt: "Test prompt",
+        templateVars: { key: "value" },
+        resumedFromCheckpointId: "checkpoint-123",
+        continuedFromSessionId: undefined,
+        artifact: undefined,
+        volumes: undefined,
+      });
+    });
+
+    it("should include artifact and volumes in vm0_start event when prepared", async () => {
+      // Arrange
+      const mockSandbox = createMockSandbox();
+      vi.mocked(Sandbox.create).mockResolvedValue(
+        mockSandbox as unknown as Sandbox,
+      );
+
+      // Mock storage service to return prepared artifact and volumes
+      mockStorageService.prepareStorages.mockResolvedValueOnce({
+        preparedStorages: [
+          {
+            name: "data-volume",
+            driver: "vas",
+            localPath: "/tmp/data",
+            mountPath: "/data",
+            vasStorageName: "data-storage",
+            vasVersionId: "vol-version-abc",
+          },
+          {
+            name: "models",
+            driver: "vas",
+            localPath: "/tmp/models",
+            mountPath: "/models",
+            vasStorageName: "models-storage",
+            vasVersionId: "vol-version-xyz",
+          },
+        ],
+        preparedArtifact: {
+          driver: "vas",
+          localPath: "/tmp/artifact",
+          mountPath: "/workspace",
+          vasStorageName: "my-artifact",
+          vasVersionId: "art-version-123",
+        },
+        tempDir: "/tmp/e2b-test",
+        errors: [],
+      });
+
+      const context: ExecutionContext = {
+        runId: "run-test-storages",
+        agentConfigId: "test-agent-storages",
+        agentConfig: {},
+        sandboxToken: "vm0_live_test_token",
+        prompt: "Test with storages",
+      };
+
+      // Act
+      await e2bService.execute(context);
+
+      // Assert - Verify vm0_start event includes artifact and volumes
+      expect(sendVm0StartEvent).toHaveBeenCalledTimes(1);
+      expect(sendVm0StartEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runId: "run-test-storages",
+          artifact: { "my-artifact": "art-version-123" },
+          volumes: {
+            "data-volume": "vol-version-abc",
+            models: "vol-version-xyz",
+          },
+        }),
+      );
     });
 
     it("should use provided run IDs for multiple calls", async () => {

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -414,6 +414,10 @@ export class RunService {
     runId: string;
     sandboxToken: string;
     userId: string;
+    // Metadata for vm0_start event
+    agentName?: string;
+    resumedFromCheckpointId?: string;
+    continuedFromSessionId?: string;
   }): Promise<ExecutionContext> {
     log.debug(`Building execution context for ${params.runId}`);
     log.debug(`params.volumeVersions=${JSON.stringify(params.volumeVersions)}`);
@@ -622,6 +626,10 @@ export class RunService {
       volumeVersions,
       resumeSession,
       resumeArtifact,
+      // Metadata for vm0_start event
+      agentName: params.agentName,
+      resumedFromCheckpointId: params.resumedFromCheckpointId,
+      continuedFromSessionId: params.continuedFromSessionId,
     };
   }
 

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -32,4 +32,9 @@ export interface ExecutionContext {
   // Resume-specific (optional)
   resumeSession?: ResumeSession;
   resumeArtifact?: ArtifactSnapshot;
+
+  // Metadata for vm0_start event
+  agentName?: string;
+  resumedFromCheckpointId?: string;
+  continuedFromSessionId?: string;
 }


### PR DESCRIPTION
## Summary

- Fix vm0_start to resolve and display volumes from agent config (for new runs and session continue)
- Volume versions are only shown in vm0_start since they don't change during execution (unlike artifacts)

## Changes

**turbo/apps/web/app/api/agent/runs/route.ts:**
- Import `resolveVolumes` and `AgentVolumeConfig`
- Store `agentConfigYaml` when loading agent configs
- Resolve volumes from agent config for new runs and session continue modes

## Expected Output After Fix

**vm0_start:**
```
[vm0_start] Run starting
  Run ID: 1c0632f2-...
  Prompt: list all my files
  Agent: vm0-standard
  Artifact:
    user-files: latest
  Volumes:
    claude-files: <version-hash>
```

**vm0_result:** (unchanged - volumes not shown since they don't change)
```
[vm0_result] ✓ Run completed successfully
  Checkpoint: 24f42296-...
  Session: 6986b1d2-...
  Conversation: 5a9a33de-...
  Artifact:
    user-files: d03d3b4c
```

## Test Plan

- [x] Type checking passes
- [x] Lint passes
- [x] All 416 tests pass
- [ ] Manual E2E testing with agent config containing volumes

Fixes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)