### PR TITLE
feat(sandbox): persist agent logs with per-run log files

### DIFF
--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -601,10 +601,9 @@ export class E2BService {
     // Start Python script in background using nohup to ignore SIGHUP signal
     // This prevents the process from being killed when E2B connection is closed
     // NOTE: Scripts already uploaded via uploadAllScripts(), do not pass envs here
-    // Create log directory and redirect output to per-run log file
-    // Use /tmp/vm0-logs since sandbox user may not have permission to write to /var/log
+    // Redirect output to per-run log file in /tmp with vm0- prefix
     await sandbox.commands.run(
-      `mkdir -p /tmp/vm0-logs && nohup python3 ${SCRIPT_PATHS.runAgent} > /tmp/vm0-logs/main-${runId}.log 2>&1 &`,
+      `nohup python3 ${SCRIPT_PATHS.runAgent} > /tmp/vm0-main-${runId}.log 2>&1 &`,
     );
 
     log.debug(`Agent execution started in background for run ${runId}`);

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -601,8 +601,9 @@ export class E2BService {
     // Start Python script in background using nohup to ignore SIGHUP signal
     // This prevents the process from being killed when E2B connection is closed
     // NOTE: Scripts already uploaded via uploadAllScripts(), do not pass envs here
+    // Create log directory and redirect output to per-run log file
     await sandbox.commands.run(
-      `nohup python3 ${SCRIPT_PATHS.runAgent} > /tmp/vm0-nohup.out 2>&1 &`,
+      `mkdir -p /var/log/vm0 && nohup python3 ${SCRIPT_PATHS.runAgent} > /var/log/vm0/main-${runId}.log 2>&1 &`,
     );
 
     log.debug(`Agent execution started in background for run ${runId}`);

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -602,8 +602,9 @@ export class E2BService {
     // This prevents the process from being killed when E2B connection is closed
     // NOTE: Scripts already uploaded via uploadAllScripts(), do not pass envs here
     // Create log directory and redirect output to per-run log file
+    // Use /tmp/vm0-logs since sandbox user may not have permission to write to /var/log
     await sandbox.commands.run(
-      `mkdir -p /var/log/vm0 && nohup python3 ${SCRIPT_PATHS.runAgent} > /var/log/vm0/main-${runId}.log 2>&1 &`,
+      `mkdir -p /tmp/vm0-logs && nohup python3 ${SCRIPT_PATHS.runAgent} > /tmp/vm0-logs/main-${runId}.log 2>&1 &`,
     );
 
     log.debug(`Agent execution started in background for run ${runId}`);

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
@@ -53,7 +53,8 @@ SESSION_HISTORY_PATH_FILE = f"/tmp/vm0-session-history-{RUN_ID}.txt"
 EVENT_ERROR_FLAG = f"/tmp/vm0-event-error-{RUN_ID}"
 
 # Log directory and files for persistent logging
-LOG_DIR = "/var/log/vm0"
+# Use /tmp/vm0-logs since sandbox user may not have permission to write to /var/log
+LOG_DIR = "/tmp/vm0-logs"
 AGENT_LOG_FILE = f"{LOG_DIR}/agent-{RUN_ID}.log"
 
 def validate_config() -> bool:

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
@@ -52,10 +52,8 @@ SESSION_HISTORY_PATH_FILE = f"/tmp/vm0-session-history-{RUN_ID}.txt"
 # Event error flag file - used to track if any events failed to send
 EVENT_ERROR_FLAG = f"/tmp/vm0-event-error-{RUN_ID}"
 
-# Log directory and files for persistent logging
-# Use /tmp/vm0-logs since sandbox user may not have permission to write to /var/log
-LOG_DIR = "/tmp/vm0-logs"
-AGENT_LOG_FILE = f"{LOG_DIR}/agent-{RUN_ID}.log"
+# Log file for persistent logging (directly in /tmp with vm0- prefix)
+AGENT_LOG_FILE = f"/tmp/vm0-agent-{RUN_ID}.log"
 
 def validate_config() -> bool:
     """Validate required configuration. Returns True if valid, exits if not."""

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
@@ -52,8 +52,9 @@ SESSION_HISTORY_PATH_FILE = f"/tmp/vm0-session-history-{RUN_ID}.txt"
 # Event error flag file - used to track if any events failed to send
 EVENT_ERROR_FLAG = f"/tmp/vm0-event-error-{RUN_ID}"
 
-# Stderr capture file - used to capture Claude's stderr for error messages
-STDERR_FILE = f"/tmp/vm0-stderr-{RUN_ID}"
+# Log directory and files for persistent logging
+LOG_DIR = "/var/log/vm0"
+AGENT_LOG_FILE = f"{LOG_DIR}/agent-{RUN_ID}.log"
 
 def validate_config() -> bool:
     """Validate required configuration. Returns True if valid, exits if not."""

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -106,72 +106,79 @@ def main():
     # Capture both stdout and stderr, write to log file, keep stderr in memory for error extraction
     claude_exit_code = 0
     stderr_lines = []  # Keep stderr in memory for error message extraction
-
-    def stderr_reader(proc_stderr, log_file, stderr_buffer):
-        """Background thread to read stderr and write to log file."""
-        for line in proc_stderr:
-            stderr_buffer.append(line)
-            log_file.write(f"[STDERR] {line}")
-            log_file.flush()
+    log_file = None
 
     try:
         # Ensure log directory exists
         os.makedirs(LOG_DIR, exist_ok=True)
+        log_file = open(AGENT_LOG_FILE, "w")
 
-        with open(AGENT_LOG_FILE, "w") as log_file:
-            proc = subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                bufsize=1  # Line buffered for real-time processing
-            )
+        # Python subprocess.PIPE can deadlock if buffer fills up
+        # Use a background thread to drain stderr while we read stdout
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1  # Line buffered for real-time processing
+        )
 
-            # Start background thread to read stderr
-            stderr_thread = threading.Thread(
-                target=stderr_reader,
-                args=(proc.stderr, log_file, stderr_lines),
-                daemon=True
-            )
-            stderr_thread.start()
+        # Read stderr in background to prevent buffer deadlock
+        def read_stderr():
+            try:
+                for line in proc.stderr:
+                    stderr_lines.append(line)
+                    if log_file and not log_file.closed:
+                        log_file.write(f"[STDERR] {line}")
+                        log_file.flush()
+            except Exception:
+                pass  # Ignore errors if file closed
 
-            # Process JSONL output line by line from stdout
-            for line in proc.stdout:
-                # Write raw line to log file
+        stderr_thread = threading.Thread(target=read_stderr, daemon=True)
+        stderr_thread.start()
+
+        # Process JSONL output line by line from stdout
+        for line in proc.stdout:
+            # Write raw line to log file
+            if log_file and not log_file.closed:
                 log_file.write(line)
                 log_file.flush()
 
-                line = line.strip()
+            stripped = line.strip()
 
-                # Skip empty lines
-                if not line:
-                    continue
+            # Skip empty lines
+            if not stripped:
+                continue
 
-                # Check if line is valid JSON (stdout should only contain JSONL)
-                try:
-                    event = json.loads(line)
+            # Check if line is valid JSON (stdout should only contain JSONL)
+            try:
+                event = json.loads(stripped)
 
-                    # Valid JSONL - send immediately
-                    send_event(event)
+                # Valid JSONL - send immediately
+                send_event(event)
 
-                    # Extract result from "result" event for stdout
-                    if event.get("type") == "result":
-                        result_content = event.get("result", "")
-                        if result_content:
-                            print(result_content)
+                # Extract result from "result" event for stdout
+                if event.get("type") == "result":
+                    result_content = event.get("result", "")
+                    if result_content:
+                        print(result_content)
 
-                except json.JSONDecodeError:
-                    # Not valid JSON, skip
-                    pass
+            except json.JSONDecodeError:
+                # Not valid JSON, skip
+                pass
 
-            # Wait for process and stderr thread to complete
-            proc.wait()
-            stderr_thread.join(timeout=5)
-            claude_exit_code = proc.returncode
+        # Wait for process to complete
+        proc.wait()
+        # Wait for stderr thread to finish (with timeout to avoid hanging)
+        stderr_thread.join(timeout=10)
+        claude_exit_code = proc.returncode
 
     except Exception as e:
         log_error(f"Failed to execute Claude: {e}")
         claude_exit_code = 1
+    finally:
+        if log_file and not log_file.closed:
+            log_file.close()
 
     # Print newline after output
     print()

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -24,7 +24,7 @@ sys.path.insert(0, "/usr/local/bin/vm0-agent/lib")
 from common import (
     WORKING_DIR, PROMPT, RESUME_SESSION_ID, COMPLETE_URL, RUN_ID,
     SESSION_ID_FILE, SESSION_HISTORY_PATH_FILE, EVENT_ERROR_FLAG,
-    HEARTBEAT_URL, HEARTBEAT_INTERVAL, LOG_DIR, AGENT_LOG_FILE,
+    HEARTBEAT_URL, HEARTBEAT_INTERVAL, AGENT_LOG_FILE,
     validate_config
 )
 from log import log_info, log_error, log_warn
@@ -109,8 +109,7 @@ def main():
     log_file = None
 
     try:
-        # Ensure log directory exists
-        os.makedirs(LOG_DIR, exist_ok=True)
+        # Open log file directly in /tmp (no need to create directory)
         log_file = open(AGENT_LOG_FILE, "w")
 
         # Python subprocess.PIPE can deadlock if buffer fills up

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -23,8 +23,7 @@ sys.path.insert(0, "/usr/local/bin/vm0-agent/lib")
 
 from common import (
     WORKING_DIR, PROMPT, RESUME_SESSION_ID, COMPLETE_URL, RUN_ID,
-    SESSION_ID_FILE, SESSION_HISTORY_PATH_FILE, EVENT_ERROR_FLAG,
-    HEARTBEAT_URL, HEARTBEAT_INTERVAL, AGENT_LOG_FILE,
+    EVENT_ERROR_FLAG, HEARTBEAT_URL, HEARTBEAT_INTERVAL, AGENT_LOG_FILE,
     validate_config
 )
 from log import log_info, log_error, log_warn
@@ -207,9 +206,7 @@ def main():
 
             # Get detailed error from captured stderr lines in memory
             if stderr_lines:
-                # Get last few lines of stderr, clean up formatting
-                last_lines = stderr_lines[-5:] if len(stderr_lines) >= 5 else stderr_lines
-                error_message = " ".join(line.strip() for line in last_lines)
+                error_message = " ".join(line.strip() for line in stderr_lines)
                 log_info(f"Captured stderr: {error_message}")
             else:
                 error_message = f"Agent exited with code {claude_exit_code}"
@@ -234,12 +231,7 @@ def main():
     shutdown_event.set()
     log_info("Heartbeat thread stopped")
 
-    # Cleanup temp files (but preserve log files in /var/log/vm0/)
-    for temp_file in [SESSION_ID_FILE, SESSION_HISTORY_PATH_FILE, EVENT_ERROR_FLAG]:
-        try:
-            os.remove(temp_file)
-        except OSError:
-            pass
+    # Note: Keep all temp files for debugging (SESSION_ID_FILE, SESSION_HISTORY_PATH_FILE, EVENT_ERROR_FLAG)
 
     sys.exit(final_exit_code)
 

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -23,8 +23,8 @@ sys.path.insert(0, "/usr/local/bin/vm0-agent/lib")
 
 from common import (
     WORKING_DIR, PROMPT, RESUME_SESSION_ID, COMPLETE_URL, RUN_ID,
-    SESSION_ID_FILE, SESSION_HISTORY_PATH_FILE, EVENT_ERROR_FLAG, STDERR_FILE,
-    HEARTBEAT_URL, HEARTBEAT_INTERVAL,
+    SESSION_ID_FILE, SESSION_HISTORY_PATH_FILE, EVENT_ERROR_FLAG,
+    HEARTBEAT_URL, HEARTBEAT_INTERVAL, LOG_DIR, AGENT_LOG_FILE,
     validate_config
 )
 from log import log_info, log_error, log_warn
@@ -103,21 +103,44 @@ def main():
     cmd = [claude_bin] + claude_args + [PROMPT]
 
     # Execute Claude and process output stream
-    # Redirect stderr to file for error capture, process stdout (JSONL) in pipe
+    # Capture both stdout and stderr, write to log file, keep stderr in memory for error extraction
     claude_exit_code = 0
+    stderr_lines = []  # Keep stderr in memory for error message extraction
+
+    def stderr_reader(proc_stderr, log_file, stderr_buffer):
+        """Background thread to read stderr and write to log file."""
+        for line in proc_stderr:
+            stderr_buffer.append(line)
+            log_file.write(f"[STDERR] {line}")
+            log_file.flush()
 
     try:
-        with open(STDERR_FILE, "w") as stderr_file:
+        # Ensure log directory exists
+        os.makedirs(LOG_DIR, exist_ok=True)
+
+        with open(AGENT_LOG_FILE, "w") as log_file:
             proc = subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,
-                stderr=stderr_file,
+                stderr=subprocess.PIPE,
                 text=True,
                 bufsize=1  # Line buffered for real-time processing
             )
 
