### PR TITLE
feat(e2e): add automatic system logs on test failure

### DIFF
--- a/e2e/helpers/setup.bash
+++ b/e2e/helpers/setup.bash
@@ -9,3 +9,14 @@ load "${TEST_ROOT}/test/libs/bats-assert/load"
 
 # Path to the CLI
 export CLI_COMMAND="vm0"
+
+# Show system logs when test fails
+# This hook is called by BATS before teardown() when a test fails
+bats::on_failure() {
+    local run_id
+    run_id=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
+    if [[ -n "$run_id" ]]; then
+        echo "# === System logs for failed run ($run_id) ==="
+        $CLI_COMMAND logs "$run_id" --system
+    fi
+}

--- a/e2e/helpers/setup.bash
+++ b/e2e/helpers/setup.bash
@@ -14,7 +14,7 @@ export CLI_COMMAND="vm0"
 # This hook is called by BATS before teardown() when a test fails
 bats::on_failure() {
     local run_id
-    run_id=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
+    run_id=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | tail -1)
     if [[ -n "$run_id" ]]; then
         echo "# === System logs for failed run ($run_id) ==="
         $CLI_COMMAND logs "$run_id" --system


### PR DESCRIPTION
## Summary
- Add `bats::on_failure` hook to `e2e/helpers/setup.bash`
- Automatically extract Run ID from test output and display system logs when tests fail
- Improves debugging for CI failures

## Test plan
- [x] Smoke tests pass (no regression for passing tests)
- [x] Verified hook doesn't output anything when no Run ID present
- [ ] CI pipeline passes

Closes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)