### PR TITLE
fix: update sandboxId in database immediately after sandbox creation

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -288,15 +288,8 @@ export async function POST(request: NextRequest) {
 
       // Start execution - returns immediately after sandbox is prepared
       // Agent execution continues in background (fire-and-forget)
+      // Note: sandboxId is persisted to database inside executeRun() immediately after sandbox creation
       const result = await runService.executeRun(context);
-
-      // Update run with sandboxId
-      await globalThis.services.db
-        .update(agentRuns)
-        .set({
-          sandboxId: result.sandboxId,
-        })
-        .where(eq(agentRuns.id, run.id));
 
       console.log(
         `[API] Run ${run.id} started successfully (sandbox: ${result.sandboxId})`,


### PR DESCRIPTION
## Summary

- Fixes race condition where complete webhook arrives before sandboxId is persisted to database
- Moves sandboxId database update from API layer into e2b-service.ts
- Updates sandboxId immediately after sandbox creation, before agent execution starts

## Root Cause

When using fire-and-forget execution with `background: true`, the agent could complete before `executeRun()` returns and the API layer updates the database with `sandboxId`. This caused the complete webhook to find `sandboxId = null` and skip sandbox cleanup, leaving orphaned sandboxes running until the 1-hour timeout.

## Solution

Update the database with `sandboxId` inside `e2b-service.ts` immediately after sandbox creation, ensuring it's always available when the complete webhook is processed.

## Test Plan

- [x] All existing tests pass (506 tests)
- [x] Added new test to verify sandboxId is persisted before agent execution starts
- [x] Linting passes
- [x] No type regressions introduced

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)