### PR TITLE
fix(cli): fix error message display in artifact/volume pull commands

### DIFF
--- a/turbo/apps/cli/src/commands/artifact/pull.ts
+++ b/turbo/apps/cli/src/commands/artifact/pull.ts
@@ -5,7 +5,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as tar from "tar";
 import { readStorageConfig } from "../../lib/storage-utils";
-import { apiClient } from "../../lib/api-client";
+import { apiClient, type ApiError } from "../../lib/api-client";
 import { listTarFiles, removeExtraFiles } from "../../lib/file-utils";
 
 /**
@@ -77,8 +77,8 @@ export const pullCommand = new Command()
             chalk.gray("  Or push the artifact first with: vm0 artifact push"),
           );
         } else {
-          const error = (await response.json()) as { error: string };
-          throw new Error(error.error || "Download failed");
+          const error = (await response.json()) as ApiError;
+          throw new Error(error.error?.message || "Download failed");
         }
         process.exit(1);
       }

--- a/turbo/apps/cli/src/commands/volume/pull.ts
+++ b/turbo/apps/cli/src/commands/volume/pull.ts
@@ -5,7 +5,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as tar from "tar";
 import { readStorageConfig } from "../../lib/storage-utils";
-import { apiClient } from "../../lib/api-client";
+import { apiClient, type ApiError } from "../../lib/api-client";
 import { listTarFiles, removeExtraFiles } from "../../lib/file-utils";
 
 /**
@@ -65,8 +65,8 @@ export const pullCommand = new Command()
             chalk.gray("  Or push the volume first with: vm0 volume push"),
           );
         } else {
-          const error = (await response.json()) as { error: string };
-          throw new Error(error.error || "Download failed");
+          const error = (await response.json()) as ApiError;
+          throw new Error(error.error?.message || "Download failed");
         }
         process.exit(1);
       }


### PR DESCRIPTION
## Summary
- Fixed error message display in `artifact/pull.ts` and `volume/pull.ts` where `[object Object]` was shown instead of actual error messages

## Root Cause
The API returns error responses in the format `{ error: { message, code } }`, but the pull commands were expecting `{ error: string }`. When `error.error` is an object, passing it to `new Error()` coerces it to `[object Object]`.

## Changes
- Updated both files to use the existing `ApiError` type from `api-client.ts`
- Changed error extraction from `error.error` to `error.error?.message`

## Test Plan
- [x] Type checks pass (no new errors introduced)
- [x] Lint passes
- [ ] Manual testing: run `vm0 artifact pull` with an invalid artifact name to verify error message is displayed correctly

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)