### PR TITLE
fix(e2b): ensure logs are written to file before telemetry upload

### DIFF
--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -617,7 +617,8 @@ export class E2BService {
     // When network security is enabled, proxy setup is done as root before this.
     // mitmproxy also runs as root, and nftables skips root's traffic (meta skuid 0)
     // to avoid redirect loops.
-    const cmd = `nohup python3 ${SCRIPT_PATHS.runAgent} > /tmp/vm0-main-${runId}.log 2>&1 &`;
+    // Use python3 -u for unbuffered stdout/stderr to ensure logs are written immediately
+    const cmd = `nohup python3 -u ${SCRIPT_PATHS.runAgent} > /tmp/vm0-main-${runId}.log 2>&1 &`;
     await sandbox.commands.run(cmd);
 
     log.debug(`Agent execution started in background for run ${runId}`);


### PR DESCRIPTION
## Summary
Add detailed logging and synchronous telemetry uploads to debug the agent startup hang issue.

## Changes
1. **Use `python3 -u`** - Unbuffered output ensures logs are written immediately
2. **Add sync telemetry upload after threads start** - Ensures startup logs are visible
3. **Add another sync upload before Claude execution** - Shows everything up to Claude
4. **Add `sys.stderr.flush()` at each step** - Guarantees log visibility

## Purpose
The previous fix removed sync telemetry upload, which prevented seeing startup logs. 
According to original production logs, we could see "Forcing immediate telemetry upload..." 
which means the upload was working. The problem might be AFTER the upload.

With these changes, we can see exactly where the agent stops:
- If we see "Startup logs upload: SUCCESS" but not "Changing to working directory" → problem is between them
- If we see "Pre-Claude logs uploaded" but not "Starting Claude Code execution" → problem is in Claude setup
- etc.

## Related Issues
- Investigating #520

## Test plan
- [ ] Deploy to production
- [ ] Run `vm0 run` with a test agent
- [ ] Check `vm0 logs --system` to see exactly where execution stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)