### PR TITLE
fix(e2b): validate checkpoint api response before returning success

### DIFF
--- a/turbo/apps/web/src/lib/e2b/scripts/lib/checkpoint.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/checkpoint.py.ts
@@ -132,10 +132,13 @@ def create_checkpoint() -> bool:
     # Call checkpoint API
     result = http_post_json(CHECKPOINT_URL, checkpoint_payload)
 
-    if result is not None:
-        log_info("Checkpoint created successfully")
+    # Validate response contains checkpointId to confirm checkpoint was actually created
+    # Note: result can be {} (empty dict) on network issues, which is not None but invalid
+    if result and result.get("checkpointId"):
+        checkpoint_id = result.get("checkpointId")
+        log_info(f"Checkpoint created successfully: {checkpoint_id}")
         return True
     else:
-        log_error("Failed to create checkpoint")
+        log_error(f"Checkpoint API returned invalid response: {result}")
         return False
 `;


### PR DESCRIPTION
## Summary
- Fix flaky E2E test caused by incorrect checkpoint creation validation
- Validate that checkpoint API response contains `checkpointId` before returning success

## Root Cause
The `create_checkpoint()` function was checking `result is not None` to determine success, but `http_post_json()` returns an empty dict `{}` on network issues or empty responses, which is not `None` but invalid.

This caused false positives where checkpoint creation appeared successful but no checkpoint was actually created, leading to "Checkpoint for run not found" errors in the complete webhook.

## Changes
- **`checkpoint.py.ts`**: Changed validation from `result is not None` to `result and result.get("checkpointId")` to ensure the checkpoint was actually created
- Added logging of the checkpoint ID on success and the invalid response on failure for better debugging

## Test plan
- [x] Pre-commit checks pass (lint, format, type-check)
- [ ] CI E2E tests pass
- [ ] Flaky test `VM0 conversation: output includes conversationId` no longer fails intermittently

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)