### PR TITLE
feat(api): migrate /api/agent/composes routes to ts-rest contract-first architecture

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/__tests__/upsert.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/upsert.test.ts
@@ -9,6 +9,25 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { agentComposes } from "../../../../../src/db/schema/agent-compose";
 import { eq } from "drizzle-orm";
 
+/**
+ * Helper to create a NextRequest for testing.
+ * Uses actual NextRequest constructor so ts-rest handler gets nextUrl property.
+ */
+function createTestRequest(
+  url: string,
+  options?: {
+    method?: string;
+    body?: string;
+    headers?: Record<string, string>;
+  },
+): NextRequest {
+  return new NextRequest(url, {
+    method: options?.method ?? "GET",
+    headers: options?.headers ?? {},
+    body: options?.body,
+  });
+}
+
 // Mock the auth module
 let mockUserId = "test-user-123";
 vi.mock("../../../../../src/lib/auth/get-user-id", () => ({
@@ -42,15 +61,16 @@ describe("Agent Compose Upsert Behavior", () => {
         },
       };
 
-      const request = new Request("http://localhost:3000/api/agent/composes", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/composes",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: config }),
         },
-        body: JSON.stringify({ content: config }),
-      });
+      );
 
-      const response = await POST(request as NextRequest);
+      const response = await POST(request);
       const data = await response.json();
 
       expect(response.status).toBe(201);
@@ -75,15 +95,16 @@ describe("Agent Compose Upsert Behavior", () => {
       };
 
       // First create
-      const request1 = new Request("http://localhost:3000/api/agent/composes", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
+      const request1 = createTestRequest(
+        "http://localhost:3000/api/agent/composes",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: config }),
         },
-        body: JSON.stringify({ content: config }),
-      });
+      );
 
-      const response1 = await POST(request1 as NextRequest);
+      const response1 = await POST(request1);
       const data1 = await response1.json();
 
       expect(data1.action).toBe("created");
@@ -100,15 +121,16 @@ describe("Agent Compose Upsert Behavior", () => {
         },
       };
 
-      const request2 = new Request("http://localhost:3000/api/agent/composes", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
+      const request2 = createTestRequest(
+        "http://localhost:3000/api/agent/composes",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: updatedConfig }),
         },
-        body: JSON.stringify({ content: updatedConfig }),
-      });
+      );
 
-      const response2 = await POST(request2 as NextRequest);
+      const response2 = await POST(request2);
       const data2 = await response2.json();
 
       expect(response2.status).toBe(200);
@@ -119,16 +141,12 @@ describe("Agent Compose Upsert Behavior", () => {
       expect(data2.updatedAt).toBeDefined();
 
       // Verify the compose was actually updated
-      const getRequest = new Request(
+      const getRequest = createTestRequest(
         `http://localhost:3000/api/agent/composes/${composeId}`,
-        {
-          method: "GET",
-        },
+        { method: "GET" },
       );
 
-      const getResponse = await GET(getRequest as NextRequest, {
-        params: Promise.resolve({ id: composeId }),
-      });
+      const getResponse = await GET(getRequest);
       const composeData = await getResponse.json();
 
       expect(composeData.content.agents["test-agent-update"].description).toBe(
@@ -150,29 +168,31 @@ describe("Agent Compose Upsert Behavior", () => {
 
       // Create compose for user 1
       mockUserId = "user-1";
-      const request1 = new Request("http://localhost:3000/api/agent/composes", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
+      const request1 = createTestRequest(
+        "http://localhost:3000/api/agent/composes",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: config }),
         },
-        body: JSON.stringify({ content: config }),
-      });
+      );
 
-      const response1 = await POST(request1 as NextRequest);
+      const response1 = await POST(request1);
       const data1 = await response1.json();
       expect(response1.status).toBe(201);
 
       // Create compose with same name for user 2 (should succeed)
       mockUserId = "user-2";
-      const request2 = new Request("http://localhost:3000/api/agent/composes", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
+      const request2 = createTestRequest(
+        "http://localhost:3000/api/agent/composes",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: config }),
         },
-        body: JSON.stringify({ content: config }),
-      });
+      );
 
-      const response2 = await POST(request2 as NextRequest);
+      const response2 = await POST(request2);
       const data2 = await response2.json();
       expect(response2.status).toBe(201);
 
@@ -210,15 +230,16 @@ describe("Agent Compose Upsert Behavior", () => {
         },
       };
 
-      const request = new Request("http://localhost:3000/api/agent/composes", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/composes",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: config }),
         },
-        body: JSON.stringify({ content: config }),
-      });
+      );
 
-      const response = await POST(request as NextRequest);
+      const response = await POST(request);
 
       expect(response.status).toBe(400);
       const data = await response.json();
