### PR TITLE
feat: implement incremental upload for sandbox checkpoint

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/storages/incremental/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/incremental/route.ts
@@ -110,6 +110,17 @@ export async function POST(request: NextRequest) {
       throw new BadRequestError("Invalid changes JSON");
     }
 
+    // Validate ChangesPayload structure
+    if (
+      !Array.isArray(changes.added) ||
+      !Array.isArray(changes.modified) ||
+      !Array.isArray(changes.deleted)
+    ) {
+      throw new BadRequestError(
+        "Invalid changes structure: added, modified, and deleted must be arrays",
+      );
+    }
+
     log.debug(
       `Received incremental upload for "${storageName}" from run ${runId}, base: ${baseVersion.slice(0, 8)}`,
     );
@@ -198,7 +209,23 @@ export async function POST(request: NextRequest) {
       // Read new/modified files
       const changedPaths = new Set([...changes.added, ...changes.modified]);
       for (const relativePath of changedPaths) {
+        // Security: Validate path to prevent path traversal attacks
+        if (
+          relativePath.includes("..") ||
+          path.isAbsolute(relativePath) ||
+          relativePath.startsWith("/")
+        ) {
+          throw new BadRequestError(`Invalid file path: ${relativePath}`);
+        }
+
         const filePath = path.join(extractPath, relativePath);
+
+        // Additional security check: ensure resolved path is within extractPath
+        const resolvedPath = path.resolve(filePath);
+        if (!resolvedPath.startsWith(path.resolve(extractPath) + path.sep)) {
+          throw new BadRequestError(`Invalid file path: ${relativePath}`);
+        }
+
         try {
           const content = await fs.promises.readFile(filePath);
           newFileEntries.push({ path: relativePath, content });

--- a/turbo/apps/web/app/api/webhooks/agent/storages/incremental/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/incremental/route.ts
@@ -1,0 +1,392 @@
+import { NextRequest } from "next/server";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import {
+  storages,
+  storageVersions,
+} from "../../../../../../src/db/schema/storage";
+import { eq, and } from "drizzle-orm";
+import { getUserId } from "../../../../../../src/lib/auth/get-user-id";
+import {
+  successResponse,
+  errorResponse,
+} from "../../../../../../src/lib/api-response";
+import {
+  BadRequestError,
+  NotFoundError,
+  UnauthorizedError,
+} from "../../../../../../src/lib/errors";
+import {
+  downloadManifest,
+  createArchiveFromBlobs,
+  uploadS3Buffer,
+} from "../../../../../../src/lib/s3/s3-client";
+import { blobService } from "../../../../../../src/lib/blob/blob-service";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import AdmZip from "adm-zip";
+import { env } from "../../../../../../src/env";
+import {
+  computeContentHash,
+  type FileEntry,
+} from "../../../../../../src/lib/storage/content-hash";
+import { logger } from "../../../../../../src/lib/logger";
+import type {
+  S3StorageManifest,
+  FileEntryWithHash,
+} from "../../../../../../src/lib/s3/types";
+
+const log = logger("webhook:storages:incremental");
+
+interface StorageVersionResponse {
+  versionId: string;
+  storageName: string;
+  size: number;
+  fileCount: number;
+  incrementalStats?: {
+    addedFiles: number;
+    modifiedFiles: number;
+    deletedFiles: number;
+    unchangedFiles: number;
+    bytesUploaded: number;
+  };
+}
+
+interface ChangesPayload {
+  added: string[];
+  modified: string[];
+  deleted: string[];
+}
+
+/**
+ * POST /api/webhooks/agent/storages/incremental
+ * Create a new version of a storage using incremental upload
+ * Only uploads changed files, reusing blob references for unchanged files
+ */
+export async function POST(request: NextRequest) {
+  let tempDir: string | null = null;
+
+  try {
+    // Initialize services
+    initServices();
+
+    // Authenticate using bearer token
+    const userId = await getUserId();
+    if (!userId) {
+      throw new UnauthorizedError("Not authenticated");
+    }
+
+    // Parse multipart form data
+    const formData = await request.formData();
+    const runId = formData.get("runId") as string;
+    const storageName = formData.get("storageName") as string;
+    const baseVersion = formData.get("baseVersion") as string;
+    const changesJson = formData.get("changes") as string;
+    const message = formData.get("message") as string | null;
+    const file = formData.get("file") as File | null;
+
+    // Validate required fields
+    if (!runId) {
+      throw new BadRequestError("Missing runId");
+    }
+
+    if (!storageName) {
+      throw new BadRequestError("Missing storageName");
+    }
+
+    if (!baseVersion) {
+      throw new BadRequestError("Missing baseVersion");
+    }
+
+    if (!changesJson) {
+      throw new BadRequestError("Missing changes");
+    }
+
+    let changes: ChangesPayload;
+    try {
+      changes = JSON.parse(changesJson) as ChangesPayload;
+    } catch {
+      throw new BadRequestError("Invalid changes JSON");
+    }
+
+    log.debug(
+      `Received incremental upload for "${storageName}" from run ${runId}, base: ${baseVersion.slice(0, 8)}`,
+    );
+    log.debug(
+      `Changes: +${changes.added.length} ~${changes.modified.length} -${changes.deleted.length}`,
+    );
+
+    // Verify run exists and belongs to the authenticated user
+    const [run] = await globalThis.services.db
+      .select()
+      .from(agentRuns)
+      .where(and(eq(agentRuns.id, runId), eq(agentRuns.userId, userId)))
+      .limit(1);
+
+    if (!run) {
+      throw new NotFoundError("Agent run");
+    }
+
+    // Find the storage by name and user
+    const [storage] = await globalThis.services.db
+      .select()
+      .from(storages)
+      .where(and(eq(storages.userId, userId), eq(storages.name, storageName)))
+      .limit(1);
+
+    if (!storage) {
+      throw new NotFoundError(`Storage "${storageName}"`);
+    }
+
+    // Get base version info
+    const [baseVersionRecord] = await globalThis.services.db
+      .select()
+      .from(storageVersions)
+      .where(
+        and(
+          eq(storageVersions.storageId, storage.id),
+          eq(storageVersions.id, baseVersion),
+        ),
+      )
+      .limit(1);
+
+    if (!baseVersionRecord) {
+      throw new NotFoundError(`Base version "${baseVersion}"`);
+    }
+
+    // Download base manifest from S3
+    const bucketName = env().S3_USER_STORAGES_NAME;
+    if (!bucketName) {
+      throw new Error("S3_USER_STORAGES_NAME environment variable is not set");
+    }
+
+    const baseManifest = await downloadManifest(
+      bucketName,
+      baseVersionRecord.s3Key,
+    );
+    log.debug(
+      `Downloaded base manifest: ${baseManifest.fileCount} files, ${baseManifest.totalSize} bytes`,
+    );
+
+    // Build a map of base files for quick lookup
+    const baseFilesMap = new Map<string, FileEntryWithHash>();
+    for (const f of baseManifest.files) {
+      baseFilesMap.set(f.path, f);
+    }
+
+    // Process uploaded file (contains added + modified files)
+    const newFileEntries: FileEntry[] = [];
+    let bytesUploaded = 0;
+
+    if (file && (changes.added.length > 0 || changes.modified.length > 0)) {
+      // Create temp directory for extraction
+      tempDir = path.join(os.tmpdir(), `vm0-storage-incremental-${Date.now()}`);
+      await fs.promises.mkdir(tempDir, { recursive: true });
+
+      // Save uploaded file to temp location
+      const zipPath = path.join(tempDir, "upload.zip");
+      const arrayBuffer = await file.arrayBuffer();
+      await fs.promises.writeFile(zipPath, Buffer.from(arrayBuffer));
+
+      // Extract zip file
+      const zip = new AdmZip(zipPath);
+      const extractPath = path.join(tempDir, "extracted");
+      await fs.promises.mkdir(extractPath, { recursive: true });
+      zip.extractAllTo(extractPath, true);
+
+      // Read new/modified files
+      const changedPaths = new Set([...changes.added, ...changes.modified]);
+      for (const relativePath of changedPaths) {
+        const filePath = path.join(extractPath, relativePath);
+        try {
+          const content = await fs.promises.readFile(filePath);
+          newFileEntries.push({ path: relativePath, content });
+          bytesUploaded += content.length;
+        } catch (err) {
+          log.warn(`File not found in upload: ${relativePath}`, err);
+        }
+      }
+    }
+
+    // Upload new blobs
+    const blobResult = await blobService.uploadBlobs(newFileEntries);
+    log.debug(
+      `Blob upload: ${blobResult.newBlobsCount} new, ${blobResult.existingBlobsCount} existing`,
+    );
+
+    // Build merged file list
+    const mergedFiles: FileEntryWithHash[] = [];
+
+    // 1. Add unchanged files from base (excluding deleted and modified)
+    const deletedSet = new Set(changes.deleted);
+    const modifiedSet = new Set(changes.modified);
+    let unchangedCount = 0;
+
+    for (const [filePath, fileInfo] of baseFilesMap) {
+      if (!deletedSet.has(filePath) && !modifiedSet.has(filePath)) {
+        mergedFiles.push(fileInfo);
+        unchangedCount++;
+      }
+    }
+
+    // 2. Add new and modified files
+    for (const entry of newFileEntries) {
+      const hash = blobResult.hashes.get(entry.path);
+      if (hash) {
+        mergedFiles.push({
+          path: entry.path,
+          hash,
+          size: entry.content.length,
+        });
+      }
+    }
+
+    // Sort by path for consistent ordering
+    mergedFiles.sort((a, b) => a.path.localeCompare(b.path));
+
+    // Compute content hash for new version
+    // We need to reconstruct FileEntry[] with content for hash computation
+    // But we can compute it from the merged files directly
+    const hashEntries: FileEntry[] = [];
+    const blobContents = await blobService.downloadBlobs(
+      mergedFiles.map((f) => f.hash),
+    );
+
+    for (const f of mergedFiles) {
+      const content = blobContents.get(f.hash);
+      if (content) {
+        hashEntries.push({ path: f.path, content });
+      }
+    }
+
+    const contentHash = computeContentHash(storage.id, hashEntries);
+    log.debug(`Computed content hash: ${contentHash}`);
+
+    // Check for duplicate version
+    const [existingVersion] = await globalThis.services.db
+      .select()
+      .from(storageVersions)
+      .where(
+        and(
+          eq(storageVersions.storageId, storage.id),
+          eq(storageVersions.id, contentHash),
+        ),
+      )
+      .limit(1);
+
+    let versionId: string;
+    let deduplicated = false;
+    const totalSize = mergedFiles.reduce((sum, f) => sum + f.size, 0);
+    const fileCount = mergedFiles.length;
+
+    if (existingVersion) {
+      log.debug(
+        `Version with same content already exists: ${existingVersion.id}`,
+      );
+      versionId = existingVersion.id;
+      deduplicated = true;
+    } else {
+      // Create new version record
+      const s3Key = `${userId}/${storageName}/${contentHash}`;
+
+      const [version] = await globalThis.services.db
+        .insert(storageVersions)
+        .values({
+          id: contentHash,
+          storageId: storage.id,
+          s3Key,
+          size: totalSize,
+          fileCount,
+          message: message || `Incremental checkpoint from run ${runId}`,
+          createdBy: "agent",
+        })
+        .returning();
+
+      if (!version) {
+        throw new Error("Failed to create storage version");
+      }
+
+      log.debug(`Created version: ${version.id}`);
+
+      // Create manifest
+      const manifest: S3StorageManifest = {
+        version: contentHash,
+        createdAt: new Date().toISOString(),
+        totalSize,
+        fileCount,
+        files: mergedFiles,
+      };
+
+      // Upload manifest
+      const manifestJson = JSON.stringify(manifest, null, 2);
+      await uploadS3Buffer(
+        bucketName,
+        `${s3Key}/manifest.json`,
+        Buffer.from(manifestJson),
+      );
+
+      // Create archive from blobs
+      await createArchiveFromBlobs(
+        bucketName,
+        `${s3Key}/archive.tar.gz`,
+        mergedFiles.map((f) => ({
+          path: f.path,
+          blobHash: f.hash,
+          size: f.size,
+        })),
+      );
+
+      versionId = version.id;
+    }
+
+    // Update storage's HEAD pointer
+    await globalThis.services.db
+      .update(storages)
+      .set({
+        headVersionId: versionId,
+        size: totalSize,
+        fileCount,
+        updatedAt: new Date(),
+      })
+      .where(eq(storages.id, storage.id));
+
+    log.debug(
+      `Successfully ${deduplicated ? "reused" : "created"} version ${versionId} for storage "${storageName}"`,
+    );
+
+    // Clean up temp directory
+    if (tempDir) {
+      await fs.promises.rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+
+    // Return response
+    const response: StorageVersionResponse = {
+      versionId,
+      storageName,
+      size: totalSize,
+      fileCount,
+      incrementalStats: {
+        addedFiles: changes.added.length,
+        modifiedFiles: changes.modified.length,
+        deletedFiles: changes.deleted.length,
+        unchangedFiles: unchangedCount,
+        bytesUploaded,
+      },
+    };
+
+    return successResponse(response, 200);
+  } catch (error) {
+    log.error("Error:", error);
+
+    // Clean up temp directory if exists
+    if (tempDir) {
+      await fs.promises
+        .rm(tempDir, { recursive: true, force: true })
+        .catch(console.error);
+    }
+
+    return errorResponse(error);
+  }
+}

--- a/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
+++ b/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
@@ -127,9 +127,9 @@ describe("E2B Service - mocked unit tests", () => {
       expect(result.error).toBeUndefined();
 
       // Verify sandbox methods were called
-      // commands.run called: 1 (mkdir) + 8 (mv/chmod for each script) + 1 (execute with background:true) = 10 times
+      // commands.run called: 1 (mkdir) + 9 (mv/chmod for each script) + 1 (execute with background:true) = 11 times
       // Note: download-storages.sh is only uploaded when there are files to download
-      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(10);
+      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(11);
       // Sandbox is NOT killed - it continues running (fire-and-forget)
       expect(mockSandbox.kill).not.toHaveBeenCalled();
     });
@@ -275,9 +275,9 @@ describe("E2B Service - mocked unit tests", () => {
 
       // Verify both sandboxes were created (but NOT cleaned up - fire-and-forget)
       expect(Sandbox.create).toHaveBeenCalledTimes(2);
-      // Each sandbox: 1 (mkdir) + 8 (mv/chmod for each script) + 1 (execute) = 10 times
-      expect(mockSandbox1.commands.run).toHaveBeenCalledTimes(10);
-      expect(mockSandbox2.commands.run).toHaveBeenCalledTimes(10);
+      // Each sandbox: 1 (mkdir) + 9 (mv/chmod for each script) + 1 (execute) = 11 times
+      expect(mockSandbox1.commands.run).toHaveBeenCalledTimes(11);
+      expect(mockSandbox2.commands.run).toHaveBeenCalledTimes(11);
       // Sandboxes NOT killed - they continue running
       expect(mockSandbox1.kill).not.toHaveBeenCalled();
       expect(mockSandbox2.kill).not.toHaveBeenCalled();
@@ -307,8 +307,8 @@ describe("E2B Service - mocked unit tests", () => {
 
       // Verify sandbox was created (but NOT cleaned up - fire-and-forget)
       expect(Sandbox.create).toHaveBeenCalledTimes(1);
-      // 1 (mkdir) + 8 (mv/chmod for each script) + 1 (execute) = 10 times
-      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(10);
+      // 1 (mkdir) + 9 (mv/chmod for each script) + 1 (execute) = 11 times
+      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(11);
       expect(mockSandbox.kill).not.toHaveBeenCalled();
     });
 
@@ -341,8 +341,8 @@ describe("E2B Service - mocked unit tests", () => {
 
       // Verify sandbox was created (but NOT cleaned up - fire-and-forget)
       expect(Sandbox.create).toHaveBeenCalledTimes(1);
-      // 1 (mkdir) + 8 (mv/chmod for each script) + 1 (execute) = 10 times
-      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(10);
+      // 1 (mkdir) + 9 (mv/chmod for each script) + 1 (execute) = 11 times
+      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(11);
       expect(mockSandbox.kill).not.toHaveBeenCalled();
     });
 

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -19,6 +19,7 @@ import {
   RUN_AGENT_SCRIPT,
   MOCK_CLAUDE_SCRIPT,
   DOWNLOAD_STORAGES_SCRIPT,
+  INCREMENTAL_UPLOAD_SCRIPT,
   SCRIPT_PATHS,
 } from "./scripts";
 import type { ExecutionContext } from "../run/types";
@@ -101,6 +102,7 @@ export class E2BService {
               mountPath: storageManifest.artifact.mountPath,
               vasStorageName: storageManifest.artifact.vasStorageName,
               vasVersionId: storageManifest.artifact.vasVersionId,
+              manifestUrl: storageManifest.artifact.manifestUrl,
             }
           : null;
 
@@ -362,6 +364,10 @@ export class E2BService {
       },
       { content: RUN_AGENT_SCRIPT, path: SCRIPT_PATHS.runAgent },
       { content: MOCK_CLAUDE_SCRIPT, path: SCRIPT_PATHS.mockClaude },
+      {
+        content: INCREMENTAL_UPLOAD_SCRIPT,
+        path: SCRIPT_PATHS.incrementalUpload,
+      },
     ];
 
     // Upload all scripts in parallel for better performance
@@ -454,6 +460,13 @@ export class E2BService {
       envs.VM0_ARTIFACT_MOUNT_PATH = preparedArtifact.mountPath;
       envs.VM0_ARTIFACT_VOLUME_NAME = preparedArtifact.vasStorageName;
       envs.VM0_ARTIFACT_VERSION_ID = preparedArtifact.vasVersionId;
+
+      // Pass manifest URL for incremental upload
+      if (preparedArtifact.manifestUrl) {
+        envs.VM0_ARTIFACT_MANIFEST_URL = preparedArtifact.manifestUrl;
+        log.debug(`Configured manifest URL for incremental upload`);
+      }
+
       log.debug(`Configured VAS artifact for checkpoint`);
     } else {
       log.debug(`No artifact configured for checkpoint`);

--- a/turbo/apps/web/src/lib/e2b/scripts/common.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/common.ts
@@ -19,11 +19,13 @@ ARTIFACT_DRIVER="\${VM0_ARTIFACT_DRIVER:-}"
 ARTIFACT_MOUNT_PATH="\${VM0_ARTIFACT_MOUNT_PATH:-}"
 ARTIFACT_VOLUME_NAME="\${VM0_ARTIFACT_VOLUME_NAME:-}"
 ARTIFACT_VERSION_ID="\${VM0_ARTIFACT_VERSION_ID:-}"
+ARTIFACT_MANIFEST_URL="\${VM0_ARTIFACT_MANIFEST_URL:-}"
 
 # Construct webhook endpoint URLs
 WEBHOOK_URL="\${API_URL}/api/webhooks/agent/events"
 CHECKPOINT_URL="\${API_URL}/api/webhooks/agent/checkpoints"
 STORAGE_WEBHOOK_URL="\${API_URL}/api/webhooks/agent/storages"
+INCREMENTAL_WEBHOOK_URL="\${API_URL}/api/webhooks/agent/storages/incremental"
 
 # Variables for checkpoint (use temp files to persist across subshells)
 SESSION_ID_FILE="/tmp/vm0-session-$RUN_ID.txt"

--- a/turbo/apps/web/src/lib/e2b/scripts/incremental-upload.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/incremental-upload.ts
@@ -1,0 +1,250 @@
+/**
+ * Incremental upload script for VAS (Versioned Artifact Storage)
+ * Computes manifest diff and uploads only changed files to reduce bandwidth
+ */
+
+// Use template literal to inject $ signs without escaping
+const dollar = "$";
+
+export const INCREMENTAL_UPLOAD_SCRIPT = `# Incremental upload for VAS storage
+# Computes local manifest, diffs with base manifest, uploads only changed files
+# Requires: COMMON_SCRIPT, LOG_SCRIPT, REQUEST_SCRIPT to be sourced first
+#
+# Environment variables:
+#   INCREMENTAL_WEBHOOK_URL - URL for incremental upload endpoint
+#   STORAGE_WEBHOOK_URL - URL for full upload endpoint (fallback)
+#   API_TOKEN - Bearer token for authentication
+#   RUN_ID - Current run ID
+#
+# Arguments:
+#   $1 - mount_path: Path to the storage directory
+#   $2 - storage_name: Display name of the storage
+#   $3 - vas_storage_name: VAS storage name
+#   $4 - base_version_id: Base version ID for diff (optional)
+#   $5 - manifest_url: URL to download base manifest (optional)
+
+# Compute SHA-256 hash for a file
+compute_file_hash() {
+  local file_path="${dollar}1"
+  sha256sum "${dollar}file_path" | cut -d' ' -f1
+}
+
+# Compute local manifest for a directory
+# Outputs JSON with files array: [{path, hash, size}, ...]
+compute_local_manifest() {
+  local dir_path="${dollar}1"
+  local temp_manifest="/tmp/local-manifest-${dollar}${dollar}.json"
+
+  cd "${dollar}dir_path" || return 1
+
+  echo '{"files":[' > "${dollar}temp_manifest"
+  local first=true
+
+  # Find all files, excluding .git and .vas
+  while IFS= read -r -d '' file; do
+    local rel_path="${dollar}{file#./}"
+    local hash=$(sha256sum "${dollar}file" | cut -d' ' -f1)
+    local size=$(stat -c%s "${dollar}file" 2>/dev/null || stat -f%z "${dollar}file" 2>/dev/null)
+
+    if [ "${dollar}first" = true ]; then
+      first=false
+    else
+      echo ',' >> "${dollar}temp_manifest"
+    fi
+
+    # Use jq to properly escape the path
+    jq -n --arg p "${dollar}rel_path" --arg h "${dollar}hash" --argjson s "${dollar}size" \\
+      '{path: ${dollar}p, hash: ${dollar}h, size: ${dollar}s}' >> "${dollar}temp_manifest"
+  done < <(find . -type f ! -path '*/.git/*' ! -path '*/.vas/*' -print0)
+
+  echo ']}' >> "${dollar}temp_manifest"
+
+  cat "${dollar}temp_manifest"
+  rm -f "${dollar}temp_manifest"
+}
+
+# Diff two manifests and output changes
+# Input: old_manifest_path new_manifest_path
+# Output: JSON with added, modified, deleted arrays
+diff_manifests() {
+  local old_manifest="${dollar}1"
+  local new_manifest="${dollar}2"
+
+  python3 << 'PYTHON_EOF'
+import json
+import sys
+
+def load_manifest(path):
+    with open(path, 'r') as f:
+        data = json.load(f)
+    return {f['path']: f for f in data.get('files', [])}
+
+old_files = load_manifest('${dollar}old_manifest')
+new_files = load_manifest('${dollar}new_manifest')
+
+old_paths = set(old_files.keys())
+new_paths = set(new_files.keys())
+
+added = list(new_paths - old_paths)
+deleted = list(old_paths - new_paths)
+modified = []
+
+for path in old_paths & new_paths:
+    if old_files[path]['hash'] != new_files[path]['hash']:
+        modified.append(path)
+
+result = {
+    'added': sorted(added),
+    'modified': sorted(modified),
+    'deleted': sorted(deleted)
+}
+
+print(json.dumps(result))
+PYTHON_EOF
+}
+
+# Create zip of only changed files
+create_incremental_zip() {
+  local mount_path="${dollar}1"
+  local zip_path="${dollar}2"
+  local changes_json="${dollar}3"
+
+  cd "${dollar}mount_path" || return 1
+
+  # Extract file lists from changes
+  local added=$(echo "${dollar}changes_json" | jq -r '.added[]')
+  local modified=$(echo "${dollar}changes_json" | jq -r '.modified[]')
+
+  # Create zip with added and modified files
+  local file_list="/tmp/incremental-files-${dollar}${dollar}.txt"
+  echo "${dollar}added" > "${dollar}file_list"
+  echo "${dollar}modified" >> "${dollar}file_list"
+
+  # Remove empty lines
+  sed -i '/^${dollar}/d' "${dollar}file_list" 2>/dev/null || sed -i '' '/^${dollar}/d' "${dollar}file_list"
+
+  if [ ! -s "${dollar}file_list" ]; then
+    # No files to add, create empty zip
+    touch "${dollar}zip_path"
+    rm -f "${dollar}file_list"
+    return 0
+  fi
+
+  # Create zip
+  if command -v zip >/dev/null 2>&1; then
+    zip -@ "${dollar}zip_path" < "${dollar}file_list" >/dev/null 2>&1
+  else
+    # Fallback to Python
+    python3 << PYEOF
+import zipfile
+with zipfile.ZipFile('${dollar}zip_path', 'w', zipfile.ZIP_DEFLATED) as zf:
+    with open('${dollar}file_list', 'r') as f:
+        for line in f:
+            path = line.strip()
+            if path:
+                zf.write(path)
+PYEOF
+  fi
+
+  rm -f "${dollar}file_list"
+}
+
+# Main incremental upload function
+create_incremental_snapshot() {
+  local mount_path="${dollar}1"
+  local storage_name="${dollar}2"
+  local vas_storage_name="${dollar}3"
+  local base_version_id="${dollar}4"
+  local manifest_url="${dollar}5"
+
+  log_info "Attempting incremental upload for '$storage_name'"
+
+  # If no base version or manifest URL, fall back to full upload
+  if [ -z "${dollar}base_version_id" ] || [ -z "${dollar}manifest_url" ]; then
+    log_info "No base version, falling back to full upload"
+    create_vas_snapshot "${dollar}mount_path" "${dollar}storage_name" "${dollar}vas_storage_name"
+    return ${dollar}?
+  fi
+
+  local temp_dir="/tmp/incremental-${dollar}RUN_ID-${dollar}storage_name"
+  mkdir -p "${dollar}temp_dir"
+
+  # Download base manifest
+  log_info "Downloading base manifest..."
+  local old_manifest="${dollar}temp_dir/old-manifest.json"
+  if ! curl -fsSL -o "${dollar}old_manifest" "${dollar}manifest_url" 2>/dev/null; then
+    log_warn "Failed to download base manifest, falling back to full upload"
+    rm -rf "${dollar}temp_dir"
+    create_vas_snapshot "${dollar}mount_path" "${dollar}storage_name" "${dollar}vas_storage_name"
+    return ${dollar}?
+  fi
+
+  # Compute local manifest
+  log_info "Computing local manifest..."
+  local new_manifest="${dollar}temp_dir/new-manifest.json"
+  compute_local_manifest "${dollar}mount_path" > "${dollar}new_manifest"
+
+  # Compute diff
+  log_info "Computing diff..."
+  local changes_json=$(diff_manifests "${dollar}old_manifest" "${dollar}new_manifest")
+
+  local added_count=$(echo "${dollar}changes_json" | jq '.added | length')
+  local modified_count=$(echo "${dollar}changes_json" | jq '.modified | length')
+  local deleted_count=$(echo "${dollar}changes_json" | jq '.deleted | length')
+
+  log_info "Changes: +${dollar}added_count ~${dollar}modified_count -${dollar}deleted_count"
+
+  # If no changes, skip upload
+  if [ "${dollar}added_count" -eq 0 ] && [ "${dollar}modified_count" -eq 0 ] && [ "${dollar}deleted_count" -eq 0 ]; then
+    log_info "No changes detected, skipping upload"
+    rm -rf "${dollar}temp_dir"
+    # Return the base version as current
+    jq -n --arg vid "${dollar}base_version_id" '{versionId: ${dollar}vid, unchanged: true}'
+    return 0
+  fi
+
+  # Create zip of changed files
+  local zip_path="${dollar}temp_dir/changes.zip"
+  create_incremental_zip "${dollar}mount_path" "${dollar}zip_path" "${dollar}changes_json"
+
+  # Upload to incremental endpoint
+  log_info "Uploading incremental changes..."
+  local response
+  response=$(http_post_form "${dollar}INCREMENTAL_WEBHOOK_URL" "${dollar}HTTP_MAX_RETRIES" \\
+    -F "runId=${dollar}RUN_ID" \\
+    -F "storageName=${dollar}vas_storage_name" \\
+    -F "baseVersion=${dollar}base_version_id" \\
+    -F "changes=${dollar}changes_json" \\
+    -F "message=Incremental checkpoint from run ${dollar}RUN_ID" \\
+    -F "file=@${dollar}zip_path")
+  local http_exit=${dollar}?
+
+  # Cleanup
+  rm -rf "${dollar}temp_dir"
+
+  if [ ${dollar}http_exit -ne 0 ]; then
+    log_warn "Incremental upload failed, falling back to full upload"
+    create_vas_snapshot "${dollar}mount_path" "${dollar}storage_name" "${dollar}vas_storage_name"
+    return ${dollar}?
+  fi
+
+  # Check response
+  local version_id=$(echo "${dollar}response" | jq -r '.versionId // empty' 2>/dev/null)
+  if [ -z "${dollar}version_id" ]; then
+    log_error "Invalid response from incremental upload"
+    log_error "Response: ${dollar}response"
+    return 1
+  fi
+
+  # Log incremental stats if available
+  local stats=$(echo "${dollar}response" | jq -r '.incrementalStats // empty' 2>/dev/null)
+  if [ -n "${dollar}stats" ]; then
+    local bytes_uploaded=$(echo "${dollar}stats" | jq -r '.bytesUploaded // 0')
+    log_info "Incremental upload complete: ${dollar}bytes_uploaded bytes uploaded"
+  fi
+
+  log_info "Incremental snapshot created: version ${dollar}version_id"
+  jq -n --arg vid "${dollar}version_id" '{versionId: ${dollar}vid}'
+  return 0
+}
+`;

--- a/turbo/apps/web/src/lib/e2b/scripts/incremental-upload.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/incremental-upload.ts
@@ -70,17 +70,17 @@ diff_manifests() {
   local old_manifest="${dollar}1"
   local new_manifest="${dollar}2"
 
-  python3 << 'PYTHON_EOF'
+  OLD_MANIFEST="${dollar}old_manifest" NEW_MANIFEST="${dollar}new_manifest" python3 << 'PYTHON_EOF'
 import json
-import sys
+import os
 
 def load_manifest(path):
     with open(path, 'r') as f:
         data = json.load(f)
     return {f['path']: f for f in data.get('files', [])}
 
-old_files = load_manifest('${dollar}old_manifest')
-new_files = load_manifest('${dollar}new_manifest')
+old_files = load_manifest(os.environ['OLD_MANIFEST'])
+new_files = load_manifest(os.environ['NEW_MANIFEST'])
 
 old_paths = set(old_files.keys())
 new_paths = set(new_files.keys())

--- a/turbo/apps/web/src/lib/e2b/scripts/index.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/index.ts
@@ -11,6 +11,7 @@ export { CREATE_CHECKPOINT_SCRIPT } from "./create-checkpoint";
 export { RUN_AGENT_SCRIPT } from "./run-agent";
 export { MOCK_CLAUDE_SCRIPT } from "./mock-claude";
 export { DOWNLOAD_STORAGES_SCRIPT } from "./download-storages";
+export { INCREMENTAL_UPLOAD_SCRIPT } from "./incremental-upload";
 
 /**
  * Script paths in the E2B sandbox
@@ -27,4 +28,5 @@ export const SCRIPT_PATHS = {
   createCheckpoint: "/usr/local/bin/vm0-agent/lib/create-checkpoint.sh",
   mockClaude: "/usr/local/bin/vm0-agent/lib/mock-claude.sh",
   downloadStorages: "/usr/local/bin/vm0-agent/lib/download-storages.sh",
+  incrementalUpload: "/usr/local/bin/vm0-agent/lib/incremental-upload.sh",
 } as const;

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.ts
@@ -12,6 +12,7 @@ source "\${SCRIPT_DIR}/lib/log.sh"
 source "\${SCRIPT_DIR}/lib/request.sh"
 source "\${SCRIPT_DIR}/lib/send-event.sh"
 source "\${SCRIPT_DIR}/lib/vas-snapshot.sh"
+source "\${SCRIPT_DIR}/lib/incremental-upload.sh"
 source "\${SCRIPT_DIR}/lib/create-checkpoint.sh"
 
 # Change to working directory

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -188,6 +188,13 @@ export class StorageService {
           const archiveKey = `${s3Key}/archive.tar.gz`;
           const archiveUrl = await generatePresignedUrl(bucketName, archiveKey);
 
+          // Generate manifest URL for incremental upload support
+          const manifestKey = `${s3Key}/manifest.json`;
+          const manifestUrl = await generatePresignedUrl(
+            bucketName,
+            manifestKey,
+          );
+
           // Get archive size from S3
           const archiveObjects = await listS3Objects(bucketName, archiveKey);
           const archiveSize = archiveObjects[0]?.size ?? 0;
@@ -198,6 +205,7 @@ export class StorageService {
             vasVersionId: versionId,
             archiveUrl,
             archiveSize,
+            manifestUrl,
           };
 
           log.debug(

--- a/turbo/apps/web/src/lib/storage/types.ts
+++ b/turbo/apps/web/src/lib/storage/types.ts
@@ -90,6 +90,8 @@ export interface PreparedArtifact {
   mountPath: string;
   vasStorageName: string;
   vasVersionId: string;
+  /** Presigned URL for manifest.json (for incremental upload) */
+  manifestUrl?: string;
 }
 
 /**
@@ -127,6 +129,8 @@ export interface ManifestArtifact {
   archiveUrl: string;
   /** Size of archive.tar.gz in bytes */
   archiveSize: number;
+  /** Presigned URL for downloading manifest.json (for incremental upload) */
+  manifestUrl?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements Phase 1 (Incremental Upload) from RFC #307, reducing checkpoint upload bandwidth by ~90% by only uploading changed files instead of the full artifact.

Closes #319

## Changes

### Server-Side
- **New API endpoint**: `POST /api/webhooks/agent/storages/incremental`
  - Accepts changed files + base version
  - Downloads base manifest, merges blob references
  - Creates new archive from mixed old/new blobs
  
- **S3 helpers** (`s3-client.ts`):
  - `downloadManifest()` - Fetch and parse manifest.json
  - `downloadBlob()` - Download single blob by hash
  - `createArchiveFromBlobs()` - Create archive from blob hashes

- **Blob service enhancements**:
  - `downloadBlob()` - Download blob content
  - `downloadBlobs()` - Batch download with concurrency limit

### Sandbox-Side
- **New script**: `incremental-upload.sh`
  - Computes local manifest (SHA-256 hashes for all files)
  - Downloads and diffs with base manifest
  - Creates ZIP with only changed files
  - Falls back to full upload if incremental fails

### Integration
- Added `manifestUrl` to `ManifestArtifact` type
- Updated `prepareStorageManifest()` to generate manifest URLs
- Updated `e2b-service` to pass `VM0_ARTIFACT_MANIFEST_URL` to sandbox
- Increased presigned URL expiration from 1 hour to 24 hours

## Test Plan

- [x] Type check passes
- [x] Lint passes  
- [x] All existing tests pass
- [x] Updated e2b-service tests for new script count

## API Request Format

```typescript
POST /api/webhooks/agent/storages/incremental
Content-Type: multipart/form-data

- runId: string
- storageName: string
- baseVersion: string (SHA-256 hash)
- changes: JSON string { added: [], modified: [], deleted: [] }
- file: ZIP containing only added + modified files
```

## Response Format

```typescript
{
  versionId: string,
  storageName: string,
  size: number,
  fileCount: number,
  incrementalStats: {
    addedFiles: number,
    modifiedFiles: number,
    deletedFiles: number,
    unchangedFiles: number,
    bytesUploaded: number
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)