-            # Process JSONL output line by line
+            # Start background thread to read stderr
+            stderr_thread = threading.Thread(
+                target=stderr_reader,
+                args=(proc.stderr, log_file, stderr_lines),
+                daemon=True
+            )
+            stderr_thread.start()
+
+            # Process JSONL output line by line from stdout
             for line in proc.stdout:
+                # Write raw line to log file
+                log_file.write(line)
+                log_file.flush()
+
                 line = line.strip()
 
                 # Skip empty lines
@@ -141,8 +164,9 @@ def main():
                     # Not valid JSON, skip
                     pass
 
-            # Wait for process to complete
+            # Wait for process and stderr thread to complete
             proc.wait()
+            stderr_thread.join(timeout=5)
             claude_exit_code = proc.returncode
 
     except Exception as e:
@@ -175,17 +199,12 @@ def main():
         if claude_exit_code != 0:
             log_info(f"Claude Code failed with exit code {claude_exit_code}")
 
-            # Try to get detailed error from stderr file
-            if os.path.exists(STDERR_FILE) and os.path.getsize(STDERR_FILE) > 0:
-                try:
-                    with open(STDERR_FILE) as f:
-                        lines = f.readlines()
-                        # Get last few lines of stderr, clean up formatting
-                        last_lines = lines[-5:] if len(lines) >= 5 else lines
-                        error_message = " ".join(line.strip() for line in last_lines)
-                    log_info(f"Captured stderr: {error_message}")
-                except IOError:
-                    error_message = f"Agent exited with code {claude_exit_code}"
+            # Get detailed error from captured stderr lines in memory
+            if stderr_lines:
+                # Get last few lines of stderr, clean up formatting
+                last_lines = stderr_lines[-5:] if len(stderr_lines) >= 5 else stderr_lines
+                error_message = " ".join(line.strip() for line in last_lines)
+                log_info(f"Captured stderr: {error_message}")
             else:
                 error_message = f"Agent exited with code {claude_exit_code}"
 
