### PR TITLE
feat: add --force flag to volume push to recreate archive

### DIFF
--- a/turbo/apps/cli/src/commands/volume/push.ts
+++ b/turbo/apps/cli/src/commands/volume/push.ts
@@ -50,7 +50,11 @@ function formatBytes(bytes: number): string {
 export const pushCommand = new Command()
   .name("push")
   .description("Push local files to cloud volume")
-  .action(async () => {
+  .option(
+    "-f, --force",
+    "Force upload even if content unchanged (recreate archive)",
+  )
+  .action(async (options: { force?: boolean }) => {
     try {
       const cwd = process.cwd();
 
@@ -103,6 +107,9 @@ export const pushCommand = new Command()
       const formData = new FormData();
       formData.append("name", config.name);
       formData.append("type", "volume");
+      if (options.force) {
+        formData.append("force", "true");
+      }
       formData.append(
         "file",
         new Blob([zipBuffer], { type: "application/zip" }),


### PR DESCRIPTION
## Summary

Fixes sandbox download failures for old storage versions created before PR #311 that don't have `archive.tar.gz`.

## Problem

Old storage versions were created before the tar.gz streaming feature (PR #311). When content is unchanged, `vm0 volume push` deduplicates and reuses the old version ID, but the old version doesn't have `archive.tar.gz`, causing sandbox download failures:

```
[ERROR] Failed to download archive for /home/user/.config/claude after 3 attempts
```

## Solution

Add `--force` flag to `vm0 volume push` that:
- Skips deduplication check
- Recreates `archive.tar.gz` for existing versions
- Uses `onConflictDoNothing` to handle existing version records

## Usage

```bash
vm0 volume push --force
# or
vm0 volume push -f
```

## Changes

- **CLI**: Add `-f, --force` option to `volume push` command
- **API**: Add `force` parameter support to `/api/storages` endpoint

## Test Plan

- [x] Type check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)