### PR TITLE
refactor(cli): unify pr-review commands to delegate to code-review

### DIFF
--- a/.claude/commands/pr-review-and-comment.md
+++ b/.claude/commands/pr-review-and-comment.md
@@ -3,20 +3,15 @@ command: pr-review-and-comment
 description: Review a pull request and post the review as a PR comment
 ---
 
-Reviews a pull request by analyzing its diff, understanding the changes, and posting the review as a comment on the PR.
+Reviews a pull request by fetching PR information, delegating the code review to `/code-review`, and posting the review as a comment on the PR.
 
 Usage: `/pr-review-and-comment [PR_NUMBER]`
 - If PR_NUMBER is provided, reviews that specific PR
 - If no argument is given, reviews the PR associated with the current branch
 
-The review includes:
-1. Summary of what the PR accomplishes
-2. List of modified files
-3. Key code changes, especially:
-   - Data structure modifications
-   - API changes
-   - Critical logic updates
-4. Code review feedback and suggestions
+## Workflow
+
+### Step 1: Get PR Information
 
 ```bash
 # Get PR number from argument or current branch
@@ -40,50 +35,32 @@ echo
 
 # Get PR information
 gh pr view "$PR_NUMBER" --json title,body,author,url | jq -r '"Title: \(.title)\nAuthor: \(.author.login)\nURL: \(.url)\n"'
-
-# Get the diff
-echo "Fetching PR diff..."
-gh pr diff "$PR_NUMBER"
 ```
 
-After fetching the diff, analyze:
+### Step 2: Execute Code Review
 
-1. **What this PR does:**
-   - Main purpose and goals
-   - Problems it solves
-   - Features it adds/modifies
+**Execute `/code-review $PR_NUMBER`** to perform the detailed code review.
 
-2. **Modified files:**
-   - List all changed files with statistics
-   - Group by type (source, config, tests, docs)
+The `/code-review` command will:
+1. Parse the PR and get the commit list
+2. Create output directory `codereviews/yyyymmdd`
+3. Generate `commit-list.md` with checkboxes for each commit
+4. Review each commit against the project's bad code smell criteria
+5. Generate individual review files per commit
+6. Update commit list with links to review files
+7. Generate overall review summary
 
-3. **Key changes:**
-   - Data structures (interfaces, types, schemas)
-   - API endpoints or function signatures
-   - Database schema changes
-   - Configuration changes
-   - Breaking changes
+### Step 3: Post Review as PR Comment
 
-4. **Code review:**
-   - Code quality and style consistency
-   - Potential bugs or edge cases
-   - Performance considerations
-   - Security implications
-   - Test coverage
-   - Documentation updates needed
-
-5. **Suggestions:**
-   - Improvements or optimizations
-   - Missing error handling
-   - Alternative approaches
-   - Additional test cases needed
-
-## Post Review as PR Comment
-
-After completing the analysis, format the review as a markdown comment and post it to the PR using:
+After the code review is complete, compile the review summary and post it to the PR:
 
 ```bash
 gh pr comment "$PR_NUMBER" --body "REVIEW_CONTENT_HERE"
 ```
 
-The comment should be formatted with clear sections and use markdown formatting for readability. Include a header indicating this is an automated review from Claude Code.
+The comment should:
+- Include a header indicating this is an automated review from Claude Code
+- Summarize the key findings from the code review
+- List any issues or suggestions found
+- Use markdown formatting for readability
+- Reference the detailed review files in `codereviews/yyyymmdd/` for full details

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -3,20 +3,13 @@ command: pr-review
 description: Review a pull request with detailed analysis of changes
 ---
 
-Reviews a pull request by analyzing its diff, understanding the changes, and providing feedback.
+Reviews a pull request by fetching PR information and delegating the code review to `/code-review`.
 
 Usage: `/pr-review [PR_NUMBER]`
 - If PR_NUMBER is provided, reviews that specific PR
 - If no argument is given, reviews the PR associated with the current branch
 
-The review includes:
-1. Summary of what the PR accomplishes
-2. List of modified files
-3. Key code changes, especially:
-   - Data structure modifications
-   - API changes
-   - Critical logic updates
-4. Code review feedback and suggestions
+## Workflow
 
 ```bash
 # Get PR number from argument or current branch
@@ -25,10 +18,10 @@ if [ -n "$1" ]; then
 else
     # Get current branch name
     CURRENT_BRANCH=$(git branch --show-current)
-    
+
     # Find PR associated with current branch
     PR_NUMBER=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number')
-    
+
     if [ -z "$PR_NUMBER" ]; then
         echo "No PR found for current branch '$CURRENT_BRANCH'. Please specify a PR number."
         exit 1
@@ -40,40 +33,17 @@ echo
 
 # Get PR information
 gh pr view "$PR_NUMBER" --json title,body,author,url | jq -r '"Title: \(.title)\nAuthor: \(.author.login)\nURL: \(.url)\n"'
-
-# Get the diff
-echo "Fetching PR diff..."
-gh pr diff "$PR_NUMBER"
 ```
 
-After fetching the diff, analyze:
+After fetching PR information, delegate to `/code-review` for the actual code review:
 
-1. **What this PR does:**
-   - Main purpose and goals
-   - Problems it solves
-   - Features it adds/modifies
+**Execute `/code-review $PR_NUMBER`** to perform the detailed code review.
 
-2. **Modified files:**
-   - List all changed files with statistics
-   - Group by type (source, config, tests, docs)
-
-3. **Key changes:**
-   - Data structures (interfaces, types, schemas)
-   - API endpoints or function signatures
-   - Database schema changes
-   - Configuration changes
-   - Breaking changes
-
-4. **Code review:**
-   - Code quality and style consistency
-   - Potential bugs or edge cases
-   - Performance considerations
-   - Security implications
-   - Test coverage
-   - Documentation updates needed
-
-5. **Suggestions:**
-   - Improvements or optimizations
-   - Missing error handling
-   - Alternative approaches
-   - Additional test cases needed
+The `/code-review` command will:
+1. Parse the PR and get the commit list
+2. Create output directory `codereviews/yyyymmdd`
+3. Generate `commit-list.md` with checkboxes for each commit
+4. Review each commit against the project's bad code smell criteria
+5. Generate individual review files per commit
+6. Update commit list with links to review files
+7. Generate overall review summary


### PR DESCRIPTION
## Summary

- Update `/pr-review` and `/pr-review-and-comment` to delegate the actual code review logic to `/code-review`
- Makes `/code-review` the single source of truth for code review implementation
- Reduces code duplication by removing redundant review criteria from both commands

## Changes

- `/pr-review`: Now fetches PR info, then calls `/code-review`
- `/pr-review-and-comment`: Same as above, plus posts review as PR comment

## Test plan

- [ ] Run `/pr-review <PR_NUMBER>` and verify it delegates to `/code-review`
- [ ] Run `/pr-review-and-comment <PR_NUMBER>` and verify it delegates to `/code-review` and posts comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)