### PR TITLE
fix(sandbox): ensure cleanup runs on early errors in run-agent.py

### DIFF
--- a/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
@@ -8,7 +8,6 @@ Common environment variables and utilities for VM0 agent scripts.
 This module should be imported by other scripts.
 """
 import os
-import sys
 
 # Environment variables
 RUN_ID = os.environ.get("VM0_RUN_ID", "")
@@ -79,9 +78,12 @@ TELEMETRY_NETWORK_POS_FILE = f"/tmp/vm0-telemetry-network-pos-{RUN_ID}.txt"
 METRICS_INTERVAL = 5  # seconds
 
 def validate_config() -> bool:
-    """Validate required configuration. Returns True if valid, exits if not."""
+    """
+    Validate required configuration.
+    Raises ValueError if configuration is invalid.
+    Returns True if valid.
+    """
     if not WORKING_DIR:
-        print("[ERROR] VM0_WORKING_DIR is required but not set", file=sys.stderr)
-        sys.exit(1)
+        raise ValueError("VM0_WORKING_DIR is required but not set")
     return True
 `;


### PR DESCRIPTION
## Summary

Fixes the issue where early errors in the sandbox agent runner (like missing working directory) would cause the sandbox to exit without notifying the server, leaving runs stuck in 'running' status.

**Problem:**
- When `os.chdir(WORKING_DIR)` failed, script called `sys.exit(1)` directly
- No `final_telemetry_upload()` was called - logs were lost
- No `complete` API call was made - server never knew the run failed
- CLI hung indefinitely polling for status that never changed
- User had to wait 2+ minutes for cron cleanup to mark run as "timeout"

**Solution:**
Refactor to use global try/except/finally pattern:
- Extract main logic into `_run()` function that raises exceptions instead of calling `sys.exit()`
- Extract cleanup logic into `_cleanup()` function
- `main()` wraps with try/except/finally to guarantee cleanup runs
- Single `sys.exit()` call at the very end of `if __name__ == "__main__"`

## Changes

- `run-agent.py.ts`: Restructure into `main()`, `_run()`, `_cleanup()` functions
- `common.py.ts`: `validate_config()` now raises `ValueError` instead of `sys.exit(1)`

## Test plan

- [x] All existing tests pass
- [ ] Manual test: Run with non-existent working directory → CLI should show error immediately
- [ ] Manual test: Run with missing config → CLI should show error immediately
- [ ] Manual test: Normal execution → should complete successfully

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)