### PR TITLE
feat(cli): integrate deep-dive workflow into issue-todo command

### DIFF
--- a/.claude/commands/issue-continue.md
+++ b/.claude/commands/issue-continue.md
@@ -14,56 +14,103 @@ Your job is to continue working on the GitHub issue from the current conversatio
 - Core principle: propose and verify hypotheses at fine granularity through continuous iteration
 
 ## Workflow
-1. **Retrieve issue ID from context**:
-   - Look through the current conversation history to find the issue ID from previous `/issue-todo` or `/issue-continue` calls
-   - If no issue ID found in context: Ask user "Which issue would you like to continue working on? Please provide the issue ID."
+
+### Step 1: Retrieve Context
+
+1. **Find issue ID** from conversation history (from previous `/issue-todo` or `/issue-continue` calls)
+   - If no issue ID found: Ask user "Which issue would you like to continue working on? Please provide the issue ID."
    - Exit and wait for user response if issue ID not found
-2. **Fetch latest updates**: Use `gh issue view <issue_id> --json title,body,comments,labels` to get all comments since last interaction
-3. **Remove pending label**: Use `gh issue edit <issue_id> --remove-label pending` to indicate work has resumed
-4. **Analyze feedback**: Review new comments for:
-   - Plan approval/rejection
-   - Modification requests
-   - Additional requirements
-   - Questions or clarifications
-5. **Take action based on feedback**:
-   - **If plan approved**: Proceed with implementation
-   - **If changes requested**: Update plan and post revised plan as comment, then add "pending" label and exit
-   - **If questions asked**: Answer questions in comment, then add "pending" label and exit
-6. **Implementation**:
-   - Create/switch to feature branch
-   - Implement changes following the approved plan
-   - Write and run tests after each change
-   - Commit with conventional commit messages
-7. **Check completion status**:
-   - **If work complete**: Create PR and go to step 8
-   - **If blocked or need clarification**: Post comment explaining the situation, add "pending" label, and exit
-   - **If intermediate checkpoint**: Post progress update comment, add "pending" label, and exit (optional)
-8. **Create PR and verify CI pipeline**:
-   - Push branch and create Pull Request
-   - Wait 60 seconds for CI workflows to start
-   - Check and fix pipeline issues:
-     - Use `gh pr checks` to check pipeline status
-     - **If checks still running**: Wait 30 seconds and retry (up to 10 times total)
-     - **If checks failing**: Attempt automatic fixes:
-       - **Lint failures** (if output contains "lint" and "fail"):
-         1. Run `cd turbo && pnpm format`
-         2. If changes detected: `git add -A && git commit -m "fix: auto-format code" && git push`
-         3. Wait 60 seconds and re-check pipeline
-       - **Type check failures** (if output contains "type" or "check-types" and "fail"):
-         1. Run `cd turbo && pnpm check-types`
-         2. Report errors (manual fix required)
-       - **Test failures** (if output contains "test" and "fail"):
-         1. Run `cd turbo && pnpm vitest`
-         2. Report failures (manual fix required)
-       - After pushing fixes, wait 60 seconds and re-check pipeline
-       - Retry fix attempts up to 2 times
-     - **If checks pass** (after fixes or initially): Post success comment to issue
-     - **If unable to fix after retries**: Post comment with failure details and add "pending" label, then exit
-   - Post comment to issue: `gh issue comment <issue_id> --body "Work completed. PR created: <PR_URL>\n\n✅ All CI checks passing"`
-   - Keep issue open (user will close it after merging PR)
+
+2. **Locate deep-dive artifacts** in `/tmp/deep-dive/{task-name}/`
+   - Find the directory associated with this issue from conversation context
+   - If multiple directories exist and association is unclear, ask user to confirm
+   - Verify these files exist:
+     - `research.md` - Codebase analysis and technical constraints
+     - `innovate.md` - Chosen approach and reasoning
+     - `plan.md` - Implementation steps to follow
+
+### Step 2: Fetch Latest Updates
+
+Use `gh issue view <issue_id> --json title,body,comments,labels` to get all comments since last interaction.
+
+### Step 3: Remove Pending Label
+
+Use `gh issue edit <issue_id> --remove-label pending` to indicate work has resumed.
+
+### Step 4: Analyze Feedback
+
+Review new comments for:
+- Plan approval/rejection
+- Modification requests
+- Additional requirements
+- Questions or clarifications
+
+### Step 5: Take Action Based on Feedback
+
+- **If plan approved**: Proceed to implementation (Step 6)
+- **If changes requested**:
+  - Update `/tmp/deep-dive/{task-name}/plan.md`
+  - Post revised plan as comment
+  - Add "pending" label and exit
+- **If questions asked**:
+  - Answer questions in comment
+  - Add "pending" label and exit
+
+### Step 6: Implementation
+
+1. **Read deep-dive artifacts**:
+   - Read `plan.md` for the exact implementation steps to follow
+   - Reference `research.md` for codebase understanding and navigation
+   - Reference `innovate.md` for the chosen approach and its rationale
+
+2. **Create/switch to feature branch**
+
+3. **Implement changes following plan.md exactly**:
+   - Follow the implementation steps in order
+   - Do not deviate from the approved plan without user approval
+   - If plan is unclear or needs adjustment, post comment and add "pending" label
+
+4. **Write and run tests after each change**
+
+5. **Commit with conventional commit messages**
+
+### Step 7: Check Completion Status
+
+- **If work complete**: Create PR and go to Step 8
+- **If blocked or need clarification**: Post comment explaining the situation, add "pending" label, and exit
+- **If intermediate checkpoint**: Post progress update comment, add "pending" label, and exit (optional)
+
+### Step 8: Create PR and Verify CI Pipeline
+
+1. Push branch and create Pull Request
+
+2. Wait 60 seconds for CI workflows to start
+
+3. Check and fix pipeline issues:
+   - Use `gh pr checks` to check pipeline status
+   - **If checks still running**: Wait 30 seconds and retry (up to 10 times total)
+   - **If checks failing**: Attempt automatic fixes:
+     - **Lint failures** (if output contains "lint" and "fail"):
+       1. Run `cd turbo && pnpm format`
+       2. If changes detected: `git add -A && git commit -m "fix: auto-format code" && git push`
+       3. Wait 60 seconds and re-check pipeline
+     - **Type check failures** (if output contains "type" or "check-types" and "fail"):
+       1. Run `cd turbo && pnpm check-types`
+       2. Report errors (manual fix required)
+     - **Test failures** (if output contains "test" and "fail"):
+       1. Run `cd turbo && pnpm vitest`
+       2. Report failures (manual fix required)
+     - After pushing fixes, wait 60 seconds and re-check pipeline
+     - Retry fix attempts up to 2 times
+   - **If checks pass** (after fixes or initially): Post success comment to issue
+   - **If unable to fix after retries**: Post comment with failure details and add "pending" label, then exit
+
+4. Post comment to issue: `gh issue comment <issue_id> --body "Work completed. PR created: <PR_URL>\n\n✅ All CI checks passing"`
+
+5. Keep issue open (user will close it after merging PR)
 
 ## Label Management
