### PR TITLE
feat(cli): support compose version specifier in vm0 run command

### DIFF
--- a/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
+++ b/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
@@ -219,6 +219,13 @@ EOF
     VERSION2=$(echo "$output" | grep -oP 'Version:\s+\K[0-9a-f]+')
     echo "# Version 2: $VERSION2"
 
+    echo "# Initializing artifact storage..."
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+    run $CLI_COMMAND artifact push
+    assert_success
+
     echo "# Running with specific version (version 1)..."
     run $CLI_COMMAND run "$AGENT_NAME:$VERSION1" \
         --artifact-name "$ARTIFACT_NAME" \
@@ -244,6 +251,13 @@ EOF
 
     echo "# Building agent..."
     run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Initializing artifact storage..."
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+    run $CLI_COMMAND artifact push
     assert_success
 
     echo "# Running with :latest tag..."
@@ -273,7 +287,7 @@ EOF
     run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
     assert_success
 
-    echo "# Running with nonexistent version..."
+    echo "# Running with nonexistent version (should fail before artifact check)..."
     run $CLI_COMMAND run "$AGENT_NAME:deadbeef" \
         --artifact-name "$ARTIFACT_NAME" \
         --timeout 120 \
@@ -299,6 +313,13 @@ EOF
 
     echo "# Building agent..."
     run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Initializing artifact storage..."
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+    run $CLI_COMMAND artifact push
     assert_success
 
     echo "# Running without version specifier (should use HEAD)..."

--- a/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
+++ b/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
@@ -175,3 +175,136 @@ EOF
         return 1
     }
 }
