### PR TITLE
feat(cli): add next steps hints after vm0 run completes

### DIFF
--- a/turbo/apps/cli/src/lib/__tests__/event-renderer.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/event-renderer.test.ts
@@ -621,10 +621,13 @@ describe("EventRenderer", () => {
       EventRenderer.render(event, options);
 
       expect(consoleLogSpy).toHaveBeenCalled();
-      const lastCall =
-        consoleLogSpy.mock.calls[consoleLogSpy.mock.calls.length - 1]![0];
-      expect(lastCall).toContain("Total time:");
-      expect(lastCall).toContain("6.7s");
+      const allCalls = consoleLogSpy.mock.calls.map(
+        (call) => call[0] as string,
+      );
+      const hasTotalTime = allCalls.some(
+        (call) => call.includes("Total time:") && call.includes("6.7s"),
+      );
+      expect(hasTotalTime).toBe(true);
     });
 
     it("should not render total time without verbose flag", () => {
@@ -649,7 +652,9 @@ describe("EventRenderer", () => {
       const allCalls = consoleLogSpy.mock.calls.map(
         (call) => call[0] as string,
       );
-      const hasTotalTime = allCalls.some((call) => call.includes("Total time"));
+      const hasTotalTime = allCalls.some(
+        (call) => call && call.includes("Total time"),
+      );
       expect(hasTotalTime).toBe(false);
     });
 
@@ -676,11 +681,15 @@ describe("EventRenderer", () => {
       expect(consoleLogSpy.mock.calls[0]![0]).toContain("[vm0_result]");
       expect(consoleLogSpy.mock.calls[0]![0]).toContain("[+200ms]");
 
-      // Check last line has total time
-      const lastCall =
-        consoleLogSpy.mock.calls[consoleLogSpy.mock.calls.length - 1]![0];
-      expect(lastCall).toContain("Total time:");
-      expect(lastCall).toContain("6.7s");
+      // Check total time is rendered somewhere
+      const allCalls = consoleLogSpy.mock.calls.map(
+        (call) => call[0] as string,
+      );
+      const hasTotalTime = allCalls.some(
+        (call) => call.includes("Total time:") && call.includes("6.7s"),
+      );
+      expect(hasTotalTime).toBe(true);
     });
   });
+
 });

--- a/turbo/apps/cli/src/lib/__tests__/event-renderer.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/event-renderer.test.ts
@@ -691,5 +691,4 @@ describe("EventRenderer", () => {
       expect(hasTotalTime).toBe(true);
     });
   });
-
 });


### PR DESCRIPTION
## Summary

- Add actionable next step commands displayed after a successful `vm0 run` completion
- Show two options with clear descriptions:
  - **Continue with session (latest state)**: `vm0 run continue <session>`
  - **Resume from checkpoint (exact snapshot state)**: `vm0 run resume <checkpoint>`
- Refactor `pollEvents` to return session/checkpoint IDs for use by the command layer

## Test plan

- [x] All existing CLI tests pass (222 tests)
- [x] Type check passes
- [x] Lint passes
- [ ] Manual test: run `vm0 run` and verify next steps are displayed after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)