-- **Remove "pending" label** when resuming work (step 3)
+- **Remove "pending" label** when resuming work (Step 3)
 - **Add "pending" label** when:
   - Waiting for plan approval (revised plan)
   - Blocked and need user input
@@ -71,6 +118,7 @@ Your job is to continue working on the GitHub issue from the current conversatio
 
 ## Error Handling
 - If issue ID cannot be found in conversation context: ask user to provide issue ID and exit
+- If deep-dive artifacts not found: ask user if they want to run `/issue-todo` first
 - If "pending" label doesn't exist: create it first with `gh label create pending --description "Waiting for human input" --color FFA500`
 - If tests fail during implementation: report failures, add "pending" label, and ask for guidance
 

--- a/.claude/commands/issue-todo.md
+++ b/.claude/commands/issue-todo.md
@@ -1,6 +1,6 @@
 # Start Working on GitHub Issue
 
-Your job is to start working on GitHub issue {{ISSUE_ID}} for the current project. This is the initial workflow for a new issue.
+Your job is to start working on GitHub issue {{ISSUE_ID}} for the current project. This command integrates with the deep-dive workflow to ensure thorough exploration before implementation.
 
 ## Important Notes
 - Follow software engineering best practices: create independent feature branches (git checkout -b feature/issue-{{ISSUE_ID}}-xxx)
