### PR TITLE
refactor: convert dynamic imports to static imports in production code

### DIFF
--- a/turbo/apps/cli/src/commands/image/delete.ts
+++ b/turbo/apps/cli/src/commands/image/delete.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import * as readline from "readline";
 import { apiClient } from "../../lib/api-client";
 
 interface Image {
@@ -44,7 +45,6 @@ export const deleteCommand = new Command()
 
       // Confirmation prompt (unless --force)
       if (!options.force) {
-        const readline = await import("readline");
         const rl = readline.createInterface({
           input: process.stdin,
           output: process.stdout,

--- a/turbo/apps/web/src/lib/image/image-service.ts
+++ b/turbo/apps/web/src/lib/image/image-service.ts
@@ -1,4 +1,5 @@
 import { eq, and, desc } from "drizzle-orm";
+import { ApiClient, ConnectionConfig, Template, BuildError } from "e2b";
 
 import { images } from "../../db/schema/image";
 import { BadRequestError, NotFoundError, ForbiddenError } from "../errors";
@@ -6,9 +7,6 @@ import { logger } from "../logger";
 import type { ImageStatusEnum } from "../../db/schema/image";
 
 const log = logger("service:image");
-
-// Note: E2B SDK is imported dynamically in functions that need it
-// to avoid loading the heavy SDK in routes that only use validation functions
 
 /**
  * Generate E2B alias from userId and user-specified alias
@@ -33,7 +31,6 @@ export function isSystemTemplate(alias: string): boolean {
 export async function tryDeleteE2bTemplateByAlias(
   e2bAlias: string,
 ): Promise<void> {
-  const { ApiClient, ConnectionConfig } = await import("e2b");
   const config = new ConnectionConfig({});
   const client = new ApiClient(config);
 
@@ -71,9 +68,6 @@ export async function buildImage(
   dockerfile: string,
   alias: string,
 ): Promise<BuildResult> {
-  // Dynamic import to avoid loading E2B SDK in routes that don't need it
-  const { Template, BuildError } = await import("e2b");
-
   const e2bAlias = generateE2bAlias(userId, alias);
 
   log.debug("starting image build", { userId, alias, e2bAlias });
@@ -159,9 +153,6 @@ export async function getBuildStatus(
   templateId: string,
   logsOffset = 0,
 ): Promise<BuildStatusResult> {
-  // Dynamic import to avoid loading E2B SDK in routes that don't need it
-  const { Template } = await import("e2b");
-
   // Query E2B for build status
   const e2bStatus = await Template.getBuildStatus(
     { buildId, templateId },
@@ -384,7 +375,6 @@ export async function deleteImage(
 
   // Delete from E2B
   if (image.e2bTemplateId) {
-    const { ApiClient, ConnectionConfig } = await import("e2b");
     const config = new ConnectionConfig({});
     const client = new ApiClient(config);
 

--- a/turbo/apps/web/src/lib/s3/s3-client.ts
+++ b/turbo/apps/web/src/lib/s3/s3-client.ts
@@ -7,6 +7,7 @@ import {
 } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import pLimit from "p-limit";
 import { env } from "../../env";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -672,7 +673,7 @@ export async function createArchiveFromBlobs(
   const uniqueHashes = [...new Set(files.map((f) => f.blobHash))];
 
   // Download blobs in parallel with concurrency limit
-  const limit = (await import("p-limit")).default(10);
+  const limit = pLimit(10);
   await Promise.all(
     uniqueHashes.map((hash) =>
       limit(async () => {


### PR DESCRIPTION
## Summary

Converts all 6 dynamic `import()` statements in production code to static imports, following the code quality guidelines in `specs/bad-smell.md` section 6.

## Changes

- **`apps/cli/src/commands/image/delete.ts`**: Convert dynamic `readline` import to static import
- **`apps/web/src/lib/image/image-service.ts`**: Convert 4 dynamic `e2b` SDK imports to a single static import, remove outdated comment about dynamic imports
- **`apps/web/src/lib/s3/s3-client.ts`**: Convert dynamic `p-limit` import to static import

## Why This Matters

Dynamic imports in production code:
- Break tree-shaking and bundle optimization
- Add unnecessary async complexity
- Make dependency analysis harder for tools
- Hide import errors until runtime instead of catching at build time

## Test Plan

- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Tests pass (`pnpm vitest`)
- [x] Build succeeds

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)