### PR TITLE
fix(e2b): use nohup to prevent agent process from being killed by SIGHUP

### DIFF
--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -598,12 +598,12 @@ export class E2BService {
   ): Promise<void> {
     log.debug(`Starting run-agent.py for run ${runId} (fire-and-forget)...`);
 
-    // Start Python script in background using E2B's native background mode
-    // This returns immediately while the command continues executing in the sandbox
+    // Start Python script in background using nohup to ignore SIGHUP signal
+    // This prevents the process from being killed when E2B connection is closed
     // NOTE: Scripts already uploaded via uploadAllScripts(), do not pass envs here
-    await sandbox.commands.run(`python3 ${SCRIPT_PATHS.runAgent}`, {
-      background: true,
-    });
+    await sandbox.commands.run(
+      `nohup python3 ${SCRIPT_PATHS.runAgent} > /tmp/vm0-nohup.out 2>&1 &`,
+    );
 
     log.debug(`Agent execution started in background for run ${runId}`);
   }


### PR DESCRIPTION
## Summary
- Replace E2B's `background: true` mode with `nohup` + shell background (`&`)
- Redirect agent output to `/tmp/vm0-nohup.out` for debugging
- Prevents agent process from receiving SIGHUP when E2B connection closes

## Problem
Long-running agent tasks were failing with `EPIPE` error after a few minutes. Investigation revealed that the Python process was being killed (likely by SIGHUP signal) when E2B's connection was closed, even though the sandbox was still running.

## Solution
Use `nohup` to make the agent process immune to SIGHUP signal, ensuring it continues running regardless of E2B connection state.

## Test plan
- [ ] Run a long-running agent task (several minutes)
- [ ] Verify the task completes without EPIPE error
- [ ] Check `/tmp/vm0-nohup.out` in sandbox for debug output if issues occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)