### PR TITLE
feat: add cookbooks page to sitemap

### DIFF
--- a/turbo/apps/web/app/sitemap.ts
+++ b/turbo/apps/web/app/sitemap.ts
@@ -11,6 +11,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1,
     },
     {
+      url: `${baseUrl}/cookbooks`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
       url: `${baseUrl}/sign-up`,
       lastModified: new Date(),
       changeFrequency: "monthly",


### PR DESCRIPTION
## Summary

Add cookbooks page to sitemap.xml for improved SEO.

## Changes

- Add `/cookbooks` to sitemap with priority 0.9 and weekly update frequency

The cookbooks page features 10 agent examples (101-intro through 110-startup-portrait) and is an important content page that should be indexed by search engines.