### PR TITLE
feat(web): add generic proxy endpoint for sandbox requests

### DIFF
--- a/e2e/fixtures/configs/vm0-enhanced-security.yaml
+++ b/e2e/fixtures/configs/vm0-enhanced-security.yaml
@@ -1,0 +1,16 @@
+version: "1.0"
+
+agents:
+  vm0-enhanced-security:
+    description: "Test agent with enhanced security (proxy mode)"
+    provider: claude-code
+    image: vm0-claude-code-dev
+    beta_enhance_security: true
+    volumes:
+      - claude-files:/home/user/.config/claude
+    working_dir: /home/user/workspace
+
+volumes:
+  claude-files:
+    name: claude-files
+    version: latest

--- a/e2e/fixtures/configs/vm0-network-security.yaml
+++ b/e2e/fixtures/configs/vm0-network-security.yaml
@@ -1,11 +1,11 @@
 version: "1.0"
 
 agents:
-  vm0-enhanced-security:
-    description: "Test agent with enhanced security (proxy mode)"
+  vm0-network-security:
+    description: "Test agent with network security (proxy mode)"
     provider: claude-code
     image: vm0-claude-code-dev
-    beta_enhance_security: true
+    beta_network_security: true
     volumes:
       - claude-files:/home/user/.config/claude
     working_dir: /home/user/workspace

--- a/e2e/fixtures/configs/vm0-network-security.yaml
+++ b/e2e/fixtures/configs/vm0-network-security.yaml
@@ -6,11 +6,4 @@ agents:
     provider: claude-code
     image: vm0-claude-code-dev
     beta_network_security: true
-    volumes:
-      - claude-files:/home/user/.config/claude
     working_dir: /home/user/workspace
-
-volumes:
-  claude-files:
-    name: claude-files
-    version: latest

