### PR TITLE
test: remove image-service import from e2b-service

### DIFF
--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -4,7 +4,7 @@ import { e2bConfig } from "./config";
 import type { RunResult } from "./types";
 import { storageService } from "../storage/storage-service";
 import { BadRequestError } from "../errors";
-import { resolveImageAlias } from "../image/image-service";
+// REMOVED for CI debugging: import { resolveImageAlias } from "../image/image-service";
 import type {
   AgentVolumeConfig,
   PreparedArtifact,
@@ -249,7 +249,6 @@ export class E2BService {
       sandbox = await this.createSandbox(
         sandboxEnvVars,
         agentCompose as AgentComposeYaml | undefined,
-        context.userId || "",
       );
       log.debug(`Sandbox created: ${sandbox.sandboxId}`);
 
@@ -402,12 +401,11 @@ export class E2BService {
    * Create E2B sandbox with Claude Code and environment variables
    * @param envVars Environment variables to pass to sandbox
    * @param agentCompose Agent compose containing image specification
-   * @param userId User ID for resolving user-owned images
+   * NOTE: userId parameter removed for CI debugging - using direct template name
    */
   private async createSandbox(
     envVars: Record<string, string>,
-    agentCompose: AgentComposeYaml | undefined,
-    userId: string,
+    agentCompose?: AgentComposeYaml,
   ): Promise<Sandbox> {
     // Use 24 hour timeout for Vercel production, 1 hour for other environments
     const isVercelProduction = process.env.VERCEL_ENV === "production";
@@ -420,29 +418,20 @@ export class E2BService {
 
     // Priority: agent.image > E2B_TEMPLATE_NAME
     const agent = getFirstAgent(agentCompose);
-    const imageAlias = agent?.image || e2bConfig.defaultTemplate;
+    const templateName = agent?.image || e2bConfig.defaultTemplate;
 
-    if (!imageAlias) {
+    if (!templateName) {
       throw new Error(
         "[E2B] No template specified. Either set agent.image in vm0.config.yaml or E2B_TEMPLATE_NAME environment variable.",
       );
     }
 
-    // Resolve user image aliases to E2B template names
-    // System templates (vm0-*) pass through unchanged
-    // User images (my-agent) resolve to user-{userId}-my-agent
-    const resolved = await resolveImageAlias(userId, imageAlias);
-    if (!resolved) {
-      throw new BadRequestError(
-        `Image "${imageAlias}" not found or not ready. Check the image status with 'vm0 image status'.`,
-      );
-    }
-
-    const templateName = resolved.templateName;
+    // REMOVED for CI debugging: resolveImageAlias call
+    // Just use templateName directly (reverted to main branch behavior)
 
     log.debug(`Using template: ${templateName}`);
     log.debug(
-      `Template source: ${agent?.image ? "agent.image" : "E2B_TEMPLATE_NAME"}, isUserImage: ${resolved.isUserImage}`,
+      `Template source: ${agent?.image ? "agent.image" : "E2B_TEMPLATE_NAME"}`,
     );
     log.debug(
       `Sandbox timeout: ${timeoutMs / 3_600_000}h (VERCEL_ENV=${process.env.VERCEL_ENV || "undefined"})`,


### PR DESCRIPTION
## Summary

Test PR to isolate CI timeout issue from PR #408.

**Changes:**
- Remove `resolveImageAlias` import from `e2b-service.ts`
- Revert `createSandbox` to use direct template name (main branch behavior)

**If CI passes:** The `image-service.ts` module import is causing the issue.

**If CI fails:** The issue is elsewhere in PR #408.

## Test plan

- [ ] Wait for CI to complete
- [ ] Check if API routes respond without timeout

---
Base branch: `feature/issue-406-image-build` (PR #408's branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)