### PR TITLE
feat(cli): auto-generate .env file for missing variables in vm0 cook

### DIFF
--- a/e2e/tests/02-commands/t13-vm0-cook.bats
+++ b/e2e/tests/02-commands/t13-vm0-cook.bats
@@ -97,3 +97,115 @@ EOF
     assert_failure
     assert_output --partial "Config file not found"
 }
+
+@test "cook command detects missing environment variables and creates .env placeholders" {
+    cd "$TEST_DIR"
+
+    echo "# Step 1: Create vm0.yaml with variable references..."
+    cat > vm0.yaml <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "E2E test agent for env check"
+    provider: claude-code
+    image: vm0-claude-code-dev
+    working_dir: /home/user/workspace
+    environment:
+      API_KEY: \${{ vars.E2E_TEST_API_KEY }}
+      SECRET_TOKEN: \${{ secrets.E2E_TEST_SECRET }}
+EOF
+
+    echo "# Step 2: Ensure no .env file exists..."
+    rm -f .env
+
+    echo "# Step 3: Run cook (should fail due to missing vars)..."
+    run $CLI_COMMAND cook
+    assert_failure
+
+    echo "# Step 4: Verify error message mentions missing variables..."
+    assert_output --partial "Missing environment variables"
+    assert_output --partial "E2E_TEST_API_KEY"
+    assert_output --partial "E2E_TEST_SECRET"
+
+    echo "# Step 5: Verify .env file was created with placeholders..."
+    [ -f ".env" ]
+
+    echo "# Step 6: Verify .env content has correct format..."
+    grep -q "^E2E_TEST_API_KEY=$" .env
+    grep -q "^E2E_TEST_SECRET=$" .env
+}
+
+@test "cook command succeeds when variables are set in .env file" {
+    # Skip if not authenticated (requires VM0_TOKEN or logged in)
+    if $CLI_COMMAND auth status 2>&1 | grep -q "Not authenticated"; then
+        skip "Not authenticated - run 'vm0 auth login' first"
+    fi
+
+    cd "$TEST_DIR"
+
+    echo "# Step 1: Create vm0.yaml with variable references..."
+    cat > vm0.yaml <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "E2E test agent for env check"
+    provider: claude-code
+    image: vm0-claude-code-dev
+    working_dir: /home/user/workspace
+    environment:
+      API_KEY: \${{ vars.E2E_TEST_VAR }}
+EOF
+
+    echo "# Step 2: Create .env file with values..."
+    cat > .env <<EOF
+E2E_TEST_VAR=test-value-123
+EOF
+
+    echo "# Step 3: Run cook (should succeed)..."
+    run $CLI_COMMAND cook
+    assert_success
+
+    echo "# Step 4: Verify normal cook output..."
+    assert_output --partial "Config validated"
+    assert_output --partial "Compose uploaded"
+}
+
+@test "cook command appends to existing .env file without overwriting" {
+    cd "$TEST_DIR"
+
+    echo "# Step 1: Create vm0.yaml with variable references..."
+    cat > vm0.yaml <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "E2E test agent for env check"
+    provider: claude-code
+    image: vm0-claude-code-dev
+    working_dir: /home/user/workspace
+    environment:
+      EXISTING_VAR: \${{ vars.EXISTING_VAR }}
+      NEW_VAR: \${{ vars.NEW_VAR }}
+EOF
+
+    echo "# Step 2: Create .env file with only one variable..."
+    cat > .env <<EOF
+EXISTING_VAR=existing-value
+EOF
+
+    echo "# Step 3: Run cook (should fail due to missing NEW_VAR)..."
+    run $CLI_COMMAND cook
+    assert_failure
+
+    echo "# Step 4: Verify error message mentions only the missing variable..."
+    assert_output --partial "Missing environment variables"
+    assert_output --partial "NEW_VAR"
+
+    echo "# Step 5: Verify .env file still has existing content..."
+    grep -q "^EXISTING_VAR=existing-value$" .env
+
+    echo "# Step 6: Verify .env file has new placeholder appended..."
+    grep -q "^NEW_VAR=$" .env
+}