@@ -240,15 +261,16 @@ describe("Agent Compose Upsert Behavior", () => {
         },
       };
 
-      const request = new Request("http://localhost:3000/api/agent/composes", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/composes",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: config }),
         },
-        body: JSON.stringify({ content: config }),
-      });
+      );
 
-      const response = await POST(request as NextRequest);
+      const response = await POST(request);
 
       expect(response.status).toBe(400);
       const data = await response.json();
@@ -267,15 +289,16 @@ describe("Agent Compose Upsert Behavior", () => {
         },
       };
 
-      const request = new Request("http://localhost:3000/api/agent/composes", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/composes",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: config }),
         },
-        body: JSON.stringify({ content: config }),
-      });
+      );
 
-      const response = await POST(request as NextRequest);
+      const response = await POST(request);
 
       expect(response.status).toBe(201);
 
@@ -302,31 +325,25 @@ describe("Agent Compose Upsert Behavior", () => {
       };
 
       // Create compose
-      const createRequest = new Request(
+      const createRequest = createTestRequest(
         "http://localhost:3000/api/agent/composes",
         {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ content: config }),
         },
       );
 
-      const createResponse = await POST(createRequest as NextRequest);
+      const createResponse = await POST(createRequest);
       const createData = await createResponse.json();
 
       // Get compose
