### PR TITLE
fix: remove deprecated neonConfig.fetchConnectionCache option

### DIFF
--- a/turbo/apps/web/src/lib/init-services.ts
+++ b/turbo/apps/web/src/lib/init-services.ts
@@ -1,5 +1,5 @@
 import { Pool as PgPool } from "pg";
-import { Pool as NeonPool, neonConfig } from "@neondatabase/serverless";
+import { Pool as NeonPool } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { schema } from "../db/db";
 import { env, type Env } from "../env";
@@ -43,7 +43,6 @@ export function initServices(): void {
         if (isVercel) {
           // Use Neon serverless driver for Vercel
           // This driver is optimized for Neon's connection pooler and serverless environments
-          neonConfig.fetchConnectionCache = true;
           _pool = new NeonPool({
             connectionString: this.env.DATABASE_URL,
             max: 1,


### PR DESCRIPTION
## Summary
- Remove deprecated `neonConfig.fetchConnectionCache = true` configuration
- Clean up unused `neonConfig` import from `@neondatabase/serverless`

The `fetchConnectionCache` option is now always `true` by default in the Neon serverless driver, making explicit configuration unnecessary and triggering a deprecation warning:

```
[warning] The `fetchConnectionCache` option is deprecated (now always `true`)
```

## Test plan
- [ ] Verify the deprecation warning no longer appears in server logs
- [ ] Confirm database connections still work correctly in Vercel environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)