### PR TITLE
fix(e2b): revert telemetry debugging changes that caused startup hang

### DIFF
--- a/turbo/apps/web/src/lib/e2b/scripts/lib/upload_telemetry.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/upload_telemetry.py.ts
@@ -125,33 +125,18 @@ def upload_telemetry() -> bool:
     Returns:
         True if upload succeeded or no data to upload, False on failure
     """
-    import sys
-
-    log_info("upload_telemetry: reading log file...")
-    sys.stderr.flush()
-
     # Read new system log content
     system_log, log_pos = read_file_from_position(SYSTEM_LOG_FILE, TELEMETRY_LOG_POS_FILE)
-
-    log_info(f"upload_telemetry: log file read, {len(system_log)} bytes")
-    sys.stderr.flush()
 
     # Read new metrics
     metrics, metrics_pos = read_metrics_from_position(TELEMETRY_METRICS_POS_FILE)
 
-    log_info(f"upload_telemetry: metrics read, {len(metrics)} entries")
-    sys.stderr.flush()
-
     # Read new network logs
     network_logs, network_pos = read_network_logs_from_position(TELEMETRY_NETWORK_POS_FILE)
 
-    log_info(f"upload_telemetry: network logs read, {len(network_logs)} entries")
-    sys.stderr.flush()
-
     # Skip if nothing new
     if not system_log and not metrics and not network_logs:
-        log_info("upload_telemetry: no new data to upload")
-        sys.stderr.flush()
+        log_debug("No new telemetry data to upload")
         return True
 
     # Upload to API
@@ -162,47 +147,36 @@ def upload_telemetry() -> bool:
         "networkLogs": network_logs
     }
 
-    log_info(f"upload_telemetry: calling http_post_json to {TELEMETRY_URL}...")
-    sys.stderr.flush()
+    log_debug(f"Uploading telemetry: {len(system_log)} bytes log, {len(metrics)} metrics, {len(network_logs)} network logs")
 
     result = http_post_json(TELEMETRY_URL, payload, max_retries=1)
-
-    log_info(f"upload_telemetry: http_post_json returned: {result is not None}")
-    sys.stderr.flush()
 
     if result:
         # Save positions only on successful upload
         save_position(TELEMETRY_LOG_POS_FILE, log_pos)
         save_position(TELEMETRY_METRICS_POS_FILE, metrics_pos)
         save_position(TELEMETRY_NETWORK_POS_FILE, network_pos)
-        log_info(f"upload_telemetry: SUCCESS, id={result.get('id', 'unknown')}")
-        sys.stderr.flush()
+        log_debug(f"Telemetry uploaded successfully: {result.get('id', 'unknown')}")
         return True
     else:
-        log_warn("upload_telemetry: FAILED (will retry next interval)")
-        sys.stderr.flush()
+        log_warn("Failed to upload telemetry (will retry next interval)")
         return False
 
 
 def telemetry_upload_loop(shutdown_event: threading.Event) -> None:
     """
     Background loop that uploads telemetry every TELEMETRY_INTERVAL seconds.
