### PR TITLE
fix: handle empty artifact/volume in storage operations

### DIFF
--- a/turbo/apps/web/app/api/storages/route.ts
+++ b/turbo/apps/web/app/api/storages/route.ts
@@ -390,6 +390,8 @@ export async function GET(request: NextRequest) {
     const downloadPath = path.join(tempDir, "download");
     console.log(`[Storage] Downloading from S3: ${s3Uri}`);
     await downloadS3Directory(s3Uri, downloadPath);
+    // Ensure download directory exists (empty artifacts won't create it)
+    await fs.promises.mkdir(downloadPath, { recursive: true });
 
     // Create zip file
     const zipPath = path.join(tempDir, "storage.zip");

--- a/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
@@ -113,6 +113,8 @@ export async function POST(request: NextRequest) {
     // Extract zip file
     const zip = new AdmZip(zipPath);
     const extractPath = path.join(tempDir, "extracted");
+    // Ensure extract directory exists before extraction (empty zips don't create it)
+    await fs.promises.mkdir(extractPath, { recursive: true });
     zip.extractAllTo(extractPath, true);
 
     log.debug(`Extracted zip to ${extractPath}`);


### PR DESCRIPTION
## Summary

- Handle empty zip uploads in storage webhook (from #305)
- Handle empty artifact download in storage API GET endpoint (#310)

Both fixes ensure the target directory exists when dealing with empty artifacts/volumes, preventing `ADM-ZIP: File not found` errors.

## Test plan

- [x] Existing empty-zip-handling tests pass
- [x] Lint passes
- [x] Type check passes
- [ ] Manual verification: push empty artifact, then pull it

Closes #305
Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)