### PR TITLE
feat(storage): support same name for volume and artifact with type isolation

### DIFF
--- a/turbo/apps/cli/src/commands/artifact/pull.ts
+++ b/turbo/apps/cli/src/commands/artifact/pull.ts
@@ -58,7 +58,7 @@ export const pullCommand = new Command()
       // Download from API
       console.log(chalk.gray("Downloading..."));
 
-      let url = `/api/storages?name=${encodeURIComponent(config.name)}`;
+      let url = `/api/storages?name=${encodeURIComponent(config.name)}&type=artifact`;
       if (versionId) {
         url += `&version=${encodeURIComponent(versionId)}`;
       }

--- a/turbo/apps/cli/src/commands/volume/pull.ts
+++ b/turbo/apps/cli/src/commands/volume/pull.ts
@@ -46,7 +46,7 @@ export const pullCommand = new Command()
       // Download from API
       console.log(chalk.gray("Downloading..."));
 
-      let url = `/api/storages?name=${encodeURIComponent(config.name)}`;
+      let url = `/api/storages?name=${encodeURIComponent(config.name)}&type=volume`;
       if (versionId) {
         url += `&version=${encodeURIComponent(versionId)}`;
       }

--- a/turbo/apps/web/app/api/storages/route.ts
+++ b/turbo/apps/web/app/api/storages/route.ts
@@ -168,7 +168,7 @@ export async function POST(request: NextRequest) {
           .values({
             userId,
             name: storageName,
-            s3Prefix: `${userId}/${storageName}`,
+            s3Prefix: `${userId}/${storageType}/${storageName}`,
             size: totalSize,
             fileCount,
             type: storageType,
@@ -231,7 +231,7 @@ export async function POST(request: NextRequest) {
 
       // Create new version record with content hash as ID
       // Use onConflictDoNothing to handle force upload case where version already exists
-      const s3Key = `${userId}/${storageName}/${contentHash}`;
+      const s3Key = `${userId}/${storageType}/${storageName}/${contentHash}`;
       const createdVersions = await tx
         .insert(storageVersions)
         .values({

--- a/turbo/apps/web/app/api/storages/route.ts
+++ b/turbo/apps/web/app/api/storages/route.ts
@@ -362,11 +362,15 @@ export async function GET(request: NextRequest) {
     // Get query parameters
     const { searchParams } = new URL(request.url);
     const storageName = searchParams.get("name");
-    const storageType = searchParams.get("type") || "volume"; // Default to "volume" for backwards compatibility
+    const storageType = searchParams.get("type");
     const versionId = searchParams.get("version");
 
     if (!storageName) {
       return errorResponse("Missing name parameter", "BAD_REQUEST", 400);
+    }
+
+    if (!storageType) {
+      return errorResponse("Missing type parameter", "BAD_REQUEST", 400);
     }
 
     // Validate storage type

--- a/turbo/apps/web/app/api/storages/route.ts
+++ b/turbo/apps/web/app/api/storages/route.ts
@@ -148,10 +148,17 @@ export async function POST(request: NextRequest) {
     }
 
     // Check if storage already exists (outside transaction for read)
+    // Must include type in query since same name can exist for different types
     const existingStorages = await globalThis.services.db
       .select()
       .from(storages)
-      .where(and(eq(storages.userId, userId), eq(storages.name, storageName)))
+      .where(
+        and(
+          eq(storages.userId, userId),
+          eq(storages.name, storageName),
+          eq(storages.type, storageType),
+        ),
+      )
       .limit(1);
 
     const existingStorage = existingStorages[0];
@@ -355,21 +362,38 @@ export async function GET(request: NextRequest) {
     // Get query parameters
     const { searchParams } = new URL(request.url);
     const storageName = searchParams.get("name");
+    const storageType = searchParams.get("type") || "volume"; // Default to "volume" for backwards compatibility
     const versionId = searchParams.get("version");
 
     if (!storageName) {
       return errorResponse("Missing name parameter", "BAD_REQUEST", 400);
     }
 
+    // Validate storage type
+    if (storageType !== "volume" && storageType !== "artifact") {
+      return errorResponse(
+        "Invalid type. Must be 'volume' or 'artifact'",
+        "BAD_REQUEST",
+        400,
+      );
+    }
+
     log.debug(
-      `Downloading storage "${storageName}"${versionId ? ` version ${versionId}` : ""} for user ${userId}`,
+      `Downloading storage "${storageName}" (type: ${storageType})${versionId ? ` version ${versionId}` : ""} for user ${userId}`,
     );
 
     // Check if storage exists and belongs to user
+    // Must include type in query since same name can exist for different types
     const [storage] = await globalThis.services.db
       .select()
       .from(storages)
-      .where(and(eq(storages.userId, userId), eq(storages.name, storageName)))
+      .where(
+        and(
+          eq(storages.userId, userId),
+          eq(storages.name, storageName),
+          eq(storages.type, storageType),
+        ),
+      )
       .limit(1);
 
     if (!storage) {

--- a/turbo/apps/web/app/api/webhooks/agent/storages/incremental/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/incremental/route.ts
@@ -73,7 +73,7 @@ export async function POST(request: NextRequest) {
     const formData = await request.formData();
     const runId = formData.get("runId") as string;
     const storageName = formData.get("storageName") as string;
-    const storageType = (formData.get("storageType") as string) || "volume"; // Default to "volume" for backwards compatibility
+    const storageType = formData.get("storageType") as string;
     const baseVersion = formData.get("baseVersion") as string;
     const changesJson = formData.get("changes") as string;
     const message = formData.get("message") as string | null;
@@ -92,7 +92,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Validate storage type
+    if (!storageType) {
+      return errorResponse(
+        "storageType: storageType is required",
+        "BAD_REQUEST",
+        400,
+      );
+    }
+
+    // Validate storage type value
     if (storageType !== "volume" && storageType !== "artifact") {
       return errorResponse(
         "storageType: must be 'volume' or 'artifact'",

--- a/turbo/apps/web/app/api/webhooks/agent/storages/incremental/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/incremental/route.ts
@@ -73,6 +73,7 @@ export async function POST(request: NextRequest) {
     const formData = await request.formData();
     const runId = formData.get("runId") as string;
     const storageName = formData.get("storageName") as string;
+    const storageType = (formData.get("storageType") as string) || "volume"; // Default to "volume" for backwards compatibility
     const baseVersion = formData.get("baseVersion") as string;
     const changesJson = formData.get("changes") as string;
     const message = formData.get("message") as string | null;
@@ -86,6 +87,15 @@ export async function POST(request: NextRequest) {
     if (!storageName) {
       return errorResponse(
         "storageName: storageName is required",
+        "BAD_REQUEST",
+        400,
+      );
+    }
+
+    // Validate storage type
+    if (storageType !== "volume" && storageType !== "artifact") {
+      return errorResponse(
+        "storageType: must be 'volume' or 'artifact'",
         "BAD_REQUEST",
         400,
       );
@@ -124,7 +134,7 @@ export async function POST(request: NextRequest) {
     }
 
     log.debug(
-      `Received incremental upload for "${storageName}" from run ${runId}, base: ${baseVersion.slice(0, 8)}`,
+      `Received incremental upload for "${storageName}" (type: ${storageType}) from run ${runId}, base: ${baseVersion.slice(0, 8)}`,
     );
     log.debug(
       `Changes: +${changes.added.length} ~${changes.modified.length} -${changes.deleted.length}`,
@@ -141,11 +151,18 @@ export async function POST(request: NextRequest) {
       return errorResponse("Agent run not found", "NOT_FOUND", 404);
     }
 
-    // Find the storage by name and user
+    // Find the storage by name, type, and user
+    // Must include type in query since same name can exist for different types
     const [storage] = await globalThis.services.db
       .select()
       .from(storages)
-      .where(and(eq(storages.userId, userId), eq(storages.name, storageName)))
+      .where(
+        and(
+          eq(storages.userId, userId),
+          eq(storages.name, storageName),
+          eq(storages.type, storageType),
+        ),
+      )
       .limit(1);
 
     if (!storage) {

--- a/turbo/apps/web/app/api/webhooks/agent/storages/incremental/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/incremental/route.ts
@@ -336,7 +336,7 @@ export async function POST(request: NextRequest) {
       deduplicated = true;
     } else {
       // Create new version record
-      const s3Key = `${userId}/${storageName}/${contentHash}`;
+      const s3Key = `${userId}/${storage.type}/${storageName}/${contentHash}`;
 
       const [version] = await globalThis.services.db
         .insert(storageVersions)

--- a/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
@@ -59,6 +59,7 @@ export async function POST(request: NextRequest) {
     const formData = await request.formData();
     const runId = formData.get("runId") as string;
     const storageName = formData.get("storageName") as string;
+    const storageType = (formData.get("storageType") as string) || "volume"; // Default to "volume" for backwards compatibility
     const message = formData.get("message") as string | null;
     const file = formData.get("file") as File;
 
@@ -75,12 +76,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Validate storage type
+    if (storageType !== "volume" && storageType !== "artifact") {
+      return errorResponse(
+        "storageType: must be 'volume' or 'artifact'",
+        "BAD_REQUEST",
+        400,
+      );
+    }
+
     if (!file) {
       return errorResponse("file: file is required", "BAD_REQUEST", 400);
     }
 
     log.debug(
-      `Received storage version request for "${storageName}" from run ${runId}`,
+      `Received storage version request for "${storageName}" (type: ${storageType}) from run ${runId}`,
     );
 
     // Verify run exists and belongs to the authenticated user
@@ -94,11 +104,18 @@ export async function POST(request: NextRequest) {
       return errorResponse("Agent run not found", "NOT_FOUND", 404);
     }
 
-    // Find the storage by name and user
+    // Find the storage by name, type, and user
+    // Must include type in query since same name can exist for different types
     const [storage] = await globalThis.services.db
       .select()
       .from(storages)
-      .where(and(eq(storages.userId, userId), eq(storages.name, storageName)))
+      .where(
+        and(
+          eq(storages.userId, userId),
+          eq(storages.name, storageName),
+          eq(storages.type, storageType),
+        ),
+      )
       .limit(1);
 
     if (!storage) {

--- a/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
@@ -172,7 +172,7 @@ export async function POST(request: NextRequest) {
       versionId = existingVersion.id;
     } else {
       // Create new version record with content hash as ID
-      const s3Key = `${userId}/${storageName}/${contentHash}`;
+      const s3Key = `${userId}/${storage.type}/${storageName}/${contentHash}`;
 
       const [version] = await globalThis.services.db
         .insert(storageVersions)

--- a/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
@@ -59,7 +59,7 @@ export async function POST(request: NextRequest) {
     const formData = await request.formData();
     const runId = formData.get("runId") as string;
     const storageName = formData.get("storageName") as string;
-    const storageType = (formData.get("storageType") as string) || "volume"; // Default to "volume" for backwards compatibility
+    const storageType = formData.get("storageType") as string;
     const message = formData.get("message") as string | null;
     const file = formData.get("file") as File;
 
@@ -76,7 +76,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Validate storage type
+    if (!storageType) {
+      return errorResponse(
+        "storageType: storageType is required",
+        "BAD_REQUEST",
+        400,
+      );
+    }
+
+    // Validate storage type value
     if (storageType !== "volume" && storageType !== "artifact") {
       return errorResponse(
         "storageType: must be 'volume' or 'artifact'",

--- a/turbo/apps/web/src/db/migrations/0032_storage_type_isolation.sql
+++ b/turbo/apps/web/src/db/migrations/0032_storage_type_isolation.sql
@@ -1,0 +1,26 @@
+-- Migration: Add type to unique constraint for storage isolation
+-- This allows volumes and artifacts to have the same name under the same user
+
+-- Step 1: Drop existing unique index on (user_id, name)
+DROP INDEX IF EXISTS "idx_storages_user_name";
+--> statement-breakpoint
+
+-- Step 2: Create new unique index on (user_id, name, type)
+-- This allows same name across different types (volume vs artifact)
+CREATE UNIQUE INDEX "idx_storages_user_name_type" ON "storages" ("user_id", "name", "type");
+--> statement-breakpoint
+
+-- Step 3: Update s3_prefix to include type for existing storages
+-- Format changes from: userId/storageName to: userId/type/storageName
+UPDATE "storages"
+SET "s3_prefix" = "user_id" || '/' || "type" || '/' || "name"
+WHERE "s3_prefix" = "user_id" || '/' || "name";
+--> statement-breakpoint
+
+-- Step 4: Update s3_key in storage_versions to include type
+-- Format changes from: userId/storageName/versionId to: userId/type/storageName/versionId
+UPDATE "storage_versions" sv
+SET "s3_key" = s."user_id" || '/' || s."type" || '/' || s."name" || '/' || sv."id"
+FROM "storages" s
+WHERE sv."storage_id" = s."id"
+  AND sv."s3_key" = s."user_id" || '/' || s."name" || '/' || sv."id";

--- a/turbo/apps/web/src/db/schema/storage.ts
+++ b/turbo/apps/web/src/db/schema/storage.ts
@@ -35,9 +35,10 @@ export const storages = pgTable(
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => ({
-    userNameIdx: uniqueIndex("idx_storages_user_name").on(
+    userNameTypeIdx: uniqueIndex("idx_storages_user_name_type").on(
       table.userId,
       table.name,
+      table.type,
     ),
   }),
 );

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/checkpoint.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/checkpoint.py.ts
@@ -94,11 +94,12 @@ def create_checkpoint() -> bool:
             "artifact",
             ARTIFACT_VOLUME_NAME,
             ARTIFACT_VERSION_ID,
-            ARTIFACT_MANIFEST_URL
+            ARTIFACT_MANIFEST_URL,
+            "artifact"  # Explicit storage type - required by webhook API
         )
     else:
         log_info("Using full upload (no base version available)")
-        snapshot = create_vas_snapshot(ARTIFACT_MOUNT_PATH, "artifact", ARTIFACT_VOLUME_NAME)
+        snapshot = create_vas_snapshot(ARTIFACT_MOUNT_PATH, "artifact", ARTIFACT_VOLUME_NAME, "artifact")
 
     if not snapshot:
         log_error("Failed to create VAS snapshot for artifact")

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/vas_snapshot.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/vas_snapshot.py.ts
@@ -21,7 +21,8 @@ from http_client import http_post_form
 def create_vas_snapshot(
     mount_path: str,
     storage_name: str,
-    vas_storage_name: str
+    vas_storage_name: str,
+    storage_type: str = "artifact"
 ) -> Optional[Dict[str, Any]]:
     """
     Create VAS snapshot for a storage.
@@ -31,11 +32,12 @@ def create_vas_snapshot(
         mount_path: Path to the storage directory
         storage_name: Display name of the storage
         vas_storage_name: VAS storage name
+        storage_type: Storage type ("volume" or "artifact"), defaults to "artifact"
 
     Returns:
         Dict with versionId on success, None on failure
     """
-    log_info(f"Creating VAS snapshot for storage '{storage_name}' ({vas_storage_name}) at {mount_path}")
+    log_info(f"Creating VAS snapshot for storage '{storage_name}' ({vas_storage_name}, type: {storage_type}) at {mount_path}")
     log_debug(f"STORAGE_WEBHOOK_URL: {STORAGE_WEBHOOK_URL}")
     log_debug(f"RUN_ID: {RUN_ID}")
 
@@ -71,6 +73,7 @@ def create_vas_snapshot(
         form_fields = {
             "runId": RUN_ID,
             "storageName": vas_storage_name,
+            "storageType": storage_type,
             "message": f"Checkpoint from run {RUN_ID}"
         }
 


### PR DESCRIPTION
## Summary

- Add database migration to change unique constraint from `(userId, name)` to `(userId, name, type)`
- Update S3 key format from `userId/name/hash` to `userId/type/name/hash`
- Update s3Prefix format to include type for proper isolation
- Migrate existing data paths in the migration script

This allows users to create a volume and an artifact with the same name, which are now properly isolated in both database and S3 storage.

## Changes

| File | Change |
|------|--------|
| `db/migrations/0032_storage_type_isolation.sql` | New migration to update unique constraint and migrate existing data |
| `db/schema/storage.ts` | Update index definition to include type |
| `api/storages/route.ts` | Update s3Prefix and s3Key generation |
| `api/webhooks/agent/storages/route.ts` | Update s3Key generation |
| `api/webhooks/agent/storages/incremental/route.ts` | Update s3Key generation |

## S3 Structure After Change

```
s3://bucket/
├── user123/
│   ├── volume/
│   │   └── my-data/
│   │       └── abc123.../
│   └── artifact/
│       └── my-data/           ← Same name, now isolated!
│           └── def456.../
```

## Test plan

- [x] All existing tests pass (688 tests)
- [x] Type check passes
- [x] Lint passes
- [ ] Verify migration works on staging database
- [ ] Test creating same-name volume and artifact

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)