### PR TITLE
fix(cli): handle run preparation failures immediately

### DIFF
--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -374,13 +374,22 @@ const runCmd = new Command()
           conversationId: options.conversation,
         });
 
-        // 4. Display run started info
+        // 4. Check for immediate failure (e.g., missing secrets)
+        if (response.status === "failed") {
+          console.error(chalk.red("✗ Run preparation failed"));
+          if (response.error) {
+            console.error(chalk.gray(`  ${response.error}`));
+          }
+          process.exit(1);
+        }
+
+        // 5. Display run started info
         EventRenderer.renderRunStarted({
           runId: response.runId,
           sandboxId: response.sandboxId,
         });
 
-        // 5. Poll for events and exit with appropriate code
+        // 6. Poll for events and exit with appropriate code
         const result = await pollEvents(response.runId, {
           verbose,
           startTimestamp,
@@ -480,13 +489,22 @@ runCmd
               : undefined,
         });
 
-        // 4. Display run started info
+        // 4. Check for immediate failure (e.g., missing secrets)
+        if (response.status === "failed") {
+          console.error(chalk.red("✗ Run preparation failed"));
+          if (response.error) {
+            console.error(chalk.gray(`  ${response.error}`));
+          }
+          process.exit(1);
+        }
+
+        // 5. Display run started info
         EventRenderer.renderRunStarted({
           runId: response.runId,
           sandboxId: response.sandboxId,
         });
 
-        // 5. Poll for events and exit with appropriate code
+        // 6. Poll for events and exit with appropriate code
         const result = await pollEvents(response.runId, {
           verbose,
           startTimestamp,
@@ -584,13 +602,22 @@ runCmd
               : undefined,
         });
 
-        // 4. Display run started info
+        // 4. Check for immediate failure (e.g., missing secrets)
+        if (response.status === "failed") {
+          console.error(chalk.red("✗ Run preparation failed"));
+          if (response.error) {
+            console.error(chalk.gray(`  ${response.error}`));
+          }
+          process.exit(1);
+        }
+
+        // 5. Display run started info
         EventRenderer.renderRunStarted({
           runId: response.runId,
           sandboxId: response.sandboxId,
         });
 
-        // 5. Poll for events and exit with appropriate code
+        // 6. Poll for events and exit with appropriate code
         const result = await pollEvents(response.runId, {
           verbose,
           startTimestamp,

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -415,6 +415,7 @@ const router = tsr.router(runsMainContract, {
         body: {
           runId: run.id,
           status: "failed" as const,
+          error: errorMessage,
           createdAt: run.createdAt.toISOString(),
         },
       };


### PR DESCRIPTION
## Summary

- Fix bug where CLI hangs when run preparation fails (e.g., missing required secrets)
- API now returns `error` field in response when preparation fails with status "failed"
- CLI checks `response.status` immediately after `createRun()` and exits with error message if failed

## Problem

When run preparation fails (e.g., missing `CLAUDE_CODE_OAUTH_TOKEN` secret), the API returns `201 Created` with `status: "failed"`, but the CLI was not checking this status. Instead, it would:
1. Try to render "run started" with undefined sandboxId
2. Start polling for events
3. Hang indefinitely or show confusing output

## Solution

**API (`route.ts`):**
```typescript
return {
  status: 201,
  body: {
    runId: run.id,
    status: "failed",
    error: errorMessage,  // ← Now included
    createdAt: run.createdAt.toISOString(),
  },
};
```

**CLI (`run.ts`):**
```typescript
if (response.status === "failed") {
  console.error(chalk.red("✗ Run preparation failed"));
  if (response.error) {
    console.error(chalk.gray(`  ${response.error}`));
  }
  process.exit(1);
}
```

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm turbo run lint` passes
- [ ] Manual test: run agent with missing secret should show error immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)