+
+# ============================================
+# vm0 run with version specifier tests
+# ============================================
+
+@test "vm0 run with version specifier runs specific version" {
+    export ARTIFACT_NAME="e2e-versioning-artifact-$(date +%s)"
+
+    echo "# Creating initial config..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Version 1"
+    provider: claude-code
+    image: vm0-claude-code-dev
+    working_dir: /home/user/workspace
+EOF
+
+    echo "# Building version 1..."
+    run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    assert_success
+    VERSION1=$(echo "$output" | grep -oP 'Version:\s+\K[0-9a-f]+')
+    echo "# Version 1: $VERSION1"
+
+    echo "# Creating updated config..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Version 2"
+    provider: claude-code
+    image: vm0-claude-code-dev
+    working_dir: /home/user/workspace
+EOF
+
+    echo "# Building version 2..."
+    run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    assert_success
+    VERSION2=$(echo "$output" | grep -oP 'Version:\s+\K[0-9a-f]+')
+    echo "# Version 2: $VERSION2"
+
+    echo "# Running with specific version (version 1)..."
+    run $CLI_COMMAND run "$AGENT_NAME:$VERSION1" \
+        --artifact-name "$ARTIFACT_NAME" \
+        --timeout 120 \
+        "echo hello"
+    assert_success
+}
+
+@test "vm0 run with :latest tag runs HEAD version" {
+    export ARTIFACT_NAME="e2e-versioning-latest-$(date +%s)"
+
+    echo "# Creating config..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Latest version test"
+    provider: claude-code
+    image: vm0-claude-code-dev
+    working_dir: /home/user/workspace
+EOF
+
+    echo "# Building agent..."
+    run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Running with :latest tag..."
+    run $CLI_COMMAND run "$AGENT_NAME:latest" \
+        --artifact-name "$ARTIFACT_NAME" \
+        --timeout 120 \
+        "echo hello"
+    assert_success
+}
+
+@test "vm0 run with nonexistent version shows error" {
+    export ARTIFACT_NAME="e2e-versioning-error-$(date +%s)"
+
+    echo "# Creating config..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Error test"
+    provider: claude-code
+    image: vm0-claude-code-dev
+    working_dir: /home/user/workspace
+EOF
+
+    echo "# Building agent..."
+    run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Running with nonexistent version..."
+    run $CLI_COMMAND run "$AGENT_NAME:deadbeef" \
+        --artifact-name "$ARTIFACT_NAME" \
+        --timeout 120 \
+        "echo hello"
+    assert_failure
+    assert_output --partial "Version not found"
+}
+
+@test "vm0 run without version specifier runs HEAD (backward compatible)" {
+    export ARTIFACT_NAME="e2e-versioning-compat-$(date +%s)"
+
+    echo "# Creating config..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Backward compatibility test"
+    provider: claude-code
+    image: vm0-claude-code-dev
+    working_dir: /home/user/workspace
+EOF
+
+    echo "# Building agent..."
+    run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Running without version specifier (should use HEAD)..."
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        --timeout 120 \
+        "echo hello"
+    assert_success
+}

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -170,7 +170,7 @@ const runCmd = new Command()
   .description("Execute an agent")
   .argument(
     "<identifier>",
-    "Agent name or config ID (e.g., 'my-agent' or 'cfg-abc-123')",
+    "Agent name, config ID, or name:version (e.g., 'my-agent', 'my-agent:abc123', 'my-agent:latest')",
   )
   .argument("<prompt>", "Prompt for the agent")
   .option(

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -42,6 +42,32 @@ function isUUID(str: string): boolean {
   return /^[0-9a-f-]{36}$/i.test(str);
 }
 
+/**
+ * Parse identifier with optional version specifier
+ * Format: name:version or just name
+ * Examples: "demo:d084948d", "demo:latest", "demo"
+ */
+function parseIdentifier(identifier: string): {
+  name: string;
+  version?: string;
+} {
+  // UUIDs don't contain colons, so check first
+  if (isUUID(identifier)) {
+    return { name: identifier };
+  }
+
+  // Parse name:version format using lastIndexOf to handle edge cases
+  const colonIndex = identifier.lastIndexOf(":");
+  if (colonIndex > 0 && colonIndex < identifier.length - 1) {
+    return {
+      name: identifier.slice(0, colonIndex),
+      version: identifier.slice(colonIndex + 1),
+    };
+  }
+
+  return { name: identifier };
+}
+
 const DEFAULT_TIMEOUT_SECONDS = 120;
 
 interface PollOptions {
@@ -212,29 +238,32 @@ const runCmd = new Command()
       const verbose = options.verbose;
 
       try {
-        // 1. Resolve identifier to composeId
+        // 1. Parse identifier for optional version specifier
+        const { name, version } = parseIdentifier(identifier);
+
+        // 2. Resolve name to composeId
         let composeId: string;
 
-        if (isUUID(identifier)) {
+        if (isUUID(name)) {
           // It's a UUID compose ID - use directly
-          composeId = identifier;
+          composeId = name;
           if (verbose) {
             console.log(chalk.gray(`  Using compose ID: ${composeId}`));
           }
         } else {
           // It's an agent name - resolve to compose ID
           if (verbose) {
-            console.log(chalk.gray(`  Resolving agent name: ${identifier}`));
+            console.log(chalk.gray(`  Resolving agent name: ${name}`));
           }
           try {
-            const compose = await apiClient.getComposeByName(identifier);
+            const compose = await apiClient.getComposeByName(name);
             composeId = compose.id;
             if (verbose) {
               console.log(chalk.gray(`  Resolved to compose ID: ${composeId}`));
             }
           } catch (error) {
             if (error instanceof Error) {
-              console.error(chalk.red(`✗ Agent not found: ${identifier}`));
+              console.error(chalk.red(`✗ Agent not found: ${name}`));
               console.error(
                 chalk.gray(
                   "  Make sure you've built the agent with: vm0 build",
@@ -245,10 +274,46 @@ const runCmd = new Command()
           }
         }
 
-        // 2. Display starting message (verbose only)
+        // 3. Resolve version if specified
+        let agentComposeVersionId: string | undefined;
+
+        if (version && version !== "latest") {
+          // Resolve version hash to full version ID
+          if (verbose) {
+            console.log(chalk.gray(`  Resolving version: ${version}`));
+          }
+          try {
+            const versionInfo = await apiClient.getComposeVersion(
+              composeId,
+              version,
+            );
+            agentComposeVersionId = versionInfo.versionId;
+            if (verbose) {
+              console.log(
+                chalk.gray(
+                  `  Resolved to version ID: ${agentComposeVersionId.slice(0, 8)}...`,
+                ),
+              );
+            }
+          } catch (error) {
+            if (error instanceof Error) {
+              console.error(chalk.red(`✗ Version not found: ${version}`));
+              console.error(
+                chalk.gray(
+                  "  Make sure the version hash exists. Use 'vm0 build' to see available versions.",
+                ),
+              );
+            }
+            process.exit(1);
+          }
+        }
+        // Note: "latest" version uses agentComposeId which resolves to HEAD
+
+        // 4. Display starting message (verbose only)
         if (verbose) {
           logVerbosePreFlight("Creating agent run", [
             { label: "Prompt", value: prompt },
+            { label: "Version", value: version || "latest (HEAD)" },
             {
               label: "Variables",
               value:
@@ -269,9 +334,12 @@ const runCmd = new Command()
           ]);
         }
 
-        // 3. Call unified API
+        // 5. Call unified API
         const response = await apiClient.createRun({
-          agentComposeId: composeId,
+          // Use agentComposeVersionId if resolved, otherwise use agentComposeId (resolves to HEAD)
+          ...(agentComposeVersionId
+            ? { agentComposeVersionId }
+            : { agentComposeId: composeId }),
           prompt,
           templateVars:
             Object.keys(options.vars).length > 0 ? options.vars : undefined,
@@ -284,7 +352,7 @@ const runCmd = new Command()
           conversationId: options.conversation,
         });
 
-        // 4. Poll for events and exit with appropriate code
+        // 6. Poll for events and exit with appropriate code
         const succeeded = await pollEvents(response.runId, timeoutSeconds, {
           verbose,
           startTimestamp,

--- a/turbo/apps/cli/src/lib/__tests__/api-client.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/api-client.test.ts
@@ -38,7 +38,7 @@ describe("ApiClient", () => {
       });
 
       const result = await apiClient.createOrUpdateCompose({
-        config: mockConfig,
+        content: mockConfig,
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
@@ -49,7 +49,7 @@ describe("ApiClient", () => {
             Authorization: "Bearer test-token",
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ config: mockConfig }),
+          body: JSON.stringify({ content: mockConfig }),
         },
       );
 
@@ -70,7 +70,7 @@ describe("ApiClient", () => {
       });
 
       const result = await apiClient.createOrUpdateCompose({
-        config: {},
+        content: {},
       });
 
       expect(result.action).toBe("created");
@@ -92,7 +92,7 @@ describe("ApiClient", () => {
       });
 
       const result = await apiClient.createOrUpdateCompose({
-        config: {},
+        content: {},
       });
 
       expect(result.action).toBe("updated");
@@ -102,7 +102,7 @@ describe("ApiClient", () => {
       vi.mocked(config.getToken).mockResolvedValue(undefined);
 
       await expect(
-        apiClient.createOrUpdateCompose({ config: {} }),
+        apiClient.createOrUpdateCompose({ content: {} }),
       ).rejects.toThrow("Not authenticated");
     });
 
@@ -110,7 +110,7 @@ describe("ApiClient", () => {
       vi.mocked(config.getApiUrl).mockResolvedValue("");
 
       await expect(
-        apiClient.createOrUpdateCompose({ config: {} }),
+        apiClient.createOrUpdateCompose({ content: {} }),
       ).rejects.toThrow("API URL not configured");
     });
 
@@ -123,7 +123,7 @@ describe("ApiClient", () => {
       });
 
       await expect(
-        apiClient.createOrUpdateCompose({ config: {} }),
+        apiClient.createOrUpdateCompose({ content: {} }),
       ).rejects.toThrow("Invalid compose");
     });
 
@@ -136,7 +136,7 @@ describe("ApiClient", () => {
       });
 
       await expect(
-        apiClient.createOrUpdateCompose({ config: {} }),
+        apiClient.createOrUpdateCompose({ content: {} }),
       ).rejects.toThrow("Failed to create compose");
     });
   });

--- a/turbo/apps/web/app/api/agent/composes/versions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/versions/__tests__/route.test.ts
@@ -1,0 +1,208 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { POST } from "../../route";
+import { initServices } from "../../../../../../src/lib/init-services";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../../../src/db/schema/agent-compose";
+import { eq } from "drizzle-orm";
+
+// Mock the auth module
+let mockUserId = "test-user-versions";
+vi.mock("../../../../../../src/lib/auth/get-user-id", () => ({
+  getUserId: async () => mockUserId,
+}));
+
+describe("GET /api/agent/composes/versions", () => {
+  const testUserId = "test-user-versions";
+  let testComposeId: string;
+  let testVersionId: string;
+
+  beforeAll(async () => {
+    initServices();
+
+    // Create a test compose with a version
+    const config = {
+      version: "1.0",
+      agents: {
+        "test-version-agent": {
+          description: "Test agent for version tests",
+          image: "vm0-claude-code-dev",
+          provider: "claude-code",
+          working_dir: "/home/user/workspace",
+        },
+      },
+    };
+
+    const createRequest = new Request(
+      "http://localhost:3000/api/agent/composes",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ content: config }),
+      },
+    );
+
+    const createResponse = await POST(createRequest as NextRequest);
+    const createData = await createResponse.json();
+    testComposeId = createData.composeId;
+    testVersionId = createData.versionId;
+  });
+
+  afterAll(async () => {
+    // Cleanup: Delete test data
+    if (testComposeId) {
+      await globalThis.services.db
+        .delete(agentComposeVersions)
+        .where(eq(agentComposeVersions.composeId, testComposeId));
+      await globalThis.services.db
+        .delete(agentComposes)
+        .where(eq(agentComposes.id, testComposeId));
+    }
+  });
+
+  it("should resolve 'latest' to HEAD version", async () => {
+    const request = new Request(
+      `http://localhost:3000/api/agent/composes/versions?composeId=${testComposeId}&version=latest`,
+      { method: "GET" },
+    );
+
+    const response = await GET(request as NextRequest);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.versionId).toBe(testVersionId);
+    expect(data.tag).toBe("latest");
+  });
+
+  it("should resolve full hash exactly", async () => {
+    const request = new Request(
+      `http://localhost:3000/api/agent/composes/versions?composeId=${testComposeId}&version=${testVersionId}`,
+      { method: "GET" },
+    );
+
+    const response = await GET(request as NextRequest);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.versionId).toBe(testVersionId);
+  });
+
+  it("should resolve hash prefix (8 chars)", async () => {
+    const prefix = testVersionId.slice(0, 8);
+    const request = new Request(
+      `http://localhost:3000/api/agent/composes/versions?composeId=${testComposeId}&version=${prefix}`,
+      { method: "GET" },
+    );
+
+    const response = await GET(request as NextRequest);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.versionId).toBe(testVersionId);
+  });
+
+  it("should return 404 for nonexistent version", async () => {
+    const request = new Request(
+      `http://localhost:3000/api/agent/composes/versions?composeId=${testComposeId}&version=deadbeef`,
+      { method: "GET" },
+    );
+
+    const response = await GET(request as NextRequest);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.message).toContain("Version 'deadbeef' not found");
+  });
+
+  it("should return 400 for invalid version format (too short)", async () => {
+    const request = new Request(
+      `http://localhost:3000/api/agent/composes/versions?composeId=${testComposeId}&version=abc`,
+      { method: "GET" },
+    );
+
+    const response = await GET(request as NextRequest);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.message).toContain("Invalid version format");
+  });
+
+  it("should return 400 for invalid version format (non-hex)", async () => {
+    const request = new Request(
+      `http://localhost:3000/api/agent/composes/versions?composeId=${testComposeId}&version=ghijklmn`,
+      { method: "GET" },
+    );
+
+    const response = await GET(request as NextRequest);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.message).toContain("Invalid version format");
+  });
+
+  it("should return 400 when composeId is missing", async () => {
+    const request = new Request(
+      "http://localhost:3000/api/agent/composes/versions?version=latest",
+      { method: "GET" },
+    );
+
+    const response = await GET(request as NextRequest);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.message).toContain("Missing composeId");
+  });
+
+  it("should return 400 when version is missing", async () => {
+    const request = new Request(
+      `http://localhost:3000/api/agent/composes/versions?composeId=${testComposeId}`,
+      { method: "GET" },
+    );
+
+    const response = await GET(request as NextRequest);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.message).toContain("Missing version");
+  });
+
+  it("should return 404 for nonexistent compose", async () => {
+    const request = new Request(
+      "http://localhost:3000/api/agent/composes/versions?composeId=nonexistent-id&version=latest",
+      { method: "GET" },
+    );
+
+    const response = await GET(request as NextRequest);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.message).toContain("Agent compose not found");
+  });
+
+  it("should isolate versions by user", async () => {
+    // Try to access compose as different user
+    mockUserId = "other-user";
+
+    const request = new Request(
+      `http://localhost:3000/api/agent/composes/versions?composeId=${testComposeId}&version=latest`,
+      { method: "GET" },
+    );
+
+    const response = await GET(request as NextRequest);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.message).toContain("Agent compose not found");
+
+    // Reset mockUserId
+    mockUserId = testUserId;
+  });
+});

