### PR TITLE
feat(image): add E2B template deletion and improve error handling

### DIFF
--- a/e2e/tests/02-commands/t14-vm0-image-build.bats
+++ b/e2e/tests/02-commands/t14-vm0-image-build.bats
@@ -10,10 +10,9 @@ load '../../helpers/setup'
 setup() {
     export TEST_DOCKERFILE="${TEST_ROOT}/fixtures/dockerfiles/Dockerfile.simple"
     export TEST_TMP_DIR="$(mktemp -d)"
-    # Use unique name with timestamp to avoid E2B buildInBackground alias conflict bug
-    # E2B buildInBackground returns 403 for existing aliases, even with --delete-existing
+    # Use fixed name with --delete-existing to test the delete functionality
     # See: https://github.com/vm0-ai/vm0/issues/428
-    export TEST_IMAGE_NAME="e2e-img-$(date +%s)"
+    export TEST_IMAGE_NAME="e2e-image-test"
 }
 
 teardown() {
@@ -70,8 +69,8 @@ teardown() {
 # ============================================
 
 @test "vm0 image build submits build request successfully" {
-    # Submit build request with unique name to avoid E2B alias conflict
-    run $CLI_COMMAND image build --file "$TEST_DOCKERFILE" --name "$TEST_IMAGE_NAME"
+    # Submit build request with --delete-existing to test delete functionality
+    run $CLI_COMMAND image build --file "$TEST_DOCKERFILE" --name "$TEST_IMAGE_NAME" --delete-existing
 
     # Build should start successfully
     assert_success

--- a/e2e/tests/02-commands/t14-vm0-image-build.bats
+++ b/e2e/tests/02-commands/t14-vm0-image-build.bats
@@ -10,7 +10,8 @@ load '../../helpers/setup'
 setup() {
     export TEST_DOCKERFILE="${TEST_ROOT}/fixtures/dockerfiles/Dockerfile.simple"
     export TEST_TMP_DIR="$(mktemp -d)"
-    # Use fixed name - E2B supports rebuilding with same alias
+    # Use fixed name with --delete-existing flag to handle E2B buildInBackground bug
+    # See: https://github.com/vm0-ai/vm0/issues/428
     export TEST_IMAGE_NAME="e2e-image-test"
 }
 
@@ -68,8 +69,8 @@ teardown() {
 # ============================================
 
 @test "vm0 image build submits build request successfully" {
-    # Submit build request
-    run $CLI_COMMAND image build --file "$TEST_DOCKERFILE" --name "$TEST_IMAGE_NAME"
+    # Submit build request with --delete-existing to handle E2B buildInBackground bug
+    run $CLI_COMMAND image build --file "$TEST_DOCKERFILE" --name "$TEST_IMAGE_NAME" --delete-existing
 
     # Build should start successfully
     assert_success

--- a/e2e/tests/02-commands/t14-vm0-image-build.bats
+++ b/e2e/tests/02-commands/t14-vm0-image-build.bats
@@ -10,9 +10,8 @@ load '../../helpers/setup'
 setup() {
     export TEST_DOCKERFILE="${TEST_ROOT}/fixtures/dockerfiles/Dockerfile.simple"
     export TEST_TMP_DIR="$(mktemp -d)"
-    # Use unique name per test run
-    # Note: Fixed names cause 500 errors in CI (needs investigation)
-    export TEST_IMAGE_NAME="e2e-test-$(date +%s)"
+    # Use fixed name - E2B supports rebuilding with same alias
+    export TEST_IMAGE_NAME="e2e-image-test"
 }
 
 teardown() {

--- a/e2e/tests/02-commands/t14-vm0-image-build.bats
+++ b/e2e/tests/02-commands/t14-vm0-image-build.bats
@@ -10,9 +10,10 @@ load '../../helpers/setup'
 setup() {
     export TEST_DOCKERFILE="${TEST_ROOT}/fixtures/dockerfiles/Dockerfile.simple"
     export TEST_TMP_DIR="$(mktemp -d)"
-    # Use fixed name with --delete-existing flag to handle E2B buildInBackground bug
+    # Use unique name with timestamp to avoid E2B buildInBackground alias conflict bug
+    # E2B buildInBackground returns 403 for existing aliases, even with --delete-existing
     # See: https://github.com/vm0-ai/vm0/issues/428
-    export TEST_IMAGE_NAME="e2e-image-test"
+    export TEST_IMAGE_NAME="e2e-img-$(date +%s)"
 }
 
 teardown() {
@@ -69,8 +70,8 @@ teardown() {
 # ============================================
 
 @test "vm0 image build submits build request successfully" {
-    # Submit build request with --delete-existing to handle E2B buildInBackground bug
-    run $CLI_COMMAND image build --file "$TEST_DOCKERFILE" --name "$TEST_IMAGE_NAME" --delete-existing
+    # Submit build request with unique name to avoid E2B alias conflict
+    run $CLI_COMMAND image build --file "$TEST_DOCKERFILE" --name "$TEST_IMAGE_NAME"
 
     # Build should start successfully
     assert_success

--- a/turbo/apps/cli/src/commands/image/build.ts
+++ b/turbo/apps/cli/src/commands/image/build.ts
@@ -19,110 +19,119 @@ export const buildCommand = new Command()
   .requiredOption("-f, --file <path>", "Path to Dockerfile")
   .requiredOption("-n, --name <name>", "Name for the image")
   .option("--delete-existing", "Delete existing image before building")
-  .action(async (options: { file: string; name: string; deleteExisting?: boolean }) => {
-    const { file, name, deleteExisting } = options;
+  .action(
+    async (options: {
+      file: string;
+      name: string;
+      deleteExisting?: boolean;
+    }) => {
+      const { file, name, deleteExisting } = options;
 
-    // Validate file exists
-    if (!existsSync(file)) {
-      console.error(chalk.red(`✗ Dockerfile not found: ${file}`));
-      process.exit(1);
-    }
-
-    // Validate name format: 3-64 chars, alphanumeric and hyphens, start/end with alphanumeric
-    const nameRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/;
-    if (!nameRegex.test(name)) {
-      console.error(
-        chalk.red(
-          "✗ Invalid name format. Must be 3-64 characters, letters, numbers, and hyphens only.",
-        ),
-      );
-      process.exit(1);
-    }
-
-    // Check reserved prefix
-    if (name.startsWith("vm0-")) {
-      console.error(
-        chalk.red(
-          '✗ Invalid name. Cannot start with "vm0-" (reserved prefix).',
-        ),
-      );
-      process.exit(1);
-    }
-
-    try {
-      // Read Dockerfile content
-      const dockerfile = await readFile(file, "utf8");
-
-      console.log(chalk.blue(`Building image: ${name}`));
-      console.log(chalk.gray(`  Dockerfile: ${file}`));
-      console.log();
-
-      // Start build
-      const buildInfo = await apiClient.createImage({
-        dockerfile,
-        alias: name,
-        deleteExisting,
-      });
-      const { imageId, buildId } = buildInfo;
-
-      console.log(chalk.gray(`  Build ID: ${buildId}`));
-      console.log();
-
-      // Poll for status
-      let logsOffset = 0;
-      let status: "building" | "ready" | "error" = "building";
-
-      while (status === "building") {
-        const statusResponse = await apiClient.get(
-          `/api/images/${imageId}/builds/${buildId}?logsOffset=${logsOffset}`,
-        );
-
-        if (!statusResponse.ok) {
-          const error = await statusResponse.json();
-          throw new Error(
-            (error as { error?: { message?: string } }).error?.message ||
-              "Failed to get build status",
-          );
-        }
-
-        const statusData = (await statusResponse.json()) as BuildStatusResponse;
-
-        // Print new logs
-        for (const log of statusData.logs) {
-          console.log(chalk.gray(`  ${log}`));
-        }
-
-        logsOffset = statusData.logsOffset;
-        status = statusData.status;
-
-        if (status === "building") {
-          await sleep(2000);
-        }
-      }
-
-      console.log();
-
-      if (status === "ready") {
-        console.log(chalk.green(`✓ Image built: ${name}`));
-        console.log();
-        console.log("Use in vm0.yaml:");
-        console.log(chalk.cyan(`  agents:`));
-        console.log(chalk.cyan(`    your-agent:`));
-        console.log(chalk.cyan(`      image: "${name}"`));
-      } else {
-        console.error(chalk.red(`✗ Build failed`));
+      // Validate file exists
+      if (!existsSync(file)) {
+        console.error(chalk.red(`✗ Dockerfile not found: ${file}`));
         process.exit(1);
       }
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.message.includes("Not authenticated")) {
-          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
-        } else {
-          console.error(chalk.red(`✗ ${error.message}`));
-        }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
+
+      // Validate name format: 3-64 chars, alphanumeric and hyphens, start/end with alphanumeric
+      const nameRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/;
+      if (!nameRegex.test(name)) {
+        console.error(
+          chalk.red(
+            "✗ Invalid name format. Must be 3-64 characters, letters, numbers, and hyphens only.",
+          ),
+        );
+        process.exit(1);
       }
-      process.exit(1);
-    }
-  });
+
+      // Check reserved prefix
+      if (name.startsWith("vm0-")) {
+        console.error(
+          chalk.red(
+            '✗ Invalid name. Cannot start with "vm0-" (reserved prefix).',
+          ),
+        );
+        process.exit(1);
+      }
+
+      try {
+        // Read Dockerfile content
+        const dockerfile = await readFile(file, "utf8");
+
+        console.log(chalk.blue(`Building image: ${name}`));
+        console.log(chalk.gray(`  Dockerfile: ${file}`));
+        console.log();
+
+        // Start build
+        const buildInfo = await apiClient.createImage({
+          dockerfile,
+          alias: name,
+          deleteExisting,
+        });
+        const { imageId, buildId } = buildInfo;
+
+        console.log(chalk.gray(`  Build ID: ${buildId}`));
+        console.log();
+
+        // Poll for status
+        let logsOffset = 0;
+        let status: "building" | "ready" | "error" = "building";
+
+        while (status === "building") {
+          const statusResponse = await apiClient.get(
+            `/api/images/${imageId}/builds/${buildId}?logsOffset=${logsOffset}`,
+          );
+
+          if (!statusResponse.ok) {
+            const error = await statusResponse.json();
+            throw new Error(
+              (error as { error?: { message?: string } }).error?.message ||
+                "Failed to get build status",
+            );
+          }
+
+          const statusData =
+            (await statusResponse.json()) as BuildStatusResponse;
+
+          // Print new logs
+          for (const log of statusData.logs) {
+            console.log(chalk.gray(`  ${log}`));
+          }
+
+          logsOffset = statusData.logsOffset;
+          status = statusData.status;
+
+          if (status === "building") {
+            await sleep(2000);
+          }
+        }
+
+        console.log();
+
+        if (status === "ready") {
+          console.log(chalk.green(`✓ Image built: ${name}`));
+          console.log();
+          console.log("Use in vm0.yaml:");
+          console.log(chalk.cyan(`  agents:`));
+          console.log(chalk.cyan(`    your-agent:`));
+          console.log(chalk.cyan(`      image: "${name}"`));
+        } else {
+          console.error(chalk.red(`✗ Build failed`));
+          process.exit(1);
+        }
+      } catch (error) {
+        if (error instanceof Error) {
+          if (error.message.includes("Not authenticated")) {
+            console.error(
+              chalk.red("✗ Not authenticated. Run: vm0 auth login"),
+            );
+          } else {
+            console.error(chalk.red(`✗ ${error.message}`));
+          }
+        } else {
+          console.error(chalk.red("✗ An unexpected error occurred"));
+        }
+        process.exit(1);
+      }
+    },
+  );

--- a/turbo/apps/cli/src/commands/image/build.ts
+++ b/turbo/apps/cli/src/commands/image/build.ts
@@ -18,8 +18,9 @@ export const buildCommand = new Command()
   .description("Build a custom image from a Dockerfile")
   .requiredOption("-f, --file <path>", "Path to Dockerfile")
   .requiredOption("-n, --name <name>", "Name for the image")
-  .action(async (options: { file: string; name: string }) => {
-    const { file, name } = options;
+  .option("--delete-existing", "Delete existing image before building")
+  .action(async (options: { file: string; name: string; deleteExisting?: boolean }) => {
+    const { file, name, deleteExisting } = options;
 
     // Validate file exists
     if (!existsSync(file)) {
@@ -60,6 +61,7 @@ export const buildCommand = new Command()
       const buildInfo = await apiClient.createImage({
         dockerfile,
         alias: name,
+        deleteExisting,
       });
       const { imageId, buildId } = buildInfo;
 

--- a/turbo/apps/cli/src/lib/api-client.ts
+++ b/turbo/apps/cli/src/lib/api-client.ts
@@ -280,6 +280,7 @@ class ApiClient {
   async createImage(body: {
     dockerfile: string;
     alias: string;
+    deleteExisting?: boolean;
   }): Promise<CreateImageResponse> {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();

--- a/turbo/apps/web/app/api/images/[imageId]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/images/[imageId]/__tests__/route.test.ts
@@ -41,6 +41,7 @@ vi.mock("e2b", () => ({
   },
   ApiClient: vi.fn().mockImplementation(() => ({
     api: {
+      GET: vi.fn().mockResolvedValue({ data: [] }),
       DELETE: vi.fn().mockResolvedValue(undefined),
     },
   })),

--- a/turbo/apps/web/app/api/images/[imageId]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/images/[imageId]/__tests__/route.test.ts
@@ -33,6 +33,18 @@ vi.mock("e2b", () => ({
       delete: vi.fn().mockResolvedValue(undefined),
     },
   ),
+  BuildError: class BuildError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "BuildError";
+    }
+  },
+  ApiClient: vi.fn().mockImplementation(() => ({
+    api: {
+      DELETE: vi.fn().mockResolvedValue(undefined),
+    },
+  })),
+  ConnectionConfig: vi.fn(),
 }));
 
 describe("DELETE /api/images/:imageId", () => {

--- a/turbo/apps/web/app/api/images/[imageId]/builds/[buildId]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/images/[imageId]/builds/[buildId]/__tests__/route.test.ts
@@ -45,7 +45,12 @@ vi.mock("e2b", () => ({
       this.name = "BuildError";
     }
   },
-  ApiClient: vi.fn(),
+  ApiClient: vi.fn().mockImplementation(() => ({
+    api: {
+      GET: vi.fn().mockResolvedValue({ data: [] }),
+      DELETE: vi.fn().mockResolvedValue(undefined),
+    },
+  })),
   ConnectionConfig: vi.fn(),
 }));
 

--- a/turbo/apps/web/app/api/images/[imageId]/builds/[buildId]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/images/[imageId]/builds/[buildId]/__tests__/route.test.ts
@@ -39,6 +39,14 @@ vi.mock("e2b", () => ({
       delete: vi.fn().mockResolvedValue(undefined),
     },
   ),
+  BuildError: class BuildError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "BuildError";
+    }
+  },
+  ApiClient: vi.fn(),
+  ConnectionConfig: vi.fn(),
 }));
 
 describe("GET /api/images/:imageId/builds/:buildId", () => {

--- a/turbo/apps/web/app/api/images/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/images/__tests__/route.test.ts
@@ -32,6 +32,14 @@ vi.mock("e2b", () => ({
       delete: vi.fn().mockResolvedValue(undefined),
     },
   ),
+  BuildError: class BuildError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "BuildError";
+    }
+  },
+  ApiClient: vi.fn(),
+  ConnectionConfig: vi.fn(),
 }));
 
 describe("/api/images", () => {

--- a/turbo/apps/web/app/api/images/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/images/__tests__/route.test.ts
@@ -38,7 +38,12 @@ vi.mock("e2b", () => ({
       this.name = "BuildError";
     }
   },
-  ApiClient: vi.fn(),
+  ApiClient: vi.fn().mockImplementation(() => ({
+    api: {
+      GET: vi.fn().mockResolvedValue({ data: [] }),
+      DELETE: vi.fn().mockResolvedValue(undefined),
+    },
+  })),
   ConnectionConfig: vi.fn(),
 }));
 

--- a/turbo/apps/web/app/api/images/route.ts
+++ b/turbo/apps/web/app/api/images/route.ts
@@ -8,6 +8,8 @@ import {
   listImages,
   deleteImageByAlias,
   getImageByAlias,
+  generateE2bAlias,
+  tryDeleteE2bTemplateByAlias,
 } from "../../../src/lib/image/image-service";
 
 interface CreateImageRequest {
@@ -92,10 +94,16 @@ export async function POST(request: NextRequest) {
 
     // Delete existing image if requested
     if (deleteExisting) {
+      // First try to delete from our database
       const existingImage = await getImageByAlias(userId, alias);
       if (existingImage) {
         await deleteImageByAlias(userId, alias);
       }
+
+      // Also try to delete from E2B directly in case database record is stale
+      // This handles the case where DB was cleaned up but E2B template still exists
+      const e2bAlias = generateE2bAlias(userId, alias);
+      await tryDeleteE2bTemplateByAlias(e2bAlias);
     }
 
     // Start image build

--- a/turbo/apps/web/app/api/images/route.ts
+++ b/turbo/apps/web/app/api/images/route.ts
@@ -3,11 +3,17 @@ import { initServices } from "../../../src/lib/init-services";
 import { getUserId } from "../../../src/lib/auth/get-user-id";
 import { successResponse, errorResponse } from "../../../src/lib/api-response";
 import { BadRequestError, UnauthorizedError } from "../../../src/lib/errors";
-import { buildImage, listImages } from "../../../src/lib/image/image-service";
+import {
+  buildImage,
+  listImages,
+  deleteImageByAlias,
+  getImageByAlias,
+} from "../../../src/lib/image/image-service";
 
 interface CreateImageRequest {
   dockerfile: string;
   alias: string;
+  deleteExisting?: boolean;
 }
 
 interface CreateImageResponse {
@@ -59,7 +65,7 @@ export async function POST(request: NextRequest) {
     const body: CreateImageRequest = await request.json();
 
     // Validate request
-    const { dockerfile, alias } = body;
+    const { dockerfile, alias, deleteExisting } = body;
 
     if (!dockerfile) {
       throw new BadRequestError("Missing dockerfile");
@@ -82,6 +88,14 @@ export async function POST(request: NextRequest) {
       throw new BadRequestError(
         'Invalid alias. User images cannot start with "vm0-" prefix (reserved for system templates).',
       );
+    }
+
+    // Delete existing image if requested
+    if (deleteExisting) {
+      const existingImage = await getImageByAlias(userId, alias);
+      if (existingImage) {
+        await deleteImageByAlias(userId, alias);
+      }
     }
 
     // Start image build

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -53,7 +53,7 @@
     "@vm0/eslint-config": "workspace:*",
     "@vm0/typescript-config": "workspace:*",
     "drizzle-kit": "^0.31.4",
-    "e2b": "^2.7.0",
+    "e2b": "^2.8.3",
     "eslint": "^9.34.0",
     "jsdom": "^26.0.0",
     "tsx": "^4.20.5",

--- a/turbo/apps/web/src/lib/image/image-service.ts
+++ b/turbo/apps/web/src/lib/image/image-service.ts
@@ -22,6 +22,39 @@ export function isSystemTemplate(alias: string): boolean {
   return alias.startsWith("vm0-");
 }
 
+/**
+ * Try to delete an E2B template by its alias
+ * This is needed when database record doesn't exist but E2B template might
+ * Uses E2B API to list templates and find the one with matching alias
+ */
+export async function tryDeleteE2bTemplateByAlias(
+  e2bAlias: string,
+): Promise<void> {
+  const { ApiClient, ConnectionConfig } = await import("e2b");
+  const config = new ConnectionConfig({});
+  const client = new ApiClient(config);
+
+  try {
+    // List templates to find the one with this alias
+    const response = await client.api.GET("/templates");
+    if (!response.data) return;
+
+    const templates = response.data as Array<{
+      templateID: string;
+      aliases?: string[];
+    }>;
+    const template = templates.find((t) => t.aliases?.includes(e2bAlias));
+
+    if (template) {
+      await client.api.DELETE("/templates/{templateID}", {
+        params: { path: { templateID: template.templateID } },
+      });
+    }
+  } catch {
+    // Ignore errors - template may not exist or deletion may fail
+  }
+}
+
 interface BuildResult {
   imageId: string;
   buildId: string;

--- a/turbo/apps/web/src/lib/image/image-service.ts
+++ b/turbo/apps/web/src/lib/image/image-service.ts
@@ -39,11 +39,16 @@ export async function tryDeleteE2bTemplateByAlias(
     const response = await client.api.GET("/templates");
     if (!response.data) return;
 
+    // E2B API returns templates with either 'alias' (singular) or 'aliases' (array)
     const templates = response.data as Array<{
       templateID: string;
+      alias?: string;
       aliases?: string[];
     }>;
-    const template = templates.find((t) => t.aliases?.includes(e2bAlias));
+
+    const template = templates.find(
+      (t) => t.alias === e2bAlias || t.aliases?.includes(e2bAlias),
+    );
 
     if (template) {
       await client.api.DELETE("/templates/{templateID}", {

--- a/turbo/apps/web/src/lib/image/image-service.ts
+++ b/turbo/apps/web/src/lib/image/image-service.ts
@@ -2,7 +2,10 @@ import { eq, and, desc } from "drizzle-orm";
 
 import { images } from "../../db/schema/image";
 import { BadRequestError, NotFoundError, ForbiddenError } from "../errors";
+import { logger } from "../logger";
 import type { ImageStatusEnum } from "../../db/schema/image";
+
+const log = logger("service:image");
 
 // Note: E2B SDK is imported dynamically in functions that need it
 // to avoid loading the heavy SDK in routes that only use validation functions
@@ -34,13 +37,21 @@ export async function tryDeleteE2bTemplateByAlias(
   const config = new ConnectionConfig({});
   const client = new ApiClient(config);
 
+  log.debug("attempting to delete E2B template", { e2bAlias });
+
   try {
     // E2B API accepts alias as templateID - same as how buildInBackground uses alias
     await client.api.DELETE("/templates/{templateID}", {
       params: { path: { templateID: e2bAlias } },
     });
-  } catch {
-    // Ignore errors - template may not exist or deletion may fail
+    log.debug("E2B template deleted successfully", { e2bAlias });
+  } catch (error) {
+    // Template may not exist - this is expected when --delete-existing is used
+    // and the image has never been built before
+    log.debug("E2B template deletion skipped (may not exist)", {
+      e2bAlias,
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 }
 
@@ -65,6 +76,8 @@ export async function buildImage(
 
   const e2bAlias = generateE2bAlias(userId, alias);
 
+  log.debug("starting image build", { userId, alias, e2bAlias });
+
   // Create template from Dockerfile content
   const template = Template().fromDockerfile(dockerfile);
 
@@ -78,6 +91,7 @@ export async function buildImage(
     // Convert E2B BuildError to BadRequestError so it's returned to user
     if (error instanceof BuildError) {
       const message = error.message;
+      log.debug("E2B build error", { alias, e2bAlias, message });
       // Provide helpful message for alias conflict (E2B buildInBackground bug)
       if (message.includes("403") && message.includes("already used")) {
         throw new BadRequestError(
@@ -88,6 +102,13 @@ export async function buildImage(
     }
     throw error;
   }
+
+  log.debug("E2B build started", {
+    alias,
+    e2bAlias,
+    buildId: buildInfo.buildId,
+    templateId: buildInfo.templateId,
+  });
 
   // Insert record into database
   const [image] = await globalThis.services.db
@@ -112,6 +133,8 @@ export async function buildImage(
       },
     })
     .returning();
+
+  log.debug("image record created", { imageId: image!.id, alias });
 
   return {
     imageId: image!.id,
@@ -357,6 +380,8 @@ export async function deleteImage(
     throw new ForbiddenError("You don't have access to this image");
   }
 
+  log.debug("deleting image", { imageId, alias: image.alias, userId });
+
   // Delete from E2B
   if (image.e2bTemplateId) {
     const { ApiClient, ConnectionConfig } = await import("e2b");
@@ -367,13 +392,19 @@ export async function deleteImage(
       await client.api.DELETE("/templates/{templateID}", {
         params: { path: { templateID: image.e2bTemplateId } },
       });
-    } catch {
-      // Ignore E2B deletion errors - template may already be deleted
+      log.debug("E2B template deleted", { templateId: image.e2bTemplateId });
+    } catch (error) {
+      // Template may already be deleted on E2B side
+      log.debug("E2B template deletion failed (may already be deleted)", {
+        templateId: image.e2bTemplateId,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
   // Delete from database
   await globalThis.services.db.delete(images).where(eq(images.id, imageId));
+  log.debug("image deleted from database", { imageId });
 }
 
 /**

--- a/turbo/apps/web/src/lib/image/image-service.ts
+++ b/turbo/apps/web/src/lib/image/image-service.ts
@@ -55,7 +55,14 @@ export async function buildImage(
   } catch (error) {
     // Convert E2B BuildError to BadRequestError so it's returned to user
     if (error instanceof BuildError) {
-      throw new BadRequestError(error.message);
+      const message = error.message;
+      // Provide helpful message for alias conflict (E2B buildInBackground bug)
+      if (message.includes("403") && message.includes("already used")) {
+        throw new BadRequestError(
+          `Image "${alias}" already exists. Delete it first with: vm0 image delete ${alias}`,
+        );
+      }
+      throw new BadRequestError(message);
     }
     throw error;
   }
@@ -311,8 +318,7 @@ export async function getImageById(imageId: string) {
 
 /**
  * Delete an image by ID
- * Note: This only deletes from our database. E2B templates remain and will
- * be garbage collected by E2B based on their retention policy.
+ * Deletes from both our database and E2B
  */
 export async function deleteImage(
   userId: string,
@@ -329,7 +335,38 @@ export async function deleteImage(
     throw new ForbiddenError("You don't have access to this image");
   }
 
+  // Delete from E2B
+  if (image.e2bTemplateId) {
+    const { ApiClient, ConnectionConfig } = await import("e2b");
+    const config = new ConnectionConfig({});
+    const client = new ApiClient(config);
+
+    try {
+      await client.api.DELETE("/templates/{templateID}", {
+        params: { path: { templateID: image.e2bTemplateId } },
+      });
+    } catch {
+      // Ignore E2B deletion errors - template may already be deleted
+    }
+  }
+
   // Delete from database
-  // Note: E2B template cleanup is handled by E2B's retention policy
   await globalThis.services.db.delete(images).where(eq(images.id, imageId));
+}
+
+/**
+ * Delete an image by alias
+ * Deletes from both our database and E2B
+ */
+export async function deleteImageByAlias(
+  userId: string,
+  alias: string,
+): Promise<void> {
+  const image = await getImageByAlias(userId, alias);
+
+  if (!image) {
+    throw new NotFoundError(`Image "${alias}" not found`);
+  }
+
+  await deleteImage(userId, image.id);
 }

--- a/turbo/apps/web/src/lib/image/image-service.ts
+++ b/turbo/apps/web/src/lib/image/image-service.ts
@@ -39,7 +39,7 @@ export async function buildImage(
   alias: string,
 ): Promise<BuildResult> {
   // Dynamic import to avoid loading E2B SDK in routes that don't need it
-  const { Template } = await import("e2b");
+  const { Template, BuildError } = await import("e2b");
 
   const e2bAlias = generateE2bAlias(userId, alias);
 
@@ -47,9 +47,18 @@ export async function buildImage(
   const template = Template().fromDockerfile(dockerfile);
 
   // Start background build
-  const buildInfo = await Template.buildInBackground(template, {
-    alias: e2bAlias,
-  });
+  let buildInfo;
+  try {
+    buildInfo = await Template.buildInBackground(template, {
+      alias: e2bAlias,
+    });
+  } catch (error) {
+    // Convert E2B BuildError to BadRequestError so it's returned to user
+    if (error instanceof BuildError) {
+      throw new BadRequestError(error.message);
+    }
+    throw error;
+  }
 
   // Insert record into database
   const [image] = await globalThis.services.db

--- a/turbo/apps/web/src/lib/image/image-service.ts
+++ b/turbo/apps/web/src/lib/image/image-service.ts
@@ -25,7 +25,7 @@ export function isSystemTemplate(alias: string): boolean {
 /**
  * Try to delete an E2B template by its alias
  * This is needed when database record doesn't exist but E2B template might
- * Uses E2B API to list templates and find the one with matching alias
+ * E2B API accepts alias as templateID parameter (same as buildInBackground)
  */
 export async function tryDeleteE2bTemplateByAlias(
   e2bAlias: string,
@@ -35,26 +35,10 @@ export async function tryDeleteE2bTemplateByAlias(
   const client = new ApiClient(config);
 
   try {
-    // List templates to find the one with this alias
-    const response = await client.api.GET("/templates");
-    if (!response.data) return;
-
-    // E2B API returns templates with either 'alias' (singular) or 'aliases' (array)
-    const templates = response.data as Array<{
-      templateID: string;
-      alias?: string;
-      aliases?: string[];
-    }>;
-
-    const template = templates.find(
-      (t) => t.alias === e2bAlias || t.aliases?.includes(e2bAlias),
-    );
-
-    if (template) {
-      await client.api.DELETE("/templates/{templateID}", {
-        params: { path: { templateID: template.templateID } },
-      });
-    }
+    // E2B API accepts alias as templateID - same as how buildInBackground uses alias
+    await client.api.DELETE("/templates/{templateID}", {
+      params: { path: { templateID: e2bAlias } },
+    });
   } catch {
     // Ignore errors - template may not exist or deletion may fail
   }

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -246,8 +246,8 @@ importers:
         specifier: ^0.31.4
         version: 0.31.4
       e2b:
-        specifier: ^2.7.0
-        version: 2.7.0
+        specifier: ^2.8.3
+        version: 2.8.3
       eslint:
         specifier: ^9.34.0
         version: 9.34.0(jiti@2.6.1)
@@ -634,6 +634,10 @@ packages:
 
   '@babel/runtime@7.28.3':
     resolution: {integrity: sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
@@ -2749,6 +2753,10 @@ packages:
     resolution: {integrity: sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -3064,6 +3072,10 @@ packages:
 
   e2b@2.7.0:
     resolution: {integrity: sha512-pbCbkkdkkY+yIhhtdSE7lM/vhIROtHNI0hNpj8lBphDILNH2qmmjhxU7/wam8/xWRbiWbfuQaOsv100lD32nag==}
+    engines: {node: '>=20'}
+
+  e2b@2.8.3:
+    resolution: {integrity: sha512-P0hA5UceZ6HVfL9VDqQ0VG+IXZTy1K+FHek3xFkg7vSgcBm6wV9KG/YcvaoEdgiF+n1KS2TsIhunLs22jbrLyQ==}
     engines: {node: '>=20'}
 
   eastasianwidth@0.2.0:
@@ -3468,6 +3480,11 @@ packages:
 
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
     hasBin: true
 
@@ -6034,6 +6051,8 @@ snapshots:
 
   '@babel/runtime@7.28.3': {}
 
+  '@babel/runtime@7.28.4': {}
+
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -6143,7 +6162,7 @@ snapshots:
 
   '@e2b/code-interpreter@2.2.0':
     dependencies:
-      e2b: 2.7.0
+      e2b: 2.8.3
 
   '@emnapi/core@1.7.1':
     dependencies:
@@ -7560,7 +7579,7 @@ snapshots:
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -7876,7 +7895,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -8118,6 +8137,8 @@ snapshots:
 
   chalk@5.6.0: {}
 
+  chalk@5.6.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -8334,6 +8355,19 @@ snapshots:
       compare-versions: 6.1.1
       dockerfile-ast: 0.7.1
       glob: 11.0.3
+      openapi-fetch: 0.14.1
+      platform: 1.3.6
+      tar: 7.5.2
+
+  e2b@2.8.3:
+    dependencies:
+      '@bufbuild/protobuf': 2.10.1
+      '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.10.1)
+      '@connectrpc/connect-web': 2.0.0-rc.3(@bufbuild/protobuf@2.10.1)(@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.10.1))
+      chalk: 5.6.2
+      compare-versions: 6.1.1
+      dockerfile-ast: 0.7.1
+      glob: 11.1.0
       openapi-fetch: 0.14.1
       platform: 1.3.6
       tar: 7.5.2
@@ -8932,6 +8966,15 @@ snapshots:
       path-scurry: 1.11.1
 
   glob@11.0.3:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.1.1
+      minimatch: 10.1.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.1
+
+  glob@11.1.0:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1


### PR DESCRIPTION
## Summary
- Upgrade E2B SDK from 2.7.0 to 2.8.3
- Add E2B template deletion when deleting image (releases alias for reuse)
- Add `--delete-existing` flag to `vm0 image build` command
- Show helpful error message when alias conflict occurs (workaround for E2B buildInBackground bug)
- Use fixed image name in e2e tests

## Changes
- `vm0 image delete` now deletes both database record and E2B template
- `vm0 image build --delete-existing` auto-deletes existing image before building
- Alias conflict error now shows: `Image "xxx" already exists. Delete it first with: vm0 image delete xxx`

## Test plan
- [ ] CI passes
- [ ] `vm0 image build` works with new `--delete-existing` flag
- [ ] `vm0 image delete` properly removes E2B template

🤖 Generated with [Claude Code](https://claude.com/claude-code)