### PR TITLE
fix(cli): render object values as json instead of string coercion

### DIFF
--- a/turbo/apps/cli/src/lib/__tests__/event-renderer.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/event-renderer.test.ts
@@ -169,6 +169,47 @@ describe("EventRenderer", () => {
       expect(consoleLogSpy).toHaveBeenCalledTimes(1);
       expect(consoleLogSpy.mock.calls[0]![0]).toContain("Read");
     });
+
+    it("should render object values as formatted JSON", () => {
+      const todos = [
+        {
+          content: "Task 1",
+          status: "pending",
+          activeForm: "Working on task 1",
+        },
+        {
+          content: "Task 2",
+          status: "completed",
+          activeForm: "Working on task 2",
+        },
+      ];
+      const event: ParsedEvent = {
+        type: "tool_use",
+        timestamp: new Date(),
+        data: {
+          tool: "TodoWrite",
+          toolUseId: "toolu_todo",
+          input: {
+            todos,
+          },
+        },
+      };
+
+      EventRenderer.render(event);
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      expect(consoleLogSpy.mock.calls[0]![0]).toContain("[tool_use]");
+      expect(consoleLogSpy.mock.calls[0]![0]).toContain("TodoWrite");
+
+      // Verify the todos are rendered as JSON, not [object Object]
+      const todosOutput = consoleLogSpy.mock.calls[1]![0] as string;
+      expect(todosOutput).toContain("todos:");
+      expect(todosOutput).not.toContain("[object Object]");
+      expect(todosOutput).toContain("Task 1");
+      expect(todosOutput).toContain("pending");
+      expect(todosOutput).toContain("Task 2");
+      expect(todosOutput).toContain("completed");
+    });
   });
 
   // ============================================

--- a/turbo/apps/cli/src/lib/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/event-renderer.ts
@@ -114,7 +114,11 @@ export class EventRenderer {
     if (input && typeof input === "object") {
       for (const [key, value] of Object.entries(input)) {
         if (value !== undefined && value !== null) {
-          console.log(`  ${key}: ${chalk.gray(String(value))}`);
+          const displayValue =
+            typeof value === "object"
+              ? JSON.stringify(value, null, 2)
+              : String(value);
+          console.log(`  ${key}: ${chalk.gray(displayValue)}`);
         }
       }
     }


### PR DESCRIPTION
## Summary
- Fixed tool input rendering in CLI event output where object/array values were displayed as `[object Object]`
- Now properly formats complex values using `JSON.stringify` with indentation
- Added test case for TodoWrite todos array rendering

## Test plan
- [x] Run `pnpm vitest run apps/cli/src/lib/__tests__/event-renderer.test.ts` to verify all tests pass
- [ ] Test manually with `vm0 run` command and observe TodoWrite output

🤖 Generated with [Claude Code](https://claude.com/claude-code)