--- a/turbo/apps/web/app/api/agent/composes/versions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/versions/__tests__/route.test.ts
@@ -207,4 +207,39 @@ describe("GET /api/agent/composes/versions", () => {
     // Reset mockUserId
     mockUserId = testUserId;
   });
+
+  it("should return 400 for ambiguous version prefix", async () => {
+    // Create a second version with the same 8-char prefix as testVersionId
+    const prefix = testVersionId.slice(0, 8);
+    // Generate a different version ID with the same prefix
+    const ambiguousVersionId =
+      prefix + "0000000000000000000000000000000000000000000000000000000a";
+
+    // Insert a second version with the same prefix
+    await globalThis.services.db.insert(agentComposeVersions).values({
+      id: ambiguousVersionId,
+      composeId: testComposeId,
+      content: { version: "1.0", agents: {} },
+      createdBy: testUserId,
+    });
+
+    try {
+      const request = new Request(
+        `http://localhost:3000/api/agent/composes/versions?composeId=${testComposeId}&version=${prefix}`,
+        { method: "GET" },
+      );
+
+      const response = await GET(request as NextRequest);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain("Ambiguous version prefix");
+      expect(data.error.message).toContain(prefix);
+    } finally {
+      // Cleanup: remove the ambiguous version
+      await globalThis.services.db
+        .delete(agentComposeVersions)
+        .where(eq(agentComposeVersions.id, ambiguousVersionId));
+    }
+  });
 });

