### PR TITLE
fix(sandbox): create working directory if it doesn't exist on agent startup

### DIFF
--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -77,11 +77,13 @@ def main():
     start_telemetry_upload(shutdown_event)
     log_info("Telemetry upload thread started")
 
-    # Change to working directory
+    # Create and change to working directory
+    # Directory may not exist if no artifact/storage was downloaded (e.g., first run)
     try:
+        os.makedirs(WORKING_DIR, exist_ok=True)
         os.chdir(WORKING_DIR)
     except OSError as e:
-        log_error(f"Failed to change to working directory: {WORKING_DIR} - {e}")
+        log_error(f"Failed to create/change to working directory: {WORKING_DIR} - {e}")
         sys.exit(1)
 
     # Set Claude config directory to ensure consistent session history location


### PR DESCRIPTION
## Summary
- Fixes agent startup failure when working directory doesn't exist
- Adds `os.makedirs(WORKING_DIR, exist_ok=True)` before `os.chdir()` in the agent startup script
- This ensures the working directory is created on first run when no artifact/storage has been downloaded yet

## Problem
The agent was failing with error:
```
[ERROR] [sandbox:run-agent] Failed to change to working directory: /home/user/workspace - [Errno 2] No such file or directory
```

This happened because the download script only creates directories when there's an archive to extract. For first-time runs of new agents with no prior artifact versions, the working directory was never created.

## Test plan
- [x] Lint passes
- [x] Type check passes
- [x] All 718 tests pass
- [ ] Manual test: Run a new agent with no prior artifact versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)