-      const getRequest = new Request(
+      const getRequest = createTestRequest(
         `http://localhost:3000/api/agent/composes/${createData.composeId}`,
-        {
-          method: "GET",
-        },
+        { method: "GET" },
       );
 
-      const getResponse = await GET(getRequest as NextRequest, {
-        params: Promise.resolve({ id: createData.composeId }),
-      });
+      const getResponse = await GET(getRequest);
 
       expect(getResponse.status).toBe(200);
       const getData = await getResponse.json();

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -1,0 +1,183 @@
+import { z } from "zod";
+import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+/**
+ * Agent name validation schema
+ * - Must be 3-64 characters
+ * - Letters, numbers, and hyphens only
+ * - Must start and end with letter or number
+ */
+const agentNameSchema = z
+  .string()
+  .min(3, "Agent name must be at least 3 characters")
+  .max(64, "Agent name must be 64 characters or less")
+  .regex(
+    /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/,
+    "Agent name must start and end with letter or number, and contain only letters, numbers, and hyphens",
+  );
+
+/**
+ * Volume configuration schema
+ */
+const volumeConfigSchema = z.object({
+  name: z.string().min(1, "Volume name is required"),
+  version: z.string().min(1, "Volume version is required"),
+});
+
+/**
+ * Agent definition schema
+ */
+const agentDefinitionSchema = z.object({
+  description: z.string().optional(),
+  image: z.string().min(1, "Image is required"),
+  provider: z.string().min(1, "Provider is required"),
+  volumes: z.array(z.string()).optional(),
+  working_dir: z.string().min(1, "Working directory is required"),
+  environment: z.record(z.string(), z.string()).optional(),
+});
+
+/**
+ * Agent compose YAML content schema
+ */
+const agentComposeContentSchema = z.object({
+  version: z.string().min(1, "Version is required"),
+  agents: z.record(z.string(), agentDefinitionSchema),
+  volumes: z.record(z.string(), volumeConfigSchema).optional(),
+});
+
+/**
+ * Compose response schema (used in GET responses)
+ */
+const composeResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  headVersionId: z.string().nullable(),
+  content: agentComposeContentSchema.nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+/**
+ * Composes main route contract (/api/agent/composes)
+ * Handles GET by name and POST create/update
+ */
+export const composesMainContract = c.router({
+  /**
+   * GET /api/agent/composes?name={name}
+   * Get agent compose by name with HEAD version content
+   */
+  getByName: {
+    method: "GET",
+    path: "/api/agent/composes",
+    query: z.object({
+      name: z.string().min(1, "Missing name query parameter"),
+    }),
+    responses: {
+      200: composeResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Get agent compose by name",
+  },
+
+  /**
+   * POST /api/agent/composes
+   * Create or update an agent compose version
+   *
+   * Returns 201 when a new compose is created, 200 when updating an existing compose.
+   * The action field indicates whether a new version was created or an existing one reused.
+   */
+  create: {
+    method: "POST",
+    path: "/api/agent/composes",
+    body: z.object({
+      content: agentComposeContentSchema,
+    }),
+    responses: {
+      200: z.object({
+        composeId: z.string(),
+        name: z.string(),
+        versionId: z.string(),
+        action: z.enum(["created", "existing"]),
+        updatedAt: z.string(),
+      }),
+      201: z.object({
+        composeId: z.string(),
+        name: z.string(),
+        versionId: z.string(),
+        action: z.enum(["created", "existing"]),
+        updatedAt: z.string(),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Create or update agent compose version",
+  },
+});
+
+/**
+ * Composes by ID route contract (/api/agent/composes/[id])
+ */
+export const composesByIdContract = c.router({
+  /**
+   * GET /api/agent/composes/:id
+   * Get agent compose by ID with HEAD version content
+   */
+  getById: {
+    method: "GET",
+    path: "/api/agent/composes/:id",
+    pathParams: z.object({
+      id: z.string().min(1, "Compose ID is required"),
+    }),
+    responses: {
+      200: composeResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get agent compose by ID",
+  },
+});
+
+/**
+ * Composes versions route contract (/api/agent/composes/versions)
+ */
+export const composesVersionsContract = c.router({
+  /**
+   * GET /api/agent/composes/versions?composeId={id}&version={hash|tag}
+   * Resolve a version specifier to a full version ID
+   */
+  resolveVersion: {
+    method: "GET",
+    path: "/api/agent/composes/versions",
+    query: z.object({
+      composeId: z.string().min(1, "Missing composeId query parameter"),
+      version: z.string().min(1, "Missing version query parameter"),
+    }),
+    responses: {
+      200: z.object({
+        versionId: z.string(),
+        tag: z.string().optional(),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Resolve version specifier to full version ID",
+  },
+});
+
+export type ComposesMainContract = typeof composesMainContract;
+export type ComposesByIdContract = typeof composesByIdContract;
+export type ComposesVersionsContract = typeof composesVersionsContract;
+
+// Export schemas for reuse
+export {
+  agentNameSchema,
+  volumeConfigSchema,
+  agentDefinitionSchema,
+  agentComposeContentSchema,
+  composeResponseSchema,
+};

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -61,6 +61,17 @@ const composeResponseSchema = z.object({
 });
 
 /**
+ * Create/update compose response schema (used in POST responses)
+ */
+const createComposeResponseSchema = z.object({
+  composeId: z.string(),
+  name: z.string(),
+  versionId: z.string(),
+  action: z.enum(["created", "existing"]),
+  updatedAt: z.string(),
+});
+
+/**
  * Composes main route contract (/api/agent/composes)
  * Handles GET by name and POST create/update
  */
@@ -97,20 +108,8 @@ export const composesMainContract = c.router({
       content: agentComposeContentSchema,
     }),
     responses: {
-      200: z.object({
-        composeId: z.string(),
-        name: z.string(),
-        versionId: z.string(),
-        action: z.enum(["created", "existing"]),
-        updatedAt: z.string(),
-      }),
-      201: z.object({
-        composeId: z.string(),
-        name: z.string(),
-        versionId: z.string(),
-        action: z.enum(["created", "existing"]),
-        updatedAt: z.string(),
-      }),
+      200: createComposeResponseSchema,
+      201: createComposeResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
     },
@@ -180,4 +179,5 @@ export {
   agentDefinitionSchema,
   agentComposeContentSchema,
   composeResponseSchema,
+  createComposeResponseSchema,
 };

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -14,3 +14,16 @@
 export { initContract } from "./base";
 export { apiErrorSchema, type ApiErrorResponse } from "./errors";
 export { secretsContract, type SecretsContract } from "./secrets";
+export {
+  composesMainContract,
+  composesByIdContract,
+  composesVersionsContract,
+  type ComposesMainContract,
+  type ComposesByIdContract,
+  type ComposesVersionsContract,
+  agentNameSchema,
+  volumeConfigSchema,
+  agentDefinitionSchema,
+  agentComposeContentSchema,
+  composeResponseSchema,
+} from "./composes";


### PR DESCRIPTION
## Summary
- Create composes contracts in `packages/core/src/contracts/composes.ts` with three separate contracts for different route files
- Migrate all `/api/agent/composes` route handlers to use ts-rest pattern
- Update tests to use NextRequest for ts-rest serverless compatibility

## Changes
- **New file: `packages/core/src/contracts/composes.ts`**
  - `composesMainContract`: GET by name and POST create/update at `/api/agent/composes`
  - `composesByIdContract`: GET by ID at `/api/agent/composes/[id]`
  - `composesVersionsContract`: Resolve version specifiers at `/api/agent/composes/versions`
  - Export all Zod schemas for reuse

- **Migrated route handlers:**
  - `apps/web/app/api/agent/composes/route.ts`
  - `apps/web/app/api/agent/composes/[id]/route.ts`
  - `apps/web/app/api/agent/composes/versions/route.ts`

- **Updated tests:**
  - All test files now use `createTestRequest` helper with `NextRequest` for ts-rest compatibility
  - Updated error message assertions to match Zod validation format

## Test plan
- [x] All 23 composes tests pass
- [x] TypeScript type checking passes
- [x] Lint passes with no warnings
- [x] Code formatted with prettier

Part of #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)