### PR TITLE
fix: add sandbox cleanup via unified complete API

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -1,0 +1,583 @@
+/**
+ * @vitest-environment node
+ */
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  afterAll,
+  vi,
+} from "vitest";
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import { checkpoints } from "../../../../../../src/db/schema/checkpoint";
+import { conversations } from "../../../../../../src/db/schema/conversation";
+import { agentSessions } from "../../../../../../src/db/schema/agent-session";
+import { agentRunEvents } from "../../../../../../src/db/schema/agent-run-event";
+import { cliTokens } from "../../../../../../src/db/schema/cli-tokens";
+import { agentConfigs } from "../../../../../../src/db/schema/agent-config";
+import { eq } from "drizzle-orm";
+import { randomUUID } from "crypto";
+
+// Mock Next.js headers() function
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+}));
+
+// Mock Clerk auth
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+// Mock e2b-service
+vi.mock("../../../../../../src/lib/e2b/e2b-service", () => ({
+  e2bService: {
+    killSandbox: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { headers } from "next/headers";
+import { auth } from "@clerk/nextjs/server";
+import { e2bService } from "../../../../../../src/lib/e2b/e2b-service";
+
+const mockHeaders = vi.mocked(headers);
+const mockAuth = vi.mocked(auth);
+
+describe("POST /api/webhooks/agent/complete", () => {
+  // Generate unique IDs for this test run
+  const testUserId = `test-user-${Date.now()}-${process.pid}`;
+  const testRunId = randomUUID();
+  const testConfigId = randomUUID();
+  const testToken = `vm0_live_test_${Date.now()}_${process.pid}`;
+  const testSandboxId = `sandbox-${Date.now()}`;
+
+  beforeEach(async () => {
+    // Clear all mocks
+    vi.clearAllMocks();
+
+    // Initialize services
+    initServices();
+
+    // Mock Clerk auth to return null (fallback for token auth)
+    mockAuth.mockResolvedValue({ userId: null } as unknown as Awaited<
+      ReturnType<typeof auth>
+    >);
+
+    // Mock headers() to return no Authorization header by default
+    mockHeaders.mockResolvedValue({
+      get: vi.fn().mockReturnValue(null),
+    } as unknown as Headers);
+
+    // Clean up any existing test data
+    await globalThis.services.db
+      .delete(agentRunEvents)
+      .where(eq(agentRunEvents.runId, testRunId));
+
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, testRunId));
+
+    await globalThis.services.db
+      .delete(cliTokens)
+      .where(eq(cliTokens.token, testToken));
+
+    await globalThis.services.db
+      .delete(agentConfigs)
+      .where(eq(agentConfigs.id, testConfigId));
+
+    // Create test agent config
+    await globalThis.services.db.insert(agentConfigs).values({
+      id: testConfigId,
+      userId: testUserId,
+      name: "test-agent",
+      config: {
+        version: "1.0",
+        agent: {
+          name: "test-agent",
+          image: "test-image",
+          provider: "claude-code",
+          artifact: {
+            working_dir: "/workspace",
+          },
+        },
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  });
+
+  afterEach(async () => {
+    // Clean up test data after each test
+    await globalThis.services.db
+      .delete(agentRunEvents)
+      .where(eq(agentRunEvents.runId, testRunId));
+
+    await globalThis.services.db
+      .delete(agentSessions)
+      .where(eq(agentSessions.agentConfigId, testConfigId));
+
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, testRunId));
+
+    await globalThis.services.db
+      .delete(cliTokens)
+      .where(eq(cliTokens.token, testToken));
+
+    await globalThis.services.db
+      .delete(agentConfigs)
+      .where(eq(agentConfigs.id, testConfigId));
+  });
+
+  afterAll(async () => {});
+
+  // ============================================
+  // Authentication Tests
+  // ============================================
+
+  describe("Authentication", () => {
+    it("should reject complete without authentication", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toBeDefined();
+      expect(data.error.message).toBeDefined();
+    });
+  });
+
+  // ============================================
+  // Validation Tests
+  // ============================================
+
+  describe("Validation", () => {
+    beforeEach(async () => {
+      // Mock headers() to return the test token
+      mockHeaders.mockResolvedValue({
+        get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+      } as unknown as Headers);
+
+      // Create valid token for validation tests
+      await globalThis.services.db.insert(cliTokens).values({
+        token: testToken,
+        userId: testUserId,
+        name: "Test Token",
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+      });
+    });
+
+    it("should reject complete without runId", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            // runId: missing
+            exitCode: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toContain("runId");
+    });
+
+    it("should reject complete without exitCode", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            // exitCode: missing
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toContain("exitCode");
+    });
+  });
+
+  // ============================================
+  // Authorization Tests
+  // ============================================
+
+  describe("Authorization", () => {
+    beforeEach(async () => {
+      // Mock headers() to return the test token
+      mockHeaders.mockResolvedValue({
+        get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+      } as unknown as Headers);
+
+      // Create valid token
+      await globalThis.services.db.insert(cliTokens).values({
+        token: testToken,
+        userId: testUserId,
+        name: "Test Token",
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+      });
+    });
+
+    it("should reject complete for non-existent run", async () => {
+      const nonExistentRunId = randomUUID();
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: nonExistentRunId,
+            exitCode: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error.message).toContain("Agent run");
+    });
+
+    it("should reject complete for run owned by different user", async () => {
+      const otherUserId = `other-user-${Date.now()}-${process.pid}`;
+
+      // Create run owned by different user
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId,
+        userId: otherUserId,
+        agentConfigId: testConfigId,
+        status: "running",
+        prompt: "Test prompt",
+        createdAt: new Date(),
+      });
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error.message).toContain("Agent run");
+    });
+  });
+
+  // ============================================
+  // Success Tests
+  // ============================================
+
+  describe("Success", () => {
+    beforeEach(async () => {
+      // Mock headers() to return the test token
+      mockHeaders.mockResolvedValue({
+        get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+      } as unknown as Headers);
+
+      // Create valid token
+      await globalThis.services.db.insert(cliTokens).values({
+        token: testToken,
+        userId: testUserId,
+        name: "Test Token",
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+      });
+    });
+
+    it("should handle successful completion (exitCode=0) and send vm0_result", async () => {
+      // Create run with sandboxId
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId,
+        userId: testUserId,
+        agentConfigId: testConfigId,
+        sandboxId: testSandboxId,
+        status: "running",
+        prompt: "Test prompt",
+        createdAt: new Date(),
+      });
+
+      // Create conversation for checkpoint
+      const conversationId = randomUUID();
+      await globalThis.services.db.insert(conversations).values({
+        id: conversationId,
+        runId: testRunId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: "test-session",
+        cliAgentSessionHistory: '{"type":"test"}',
+        createdAt: new Date(),
+      });
+
+      // Create checkpoint (required for success case)
+      const checkpointId = randomUUID();
+      await globalThis.services.db.insert(checkpoints).values({
+        id: checkpointId,
+        runId: testRunId,
+        conversationId: conversationId,
+        agentConfigSnapshot: { config: {}, templateVars: {} },
+        artifactSnapshot: {
+          artifactName: "test-artifact",
+          artifactVersion: "v1",
+        },
+        createdAt: new Date(),
+      });
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.status).toBe("completed");
+
+      // Verify run status was updated
+      const [updatedRun] = await globalThis.services.db
+        .select()
+        .from(agentRuns)
+        .where(eq(agentRuns.id, testRunId));
+
+      expect(updatedRun?.status).toBe("completed");
+      expect(updatedRun?.completedAt).toBeDefined();
+
+      // Verify vm0_result event was created
+      const events = await globalThis.services.db
+        .select()
+        .from(agentRunEvents)
+        .where(eq(agentRunEvents.runId, testRunId));
+
+      const resultEvent = events.find(
+        (e) => (e.eventData as { type: string }).type === "vm0_result",
+      );
+      expect(resultEvent).toBeDefined();
+
+      // Verify sandbox was killed
+      expect(e2bService.killSandbox).toHaveBeenCalledWith(testSandboxId);
+    });
+
+    it("should handle failed completion (exitCode≠0) and send vm0_error", async () => {
+      // Create run with sandboxId
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId,
+        userId: testUserId,
+        agentConfigId: testConfigId,
+        sandboxId: testSandboxId,
+        status: "running",
+        prompt: "Test prompt",
+        createdAt: new Date(),
+      });
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 1,
+            error: "Agent crashed",
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.status).toBe("failed");
+
+      // Verify run status was updated
+      const [updatedRun] = await globalThis.services.db
+        .select()
+        .from(agentRuns)
+        .where(eq(agentRuns.id, testRunId));
+
+      expect(updatedRun?.status).toBe("failed");
+      expect(updatedRun?.completedAt).toBeDefined();
+
+      // Verify vm0_error event was created
+      const events = await globalThis.services.db
+        .select()
+        .from(agentRunEvents)
+        .where(eq(agentRunEvents.runId, testRunId));
+
+      const errorEvent = events.find(
+        (e) => (e.eventData as { type: string }).type === "vm0_error",
+      );
+      expect(errorEvent).toBeDefined();
+      expect((errorEvent?.eventData as { error: string }).error).toBe(
+        "Agent crashed",
+      );
+
+      // Verify sandbox was killed
+      expect(e2bService.killSandbox).toHaveBeenCalledWith(testSandboxId);
+    });
+
+    it("should use default error message when exitCode≠0 and no error provided", async () => {
+      // Create run
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId,
+        userId: testUserId,
+        agentConfigId: testConfigId,
+        status: "running",
+        prompt: "Test prompt",
+        createdAt: new Date(),
+      });
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 127,
+            // no error provided
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      // Verify vm0_error event has default message
+      const events = await globalThis.services.db
+        .select()
+        .from(agentRunEvents)
+        .where(eq(agentRunEvents.runId, testRunId));
+
+      const errorEvent = events.find(
+        (e) => (e.eventData as { type: string }).type === "vm0_error",
+      );
+      expect((errorEvent?.eventData as { error: string }).error).toBe(
+        "Agent exited with code 127",
+      );
+    });
+  });
+
+  // ============================================
+  // Error Handling Tests
+  // ============================================
+
+  describe("Error Handling", () => {
+    beforeEach(async () => {
+      // Mock headers() to return the test token
+      mockHeaders.mockResolvedValue({
+        get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+      } as unknown as Headers);
+
+      // Create valid token
+      await globalThis.services.db.insert(cliTokens).values({
+        token: testToken,
+        userId: testUserId,
+        name: "Test Token",
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+      });
+    });
+
+    it("should return 404 when checkpoint not found for successful run", async () => {
+      // Create run without checkpoint
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId,
+        userId: testUserId,
+        agentConfigId: testConfigId,
+        status: "running",
+        prompt: "Test prompt",
+        createdAt: new Date(),
+      });
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error.message).toContain("Checkpoint");
+    });
+  });
+});

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -580,4 +580,119 @@ describe("POST /api/webhooks/agent/complete", () => {
       expect(data.error.message).toContain("Checkpoint");
     });
   });