@@ -13,21 +13,133 @@ Your job is to start working on GitHub issue {{ISSUE_ID}} for the current projec
 - Core principle: propose and verify hypotheses at fine granularity through continuous iteration
 
 ## Workflow
-1. **Fetch issue details**: Use `gh issue view {{ISSUE_ID}} --json title,body,comments,labels` to read complete issue information
-2. **Analyze and plan**:
-   - Review issue description and all comments for requirements, suggestions, and context
-   - Create detailed work plan with specific implementation steps
-   - Post plan as issue comment: `gh issue comment {{ISSUE_ID}} --body "..."`
-3. **Add pending label**: Use `gh issue edit {{ISSUE_ID}} --add-label pending` to wait for user approval
-4. **Remember issue ID**: Store {{ISSUE_ID}} in context for future `/issue-continue` calls
-5. **Exit and wait**: Stop here and wait for user to review the plan and call `/issue-continue`
+
+### Step 1: Fetch Issue Details
+
+Use `gh issue view {{ISSUE_ID}} --json title,body,comments,labels` to read complete issue information.
+
+### Step 2: Check for Existing Deep-Dive Artifacts
+
+Look for existing deep-dive work in the current conversation context:
+
+1. **Search for existing directories** in `/tmp/deep-dive/*/`
+2. **Check for artifacts**:
+   - `research.md` - Research phase completed
+   - `innovate.md` - Innovation phase completed
+   - `plan.md` - Plan phase completed
+3. **If multiple directories exist** and it's unclear which relates to this issue, ask the user to confirm
+4. **If a matching directory is found**, note which phases are already complete
+
+### Step 3: Execute Deep-Dive Workflow
+
+For each missing phase, execute in order and post comments to the issue:
+
+#### Phase 1: Research (if no research.md exists)
+
+1. **Execute research phase**:
+   - Create directory `/tmp/deep-dive/issue-{{ISSUE_ID}}/` if not exists
+   - Systematically analyze the codebase related to the issue
+   - Identify core files, trace code flow, map architecture
+   - Document findings in `/tmp/deep-dive/issue-{{ISSUE_ID}}/research.md`
+
+2. **Post research comment to issue**:
+   ```
+   gh issue comment {{ISSUE_ID}} --body "$(cat <<'EOF'
+   ## 🔬 Research Phase
+
+   [Contents of research.md]
+
+   ---
+   *Phase 1/3 of deep-dive workflow*
+   EOF
+   )"
+   ```
+
+#### Phase 2: Innovate (if no innovate.md exists)
+
+1. **Execute innovation phase**:
+   - Read research findings from `research.md`
+   - Explore multiple solution approaches
+   - Evaluate pros and cons of each approach
+   - Document in `/tmp/deep-dive/issue-{{ISSUE_ID}}/innovate.md`
+
+2. **Post innovation comment to issue**:
+   ```
+   gh issue comment {{ISSUE_ID}} --body "$(cat <<'EOF'
+   ## 💡 Innovation Phase
+
+   [Contents of innovate.md]
+
+   ---
+   *Phase 2/3 of deep-dive workflow*
+   EOF
+   )"
+   ```
+
+#### Phase 3: Plan (if no plan.md exists)
+
+1. **Execute planning phase**:
+   - Read research and innovation documents
+   - Create detailed implementation plan with specific steps
+   - Ensure goal focus - connect all planning to original requirements
+   - Do not skip or abbreviate specifications
+   - Document in `/tmp/deep-dive/issue-{{ISSUE_ID}}/plan.md`
+
+2. **Post plan comment to issue**:
+   ```
+   gh issue comment {{ISSUE_ID}} --body "$(cat <<'EOF'
+   ## 📋 Plan Phase
+
+   [Contents of plan.md]
+
+   ---
+   *Phase 3/3 - Ready for approval*
+   EOF
+   )"
+   ```
+
+### Step 4: Finalize
+
+1. **Add pending label**: Use `gh issue edit {{ISSUE_ID}} --add-label pending` to wait for user approval
+2. **Remember issue ID**: Store {{ISSUE_ID}} in context for future `/issue-continue` calls
+3. **Exit and wait**: Stop here and wait for user to review the plan and call `/issue-continue`
+
+## Deep-Dive Phase Guidelines
+
+### Research Phase Focus
+- Understanding the current codebase state
+- Identifying technical constraints
+- Mapping dependencies and relationships
+- NO suggestions or solutions
+
+### Innovation Phase Focus
+- Exploring multiple solution paths
+- Evaluating trade-offs
+- Considering feasibility and maintainability
+- NO concrete planning or implementation details
+
+### Plan Phase Focus
+- Creating actionable implementation steps
+- Specifying file changes
+- Defining acceptance criteria
+- Ensuring goal alignment with original requirements
 
 ## Label Management
