### PR TITLE
fix(e2b): remove blocking telemetry upload calls during startup

### DIFF
--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -68,14 +68,10 @@ def main():
     else:
         log_error("API connectivity test: FAILED - webhooks may not work")
 
-    # Force immediate telemetry upload so startup logs are visible even if script crashes
-    log_info("Forcing immediate telemetry upload for startup diagnostics...")
+    # Skip startup telemetry upload - it seems to cause hanging
+    # The telemetry upload thread will handle uploads later
     import sys
-    sys.stderr.flush()  # Ensure logs are written before upload
-    from upload_telemetry import upload_telemetry
-    upload_result = upload_telemetry()
-    log_info(f"Startup telemetry upload: {'SUCCESS' if upload_result else 'FAILED'}")
-    sys.stderr.flush()  # Flush again after result
+    log_info("Skipping startup telemetry upload (will be handled by background thread)")
 
     # Log proxy mode status
     # NOTE: Proxy setup is done as root by e2b-service.ts BEFORE this script starts
@@ -101,10 +97,9 @@ def main():
     start_telemetry_upload(shutdown_event)
     log_info("Telemetry upload thread started")
 
-    # Second telemetry upload to capture all startup logs
-    log_info("Uploading startup completion logs...")
+    # Flush stderr to ensure all startup logs are written
+    # Telemetry upload thread will handle sending them
     sys.stderr.flush()
-    upload_telemetry()
     log_info("Startup phase complete, proceeding to Claude execution")
 
     # Change to working directory

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -70,30 +70,42 @@ def main():
 
     # Force immediate telemetry upload so startup logs are visible even if script crashes
     log_info("Forcing immediate telemetry upload for startup diagnostics...")
+    import sys
+    sys.stderr.flush()  # Ensure logs are written before upload
     from upload_telemetry import upload_telemetry
-    if upload_telemetry():
-        log_info("Startup telemetry upload: SUCCESS")
-    else:
-        log_warn("Startup telemetry upload: FAILED")
+    upload_result = upload_telemetry()
+    log_info(f"Startup telemetry upload: {'SUCCESS' if upload_result else 'FAILED'}")
+    sys.stderr.flush()  # Flush again after result
 
     # Log proxy mode status
     # NOTE: Proxy setup is done as root by e2b-service.ts BEFORE this script starts
     # This ensures mitmproxy is running and nftables rules are in place
     if PROXY_ENABLED:
         log_info("Network security mode enabled (proxy configured by e2b-service)")
+    else:
+        log_info("Network security mode disabled (direct connections)")
 
     # Start heartbeat thread
+    log_info("Starting heartbeat thread...")
     heartbeat_thread = threading.Thread(target=heartbeat_loop, daemon=True)
     heartbeat_thread.start()
     log_info("Heartbeat thread started")
 
     # Start metrics collector thread
+    log_info("Starting metrics collector thread...")
     start_metrics_collector(shutdown_event)
     log_info("Metrics collector thread started")
 
     # Start telemetry upload thread
+    log_info("Starting telemetry upload thread...")
     start_telemetry_upload(shutdown_event)
     log_info("Telemetry upload thread started")
+
+    # Second telemetry upload to capture all startup logs
+    log_info("Uploading startup completion logs...")
+    sys.stderr.flush()
+    upload_telemetry()
+    log_info("Startup phase complete, proceeding to Claude execution")
 
     # Change to working directory
     try:


### PR DESCRIPTION
## Summary
Remove blocking `upload_telemetry()` calls that were causing agent startup to hang.

## Root Cause
The synchronous `upload_telemetry()` calls were blocking/hanging during agent startup, preventing the script from progressing to Claude execution. Production logs showed the script stopping at "Forcing immediate telemetry upload..." and never proceeding further.

## Fix
- Remove the initial `upload_telemetry()` call after API connectivity test
- Remove the second `upload_telemetry()` call after starting background threads
- Rely on the background telemetry upload thread to handle log uploads asynchronously

## Test plan
- [ ] Deploy to production
- [ ] Run a test agent with `vm0 run`
- [ ] Verify the run progresses past startup and executes Claude
- [ ] Check `vm0 logs --system` to confirm logs are being uploaded by background thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)