### PR TITLE
fix: rename VERCEL_CRON_SECRET to CRON_SECRET for Vercel cron authentication

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -105,7 +105,7 @@ jobs:
             AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
             S3_USER_STORAGES_NAME=${{ secrets.S3_USER_STORAGES_NAME }}
             SECRETS_ENCRYPTION_KEY=${{ secrets.SECRETS_ENCRYPTION_KEY }}
-            VERCEL_CRON_SECRET=${{ secrets.VERCEL_CRON_SECRET }}
+            CRON_SECRET=${{ secrets.CRON_SECRET }}
 
   # Deploy docs app to production
   deploy-docs-production:

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
@@ -38,7 +38,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     initServices();
 
     // Set CRON_SECRET for tests
-    process.env.VERCEL_CRON_SECRET = cronSecret;
+    process.env.CRON_SECRET = cronSecret;
 
     // Clean up any existing test data
     await globalThis.services.db
@@ -102,7 +102,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       .delete(agentComposes)
       .where(eq(agentComposes.id, testComposeId));
 
-    delete process.env.VERCEL_CRON_SECRET;
+    delete process.env.CRON_SECRET;
   });
 
   describe("Authentication", () => {

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
@@ -40,9 +40,9 @@ export async function GET(request: NextRequest) {
   try {
     initServices();
 
-    // Verify cron secret (Vercel adds this header for cron jobs)
+    // Verify cron secret (Vercel automatically injects CRON_SECRET into Authorization header)
     const authHeader = request.headers.get("authorization");
-    const cronSecret = process.env.VERCEL_CRON_SECRET;
+    const cronSecret = process.env.CRON_SECRET;
 
     if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
       throw new UnauthorizedError("Invalid cron secret");

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -24,7 +24,7 @@
     "S3_USER_STORAGES_NAME",
     "SECRETS_ENCRYPTION_KEY",
     "USE_MOCK_CLAUDE",
-    "VERCEL_CRON_SECRET"
+    "CRON_SECRET"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary

- Rename `VERCEL_CRON_SECRET` to `CRON_SECRET` in route handler, tests, turbo.json, and GitHub Actions workflow
- Vercel only recognizes the environment variable named `CRON_SECRET` and automatically injects its value into the Authorization header when invoking cron job endpoints

## Test plan

- [ ] Add `CRON_SECRET` to GitHub Secrets with value: `694d3c83807f0c20fc531a5d08d091f5a55e97971cdab642ffeca083cd43d05e`
- [ ] Deploy to production
- [ ] Verify cron job no longer returns 401 Unauthorized error

🤖 Generated with [Claude Code](https://claude.com/claude-code)