-- **Add "pending" label** when waiting for user input (step 3)
+- **Add "pending" label** when waiting for user input (after all phases complete)
 
 ## Error Handling
 - If issue doesn't exist or is inaccessible: report error and exit
 - If "pending" label doesn't exist: create it first with `gh label create pending --description "Waiting for human input" --color FFA500`
 - If feature branch already exists: ask user whether to reuse or create new branch
+- If deep-dive directory association is unclear: ask user to confirm which directory to use
+
+## Skipping Phases
+
+If artifacts already exist from previous deep-dive work:
+- **If research.md exists**: Skip research phase, post existing content as comment (if not already posted)
+- **If innovate.md exists**: Skip innovation phase, post existing content as comment (if not already posted)
+- **If plan.md exists**: Skip plan phase, post existing content as comment (if not already posted)
+
+To determine if a comment was already posted, check the issue comments for the phase headers (🔬 Research Phase, 💡 Innovation Phase, 📋 Plan Phase).
 
 Let's get started!

--- a/.claude/commands/issue-todo.md
+++ b/.claude/commands/issue-todo.md
@@ -37,8 +37,7 @@ For each missing phase, execute in order using the corresponding slash command, 
 #### Phase 1: Research (if no research.md exists)
 
 1. **Execute `/deep-research`** with the issue context
-   - Use task-name: `issue-{{ISSUE_ID}}`
-   - This will create `/tmp/deep-dive/issue-{{ISSUE_ID}}/research.md`
+   - This will create `/tmp/deep-dive/{task-name}/research.md`
 
 2. **Post research comment to issue**:
    ```
@@ -56,7 +55,7 @@ For each missing phase, execute in order using the corresponding slash command, 
 #### Phase 2: Innovate (if no innovate.md exists)
 
 1. **Execute `/deep-innovate`** with the issue context
-   - This will read research.md and create `/tmp/deep-dive/issue-{{ISSUE_ID}}/innovate.md`
+   - This will read research.md and create `/tmp/deep-dive/{task-name}/innovate.md`
 
 2. **Post innovation comment to issue**:
    ```
@@ -74,7 +73,7 @@ For each missing phase, execute in order using the corresponding slash command, 
 #### Phase 3: Plan (if no plan.md exists)
 
 1. **Execute `/deep-plan`** with the issue context
-   - This will read research.md and innovate.md, then create `/tmp/deep-dive/issue-{{ISSUE_ID}}/plan.md`
+   - This will read research.md and innovate.md, then create `/tmp/deep-dive/{task-name}/plan.md`
 
 2. **Post plan comment to issue**:
    ```

--- a/.claude/commands/issue-todo.md
+++ b/.claude/commands/issue-todo.md
@@ -32,15 +32,13 @@ Look for existing deep-dive work in the current conversation context:
 
 ### Step 3: Execute Deep-Dive Workflow
 
-For each missing phase, execute in order and post comments to the issue:
+For each missing phase, execute in order using the corresponding slash command, then post comments to the issue:
 
 #### Phase 1: Research (if no research.md exists)
 
-1. **Execute research phase**:
-   - Create directory `/tmp/deep-dive/issue-{{ISSUE_ID}}/` if not exists
-   - Systematically analyze the codebase related to the issue
-   - Identify core files, trace code flow, map architecture
-   - Document findings in `/tmp/deep-dive/issue-{{ISSUE_ID}}/research.md`
+1. **Execute `/deep-research`** with the issue context
+   - Use task-name: `issue-{{ISSUE_ID}}`
+   - This will create `/tmp/deep-dive/issue-{{ISSUE_ID}}/research.md`
 
 2. **Post research comment to issue**:
    ```
@@ -57,11 +55,8 @@ For each missing phase, execute in order and post comments to the issue:
 
 #### Phase 2: Innovate (if no innovate.md exists)
 