-    NOTE: Waits for interval FIRST to avoid racing with main thread's startup upload.
     """
     log_info(f"Telemetry upload started (interval: {TELEMETRY_INTERVAL}s)")
 
     while not shutdown_event.is_set():
-        # Wait for interval FIRST (avoids concurrent requests with main thread startup upload)
-        shutdown_event.wait(TELEMETRY_INTERVAL)
-
-        # Check if shutdown was triggered during wait
-        if shutdown_event.is_set():
-            break
-
         try:
             upload_telemetry()
         except Exception as e:
             log_error(f"Telemetry upload error: {e}")
+
+        # Wait for interval or shutdown
+        shutdown_event.wait(TELEMETRY_INTERVAL)
 
     log_info("Telemetry upload stopped")
 

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -53,66 +53,33 @@ def heartbeat_loop():
 
 def main():
     """Main entry point for agent execution."""
-    # Validate configuration (this logs all env vars to stderr)
+    # Validate configuration
     validate_config()
 
     log_info(f"Working directory: {WORKING_DIR}")
-
-    # Test API connectivity immediately after startup
-    # This helps diagnose connection issues early
-    log_info(f"Testing API connectivity to heartbeat endpoint...")
-    from common import HEARTBEAT_URL
-    test_result = http_post_json(HEARTBEAT_URL, {"runId": RUN_ID})
-    if test_result:
-        log_info("API connectivity test: SUCCESS")
-    else:
-        log_error("API connectivity test: FAILED - webhooks may not work")
 
     # Log proxy mode status
     # NOTE: Proxy setup is done as root by e2b-service.ts BEFORE this script starts
     # This ensures mitmproxy is running and nftables rules are in place
     if PROXY_ENABLED:
         log_info("Network security mode enabled (proxy configured by e2b-service)")
-    else:
-        log_info("Network security mode disabled (direct connections)")
 
     # Start heartbeat thread
-    log_info("Starting heartbeat thread...")
     heartbeat_thread = threading.Thread(target=heartbeat_loop, daemon=True)
     heartbeat_thread.start()
     log_info("Heartbeat thread started")
 
     # Start metrics collector thread
-    log_info("Starting metrics collector thread...")
     start_metrics_collector(shutdown_event)
     log_info("Metrics collector thread started")
 
     # Start telemetry upload thread
-    log_info("Starting telemetry upload thread...")
     start_telemetry_upload(shutdown_event)
     log_info("Telemetry upload thread started")
 
-    # Synchronous telemetry upload to ensure startup logs are visible
-    # This is critical for debugging - without this, we can't see what happens
-    import sys
-    sys.stderr.flush()
-    log_info("Uploading startup logs...")
-    sys.stderr.flush()
-    from upload_telemetry import upload_telemetry
-    upload_result = upload_telemetry()
-    log_info(f"Startup logs upload: {'SUCCESS' if upload_result else 'FAILED'}")
-    sys.stderr.flush()
-
-    log_info("Startup phase complete, proceeding to Claude execution")
-    sys.stderr.flush()
-
     # Change to working directory
-    log_info(f"Changing to working directory: {WORKING_DIR}")
-    sys.stderr.flush()
     try:
         os.chdir(WORKING_DIR)
-        log_info("Working directory changed successfully")
-        sys.stderr.flush()
     except OSError as e:
         log_error(f"Failed to change to working directory: {WORKING_DIR} - {e}")
         sys.exit(1)
@@ -123,19 +90,10 @@ def main():
     claude_config_dir = f"{home_dir}/.config/claude"
     os.environ["CLAUDE_CONFIG_DIR"] = claude_config_dir
     log_info(f"Claude config directory: {claude_config_dir}")
-    sys.stderr.flush()
-
-    # Upload logs before Claude execution so we can see everything up to this point
-    log_info("Uploading pre-Claude logs...")
-    sys.stderr.flush()
-    upload_telemetry()
-    log_info("Pre-Claude logs uploaded")
-    sys.stderr.flush()
 
     # Execute Claude Code with JSONL output
     log_info("Starting Claude Code execution...")
     log_info(f"Prompt: {PROMPT}")
-    sys.stderr.flush()
 
     # Build Claude command - unified for both new and resume sessions
     claude_args = [


### PR DESCRIPTION
## Summary

- Reverts telemetry changes from commits #524-#529 that caused "run started" hang in production
- Restores original telemetry implementation from #510 which worked correctly

## Root Cause

The debugging changes introduced:
1. **Synchronous `upload_telemetry()` calls in main thread** - blocked startup while waiting for HTTP response
2. **Changed telemetry loop to wait-first** - 30s delay before first upload meant logs weren't visible if something went wrong early
3. **Excessive `log_info` and `sys.stderr.flush()` calls** - unnecessary overhead

## Changes

| File | Change |
|------|--------|
| `upload_telemetry.py.ts` | Removed debugging `log_info` calls, restored upload-first loop order |
| `run-agent.py.ts` | Removed sync telemetry uploads, API connectivity test, excessive flushes |

## Test plan

- [x] Type check passes
- [x] Lint passes  
- [x] E2B service unit tests pass (13/13)
- [ ] Manual test: `vm0 cook` should not hang on "run started"

🤖 Generated with [Claude Code](https://claude.com/claude-code)