### PR TITLE
fix: use client receive time for event elapsed calculation

### DIFF
--- a/turbo/apps/cli/src/lib/event-parser.ts
+++ b/turbo/apps/cli/src/lib/event-parser.ts
@@ -248,7 +248,7 @@ export class ClaudeEventParser {
   private static parseVm0StartEvent(event: Vm0StartEvent): ParsedEvent | null {
     return {
       type: "vm0_start",
-      timestamp: new Date(event.timestamp),
+      timestamp: new Date(), // Use client receive time for consistent elapsed calculation
       data: {
         runId: event.runId,
         agentComposeId: event.agentComposeId,
@@ -268,7 +268,7 @@ export class ClaudeEventParser {
   ): ParsedEvent | null {
     return {
       type: "vm0_result",
-      timestamp: new Date(event.timestamp),
+      timestamp: new Date(), // Use client receive time for consistent elapsed calculation
       data: {
         runId: event.runId,
         checkpointId: event.checkpointId,
@@ -283,7 +283,7 @@ export class ClaudeEventParser {
   private static parseVm0ErrorEvent(event: Vm0ErrorEvent): ParsedEvent | null {
     return {
       type: "vm0_error",
-      timestamp: new Date(event.timestamp),
+      timestamp: new Date(), // Use client receive time for consistent elapsed calculation
       data: {
         runId: event.runId,
         error: event.error,


### PR DESCRIPTION
## Summary
- Fix incorrect elapsed time display in verbose mode (e.g., `[+-2362ms]` showing negative values)
- Use client receive time consistently for all events instead of mixing server and client timestamps
- Preserve server timestamps in event data for potential future use

## Problem
When running `vm0 run` with `--verbose`, the elapsed time between events was incorrectly calculated because:
- `vm0_*` events used server timestamps (`new Date(event.timestamp)`)
- Other events used client timestamps (`new Date()`)
- This caused negative elapsed times when server time was earlier than client time

## Test plan
- [x] Unit tests pass (`pnpm vitest run event-parser event-renderer`)
- [ ] Manual test: Run `vm0 run` with `--verbose` and verify elapsed times are positive and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)