-1. **Execute innovation phase**:
-   - Read research findings from `research.md`
-   - Explore multiple solution approaches
-   - Evaluate pros and cons of each approach
-   - Document in `/tmp/deep-dive/issue-{{ISSUE_ID}}/innovate.md`
+1. **Execute `/deep-innovate`** with the issue context
+   - This will read research.md and create `/tmp/deep-dive/issue-{{ISSUE_ID}}/innovate.md`
 
 2. **Post innovation comment to issue**:
    ```
@@ -78,12 +73,8 @@ For each missing phase, execute in order and post comments to the issue:
 
 #### Phase 3: Plan (if no plan.md exists)
 
-1. **Execute planning phase**:
-   - Read research and innovation documents
-   - Create detailed implementation plan with specific steps
-   - Ensure goal focus - connect all planning to original requirements
-   - Do not skip or abbreviate specifications
-   - Document in `/tmp/deep-dive/issue-{{ISSUE_ID}}/plan.md`
+1. **Execute `/deep-plan`** with the issue context
+   - This will read research.md and innovate.md, then create `/tmp/deep-dive/issue-{{ISSUE_ID}}/plan.md`
 
 2. **Post plan comment to issue**:
    ```
@@ -104,26 +95,6 @@ For each missing phase, execute in order and post comments to the issue:
 2. **Remember issue ID**: Store {{ISSUE_ID}} in context for future `/issue-continue` calls
 3. **Exit and wait**: Stop here and wait for user to review the plan and call `/issue-continue`
 
-## Deep-Dive Phase Guidelines
-
-### Research Phase Focus
-- Understanding the current codebase state
-- Identifying technical constraints
-- Mapping dependencies and relationships
-- NO suggestions or solutions
-
-### Innovation Phase Focus
-- Exploring multiple solution paths
-- Evaluating trade-offs
-- Considering feasibility and maintainability
-- NO concrete planning or implementation details
-
-### Plan Phase Focus
-- Creating actionable implementation steps
-- Specifying file changes
-- Defining acceptance criteria
-- Ensuring goal alignment with original requirements
-
 ## Label Management
 - **Add "pending" label** when waiting for user input (after all phases complete)
 
@@ -136,9 +107,9 @@ For each missing phase, execute in order and post comments to the issue:
 ## Skipping Phases
 
 If artifacts already exist from previous deep-dive work:
-- **If research.md exists**: Skip research phase, post existing content as comment (if not already posted)
-- **If innovate.md exists**: Skip innovation phase, post existing content as comment (if not already posted)
-- **If plan.md exists**: Skip plan phase, post existing content as comment (if not already posted)
+- **If research.md exists**: Skip `/deep-research`, post existing content as comment (if not already posted)
+- **If innovate.md exists**: Skip `/deep-innovate`, post existing content as comment (if not already posted)
+- **If plan.md exists**: Skip `/deep-plan`, post existing content as comment (if not already posted)
 
 To determine if a comment was already posted, check the issue comments for the phase headers (🔬 Research Phase, 💡 Innovation Phase, 📋 Plan Phase).
 


### PR DESCRIPTION
## Summary

- Integrate the deep-dive workflow (research → innovate → plan) into `/issue-todo`
- Each phase posts a comment to the issue in real-time
- Support composable workflow: reuse existing artifacts from `/tmp/deep-dive/` if present
- Add phase-specific guidelines (research focus, innovation focus, plan focus)

## Workflow

When `/issue-todo #123` is called:

1. Check for existing deep-dive artifacts in `/tmp/deep-dive/`
2. Execute missing phases in order:
   - Research → post 🔬 Research Phase comment
   - Innovate → post 💡 Innovation Phase comment
   - Plan → post 📋 Plan Phase comment
3. Add `pending` label and wait for user approval
4. User calls `/issue-continue` to start implementation

## Composability

If user has already done `/deep-research` or `/deep-innovate` before calling `/issue-todo`:
- Existing artifacts are detected and reused
- Only missing phases are executed
- All phase comments are posted to the issue

## Test plan

- [ ] Run `/issue-todo <id>` on a fresh issue - should execute all 3 phases
- [ ] Run `/deep-research` first, then `/issue-todo <id>` - should skip research phase
- [ ] Verify comments are posted correctly to the issue
- [ ] Verify pending label is added after all phases complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)