### PR TITLE
feat(cli)!: rename build command to compose

### DIFF
--- a/e2e/tests/02-commands/t01-validation.bats
+++ b/e2e/tests/02-commands/t01-validation.bats
@@ -10,7 +10,7 @@ setup() {
 
 @test "vm0 run should fail when template variables are missing" {
     # First build the config
-    run $CLI_COMMAND build "$TEST_CONFIG_TEMPLATE"
+    run $CLI_COMMAND compose "$TEST_CONFIG_TEMPLATE"
     assert_success
 
     # Then try to run without providing template vars

--- a/e2e/tests/02-commands/t04-vm0-artifact-checkpoint.bats
+++ b/e2e/tests/02-commands/t04-vm0-artifact-checkpoint.bats
@@ -25,7 +25,7 @@ teardown() {
 }
 
 @test "Build VM0 artifact checkpoint test agent configuration" {
-    run $CLI_COMMAND build "$TEST_CONFIG"
+    run $CLI_COMMAND compose "$TEST_CONFIG"
     assert_success
     assert_output --partial "vm0-standard"
 }

--- a/e2e/tests/02-commands/t05-vm0-artifact-mount.bats
+++ b/e2e/tests/02-commands/t05-vm0-artifact-mount.bats
@@ -21,7 +21,7 @@ teardown() {
 }
 
 @test "Build VM0 artifact mount test agent configuration" {
-    run $CLI_COMMAND build "$TEST_CONFIG"
+    run $CLI_COMMAND compose "$TEST_CONFIG"
     assert_success
     assert_output --partial "vm0-standard"
 }

--- a/e2e/tests/02-commands/t06-vm0-agent-session.bats
+++ b/e2e/tests/02-commands/t06-vm0-agent-session.bats
@@ -26,7 +26,7 @@ teardown() {
 }
 
 @test "Build VM0 agent session test agent configuration" {
-    run $CLI_COMMAND build "$TEST_CONFIG"
+    run $CLI_COMMAND compose "$TEST_CONFIG"
     assert_success
     assert_output --partial "vm0-standard"
 }

--- a/e2e/tests/02-commands/t07-vm0-volume-version-override.bats
+++ b/e2e/tests/02-commands/t07-vm0-volume-version-override.bats
@@ -54,7 +54,7 @@ volumes:
 EOF
     fi
 
-    run $CLI_COMMAND build "$TEST_CONFIG"
+    run $CLI_COMMAND compose "$TEST_CONFIG"
     assert_success
     assert_output --partial "vm0-volume-override"
 }

--- a/e2e/tests/02-commands/t09-vm0-artifact-empty.bats
+++ b/e2e/tests/02-commands/t09-vm0-artifact-empty.bats
@@ -20,7 +20,7 @@ teardown() {
 }
 
 @test "Build VM0 empty artifact test agent configuration" {
-    run $CLI_COMMAND build "$TEST_CONFIG"
+    run $CLI_COMMAND compose "$TEST_CONFIG"
     assert_success
     assert_output --partial "vm0-standard"
 }

--- a/e2e/tests/02-commands/t10-vm0-error-messages.bats
+++ b/e2e/tests/02-commands/t10-vm0-error-messages.bats
@@ -24,7 +24,7 @@ teardown() {
 }
 
 @test "Build VM0 error message test agent configuration" {
-    run $CLI_COMMAND build "$TEST_CONFIG"
+    run $CLI_COMMAND compose "$TEST_CONFIG"
     assert_success
     assert_output --partial "vm0-standard"
 }

--- a/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
+++ b/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
@@ -15,10 +15,10 @@ teardown() {
 }
 
 # ============================================
-# vm0 build versioning tests
+# vm0 compose versioning tests
 # ============================================
 
-@test "vm0 build should display version ID" {
+@test "vm0 compose should display version ID" {
     echo "# Creating config file..."
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
@@ -31,8 +31,8 @@ agents:
     working_dir: /home/user/workspace
 EOF
 
-    echo "# Running vm0 build..."
-    run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    echo "# Running vm0 compose..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
     echo "# Verifying output contains Version..."
@@ -41,7 +41,7 @@ EOF
     assert_output --regexp "Version:[ ]+[0-9a-f]{8}"
 }
 
-@test "vm0 build with same content should return 'version exists'" {
+@test "vm0 compose with same content should return 'version exists'" {
     echo "# Creating config file..."
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
@@ -54,21 +54,21 @@ agents:
     working_dir: /home/user/workspace
 EOF
 
-    echo "# First build..."
-    run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    echo "# First compose..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
-    # Extract version from first build
+    # Extract version from first compose
     VERSION1=$(echo "$output" | grep -oP 'Version:\s+\K[0-9a-f]+')
 
     echo "# Version 1: $VERSION1"
 
-    echo "# Second build with identical content..."
-    run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    echo "# Second compose with identical content..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
     # Should indicate version already exists (content deduplication)
     assert_output --partial "version exists"
 
-    # Extract version from second build
+    # Extract version from second compose
     VERSION2=$(echo "$output" | grep -oP 'Version:\s+\K[0-9a-f]+')
     echo "# Version 2: $VERSION2"
 
@@ -81,7 +81,7 @@ EOF
     }
 }
 
-@test "vm0 build with different content should create new version" {
+@test "vm0 compose with different content should create new version" {
     echo "# Creating initial config..."
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
@@ -94,8 +94,8 @@ agents:
     working_dir: /home/user/workspace
 EOF
 
-    echo "# First build..."
-    run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    echo "# First compose..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
     VERSION1=$(echo "$output" | grep -oP 'Version:\s+\K[0-9a-f]+')
     echo "# Version 1: $VERSION1"
@@ -112,8 +112,8 @@ agents:
     working_dir: /home/user/workspace
 EOF
 
-    echo "# Second build with different content..."
-    run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    echo "# Second compose with different content..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
     # Should indicate new version created
     assert_output --partial "Compose created"
@@ -130,7 +130,7 @@ EOF
     }
 }
 
-@test "vm0 build version ID is deterministic (key order independent)" {
+@test "vm0 compose version ID is deterministic (key order independent)" {
     echo "# Creating config with keys in one order..."
     cat > "$TEST_DIR/vm0-a.yaml" <<EOF
 version: "1.0"
@@ -143,8 +143,8 @@ agents:
     working_dir: /home/user/workspace
 EOF
 
-    echo "# First build..."
-    run $CLI_COMMAND build "$TEST_DIR/vm0-a.yaml"
+    echo "# First compose..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0-a.yaml"
     assert_success
     VERSION1=$(echo "$output" | grep -oP 'Version:\s+\K[0-9a-f]+')
     echo "# Version 1: $VERSION1"
@@ -161,8 +161,8 @@ agents:
     description: "Deterministic test"
 EOF
 
-    echo "# Second build with same content, different key order..."
-    run $CLI_COMMAND build "$TEST_DIR/vm0-b.yaml"
+    echo "# Second compose with same content, different key order..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0-b.yaml"
     assert_success
     VERSION2=$(echo "$output" | grep -oP 'Version:\s+\K[0-9a-f]+')
     echo "# Version 2: $VERSION2"
@@ -196,7 +196,7 @@ agents:
 EOF
 
     echo "# Building version 1..."
-    run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
     VERSION1=$(echo "$output" | grep -oP 'Version:\s+\K[0-9a-f]+')
     echo "# Version 1: $VERSION1"
@@ -214,7 +214,7 @@ agents:
 EOF
 
     echo "# Building version 2..."
-    run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
     VERSION2=$(echo "$output" | grep -oP 'Version:\s+\K[0-9a-f]+')
     echo "# Version 2: $VERSION2"
@@ -250,7 +250,7 @@ agents:
 EOF
 
     echo "# Building agent..."
-    run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
     echo "# Initializing artifact storage..."
@@ -284,7 +284,7 @@ agents:
 EOF
 
     echo "# Building agent..."
-    run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
     echo "# Running with nonexistent version (should fail before artifact check)..."
@@ -312,7 +312,7 @@ agents:
 EOF
 
     echo "# Building agent..."
-    run $CLI_COMMAND build "$TEST_DIR/vm0.yaml"
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
     echo "# Initializing artifact storage..."

--- a/e2e/tests/02-commands/t12-vm0-env-expansion.bats
+++ b/e2e/tests/02-commands/t12-vm0-env-expansion.bats
@@ -93,7 +93,7 @@ teardown() {
     $CLI_COMMAND artifact push >/dev/null 2>&1
 
     # 3. Build the compose
-    run $CLI_COMMAND build "$TEST_CONFIG"
+    run $CLI_COMMAND compose "$TEST_CONFIG"
     assert_success
 
     # 4. Run with vars and echo the environment variables
@@ -110,7 +110,7 @@ teardown() {
 
 @test "vm0 run fails when required secret is missing" {
     # Build compose that requires a secret that doesn't exist
-    run $CLI_COMMAND build "$TEST_CONFIG"
+    run $CLI_COMMAND compose "$TEST_CONFIG"
     assert_success
 
     # Delete the secret if it exists
@@ -131,7 +131,7 @@ teardown() {
     $CLI_COMMAND secret set TEST_SECRET "$SECRET_VALUE" >/dev/null 2>&1
 
     # Build compose
-    run $CLI_COMMAND build "$TEST_CONFIG"
+    run $CLI_COMMAND compose "$TEST_CONFIG"
     assert_success
 
     # Try to run without --vars - should fail

--- a/e2e/tests/02-commands/t13-vm0-cook.bats
+++ b/e2e/tests/02-commands/t13-vm0-cook.bats
@@ -58,8 +58,8 @@ EOF
     assert_output --partial "test-volume"
     assert_output --partial "Pushed"
     assert_output --partial "Processing artifact"
-    assert_output --partial "Building compose"
-    assert_output --partial "Compose built"
+    assert_output --partial "Uploading compose"
+    assert_output --partial "Compose uploaded"
 
     echo "# Step 5: Verify volume was initialized..."
     [ -f "test-volume/.vm0/storage.yaml" ]

--- a/turbo/apps/cli/src/commands/__tests__/compose.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/compose.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { buildCommand } from "../build";
+import { composeCommand } from "../compose";
 import * as fs from "fs/promises";
 import { existsSync } from "fs";
 import * as yaml from "yaml";
@@ -13,7 +13,7 @@ vi.mock("yaml");
 vi.mock("../../lib/api-client");
 vi.mock("../../lib/yaml-validator");
 
-describe("build command", () => {
+describe("compose command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
   }) as never);
@@ -37,7 +37,7 @@ describe("build command", () => {
       vi.mocked(existsSync).mockReturnValue(false);
 
       await expect(async () => {
-        await buildCommand.parseAsync(["node", "cli", "nonexistent.yaml"]);
+        await composeCommand.parseAsync(["node", "cli", "nonexistent.yaml"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
@@ -61,7 +61,7 @@ describe("build command", () => {
         action: "created",
       });
 
-      await buildCommand.parseAsync(["node", "cli", "config.yaml"]);
+      await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
 
       expect(fs.readFile).toHaveBeenCalledWith("config.yaml", "utf8");
     });
@@ -79,7 +79,7 @@ describe("build command", () => {
       });
 
       await expect(async () => {
-        await buildCommand.parseAsync(["node", "cli", "config.yaml"]);
+        await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
@@ -105,7 +105,7 @@ describe("build command", () => {
         action: "created",
       });
 
-      await buildCommand.parseAsync(["node", "cli", "config.yaml"]);
+      await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
 
       expect(yaml.parse).toHaveBeenCalled();
       expect(yamlValidator.validateAgentCompose).toHaveBeenCalledWith(
@@ -128,7 +128,7 @@ describe("build command", () => {
       });
 
       await expect(async () => {
-        await buildCommand.parseAsync(["node", "cli", "config.yaml"]);
+        await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
@@ -149,7 +149,7 @@ describe("build command", () => {
         action: "created",
       });
 
-      await buildCommand.parseAsync(["node", "cli", "config.yaml"]);
+      await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
 
       expect(apiClient.createOrUpdateCompose).toHaveBeenCalled();
     });
@@ -177,7 +177,7 @@ describe("build command", () => {
         action: "created",
       });
 
-      await buildCommand.parseAsync(["node", "cli", "config.yaml"]);
+      await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("Uploading compose"),
@@ -193,7 +193,7 @@ describe("build command", () => {
         action: "created",
       });
 
-      await buildCommand.parseAsync(["node", "cli", "config.yaml"]);
+      await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("Compose created: test-agent"),
@@ -212,7 +212,7 @@ describe("build command", () => {
         action: "existing",
       });
 
-      await buildCommand.parseAsync(["node", "cli", "config.yaml"]);
+      await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("Compose version exists: test-agent"),
@@ -228,7 +228,7 @@ describe("build command", () => {
         action: "created",
       });
 
-      await buildCommand.parseAsync(["node", "cli", "config.yaml"]);
+      await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("vm0 run test"),
@@ -252,7 +252,7 @@ describe("build command", () => {
       );
 
       await expect(async () => {
-        await buildCommand.parseAsync(["node", "cli", "config.yaml"]);
+        await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
@@ -270,7 +270,7 @@ describe("build command", () => {
       );
 
       await expect(async () => {
-        await buildCommand.parseAsync(["node", "cli", "config.yaml"]);
+        await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
@@ -285,7 +285,7 @@ describe("build command", () => {
       );
 
       await expect(async () => {
-        await buildCommand.parseAsync(["node", "cli", "config.yaml"]);
+        await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(

--- a/turbo/apps/cli/src/commands/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/run.test.ts
@@ -177,7 +177,7 @@ describe("run command", () => {
         expect.stringContaining("Agent not found: nonexistent-agent"),
       );
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("vm0 build"),
+        expect.stringContaining("vm0 compose"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
@@ -633,7 +633,7 @@ describe("run command", () => {
         expect.stringContaining("Agent not found"),
       );
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("vm0 build"),
+        expect.stringContaining("vm0 compose"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });

--- a/turbo/apps/cli/src/commands/compose.ts
+++ b/turbo/apps/cli/src/commands/compose.ts
@@ -6,8 +6,8 @@ import { parse as parseYaml } from "yaml";
 import { apiClient } from "../lib/api-client";
 import { validateAgentCompose } from "../lib/yaml-validator";
 
-export const buildCommand = new Command()
-  .name("build")
+export const composeCommand = new Command()
+  .name("compose")
   .description("Create or update agent compose")
   .argument("<config-file>", "Path to config YAML file")
   .action(async (configFile: string) => {

--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -295,7 +295,7 @@ export const cookCommand = new Command()
     console.log(chalk.blue("Building compose..."));
 
     try {
-      await execVm0Command(["build", CONFIG_FILE], {
+      await execVm0Command(["compose", CONFIG_FILE], {
         cwd,
         silent: true,
       });

--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -290,18 +290,18 @@ export const cookCommand = new Command()
       process.exit(1);
     }
 
-    // Step 4: Build compose
+    // Step 4: Upload compose
     console.log();
-    console.log(chalk.blue("Building compose..."));
+    console.log(chalk.blue("Uploading compose..."));
 
     try {
       await execVm0Command(["compose", CONFIG_FILE], {
         cwd,
         silent: true,
       });
-      console.log(chalk.green(`✓ Compose built: ${agentName}`));
+      console.log(chalk.green(`✓ Compose uploaded: ${agentName}`));
     } catch (error) {
-      console.error(chalk.red(`✗ Build failed`));
+      console.error(chalk.red(`✗ Compose failed`));
       if (error instanceof Error) {
         console.error(chalk.gray(`  ${error.message}`));
       }

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -342,9 +342,7 @@ const runCmd = new Command()
             if (error instanceof Error) {
               console.error(chalk.red(`✗ Version not found: ${version}`));
               console.error(
-                chalk.gray(
-                  "  Make sure the version hash exists. Use 'vm0 compose' to see available versions.",
-                ),
+                chalk.gray("  Make sure the version hash is correct."),
               );
             }
             process.exit(1);

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -309,7 +309,7 @@ const runCmd = new Command()
               console.error(chalk.red(`✗ Agent not found: ${name}`));
               console.error(
                 chalk.gray(
-                  "  Make sure you've built the agent with: vm0 build",
+                  "  Make sure you've built the agent with: vm0 compose",
                 ),
               );
             }
@@ -343,7 +343,7 @@ const runCmd = new Command()
               console.error(chalk.red(`✗ Version not found: ${version}`));
               console.error(
                 chalk.gray(
-                  "  Make sure the version hash exists. Use 'vm0 build' to see available versions.",
+                  "  Make sure the version hash exists. Use 'vm0 compose' to see available versions.",
                 ),
               );
             }
@@ -413,7 +413,9 @@ const runCmd = new Command()
           } else if (error.message.includes("not found")) {
             console.error(chalk.red(`✗ Agent not found: ${identifier}`));
             console.error(
-              chalk.gray("  Make sure you've built the agent with: vm0 build"),
+              chalk.gray(
+                "  Make sure you've built the agent with: vm0 compose",
+              ),
             );
           } else {
             console.error(chalk.red("✗ Run failed"));

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -309,7 +309,7 @@ const runCmd = new Command()
               console.error(chalk.red(`✗ Agent not found: ${name}`));
               console.error(
                 chalk.gray(
-                  "  Make sure you've built the agent with: vm0 compose",
+                  "  Make sure you've composed the agent with: vm0 compose",
                 ),
               );
             }
@@ -414,7 +414,7 @@ const runCmd = new Command()
             console.error(chalk.red(`✗ Agent not found: ${identifier}`));
             console.error(
               chalk.gray(
-                "  Make sure you've built the agent with: vm0 compose",
+                "  Make sure you've composed the agent with: vm0 compose",
               ),
             );
           } else {

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -3,7 +3,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { authenticate, logout, checkAuthStatus } from "./lib/auth";
 import { getApiUrl } from "./lib/config";
-import { buildCommand } from "./commands/build";
+import { composeCommand } from "./commands/compose";
 import { runCommand } from "./commands/run";
 import { volumeCommand } from "./commands/volume";
 import { artifactCommand } from "./commands/artifact";
@@ -64,8 +64,8 @@ authCommand
     await checkAuthStatus();
   });
 
-// Register build, run, volume, artifact, secret, and cook commands
-program.addCommand(buildCommand);
+// Register compose, run, volume, artifact, secret, and cook commands
+program.addCommand(composeCommand);
 program.addCommand(runCommand);
 program.addCommand(volumeCommand);
 program.addCommand(artifactCommand);


### PR DESCRIPTION
## Summary
- Rename `vm0 build` command to `vm0 compose` to align with the API endpoint rename
- Prepare for the upcoming `vm0 image build` command by differentiating the concepts:
  - `vm0 compose` - Upload and register agent compose configurations (declarative, orchestration-focused)
  - `vm0 image build` - Build custom container images (future feature)

## Changes
- Renamed `build.ts` → `compose.ts`
- Renamed `build.test.ts` → `compose.test.ts`
- Updated all exports and command registration in `index.ts`

## Breaking Change
Users must now use `vm0 compose` instead of `vm0 build`

## Test plan
- [x] All 13 existing tests pass
- [x] Lint passes
- [x] Type check passes

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)