### PR TITLE
feat: support empty artifact and volume push

### DIFF
--- a/e2e/tests/02-commands/t03-artifacts.bats
+++ b/e2e/tests/02-commands/t03-artifacts.bats
@@ -47,6 +47,20 @@ teardown() {
     assert_output --partial "Invalid artifact name"
 }
 
+@test "Push empty artifact to cloud succeeds" {
+    mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+
+    # Push without any files (empty artifact)
+    run $CLI_COMMAND artifact push
+    assert_success
+    assert_output --partial "No files found (empty artifact)"
+    assert_output --partial "Version:"
+    assert_output --partial "Files: 0"
+    assert_output --regexp "[0-9a-f]{8}"
+}
+
 @test "Push artifact to cloud and returns versionId" {
     mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
     cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"

--- a/e2e/tests/02-commands/t03-volumes.bats
+++ b/e2e/tests/02-commands/t03-volumes.bats
@@ -45,6 +45,20 @@ teardown() {
     assert_output --partial "Invalid volume name"
 }
 
+@test "Push empty volume to cloud succeeds" {
+    mkdir -p "$TEST_VOLUME_DIR/$VOLUME_NAME"
+    cd "$TEST_VOLUME_DIR/$VOLUME_NAME"
+    $CLI_COMMAND volume init >/dev/null
+
+    # Push without any files (empty volume)
+    run $CLI_COMMAND volume push
+    assert_success
+    assert_output --partial "No files found (empty volume)"
+    assert_output --partial "Version:"
+    assert_output --partial "Files: 0"
+    assert_output --regexp "[0-9a-f]{8}"
+}
+
 @test "Push volume to cloud and returns versionId" {
     mkdir -p "$TEST_VOLUME_DIR/$VOLUME_NAME"
     cd "$TEST_VOLUME_DIR/$VOLUME_NAME"

--- a/turbo/apps/cli/src/commands/artifact/push.ts
+++ b/turbo/apps/cli/src/commands/artifact/push.ts
@@ -78,11 +78,6 @@ export const pushCommand = new Command()
       console.log(chalk.gray("Collecting files..."));
       const files = await getAllFiles(cwd);
 
-      if (files.length === 0) {
-        console.log(chalk.yellow("No files to upload"));
-        return;
-      }
-
       // Calculate total size
       let totalSize = 0;
       for (const file of files) {
@@ -90,11 +85,15 @@ export const pushCommand = new Command()
         totalSize += stats.size;
       }
 
-      console.log(
-        chalk.gray(`Found ${files.length} files (${formatBytes(totalSize)})`),
-      );
+      if (files.length === 0) {
+        console.log(chalk.gray("No files found (empty artifact)"));
+      } else {
+        console.log(
+          chalk.gray(`Found ${files.length} files (${formatBytes(totalSize)})`),
+        );
+      }
 
-      // Create zip file
+      // Create zip file (empty zip for empty artifact)
       console.log(chalk.gray("Compressing files..."));
       const zip = new AdmZip();
 

--- a/turbo/apps/cli/src/commands/volume/push.ts
+++ b/turbo/apps/cli/src/commands/volume/push.ts
@@ -68,11 +68,6 @@ export const pushCommand = new Command()
       console.log(chalk.gray("Collecting files..."));
       const files = await getAllFiles(cwd);
 
-      if (files.length === 0) {
-        console.log(chalk.yellow("No files to upload"));
-        return;
-      }
-
       // Calculate total size
       let totalSize = 0;
       for (const file of files) {
@@ -80,11 +75,15 @@ export const pushCommand = new Command()
         totalSize += stats.size;
       }
 
-      console.log(
-        chalk.gray(`Found ${files.length} files (${formatBytes(totalSize)})`),
-      );
+      if (files.length === 0) {
+        console.log(chalk.gray("No files found (empty volume)"));
+      } else {
+        console.log(
+          chalk.gray(`Found ${files.length} files (${formatBytes(totalSize)})`),
+        );
+      }
 
-      // Create zip file
+      // Create zip file (empty zip for empty volume)
       console.log(chalk.gray("Compressing files..."));
       const zip = new AdmZip();
 

--- a/turbo/apps/web/app/api/storages/__tests__/empty-zip-handling.test.ts
+++ b/turbo/apps/web/app/api/storages/__tests__/empty-zip-handling.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import AdmZip from "adm-zip";
+
+/**
+ * Tests for empty zip handling behavior.
+ *
+ * This tests the key fix in the storages API route:
+ * - AdmZip.extractAllTo() does NOT create the target directory for empty zips
+ * - We must ensure the directory exists before/after extraction
+ */
+describe("Empty Zip Handling", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    // Cleanup temp directories
+    for (const dir of tempDirs) {
+      await fs.promises.rm(dir, { recursive: true, force: true }).catch(() => {
+        // Ignore cleanup errors
+      });
+    }
+    tempDirs.length = 0;
+  });
+
+  it("AdmZip does NOT create directory for empty zip extraction", async () => {
+    // Create temp directory
+    const tempDir = path.join(os.tmpdir(), `test-empty-zip-${Date.now()}`);
+    tempDirs.push(tempDir);
+    await fs.promises.mkdir(tempDir, { recursive: true });
+
+    // Create empty zip
+    const zip = new AdmZip();
+    const zipPath = path.join(tempDir, "empty.zip");
+    zip.writeZip(zipPath);
+
+    // Extract empty zip
+    const extractPath = path.join(tempDir, "extracted");
+    const zip2 = new AdmZip(zipPath);
+    zip2.extractAllTo(extractPath, true);
+
+    // Verify: directory should NOT exist (this is the problematic behavior we're working around)
+    const exists = fs.existsSync(extractPath);
+    expect(exists).toBe(false);
+  });
+
+  it("mkdir after extraction ensures directory exists for empty zip", async () => {
+    // Create temp directory
+    const tempDir = path.join(os.tmpdir(), `test-empty-zip-${Date.now()}`);
+    tempDirs.push(tempDir);
+    await fs.promises.mkdir(tempDir, { recursive: true });
+
+    // Create empty zip
+    const zip = new AdmZip();
+    const zipPath = path.join(tempDir, "empty.zip");
+    zip.writeZip(zipPath);
+
+    // Extract empty zip (directory won't be created)
+    const extractPath = path.join(tempDir, "extracted");
+    const zip2 = new AdmZip(zipPath);
+    zip2.extractAllTo(extractPath, true);
+
+    // Apply fix: ensure directory exists
+    await fs.promises.mkdir(extractPath, { recursive: true });
+
+    // Verify: directory should now exist
+    const exists = fs.existsSync(extractPath);
+    expect(exists).toBe(true);
+
+    // Verify: directory should be empty
+    const files = await fs.promises.readdir(extractPath);
+    expect(files).toHaveLength(0);
+  });
+
+  it("mkdir before extraction also works (our implementation)", async () => {
+    // Create temp directory
+    const tempDir = path.join(os.tmpdir(), `test-empty-zip-${Date.now()}`);
+    tempDirs.push(tempDir);
+    await fs.promises.mkdir(tempDir, { recursive: true });
+
+    // Create empty zip
+    const zip = new AdmZip();
+    const zipPath = path.join(tempDir, "empty.zip");
+    zip.writeZip(zipPath);
+
+    // This is how we implement it in route.ts:
+    // 1. Create extract directory first
+    // 2. Then extract (which does nothing for empty zip, but directory exists)
+    const extractPath = path.join(tempDir, "extracted");
+    await fs.promises.mkdir(extractPath, { recursive: true });
+
+    const zip2 = new AdmZip(zipPath);
+    zip2.extractAllTo(extractPath, true);
+
+    // Verify: directory should exist
+    const exists = fs.existsSync(extractPath);
+    expect(exists).toBe(true);
+
+    // Verify: directory should be empty
+    const files = await fs.promises.readdir(extractPath);
+    expect(files).toHaveLength(0);
+  });
+
+  it("non-empty zip extraction creates directory automatically", async () => {
+    // Create temp directory
+    const tempDir = path.join(os.tmpdir(), `test-nonempty-zip-${Date.now()}`);
+    tempDirs.push(tempDir);
+    await fs.promises.mkdir(tempDir, { recursive: true });
+
+    // Create zip with a file
+    const zip = new AdmZip();
+    zip.addFile("test.txt", Buffer.from("hello world"));
+    const zipPath = path.join(tempDir, "nonempty.zip");
+    zip.writeZip(zipPath);
+
+    // Extract non-empty zip
+    const extractPath = path.join(tempDir, "extracted");
+    const zip2 = new AdmZip(zipPath);
+    zip2.extractAllTo(extractPath, true);
+
+    // Verify: directory should exist (created by AdmZip for non-empty zip)
+    const exists = fs.existsSync(extractPath);
+    expect(exists).toBe(true);
+
+    // Verify: should contain the file
+    const files = await fs.promises.readdir(extractPath);
+    expect(files).toContain("test.txt");
+  });
+
+  it("mkdir with recursive:true is idempotent (safe to call multiple times)", async () => {
+    // Create temp directory
+    const tempDir = path.join(os.tmpdir(), `test-mkdir-${Date.now()}`);
+    tempDirs.push(tempDir);
+    await fs.promises.mkdir(tempDir, { recursive: true });
+
+    const extractPath = path.join(tempDir, "extracted");
+
+    // Call mkdir multiple times - should not throw
+    await fs.promises.mkdir(extractPath, { recursive: true });
+    await fs.promises.mkdir(extractPath, { recursive: true });
+    await fs.promises.mkdir(extractPath, { recursive: true });
+
+    // Directory should exist
+    const exists = fs.existsSync(extractPath);
+    expect(exists).toBe(true);
+  });
+});

