### PR TITLE
feat(e2b): add heartbeat-based sandbox cleanup mechanism

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -105,6 +105,7 @@ jobs:
             AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
             S3_USER_STORAGES_NAME=${{ secrets.S3_USER_STORAGES_NAME }}
             SECRETS_ENCRYPTION_KEY=${{ secrets.SECRETS_ENCRYPTION_KEY }}
+            VERCEL_CRON_SECRET=${{ secrets.VERCEL_CRON_SECRET }}
 
   # Deploy docs app to production
   deploy-docs-production:

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -254,11 +254,13 @@ export async function POST(request: NextRequest) {
     console.log(`[API] Generated sandbox token for run: ${run.id}`);
 
     // Update run status to 'running' before starting E2B execution
+    // Initialize lastHeartbeatAt for sandbox cleanup monitoring
     await globalThis.services.db
       .update(agentRuns)
       .set({
         status: "running",
         startedAt: new Date(),
+        lastHeartbeatAt: new Date(),
       })
       .where(eq(agentRuns.id, run.id));
 

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
@@ -4,23 +4,23 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { GET } from "../route";
 import { NextRequest } from "next/server";
-import { initServices } from "../../../../../../src/lib/init-services";
-import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import { initServices } from "../../../../../src/lib/init-services";
+import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import {
   agentComposes,
   agentComposeVersions,
-} from "../../../../../../src/db/schema/agent-compose";
+} from "../../../../../src/db/schema/agent-compose";
 import { eq } from "drizzle-orm";
 import { randomUUID } from "crypto";
 
 // Mock e2bService
