### PR TITLE
feat(storage): optimize empty storage handling by skipping tar upload/download

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/storages/incremental/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/incremental/route.ts
@@ -225,6 +225,13 @@ export async function POST(request: NextRequest) {
     const newFileEntries: FileEntry[] = [];
     let bytesUploaded = 0;
 
+    // File is optional - delete-only changes don't need a file upload
+    if (!file && (changes.added.length > 0 || changes.modified.length > 0)) {
+      log.warn(
+        "No file provided but there are added/modified files - treating as delete-only",
+      );
+    }
+
     if (file && (changes.added.length > 0 || changes.modified.length > 0)) {
       // Create temp directory for extraction
       tempDir = path.join(os.tmpdir(), `vm0-storage-incremental-${Date.now()}`);


### PR DESCRIPTION
## Summary

- Skip tar.gz creation when storage has no files (Python scripts)
- Make file upload optional in storage webhooks (server)
- Change excluded directory from `.vas` to `.vm0` (the actual directory name used by CLI)
- Handle delete-only incremental changes without file upload

## Changes

### Python Scripts (sandbox)

**`vas_snapshot.py.ts`:**
- Check for files before creating tar.gz
- If no files exist (excluding `.git` and `.vm0`), call webhook without file attachment
- Log: "No files to snapshot for '{storage_name}', creating empty version"

**`incremental.py.ts`:**
- Change `.vas` exclusion to `.vm0`
- Return `None` from `create_incremental_tar` when no files to add
- Handle delete-only changes by uploading without file attachment

### Server Webhooks

**`storages/route.ts`:**
- Make `file` parameter optional
- Handle missing file by creating empty storage version (fileCount=0, size=0)

**`storages/incremental/route.ts`:**
- Add warning log when no file provided but there are added/modified changes
- Already handles delete-only changes correctly

## Benefits

- No network transfer for empty archives
- Simpler code path (no tar format compatibility issues)
- More explicit intent ("empty" vs "empty archive")
- Fixes incorrect `.vas` reference to use actual `.vm0` directory

## Test plan

- [x] All existing tests pass
- [x] TypeScript type check passes
- [x] Lint check passes
- [ ] Manual testing with empty storage upload
- [ ] Manual testing with delete-only incremental upload

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)