### PR TITLE
fix(e2b): add -f flag to curl in http_post_form for proper HTTP error handling

### DIFF
--- a/turbo/apps/web/src/lib/e2b/scripts/lib/http_client.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/http_client.py.ts
@@ -102,8 +102,9 @@ def http_post_form(
         log_debug(f"HTTP POST form attempt {attempt}/{max_retries} to {url}")
 
         # Build curl command
+        # -f flag makes curl return non-zero exit code on HTTP 4xx/5xx errors
         curl_cmd = [
-            "curl", "-X", "POST", url,
+            "curl", "-f", "-X", "POST", url,
             "-H", f"Authorization: Bearer {API_TOKEN}",
             "--connect-timeout", str(HTTP_CONNECT_TIMEOUT),
             "--max-time", str(HTTP_MAX_TIME_UPLOAD),
@@ -134,7 +135,11 @@ def http_post_form(
                     return json.loads(result.stdout)
                 return {}
 
-            log_warn(f"HTTP POST form failed (attempt {attempt}/{max_retries}): curl exit {result.returncode}")
+            # Log curl exit code and stderr for better debugging
+            error_msg = f"curl exit {result.returncode}"
+            if result.stderr:
+                error_msg += f": {result.stderr.strip()}"
+            log_warn(f"HTTP POST form failed (attempt {attempt}/{max_retries}): {error_msg}")
             if attempt < max_retries:
                 time.sleep(1)
 
@@ -144,6 +149,9 @@ def http_post_form(
                 time.sleep(1)
         except json.JSONDecodeError as e:
             log_warn(f"HTTP POST form failed (attempt {attempt}/{max_retries}): Invalid JSON response")
+            # Log raw response for debugging (truncate to avoid log spam)
+            if result.stdout:
+                log_debug(f"Raw response: {result.stdout[:500]}")
             if attempt < max_retries:
                 time.sleep(1)
         except Exception as e:

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/http_client.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/http_client.py.ts
@@ -122,6 +122,7 @@ def http_post_form(
         if file_path:
             curl_cmd.extend(["-F", f"{file_field}=@{file_path}"])
 
+        result = None  # Initialize for use in except blocks
         try:
             result = subprocess.run(
                 curl_cmd,
@@ -148,9 +149,9 @@ def http_post_form(
             if attempt < max_retries:
                 time.sleep(1)
         except json.JSONDecodeError as e:
-            log_warn(f"HTTP POST form failed (attempt {attempt}/{max_retries}): Invalid JSON response")
+            log_warn(f"HTTP POST form failed (attempt {attempt}/{max_retries}): Invalid JSON response: {e}")
             # Log raw response for debugging (truncate to avoid log spam)
-            if result.stdout:
+            if result and result.stdout:
                 log_debug(f"Raw response: {result.stdout[:500]}")
             if attempt < max_retries:
                 time.sleep(1)


### PR DESCRIPTION
## Summary

- Add `-f` (--fail) flag to curl in `http_post_form` to return non-zero exit code on HTTP 4xx/5xx errors
- Log curl stderr for better error debugging when requests fail
- Log raw response body (truncated to 500 chars) when JSON decode fails

## Problem

Without the `-f` flag, curl returns exit code 0 even when the server returns HTTP 4xx/5xx errors. This causes the HTML error page to be parsed as JSON, resulting in misleading "Invalid JSON response" errors that mask the actual server error.

## Changes

**File:** `turbo/apps/web/src/lib/e2b/scripts/lib/http_client.py.ts`

1. Added `-f` flag to curl command (consistent with `http_download` which uses `-fsSL`)
2. Enhanced error logging to include curl stderr
3. Added debug logging of raw response when JSON parsing fails

## Test plan

- [x] Lint check passes
- [x] Type check passes
- [x] e2b-service tests pass

Fixes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)