### PR TITLE
fix(web): use entry.message instead of toString() for E2B build logs

### DIFF
--- a/turbo/apps/web/app/api/images/[imageId]/builds/[buildId]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/images/[imageId]/builds/[buildId]/__tests__/route.test.ts
@@ -28,7 +28,7 @@ vi.mock("e2b", () => ({
       }),
       getBuildStatus: vi.fn().mockResolvedValue({
         status: "building",
-        logEntries: [{ toString: () => "Building layer 1..." }],
+        logEntries: [{ message: "Building layer 1...", level: "info", timestamp: new Date().toISOString() }],
       }),
       delete: vi.fn().mockResolvedValue(undefined),
     },

--- a/turbo/apps/web/app/api/images/[imageId]/builds/[buildId]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/images/[imageId]/builds/[buildId]/__tests__/route.test.ts
@@ -28,7 +28,13 @@ vi.mock("e2b", () => ({
       }),
       getBuildStatus: vi.fn().mockResolvedValue({
         status: "building",
-        logEntries: [{ message: "Building layer 1...", level: "info", timestamp: new Date().toISOString() }],
+        logEntries: [
+          {
+            message: "Building layer 1...",
+            level: "info",
+            timestamp: new Date().toISOString(),
+          },
+        ],
       }),
       delete: vi.fn().mockResolvedValue(undefined),
     },

--- a/turbo/apps/web/src/lib/image/image-service.ts
+++ b/turbo/apps/web/src/lib/image/image-service.ts
@@ -109,7 +109,7 @@ export async function getBuildStatus(
 
   // Map E2B status to our status enum
   const status: ImageStatusEnum = e2bStatus.status as ImageStatusEnum;
-  const logs = e2bStatus.logEntries.map((entry) => entry.toString());
+  const logs = e2bStatus.logEntries.map((entry) => entry.message);
   const newLogsOffset = logsOffset + logs.length;
 
   // Extract error message from logs if build failed


### PR DESCRIPTION
## Summary
- Fix `[object Object]` being displayed instead of actual build logs in `vm0 image build`
- E2B SDK's `logEntries` are objects with a `message` property, not methods with `toString()`
- Update test mock to match correct E2B log entry structure

## Test plan
- [x] Type check passes
- [x] Unit tests pass
- [ ] Manual test: `vm0 image build -f Dockerfile -n test-image` shows actual log content

🤖 Generated with [Claude Code](https://claude.com/claude-code)