### PR TITLE
feat(cli): add deep-dive workflow slash commands

### DIFF
--- a/.claude/commands/deep-innovate.md
+++ b/.claude/commands/deep-innovate.md
@@ -1,0 +1,86 @@
+---
+description: Deep brainstorming and solution exploration based on research findings
+---
+
+# DEEP INNOVATE MODE
+
+You are entering **Deep Innovate Mode**. This is a creative brainstorming phase that builds upon research findings to explore multiple potential approaches.
+
+## PREREQUISITES
+
+Before starting, locate and read the research document at `/tmp/deep-dive/{task-name}/research.md` where `{task-name}` matches the research phase. If no research exists, inform the user and suggest running `/deep-research` first.
+
+## CRITICAL RESTRICTIONS
+
+**PERMITTED:**
+- Discussing multiple solution ideas
+- Evaluating advantages and disadvantages of each approach
+- Seeking feedback on approaches from the user
+- Exploring architectural alternatives
+- Comparing different technical strategies
+- Considering trade-offs (performance, maintainability, complexity)
+- Documenting findings in `/tmp/deep-dive/{task-name}/innovate.md`
+
+**ABSOLUTELY FORBIDDEN:**
+- Concrete planning with specific steps
+- Implementation details or pseudo-code
+- Any actual code writing
+- Committing to a single specific solution
+- Timeline or effort estimates
+- File-by-file change specifications
+
+## CORE THINKING PRINCIPLES
+
+Apply these thinking approaches during innovation:
+
+- **Dialectical Thinking**: Explore multiple solution paths, understand opposing approaches and their merits
+- **Innovative Thinking**: Break conventional patterns, consider unconventional solutions
+- **Systems Thinking**: Consider how solutions fit into the overall architecture
+- **Practical Thinking**: Balance theoretical elegance with implementation feasibility
+
+## INNOVATION WORKFLOW
+
+### Phase 1: Research Review
+
+1. **Read the research document** at `/tmp/deep-dive/{task-name}/research.md`
+2. **Summarize key findings** that will inform solution approaches
+3. **Identify constraints** discovered during research
+
+### Phase 2: Solution Exploration
+
+1. **Generate multiple approaches** - aim for at least 2-3 distinct solutions
+2. **For each approach, document:**
+   - Core concept and philosophy
+   - Key advantages
+   - Potential challenges or risks
+   - Compatibility with existing architecture
+   - Scalability and maintainability considerations
+
+3. **Apply dialectical analysis:**
+   - What are the trade-offs between approaches?
+   - Where do approaches converge or diverge?
+   - What assumptions does each approach make?
+
+### Phase 3: Documentation
+
+1. **Create innovate file** at `/tmp/deep-dive/{task-name}/innovate.md`
+2. **Structure the document:**
+   - Summary of research findings
+   - Proposed approaches (with pros/cons)
+   - Trade-off analysis
+   - Open questions for user consideration
+
+### Phase 4: User Discussion
+
+1. **Present the approaches** to the user
+2. **Facilitate discussion** about preferences and constraints
+3. **Refine understanding** based on user feedback
+4. **Ask the user**: "Which direction would you like to explore further, or shall we move to `/deep-plan`?"
+
+## TASK TO INNOVATE
+
+$ARGUMENTS
+
+---
+
+**Remember**: You are exploring possibilities and facilitating creative thinking. You are NOT making final decisions or planning implementation. Present options objectively and let the user guide the direction.

--- a/.claude/commands/deep-plan.md
+++ b/.claude/commands/deep-plan.md
@@ -22,6 +22,7 @@ If either document is missing, inform the user and suggest running the appropria
 - Defining task dependencies and order
 - Breaking down work into actionable items
 - Identifying potential blockers or risks
+- Ensuring goal focus - connecting all planning to original requirements
 - Documenting the plan in `/tmp/deep-dive/{task-name}/plan.md`
 
 **ABSOLUTELY FORBIDDEN:**
@@ -30,6 +31,7 @@ If either document is missing, inform the user and suggest running the appropria
 - Running tests or build commands
 - Any implementation execution
 - Deviating from the chosen approach without user approval
+- Skipping or abbreviating specifications
 
 ## CORE THINKING PRINCIPLES
 

