### PR TITLE
fix: preserve file permissions during tar extraction in sandbox

### DIFF
--- a/turbo/apps/web/src/lib/e2b/scripts/download-storages.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/download-storages.ts
@@ -57,7 +57,7 @@ download_storage() {
   # Extract to mount path (handle empty archive gracefully)
   mkdir -p "${dollar}mount_path"
   # tar handles empty archives gracefully
-  tar -xzf "${dollar}temp_tar" -C "${dollar}mount_path" 2>/dev/null || true
+  tar -xpzf "${dollar}temp_tar" -C "${dollar}mount_path" 2>/dev/null || true
   rm -f "${dollar}temp_tar"
 
   log_info "Successfully extracted to ${dollar}mount_path"


### PR DESCRIPTION
## Summary
- Add `-p` flag to tar extraction command to preserve file permissions

## Changes
This PR fixes a bug where file permissions (especially execute bits) were lost when volumes and artifacts were extracted in the E2B sandbox.

**Root cause:** The `tar -xzf` command in `download-storages.ts` was missing the `-p` (preserve permissions) flag.

**Fix:** Changed `tar -xzf` to `tar -xpzf`

## Test plan
- [x] Type check passes
- [x] Lint passes
- [ ] Manual verification with executable script in volume

Fixes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)