### PR TITLE
feat(cli): add system logs tip on run failure

### DIFF
--- a/codereviews/20251217/review-pr578.md
+++ b/codereviews/20251217/review-pr578.md
@@ -1,0 +1,71 @@
+# Code Review: PR #578 - feat(e2b): standardize sandbox logging format
+
+**PR**: https://github.com/vm0-ai/vm0/pull/578
+**Reviewer**: Claude Code
+**Date**: 2025-12-17
+
+## Summary
+
+This PR adds lifecycle markers to the sandbox logging in `run-agent.py.ts`. The final implementation is minimal and clean - it only adds visual markers (`▶`, `▷`, `✓`, `✗`) at key lifecycle points while preserving all existing logging.
+
+## Files Changed
+
+| File | Changes |
+|------|---------|
+| `turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts` | +43 lines |
+
+## Review
+
+### What Changed
+
+The PR adds lifecycle markers at key execution phases:
+
+1. **Header** (line 115): `log_info(f"▶ VM0 Sandbox {RUN_ID}")`
+2. **Initialization** (lines 118, 157-158): Start marker and completion with duration
+3. **Execution** (lines 161-162, 283-287): Start marker and completion/failure with duration
+4. **Checkpoint** (lines 294-295, 301-304): Start marker and completion/failure with duration
+5. **Cleanup** (lines 66, 99-102): Start marker and final status
+
+### Code Quality Assessment
+
+| Aspect | Status | Notes |
+|--------|--------|-------|
+| **Functionality** | ✅ Good | Changes are purely additive logging |
+| **No Breaking Changes** | ✅ Good | All existing `log_info`, `log_warn`, `log_error` preserved |
+| **Test Coverage** | ✅ Good | E2E tests pass (85/85) |
+| **Code Style** | ✅ Good | Follows existing patterns |
+| **Error Handling** | ✅ Good | No changes to error handling logic |
+
+### Positive Observations
+
+1. **Minimal Changes**: Only adds lifecycle markers without modifying existing functionality
+2. **Preserves Original API**: Keeps `log_info`, `log_warn`, `log_error`, `log_debug` functions
+3. **Duration Tracking**: Adds useful timing information for each phase
+4. **Clear Visual Hierarchy**: Uses symbols consistently:
+   - `▶` - Main header (sandbox start)
+   - `▷` - Phase start (initialization, execution, checkpoint, cleanup)
+   - `✓` - Phase success
+   - `✗` - Phase failure
+
+### Potential Concerns
+
+1. **PR Description Mismatch**: The PR body describes a much larger change (replacing logging API, silencing background services) that doesn't match the final implementation. This appears to be from an earlier iteration that was reverted based on user feedback.
+
+2. **Import Statement**: Added `import time` at line 26 - this is necessary for the duration tracking and is appropriate.
+
+### No Issues Found
+
+- No new mocks or unnecessary abstractions
+- No over-engineering
+- No unnecessary try/catch blocks
+- No timer/delay usage issues
+- No security concerns
+
+## Verdict
+
+**APPROVED** - This is a clean, minimal change that improves observability of sandbox execution without modifying core functionality. All tests pass.
+
+## Suggestions for Future
+
+1. Consider updating the PR description to match the actual final implementation
+2. The lifecycle markers could potentially be documented in a README for operators to understand the log format

--- a/turbo/apps/cli/src/commands/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/run.test.ts
@@ -1190,6 +1190,7 @@ describe("run command", () => {
       // Note: EventRenderer.renderRunFailed is mocked, so we check it was called
       expect(EventRenderer.renderRunFailed).toHaveBeenCalledWith(
         "Agent crashed",
+        "run-123",
       );
     });
 

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -221,11 +221,14 @@ async function pollEvents(
     } else if (runStatus === "failed") {
       complete = true;
       // Render error info
-      EventRenderer.renderRunFailed(response.run.error);
+      EventRenderer.renderRunFailed(response.run.error, runId);
       result = { succeeded: false, runId };
     } else if (runStatus === "timeout") {
       complete = true;
       console.error(chalk.red("\n✗ Run timed out"));
+      console.error(
+        chalk.gray(`  (use "vm0 logs ${runId} --system" to view system logs)`),
+      );
       result = { succeeded: false, runId };
     }
 

--- a/turbo/apps/cli/src/lib/__tests__/event-renderer.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/event-renderer.test.ts
@@ -686,7 +686,7 @@ describe("EventRenderer", () => {
     });
 
     it("should render run failed with error", () => {
-      EventRenderer.renderRunFailed("Something went wrong");
+      EventRenderer.renderRunFailed("Something went wrong", "run-123");
 
       expect(consoleLogSpy).toHaveBeenCalled();
       const allCalls = consoleLogSpy.mock.calls.map(
@@ -696,10 +696,13 @@ describe("EventRenderer", () => {
       expect(
         allCalls.some((call) => call.includes("Something went wrong")),
       ).toBe(true);
+      expect(
+        allCalls.some((call) => call.includes("vm0 logs run-123 --system")),
+      ).toBe(true);
     });
 
     it("should render run failed without error", () => {
-      EventRenderer.renderRunFailed(undefined);
+      EventRenderer.renderRunFailed(undefined, "run-456");
 
       expect(consoleLogSpy).toHaveBeenCalled();
       const allCalls = consoleLogSpy.mock.calls.map(
@@ -709,6 +712,9 @@ describe("EventRenderer", () => {
       expect(allCalls.some((call) => call.includes("Unknown error"))).toBe(
         true,
       );
+      expect(
+        allCalls.some((call) => call.includes("vm0 logs run-456 --system")),
+      ).toBe(true);
     });
 
     it("should render total time in verbose mode", () => {

--- a/turbo/apps/cli/src/lib/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/event-renderer.ts
@@ -160,11 +160,14 @@ export class EventRenderer {
    * Render run failed state
    * Note: This is run lifecycle status, not an event
    */
-  static renderRunFailed(error: string | undefined): void {
+  static renderRunFailed(error: string | undefined, runId: string): void {
     // Visual separator to distinguish from event stream
     console.log("");
     console.log(chalk.red("✗ Run failed"));
     console.log(`  Error: ${chalk.red(error || "Unknown error")}`);
+    console.log(
+      chalk.gray(`  (use "vm0 logs ${runId} --system" to view system logs)`),
+    );
   }
 
   private static renderInit(


### PR DESCRIPTION
## Summary

- Add system logs tip when run fails or times out
- Display: `(use "vm0 logs <runId> --system" to view system logs)`
- Follows existing pattern from `renderRunStarted()`

## Changes

- Modified `renderRunFailed()` to accept `runId` parameter and display tip
- Updated timeout case in `run.ts` to also show the tip
- Added test coverage for the new tip output

## Before

```
✗ Run failed
  Error: <error message>
```

## After

```
✗ Run failed
  Error: <error message>
  (use "vm0 logs <runId> --system" to view system logs)
```

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)