--- a/.claude/commands/deep-plan.md
+++ b/.claude/commands/deep-plan.md
@@ -1,0 +1,93 @@
+---
+description: Create concrete implementation plan based on research and innovation findings
+---
+
+# DEEP PLAN MODE
+
+You are entering **Deep Plan Mode**. This is the planning phase that transforms research findings and innovation discussions into a concrete implementation plan.
+
+## PREREQUISITES
+
+Before starting:
+1. **Read research document** at `/tmp/deep-dive/{task-name}/research.md`
+2. **Read innovation document** at `/tmp/deep-dive/{task-name}/innovate.md`
+
+If either document is missing, inform the user and suggest running the appropriate phase first (`/deep-research` or `/deep-innovate`).
+
+## CRITICAL RESTRICTIONS
+
+**PERMITTED:**
+- Creating detailed implementation steps
+- Specifying file changes and modifications
+- Defining task dependencies and order
+- Breaking down work into actionable items
+- Identifying potential blockers or risks
+- Documenting the plan in `/tmp/deep-dive/{task-name}/plan.md`
+
+**ABSOLUTELY FORBIDDEN:**
+- Actually writing or modifying code
+- Making commits or file changes
+- Running tests or build commands
+- Any implementation execution
+- Deviating from the chosen approach without user approval
+
+## CORE THINKING PRINCIPLES
+
+Apply these thinking approaches during planning:
+
+- **Systems Thinking**: Ensure the plan considers the full impact on the system
+- **Sequential Thinking**: Order tasks logically based on dependencies
+- **Risk Thinking**: Identify potential issues and mitigation strategies
+- **Practical Thinking**: Keep the plan actionable and realistic
+
+## PLANNING WORKFLOW
+
+### Phase 1: Context Review
+
+1. **Read research findings** from `/tmp/deep-dive/{task-name}/research.md`
+2. **Read innovation document** from `/tmp/deep-dive/{task-name}/innovate.md`
+3. **Confirm the chosen approach** with the user if not already decided
+
+### Phase 2: Plan Development
+
+1. **Break down into tasks:**
+   - Identify all discrete work items
+   - Order tasks by dependency
+   - Group related tasks logically
+
+2. **For each task, specify:**
+   - Clear description of what needs to be done
+   - Files that will be affected
+   - Dependencies on other tasks
+   - Acceptance criteria
+
+3. **Identify risks and blockers:**
+   - Technical challenges
+   - External dependencies
+   - Areas requiring further investigation
+
+### Phase 3: Documentation
+
+1. **Create plan file** at `/tmp/deep-dive/{task-name}/plan.md`
+2. **Structure the document:**
+   - Chosen approach summary
+   - Task breakdown with details
+   - Dependency graph (if complex)
+   - Risk assessment
+   - Definition of done
+
+### Phase 4: User Approval
+
+1. **Present the plan** to the user
+2. **Walk through** each major section
+3. **Address questions** and concerns
+4. **Get explicit approval** before proceeding to implementation
+5. **Ask the user**: "Does this plan look good? Ready to proceed with implementation?"
+
+## TASK TO PLAN
+
+$ARGUMENTS
+
+---
+
+**Remember**: You are creating a roadmap for implementation. You are NOT implementing yet. The plan should be detailed enough that implementation can proceed smoothly, but no code should be written until the user approves and explicitly requests implementation.

--- a/.claude/commands/deep-research.md
+++ b/.claude/commands/deep-research.md
@@ -45,7 +45,7 @@ Before diving into code, ask the user any clarifying questions needed to underst
 
 ### Phase 2: Research Execution
 
-1. **Create research file** at `/tmp/claude/research/{name}.md` where `{name}` is a short descriptive name you choose based on the task.
+1. **Create research file** at `/tmp/deep-dive/{task-name}/research.md` where `{task-name}` is a short descriptive name you choose based on the task.
 
 2. **Systematically analyze**:
    - Identify core files and functions related to the task

--- a/.claude/commands/deep-research.md
+++ b/.claude/commands/deep-research.md
@@ -64,7 +64,7 @@ When research is complete:
 2. Briefly summarize what you've learned (facts only, no recommendations)
 3. Ask the user: **"What would you like to do next?"**
    - Continue exploring specific areas
-   - Move to solution discussion
+   - Move to `/deep-innovate` to brainstorm potential approaches
    - Something else entirely
 
 ## TASK TO RESEARCH


### PR DESCRIPTION
## Summary

- Add `/deep-innovate` command for brainstorming phase based on research findings
- Add `/deep-plan` command for creating concrete implementation plans
- Update `/deep-research` to use unified `/tmp/deep-dive/{task-name}/` directory structure

This creates a cohesive three-phase deep-dive workflow:
1. `/deep-research` - Gather information (no suggestions)
2. `/deep-innovate` - Brainstorm approaches (no concrete plans)  
3. `/deep-plan` - Create implementation plan (no code execution)

## Test plan

- [ ] Run `/deep-research <task>` and verify it creates `/tmp/deep-dive/{task-name}/research.md`
- [ ] Run `/deep-innovate <task>` and verify it reads research and creates `innovate.md`
- [ ] Run `/deep-plan <task>` and verify it reads both documents and creates `plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)