### PR TITLE
feat(cli): show logs command hint when run starts

### DIFF
--- a/turbo/apps/cli/src/lib/__tests__/event-renderer.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/event-renderer.test.ts
@@ -621,6 +621,37 @@ describe("EventRenderer", () => {
   // ============================================
 
   describe("Run State Rendering", () => {
+    it("should render run started with run ID and logs hint", () => {
+      EventRenderer.renderRunStarted({
+        runId: "test-run-123",
+      });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const allCalls = consoleLogSpy.mock.calls.map(
+        (call) => call[0] as string,
+      );
+      expect(allCalls.some((call) => call.includes("Run started"))).toBe(true);
+      expect(allCalls.some((call) => call.includes("Run ID:"))).toBe(true);
+      expect(allCalls.some((call) => call.includes("test-run-123"))).toBe(true);
+      expect(
+        allCalls.some((call) => call.includes("vm0 logs test-run-123")),
+      ).toBe(true);
+    });
+
+    it("should render run started with sandbox ID when provided", () => {
+      EventRenderer.renderRunStarted({
+        runId: "test-run-456",
+        sandboxId: "sandbox-abc",
+      });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const allCalls = consoleLogSpy.mock.calls.map(
+        (call) => call[0] as string,
+      );
+      expect(allCalls.some((call) => call.includes("Sandbox:"))).toBe(true);
+      expect(allCalls.some((call) => call.includes("sandbox-abc"))).toBe(true);
+    });
+
     it("should render run completed with result", () => {
       const result = {
         checkpointId: "checkpoint-123",

--- a/turbo/apps/cli/src/lib/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/event-renderer.ts
@@ -43,6 +43,7 @@ export class EventRenderer {
     if (info.sandboxId) {
       console.log(`  Sandbox:  ${chalk.gray(info.sandboxId)}`);
     }
+    console.log(chalk.gray(`  (use "vm0 logs ${info.runId}" to view logs)`));
     console.log();
   }
 


### PR DESCRIPTION
## Summary
- Add logs command hint to run started output so users know how to view logs even if they cancel the run before completion
- Add unit tests for `renderRunStarted` method

## Test plan
- [x] Unit tests pass
- [x] Lint and type check pass
- [ ] E2E tests should pass (existing test already checks for `vm0 logs` in output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)