### PR TITLE
feat(api): migrate /api/agent/sessions to ts-rest contract-first architecture

### DIFF
--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -41,3 +41,12 @@ export {
   type RunsByIdContract,
   type RunEventsContract,
 } from "./runs";
+export {
+  sessionsMainContract,
+  sessionsByIdContract,
+  agentSessionSchema,
+  conversationSchema,
+  agentSessionWithConversationSchema,
+  type SessionsMainContract,
+  type SessionsByIdContract,
+} from "./sessions";

--- a/turbo/packages/core/src/contracts/sessions.ts
+++ b/turbo/packages/core/src/contracts/sessions.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+/**
+ * Agent session schema
+ */
+const agentSessionSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  agentComposeId: z.string(),
+  conversationId: z.string().nullable(),
+  artifactName: z.string(),
+  templateVars: z.record(z.string(), z.string()).nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+/**
+ * Conversation schema for session with conversation data
+ */
+const conversationSchema = z.object({
+  id: z.string(),
+  cliAgentType: z.string(),
+  cliAgentSessionId: z.string(),
+  cliAgentSessionHistory: z.string(),
+});
+
+/**
+ * Agent session with conversation data
+ */
+const agentSessionWithConversationSchema = agentSessionSchema.extend({
+  conversation: conversationSchema.nullable(),
+});
+
+/**
+ * Sessions main route contract (/api/agent/sessions)
+ * Handles GET list
+ */
+export const sessionsMainContract = c.router({
+  /**
+   * GET /api/agent/sessions
+   * List all agent sessions for the authenticated user
+   */
+  list: {
+    method: "GET",
+    path: "/api/agent/sessions",
+    responses: {
+      200: z.object({
+        sessions: z.array(agentSessionSchema),
+      }),
+      401: apiErrorSchema,
+    },
+    summary: "List agent sessions",
+  },
+});
+
+/**
+ * Sessions by ID route contract (/api/agent/sessions/[id])
+ * Handles GET and DELETE
+ */
+export const sessionsByIdContract = c.router({
+  /**
+   * GET /api/agent/sessions/:id
+   * Get a specific agent session with conversation data
+   */
+  getById: {
+    method: "GET",
+    path: "/api/agent/sessions/:id",
+    pathParams: z.object({
+      id: z.string().min(1, "Session ID is required"),
+    }),
+    responses: {
+      200: z.object({
+        session: agentSessionWithConversationSchema,
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get agent session by ID",
+  },
+  /**
+   * DELETE /api/agent/sessions/:id
+   * Delete an agent session
+   */
+  delete: {
+    method: "DELETE",
+    path: "/api/agent/sessions/:id",
+    pathParams: z.object({
+      id: z.string().min(1, "Session ID is required"),
+    }),
+    body: z.undefined(),
+    responses: {
+      200: z.object({
+        deleted: z.literal(true),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Delete agent session",
+  },
+});
+
+export type SessionsMainContract = typeof sessionsMainContract;
+export type SessionsByIdContract = typeof sessionsByIdContract;
+
+// Export schemas for reuse
+export {
+  agentSessionSchema,
+  conversationSchema,
+  agentSessionWithConversationSchema,
+};


### PR DESCRIPTION
## Summary
- Add `packages/core/src/contracts/sessions.ts` with two contracts: `sessionsMainContract` and `sessionsByIdContract`
- Migrate `/api/agent/sessions` (GET list) to use ts-rest handler
- Migrate `/api/agent/sessions/[id]` (GET, DELETE) to use ts-rest handler
- Add custom error handler with field path in validation messages
- Return 404 for ownership violations (security best practice - don't reveal resource exists)

Part of #450 - Phase 2 sessions migration

## Test plan
- [x] TypeScript type checks pass
- [x] Lint passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)