### PR TITLE
feat(api): migrate /api/agent/runs to ts-rest contract-first architecture

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
@@ -39,6 +39,14 @@ import { auth } from "@clerk/nextjs/server";
 const mockHeaders = vi.mocked(headers);
 const mockAuth = vi.mocked(auth);
 
+/**
+ * Helper to create a NextRequest for testing.
+ * Uses actual NextRequest constructor so ts-rest handler gets nextUrl property.
+ */
+function createTestRequest(url: string): NextRequest {
+  return new NextRequest(url, { method: "GET" });
+}
+
 describe("GET /api/agent/runs/:id/events", () => {
   // Generate unique IDs for this test run to avoid conflicts
   const testUserId = `test-user-${Date.now()}-${process.pid}`;
@@ -156,16 +164,11 @@ describe("GET /api/agent/runs/:id/events", () => {
         userId: null,
       } as unknown as Awaited<ReturnType<typeof auth>>);
 
-      const request = new NextRequest(
+      const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/events`,
-        {
-          method: "GET",
-        },
       );
 
-      const response = await GET(request, {
-        params: Promise.resolve({ id: testRunId }),
-      });
+      const response = await GET(request);
 
       expect(response.status).toBe(401);
       const data = await response.json();
@@ -182,16 +185,11 @@ describe("GET /api/agent/runs/:id/events", () => {
     it("should reject request for non-existent run", async () => {
       const nonExistentRunId = randomUUID();
 
-      const request = new NextRequest(
+      const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${nonExistentRunId}/events`,
-        {
-          method: "GET",
-        },
       );
 
-      const response = await GET(request, {
-        params: Promise.resolve({ id: nonExistentRunId }),
-      });
+      const response = await GET(request);
 
       expect(response.status).toBe(404);
       const data = await response.json();
@@ -242,16 +240,11 @@ describe("GET /api/agent/runs/:id/events", () => {
         createdAt: new Date(),
       });
 
-      const request = new NextRequest(
+      const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${otherRunId}/events`,
-        {
-          method: "GET",
-        },
       );
 
-      const response = await GET(request, {
-        params: Promise.resolve({ id: otherRunId }),
-      });
+      const response = await GET(request);
 
       expect(response.status).toBe(404); // 404 for security (not 403)
       const data = await response.json();
@@ -276,16 +269,11 @@ describe("GET /api/agent/runs/:id/events", () => {
 
   describe("Success - Basic Retrieval", () => {
     it("should return empty events list when no events exist", async () => {
-      const request = new NextRequest(
+      const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/events`,
-        {
-          method: "GET",
-        },
       );
 
-      const response = await GET(request, {
-        params: Promise.resolve({ id: testRunId }),
-      });
+      const response = await GET(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -339,16 +327,11 @@ describe("GET /api/agent/runs/:id/events", () => {
 
       await globalThis.services.db.insert(agentRunEvents).values(testEvents);
 
-      const request = new NextRequest(
+      const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/events`,
-        {
-          method: "GET",
-        },
       );
 
-      const response = await GET(request, {
-        params: Promise.resolve({ id: testRunId }),
-      });
+      const response = await GET(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -380,16 +363,11 @@ describe("GET /api/agent/runs/:id/events", () => {
       await globalThis.services.db.insert(agentRunEvents).values(testEvents);
 
       // Request events since sequence 2
-      const request = new NextRequest(
+      const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/events?since=2`,
-        {
-          method: "GET",
-        },
       );
 
-      const response = await GET(request, {
-        params: Promise.resolve({ id: testRunId }),
-      });
+      const response = await GET(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -415,16 +393,11 @@ describe("GET /api/agent/runs/:id/events", () => {
       await globalThis.services.db.insert(agentRunEvents).values(testEvents);
 
       // Request with limit=3
-      const request = new NextRequest(
+      const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/events?limit=3`,
-        {
-          method: "GET",
-        },
       );
 
-      const response = await GET(request, {
-        params: Promise.resolve({ id: testRunId }),
-      });
+      const response = await GET(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -450,16 +423,11 @@ describe("GET /api/agent/runs/:id/events", () => {
       await globalThis.services.db.insert(agentRunEvents).values(testEvents);
 
       // Request events since=3 with limit=2
-      const request = new NextRequest(
+      const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/events?since=3&limit=2`,
-        {
-          method: "GET",
-        },
       );
 
-      const response = await GET(request, {
-        params: Promise.resolve({ id: testRunId }),
-      });
+      const response = await GET(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -484,16 +452,11 @@ describe("GET /api/agent/runs/:id/events", () => {
       await globalThis.services.db.insert(agentRunEvents).values(testEvents);
 
       // Request with limit=10 (more than available)
-      const request = new NextRequest(
+      const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/events?limit=10`,
-        {
-          method: "GET",
-        },
       );
 
-      const response = await GET(request, {
-        params: Promise.resolve({ id: testRunId }),
-      });
+      const response = await GET(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -539,16 +502,11 @@ describe("GET /api/agent/runs/:id/events", () => {
 
       await globalThis.services.db.insert(agentRunEvents).values(testEvents);
 
-      const request = new NextRequest(
+      const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/events`,
-        {
-          method: "GET",
-        },
       );
 
-      const response = await GET(request, {
-        params: Promise.resolve({ id: testRunId }),
-      });
+      const response = await GET(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -593,16 +551,11 @@ describe("GET /api/agent/runs/:id/events", () => {
         createdAt: new Date(),
       });
 
-      const request = new NextRequest(
+      const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/events`,
-        {
-          method: "GET",
-        },
       );
 
-      const response = await GET(request, {
-        params: Promise.resolve({ id: testRunId }),
-      });
+      const response = await GET(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -622,16 +575,11 @@ describe("GET /api/agent/runs/:id/events", () => {
         createdAt: now,
       });
 
-      const request = new NextRequest(
+      const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/events`,
-        {
-          method: "GET",
-        },
       );
 
-      const response = await GET(request, {
-        params: Promise.resolve({ id: testRunId }),
-      });
+      const response = await GET(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -662,16 +610,11 @@ describe("GET /api/agent/runs/:id/events", () => {
 
       await globalThis.services.db.insert(agentRunEvents).values(testEvents);
 
-      const request = new NextRequest(
+      const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/events?since=0`,
-        {
-          method: "GET",
-        },
       );
 
-      const response = await GET(request, {
-        params: Promise.resolve({ id: testRunId }),
-      });
+      const response = await GET(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -691,16 +634,11 @@ describe("GET /api/agent/runs/:id/events", () => {
 
       await globalThis.services.db.insert(agentRunEvents).values(testEvents);
 
-      const request = new NextRequest(
+      const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/events?since=100`,
-        {
-          method: "GET",
-        },
       );
 
-      const response = await GET(request, {
-        params: Promise.resolve({ id: testRunId }),
-      });
+      const response = await GET(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -722,16 +660,11 @@ describe("GET /api/agent/runs/:id/events", () => {
 
       await globalThis.services.db.insert(agentRunEvents).values(testEvents);
 
-      const request = new NextRequest(
+      const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/events`,
-        {
-          method: "GET",
-        },
       );
 
-      const response = await GET(request, {
-        params: Promise.resolve({ id: testRunId }),
-      });
+      const response = await GET(request);
 
       expect(response.status).toBe(200);
       const data = await response.json();

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
@@ -100,8 +100,10 @@ function errorHandler(err: unknown): TsRestResponse | void {
     if (validationError.pathParamsError) {
       const issue = validationError.pathParamsError.issues[0];
       if (issue) {
+        const path = issue.path.join(".");
+        const message = path ? `${path}: ${issue.message}` : issue.message;
         return TsRestResponse.fromJson(
-          { error: { message: issue.message, code: "BAD_REQUEST" } },
+          { error: { message, code: "BAD_REQUEST" } },
           { status: 400 },
         );
       }
@@ -110,8 +112,10 @@ function errorHandler(err: unknown): TsRestResponse | void {
     if (validationError.queryError) {
       const issue = validationError.queryError.issues[0];
       if (issue) {
+        const path = issue.path.join(".");
+        const message = path ? `${path}: ${issue.message}` : issue.message;
         return TsRestResponse.fromJson(
-          { error: { message: issue.message, code: "BAD_REQUEST" } },
+          { error: { message, code: "BAD_REQUEST" } },
           { status: 400 },
         );
       }

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
@@ -1,72 +1,42 @@
-import { NextRequest } from "next/server";
+import { createNextHandler, tsr } from "@ts-rest/serverless/next";
+import { TsRestResponse } from "@ts-rest/serverless";
+import { runEventsContract } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { agentRunEvents } from "../../../../../../src/db/schema/agent-run-event";
 import { eq, gt, and } from "drizzle-orm";
 import { getUserId } from "../../../../../../src/lib/auth/get-user-id";
-import {
-  successResponse,
-  errorResponse,
-} from "../../../../../../src/lib/api-response";
-import {
-  NotFoundError,
-  UnauthorizedError,
-} from "../../../../../../src/lib/errors";
 
-export type RunStatus =
-  | "pending"
-  | "running"
-  | "completed"
-  | "failed"
-  | "timeout";
-
-export interface EventsResponse {
-  events: Array<{
-    sequenceNumber: number;
-    eventType: string;
-    eventData: unknown;
-    createdAt: string;
-  }>;
-  hasMore: boolean;
-  nextSequence: number;
-  status: RunStatus;
-}
-
-/**
- * GET /api/agent/runs/:id/events
- * Poll for agent run events with pagination
- */
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  try {
-    // Initialize services
+const router = tsr.router(runEventsContract, {
+  getEvents: async ({ params, query }) => {
     initServices();
 
-    // Authenticate
     const userId = await getUserId();
     if (!userId) {
-      throw new UnauthorizedError("Not authenticated");
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        },
+      };
     }
 
-    // Await params
-    const { id } = await params;
-
-    // Parse query parameters
-    const { searchParams } = new URL(request.url);
-    const since = parseInt(searchParams.get("since") || "0");
-    const limit = parseInt(searchParams.get("limit") || "100");
+    const { since, limit } = query;
 
     // Verify run exists and belongs to user
     const [run] = await globalThis.services.db
       .select()
       .from(agentRuns)
-      .where(eq(agentRuns.id, id))
+      .where(eq(agentRuns.id, params.id))
       .limit(1);
 
     if (!run || run.userId !== userId) {
-      throw new NotFoundError("Agent run");
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Agent run not found", code: "NOT_FOUND" },
+        },
+      };
     }
 
     // Query events from database
@@ -75,7 +45,7 @@ export async function GET(
       .from(agentRunEvents)
       .where(
         and(
-          eq(agentRunEvents.runId, id),
+          eq(agentRunEvents.runId, params.id),
           gt(agentRunEvents.sequenceNumber, since),
         ),
       )
@@ -87,21 +57,74 @@ export async function GET(
     const nextSequence =
       events.length > 0 ? events[events.length - 1]!.sequenceNumber : since;
 
-    // Format response
-    const response: EventsResponse = {
-      events: events.map((e) => ({
-        sequenceNumber: e.sequenceNumber,
-        eventType: e.eventType,
-        eventData: e.eventData,
-        createdAt: e.createdAt.toISOString(),
-      })),
-      hasMore,
-      nextSequence,
-      status: run.status as RunStatus,
+    return {
+      status: 200 as const,
+      body: {
+        events: events.map((e) => ({
+          sequenceNumber: e.sequenceNumber,
+          eventType: e.eventType,
+          eventData: e.eventData,
+          createdAt: e.createdAt.toISOString(),
+        })),
+        hasMore,
+        nextSequence,
+        status: run.status as
+          | "pending"
+          | "running"
+          | "completed"
+          | "failed"
+          | "timeout",
+      },
+    };
+  },
+});
+
+/**
+ * Custom error handler to convert validation errors to API error format
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (
+    err &&
+    typeof err === "object" &&
+    ("pathParamsError" in err || "queryError" in err)
+  ) {
+    const validationError = err as {
+      pathParamsError: {
+        issues: Array<{ path: string[]; message: string }>;
+      } | null;
+      queryError: {
+        issues: Array<{ path: string[]; message: string }>;
+      } | null;
     };
 
-    return successResponse(response);
-  } catch (error) {
-    return errorResponse(error);
+    if (validationError.pathParamsError) {
+      const issue = validationError.pathParamsError.issues[0];
+      if (issue) {
+        return TsRestResponse.fromJson(
+          { error: { message: issue.message, code: "BAD_REQUEST" } },
+          { status: 400 },
+        );
+      }
+    }
+
+    if (validationError.queryError) {
+      const issue = validationError.queryError.issues[0];
+      if (issue) {
+        return TsRestResponse.fromJson(
+          { error: { message: issue.message, code: "BAD_REQUEST" } },
+          { status: 400 },
+        );
+      }
+    }
   }
+
+  return undefined;
 }
+
+const handler = createNextHandler(runEventsContract, router, {
+  handlerType: "app-router",
+  jsonQuery: true,
+  errorHandler,
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/agent/runs/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/route.ts
@@ -1,69 +1,96 @@
-import { NextRequest } from "next/server";
+import { createNextHandler, tsr } from "@ts-rest/serverless/next";
+import { TsRestResponse } from "@ts-rest/serverless";
+import { runsByIdContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import { eq } from "drizzle-orm";
 import { getUserId } from "../../../../../src/lib/auth/get-user-id";
-import {
-  successResponse,
-  errorResponse,
-} from "../../../../../src/lib/api-response";
-import {
-  NotFoundError,
-  UnauthorizedError,
-} from "../../../../../src/lib/errors";
-import type { GetAgentRunResponse } from "../../../../../src/types/agent-run";
 
-/**
- * GET /api/agent/runs/:id
- * Get agent run status and results
- */
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  try {
-    // Initialize services
+const router = tsr.router(runsByIdContract, {
+  getById: async ({ params }) => {
     initServices();
 
-    // Authenticate
     const userId = await getUserId();
     if (!userId) {
-      throw new UnauthorizedError("Not authenticated");
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        },
+      };
     }
-
-    // Await params
-    const { id } = await params;
 
     // Query run from database
     const [run] = await globalThis.services.db
       .select()
       .from(agentRuns)
-      .where(eq(agentRuns.id, id))
+      .where(eq(agentRuns.id, params.id))
       .limit(1);
 
     if (!run) {
-      throw new NotFoundError("Agent run");
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Agent run not found", code: "NOT_FOUND" },
+        },
+      };
     }
 
-    // Return response
-    const response: GetAgentRunResponse = {
-      runId: run.id,
-      agentComposeVersionId: run.agentComposeVersionId,
-      status: run.status as "pending" | "running" | "completed" | "failed",
-      prompt: run.prompt,
-      templateVars: run.templateVars as Record<string, string> | undefined,
-      sandboxId: run.sandboxId || undefined,
-      result: run.result as
-        | { output: string; executionTimeMs: number }
-        | undefined,
-      error: run.error || undefined,
-      createdAt: run.createdAt.toISOString(),
-      startedAt: run.startedAt?.toISOString(),
-      completedAt: run.completedAt?.toISOString(),
+    return {
+      status: 200 as const,
+      body: {
+        runId: run.id,
+        agentComposeVersionId: run.agentComposeVersionId,
+        status: run.status as
+          | "pending"
+          | "running"
+          | "completed"
+          | "failed"
+          | "timeout",
+        prompt: run.prompt,
+        templateVars: run.templateVars as Record<string, string> | undefined,
+        sandboxId: run.sandboxId || undefined,
+        result: run.result as
+          | { output: string; executionTimeMs: number }
+          | undefined,
+        error: run.error || undefined,
+        createdAt: run.createdAt.toISOString(),
+        startedAt: run.startedAt?.toISOString(),
+        completedAt: run.completedAt?.toISOString(),
+      },
+    };
+  },
+});
+
+/**
+ * Custom error handler to convert validation errors to API error format
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (err && typeof err === "object" && "pathParamsError" in err) {
+    const validationError = err as {
+      pathParamsError: {
+        issues: Array<{ path: string[]; message: string }>;
+      } | null;
     };
 
-    return successResponse(response);
-  } catch (error) {
-    return errorResponse(error);
+    if (validationError.pathParamsError) {
+      const issue = validationError.pathParamsError.issues[0];
+      if (issue) {
+        return TsRestResponse.fromJson(
+          { error: { message: issue.message, code: "BAD_REQUEST" } },
+          { status: 400 },
+        );
+      }
+    }
   }
+
+  return undefined;
 }
+
+const handler = createNextHandler(runsByIdContract, router, {
+  handlerType: "app-router",
+  jsonQuery: true,
+  errorHandler,
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/agent/runs/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/route.ts
@@ -76,8 +76,10 @@ function errorHandler(err: unknown): TsRestResponse | void {
     if (validationError.pathParamsError) {
       const issue = validationError.pathParamsError.issues[0];
       if (issue) {
+        const path = issue.path.join(".");
+        const message = path ? `${path}: ${issue.message}` : issue.message;
         return TsRestResponse.fromJson(
-          { error: { message: issue.message, code: "BAD_REQUEST" } },
+          { error: { message, code: "BAD_REQUEST" } },
           { status: 400 },
         );
       }

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -27,3 +27,17 @@ export {
   agentComposeContentSchema,
   composeResponseSchema,
 } from "./composes";
+export {
+  runsMainContract,
+  runsByIdContract,
+  runEventsContract,
+  runStatusSchema,
+  unifiedRunRequestSchema,
+  createRunResponseSchema,
+  getRunResponseSchema,
+  runEventSchema,
+  eventsResponseSchema,
+  type RunsMainContract,
+  type RunsByIdContract,
+  type RunEventsContract,
+} from "./runs";

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -1,0 +1,179 @@
+import { z } from "zod";
+import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+/**
+ * Run status enum
+ */
+const runStatusSchema = z.enum([
+  "pending",
+  "running",
+  "completed",
+  "failed",
+  "timeout",
+]);
+
+/**
+ * Unified run request schema - supports all run modes via optional parameters
+ */
+const unifiedRunRequestSchema = z.object({
+  // High-level shortcuts (mutually exclusive with each other)
+  checkpointId: z.string().optional(),
+  sessionId: z.string().optional(),
+
+  // Base parameters (can be used directly or overridden after shortcut expansion)
+  agentComposeId: z.string().optional(),
+  agentComposeVersionId: z.string().optional(),
+  conversationId: z.string().optional(),
+  artifactName: z.string().optional(),
+  artifactVersion: z.string().optional(),
+  templateVars: z.record(z.string(), z.string()).optional(),
+  volumeVersions: z.record(z.string(), z.string()).optional(),
+
+  // Required
+  prompt: z.string().min(1, "Missing prompt"),
+});
+
+/**
+ * Create run response schema
+ */
+const createRunResponseSchema = z.object({
+  runId: z.string(),
+  status: runStatusSchema,
+  sandboxId: z.string().optional(),
+  output: z.string().optional(),
+  error: z.string().optional(),
+  executionTimeMs: z.number().optional(),
+  createdAt: z.string(),
+});
+
+/**
+ * Get run response schema
+ */
+const getRunResponseSchema = z.object({
+  runId: z.string(),
+  agentComposeVersionId: z.string(),
+  status: runStatusSchema,
+  prompt: z.string(),
+  templateVars: z.record(z.string(), z.string()).optional(),
+  sandboxId: z.string().optional(),
+  result: z
+    .object({
+      output: z.string(),
+      executionTimeMs: z.number(),
+    })
+    .optional(),
+  error: z.string().optional(),
+  createdAt: z.string(),
+  startedAt: z.string().optional(),
+  completedAt: z.string().optional(),
+});
+
+/**
+ * Run event schema
+ */
+const runEventSchema = z.object({
+  sequenceNumber: z.number(),
+  eventType: z.string(),
+  eventData: z.unknown(),
+  createdAt: z.string(),
+});
+
+/**
+ * Events response schema
+ */
+const eventsResponseSchema = z.object({
+  events: z.array(runEventSchema),
+  hasMore: z.boolean(),
+  nextSequence: z.number(),
+  status: runStatusSchema,
+});
+
+/**
+ * Runs main route contract (/api/agent/runs)
+ * Handles POST create
+ */
+export const runsMainContract = c.router({
+  /**
+   * POST /api/agent/runs
+   * Create and execute a new agent run
+   */
+  create: {
+    method: "POST",
+    path: "/api/agent/runs",
+    body: unifiedRunRequestSchema,
+    responses: {
+      201: createRunResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Create and execute agent run",
+  },
+});
+
+/**
+ * Runs by ID route contract (/api/agent/runs/[id])
+ */
+export const runsByIdContract = c.router({
+  /**
+   * GET /api/agent/runs/:id
+   * Get agent run status and results
+   */
+  getById: {
+    method: "GET",
+    path: "/api/agent/runs/:id",
+    pathParams: z.object({
+      id: z.string().min(1, "Run ID is required"),
+    }),
+    responses: {
+      200: getRunResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get agent run by ID",
+  },
+});
+
+/**
+ * Run events route contract (/api/agent/runs/[id]/events)
+ */
+export const runEventsContract = c.router({
+  /**
+   * GET /api/agent/runs/:id/events
+   * Poll for agent run events with pagination
+   */
+  getEvents: {
+    method: "GET",
+    path: "/api/agent/runs/:id/events",
+    pathParams: z.object({
+      id: z.string().min(1, "Run ID is required"),
+    }),
+    query: z.object({
+      since: z.coerce.number().default(0),
+      limit: z.coerce.number().default(100),
+    }),
+    responses: {
+      200: eventsResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get agent run events",
+  },
+});
+
+export type RunsMainContract = typeof runsMainContract;
+export type RunsByIdContract = typeof runsByIdContract;
+export type RunEventsContract = typeof runEventsContract;
+
+// Export schemas for reuse
+export {
+  runStatusSchema,
+  unifiedRunRequestSchema,
+  createRunResponseSchema,
+  getRunResponseSchema,
+  runEventSchema,
+  eventsResponseSchema,
+};

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -130,6 +130,7 @@ export const runsByIdContract = c.router({
     }),
     responses: {
       200: getRunResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
     },


### PR DESCRIPTION
## Summary
- Add `packages/core/src/contracts/runs.ts` with three contracts: `runsMainContract`, `runsByIdContract`, and `runEventsContract`
- Migrate `/api/agent/runs` (POST) to use ts-rest handler with proper Zod validation
- Migrate `/api/agent/runs/[id]` (GET) to use ts-rest handler
- Migrate `/api/agent/runs/[id]/events` (GET) to use ts-rest handler with pagination support
- Update error handlers to include field path in validation error messages
- Update tests to work with ts-rest handlers using NextRequest

Part of #450 - Phase 2 runs migration

## Test plan
- [x] All existing runs route tests pass (24 tests)
- [x] TypeScript type checks pass
- [x] Lint passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)