### PR TITLE
fix(e2b): make telemetry uploads non-blocking to agent startup

### DIFF
--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -92,17 +92,10 @@ def main():
     start_telemetry_upload(shutdown_event)
     log_info("Telemetry upload thread started")
 
-    # Synchronous telemetry upload to ensure startup logs are visible
-    # This is critical for debugging - without this, we can't see what happens
+    # Telemetry uploads are now handled by the background thread
+    # We don't block startup waiting for telemetry - if it's slow, agent should still start
     import sys
     sys.stderr.flush()
-    log_info("Uploading startup logs...")
-    sys.stderr.flush()
-    from upload_telemetry import upload_telemetry
-    upload_result = upload_telemetry()
-    log_info(f"Startup logs upload: {'SUCCESS' if upload_result else 'FAILED'}")
-    sys.stderr.flush()
-
     log_info("Startup phase complete, proceeding to Claude execution")
     sys.stderr.flush()
 
@@ -123,13 +116,6 @@ def main():
     claude_config_dir = f"{home_dir}/.config/claude"
     os.environ["CLAUDE_CONFIG_DIR"] = claude_config_dir
     log_info(f"Claude config directory: {claude_config_dir}")
-    sys.stderr.flush()
-
-    # Upload logs before Claude execution so we can see everything up to this point
-    log_info("Uploading pre-Claude logs...")
-    sys.stderr.flush()
-    upload_telemetry()
-    log_info("Pre-Claude logs uploaded")
     sys.stderr.flush()
 
     # Execute Claude Code with JSONL output


### PR DESCRIPTION
## Summary

Fix production hang where slow telemetry response blocked agent startup.

## Root Cause

The main thread had synchronous `upload_telemetry()` calls that blocked startup if the server was slow to respond (30s timeout). Even though the server received and stored the data, the response was slow, causing the agent to hang.

## Fix

- Remove blocking `upload_telemetry()` calls from main thread
- Background thread now handles all telemetry uploads
- Background thread uploads immediately on start (so startup logs are visible)
- Then waits for interval between subsequent uploads

This way, telemetry upload happens in the background and doesn't block agent startup.

## Testing

- Local testing with dev-tunnel passes
- Agent starts immediately without waiting for telemetry response

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)