### PR TITLE
feat: add --force flag to artifact push command

### DIFF
--- a/turbo/apps/cli/src/commands/artifact/push.ts
+++ b/turbo/apps/cli/src/commands/artifact/push.ts
@@ -50,7 +50,11 @@ function formatBytes(bytes: number): string {
 export const pushCommand = new Command()
   .name("push")
   .description("Push local files to cloud artifact")
-  .action(async () => {
+  .option(
+    "-f, --force",
+    "Force upload even if content unchanged (recreate archive)",
+  )
+  .action(async (options: { force?: boolean }) => {
     try {
       const cwd = process.cwd();
 
@@ -113,6 +117,9 @@ export const pushCommand = new Command()
       const formData = new FormData();
       formData.append("name", config.name);
       formData.append("type", "artifact");
+      if (options.force) {
+        formData.append("force", "true");
+      }
       formData.append(
         "file",
         new Blob([zipBuffer], { type: "application/zip" }),


### PR DESCRIPTION
## Summary

- Added `-f, --force` option to `vm0 artifact push` command
- Matches existing functionality in `vm0 volume push --force` (PR #321)
- Passes `force=true` parameter to `/api/storages` API endpoint when flag is set
- Allows users to skip deduplication and force recreation of archive.tar.gz

## Changes

1. Added `.option("-f, --force", ...)` to the artifact push command definition
2. Updated action handler to accept `options: { force?: boolean }` parameter
3. Added conditional logic to append `force=true` to formData when flag is present

## Test plan

- [x] Run local CI checks (lint, format, type-check, build, tests)
- [x] All 215 tests pass
- [x] No TypeScript errors
- [x] No lint violations
- [x] Build succeeds

## Testing

The implementation follows the exact same pattern as volume push (lines 53-56, 110-112 in volume/push.ts), ensuring consistency across commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)