### PR TITLE
fix(sandbox): add timestamp to main log output

### DIFF
--- a/turbo/apps/web/src/lib/e2b/scripts/lib/log.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/log.py.ts
@@ -5,33 +5,39 @@
 export const LOG_SCRIPT = `#!/usr/bin/env python3
 """
 Unified logging functions for VM0 agent scripts.
-Format: [LEVEL] [sandbox:SCRIPT_NAME] message
+Format: [TIMESTAMP] [LEVEL] [sandbox:SCRIPT_NAME] message
 """
 import os
 import sys
+from datetime import datetime, timezone
 
 # Default script name, can be overridden by setting LOG_SCRIPT_NAME env var
 SCRIPT_NAME = os.environ.get("LOG_SCRIPT_NAME", "run-agent")
 DEBUG_MODE = os.environ.get("VM0_DEBUG", "") == "1"
 
 
+def _timestamp() -> str:
+    """Get current UTC timestamp in ISO 8601 format."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def log_info(msg: str) -> None:
     """Log info message to stderr."""
-    print(f"[INFO] [sandbox:{SCRIPT_NAME}] {msg}", file=sys.stderr)
+    print(f"[{_timestamp()}] [INFO] [sandbox:{SCRIPT_NAME}] {msg}", file=sys.stderr)
 
 
 def log_warn(msg: str) -> None:
     """Log warning message to stderr."""
-    print(f"[WARN] [sandbox:{SCRIPT_NAME}] {msg}", file=sys.stderr)
+    print(f"[{_timestamp()}] [WARN] [sandbox:{SCRIPT_NAME}] {msg}", file=sys.stderr)
 
 
 def log_error(msg: str) -> None:
     """Log error message to stderr."""
-    print(f"[ERROR] [sandbox:{SCRIPT_NAME}] {msg}", file=sys.stderr)
+    print(f"[{_timestamp()}] [ERROR] [sandbox:{SCRIPT_NAME}] {msg}", file=sys.stderr)
 
 
 def log_debug(msg: str) -> None:
     """Log debug message to stderr (only if VM0_DEBUG=1)."""
     if DEBUG_MODE:
-        print(f"[DEBUG] [sandbox:{SCRIPT_NAME}] {msg}", file=sys.stderr)
+        print(f"[{_timestamp()}] [DEBUG] [sandbox:{SCRIPT_NAME}] {msg}", file=sys.stderr)
 `;


### PR DESCRIPTION
## Summary

Add ISO 8601 UTC timestamp to all log functions in the sandbox log module.

Closes #461
Prerequisite for #460

## Changes

Update `log.py` format from:
```
[INFO] [sandbox:run-agent] message
```

To:
```
[2025-12-09T10:00:00Z] [INFO] [sandbox:run-agent] message
```

## Implementation

- Added `_timestamp()` helper function using `datetime` module
- Updated `log_info`, `log_warn`, `log_error`, `log_debug` to include timestamp
- Timestamp is in UTC timezone, ISO 8601 format

## Test Plan

- [x] Lint passes
- [ ] CI checks (cli-e2e will verify in real sandbox)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)