### PR TITLE
fix(web): use pretty_host for transparent proxy hostname resolution

### DIFF
--- a/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
@@ -54,7 +54,10 @@ def log_network_entry(entry: dict) -> None:
 def get_original_url(flow: http.HTTPFlow) -> str:
     """Reconstruct the original target URL from the request."""
     scheme = "https" if flow.request.port == 443 else "http"
-    host = flow.request.host
+    # Use pretty_host which prefers Host header over IP in transparent proxy mode
+    # This is critical because flow.request.host returns the destination IP address
+    # in transparent mode, but SSL certificates are issued for hostnames
+    host = flow.request.pretty_host
     port = flow.request.port
 
     # Include port in URL only if non-standard


### PR DESCRIPTION
## Summary

- Fix 502 errors on API requests in transparent proxy mode
- In transparent proxy mode, `flow.request.host` returns the destination IP address instead of the hostname
- This caused SSL certificate validation failures when VM0 Proxy forwarded requests to the IP (e.g., `160.79.104.10`) because certificates are issued for hostnames (e.g., `api.anthropic.com`)
- Using `flow.request.pretty_host` resolves this by preferring the Host header over the resolved IP address

## Root Cause

The network logs showed requests going to IP addresses instead of hostnames:
```
[2025-12-12T05:31:48] POST   502 556ms 248.0 B/139.0 B https://160.79.104.10/v1/messages?beta=true
```

When VM0 Proxy tried to forward to the IP, SSL validation failed because the certificate is issued for `api.anthropic.com`, not the IP address.

## Test plan

- [x] All 43 proxy-related tests pass
- [x] Lint and type checks pass
- [ ] E2E test with network security mode enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)