### PR TITLE
fix(e2b): await sandbox kill in complete api to prevent orphaned sandboxes

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -169,14 +169,9 @@ export async function POST(request: NextRequest) {
       console.log(`[Complete API] Run ${runId} failed: ${errorMessage}`);
     }
 
-    // Kill sandbox (fire-and-forget, don't block response)
+    // Kill sandbox (wait for completion to ensure cleanup before response)
     if (sandboxId) {
-      e2bService.killSandbox(sandboxId).catch((error) => {
-        console.error(
-          `[Complete API] Failed to kill sandbox ${sandboxId}:`,
-          error,
-        );
-      });
+      await e2bService.killSandbox(sandboxId);
     }
 
     const response: CompleteResponse = {
@@ -205,9 +200,7 @@ export async function POST(request: NextRequest) {
 
     // Still try to kill sandbox on error
     if (sandboxId) {
-      e2bService.killSandbox(sandboxId).catch(() => {
-        // Ignore cleanup errors
-      });
+      await e2bService.killSandbox(sandboxId);
     }
 
     return errorResponse(error);


### PR DESCRIPTION
## Summary

- Change `killSandbox()` from fire-and-forget to await in complete API
- Prevents orphaned sandboxes when Vercel terminates serverless function before kill completes
- Applies to both success and error handling paths

## Root Cause

The complete API was using fire-and-forget pattern:
```typescript
e2bService.killSandbox(sandboxId).catch(...);
return successResponse(response, 200);  // Returns immediately
```

Serverless functions may terminate after returning a response, causing the background `killSandbox()` Promise to be interrupted before completion.

## Test plan

- [x] All existing tests pass
- [x] Type check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)