### PR TITLE
test: increase bats parallelism from -j 4 to -j 8

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -296,7 +296,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run CLI E2E Tests
-        run: ./e2e/test/libs/bats/bin/bats -j 4 --no-parallelize-within-files ./e2e/tests/**/*.bats
+        run: ./e2e/test/libs/bats/bin/bats -j 8 --no-parallelize-within-files ./e2e/tests/**/*.bats
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -11,8 +11,8 @@ init:
 	@git submodule update --init --recursive
 	
 # Run all tests
-# -j 4: run up to 4 files in parallel
+# -j 8: run up to 8 files in parallel
 # --no-parallelize-within-files: run tests sequentially within each file
 test:
-	@$(BATS) --abort -j 4 --no-parallelize-within-files $(TESTS_DIR)/**/*.bats
+	@$(BATS) --abort -j 8 --no-parallelize-within-files $(TESTS_DIR)/**/*.bats
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -35,11 +35,11 @@ echo -e "${YELLOW}Linking CLI globally...${NC}"
 echo -e "${GREEN}Running BATS tests...${NC}"
 
 # Default: run all tests
-# -j 4: run up to 4 files in parallel
+# -j 8: run up to 8 files in parallel
 # --no-parallelize-within-files: run tests sequentially within each file
 if [[ $# -eq 0 ]]; then
-    "$BATS_BIN" --abort -j 4 --no-parallelize-within-files "$SCRIPT_DIR"/tests/**/*.bats
+    "$BATS_BIN" --abort -j 8 --no-parallelize-within-files "$SCRIPT_DIR"/tests/**/*.bats
 else
     # Run specific tests passed as arguments
-    "$BATS_BIN" --abort -j 4 --no-parallelize-within-files "$@"
+    "$BATS_BIN" --abort -j 8 --no-parallelize-within-files "$@"
 fi


### PR DESCRIPTION
## Summary
- Increase BATS parallel job count from 4 to 8
- Test if higher parallelism improves CI test duration

## Baseline (current -j 4)
| Run | Duration |
|-----|----------|
| 20018612523 | ~5m 8s |
| 20017491592 | ~5m 10s |
| 20015960187 | ~4m 57s |
| 20015546114 | ~5m 32s |
| **Average** | **~5 minutes** |

## Test plan
- [ ] Let CI run to completion
- [ ] Compare `cli-e2e` job duration with baseline
- [ ] Decide whether to keep -j 8 or revert to -j 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)