### PR TITLE
fix(web): implement transparent proxy for Authorization header

### DIFF
--- a/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/mitm_addon.py.ts
@@ -124,6 +124,11 @@ def request(flow: http.HTTPFlow) -> None:
     flow.request.scheme = parsed.scheme
     flow.request.path = f"{parsed.path}?{query_string}"
 
+    # Save original Authorization header before overwriting (for transparent proxy)
+    # VM0 Proxy will restore this and decrypt any proxy tokens
+    if "Authorization" in flow.request.headers:
+        flow.request.headers["x-vm0-original-authorization"] = flow.request.headers["Authorization"]
+
     # Add sandbox authentication token
     if API_TOKEN:
         flow.request.headers["Authorization"] = f"Bearer {API_TOKEN}"

--- a/turbo/apps/web/src/lib/proxy/proxy-service.ts
+++ b/turbo/apps/web/src/lib/proxy/proxy-service.ts
@@ -16,6 +16,11 @@ const HOP_BY_HOP_HEADERS = new Set([
   "transfer-encoding",
   "upgrade",
   "host",
+  // Authorization header from mitmproxy contains sandbox token for VM0 Proxy auth
+  // We'll restore the original Authorization from x-vm0-original-authorization
+  "authorization",
+  // Internal header used by mitmproxy to preserve original Authorization
+  "x-vm0-original-authorization",
 ]);
 
 /**
@@ -81,32 +86,41 @@ export async function forwardRequest(
     }
   });
 
-  // Check and decrypt proxy token in Authorization header
-  const authHeader = forwardHeaders.get("authorization");
-  if (authHeader) {
+  // Restore original Authorization header from x-vm0-original-authorization
+  // mitmproxy saves the original header there before overwriting with sandbox token
+  const originalAuthHeader = request.headers.get("x-vm0-original-authorization");
+  if (originalAuthHeader) {
     // Extract token from "Bearer <token>" format or raw token
-    const token = authHeader.startsWith("Bearer ")
-      ? authHeader.slice(7)
-      : authHeader;
+    const token = originalAuthHeader.startsWith("Bearer ")
+      ? originalAuthHeader.slice(7)
+      : originalAuthHeader;
 
     if (isProxyToken(token)) {
-      log.debug("Detected proxy token in Authorization header, decrypting");
+      log.debug(
+        "Detected proxy token in original Authorization header, decrypting",
+      );
       const secret = extractSecretFromToken(token, runId);
 
       if (secret) {
         // Replace with decrypted secret in same format
-        const newAuthHeader = authHeader.startsWith("Bearer ")
+        const newAuthHeader = originalAuthHeader.startsWith("Bearer ")
           ? `Bearer ${secret}`
           : secret;
         forwardHeaders.set("authorization", newAuthHeader);
-        log.debug("Successfully decrypted proxy token");
+        log.debug("Successfully decrypted Authorization proxy token");
       } else {
-        log.warn("Failed to decrypt proxy token - token invalid or expired");
+        log.warn(
+          "Failed to decrypt Authorization proxy token - token invalid or expired",
+        );
         throw new ProxyTokenDecryptionError(
           "Proxy token decryption failed - token may be invalid or expired",
           "Authorization",
         );
       }
+    } else {
+      // Not a proxy token, restore original value as-is
+      forwardHeaders.set("authorization", originalAuthHeader);
+      log.debug("Restored original Authorization header (no proxy token)");
     }
   }
 

--- a/turbo/apps/web/src/lib/proxy/proxy-service.ts
+++ b/turbo/apps/web/src/lib/proxy/proxy-service.ts
@@ -88,7 +88,9 @@ export async function forwardRequest(
 
   // Restore original Authorization header from x-vm0-original-authorization
   // mitmproxy saves the original header there before overwriting with sandbox token
-  const originalAuthHeader = request.headers.get("x-vm0-original-authorization");
+  const originalAuthHeader = request.headers.get(
+    "x-vm0-original-authorization",
+  );
   if (originalAuthHeader) {
     // Extract token from "Bearer <token>" format or raw token
     const token = originalAuthHeader.startsWith("Bearer ")


### PR DESCRIPTION
## Summary

- Fix 401 "Invalid bearer token" errors when using network security mode
- Implement transparent proxy that preserves original Authorization header
- Support all APIs that use Authorization header (OpenAI, Google, etc.)

## Problem

The mitmproxy addon was overwriting the original Authorization header with the sandbox token for VM0 Proxy authentication. This sandbox token was then forwarded to target APIs (like Anthropic), causing authentication failures.

**Flow before fix:**
```
Claude Code → Authorization: Bearer vm0_enc_xxx
mitmproxy   → Authorization: Bearer vm0_live_xxx (OVERWRITES!)
VM0 Proxy   → forwards vm0_live_xxx to Anthropic
Anthropic   → 401 "Invalid bearer token"
```

## Solution

Use `x-vm0-original-authorization` header to preserve the original Authorization:

**Flow after fix:**
```
Claude Code → Authorization: Bearer vm0_enc_xxx
mitmproxy   → x-vm0-original-authorization: Bearer vm0_enc_xxx (SAVES original)
            → Authorization: Bearer vm0_live_xxx (for VM0 Proxy auth)
VM0 Proxy   → reads x-vm0-original-authorization, decrypts vm0_enc_xxx
            → forwards Authorization: Bearer <real_key> to Anthropic
Anthropic   → 200 OK
```

## Changes

- **mitm_addon.py.ts**: Save original Authorization to `x-vm0-original-authorization` before overwriting
- **proxy-service.ts**: Restore original Authorization from custom header, decrypt proxy tokens, forward to target

## Test plan

- [x] All 43 proxy-related tests pass
- [x] Lint and type checks pass
- [ ] E2E test with network security mode (Claude API call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)