### PR TITLE
test: remove bats parallel flags to measure CI performance impact

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -296,7 +296,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run CLI E2E Tests
-        run: ./e2e/test/libs/bats/bin/bats -j 4 --no-parallelize-within-files ./e2e/tests/**/*.bats
+        run: ./e2e/test/libs/bats/bin/bats ./e2e/tests/**/*.bats
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -10,9 +10,7 @@ TESTS_DIR := tests
 init:
 	@git submodule update --init --recursive
 	
-# Run all tests
-# -j 4: run up to 4 files in parallel
-# --no-parallelize-within-files: run tests sequentially within each file
+# Run all tests sequentially
 test:
-	@$(BATS) --abort -j 4 --no-parallelize-within-files $(TESTS_DIR)/**/*.bats
+	@$(BATS) --abort $(TESTS_DIR)/**/*.bats
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -34,12 +34,10 @@ echo -e "${YELLOW}Linking CLI globally...${NC}"
 # Run tests
 echo -e "${GREEN}Running BATS tests...${NC}"
 
-# Default: run all tests
-# -j 4: run up to 4 files in parallel
-# --no-parallelize-within-files: run tests sequentially within each file
+# Default: run all tests sequentially
 if [[ $# -eq 0 ]]; then
-    "$BATS_BIN" --abort -j 4 --no-parallelize-within-files "$SCRIPT_DIR"/tests/**/*.bats
+    "$BATS_BIN" --abort "$SCRIPT_DIR"/tests/**/*.bats
 else
     # Run specific tests passed as arguments
-    "$BATS_BIN" --abort -j 4 --no-parallelize-within-files "$@"
+    "$BATS_BIN" --abort "$@"
 fi


### PR DESCRIPTION
## Summary
- Remove `-j 4 --no-parallelize-within-files` flags from BATS test execution
- This is a test to measure if sequential execution affects CI test duration

## Purpose
We want to compare the E2E test execution time:
- **With parallelization**: `-j 4 --no-parallelize-within-files` (current)
- **Without parallelization**: sequential execution (this PR)

## What to measure
After CI completes, compare the `cli-e2e` job duration with previous PR runs.

## Test plan
- [ ] Let CI run to completion
- [ ] Compare `cli-e2e` job duration with recent PRs
- [ ] Decide whether to keep or revert this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)