--- a/turbo/apps/web/app/api/storages/route.ts
+++ b/turbo/apps/web/app/api/storages/route.ts
@@ -106,6 +106,9 @@ export async function POST(request: NextRequest) {
     const extractPath = path.join(tempDir, "extracted");
     zip.extractAllTo(extractPath, true);
 
+    // Ensure extract directory exists (empty zips don't create it)
+    await fs.promises.mkdir(extractPath, { recursive: true });
+
     log.debug(`Extracted zip to ${extractPath}`);
 
     // Calculate file count, size, and collect file entries for hashing

--- a/turbo/apps/web/app/api/storages/route.ts
+++ b/turbo/apps/web/app/api/storages/route.ts
@@ -104,10 +104,9 @@ export async function POST(request: NextRequest) {
     // Extract zip file
     const zip = new AdmZip(zipPath);
     const extractPath = path.join(tempDir, "extracted");
-    zip.extractAllTo(extractPath, true);
-
-    // Ensure extract directory exists (empty zips don't create it)
+    // Ensure extract directory exists before extraction (empty zips don't create it)
     await fs.promises.mkdir(extractPath, { recursive: true });
+    zip.extractAllTo(extractPath, true);
 
     log.debug(`Extracted zip to ${extractPath}`);
 


### PR DESCRIPTION
## Summary

- Allow users to push empty artifacts and volumes
- Previously, pushing an empty directory would skip the API call entirely, leaving the storage unregistered in the database
- This caused agent runs to fail with "Storage not found" errors when using empty artifacts

## Changes

- Remove early return when no files found in CLI push commands (`artifact/push.ts`, `volume/push.ts`)
- Ensure API creates extract directory for empty zip files (`storages/route.ts`)
- Both artifact and volume push now work with empty directories

## Test plan

- [ ] Create empty directory, run `vm0 artifact init`, then `vm0 artifact push` - should succeed
- [ ] Run agent with the empty artifact - should work without "Storage not found" error
- [ ] Same workflow for volumes

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)