### PR TITLE
fix(cli): change timeout to interval-based instead of total runtime

### DIFF
--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -168,7 +168,7 @@ export const cookCommand = new Command()
   .argument("[prompt]", "Prompt for the agent")
   .option(
     "-t, --timeout <seconds>",
-    "Polling timeout in seconds for agent run (default: 120)",
+    "Timeout in seconds without new events for agent run (default: 120)",
   )
   .action(async (prompt: string | undefined, options: { timeout?: string }) => {
     const cwd = process.cwd();


### PR DESCRIPTION
## Summary
- Changed `--timeout` behavior from total runtime timeout to interval-based timeout (time since last event)
- Renamed internal variable from `startTime` to `lastEventTime` for clarity
- Timer resets whenever new events are received, allowing long-running agents to execute indefinitely
- Updated help text to describe the new behavior: "Timeout in seconds without new events"

## Test plan
- [ ] Run `vm0 run` with a long-running agent and verify it doesn't timeout if events are being produced
- [ ] Verify timeout still triggers correctly when no events are received for the specified duration
- [ ] Check `vm0 run --help` and `vm0 cook --help` show updated timeout description

🤖 Generated with [Claude Code](https://claude.com/claude-code)