### PR TITLE
feat(cli): remove timeout option and detect sandbox termination via events API

### DIFF
--- a/e2e/tests/02-commands/t04-vm0-artifact-checkpoint.bats
+++ b/e2e/tests/02-commands/t04-vm0-artifact-checkpoint.bats
@@ -55,7 +55,7 @@ teardown() {
     # Use extended timeout for CI environments which may be slower
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "echo 'created by agent' > agent-marker.txt && echo 101 > counter.txt"
 
     assert_success
@@ -94,7 +94,7 @@ teardown() {
     # Use 120s timeout as resume involves S3 download + sandbox startup + session restore
     echo "# Step 4: Resuming from checkpoint..."
     run $CLI_COMMAND run resume "$CHECKPOINT_ID" \
-        --timeout 120 \
+        \
         "ls && cat counter.txt"
 
     assert_success

--- a/e2e/tests/02-commands/t04-vm0-artifact-checkpoint.bats
+++ b/e2e/tests/02-commands/t04-vm0-artifact-checkpoint.bats
@@ -55,7 +55,6 @@ teardown() {
     # Use extended timeout for CI environments which may be slower
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "echo 'created by agent' > agent-marker.txt && echo 101 > counter.txt"
 
     assert_success
@@ -94,7 +93,6 @@ teardown() {
     # Use 120s timeout as resume involves S3 download + sandbox startup + session restore
     echo "# Step 4: Resuming from checkpoint..."
     run $CLI_COMMAND run resume "$CHECKPOINT_ID" \
-        \
         "ls && cat counter.txt"
 
     assert_success

--- a/e2e/tests/02-commands/t05-vm0-artifact-mount.bats
+++ b/e2e/tests/02-commands/t05-vm0-artifact-mount.bats
@@ -44,7 +44,7 @@ teardown() {
     # Use extended timeout for CI environments which may be slower
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "ls -la && cat test-file.txt && cat subdir/nested.txt"
 
     assert_success
@@ -74,7 +74,7 @@ teardown() {
     # Use extended timeout for CI environments which may be slower
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "echo done"
 
     assert_success

--- a/e2e/tests/02-commands/t05-vm0-artifact-mount.bats
+++ b/e2e/tests/02-commands/t05-vm0-artifact-mount.bats
@@ -44,7 +44,6 @@ teardown() {
     # Use extended timeout for CI environments which may be slower
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "ls -la && cat test-file.txt && cat subdir/nested.txt"
 
     assert_success
@@ -74,7 +73,6 @@ teardown() {
     # Use extended timeout for CI environments which may be slower
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "echo done"
 
     assert_success

--- a/e2e/tests/02-commands/t06-vm0-agent-session.bats
+++ b/e2e/tests/02-commands/t06-vm0-agent-session.bats
@@ -52,7 +52,7 @@ teardown() {
     # Use extended timeout for CI environments which may be slower
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "echo 'agent-created' > agent.txt && echo 200 > counter.txt"
 
     assert_success
@@ -85,7 +85,7 @@ teardown() {
     # Step 4: Continue from session - should get LATEST artifact (HEAD), not checkpoint
     # This is the KEY DIFFERENCE from checkpoint resume
     echo "# Step 4: Continuing from session (should use latest artifact)..."
-    run $CLI_COMMAND run continue --timeout 120 "$SESSION_ID" "ls && cat counter.txt"
+    run $CLI_COMMAND run continue "$SESSION_ID" "ls && cat counter.txt"
 
     assert_success
     assert_output --partial "[tool_use] Bash"
@@ -125,7 +125,7 @@ teardown() {
     # Use extended timeout for CI environments which may be slower
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "echo 'first run'"
 
     assert_success
@@ -140,7 +140,7 @@ teardown() {
     # Use extended timeout for CI environments which may be slower
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "echo 'second run'"
 
     assert_success
@@ -187,7 +187,7 @@ teardown() {
     run $CLI_COMMAND run vm0-standard \
         --vars "testKey=testValue" \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "echo 'initial run' && cat testfile.txt"
 
     assert_success
@@ -216,7 +216,7 @@ teardown() {
     # 1. The continue API correctly retrieves templateVars from the session
     # 2. The continue works even when original run had templateVars
     echo "# Step 4: Continuing from session..."
-    run $CLI_COMMAND run continue --timeout 120 "$SESSION_ID" "cat testfile.txt"
+    run $CLI_COMMAND run continue "$SESSION_ID" "cat testfile.txt"
 
     assert_success
     assert_output --partial "[tool_use] Bash"

--- a/e2e/tests/02-commands/t06-vm0-agent-session.bats
+++ b/e2e/tests/02-commands/t06-vm0-agent-session.bats
@@ -52,7 +52,6 @@ teardown() {
     # Use extended timeout for CI environments which may be slower
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "echo 'agent-created' > agent.txt && echo 200 > counter.txt"
 
     assert_success
@@ -125,7 +124,6 @@ teardown() {
     # Use extended timeout for CI environments which may be slower
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "echo 'first run'"
 
     assert_success
@@ -140,7 +138,6 @@ teardown() {
     # Use extended timeout for CI environments which may be slower
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "echo 'second run'"
 
     assert_success
@@ -187,7 +184,6 @@ teardown() {
     run $CLI_COMMAND run vm0-standard \
         --vars "testKey=testValue" \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "echo 'initial run' && cat testfile.txt"
 
     assert_success

--- a/e2e/tests/02-commands/t07-vm0-volume-version-override.bats
+++ b/e2e/tests/02-commands/t07-vm0-volume-version-override.bats
@@ -170,7 +170,6 @@ EOF
     # Should use the override version, not the checkpoint's stored version
     echo "# Step 4: Resuming with --volume-version override..."
     run $CLI_COMMAND run resume "$CHECKPOINT_ID" \
-        \
         --volume-version "$VOLUME_NAME=$OVERRIDE_VERSION" \
         "cat /home/user/data/data.txt"
 
@@ -237,7 +236,6 @@ EOF
     # Should use the overridden version (initial), not latest
     echo "# Step 4: Continuing session with --volume-version override..."
     run $CLI_COMMAND run continue "$SESSION_ID" \
-        \
         --volume-version "$VOLUME_NAME=$INITIAL_VERSION" \
         "cat /home/user/data/data.txt"
 

--- a/e2e/tests/02-commands/t07-vm0-volume-version-override.bats
+++ b/e2e/tests/02-commands/t07-vm0-volume-version-override.bats
@@ -170,7 +170,7 @@ EOF
     # Should use the override version, not the checkpoint's stored version
     echo "# Step 4: Resuming with --volume-version override..."
     run $CLI_COMMAND run resume "$CHECKPOINT_ID" \
-        --timeout 120 \
+        \
         --volume-version "$VOLUME_NAME=$OVERRIDE_VERSION" \
         "cat /home/user/data/data.txt"
 
@@ -237,7 +237,7 @@ EOF
     # Should use the overridden version (initial), not latest
     echo "# Step 4: Continuing session with --volume-version override..."
     run $CLI_COMMAND run continue "$SESSION_ID" \
-        --timeout 120 \
+        \
         --volume-version "$VOLUME_NAME=$INITIAL_VERSION" \
         "cat /home/user/data/data.txt"
 

--- a/e2e/tests/02-commands/t08-vm0-conversation-fork.bats
+++ b/e2e/tests/02-commands/t08-vm0-conversation-fork.bats
@@ -42,7 +42,6 @@ teardown() {
     echo "# Step 2: Running agent..."
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "echo 'hello world'"
 
     assert_success
@@ -86,7 +85,6 @@ teardown() {
     echo "# Step 2: Running agent to create conversation..."
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "echo 'original run' && cat version.txt && echo 200 > counter.txt"
 
     assert_success
@@ -118,7 +116,6 @@ teardown() {
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
         --conversation "$CONVERSATION_ID" \
-        \
         "cat version.txt && cat counter.txt && ls"
 
     assert_success

--- a/e2e/tests/02-commands/t08-vm0-conversation-fork.bats
+++ b/e2e/tests/02-commands/t08-vm0-conversation-fork.bats
@@ -42,7 +42,7 @@ teardown() {
     echo "# Step 2: Running agent..."
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "echo 'hello world'"
 
     assert_success
@@ -86,7 +86,7 @@ teardown() {
     echo "# Step 2: Running agent to create conversation..."
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "echo 'original run' && cat version.txt && echo 200 > counter.txt"
 
     assert_success
@@ -118,7 +118,7 @@ teardown() {
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
         --conversation "$CONVERSATION_ID" \
-        --timeout 120 \
+        \
         "cat version.txt && cat counter.txt && ls"
 
     assert_success

--- a/e2e/tests/02-commands/t09-vm0-artifact-empty.bats
+++ b/e2e/tests/02-commands/t09-vm0-artifact-empty.bats
@@ -39,7 +39,6 @@ teardown() {
     # This tests the storage webhook handling of empty zip uploads
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "echo 'hello world'"
 
     assert_success
@@ -66,7 +65,6 @@ teardown() {
     # The storage webhook should handle unchanged artifact content correctly
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "cat data.txt && cat subdir/nested.txt"
 
     assert_success
@@ -95,7 +93,6 @@ teardown() {
     # This creates a checkpoint with empty artifact
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "rm -rf delete-me.txt subdir"
 
     assert_success

--- a/e2e/tests/02-commands/t09-vm0-artifact-empty.bats
+++ b/e2e/tests/02-commands/t09-vm0-artifact-empty.bats
@@ -39,7 +39,7 @@ teardown() {
     # This tests the storage webhook handling of empty zip uploads
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "echo 'hello world'"
 
     assert_success
@@ -66,7 +66,7 @@ teardown() {
     # The storage webhook should handle unchanged artifact content correctly
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "cat data.txt && cat subdir/nested.txt"
 
     assert_success
@@ -95,7 +95,7 @@ teardown() {
     # This creates a checkpoint with empty artifact
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "rm -rf delete-me.txt subdir"
 
     assert_success

--- a/e2e/tests/02-commands/t10-vm0-error-messages.bats
+++ b/e2e/tests/02-commands/t10-vm0-error-messages.bats
@@ -48,7 +48,6 @@ teardown() {
     echo "# Step 2: Running agent with simulated failure..."
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "@fail:Error: Could not resume session 'test-session': Session history file not found"
 
     # CLI should exit with non-zero code when agent fails (vm0_error received)

--- a/e2e/tests/02-commands/t10-vm0-error-messages.bats
+++ b/e2e/tests/02-commands/t10-vm0-error-messages.bats
@@ -48,7 +48,7 @@ teardown() {
     echo "# Step 2: Running agent with simulated failure..."
     run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "@fail:Error: Could not resume session 'test-session': Session history file not found"
 
     # CLI should exit with non-zero code when agent fails (vm0_error received)

--- a/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
+++ b/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
@@ -229,7 +229,7 @@ EOF
     echo "# Running with specific version (version 1)..."
     run $CLI_COMMAND run "$AGENT_NAME:$VERSION1" \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "echo hello"
     assert_success
 }
@@ -263,7 +263,7 @@ EOF
     echo "# Running with :latest tag..."
     run $CLI_COMMAND run "$AGENT_NAME:latest" \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "echo hello"
     assert_success
 }
@@ -290,7 +290,7 @@ EOF
     echo "# Running with nonexistent version (should fail before artifact check)..."
     run $CLI_COMMAND run "$AGENT_NAME:deadbeef" \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "echo hello"
     assert_failure
     assert_output --partial "Version not found"
@@ -325,7 +325,7 @@ EOF
     echo "# Running without version specifier (should use HEAD)..."
     run $CLI_COMMAND run "$AGENT_NAME" \
         --artifact-name "$ARTIFACT_NAME" \
-        --timeout 120 \
+        \
         "echo hello"
     assert_success
 }

--- a/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
+++ b/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
@@ -229,7 +229,6 @@ EOF
     echo "# Running with specific version (version 1)..."
     run $CLI_COMMAND run "$AGENT_NAME:$VERSION1" \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "echo hello"
     assert_success
 }
@@ -263,7 +262,6 @@ EOF
     echo "# Running with :latest tag..."
     run $CLI_COMMAND run "$AGENT_NAME:latest" \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "echo hello"
     assert_success
 }
@@ -290,7 +288,6 @@ EOF
     echo "# Running with nonexistent version (should fail before artifact check)..."
     run $CLI_COMMAND run "$AGENT_NAME:deadbeef" \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "echo hello"
     assert_failure
     assert_output --partial "Version not found"
@@ -325,7 +322,6 @@ EOF
     echo "# Running without version specifier (should use HEAD)..."
     run $CLI_COMMAND run "$AGENT_NAME" \
         --artifact-name "$ARTIFACT_NAME" \
-        \
         "echo hello"
     assert_success
 }

--- a/e2e/tests/02-commands/t13-vm0-cook.bats
+++ b/e2e/tests/02-commands/t13-vm0-cook.bats
@@ -70,7 +70,7 @@ EOF
 
     echo "# Step 7: Run cook with prompt to test auto-pull..."
     # Use bash command for mock agent compatibility
-    run $CLI_COMMAND cook --timeout 120 "echo 'hello' > /home/user/workspace/result.txt"
+    run $CLI_COMMAND cook "echo 'hello' > /home/user/workspace/result.txt"
     # Verify cook started the run
     assert_output --partial "Running agent"
     assert_output --partial "vm0_start"

--- a/turbo/apps/cli/src/commands/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/run.test.ts
@@ -974,5 +974,109 @@ describe("run command", () => {
         chalk.gray("  Network error"),
       );
     });
+
+    it("should exit with error when sandbox is terminated (status: failed)", async () => {
+      vi.mocked(apiClient.createRun).mockResolvedValue({
+        runId: "run-123",
+        status: "running",
+        sandboxId: "sbx-456",
+        output: "",
+        executionTimeMs: 0,
+        createdAt: "2025-01-01T00:00:00Z",
+      });
+
+      // Return no events with "failed" status - sandbox was terminated
+      vi.mocked(apiClient.getEvents).mockResolvedValue({
+        events: [],
+        hasMore: false,
+        nextSequence: 0,
+        status: "failed",
+      });
+
+      await expect(async () => {
+        await runCommand.parseAsync([
+          "node",
+          "cli",
+          testUuid,
+          "test prompt",
+          "--artifact-name",
+          "test-artifact",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        chalk.red("\n✗ Sandbox terminated unexpectedly (status: failed)"),
+      );
+    });
+
+    it("should exit with error when sandbox times out (status: timeout)", async () => {
+      vi.mocked(apiClient.createRun).mockResolvedValue({
+        runId: "run-123",
+        status: "running",
+        sandboxId: "sbx-456",
+        output: "",
+        executionTimeMs: 0,
+        createdAt: "2025-01-01T00:00:00Z",
+      });
+
+      // Return no events with "timeout" status - sandbox heartbeat expired
+      vi.mocked(apiClient.getEvents).mockResolvedValue({
+        events: [],
+        hasMore: false,
+        nextSequence: 0,
+        status: "timeout",
+      });
+
+      await expect(async () => {
+        await runCommand.parseAsync([
+          "node",
+          "cli",
+          testUuid,
+          "test prompt",
+          "--artifact-name",
+          "test-artifact",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        chalk.red("\n✗ Sandbox terminated unexpectedly (status: timeout)"),
+      );
+    });
+
+    it("should handle completed status without result event", async () => {
+      vi.mocked(apiClient.createRun).mockResolvedValue({
+        runId: "run-123",
+        status: "running",
+        sandboxId: "sbx-456",
+        output: "",
+        executionTimeMs: 0,
+        createdAt: "2025-01-01T00:00:00Z",
+      });
+
+      // Return no events but status is "completed" - edge case
+      vi.mocked(apiClient.getEvents).mockResolvedValue({
+        events: [],
+        hasMore: false,
+        nextSequence: 0,
+        status: "completed",
+      });
+
+      await expect(async () => {
+        await runCommand.parseAsync([
+          "node",
+          "cli",
+          testUuid,
+          "test prompt",
+          "--artifact-name",
+          "test-artifact",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        chalk.yellow(
+          "\n⚠ Run completed but no result event received. This may indicate an issue.",
+        ),
+      );
+    });
   });
 });

--- a/turbo/apps/cli/src/commands/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/run.test.ts
@@ -80,6 +80,7 @@ describe("run command", () => {
         ],
         hasMore: false,
         nextSequence: 1,
+        status: "running",
       });
 
       await runCommand.parseAsync([
@@ -134,6 +135,7 @@ describe("run command", () => {
         ],
         hasMore: false,
         nextSequence: 1,
+        status: "running",
       });
 
       await runCommand.parseAsync([
@@ -216,6 +218,7 @@ describe("run command", () => {
         ],
         hasMore: false,
         nextSequence: 1,
+        status: "running",
       });
 
       await runCommand.parseAsync([
@@ -270,6 +273,7 @@ describe("run command", () => {
         ],
         hasMore: false,
         nextSequence: 1,
+        status: "running",
       });
 
       await runCommand.parseAsync([
@@ -347,6 +351,7 @@ describe("run command", () => {
         ],
         hasMore: false,
         nextSequence: 1,
+        status: "running",
       });
     });
 
@@ -502,6 +507,7 @@ describe("run command", () => {
         ],
         hasMore: false,
         nextSequence: 1,
+        status: "running",
       });
     });
 
@@ -681,131 +687,6 @@ describe("run command", () => {
     });
   });
 
-  describe("timeout option", () => {
-    beforeEach(() => {
-      vi.mocked(apiClient.createRun).mockResolvedValue({
-        runId: "run-123",
-        status: "completed",
-        sandboxId: "sbx-456",
-        output: "Success",
-        executionTimeMs: 1000,
-        createdAt: "2025-01-01T00:00:00Z",
-      });
-
-      vi.mocked(apiClient.getEvents).mockResolvedValue({
-        events: [
-          {
-            sequenceNumber: 1,
-            eventType: "vm0_result",
-            eventData: { type: "vm0_result", success: true, result: "Done" },
-            createdAt: "2025-01-01T00:00:00Z",
-          },
-        ],
-        hasMore: false,
-        nextSequence: 1,
-      });
-    });
-
-    it("should accept custom timeout value", async () => {
-      await runCommand.parseAsync([
-        "node",
-        "cli",
-        testUuid,
-        "test prompt",
-        "--artifact-name",
-        "test-artifact",
-        "-t",
-        "30",
-      ]);
-
-      expect(apiClient.createRun).toHaveBeenCalled();
-    });
-
-    it("should accept timeout with long form --timeout", async () => {
-      await runCommand.parseAsync([
-        "node",
-        "cli",
-        testUuid,
-        "test prompt",
-        "--artifact-name",
-        "test-artifact",
-        "--timeout",
-        "120",
-      ]);
-
-      expect(apiClient.createRun).toHaveBeenCalled();
-    });
-
-    it("should reject invalid timeout value (non-numeric)", async () => {
-      await expect(async () => {
-        await runCommand.parseAsync([
-          "node",
-          "cli",
-          testUuid,
-          "test prompt",
-          "--artifact-name",
-          "test-artifact",
-          "-t",
-          "invalid",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Invalid timeout value"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should accept zero timeout value (no timeout)", async () => {
-      await runCommand.parseAsync([
-        "node",
-        "cli",
-        testUuid,
-        "test prompt",
-        "--artifact-name",
-        "test-artifact",
-        "-t",
-        "0",
-      ]);
-
-      expect(apiClient.createRun).toHaveBeenCalled();
-    });
-
-    it("should reject negative timeout value", async () => {
-      await expect(async () => {
-        await runCommand.parseAsync([
-          "node",
-          "cli",
-          testUuid,
-          "test prompt",
-          "--artifact-name",
-          "test-artifact",
-          "-t",
-          "-10",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Invalid timeout value"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should use default timeout (120 seconds) when not specified", async () => {
-      await runCommand.parseAsync([
-        "node",
-        "cli",
-        testUuid,
-        "test prompt",
-        "--artifact-name",
-        "test-artifact",
-      ]);
-
-      // Command should complete successfully with default timeout
-      expect(apiClient.createRun).toHaveBeenCalled();
-    });
-  });
-
   describe("event polling", () => {
     beforeEach(() => {
       // Mock EventRenderer to track render calls
@@ -861,6 +742,7 @@ describe("run command", () => {
           ],
           hasMore: false,
           nextSequence: 1,
+          status: "running",
         })
         .mockResolvedValueOnce({
           events: [
@@ -879,6 +761,7 @@ describe("run command", () => {
           ],
           hasMore: false,
           nextSequence: 3,
+          status: "running",
         });
 
       await runCommand.parseAsync([
@@ -925,6 +808,7 @@ describe("run command", () => {
         ],
         hasMore: false,
         nextSequence: 2,
+        status: "running",
       });
 
       await runCommand.parseAsync([
@@ -969,6 +853,7 @@ describe("run command", () => {
         ],
         hasMore: false,
         nextSequence: 1,
+        status: "running",
       });
 
       await runCommand.parseAsync([
@@ -1029,6 +914,7 @@ describe("run command", () => {
         ],
         hasMore: false,
         nextSequence: 2,
+        status: "running",
       });
 
       await runCommand.parseAsync([
@@ -1067,6 +953,7 @@ describe("run command", () => {
           ],
           hasMore: false,
           nextSequence: 1,
+          status: "running",
         })
         .mockRejectedValueOnce(new Error("Network error"));
 

--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -166,11 +166,7 @@ export const cookCommand = new Command()
   .name("cook")
   .description("One-click agent preparation and execution from vm0.yaml")
   .argument("[prompt]", "Prompt for the agent")
-  .option(
-    "-t, --timeout <seconds>",
-    "Timeout in seconds without new events for agent run, 0 = no timeout (default: 120)",
-  )
-  .action(async (prompt: string | undefined, options: { timeout?: string }) => {
+  .action(async (prompt: string | undefined) => {
     const cwd = process.cwd();
 
     // Step 1: Read and parse config
@@ -321,7 +317,6 @@ export const cookCommand = new Command()
           agentName,
           "--artifact-name",
           ARTIFACT_DIR,
-          ...(options.timeout ? ["--timeout", options.timeout] : []),
           prompt,
         ];
         runOutput = await execVm0RunWithCapture(runArgs, { cwd });

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -134,7 +134,7 @@ async function pollEvents(
 
     // If no new events and not complete, check sandbox status and wait
     if (response.events.length === 0 && !complete) {
-      // Check if sandbox was terminated
+      // Check if sandbox was terminated unexpectedly
       if (response.status === "failed" || response.status === "timeout") {
         console.error(
           chalk.red(
@@ -142,6 +142,16 @@ async function pollEvents(
           ),
         );
         throw new Error(`Sandbox terminated: ${response.status}`);
+      }
+
+      // Edge case: run completed but no result event received
+      if (response.status === "completed") {
+        console.error(
+          chalk.yellow(
+            "\n⚠ Run completed but no result event received. This may indicate an issue.",
+          ),
+        );
+        return { succeeded: false };
       }
 
       await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -68,8 +68,6 @@ function parseIdentifier(identifier: string): {
   return { name: identifier };
 }
 
-const DEFAULT_TIMEOUT_SECONDS = 120;
-
 interface PollOptions {
   verbose?: boolean;
   startTimestamp: Date;
@@ -87,33 +85,17 @@ interface PollResult {
  */
 async function pollEvents(
   runId: string,
-  timeoutSeconds: number,
   options: PollOptions,
 ): Promise<PollResult> {
   let nextSequence = -1;
   let complete = false;
   let result: PollResult = { succeeded: true };
   const pollIntervalMs = 500;
-  const timeoutMs = timeoutSeconds * 1000;
-  let lastEventTime = Date.now();
   const startTimestamp = options.startTimestamp;
   let previousTimestamp = startTimestamp;
   const verbose = options.verbose;
 
   while (!complete) {
-    // Check timeout since last event (skip if timeout is 0 = no timeout)
-    if (timeoutSeconds > 0) {
-      const timeSinceLastEvent = Date.now() - lastEventTime;
-      if (timeSinceLastEvent > timeoutMs) {
-        console.error(
-          chalk.red(
-            `\n✗ Agent execution timed out after ${timeoutSeconds} seconds without receiving new events`,
-          ),
-        );
-        throw new Error("Agent execution timed out");
-      }
-    }
-
     const response = await apiClient.getEvents(runId, {
       since: nextSequence,
     });
@@ -150,13 +132,18 @@ async function pollEvents(
 
     nextSequence = response.nextSequence;
 
-    // Reset timeout timer when we receive events
-    if (response.events.length > 0) {
-      lastEventTime = Date.now();
-    }
-
-    // If no new events and not complete, wait before next poll
+    // If no new events and not complete, check sandbox status and wait
     if (response.events.length === 0 && !complete) {
+      // Check if sandbox was terminated
+      if (response.status === "failed" || response.status === "timeout") {
+        console.error(
+          chalk.red(
+            `\n✗ Sandbox terminated unexpectedly (status: ${response.status})`,
+          ),
+        );
+        throw new Error(`Sandbox terminated: ${response.status}`);
+      }
+
       await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
     }
   }
@@ -235,11 +222,6 @@ const runCmd = new Command()
     "--conversation <id>",
     "Resume from conversation ID (for fine-grained control)",
   )
-  .option(
-    "-t, --timeout <seconds>",
-    "Timeout in seconds without new events, 0 = no timeout (default: 120)",
-    String(DEFAULT_TIMEOUT_SECONDS),
-  )
   .option("-v, --verbose", "Show verbose output with timing information")
   .action(
     async (
@@ -251,21 +233,10 @@ const runCmd = new Command()
         artifactVersion?: string;
         volumeVersion: Record<string, string>;
         conversation?: string;
-        timeout: string;
         verbose?: boolean;
       },
     ) => {
       const startTimestamp = new Date(); // Capture command start time for elapsed calculation
-
-      const timeoutSeconds = parseInt(options.timeout, 10);
-      if (isNaN(timeoutSeconds) || timeoutSeconds < 0) {
-        console.error(
-          chalk.red(
-            "✗ Invalid timeout value. Must be a non-negative number (0 = no timeout).",
-          ),
-        );
-        process.exit(1);
-      }
 
       // Validate artifact-name is provided for non-resume runs
       if (!options.artifactName) {
@@ -396,7 +367,7 @@ const runCmd = new Command()
         });
 
         // 4. Poll for events and exit with appropriate code
-        const result = await pollEvents(response.runId, timeoutSeconds, {
+        const result = await pollEvents(response.runId, {
           verbose,
           startTimestamp,
         });
@@ -439,17 +410,12 @@ runCmd
     collectVolumeVersions,
     {},
   )
-  .option(
-    "-t, --timeout <seconds>",
-    "Timeout in seconds without new events, 0 = no timeout (default: 120)",
-    String(DEFAULT_TIMEOUT_SECONDS),
-  )
   .option("-v, --verbose", "Show verbose output with timing information")
   .action(
     async (
       checkpointId: string,
       prompt: string,
-      options: { timeout: string; verbose?: boolean },
+      options: { verbose?: boolean },
       command: { optsWithGlobals: () => Record<string, unknown> },
     ) => {
       const startTimestamp = new Date(); // Capture command start time for elapsed calculation
@@ -458,18 +424,8 @@ runCmd
       // the option value goes to parent. Use optsWithGlobals() to get all options.
       const allOpts = command.optsWithGlobals() as {
         volumeVersion: Record<string, string>;
-        timeout: string;
         verbose?: boolean;
       };
-      const timeoutSeconds = parseInt(options.timeout, 10);
-      if (isNaN(timeoutSeconds) || timeoutSeconds < 0) {
-        console.error(
-          chalk.red(
-            "✗ Invalid timeout value. Must be a non-negative number (0 = no timeout).",
-          ),
-        );
-        process.exit(1);
-      }
 
       const verbose = options.verbose || allOpts.verbose;
 
@@ -509,7 +465,7 @@ runCmd
         });
 
         // 4. Poll for events and exit with appropriate code
-        const result = await pollEvents(response.runId, timeoutSeconds, {
+        const result = await pollEvents(response.runId, {
           verbose,
           startTimestamp,
         });
@@ -551,17 +507,12 @@ runCmd
     collectVolumeVersions,
     {},
   )
-  .option(
-    "-t, --timeout <seconds>",
-    "Timeout in seconds without new events, 0 = no timeout (default: 120)",
-    String(DEFAULT_TIMEOUT_SECONDS),
-  )
   .option("-v, --verbose", "Show verbose output with timing information")
   .action(
     async (
       agentSessionId: string,
       prompt: string,
-      options: { timeout: string; verbose?: boolean },
+      options: { verbose?: boolean },
       command: { optsWithGlobals: () => Record<string, unknown> },
     ) => {
       const startTimestamp = new Date(); // Capture command start time for elapsed calculation
@@ -570,18 +521,8 @@ runCmd
       // the option value goes to parent. Use optsWithGlobals() to get all options.
       const allOpts = command.optsWithGlobals() as {
         volumeVersion: Record<string, string>;
-        timeout: string;
         verbose?: boolean;
       };
-      const timeoutSeconds = parseInt(options.timeout, 10);
-      if (isNaN(timeoutSeconds) || timeoutSeconds < 0) {
-        console.error(
-          chalk.red(
-            "✗ Invalid timeout value. Must be a non-negative number (0 = no timeout).",
-          ),
-        );
-        process.exit(1);
-      }
 
       const verbose = options.verbose || allOpts.verbose;
 
@@ -622,7 +563,7 @@ runCmd
         });
 
         // 4. Poll for events and exit with appropriate code
-        const result = await pollEvents(response.runId, timeoutSeconds, {
+        const result = await pollEvents(response.runId, {
           verbose,
           startTimestamp,
         });

--- a/turbo/apps/cli/src/lib/api-client.ts
+++ b/turbo/apps/cli/src/lib/api-client.ts
@@ -53,6 +53,13 @@ export interface ApiError {
   };
 }
 
+export type RunStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "timeout";
+
 export interface GetEventsResponse {
   events: Array<{
     sequenceNumber: number;
@@ -62,7 +69,7 @@ export interface GetEventsResponse {
   }>;
   hasMore: boolean;
   nextSequence: number;
-  status: string;
+  status: RunStatus;
 }
 
 export interface GetComposeVersionResponse {

--- a/turbo/apps/cli/src/lib/api-client.ts
+++ b/turbo/apps/cli/src/lib/api-client.ts
@@ -62,6 +62,7 @@ export interface GetEventsResponse {
   }>;
   hasMore: boolean;
   nextSequence: number;
+  status: string;
 }
 
 export interface GetComposeVersionResponse {

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
@@ -22,6 +22,7 @@ export interface EventsResponse {
   }>;
   hasMore: boolean;
   nextSequence: number;
+  status: string;
 }
 
 /**
@@ -89,6 +90,7 @@ export async function GET(
       })),
       hasMore,
       nextSequence,
+      status: run.status,
     };
 
     return successResponse(response);

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
@@ -13,6 +13,13 @@ import {
   UnauthorizedError,
 } from "../../../../../../src/lib/errors";
 
+export type RunStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "timeout";
+
 export interface EventsResponse {
   events: Array<{
     sequenceNumber: number;
@@ -22,7 +29,7 @@ export interface EventsResponse {
   }>;
   hasMore: boolean;
   nextSequence: number;
-  status: string;
+  status: RunStatus;
 }
 
 /**
@@ -90,7 +97,7 @@ export async function GET(
       })),
       hasMore,
       nextSequence,
-      status: run.status,
+      status: run.status as RunStatus,
     };
 
     return successResponse(response);


### PR DESCRIPTION
## Summary
- Remove `--timeout` option from `run`, `run resume`, `run continue`, and `cook` commands
- Add `status` field to events API response for sandbox status detection
- CLI now detects sandbox termination (status: `failed`/`timeout`) during polling and exits with error message
- CLI polls indefinitely until agent completes or sandbox is terminated

## Changes
### API Changes
- `GET /api/agent/runs/{id}/events` now includes `status` field in response

### CLI Changes
- Removed `-t, --timeout` option from all run and cook commands
- `pollEvents()` now checks sandbox status when no new events received
- Clear error message when sandbox is terminated unexpectedly

## Test plan
- [x] CLI type check passes
- [x] CLI unit tests pass (217 tests)
- [x] Web type check passes
- [x] Lint passes
- [ ] Manual test: Run agent and verify normal completion
- [ ] Manual test: Verify CLI exits with error when sandbox terminates

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)