-vi.mock("../../../../../../src/lib/e2b/e2b-service", () => ({
+vi.mock("../../../../../src/lib/e2b/e2b-service", () => ({
   e2bService: {
     killSandbox: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
-import { e2bService } from "../../../../../../src/lib/e2b/e2b-service";
+import { e2bService } from "../../../../../src/lib/e2b/e2b-service";
 
 const mockKillSandbox = vi.mocked(e2bService.killSandbox);
 

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
@@ -38,7 +38,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     initServices();
 
     // Set CRON_SECRET for tests
-    process.env.CRON_SECRET = cronSecret;
+    process.env.VERCEL_CRON_SECRET = cronSecret;
 
     // Clean up any existing test data
     await globalThis.services.db
@@ -102,7 +102,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       .delete(agentComposes)
       .where(eq(agentComposes.id, testComposeId));
 
-    delete process.env.CRON_SECRET;
+    delete process.env.VERCEL_CRON_SECRET;
   });
 
   describe("Authentication", () => {

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
@@ -1,0 +1,391 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { GET } from "../route";
+import { NextRequest } from "next/server";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../../../src/db/schema/agent-compose";
+import { eq } from "drizzle-orm";
+import { randomUUID } from "crypto";
+
+// Mock e2bService
+vi.mock("../../../../../../src/lib/e2b/e2b-service", () => ({
+  e2bService: {
+    killSandbox: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { e2bService } from "../../../../../../src/lib/e2b/e2b-service";
+
+const mockKillSandbox = vi.mocked(e2bService.killSandbox);
+
+describe("GET /api/cron/cleanup-sandboxes", () => {
+  const testUserId = `test-user-${Date.now()}-${process.pid}`;
+  const testRunId1 = randomUUID();
+  const testRunId2 = randomUUID();
+  const testComposeId = randomUUID();
+  const testVersionId =
+    randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
+  const cronSecret = "test-cron-secret";
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    initServices();
+
+    // Set CRON_SECRET for tests
+    process.env.CRON_SECRET = cronSecret;
+
+    // Clean up any existing test data
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, testRunId1));
+
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, testRunId2));
+
+    await globalThis.services.db
+      .delete(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, testVersionId));
+
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, testComposeId));
+
+    // Create test agent compose
+    await globalThis.services.db.insert(agentComposes).values({
+      id: testComposeId,
+      userId: testUserId,
+      name: "test-agent",
+      headVersionId: testVersionId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // Create test agent version
+    await globalThis.services.db.insert(agentComposeVersions).values({
+      id: testVersionId,
+      composeId: testComposeId,
+      content: {
+        agents: {
+          "test-agent": {
+            name: "test-agent",
+            model: "claude-3-5-sonnet-20241022",
+            working_dir: "/workspace",
+          },
+        },
+      },
+      createdBy: testUserId,
+      createdAt: new Date(),
+    });
+  });
+
+  afterEach(async () => {
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, testRunId1));
+
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, testRunId2));
+
+    await globalThis.services.db
+      .delete(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, testVersionId));
+
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, testComposeId));
+
+    delete process.env.CRON_SECRET;
+  });
+
+  describe("Authentication", () => {
+    it("should reject request without cron secret", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/cron/cleanup-sandboxes",
+        {
+          method: "GET",
+        },
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toBeDefined();
+    });
+
+    it("should reject request with invalid cron secret", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/cron/cleanup-sandboxes",
+        {
+          method: "GET",
+          headers: {
+            Authorization: "Bearer invalid-secret",
+          },
+        },
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should accept request with valid cron secret", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/cron/cleanup-sandboxes",
+        {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${cronSecret}`,
+          },
+        },
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("Cleanup Logic", () => {
+    it("should return empty results when no expired sandboxes exist", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/cron/cleanup-sandboxes",
+        {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${cronSecret}`,
+          },
+        },
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.cleaned).toBe(0);
+      expect(data.errors).toBe(0);
+      expect(data.results).toEqual([]);
+    });
+
+    it("should cleanup expired sandbox (heartbeat > 2 minutes ago)", async () => {
+      // Create a run with expired heartbeat (3 minutes ago)
+      const expiredTime = new Date(Date.now() - 3 * 60 * 1000);
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId1,
+        userId: testUserId,
+        agentComposeVersionId: testVersionId,
+        status: "running",
+        prompt: "Test prompt",
+        sandboxId: "test-sandbox-123",
+        createdAt: new Date(),
+        lastHeartbeatAt: expiredTime,
+      });
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/cron/cleanup-sandboxes",
+        {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${cronSecret}`,
+          },
+        },
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.cleaned).toBe(1);
+      expect(data.errors).toBe(0);
+      expect(data.results).toHaveLength(1);
+      expect(data.results[0].runId).toBe(testRunId1);
+      expect(data.results[0].status).toBe("cleaned");
+
+      // Verify sandbox was killed
+      expect(mockKillSandbox).toHaveBeenCalledWith("test-sandbox-123");
+
+      // Verify run status was updated to timeout
+      const [updatedRun] = await globalThis.services.db
+        .select()
+        .from(agentRuns)
+        .where(eq(agentRuns.id, testRunId1));
+
+      expect(updatedRun?.status).toBe("timeout");
+      expect(updatedRun?.completedAt).toBeDefined();
+    });
+
+    it("should NOT cleanup sandbox with recent heartbeat", async () => {
+      // Create a run with recent heartbeat (30 seconds ago)
+      const recentTime = new Date(Date.now() - 30 * 1000);
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId1,
+        userId: testUserId,
+        agentComposeVersionId: testVersionId,
+        status: "running",
+        prompt: "Test prompt",
+        sandboxId: "test-sandbox-123",
+        createdAt: new Date(),
+        lastHeartbeatAt: recentTime,
+      });
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/cron/cleanup-sandboxes",
+        {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${cronSecret}`,
+          },
+        },
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.cleaned).toBe(0);
+      expect(data.results).toEqual([]);
+
+      // Verify sandbox was NOT killed
+      expect(mockKillSandbox).not.toHaveBeenCalled();
+
+      // Verify run status unchanged
+      const [unchangedRun] = await globalThis.services.db
+        .select()
+        .from(agentRuns)
+        .where(eq(agentRuns.id, testRunId1));
+
+      expect(unchangedRun?.status).toBe("running");
+    });
+
+    it("should NOT cleanup completed runs even with old heartbeat", async () => {
+      // Create a completed run with old heartbeat
+      const oldTime = new Date(Date.now() - 10 * 60 * 1000);
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId1,
+        userId: testUserId,
+        agentComposeVersionId: testVersionId,
+        status: "completed",
+        prompt: "Test prompt",
+        sandboxId: "test-sandbox-123",
+        createdAt: new Date(),
+        lastHeartbeatAt: oldTime,
+      });
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/cron/cleanup-sandboxes",
+        {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${cronSecret}`,
+          },
+        },
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.cleaned).toBe(0);
+
+      // Verify sandbox was NOT killed
+      expect(mockKillSandbox).not.toHaveBeenCalled();
+    });
+
+    it("should cleanup multiple expired sandboxes", async () => {
+      const expiredTime = new Date(Date.now() - 5 * 60 * 1000);
+
+      // Create two runs with expired heartbeats
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId1,
+        userId: testUserId,
+        agentComposeVersionId: testVersionId,
+        status: "running",
+        prompt: "Test prompt 1",
+        sandboxId: "test-sandbox-1",
+        createdAt: new Date(),
+        lastHeartbeatAt: expiredTime,
+      });
+
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId2,
+        userId: testUserId,
+        agentComposeVersionId: testVersionId,
+        status: "running",
+        prompt: "Test prompt 2",
+        sandboxId: "test-sandbox-2",
+        createdAt: new Date(),
+        lastHeartbeatAt: expiredTime,
+      });
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/cron/cleanup-sandboxes",
+        {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${cronSecret}`,
+          },
+        },
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.cleaned).toBe(2);
+      expect(data.errors).toBe(0);
+      expect(data.results).toHaveLength(2);
+
+      // Verify both sandboxes were killed
+      expect(mockKillSandbox).toHaveBeenCalledTimes(2);
+    });
+
+    it("should handle sandbox without sandboxId gracefully", async () => {
+      const expiredTime = new Date(Date.now() - 3 * 60 * 1000);
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId1,
+        userId: testUserId,
+        agentComposeVersionId: testVersionId,
+        status: "running",
+        prompt: "Test prompt",
+        sandboxId: null, // No sandbox ID
+        createdAt: new Date(),
+        lastHeartbeatAt: expiredTime,
+      });
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/cron/cleanup-sandboxes",
+        {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${cronSecret}`,
+          },
+        },
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.cleaned).toBe(1);
+
+      // Verify killSandbox was NOT called (no sandboxId)
+      expect(mockKillSandbox).not.toHaveBeenCalled();
+
+      // Verify run status was still updated
+      const [updatedRun] = await globalThis.services.db
+        .select()
+        .from(agentRuns)
+        .where(eq(agentRuns.id, testRunId1));
+
+      expect(updatedRun?.status).toBe("timeout");
+    });
+  });
+});

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest } from "next/server";
+import { initServices } from "../../../../src/lib/init-services";
+import { agentRuns } from "../../../../src/db/schema/agent-run";
+import { eq, and, lt, isNotNull } from "drizzle-orm";
+import { e2bService } from "../../../../src/lib/e2b/e2b-service";
+import {
+  successResponse,
+  errorResponse,
+} from "../../../../src/lib/api-response";
+import { UnauthorizedError } from "../../../../src/lib/errors";
+import { logger } from "../../../../src/lib/logger";
+
+const log = logger("cron:cleanup-sandboxes");
+
+// Heartbeat timeout: 2 minutes (2x the 60s heartbeat interval)
+const HEARTBEAT_TIMEOUT_MS = 2 * 60 * 1000;
+
+interface CleanupResult {
+  runId: string;
+  sandboxId: string | null;
+  status: "cleaned" | "error";
+  error?: string;
+}
+
+interface CleanupResponse {
+  cleaned: number;
+  errors: number;
+  results: CleanupResult[];
+}
+
+/**
+ * GET /api/cron/cleanup-sandboxes
+ * Cron job to cleanup sandboxes that have stopped sending heartbeats
+ *
+ * This endpoint is called by Vercel Cron every minute.
+ * It finds all running agent runs that haven't sent a heartbeat in 2+ minutes
+ * and cleans them up.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    initServices();
+
+    // Verify cron secret (Vercel adds this header for cron jobs)
+    const authHeader = request.headers.get("authorization");
+    const cronSecret = process.env.CRON_SECRET;
+
+    if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+      throw new UnauthorizedError("Invalid cron secret");
+    }
+
+    const cutoffTime = new Date(Date.now() - HEARTBEAT_TIMEOUT_MS);
+
+    log.debug(
+      `Checking for expired sandboxes (heartbeat before ${cutoffTime.toISOString()})...`,
+    );
+
+    // Find all running runs with expired heartbeats
+    const expiredRuns = await globalThis.services.db
+      .select({
+        id: agentRuns.id,
+        sandboxId: agentRuns.sandboxId,
+        lastHeartbeatAt: agentRuns.lastHeartbeatAt,
+      })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.status, "running"),
+          isNotNull(agentRuns.lastHeartbeatAt),
+          lt(agentRuns.lastHeartbeatAt, cutoffTime),
+        ),
+      );
+
+    if (expiredRuns.length === 0) {
+      log.debug("No expired sandboxes found");
+      const response: CleanupResponse = {
+        cleaned: 0,
+        errors: 0,
+        results: [],
+      };
+      return successResponse(response, 200);
+    }
+
+    log.debug(`Found ${expiredRuns.length} expired sandboxes to cleanup`);
+
+    const results: CleanupResult[] = [];
+
+    for (const run of expiredRuns) {
+      try {
+        // Kill the E2B sandbox if it exists
+        if (run.sandboxId) {
+          await e2bService.killSandbox(run.sandboxId);
+        }
+
+        // Update run status to timeout
+        await globalThis.services.db
+          .update(agentRuns)
+          .set({
+            status: "timeout",
+            completedAt: new Date(),
+          })
+          .where(eq(agentRuns.id, run.id));
+
+        log.debug(
+          `Cleaned up expired run ${run.id} (sandbox: ${run.sandboxId}, last heartbeat: ${run.lastHeartbeatAt?.toISOString()})`,
+        );
+
+        results.push({
+          runId: run.id,
+          sandboxId: run.sandboxId,
+          status: "cleaned",
+        });
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error";
+        log.error(`Failed to cleanup run ${run.id}: ${errorMessage}`);
+
+        results.push({
+          runId: run.id,
+          sandboxId: run.sandboxId,
+          status: "error",
+          error: errorMessage,
+        });
+      }
+    }
+
+    const response: CleanupResponse = {
+      cleaned: results.filter((r) => r.status === "cleaned").length,
+      errors: results.filter((r) => r.status === "error").length,
+      results,
+    };
+
+    return successResponse(response, 200);
+  } catch (error) {
+    log.error("Cron cleanup error:", error);
+    return errorResponse(error);
+  }
+}

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
@@ -42,7 +42,7 @@ export async function GET(request: NextRequest) {
 
     // Verify cron secret (Vercel adds this header for cron jobs)
     const authHeader = request.headers.get("authorization");
-    const cronSecret = process.env.CRON_SECRET;
+    const cronSecret = process.env.VERCEL_CRON_SECRET;
 
     if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
       throw new UnauthorizedError("Invalid cron secret");

--- a/turbo/apps/web/app/api/webhooks/agent/heartbeat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/heartbeat/__tests__/route.test.ts
@@ -1,0 +1,389 @@
+/**
+ * @vitest-environment node
+ */
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import { cliTokens } from "../../../../../../src/db/schema/cli-tokens";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../../../src/db/schema/agent-compose";
+import { eq } from "drizzle-orm";
+import { randomUUID } from "crypto";
+
+// Mock Next.js headers() function
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+}));
+
+// Mock Clerk auth
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+import { headers } from "next/headers";
+import { auth } from "@clerk/nextjs/server";
+
+const mockHeaders = vi.mocked(headers);
+const mockAuth = vi.mocked(auth);
+
+describe("POST /api/webhooks/agent/heartbeat", () => {
+  const testUserId = `test-user-${Date.now()}-${process.pid}`;
+  const testRunId = randomUUID();
+  const testComposeId = randomUUID();
+  const testVersionId =
+    randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
+  const testToken = `vm0_live_test_${Date.now()}_${process.pid}`;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    initServices();
+
+    mockAuth.mockResolvedValue({ userId: null } as unknown as Awaited<
+      ReturnType<typeof auth>
+    >);
+
+    mockHeaders.mockResolvedValue({
+      get: vi.fn().mockReturnValue(null),
+    } as unknown as Headers);
+
+    // Clean up any existing test data
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, testRunId));
+
+    await globalThis.services.db
+      .delete(cliTokens)
+      .where(eq(cliTokens.token, testToken));
+
+    await globalThis.services.db
+      .delete(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, testVersionId));
+
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, testComposeId));
+
+    // Create test agent compose
+    await globalThis.services.db.insert(agentComposes).values({
+      id: testComposeId,
+      userId: testUserId,
+      name: "test-agent",
+      headVersionId: testVersionId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // Create test agent version
+    await globalThis.services.db.insert(agentComposeVersions).values({
+      id: testVersionId,
+      composeId: testComposeId,
+      content: {
+        agents: {
+          "test-agent": {
+            name: "test-agent",
+            model: "claude-3-5-sonnet-20241022",
+            working_dir: "/workspace",
+          },
+        },
+      },
+      createdBy: testUserId,
+      createdAt: new Date(),
+    });
+  });
+
+  afterEach(async () => {
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, testRunId));
+
+    await globalThis.services.db
+      .delete(cliTokens)
+      .where(eq(cliTokens.token, testToken));
+
+    await globalThis.services.db
+      .delete(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, testVersionId));
+
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, testComposeId));
+  });
+
+  describe("Authentication", () => {
+    it("should reject heartbeat without authentication", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/heartbeat",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("Validation", () => {
+    beforeEach(async () => {
+      mockHeaders.mockResolvedValue({
+        get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+      } as unknown as Headers);
+
+      await globalThis.services.db.insert(cliTokens).values({
+        token: testToken,
+        userId: testUserId,
+        name: "Test Token",
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+      });
+    });
+
+    it("should reject heartbeat without runId", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/heartbeat",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({}),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toContain("runId");
+    });
+  });
+
+  describe("Authorization", () => {
+    beforeEach(async () => {
+      mockHeaders.mockResolvedValue({
+        get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+      } as unknown as Headers);
+
+      await globalThis.services.db.insert(cliTokens).values({
+        token: testToken,
+        userId: testUserId,
+        name: "Test Token",
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+      });
+    });
+
+    it("should reject heartbeat for non-existent run", async () => {
+      const nonExistentRunId = randomUUID();
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/heartbeat",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: nonExistentRunId,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error.message).toContain("Agent run");
+    });
+
+    it("should reject heartbeat for run owned by different user", async () => {
+      const otherUserId = `other-user-${Date.now()}-${process.pid}`;
+
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId,
+        userId: otherUserId,
+        agentComposeVersionId: testVersionId,
+        status: "running",
+        prompt: "Test prompt",
+        createdAt: new Date(),
+      });
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/heartbeat",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("Success", () => {
+    it("should update lastHeartbeatAt for valid heartbeat", async () => {
+      mockHeaders.mockResolvedValue({
+        get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+      } as unknown as Headers);
+
+      await globalThis.services.db.insert(cliTokens).values({
+        token: testToken,
+        userId: testUserId,
+        name: "Test Token",
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+      });
+
+      const initialTime = new Date(Date.now() - 60000); // 1 minute ago
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId,
+        userId: testUserId,
+        agentComposeVersionId: testVersionId,
+        status: "running",
+        prompt: "Test prompt",
+        createdAt: new Date(),
+        lastHeartbeatAt: initialTime,
+      });
+
+      const beforeRequest = new Date();
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/heartbeat",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.ok).toBe(true);
+
+      // Verify database was updated
+      const [updatedRun] = await globalThis.services.db
+        .select()
+        .from(agentRuns)
+        .where(eq(agentRuns.id, testRunId));
+
+      expect(updatedRun).toBeDefined();
+      expect(updatedRun?.lastHeartbeatAt).toBeDefined();
+      expect(updatedRun?.lastHeartbeatAt!.getTime()).toBeGreaterThanOrEqual(
+        beforeRequest.getTime(),
+      );
+      expect(updatedRun?.lastHeartbeatAt!.getTime()).toBeGreaterThan(
+        initialTime.getTime(),
+      );
+    });
+
+    it("should handle multiple consecutive heartbeats", async () => {
+      mockHeaders.mockResolvedValue({
+        get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+      } as unknown as Headers);
+
+      await globalThis.services.db.insert(cliTokens).values({
+        token: testToken,
+        userId: testUserId,
+        name: "Test Token",
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+      });
+
+      await globalThis.services.db.insert(agentRuns).values({
+        id: testRunId,
+        userId: testUserId,
+        agentComposeVersionId: testVersionId,
+        status: "running",
+        prompt: "Test prompt",
+        createdAt: new Date(),
+      });
+
+      // Send first heartbeat
+      const request1 = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/heartbeat",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({ runId: testRunId }),
+        },
+      );
+
+      const response1 = await POST(request1);
+      expect(response1.status).toBe(200);
+
+      const [run1] = await globalThis.services.db
+        .select()
+        .from(agentRuns)
+        .where(eq(agentRuns.id, testRunId));
+      const firstHeartbeat = run1?.lastHeartbeatAt;
+
+      // Small delay to ensure different timestamp
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Send second heartbeat
+      const request2 = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/heartbeat",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({ runId: testRunId }),
+        },
+      );
+
+      const response2 = await POST(request2);
+      expect(response2.status).toBe(200);
+
+      const [run2] = await globalThis.services.db
+        .select()
+        .from(agentRuns)
+        .where(eq(agentRuns.id, testRunId));
+
+      expect(run2?.lastHeartbeatAt!.getTime()).toBeGreaterThanOrEqual(
+        firstHeartbeat!.getTime(),
+      );
+    });
+  });
+});

--- a/turbo/apps/web/app/api/webhooks/agent/heartbeat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/heartbeat/__tests__/route.test.ts
@@ -1,14 +1,7 @@
 /**
  * @vitest-environment node
  */
-import {
-  describe,
-  it,
-  expect,
-  beforeEach,
-  afterEach,
-  vi,
-} from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { POST } from "../route";
 import { NextRequest } from "next/server";
 import { initServices } from "../../../../../../src/lib/init-services";

--- a/turbo/apps/web/app/api/webhooks/agent/heartbeat/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/heartbeat/route.ts
@@ -12,6 +12,9 @@ import {
   NotFoundError,
   UnauthorizedError,
 } from "../../../../../src/lib/errors";
+import { logger } from "../../../../../src/lib/logger";
+
+const log = logger("webhooks:heartbeat");
 
 interface HeartbeatRequest {
   runId: string;
@@ -50,12 +53,12 @@ export async function POST(request: NextRequest) {
       throw new NotFoundError("Agent run");
     }
 
-    console.log(`[Heartbeat] Updated heartbeat for run ${body.runId}`);
+    log.debug(`Updated heartbeat for run ${body.runId}`);
 
     const response: HeartbeatResponse = { ok: true };
     return successResponse(response, 200);
   } catch (error) {
-    console.error("[Heartbeat] Error:", error);
+    log.error("Heartbeat error:", error);
     return errorResponse(error);
   }
 }

--- a/turbo/apps/web/app/api/webhooks/agent/heartbeat/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/heartbeat/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest } from "next/server";
+import { initServices } from "../../../../../src/lib/init-services";
+import { agentRuns } from "../../../../../src/db/schema/agent-run";
+import { eq, and } from "drizzle-orm";
+import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import {
+  successResponse,
+  errorResponse,
+} from "../../../../../src/lib/api-response";
+import {
+  BadRequestError,
+  NotFoundError,
+  UnauthorizedError,
+} from "../../../../../src/lib/errors";
+
+interface HeartbeatRequest {
+  runId: string;
+}
+
+interface HeartbeatResponse {
+  ok: boolean;
+}
+
+/**
+ * POST /api/webhooks/agent/heartbeat
+ * Receive heartbeat signals from E2B sandbox to indicate agent is still alive
+ */
+export async function POST(request: NextRequest) {
+  try {
+    initServices();
+
+    const userId = await getUserId();
+    if (!userId) {
+      throw new UnauthorizedError("Not authenticated");
+    }
+
+    const body: HeartbeatRequest = await request.json();
+
+    if (!body.runId) {
+      throw new BadRequestError("Missing runId");
+    }
+
+    const result = await globalThis.services.db
+      .update(agentRuns)
+      .set({ lastHeartbeatAt: new Date() })
+      .where(and(eq(agentRuns.id, body.runId), eq(agentRuns.userId, userId)))
+      .returning({ id: agentRuns.id });
+
+    if (result.length === 0) {
+      throw new NotFoundError("Agent run");
+    }
+
+    console.log(`[Heartbeat] Updated heartbeat for run ${body.runId}`);
+
+    const response: HeartbeatResponse = { ok: true };
+    return successResponse(response, 200);
+  } catch (error) {
+    console.error("[Heartbeat] Error:", error);
+    return errorResponse(error);
+  }
+}

--- a/turbo/apps/web/src/db/migrations/0029_add_last_heartbeat_at.sql
+++ b/turbo/apps/web/src/db/migrations/0029_add_last_heartbeat_at.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "agent_runs" ADD COLUMN "last_heartbeat_at" timestamp;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_agent_runs_status_heartbeat" ON "agent_runs" USING btree ("status","last_heartbeat_at");

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1765300000000,
       "tag": "0028_add_user_secrets",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1765400000000,
+      "tag": "0029_add_last_heartbeat_at",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/agent-run.ts
+++ b/turbo/apps/web/src/db/schema/agent-run.ts
@@ -29,4 +29,5 @@ export const agentRuns = pgTable("agent_runs", {
   createdAt: timestamp("created_at").defaultNow().notNull(),
   startedAt: timestamp("started_at"),
   completedAt: timestamp("completed_at"),
+  lastHeartbeatAt: timestamp("last_heartbeat_at"),
 });

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
@@ -34,6 +34,10 @@ CHECKPOINT_URL = f"{API_URL}/api/webhooks/agent/checkpoints"
 COMPLETE_URL = f"{API_URL}/api/webhooks/agent/complete"
 STORAGE_WEBHOOK_URL = f"{API_URL}/api/webhooks/agent/storages"
 INCREMENTAL_WEBHOOK_URL = f"{API_URL}/api/webhooks/agent/storages/incremental"
+HEARTBEAT_URL = f"{API_URL}/api/webhooks/agent/heartbeat"
+
+# Heartbeat configuration
+HEARTBEAT_INTERVAL = 60  # seconds
 
 # HTTP request configuration
 HTTP_CONNECT_TIMEOUT = 10

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -38,9 +38,6 @@ shutdown_event = threading.Event()
 
 def heartbeat_loop():
     """Send periodic heartbeat signals to indicate agent is still alive."""
-    # Wait before first heartbeat since lastHeartbeatAt is initialized on run start
-    shutdown_event.wait(HEARTBEAT_INTERVAL)
-
     while not shutdown_event.is_set():
         try:
             if http_post_json(HEARTBEAT_URL, {"runId": RUN_ID}):

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -38,6 +38,9 @@ shutdown_event = threading.Event()
 
 def heartbeat_loop():
     """Send periodic heartbeat signals to indicate agent is still alive."""
+    # Wait before first heartbeat since lastHeartbeatAt is initialized on run start
+    shutdown_event.wait(HEARTBEAT_INTERVAL)
+
     while not shutdown_event.is_set():
         try:
             if http_post_json(HEARTBEAT_URL, {"runId": RUN_ID}):

--- a/turbo/apps/web/vercel.json
+++ b/turbo/apps/web/vercel.json
@@ -1,5 +1,11 @@
 {
   "buildCommand": "cd ../.. && pnpm run build --filter=web",
   "installCommand": "cd ../.. && pnpm install",
-  "outputDirectory": ".next"
+  "outputDirectory": ".next",
+  "crons": [
+    {
+      "path": "/api/cron/cleanup-sandboxes",
+      "schedule": "* * * * *"
+    }
+  ]
 }

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -24,7 +24,7 @@
     "S3_USER_STORAGES_NAME",
     "SECRETS_ENCRYPTION_KEY",
     "USE_MOCK_CLAUDE",
-    "CRON_SECRET"
+    "VERCEL_CRON_SECRET"
   ],
   "tasks": {
     "build": {

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -23,7 +23,8 @@
     "AWS_SECRET_ACCESS_KEY",
     "S3_USER_STORAGES_NAME",
     "SECRETS_ENCRYPTION_KEY",
-    "USE_MOCK_CLAUDE"
+    "USE_MOCK_CLAUDE",
+    "CRON_SECRET"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary

Implements a reliable sandbox cleanup strategy using heartbeat signals to ensure sandboxes are properly cleaned up even when the container's main process is suddenly killed.

### Changes

- **Database**: Add `lastHeartbeatAt` field to `agent_runs` table with index for efficient querying
- **Heartbeat Endpoint**: Create `/api/webhooks/agent/heartbeat` for sandbox to report liveness
- **Cron Job**: Create `/api/cron/cleanup-sandboxes` that runs every minute to cleanup expired sandboxes
- **Python Agent**: Add heartbeat loop to `run-agent.py` that sends heartbeat every 60 seconds
- **Integration**: Initialize `lastHeartbeatAt` when agent run starts

### Architecture

```
Sandbox (E2B)                        Web Server
┌──────────────────┐                ┌─────────────────────────────┐
│ run-agent.py     │                │ /api/webhooks/agent/        │
│                  │                │ heartbeat                   │
│ while running:   │                │                             │
│   every 60s ─────┼───POST────────▶│ UPDATE agent_runs           │
│   send heartbeat │                │ SET lastHeartbeatAt = now() │
└──────────────────┘                └─────────────────────────────┘

Vercel Cron Job (every 1 minute)
┌─────────────────────────────────────────────────────────────────┐
│ /api/cron/cleanup-sandboxes                                     │
│                                                                 │
│ 1. SELECT * FROM agent_runs                                     │
│    WHERE status = 'running'                                     │
│    AND lastHeartbeatAt < now() - 2 minutes                      │
│                                                                 │
│ 2. For each expired sandbox:                                    │
│    - Kill E2B sandbox                                           │
│    - UPDATE status = 'timeout'                                  │
│    - Log cleanup event                                          │
└─────────────────────────────────────────────────────────────────┘
```

### Configuration

| Parameter | Value | Rationale |
|-----------|-------|-----------|
| Heartbeat interval | 60s | Balance between responsiveness and overhead |
| Cron check interval | 1 min | Minimum for Vercel Pro plan |
| Timeout threshold | 120s | 2x heartbeat interval for tolerance |

## Test plan

- [ ] Verify heartbeat endpoint accepts valid requests and updates `lastHeartbeatAt`
- [ ] Verify heartbeat endpoint rejects unauthorized requests
- [ ] Verify cron job finds and cleans up expired sandboxes
- [ ] Verify cron job skips sandboxes with recent heartbeats
- [ ] Verify `lastHeartbeatAt` is initialized when agent run starts
- [ ] End-to-end: Start sandbox, verify heartbeats are sent, kill process, verify cleanup

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)