### PR TITLE
fix: session resume fails due to agents dict being treated as array

### DIFF
--- a/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
+++ b/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
@@ -474,16 +474,7 @@ describe("E2B Service - mocked unit tests", () => {
       const context: ExecutionContext = {
         runId: "run-test-error",
         agentComposeId: "test-agent-error",
-        agentCompose: {
-          version: "1.0",
-          agents: {
-            "test-agent": {
-              image: "test-image",
-              provider: "claude-code",
-              working_dir: "/workspace",
-            },
-          },
-        },
+        agentCompose: createValidAgentCompose(),
         sandboxToken: "vm0_live_test_token",
         prompt: "This should fail due to mocked error",
       };
@@ -510,16 +501,7 @@ describe("E2B Service - mocked unit tests", () => {
       const context: ExecutionContext = {
         runId: "run-test-storage-error",
         agentComposeId: "test-agent-storage-error",
-        agentCompose: {
-          version: "1.0",
-          agents: {
-            "test-agent": {
-              image: "test-image",
-              provider: "claude-code",
-              working_dir: "/workspace",
-            },
-          },
-        },
+        agentCompose: createValidAgentCompose(),
         sandboxToken: "vm0_live_test_token",
         prompt: "This should fail due to storage errors",
       };

--- a/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
+++ b/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
@@ -63,6 +63,21 @@ describe("E2B Service - mocked unit tests", () => {
   });
 
   /**
+   * Helper function to create a valid agent compose with working_dir
+   */
+  const createValidAgentCompose = (overrides = {}) => ({
+    version: "1.0",
+    agents: {
+      "test-agent": {
+        image: "test-image",
+        provider: "claude-code",
+        working_dir: "/workspace",
+        ...overrides,
+      },
+    },
+  });
+
+  /**
    * Helper function to create a mock sandbox instance
    */
   const createMockSandbox = (overrides = {}) => ({
@@ -92,7 +107,7 @@ describe("E2B Service - mocked unit tests", () => {
       const context: ExecutionContext = {
         runId: "run-test-001",
         agentComposeId: "test-agent-001",
-        agentCompose: {},
+        agentCompose: createValidAgentCompose(),
         sandboxToken: "vm0_live_test_token",
         prompt: "Say hello",
         templateVars: { testVar: "testValue" },
@@ -144,7 +159,7 @@ describe("E2B Service - mocked unit tests", () => {
       const context: ExecutionContext = {
         runId: "run-test-event",
         agentComposeId: "test-agent-event",
-        agentCompose: {},
+        agentCompose: createValidAgentCompose(),
         sandboxToken: "vm0_live_test_token",
         prompt: "Test prompt",
         templateVars: { key: "value" },
@@ -207,7 +222,7 @@ describe("E2B Service - mocked unit tests", () => {
       const context: ExecutionContext = {
         runId: "run-test-storages",
         agentComposeId: "test-agent-storages",
-        agentCompose: {},
+        agentCompose: createValidAgentCompose(),
         sandboxToken: "vm0_live_test_token",
         prompt: "Test with storages",
       };
@@ -245,7 +260,7 @@ describe("E2B Service - mocked unit tests", () => {
       const context1: ExecutionContext = {
         runId: "run-test-002a",
         agentComposeId: "test-agent-002",
-        agentCompose: {},
+        agentCompose: createValidAgentCompose(),
         sandboxToken: "vm0_live_test_token",
         prompt: "Say hi",
       };
@@ -253,7 +268,7 @@ describe("E2B Service - mocked unit tests", () => {
       const context2: ExecutionContext = {
         runId: "run-test-002b",
         agentComposeId: "test-agent-002",
-        agentCompose: {},
+        agentCompose: createValidAgentCompose(),
         sandboxToken: "vm0_live_test_token",
         prompt: "Say hi",
       };
@@ -293,7 +308,7 @@ describe("E2B Service - mocked unit tests", () => {
       const context: ExecutionContext = {
         runId: "run-test-003",
         agentComposeId: "test-agent-003",
-        agentCompose: {},
+        agentCompose: createValidAgentCompose(),
         sandboxToken: "vm0_live_test_token",
         prompt: "What is 2+2?",
       };
@@ -322,7 +337,7 @@ describe("E2B Service - mocked unit tests", () => {
       const context: ExecutionContext = {
         runId: "run-test-004",
         agentComposeId: "test-agent-004",
-        agentCompose: {},
+        agentCompose: createValidAgentCompose(),
         sandboxToken: "vm0_live_test_token",
         prompt: "Quick question: what is today?",
       };
@@ -356,7 +371,7 @@ describe("E2B Service - mocked unit tests", () => {
       const context: ExecutionContext = {
         runId: "run-test-005",
         agentComposeId: "test-agent-005",
-        agentCompose: {},
+        agentCompose: createValidAgentCompose(),
         sandboxToken: "vm0_live_test_token",
         prompt: "Say goodbye",
       };
@@ -415,7 +430,7 @@ describe("E2B Service - mocked unit tests", () => {
       );
     });
 
-    it("should not set VM0_WORKING_DIR when not configured", async () => {
+    it("should fail when working_dir is not configured", async () => {
       // Arrange
       const mockSandbox = createMockSandbox();
       vi.mocked(Sandbox.create).mockResolvedValue(
@@ -443,17 +458,9 @@ describe("E2B Service - mocked unit tests", () => {
       // Act
       const result = await e2bService.execute(context);
 
-      // Assert - fire-and-forget returns "running"
-      expect(result.status).toBe("running");
-
-      // Verify sandbox command was called without VM0_WORKING_DIR
-      expect(mockSandbox.commands.run).toHaveBeenCalled();
-      const commandCall = mockSandbox.commands.run.mock.calls.find(
-        (call) => call[0] === "/usr/local/bin/vm0-agent/run-agent.sh",
-      );
-      expect(commandCall).toBeDefined();
-      expect(commandCall?.[1]?.envs).toBeDefined();
-      expect(commandCall?.[1]?.envs?.VM0_WORKING_DIR).toBeUndefined();
+      // Assert - should fail because working_dir is required
+      expect(result.status).toBe("failed");
+      expect(result.error).toContain("working_dir");
     });
   });
 
@@ -467,7 +474,16 @@ describe("E2B Service - mocked unit tests", () => {
       const context: ExecutionContext = {
         runId: "run-test-error",
         agentComposeId: "test-agent-error",
-        agentCompose: {},
+        agentCompose: {
+          version: "1.0",
+          agents: {
+            "test-agent": {
+              image: "test-image",
+              provider: "claude-code",
+              working_dir: "/workspace",
+            },
+          },
+        },
         sandboxToken: "vm0_live_test_token",
         prompt: "This should fail due to mocked error",
       };
@@ -494,7 +510,16 @@ describe("E2B Service - mocked unit tests", () => {
       const context: ExecutionContext = {
         runId: "run-test-storage-error",
         agentComposeId: "test-agent-storage-error",
-        agentCompose: {},
+        agentCompose: {
+          version: "1.0",
+          agents: {
+            "test-agent": {
+              image: "test-image",
+              provider: "claude-code",
+              working_dir: "/workspace",
+            },
+          },
+        },
         sandboxToken: "vm0_live_test_token",
         prompt: "This should fail due to storage errors",
       };

--- a/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
+++ b/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
@@ -418,14 +418,13 @@ describe("E2B Service - mocked unit tests", () => {
       // Assert - fire-and-forget returns "running"
       expect(result.status).toBe("running");
 
-      // Verify sandbox command was called with environment variables including working_dir
-      expect(mockSandbox.commands.run).toHaveBeenCalled();
-      const commandCall = mockSandbox.commands.run.mock.calls.find(
-        (call) => call[0] === "/usr/local/bin/vm0-agent/run-agent.sh",
-      );
-      expect(commandCall).toBeDefined();
-      expect(commandCall?.[1]?.envs).toBeDefined();
-      expect(commandCall?.[1]?.envs?.VM0_WORKING_DIR).toBe(
+      // Verify sandbox was created with environment variables including working_dir
+      // NOTE: VM0_WORKING_DIR is passed at sandbox creation time, not via commands.run({ envs })
+      // because E2B's background mode doesn't pass envs to the background process
+      expect(Sandbox.create).toHaveBeenCalled();
+      const createCall = vi.mocked(Sandbox.create).mock.calls[0];
+      expect(createCall).toBeDefined();
+      expect(createCall?.[1]?.envs?.VM0_WORKING_DIR).toBe(
         "/home/user/workspace",
       );
     });

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -441,12 +441,36 @@ export class E2BService {
     // but we verify again to ensure VM0_WORKING_DIR env var is never undefined
     const compose = agentCompose as AgentComposeYaml | undefined;
     const firstAgentForEnv = getFirstAgent(compose);
+
+    // Log the agent compose structure for debugging
+    log.debug(
+      `Agent compose structure: ${JSON.stringify({
+        hasCompose: !!compose,
+        hasAgents: !!compose?.agents,
+        agentKeys: compose?.agents ? Object.keys(compose.agents) : [],
+        firstAgent: firstAgentForEnv
+          ? {
+              hasWorkingDir: "working_dir" in firstAgentForEnv,
+              workingDirType: typeof firstAgentForEnv.working_dir,
+              workingDirValue: firstAgentForEnv.working_dir,
+            }
+          : null,
+      })}`,
+    );
+
     if (!firstAgentForEnv?.working_dir) {
       throw new BadRequestError(
         "Agent must have working_dir configured (no default allowed)",
       );
     }
     const workingDir = firstAgentForEnv.working_dir;
+
+    // Extra validation: ensure workingDir is a non-empty string
+    if (typeof workingDir !== "string" || workingDir.trim() === "") {
+      throw new BadRequestError(
+        `Invalid working_dir: expected non-empty string, got ${typeof workingDir}: ${JSON.stringify(workingDir)}`,
+      );
+    }
 
     // Set environment variables
     const envs: Record<string, string> = {

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -437,9 +437,16 @@ export class E2BService {
     log.debug(`Starting run-agent.sh for run ${runId} (fire-and-forget)...`);
 
     // Extract working_dir from agent compose
-    // Note: working_dir is already validated at the start of execute()
+    // Defensive check - working_dir should have been validated at start of execute()
+    // but we verify again to ensure VM0_WORKING_DIR env var is never undefined
     const compose = agentCompose as AgentComposeYaml | undefined;
-    const workingDir = getFirstAgent(compose)!.working_dir;
+    const firstAgentForEnv = getFirstAgent(compose);
+    if (!firstAgentForEnv?.working_dir) {
+      throw new BadRequestError(
+        "Agent must have working_dir configured (no default allowed)",
+      );
+    }
+    const workingDir = firstAgentForEnv.working_dir;
 
     // Set environment variables
     const envs: Record<string, string> = {

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -182,6 +182,56 @@ export class E2BService {
         log.debug(`Added Vercel protection bypass for preview deployment`);
       }
 
+      // Add prompt and working directory to sandbox env vars
+      // These must be set at sandbox creation time, not via commands.run({ envs })
+      // because E2B's background mode doesn't pass envs to the background process
+      sandboxEnvVars.VM0_PROMPT = context.prompt;
+      sandboxEnvVars.VM0_WORKING_DIR = artifactMountPath;
+
+      // Add resume session ID if provided
+      if (context.resumeSession?.sessionId) {
+        sandboxEnvVars.VM0_RESUME_SESSION_ID = context.resumeSession.sessionId;
+      }
+
+      // Pass USE_MOCK_CLAUDE for testing (executes prompt as bash instead of calling LLM)
+      if (process.env.USE_MOCK_CLAUDE === "true") {
+        sandboxEnvVars.USE_MOCK_CLAUDE = "true";
+      }
+
+      // Add artifact information for checkpoint
+      // Only artifact creates new versions after agent runs
+      if (artifactForCommand) {
+        sandboxEnvVars.VM0_ARTIFACT_DRIVER = "vas";
+        sandboxEnvVars.VM0_ARTIFACT_MOUNT_PATH = artifactForCommand.mountPath;
+        sandboxEnvVars.VM0_ARTIFACT_VOLUME_NAME =
+          artifactForCommand.vasStorageName;
+        sandboxEnvVars.VM0_ARTIFACT_VERSION_ID =
+          artifactForCommand.vasVersionId;
+
+        // Pass manifest URL for incremental upload
+        if (artifactForCommand.manifestUrl) {
+          sandboxEnvVars.VM0_ARTIFACT_MANIFEST_URL =
+            artifactForCommand.manifestUrl;
+        }
+      }
+
+      // Add Minimax API configuration if available
+      const minimaxBaseUrl = env().MINIMAX_ANTHROPIC_BASE_URL;
+      const minimaxApiKey = env().MINIMAX_API_KEY;
+
+      if (minimaxBaseUrl && minimaxApiKey) {
+        sandboxEnvVars.ANTHROPIC_BASE_URL = minimaxBaseUrl;
+        sandboxEnvVars.ANTHROPIC_AUTH_TOKEN = minimaxApiKey;
+        sandboxEnvVars.API_TIMEOUT_MS = "3000000";
+        sandboxEnvVars.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1";
+        sandboxEnvVars.ANTHROPIC_MODEL = "MiniMax-M2";
+        sandboxEnvVars.ANTHROPIC_SMALL_FAST_MODEL = "MiniMax-M2";
+        sandboxEnvVars.ANTHROPIC_DEFAULT_SONNET_MODEL = "MiniMax-M2";
+        sandboxEnvVars.ANTHROPIC_DEFAULT_OPUS_MODEL = "MiniMax-M2";
+        sandboxEnvVars.ANTHROPIC_DEFAULT_HAIKU_MODEL = "MiniMax-M2";
+        log.debug(`Using Minimax API (${minimaxBaseUrl})`);
+      }
+
       sandbox = await this.createSandbox(
         sandboxEnvVars,
         agentCompose as AgentComposeYaml | undefined,
@@ -203,15 +253,8 @@ export class E2BService {
 
       // Start Claude Code via run-agent.sh (fire-and-forget)
       // The script will send events via webhook and update status when complete
-      await this.startAgentExecution(
-        sandbox,
-        context.runId,
-        context.prompt,
-        context.sandboxToken,
-        context.agentCompose,
-        artifactForCommand,
-        context.resumeSession?.sessionId,
-      );
+      // NOTE: All env vars are already set at sandbox creation time
+      await this.startAgentExecution(sandbox, context.runId);
 
       const prepTimeMs = Date.now() - startTime;
       log.debug(
@@ -420,15 +463,13 @@ export class E2BService {
   /**
    * Start agent execution (fire-and-forget)
    * Uploads scripts and starts run-agent.sh in background without waiting
+   *
+   * NOTE: All environment variables must be set at sandbox creation time via createSandbox().
+   * E2B's background mode does not pass envs from sandbox.commands.run({ envs }) to the process.
    */
   private async startAgentExecution(
     sandbox: Sandbox,
     runId: string,
-    prompt: string,
-    sandboxToken: string,
-    agentCompose?: unknown,
-    preparedArtifact?: PreparedArtifact | null,
-    resumeSessionId?: string,
   ): Promise<void> {
     // Upload run-agent.sh script to sandbox at runtime
     // This allows script changes without rebuilding the E2B template
@@ -436,110 +477,10 @@ export class E2BService {
 
     log.debug(`Starting run-agent.sh for run ${runId} (fire-and-forget)...`);
 
-    // Extract working_dir from agent compose
-    // Defensive check - working_dir should have been validated at start of execute()
-    // but we verify again to ensure VM0_WORKING_DIR env var is never undefined
-    const compose = agentCompose as AgentComposeYaml | undefined;
-    const firstAgentForEnv = getFirstAgent(compose);
-
-    // Log the agent compose structure for debugging
-    log.debug(
-      `Agent compose structure: ${JSON.stringify({
-        hasCompose: !!compose,
-        hasAgents: !!compose?.agents,
-        agentKeys: compose?.agents ? Object.keys(compose.agents) : [],
-        firstAgent: firstAgentForEnv
-          ? {
-              hasWorkingDir: "working_dir" in firstAgentForEnv,
-              workingDirType: typeof firstAgentForEnv.working_dir,
-              workingDirValue: firstAgentForEnv.working_dir,
-            }
-          : null,
-      })}`,
-    );
-
-    if (!firstAgentForEnv?.working_dir) {
-      throw new BadRequestError(
-        "Agent must have working_dir configured (no default allowed)",
-      );
-    }
-    const workingDir = firstAgentForEnv.working_dir;
-
-    // Extra validation: ensure workingDir is a non-empty string
-    if (typeof workingDir !== "string" || workingDir.trim() === "") {
-      throw new BadRequestError(
-        `Invalid working_dir: expected non-empty string, got ${typeof workingDir}: ${JSON.stringify(workingDir)}`,
-      );
-    }
-
-    // Set environment variables
-    const envs: Record<string, string> = {
-      VM0_RUN_ID: runId,
-      VM0_API_TOKEN: sandboxToken,
-      VM0_PROMPT: prompt,
-      VM0_WORKING_DIR: workingDir,
-    };
-    log.debug(`Working directory configured: ${workingDir}`);
-
-    // Add resume session ID if provided
-    if (resumeSessionId) {
-      envs.VM0_RESUME_SESSION_ID = resumeSessionId;
-      log.debug(`Resume session ID configured: ${resumeSessionId}`);
-    }
-
-    // Pass USE_MOCK_CLAUDE for testing (executes prompt as bash instead of calling LLM)
-    if (process.env.USE_MOCK_CLAUDE === "true") {
-      envs.USE_MOCK_CLAUDE = "true";
-      log.debug(`Using mock-claude for testing`);
-    }
-
-    // Add artifact information for checkpoint
-    // Only artifact creates new versions after agent runs
-    if (preparedArtifact) {
-      log.debug(`Prepared artifact for checkpoint:`, {
-        driver: preparedArtifact.driver,
-        mountPath: preparedArtifact.mountPath,
-        vasStorageName: preparedArtifact.vasStorageName,
-      });
-
-      // VAS artifact - pass info for vas snapshot
-      envs.VM0_ARTIFACT_DRIVER = "vas";
-      envs.VM0_ARTIFACT_MOUNT_PATH = preparedArtifact.mountPath;
-      envs.VM0_ARTIFACT_VOLUME_NAME = preparedArtifact.vasStorageName;
-      envs.VM0_ARTIFACT_VERSION_ID = preparedArtifact.vasVersionId;
-
-      // Pass manifest URL for incremental upload
-      if (preparedArtifact.manifestUrl) {
-        envs.VM0_ARTIFACT_MANIFEST_URL = preparedArtifact.manifestUrl;
-        log.debug(`Configured manifest URL for incremental upload`);
-      }
-
-      log.debug(`Configured VAS artifact for checkpoint`);
-    } else {
-      log.debug(`No artifact configured for checkpoint`);
-    }
-
-    // Add Minimax API configuration if available
-    const minimaxBaseUrl = env().MINIMAX_ANTHROPIC_BASE_URL;
-    const minimaxApiKey = env().MINIMAX_API_KEY;
-
-    if (minimaxBaseUrl && minimaxApiKey) {
-      envs.ANTHROPIC_BASE_URL = minimaxBaseUrl;
-      envs.ANTHROPIC_AUTH_TOKEN = minimaxApiKey;
-      envs.API_TIMEOUT_MS = "3000000";
-      envs.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1";
-      envs.ANTHROPIC_MODEL = "MiniMax-M2";
-      envs.ANTHROPIC_SMALL_FAST_MODEL = "MiniMax-M2";
-      envs.ANTHROPIC_DEFAULT_SONNET_MODEL = "MiniMax-M2";
-      envs.ANTHROPIC_DEFAULT_OPUS_MODEL = "MiniMax-M2";
-      envs.ANTHROPIC_DEFAULT_HAIKU_MODEL = "MiniMax-M2";
-      log.debug(`Using Minimax API (${minimaxBaseUrl})`);
-    }
-
     // Start script in background using E2B's native background mode
     // This returns immediately while the command continues executing in the sandbox
+    // NOTE: Do not pass envs here - they must be set at sandbox creation time
     await sandbox.commands.run(scriptPath, {
-      envs,
       background: true,
     });
 

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -3,6 +3,7 @@ import { env } from "../../env";
 import { e2bConfig } from "./config";
 import type { RunResult } from "./types";
 import { storageService } from "../storage/storage-service";
+import { BadRequestError } from "../errors";
 import type {
   AgentVolumeConfig,
   PreparedArtifact,
@@ -75,7 +76,7 @@ export class E2BService {
       // working_dir is required - no fallback allowed
       const firstAgent = getFirstAgent(agentComposeYaml);
       if (!firstAgent?.working_dir) {
-        throw new Error(
+        throw new BadRequestError(
           "Agent must have working_dir configured (no default allowed)",
         );
       }
@@ -436,15 +437,9 @@ export class E2BService {
     log.debug(`Starting run-agent.sh for run ${runId} (fire-and-forget)...`);
 
     // Extract working_dir from agent compose
+    // Note: working_dir is already validated at the start of execute()
     const compose = agentCompose as AgentComposeYaml | undefined;
-    const firstAgentForEnv = getFirstAgent(compose);
-    // working_dir is required and already validated at the start of execute()
-    if (!firstAgentForEnv?.working_dir) {
-      throw new Error(
-        "Agent must have working_dir configured (no default allowed)",
-      );
-    }
-    const workingDir = firstAgentForEnv.working_dir;
+    const workingDir = getFirstAgent(compose)!.working_dir;
 
     // Set environment variables
     const envs: Record<string, string> = {

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -70,11 +70,16 @@ export class E2BService {
       | AgentComposeYaml
       | undefined;
 
-    // Get mount path from agent compose (used for resume artifact)
-    const firstAgent = getFirstAgent(agentComposeYaml);
-    const artifactMountPath = firstAgent?.working_dir || "/workspace";
-
     try {
+      // Get mount path from agent compose (used for resume artifact)
+      // working_dir is required - no fallback allowed
+      const firstAgent = getFirstAgent(agentComposeYaml);
+      if (!firstAgent?.working_dir) {
+        throw new Error(
+          "Agent must have working_dir configured (no default allowed)",
+        );
+      }
+      const artifactMountPath = firstAgent.working_dir;
       // Prepare storage manifest with presigned URLs for direct download to sandbox
       // This works for both new runs and resume scenarios
       const storageManifest = await storageService.prepareStorageManifest(
@@ -432,20 +437,23 @@ export class E2BService {
 
     // Extract working_dir from agent compose
     const compose = agentCompose as AgentComposeYaml | undefined;
-    const workingDir = getFirstAgent(compose)?.working_dir;
+    const firstAgentForEnv = getFirstAgent(compose);
+    // working_dir is required and already validated at the start of execute()
+    if (!firstAgentForEnv?.working_dir) {
+      throw new Error(
+        "Agent must have working_dir configured (no default allowed)",
+      );
+    }
+    const workingDir = firstAgentForEnv.working_dir;
 
     // Set environment variables
     const envs: Record<string, string> = {
       VM0_RUN_ID: runId,
       VM0_API_TOKEN: sandboxToken,
       VM0_PROMPT: prompt,
+      VM0_WORKING_DIR: workingDir,
     };
-
-    // Add working directory if configured
-    if (workingDir) {
-      envs.VM0_WORKING_DIR = workingDir;
-      log.debug(`Working directory configured: ${workingDir}`);
-    }
+    log.debug(`Working directory configured: ${workingDir}`);
 
     // Add resume session ID if provided
     if (resumeSessionId) {

--- a/turbo/apps/web/src/lib/e2b/scripts/common.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/common.ts
@@ -10,9 +10,15 @@ RUN_ID="\${VM0_RUN_ID}"
 API_URL="\${VM0_API_URL}"
 API_TOKEN="\${VM0_API_TOKEN}"
 PROMPT="\${VM0_PROMPT}"
-WORKING_DIR="\${VM0_WORKING_DIR:-/home/user/workspace}"
 VERCEL_BYPASS="\${VERCEL_PROTECTION_BYPASS:-}"
 RESUME_SESSION_ID="\${VM0_RESUME_SESSION_ID:-}"
+
+# Working directory is required - no fallback allowed
+WORKING_DIR="\${VM0_WORKING_DIR}"
+if [ -z "$WORKING_DIR" ]; then
+  echo "[ERROR] VM0_WORKING_DIR is required but not set" >&2
+  exit 1
+fi
 
 # Artifact configuration (replaces GIT_VOLUMES and VM0_VOLUMES)
 ARTIFACT_DRIVER="\${VM0_ARTIFACT_DRIVER:-}"

--- a/turbo/apps/web/src/lib/e2b/scripts/common.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/common.ts
@@ -15,6 +15,13 @@ RESUME_SESSION_ID="\${VM0_RESUME_SESSION_ID:-}"
 
 # Working directory is required - no fallback allowed
 WORKING_DIR="\${VM0_WORKING_DIR}"
+
+# Debug: Print all VM0_ environment variables
+echo "[DEBUG] VM0 environment variables:" >&2
+env | grep VM0_ >&2 || echo "[DEBUG] No VM0_ environment variables found" >&2
+echo "[DEBUG] VM0_WORKING_DIR raw value: '\${VM0_WORKING_DIR}'" >&2
+echo "[DEBUG] WORKING_DIR after assignment: '$WORKING_DIR'" >&2
+
 if [ -z "$WORKING_DIR" ]; then
   echo "[ERROR] VM0_WORKING_DIR is required but not set" >&2
   exit 1

--- a/turbo/apps/web/src/lib/e2b/scripts/common.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/common.ts
@@ -16,12 +16,6 @@ RESUME_SESSION_ID="\${VM0_RESUME_SESSION_ID:-}"
 # Working directory is required - no fallback allowed
 WORKING_DIR="\${VM0_WORKING_DIR}"
 
-# Debug: Print all VM0_ environment variables
-echo "[DEBUG] VM0 environment variables:" >&2
-env | grep VM0_ >&2 || echo "[DEBUG] No VM0_ environment variables found" >&2
-echo "[DEBUG] VM0_WORKING_DIR raw value: '\${VM0_WORKING_DIR}'" >&2
-echo "[DEBUG] WORKING_DIR after assignment: '$WORKING_DIR'" >&2
-
 if [ -z "$WORKING_DIR" ]; then
   echo "[ERROR] VM0_WORKING_DIR is required but not set" >&2
   exit 1

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -168,11 +168,17 @@ export class StorageService {
     });
 
     // Handle artifact: either from resumeArtifact or from volumeResult
+    // Note: resumeArtifactMountPath is required when resumeArtifact is provided (no fallback)
+    if (resumeArtifact && !resumeArtifactMountPath) {
+      throw new Error(
+        "resumeArtifactMountPath is required when resumeArtifact is provided (working_dir must be configured)",
+      );
+    }
     const artifactSource = resumeArtifact
       ? {
           vasStorageName: resumeArtifact.artifactName,
           vasVersion: resumeArtifact.artifactVersion,
-          mountPath: resumeArtifactMountPath || "/workspace",
+          mountPath: resumeArtifactMountPath!,
         }
       : volumeResult.artifact;
 

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -1,6 +1,7 @@
 import { resolveVolumes } from "./storage-resolver";
 import { generatePresignedUrl, listS3Objects } from "../s3/s3-client";
 import { logger } from "../logger";
+import { BadRequestError } from "../errors";
 import type {
   AgentVolumeConfig,
   StorageManifest,
@@ -169,18 +170,19 @@ export class StorageService {
 
     // Handle artifact: either from resumeArtifact or from volumeResult
     // Note: resumeArtifactMountPath is required when resumeArtifact is provided (no fallback)
-    if (resumeArtifact && !resumeArtifactMountPath) {
-      throw new Error(
-        "resumeArtifactMountPath is required when resumeArtifact is provided (working_dir must be configured)",
-      );
+    let artifactSource = volumeResult.artifact;
+    if (resumeArtifact) {
+      if (!resumeArtifactMountPath) {
+        throw new BadRequestError(
+          "resumeArtifactMountPath is required when resumeArtifact is provided (working_dir must be configured)",
+        );
+      }
+      artifactSource = {
+        vasStorageName: resumeArtifact.artifactName,
+        vasVersion: resumeArtifact.artifactVersion,
+        mountPath: resumeArtifactMountPath,
+      };
     }
-    const artifactSource = resumeArtifact
-      ? {
-          vasStorageName: resumeArtifact.artifactName,
-          vasVersion: resumeArtifact.artifactVersion,
-          mountPath: resumeArtifactMountPath!,
-        }
-      : volumeResult.artifact;
 
     const artifactPromise = artifactSource
       ? (async () => {

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -178,6 +178,7 @@ export class StorageService {
         );
       }
       artifactSource = {
+        driver: "vas" as const,
         vasStorageName: resumeArtifact.artifactName,
         vasVersion: resumeArtifact.artifactVersion,
         mountPath: resumeArtifactMountPath,


### PR DESCRIPTION
## Summary

- Fix `extractWorkingDir` function to correctly handle agents as dictionary instead of array
- Make `working_dir` required with no fallback allowed (fail-fast on misconfiguration)
- Add validation in e2b-service, storage-service, and shell script
- Update tests for required working_dir behavior

## Root Cause

After the refactor in #334 that changed `agents` from array to dictionary (`Record<string, AgentDefinition>`), the `extractWorkingDir` function in `run-service.ts` was still treating it as an array:

```typescript
// Before (bug)
configWithAgents?.agents?.[0]?.working_dir || "/workspace"

// After (fix)
Object.values(compose.agents)[0]?.working_dir
```

This caused session resume to always use `/workspace` as the working directory instead of the configured value, resulting in session history being restored to the wrong path.

## Test plan

- [x] Unit tests pass for run-service (27 tests)
- [x] Unit tests pass for e2b-service (15 tests)
- [x] Added tests for missing agents, missing working_dir, and custom working_dir scenarios

Fixes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)