### PR TITLE
feat: enforce promise await with eslint rules

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest } from "next/server";
-import { waitUntil } from "@vercel/functions";
 import { initServices } from "../../../../src/lib/init-services";
 import { agentConfigs } from "../../../../src/db/schema/agent-config";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
@@ -190,84 +189,85 @@ export async function POST(request: NextRequest) {
       })
       .where(eq(agentRuns.id, run.id));
 
-    // Execute in E2B asynchronously using waitUntil to ensure completion
-    // waitUntil extends the function lifetime until the promise resolves
+    // Execute in E2B and wait for completion
     // vm0_start event is sent by E2B service after storage preparation
-    waitUntil(
-      runService
-        .buildExecutionContext({
-          checkpointId: body.checkpointId,
-          sessionId: body.sessionId,
-          agentConfigId: body.agentConfigId,
-          conversationId: body.conversationId,
-          artifactName: body.artifactName,
-          artifactVersion: body.artifactVersion,
-          templateVars: body.templateVars,
-          volumeVersions: body.volumeVersions,
-          prompt: body.prompt,
-          runId: run.id,
-          sandboxToken,
-          userId,
-          // Metadata for vm0_start event (sent by E2B service)
-          agentName: agentConfigName,
-          resumedFromCheckpointId: body.checkpointId,
-          continuedFromSessionId: body.sessionId,
+    let finalStatus: "completed" | "failed" = "completed";
+
+    try {
+      const context = await runService.buildExecutionContext({
+        checkpointId: body.checkpointId,
+        sessionId: body.sessionId,
+        agentConfigId: body.agentConfigId,
+        conversationId: body.conversationId,
+        artifactName: body.artifactName,
+        artifactVersion: body.artifactVersion,
+        templateVars: body.templateVars,
+        volumeVersions: body.volumeVersions,
+        prompt: body.prompt,
+        runId: run.id,
+        sandboxToken,
+        userId,
+        // Metadata for vm0_start event (sent by E2B service)
+        agentName: agentConfigName,
+        resumedFromCheckpointId: body.checkpointId,
+        continuedFromSessionId: body.sessionId,
+      });
+
+      const result = await runService.executeRun(context);
+
+      // Update run with results on success
+      await globalThis.services.db
+        .update(agentRuns)
+        .set({
+          status: result.status,
+          sandboxId: result.sandboxId,
+          result: {
+            output: result.output,
+            executionTimeMs: result.executionTimeMs,
+          },
+          error: result.error || null,
+          completedAt: result.completedAt || new Date(),
         })
-        .then((context) => runService.executeRun(context))
-        .then((result) => {
-          // Update run with results on success
-          return globalThis.services.db
-            .update(agentRuns)
-            .set({
-              status: result.status,
-              sandboxId: result.sandboxId,
-              result: {
-                output: result.output,
-                executionTimeMs: result.executionTimeMs,
-              },
-              error: result.error || null,
-              completedAt: result.completedAt || new Date(),
-            })
-            .where(eq(agentRuns.id, run.id));
+        .where(eq(agentRuns.id, run.id));
+
+      console.log(`[API] Run ${run.id} completed successfully`);
+      finalStatus = result.status === "failed" ? "failed" : "completed";
+    } catch (error) {
+      // Extract error message - E2B CommandExitError includes result with stderr
+      let errorMessage =
+        error instanceof Error ? error.message : "Unknown error";
+
+      // Check if error has result property (E2B CommandExitError)
+      const errorWithResult = error as { result?: { stderr?: string } };
+      if (errorWithResult.result?.stderr) {
+        errorMessage = errorWithResult.result.stderr;
+      }
+
+      // Update run with error on failure
+      console.error(`[API] Run ${run.id} failed:`, errorMessage);
+      await globalThis.services.db
+        .update(agentRuns)
+        .set({
+          status: "failed",
+          error: errorMessage,
+          completedAt: new Date(),
         })
-        .then(() => {
-          console.log(`[API] Run ${run.id} completed successfully`);
-        })
-        .catch(async (error) => {
-          // Extract error message - E2B CommandExitError includes result with stderr
-          let errorMessage =
-            error instanceof Error ? error.message : "Unknown error";
+        .where(eq(agentRuns.id, run.id));
 
-          // Check if error has result property (E2B CommandExitError)
-          const errorWithResult = error as { result?: { stderr?: string } };
-          if (errorWithResult.result?.stderr) {
-            errorMessage = errorWithResult.result.stderr;
-          }
+      // Send vm0_error event
+      await sendVm0ErrorEvent({
+        runId: run.id,
+        error: errorMessage,
+        errorType: "sandbox_error",
+      });
 
-          // Update run with error on failure
-          console.error(`[API] Run ${run.id} failed:`, errorMessage);
-          await globalThis.services.db
-            .update(agentRuns)
-            .set({
-              status: "failed",
-              error: errorMessage,
-              completedAt: new Date(),
-            })
-            .where(eq(agentRuns.id, run.id));
+      finalStatus = "failed";
+    }
 
-          // Send vm0_error event
-          await sendVm0ErrorEvent({
-            runId: run.id,
-            error: errorMessage,
-            errorType: "sandbox_error",
-          });
-        }),
-    );
-
-    // Return response immediately with 'running' status
+    // Return response with final status
     const response: CreateAgentRunResponse = {
       runId: run.id,
-      status: "running",
+      status: finalStatus,
       createdAt: run.createdAt.toISOString(),
     };
 

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -189,10 +189,9 @@ export async function POST(request: NextRequest) {
       })
       .where(eq(agentRuns.id, run.id));
 
-    // Execute in E2B and wait for completion
+    // Build execution context and start sandbox (fire-and-forget)
     // vm0_start event is sent by E2B service after storage preparation
-    let finalStatus: "completed" | "failed" = "completed";
-
+    // Final status will be updated by webhook when run-agent.sh completes
     try {
       const context = await runService.buildExecutionContext({
         checkpointId: body.checkpointId,
@@ -213,25 +212,21 @@ export async function POST(request: NextRequest) {
         continuedFromSessionId: body.sessionId,
       });
 
+      // Start execution - returns immediately after sandbox is prepared
+      // Agent execution continues in background (fire-and-forget)
       const result = await runService.executeRun(context);
 
-      // Update run with results on success
+      // Update run with sandboxId
       await globalThis.services.db
         .update(agentRuns)
         .set({
-          status: result.status,
           sandboxId: result.sandboxId,
-          result: {
-            output: result.output,
-            executionTimeMs: result.executionTimeMs,
-          },
-          error: result.error || null,
-          completedAt: result.completedAt || new Date(),
         })
         .where(eq(agentRuns.id, run.id));
 
-      console.log(`[API] Run ${run.id} completed successfully`);
-      finalStatus = result.status === "failed" ? "failed" : "completed";
+      console.log(
+        `[API] Run ${run.id} started successfully (sandbox: ${result.sandboxId})`,
+      );
     } catch (error) {
       // Extract error message - E2B CommandExitError includes result with stderr
       let errorMessage =
@@ -243,8 +238,8 @@ export async function POST(request: NextRequest) {
         errorMessage = errorWithResult.result.stderr;
       }
 
-      // Update run with error on failure
-      console.error(`[API] Run ${run.id} failed:`, errorMessage);
+      // Update run with error on preparation failure
+      console.error(`[API] Run ${run.id} preparation failed:`, errorMessage);
       await globalThis.services.db
         .update(agentRuns)
         .set({
@@ -261,13 +256,20 @@ export async function POST(request: NextRequest) {
         errorType: "sandbox_error",
       });
 
-      finalStatus = "failed";
+      // Return error response for preparation failures
+      const response: CreateAgentRunResponse = {
+        runId: run.id,
+        status: "failed",
+        createdAt: run.createdAt.toISOString(),
+      };
+      return successResponse(response, 201);
     }
 
-    // Return response with final status
+    // Return response with 'running' status
+    // Final status will be updated by webhook when agent completes
     const response: CreateAgentRunResponse = {
       runId: run.id,
-      status: finalStatus,
+      status: "running",
       createdAt: run.createdAt.toISOString(),
     };
 

--- a/turbo/apps/web/app/cli-auth/page.tsx
+++ b/turbo/apps/web/app/cli-auth/page.tsx
@@ -31,9 +31,7 @@ export default function CliAuthPage(): React.JSX.Element {
     setError("");
   };
 
-  const handleSubmit = async (
-    e: React.FormEvent<HTMLFormElement>,
-  ): Promise<void> => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
     e.preventDefault();
 
     if (code.length !== 9) {
@@ -44,14 +42,19 @@ export default function CliAuthPage(): React.JSX.Element {
     setLoading(true);
     setError("");
 
-    const result = await verifyDeviceAction(code);
-
-    if (result.success) {
-      router.push("/cli-auth/success");
-    } else {
-      setError(result.error ?? "Failed to verify device code");
-      setLoading(false);
-    }
+    verifyDeviceAction(code)
+      .then((result) => {
+        if (result.success) {
+          router.push("/cli-auth/success");
+        } else {
+          setError(result.error ?? "Failed to verify device code");
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "An error occurred");
+        setLoading(false);
+      });
   };
 
   return (

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -25,7 +25,6 @@
     "@t3-oss/env-nextjs": "^0.13.8",
     "@ts-rest/core": "^3.52.1",
     "@ts-rest/serverless": "^3.52.1",
-    "@vercel/functions": "^3.3.4",
     "@vm0/core": "workspace:*",
     "@vm0/ui": "workspace:*",
     "adm-zip": "^0.5.16",

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -476,17 +476,11 @@ export class E2BService {
       log.debug(`Using Minimax API (${minimaxBaseUrl})`);
     }
 
-    // Build environment export string for background execution
-    const envExports = Object.entries(envs)
-      .map(([key, value]) => `export ${key}=${JSON.stringify(value)}`)
-      .join("; ");
-
-    // Start script in background using nohup
-    // This ensures the script continues running after we return
-    const backgroundCommand = `nohup bash -c '${envExports}; ${scriptPath}' > /tmp/run-agent-${runId}.log 2>&1 &`;
-
-    await sandbox.commands.run(backgroundCommand, {
-      timeoutMs: 10000, // Short timeout - just starting the background process
+    // Start script in background using E2B's native background mode
+    // This returns immediately while the command continues executing in the sandbox
+    await sandbox.commands.run(scriptPath, {
+      envs,
+      background: true,
     });
 
     log.debug(`Agent execution started in background for run ${runId}`);

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -1,7 +1,7 @@
 import { Sandbox } from "@e2b/code-interpreter";
 import { env } from "../../env";
 import { e2bConfig } from "./config";
-import type { RunResult, SandboxExecutionResult } from "./types";
+import type { RunResult } from "./types";
 import { storageService } from "../storage/storage-service";
 import type {
   AgentVolumeConfig,
@@ -180,8 +180,9 @@ export class E2BService {
         );
       }
 
-      // Execute Claude Code via run-agent.sh
-      const result = await this.executeCommand(
+      // Start Claude Code via run-agent.sh (fire-and-forget)
+      // The script will send events via webhook and update status when complete
+      await this.startAgentExecution(
         sandbox,
         context.runId,
         context.prompt,
@@ -191,36 +192,20 @@ export class E2BService {
         context.resumeSession?.sessionId,
       );
 
-      const executionTimeMs = Date.now() - startTime;
-      const completedAt = new Date();
+      const prepTimeMs = Date.now() - startTime;
+      log.debug(
+        `Run ${context.runId} sandbox prepared in ${prepTimeMs}ms, agent execution started (fire-and-forget)`,
+      );
 
-      log.debug(`Run ${context.runId} completed in ${executionTimeMs}ms`);
-
-      // If sandbox script failed, send vm0_error event
-      // This ensures CLI doesn't timeout waiting for events
-      if (result.exitCode !== 0) {
-        try {
-          await sendVm0ErrorEvent({
-            runId: context.runId,
-            error: result.stderr || "Agent execution failed",
-          });
-        } catch (e) {
-          log.error(
-            `Failed to send vm0_error event for run ${context.runId}:`,
-            e,
-          );
-        }
-      }
-
+      // Return immediately with "running" status
+      // Final status will be updated by webhook when run-agent.sh completes
       return {
         runId: context.runId,
         sandboxId: sandbox.sandboxId,
-        status: result.exitCode === 0 ? "completed" : "failed",
-        output: result.stdout,
-        error: result.exitCode !== 0 ? result.stderr : undefined,
-        executionTimeMs,
+        status: "running",
+        output: "",
+        executionTimeMs: prepTimeMs,
         createdAt: new Date(startTime),
-        completedAt,
       };
     } catch (error) {
       const executionTimeMs = Date.now() - startTime;
@@ -252,6 +237,11 @@ export class E2BService {
         );
       }
 
+      // Cleanup sandbox on preparation failure
+      if (sandbox) {
+        await this.cleanupSandbox(sandbox);
+      }
+
       return {
         runId: context.runId,
         sandboxId: sandbox?.sandboxId || "unknown",
@@ -262,13 +252,9 @@ export class E2BService {
         createdAt: new Date(startTime),
         completedAt,
       };
-    } finally {
-      // Always cleanup sandbox
-      if (sandbox) {
-        await this.cleanupSandbox(sandbox);
-      }
-      // No temp directory cleanup needed - direct download doesn't use local storage
     }
+    // Note: No finally cleanup - sandbox continues running for fire-and-forget execution
+    // Sandbox will auto-terminate after timeout (1 hour) or when run-agent.sh completes
   }
 
   /**
@@ -407,9 +393,10 @@ export class E2BService {
   }
 
   /**
-   * Execute Claude Code via run-agent.sh script
+   * Start agent execution (fire-and-forget)
+   * Uploads scripts and starts run-agent.sh in background without waiting
    */
-  private async executeCommand(
+  private async startAgentExecution(
     sandbox: Sandbox,
     runId: string,
     prompt: string,
@@ -417,20 +404,18 @@ export class E2BService {
     agentConfig?: unknown,
     preparedArtifact?: PreparedArtifact | null,
     resumeSessionId?: string,
-  ): Promise<SandboxExecutionResult> {
-    const execStart = Date.now();
-
+  ): Promise<void> {
     // Upload run-agent.sh script to sandbox at runtime
     // This allows script changes without rebuilding the E2B template
     const scriptPath = await this.uploadRunAgentScript(sandbox);
 
-    log.debug(`Executing run-agent.sh for run ${runId}...`);
+    log.debug(`Starting run-agent.sh for run ${runId} (fire-and-forget)...`);
 
     // Extract working_dir from agent config
     const config = agentConfig as AgentConfigYaml | undefined;
     const workingDir = config?.agents?.[0]?.working_dir;
 
-    // Set environment variables and execute script
+    // Set environment variables
     const envs: Record<string, string> = {
       VM0_RUN_ID: runId,
       VM0_API_TOKEN: sandboxToken,
@@ -491,29 +476,20 @@ export class E2BService {
       log.debug(`Using Minimax API (${minimaxBaseUrl})`);
     }
 
-    const result = await sandbox.commands.run(scriptPath, {
-      envs,
-      timeoutMs: 0, // No timeout - allows indefinite execution
+    // Build environment export string for background execution
+    const envExports = Object.entries(envs)
+      .map(([key, value]) => `export ${key}=${JSON.stringify(value)}`)
+      .join("; ");
+
+    // Start script in background using nohup
+    // This ensures the script continues running after we return
+    const backgroundCommand = `nohup bash -c '${envExports}; ${scriptPath}' > /tmp/run-agent-${runId}.log 2>&1 &`;
+
+    await sandbox.commands.run(backgroundCommand, {
+      timeoutMs: 10000, // Short timeout - just starting the background process
     });
 
-    const executionTimeMs = Date.now() - execStart;
-
-    // Always log stderr to capture [VM0] checkpoint logs (even on success)
-    log.debug(`stderr (${result.stderr.length} chars):`, result.stderr);
-
-    if (result.exitCode === 0) {
-      log.debug(`Run ${runId} completed successfully`);
-    } else {
-      log.error(`Run ${runId} failed with exit code ${result.exitCode}`);
-      log.error(`stderr: ${result.stderr}`);
-    }
-
-    return {
-      stdout: result.stdout,
-      stderr: result.stderr,
-      exitCode: result.exitCode,
-      executionTimeMs,
-    };
+    log.debug(`Agent execution started in background for run ${runId}`);
   }
 
   /**

--- a/turbo/apps/web/src/lib/e2b/types.ts
+++ b/turbo/apps/web/src/lib/e2b/types.ts
@@ -14,7 +14,7 @@ export interface CreateRunOptions {
 export interface RunResult {
   runId: string;
   sandboxId: string;
-  status: "completed" | "failed";
+  status: "running" | "completed" | "failed";
   output: string;
   error?: string;
   executionTimeMs: number;

--- a/turbo/packages/eslint-config/base.js
+++ b/turbo/packages/eslint-config/base.js
@@ -22,6 +22,23 @@ export const config = [
     },
   },
   {
+    files: ["**/*.ts", "**/*.tsx"],
+    languageOptions: {
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["*.config.ts", "*.config.mjs", "*.config.js"],
+        },
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-floating-promises": [
+        "error",
+        { ignoreVoid: false },
+      ],
+      "@typescript-eslint/no-misused-promises": "error",
+    },
+  },
+  {
     plugins: {
       onlyWarn,
     },

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -166,9 +166,6 @@ importers:
       '@ts-rest/serverless':
         specifier: ^3.52.1
         version: 3.52.1(@ts-rest/core@3.52.1(@types/node@24.3.0)(zod@4.1.5))(next@15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(zod@4.1.5)
-      '@vercel/functions':
-        specifier: ^3.3.4
-        version: 3.3.4(@aws-sdk/credential-provider-web-identity@3.936.0)
       '@vm0/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -2465,19 +2462,6 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-
-  '@vercel/functions@3.3.4':
-    resolution: {integrity: sha512-IoP8Xfr1QeCm+Dv5od3bfPiw/VgLKsA7IBd/88M/Wr421HdbH4b6bW5z8CTxiz1QRpalrPFZcLdMdxu+2hAjZg==}
-    engines: {node: '>= 20'}
-    peerDependencies:
-      '@aws-sdk/credential-provider-web-identity': '*'
-    peerDependenciesMeta:
-      '@aws-sdk/credential-provider-web-identity':
-        optional: true
-
-  '@vercel/oidc@3.0.5':
-    resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
-    engines: {node: '>= 20'}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -7618,14 +7602,6 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vercel/functions@3.3.4(@aws-sdk/credential-provider-web-identity@3.936.0)':
-    dependencies:
-      '@vercel/oidc': 3.0.5
-    optionalDependencies:
-      '@aws-sdk/credential-provider-web-identity': 3.936.0
-
-  '@vercel/oidc@3.0.5': {}
-
   '@vitejs/plugin-react@4.7.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.3
@@ -7710,7 +7686,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:


### PR DESCRIPTION
## Summary
- Add `@typescript-eslint/no-floating-promises` and `@typescript-eslint/no-misused-promises` ESLint rules to enforce proper Promise handling
- Implement fire-and-forget execution pattern for agent runs:
  - API waits for sandbox preparation only
  - Agent execution (run-agent.sh) starts in background via E2B SDK's native `background: true` option
  - Returns `running` status immediately after sandbox is ready
  - Final status updated by webhook when agent completes
- Remove unused `@vercel/functions` dependency (waitUntil no longer needed)

## Changes
- `packages/eslint-config/base.js`: Add promise-related ESLint rules with `projectService` for type-aware linting
- `apps/web/src/lib/e2b/e2b-service.ts`: Implement `startAgentExecution` for fire-and-forget pattern using E2B native background mode
- `apps/web/src/lib/e2b/types.ts`: Add `running` status to `RunResult` type
- `apps/web/app/api/agent/runs/route.ts`: Simplify to return immediately after sandbox prep
- `apps/web/app/cli-auth/page.tsx`: Fix async event handler to comply with new ESLint rules
- Update tests to match fire-and-forget behavior

## Test plan
- [x] `pnpm turbo run lint` passes
- [x] `pnpm vitest` passes
- [x] `pnpm run build --filter=web` passes
- [ ] Manual test: verify agent runs start successfully and webhook updates final status

🤖 Generated with [Claude Code](https://claude.com/claude-code)