### PR TITLE
refactor(api): migrate console.log to structured logger

### DIFF
--- a/turbo/apps/web/app/api/auth/me/route.ts
+++ b/turbo/apps/web/app/api/auth/me/route.ts
@@ -2,6 +2,9 @@ import { createNextHandler, tsr } from "@ts-rest/serverless/next";
 import { authContract } from "@vm0/core";
 import { clerkClient } from "@clerk/nextjs/server";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { logger } from "../../../../src/lib/logger";
+
+const log = logger("api:auth");
 
 const router = tsr.router(authContract, {
   me: async () => {
@@ -41,7 +44,7 @@ const router = tsr.router(authContract, {
         },
       };
     } catch (error) {
-      console.error("Failed to get user info:", error);
+      log.error("Failed to get user info:", error);
       return {
         status: 500 as const,
         body: {

--- a/turbo/apps/web/app/api/storages/route.ts
+++ b/turbo/apps/web/app/api/storages/route.ts
@@ -316,13 +316,13 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(result);
   } catch (error) {
-    console.error("[Storage] Upload error:", error);
+    log.error("Upload error:", error);
 
     // Clean up temp directory if exists
     if (tempDir) {
       await fs.promises
         .rm(tempDir, { recursive: true, force: true })
-        .catch(console.error);
+        .catch((err) => log.error("Failed to clean up temp directory:", err));
     }
 
     return errorResponse(
@@ -514,13 +514,13 @@ export async function GET(request: NextRequest) {
       },
     });
   } catch (error) {
-    console.error("[Storage] Download error:", error);
+    log.error("Download error:", error);
 
     // Clean up temp directory if exists
     if (tempDir) {
       await fs.promises
         .rm(tempDir, { recursive: true, force: true })
-        .catch(console.error);
+        .catch((err) => log.error("Failed to clean up temp directory:", err));
     }
 
     return errorResponse(

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/route.ts
@@ -6,6 +6,9 @@ import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import { eq, and } from "drizzle-orm";
 import { getUserId } from "../../../../../src/lib/auth/get-user-id";
 import { checkpointService } from "../../../../../src/lib/checkpoint";
+import { logger } from "../../../../../src/lib/logger";
+
+const log = logger("webhook:checkpoints");
 
 const router = tsr.router(webhookCheckpointsContract, {
   create: async ({ body }) => {
@@ -21,8 +24,8 @@ const router = tsr.router(webhookCheckpointsContract, {
       };
     }
 
-    console.log(
-      `[Checkpoint API] Received checkpoint request for run ${body.runId} from user ${userId}`,
+    log.debug(
+      `Received checkpoint request for run ${body.runId} from user ${userId}`,
     );
 
     // Verify run exists and belongs to the authenticated user
@@ -48,8 +51,8 @@ const router = tsr.router(webhookCheckpointsContract, {
       // Create checkpoint
       const result = await checkpointService.createCheckpoint(body);
 
-      console.log(
-        `[Checkpoint API] Checkpoint created: ${result.checkpointId}, session: ${result.agentSessionId}, conversation: ${result.conversationId}`,
+      log.debug(
+        `Checkpoint created: ${result.checkpointId}, session: ${result.agentSessionId}, conversation: ${result.conversationId}`,
       );
 
       // Note: vm0_result event is now sent by the complete API
@@ -66,7 +69,7 @@ const router = tsr.router(webhookCheckpointsContract, {
         },
       };
     } catch (error) {
-      console.error("[Checkpoint API] Error:", error);
+      log.error("Error:", error);
 
       // Note: vm0_error event is now sent by the complete API
       // If checkpoint fails, run-agent.sh will call complete API with exitCode != 0

--- a/turbo/apps/web/app/api/webhooks/agent/events/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/route.ts
@@ -8,6 +8,9 @@ import { eq, max, and } from "drizzle-orm";
 import { getUserId } from "../../../../../src/lib/auth/get-user-id";
 import { createSecretMasker } from "../../../../../src/lib/secrets/secret-masker";
 import { getAllSecretValues } from "../../../../../src/lib/secrets/secrets-service";
+import { logger } from "../../../../../src/lib/logger";
+
+const log = logger("webhook:events");
 
 const router = tsr.router(webhookEventsContract, {
   send: async ({ body }) => {
@@ -23,8 +26,8 @@ const router = tsr.router(webhookEventsContract, {
       };
     }
 
-    console.log(
-      `[Webhook] Received ${body.events.length} events for run ${body.runId} from user ${userId}`,
+    log.debug(
+      `Received ${body.events.length} events for run ${body.runId} from user ${userId}`,
     );
 
     // Verify run exists and belongs to the authenticated user
@@ -69,8 +72,8 @@ const router = tsr.router(webhookEventsContract, {
     const firstSequence = lastSequence + 1;
     const lastInsertedSequence = lastSequence + body.events.length;
 
-    console.log(
-      `[Webhook] Stored events ${firstSequence}-${lastInsertedSequence} for run ${body.runId}`,
+    log.debug(
+      `Stored events ${firstSequence}-${lastInsertedSequence} for run ${body.runId}`,
     );
 
     return {

--- a/turbo/apps/web/app/api/webhooks/agent/storages/incremental/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/incremental/route.ts
@@ -455,7 +455,7 @@ export async function POST(request: NextRequest) {
     if (tempDir) {
       await fs.promises
         .rm(tempDir, { recursive: true, force: true })
-        .catch(console.error);
+        .catch((err) => log.error("Failed to clean up temp directory:", err));
     }
 
     return errorResponse(

--- a/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/route.ts
@@ -276,7 +276,7 @@ export async function POST(request: NextRequest) {
     if (tempDir) {
       await fs.promises
         .rm(tempDir, { recursive: true, force: true })
-        .catch(console.error);
+        .catch((err) => log.error("Failed to clean up temp directory:", err));
     }
 
     return errorResponse(


### PR DESCRIPTION
## Summary
- Replace direct `console.*` calls with structured logger utility across 8 API route files
- Add logger imports with appropriate namespaces for each route
- Enable controllable debug output via `DEBUG` environment variable

## Changes
| File | Logger Namespace | Modifications |
|------|------------------|---------------|
| `agent/runs/route.ts` | `api:runs` | 6 |
| `webhooks/agent/complete/route.ts` | `webhook:complete` | 6 |
| `webhooks/agent/events/route.ts` | `webhook:events` | 2 |
| `webhooks/agent/checkpoints/route.ts` | `webhook:checkpoints` | 3 |
| `auth/me/route.ts` | `api:auth` | 1 |
| `storages/route.ts` | `api:storages` | 4 |
| `webhooks/agent/storages/route.ts` | `webhook:storages` | 1 |
| `webhooks/agent/storages/incremental/route.ts` | `webhook:storages:incremental` | 1 |

## Log Level Mapping
- `console.log` → `log.debug` (diagnostic messages)
- `console.error` → `log.error` (error handling)
- Failure messages → `log.warn`

## Test plan
- [x] Lint passes
- [x] Type check passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)