### PR TITLE
fix: handle empty zip uploads in storage webhook

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
@@ -113,6 +113,8 @@ export async function POST(request: NextRequest) {
     // Extract zip file
     const zip = new AdmZip(zipPath);
     const extractPath = path.join(tempDir, "extracted");
+    // Ensure extract directory exists before extraction (empty zips don't create it)
+    await fs.promises.mkdir(extractPath, { recursive: true });
     zip.extractAllTo(extractPath, true);
 
     log.debug(`Extracted zip to ${extractPath}`);


### PR DESCRIPTION
## Summary

- Fix storage webhook failing with ENOENT when processing empty artifact uploads
- Add mkdir before extractAllTo to ensure directory exists (consistent with /api/storages/route.ts)
- Add e2e tests for empty and unchanged artifact scenarios

## Root Cause

When an agent run completes without modifying the artifact:
1. Sandbox uploads an empty zip file
2. `AdmZip.extractAllTo()` does **NOT** create the target directory for empty zips
3. Subsequent `getAllFiles()` calls `fs.promises.readdir()` which throws ENOENT
4. Webhook returns 500 error, blocking run completion

## Changes

1. **turbo/apps/web/app/api/webhooks/agent/storages/route.ts**
   - Add `await fs.promises.mkdir(extractPath, { recursive: true })` before extraction

2. **e2e/tests/02-commands/t09-vm0-artifact-empty.bats** (new)
   - Test: VM0 run with empty artifact completes successfully
   - Test: VM0 run with unchanged artifact completes successfully

## Test plan

- [ ] Run lint: `cd turbo && pnpm turbo run lint`
- [ ] Run type check: `cd turbo && pnpm check-types`
- [ ] E2E test: `bats e2e/tests/02-commands/t09-vm0-artifact-empty.bats`
- [ ] Manual test: Run agent with empty artifact and verify completion

Fixes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)