### PR TITLE
feat(cli): add system_prompt and system_skills support for agent compose

### DIFF
--- a/e2e/fixtures/prompts/AGENTS.md
+++ b/e2e/fixtures/prompts/AGENTS.md
@@ -1,0 +1,13 @@
+# E2E Test Agent Instructions
+
+You are a test agent for vm0 E2E testing.
+
+## Rules
+
+1. Always respond with "E2E_TEST_SUCCESS" when asked to confirm system prompt is loaded
+2. Be concise in responses
+3. Follow all instructions exactly
+
+## Test Marker
+
+This file contains a unique marker: VM0_E2E_SYSTEM_PROMPT_LOADED

--- a/e2e/tests/02-commands/t17-vm0-simplified-compose.bats
+++ b/e2e/tests/02-commands/t17-vm0-simplified-compose.bats
@@ -61,11 +61,6 @@ EOF
     assert_output --partial "Auto-configured working_dir"
 }
 
-# Skip: This test requires Anthropic API key in sandbox environment
-# @test "vm0 run with simplified compose works end-to-end" {
-#     ...
-# }
-
 # ============================================
 # system_prompt tests
 # ============================================
@@ -215,10 +210,85 @@ EOF
     assert_output --partial "system skill"
 }
 
-# Skip: This test requires Anthropic API key in sandbox environment
-# @test "vm0 run with system_skills executes successfully" {
-#     ...
-# }
+# ============================================
+# Run tests (verify files are mounted)
+# ============================================
+
+@test "vm0 run with system_prompt mounts CLAUDE.md file" {
+    echo "# Creating config with system_prompt..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    provider: claude-code
+    system_prompt: AGENTS.md
+EOF
+
+    echo "# Creating AGENTS.md with unique marker..."
+    cat > "$TEST_DIR/AGENTS.md" <<EOF
+# Test System Prompt
+
+UNIQUE_MARKER_FOR_E2E_TEST_${AGENT_NAME}
+EOF
+
+    echo "# Running vm0 compose..."
+    cd "$TEST_DIR"
+    run $CLI_COMMAND compose vm0.yaml
+    assert_success
+
+    echo "# Initializing artifact storage..."
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    echo "# Running agent to verify system_prompt is mounted..."
+    # The system_prompt is mounted at /home/user/.config/claude/CLAUDE.md
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "cat /home/user/.config/claude/CLAUDE.md"
+    assert_success
+
+    echo "# Verifying output contains the marker from AGENTS.md..."
+    assert_output --partial "UNIQUE_MARKER_FOR_E2E_TEST"
+}
+
+@test "vm0 run with system_skills mounts skill directory" {
+    echo "# Creating config with system_skills..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    provider: claude-code
+    image: vm0-github-cli-dev
+    system_skills:
+      - https://github.com/vm0-ai/vm0-skills/tree/main/github
+EOF
+
+    echo "# Running vm0 compose..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Initializing artifact storage..."
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    echo "# Running agent to verify system_skill is mounted..."
+    # The system_skill is mounted at /home/user/.config/claude/skills/github/
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "ls /home/user/.config/claude/skills/github/"
+    assert_success
+
+    echo "# Verifying skill directory contains SKILL.md..."
+    assert_output --partial "SKILL.md"
+}
 
 # ============================================
 # Validation tests

--- a/e2e/tests/02-commands/t17-vm0-simplified-compose.bats
+++ b/e2e/tests/02-commands/t17-vm0-simplified-compose.bats
@@ -1,0 +1,277 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+
+setup() {
+    # Create temporary test directory for dynamic configs
+    export TEST_DIR="$(mktemp -d)"
+    # Use unique agent name with timestamp to avoid conflicts
+    export AGENT_NAME="e2e-simplified-$(date +%s)"
+    export ARTIFACT_NAME="e2e-simplified-artifact-$(date +%s)"
+}
+
+teardown() {
+    # Clean up temporary directory
+    [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ] && rm -rf "$TEST_DIR"
+}
+
+# ============================================
+# Provider auto-configuration tests
+# ============================================
+
+@test "vm0 compose with provider auto-config (no explicit image/working_dir)" {
+    echo "# Creating simplified config without image and working_dir..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent with provider auto-config"
+    provider: claude-code
+EOF
+
+    echo "# Running vm0 compose..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Verifying auto-configuration messages..."
+    assert_output --partial "Auto-configured image"
+    assert_output --partial "Auto-configured working_dir"
+    assert_output --partial "Compose created"
+}
+
+@test "vm0 compose with explicit image overrides auto-config" {
+    echo "# Creating config with explicit image..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent with explicit image"
+    provider: claude-code
+    image: vm0-github-cli-dev
+EOF
+
+    echo "# Running vm0 compose..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Verifying only working_dir was auto-configured..."
+    refute_output --partial "Auto-configured image"
+    assert_output --partial "Auto-configured working_dir"
+}
+
+# Skip: This test requires Anthropic API key in sandbox environment
+# @test "vm0 run with simplified compose works end-to-end" {
+#     ...
+# }
+
+# ============================================
+# system_prompt tests
+# ============================================
+
+@test "vm0 compose with system_prompt uploads prompt file" {
+    echo "# Creating config with system_prompt..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    provider: claude-code
+    system_prompt: AGENTS.md
+EOF
+
+    echo "# Creating AGENTS.md file..."
+    cat > "$TEST_DIR/AGENTS.md" <<EOF
+# Test System Prompt
+
+You are a test agent. Always respond with TEST_PROMPT_LOADED.
+EOF
+
+    echo "# Running vm0 compose..."
+    cd "$TEST_DIR"
+    run $CLI_COMMAND compose vm0.yaml
+    assert_success
+
+    echo "# Verifying system prompt upload..."
+    assert_output --partial "Uploading system prompt"
+    assert_output --partial "System prompt"
+}
+
+@test "vm0 compose with system_prompt deduplicates unchanged content" {
+    echo "# Creating config with system_prompt..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    provider: claude-code
+    system_prompt: AGENTS.md
+EOF
+
+    echo "# Creating AGENTS.md file..."
+    cat > "$TEST_DIR/AGENTS.md" <<EOF
+# Test System Prompt for Deduplication
+
+This content should be deduplicated on second upload.
+EOF
+
+    echo "# First compose..."
+    cd "$TEST_DIR"
+    run $CLI_COMMAND compose vm0.yaml
+    assert_success
+    assert_output --partial "System prompt"
+
+    echo "# Second compose with same content..."
+    run $CLI_COMMAND compose vm0.yaml
+    assert_success
+    # Should show unchanged indicator
+    assert_output --partial "unchanged"
+}
+
+# ============================================
+# system_skills tests
+# ============================================
+
+@test "vm0 compose with system_skills downloads and uploads skill" {
+    echo "# Creating config with system_skills..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    provider: claude-code
+    image: vm0-github-cli-dev
+    system_skills:
+      - https://github.com/vm0-ai/vm0-skills/tree/main/github
+EOF
+
+    echo "# Running vm0 compose..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Verifying skill download and upload..."
+    assert_output --partial "Uploading"
+    assert_output --partial "system skill"
+    assert_output --partial "Downloading"
+}
+
+@test "vm0 compose with system_skills deduplicates unchanged skill" {
+    echo "# Creating config with system_skills..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    provider: claude-code
+    image: vm0-github-cli-dev
+    system_skills:
+      - https://github.com/vm0-ai/vm0-skills/tree/main/github
+EOF
+
+    echo "# First compose..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Second compose with same skill..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+    # Should show unchanged indicator for the skill
+    assert_output --partial "unchanged"
+}
+
+# ============================================
+# Combined system_prompt and system_skills tests
+# ============================================
+
+@test "vm0 compose with both system_prompt and system_skills" {
+    echo "# Creating config with both system_prompt and system_skills..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    provider: claude-code
+    image: vm0-github-cli-dev
+    system_prompt: AGENTS.md
+    system_skills:
+      - https://github.com/vm0-ai/vm0-skills/tree/main/github
+EOF
+
+    echo "# Creating AGENTS.md file..."
+    cat > "$TEST_DIR/AGENTS.md" <<EOF
+# Test Agent with Skills
+
+You are a test agent with GitHub skills enabled.
+EOF
+
+    echo "# Running vm0 compose..."
+    cd "$TEST_DIR"
+    run $CLI_COMMAND compose vm0.yaml
+    assert_success
+
+    echo "# Verifying both uploads..."
+    assert_output --partial "system prompt"
+    assert_output --partial "system skill"
+}
+
+# Skip: This test requires Anthropic API key in sandbox environment
+# @test "vm0 run with system_skills executes successfully" {
+#     ...
+# }
+
+# ============================================
+# Validation tests
+# ============================================
+
+@test "vm0 compose rejects invalid GitHub URL in system_skills" {
+    echo "# Creating config with invalid system_skills URL..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    provider: claude-code
+    system_skills:
+      - https://example.com/not-a-github-url
+EOF
+
+    echo "# Running vm0 compose (should fail)..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_failure
+    assert_output --partial "Invalid system_skill URL"
+}
+
+@test "vm0 compose rejects empty system_prompt" {
+    echo "# Creating config with empty system_prompt..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    provider: claude-code
+    system_prompt: ""
+EOF
+
+    echo "# Running vm0 compose (should fail)..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_failure
+    assert_output --partial "empty"
+}
+
+@test "vm0 compose with nonexistent system_prompt file fails" {
+    echo "# Creating config with nonexistent system_prompt file..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    provider: claude-code
+    system_prompt: nonexistent-file.md
+EOF
+
+    echo "# Running vm0 compose (should fail)..."
+    cd "$TEST_DIR"
+    run $CLI_COMMAND compose vm0.yaml
+    assert_failure
+}