--- a/e2e/tests/02-commands/t16-vm0-network-logs.bats
+++ b/e2e/tests/02-commands/t16-vm0-network-logs.bats
@@ -78,9 +78,13 @@ teardown() {
     #
     # Format: [timestamp] METHOD status latency request_size/response_size url
 
-    # Should see POST requests from webhook calls
+    # Should see POST requests to webhook endpoints
     assert_output --partial "POST"
-    echo "# Network logs contain POST requests from webhooks"
+
+    # Verify specific webhook endpoints are captured
+    # Events endpoint is always called during agent execution
+    assert_output --partial "/api/webhooks/agent/events"
+    echo "# Network logs contain /api/webhooks/agent/events requests"
 
     # Step 5: Verify --network is mutually exclusive with other options
     echo "# Step 5: Testing --network mutually exclusive with --agent..."

--- a/e2e/tests/02-commands/t16-vm0-network-logs.bats
+++ b/e2e/tests/02-commands/t16-vm0-network-logs.bats
@@ -68,21 +68,19 @@ teardown() {
 
     assert_success
 
-    # Network logs should contain HTTP request information
+    # Network logs should contain HTTP request information from webhook calls
+    # The mitmproxy intercepts ALL traffic including:
+    # - Heartbeat requests (POST /api/webhooks/agent/heartbeat)
+    # - Event requests (POST /api/webhooks/agent/events)
+    # - Telemetry requests (POST /api/webhooks/agent/telemetry)
+    # - Checkpoint requests (POST /api/webhooks/agent/checkpoints)
+    # - Storage requests (POST /api/webhooks/agent/storages)
+    #
     # Format: [timestamp] METHOD status latency request_size/response_size url
-    # The proxy intercepts Claude API calls, so we expect to see POST requests
 
-    # Check for expected format elements
-    # Note: If no network logs, the command shows a warning message
-    if [[ "$output" == *"No network logs found"* ]]; then
-        echo "# No network logs captured (proxy may not have intercepted traffic)"
-        # This is acceptable - mock-claude may not make real HTTP calls
-        # The test verifies the --network option works correctly
-    else
-        # If we have logs, verify the format
-        assert_output --partial "POST" || assert_output --partial "GET"
-        echo "# Network logs contain HTTP methods"
-    fi
+    # Should see POST requests from webhook calls
+    assert_output --partial "POST"
+    echo "# Network logs contain POST requests from webhooks"
 
     # Step 5: Verify --network is mutually exclusive with other options
     echo "# Step 5: Testing --network mutually exclusive with --agent..."

--- a/e2e/tests/02-commands/t16-vm0-network-logs.bats
+++ b/e2e/tests/02-commands/t16-vm0-network-logs.bats
@@ -1,13 +1,10 @@
 #!/usr/bin/env bats
 
-# Test VM0 network logs CLI command
+# Test VM0 network logs with network security mode
 # This test verifies that:
-# 1. The vm0 logs --network command works correctly
-# 2. Network log options are mutually exclusive with other log types
-#
-# Note: Network logs are only populated when beta_network_security is enabled
-# and actual HTTPS traffic goes through the proxy. In mock mode, we test
-# the CLI behavior rather than the full proxy flow.
+# 1. Agent runs with beta_network_security enabled capture network traffic
+# 2. The vm0 logs --network command retrieves network logs
+# 3. Network logs contain expected fields (method, url, status, latency)
 #
 # Test count: 2 tests with 1 vm0 run call
 
@@ -16,8 +13,7 @@ load '../../helpers/setup'
 setup() {
     export TEST_ARTIFACT_DIR="$(mktemp -d)"
     export ARTIFACT_NAME="e2e-network-logs-test-$(date +%s)"
-    # Use standard test config (no network security)
-    export TEST_CONFIG="${TEST_ROOT}/fixtures/configs/vm0-standard.yaml"
+    export TEST_CONFIG="${TEST_ROOT}/fixtures/configs/vm0-network-security.yaml"
 }
 
 teardown() {
@@ -26,13 +22,13 @@ teardown() {
     fi
 }
 
-@test "Build VM0 standard agent configuration" {
+@test "Build VM0 network security test agent configuration" {
     run $CLI_COMMAND compose "$TEST_CONFIG"
     assert_success
-    assert_output --partial "vm0-standard"
+    assert_output --partial "vm0-network-security"
 }
 
-@test "VM0 logs --network: CLI options work correctly" {
+@test "VM0 network logs: run with network security captures network traffic" {
     # Step 1: Create artifact with initial content
     echo "# Step 1: Creating initial artifact..."
     mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
@@ -42,15 +38,19 @@ teardown() {
     run $CLI_COMMAND artifact push
     assert_success
 
-    # Step 2: Run agent to get a valid run ID
-    echo "# Step 2: Running agent..."
-    run $CLI_COMMAND run vm0-standard \
+    # Step 2: Run agent with network security enabled
+    # The agent will make API calls to Claude which will be proxied
+    echo "# Step 2: Running agent with network security (proxy mode)..."
+    run $CLI_COMMAND run vm0-network-security \
         --artifact-name "$ARTIFACT_NAME" \
         "echo 'testing network logs'"
 
     assert_success
+
+    # Verify run completed successfully
     assert_output --partial "Run started"
     assert_output --partial "Run ID:"
+    assert_output --partial "[result]"
     assert_output --partial "Run completed successfully"
 
     # Step 3: Extract Run ID from output
@@ -62,17 +62,27 @@ teardown() {
         return 1
     }
 
-    # Step 4: Verify vm0 logs --network command returns successfully
-    # (may show "No network logs found" since proxy wasn't enabled)
+    # Step 4: Verify vm0 logs --network command retrieves network logs
     echo "# Step 4: Fetching network logs..."
     run $CLI_COMMAND logs "$RUN_ID" --network --limit 100
 
     assert_success
-    # Network logs may be empty (no proxy) or contain data (with proxy)
-    # Just verify the command succeeds
-    echo "# Network logs command succeeded"
 
-    # Step 5: Verify --network is mutually exclusive with --agent
+    # Network logs should contain HTTP request information from webhook calls
+    # The mitmproxy intercepts ALL traffic including:
+    # - Heartbeat requests (POST /api/webhooks/agent/heartbeat)
+    # - Event requests (POST /api/webhooks/agent/events)
+    # - Telemetry requests (POST /api/webhooks/agent/telemetry)
+    # - Checkpoint requests (POST /api/webhooks/agent/checkpoints)
+    # - Storage requests (POST /api/webhooks/agent/storages)
+    #
+    # Format: [timestamp] METHOD status latency request_size/response_size url
+
+    # Should see POST requests from webhook calls
+    assert_output --partial "POST"
+    echo "# Network logs contain POST requests from webhooks"
+
+    # Step 5: Verify --network is mutually exclusive with other options
     echo "# Step 5: Testing --network mutually exclusive with --agent..."
     run $CLI_COMMAND logs "$RUN_ID" --network --agent
 

--- a/e2e/tests/02-commands/t16-vm0-network-logs.bats
+++ b/e2e/tests/02-commands/t16-vm0-network-logs.bats
@@ -17,7 +17,7 @@ setup() {
     export TEST_ARTIFACT_DIR="$(mktemp -d)"
     export ARTIFACT_NAME="e2e-network-logs-test-$(date +%s)"
     # Use standard test config (no network security)
-    export TEST_CONFIG="${TEST_ROOT}/fixtures/configs/vm0-test.yaml"
+    export TEST_CONFIG="${TEST_ROOT}/fixtures/configs/vm0-standard.yaml"
 }
 
 teardown() {
@@ -26,10 +26,10 @@ teardown() {
     fi
 }
 
-@test "Build VM0 test agent configuration" {
+@test "Build VM0 standard agent configuration" {
     run $CLI_COMMAND compose "$TEST_CONFIG"
     assert_success
-    assert_output --partial "vm0-test"
+    assert_output --partial "vm0-standard"
 }
 
 @test "VM0 logs --network: CLI options work correctly" {
@@ -44,7 +44,7 @@ teardown() {
 
     # Step 2: Run agent to get a valid run ID
     echo "# Step 2: Running agent..."
-    run $CLI_COMMAND run vm0-test \
+    run $CLI_COMMAND run vm0-standard \
         --artifact-name "$ARTIFACT_NAME" \
         "echo 'testing network logs'"
 

--- a/e2e/tests/02-commands/t16-vm0-network-logs.bats
+++ b/e2e/tests/02-commands/t16-vm0-network-logs.bats
@@ -1,10 +1,13 @@
 #!/usr/bin/env bats
 
-# Test VM0 network logs with network security mode
+# Test VM0 network logs CLI command
 # This test verifies that:
-# 1. Agent runs with beta_network_security enabled capture network traffic
-# 2. The vm0 logs --network command retrieves network logs
-# 3. Network logs contain expected fields (method, url, status, latency)
+# 1. The vm0 logs --network command works correctly
+# 2. Network log options are mutually exclusive with other log types
+#
+# Note: Network logs are only populated when beta_network_security is enabled
+# and actual HTTPS traffic goes through the proxy. In mock mode, we test
+# the CLI behavior rather than the full proxy flow.
 #
 # Test count: 2 tests with 1 vm0 run call
 
@@ -13,7 +16,8 @@ load '../../helpers/setup'
 setup() {
     export TEST_ARTIFACT_DIR="$(mktemp -d)"
     export ARTIFACT_NAME="e2e-network-logs-test-$(date +%s)"
-    export TEST_CONFIG="${TEST_ROOT}/fixtures/configs/vm0-network-security.yaml"
+    # Use standard test config (no network security)
+    export TEST_CONFIG="${TEST_ROOT}/fixtures/configs/vm0-test.yaml"
 }
 
 teardown() {
@@ -22,13 +26,13 @@ teardown() {
     fi
 }
 
-@test "Build VM0 network security test agent configuration" {
+@test "Build VM0 test agent configuration" {
     run $CLI_COMMAND compose "$TEST_CONFIG"
     assert_success
-    assert_output --partial "vm0-network-security"
+    assert_output --partial "vm0-test"
 }
 
-@test "VM0 network logs: run with network security captures network traffic" {
+@test "VM0 logs --network: CLI options work correctly" {
     # Step 1: Create artifact with initial content
     echo "# Step 1: Creating initial artifact..."
     mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
@@ -38,19 +42,15 @@ teardown() {
     run $CLI_COMMAND artifact push
     assert_success
 
-    # Step 2: Run agent with network security enabled
-    # The agent will make API calls to Claude which will be proxied
-    echo "# Step 2: Running agent with network security (proxy mode)..."
-    run $CLI_COMMAND run vm0-network-security \
+    # Step 2: Run agent to get a valid run ID
+    echo "# Step 2: Running agent..."
+    run $CLI_COMMAND run vm0-test \
         --artifact-name "$ARTIFACT_NAME" \
         "echo 'testing network logs'"
 
     assert_success
-
-    # Verify run completed successfully
     assert_output --partial "Run started"
     assert_output --partial "Run ID:"
-    assert_output --partial "[result]"
     assert_output --partial "Run completed successfully"
 
     # Step 3: Extract Run ID from output
@@ -62,27 +62,17 @@ teardown() {
         return 1
     }
 
-    # Step 4: Verify vm0 logs --network command retrieves network logs
+    # Step 4: Verify vm0 logs --network command returns successfully
+    # (may show "No network logs found" since proxy wasn't enabled)
     echo "# Step 4: Fetching network logs..."
     run $CLI_COMMAND logs "$RUN_ID" --network --limit 100
 
     assert_success
+    # Network logs may be empty (no proxy) or contain data (with proxy)
+    # Just verify the command succeeds
+    echo "# Network logs command succeeded"
 
-    # Network logs should contain HTTP request information from webhook calls
-    # The mitmproxy intercepts ALL traffic including:
-    # - Heartbeat requests (POST /api/webhooks/agent/heartbeat)
-    # - Event requests (POST /api/webhooks/agent/events)
-    # - Telemetry requests (POST /api/webhooks/agent/telemetry)
-    # - Checkpoint requests (POST /api/webhooks/agent/checkpoints)
-    # - Storage requests (POST /api/webhooks/agent/storages)
-    #
-    # Format: [timestamp] METHOD status latency request_size/response_size url
-
-    # Should see POST requests from webhook calls
-    assert_output --partial "POST"
-    echo "# Network logs contain POST requests from webhooks"
-
-    # Step 5: Verify --network is mutually exclusive with other options
+    # Step 5: Verify --network is mutually exclusive with --agent
     echo "# Step 5: Testing --network mutually exclusive with --agent..."
     run $CLI_COMMAND logs "$RUN_ID" --network --agent
 

--- a/e2e/tests/02-commands/t16-vm0-network-logs.bats
+++ b/e2e/tests/02-commands/t16-vm0-network-logs.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+
+# Test VM0 network logs with enhanced security mode
+# This test verifies that:
+# 1. Agent runs with beta_enhance_security enabled capture network traffic
+# 2. The vm0 logs --network command retrieves network logs
+# 3. Network logs contain expected fields (method, url, status, latency)
+#
+# Test count: 2 tests with 1 vm0 run call
+
+load '../../helpers/setup'
+
+setup() {
+    export TEST_ARTIFACT_DIR="$(mktemp -d)"
+    export ARTIFACT_NAME="e2e-network-logs-test-$(date +%s)"
+    export TEST_CONFIG="${TEST_ROOT}/fixtures/configs/vm0-enhanced-security.yaml"
+}
+
+teardown() {
+    if [ -n "$TEST_ARTIFACT_DIR" ] && [ -d "$TEST_ARTIFACT_DIR" ]; then
+        rm -rf "$TEST_ARTIFACT_DIR"
+    fi
+}
+
+@test "Build VM0 enhanced security test agent configuration" {
+    run $CLI_COMMAND compose "$TEST_CONFIG"
+    assert_success
+    assert_output --partial "vm0-enhanced-security"
+}
+
+@test "VM0 network logs: run with enhanced security captures network traffic" {
+    # Step 1: Create artifact with initial content
+    echo "# Step 1: Creating initial artifact..."
+    mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+    echo "test content for network logs" > test.txt
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    # Step 2: Run agent with enhanced security enabled
+    # The agent will make API calls to Claude which will be proxied
+    echo "# Step 2: Running agent with enhanced security (proxy mode)..."
+    run $CLI_COMMAND run vm0-enhanced-security \
+        --artifact-name "$ARTIFACT_NAME" \
+        "echo 'testing network logs'"
+
+    assert_success
+
+    # Verify run completed successfully
+    assert_output --partial "Run started"
+    assert_output --partial "Run ID:"
+    assert_output --partial "[result]"
+    assert_output --partial "Run completed successfully"
+
+    # Step 3: Extract Run ID from output
+    RUN_ID=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
+    echo "# Run ID: $RUN_ID"
+    [ -n "$RUN_ID" ] || {
+        echo "# Failed to extract Run ID from output"
+        echo "$output"
+        return 1
+    }
+
+    # Step 4: Verify vm0 logs --network command retrieves network logs
+    echo "# Step 4: Fetching network logs..."
+    run $CLI_COMMAND logs "$RUN_ID" --network --limit 100
+
+    assert_success
+
+    # Network logs should contain HTTP request information
+    # Format: [timestamp] METHOD status latency request_size/response_size url
+    # The proxy intercepts Claude API calls, so we expect to see POST requests
+
+    # Check for expected format elements
+    # Note: If no network logs, the command shows a warning message
+    if [[ "$output" == *"No network logs found"* ]]; then
+        echo "# No network logs captured (proxy may not have intercepted traffic)"
+        # This is acceptable - mock-claude may not make real HTTP calls
+        # The test verifies the --network option works correctly
+    else
+        # If we have logs, verify the format
+        assert_output --partial "POST" || assert_output --partial "GET"
+        echo "# Network logs contain HTTP methods"
+    fi
+
+    # Step 5: Verify --network is mutually exclusive with other options
+    echo "# Step 5: Testing --network mutually exclusive with --agent..."
+    run $CLI_COMMAND logs "$RUN_ID" --network --agent
+
+    assert_failure
+    assert_output --partial "mutually exclusive"
+    echo "# --network is mutually exclusive with --agent"
+
+    # Step 6: Verify --network is mutually exclusive with --system
+    echo "# Step 6: Testing --network mutually exclusive with --system..."
+    run $CLI_COMMAND logs "$RUN_ID" --network --system
+
+    assert_failure
+    assert_output --partial "mutually exclusive"
+    echo "# --network is mutually exclusive with --system"
+
+    # Step 7: Verify --network is mutually exclusive with --metrics
+    echo "# Step 7: Testing --network mutually exclusive with --metrics..."
+    run $CLI_COMMAND logs "$RUN_ID" --network --metrics
+
+    assert_failure
+    assert_output --partial "mutually exclusive"
+    echo "# --network is mutually exclusive with --metrics"
+
+    # Step 8: Verify -n short option works
+    echo "# Step 8: Testing -n short option..."
+    run $CLI_COMMAND logs "$RUN_ID" -n --limit 10
+
+    assert_success
+    echo "# -n short option works correctly"
+}

--- a/e2e/tests/02-commands/t16-vm0-network-logs.bats
+++ b/e2e/tests/02-commands/t16-vm0-network-logs.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 
-# Test VM0 network logs with enhanced security mode
+# Test VM0 network logs with network security mode
 # This test verifies that:
-# 1. Agent runs with beta_enhance_security enabled capture network traffic
+# 1. Agent runs with beta_network_security enabled capture network traffic
 # 2. The vm0 logs --network command retrieves network logs
 # 3. Network logs contain expected fields (method, url, status, latency)
 #
@@ -13,7 +13,7 @@ load '../../helpers/setup'
 setup() {
     export TEST_ARTIFACT_DIR="$(mktemp -d)"
     export ARTIFACT_NAME="e2e-network-logs-test-$(date +%s)"
-    export TEST_CONFIG="${TEST_ROOT}/fixtures/configs/vm0-enhanced-security.yaml"
+    export TEST_CONFIG="${TEST_ROOT}/fixtures/configs/vm0-network-security.yaml"
 }
 
 teardown() {
@@ -22,13 +22,13 @@ teardown() {
     fi
 }
 
-@test "Build VM0 enhanced security test agent configuration" {
+@test "Build VM0 network security test agent configuration" {
     run $CLI_COMMAND compose "$TEST_CONFIG"
     assert_success
-    assert_output --partial "vm0-enhanced-security"
+    assert_output --partial "vm0-network-security"
 }
 
-@test "VM0 network logs: run with enhanced security captures network traffic" {
+@test "VM0 network logs: run with network security captures network traffic" {
     # Step 1: Create artifact with initial content
     echo "# Step 1: Creating initial artifact..."
     mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
@@ -38,10 +38,10 @@ teardown() {
     run $CLI_COMMAND artifact push
     assert_success
 
-    # Step 2: Run agent with enhanced security enabled
+    # Step 2: Run agent with network security enabled
     # The agent will make API calls to Claude which will be proxied
-    echo "# Step 2: Running agent with enhanced security (proxy mode)..."
-    run $CLI_COMMAND run vm0-enhanced-security \
+    echo "# Step 2: Running agent with network security (proxy mode)..."
+    run $CLI_COMMAND run vm0-network-security \
         --artifact-name "$ARTIFACT_NAME" \
         "echo 'testing network logs'"
 

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -1,6 +1,11 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient, TelemetryMetric, RunEvent } from "../../lib/api-client";
+import {
+  apiClient,
+  TelemetryMetric,
+  RunEvent,
+  NetworkLogEntry,
+} from "../../lib/api-client";
 import { parseTime } from "../../lib/time-parser";
 import { ClaudeEventParser } from "../../lib/event-parser";
 import { EventRenderer } from "../../lib/event-renderer";
@@ -8,7 +13,7 @@ import { EventRenderer } from "../../lib/event-renderer";
 /**
  * Log type for mutually exclusive options
  */
-type LogType = "agent" | "system" | "metrics";
+type LogType = "agent" | "system" | "metrics" | "network";
 
 /**
  * Format bytes to human-readable string
@@ -32,6 +37,35 @@ function formatMetric(metric: TelemetryMetric): string {
 }
 
 /**
+ * Format a single network log entry
+ */
+function formatNetworkLog(entry: NetworkLogEntry): string {
+  // Color status code based on HTTP status
+  let statusColor: typeof chalk.green;
+  if (entry.status >= 200 && entry.status < 300) {
+    statusColor = chalk.green;
+  } else if (entry.status >= 300 && entry.status < 400) {
+    statusColor = chalk.yellow;
+  } else if (entry.status >= 400) {
+    statusColor = chalk.red;
+  } else {
+    statusColor = chalk.gray;
+  }
+
+  // Format latency with color
+  let latencyColor: typeof chalk.green;
+  if (entry.latency_ms < 500) {
+    latencyColor = chalk.green;
+  } else if (entry.latency_ms < 2000) {
+    latencyColor = chalk.yellow;
+  } else {
+    latencyColor = chalk.red;
+  }
+
+  return `[${entry.timestamp}] ${chalk.cyan(entry.method.padEnd(6))} ${statusColor(entry.status)} ${latencyColor(entry.latency_ms + "ms")} ${formatBytes(entry.request_size)}/${formatBytes(entry.response_size)} ${chalk.gray(entry.url)}`;
+}
+
+/**
  * Render an agent event with timestamp for historical log viewing
  */
 function renderAgentEvent(event: RunEvent): void {
@@ -52,15 +86,19 @@ function getLogType(options: {
   agent?: boolean;
   system?: boolean;
   metrics?: boolean;
+  network?: boolean;
 }): LogType {
-  const selected = [options.agent, options.system, options.metrics].filter(
-    Boolean,
-  ).length;
+  const selected = [
+    options.agent,
+    options.system,
+    options.metrics,
+    options.network,
+  ].filter(Boolean).length;
 
   if (selected > 1) {
     console.error(
       chalk.red(
-        "Options --agent, --system, and --metrics are mutually exclusive",
+        "Options --agent, --system, --metrics, and --network are mutually exclusive",
       ),
     );
     process.exit(1);
@@ -68,6 +106,7 @@ function getLogType(options: {
 
   if (options.system) return "system";
   if (options.metrics) return "metrics";
+  if (options.network) return "network";
   return "agent"; // Default
 }
 
@@ -78,6 +117,7 @@ export const logsCommand = new Command()
   .option("-a, --agent", "Show agent events (default)")
   .option("-s, --system", "Show system log")
   .option("-m, --metrics", "Show metrics")
+  .option("-n, --network", "Show network logs (proxy traffic)")
   .option(
     "--since <time>",
     "Show logs since timestamp (e.g., 5m, 2h, 1d, 2024-01-15T10:30:00Z, 1705312200)",
@@ -94,6 +134,7 @@ export const logsCommand = new Command()
         agent?: boolean;
         system?: boolean;
         metrics?: boolean;
+        network?: boolean;
         since?: string;
         limit?: string;
       },
@@ -122,6 +163,9 @@ export const logsCommand = new Command()
             break;
           case "metrics":
             await showMetrics(runId, { since, limit });
+            break;
+          case "network":
+            await showNetworkLogs(runId, { since, limit });
             break;
         }
       } catch (error) {
@@ -206,6 +250,38 @@ async function showMetrics(
     console.log(
       chalk.gray(
         `Showing ${response.metrics.length} metrics. Use --limit to see more.`,
+      ),
+    );
+  }
+}
+
+/**
+ * Show network logs
+ */
+async function showNetworkLogs(
+  runId: string,
+  options: { since?: number; limit: number },
+): Promise<void> {
+  const response = await apiClient.getNetworkLogs(runId, options);
+
+  if (response.networkLogs.length === 0) {
+    console.log(
+      chalk.yellow(
+        "No network logs found for this run. Network logs are only captured when beta_enhance_security is enabled.",
+      ),
+    );
+    return;
+  }
+
+  for (const entry of response.networkLogs) {
+    console.log(formatNetworkLog(entry));
+  }
+
+  if (response.hasMore) {
+    console.log();
+    console.log(
+      chalk.gray(
+        `Showing ${response.networkLogs.length} network logs. Use --limit to see more.`,
       ),
     );
   }

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -267,7 +267,7 @@ async function showNetworkLogs(
   if (response.networkLogs.length === 0) {
     console.log(
       chalk.yellow(
-        "No network logs found for this run. Network logs are only captured when beta_enhance_security is enabled.",
+        "No network logs found for this run. Network logs are only captured when beta_network_security is enabled.",
       ),
     );
     return;

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
@@ -1,0 +1,150 @@
+import { createNextHandler, tsr } from "@ts-rest/serverless/next";
+import { TsRestResponse } from "@ts-rest/serverless";
+import { runNetworkLogsContract } from "@vm0/core";
+import { initServices } from "../../../../../../../src/lib/init-services";
+import { agentRuns } from "../../../../../../../src/db/schema/agent-run";
+import { sandboxTelemetry } from "../../../../../../../src/db/schema/sandbox-telemetry";
+import { eq, gt, and, asc } from "drizzle-orm";
+import { getUserId } from "../../../../../../../src/lib/auth/get-user-id";
+
+/**
+ * Network log entry structure
+ */
+interface NetworkLogEntry {
+  timestamp: string;
+  method: string;
+  url: string;
+  status: number;
+  latency_ms: number;
+  request_size: number;
+  response_size: number;
+}
+
+/**
+ * Telemetry data structure stored in JSONB
+ */
+interface TelemetryData {
+  networkLogs?: NetworkLogEntry[];
+}
+
+const router = tsr.router(runNetworkLogsContract, {
+  getNetworkLogs: async ({ params, query }) => {
+    initServices();
+
+    const userId = await getUserId();
+    if (!userId) {
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        },
+      };
+    }
+
+    // Verify run exists and belongs to user
+    const [run] = await globalThis.services.db
+      .select()
+      .from(agentRuns)
+      .where(eq(agentRuns.id, params.id))
+      .limit(1);
+
+    if (!run || run.userId !== userId) {
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Agent run not found", code: "NOT_FOUND" },
+        },
+      };
+    }
+
+    const { since, limit } = query;
+
+    // Build query conditions
+    const conditions = [eq(sandboxTelemetry.runId, params.id)];
+    if (since !== undefined) {
+      conditions.push(gt(sandboxTelemetry.createdAt, new Date(since)));
+    }
+
+    // Query all telemetry records (we need to extract networkLogs from them)
+    const telemetryRecords = await globalThis.services.db
+      .select()
+      .from(sandboxTelemetry)
+      .where(and(...conditions))
+      .orderBy(asc(sandboxTelemetry.createdAt));
+
+    // Collect all network log entries
+    const allNetworkLogs: NetworkLogEntry[] = [];
+    for (const record of telemetryRecords) {
+      const data = record.data as TelemetryData;
+      if (data.networkLogs) {
+        allNetworkLogs.push(...data.networkLogs);
+      }
+    }
+
+    // Apply limit to network logs
+    const hasMore = allNetworkLogs.length > limit;
+    const networkLogs = hasMore ? allNetworkLogs.slice(0, limit) : allNetworkLogs;
+
+    return {
+      status: 200 as const,
+      body: {
+        networkLogs,
+        hasMore,
+      },
+    };
+  },
+});
+
+/**
+ * Custom error handler to convert validation errors to API error format
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (
+    err &&
+    typeof err === "object" &&
+    ("pathParamsError" in err || "queryError" in err)
+  ) {
+    const validationError = err as {
+      pathParamsError: {
+        issues: Array<{ path: string[]; message: string }>;
+      } | null;
+      queryError: {
+        issues: Array<{ path: string[]; message: string }>;
+      } | null;
+    };
+
+    if (validationError.pathParamsError) {
+      const issue = validationError.pathParamsError.issues[0];
+      if (issue) {
+        const path = issue.path.join(".");
+        const message = path ? `${path}: ${issue.message}` : issue.message;
+        return TsRestResponse.fromJson(
+          { error: { message, code: "BAD_REQUEST" } },
+          { status: 400 },
+        );
+      }
+    }
+
+    if (validationError.queryError) {
+      const issue = validationError.queryError.issues[0];
+      if (issue) {
+        const path = issue.path.join(".");
+        const message = path ? `${path}: ${issue.message}` : issue.message;
+        return TsRestResponse.fromJson(
+          { error: { message, code: "BAD_REQUEST" } },
+          { status: 400 },
+        );
+      }
+    }
+  }
+
+  return undefined;
+}
+
+const handler = createNextHandler(runNetworkLogsContract, router, {
+  handlerType: "app-router",
+  jsonQuery: true,
+  errorHandler,
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
@@ -83,7 +83,9 @@ const router = tsr.router(runNetworkLogsContract, {
 
     // Apply limit to network logs
     const hasMore = allNetworkLogs.length > limit;
-    const networkLogs = hasMore ? allNetworkLogs.slice(0, limit) : allNetworkLogs;
+    const networkLogs = hasMore
+      ? allNetworkLogs.slice(0, limit)
+      : allNetworkLogs;
 
     return {
       status: 200 as const,

--- a/turbo/apps/web/app/api/webhooks/agent/proxy/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/proxy/__tests__/route.test.ts
@@ -118,7 +118,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
 
     it("should reject request without url parameter", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy",
+        "http://localhost:3000/api/webhooks/agent/proxy?runId=test-run-123",
         {
           method: "POST",
           headers: { Authorization: `Bearer ${testToken}` },
@@ -135,7 +135,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
 
     it("should reject request with invalid url", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=not-a-valid-url",
+        "http://localhost:3000/api/webhooks/agent/proxy?url=not-a-valid-url&runId=test-run-123",
         {
           method: "POST",
           headers: { Authorization: `Bearer ${testToken}` },
@@ -149,7 +149,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
 
     it("should reject request with non-http protocol", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=ftp%3A%2F%2Fexample.com",
+        "http://localhost:3000/api/webhooks/agent/proxy?url=ftp%3A%2F%2Fexample.com&runId=test-run-123",
         {
           method: "POST",
           headers: { Authorization: `Bearer ${testToken}` },
@@ -164,7 +164,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
     // SSRF Protection Tests
     it("should reject localhost URLs (SSRF protection)", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2Flocalhost%3A8080%2Fadmin",
+        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2Flocalhost%3A8080%2Fadmin&runId=test-run-123",
         {
           method: "POST",
           headers: { Authorization: `Bearer ${testToken}` },
@@ -177,7 +177,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
 
     it("should reject 127.0.0.1 URLs (SSRF protection)", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2F127.0.0.1%3A3000%2Fapi",
+        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2F127.0.0.1%3A3000%2Fapi&runId=test-run-123",
         {
           method: "POST",
           headers: { Authorization: `Bearer ${testToken}` },
@@ -190,7 +190,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
 
     it("should reject AWS metadata URL (SSRF protection)", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2F169.254.169.254%2Flatest%2Fmeta-data%2F",
+        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2F169.254.169.254%2Flatest%2Fmeta-data%2F&runId=test-run-123",
         {
           method: "POST",
           headers: { Authorization: `Bearer ${testToken}` },
@@ -203,7 +203,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
 
     it("should reject private network 10.x.x.x URLs (SSRF protection)", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2F10.0.0.1%2Finternal",
+        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2F10.0.0.1%2Finternal&runId=test-run-123",
         {
           method: "POST",
           headers: { Authorization: `Bearer ${testToken}` },
@@ -216,7 +216,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
 
     it("should reject private network 172.16.x.x URLs (SSRF protection)", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2F172.16.0.1%2Finternal",
+        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2F172.16.0.1%2Finternal&runId=test-run-123",
         {
           method: "POST",
           headers: { Authorization: `Bearer ${testToken}` },
@@ -229,7 +229,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
 
     it("should reject private network 192.168.x.x URLs (SSRF protection)", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2F192.168.1.1%2Finternal",
+        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2F192.168.1.1%2Finternal&runId=test-run-123",
         {
           method: "POST",
           headers: { Authorization: `Bearer ${testToken}` },
@@ -242,7 +242,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
 
     it("should reject .internal hostnames (SSRF protection)", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2Fmetadata.google.internal%2F",
+        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2Fmetadata.google.internal%2F&runId=test-run-123",
         {
           method: "POST",
           headers: { Authorization: `Bearer ${testToken}` },
@@ -282,7 +282,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
       mockFetch.mockResolvedValueOnce(targetResponse);
 
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.example.com%2Ftest",
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.example.com%2Ftest&runId=test-run-123",
         {
           method: "POST",
           headers: {
@@ -316,7 +316,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
         "https://api.example.com/v1/messages?stream=true&model=claude",
       );
       const request = new NextRequest(
-        `http://localhost:3000/api/webhooks/agent/proxy?url=${encodedUrl}`,
+        `http://localhost:3000/api/webhooks/agent/proxy?url=${encodedUrl}&runId=test-run-123`,
         {
           method: "POST",
           headers: { Authorization: `Bearer ${testToken}` },
@@ -336,7 +336,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
       mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
 
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Funreachable.example.com",
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Funreachable.example.com&runId=test-run-123",
         {
           method: "POST",
           headers: { Authorization: `Bearer ${testToken}` },
@@ -378,7 +378,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
       mockFetch.mockResolvedValueOnce(targetResponse);
 
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages",
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages&runId=test-run-123",
         {
           method: "POST",
           headers: {
@@ -409,7 +409,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
       mockFetch.mockResolvedValueOnce(targetResponse);
 
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.example.com",
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.example.com&runId=test-run-123",
         {
           method: "POST",
           headers: {
@@ -471,7 +471,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
       mockFetch.mockResolvedValueOnce(targetResponse);
 
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages",
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages&runId=test-run-123",
         {
           method: "POST",
           headers: { Authorization: `Bearer ${testToken}` },
@@ -560,7 +560,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
       mockFetch.mockResolvedValueOnce(targetResponse);
 
       const request = new NextRequest(
-        `http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages`,
+        `http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages&runId=${testRunId}`,
         {
           method: "POST",
           headers: {
@@ -590,7 +590,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
       mockFetch.mockResolvedValueOnce(targetResponse);
 
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages",
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages&runId=test-run-123",
         {
           method: "POST",
           headers: {
@@ -654,7 +654,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
       );
 
       const request = new NextRequest(
-        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages",
+        `http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages&runId=${testRunId}`,
         {
           method: "POST",
           headers: {
@@ -675,7 +675,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it("should decrypt without runId validation when runId not provided", async () => {
+    it("should reject request without runId parameter (security)", async () => {
       const proxyToken = createProxyToken(
         testRunId,
         testUserId,
@@ -683,14 +683,8 @@ describe("POST /api/webhooks/agent/proxy", () => {
         testSecretValue,
       );
 
-      const targetResponse = new Response(JSON.stringify({ success: true }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
-      mockFetch.mockResolvedValueOnce(targetResponse);
-
       const request = new NextRequest(
-        // No runId in query params
+        // No runId in query params - should be rejected
         "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages",
         {
           method: "POST",
@@ -703,12 +697,14 @@ describe("POST /api/webhooks/agent/proxy", () => {
 
       const response = await POST(request);
 
-      expect(response.status).toBe(200);
+      // runId is required to prevent token replay attacks
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("BAD_REQUEST");
+      expect(data.error.message).toContain("runId");
 
-      // Should still decrypt successfully without runId validation
-      const fetchCall = mockFetch.mock.calls[0];
-      const fetchHeaders = fetchCall?.[1]?.headers as Headers;
-      expect(fetchHeaders.get("x-api-key")).toBe(testSecretValue);
+      // Should not have made any fetch calls
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/proxy/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/proxy/__tests__/route.test.ts
@@ -518,22 +518,13 @@ describe("POST /api/webhooks/agent/proxy", () => {
       expect(fetchHeaders.get("x-api-key")).toBe(regularApiKey);
     });
 
-    it("should reject decryption when runId doesn't match", async () => {
+    it("should return 401 when runId doesn't match", async () => {
       const proxyToken = createProxyToken(
         testRunId,
         testUserId,
         testSecretName,
         testSecretValue,
       );
-
-      const targetResponse = new Response(
-        JSON.stringify({ error: "invalid key" }),
-        {
-          status: 401,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-      mockFetch.mockResolvedValueOnce(targetResponse);
 
       const request = new NextRequest(
         // Different runId than what's in the token
@@ -549,13 +540,47 @@ describe("POST /api/webhooks/agent/proxy", () => {
 
       const response = await POST(request);
 
-      // Request still goes through (401 from target expected since decryption failed)
+      // Should return 401 with clear error message instead of forwarding
       expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error.code).toBe("UNAUTHORIZED");
+      expect(data.error.message).toContain("decryption failed");
+      expect(data.error.header).toBe("x-api-key");
 
-      // The proxy token should be passed through unchanged (not decrypted)
-      const fetchCall = mockFetch.mock.calls[0];
-      const fetchHeaders = fetchCall?.[1]?.headers as Headers;
-      expect(fetchHeaders.get("x-api-key")).toBe(proxyToken);
+      // Should NOT have called fetch since decryption failed
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 when proxy token is expired", async () => {
+      // Create an expired token
+      const expiredToken = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+        -1000, // expired 1 second ago
+      );
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${testToken}`,
+            "x-api-key": expiredToken,
+          },
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error.code).toBe("UNAUTHORIZED");
+      expect(data.error.message).toContain("decryption failed");
+
+      // Should NOT have called fetch
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     it("should decrypt without runId validation when runId not provided", async () => {

--- a/turbo/apps/web/app/api/webhooks/agent/proxy/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/proxy/__tests__/route.test.ts
@@ -160,6 +160,98 @@ describe("POST /api/webhooks/agent/proxy", () => {
 
       expect(response.status).toBe(400);
     });
+
+    // SSRF Protection Tests
+    it("should reject localhost URLs (SSRF protection)", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2Flocalhost%3A8080%2Fadmin",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${testToken}` },
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+    });
+
+    it("should reject 127.0.0.1 URLs (SSRF protection)", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2F127.0.0.1%3A3000%2Fapi",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${testToken}` },
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+    });
+
+    it("should reject AWS metadata URL (SSRF protection)", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2F169.254.169.254%2Flatest%2Fmeta-data%2F",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${testToken}` },
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+    });
+
+    it("should reject private network 10.x.x.x URLs (SSRF protection)", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2F10.0.0.1%2Finternal",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${testToken}` },
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+    });
+
+    it("should reject private network 172.16.x.x URLs (SSRF protection)", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2F172.16.0.1%2Finternal",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${testToken}` },
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+    });
+
+    it("should reject private network 192.168.x.x URLs (SSRF protection)", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2F192.168.1.1%2Finternal",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${testToken}` },
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+    });
+
+    it("should reject .internal hostnames (SSRF protection)", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=http%3A%2F%2Fmetadata.google.internal%2F",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${testToken}` },
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+    });
   });
 
   // ============================================

--- a/turbo/apps/web/app/api/webhooks/agent/proxy/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/proxy/__tests__/route.test.ts
@@ -1,0 +1,394 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { cliTokens } from "../../../../../../src/db/schema/cli-tokens";
+import { eq } from "drizzle-orm";
+
+// Mock Next.js headers() function
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+}));
+
+// Mock Clerk auth
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+// Mock fetch for proxying
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { headers } from "next/headers";
+import { auth } from "@clerk/nextjs/server";
+
+const mockHeaders = vi.mocked(headers);
+const mockAuth = vi.mocked(auth);
+
+describe("POST /api/webhooks/agent/proxy", () => {
+  const testUserId = `test-user-proxy-${Date.now()}-${process.pid}`;
+  const testToken = `vm0_live_proxy_test_${Date.now()}_${process.pid}`;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    initServices();
+
+    // Mock Clerk auth to return null (webhook uses token auth)
+    mockAuth.mockResolvedValue({ userId: null } as unknown as Awaited<
+      ReturnType<typeof auth>
+    >);
+
+    // Default: no auth header
+    mockHeaders.mockResolvedValue({
+      get: vi.fn().mockReturnValue(null),
+    } as unknown as Headers);
+
+    // Clean up test tokens
+    await globalThis.services.db
+      .delete(cliTokens)
+      .where(eq(cliTokens.token, testToken));
+  });
+
+  afterEach(async () => {
+    await globalThis.services.db
+      .delete(cliTokens)
+      .where(eq(cliTokens.token, testToken));
+  });
+
+  // ============================================
+  // Authentication Tests
+  // ============================================
+
+  describe("Authentication", () => {
+    it("should reject request without authentication", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fhttpbin.org%2Fget",
+        { method: "POST" },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("should reject request with invalid token", async () => {
+      mockHeaders.mockResolvedValue({
+        get: vi.fn().mockReturnValue("Bearer vm0_live_invalid_token"),
+      } as unknown as Headers);
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fhttpbin.org%2Fget",
+        {
+          method: "POST",
+          headers: { Authorization: "Bearer vm0_live_invalid_token" },
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  // ============================================
+  // URL Validation Tests
+  // ============================================
+
+  describe("URL Validation", () => {
+    beforeEach(async () => {
+      // Setup valid token
+      mockHeaders.mockResolvedValue({
+        get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+      } as unknown as Headers);
+
+      await globalThis.services.db.insert(cliTokens).values({
+        token: testToken,
+        userId: testUserId,
+        name: "Test Token",
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+      });
+    });
+
+    it("should reject request without url parameter", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${testToken}` },
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("BAD_REQUEST");
+      expect(data.error.message).toContain("url");
+    });
+
+    it("should reject request with invalid url", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=not-a-valid-url",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${testToken}` },
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+    });
+
+    it("should reject request with non-http protocol", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=ftp%3A%2F%2Fexample.com",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${testToken}` },
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  // ============================================
+  // Proxy Forwarding Tests
+  // ============================================
+
+  describe("Proxy Forwarding", () => {
+    beforeEach(async () => {
+      // Setup valid token
+      mockHeaders.mockResolvedValue({
+        get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+      } as unknown as Headers);
+
+      await globalThis.services.db.insert(cliTokens).values({
+        token: testToken,
+        userId: testUserId,
+        name: "Test Token",
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+      });
+    });
+
+    it("should forward request to target URL", async () => {
+      const targetResponse = new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+      mockFetch.mockResolvedValueOnce(targetResponse);
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.example.com%2Ftest",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${testToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ data: "test" }),
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.example.com/test",
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+    });
+
+    it("should handle target URL with query parameters", async () => {
+      const targetResponse = new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+      mockFetch.mockResolvedValueOnce(targetResponse);
+
+      // URL with query params: https://api.example.com/v1/messages?stream=true
+      const encodedUrl = encodeURIComponent(
+        "https://api.example.com/v1/messages?stream=true&model=claude",
+      );
+      const request = new NextRequest(
+        `http://localhost:3000/api/webhooks/agent/proxy?url=${encodedUrl}`,
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${testToken}` },
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.example.com/v1/messages?stream=true&model=claude",
+        expect.anything(),
+      );
+    });
+
+    it("should return 502 when target is unreachable", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Funreachable.example.com",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${testToken}` },
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(502);
+      const data = await response.json();
+      expect(data.error.code).toBe("BAD_GATEWAY");
+    });
+  });
+
+  // ============================================
+  // Header Forwarding Tests
+  // ============================================
+
+  describe("Header Forwarding", () => {
+    beforeEach(async () => {
+      mockHeaders.mockResolvedValue({
+        get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+      } as unknown as Headers);
+
+      await globalThis.services.db.insert(cliTokens).values({
+        token: testToken,
+        userId: testUserId,
+        name: "Test Token",
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+      });
+    });
+
+    it("should forward custom headers to target", async () => {
+      const targetResponse = new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+      mockFetch.mockResolvedValueOnce(targetResponse);
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${testToken}`,
+            "Content-Type": "application/json",
+            "X-Api-Key": "sk-ant-test-key",
+            "anthropic-version": "2023-06-01",
+          },
+        },
+      );
+
+      await POST(request);
+
+      const fetchCall = mockFetch.mock.calls[0];
+      const fetchHeaders = fetchCall?.[1]?.headers as Headers;
+
+      // Should forward custom headers
+      expect(fetchHeaders.get("X-Api-Key")).toBe("sk-ant-test-key");
+      expect(fetchHeaders.get("anthropic-version")).toBe("2023-06-01");
+      expect(fetchHeaders.get("Content-Type")).toBe("application/json");
+    });
+
+    it("should not forward hop-by-hop headers", async () => {
+      const targetResponse = new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+      mockFetch.mockResolvedValueOnce(targetResponse);
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.example.com",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${testToken}`,
+            Host: "localhost:3000",
+            Connection: "keep-alive",
+          },
+        },
+      );
+
+      await POST(request);
+
+      const fetchCall = mockFetch.mock.calls[0];
+      const fetchHeaders = fetchCall?.[1]?.headers as Headers;
+
+      // Should not forward hop-by-hop headers
+      expect(fetchHeaders.get("Host")).toBeNull();
+      expect(fetchHeaders.get("Connection")).toBeNull();
+    });
+  });
+
+  // ============================================
+  // SSE Streaming Tests
+  // ============================================
+
+  describe("SSE Streaming", () => {
+    beforeEach(async () => {
+      mockHeaders.mockResolvedValue({
+        get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+      } as unknown as Headers);
+
+      await globalThis.services.db.insert(cliTokens).values({
+        token: testToken,
+        userId: testUserId,
+        name: "Test Token",
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+      });
+    });
+
+    it("should pass through SSE content-type", async () => {
+      // Mock SSE response
+      const sseBody = new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode('data: {"type":"message"}\n\n'),
+          );
+          controller.close();
+        },
+      });
+
+      const targetResponse = new Response(sseBody, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+        },
+      });
+      mockFetch.mockResolvedValueOnce(targetResponse);
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${testToken}` },
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+    });
+  });
+});

--- a/turbo/apps/web/app/api/webhooks/agent/proxy/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/proxy/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import { NextRequest } from "next/server";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { cliTokens } from "../../../../../../src/db/schema/cli-tokens";
 import { eq } from "drizzle-orm";
+import { createProxyToken } from "../../../../../../src/lib/proxy/token-service";
 
 // Mock Next.js headers() function
 vi.mock("next/headers", () => ({
@@ -389,6 +390,208 @@ describe("POST /api/webhooks/agent/proxy", () => {
 
       expect(response.status).toBe(200);
       expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+    });
+  });
+
+  // ============================================
+  // Proxy Token Decryption Tests
+  // ============================================
+
+  describe("Proxy Token Decryption", () => {
+    const testRunId = "run-test-123";
+    const testSecretName = "ANTHROPIC_API_KEY";
+    const testSecretValue = "sk-ant-real-api-key-12345";
+
+    beforeEach(async () => {
+      mockHeaders.mockResolvedValue({
+        get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+      } as unknown as Headers);
+
+      await globalThis.services.db.insert(cliTokens).values({
+        token: testToken,
+        userId: testUserId,
+        name: "Test Token",
+        expiresAt: new Date(Date.now() + 3600000),
+        createdAt: new Date(),
+      });
+    });
+
+    it("should decrypt proxy token in Authorization header (Bearer format)", async () => {
+      const proxyToken = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+
+      const targetResponse = new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+      mockFetch.mockResolvedValueOnce(targetResponse);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages&runId=${testRunId}`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${testToken}`,
+            "Content-Type": "application/json",
+            // The proxy token goes in the x-api-key for Anthropic
+            "x-api-key": proxyToken,
+          },
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      // Verify the decrypted secret was sent to target
+      const fetchCall = mockFetch.mock.calls[0];
+      const fetchHeaders = fetchCall?.[1]?.headers as Headers;
+      expect(fetchHeaders.get("x-api-key")).toBe(testSecretValue);
+    });
+
+    it("should decrypt proxy token in x-api-key header", async () => {
+      const proxyToken = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+
+      const targetResponse = new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+      mockFetch.mockResolvedValueOnce(targetResponse);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${testToken}`,
+            "x-api-key": proxyToken,
+          },
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      // Verify the decrypted secret was sent to target
+      const fetchCall = mockFetch.mock.calls[0];
+      const fetchHeaders = fetchCall?.[1]?.headers as Headers;
+      expect(fetchHeaders.get("x-api-key")).toBe(testSecretValue);
+    });
+
+    it("should pass through non-proxy tokens unchanged", async () => {
+      const regularApiKey = "sk-ant-regular-api-key";
+
+      const targetResponse = new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+      mockFetch.mockResolvedValueOnce(targetResponse);
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${testToken}`,
+            "x-api-key": regularApiKey,
+          },
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      // Verify the regular API key was passed through unchanged
+      const fetchCall = mockFetch.mock.calls[0];
+      const fetchHeaders = fetchCall?.[1]?.headers as Headers;
+      expect(fetchHeaders.get("x-api-key")).toBe(regularApiKey);
+    });
+
+    it("should reject decryption when runId doesn't match", async () => {
+      const proxyToken = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+
+      const targetResponse = new Response(
+        JSON.stringify({ error: "invalid key" }),
+        {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+      mockFetch.mockResolvedValueOnce(targetResponse);
+
+      const request = new NextRequest(
+        // Different runId than what's in the token
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages&runId=different-run-id",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${testToken}`,
+            "x-api-key": proxyToken,
+          },
+        },
+      );
+
+      const response = await POST(request);
+
+      // Request still goes through (401 from target expected since decryption failed)
+      expect(response.status).toBe(401);
+
+      // The proxy token should be passed through unchanged (not decrypted)
+      const fetchCall = mockFetch.mock.calls[0];
+      const fetchHeaders = fetchCall?.[1]?.headers as Headers;
+      expect(fetchHeaders.get("x-api-key")).toBe(proxyToken);
+    });
+
+    it("should decrypt without runId validation when runId not provided", async () => {
+      const proxyToken = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+
+      const targetResponse = new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+      mockFetch.mockResolvedValueOnce(targetResponse);
+
+      const request = new NextRequest(
+        // No runId in query params
+        "http://localhost:3000/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${testToken}`,
+            "x-api-key": proxyToken,
+          },
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      // Should still decrypt successfully without runId validation
+      const fetchCall = mockFetch.mock.calls[0];
+      const fetchHeaders = fetchCall?.[1]?.headers as Headers;
+      expect(fetchHeaders.get("x-api-key")).toBe(testSecretValue);
     });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/proxy/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/proxy/route.ts
@@ -4,6 +4,7 @@ import { getUserId } from "../../../../../src/lib/auth/get-user-id";
 import {
   forwardRequest,
   decodeTargetUrl,
+  ProxyTokenDecryptionError,
 } from "../../../../../src/lib/proxy/proxy-service";
 import { logger } from "../../../../../src/lib/logger";
 
@@ -57,6 +58,21 @@ export async function POST(request: Request) {
     const result = await forwardRequest(request, targetUrl, runId);
     return result.response;
   } catch (err) {
+    // Handle proxy token decryption errors specifically
+    if (err instanceof ProxyTokenDecryptionError) {
+      log.warn(`Token decryption failed for ${targetUrl}: ${err.message}`);
+      return NextResponse.json(
+        {
+          error: {
+            message: err.message,
+            code: "UNAUTHORIZED",
+            header: err.header,
+          },
+        },
+        { status: 401 },
+      );
+    }
+
     const message = err instanceof Error ? err.message : "Unknown error";
     log.error(`Proxy request failed for ${targetUrl}: ${message}`);
 

--- a/turbo/apps/web/app/api/webhooks/agent/proxy/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/proxy/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { initServices } from "../../../../../src/lib/init-services";
+import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import {
+  forwardRequest,
+  decodeTargetUrl,
+} from "../../../../../src/lib/proxy/proxy-service";
+import { logger } from "../../../../../src/lib/logger";
+
+const log = logger("webhook:proxy");
+
+/**
+ * POST /api/webhooks/agent/proxy?url=<encoded_target_url>
+ *
+ * Generic proxy endpoint for sandbox requests.
+ * Validates sandbox token, decodes target URL, and forwards the request.
+ * Supports SSE streaming responses.
+ */
+export async function POST(request: Request) {
+  initServices();
+
+  // 1. Authenticate via sandbox token
+  const userId = await getUserId();
+  if (!userId) {
+    log.warn("Proxy request without valid authentication");
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  // 2. Extract and validate target URL from query param
+  const { searchParams } = new URL(request.url);
+  const encodedUrl = searchParams.get("url");
+
+  const targetUrl = decodeTargetUrl(encodedUrl);
+  if (!targetUrl) {
+    log.warn(`Invalid or missing target URL: ${encodedUrl}`);
+    return NextResponse.json(
+      {
+        error: {
+          message: "Missing or invalid url parameter",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  log.debug(`Proxying request for user ${userId} to ${targetUrl}`);
+
+  // 3. Forward request to target
+  try {
+    const result = await forwardRequest(request, targetUrl);
+    return result.response;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    log.error(`Proxy request failed for ${targetUrl}: ${message}`);
+
+    return NextResponse.json(
+      {
+        error: {
+          message: `Failed to reach target: ${message}`,
+          code: "BAD_GATEWAY",
+          targetUrl,
+        },
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/turbo/apps/web/app/api/webhooks/agent/proxy/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/proxy/route.ts
@@ -67,7 +67,9 @@ async function handleProxyRequest(request: Request) {
     );
   }
 
-  log.debug(`Proxying request for user ${userId} to ${targetUrl} (runId: ${runId})`);
+  log.debug(
+    `Proxying request for user ${userId} to ${targetUrl} (runId: ${runId})`,
+  );
 
   // 3. Forward request to target (handles proxy token decryption)
   try {

--- a/turbo/apps/web/app/api/webhooks/agent/proxy/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/proxy/route.ts
@@ -11,13 +11,16 @@ import { logger } from "../../../../../src/lib/logger";
 const log = logger("webhook:proxy");
 
 /**
- * POST /api/webhooks/agent/proxy?url=<encoded_target_url>
+ * /api/webhooks/agent/proxy?url=<encoded_target_url>
  *
  * Generic proxy endpoint for sandbox requests.
  * Validates sandbox token, decodes target URL, and forwards the request.
  * Supports SSE streaming responses.
+ *
+ * NOTE: All HTTP methods are supported because mitmproxy preserves the original
+ * request method when forwarding through this proxy.
  */
-export async function POST(request: Request) {
+async function handleProxyRequest(request: Request) {
   initServices();
 
   // 1. Authenticate via sandbox token
@@ -88,3 +91,15 @@ export async function POST(request: Request) {
     );
   }
 }
+
+// Export handler for all HTTP methods that might be proxied
+// mitmproxy preserves the original request method when forwarding
+export {
+  handleProxyRequest as GET,
+  handleProxyRequest as POST,
+  handleProxyRequest as PUT,
+  handleProxyRequest as DELETE,
+  handleProxyRequest as PATCH,
+  handleProxyRequest as OPTIONS,
+  handleProxyRequest as HEAD,
+};

--- a/turbo/apps/web/app/api/webhooks/agent/proxy/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/proxy/route.ts
@@ -33,10 +33,25 @@ async function handleProxyRequest(request: Request) {
     );
   }
 
-  // 2. Extract and validate target URL from query param
+  // 2. Extract and validate parameters from query
   const { searchParams } = new URL(request.url);
   const encodedUrl = searchParams.get("url");
-  const runId = searchParams.get("runId") || undefined;
+  const runId = searchParams.get("runId");
+
+  // runId is required to prevent token replay attacks across runs
+  // mitmproxy addon always includes runId in requests
+  if (!runId) {
+    log.warn("Proxy request without runId parameter");
+    return NextResponse.json(
+      {
+        error: {
+          message: "runId parameter is required",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
 
   const targetUrl = decodeTargetUrl(encodedUrl);
   if (!targetUrl) {
@@ -52,9 +67,7 @@ async function handleProxyRequest(request: Request) {
     );
   }
 
-  log.debug(
-    `Proxying request for user ${userId} to ${targetUrl}${runId ? ` (runId: ${runId})` : ""}`,
-  );
+  log.debug(`Proxying request for user ${userId} to ${targetUrl} (runId: ${runId})`);
 
   // 3. Forward request to target (handles proxy token decryption)
   try {

--- a/turbo/apps/web/app/api/webhooks/agent/proxy/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/proxy/route.ts
@@ -32,6 +32,7 @@ export async function POST(request: Request) {
   // 2. Extract and validate target URL from query param
   const { searchParams } = new URL(request.url);
   const encodedUrl = searchParams.get("url");
+  const runId = searchParams.get("runId") || undefined;
 
   const targetUrl = decodeTargetUrl(encodedUrl);
   if (!targetUrl) {
@@ -47,11 +48,13 @@ export async function POST(request: Request) {
     );
   }
 
-  log.debug(`Proxying request for user ${userId} to ${targetUrl}`);
+  log.debug(
+    `Proxying request for user ${userId} to ${targetUrl}${runId ? ` (runId: ${runId})` : ""}`,
+  );
 
-  // 3. Forward request to target
+  // 3. Forward request to target (handles proxy token decryption)
   try {
-    const result = await forwardRequest(request, targetUrl);
+    const result = await forwardRequest(request, targetUrl, runId);
     return result.response;
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
@@ -48,6 +48,7 @@ const router = tsr.router(webhookTelemetryContract, {
         data: {
           systemLog: body.systemLog ?? "",
           metrics: body.metrics ?? [],
+          networkLogs: body.networkLogs ?? [],
         },
       })
       .returning({ id: sandboxTelemetry.id });
@@ -66,7 +67,7 @@ const router = tsr.router(webhookTelemetryContract, {
     }
 
     log.debug(
-      `Stored telemetry for run ${body.runId}: systemLog=${body.systemLog?.length ?? 0} bytes, metrics=${body.metrics?.length ?? 0} entries`,
+      `Stored telemetry for run ${body.runId}: systemLog=${body.systemLog?.length ?? 0} bytes, metrics=${body.metrics?.length ?? 0} entries, networkLogs=${body.networkLogs?.length ?? 0} entries`,
     );
 
     return {

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -248,11 +248,7 @@ export class E2BService {
       // Start Claude Code via run-agent.sh (fire-and-forget)
       // The script will send events via webhook and update status when complete
       // NOTE: All env vars are already set at sandbox creation time, scripts already uploaded
-      await this.startAgentExecution(
-        sandbox,
-        context.runId,
-        context.betaNetworkSecurity,
-      );
+      await this.startAgentExecution(sandbox, context.runId);
 
       const prepTimeMs = Date.now() - startTime;
       log.debug(
@@ -585,7 +581,6 @@ export class E2BService {
   private async startAgentExecution(
     sandbox: Sandbox,
     runId: string,
-    _betaNetworkSecurity?: boolean,
   ): Promise<void> {
     log.debug(`Starting run-agent.py for run ${runId} (fire-and-forget)...`);
 

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -248,7 +248,11 @@ export class E2BService {
       // Start Claude Code via run-agent.sh (fire-and-forget)
       // The script will send events via webhook and update status when complete
       // NOTE: All env vars are already set at sandbox creation time, scripts already uploaded
-      await this.startAgentExecution(sandbox, context.runId);
+      await this.startAgentExecution(
+        sandbox,
+        context.runId,
+        context.betaNetworkSecurity,
+      );
 
       const prepTimeMs = Date.now() - startTime;
       log.debug(
@@ -581,6 +585,7 @@ export class E2BService {
   private async startAgentExecution(
     sandbox: Sandbox,
     runId: string,
+    betaNetworkSecurity?: boolean,
   ): Promise<void> {
     log.debug(`Starting run-agent.py for run ${runId} (fire-and-forget)...`);
 
@@ -588,9 +593,17 @@ export class E2BService {
     // This prevents the process from being killed when E2B connection is closed
     // NOTE: Scripts already uploaded via uploadAllScripts(), do not pass envs here
     // Redirect output to per-run log file in /tmp with vm0- prefix
-    await sandbox.commands.run(
-      `nohup python3 ${SCRIPT_PATHS.runAgent} > /tmp/vm0-main-${runId}.log 2>&1 &`,
-    );
+    const cmd = `nohup python3 ${SCRIPT_PATHS.runAgent} > /tmp/vm0-main-${runId}.log 2>&1 &`;
+
+    // When network security is enabled, run as 'user' instead of root
+    // This is required because nftables skips root traffic to prevent proxy loops
+    // The mitmproxy runs as root, but agent traffic must go through it
+    if (betaNetworkSecurity) {
+      log.debug(`Running agent as 'user' for network security mode`);
+      await sandbox.commands.run(cmd, { user: "user" });
+    } else {
+      await sandbox.commands.run(cmd);
+    }
 
     log.debug(`Agent execution started in background for run ${runId}`);
   }

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -172,13 +172,13 @@ export class E2BService {
         sandboxEnvVars.USE_MOCK_CLAUDE = "true";
       }
 
-      // Enable proxy mode for enhanced security
+      // Enable proxy mode for network security
       // When true, mitmproxy will be set up to intercept traffic
       // and decrypt vm0_enc_ tokens before forwarding to APIs
-      if (context.betaEnhanceSecurity) {
+      if (context.betaNetworkSecurity) {
         sandboxEnvVars.VM0_PROXY_ENABLED = "true";
         log.debug(
-          `Enhanced security enabled for run ${context.runId} - proxy mode active`,
+          `Network security enabled for run ${context.runId} - proxy mode active`,
         );
       }
 

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -23,6 +23,8 @@ import {
   MOCK_CLAUDE_SCRIPT,
   METRICS_SCRIPT,
   UPLOAD_TELEMETRY_SCRIPT,
+  PROXY_SETUP_SCRIPT,
+  MITM_ADDON_SCRIPT,
   RUN_AGENT_SCRIPT,
   SCRIPT_PATHS,
 } from "./scripts";
@@ -168,6 +170,16 @@ export class E2BService {
       // Pass USE_MOCK_CLAUDE for testing (executes prompt as bash instead of calling LLM)
       if (process.env.USE_MOCK_CLAUDE === "true") {
         sandboxEnvVars.USE_MOCK_CLAUDE = "true";
+      }
+
+      // Enable proxy mode for enhanced security
+      // When true, mitmproxy will be set up to intercept traffic
+      // and decrypt vm0_enc_ tokens before forwarding to APIs
+      if (context.betaEnhanceSecurity) {
+        sandboxEnvVars.VM0_PROXY_ENABLED = "true";
+        log.debug(
+          `Enhanced security enabled for run ${context.runId} - proxy mode active`,
+        );
       }
 
       // Add artifact information for checkpoint
@@ -418,6 +430,8 @@ export class E2BService {
       { content: MOCK_CLAUDE_SCRIPT, path: SCRIPT_PATHS.mockClaude },
       { content: METRICS_SCRIPT, path: SCRIPT_PATHS.metrics },
       { content: UPLOAD_TELEMETRY_SCRIPT, path: SCRIPT_PATHS.uploadTelemetry },
+      { content: PROXY_SETUP_SCRIPT, path: SCRIPT_PATHS.proxySetup },
+      { content: MITM_ADDON_SCRIPT, path: SCRIPT_PATHS.mitmAddon },
       { content: RUN_AGENT_SCRIPT, path: SCRIPT_PATHS.runAgent },
     ];
   }

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -585,7 +585,7 @@ export class E2BService {
   private async startAgentExecution(
     sandbox: Sandbox,
     runId: string,
-    betaNetworkSecurity?: boolean,
+    _betaNetworkSecurity?: boolean,
   ): Promise<void> {
     log.debug(`Starting run-agent.py for run ${runId} (fire-and-forget)...`);
 
@@ -593,17 +593,12 @@ export class E2BService {
     // This prevents the process from being killed when E2B connection is closed
     // NOTE: Scripts already uploaded via uploadAllScripts(), do not pass envs here
     // Redirect output to per-run log file in /tmp with vm0- prefix
+    //
+    // NOTE: Agent must run as root because:
+    // 1. Proxy setup requires root for apt-get and nftables configuration
+    // 2. Claude Code subprocess will be run as 'user' via su when network security is enabled
     const cmd = `nohup python3 ${SCRIPT_PATHS.runAgent} > /tmp/vm0-main-${runId}.log 2>&1 &`;
-
-    // When network security is enabled, run as 'user' instead of root
-    // This is required because nftables skips root traffic to prevent proxy loops
-    // The mitmproxy runs as root, but agent traffic must go through it
-    if (betaNetworkSecurity) {
-      log.debug(`Running agent as 'user' for network security mode`);
-      await sandbox.commands.run(cmd, { user: "user" });
-    } else {
-      await sandbox.commands.run(cmd);
-    }
+    await sandbox.commands.run(cmd);
 
     log.debug(`Agent execution started in background for run ${runId}`);
   }

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -177,6 +177,15 @@ export class E2BService {
       // and decrypt vm0_enc_ tokens before forwarding to APIs
       if (context.betaNetworkSecurity) {
         sandboxEnvVars.VM0_PROXY_ENABLED = "true";
+        // Set SSL certificate environment variables for mitmproxy CA
+        // These ensure Python's requests/urllib and other libraries trust the proxy CA
+        sandboxEnvVars.REQUESTS_CA_BUNDLE =
+          "/etc/ssl/certs/ca-certificates.crt";
+        sandboxEnvVars.SSL_CERT_FILE = "/etc/ssl/certs/ca-certificates.crt";
+        sandboxEnvVars.CURL_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt";
+        // Node.js also needs the CA cert
+        sandboxEnvVars.NODE_EXTRA_CA_CERTS =
+          "/etc/ssl/certs/ca-certificates.crt";
         log.debug(
           `Network security enabled for run ${context.runId} - proxy mode active`,
         );
@@ -248,7 +257,11 @@ export class E2BService {
       // Start Claude Code via run-agent.sh (fire-and-forget)
       // The script will send events via webhook and update status when complete
       // NOTE: All env vars are already set at sandbox creation time, scripts already uploaded
-      await this.startAgentExecution(sandbox, context.runId);
+      await this.startAgentExecution(
+        sandbox,
+        context.runId,
+        context.betaNetworkSecurity || false,
+      );
 
       const prepTimeMs = Date.now() - startTime;
       log.debug(
@@ -581,17 +594,29 @@ export class E2BService {
   private async startAgentExecution(
     sandbox: Sandbox,
     runId: string,
+    networkSecurityEnabled: boolean,
   ): Promise<void> {
     log.debug(`Starting run-agent.py for run ${runId} (fire-and-forget)...`);
+
+    // Run proxy setup as root BEFORE starting agent if network security is enabled
+    // This is done synchronously to ensure proxy is ready before agent starts
+    // The agent then runs as default user ('user') for normal operation
+    if (networkSecurityEnabled) {
+      log.debug(`Running proxy setup as root for run ${runId}...`);
+      const proxySetupCmd = `python3 ${SCRIPT_PATHS.libDir}/proxy_setup.py > /tmp/vm0-proxy-setup-${runId}.log 2>&1`;
+      await sandbox.commands.run(proxySetupCmd, { user: "root" });
+      log.debug(`Proxy setup completed for run ${runId}`);
+    }
 
     // Start Python script in background using nohup to ignore SIGHUP signal
     // This prevents the process from being killed when E2B connection is closed
     // NOTE: Scripts already uploaded via uploadAllScripts(), do not pass envs here
     // Redirect output to per-run log file in /tmp with vm0- prefix
     //
-    // NOTE: Agent must run as root because:
-    // 1. Proxy setup requires root for apt-get and nftables configuration
-    // 2. Claude Code subprocess will be run as 'user' via su when network security is enabled
+    // NOTE: Agent runs as E2B default user ('user').
+    // When network security is enabled, proxy setup is done as root before this.
+    // mitmproxy also runs as root, and nftables skips root's traffic (meta skuid 0)
+    // to avoid redirect loops.
     const cmd = `nohup python3 ${SCRIPT_PATHS.runAgent} > /tmp/vm0-main-${runId}.log 2>&1 &`;
     await sandbox.commands.run(cmd);
 

--- a/turbo/apps/web/src/lib/e2b/scripts/index.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/index.ts
@@ -14,6 +14,8 @@ export { CHECKPOINT_SCRIPT } from "./lib/checkpoint.py";
 export { MOCK_CLAUDE_SCRIPT } from "./lib/mock_claude.py";
 export { METRICS_SCRIPT } from "./lib/metrics.py";
 export { UPLOAD_TELEMETRY_SCRIPT } from "./lib/upload_telemetry.py";
+export { PROXY_SETUP_SCRIPT } from "./lib/proxy_setup.py";
+export { MITM_ADDON_SCRIPT } from "./lib/mitm_addon.py";
 export { RUN_AGENT_SCRIPT } from "./run-agent.py";
 
 /**
@@ -35,4 +37,6 @@ export const SCRIPT_PATHS = {
   mockClaude: "/usr/local/bin/vm0-agent/lib/mock_claude.py",
   metrics: "/usr/local/bin/vm0-agent/lib/metrics.py",
   uploadTelemetry: "/usr/local/bin/vm0-agent/lib/upload_telemetry.py",
+  proxySetup: "/usr/local/bin/vm0-agent/lib/proxy_setup.py",
+  mitmAddon: "/usr/local/bin/vm0-agent/lib/mitm_addon.py",
 } as const;

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
@@ -38,7 +38,7 @@ HEARTBEAT_URL = f"{API_URL}/api/webhooks/agent/heartbeat"
 TELEMETRY_URL = f"{API_URL}/api/webhooks/agent/telemetry"
 PROXY_URL = f"{API_URL}/api/webhooks/agent/proxy"
 
-# Proxy configuration (for beta_enhance_security feature)
+# Proxy configuration (for beta_network_security feature)
 PROXY_ENABLED = os.environ.get("VM0_PROXY_ENABLED", "false").lower() == "true"
 
 # Heartbeat configuration

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
@@ -36,6 +36,10 @@ STORAGE_WEBHOOK_URL = f"{API_URL}/api/webhooks/agent/storages"
 INCREMENTAL_WEBHOOK_URL = f"{API_URL}/api/webhooks/agent/storages/incremental"
 HEARTBEAT_URL = f"{API_URL}/api/webhooks/agent/heartbeat"
 TELEMETRY_URL = f"{API_URL}/api/webhooks/agent/telemetry"
+PROXY_URL = f"{API_URL}/api/webhooks/agent/proxy"
+
+# Proxy configuration (for beta_enhance_security feature)
+PROXY_ENABLED = os.environ.get("VM0_PROXY_ENABLED", "false").lower() == "true"
 
 # Heartbeat configuration
 HEARTBEAT_INTERVAL = 60  # seconds

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
@@ -67,9 +67,13 @@ AGENT_LOG_FILE = f"/tmp/vm0-agent-{RUN_ID}.log"
 # Metrics log file for system resource metrics (JSONL format)
 METRICS_LOG_FILE = f"/tmp/vm0-metrics-{RUN_ID}.jsonl"
 
+# Network log file for proxy request logs (JSONL format)
+NETWORK_LOG_FILE = f"/tmp/vm0-network-{RUN_ID}.jsonl"
+
 # Telemetry position tracking files (to avoid duplicate uploads)
 TELEMETRY_LOG_POS_FILE = f"/tmp/vm0-telemetry-log-pos-{RUN_ID}.txt"
 TELEMETRY_METRICS_POS_FILE = f"/tmp/vm0-telemetry-metrics-pos-{RUN_ID}.txt"
+TELEMETRY_NETWORK_POS_FILE = f"/tmp/vm0-telemetry-network-pos-{RUN_ID}.txt"
 
 # Metrics collection configuration
 METRICS_INTERVAL = 5  # seconds

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/events.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/events.py.ts
@@ -46,7 +46,10 @@ def send_event(event: Dict[str, Any]) -> bool:
                 # Claude Code uses hyphen-separated path encoding
                 # e.g., /home/user/workspace -> -home-user-workspace
                 project_name = WORKING_DIR.lstrip("/").replace("/", "-")
-                home_dir = os.environ.get("HOME", "/home/user")
+                # When network security (proxy) is enabled, Claude runs as 'user' via su,
+                # so use /home/user instead of root's HOME
+                proxy_enabled = os.environ.get("VM0_PROXY_ENABLED", "false").lower() == "true"
+                home_dir = "/home/user" if proxy_enabled else os.environ.get("HOME", "/home/user")
                 session_history_path = f"{home_dir}/.config/claude/projects/-{project_name}/{session_id}.jsonl"
 
                 with open(SESSION_HISTORY_PATH_FILE, "w") as f:

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/events.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/events.py.ts
@@ -45,11 +45,9 @@ def send_event(event: Dict[str, Any]) -> bool:
                 # Calculate session history path
                 # Claude Code uses hyphen-separated path encoding
                 # e.g., /home/user/workspace -> -home-user-workspace
+                # Agent runs as E2B default user ('user'), so HOME is /home/user
                 project_name = WORKING_DIR.lstrip("/").replace("/", "-")
-                # When network security (proxy) is enabled, Claude runs as 'user' via su,
-                # so use /home/user instead of root's HOME
-                proxy_enabled = os.environ.get("VM0_PROXY_ENABLED", "false").lower() == "true"
-                home_dir = "/home/user" if proxy_enabled else os.environ.get("HOME", "/home/user")
+                home_dir = os.environ.get("HOME", "/home/user")
                 session_history_path = f"{home_dir}/.config/claude/projects/-{project_name}/{session_id}.jsonl"
 
                 with open(SESSION_HISTORY_PATH_FILE, "w") as f:

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
@@ -4,7 +4,7 @@
  */
 export const MITM_ADDON_SCRIPT = `#!/usr/bin/env python3
 """
-mitmproxy addon for VM0 enhanced security mode.
+mitmproxy addon for VM0 network security mode.
 This addon:
 1. Intercepts all HTTPS requests
 2. Rewrites them to go through VM0 Proxy endpoint

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
@@ -38,6 +38,12 @@ PROXY_URL = f"{API_URL}/api/webhooks/agent/proxy"
 def log_network_entry(entry: dict) -> None:
     """Write a network log entry to the JSONL file."""
     try:
+        # Create file with world-readable permissions (0644) if it doesn't exist
+        # This allows the agent process (running as 'user') to read the logs
+        # written by mitmproxy (running as root)
+        if not os.path.exists(NETWORK_LOG_FILE):
+            fd = os.open(NETWORK_LOG_FILE, os.O_CREAT | os.O_WRONLY, 0o644)
+            os.close(fd)
         with open(NETWORK_LOG_FILE, "a") as f:
             f.write(json.dumps(entry) + "\\n")
     except Exception as e:

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
@@ -1,0 +1,119 @@
+/**
+ * mitmproxy addon for VM0 proxy forwarding (Python)
+ * Intercepts HTTPS traffic and rewrites requests to VM0 Proxy
+ */
+export const MITM_ADDON_SCRIPT = `#!/usr/bin/env python3
+"""
+mitmproxy addon for VM0 enhanced security mode.
+This addon:
+1. Intercepts all HTTPS requests
+2. Rewrites them to go through VM0 Proxy endpoint
+3. Preserves all original headers (including encrypted tokens)
+"""
+import os
+import urllib.parse
+from mitmproxy import http, ctx
+
+
+# VM0 Proxy configuration
+# API_URL is set by sandbox environment
+API_URL = os.environ.get("VM0_API_URL", "")
+API_TOKEN = os.environ.get("VM0_API_TOKEN", "")
+RUN_ID = os.environ.get("VM0_RUN_ID", "")
+VERCEL_BYPASS = os.environ.get("VERCEL_PROTECTION_BYPASS", "")
+
+# Construct proxy URL
+PROXY_URL = f"{API_URL}/api/webhooks/agent/proxy"
+
+
+def get_original_url(flow: http.HTTPFlow) -> str:
+    """Reconstruct the original target URL from the request."""
+    scheme = "https" if flow.request.port == 443 else "http"
+    host = flow.request.host
+    port = flow.request.port
+
+    # Include port in URL only if non-standard
+    if (scheme == "https" and port != 443) or (scheme == "http" and port != 80):
+        host_with_port = f"{host}:{port}"
+    else:
+        host_with_port = host
+
+    # Reconstruct full URL with path and query
+    path = flow.request.path
+    return f"{scheme}://{host_with_port}{path}"
+
+
+def request(flow: http.HTTPFlow) -> None:
+    """
+    Intercept request and rewrite to VM0 Proxy.
+
+    Original request:
+        POST https://api.anthropic.com/v1/messages
+        Headers: x-api-key: vm0_enc_xxx, Content-Type: application/json
+        Body: {...}
+
+    Rewritten to:
+        POST https://vm0.ai/api/webhooks/agent/proxy?url=https%3A%2F%2Fapi.anthropic.com%2Fv1%2Fmessages&runId=xxx
+        Headers: Authorization: Bearer vm0_live_xxx, x-api-key: vm0_enc_xxx, Content-Type: application/json
+        Body: {...}
+    """
+    # Skip if no API URL configured
+    if not API_URL:
+        ctx.log.warn("VM0_API_URL not set, passing through")
+        return
+
+    # Skip requests already going to VM0 (avoid loops)
+    if API_URL in flow.request.pretty_url:
+        return
+
+    # Get original target URL
+    original_url = get_original_url(flow)
+
+    # Build new proxy URL with encoded target
+    encoded_url = urllib.parse.quote(original_url, safe="")
+    new_url = f"{PROXY_URL}?url={encoded_url}"
+
+    # Add runId for token validation
+    if RUN_ID:
+        new_url += f"&runId={RUN_ID}"
+
+    ctx.log.info(f"Proxying: {original_url} -> VM0 Proxy")
+
+    # Parse proxy URL
+    parsed = urllib.parse.urlparse(PROXY_URL)
+
+    # Rewrite request to proxy
+    flow.request.host = parsed.hostname
+    flow.request.port = 443 if parsed.scheme == "https" else 80
+    flow.request.scheme = parsed.scheme
+    flow.request.path = f"{parsed.path}?url={encoded_url}"
+    if RUN_ID:
+        flow.request.path += f"&runId={RUN_ID}"
+
+    # Add sandbox authentication token
+    if API_TOKEN:
+        flow.request.headers["Authorization"] = f"Bearer {API_TOKEN}"
+
+    # Add Vercel bypass header if configured
+    if VERCEL_BYPASS:
+        flow.request.headers["x-vercel-protection-bypass"] = VERCEL_BYPASS
+
+    # All other headers (including x-api-key with vm0_enc_xxx) are preserved
+    # The proxy endpoint will decrypt the token before forwarding
+
+
+def response(flow: http.HTTPFlow) -> None:
+    """
+    Handle response from VM0 Proxy.
+    Log any errors for debugging.
+    """
+    if flow.response and flow.response.status_code >= 400:
+        ctx.log.warn(
+            f"Proxy response {flow.response.status_code}: "
+            f"{flow.request.pretty_url}"
+        )
+
+
+# mitmproxy addon registration
+addons = [request, response]
+`;

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
@@ -38,14 +38,15 @@ PROXY_URL = f"{API_URL}/api/webhooks/agent/proxy"
 def log_network_entry(entry: dict) -> None:
     """Write a network log entry to the JSONL file."""
     try:
-        # Create file with world-readable permissions (0644) if it doesn't exist
-        # This allows the agent process (running as 'user') to read the logs
-        # written by mitmproxy (running as root)
-        if not os.path.exists(NETWORK_LOG_FILE):
-            fd = os.open(NETWORK_LOG_FILE, os.O_CREAT | os.O_WRONLY, 0o644)
+        # Use O_CREAT | O_APPEND | O_WRONLY with mode 0o644 atomically
+        # This avoids race conditions and ensures world-readable permissions
+        # so the agent process (running as 'user') can read logs written by
+        # mitmproxy (running as root)
+        fd = os.open(NETWORK_LOG_FILE, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o644)
+        try:
+            os.write(fd, (json.dumps(entry) + "\\n").encode())
+        finally:
             os.close(fd)
-        with open(NETWORK_LOG_FILE, "a") as f:
-            f.write(json.dumps(entry) + "\\n")
     except Exception as e:
         ctx.log.warn(f"Failed to write network log: {e}")
 
@@ -103,26 +104,22 @@ def request(flow: http.HTTPFlow) -> None:
     # Store original URL for logging in response handler
     flow.metadata["original_url"] = original_url
 
-    # Build new proxy URL with encoded target
-    encoded_url = urllib.parse.quote(original_url, safe="")
-    new_url = f"{PROXY_URL}?url={encoded_url}"
-
-    # Add runId for token validation
-    if RUN_ID:
-        new_url += f"&runId={RUN_ID}"
-
     ctx.log.info(f"Proxying: {original_url} -> VM0 Proxy")
 
     # Parse proxy URL
     parsed = urllib.parse.urlparse(PROXY_URL)
 
+    # Build query params properly using urlencode
+    query_params = {"url": original_url}
+    if RUN_ID:
+        query_params["runId"] = RUN_ID
+    query_string = urllib.parse.urlencode(query_params)
+
     # Rewrite request to proxy
     flow.request.host = parsed.hostname
     flow.request.port = 443 if parsed.scheme == "https" else 80
     flow.request.scheme = parsed.scheme
-    flow.request.path = f"{parsed.path}?url={encoded_url}"
-    if RUN_ID:
-        flow.request.path += f"&runId={RUN_ID}"
+    flow.request.path = f"{parsed.path}?{query_string}"
 
     # Add sandbox authentication token
     if API_TOKEN:

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
@@ -9,8 +9,11 @@ This addon:
 1. Intercepts all HTTPS requests
 2. Rewrites them to go through VM0 Proxy endpoint
 3. Preserves all original headers (including encrypted tokens)
+4. Logs network activity to JSONL file for observability
 """
 import os
+import json
+import time
 import urllib.parse
 from mitmproxy import http, ctx
 
@@ -22,8 +25,23 @@ API_TOKEN = os.environ.get("VM0_API_TOKEN", "")
 RUN_ID = os.environ.get("VM0_RUN_ID", "")
 VERCEL_BYPASS = os.environ.get("VERCEL_PROTECTION_BYPASS", "")
 
+# Network log file path
+NETWORK_LOG_FILE = f"/tmp/vm0-network-{RUN_ID}.jsonl"
+
+# Track request start times for latency calculation
+request_start_times = {}
+
 # Construct proxy URL
 PROXY_URL = f"{API_URL}/api/webhooks/agent/proxy"
+
+
+def log_network_entry(entry: dict) -> None:
+    """Write a network log entry to the JSONL file."""
+    try:
+        with open(NETWORK_LOG_FILE, "a") as f:
+            f.write(json.dumps(entry) + "\\n")
+    except Exception as e:
+        ctx.log.warn(f"Failed to write network log: {e}")
 
 
 def get_original_url(flow: http.HTTPFlow) -> str:
@@ -57,6 +75,9 @@ def request(flow: http.HTTPFlow) -> None:
         Headers: Authorization: Bearer vm0_live_xxx, x-api-key: vm0_enc_xxx, Content-Type: application/json
         Body: {...}
     """
+    # Track request start time for latency calculation
+    request_start_times[flow.id] = time.time()
+
     # Skip if no API URL configured
     if not API_URL:
         ctx.log.warn("VM0_API_URL not set, passing through")
@@ -68,6 +89,9 @@ def request(flow: http.HTTPFlow) -> None:
 
     # Get original target URL
     original_url = get_original_url(flow)
+
+    # Store original URL for logging in response handler
+    flow.metadata["original_url"] = original_url
 
     # Build new proxy URL with encoded target
     encoded_url = urllib.parse.quote(original_url, safe="")
@@ -105,12 +129,39 @@ def request(flow: http.HTTPFlow) -> None:
 def response(flow: http.HTTPFlow) -> None:
     """
     Handle response from VM0 Proxy.
-    Log any errors for debugging.
+    Log network activity and any errors for debugging.
     """
+    # Calculate latency
+    start_time = request_start_times.pop(flow.id, None)
+    latency_ms = int((time.time() - start_time) * 1000) if start_time else 0
+
+    # Get original URL (stored in request handler) or use current URL
+    original_url = flow.metadata.get("original_url", flow.request.pretty_url)
+
+    # Calculate request/response sizes
+    request_size = len(flow.request.content) if flow.request.content else 0
+    response_size = len(flow.response.content) if flow.response and flow.response.content else 0
+
+    # Determine status code
+    status_code = flow.response.status_code if flow.response else 0
+
+    # Log network entry
+    log_entry = {
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()),
+        "method": flow.request.method,
+        "url": original_url,
+        "status": status_code,
+        "latency_ms": latency_ms,
+        "request_size": request_size,
+        "response_size": response_size,
+    }
+    log_network_entry(log_entry)
+
+    # Log errors to mitmproxy console
     if flow.response and flow.response.status_code >= 400:
         ctx.log.warn(
             f"Proxy response {flow.response.status_code}: "
-            f"{flow.request.pretty_url}"
+            f"{original_url}"
         )
 
 

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
@@ -83,8 +83,12 @@ def request(flow: http.HTTPFlow) -> None:
         ctx.log.warn("VM0_API_URL not set, passing through")
         return
 
-    # Skip requests already going to VM0 (avoid loops)
+    # Skip rewriting requests already going to VM0 (avoid loops)
+    # But still allow them to be logged in the response handler
     if API_URL in flow.request.pretty_url:
+        # Store original URL for logging
+        flow.metadata["original_url"] = flow.request.pretty_url
+        flow.metadata["skip_rewrite"] = True
         return
 
     # Get original target URL

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/proxy_setup.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/proxy_setup.py.ts
@@ -23,7 +23,7 @@ from log import log_info, log_error, log_warn
 
 # Proxy configuration
 MITM_PORT = 8080
-MITM_CA_DIR = "/root/.mitmproxy"
+MITM_CA_DIR = "/root/.mitmproxy"  # Proxy setup runs as root
 MITM_CA_CERT = f"{MITM_CA_DIR}/mitmproxy-ca-cert.pem"
 ADDON_PATH = "/usr/local/bin/vm0-agent/lib/mitm_addon.py"
 
@@ -42,7 +42,7 @@ def run_cmd(cmd: list, check: bool = True) -> subprocess.CompletedProcess:
 
 
 def install_dependencies():
-    """Install required packages."""
+    """Install required packages (must run as root)."""
     log_info("Installing dependencies...")
 
     # Update apt cache
@@ -56,7 +56,7 @@ def install_dependencies():
         "ca-certificates"
     ])
 
-    # Install mitmproxy
+    # Install mitmproxy system-wide
     log_info("Installing mitmproxy (this may take a minute)...")
     run_cmd([
         "pip3", "install", "mitmproxy",
@@ -114,8 +114,9 @@ def configure_nftables():
     log_info("Configuring nftables for transparent proxy...")
 
     # nftables rules for transparent proxy
-    # - Skip root user traffic (uid 0) to avoid proxy loop
+    # - Skip traffic from root (UID 0) - mitmproxy runs as root
     # - Redirect all other TCP traffic to mitmproxy
+    # NOTE: We use UID-based filtering because mitmproxy doesn't support SO_MARK
     nft_rules = f"""
 flush ruleset
 
@@ -127,7 +128,8 @@ table ip nat {{
     chain output {{
         type nat hook output priority -100;
 
-        # Skip traffic from root (mitmproxy runs as root)
+        # Skip traffic from root (UID 0) - mitmproxy runs as root
+        # This prevents redirect loop: mitmproxy -> nftables -> mitmproxy
         meta skuid 0 return
 
         # Skip traffic to localhost
@@ -167,7 +169,8 @@ def start_mitmproxy():
         raise RuntimeError(f"Addon not found: {ADDON_PATH}")
 
     # Start mitmproxy in transparent mode with addon
-    # Run as daemon in background
+    # NOTE: mitmproxy runs as root, and nftables skips root's traffic (meta skuid 0)
+    # to avoid redirect loop
     cmd = [
         "mitmdump",
         "--mode", "transparent",

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/proxy_setup.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/proxy_setup.py.ts
@@ -1,0 +1,225 @@
+/**
+ * Proxy setup script for mitmproxy transparent proxy (Python)
+ * Installs and configures mitmproxy to intercept HTTPS traffic
+ */
+export const PROXY_SETUP_SCRIPT = `#!/usr/bin/env python3
+"""
+Proxy setup for VM0 enhanced security mode.
+This script:
+1. Installs mitmproxy and dependencies
+2. Generates and installs CA certificate
+3. Configures nftables for transparent proxying
+4. Starts mitmproxy with the VM0 addon
+"""
+import os
+import sys
+import subprocess
+import time
+
+# Add lib to path for imports
+sys.path.insert(0, "/usr/local/bin/vm0-agent/lib")
+
+from log import log_info, log_error, log_warn
+
+# Proxy configuration
+MITM_PORT = 8080
+MITM_CA_DIR = "/root/.mitmproxy"
+MITM_CA_CERT = f"{MITM_CA_DIR}/mitmproxy-ca-cert.pem"
+ADDON_PATH = "/usr/local/bin/vm0-agent/lib/mitm_addon.py"
+
+
+def run_cmd(cmd: list, check: bool = True) -> subprocess.CompletedProcess:
+    """Run a command and log output."""
+    log_info(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.stdout:
+        log_info(f"stdout: {result.stdout.strip()}")
+    if result.stderr:
+        log_warn(f"stderr: {result.stderr.strip()}")
+    if check and result.returncode != 0:
+        raise RuntimeError(f"Command failed with code {result.returncode}")
+    return result
+
+
+def install_dependencies():
+    """Install required packages."""
+    log_info("Installing dependencies...")
+
+    # Update apt cache
+    run_cmd(["apt-get", "update", "-qq"])
+
+    # Install required packages
+    run_cmd([
+        "apt-get", "install", "-y", "-qq",
+        "python3-pip",
+        "nftables",
+        "ca-certificates"
+    ])
+
+    # Install mitmproxy
+    log_info("Installing mitmproxy (this may take a minute)...")
+    run_cmd([
+        "pip3", "install", "mitmproxy",
+        "--break-system-packages",
+        "--quiet"
+    ])
+
+    log_info("Dependencies installed successfully")
+
+
+def setup_ca_certificate():
+    """Generate and install mitmproxy CA certificate."""
+    log_info("Setting up CA certificate...")
+
+    # Create mitmproxy config directory
+    os.makedirs(MITM_CA_DIR, exist_ok=True)
+
+    # Generate CA certificate by running mitmproxy briefly
+    # This creates the CA cert if it doesn't exist
+    log_info("Generating mitmproxy CA certificate...")
+    proc = subprocess.Popen(
+        ["mitmdump", "--set", "confdir=" + MITM_CA_DIR],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+    time.sleep(3)  # Wait for cert generation
+    proc.terminate()
+    proc.wait()
+
+    # Verify cert was created
+    if not os.path.exists(MITM_CA_CERT):
+        raise RuntimeError("Failed to generate CA certificate")
+
+    # Install CA certificate system-wide
+    log_info("Installing CA certificate system-wide...")
+
+    # Copy to system CA directory
+    run_cmd([
+        "cp", MITM_CA_CERT,
+        "/usr/local/share/ca-certificates/mitmproxy-ca.crt"
+    ])
+
+    # Update CA certificates
+    run_cmd(["update-ca-certificates"])
+
+    # Set environment for Python requests library
+    os.environ["REQUESTS_CA_BUNDLE"] = "/etc/ssl/certs/ca-certificates.crt"
+    os.environ["SSL_CERT_FILE"] = "/etc/ssl/certs/ca-certificates.crt"
+
+    log_info("CA certificate installed successfully")
+
+
+def configure_nftables():
+    """Configure nftables for transparent proxying."""
+    log_info("Configuring nftables for transparent proxy...")
+
+    # nftables rules for transparent proxy
+    # - Skip root user traffic (uid 0) to avoid proxy loop
+    # - Redirect all other TCP traffic to mitmproxy
+    nft_rules = f"""
+flush ruleset
+
+table ip nat {{
+    chain prerouting {{
+        type nat hook prerouting priority -100;
+    }}
+
+    chain output {{
+        type nat hook output priority -100;
+
+        # Skip traffic from root (mitmproxy runs as root)
+        meta skuid 0 return
+
+        # Skip traffic to localhost
+        ip daddr 127.0.0.0/8 return
+
+        # Skip traffic to private networks (internal communication)
+        ip daddr 10.0.0.0/8 return
+        ip daddr 172.16.0.0/12 return
+        ip daddr 192.168.0.0/16 return
+
+        # Redirect HTTP traffic (port 80)
+        tcp dport 80 redirect to :{MITM_PORT}
+
+        # Redirect HTTPS traffic (port 443)
+        tcp dport 443 redirect to :{MITM_PORT}
+    }}
+}}
+"""
+
+    # Write rules to file
+    nft_file = "/tmp/vm0-proxy-rules.nft"
+    with open(nft_file, "w") as f:
+        f.write(nft_rules)
+
+    # Apply rules
+    run_cmd(["nft", "-f", nft_file])
+
+    log_info("nftables configured successfully")
+
+
+def start_mitmproxy():
+    """Start mitmproxy with the VM0 addon in background."""
+    log_info("Starting mitmproxy...")
+
+    # Verify addon exists
+    if not os.path.exists(ADDON_PATH):
+        raise RuntimeError(f"Addon not found: {ADDON_PATH}")
+
+    # Start mitmproxy in transparent mode with addon
+    # Run as daemon in background
+    cmd = [
+        "mitmdump",
+        "--mode", "transparent",
+        "--listen-port", str(MITM_PORT),
+        "--set", f"confdir={MITM_CA_DIR}",
+        "--scripts", ADDON_PATH,
+        "--quiet"  # Reduce log noise
+    ]
+
+    log_info(f"mitmproxy command: {' '.join(cmd)}")
+
+    # Start in background
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True
+    )
+
+    # Wait briefly and check if it's running
+    time.sleep(2)
+    if proc.poll() is not None:
+        raise RuntimeError("mitmproxy failed to start")
+
+    log_info(f"mitmproxy started (PID: {proc.pid})")
+
+    # Save PID for later cleanup if needed
+    with open("/tmp/vm0-mitmproxy.pid", "w") as f:
+        f.write(str(proc.pid))
+
+
+def setup_proxy():
+    """Main setup function."""
+    log_info("=== VM0 Proxy Setup Starting ===")
+    start_time = time.time()
+
+    try:
+        install_dependencies()
+        setup_ca_certificate()
+        configure_nftables()
+        start_mitmproxy()
+
+        elapsed = time.time() - start_time
+        log_info(f"=== Proxy Setup Complete ({elapsed:.1f}s) ===")
+        return True
+
+    except Exception as e:
+        log_error(f"Proxy setup failed: {e}")
+        return False
+
+
+if __name__ == "__main__":
+    success = setup_proxy()
+    sys.exit(0 if success else 1)
+`;

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/proxy_setup.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/proxy_setup.py.ts
@@ -4,7 +4,7 @@
  */
 export const PROXY_SETUP_SCRIPT = `#!/usr/bin/env python3
 """
-Proxy setup for VM0 enhanced security mode.
+Proxy setup for VM0 network security mode.
 This script:
 1. Installs mitmproxy and dependencies
 2. Generates and installs CA certificate

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -58,10 +58,10 @@ def main():
 
     log_info(f"Working directory: {WORKING_DIR}")
 
-    # Set up proxy if enhanced security is enabled
+    # Set up proxy if network security is enabled
     # This must be done before any network requests to Claude API
     if PROXY_ENABLED:
-        log_info("Enhanced security mode enabled, setting up mitmproxy...")
+        log_info("Network security mode enabled, setting up mitmproxy...")
         try:
             from proxy_setup import setup_proxy
             if setup_proxy():

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -17,6 +17,7 @@ import sys
 import subprocess
 import json
 import threading
+import shlex
 
 # Add lib to path for imports
 sys.path.insert(0, "/usr/local/bin/vm0-agent/lib")
@@ -124,7 +125,16 @@ def main():
         claude_bin = "claude"
 
     # Build full command
-    cmd = [claude_bin] + claude_args + [PROMPT]
+    # When proxy is enabled, run Claude as 'user' so traffic goes through mitmproxy
+    # (nftables skips traffic from root to prevent proxy loops)
+    if PROXY_ENABLED:
+        log_info("Running Claude as 'user' for network security mode")
+        # Use su to run as user, with proper shell quoting
+        # The prompt needs to be passed through shell, so we use a shell wrapper
+        claude_cmd_str = " ".join([shlex.quote(arg) for arg in [claude_bin] + claude_args + [PROMPT]])
+        cmd = ["su", "-", "user", "-c", claude_cmd_str]
+    else:
+        cmd = [claude_bin] + claude_args + [PROMPT]
 
     # Execute Claude and process output stream
     # Capture both stdout and stderr, write to log file, keep stderr in memory for error extraction

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -24,7 +24,7 @@ sys.path.insert(0, "/usr/local/bin/vm0-agent/lib")
 from common import (
     WORKING_DIR, PROMPT, RESUME_SESSION_ID, COMPLETE_URL, RUN_ID,
     EVENT_ERROR_FLAG, HEARTBEAT_URL, HEARTBEAT_INTERVAL, AGENT_LOG_FILE,
-    validate_config
+    PROXY_ENABLED, validate_config
 )
 from log import log_info, log_error, log_warn
 from events import send_event
@@ -57,6 +57,21 @@ def main():
     validate_config()
 
     log_info(f"Working directory: {WORKING_DIR}")
+
+    # Set up proxy if enhanced security is enabled
+    # This must be done before any network requests to Claude API
+    if PROXY_ENABLED:
+        log_info("Enhanced security mode enabled, setting up mitmproxy...")
+        try:
+            from proxy_setup import setup_proxy
+            if setup_proxy():
+                log_info("Proxy setup completed successfully")
+            else:
+                log_error("Proxy setup failed, continuing without proxy")
+        except Exception as e:
+            log_error(f"Proxy setup error: {e}")
+            # Continue without proxy - traffic will fail at API level
+            # but this allows debugging
 
     # Start heartbeat thread
     heartbeat_thread = threading.Thread(target=heartbeat_loop, daemon=True)

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -95,9 +95,16 @@ def main():
         sys.exit(1)
 
     # Set Claude config directory to ensure consistent session history location
-    home_dir = os.environ.get("HOME", "/home/user")
-    os.environ["CLAUDE_CONFIG_DIR"] = f"{home_dir}/.config/claude"
-    log_info(f"Claude config directory: {os.environ['CLAUDE_CONFIG_DIR']}")
+    # When proxy is enabled, Claude runs as 'user', so use /home/user
+    if PROXY_ENABLED:
+        claude_config_dir = "/home/user/.config/claude"
+        # Ensure the directory is writable by 'user'
+        subprocess.run(["chown", "-R", "user:user", "/home/user/.config"], check=False)
+    else:
+        home_dir = os.environ.get("HOME", "/home/user")
+        claude_config_dir = f"{home_dir}/.config/claude"
+    os.environ["CLAUDE_CONFIG_DIR"] = claude_config_dir
+    log_info(f"Claude config directory: {claude_config_dir}")
 
     # Execute Claude Code with JSONL output
     log_info("Starting Claude Code execution...")

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -98,8 +98,11 @@ def main():
     # When proxy is enabled, Claude runs as 'user', so use /home/user
     if PROXY_ENABLED:
         claude_config_dir = "/home/user/.config/claude"
-        # Ensure the directory is writable by 'user'
+        # Ensure claude config directory exists and is writable by 'user'
+        os.makedirs(claude_config_dir, exist_ok=True)
         subprocess.run(["chown", "-R", "user:user", "/home/user/.config"], check=False)
+        # Also ensure working directory is writable by 'user'
+        subprocess.run(["chown", "-R", "user:user", WORKING_DIR], check=False)
     else:
         home_dir = os.environ.get("HOME", "/home/user")
         claude_config_dir = f"{home_dir}/.config/claude"

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -17,7 +17,6 @@ import sys
 import subprocess
 import json
 import threading
-import shlex
 
 # Add lib to path for imports
 sys.path.insert(0, "/usr/local/bin/vm0-agent/lib")
@@ -59,20 +58,11 @@ def main():
 
     log_info(f"Working directory: {WORKING_DIR}")
 
-    # Set up proxy if network security is enabled
-    # This must be done before any network requests to Claude API
+    # Log proxy mode status
+    # NOTE: Proxy setup is done as root by e2b-service.ts BEFORE this script starts
+    # This ensures mitmproxy is running and nftables rules are in place
     if PROXY_ENABLED:
-        log_info("Network security mode enabled, setting up mitmproxy...")
-        try:
-            from proxy_setup import setup_proxy
-            if setup_proxy():
-                log_info("Proxy setup completed successfully")
-            else:
-                log_error("Proxy setup failed, continuing without proxy")
-        except Exception as e:
-            log_error(f"Proxy setup error: {e}")
-            # Continue without proxy - traffic will fail at API level
-            # but this allows debugging
+        log_info("Network security mode enabled (proxy configured by e2b-service)")
 
     # Start heartbeat thread
     heartbeat_thread = threading.Thread(target=heartbeat_loop, daemon=True)
@@ -95,20 +85,9 @@ def main():
         sys.exit(1)
 
     # Set Claude config directory to ensure consistent session history location
-    # When proxy is enabled, Claude runs as 'user', so use /home/user
-    if PROXY_ENABLED:
-        claude_config_dir = "/home/user/.config/claude"
-        # Ensure claude config directory and projects subdirectory exist
-        # Mock claude will need to create session history in projects/-{path}/
-        os.makedirs(f"{claude_config_dir}/projects", exist_ok=True)
-        # Change ownership recursively so 'user' can write files
-        subprocess.run(["chown", "-R", "user:user", claude_config_dir], check=False)
-        # Also ensure working directory is writable by 'user'
-        subprocess.run(["chown", "-R", "user:user", WORKING_DIR], check=False)
-        log_info(f"Set ownership of {claude_config_dir} and {WORKING_DIR} to user:user")
-    else:
-        home_dir = os.environ.get("HOME", "/home/user")
-        claude_config_dir = f"{home_dir}/.config/claude"
+    # Agent runs as E2B default user ('user'), so HOME is /home/user
+    home_dir = os.environ.get("HOME", "/home/user")
+    claude_config_dir = f"{home_dir}/.config/claude"
     os.environ["CLAUDE_CONFIG_DIR"] = claude_config_dir
     log_info(f"Claude config directory: {claude_config_dir}")
 
@@ -138,16 +117,7 @@ def main():
         claude_bin = "claude"
 
     # Build full command
-    # When proxy is enabled, run Claude as 'user' so traffic goes through mitmproxy
-    # (nftables skips traffic from root to prevent proxy loops)
-    if PROXY_ENABLED:
-        log_info("Running Claude as 'user' for network security mode")
-        # Use su to run as user, with proper shell quoting
-        # The prompt needs to be passed through shell, so we use a shell wrapper
-        claude_cmd_str = " ".join([shlex.quote(arg) for arg in [claude_bin] + claude_args + [PROMPT]])
-        cmd = ["su", "-", "user", "-c", claude_cmd_str]
-    else:
-        cmd = [claude_bin] + claude_args + [PROMPT]
+    cmd = [claude_bin] + claude_args + [PROMPT]
 
     # Execute Claude and process output stream
     # Capture both stdout and stderr, write to log file, keep stderr in memory for error extraction

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -98,11 +98,14 @@ def main():
     # When proxy is enabled, Claude runs as 'user', so use /home/user
     if PROXY_ENABLED:
         claude_config_dir = "/home/user/.config/claude"
-        # Ensure claude config directory exists and is writable by 'user'
-        os.makedirs(claude_config_dir, exist_ok=True)
-        subprocess.run(["chown", "-R", "user:user", "/home/user/.config"], check=False)
+        # Ensure claude config directory and projects subdirectory exist
+        # Mock claude will need to create session history in projects/-{path}/
+        os.makedirs(f"{claude_config_dir}/projects", exist_ok=True)
+        # Change ownership recursively so 'user' can write files
+        subprocess.run(["chown", "-R", "user:user", claude_config_dir], check=False)
         # Also ensure working directory is writable by 'user'
         subprocess.run(["chown", "-R", "user:user", WORKING_DIR], check=False)
+        log_info(f"Set ownership of {claude_config_dir} and {WORKING_DIR} to user:user")
     else:
         home_dir = os.environ.get("HOME", "/home/user")
         claude_config_dir = f"{home_dir}/.config/claude"

--- a/turbo/apps/web/src/lib/proxy/__tests__/token-service.test.ts
+++ b/turbo/apps/web/src/lib/proxy/__tests__/token-service.test.ts
@@ -1,0 +1,271 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect } from "vitest";
+import {
+  createProxyToken,
+  decryptProxyToken,
+  isProxyToken,
+  extractSecretFromToken,
+  PROXY_TOKEN_PREFIX,
+} from "../token-service";
+
+describe("Token Service", () => {
+  const testRunId = "run-123";
+  const testUserId = "user-456";
+  const testSecretName = "ANTHROPIC_API_KEY";
+  const testSecretValue = "sk-ant-test-secret-key";
+
+  describe("createProxyToken", () => {
+    it("should create a token with correct prefix", () => {
+      const token = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+
+      expect(token.startsWith(PROXY_TOKEN_PREFIX)).toBe(true);
+    });
+
+    it("should create different tokens for same input (due to random IV)", () => {
+      const token1 = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+      const token2 = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+
+      expect(token1).not.toBe(token2);
+    });
+  });
+
+  describe("decryptProxyToken", () => {
+    it("should decrypt a valid token", () => {
+      const token = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+
+      const result = decryptProxyToken(token);
+
+      expect(result.valid).toBe(true);
+      expect(result.payload?.runId).toBe(testRunId);
+      expect(result.payload?.userId).toBe(testUserId);
+      expect(result.payload?.secretName).toBe(testSecretName);
+      expect(result.payload?.secretValue).toBe(testSecretValue);
+    });
+
+    it("should work with or without prefix", () => {
+      const token = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+      const tokenWithoutPrefix = token.slice(PROXY_TOKEN_PREFIX.length);
+
+      const result1 = decryptProxyToken(token);
+      const result2 = decryptProxyToken(tokenWithoutPrefix);
+
+      expect(result1.valid).toBe(true);
+      expect(result2.valid).toBe(true);
+      expect(result1.payload?.secretValue).toBe(result2.payload?.secretValue);
+    });
+
+    it("should reject expired tokens", () => {
+      // Create token that expires in -1 second (already expired)
+      const token = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+        -1000,
+      );
+
+      const result = decryptProxyToken(token);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe("Token expired");
+    });
+
+    it("should reject invalid run ID when expectedRunId is provided", () => {
+      const token = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+
+      const result = decryptProxyToken(token, "different-run-id");
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe("Run ID mismatch");
+    });
+
+    it("should accept matching run ID when expectedRunId is provided", () => {
+      const token = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+
+      const result = decryptProxyToken(token, testRunId);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject tampered tokens", () => {
+      const token = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+
+      // Tamper with the base64 payload
+      const tampered =
+        PROXY_TOKEN_PREFIX +
+        token.slice(PROXY_TOKEN_PREFIX.length + 5) +
+        "xxxx";
+
+      const result = decryptProxyToken(tampered);
+
+      expect(result.valid).toBe(false);
+    });
+
+    it("should reject completely invalid tokens", () => {
+      const result = decryptProxyToken("not-a-valid-token");
+
+      expect(result.valid).toBe(false);
+      // Short tokens return "Token too short", malformed base64 returns "Invalid token"
+      expect(["Token too short", "Invalid token"]).toContain(result.error);
+    });
+
+    it("should reject tokens that are too short", () => {
+      const result = decryptProxyToken(PROXY_TOKEN_PREFIX + "abc");
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe("Token too short");
+    });
+  });
+
+  describe("isProxyToken", () => {
+    it("should return true for proxy tokens", () => {
+      const token = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+
+      expect(isProxyToken(token)).toBe(true);
+    });
+
+    it("should return false for regular API keys", () => {
+      expect(isProxyToken("sk-ant-api03-xxxx")).toBe(false);
+      expect(isProxyToken("Bearer token")).toBe(false);
+      expect(isProxyToken("vm0_live_xxx")).toBe(false);
+    });
+
+    it("should return true for tokens with prefix only", () => {
+      expect(isProxyToken(PROXY_TOKEN_PREFIX + "anything")).toBe(true);
+    });
+  });
+
+  describe("extractSecretFromToken", () => {
+    it("should extract secret from valid token", () => {
+      const token = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+
+      const secret = extractSecretFromToken(token);
+
+      expect(secret).toBe(testSecretValue);
+    });
+
+    it("should return null for invalid token", () => {
+      const secret = extractSecretFromToken("invalid-token");
+
+      expect(secret).toBeNull();
+    });
+
+    it("should return null for expired token", () => {
+      const token = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+        -1000,
+      );
+
+      const secret = extractSecretFromToken(token);
+
+      expect(secret).toBeNull();
+    });
+
+    it("should return null when run ID doesn't match", () => {
+      const token = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+
+      const secret = extractSecretFromToken(token, "wrong-run-id");
+
+      expect(secret).toBeNull();
+    });
+  });
+
+  describe("Token Expiration", () => {
+    it("should create token with custom expiration", () => {
+      // Create token that expires in 1 hour
+      const oneHourMs = 60 * 60 * 1000;
+      const token = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+        oneHourMs,
+      );
+
+      const result = decryptProxyToken(token);
+
+      expect(result.valid).toBe(true);
+      // Check expiration is roughly 1 hour from now
+      const expiresAt = result.payload?.expiresAt ?? 0;
+      const expectedExpiry = Date.now() + oneHourMs;
+      expect(Math.abs(expiresAt - expectedExpiry)).toBeLessThan(1000);
+    });
+
+    it("should use default 2 hour expiration", () => {
+      const token = createProxyToken(
+        testRunId,
+        testUserId,
+        testSecretName,
+        testSecretValue,
+      );
+
+      const result = decryptProxyToken(token);
+
+      expect(result.valid).toBe(true);
+      const expiresAt = result.payload?.expiresAt ?? 0;
+      const twoHoursMs = 2 * 60 * 60 * 1000;
+      const expectedExpiry = Date.now() + twoHoursMs;
+      expect(Math.abs(expiresAt - expectedExpiry)).toBeLessThan(1000);
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/proxy/proxy-service.ts
+++ b/turbo/apps/web/src/lib/proxy/proxy-service.ts
@@ -1,0 +1,146 @@
+import { logger } from "../logger";
+
+const log = logger("proxy");
+
+/**
+ * Headers that should not be forwarded to the target
+ */
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailers",
+  "transfer-encoding",
+  "upgrade",
+  "host",
+]);
+
+/**
+ * Headers that should not be forwarded back from the target
+ */
+const RESPONSE_HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailers",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+export interface ProxyResult {
+  response: Response;
+  targetUrl: string;
+}
+
+export interface ProxyError {
+  error: {
+    message: string;
+    code: string;
+    targetUrl?: string;
+  };
+}
+
+/**
+ * Forward a request to a target URL
+ *
+ * @param request - The incoming request
+ * @param targetUrl - The target URL to forward to
+ * @returns The proxied response
+ */
+export async function forwardRequest(
+  request: Request,
+  targetUrl: string,
+): Promise<ProxyResult> {
+  log.debug(`Forwarding request to ${targetUrl}`);
+
+  // Build headers to forward (excluding hop-by-hop headers)
+  const forwardHeaders = new Headers();
+  request.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+      forwardHeaders.set(key, value);
+    }
+  });
+
+  // Get request body
+  const body = await request.arrayBuffer();
+
+  // Make request to target
+  const targetResponse = await fetch(targetUrl, {
+    method: request.method,
+    headers: forwardHeaders,
+    body: body.byteLength > 0 ? body : undefined,
+  });
+
+  log.debug(
+    `Target responded with status ${targetResponse.status} for ${targetUrl}`,
+  );
+
+  // Build response headers (excluding hop-by-hop headers)
+  const responseHeaders = new Headers();
+  targetResponse.headers.forEach((value, key) => {
+    if (!RESPONSE_HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+      responseHeaders.set(key, value);
+    }
+  });
+
+  // Check if this is a streaming response (SSE)
+  const contentType = targetResponse.headers.get("content-type") || "";
+  const isStreaming = contentType.includes("text/event-stream");
+
+  if (isStreaming && targetResponse.body) {
+    // For SSE, stream the response directly
+    log.debug(`Streaming SSE response from ${targetUrl}`);
+    return {
+      response: new Response(targetResponse.body, {
+        status: targetResponse.status,
+        statusText: targetResponse.statusText,
+        headers: responseHeaders,
+      }),
+      targetUrl,
+    };
+  }
+
+  // For non-streaming responses, pass through the body
+  return {
+    response: new Response(targetResponse.body, {
+      status: targetResponse.status,
+      statusText: targetResponse.statusText,
+      headers: responseHeaders,
+    }),
+    targetUrl,
+  };
+}
+
+/**
+ * Validate and decode a target URL from query parameter
+ *
+ * @param encodedUrl - The URL-encoded target URL
+ * @returns The decoded URL or null if invalid
+ */
+export function decodeTargetUrl(encodedUrl: string | null): string | null {
+  if (!encodedUrl) {
+    return null;
+  }
+
+  try {
+    const decoded = decodeURIComponent(encodedUrl);
+
+    // Validate it's a proper URL
+    const url = new URL(decoded);
+
+    // Only allow http and https protocols
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      log.warn(`Invalid protocol in target URL: ${url.protocol}`);
+      return null;
+    }
+
+    return decoded;
+  } catch {
+    log.warn(`Failed to decode target URL: ${encodedUrl}`);
+    return null;
+  }
+}

--- a/turbo/apps/web/src/lib/proxy/proxy-service.ts
+++ b/turbo/apps/web/src/lib/proxy/proxy-service.ts
@@ -1,4 +1,5 @@
 import { logger } from "../logger";
+import { isProxyToken, extractSecretFromToken } from "./token-service";
 
 const log = logger("proxy");
 
@@ -49,11 +50,13 @@ export interface ProxyError {
  *
  * @param request - The incoming request
  * @param targetUrl - The target URL to forward to
+ * @param runId - Optional run ID for proxy token validation
  * @returns The proxied response
  */
 export async function forwardRequest(
   request: Request,
   targetUrl: string,
+  runId?: string,
 ): Promise<ProxyResult> {
   log.debug(`Forwarding request to ${targetUrl}`);
 
@@ -64,6 +67,48 @@ export async function forwardRequest(
       forwardHeaders.set(key, value);
     }
   });
+
+  // Check and decrypt proxy token in Authorization header
+  const authHeader = forwardHeaders.get("authorization");
+  if (authHeader) {
+    // Extract token from "Bearer <token>" format or raw token
+    const token = authHeader.startsWith("Bearer ")
+      ? authHeader.slice(7)
+      : authHeader;
+
+    if (isProxyToken(token)) {
+      log.debug("Detected proxy token in Authorization header, decrypting");
+      const secret = extractSecretFromToken(token, runId);
+
+      if (secret) {
+        // Replace with decrypted secret in same format
+        const newAuthHeader = authHeader.startsWith("Bearer ")
+          ? `Bearer ${secret}`
+          : secret;
+        forwardHeaders.set("authorization", newAuthHeader);
+        log.debug("Successfully decrypted proxy token");
+      } else {
+        log.warn("Failed to decrypt proxy token - token invalid or expired");
+        // Keep original header if decryption fails (will likely fail at target)
+      }
+    }
+  }
+
+  // Also check x-api-key header for proxy tokens
+  const apiKeyHeader = forwardHeaders.get("x-api-key");
+  if (apiKeyHeader && isProxyToken(apiKeyHeader)) {
+    log.debug("Detected proxy token in x-api-key header, decrypting");
+    const secret = extractSecretFromToken(apiKeyHeader, runId);
+
+    if (secret) {
+      forwardHeaders.set("x-api-key", secret);
+      log.debug("Successfully decrypted x-api-key proxy token");
+    } else {
+      log.warn(
+        "Failed to decrypt x-api-key proxy token - token invalid or expired",
+      );
+    }
+  }
 
   // Get request body
   const body = await request.arrayBuffer();

--- a/turbo/apps/web/src/lib/proxy/proxy-service.ts
+++ b/turbo/apps/web/src/lib/proxy/proxy-service.ts
@@ -152,24 +152,13 @@ export async function forwardRequest(
     }
   });
 
-  // Check if this is a streaming response (SSE)
+  // Log SSE streaming for debugging
   const contentType = targetResponse.headers.get("content-type") || "";
-  const isStreaming = contentType.includes("text/event-stream");
-
-  if (isStreaming && targetResponse.body) {
-    // For SSE, stream the response directly
+  if (contentType.includes("text/event-stream")) {
     log.debug(`Streaming SSE response from ${targetUrl}`);
-    return {
-      response: new Response(targetResponse.body, {
-        status: targetResponse.status,
-        statusText: targetResponse.statusText,
-        headers: responseHeaders,
-      }),
-      targetUrl,
-    };
   }
 
-  // For non-streaming responses, pass through the body
+  // Return response (works for both streaming and non-streaming)
   return {
     response: new Response(targetResponse.body, {
       status: targetResponse.status,

--- a/turbo/apps/web/src/lib/proxy/proxy-service.ts
+++ b/turbo/apps/web/src/lib/proxy/proxy-service.ts
@@ -181,7 +181,100 @@ export async function forwardRequest(
 }
 
 /**
+ * Check if a hostname is a private/internal address (SSRF protection)
+ *
+ * Blocks:
+ * - localhost, 127.0.0.1, ::1 (loopback)
+ * - 169.254.169.254 (cloud metadata services - AWS, GCP, Azure)
+ * - 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 (RFC 1918 private)
+ * - 169.254.0.0/16 (link-local)
+ * - 0.0.0.0 (can resolve to localhost)
+ * - [::], [::1] (IPv6 loopback)
+ * - Internal hostnames
+ */
+function isPrivateOrInternalHost(hostname: string): boolean {
+  // Normalize hostname (remove brackets for IPv6)
+  const normalizedHost = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+
+  // Block localhost and common aliases
+  if (
+    normalizedHost === "localhost" ||
+    normalizedHost === "localhost.localdomain" ||
+    normalizedHost.endsWith(".localhost") ||
+    normalizedHost.endsWith(".local")
+  ) {
+    return true;
+  }
+
+  // Block cloud metadata service IPs
+  // AWS: 169.254.169.254, fd00:ec2::254
+  // GCP: metadata.google.internal, 169.254.169.254
+  // Azure: 169.254.169.254
+  if (
+    normalizedHost === "169.254.169.254" ||
+    normalizedHost === "metadata.google.internal" ||
+    normalizedHost.startsWith("fd00:ec2")
+  ) {
+    return true;
+  }
+
+  // Block internal kubernetes/docker hostnames
+  if (
+    normalizedHost.endsWith(".internal") ||
+    normalizedHost.endsWith(".svc.cluster.local") ||
+    normalizedHost === "kubernetes" ||
+    normalizedHost === "kubernetes.default"
+  ) {
+    return true;
+  }
+
+  // Parse IP address to check for private ranges
+  // IPv4 check
+  const ipv4Match = normalizedHost.match(
+    /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/,
+  );
+  if (ipv4Match) {
+    const [, a, b, c, d] = ipv4Match.map(Number);
+
+    // 0.0.0.0 - can resolve to localhost
+    if (a === 0 && b === 0 && c === 0 && d === 0) return true;
+
+    // 127.0.0.0/8 - loopback
+    if (a === 127) return true;
+
+    // 10.0.0.0/8 - private
+    if (a === 10) return true;
+
+    // 172.16.0.0/12 - private (172.16.0.0 - 172.31.255.255)
+    if (a === 172 && b !== undefined && b >= 16 && b <= 31) return true;
+
+    // 192.168.0.0/16 - private
+    if (a === 192 && b === 168) return true;
+
+    // 169.254.0.0/16 - link-local
+    if (a === 169 && b === 254) return true;
+
+    // 100.64.0.0/10 - Carrier-grade NAT (100.64.0.0 - 100.127.255.255)
+    if (a === 100 && b !== undefined && b >= 64 && b <= 127) return true;
+  }
+
+  // IPv6 loopback and private ranges
+  if (
+    normalizedHost === "::" ||
+    normalizedHost === "::1" ||
+    normalizedHost.startsWith("fc") || // fc00::/7 - unique local
+    normalizedHost.startsWith("fd") || // fd00::/8 - unique local
+    normalizedHost.startsWith("fe80") // fe80::/10 - link-local
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
  * Validate and decode a target URL from query parameter
+ * Includes SSRF protection to block private/internal addresses
  *
  * @param encodedUrl - The URL-encoded target URL
  * @returns The decoded URL or null if invalid
@@ -200,6 +293,12 @@ export function decodeTargetUrl(encodedUrl: string | null): string | null {
     // Only allow http and https protocols
     if (url.protocol !== "http:" && url.protocol !== "https:") {
       log.warn(`Invalid protocol in target URL: ${url.protocol}`);
+      return null;
+    }
+
+    // SSRF protection: block private/internal addresses
+    if (isPrivateOrInternalHost(url.hostname)) {
+      log.warn(`Blocked SSRF attempt to internal address: ${url.hostname}`);
       return null;
     }
 

--- a/turbo/apps/web/src/lib/proxy/proxy-service.ts
+++ b/turbo/apps/web/src/lib/proxy/proxy-service.ts
@@ -46,6 +46,19 @@ export interface ProxyError {
 }
 
 /**
+ * Error thrown when proxy token decryption fails
+ */
+export class ProxyTokenDecryptionError extends Error {
+  constructor(
+    message: string,
+    public readonly header: string,
+  ) {
+    super(message);
+    this.name = "ProxyTokenDecryptionError";
+  }
+}
+
+/**
  * Forward a request to a target URL
  *
  * @param request - The incoming request
@@ -89,7 +102,10 @@ export async function forwardRequest(
         log.debug("Successfully decrypted proxy token");
       } else {
         log.warn("Failed to decrypt proxy token - token invalid or expired");
-        // Keep original header if decryption fails (will likely fail at target)
+        throw new ProxyTokenDecryptionError(
+          "Proxy token decryption failed - token may be invalid or expired",
+          "Authorization",
+        );
       }
     }
   }
@@ -106,6 +122,10 @@ export async function forwardRequest(
     } else {
       log.warn(
         "Failed to decrypt x-api-key proxy token - token invalid or expired",
+      );
+      throw new ProxyTokenDecryptionError(
+        "Proxy token decryption failed - token may be invalid or expired",
+        "x-api-key",
       );
     }
   }

--- a/turbo/apps/web/src/lib/proxy/token-service.ts
+++ b/turbo/apps/web/src/lib/proxy/token-service.ts
@@ -1,0 +1,182 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
+import { env } from "../../env";
+import { logger } from "../logger";
+
+const log = logger("proxy:token");
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+
+/**
+ * Proxy token prefix - tokens with this prefix contain encrypted secrets
+ */
+export const PROXY_TOKEN_PREFIX = "vm0_enc_";
+
+/**
+ * Token payload structure
+ */
+export interface ProxyTokenPayload {
+  runId: string;
+  userId: string;
+  secretName: string;
+  secretValue: string;
+  expiresAt: number; // Unix timestamp in milliseconds
+}
+
+/**
+ * Token validation result
+ */
+export interface TokenValidationResult {
+  valid: boolean;
+  payload?: ProxyTokenPayload;
+  error?: string;
+}
+
+/**
+ * Get the encryption key from environment
+ */
+function getEncryptionKey(): Buffer {
+  const keyHex = env().SECRETS_ENCRYPTION_KEY;
+  if (!keyHex) {
+    if (env().NODE_ENV === "production") {
+      throw new Error("SECRETS_ENCRYPTION_KEY must be set in production");
+    }
+    // Development fallback
+    return Buffer.from(
+      "0000000000000000000000000000000000000000000000000000000000000000",
+      "hex",
+    );
+  }
+  return Buffer.from(keyHex, "hex");
+}
+
+/**
+ * Create an encrypted proxy token that wraps a secret value
+ *
+ * @param runId - The run ID this token is bound to
+ * @param userId - The user ID who owns the run
+ * @param secretName - The name of the secret (e.g., ANTHROPIC_API_KEY)
+ * @param secretValue - The actual secret value to encrypt
+ * @param expiresInMs - Token expiration time in milliseconds (default: 2 hours)
+ * @returns Encrypted token in format: vm0_enc_<base64>
+ */
+export function createProxyToken(
+  runId: string,
+  userId: string,
+  secretName: string,
+  secretValue: string,
+  expiresInMs: number = 2 * 60 * 60 * 1000, // 2 hours default
+): string {
+  const payload: ProxyTokenPayload = {
+    runId,
+    userId,
+    secretName,
+    secretValue,
+    expiresAt: Date.now() + expiresInMs,
+  };
+
+  const key = getEncryptionKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+
+  const plaintext = JSON.stringify(payload);
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+
+  const authTag = cipher.getAuthTag();
+
+  // Combine iv + authTag + ciphertext
+  const combined = Buffer.concat([iv, authTag, encrypted]);
+  const base64 = combined.toString("base64");
+
+  return `${PROXY_TOKEN_PREFIX}${base64}`;
+}
+
+/**
+ * Decrypt and validate a proxy token
+ *
+ * @param token - The encrypted token (with or without vm0_enc_ prefix)
+ * @param expectedRunId - Optional run ID to validate against
+ * @returns Validation result with payload if valid
+ */
+export function decryptProxyToken(
+  token: string,
+  expectedRunId?: string,
+): TokenValidationResult {
+  // Remove prefix if present
+  const base64 = token.startsWith(PROXY_TOKEN_PREFIX)
+    ? token.slice(PROXY_TOKEN_PREFIX.length)
+    : token;
+
+  try {
+    const combined = Buffer.from(base64, "base64");
+
+    if (combined.length < IV_LENGTH + AUTH_TAG_LENGTH + 1) {
+      return { valid: false, error: "Token too short" };
+    }
+
+    const iv = combined.subarray(0, IV_LENGTH);
+    const authTag = combined.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
+    const ciphertext = combined.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
+
+    const key = getEncryptionKey();
+    const decipher = createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(authTag);
+
+    const decrypted = Buffer.concat([
+      decipher.update(ciphertext),
+      decipher.final(),
+    ]);
+
+    const payload = JSON.parse(decrypted.toString("utf8")) as ProxyTokenPayload;
+
+    // Validate expiration
+    if (payload.expiresAt < Date.now()) {
+      log.warn(`Token expired for run ${payload.runId}`);
+      return { valid: false, error: "Token expired" };
+    }
+
+    // Validate run ID if provided
+    if (expectedRunId && payload.runId !== expectedRunId) {
+      log.warn(
+        `Token run ID mismatch: expected ${expectedRunId}, got ${payload.runId}`,
+      );
+      return { valid: false, error: "Run ID mismatch" };
+    }
+
+    return { valid: true, payload };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    log.warn(`Failed to decrypt token: ${message}`);
+    return { valid: false, error: "Invalid token" };
+  }
+}
+
+/**
+ * Check if a string is a proxy token (has the vm0_enc_ prefix)
+ */
+export function isProxyToken(value: string): boolean {
+  return value.startsWith(PROXY_TOKEN_PREFIX);
+}
+
+/**
+ * Extract the secret value from a proxy token
+ * Returns null if token is invalid or expired
+ *
+ * @param token - The encrypted token
+ * @param expectedRunId - Optional run ID to validate against
+ * @returns The decrypted secret value or null
+ */
+export function extractSecretFromToken(
+  token: string,
+  expectedRunId?: string,
+): string | null {
+  const result = decryptProxyToken(token, expectedRunId);
+  if (result.valid && result.payload) {
+    return result.payload.secretValue;
+  }
+  return null;
+}

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -33,21 +33,21 @@ const log = logger("service:run");
  */
 interface ExpandedEnvironmentResult {
   environment?: Record<string, string>;
-  betaEnhanceSecurity: boolean;
+  betaNetworkSecurity: boolean;
 }
 
 /**
  * Extract and expand environment variables from agent compose config
  * Expands ${{ vars.xxx }} and ${{ secrets.xxx }} references
  *
- * When beta_enhance_security is enabled:
+ * When beta_network_security is enabled:
  * - Secrets are encrypted into proxy tokens (vm0_enc_xxx)
- * - The betaEnhanceSecurity flag is set to true for e2b-service
+ * - The betaNetworkSecurity flag is set to true for e2b-service
  *
  * @param agentCompose Agent compose configuration
  * @param templateVars Template variables for expansion
  * @param userId User ID for fetching secrets
- * @param runId Run ID for token binding (required for enhanced security)
+ * @param runId Run ID for token binding (required for network security)
  * @returns Expanded environment variables and security flag
  */
 async function expandEnvironmentFromCompose(
@@ -58,7 +58,7 @@ async function expandEnvironmentFromCompose(
 ): Promise<ExpandedEnvironmentResult> {
   const compose = agentCompose as AgentComposeYaml | undefined;
   if (!compose?.agents) {
-    return { environment: undefined, betaEnhanceSecurity: false };
+    return { environment: undefined, betaNetworkSecurity: false };
   }
 
   // Get first agent's environment (currently only one agent supported)
@@ -67,12 +67,12 @@ async function expandEnvironmentFromCompose(
   if (!firstAgent?.environment) {
     return {
       environment: undefined,
-      betaEnhanceSecurity: firstAgent?.beta_enhance_security ?? false,
+      betaNetworkSecurity: firstAgent?.beta_network_security ?? false,
     };
   }
 
   const environment = firstAgent.environment;
-  const betaEnhanceSecurity = firstAgent.beta_enhance_security ?? false;
+  const betaNetworkSecurity = firstAgent.beta_network_security ?? false;
 
   // Extract all variable references to determine what we need
   const refs = extractVariableReferences(environment);
@@ -101,10 +101,10 @@ async function expandEnvironmentFromCompose(
       );
     }
 
-    // If enhanced security is enabled, encrypt secrets into proxy tokens
-    if (betaEnhanceSecurity) {
+    // If network security is enabled, encrypt secrets into proxy tokens
+    if (betaNetworkSecurity) {
       log.debug(
-        `Enhanced security enabled for run ${runId}, encrypting ${secretNames.length} secret(s)`,
+        `Network security enabled for run ${runId}, encrypting ${secretNames.length} secret(s)`,
       );
       secrets = {};
       for (const name of secretNames) {
@@ -154,7 +154,7 @@ async function expandEnvironmentFromCompose(
     );
   }
 
-  return { environment: result, betaEnhanceSecurity };
+  return { environment: result, betaNetworkSecurity };
 }
 
 /**
@@ -718,8 +718,8 @@ export class RunService {
     }
 
     // Step 4: Expand environment variables from compose config using templateVars and secrets
-    // When beta_enhance_security is enabled, secrets are encrypted into proxy tokens
-    const { environment, betaEnhanceSecurity } =
+    // When beta_network_security is enabled, secrets are encrypted into proxy tokens
+    const { environment, betaNetworkSecurity } =
       await expandEnvironmentFromCompose(
         agentCompose,
         templateVars,
@@ -740,7 +740,7 @@ export class RunService {
       artifactVersion,
       volumeVersions,
       environment,
-      betaEnhanceSecurity,
+      betaNetworkSecurity,
       resumeSession,
       resumeArtifact,
       // Metadata for vm0_start event

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -24,35 +24,55 @@ import {
   groupVariablesBySource,
 } from "@vm0/core";
 import { getSecretValues } from "../secrets/secrets-service";
+import { createProxyToken } from "../proxy/token-service";
 
 const log = logger("service:run");
 
 /**
+ * Result of environment expansion
+ */
+interface ExpandedEnvironmentResult {
+  environment?: Record<string, string>;
+  betaEnhanceSecurity: boolean;
+}
+
+/**
  * Extract and expand environment variables from agent compose config
  * Expands ${{ vars.xxx }} and ${{ secrets.xxx }} references
+ *
+ * When beta_enhance_security is enabled:
+ * - Secrets are encrypted into proxy tokens (vm0_enc_xxx)
+ * - The betaEnhanceSecurity flag is set to true for e2b-service
+ *
  * @param agentCompose Agent compose configuration
  * @param templateVars Template variables for expansion
  * @param userId User ID for fetching secrets
- * @returns Expanded environment variables or undefined
+ * @param runId Run ID for token binding (required for enhanced security)
+ * @returns Expanded environment variables and security flag
  */
 async function expandEnvironmentFromCompose(
   agentCompose: unknown,
   templateVars: Record<string, string> | undefined,
   userId: string,
-): Promise<Record<string, string> | undefined> {
+  runId: string,
+): Promise<ExpandedEnvironmentResult> {
   const compose = agentCompose as AgentComposeYaml | undefined;
   if (!compose?.agents) {
-    return undefined;
+    return { environment: undefined, betaEnhanceSecurity: false };
   }
 
   // Get first agent's environment (currently only one agent supported)
   const agents = Object.values(compose.agents);
   const firstAgent = agents[0];
   if (!firstAgent?.environment) {
-    return undefined;
+    return {
+      environment: undefined,
+      betaEnhanceSecurity: firstAgent?.beta_enhance_security ?? false,
+    };
   }
 
   const environment = firstAgent.environment;
+  const betaEnhanceSecurity = firstAgent.beta_enhance_security ?? false;
 
   // Extract all variable references to determine what we need
   const refs = extractVariableReferences(environment);
@@ -71,14 +91,32 @@ async function expandEnvironmentFromCompose(
   let secrets: Record<string, string> | undefined;
   if (grouped.secrets.length > 0) {
     const secretNames = grouped.secrets.map((r) => r.name);
-    secrets = await getSecretValues(userId, secretNames);
+    const rawSecrets = await getSecretValues(userId, secretNames);
 
     // Check for missing secrets
-    const missingSecrets = secretNames.filter((name) => !secrets![name]);
+    const missingSecrets = secretNames.filter((name) => !rawSecrets[name]);
     if (missingSecrets.length > 0) {
       throw new BadRequestError(
         `Missing required secrets: ${missingSecrets.join(", ")}. Use 'vm0 secret set <name> <value>' to configure them.`,
       );
+    }
+
+    // If enhanced security is enabled, encrypt secrets into proxy tokens
+    if (betaEnhanceSecurity) {
+      log.debug(
+        `Enhanced security enabled for run ${runId}, encrypting ${secretNames.length} secret(s)`,
+      );
+      secrets = {};
+      for (const name of secretNames) {
+        const secretValue = rawSecrets[name];
+        if (secretValue) {
+          // Create encrypted proxy token bound to this run
+          secrets[name] = createProxyToken(runId, userId, name, secretValue);
+        }
+      }
+    } else {
+      // Default: use plaintext secrets
+      secrets = rawSecrets;
     }
   }
 
@@ -116,7 +154,7 @@ async function expandEnvironmentFromCompose(
     );
   }
 
-  return result;
+  return { environment: result, betaEnhanceSecurity };
 }
 
 /**
@@ -680,11 +718,14 @@ export class RunService {
     }
 
     // Step 4: Expand environment variables from compose config using templateVars and secrets
-    const environment = await expandEnvironmentFromCompose(
-      agentCompose,
-      templateVars,
-      params.userId,
-    );
+    // When beta_enhance_security is enabled, secrets are encrypted into proxy tokens
+    const { environment, betaEnhanceSecurity } =
+      await expandEnvironmentFromCompose(
+        agentCompose,
+        templateVars,
+        params.userId,
+        params.runId,
+      );
 
     // Build final execution context
     return {
@@ -699,6 +740,7 @@ export class RunService {
       artifactVersion,
       volumeVersions,
       environment,
+      betaEnhanceSecurity,
       resumeSession,
       resumeArtifact,
       // Metadata for vm0_start event

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -65,9 +65,9 @@ export interface ExecutionContext {
   // Uses templateVars to resolve ${{ vars.xxx }} references
   environment?: Record<string, string>;
 
-  // Enhanced security mode - when true, secrets are encrypted into proxy tokens
+  // Network security mode - when true, secrets are encrypted into proxy tokens
   // and traffic is routed through mitmproxy -> VM0 Proxy for decryption
-  betaEnhanceSecurity?: boolean;
+  betaNetworkSecurity?: boolean;
 
   // Resume-specific (optional)
   resumeSession?: ResumeSession;

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -65,6 +65,10 @@ export interface ExecutionContext {
   // Uses templateVars to resolve ${{ vars.xxx }} references
   environment?: Record<string, string>;
 
+  // Enhanced security mode - when true, secrets are encrypted into proxy tokens
+  // and traffic is routed through mitmproxy -> VM0 Proxy for decryption
+  betaEnhanceSecurity?: boolean;
+
   // Resume-specific (optional)
   resumeSession?: ResumeSession;
   resumeArtifact?: ArtifactSnapshot;

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -23,12 +23,12 @@ export interface AgentDefinition {
   working_dir: string; // Working directory for artifact mount
   environment?: Record<string, string>; // Environment variables using ${{ vars.X }}, ${{ secrets.X }} syntax
   /**
-   * Enable enhanced security mode for secrets.
+   * Enable network security mode for secrets.
    * When true, secrets are encrypted into proxy tokens and all traffic
    * is routed through mitmproxy -> VM0 Proxy for decryption.
    * Default: false (plaintext secrets in env vars)
    */
-  beta_enhance_security?: boolean;
+  beta_network_security?: boolean;
 }
 
 export interface AgentComposeYaml {

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -22,6 +22,13 @@ export interface AgentDefinition {
   volumes?: string[]; // Format: "volume-key:/mount/path"
   working_dir: string; // Working directory for artifact mount
   environment?: Record<string, string>; // Environment variables using ${{ vars.X }}, ${{ secrets.X }} syntax
+  /**
+   * Enable enhanced security mode for secrets.
+   * When true, secrets are encrypted into proxy tokens and all traffic
+   * is routed through mitmproxy -> VM0 Proxy for decryption.
+   * Default: false (plaintext secrets in env vars)
+   */
+  beta_enhance_security?: boolean;
 }
 
 export interface AgentComposeYaml {

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -37,6 +37,13 @@ const agentDefinitionSchema = z.object({
   volumes: z.array(z.string()).optional(),
   working_dir: z.string().min(1, "Working directory is required"),
   environment: z.record(z.string(), z.string()).optional(),
+  /**
+   * Enable enhanced security mode for secrets.
+   * When true, secrets are encrypted into proxy tokens and all traffic
+   * is routed through mitmproxy -> VM0 Proxy for decryption.
+   * Default: false (plaintext secrets in env vars)
+   */
+  beta_enhance_security: z.boolean().optional().default(false),
 });
 
 /**

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -38,12 +38,12 @@ const agentDefinitionSchema = z.object({
   working_dir: z.string().min(1, "Working directory is required"),
   environment: z.record(z.string(), z.string()).optional(),
   /**
-   * Enable enhanced security mode for secrets.
+   * Enable network security mode for secrets.
    * When true, secrets are encrypted into proxy tokens and all traffic
    * is routed through mitmproxy -> VM0 Proxy for decryption.
    * Default: false (plaintext secrets in env vars)
    */
-  beta_enhance_security: z.boolean().optional().default(false),
+  beta_network_security: z.boolean().optional().default(false),
 });
 
 /**

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -41,6 +41,7 @@ export {
   runSystemLogContract,
   runMetricsContract,
   runAgentEventsContract,
+  runNetworkLogsContract,
   runStatusSchema,
   unifiedRunRequestSchema,
   createRunResponseSchema,
@@ -52,6 +53,8 @@ export {
   systemLogResponseSchema,
   metricsResponseSchema,
   agentEventsResponseSchema,
+  networkLogEntrySchema,
+  networkLogsResponseSchema,
   type RunsMainContract,
   type RunsByIdContract,
   type RunEventsContract,
@@ -59,6 +62,7 @@ export {
   type RunSystemLogContract,
   type RunMetricsContract,
   type RunAgentEventsContract,
+  type RunNetworkLogsContract,
 } from "./runs";
 export {
   sessionsMainContract,

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -117,3 +117,9 @@ export {
   cleanupResponseSchema,
   type CronCleanupSandboxesContract,
 } from "./cron";
+export {
+  proxyErrorSchema,
+  ProxyErrorCode,
+  type ProxyError,
+  type ProxyErrorCode as ProxyErrorCodeType,
+} from "./proxy";

--- a/turbo/packages/core/src/contracts/proxy.ts
+++ b/turbo/packages/core/src/contracts/proxy.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+/**
+ * Proxy endpoint types for /api/webhooks/agent/proxy
+ *
+ * This endpoint acts as a generic HTTP proxy for sandbox requests.
+ * It validates the sandbox token, extracts the target URL from query params,
+ * and forwards the request with full body/header passthrough.
+ *
+ * Note: This endpoint doesn't use ts-rest router because it needs to:
+ * - Handle raw request/response streaming (SSE support)
+ * - Pass through request body without validation
+ * - Stream response back directly
+ *
+ * API Design:
+ * POST /api/webhooks/agent/proxy?url=<encoded_target_url>
+ *
+ * Headers:
+ *   Authorization: Bearer vm0_live_xxx (sandbox token)
+ *   Content-Type: (passthrough)
+ *
+ * Body: (passthrough to target)
+ * Response: (passthrough from target, supports SSE streaming)
+ */
+
+/**
+ * Proxy error response schema
+ */
+export const proxyErrorSchema = z.object({
+  error: z.object({
+    message: z.string(),
+    code: z.enum([
+      "UNAUTHORIZED",
+      "BAD_REQUEST",
+      "BAD_GATEWAY",
+      "INTERNAL_ERROR",
+    ]),
+    targetUrl: z.string().optional(),
+  }),
+});
+
+export type ProxyError = z.infer<typeof proxyErrorSchema>;
+
+/**
+ * Proxy error codes
+ */
+export const ProxyErrorCode = {
+  UNAUTHORIZED: "UNAUTHORIZED",
+  BAD_REQUEST: "BAD_REQUEST",
+  BAD_GATEWAY: "BAD_GATEWAY",
+  INTERNAL_ERROR: "INTERNAL_ERROR",
+} as const;
+
+export type ProxyErrorCode =
+  (typeof ProxyErrorCode)[keyof typeof ProxyErrorCode];

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -222,6 +222,27 @@ const agentEventsResponseSchema = z.object({
 });
 
 /**
+ * Network log entry schema
+ */
+const networkLogEntrySchema = z.object({
+  timestamp: z.string(),
+  method: z.string(),
+  url: z.string(),
+  status: z.number(),
+  latency_ms: z.number(),
+  request_size: z.number(),
+  response_size: z.number(),
+});
+
+/**
+ * Network logs response schema
+ */
+const networkLogsResponseSchema = z.object({
+  networkLogs: z.array(networkLogEntrySchema),
+  hasMore: z.boolean(),
+});
+
+/**
  * Telemetry response schema (legacy - combined format)
  */
 const telemetryResponseSchema = z.object({
@@ -334,6 +355,33 @@ export const runAgentEventsContract = c.router({
   },
 });
 
+/**
+ * Network logs route contract (/api/agent/runs/[id]/telemetry/network)
+ */
+export const runNetworkLogsContract = c.router({
+  /**
+   * GET /api/agent/runs/:id/telemetry/network
+   * Get network logs with pagination (for vm0 logs --network)
+   */
+  getNetworkLogs: {
+    method: "GET",
+    path: "/api/agent/runs/:id/telemetry/network",
+    pathParams: z.object({
+      id: z.string().min(1, "Run ID is required"),
+    }),
+    query: z.object({
+      since: z.coerce.number().optional(),
+      limit: z.coerce.number().min(1).max(100).default(5),
+    }),
+    responses: {
+      200: networkLogsResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get network logs with pagination",
+  },
+});
+
 export type RunsMainContract = typeof runsMainContract;
 export type RunsByIdContract = typeof runsByIdContract;
 export type RunEventsContract = typeof runEventsContract;
@@ -341,6 +389,7 @@ export type RunTelemetryContract = typeof runTelemetryContract;
 export type RunSystemLogContract = typeof runSystemLogContract;
 export type RunMetricsContract = typeof runMetricsContract;
 export type RunAgentEventsContract = typeof runAgentEventsContract;
+export type RunNetworkLogsContract = typeof runNetworkLogsContract;
 
 // Export schemas for reuse
 export {
@@ -357,4 +406,6 @@ export {
   systemLogResponseSchema,
   metricsResponseSchema,
   agentEventsResponseSchema,
+  networkLogEntrySchema,
+  networkLogsResponseSchema,
 };

--- a/turbo/packages/core/src/contracts/webhooks.ts
+++ b/turbo/packages/core/src/contracts/webhooks.ts
@@ -253,12 +253,25 @@ const metricDataSchema = z.object({
 });
 
 /**
+ * Network log entry schema (from mitmproxy addon)
+ */
+const networkLogSchema = z.object({
+  timestamp: z.string(),
+  method: z.string(),
+  url: z.string(),
+  status: z.number(),
+  latency_ms: z.number(),
+  request_size: z.number(),
+  response_size: z.number(),
+});
+
+/**
  * Webhook telemetry contract for /api/webhooks/agent/telemetry
  */
 export const webhookTelemetryContract = c.router({
   /**
    * POST /api/webhooks/agent/telemetry
-   * Receive telemetry data (system log and metrics) from sandbox
+   * Receive telemetry data (system log, metrics, and network logs) from sandbox
    */
   send: {
     method: "POST",
@@ -267,6 +280,7 @@ export const webhookTelemetryContract = c.router({
       runId: z.string().min(1, "runId is required"),
       systemLog: z.string().optional(),
       metrics: z.array(metricDataSchema).optional(),
+      networkLogs: z.array(networkLogSchema).optional(),
     }),
     responses: {
       200: z.object({


### PR DESCRIPTION
## Summary

Complete implementation of sandbox network security and observability features for issue #502:

- **Phase 1**: Generic proxy endpoint for forwarding sandbox requests
- **Phase 2**: Proxy token encryption/decryption for secure secret handling
- **Phase 5**: Network logs observability via mitmproxy transparent proxy

## Architecture

```
┌─────────────────────────────────────────────────────────────────┐
│                         E2B Sandbox                              │
│  ┌──────────────┐    ┌─────────────┐    ┌────────────────────┐  │
│  │  Agent/Claude │───▶│  nftables   │───▶│    mitmproxy       │  │
│  │  (user)       │    │  redirect   │    │    (root)          │  │
│  └──────────────┘    └─────────────┘    └─────────┬──────────┘  │
│                                                    │              │
│                                      Logs to /tmp/vm0-network.jsonl
└────────────────────────────────────────────────────┼─────────────┘
                                                     │
                                                     ▼
                              ┌──────────────────────────────────┐
                              │  VM0 Proxy Endpoint              │
                              │  /api/webhooks/agent/proxy       │
                              │  - Decrypt vm0_enc_ tokens       │
                              │  - Forward to target API         │
                              │  - Stream SSE responses          │
                              └──────────────────────────────────┘
```

## Changes

### Proxy Endpoint (`/api/webhooks/agent/proxy`)
- `apps/web/app/api/webhooks/agent/proxy/route.ts` - API route supporting all HTTP methods (GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD)
- `apps/web/src/lib/proxy/proxy-service.ts` - Request forwarding with hop-by-hop header filtering and SSE streaming
- `apps/web/src/lib/proxy/token-service.ts` - Proxy token encryption/decryption using AES-256-GCM
- `packages/core/src/contracts/proxy.ts` - Proxy error types

### Transparent Proxy (mitmproxy)
- `apps/web/src/lib/e2b/scripts/lib/proxy_setup.py.ts` - Install mitmproxy, configure nftables, setup CA certificate
- `apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts` - Intercept requests, rewrite to VM0 proxy, log network activity

### Network Logs API
- `apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts` - API endpoint for fetching network logs
- `apps/web/app/api/webhooks/agent/telemetry/route.ts` - Accept network logs from sandbox telemetry uploads
- `apps/web/src/lib/e2b/scripts/lib/upload_telemetry.py.ts` - Include network logs in telemetry uploads

### CLI (`vm0 logs --network`)
- `apps/cli/src/commands/logs/index.ts` - Add `--network` / `-n` option for viewing network logs
- `apps/cli/src/lib/api-client.ts` - Add `getNetworkLogs()` API client method

### Agent Configuration
- `apps/web/src/lib/e2b/e2b-service.ts` - Run proxy setup as root before agent starts, configure SSL env vars
- `apps/web/src/lib/e2b/scripts/run-agent.py.ts` - Agent runs as 'user' so traffic goes through proxy
- `apps/web/src/types/agent-compose.ts` - Add `beta_network_security` option
- `packages/core/src/contracts/composes.ts` - Add `beta_network_security` to compose schema

### Tests
- `apps/web/app/api/webhooks/agent/proxy/__tests__/route.test.ts` - 11 unit tests for proxy endpoint
- `apps/web/src/lib/proxy/__tests__/token-service.test.ts` - Token encryption/decryption tests
- `e2e/tests/02-commands/t16-vm0-network-logs.bats` - E2E test for network logs command

## API Design

### Proxy Endpoint
```
<METHOD> /api/webhooks/agent/proxy?url=<encoded_target_url>&runId=<run_id>

Headers:
  Authorization: Bearer vm0_live_xxx  (sandbox token)
  x-api-key: vm0_enc_xxx             (encrypted secret, decrypted before forwarding)
  Content-Type: (passthrough)

Body: (passthrough to target)
Response: (passthrough from target, supports SSE streaming)
```

### Network Logs Endpoint
```
GET /api/agent/runs/{id}/telemetry/network?since=<timestamp>&limit=<n>

Response:
{
  "networkLogs": [
    {
      "timestamp": "2024-01-15T10:30:00",
      "method": "POST",
      "url": "https://api.anthropic.com/v1/messages",
      "status": 200,
      "latency_ms": 1234,
      "request_size": 1024,
      "response_size": 2048
    }
  ],
  "hasMore": false
}
```

## Test Plan

- [x] Type check passes
- [x] Lint passes
- [x] Unit tests pass (11 proxy tests + token tests)
- [x] E2E test passes (`t16-vm0-network-logs.bats`)
- [x] CI pipeline passes

## Bug Fixes in This PR

1. **Proxy route only supported POST** - Fixed by exporting handler for all HTTP methods
2. **URL encoding** - Use `urllib.parse.urlencode()` instead of string concatenation
3. **File write race condition** - Use atomic `O_CREAT | O_APPEND | O_WRONLY` for network log writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)