+
+  // ============================================
+  // Idempotency Tests
+  // ============================================
+
+  describe("Idempotency", () => {
+    beforeEach(async () => {
+      // Mock headers() to return the test token
+      mockHeaders.mockResolvedValue({
+        get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+      } as unknown as Headers);
+
+      // Create valid token
+      await globalThis.services.db.insert(cliTokens).values({
+        token: testToken,
+        userId: testUserId,
+        name: "Test Token",
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+      });
+    });
+
+    it("should return success without processing for already completed run", async () => {
+      // Create already completed run
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId,
+        userId: testUserId,
+        agentConfigId: testConfigId,
+        status: "completed",
+        prompt: "Test prompt",
+        completedAt: new Date(),
+        createdAt: new Date(),
+      });
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.status).toBe("completed");
+
+      // Verify no events were sent (idempotent)
+      const events = await globalThis.services.db
+        .select()
+        .from(agentRunEvents)
+        .where(eq(agentRunEvents.runId, testRunId));
+
+      expect(events).toHaveLength(0);
+
+      // Verify sandbox kill was NOT called
+      expect(e2bService.killSandbox).not.toHaveBeenCalled();
+    });
+
+    it("should return success without processing for already failed run", async () => {
+      // Create already failed run
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId,
+        userId: testUserId,
+        agentConfigId: testConfigId,
+        status: "failed",
+        prompt: "Test prompt",
+        completedAt: new Date(),
+        createdAt: new Date(),
+      });
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 1,
+            error: "Some error",
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.status).toBe("failed");
+
+      // Verify no events were sent (idempotent)
+      const events = await globalThis.services.db
+        .select()
+        .from(agentRunEvents)
+        .where(eq(agentRunEvents.runId, testRunId));
+
+      expect(events).toHaveLength(0);
+
+      // Verify sandbox kill was NOT called
+      expect(e2bService.killSandbox).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -90,6 +90,17 @@ export async function POST(request: NextRequest) {
 
     sandboxId = run.sandboxId ?? undefined;
 
+    // Idempotency check: if run is already completed/failed, return early
+    if (run.status === "completed" || run.status === "failed") {
+      console.log(
+        `[Complete API] Run ${runId} already ${run.status}, skipping duplicate completion`,
+      );
+      return successResponse(
+        { success: true, status: run.status as "completed" | "failed" },
+        200,
+      );
+    }
+
     let finalStatus: "completed" | "failed";
 
     if (body.exitCode === 0) {

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -1,0 +1,204 @@
+import { NextRequest } from "next/server";
+import { initServices } from "../../../../../src/lib/init-services";
+import { agentRuns } from "../../../../../src/db/schema/agent-run";
+import { checkpoints } from "../../../../../src/db/schema/checkpoint";
+import { agentSessions } from "../../../../../src/db/schema/agent-session";
+import { eq, and } from "drizzle-orm";
+import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import {
+  successResponse,
+  errorResponse,
+} from "../../../../../src/lib/api-response";
+import {
+  BadRequestError,
+  NotFoundError,
+  UnauthorizedError,
+} from "../../../../../src/lib/errors";
+import {
+  sendVm0ResultEvent,
+  sendVm0ErrorEvent,
+} from "../../../../../src/lib/events";
+import { e2bService } from "../../../../../src/lib/e2b/e2b-service";
+import type { ArtifactSnapshot } from "../../../../../src/lib/checkpoint";
+
+/**
+ * Request body for complete webhook endpoint
+ */
+interface CompleteRequest {
+  runId: string;
+  exitCode: number;
+  error?: string;
+}
+
+/**
+ * Response from complete endpoint
+ */
+interface CompleteResponse {
+  success: boolean;
+  status: "completed" | "failed";
+}
+
+/**
+ * POST /api/webhooks/agent/complete
+ * Handle agent run completion (success or failure)
+ * - Sends vm0_result or vm0_error event
+ * - Updates run status
+ * - Kills sandbox
+ */
+export async function POST(request: NextRequest) {
+  let runId: string | undefined;
+  let sandboxId: string | undefined;
+
+  try {
+    // Initialize services
+    initServices();
+
+    // Authenticate using bearer token
+    const userId = await getUserId();
+    if (!userId) {
+      throw new UnauthorizedError("Not authenticated");
+    }
+
+    // Parse request body
+    const body: CompleteRequest = await request.json();
+
+    // Validate required fields
+    if (!body.runId) {
+      throw new BadRequestError("Missing runId");
+    }
+
+    if (typeof body.exitCode !== "number") {
+      throw new BadRequestError("Missing or invalid exitCode");
+    }
+
+    runId = body.runId;
+
+    console.log(
+      `[Complete API] Received completion for run ${runId}, exitCode=${body.exitCode}`,
+    );
+
+    // Get run record
+    const [run] = await globalThis.services.db
+      .select()
+      .from(agentRuns)
+      .where(and(eq(agentRuns.id, runId), eq(agentRuns.userId, userId)))
+      .limit(1);
+
+    if (!run) {
+      throw new NotFoundError("Agent run");
+    }
+
+    sandboxId = run.sandboxId ?? undefined;
+
+    let finalStatus: "completed" | "failed";
+
+    if (body.exitCode === 0) {
+      // Success: query checkpoint and send vm0_result
+      const [checkpoint] = await globalThis.services.db
+        .select()
+        .from(checkpoints)
+        .where(eq(checkpoints.runId, runId))
+        .limit(1);
+
+      if (!checkpoint) {
+        throw new NotFoundError("Checkpoint for run");
+      }
+
+      // Get agent session for the conversation
+      const [session] = await globalThis.services.db
+        .select()
+        .from(agentSessions)
+        .where(eq(agentSessions.conversationId, checkpoint.conversationId))
+        .limit(1);
+
+      // Extract artifact info from checkpoint
+      const artifactSnapshot = checkpoint.artifactSnapshot as ArtifactSnapshot;
+      const volumeVersions = checkpoint.volumeVersionsSnapshot as
+        | { versions: Record<string, string> }
+        | undefined;
+
+      // Send vm0_result event
+      await sendVm0ResultEvent({
+        runId,
+        checkpointId: checkpoint.id,
+        agentSessionId: session?.id ?? checkpoint.conversationId,
+        conversationId: checkpoint.conversationId,
+        artifact: {
+          [artifactSnapshot.artifactName]: artifactSnapshot.artifactVersion,
+        },
+        volumes: volumeVersions?.versions,
+      });
+
+      // Update run status to completed
+      await globalThis.services.db
+        .update(agentRuns)
+        .set({ status: "completed", completedAt: new Date() })
+        .where(eq(agentRuns.id, runId));
+
+      finalStatus = "completed";
+      console.log(`[Complete API] Run ${runId} completed successfully`);
+    } else {
+      // Failure: send vm0_error event
+      const errorMessage =
+        body.error || `Agent exited with code ${body.exitCode}`;
+
+      await sendVm0ErrorEvent({
+        runId,
+        error: errorMessage,
+        sandboxId,
+      });
+
+      // Update run status to failed
+      await globalThis.services.db
+        .update(agentRuns)
+        .set({ status: "failed", completedAt: new Date() })
+        .where(eq(agentRuns.id, runId));
+
+      finalStatus = "failed";
+      console.log(`[Complete API] Run ${runId} failed: ${errorMessage}`);
+    }
+
+    // Kill sandbox (fire-and-forget, don't block response)
+    if (sandboxId) {
+      e2bService.killSandbox(sandboxId).catch((error) => {
+        console.error(
+          `[Complete API] Failed to kill sandbox ${sandboxId}:`,
+          error,
+        );
+      });
+    }
+
+    const response: CompleteResponse = {
+      success: true,
+      status: finalStatus,
+    };
+
+    return successResponse(response, 200);
+  } catch (error) {
+    console.error("[Complete API] Error:", error);
+
+    // Try to send vm0_error event if we have runId
+    if (runId) {
+      try {
+        await sendVm0ErrorEvent({
+          runId,
+          error: error instanceof Error ? error.message : "Complete API failed",
+          sandboxId,
+        });
+      } catch {
+        console.error(
+          "[Complete API] Failed to send vm0_error event after error",
+        );
+      }
+    }
+
+    // Still try to kill sandbox on error
+    if (sandboxId) {
+      e2bService.killSandbox(sandboxId).catch(() => {
+        // Ignore cleanup errors
+      });
+    }
+
+    return errorResponse(error);
+  }
+}

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -608,7 +608,7 @@ export class E2BService {
   }
 
   /**
-   * Cleanup sandbox
+   * Cleanup sandbox (used internally during preparation failures)
    */
   private async cleanupSandbox(sandbox: Sandbox): Promise<void> {
     try {
@@ -617,6 +617,24 @@ export class E2BService {
       log.debug(`Sandbox ${sandbox.sandboxId} cleaned up`);
     } catch (error) {
       log.error(`Failed to cleanup sandbox ${sandbox.sandboxId}:`, error);
+    }
+  }
+
+  /**
+   * Kill a sandbox by its ID
+   * Used by the complete API to cleanup sandboxes after run completion
+   *
+   * @param sandboxId The sandbox ID to kill
+   */
+  async killSandbox(sandboxId: string): Promise<void> {
+    try {
+      log.debug(`Killing sandbox ${sandboxId}...`);
+      const sandbox = await Sandbox.connect(sandboxId);
+      await sandbox.kill();
+      log.debug(`Sandbox ${sandboxId} killed successfully`);
+    } catch (error) {
+      // Log but don't throw - sandbox may already be terminated
+      log.error(`Failed to kill sandbox ${sandboxId}:`, error);
     }
   }
 }

--- a/turbo/apps/web/src/lib/e2b/scripts/common.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/common.ts
@@ -24,6 +24,7 @@ ARTIFACT_MANIFEST_URL="\${VM0_ARTIFACT_MANIFEST_URL:-}"
 # Construct webhook endpoint URLs
 WEBHOOK_URL="\${API_URL}/api/webhooks/agent/events"
 CHECKPOINT_URL="\${API_URL}/api/webhooks/agent/checkpoints"
+COMPLETE_URL="\${API_URL}/api/webhooks/agent/complete"
 STORAGE_WEBHOOK_URL="\${API_URL}/api/webhooks/agent/storages"
 INCREMENTAL_WEBHOOK_URL="\${API_URL}/api/webhooks/agent/storages/incremental"
 


### PR DESCRIPTION
## Summary

- Add `killSandbox()` method to e2b-service for killing sandboxes by ID
- Create `/api/webhooks/agent/complete` endpoint for unified lifecycle management
- Update checkpoint API to only handle data persistence (remove vm0_result sending)
- Add `COMPLETE_URL` to common.sh for sandbox scripts
- Update run-agent.sh to always call complete API at the end

## Problem

E2B sandboxes were not being properly cleaned up after agent runs complete. The "fire-and-forget" architecture started sandboxes but never explicitly terminated them, causing sandboxes to run for the full 1-hour timeout even when tasks completed in minutes.

## Solution

The complete API now handles the entire run lifecycle termination:
- **Success (exitCode=0)**: Query checkpoint from DB, send `vm0_result` event, kill sandbox
- **Failure (exitCode≠0)**: Send `vm0_error` event with error message, kill sandbox

### New Lifecycle Flow

```
run-agent.sh execution
        │
        ▼
   exit code?
    /      \
  =0       ≠0
   │        │
   ▼        │
checkpoint  │
API ────────┼─────────────────────────
(data only) │
   │        │
   └────────┴────────┐
                     ▼
           ┌─────────────────┐
           │  complete API   │  ◄── ALWAYS called at end
           │  {runId,        │
           │   exitCode,     │
           │   error?}       │
           └─────────────────┘
                     │
                     ▼
           - Send vm0_result/error
           - Kill sandbox
```

### Cleanup Matrix (After Fix)

| Scenario | vm0_error | vm0_result | Sandbox Cleanup |
|----------|-----------|------------|-----------------|
| Prep failure | ✅ (existing) | - | ✅ (existing catch) |
| Claude success | - | ✅ complete API | ✅ complete API |
| Claude failure | ✅ complete API | - | ✅ complete API |
| Checkpoint failure | ✅ complete API | - | ✅ complete API |

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] All existing tests pass (438 tests)
- [ ] Manual test: successful run triggers vm0_result and sandbox cleanup
- [ ] Manual test: failed run triggers vm0_error and sandbox cleanup

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)