### PR TITLE
fix: use waituntil to ensure background execution completes

### DIFF
--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -24,6 +24,7 @@
     "@t3-oss/env-nextjs": "^0.13.8",
     "@ts-rest/core": "^3.52.1",
     "@ts-rest/serverless": "^3.52.1",
+    "@vercel/functions": "^3.3.4",
     "@vm0/core": "workspace:*",
     "@vm0/ui": "workspace:*",
     "adm-zip": "^0.5.16",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       '@ts-rest/serverless':
         specifier: ^3.52.1
         version: 3.52.1(@ts-rest/core@3.52.1(@types/node@24.3.0)(zod@4.1.5))(next@15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(zod@4.1.5)
+      '@vercel/functions':
+        specifier: ^3.3.4
+        version: 3.3.4(@aws-sdk/credential-provider-web-identity@3.936.0)
       '@vm0/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -2439,6 +2442,19 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vercel/functions@3.3.4':
+    resolution: {integrity: sha512-IoP8Xfr1QeCm+Dv5od3bfPiw/VgLKsA7IBd/88M/Wr421HdbH4b6bW5z8CTxiz1QRpalrPFZcLdMdxu+2hAjZg==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+
+  '@vercel/oidc@3.0.5':
+    resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
+    engines: {node: '>= 20'}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -7519,6 +7535,14 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vercel/functions@3.3.4(@aws-sdk/credential-provider-web-identity@3.936.0)':
+    dependencies:
+      '@vercel/oidc': 3.0.5
+    optionalDependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.936.0
+
+  '@vercel/oidc@3.0.5': {}
+
   '@vitejs/plugin-react@4.7.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.3
@@ -7603,7 +7627,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:


### PR DESCRIPTION
## Summary

- Add `@vercel/functions` dependency to use Vercel's `waitUntil()` API
- Wrap E2B execution in `waitUntil()` to ensure background tasks complete reliably

## Problem

The E2B execution was started as a "fire-and-forget" promise without await. This caused Vercel serverless functions to potentially terminate before the background task completed, resulting in flaky test failures where runs would timeout without receiving events.

### Root Cause Analysis

From Vercel logs, we observed that some runs would:
1. Create run record successfully ✅
2. Start `buildExecutionContext` ✅
3. Return response to client ✅
4. **Silently terminate** before E2B sandbox creation ❌

The function returned the response but Vercel terminated the execution environment before the async promise chain completed.

## Solution

Use Vercel's `waitUntil()` which extends the function lifetime until the promise resolves, ensuring the E2B sandbox execution completes reliably.

```typescript
// Before: fire-and-forget (could be terminated)
runService.buildExecutionContext({...}).then(...);

// After: waitUntil ensures completion
waitUntil(
  runService.buildExecutionContext({...}).then(...)
);
```

## Test plan

- [ ] Verify CI cli-e2e tests pass without timeout failures
- [ ] Monitor Vercel logs to confirm runs complete with `waitUntil`
- [ ] Check that response time remains fast (waitUntil doesn't block response)

Fixes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)