--- a/turbo/apps/cli/src/commands/__tests__/compose.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/compose.test.ts
@@ -12,6 +12,20 @@ vi.mock("fs");
 vi.mock("yaml");
 vi.mock("../../lib/api-client");
 vi.mock("../../lib/yaml-validator");
+vi.mock("../../lib/provider-config");
+vi.mock("../../lib/system-storage");
+
+// Valid minimal config that passes validation
+const validConfig = {
+  version: "1.0",
+  agents: {
+    "test-agent": {
+      provider: "claude-code",
+      image: "vm0-claude-code-dev",
+      working_dir: "/home/user/workspace",
+    },
+  },
+};
 
 describe("compose command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
@@ -49,13 +63,13 @@ describe("compose command", () => {
     it("should read file when it exists", async () => {
       vi.mocked(existsSync).mockReturnValue(true);
       vi.mocked(fs.readFile).mockResolvedValue("version: 1.0");
-      vi.mocked(yaml.parse).mockReturnValue({ version: "1.0" });
+      vi.mocked(yaml.parse).mockReturnValue(validConfig);
       vi.mocked(yamlValidator.validateAgentCompose).mockReturnValue({
         valid: true,
       });
       vi.mocked(apiClient.createOrUpdateCompose).mockResolvedValue({
         composeId: "cmp-123",
-        name: "test",
+        name: "test-agent",
         versionId:
           "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6",
         action: "created",
@@ -118,10 +132,10 @@ describe("compose command", () => {
     beforeEach(() => {
       vi.mocked(existsSync).mockReturnValue(true);
       vi.mocked(fs.readFile).mockResolvedValue("yaml content");
-      vi.mocked(yaml.parse).mockReturnValue({});
     });
 
     it("should exit with error on invalid compose", async () => {
+      vi.mocked(yaml.parse).mockReturnValue({});
       vi.mocked(yamlValidator.validateAgentCompose).mockReturnValue({
         valid: false,
         error: "Missing agent.name",
@@ -138,12 +152,13 @@ describe("compose command", () => {
     });
 
     it("should proceed with valid compose", async () => {
+      vi.mocked(yaml.parse).mockReturnValue(validConfig);
       vi.mocked(yamlValidator.validateAgentCompose).mockReturnValue({
         valid: true,
       });
       vi.mocked(apiClient.createOrUpdateCompose).mockResolvedValue({
         composeId: "cmp-123",
-        name: "test",
+        name: "test-agent",
         versionId:
           "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6",
         action: "created",
@@ -240,7 +255,7 @@ describe("compose command", () => {
     beforeEach(() => {
       vi.mocked(existsSync).mockReturnValue(true);
       vi.mocked(fs.readFile).mockResolvedValue("yaml content");
-      vi.mocked(yaml.parse).mockReturnValue({});
+      vi.mocked(yaml.parse).mockReturnValue(validConfig);
       vi.mocked(yamlValidator.validateAgentCompose).mockReturnValue({
         valid: true,
       });

--- a/turbo/apps/cli/src/commands/compose.ts
+++ b/turbo/apps/cli/src/commands/compose.ts
@@ -2,9 +2,12 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { readFile } from "fs/promises";
 import { existsSync } from "fs";
+import { dirname } from "path";
 import { parse as parseYaml } from "yaml";
 import { apiClient } from "../lib/api-client";
 import { validateAgentCompose } from "../lib/yaml-validator";
+import { getProviderDefaults } from "../lib/provider-config";
+import { uploadSystemPrompt, uploadSystemSkill } from "../lib/system-storage";
 
 export const composeCommand = new Command()
   .name("compose")
@@ -39,14 +42,91 @@ export const composeCommand = new Command()
         process.exit(1);
       }
 
-      // 4. Call API
+      // 4. Process system_prompt and system_skills
+      const cfg = config as Record<string, unknown>;
+      const agents = cfg.agents as Record<string, Record<string, unknown>>;
+      const agentName = Object.keys(agents)[0]!;
+      const agent = agents[agentName]!;
+      const basePath = dirname(configFile);
+
+      // Apply provider auto-configuration if not explicitly set
+      if (agent.provider) {
+        const defaults = getProviderDefaults(agent.provider as string);
+        if (defaults) {
+          if (!agent.image) {
+            agent.image = defaults.image;
+            console.log(
+              chalk.gray(`  Auto-configured image: ${defaults.image}`),
+            );
+          }
+          if (!agent.working_dir) {
+            agent.working_dir = defaults.workingDir;
+            console.log(
+              chalk.gray(
+                `  Auto-configured working_dir: ${defaults.workingDir}`,
+              ),
+            );
+          }
+        }
+      }
+
+      // Upload system_prompt if specified
+      if (agent.system_prompt) {
+        const promptPath = agent.system_prompt as string;
+        console.log(chalk.blue(`Uploading system prompt: ${promptPath}`));
+        try {
+          const result = await uploadSystemPrompt(
+            agentName,
+            promptPath,
+            basePath,
+          );
+          console.log(
+            chalk.green(
+              `✓ System prompt ${result.action === "deduplicated" ? "(unchanged)" : "uploaded"}: ${result.versionId.slice(0, 8)}`,
+            ),
+          );
+        } catch (error) {
+          console.error(chalk.red(`✗ Failed to upload system prompt`));
+          if (error instanceof Error) {
+            console.error(chalk.gray(`  ${error.message}`));
+          }
+          process.exit(1);
+        }
+      }
+
+      // Upload system_skills if specified
+      if (agent.system_skills && Array.isArray(agent.system_skills)) {
+        const skillUrls = agent.system_skills as string[];
+        console.log(
+          chalk.blue(`Uploading ${skillUrls.length} system skill(s)...`),
+        );
+        for (const skillUrl of skillUrls) {
+          try {
+            console.log(chalk.gray(`  Downloading: ${skillUrl}`));
+            const result = await uploadSystemSkill(skillUrl);
+            console.log(
+              chalk.green(
+                `  ✓ Skill ${result.action === "deduplicated" ? "(unchanged)" : "uploaded"}: ${result.versionId.slice(0, 8)}`,
+              ),
+            );
+          } catch (error) {
+            console.error(chalk.red(`✗ Failed to upload skill: ${skillUrl}`));
+            if (error instanceof Error) {
+              console.error(chalk.gray(`  ${error.message}`));
+            }
+            process.exit(1);
+          }
+        }
+      }
+
+      // 5. Call API
       console.log(chalk.blue("Uploading compose..."));
 
       const response = await apiClient.createOrUpdateCompose({
         content: config,
       });
 
-      // 5. Display result
+      // 6. Display result
       const shortVersionId = response.versionId.slice(0, 8);
       if (response.action === "created") {
         console.log(chalk.green(`✓ Compose created: ${response.name}`));

--- a/turbo/apps/cli/src/lib/__tests__/github-skills.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/github-skills.test.ts
@@ -92,7 +92,7 @@ describe("parseGitHubTreeUrl", () => {
 });
 
 describe("getSkillStorageName", () => {
-  it("should generate correct storage name using URI scheme format", () => {
+  it("should generate correct storage name using @ format", () => {
     const parsed = {
       owner: "vm0-ai",
       repo: "vm0-skills",
@@ -103,7 +103,7 @@ describe("getSkillStorageName", () => {
     };
 
     expect(getSkillStorageName(parsed)).toBe(
-      "skill://vm0-ai/vm0-skills/tree/main/github-cli",
+      "system-skill@vm0-ai/vm0-skills/tree/main/github-cli",
     );
   });
 
@@ -118,19 +118,21 @@ describe("getSkillStorageName", () => {
     };
 
     expect(getSkillStorageName(parsed)).toBe(
-      "skill://owner/repo/tree/develop/skills/programming/python",
+      "system-skill@owner/repo/tree/develop/skills/programming/python",
     );
   });
 });
 
 describe("getSystemPromptStorageName", () => {
-  it("should generate correct storage name using URI scheme format", () => {
-    expect(getSystemPromptStorageName("my-agent")).toBe("prompt://my-agent");
+  it("should generate correct storage name using @ format", () => {
+    expect(getSystemPromptStorageName("my-agent")).toBe(
+      "system-prompt@my-agent",
+    );
   });
 
   it("should handle complex agent names", () => {
     expect(getSystemPromptStorageName("My-Test-Agent-123")).toBe(
-      "prompt://My-Test-Agent-123",
+      "system-prompt@My-Test-Agent-123",
     );
   });
 });

--- a/turbo/apps/cli/src/lib/__tests__/github-skills.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/github-skills.test.ts
@@ -16,6 +16,7 @@ describe("parseGitHubTreeUrl", () => {
       expect(result.branch).toBe("main");
       expect(result.path).toBe("github-cli");
       expect(result.skillName).toBe("github-cli");
+      expect(result.fullPath).toBe("vm0-ai/vm0-skills/tree/main/github-cli");
     });
 
     it("should parse URL with nested path", () => {
@@ -28,6 +29,9 @@ describe("parseGitHubTreeUrl", () => {
       expect(result.branch).toBe("develop");
       expect(result.path).toBe("skills/programming/python");
       expect(result.skillName).toBe("python");
+      expect(result.fullPath).toBe(
+        "owner/repo/tree/develop/skills/programming/python",
+      );
     });
 
     it("should parse URL with numbers and hyphens", () => {
@@ -40,6 +44,9 @@ describe("parseGitHubTreeUrl", () => {
       expect(result.branch).toBe("release-1.0");
       expect(result.path).toBe("my-skill");
       expect(result.skillName).toBe("my-skill");
+      expect(result.fullPath).toBe(
+        "my-org-123/skill-repo-v2/tree/release-1.0/my-skill",
+      );
     });
 
     it("should handle commit hash as branch", () => {
@@ -49,6 +56,7 @@ describe("parseGitHubTreeUrl", () => {
       expect(result.branch).toBe("abc123def");
       expect(result.path).toBe("path/to/skill");
       expect(result.skillName).toBe("skill");
+      expect(result.fullPath).toBe("owner/repo/tree/abc123def/path/to/skill");
     });
   });
 
@@ -56,7 +64,7 @@ describe("parseGitHubTreeUrl", () => {
     it("should throw for non-GitHub URL", () => {
       expect(() =>
         parseGitHubTreeUrl("https://gitlab.com/owner/repo/tree/main/skill"),
-      ).toThrow("Invalid GitHub tree URL");
+      ).toThrow("Invalid GitHub URL");
     });
 
     it("should throw for URL without tree", () => {
@@ -72,7 +80,7 @@ describe("parseGitHubTreeUrl", () => {
     });
 
     it("should throw for empty string", () => {
-      expect(() => parseGitHubTreeUrl("")).toThrow("Invalid GitHub tree URL");
+      expect(() => parseGitHubTreeUrl("")).toThrow("Invalid GitHub URL");
     });
 
     it("should throw for repository root URL", () => {
@@ -84,17 +92,18 @@ describe("parseGitHubTreeUrl", () => {
 });
 
 describe("getSkillStorageName", () => {
-  it("should generate correct storage name", () => {
+  it("should generate correct storage name using fullPath", () => {
     const parsed = {
       owner: "vm0-ai",
       repo: "vm0-skills",
       branch: "main",
       path: "github-cli",
       skillName: "github-cli",
+      fullPath: "vm0-ai/vm0-skills/tree/main/github-cli",
     };
 
     expect(getSkillStorageName(parsed)).toBe(
-      "__system-skill-vm0-ai/vm0-skills/main/github-cli__",
+      "__system-skill-vm0-ai/vm0-skills/tree/main/github-cli__",
     );
   });
 
@@ -105,10 +114,11 @@ describe("getSkillStorageName", () => {
       branch: "develop",
       path: "skills/programming/python",
       skillName: "python",
+      fullPath: "owner/repo/tree/develop/skills/programming/python",
     };
 
     expect(getSkillStorageName(parsed)).toBe(
-      "__system-skill-owner/repo/develop/skills/programming/python__",
+      "__system-skill-owner/repo/tree/develop/skills/programming/python__",
     );
   });
 });

--- a/turbo/apps/cli/src/lib/__tests__/github-skills.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/github-skills.test.ts
@@ -92,7 +92,7 @@ describe("parseGitHubTreeUrl", () => {
 });
 
 describe("getSkillStorageName", () => {
-  it("should generate correct storage name using fullPath", () => {
+  it("should generate correct storage name using URI scheme format", () => {
     const parsed = {
       owner: "vm0-ai",
       repo: "vm0-skills",
@@ -103,7 +103,7 @@ describe("getSkillStorageName", () => {
     };
 
     expect(getSkillStorageName(parsed)).toBe(
-      "__system-skill-vm0-ai/vm0-skills/tree/main/github-cli__",
+      "skill://vm0-ai/vm0-skills/tree/main/github-cli",
     );
   });
 
@@ -118,21 +118,19 @@ describe("getSkillStorageName", () => {
     };
 
     expect(getSkillStorageName(parsed)).toBe(
-      "__system-skill-owner/repo/tree/develop/skills/programming/python__",
+      "skill://owner/repo/tree/develop/skills/programming/python",
     );
   });
 });
 
 describe("getSystemPromptStorageName", () => {
-  it("should generate correct storage name", () => {
-    expect(getSystemPromptStorageName("my-agent")).toBe(
-      "__system-prompt-my-agent__",
-    );
+  it("should generate correct storage name using URI scheme format", () => {
+    expect(getSystemPromptStorageName("my-agent")).toBe("prompt://my-agent");
   });
 
   it("should handle complex agent names", () => {
     expect(getSystemPromptStorageName("My-Test-Agent-123")).toBe(
-      "__system-prompt-My-Test-Agent-123__",
+      "prompt://My-Test-Agent-123",
     );
   });
 });

--- a/turbo/apps/cli/src/lib/__tests__/github-skills.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/github-skills.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseGitHubTreeUrl,
+  getSkillStorageName,
+  getSystemPromptStorageName,
+} from "../github-skills";
+
+describe("parseGitHubTreeUrl", () => {
+  describe("valid URLs", () => {
+    it("should parse standard GitHub tree URL", () => {
+      const url = "https://github.com/vm0-ai/vm0-skills/tree/main/github-cli";
+      const result = parseGitHubTreeUrl(url);
+
+      expect(result.owner).toBe("vm0-ai");
+      expect(result.repo).toBe("vm0-skills");
+      expect(result.branch).toBe("main");
+      expect(result.path).toBe("github-cli");
+      expect(result.skillName).toBe("github-cli");
+    });
+
+    it("should parse URL with nested path", () => {
+      const url =
+        "https://github.com/owner/repo/tree/develop/skills/programming/python";
+      const result = parseGitHubTreeUrl(url);
+
+      expect(result.owner).toBe("owner");
+      expect(result.repo).toBe("repo");
+      expect(result.branch).toBe("develop");
+      expect(result.path).toBe("skills/programming/python");
+      expect(result.skillName).toBe("python");
+    });
+
+    it("should parse URL with numbers and hyphens", () => {
+      const url =
+        "https://github.com/my-org-123/skill-repo-v2/tree/release-1.0/my-skill";
+      const result = parseGitHubTreeUrl(url);
+
+      expect(result.owner).toBe("my-org-123");
+      expect(result.repo).toBe("skill-repo-v2");
+      expect(result.branch).toBe("release-1.0");
+      expect(result.path).toBe("my-skill");
+      expect(result.skillName).toBe("my-skill");
+    });
+
+    it("should handle commit hash as branch", () => {
+      const url = "https://github.com/owner/repo/tree/abc123def/path/to/skill";
+      const result = parseGitHubTreeUrl(url);
+
+      expect(result.branch).toBe("abc123def");
+      expect(result.path).toBe("path/to/skill");
+      expect(result.skillName).toBe("skill");
+    });
+  });
+
+  describe("invalid URLs", () => {
+    it("should throw for non-GitHub URL", () => {
+      expect(() =>
+        parseGitHubTreeUrl("https://gitlab.com/owner/repo/tree/main/skill"),
+      ).toThrow("Invalid GitHub tree URL");
+    });
+
+    it("should throw for URL without tree", () => {
+      expect(() =>
+        parseGitHubTreeUrl("https://github.com/owner/repo/blob/main/file.md"),
+      ).toThrow("Invalid GitHub tree URL");
+    });
+
+    it("should throw for URL without path after branch", () => {
+      expect(() =>
+        parseGitHubTreeUrl("https://github.com/owner/repo/tree/main"),
+      ).toThrow("Invalid GitHub tree URL");
+    });
+
+    it("should throw for empty string", () => {
+      expect(() => parseGitHubTreeUrl("")).toThrow("Invalid GitHub tree URL");
+    });
+
+    it("should throw for repository root URL", () => {
+      expect(() => parseGitHubTreeUrl("https://github.com/owner/repo")).toThrow(
+        "Invalid GitHub tree URL",
+      );
+    });
+  });
+});
+
+describe("getSkillStorageName", () => {
+  it("should generate correct storage name", () => {
+    const parsed = {
+      owner: "vm0-ai",
+      repo: "vm0-skills",
+      branch: "main",
+      path: "github-cli",
+      skillName: "github-cli",
+    };
+
+    expect(getSkillStorageName(parsed)).toBe(
+      "__system-skill-vm0-ai/vm0-skills/main/github-cli__",
+    );
+  });
+
+  it("should handle nested paths", () => {
+    const parsed = {
+      owner: "owner",
+      repo: "repo",
+      branch: "develop",
+      path: "skills/programming/python",
+      skillName: "python",
+    };
+
+    expect(getSkillStorageName(parsed)).toBe(
+      "__system-skill-owner/repo/develop/skills/programming/python__",
+    );
+  });
+});
+
+describe("getSystemPromptStorageName", () => {
+  it("should generate correct storage name", () => {
+    expect(getSystemPromptStorageName("my-agent")).toBe(
+      "__system-prompt-my-agent__",
+    );
+  });
+
+  it("should handle complex agent names", () => {
+    expect(getSystemPromptStorageName("My-Test-Agent-123")).toBe(
+      "__system-prompt-My-Test-Agent-123__",
+    );
+  });
+});

--- a/turbo/apps/cli/src/lib/__tests__/yaml-validator.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/yaml-validator.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { validateAgentName, validateAgentCompose } from "../yaml-validator";
+import {
+  validateAgentName,
+  validateAgentCompose,
+  validateGitHubTreeUrl,
+} from "../yaml-validator";
 
 describe("validateAgentName", () => {
   describe("valid names", () => {
@@ -74,7 +78,22 @@ describe("validateAgentName", () => {
 
 describe("validateAgentCompose", () => {
   describe("valid configs", () => {
-    it("should accept minimal valid config", () => {
+    it("should accept minimal valid config with supported provider (auto-config)", () => {
+      const config = {
+        version: "1.0",
+        agents: {
+          "test-agent": {
+            provider: "claude-code",
+          },
+        },
+      };
+
+      const result = validateAgentCompose(config);
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("should accept full config with explicit image and working_dir", () => {
       const config = {
         version: "1.0",
         agents: {
@@ -107,6 +126,38 @@ describe("validateAgentCompose", () => {
           "claude-files": {
             name: "claude-files",
             version: "latest",
+          },
+        },
+      };
+
+      const result = validateAgentCompose(config);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should accept config with system_prompt", () => {
+      const config = {
+        version: "1.0",
+        agents: {
+          "test-agent": {
+            provider: "claude-code",
+            system_prompt: "AGENTS.md",
+          },
+        },
+      };
+
+      const result = validateAgentCompose(config);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should accept config with system_skills", () => {
+      const config = {
+        version: "1.0",
+        agents: {
+          "test-agent": {
+            provider: "claude-code",
+            system_skills: [
+              "https://github.com/vm0-ai/vm0-skills/tree/main/github-cli",
+            ],
           },
         },
       };
@@ -275,28 +326,28 @@ describe("validateAgentCompose", () => {
       expect(result.error).toContain("Invalid agent name format");
     });
 
-    it("should reject config with missing working_dir", () => {
+    it("should reject config with missing working_dir for unsupported provider", () => {
       const config = {
         version: "1.0",
         agents: {
           "test-agent": {
-            image: "vm0-claude-code-dev",
-            provider: "claude-code",
+            image: "custom-image",
+            provider: "unsupported-provider",
           },
         },
       };
 
       const result = validateAgentCompose(config);
       expect(result.valid).toBe(false);
-      expect(result.error).toContain("agent.working_dir");
+      expect(result.error).toContain("working_dir");
     });
 
-    it("should reject config with missing image", () => {
+    it("should reject config with missing image for unsupported provider", () => {
       const config = {
         version: "1.0",
         agents: {
           "test-agent": {
-            provider: "claude-code",
+            provider: "unsupported-provider",
             working_dir: "/home/user/workspace",
           },
         },
@@ -304,7 +355,7 @@ describe("validateAgentCompose", () => {
 
       const result = validateAgentCompose(config);
       expect(result.valid).toBe(false);
-      expect(result.error).toContain("agent.image");
+      expect(result.error).toContain("image");
     });
 
     it("should reject config with missing provider", () => {
@@ -321,6 +372,70 @@ describe("validateAgentCompose", () => {
       const result = validateAgentCompose(config);
       expect(result.valid).toBe(false);
       expect(result.error).toContain("agent.provider");
+    });
+
+    it("should reject config with invalid system_prompt (not a string)", () => {
+      const config = {
+        version: "1.0",
+        agents: {
+          "test-agent": {
+            provider: "claude-code",
+            system_prompt: 123,
+          },
+        },
+      };
+
+      const result = validateAgentCompose(config);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("system_prompt");
+    });
+
+    it("should reject config with empty system_prompt", () => {
+      const config = {
+        version: "1.0",
+        agents: {
+          "test-agent": {
+            provider: "claude-code",
+            system_prompt: "",
+          },
+        },
+      };
+
+      const result = validateAgentCompose(config);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("empty");
+    });
+
+    it("should reject config with invalid system_skills (not an array)", () => {
+      const config = {
+        version: "1.0",
+        agents: {
+          "test-agent": {
+            provider: "claude-code",
+            system_skills: "not-an-array",
+          },
+        },
+      };
+
+      const result = validateAgentCompose(config);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("array");
+    });
+
+    it("should reject config with invalid GitHub URL in system_skills", () => {
+      const config = {
+        version: "1.0",
+        agents: {
+          "test-agent": {
+            provider: "claude-code",
+            system_skills: ["https://example.com/not-github"],
+          },
+        },
+      };
+
+      const result = validateAgentCompose(config);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("Invalid system_skill URL");
     });
 
     it("should reject config with volume reference missing from volumes section", () => {
@@ -391,6 +506,88 @@ describe("validateAgentCompose", () => {
       const result = validateAgentCompose(config);
       expect(result.valid).toBe(false);
       expect(result.error).toContain("'version' field");
+    });
+  });
+});
+
+describe("validateGitHubTreeUrl", () => {
+  describe("valid URLs", () => {
+    it("should accept standard GitHub tree URL", () => {
+      expect(
+        validateGitHubTreeUrl(
+          "https://github.com/vm0-ai/vm0-skills/tree/main/github-cli",
+        ),
+      ).toBe(true);
+    });
+
+    it("should accept URL with nested path", () => {
+      expect(
+        validateGitHubTreeUrl(
+          "https://github.com/owner/repo/tree/main/path/to/skill",
+        ),
+      ).toBe(true);
+    });
+
+    it("should accept URL with branch name containing slashes", () => {
+      expect(
+        validateGitHubTreeUrl(
+          "https://github.com/owner/repo/tree/feature/branch/skill",
+        ),
+      ).toBe(true);
+    });
+
+    it("should accept URL with numbers in owner/repo", () => {
+      expect(
+        validateGitHubTreeUrl(
+          "https://github.com/owner123/repo456/tree/main/skill",
+        ),
+      ).toBe(true);
+    });
+
+    it("should accept URL with hyphens and underscores", () => {
+      expect(
+        validateGitHubTreeUrl(
+          "https://github.com/my-org/my_repo/tree/main/my-skill",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("invalid URLs", () => {
+    it("should reject non-GitHub URL", () => {
+      expect(
+        validateGitHubTreeUrl("https://gitlab.com/owner/repo/tree/main/skill"),
+      ).toBe(false);
+    });
+
+    it("should reject URL without tree path", () => {
+      expect(
+        validateGitHubTreeUrl(
+          "https://github.com/owner/repo/blob/main/file.md",
+        ),
+      ).toBe(false);
+    });
+
+    it("should reject URL without path after tree/branch", () => {
+      expect(
+        validateGitHubTreeUrl("https://github.com/owner/repo/tree/main"),
+      ).toBe(false);
+    });
+
+    it("should reject repository root URL", () => {
+      expect(validateGitHubTreeUrl("https://github.com/owner/repo")).toBe(
+        false,
+      );
+    });
+
+    it("should reject http URL (must be https)", () => {
+      expect(
+        validateGitHubTreeUrl("http://github.com/owner/repo/tree/main/skill"),
+      ).toBe(false);
+    });
+
+    it("should reject empty string", () => {
+      expect(validateGitHubTreeUrl("")).toBe(false);
     });
   });
 });

--- a/turbo/apps/cli/src/lib/github-skills.ts
+++ b/turbo/apps/cli/src/lib/github-skills.ts
@@ -1,0 +1,161 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+
+/**
+ * Parsed GitHub tree URL components
+ */
+export interface ParsedGitHubUrl {
+  owner: string;
+  repo: string;
+  branch: string;
+  path: string;
+  skillName: string; // Last segment of path (used for mount directory name)
+}
+
+/**
+ * Parse a GitHub tree URL into its components
+ * Expected format: https://github.com/{owner}/{repo}/tree/{branch}/{path}
+ *
+ * @param url - GitHub tree URL
+ * @returns Parsed URL components
+ * @throws Error if URL format is invalid
+ */
+export function parseGitHubTreeUrl(url: string): ParsedGitHubUrl {
+  const regex =
+    /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)$/;
+  const match = url.match(regex);
+
+  if (!match) {
+    throw new Error(
+      `Invalid GitHub tree URL: ${url}. Expected format: https://github.com/{owner}/{repo}/tree/{branch}/{path}`,
+    );
+  }
+
+  const [, owner, repo, branch, pathPart] = match;
+  const pathSegments = pathPart!.split("/");
+  const skillName = pathSegments[pathSegments.length - 1]!;
+
+  return {
+    owner: owner!,
+    repo: repo!,
+    branch: branch!,
+    path: pathPart!,
+    skillName,
+  };
+}
+
+/**
+ * Generate the storage name for a system skill
+ * Format: __system-skill-{owner}/{repo}/{branch}/{path}__
+ *
+ * @param parsed - Parsed GitHub URL
+ * @returns Storage name for the skill
+ */
+export function getSkillStorageName(parsed: ParsedGitHubUrl): string {
+  return `__system-skill-${parsed.owner}/${parsed.repo}/${parsed.branch}/${parsed.path}__`;
+}
+
+/**
+ * Generate the storage name for a system prompt
+ * Format: __system-prompt-{composeName}__
+ *
+ * @param composeName - Name of the compose (agent name)
+ * @returns Storage name for the system prompt
+ */
+export function getSystemPromptStorageName(composeName: string): string {
+  return `__system-prompt-${composeName}__`;
+}
+
+/**
+ * Download a GitHub directory using git sparse-checkout
+ *
+ * @param parsed - Parsed GitHub URL
+ * @param destDir - Destination directory for the downloaded content
+ * @returns Path to the downloaded skill directory
+ */
+export async function downloadGitHubSkill(
+  parsed: ParsedGitHubUrl,
+  destDir: string,
+): Promise<string> {
+  const repoUrl = `https://github.com/${parsed.owner}/${parsed.repo}.git`;
+  const skillDir = path.join(destDir, parsed.skillName);
+
+  // Create a temporary directory for sparse checkout
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vm0-skill-"));
+
+  try {
+    // Initialize sparse checkout
+    await execAsync(`git init`, { cwd: tempDir });
+    await execAsync(`git remote add origin "${repoUrl}"`, { cwd: tempDir });
+    await execAsync(`git config core.sparseCheckout true`, { cwd: tempDir });
+
+    // Configure sparse checkout to only fetch the skill path
+    const sparseFile = path.join(tempDir, ".git", "info", "sparse-checkout");
+    await fs.writeFile(sparseFile, parsed.path + "\n");
+
+    // Fetch only the required branch
+    await execAsync(`git fetch --depth 1 origin "${parsed.branch}"`, {
+      cwd: tempDir,
+    });
+    await execAsync(`git checkout "${parsed.branch}"`, { cwd: tempDir });
+
+    // Move the skill directory to destination
+    const fetchedPath = path.join(tempDir, parsed.path);
+    await fs.mkdir(path.dirname(skillDir), { recursive: true });
+    await fs.rename(fetchedPath, skillDir);
+
+    return skillDir;
+  } finally {
+    // Clean up temp directory
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Download multiple skills in parallel
+ *
+ * @param skillUrls - Array of GitHub tree URLs
+ * @param destDir - Destination directory for downloaded skills
+ * @returns Map of skill URL to local path
+ */
+export async function downloadSkills(
+  skillUrls: string[],
+  destDir: string,
+): Promise<Map<string, string>> {
+  const results = new Map<string, string>();
+
+  // Create destination directory
+  await fs.mkdir(destDir, { recursive: true });
+
+  // Download skills in parallel
+  const downloads = skillUrls.map(async (url) => {
+    const parsed = parseGitHubTreeUrl(url);
+    const skillPath = await downloadGitHubSkill(parsed, destDir);
+    results.set(url, skillPath);
+  });
+
+  await Promise.all(downloads);
+  return results;
+}
+
+/**
+ * Validate that a downloaded skill has the required SKILL.md file
+ *
+ * @param skillDir - Path to the downloaded skill directory
+ * @returns True if valid, throws error otherwise
+ */
+export async function validateSkillDirectory(skillDir: string): Promise<void> {
+  const skillMdPath = path.join(skillDir, "SKILL.md");
+  try {
+    await fs.access(skillMdPath);
+  } catch {
+    throw new Error(
+      `Skill directory missing required SKILL.md file: ${skillDir}`,
+    );
+  }
+}

--- a/turbo/apps/cli/src/lib/github-skills.ts
+++ b/turbo/apps/cli/src/lib/github-skills.ts
@@ -66,25 +66,26 @@ export function parseGitHubTreeUrl(url: string): ParsedGitHubUrl {
 
 /**
  * Generate the storage name for a system skill
- * Format: __system-skill-{fullPath}__
- * Uses the full path after github.com/ for unique, unambiguous naming
+ * Format: skill://{fullPath}
+ * Uses URI scheme format with the full path after github.com/
  *
  * @param parsed - Parsed GitHub URL
  * @returns Storage name for the skill
  */
 export function getSkillStorageName(parsed: ParsedGitHubUrl): string {
-  return `__system-skill-${parsed.fullPath}__`;
+  return `skill://${parsed.fullPath}`;
 }
 
 /**
  * Generate the storage name for a system prompt
- * Format: __system-prompt-{composeName}__
+ * Format: prompt://{composeName}
+ * Uses URI scheme format for clarity
  *
  * @param composeName - Name of the compose (agent name)
  * @returns Storage name for the system prompt
  */
 export function getSystemPromptStorageName(composeName: string): string {
-  return `__system-prompt-${composeName}__`;
+  return `prompt://${composeName}`;
 }
 
 /**

--- a/turbo/apps/cli/src/lib/github-skills.ts
+++ b/turbo/apps/cli/src/lib/github-skills.ts
@@ -66,26 +66,24 @@ export function parseGitHubTreeUrl(url: string): ParsedGitHubUrl {
 
 /**
  * Generate the storage name for a system skill
- * Format: skill://{fullPath}
- * Uses URI scheme format with the full path after github.com/
+ * Format: system-skill@{fullPath}
  *
  * @param parsed - Parsed GitHub URL
  * @returns Storage name for the skill
  */
 export function getSkillStorageName(parsed: ParsedGitHubUrl): string {
-  return `skill://${parsed.fullPath}`;
+  return `system-skill@${parsed.fullPath}`;
 }
 
 /**
  * Generate the storage name for a system prompt
- * Format: prompt://{composeName}
- * Uses URI scheme format for clarity
+ * Format: system-prompt@{composeName}
  *
  * @param composeName - Name of the compose (agent name)
  * @returns Storage name for the system prompt
  */
 export function getSystemPromptStorageName(composeName: string): string {
-  return `prompt://${composeName}`;
+  return `system-prompt@${composeName}`;
 }
 
 /**

--- a/turbo/apps/cli/src/lib/github-skills.ts
+++ b/turbo/apps/cli/src/lib/github-skills.ts
@@ -15,17 +15,31 @@ export interface ParsedGitHubUrl {
   branch: string;
   path: string;
   skillName: string; // Last segment of path (used for mount directory name)
+  fullPath: string; // Full path after github.com/ (unique identifier)
 }
 
 /**
  * Parse a GitHub tree URL into its components
  * Expected format: https://github.com/{owner}/{repo}/tree/{branch}/{path}
  *
+ * Note: Branch names containing slashes (e.g., feature/foo) may not parse correctly.
+ * The fullPath field is always correct and used for unique storage naming.
+ *
  * @param url - GitHub tree URL
  * @returns Parsed URL components
  * @throws Error if URL format is invalid
  */
 export function parseGitHubTreeUrl(url: string): ParsedGitHubUrl {
+  // First, extract the full path after github.com/ (always correct)
+  const fullPathMatch = url.match(/^https:\/\/github\.com\/(.+)$/);
+  if (!fullPathMatch) {
+    throw new Error(
+      `Invalid GitHub URL: ${url}. Expected format: https://github.com/{owner}/{repo}/tree/{branch}/{path}`,
+    );
+  }
+  const fullPath = fullPathMatch[1]!;
+
+  // Parse components (may be incorrect for branches with slashes)
   const regex =
     /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)$/;
   const match = url.match(regex);
@@ -46,18 +60,20 @@ export function parseGitHubTreeUrl(url: string): ParsedGitHubUrl {
     branch: branch!,
     path: pathPart!,
     skillName,
+    fullPath,
   };
 }
 
 /**
  * Generate the storage name for a system skill
- * Format: __system-skill-{owner}/{repo}/{branch}/{path}__
+ * Format: __system-skill-{fullPath}__
+ * Uses the full path after github.com/ for unique, unambiguous naming
  *
  * @param parsed - Parsed GitHub URL
  * @returns Storage name for the skill
  */
 export function getSkillStorageName(parsed: ParsedGitHubUrl): string {
-  return `__system-skill-${parsed.owner}/${parsed.repo}/${parsed.branch}/${parsed.path}__`;
+  return `__system-skill-${parsed.fullPath}__`;
 }
 
 /**

--- a/turbo/apps/cli/src/lib/provider-config.ts
+++ b/turbo/apps/cli/src/lib/provider-config.ts
@@ -1,0 +1,47 @@
+/**
+ * Provider configuration for auto-resolving image and working_dir
+ * When a provider is specified, these defaults can be used if not explicitly set
+ */
+
+export interface ProviderDefaults {
+  image: string;
+  workingDir: string;
+}
+
+/**
+ * Mapping of provider names to their default configurations
+ */
+const PROVIDER_DEFAULTS: Record<string, ProviderDefaults> = {
+  "claude-code": {
+    image: "vm0-claude-code-dev",
+    workingDir: "/home/user/workspace",
+  },
+};
+
+/**
+ * Get default configuration for a provider
+ * @param provider - The provider name
+ * @returns Provider defaults or undefined if provider is not recognized
+ */
+export function getProviderDefaults(
+  provider: string,
+): ProviderDefaults | undefined {
+  return PROVIDER_DEFAULTS[provider];
+}
+
+/**
+ * Check if a provider is supported (has default configuration)
+ * @param provider - The provider name
+ * @returns True if provider is supported
+ */
+export function isProviderSupported(provider: string): boolean {
+  return provider in PROVIDER_DEFAULTS;
+}
+
+/**
+ * Get the list of supported providers
+ * @returns Array of supported provider names
+ */
+export function getSupportedProviders(): string[] {
+  return Object.keys(PROVIDER_DEFAULTS);
+}

--- a/turbo/apps/cli/src/lib/system-storage.ts
+++ b/turbo/apps/cli/src/lib/system-storage.ts
@@ -77,8 +77,14 @@ export async function uploadSystemPrompt(
     });
 
     if (!response.ok) {
-      const error = (await response.json()) as { error: string };
-      throw new Error(error.error || "Upload failed");
+      const errorBody = (await response.json()) as {
+        error: string | { message: string; code: string };
+      };
+      const errorMessage =
+        typeof errorBody.error === "string"
+          ? errorBody.error
+          : errorBody.error?.message || "Upload failed";
+      throw new Error(errorMessage);
     }
 
     const result = (await response.json()) as {
@@ -148,8 +154,14 @@ export async function uploadSystemSkill(
     });
 
     if (!response.ok) {
-      const error = (await response.json()) as { error: string };
-      throw new Error(error.error || "Upload failed");
+      const errorBody = (await response.json()) as {
+        error: string | { message: string; code: string };
+      };
+      const errorMessage =
+        typeof errorBody.error === "string"
+          ? errorBody.error
+          : errorBody.error?.message || "Upload failed";
+      throw new Error(errorMessage);
     }
 
     const result = (await response.json()) as {

--- a/turbo/apps/cli/src/lib/system-storage.ts
+++ b/turbo/apps/cli/src/lib/system-storage.ts
@@ -1,0 +1,170 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import * as tar from "tar";
+import { apiClient } from "./api-client";
+import {
+  parseGitHubTreeUrl,
+  downloadGitHubSkill,
+  getSkillStorageName,
+  getSystemPromptStorageName,
+  validateSkillDirectory,
+} from "./github-skills";
+
+export interface SystemStorageUploadResult {
+  name: string;
+  versionId: string;
+  action: "created" | "deduplicated";
+}
+
+/**
+ * Upload system prompt file as a volume
+ *
+ * @param agentName - Name of the agent (used for storage name)
+ * @param promptFilePath - Path to the system prompt file (AGENTS.md)
+ * @param basePath - Base path for resolving relative paths
+ * @returns Upload result with storage name and version
+ */
+export async function uploadSystemPrompt(
+  agentName: string,
+  promptFilePath: string,
+  basePath: string,
+): Promise<SystemStorageUploadResult> {
+  const storageName = getSystemPromptStorageName(agentName);
+
+  // Resolve file path relative to base path
+  const absolutePath = path.isAbsolute(promptFilePath)
+    ? promptFilePath
+    : path.join(basePath, promptFilePath);
+
+  // Read the prompt file
+  const content = await fs.readFile(absolutePath, "utf8");
+
+  // Create a temporary directory with the file
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vm0-prompt-"));
+  const promptDir = path.join(tmpDir, "prompt");
+  await fs.mkdir(promptDir);
+
+  // Write file as CLAUDE.md (the canonical name for Claude Code system prompts)
+  await fs.writeFile(path.join(promptDir, "CLAUDE.md"), content);
+
+  try {
+    // Create tar.gz archive
+    const tarPath = path.join(tmpDir, "prompt.tar.gz");
+    await tar.create(
+      {
+        gzip: true,
+        file: tarPath,
+        cwd: promptDir,
+      },
+      ["."],
+    );
+
+    const tarBuffer = await fs.readFile(tarPath);
+
+    // Upload to storage API
+    const formData = new FormData();
+    formData.append("name", storageName);
+    formData.append("type", "volume");
+    formData.append(
+      "file",
+      new Blob([tarBuffer], { type: "application/gzip" }),
+      "volume.tar.gz",
+    );
+
+    const response = await apiClient.post("/api/storages", {
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const error = (await response.json()) as { error: string };
+      throw new Error(error.error || "Upload failed");
+    }
+
+    const result = (await response.json()) as {
+      name: string;
+      versionId: string;
+      deduplicated?: boolean;
+    };
+
+    return {
+      name: storageName,
+      versionId: result.versionId,
+      action: result.deduplicated ? "deduplicated" : "created",
+    };
+  } finally {
+    // Clean up temp directory
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Upload a skill from GitHub as a volume
+ *
+ * @param skillUrl - GitHub tree URL for the skill
+ * @returns Upload result with storage name and version
+ */
+export async function uploadSystemSkill(
+  skillUrl: string,
+): Promise<SystemStorageUploadResult> {
+  const parsed = parseGitHubTreeUrl(skillUrl);
+  const storageName = getSkillStorageName(parsed);
+
+  // Create temp directory for download
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vm0-skill-"));
+
+  try {
+    // Download skill from GitHub
+    const skillDir = await downloadGitHubSkill(parsed, tmpDir);
+
+    // Validate the skill has SKILL.md
+    await validateSkillDirectory(skillDir);
+
+    // Create tar.gz archive
+    const tarPath = path.join(tmpDir, "skill.tar.gz");
+    await tar.create(
+      {
+        gzip: true,
+        file: tarPath,
+        cwd: skillDir,
+      },
+      ["."],
+    );
+
+    const tarBuffer = await fs.readFile(tarPath);
+
+    // Upload to storage API
+    const formData = new FormData();
+    formData.append("name", storageName);
+    formData.append("type", "volume");
+    formData.append(
+      "file",
+      new Blob([tarBuffer], { type: "application/gzip" }),
+      "volume.tar.gz",
+    );
+
+    const response = await apiClient.post("/api/storages", {
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const error = (await response.json()) as { error: string };
+      throw new Error(error.error || "Upload failed");
+    }
+
+    const result = (await response.json()) as {
+      name: string;
+      versionId: string;
+      deduplicated?: boolean;
+    };
+
+    return {
+      name: storageName,
+      versionId: result.versionId,
+      action: result.deduplicated ? "deduplicated" : "created",
+    };
+  } finally {
+    // Clean up temp directory
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+}

--- a/turbo/apps/cli/src/lib/yaml-validator.ts
+++ b/turbo/apps/cli/src/lib/yaml-validator.ts
@@ -1,3 +1,5 @@
+import { isProviderSupported } from "./provider-config";
+
 /**
  * Validates agent.name format
  * Rules:
@@ -8,6 +10,16 @@
 export function validateAgentName(name: string): boolean {
   const nameRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-]{1,62}[a-zA-Z0-9])?$/;
   return nameRegex.test(name);
+}
+
+/**
+ * Validates GitHub tree URL format for system_skills
+ * Expected format: https://github.com/{owner}/{repo}/tree/{branch}/{path}
+ */
+export function validateGitHubTreeUrl(url: string): boolean {
+  const githubTreeRegex =
+    /^https:\/\/github\.com\/[a-zA-Z0-9_-]+\/[a-zA-Z0-9_.-]+\/tree\/[^/]+\/.+$/;
+  return githubTreeRegex.test(url);
 }
 
 /**
@@ -100,28 +112,87 @@ export function validateAgentCompose(config: unknown): {
     return { valid: false, error: "Agent definition must be an object" };
   }
 
-  // Check agent.working_dir
-  if (!agent.working_dir || typeof agent.working_dir !== "string") {
-    return {
-      valid: false,
-      error: "Missing or invalid agent.working_dir (must be a string)",
-    };
-  }
-
-  // Check agent.image
-  if (!agent.image || typeof agent.image !== "string") {
-    return {
-      valid: false,
-      error: "Missing or invalid agent.image (must be a string)",
-    };
-  }
-
-  // Check agent.provider
+  // Check agent.provider (required)
   if (!agent.provider || typeof agent.provider !== "string") {
     return {
       valid: false,
       error: "Missing or invalid agent.provider (must be a string)",
     };
+  }
+
+  const providerIsSupported = isProviderSupported(agent.provider as string);
+
+  // Check agent.image (optional when provider is supported)
+  if (agent.image !== undefined && typeof agent.image !== "string") {
+    return {
+      valid: false,
+      error: "agent.image must be a string if provided",
+    };
+  }
+  if (!agent.image && !providerIsSupported) {
+    return {
+      valid: false,
+      error:
+        "Missing agent.image (required when provider is not auto-configured)",
+    };
+  }
+
+  // Check agent.working_dir (optional when provider is supported)
+  if (
+    agent.working_dir !== undefined &&
+    typeof agent.working_dir !== "string"
+  ) {
+    return {
+      valid: false,
+      error: "agent.working_dir must be a string if provided",
+    };
+  }
+  if (!agent.working_dir && !providerIsSupported) {
+    return {
+      valid: false,
+      error:
+        "Missing agent.working_dir (required when provider is not auto-configured)",
+    };
+  }
+
+  // Validate system_prompt if present (must be a relative file path)
+  if (agent.system_prompt !== undefined) {
+    if (typeof agent.system_prompt !== "string") {
+      return {
+        valid: false,
+        error: "agent.system_prompt must be a string (path to AGENTS.md file)",
+      };
+    }
+    if (agent.system_prompt.length === 0) {
+      return {
+        valid: false,
+        error: "agent.system_prompt cannot be empty",
+      };
+    }
+  }
+
+  // Validate system_skills if present (must be array of GitHub tree URLs)
+  if (agent.system_skills !== undefined) {
+    if (!Array.isArray(agent.system_skills)) {
+      return {
+        valid: false,
+        error: "agent.system_skills must be an array of GitHub tree URLs",
+      };
+    }
+    for (const skillUrl of agent.system_skills as unknown[]) {
+      if (typeof skillUrl !== "string") {
+        return {
+          valid: false,
+          error: "Each system_skill must be a string URL",
+        };
+      }
+      if (!validateGitHubTreeUrl(skillUrl)) {
+        return {
+          valid: false,
+          error: `Invalid system_skill URL: ${skillUrl}. Expected format: https://github.com/{owner}/{repo}/tree/{branch}/{path}`,
+        };
+      }
+    }
   }
 
   // Validate environment field if present

--- a/turbo/apps/web/app/api/storages/route.ts
+++ b/turbo/apps/web/app/api/storages/route.ts
@@ -37,12 +37,12 @@ function errorResponse(
 
 /**
  * Check if name is a system storage name
- * System storage names use URI scheme format:
- * - prompt://{name} for system prompts
- * - skill://{path} for system skills
+ * System storage names use @ format:
+ * - system-prompt@{name} for system prompts
+ * - system-skill@{path} for system skills
  */
 function isSystemStorageName(name: string): boolean {
-  return name.startsWith("prompt://") || name.startsWith("skill://");
+  return name.startsWith("system-prompt@") || name.startsWith("system-skill@");
 }
 
 /**
@@ -54,23 +54,23 @@ function isSystemStorageName(name: string): boolean {
  * - Must start and end with alphanumeric
  * - No consecutive hyphens
  *
- * System storage names (URI scheme format):
- * - prompt://{name} for system prompts (name: alphanumeric with hyphens)
- * - skill://{path} for system skills (path: GitHub path with slashes, dots, hyphens)
+ * System storage names (@ format):
+ * - system-prompt@{name} for system prompts (name: alphanumeric with hyphens)
+ * - system-skill@{path} for system skills (path: GitHub path with slashes, dots, hyphens)
  * - Length: up to 256 characters
  */
 function isValidStorageName(name: string): boolean {
   // System storage names have different validation rules
   if (isSystemStorageName(name)) {
     // Length: up to 256 characters (DB limit is 256)
-    if (name.length < 10 || name.length > 256) {
+    if (name.length < 15 || name.length > 256) {
       return false;
     }
     // Must be a valid system storage type
-    // prompt://agent-name
-    const systemPromptPattern = /^prompt:\/\/[a-zA-Z0-9-]+$/;
-    // skill://owner/repo/tree/branch/path (allows dots for branch names like v1.0)
-    const systemSkillPattern = /^skill:\/\/[a-zA-Z0-9/._-]+$/;
+    // system-prompt@agent-name
+    const systemPromptPattern = /^system-prompt@[a-zA-Z0-9-]+$/;
+    // system-skill@owner/repo/tree/branch/path (allows dots for branch names like v1.0)
+    const systemSkillPattern = /^system-skill@[a-zA-Z0-9/._-]+$/;
     return systemPromptPattern.test(name) || systemSkillPattern.test(name);
   }
 

--- a/turbo/apps/web/app/api/storages/route.ts
+++ b/turbo/apps/web/app/api/storages/route.ts
@@ -36,12 +36,42 @@ function errorResponse(
 }
 
 /**
+ * Check if name is a system storage name
+ * System storage names start and end with __
+ * Format: __system-prompt-{name}__ or __system-skill-{path}__
+ */
+function isSystemStorageName(name: string): boolean {
+  return name.startsWith("__") && name.endsWith("__");
+}
+
+/**
  * Validate storage name format
- * Length: 3-64 characters
- * Characters: lowercase letters, numbers, hyphens
- * Must start and end with alphanumeric
+ *
+ * Regular storage names:
+ * - Length: 3-64 characters
+ * - Characters: lowercase letters, numbers, hyphens
+ * - Must start and end with alphanumeric
+ * - No consecutive hyphens
+ *
+ * System storage names (prefixed/suffixed with __):
+ * - Length: 3-256 characters
+ * - Must start with __system-prompt- or __system-skill-
+ * - Can contain additional characters for paths
  */
 function isValidStorageName(name: string): boolean {
+  // System storage names have different validation rules
+  if (isSystemStorageName(name)) {
+    // Length: 3-256 characters (DB limit is 256)
+    if (name.length < 3 || name.length > 256) {
+      return false;
+    }
+    // Must be a valid system storage type
+    const systemPromptPattern = /^__system-prompt-[a-zA-Z0-9-]+__$/;
+    const systemSkillPattern = /^__system-skill-[a-zA-Z0-9/_-]+__$/;
+    return systemPromptPattern.test(name) || systemSkillPattern.test(name);
+  }
+
+  // Regular storage names
   if (name.length < 3 || name.length > 64) {
     return false;
   }

--- a/turbo/apps/web/app/api/storages/route.ts
+++ b/turbo/apps/web/app/api/storages/route.ts
@@ -67,7 +67,8 @@ function isValidStorageName(name: string): boolean {
     }
     // Must be a valid system storage type
     const systemPromptPattern = /^__system-prompt-[a-zA-Z0-9-]+__$/;
-    const systemSkillPattern = /^__system-skill-[a-zA-Z0-9/_-]+__$/;
+    // Skill pattern uses full GitHub path (allows dots for branch names like v1.0 and file extensions)
+    const systemSkillPattern = /^__system-skill-[a-zA-Z0-9/._-]+__$/;
     return systemPromptPattern.test(name) || systemSkillPattern.test(name);
   }
 

--- a/turbo/apps/web/app/api/storages/route.ts
+++ b/turbo/apps/web/app/api/storages/route.ts
@@ -37,11 +37,12 @@ function errorResponse(
 
 /**
  * Check if name is a system storage name
- * System storage names start and end with __
- * Format: __system-prompt-{name}__ or __system-skill-{path}__
+ * System storage names use URI scheme format:
+ * - prompt://{name} for system prompts
+ * - skill://{path} for system skills
  */
 function isSystemStorageName(name: string): boolean {
-  return name.startsWith("__") && name.endsWith("__");
+  return name.startsWith("prompt://") || name.startsWith("skill://");
 }
 
 /**
@@ -53,22 +54,23 @@ function isSystemStorageName(name: string): boolean {
  * - Must start and end with alphanumeric
  * - No consecutive hyphens
  *
- * System storage names (prefixed/suffixed with __):
- * - Length: 3-256 characters
- * - Must start with __system-prompt- or __system-skill-
- * - Can contain additional characters for paths
+ * System storage names (URI scheme format):
+ * - prompt://{name} for system prompts (name: alphanumeric with hyphens)
+ * - skill://{path} for system skills (path: GitHub path with slashes, dots, hyphens)
+ * - Length: up to 256 characters
  */
 function isValidStorageName(name: string): boolean {
   // System storage names have different validation rules
   if (isSystemStorageName(name)) {
-    // Length: 3-256 characters (DB limit is 256)
-    if (name.length < 3 || name.length > 256) {
+    // Length: up to 256 characters (DB limit is 256)
+    if (name.length < 10 || name.length > 256) {
       return false;
     }
     // Must be a valid system storage type
-    const systemPromptPattern = /^__system-prompt-[a-zA-Z0-9-]+__$/;
-    // Skill pattern uses full GitHub path (allows dots for branch names like v1.0 and file extensions)
-    const systemSkillPattern = /^__system-skill-[a-zA-Z0-9/._-]+__$/;
+    // prompt://agent-name
+    const systemPromptPattern = /^prompt:\/\/[a-zA-Z0-9-]+$/;
+    // skill://owner/repo/tree/branch/path (allows dots for branch names like v1.0)
+    const systemSkillPattern = /^skill:\/\/[a-zA-Z0-9/._-]+$/;
     return systemPromptPattern.test(name) || systemSkillPattern.test(name);
   }
 

--- a/turbo/apps/web/src/db/migrations/0033_storage_name_256.sql
+++ b/turbo/apps/web/src/db/migrations/0033_storage_name_256.sql
@@ -1,0 +1,5 @@
+-- Migration: Increase storage name column length for system volumes
+-- System volumes use naming convention: __system-prompt-{name}__ and __system-skill-{owner}/{repo}/{branch}/{path}__
+-- These names can exceed 64 characters, so we increase to 256
+
+ALTER TABLE "storages" ALTER COLUMN "name" TYPE varchar(256);

--- a/turbo/apps/web/src/db/schema/storage.ts
+++ b/turbo/apps/web/src/db/schema/storage.ts
@@ -25,7 +25,7 @@ export const storages = pgTable(
   {
     id: uuid("id").defaultRandom().primaryKey(),
     userId: text("user_id").notNull(),
-    name: varchar("name", { length: 64 }).notNull(),
+    name: varchar("name", { length: 256 }).notNull(), // 256 to support system volume naming convention
     type: varchar("type", { length: 16 }).notNull().default("volume"),
     s3Prefix: text("s3_prefix").notNull(),
     size: bigint("size", { mode: "number" }).notNull().default(0),

--- a/turbo/apps/web/src/lib/storage/storage-resolver.ts
+++ b/turbo/apps/web/src/lib/storage/storage-resolver.ts
@@ -10,6 +10,60 @@ import type {
 import { expandVariablesInString } from "@vm0/core";
 
 /**
+ * Fixed mount paths for system volumes
+ */
+const SYSTEM_PROMPT_MOUNT_PATH = "/home/user/.config/claude";
+const SYSTEM_SKILLS_BASE_PATH = "/home/user/.config/claude/skills";
+
+/**
+ * Parse GitHub tree URL to extract skill name (last path segment)
+ * Expected format: https://github.com/{owner}/{repo}/tree/{branch}/{path}
+ */
+function parseGitHubTreeUrl(
+  url: string,
+): { owner: string; repo: string; branch: string; path: string } | null {
+  const regex =
+    /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)$/;
+  const match = url.match(regex);
+  if (!match) return null;
+
+  const [, owner, repo, branch, pathPart] = match;
+  return {
+    owner: owner!,
+    repo: repo!,
+    branch: branch!,
+    path: pathPart!,
+  };
+}
+
+/**
+ * Get storage name for system prompt
+ */
+function getSystemPromptStorageName(agentName: string): string {
+  return `__system-prompt-${agentName}__`;
+}
+
+/**
+ * Get storage name for system skill
+ */
+function getSystemSkillStorageName(
+  owner: string,
+  repo: string,
+  branch: string,
+  path: string,
+): string {
+  return `__system-skill-${owner}/${repo}/${branch}/${path}__`;
+}
+
+/**
+ * Get skill name from path (last segment)
+ */
+function getSkillName(path: string): string {
+  const segments = path.split("/");
+  return segments[segments.length - 1]!;
+}
+
+/**
  * Parse mount path declaration
  * @param declaration - Volume declaration in format "volume-name:/mount/path"
  * @returns Parsed volume name and mount path
@@ -208,6 +262,45 @@ export function resolveVolumes(
           volumeName: "unknown",
           message: error instanceof Error ? error.message : "Unknown error",
           type: "invalid_config",
+        });
+      }
+    }
+  }
+
+  // Process system_prompt if specified
+  if (agent?.system_prompt) {
+    // Get the agent name (key in agents dictionary)
+    const agentName = config.agents ? Object.keys(config.agents)[0] : undefined;
+    if (agentName) {
+      const storageName = getSystemPromptStorageName(agentName);
+      volumes.push({
+        name: `__system-prompt__`,
+        driver: "vas",
+        mountPath: SYSTEM_PROMPT_MOUNT_PATH,
+        vasStorageName: storageName,
+        vasVersion: "latest", // System prompt uses latest version
+      });
+    }
+  }
+
+  // Process system_skills if specified
+  if (agent?.system_skills && agent.system_skills.length > 0) {
+    for (const skillUrl of agent.system_skills) {
+      const parsed = parseGitHubTreeUrl(skillUrl);
+      if (parsed) {
+        const storageName = getSystemSkillStorageName(
+          parsed.owner,
+          parsed.repo,
+          parsed.branch,
+          parsed.path,
+        );
+        const skillName = getSkillName(parsed.path);
+        volumes.push({
+          name: `__system-skill-${skillName}__`,
+          driver: "vas",
+          mountPath: `${SYSTEM_SKILLS_BASE_PATH}/${skillName}`,
+          vasStorageName: storageName,
+          vasVersion: "latest", // System skills use latest version
         });
       }
     }

--- a/turbo/apps/web/src/lib/storage/storage-resolver.ts
+++ b/turbo/apps/web/src/lib/storage/storage-resolver.ts
@@ -40,19 +40,14 @@ function parseGitHubTreeUrl(
  * Get storage name for system prompt
  */
 function getSystemPromptStorageName(agentName: string): string {
-  return `__system-prompt-${agentName}__`;
+  return `system-prompt@${agentName}`;
 }
 
 /**
  * Get storage name for system skill
  */
-function getSystemSkillStorageName(
-  owner: string,
-  repo: string,
-  branch: string,
-  path: string,
-): string {
-  return `__system-skill-${owner}/${repo}/${branch}/${path}__`;
+function getSystemSkillStorageName(fullPath: string): string {
+  return `system-skill@${fullPath}`;
 }
 
 /**
@@ -288,12 +283,8 @@ export function resolveVolumes(
     for (const skillUrl of agent.system_skills) {
       const parsed = parseGitHubTreeUrl(skillUrl);
       if (parsed) {
-        const storageName = getSystemSkillStorageName(
-          parsed.owner,
-          parsed.repo,
-          parsed.branch,
-          parsed.path,
-        );
+        const fullPath = `${parsed.owner}/${parsed.repo}/tree/${parsed.branch}/${parsed.path}`;
+        const storageName = getSystemSkillStorageName(fullPath);
         const skillName = getSkillName(parsed.path);
         volumes.push({
           name: `__system-skill-${skillName}__`,

--- a/turbo/apps/web/src/lib/storage/types.ts
+++ b/turbo/apps/web/src/lib/storage/types.ts
@@ -66,7 +66,9 @@ export interface AgentVolumeConfig {
     string,
     {
       volumes?: string[];
-      working_dir: string;
+      working_dir?: string; // Optional when provider is auto-configured
+      system_prompt?: string; // Path to AGENTS.md file (stored as __system-prompt-{name}__ volume)
+      system_skills?: string[]; // GitHub tree URLs (stored as __system-skill-{path}__ volumes)
     }
   >;
   volumes?: Record<string, VolumeConfig>;

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -17,10 +17,10 @@ export interface VolumeConfig {
  */
 export interface AgentDefinition {
   description?: string;
-  image: string;
+  image?: string; // Optional when provider is specified (auto-resolved from provider)
   provider: string;
   volumes?: string[]; // Format: "volume-key:/mount/path"
-  working_dir: string; // Working directory for artifact mount
+  working_dir?: string; // Optional when provider is specified (defaults to /home/user/workspace)
   environment?: Record<string, string>; // Environment variables using ${{ vars.X }}, ${{ secrets.X }} syntax
   /**
    * Enable network security mode for secrets.
@@ -29,6 +29,8 @@ export interface AgentDefinition {
    * Default: false (plaintext secrets in env vars)
    */
   beta_network_security?: boolean;
+  system_prompt?: string; // Path to AGENTS.md file (stored as __system-prompt-{name}__ volume)
+  system_skills?: string[]; // GitHub tree URLs (stored as __system-skill-{path}__ volumes)
 }
 
 export interface AgentComposeYaml {

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -29,13 +29,14 @@ const volumeConfigSchema = z.object({
 
 /**
  * Agent definition schema
+ * Note: image and working_dir are optional when provider is specified (auto-resolved)
  */
 const agentDefinitionSchema = z.object({
   description: z.string().optional(),
-  image: z.string().min(1, "Image is required"),
+  image: z.string().optional(), // Optional when provider is specified (auto-resolved)
   provider: z.string().min(1, "Provider is required"),
   volumes: z.array(z.string()).optional(),
-  working_dir: z.string().min(1, "Working directory is required"),
+  working_dir: z.string().optional(), // Optional when provider is specified (defaults to /home/user/workspace)
   environment: z.record(z.string(), z.string()).optional(),
   /**
    * Enable network security mode for secrets.
@@ -44,6 +45,8 @@ const agentDefinitionSchema = z.object({
    * Default: false (plaintext secrets in env vars)
    */
   beta_network_security: z.boolean().optional().default(false),
+  system_prompt: z.string().optional(), // Path to AGENTS.md file
+  system_skills: z.array(z.string()).optional(), // GitHub tree URLs for skills
 });
 
 /**


### PR DESCRIPTION
## Summary

- Add `system_prompt` field for local AGENTS.md file (auto-uploaded as volume)
- Add `system_skills` field for GitHub tree URLs (auto-downloaded and uploaded)
- Implement provider auto-configuration (`claude-code` → default image/working_dir)
- Use volume naming convention: `__system-prompt-{name}__` and `__system-skill-{path}__`
- Increase storage name length to 256 chars for skill paths
- Add runtime resolution for system volumes with fixed mount paths

## Example Usage

**Before (verbose):**
```yaml
version: "1.0"
agents:
  my-agent:
    image: vm0-claude-code-dev
    provider: claude-code
    working_dir: /home/user/workspace
    volumes:
      - claude-files:/home/user/.config/claude
volumes:
  claude-files:
    name: claude-files
    version: latest
```

**After (simplified):**
```yaml
version: "1.0"
agents:
  my-agent:
    provider: claude-code
    system_prompt: AGENTS.md
    system_skills:
      - https://github.com/vm0-ai/vm0-skills/tree/main/github-cli
```

## Test plan

- [x] CLI unit tests pass (254 tests)
- [x] Lint passes
- [x] Format passes
- [ ] Manual test: compose with system_prompt
- [ ] Manual test: compose with system_skills

Resolves #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)