### PR TITLE
feat(e2b): add vm0-github-cli template

### DIFF
--- a/turbo/package.json
+++ b/turbo/package.json
@@ -17,7 +17,9 @@
     "generate-certs": "bash ../scripts/generate-certs.sh",
     "check-certs": "node packages/proxy/scripts/check-certs.js",
     "e2b:build:prod": "dotenv -e apps/web/.env.local -- npx tsx scripts/e2b/vm0-claude-code/build.prod.ts",
-    "e2b:build:dev": "dotenv -e apps/web/.env.local -- npx tsx scripts/e2b/vm0-claude-code/build.dev.ts"
+    "e2b:build:dev": "dotenv -e apps/web/.env.local -- npx tsx scripts/e2b/vm0-claude-code/build.dev.ts",
+    "e2b:github-cli:build:prod": "dotenv -e apps/web/.env.local -- npx tsx scripts/e2b/vm0-github-cli/build.prod.ts",
+    "e2b:github-cli:build:dev": "dotenv -e apps/web/.env.local -- npx tsx scripts/e2b/vm0-github-cli/build.dev.ts"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "3.2.4",

--- a/turbo/scripts/e2b/vm0-github-cli/build.dev.ts
+++ b/turbo/scripts/e2b/vm0-github-cli/build.dev.ts
@@ -1,0 +1,22 @@
+import { Template, defaultBuildLogger } from "e2b";
+import { template } from "./template";
+
+// E2B_API_KEY should be set as an environment variable
+// In CI: from GitHub secrets
+// Locally: from turbo/apps/web/.env.local (loaded by build command)
+if (!process.env.E2B_API_KEY) {
+  console.error("Error: E2B_API_KEY environment variable is not set");
+  console.error(
+    "Please set E2B_API_KEY in turbo/apps/web/.env.local or as an environment variable",
+  );
+  process.exit(1);
+}
+
+async function main() {
+  await Template.build(template, {
+    alias: "vm0-github-cli-dev",
+    onBuildLogs: defaultBuildLogger(),
+  });
+}
+
+main().catch(console.error);

--- a/turbo/scripts/e2b/vm0-github-cli/build.prod.ts
+++ b/turbo/scripts/e2b/vm0-github-cli/build.prod.ts
@@ -1,0 +1,22 @@
+import { Template, defaultBuildLogger } from "e2b";
+import { template } from "./template";
+
+// E2B_API_KEY should be set as an environment variable
+// In CI: from GitHub secrets
+// Locally: from turbo/apps/web/.env.local (loaded by build command)
+if (!process.env.E2B_API_KEY) {
+  console.error("Error: E2B_API_KEY environment variable is not set");
+  console.error(
+    "Please set E2B_API_KEY in turbo/apps/web/.env.local or as an environment variable",
+  );
+  process.exit(1);
+}
+
+async function main() {
+  await Template.build(template, {
+    alias: "vm0-github-cli",
+    onBuildLogs: defaultBuildLogger(),
+  });
+}
+
+main().catch(console.error);

--- a/turbo/scripts/e2b/vm0-github-cli/template.ts
+++ b/turbo/scripts/e2b/vm0-github-cli/template.ts
@@ -1,0 +1,24 @@
+import { Template } from "e2b";
+
+/**
+ * VM0 GitHub CLI Template Configuration
+ *
+ * This template includes:
+ * - Node.js 24.x
+ * - Claude Code CLI (globally installed as "claude")
+ * - curl, git, ripgrep for development
+ * - GitHub CLI (gh) for GitHub operations
+ */
+export const template = Template()
+  .fromNodeImage("24")
+  .aptInstall(["curl", "git", "ripgrep"])
+  .npmInstall("@anthropic-ai/claude-code@latest", { g: true })
+  // Install GitHub CLI
+  .runCmd(
+    "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg",
+  )
+  .runCmd(
+    'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null',
+  )
+  .runCmd("sudo apt-get update")
+  .aptInstall(["gh"]);


### PR DESCRIPTION
## Summary
- Add new E2B template `vm0-github-cli` with Claude Code + GitHub CLI
- Based on `vm0-claude-code` template with `gh` CLI added
- Add build scripts: `pnpm e2b:github-cli:build:prod` / `pnpm e2b:github-cli:build:dev`

## Template includes
- Node.js 24.x
- Claude Code CLI (globally installed as "claude")
- curl, git, ripgrep for development
- GitHub CLI (gh) for GitHub operations

## Test plan
- [x] Manually tested `pnpm e2b:github-cli:build:prod` - builds successfully in ~28s

🤖 Generated with [Claude Code](https://claude.com/claude-code)