@@ -209,8 +228,8 @@ def main():
     shutdown_event.set()
     log_info("Heartbeat thread stopped")
 
-    # Cleanup temp files
-    for temp_file in [SESSION_ID_FILE, SESSION_HISTORY_PATH_FILE, EVENT_ERROR_FLAG, STDERR_FILE]:
+    # Cleanup temp files (but preserve log files in /var/log/vm0/)
+    for temp_file in [SESSION_ID_FILE, SESSION_HISTORY_PATH_FILE, EVENT_ERROR_FLAG]:
         try:
             os.remove(temp_file)
         except OSError:


### PR DESCRIPTION
## Summary

Persist sandbox agent logs to files for debugging and observability.

Closes #449

## Changes

1. **Per-run log files** - Each run gets its own log files instead of shared files:
   - `/tmp/vm0-main-{RUN_ID}.log` - run-agent.py nohup output
   - `/tmp/vm0-agent-{RUN_ID}.log` - Claude stdout/stderr merged

2. **Fix subprocess deadlock** - Use background thread to drain stderr while reading stdout, preventing PIPE buffer deadlock

3. **Keep temp files for debugging** - Remove cleanup of temp files so they persist for post-mortem analysis

4. **Send full stderr on error** - Send all stderr lines instead of last 5 only

## Files Modified

- `e2b-service.ts` - Update nohup command to per-run log path
- `scripts/lib/common.py.ts` - Replace `STDERR_FILE` with `AGENT_LOG_FILE`
- `scripts/run-agent.py.ts` - Implement merged logging with threading

## Test Plan

- [x] CI passes (lint, test, cli-e2e)
- [x] Log files created in `/tmp` with correct naming

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)