### PR TITLE
fix(storage): reorder s3 upload before database write for transactional consistency

### DIFF
--- a/turbo/apps/web/app/api/storages/route.ts
+++ b/turbo/apps/web/app/api/storages/route.ts
@@ -269,9 +269,34 @@ export async function POST(request: NextRequest) {
         log.debug("Force upload enabled, skipping deduplication check");
       }
 
-      // Create new version record with content hash as ID
-      // Use onConflictDoNothing to handle force upload case where version already exists
+      // Upload to S3 first, then write database
+      // This ensures database records only exist when S3 files are present
       const s3Key = `${userId}/${storageType}/${storageName}/${contentHash}`;
+
+      // 1. Upload blobs with deduplication (S3)
+      const blobResult = await blobService.uploadBlobs(fileEntries);
+      log.debug(
+        `Blob upload: ${blobResult.newBlobsCount} new, ${blobResult.existingBlobsCount} existing`,
+      );
+
+      // 2. Upload manifest and archive.tar.gz (S3)
+      const bucketName = env().S3_USER_STORAGES_NAME;
+      if (!bucketName) {
+        throw new Error(
+          "S3_USER_STORAGES_NAME environment variable is not set",
+        );
+      }
+      const s3Uri = `s3://${bucketName}/${s3Key}`;
+      log.debug(`Uploading manifest and archive to ${s3Uri}...`);
+      await uploadStorageVersionArchive(
+        s3Uri,
+        contentHash,
+        fileEntries,
+        blobResult.hashes,
+      );
+
+      // 3. Create database record (only after S3 upload succeeds)
+      // Use onConflictDoNothing to handle force upload case where version already exists
       const createdVersions = await tx
         .insert(storageVersions)
         .values({
@@ -288,7 +313,6 @@ export async function POST(request: NextRequest) {
 
       const version = createdVersions[0];
       const versionId = version?.id ?? contentHash;
-      const versionS3Key = version?.s3Key ?? s3Key;
 
       if (version) {
         log.debug(`Created version: ${version.id}`);
@@ -296,29 +320,7 @@ export async function POST(request: NextRequest) {
         log.debug(`Version ${contentHash} already exists, recreating archive`);
       }
 
-      // Upload blobs with deduplication
-      const blobResult = await blobService.uploadBlobs(fileEntries);
-      log.debug(
-        `Blob upload: ${blobResult.newBlobsCount} new, ${blobResult.existingBlobsCount} existing`,
-      );
-
-      // Upload manifest and archive.tar.gz
-      const bucketName = env().S3_USER_STORAGES_NAME;
-      if (!bucketName) {
-        throw new Error(
-          "S3_USER_STORAGES_NAME environment variable is not set",
-        );
-      }
-      const s3Uri = `s3://${bucketName}/${versionS3Key}`;
-      log.debug(`Uploading manifest and archive to ${s3Uri}...`);
-      await uploadStorageVersionArchive(
-        s3Uri,
-        contentHash,
-        fileEntries,
-        blobResult.hashes,
-      );
-
-      // Update storage's HEAD pointer and metadata within transaction
+      // 4. Update storage's HEAD pointer and metadata within transaction
       await tx
         .update(storages)
         .set({


### PR DESCRIPTION
## Summary

Reorders storage upload operations to ensure transactional consistency: S3 upload completes before database records are created.

## Problem

When uploading storage versions, the previous order was:
1. Create database record
2. Upload to S3

If S3 upload failed (timeout, network error), the database record would exist but the S3 archive wouldn't. Subsequent uploads would hit deduplication, find the existing record, and skip uploading - leaving the S3 file permanently missing.

## Solution

Reorder operations to upload S3 first:
1. Upload blobs to S3
2. Upload manifest and archive.tar.gz to S3
3. Create database record (only after S3 succeeds)

**Failure scenarios:**
- S3 fails → No database record → Next retry works normally
- Database fails after S3 → Orphan S3 files → Can be overwritten on retry, harmless

## Files Changed

- `apps/web/app/api/webhooks/agent/storages/route.ts` - Sandbox webhook
- `apps/web/app/api/webhooks/agent/storages/incremental/route.ts` - Incremental webhook
- `apps/web/app/api/storages/route.ts` - CLI upload

## Test Plan

- [ ] Run `vm0 cook` and verify artifact pull succeeds
- [ ] Verify deduplication still works for repeated uploads
- [ ] Simulate S3 timeout and verify no orphan database records

Fixes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)