### PR TITLE
feat(api): migrate webhooks and auth routes to ts-rest contracts

### DIFF
--- a/turbo/apps/web/app/api/auth/me/route.ts
+++ b/turbo/apps/web/app/api/auth/me/route.ts
@@ -1,35 +1,60 @@
-import { NextResponse } from "next/server";
+import { createNextHandler, tsr } from "@ts-rest/serverless/next";
+import { authContract } from "@vm0/core";
 import { clerkClient } from "@clerk/nextjs/server";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
 
-export async function GET() {
-  const userId = await getUserId();
+const router = tsr.router(authContract, {
+  me: async () => {
+    const userId = await getUserId();
 
-  if (!userId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  try {
-    const client = await clerkClient();
-    const user = await client.users.getUser(userId);
-
-    if (!user) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    if (!userId) {
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "Unauthorized", code: "UNAUTHORIZED" },
+        },
+      };
     }
 
-    const email = user.emailAddresses.find(
-      (e) => e.id === user.primaryEmailAddressId,
-    )?.emailAddress;
+    try {
+      const client = await clerkClient();
+      const user = await client.users.getUser(userId);
 
-    return NextResponse.json({
-      userId: user.id,
-      email: email || "",
-    });
-  } catch (error) {
-    console.error("Failed to get user info:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
-  }
-}
+      if (!user) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "User not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+
+      const email = user.emailAddresses.find(
+        (e) => e.id === user.primaryEmailAddressId,
+      )?.emailAddress;
+
+      return {
+        status: 200 as const,
+        body: {
+          userId: user.id,
+          email: email || "",
+        },
+      };
+    } catch (error) {
+      console.error("Failed to get user info:", error);
+      return {
+        status: 500 as const,
+        body: {
+          error: { message: "Internal server error", code: "INTERNAL_ERROR" },
+        },
+      };
+    }
+  },
+});
+
+const handler = createNextHandler(authContract, router, {
+  handlerType: "app-router",
+  jsonQuery: true,
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/cli/auth/token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/route.ts
@@ -1,118 +1,145 @@
-import { NextResponse } from "next/server";
+import { createNextHandler, tsr } from "@ts-rest/serverless/next";
+import { TsRestResponse } from "@ts-rest/serverless";
+import { cliAuthTokenContract } from "@vm0/core";
 import crypto from "crypto";
 import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import { deviceCodes } from "../../../../../src/db/schema/device-codes";
 import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
 
-interface TokenRequest {
-  device_code: string;
-}
+const router = tsr.router(cliAuthTokenContract, {
+  exchange: async ({ body }) => {
+    initServices();
 
-export async function POST(request: Request): Promise<NextResponse> {
-  initServices();
+    const { device_code } = body;
 
-  const body = (await request.json()) as TokenRequest;
-  const { device_code } = body;
+    const [session] = await globalThis.services.db
+      .select()
+      .from(deviceCodes)
+      .where(eq(deviceCodes.code, device_code))
+      .limit(1);
 
-  if (!device_code) {
-    return NextResponse.json(
-      {
-        error: "invalid_request",
-        error_description: "device_code is required",
-      },
-      { status: 400 },
-    );
-  }
-
-  const [session] = await globalThis.services.db
-    .select()
-    .from(deviceCodes)
-    .where(eq(deviceCodes.code, device_code))
-    .limit(1);
-
-  if (!session) {
-    return NextResponse.json(
-      {
-        error: "invalid_request",
-        error_description: "Invalid device code",
-      },
-      { status: 400 },
-    );
-  }
-
-  // Check if expired
-  if (new Date() > session.expiresAt) {
-    return NextResponse.json(
-      {
-        error: "expired_token",
-        error_description: "The device code has expired",
-      },
-      { status: 400 },
-    );
-  }
-
-  // Check status
-  switch (session.status) {
-    case "pending":
-      return NextResponse.json(
-        {
-          error: "authorization_pending",
-          error_description:
-            "The user has not yet completed authorization in the browser",
+    if (!session) {
+      return {
+        status: 400 as const,
+        body: {
+          error: "invalid_request",
+          error_description: "Invalid device code",
         },
-        { status: 202 },
-      );
-
-    case "denied":
-      // Clean up
-      await globalThis.services.db
-        .delete(deviceCodes)
-        .where(eq(deviceCodes.code, device_code));
-
-      return NextResponse.json(
-        {
-          error: "access_denied",
-          error_description: "The user denied the authorization request",
-        },
-        { status: 400 },
-      );
-
-    case "authenticated": {
-      // Generate CLI token
-      const randomBytes = crypto.randomBytes(32);
-      const cliToken = `vm0_live_${randomBytes.toString("base64url")}`;
-      const now = new Date();
-      const expiresAt = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000); // 90 days
-
-      await globalThis.services.db.insert(cliTokens).values({
-        token: cliToken,
-        userId: session.userId as string,
-        name: "CLI Device Flow Authentication",
-        expiresAt,
-        createdAt: now,
-      });
-
-      // Clean up device code
-      await globalThis.services.db
-        .delete(deviceCodes)
-        .where(eq(deviceCodes.code, device_code));
-
-      return NextResponse.json({
-        access_token: cliToken,
-        refresh_token: `refresh_${crypto.randomBytes(16).toString("hex")}`,
-        token_type: "Bearer",
-        expires_in: 90 * 24 * 60 * 60, // 90 days in seconds
-      });
+      };
     }
 
-    default:
-      return NextResponse.json(
-        {
-          error: "server_error",
-          error_description: "Unknown device code status",
+    // Check if expired
+    if (new Date() > session.expiresAt) {
+      return {
+        status: 400 as const,
+        body: {
+          error: "expired_token",
+          error_description: "The device code has expired",
         },
-        { status: 500 },
-      );
+      };
+    }
+
+    // Check status
+    switch (session.status) {
+      case "pending":
+        return {
+          status: 202 as const,
+          body: {
+            error: "authorization_pending",
+            error_description:
+              "The user has not yet completed authorization in the browser",
+          },
+        };
+
+      case "denied": {
+        // Clean up
+        await globalThis.services.db
+          .delete(deviceCodes)
+          .where(eq(deviceCodes.code, device_code));
+
+        return {
+          status: 400 as const,
+          body: {
+            error: "access_denied",
+            error_description: "The user denied the authorization request",
+          },
+        };
+      }
+
+      case "authenticated": {
+        // Generate CLI token
+        const randomBytes = crypto.randomBytes(32);
+        const cliToken = `vm0_live_${randomBytes.toString("base64url")}`;
+        const now = new Date();
+        const expiresAt = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000); // 90 days
+
+        await globalThis.services.db.insert(cliTokens).values({
+          token: cliToken,
+          userId: session.userId as string,
+          name: "CLI Device Flow Authentication",
+          expiresAt,
+          createdAt: now,
+        });
+
+        // Clean up device code
+        await globalThis.services.db
+          .delete(deviceCodes)
+          .where(eq(deviceCodes.code, device_code));
+
+        return {
+          status: 200 as const,
+          body: {
+            access_token: cliToken,
+            refresh_token: `refresh_${crypto.randomBytes(16).toString("hex")}`,
+            token_type: "Bearer" as const,
+            expires_in: 90 * 24 * 60 * 60, // 90 days in seconds
+          },
+        };
+      }
+
+      default:
+        return {
+          status: 500 as const,
+          body: {
+            error: "server_error",
+            error_description: "Unknown device code status",
+          },
+        };
+    }
+  },
+});
+
+/**
+ * Custom error handler to convert Zod validation errors to OAuth error format
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (err && typeof err === "object" && "bodyError" in err) {
+    const validationError = err as {
+      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
+    };
+
+    if (validationError.bodyError) {
+      const issue = validationError.bodyError.issues[0];
+      if (issue) {
+        return TsRestResponse.fromJson(
+          {
+            error: "invalid_request",
+            error_description: `${issue.path.join(".")}: ${issue.message}`,
+          },
+          { status: 400 },
+        );
+      }
+    }
   }
+
+  return undefined;
 }
+
+const handler = createNextHandler(cliAuthTokenContract, router, {
+  handlerType: "app-router",
+  jsonQuery: true,
+  errorHandler,
+});
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -1,4 +1,6 @@
-import { NextRequest } from "next/server";
+import { createNextHandler, tsr } from "@ts-rest/serverless/next";
+import { TsRestResponse } from "@ts-rest/serverless";
+import { webhookCompleteContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import { checkpoints } from "../../../../../src/db/schema/checkpoint";
@@ -6,188 +8,175 @@ import { agentSessions } from "../../../../../src/db/schema/agent-session";
 import { eq, and } from "drizzle-orm";
 import { getUserId } from "../../../../../src/lib/auth/get-user-id";
 import {
-  successResponse,
-  errorResponse,
-} from "../../../../../src/lib/api-response";
-import {
-  BadRequestError,
-  NotFoundError,
-  UnauthorizedError,
-} from "../../../../../src/lib/errors";
-import {
   sendVm0ResultEvent,
   sendVm0ErrorEvent,
 } from "../../../../../src/lib/events";
 import { e2bService } from "../../../../../src/lib/e2b/e2b-service";
 import type { ArtifactSnapshot } from "../../../../../src/lib/checkpoint";
 
-/**
- * Request body for complete webhook endpoint
- */
-interface CompleteRequest {
-  runId: string;
-  exitCode: number;
-  error?: string;
-}
-
-/**
- * Response from complete endpoint
- */
-interface CompleteResponse {
-  success: boolean;
-  status: "completed" | "failed";
-}
-
-/**
- * POST /api/webhooks/agent/complete
- * Handle agent run completion (success or failure)
- * - Sends vm0_result or vm0_error event
- * - Updates run status
- * - Kills sandbox
- */
-export async function POST(request: NextRequest) {
-  let runId: string | undefined;
-  let sandboxId: string | undefined;
-
-  try {
-    // Initialize services
+const router = tsr.router(webhookCompleteContract, {
+  complete: async ({ body }) => {
     initServices();
 
-    // Authenticate using bearer token
     const userId = await getUserId();
     if (!userId) {
-      throw new UnauthorizedError("Not authenticated");
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        },
+      };
     }
-
-    // Parse request body
-    const body: CompleteRequest = await request.json();
-
-    // Validate required fields
-    if (!body.runId) {
-      throw new BadRequestError("Missing runId");
-    }
-
-    if (typeof body.exitCode !== "number") {
-      throw new BadRequestError("Missing or invalid exitCode");
-    }
-
-    runId = body.runId;
 
     console.log(
-      `[Complete API] Received completion for run ${runId}, exitCode=${body.exitCode}`,
+      `[Complete API] Received completion for run ${body.runId}, exitCode=${body.exitCode}`,
     );
 
     // Get run record
     const [run] = await globalThis.services.db
       .select()
       .from(agentRuns)
-      .where(and(eq(agentRuns.id, runId), eq(agentRuns.userId, userId)))
+      .where(and(eq(agentRuns.id, body.runId), eq(agentRuns.userId, userId)))
       .limit(1);
 
     if (!run) {
-      throw new NotFoundError("Agent run");
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Agent run not found", code: "NOT_FOUND" },
+        },
+      };
     }
 
-    sandboxId = run.sandboxId ?? undefined;
+    const sandboxId = run.sandboxId ?? undefined;
 
     // Idempotency check: if run is already completed/failed, return early
     if (run.status === "completed" || run.status === "failed") {
       console.log(
-        `[Complete API] Run ${runId} already ${run.status}, skipping duplicate completion`,
+        `[Complete API] Run ${body.runId} already ${run.status}, skipping duplicate completion`,
       );
-      return successResponse(
-        { success: true, status: run.status as "completed" | "failed" },
-        200,
-      );
+      return {
+        status: 200 as const,
+        body: {
+          success: true,
+          status: run.status as "completed" | "failed",
+        },
+      };
     }
 
     let finalStatus: "completed" | "failed";
 
-    if (body.exitCode === 0) {
-      // Success: query checkpoint and send vm0_result
-      const [checkpoint] = await globalThis.services.db
-        .select()
-        .from(checkpoints)
-        .where(eq(checkpoints.runId, runId))
-        .limit(1);
+    try {
+      if (body.exitCode === 0) {
+        // Success: query checkpoint and send vm0_result
+        const [checkpoint] = await globalThis.services.db
+          .select()
+          .from(checkpoints)
+          .where(eq(checkpoints.runId, body.runId))
+          .limit(1);
 
-      if (!checkpoint) {
-        throw new NotFoundError("Checkpoint for run");
+        if (!checkpoint) {
+          // Send error event and update run status
+          await sendVm0ErrorEvent({
+            runId: body.runId,
+            error: "Checkpoint for run not found",
+            sandboxId,
+          });
+
+          await globalThis.services.db
+            .update(agentRuns)
+            .set({ status: "failed", completedAt: new Date() })
+            .where(eq(agentRuns.id, body.runId));
+
+          if (sandboxId) {
+            await e2bService.killSandbox(sandboxId);
+          }
+
+          return {
+            status: 404 as const,
+            body: {
+              error: {
+                message: "Checkpoint for run not found",
+                code: "NOT_FOUND",
+              },
+            },
+          };
+        }
+
+        // Get agent session for the conversation
+        const [session] = await globalThis.services.db
+          .select()
+          .from(agentSessions)
+          .where(eq(agentSessions.conversationId, checkpoint.conversationId))
+          .limit(1);
+
+        // Extract artifact info from checkpoint
+        const artifactSnapshot =
+          checkpoint.artifactSnapshot as ArtifactSnapshot;
+        const volumeVersions = checkpoint.volumeVersionsSnapshot as
+          | { versions: Record<string, string> }
+          | undefined;
+
+        // Send vm0_result event
+        await sendVm0ResultEvent({
+          runId: body.runId,
+          checkpointId: checkpoint.id,
+          agentSessionId: session?.id ?? checkpoint.conversationId,
+          conversationId: checkpoint.conversationId,
+          artifact: {
+            [artifactSnapshot.artifactName]: artifactSnapshot.artifactVersion,
+          },
+          volumes: volumeVersions?.versions,
+        });
+
+        // Update run status to completed
+        await globalThis.services.db
+          .update(agentRuns)
+          .set({ status: "completed", completedAt: new Date() })
+          .where(eq(agentRuns.id, body.runId));
+
+        finalStatus = "completed";
+        console.log(`[Complete API] Run ${body.runId} completed successfully`);
+      } else {
+        // Failure: send vm0_error event
+        const errorMessage =
+          body.error || `Agent exited with code ${body.exitCode}`;
+
+        await sendVm0ErrorEvent({
+          runId: body.runId,
+          error: errorMessage,
+          sandboxId,
+        });
+
+        // Update run status to failed
+        await globalThis.services.db
+          .update(agentRuns)
+          .set({ status: "failed", completedAt: new Date() })
+          .where(eq(agentRuns.id, body.runId));
+
+        finalStatus = "failed";
+        console.log(`[Complete API] Run ${body.runId} failed: ${errorMessage}`);
       }
 
-      // Get agent session for the conversation
-      const [session] = await globalThis.services.db
-        .select()
-        .from(agentSessions)
-        .where(eq(agentSessions.conversationId, checkpoint.conversationId))
-        .limit(1);
+      // Kill sandbox (wait for completion to ensure cleanup before response)
+      if (sandboxId) {
+        await e2bService.killSandbox(sandboxId);
+      }
 
-      // Extract artifact info from checkpoint
-      const artifactSnapshot = checkpoint.artifactSnapshot as ArtifactSnapshot;
-      const volumeVersions = checkpoint.volumeVersionsSnapshot as
-        | { versions: Record<string, string> }
-        | undefined;
-
-      // Send vm0_result event
-      await sendVm0ResultEvent({
-        runId,
-        checkpointId: checkpoint.id,
-        agentSessionId: session?.id ?? checkpoint.conversationId,
-        conversationId: checkpoint.conversationId,
-        artifact: {
-          [artifactSnapshot.artifactName]: artifactSnapshot.artifactVersion,
+      return {
+        status: 200 as const,
+        body: {
+          success: true,
+          status: finalStatus,
         },
-        volumes: volumeVersions?.versions,
-      });
+      };
+    } catch (error) {
+      console.error("[Complete API] Error:", error);
 
-      // Update run status to completed
-      await globalThis.services.db
-        .update(agentRuns)
-        .set({ status: "completed", completedAt: new Date() })
-        .where(eq(agentRuns.id, runId));
-
-      finalStatus = "completed";
-      console.log(`[Complete API] Run ${runId} completed successfully`);
-    } else {
-      // Failure: send vm0_error event
-      const errorMessage =
-        body.error || `Agent exited with code ${body.exitCode}`;
-
-      await sendVm0ErrorEvent({
-        runId,
-        error: errorMessage,
-        sandboxId,
-      });
-
-      // Update run status to failed
-      await globalThis.services.db
-        .update(agentRuns)
-        .set({ status: "failed", completedAt: new Date() })
-        .where(eq(agentRuns.id, runId));
-
-      finalStatus = "failed";
-      console.log(`[Complete API] Run ${runId} failed: ${errorMessage}`);
-    }
-
-    // Kill sandbox (wait for completion to ensure cleanup before response)
-    if (sandboxId) {
-      await e2bService.killSandbox(sandboxId);
-    }
-
-    const response: CompleteResponse = {
-      success: true,
-      status: finalStatus,
-    };
-
-    return successResponse(response, 200);
-  } catch (error) {
-    console.error("[Complete API] Error:", error);
-
-    // Try to send vm0_error event if we have runId
-    if (runId) {
+      // Try to send vm0_error event
       try {
         await sendVm0ErrorEvent({
-          runId,
+          runId: body.runId,
           error: error instanceof Error ? error.message : "Complete API failed",
           sandboxId,
         });
@@ -196,13 +185,55 @@ export async function POST(request: NextRequest) {
           "[Complete API] Failed to send vm0_error event after error",
         );
       }
-    }
 
-    // Still try to kill sandbox on error
-    if (sandboxId) {
-      await e2bService.killSandbox(sandboxId);
-    }
+      // Still try to kill sandbox on error
+      if (sandboxId) {
+        await e2bService.killSandbox(sandboxId);
+      }
 
-    return errorResponse(error);
+      return {
+        status: 500 as const,
+        body: {
+          error: {
+            message:
+              error instanceof Error ? error.message : "Internal server error",
+            code: "INTERNAL_ERROR",
+          },
+        },
+      };
+    }
+  },
+});
+
+/**
+ * Custom error handler to convert Zod validation errors to API error format
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (err && typeof err === "object" && "bodyError" in err) {
+    const validationError = err as {
+      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
+    };
+
+    if (validationError.bodyError) {
+      const issue = validationError.bodyError.issues[0];
+      if (issue) {
+        const path = issue.path.join(".");
+        const message = path ? `${path}: ${issue.message}` : issue.message;
+        return TsRestResponse.fromJson(
+          { error: { message, code: "BAD_REQUEST" } },
+          { status: 400 },
+        );
+      }
+    }
   }
+
+  return undefined;
 }
+
+const handler = createNextHandler(webhookCompleteContract, router, {
+  handlerType: "app-router",
+  jsonQuery: true,
+  errorHandler,
+});
+
+export { handler as POST };

--- a/turbo/packages/core/src/contracts/auth.ts
+++ b/turbo/packages/core/src/contracts/auth.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+/**
+ * Auth contract for /api/auth/me
+ */
+export const authContract = c.router({
+  /**
+   * GET /api/auth/me
+   * Get current user information
+   */
+  me: {
+    method: "GET",
+    path: "/api/auth/me",
+    responses: {
+      200: z.object({
+        userId: z.string(),
+        email: z.string(),
+      }),
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get current user information",
+  },
+});
+
+export type AuthContract = typeof authContract;

--- a/turbo/packages/core/src/contracts/cli-auth.ts
+++ b/turbo/packages/core/src/contracts/cli-auth.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import { initContract } from "./base";
+
+const c = initContract();
+
+/**
+ * OAuth-style error response schema for device flow
+ * Uses standard OAuth 2.0 error format
+ */
+const oauthErrorSchema = z.object({
+  error: z.string(),
+  error_description: z.string(),
+});
+
+/**
+ * CLI auth device contract for /api/cli/auth/device
+ */
+export const cliAuthDeviceContract = c.router({
+  /**
+   * POST /api/cli/auth/device
+   * Initiate device authorization flow
+   */
+  create: {
+    method: "POST",
+    path: "/api/cli/auth/device",
+    body: z.object({}).optional(),
+    responses: {
+      200: z.object({
+        device_code: z.string(),
+        user_code: z.string(),
+        verification_url: z.string(),
+        expires_in: z.number(),
+        interval: z.number(),
+      }),
+      500: oauthErrorSchema,
+    },
+    summary: "Initiate device authorization flow",
+  },
+});
+
+/**
+ * CLI auth token contract for /api/cli/auth/token
+ */
+export const cliAuthTokenContract = c.router({
+  /**
+   * POST /api/cli/auth/token
+   * Exchange device code for access token
+   */
+  exchange: {
+    method: "POST",
+    path: "/api/cli/auth/token",
+    body: z.object({
+      device_code: z.string().min(1, "device_code is required"),
+    }),
+    responses: {
+      // Success - token issued
+      200: z.object({
+        access_token: z.string(),
+        refresh_token: z.string(),
+        token_type: z.literal("Bearer"),
+        expires_in: z.number(),
+      }),
+      // Authorization pending
+      202: oauthErrorSchema,
+      // Various error states
+      400: oauthErrorSchema,
+      500: oauthErrorSchema,
+    },
+    summary: "Exchange device code for access token",
+  },
+});
+
+export type CliAuthDeviceContract = typeof cliAuthDeviceContract;
+export type CliAuthTokenContract = typeof cliAuthTokenContract;

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -56,3 +56,24 @@ export {
   uploadStorageResponseSchema,
   type StoragesContract,
 } from "./storages";
+export {
+  webhookEventsContract,
+  webhookCompleteContract,
+  webhookCheckpointsContract,
+  webhookHeartbeatContract,
+  webhookStoragesContract,
+  webhookStoragesIncrementalContract,
+  type WebhookEventsContract,
+  type WebhookCompleteContract,
+  type WebhookCheckpointsContract,
+  type WebhookHeartbeatContract,
+  type WebhookStoragesContract,
+  type WebhookStoragesIncrementalContract,
+} from "./webhooks";
+export {
+  cliAuthDeviceContract,
+  cliAuthTokenContract,
+  type CliAuthDeviceContract,
+  type CliAuthTokenContract,
+} from "./cli-auth";
+export { authContract, type AuthContract } from "./auth";

--- a/turbo/packages/core/src/contracts/webhooks.ts
+++ b/turbo/packages/core/src/contracts/webhooks.ts
@@ -1,0 +1,247 @@
+import { z } from "zod";
+import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+/**
+ * Agent event schema for webhook events
+ */
+const agentEventSchema = z.object({
+  type: z.string(),
+  timestamp: z.number(),
+  sessionId: z.string().optional(),
+  data: z.record(z.string(), z.unknown()),
+});
+
+/**
+ * Artifact snapshot schema
+ */
+const artifactSnapshotSchema = z.object({
+  artifactName: z.string(),
+  artifactVersion: z.string(),
+});
+
+/**
+ * Volume versions snapshot schema
+ */
+const volumeVersionsSnapshotSchema = z.object({
+  versions: z.record(z.string(), z.string()),
+});
+
+/**
+ * Webhook events contract for /api/webhooks/agent/events
+ */
+export const webhookEventsContract = c.router({
+  /**
+   * POST /api/webhooks/agent/events
+   * Receive agent events from E2B sandbox
+   */
+  send: {
+    method: "POST",
+    path: "/api/webhooks/agent/events",
+    body: z.object({
+      runId: z.string().min(1, "runId is required"),
+      events: z.array(agentEventSchema).min(1, "events array cannot be empty"),
+    }),
+    responses: {
+      200: z.object({
+        received: z.number(),
+        firstSequence: z.number(),
+        lastSequence: z.number(),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Receive agent events from sandbox",
+  },
+});
+
+/**
+ * Webhook complete contract for /api/webhooks/agent/complete
+ */
+export const webhookCompleteContract = c.router({
+  /**
+   * POST /api/webhooks/agent/complete
+   * Handle agent run completion (success or failure)
+   */
+  complete: {
+    method: "POST",
+    path: "/api/webhooks/agent/complete",
+    body: z.object({
+      runId: z.string().min(1, "runId is required"),
+      exitCode: z.number(),
+      error: z.string().optional(),
+    }),
+    responses: {
+      200: z.object({
+        success: z.boolean(),
+        status: z.enum(["completed", "failed"]),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Handle agent run completion",
+  },
+});
+
+/**
+ * Webhook checkpoints contract for /api/webhooks/agent/checkpoints
+ */
+export const webhookCheckpointsContract = c.router({
+  /**
+   * POST /api/webhooks/agent/checkpoints
+   * Create checkpoint for completed agent run
+   */
+  create: {
+    method: "POST",
+    path: "/api/webhooks/agent/checkpoints",
+    body: z.object({
+      runId: z.string().min(1, "runId is required"),
+      cliAgentType: z.string().min(1, "cliAgentType is required"),
+      cliAgentSessionId: z.string().min(1, "cliAgentSessionId is required"),
+      cliAgentSessionHistory: z
+        .string()
+        .min(1, "cliAgentSessionHistory is required"),
+      artifactSnapshot: artifactSnapshotSchema,
+      volumeVersionsSnapshot: volumeVersionsSnapshotSchema.optional(),
+    }),
+    responses: {
+      200: z.object({
+        checkpointId: z.string(),
+        agentSessionId: z.string(),
+        conversationId: z.string(),
+        artifact: artifactSnapshotSchema,
+        volumes: z.record(z.string(), z.string()).optional(),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Create checkpoint for agent run",
+  },
+});
+
+/**
+ * Webhook heartbeat contract for /api/webhooks/agent/heartbeat
+ */
+export const webhookHeartbeatContract = c.router({
+  /**
+   * POST /api/webhooks/agent/heartbeat
+   * Receive heartbeat signals from E2B sandbox
+   */
+  send: {
+    method: "POST",
+    path: "/api/webhooks/agent/heartbeat",
+    body: z.object({
+      runId: z.string().min(1, "runId is required"),
+    }),
+    responses: {
+      200: z.object({
+        ok: z.boolean(),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Receive heartbeat from sandbox",
+  },
+});
+
+/**
+ * Webhook storages contract for /api/webhooks/agent/storages
+ * Note: This endpoint handles multipart form data upload
+ * The contract defines the JSON response schema
+ */
+export const webhookStoragesContract = c.router({
+  /**
+   * POST /api/webhooks/agent/storages
+   * Create a new version of a storage from sandbox
+   *
+   * Form fields:
+   * - runId: string (required)
+   * - storageName: string (required)
+   * - message: string (optional)
+   * - file: File (required, tar.gz archive)
+   */
+  upload: {
+    method: "POST",
+    path: "/api/webhooks/agent/storages",
+    contentType: "multipart/form-data",
+    body: c.type<FormData>(),
+    responses: {
+      200: z.object({
+        versionId: z.string(),
+        storageName: z.string(),
+        size: z.number(),
+        fileCount: z.number(),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Upload storage version from sandbox",
+  },
+});
+
+/**
+ * Webhook storages incremental contract for /api/webhooks/agent/storages/incremental
+ * Note: This endpoint handles multipart form data upload
+ */
+export const webhookStoragesIncrementalContract = c.router({
+  /**
+   * POST /api/webhooks/agent/storages/incremental
+   * Create a new version using incremental upload
+   *
+   * Form fields:
+   * - runId: string (required)
+   * - storageName: string (required)
+   * - baseVersion: string (required)
+   * - changes: JSON string (required)
+   * - message: string (optional)
+   * - file: File (optional, tar.gz of changed files)
+   */
+  upload: {
+    method: "POST",
+    path: "/api/webhooks/agent/storages/incremental",
+    contentType: "multipart/form-data",
+    body: c.type<FormData>(),
+    responses: {
+      200: z.object({
+        versionId: z.string(),
+        storageName: z.string(),
+        size: z.number(),
+        fileCount: z.number(),
+        incrementalStats: z
+          .object({
+            addedFiles: z.number(),
+            modifiedFiles: z.number(),
+            deletedFiles: z.number(),
+            unchangedFiles: z.number(),
+            bytesUploaded: z.number(),
+          })
+          .optional(),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Upload storage version incrementally from sandbox",
+  },
+});
+
+export type WebhookEventsContract = typeof webhookEventsContract;
+export type WebhookCompleteContract = typeof webhookCompleteContract;
+export type WebhookCheckpointsContract = typeof webhookCheckpointsContract;
+export type WebhookHeartbeatContract = typeof webhookHeartbeatContract;
+export type WebhookStoragesContract = typeof webhookStoragesContract;
+export type WebhookStoragesIncrementalContract =
+  typeof webhookStoragesIncrementalContract;

--- a/turbo/packages/core/src/contracts/webhooks.ts
+++ b/turbo/packages/core/src/contracts/webhooks.ts
@@ -6,13 +6,15 @@ const c = initContract();
 
 /**
  * Agent event schema for webhook events
+ * Note: Claude Code JSONL events have varying structures with different fields
+ * depending on the event type (system, assistant, user, result, etc.)
+ * We only require `type` and allow any other fields to pass through
  */
-const agentEventSchema = z.object({
-  type: z.string(),
-  timestamp: z.number(),
-  sessionId: z.string().optional(),
-  data: z.record(z.string(), z.unknown()),
-});
+const agentEventSchema = z
+  .object({
+    type: z.string(),
+  })
+  .passthrough();
 
 /**
  * Artifact snapshot schema


### PR DESCRIPTION
## Summary
- Migrates all webhook routes (`/api/webhooks/agent/*`) to ts-rest contract-first architecture
- Migrates CLI auth routes (`/api/cli/auth/device`, `/api/cli/auth/token`) to ts-rest
- Migrates `/api/auth/me` route to ts-rest
- Creates new contracts: `webhooks.ts`, `cli-auth.ts`, `auth.ts`
- Standardizes error responses across all routes

Phase 3 of Issue #450.

## Routes Migrated

### Webhook Routes
- `/api/webhooks/agent/events` - Agent event webhook (streams events from sandbox)
- `/api/webhooks/agent/complete` - Agent completion webhook (success/failure handling)
- `/api/webhooks/agent/checkpoints` - Checkpoint creation webhook
- `/api/webhooks/agent/heartbeat` - Heartbeat webhook
- `/api/webhooks/agent/storages` - Storage upload webhook (multipart)
- `/api/webhooks/agent/storages/incremental` - Incremental storage upload webhook (multipart)

### Auth Routes
- `/api/cli/auth/device` - CLI device authorization flow
- `/api/cli/auth/token` - CLI token exchange
- `/api/auth/me` - Current user info

## Test plan
- [x] All webhook tests pass (37 tests)
- [x] Type check passes
- [x] Lint passes

Closes part of #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)