### PR TITLE
ci: enable debug logging for production deployment

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -104,6 +104,7 @@ jobs:
             S3_USER_STORAGES_NAME=${{ secrets.S3_USER_STORAGES_NAME }}
             SECRETS_ENCRYPTION_KEY=${{ secrets.SECRETS_ENCRYPTION_KEY }}
             CRON_SECRET=${{ secrets.CRON_SECRET }}
+            DEBUG=*
 
   # Deploy docs app to production
   deploy-docs-production:


### PR DESCRIPTION
## Summary

Add `DEBUG=*` environment variable to production web deployment in `release-please.yml`.

## Why

- Production deployment was missing `DEBUG=*` (preview had it)
- Without debug logs, we can't see what's happening when sandbox startup hangs
- No WARN/ERROR logs means the code path isn't reaching error handlers

## Changes

```diff
+ DEBUG=*
```

Added to production `environment-variables` in `deploy-web-production` job.

## Note

This needs to trigger a new release to take effect. After merging, we may need to manually trigger the release workflow or wait for the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)