### PR TITLE
feat(cli): add --verbose flag and elapsed time display for run command

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/run.test.ts
@@ -331,7 +331,35 @@ describe("run command", () => {
       });
     });
 
-    it("should display starting messages", async () => {
+    it("should display starting messages in verbose mode", async () => {
+      vi.mocked(apiClient.createRun).mockResolvedValue({
+        runId: "run-123",
+        status: "completed",
+        sandboxId: "sbx-456",
+        output: "Success",
+        executionTimeMs: 1000,
+        createdAt: "2025-01-01T00:00:00Z",
+      });
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "test prompt",
+        "--artifact-name",
+        "test-artifact",
+        "--verbose",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Creating agent run"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Prompt: test prompt"),
+      );
+    });
+
+    it("should not display starting messages without verbose flag", async () => {
       vi.mocked(apiClient.createRun).mockResolvedValue({
         runId: "run-123",
         status: "completed",
@@ -350,15 +378,12 @@ describe("run command", () => {
         "test-artifact",
       ]);
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleLog).not.toHaveBeenCalledWith(
         expect.stringContaining("Creating agent run"),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Prompt: test prompt"),
       );
     });
 
-    it("should display vars when provided", async () => {
+    it("should display vars when provided in verbose mode", async () => {
       vi.mocked(apiClient.createRun).mockResolvedValue({
         runId: "run-123",
         status: "completed",
@@ -377,6 +402,7 @@ describe("run command", () => {
         "test-artifact",
         "--vars",
         "KEY=value",
+        "--verbose",
       ]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { apiClient } from "../lib/api-client";
 import { ClaudeEventParser } from "../lib/event-parser";
-import { EventRenderer } from "../lib/event-renderer";
+import { EventRenderer, type RenderOptions } from "../lib/event-renderer";
 
 function collectVars(
   value: string,
@@ -44,15 +44,22 @@ function isUUID(str: string): boolean {
 
 const DEFAULT_TIMEOUT_SECONDS = 120;
 
+interface PollOptions {
+  verbose?: boolean;
+}
+
 async function pollEvents(
   runId: string,
   timeoutSeconds: number,
+  options?: PollOptions,
 ): Promise<void> {
   let nextSequence = -1;
   let complete = false;
   const pollIntervalMs = 500;
   const timeoutMs = timeoutSeconds * 1000;
   const startTime = Date.now();
+  const startTimestamp = new Date();
+  let previousTimestamp = startTimestamp;
 
   while (!complete) {
     // Check timeout
@@ -76,7 +83,16 @@ async function pollEvents(
       );
 
       if (parsed) {
-        EventRenderer.render(parsed);
+        const renderOptions: RenderOptions = {
+          verbose: options?.verbose,
+          previousTimestamp: options?.verbose ? previousTimestamp : undefined,
+          startTimestamp,
+        };
+
+        EventRenderer.render(parsed, renderOptions);
+
+        // Update previous timestamp for next event
+        previousTimestamp = parsed.timestamp;
 
         // Complete when we receive vm0_result or vm0_error
         if (parsed.type === "vm0_result" || parsed.type === "vm0_error") {
@@ -128,6 +144,7 @@ const runCmd = new Command()
     "Polling timeout in seconds (default: 120)",
     String(DEFAULT_TIMEOUT_SECONDS),
   )
+  .option("-v, --verbose", "Show verbose output with timing information")
   .action(
     async (
       identifier: string,
@@ -139,6 +156,7 @@ const runCmd = new Command()
         volumeVersion: Record<string, string>;
         conversation?: string;
         timeout: string;
+        verbose?: boolean;
       },
     ) => {
       const timeoutSeconds = parseInt(options.timeout, 10);
@@ -160,6 +178,8 @@ const runCmd = new Command()
         process.exit(1);
       }
 
+      const verbose = options.verbose;
+
       try {
         // 1. Resolve identifier to configId
         let configId: string;
@@ -167,14 +187,20 @@ const runCmd = new Command()
         if (isUUID(identifier)) {
           // It's a UUID config ID - use directly
           configId = identifier;
-          console.log(chalk.gray(`  Using config ID: ${configId}`));
+          if (verbose) {
+            console.log(chalk.gray(`  Using config ID: ${configId}`));
+          }
         } else {
           // It's an agent name - resolve to config ID
-          console.log(chalk.gray(`  Resolving agent name: ${identifier}`));
+          if (verbose) {
+            console.log(chalk.gray(`  Resolving agent name: ${identifier}`));
+          }
           try {
             const config = await apiClient.getConfigByName(identifier);
             configId = config.id;
-            console.log(chalk.gray(`  Resolved to config ID: ${configId}`));
+            if (verbose) {
+              console.log(chalk.gray(`  Resolved to config ID: ${configId}`));
+            }
           } catch (error) {
             if (error instanceof Error) {
               console.error(chalk.red(`✗ Agent not found: ${identifier}`));
@@ -188,38 +214,40 @@ const runCmd = new Command()
           }
         }
 
-        // 2. Display starting message
-        console.log(chalk.blue("\nCreating agent run..."));
-        console.log(chalk.gray(`  Prompt: ${prompt}`));
+        // 2. Display starting message (verbose only)
+        if (verbose) {
+          console.log(chalk.blue("\nCreating agent run..."));
+          console.log(chalk.gray(`  Prompt: ${prompt}`));
 
-        if (Object.keys(options.vars).length > 0) {
-          console.log(
-            chalk.gray(`  Variables: ${JSON.stringify(options.vars)}`),
-          );
+          if (Object.keys(options.vars).length > 0) {
+            console.log(
+              chalk.gray(`  Variables: ${JSON.stringify(options.vars)}`),
+            );
+          }
+
+          console.log(chalk.gray(`  Artifact: ${options.artifactName}`));
+          if (options.artifactVersion) {
+            console.log(
+              chalk.gray(`  Artifact version: ${options.artifactVersion}`),
+            );
+          }
+
+          if (Object.keys(options.volumeVersion).length > 0) {
+            console.log(
+              chalk.gray(
+                `  Volume versions: ${JSON.stringify(options.volumeVersion)}`,
+              ),
+            );
+          }
+
+          if (options.conversation) {
+            console.log(chalk.gray(`  Conversation: ${options.conversation}`));
+          }
+
+          console.log();
+          console.log(chalk.blue("Executing in sandbox..."));
+          console.log();
         }
-
-        console.log(chalk.gray(`  Artifact: ${options.artifactName}`));
-        if (options.artifactVersion) {
-          console.log(
-            chalk.gray(`  Artifact version: ${options.artifactVersion}`),
-          );
-        }
-
-        if (Object.keys(options.volumeVersion).length > 0) {
-          console.log(
-            chalk.gray(
-              `  Volume versions: ${JSON.stringify(options.volumeVersion)}`,
-            ),
-          );
-        }
-
-        if (options.conversation) {
-          console.log(chalk.gray(`  Conversation: ${options.conversation}`));
-        }
-
-        console.log();
-        console.log(chalk.blue("Executing in sandbox..."));
-        console.log();
 
         // 3. Call unified API
         const response = await apiClient.createRun({
@@ -237,7 +265,7 @@ const runCmd = new Command()
         });
 
         // 4. Poll for events
-        await pollEvents(response.runId, timeoutSeconds);
+        await pollEvents(response.runId, timeoutSeconds, { verbose });
       } catch (error) {
         if (error instanceof Error) {
           if (error.message.includes("Not authenticated")) {
@@ -278,11 +306,12 @@ runCmd
     "Polling timeout in seconds (default: 120)",
     String(DEFAULT_TIMEOUT_SECONDS),
   )
+  .option("-v, --verbose", "Show verbose output with timing information")
   .action(
     async (
       checkpointId: string,
       prompt: string,
-      options: { timeout: string },
+      options: { timeout: string; verbose?: boolean },
       command: { optsWithGlobals: () => Record<string, unknown> },
     ) => {
       // Commander.js quirk: when parent command has same option name,
@@ -290,6 +319,7 @@ runCmd
       const allOpts = command.optsWithGlobals() as {
         volumeVersion: Record<string, string>;
         timeout: string;
+        verbose?: boolean;
       };
       const timeoutSeconds = parseInt(options.timeout, 10);
       if (isNaN(timeoutSeconds) || timeoutSeconds <= 0) {
@@ -298,6 +328,9 @@ runCmd
         );
         process.exit(1);
       }
+
+      const verbose = options.verbose || allOpts.verbose;
+
       try {
         // 1. Validate checkpoint ID format
         if (!isUUID(checkpointId)) {
@@ -308,22 +341,24 @@ runCmd
           process.exit(1);
         }
 
-        // 2. Display starting message
-        console.log(chalk.blue("\nResuming agent run from checkpoint..."));
-        console.log(chalk.gray(`  Checkpoint ID: ${checkpointId}`));
-        console.log(chalk.gray(`  Prompt: ${prompt}`));
+        // 2. Display starting message (verbose only)
+        if (verbose) {
+          console.log(chalk.blue("\nResuming agent run from checkpoint..."));
+          console.log(chalk.gray(`  Checkpoint ID: ${checkpointId}`));
+          console.log(chalk.gray(`  Prompt: ${prompt}`));
 
-        if (Object.keys(allOpts.volumeVersion).length > 0) {
-          console.log(
-            chalk.gray(
-              `  Volume overrides: ${JSON.stringify(allOpts.volumeVersion)}`,
-            ),
-          );
+          if (Object.keys(allOpts.volumeVersion).length > 0) {
+            console.log(
+              chalk.gray(
+                `  Volume overrides: ${JSON.stringify(allOpts.volumeVersion)}`,
+              ),
+            );
+          }
+
+          console.log();
+          console.log(chalk.blue("Executing in sandbox..."));
+          console.log();
         }
-
-        console.log();
-        console.log(chalk.blue("Executing in sandbox..."));
-        console.log();
 
         // 3. Call unified API with checkpointId
         const response = await apiClient.createRun({
@@ -336,7 +371,7 @@ runCmd
         });
 
         // 4. Poll for events
-        await pollEvents(response.runId, timeoutSeconds);
+        await pollEvents(response.runId, timeoutSeconds, { verbose });
       } catch (error) {
         if (error instanceof Error) {
           if (error.message.includes("Not authenticated")) {
@@ -376,11 +411,12 @@ runCmd
     "Polling timeout in seconds (default: 120)",
     String(DEFAULT_TIMEOUT_SECONDS),
   )
+  .option("-v, --verbose", "Show verbose output with timing information")
   .action(
     async (
       agentSessionId: string,
       prompt: string,
-      options: { timeout: string },
+      options: { timeout: string; verbose?: boolean },
       command: { optsWithGlobals: () => Record<string, unknown> },
     ) => {
       // Commander.js quirk: when parent command has same option name,
@@ -388,6 +424,7 @@ runCmd
       const allOpts = command.optsWithGlobals() as {
         volumeVersion: Record<string, string>;
         timeout: string;
+        verbose?: boolean;
       };
       const timeoutSeconds = parseInt(options.timeout, 10);
       if (isNaN(timeoutSeconds) || timeoutSeconds <= 0) {
@@ -396,6 +433,9 @@ runCmd
         );
         process.exit(1);
       }
+
+      const verbose = options.verbose || allOpts.verbose;
+
       try {
         // 1. Validate session ID format
         if (!isUUID(agentSessionId)) {
@@ -406,23 +446,25 @@ runCmd
           process.exit(1);
         }
 
-        // 2. Display starting message
-        console.log(chalk.blue("\nContinuing agent run from session..."));
-        console.log(chalk.gray(`  Session ID: ${agentSessionId}`));
-        console.log(chalk.gray(`  Prompt: ${prompt}`));
-        console.log(chalk.gray(`  Note: Using latest artifact version`));
+        // 2. Display starting message (verbose only)
+        if (verbose) {
+          console.log(chalk.blue("\nContinuing agent run from session..."));
+          console.log(chalk.gray(`  Session ID: ${agentSessionId}`));
+          console.log(chalk.gray(`  Prompt: ${prompt}`));
+          console.log(chalk.gray(`  Note: Using latest artifact version`));
 
-        if (Object.keys(allOpts.volumeVersion).length > 0) {
-          console.log(
-            chalk.gray(
-              `  Volume overrides: ${JSON.stringify(allOpts.volumeVersion)}`,
-            ),
-          );
+          if (Object.keys(allOpts.volumeVersion).length > 0) {
+            console.log(
+              chalk.gray(
+                `  Volume overrides: ${JSON.stringify(allOpts.volumeVersion)}`,
+              ),
+            );
+          }
+
+          console.log();
+          console.log(chalk.blue("Executing in sandbox..."));
+          console.log();
         }
-
-        console.log();
-        console.log(chalk.blue("Executing in sandbox..."));
-        console.log();
 
         // 3. Call unified API with sessionId
         const response = await apiClient.createRun({
@@ -435,7 +477,7 @@ runCmd
         });
 
         // 4. Poll for events
-        await pollEvents(response.runId, timeoutSeconds);
+        await pollEvents(response.runId, timeoutSeconds, { verbose });
       } catch (error) {
         if (error instanceof Error) {
           if (error.message.includes("Not authenticated")) {

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { apiClient } from "../lib/api-client";
 import { ClaudeEventParser } from "../lib/event-parser";
-import { EventRenderer, type RenderOptions } from "../lib/event-renderer";
+import { EventRenderer } from "../lib/event-renderer";
 
 function collectVars(
   value: string,
@@ -60,6 +60,7 @@ async function pollEvents(
   const startTime = Date.now();
   const startTimestamp = new Date();
   let previousTimestamp = startTimestamp;
+  const verbose = options?.verbose;
 
   while (!complete) {
     // Check timeout
@@ -83,13 +84,11 @@ async function pollEvents(
       );
 
       if (parsed) {
-        const renderOptions: RenderOptions = {
-          verbose: options?.verbose,
-          previousTimestamp: options?.verbose ? previousTimestamp : undefined,
+        EventRenderer.render(parsed, {
+          verbose,
+          previousTimestamp,
           startTimestamp,
-        };
-
-        EventRenderer.render(parsed, renderOptions);
+        });
 
         // Update previous timestamp for next event
         previousTimestamp = parsed.timestamp;
@@ -108,6 +107,24 @@ async function pollEvents(
       await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
     }
   }
+}
+
+/**
+ * Log verbose pre-flight messages
+ */
+function logVerbosePreFlight(
+  action: string,
+  details: Array<{ label: string; value: string | undefined }>,
+): void {
+  console.log(chalk.blue(`\n${action}...`));
+  for (const { label, value } of details) {
+    if (value !== undefined) {
+      console.log(chalk.gray(`  ${label}: ${value}`));
+    }
+  }
+  console.log();
+  console.log(chalk.blue("Executing in sandbox..."));
+  console.log();
 }
 
 const runCmd = new Command()
@@ -216,37 +233,26 @@ const runCmd = new Command()
 
         // 2. Display starting message (verbose only)
         if (verbose) {
-          console.log(chalk.blue("\nCreating agent run..."));
-          console.log(chalk.gray(`  Prompt: ${prompt}`));
-
-          if (Object.keys(options.vars).length > 0) {
-            console.log(
-              chalk.gray(`  Variables: ${JSON.stringify(options.vars)}`),
-            );
-          }
-
-          console.log(chalk.gray(`  Artifact: ${options.artifactName}`));
-          if (options.artifactVersion) {
-            console.log(
-              chalk.gray(`  Artifact version: ${options.artifactVersion}`),
-            );
-          }
-
-          if (Object.keys(options.volumeVersion).length > 0) {
-            console.log(
-              chalk.gray(
-                `  Volume versions: ${JSON.stringify(options.volumeVersion)}`,
-              ),
-            );
-          }
-
-          if (options.conversation) {
-            console.log(chalk.gray(`  Conversation: ${options.conversation}`));
-          }
-
-          console.log();
-          console.log(chalk.blue("Executing in sandbox..."));
-          console.log();
+          logVerbosePreFlight("Creating agent run", [
+            { label: "Prompt", value: prompt },
+            {
+              label: "Variables",
+              value:
+                Object.keys(options.vars).length > 0
+                  ? JSON.stringify(options.vars)
+                  : undefined,
+            },
+            { label: "Artifact", value: options.artifactName },
+            { label: "Artifact version", value: options.artifactVersion },
+            {
+              label: "Volume versions",
+              value:
+                Object.keys(options.volumeVersion).length > 0
+                  ? JSON.stringify(options.volumeVersion)
+                  : undefined,
+            },
+            { label: "Conversation", value: options.conversation },
+          ]);
         }
 
         // 3. Call unified API
@@ -343,21 +349,17 @@ runCmd
 
         // 2. Display starting message (verbose only)
         if (verbose) {
-          console.log(chalk.blue("\nResuming agent run from checkpoint..."));
-          console.log(chalk.gray(`  Checkpoint ID: ${checkpointId}`));
-          console.log(chalk.gray(`  Prompt: ${prompt}`));
-
-          if (Object.keys(allOpts.volumeVersion).length > 0) {
-            console.log(
-              chalk.gray(
-                `  Volume overrides: ${JSON.stringify(allOpts.volumeVersion)}`,
-              ),
-            );
-          }
-
-          console.log();
-          console.log(chalk.blue("Executing in sandbox..."));
-          console.log();
+          logVerbosePreFlight("Resuming agent run from checkpoint", [
+            { label: "Checkpoint ID", value: checkpointId },
+            { label: "Prompt", value: prompt },
+            {
+              label: "Volume overrides",
+              value:
+                Object.keys(allOpts.volumeVersion).length > 0
+                  ? JSON.stringify(allOpts.volumeVersion)
+                  : undefined,
+            },
+          ]);
         }
 
         // 3. Call unified API with checkpointId
@@ -448,22 +450,18 @@ runCmd
 
         // 2. Display starting message (verbose only)
         if (verbose) {
-          console.log(chalk.blue("\nContinuing agent run from session..."));
-          console.log(chalk.gray(`  Session ID: ${agentSessionId}`));
-          console.log(chalk.gray(`  Prompt: ${prompt}`));
-          console.log(chalk.gray(`  Note: Using latest artifact version`));
-
-          if (Object.keys(allOpts.volumeVersion).length > 0) {
-            console.log(
-              chalk.gray(
-                `  Volume overrides: ${JSON.stringify(allOpts.volumeVersion)}`,
-              ),
-            );
-          }
-
-          console.log();
-          console.log(chalk.blue("Executing in sandbox..."));
-          console.log();
+          logVerbosePreFlight("Continuing agent run from session", [
+            { label: "Session ID", value: agentSessionId },
+            { label: "Prompt", value: prompt },
+            { label: "Note", value: "Using latest artifact version" },
+            {
+              label: "Volume overrides",
+              value:
+                Object.keys(allOpts.volumeVersion).length > 0
+                  ? JSON.stringify(allOpts.volumeVersion)
+                  : undefined,
+            },
+          ]);
         }
 
         // 3. Call unified API with sessionId

--- a/turbo/apps/cli/src/lib/__tests__/event-renderer.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/event-renderer.test.ts
@@ -602,7 +602,7 @@ describe("EventRenderer", () => {
   // ============================================
 
   describe("Total Time Display", () => {
-    it("should render total time in vm0_result when startTimestamp is provided", () => {
+    it("should render total time in vm0_result in verbose mode", () => {
       const event: ParsedEvent = {
         type: "vm0_result",
         timestamp: new Date("2024-01-01T00:00:06.700Z"),
@@ -614,6 +614,7 @@ describe("EventRenderer", () => {
       };
 
       const options: RenderOptions = {
+        verbose: true,
         startTimestamp: new Date("2024-01-01T00:00:00.000Z"),
       };
 
@@ -626,7 +627,7 @@ describe("EventRenderer", () => {
       expect(lastCall).toContain("6.7s");
     });
 
-    it("should not render total time without startTimestamp", () => {
+    it("should not render total time without verbose flag", () => {
       const event: ParsedEvent = {
         type: "vm0_result",
         timestamp: new Date("2024-01-01T00:00:06.700Z"),
@@ -637,7 +638,12 @@ describe("EventRenderer", () => {
         },
       };
 
-      EventRenderer.render(event);
+      const options: RenderOptions = {
+        verbose: false,
+        startTimestamp: new Date("2024-01-01T00:00:00.000Z"),
+      };
+
+      EventRenderer.render(event, options);
 
       // Check no call contains "Total time"
       const allCalls = consoleLogSpy.mock.calls.map(

--- a/turbo/apps/cli/src/lib/__tests__/event-renderer.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/event-renderer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { EventRenderer } from "../event-renderer";
+import { EventRenderer, type RenderOptions } from "../event-renderer";
 import type { ParsedEvent } from "../event-parser";
 
 describe("EventRenderer", () => {
@@ -390,6 +390,291 @@ describe("EventRenderer", () => {
       EventRenderer.render(event);
 
       expect(consoleLogSpy).toHaveBeenCalled();
+    });
+  });
+
+  // ============================================
+  // Elapsed Time Formatting Tests
+  // ============================================
+
+  describe("formatElapsed", () => {
+    it("should format milliseconds for values under 1000ms", () => {
+      const start = new Date("2024-01-01T00:00:00.000Z");
+      const end = new Date("2024-01-01T00:00:00.500Z");
+
+      const result = EventRenderer.formatElapsed(start, end);
+
+      expect(result).toBe("[+500ms]");
+    });
+
+    it("should format seconds for values 1000ms and above", () => {
+      const start = new Date("2024-01-01T00:00:00.000Z");
+      const end = new Date("2024-01-01T00:00:02.300Z");
+
+      const result = EventRenderer.formatElapsed(start, end);
+
+      expect(result).toBe("[+2.3s]");
+    });
+
+    it("should handle exact 1000ms boundary", () => {
+      const start = new Date("2024-01-01T00:00:00.000Z");
+      const end = new Date("2024-01-01T00:00:01.000Z");
+
+      const result = EventRenderer.formatElapsed(start, end);
+
+      expect(result).toBe("[+1.0s]");
+    });
+
+    it("should handle zero elapsed time", () => {
+      const time = new Date("2024-01-01T00:00:00.000Z");
+
+      const result = EventRenderer.formatElapsed(time, time);
+
+      expect(result).toBe("[+0ms]");
+    });
+  });
+
+  describe("formatTotalTime", () => {
+    it("should format total time in seconds", () => {
+      const start = new Date("2024-01-01T00:00:00.000Z");
+      const end = new Date("2024-01-01T00:00:06.700Z");
+
+      const result = EventRenderer.formatTotalTime(start, end);
+
+      expect(result).toBe("6.7s");
+    });
+
+    it("should handle short durations", () => {
+      const start = new Date("2024-01-01T00:00:00.000Z");
+      const end = new Date("2024-01-01T00:00:00.500Z");
+
+      const result = EventRenderer.formatTotalTime(start, end);
+
+      expect(result).toBe("0.5s");
+    });
+  });
+
+  // ============================================
+  // Verbose Mode Tests
+  // ============================================
+
+  describe("Verbose Mode", () => {
+    it("should render elapsed time prefix in verbose mode", () => {
+      const event: ParsedEvent = {
+        type: "text",
+        timestamp: new Date("2024-01-01T00:00:01.500Z"),
+        data: {
+          text: "Hello world",
+        },
+      };
+
+      const options: RenderOptions = {
+        verbose: true,
+        previousTimestamp: new Date("2024-01-01T00:00:00.000Z"),
+      };
+
+      EventRenderer.render(event, options);
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      expect(consoleLogSpy.mock.calls[0]![0]).toContain("[text]");
+      expect(consoleLogSpy.mock.calls[0]![0]).toContain("[+1.5s]");
+      expect(consoleLogSpy.mock.calls[0]![0]).toContain("Hello world");
+    });
+
+    it("should not render elapsed time without verbose flag", () => {
+      const event: ParsedEvent = {
+        type: "text",
+        timestamp: new Date("2024-01-01T00:00:01.500Z"),
+        data: {
+          text: "Hello world",
+        },
+      };
+
+      const options: RenderOptions = {
+        verbose: false,
+        previousTimestamp: new Date("2024-01-01T00:00:00.000Z"),
+      };
+
+      EventRenderer.render(event, options);
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      expect(consoleLogSpy.mock.calls[0]![0]).toContain("[text]");
+      expect(consoleLogSpy.mock.calls[0]![0]).not.toContain("[+");
+    });
+
+    it("should not render elapsed time without previousTimestamp", () => {
+      const event: ParsedEvent = {
+        type: "text",
+        timestamp: new Date("2024-01-01T00:00:01.500Z"),
+        data: {
+          text: "Hello world",
+        },
+      };
+
+      const options: RenderOptions = {
+        verbose: true,
+      };
+
+      EventRenderer.render(event, options);
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      expect(consoleLogSpy.mock.calls[0]![0]).toContain("[text]");
+      expect(consoleLogSpy.mock.calls[0]![0]).not.toContain("[+");
+    });
+
+    it("should render elapsed time for all event types in verbose mode", () => {
+      const baseTimestamp = new Date("2024-01-01T00:00:00.000Z");
+      const eventTimestamp = new Date("2024-01-01T00:00:00.100Z");
+
+      const options: RenderOptions = {
+        verbose: true,
+        previousTimestamp: baseTimestamp,
+      };
+
+      // Test init event
+      const initEvent: ParsedEvent = {
+        type: "init",
+        timestamp: eventTimestamp,
+        data: { sessionId: "test", model: "test", tools: [] },
+      };
+      EventRenderer.render(initEvent, options);
+      expect(consoleLogSpy.mock.calls[0]![0]).toContain("[+100ms]");
+
+      consoleLogSpy.mockClear();
+
+      // Test tool_use event
+      const toolUseEvent: ParsedEvent = {
+        type: "tool_use",
+        timestamp: eventTimestamp,
+        data: { tool: "Bash", input: {} },
+      };
+      EventRenderer.render(toolUseEvent, options);
+      expect(consoleLogSpy.mock.calls[0]![0]).toContain("[+100ms]");
+
+      consoleLogSpy.mockClear();
+
+      // Test tool_result event
+      const toolResultEvent: ParsedEvent = {
+        type: "tool_result",
+        timestamp: eventTimestamp,
+        data: { result: "done", isError: false },
+      };
+      EventRenderer.render(toolResultEvent, options);
+      expect(consoleLogSpy.mock.calls[0]![0]).toContain("[+100ms]");
+
+      consoleLogSpy.mockClear();
+
+      // Test result event
+      const resultEvent: ParsedEvent = {
+        type: "result",
+        timestamp: eventTimestamp,
+        data: { success: true, durationMs: 0, numTurns: 0, cost: 0, usage: {} },
+      };
+      EventRenderer.render(resultEvent, options);
+      expect(consoleLogSpy.mock.calls[0]![0]).toContain("[+100ms]");
+
+      consoleLogSpy.mockClear();
+
+      // Test vm0_start event
+      const vm0StartEvent: ParsedEvent = {
+        type: "vm0_start",
+        timestamp: eventTimestamp,
+        data: { runId: "test", prompt: "test" },
+      };
+      EventRenderer.render(vm0StartEvent, options);
+      expect(consoleLogSpy.mock.calls[0]![0]).toContain("[+100ms]");
+
+      consoleLogSpy.mockClear();
+
+      // Test vm0_error event
+      const vm0ErrorEvent: ParsedEvent = {
+        type: "vm0_error",
+        timestamp: eventTimestamp,
+        data: { error: "test error" },
+      };
+      EventRenderer.render(vm0ErrorEvent, options);
+      expect(consoleLogSpy.mock.calls[0]![0]).toContain("[+100ms]");
+    });
+  });
+
+  // ============================================
+  // Total Time Display Tests
+  // ============================================
+
+  describe("Total Time Display", () => {
+    it("should render total time in vm0_result when startTimestamp is provided", () => {
+      const event: ParsedEvent = {
+        type: "vm0_result",
+        timestamp: new Date("2024-01-01T00:00:06.700Z"),
+        data: {
+          checkpointId: "checkpoint-123",
+          agentSessionId: "session-456",
+          conversationId: "conv-789",
+        },
+      };
+
+      const options: RenderOptions = {
+        startTimestamp: new Date("2024-01-01T00:00:00.000Z"),
+      };
+
+      EventRenderer.render(event, options);
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const lastCall =
+        consoleLogSpy.mock.calls[consoleLogSpy.mock.calls.length - 1]![0];
+      expect(lastCall).toContain("Total time:");
+      expect(lastCall).toContain("6.7s");
+    });
+
+    it("should not render total time without startTimestamp", () => {
+      const event: ParsedEvent = {
+        type: "vm0_result",
+        timestamp: new Date("2024-01-01T00:00:06.700Z"),
+        data: {
+          checkpointId: "checkpoint-123",
+          agentSessionId: "session-456",
+          conversationId: "conv-789",
+        },
+      };
+
+      EventRenderer.render(event);
+
+      // Check no call contains "Total time"
+      const allCalls = consoleLogSpy.mock.calls.map(
+        (call) => call[0] as string,
+      );
+      const hasTotalTime = allCalls.some((call) => call.includes("Total time"));
+      expect(hasTotalTime).toBe(false);
+    });
+
+    it("should render both elapsed time and total time in verbose mode", () => {
+      const event: ParsedEvent = {
+        type: "vm0_result",
+        timestamp: new Date("2024-01-01T00:00:06.700Z"),
+        data: {
+          checkpointId: "checkpoint-123",
+          agentSessionId: "session-456",
+          conversationId: "conv-789",
+        },
+      };
+
+      const options: RenderOptions = {
+        verbose: true,
+        previousTimestamp: new Date("2024-01-01T00:00:06.500Z"),
+        startTimestamp: new Date("2024-01-01T00:00:00.000Z"),
+      };
+
+      EventRenderer.render(event, options);
+
+      // Check first line has elapsed time
+      expect(consoleLogSpy.mock.calls[0]![0]).toContain("[vm0_result]");
+      expect(consoleLogSpy.mock.calls[0]![0]).toContain("[+200ms]");
+
+      // Check last line has total time
+      const lastCall =
+        consoleLogSpy.mock.calls[consoleLogSpy.mock.calls.length - 1]![0];
+      expect(lastCall).toContain("Total time:");
+      expect(lastCall).toContain("6.7s");
     });
   });
 });

--- a/turbo/apps/cli/src/lib/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/event-renderer.ts
@@ -70,7 +70,11 @@ export class EventRenderer {
         this.renderVm0Start(event, elapsedPrefix);
         break;
       case "vm0_result":
-        this.renderVm0Result(event, elapsedPrefix, options?.startTimestamp);
+        this.renderVm0Result(
+          event,
+          elapsedPrefix,
+          options?.verbose ? options?.startTimestamp : undefined,
+        );
         break;
       case "vm0_error":
         this.renderVm0Error(event, elapsedPrefix);
@@ -211,7 +215,7 @@ export class EventRenderer {
 
     this.renderArtifactAndVolumes(event.data);
 
-    // Always show total time if startTimestamp is provided
+    // Show total time in verbose mode
     if (startTimestamp) {
       const totalTime = this.formatTotalTime(startTimestamp, event.timestamp);
       console.log(`  Total time: ${chalk.gray(totalTime)}`);

--- a/turbo/apps/cli/src/lib/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/event-renderer.ts
@@ -6,41 +6,82 @@
 import chalk from "chalk";
 import type { ParsedEvent } from "./event-parser";
 
+/**
+ * Options for rendering events
+ */
+export interface RenderOptions {
+  /** Whether to show verbose output including elapsed time */
+  verbose?: boolean;
+  /** Timestamp of previous event for elapsed time calculation */
+  previousTimestamp?: Date;
+  /** Start timestamp for total time calculation */
+  startTimestamp?: Date;
+}
+
 export class EventRenderer {
+  /**
+   * Format elapsed time between two timestamps
+   * Returns [+Nms] for < 1000ms, [+N.Ns] for >= 1000ms
+   */
+  static formatElapsed(previous: Date, current: Date): string {
+    const elapsedMs = current.getTime() - previous.getTime();
+    if (elapsedMs < 1000) {
+      return `[+${elapsedMs}ms]`;
+    }
+    return `[+${(elapsedMs / 1000).toFixed(1)}s]`;
+  }
+
+  /**
+   * Format total elapsed time
+   * Returns N.Ns format
+   */
+  static formatTotalTime(start: Date, end: Date): string {
+    const elapsedMs = end.getTime() - start.getTime();
+    return `${(elapsedMs / 1000).toFixed(1)}s`;
+  }
+
   /**
    * Render a parsed event to console
    */
-  static render(event: ParsedEvent): void {
+  static render(event: ParsedEvent, options?: RenderOptions): void {
+    const elapsedPrefix =
+      options?.verbose && options?.previousTimestamp
+        ? chalk.gray(
+            this.formatElapsed(options.previousTimestamp, event.timestamp),
+          )
+        : "";
     switch (event.type) {
       case "init":
-        this.renderInit(event);
+        this.renderInit(event, elapsedPrefix);
         break;
       case "text":
-        this.renderText(event);
+        this.renderText(event, elapsedPrefix);
         break;
       case "tool_use":
-        this.renderToolUse(event);
+        this.renderToolUse(event, elapsedPrefix);
         break;
       case "tool_result":
-        this.renderToolResult(event);
+        this.renderToolResult(event, elapsedPrefix);
         break;
       case "result":
-        this.renderResult(event);
+        this.renderResult(event, elapsedPrefix);
         break;
       case "vm0_start":
-        this.renderVm0Start(event);
+        this.renderVm0Start(event, elapsedPrefix);
         break;
       case "vm0_result":
-        this.renderVm0Result(event);
+        this.renderVm0Result(event, elapsedPrefix, options?.startTimestamp);
         break;
       case "vm0_error":
-        this.renderVm0Error(event);
+        this.renderVm0Error(event, elapsedPrefix);
         break;
     }
   }
 
-  private static renderInit(event: ParsedEvent): void {
-    console.log(chalk.cyan("[init]") + " Starting Claude Code agent");
+  private static renderInit(event: ParsedEvent, elapsedPrefix: string): void {
+    console.log(
+      chalk.cyan("[init]") + elapsedPrefix + " Starting Claude Code agent",
+    );
     console.log(`  Session: ${chalk.gray(String(event.data.sessionId || ""))}`);
     console.log(`  Model: ${chalk.gray(String(event.data.model || ""))}`);
     console.log(
@@ -52,14 +93,17 @@ export class EventRenderer {
     );
   }
 
-  private static renderText(event: ParsedEvent): void {
+  private static renderText(event: ParsedEvent, elapsedPrefix: string): void {
     const text = String(event.data.text || "");
-    console.log(chalk.blue("[text]") + " " + text);
+    console.log(chalk.blue("[text]") + elapsedPrefix + " " + text);
   }
 
-  private static renderToolUse(event: ParsedEvent): void {
+  private static renderToolUse(
+    event: ParsedEvent,
+    elapsedPrefix: string,
+  ): void {
     const tool = String(event.data.tool || "");
-    console.log(chalk.yellow("[tool_use]") + " " + tool);
+    console.log(chalk.yellow("[tool_use]") + elapsedPrefix + " " + tool);
 
     // Show full input without truncation
     const input = event.data.input as Record<string, unknown>;
@@ -72,24 +116,27 @@ export class EventRenderer {
     }
   }
 
-  private static renderToolResult(event: ParsedEvent): void {
+  private static renderToolResult(
+    event: ParsedEvent,
+    elapsedPrefix: string,
+  ): void {
     const isError = Boolean(event.data.isError);
     const status = isError ? "Error" : "Completed";
     const color = isError ? chalk.red : chalk.green;
 
-    console.log(color("[tool_result]") + " " + status);
+    console.log(color("[tool_result]") + elapsedPrefix + " " + status);
 
     // Show full result without truncation
     const result = String(event.data.result || "");
     console.log(`  ${chalk.gray(result)}`);
   }
 
-  private static renderResult(event: ParsedEvent): void {
+  private static renderResult(event: ParsedEvent, elapsedPrefix: string): void {
     const success = Boolean(event.data.success);
     const status = success ? "✓ completed successfully" : "✗ failed";
     const color = success ? chalk.green : chalk.red;
 
-    console.log(color("[result]") + " " + status);
+    console.log(color("[result]") + elapsedPrefix + " " + status);
 
     const durationMs = Number(event.data.durationMs || 0);
     const durationSec = (durationMs / 1000).toFixed(1);
@@ -121,8 +168,11 @@ export class EventRenderer {
     }
   }
 
-  private static renderVm0Start(event: ParsedEvent): void {
-    console.log(chalk.cyan("[vm0_start]") + " Run starting");
+  private static renderVm0Start(
+    event: ParsedEvent,
+    elapsedPrefix: string,
+  ): void {
+    console.log(chalk.cyan("[vm0_start]") + elapsedPrefix + " Run starting");
 
     if (event.data.runId) {
       console.log(`  Run ID: ${chalk.gray(String(event.data.runId))}`);
@@ -139,8 +189,16 @@ export class EventRenderer {
     this.renderArtifactAndVolumes(event.data);
   }
 
-  private static renderVm0Result(event: ParsedEvent): void {
-    console.log(chalk.green("[vm0_result]") + " ✓ Run completed successfully");
+  private static renderVm0Result(
+    event: ParsedEvent,
+    elapsedPrefix: string,
+    startTimestamp?: Date,
+  ): void {
+    console.log(
+      chalk.green("[vm0_result]") +
+        elapsedPrefix +
+        " ✓ Run completed successfully",
+    );
     console.log(
       `  Checkpoint: ${chalk.gray(String(event.data.checkpointId || ""))}`,
     );
@@ -152,6 +210,12 @@ export class EventRenderer {
     );
 
     this.renderArtifactAndVolumes(event.data);
+
+    // Always show total time if startTimestamp is provided
+    if (startTimestamp) {
+      const totalTime = this.formatTotalTime(startTimestamp, event.timestamp);
+      console.log(`  Total time: ${chalk.gray(totalTime)}`);
+    }
   }
 
   /**
@@ -188,8 +252,11 @@ export class EventRenderer {
     }
   }
 
-  private static renderVm0Error(event: ParsedEvent): void {
-    console.log(chalk.red("[vm0_error]") + " ✗ Run failed");
+  private static renderVm0Error(
+    event: ParsedEvent,
+    elapsedPrefix: string,
+  ): void {
+    console.log(chalk.red("[vm0_error]") + elapsedPrefix + " ✗ Run failed");
 
     // Handle error as string or object
     let errorMessage = "";


### PR DESCRIPTION
## Summary

- Add `-v`/`--verbose` option to `run`, `resume`, and `continue` commands
- Move pre-flight messages (resolving agent, creating run, etc.) to verbose mode only
- Add elapsed time display between events in verbose mode (`[+Nms]` or `[+N.Ns]`)
- Add total execution time display at end of `vm0_result`

## Changes

### Normal mode (cleaner output)
```
[vm0_start] Run starting
  Run ID: 318e9c2d-...
  ...
[init] Starting Claude Code agent
  ...
[text] I'll list the files...
[tool_use] Bash
  command: ls -la
[tool_result] Completed
  ...
[result] ✓ completed successfully
  Duration: 6.7s
  ...
[vm0_result] ✓ Run completed successfully
  ...
  Total time: 6.7s
```

### Verbose mode (`--verbose`)
```
  Resolving agent name: demo
  Resolved to config ID: 1bd66b8c-...

Creating agent run...
  Prompt: list my files.
  Artifact: user-files

Executing in sandbox...

[vm0_start][+0ms] Run starting
  ...
[init][+45ms] Starting Claude Code agent
  ...
[text][+1.2s] I'll list the files...
[tool_use][+50ms] Bash
  ...
[tool_result][+2.3s] Completed
  ...
[result][+80ms] ✓ completed successfully
  ...
[vm0_result][+30ms] ✓ Run completed successfully
  ...
  Total time: 6.7s
```

## Test plan

- [x] Unit tests for EventRenderer elapsed time formatting
- [x] Unit tests for verbose mode rendering
- [x] Unit tests for total time display
- [x] Run command tests updated for new behavior

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)