--- a/turbo/apps/web/app/api/agent/composes/versions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/versions/__tests__/route.test.ts
@@ -175,8 +175,10 @@ describe("GET /api/agent/composes/versions", () => {
   });
 
   it("should return 404 for nonexistent compose", async () => {
+    // Use a valid UUID format that doesn't exist
+    const nonexistentUuid = "00000000-0000-0000-0000-000000000000";
     const request = new Request(
-      "http://localhost:3000/api/agent/composes/versions?composeId=nonexistent-id&version=latest",
+      `http://localhost:3000/api/agent/composes/versions?composeId=${nonexistentUuid}&version=latest`,
       { method: "GET" },
     );
 

--- a/turbo/apps/web/app/api/agent/composes/versions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/versions/route.ts
@@ -127,13 +127,9 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const match = prefixMatches[0];
-    if (!match) {
-      throw new NotFoundError(`Version '${version}'`);
-    }
-
+    // Safe to access [0] since we checked length === 0 and length > 1 above
     return successResponse({
-      versionId: match.id,
+      versionId: prefixMatches[0]!.id,
     });
   } catch (error) {
     return errorResponse(error);

--- a/turbo/apps/web/app/api/agent/composes/versions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/versions/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest } from "next/server";
+import { initServices } from "../../../../../src/lib/init-services";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../../src/db/schema/agent-compose";
+import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import {
+  successResponse,
+  errorResponse,
+} from "../../../../../src/lib/api-response";
+import {
+  BadRequestError,
+  NotFoundError,
+  UnauthorizedError,
+} from "../../../../../src/lib/errors";
+import { eq, and, like } from "drizzle-orm";
+
+/**
+ * GET /api/agent/composes/versions?composeId={id}&version={hashOrTag}
+ * Resolve a version specifier to a full version ID
+ *
+ * Supports:
+ * - "latest": returns HEAD version
+ * - Full hash (64 chars): exact match
+ * - Hash prefix (8+ chars): prefix match
+ */
+export async function GET(request: NextRequest) {
+  try {
+    // Initialize services at serverless function entry
+    initServices();
+
+    // Authenticate
+    const userId = await getUserId();
+    if (!userId) {
+      throw new UnauthorizedError("Not authenticated");
+    }
+
+    // Get parameters from query
+    const { searchParams } = new URL(request.url);
+    const composeId = searchParams.get("composeId");
+    const version = searchParams.get("version");
+
+    if (!composeId) {
+      throw new BadRequestError("Missing composeId query parameter");
+    }
+
+    if (!version) {
+      throw new BadRequestError("Missing version query parameter");
+    }
+
+    // Verify compose belongs to user
+    const [compose] = await globalThis.services.db
+      .select()
+      .from(agentComposes)
+      .where(
+        and(eq(agentComposes.id, composeId), eq(agentComposes.userId, userId)),
+      )
+      .limit(1);
+
+    if (!compose) {
+      throw new NotFoundError("Agent compose");
+    }
+
+    // Handle "latest" tag - return HEAD version
+    if (version === "latest") {
+      if (!compose.headVersionId) {
+        throw new BadRequestError(
+          "Agent compose has no versions. Run 'vm0 build' first.",
+        );
+      }
+
+      return successResponse({
+        versionId: compose.headVersionId,
+        tag: "latest",
+      });
+    }
+
+    // Validate version format (must be hex string, at least 8 chars)
+    if (!/^[0-9a-f]{8,64}$/i.test(version)) {
+      throw new BadRequestError(
+        "Invalid version format. Must be 8-64 hex characters or 'latest'.",
+      );
+    }
+
+    // Try exact match first (full 64-char hash)
+    if (version.length === 64) {
+      const [exactMatch] = await globalThis.services.db
+        .select()
+        .from(agentComposeVersions)
+        .where(
+          and(
+            eq(agentComposeVersions.id, version),
+            eq(agentComposeVersions.composeId, composeId),
+          ),
+        )
+        .limit(1);
+
+      if (!exactMatch) {
+        throw new NotFoundError(`Version '${version.slice(0, 8)}...'`);
+      }
+
+      return successResponse({
+        versionId: exactMatch.id,
+      });
+    }
+
+    // Prefix match for shorter hashes
+    const prefixMatches = await globalThis.services.db
+      .select()
+      .from(agentComposeVersions)
+      .where(
+        and(
+          like(agentComposeVersions.id, `${version}%`),
+          eq(agentComposeVersions.composeId, composeId),
+        ),
+      )
+      .limit(2); // Get 2 to detect ambiguous matches
+
+    if (prefixMatches.length === 0) {
+      throw new NotFoundError(`Version '${version}'`);
+    }
+
+    if (prefixMatches.length > 1) {
+      throw new BadRequestError(
+        `Ambiguous version prefix '${version}'. Please use more characters.`,
+      );
+    }
+
+    const match = prefixMatches[0];
+    if (!match) {
+      throw new NotFoundError(`Version '${version}'`);
+    }
+
+    return successResponse({
+      versionId: match.id,
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}


### PR DESCRIPTION
## Summary

- Add support for running specific compose versions using the `name:version` format
- Users can now pin to a specific version hash (e.g., `vm0 run demo:d084948d`)
- Support for `latest` tag (e.g., `vm0 run demo:latest`)
- Hash prefix matching (8+ characters) for convenience
- Backend API endpoint for version resolution

## Test plan

- [ ] `vm0 run demo "prompt"` - runs HEAD version (existing behavior preserved)
- [ ] `vm0 run demo:d084948d "prompt"` - runs specific version by hash prefix
- [ ] `vm0 run demo:latest "prompt"` - runs HEAD version explicitly
- [ ] `vm0 run demo:nonexistent "prompt"` - shows clear error message
- [ ] Version specifier works with verbose mode (`-v`)

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)