### PR TITLE
feat(cli): support timeout=0 for no timeout in run and cook commands

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/run.test.ts
@@ -756,24 +756,19 @@ describe("run command", () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it("should reject zero timeout value", async () => {
-      await expect(async () => {
-        await runCommand.parseAsync([
-          "node",
-          "cli",
-          testUuid,
-          "test prompt",
-          "--artifact-name",
-          "test-artifact",
-          "-t",
-          "0",
-        ]);
-      }).rejects.toThrow("process.exit called");
+    it("should accept zero timeout value (no timeout)", async () => {
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        testUuid,
+        "test prompt",
+        "--artifact-name",
+        "test-artifact",
+        "-t",
+        "0",
+      ]);
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Invalid timeout value"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(apiClient.createRun).toHaveBeenCalled();
     });
 
     it("should reject negative timeout value", async () => {

--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -168,7 +168,7 @@ export const cookCommand = new Command()
   .argument("[prompt]", "Prompt for the agent")
   .option(
     "-t, --timeout <seconds>",
-    "Timeout in seconds without new events for agent run (default: 120)",
+    "Timeout in seconds without new events for agent run, 0 = no timeout (default: 120)",
   )
   .action(async (prompt: string | undefined, options: { timeout?: string }) => {
     const cwd = process.cwd();

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -101,15 +101,17 @@ async function pollEvents(
   const verbose = options.verbose;
 
   while (!complete) {
-    // Check timeout since last event
-    const timeSinceLastEvent = Date.now() - lastEventTime;
-    if (timeSinceLastEvent > timeoutMs) {
-      console.error(
-        chalk.red(
-          `\n✗ Agent execution timed out after ${timeoutSeconds} seconds without receiving new events`,
-        ),
-      );
-      throw new Error("Agent execution timed out");
+    // Check timeout since last event (skip if timeout is 0 = no timeout)
+    if (timeoutSeconds > 0) {
+      const timeSinceLastEvent = Date.now() - lastEventTime;
+      if (timeSinceLastEvent > timeoutMs) {
+        console.error(
+          chalk.red(
+            `\n✗ Agent execution timed out after ${timeoutSeconds} seconds without receiving new events`,
+          ),
+        );
+        throw new Error("Agent execution timed out");
+      }
     }
 
     const response = await apiClient.getEvents(runId, {
@@ -235,7 +237,7 @@ const runCmd = new Command()
   )
   .option(
     "-t, --timeout <seconds>",
-    "Timeout in seconds without new events (default: 120)",
+    "Timeout in seconds without new events, 0 = no timeout (default: 120)",
     String(DEFAULT_TIMEOUT_SECONDS),
   )
   .option("-v, --verbose", "Show verbose output with timing information")
@@ -256,9 +258,11 @@ const runCmd = new Command()
       const startTimestamp = new Date(); // Capture command start time for elapsed calculation
 
       const timeoutSeconds = parseInt(options.timeout, 10);
-      if (isNaN(timeoutSeconds) || timeoutSeconds <= 0) {
+      if (isNaN(timeoutSeconds) || timeoutSeconds < 0) {
         console.error(
-          chalk.red("✗ Invalid timeout value. Must be a positive number."),
+          chalk.red(
+            "✗ Invalid timeout value. Must be a non-negative number (0 = no timeout).",
+          ),
         );
         process.exit(1);
       }
@@ -437,7 +441,7 @@ runCmd
   )
   .option(
     "-t, --timeout <seconds>",
-    "Timeout in seconds without new events (default: 120)",
+    "Timeout in seconds without new events, 0 = no timeout (default: 120)",
     String(DEFAULT_TIMEOUT_SECONDS),
   )
   .option("-v, --verbose", "Show verbose output with timing information")
@@ -458,9 +462,11 @@ runCmd
         verbose?: boolean;
       };
       const timeoutSeconds = parseInt(options.timeout, 10);
-      if (isNaN(timeoutSeconds) || timeoutSeconds <= 0) {
+      if (isNaN(timeoutSeconds) || timeoutSeconds < 0) {
         console.error(
-          chalk.red("✗ Invalid timeout value. Must be a positive number."),
+          chalk.red(
+            "✗ Invalid timeout value. Must be a non-negative number (0 = no timeout).",
+          ),
         );
         process.exit(1);
       }
@@ -547,7 +553,7 @@ runCmd
   )
   .option(
     "-t, --timeout <seconds>",
-    "Timeout in seconds without new events (default: 120)",
+    "Timeout in seconds without new events, 0 = no timeout (default: 120)",
     String(DEFAULT_TIMEOUT_SECONDS),
   )
   .option("-v, --verbose", "Show verbose output with timing information")
@@ -568,9 +574,11 @@ runCmd
         verbose?: boolean;
       };
       const timeoutSeconds = parseInt(options.timeout, 10);
-      if (isNaN(timeoutSeconds) || timeoutSeconds <= 0) {
+      if (isNaN(timeoutSeconds) || timeoutSeconds < 0) {
         console.error(
-          chalk.red("✗ Invalid timeout value. Must be a positive number."),
+          chalk.red(
+            "✗ Invalid timeout value. Must be a non-negative number (0 = no timeout).",
+          ),
         );
         process.exit(1);
       }


### PR DESCRIPTION
## Summary
- Allow `--timeout 0` to disable timeout checking entirely for `vm0 run` and `vm0 cook` commands
- Useful for long-running agent executions where the default 120s timeout may be insufficient
- Timeout logic is shared between run and cook (cook passes through to run)

## Test plan
- [x] Verify `vm0 run -t 0` accepts zero timeout
- [x] Verify `vm0 run -t -1` still rejects negative values
- [x] Verify help text shows `0 = no timeout`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)