--- a/turbo/apps/cli/src/commands/__tests__/cook.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/cook.test.ts
@@ -44,9 +44,21 @@ describe("cook command - environment variable check", () => {
   describe("extractRequiredVarNames", () => {
     it("should extract variable names from vars and secrets references", () => {
       const mockRefs = [
-        { source: "vars" as const, name: TEST_VAR_1, fullMatch: `\${{ vars.${TEST_VAR_1} }}` },
-        { source: "secrets" as const, name: TEST_VAR_2, fullMatch: `\${{ secrets.${TEST_VAR_2} }}` },
-        { source: "vars" as const, name: TEST_VAR_3, fullMatch: `\${{ vars.${TEST_VAR_3} }}` },
+        {
+          source: "vars" as const,
+          name: TEST_VAR_1,
+          fullMatch: `\${{ vars.${TEST_VAR_1} }}`,
+        },
+        {
+          source: "secrets" as const,
+          name: TEST_VAR_2,
+          fullMatch: `\${{ secrets.${TEST_VAR_2} }}`,
+        },
+        {
+          source: "vars" as const,
+          name: TEST_VAR_3,
+          fullMatch: `\${{ vars.${TEST_VAR_3} }}`,
+        },
       ];
 
       vi.mocked(core.extractVariableReferences).mockReturnValue(mockRefs);
@@ -57,7 +69,9 @@ describe("cook command - environment variable check", () => {
       });
 
       // The actual function is internal, so we verify the logic through integration
-      const result = core.groupVariablesBySource(core.extractVariableReferences({}));
+      const result = core.groupVariablesBySource(
+        core.extractVariableReferences({}),
+      );
       const varNames = result.vars.map((r) => r.name);
       const secretNames = result.secrets.map((r) => r.name);
       const combined = [...new Set([...varNames, ...secretNames])];
@@ -154,7 +168,10 @@ describe("cook command - environment variable check", () => {
 
       await fs.writeFile(".env", `${placeholders}\n`);
 
-      expect(mockWriteFile).toHaveBeenCalledWith(".env", "API_KEY=\nDB_PASSWORD=\n");
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        ".env",
+        "API_KEY=\nDB_PASSWORD=\n",
+      );
     });
 
     it("should append to existing .env file", async () => {
@@ -163,7 +180,8 @@ describe("cook command - environment variable check", () => {
       const mockAppendFile = vi.mocked(fs.appendFile).mockResolvedValue();
 
       const existingContent = readFileSync(".env", "utf8");
-      const needsNewline = existingContent.length > 0 && !existingContent.endsWith("\n");
+      const needsNewline =
+        existingContent.length > 0 && !existingContent.endsWith("\n");
       const prefix = needsNewline ? "\n" : "";
       const missingVars = ["NEW_VAR"];
       const placeholders = missingVars.map((name) => `${name}=`).join("\n");
@@ -179,7 +197,8 @@ describe("cook command - environment variable check", () => {
       const mockAppendFile = vi.mocked(fs.appendFile).mockResolvedValue();
 
       const existingContent = readFileSync(".env", "utf8");
-      const needsNewline = existingContent.length > 0 && !existingContent.endsWith("\n");
+      const needsNewline =
+        existingContent.length > 0 && !existingContent.endsWith("\n");
       const prefix = needsNewline ? "\n" : "";
       const missingVars = ["NEW_VAR"];
       const placeholders = missingVars.map((name) => `${name}=`).join("\n");

--- a/turbo/apps/cli/src/commands/__tests__/cook.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/cook.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs/promises";
+import { existsSync, readFileSync } from "fs";
+import * as dotenv from "dotenv";
+import * as core from "@vm0/core";
+
+// Mock dependencies
+vi.mock("fs/promises");
+vi.mock("fs");
+vi.mock("dotenv");
+vi.mock("@vm0/core", async () => {
+  const actual = await vi.importActual("@vm0/core");
+  return {
+    ...actual,
+    extractVariableReferences: vi.fn(),
+    groupVariablesBySource: vi.fn(),
+  };
+});
+
+// Test variable names (using constants to avoid turbo env var lint warnings)
+const TEST_VAR_1 = "TEST_VAR_1";
+const TEST_VAR_2 = "TEST_VAR_2";
+const TEST_VAR_3 = "TEST_VAR_3";
+const TEST_VAR_4 = "TEST_VAR_4";
+
+describe("cook command - environment variable check", () => {
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("extractRequiredVarNames", () => {
+    it("should extract variable names from vars and secrets references", () => {
+      const mockRefs = [
+        { source: "vars" as const, name: TEST_VAR_1, fullMatch: `\${{ vars.${TEST_VAR_1} }}` },
+        { source: "secrets" as const, name: TEST_VAR_2, fullMatch: `\${{ secrets.${TEST_VAR_2} }}` },
+        { source: "vars" as const, name: TEST_VAR_3, fullMatch: `\${{ vars.${TEST_VAR_3} }}` },
+      ];
+
+      vi.mocked(core.extractVariableReferences).mockReturnValue(mockRefs);
+      vi.mocked(core.groupVariablesBySource).mockReturnValue({
+        env: [],
+        vars: [mockRefs[0]!, mockRefs[2]!],
+        secrets: [mockRefs[1]!],
+      });
+
+      // The actual function is internal, so we verify the logic through integration
+      const result = core.groupVariablesBySource(core.extractVariableReferences({}));
+      const varNames = result.vars.map((r) => r.name);
+      const secretNames = result.secrets.map((r) => r.name);
+      const combined = [...new Set([...varNames, ...secretNames])];
+
+      expect(combined).toContain(TEST_VAR_1);
+      expect(combined).toContain(TEST_VAR_2);
+      expect(combined).toContain(TEST_VAR_3);
+    });
+  });
+
+  describe("checkMissingVariables", () => {
+    it("should return empty array when all variables are in process.env", () => {
+      process.env[TEST_VAR_1] = "test-key";
+      process.env[TEST_VAR_2] = "test-password";
+
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const varNames = [TEST_VAR_1, TEST_VAR_2];
+      const missing: string[] = [];
+
+      for (const name of varNames) {
+        if (process.env[name] === undefined) {
+          missing.push(name);
+        }
+      }
+
+      expect(missing).toHaveLength(0);
+    });
+
+    it("should return empty array when variables are in .env file", () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(dotenv.config).mockReturnValue({
+        parsed: {
+          [TEST_VAR_1]: "from-dotenv",
+          [TEST_VAR_2]: "from-dotenv",
+        },
+      });
+
+      const result = dotenv.config({ path: ".env" });
+      const dotenvValues = result.parsed ?? {};
+      const varNames = [TEST_VAR_1, TEST_VAR_2];
+      const missing: string[] = [];
+
+      for (const name of varNames) {
+        const inEnv = process.env[name] !== undefined;
+        const inDotenv = dotenvValues[name] !== undefined;
+        if (!inEnv && !inDotenv) {
+          missing.push(name);
+        }
+      }
+
+      expect(missing).toHaveLength(0);
+    });
+
+    it("should return missing variables not in env or .env", () => {
+      // Clear env
+      delete process.env[TEST_VAR_1];
+      delete process.env[TEST_VAR_2];
+      delete process.env[TEST_VAR_4];
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(dotenv.config).mockReturnValue({
+        parsed: {
+          [TEST_VAR_1]: "from-dotenv",
+        },
+      });
+
+      const result = dotenv.config({ path: ".env" });
+      const dotenvValues = result.parsed ?? {};
+      const varNames = [TEST_VAR_1, TEST_VAR_2, TEST_VAR_4];
+      const missing: string[] = [];
+
+      for (const name of varNames) {
+        const inEnv = process.env[name] !== undefined;
+        const inDotenv = dotenvValues[name] !== undefined;
+        if (!inEnv && !inDotenv) {
+          missing.push(name);
+        }
+      }
+
+      expect(missing).toContain(TEST_VAR_2);
+      expect(missing).toContain(TEST_VAR_4);
+      expect(missing).not.toContain(TEST_VAR_1);
+    });
+  });
+
+  describe("generateEnvPlaceholders", () => {
+    it("should create new .env file with placeholders", async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      const mockWriteFile = vi.mocked(fs.writeFile).mockResolvedValue();
+
+      const missingVars = ["API_KEY", "DB_PASSWORD"];
+      const placeholders = missingVars.map((name) => `${name}=`).join("\n");
+
+      await fs.writeFile(".env", `${placeholders}\n`);
+
+      expect(mockWriteFile).toHaveBeenCalledWith(".env", "API_KEY=\nDB_PASSWORD=\n");
+    });
+
+    it("should append to existing .env file", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue("EXISTING_VAR=value\n");
+      const mockAppendFile = vi.mocked(fs.appendFile).mockResolvedValue();
+
+      const existingContent = readFileSync(".env", "utf8");
+      const needsNewline = existingContent.length > 0 && !existingContent.endsWith("\n");
+      const prefix = needsNewline ? "\n" : "";
+      const missingVars = ["NEW_VAR"];
+      const placeholders = missingVars.map((name) => `${name}=`).join("\n");
+
+      await fs.appendFile(".env", `${prefix}${placeholders}\n`);
+
+      expect(mockAppendFile).toHaveBeenCalledWith(".env", "NEW_VAR=\n");
+    });
+
+    it("should add newline before appending if file doesn't end with newline", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue("EXISTING_VAR=value"); // No trailing newline
+      const mockAppendFile = vi.mocked(fs.appendFile).mockResolvedValue();
+
+      const existingContent = readFileSync(".env", "utf8");
+      const needsNewline = existingContent.length > 0 && !existingContent.endsWith("\n");
+      const prefix = needsNewline ? "\n" : "";
+      const missingVars = ["NEW_VAR"];
+      const placeholders = missingVars.map((name) => `${name}=`).join("\n");
+
+      await fs.appendFile(".env", `${prefix}${placeholders}\n`);
+
+      expect(mockAppendFile).toHaveBeenCalledWith(".env", "\nNEW_VAR=\n");
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -1,10 +1,15 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { readFile, mkdir } from "fs/promises";
-import { existsSync } from "fs";
+import { readFile, mkdir, writeFile, appendFile } from "fs/promises";
+import { existsSync, readFileSync } from "fs";
 import path from "path";
 import { spawn } from "child_process";
 import { parse as parseYaml } from "yaml";
+import { config as dotenvConfig } from "dotenv";
+import {
+  extractVariableReferences,
+  groupVariablesBySource,
+} from "@vm0/core";
 import { validateAgentCompose } from "../lib/yaml-validator";
 import { readStorageConfig } from "../lib/storage-utils";
 
@@ -155,6 +160,74 @@ function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/**
+ * Extract all required variable names from compose config
+ * Returns unique names from both vars and secrets references
+ */
+function extractRequiredVarNames(config: AgentComposeConfig): string[] {
+  const refs = extractVariableReferences(config);
+  const grouped = groupVariablesBySource(refs);
+  // Combine vars and secrets names (both are loaded from .env)
+  const varNames = grouped.vars.map((r) => r.name);
+  const secretNames = grouped.secrets.map((r) => r.name);
+  return [...new Set([...varNames, ...secretNames])];
+}
+
+/**
+ * Check which variables are missing from environment and .env file
+ * @param varNames - Variable names to check
+ * @param envFilePath - Path to .env file
+ * @returns Array of missing variable names
+ */
+function checkMissingVariables(
+  varNames: string[],
+  envFilePath: string,
+): string[] {
+  // Load .env file if it exists
+  let dotenvValues: Record<string, string> = {};
+  if (existsSync(envFilePath)) {
+    const result = dotenvConfig({ path: envFilePath });
+    if (result.parsed) {
+      dotenvValues = result.parsed;
+    }
+  }
+
+  // Check which variables are missing
+  const missing: string[] = [];
+  for (const name of varNames) {
+    const inEnv = process.env[name] !== undefined;
+    const inDotenv = dotenvValues[name] !== undefined;
+    if (!inEnv && !inDotenv) {
+      missing.push(name);
+    }
+  }
+
+  return missing;
+}
+
+/**
+ * Generate .env file with placeholder entries for missing variables
+ * Creates file if it doesn't exist, appends to existing file
+ * @param missingVars - Variable names to add as placeholders
+ * @param envFilePath - Path to .env file
+ */
+async function generateEnvPlaceholders(
+  missingVars: string[],
+  envFilePath: string,
+): Promise<void> {
+  const placeholders = missingVars.map((name) => `${name}=`).join("\n");
+
+  if (existsSync(envFilePath)) {
+    // Read existing content to check if we need a newline
+    const existingContent = readFileSync(envFilePath, "utf8");
+    const needsNewline = existingContent.length > 0 && !existingContent.endsWith("\n");
+    const prefix = needsNewline ? "\n" : "";
+    await appendFile(envFilePath, `${prefix}${placeholders}\n`);
+  } else {
+    await writeFile(envFilePath, `${placeholders}\n`);
+  }
+}
+
 export const cookCommand = new Command()
   .name("cook")
   .description("One-click agent preparation and execution from vm0.yaml")
@@ -195,6 +268,27 @@ export const cookCommand = new Command()
     console.log(
       chalk.green(`✓ Config validated: 1 agent, ${volumeCount} volume(s)`),
     );
+
+    // Step 1.5: Check for missing environment variables
+    const requiredVarNames = extractRequiredVarNames(config);
+    if (requiredVarNames.length > 0) {
+      const envFilePath = path.join(cwd, ".env");
+      const missingVars = checkMissingVariables(requiredVarNames, envFilePath);
+
+      if (missingVars.length > 0) {
+        await generateEnvPlaceholders(missingVars, envFilePath);
+        console.log();
+        console.log(
+          chalk.yellow(
+            `⚠ Missing environment variables. Please fill in values in .env file:`,
+          ),
+        );
+        for (const varName of missingVars) {
+          console.log(chalk.yellow(`    ${varName}`));
+        }
+        process.exit(1);
+      }
+    }
 
     // Step 2: Process volumes
     if (config.volumes && Object.keys(config.volumes).length > 0) {

--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -6,10 +6,7 @@ import path from "path";
 import { spawn } from "child_process";
 import { parse as parseYaml } from "yaml";
 import { config as dotenvConfig } from "dotenv";
-import {
-  extractVariableReferences,
-  groupVariablesBySource,
-} from "@vm0/core";
+import { extractVariableReferences, groupVariablesBySource } from "@vm0/core";
 import { validateAgentCompose } from "../lib/yaml-validator";
 import { readStorageConfig } from "../lib/storage-utils";
 
@@ -220,7 +217,8 @@ async function generateEnvPlaceholders(
   if (existsSync(envFilePath)) {
     // Read existing content to check if we need a newline
     const existingContent = readFileSync(envFilePath, "utf8");
-    const needsNewline = existingContent.length > 0 && !existingContent.endsWith("\n");
+    const needsNewline =
+      existingContent.length > 0 && !existingContent.endsWith("\n");
     const prefix = needsNewline ? "\n" : "";
     await appendFile(envFilePath, `${prefix}${placeholders}\n`);
   } else {


### PR DESCRIPTION
## Summary

- Add environment variable validation to `vm0 cook` command
- Auto-detect missing `${{ vars.* }}` and `${{ secrets.* }}` references from compose config
- Create/update `.env` file with `VAR=` placeholders for missing variables
- Prompt user to fill in values before proceeding with the cook workflow

## Test plan

- [ ] Run `vm0 cook` with compose file containing `${{ vars.API_KEY }}` without `.env` file - should create `.env` with `API_KEY=`
- [ ] Run `vm0 cook` with partial `.env` (some vars missing) - should append missing vars
- [ ] Run `vm0 cook` with all variables set - should proceed normally
- [ ] Run unit tests: `pnpm vitest run apps/cli/src/commands/__tests__/cook.test.ts`

Closes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)
