### PR TITLE
feat(cli): add auto-upgrade check for cook command

### DIFF
--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -9,6 +9,9 @@ import { config as dotenvConfig } from "dotenv";
 import { extractVariableReferences, groupVariablesBySource } from "@vm0/core";
 import { validateAgentCompose } from "../lib/yaml-validator";
 import { readStorageConfig } from "../lib/storage-utils";
+import { checkAndUpgrade } from "../lib/update-checker";
+
+declare const __CLI_VERSION__: string;
 
 interface VolumeConfig {
   name: string;
@@ -231,6 +234,12 @@ export const cookCommand = new Command()
   .description("One-click agent preparation and execution from vm0.yaml")
   .argument("[prompt]", "Prompt for the agent")
   .action(async (prompt: string | undefined) => {
+    // Step 0: Check for updates and auto-upgrade if needed
+    const shouldExit = await checkAndUpgrade(__CLI_VERSION__, prompt);
+    if (shouldExit) {
+      process.exit(0);
+    }
+
     const cwd = process.cwd();
 
     // Step 1: Read and parse config

--- a/turbo/apps/cli/src/lib/__tests__/update-checker.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/update-checker.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  escapeForShell,
+  buildRerunCommand,
+  getLatestVersion,
+  checkAndUpgrade,
+} from "../update-checker";
+import https from "https";
+import { EventEmitter } from "events";
+
+// Mock https module
+vi.mock("https", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+// Mock child_process module
+vi.mock("child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+describe("update-checker", () => {
+  describe("escapeForShell", () => {
+    it("should wrap string in double quotes", () => {
+      expect(escapeForShell("hello world")).toBe('"hello world"');
+    });
+
+    it("should escape internal double quotes", () => {
+      expect(escapeForShell('say "hello"')).toBe('"say \\"hello\\""');
+    });
+
+    it("should handle empty string", () => {
+      expect(escapeForShell("")).toBe('""');
+    });
+
+    it("should handle string with multiple double quotes", () => {
+      expect(escapeForShell('"a" and "b"')).toBe('"\\"a\\" and \\"b\\""');
+    });
+
+    it("should handle string with single quotes (no escaping needed)", () => {
+      expect(escapeForShell("it's fine")).toBe('"it\'s fine"');
+    });
+
+    it("should handle string with special characters", () => {
+      expect(escapeForShell("hello $world")).toBe('"hello $world"');
+    });
+  });
+
+  describe("buildRerunCommand", () => {
+    it("should build command with prompt", () => {
+      expect(buildRerunCommand("hello world")).toBe('vm0 cook "hello world"');
+    });
+
+    it("should build command without prompt", () => {
+      expect(buildRerunCommand(undefined)).toBe("vm0 cook");
+    });
+
+    it("should escape double quotes in prompt", () => {
+      expect(buildRerunCommand('say "hi"')).toBe('vm0 cook "say \\"hi\\""');
+    });
+
+    it("should handle empty string prompt (treated as no prompt)", () => {
+      // Empty string is falsy, so treated as no prompt
+      expect(buildRerunCommand("")).toBe("vm0 cook");
+    });
+  });
+
+  describe("getLatestVersion", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("should return version from npm registry response", async () => {
+      const mockResponse = new EventEmitter() as EventEmitter & {
+        on: (event: string, cb: (data?: Buffer) => void) => void;
+      };
+
+      vi.mocked(https.get).mockImplementation((_url, callback) => {
+        const cb = callback as (res: typeof mockResponse) => void;
+        setTimeout(() => {
+          cb(mockResponse);
+          mockResponse.emit("data", Buffer.from('{"version":"4.11.0"}'));
+          mockResponse.emit("end");
+        }, 0);
+        const req = new EventEmitter() as EventEmitter & {
+          setTimeout: (ms: number, cb: () => void) => void;
+          destroy: () => void;
+        };
+        req.setTimeout = vi.fn();
+        req.destroy = vi.fn();
+        return req as ReturnType<typeof https.get>;
+      });
+
+      const version = await getLatestVersion();
+      expect(version).toBe("4.11.0");
+    });
+
+    it("should return null on invalid JSON response", async () => {
+      const mockResponse = new EventEmitter();
+
+      vi.mocked(https.get).mockImplementation((_url, callback) => {
+        const cb = callback as (res: typeof mockResponse) => void;
+        setTimeout(() => {
+          cb(mockResponse);
+          mockResponse.emit("data", Buffer.from("not valid json"));
+          mockResponse.emit("end");
+        }, 0);
+        const req = new EventEmitter() as EventEmitter & {
+          setTimeout: (ms: number, cb: () => void) => void;
+          destroy: () => void;
+        };
+        req.setTimeout = vi.fn();
+        req.destroy = vi.fn();
+        return req as ReturnType<typeof https.get>;
+      });
+
+      const version = await getLatestVersion();
+      expect(version).toBeNull();
+    });
+
+    it("should return null when response has no version field", async () => {
+      const mockResponse = new EventEmitter();
+
+      vi.mocked(https.get).mockImplementation((_url, callback) => {
+        const cb = callback as (res: typeof mockResponse) => void;
+        setTimeout(() => {
+          cb(mockResponse);
+          mockResponse.emit("data", Buffer.from('{"name":"@vm0/cli"}'));
+          mockResponse.emit("end");
+        }, 0);
+        const req = new EventEmitter() as EventEmitter & {
+          setTimeout: (ms: number, cb: () => void) => void;
+          destroy: () => void;
+        };
+        req.setTimeout = vi.fn();
+        req.destroy = vi.fn();
+        return req as ReturnType<typeof https.get>;
+      });
+
+      const version = await getLatestVersion();
+      expect(version).toBeNull();
+    });
+
+    it("should return null on network error", async () => {
+      vi.mocked(https.get).mockImplementation(() => {
+        const req = new EventEmitter() as EventEmitter & {
+          setTimeout: (ms: number, cb: () => void) => void;
+          destroy: () => void;
+        };
+        req.setTimeout = vi.fn();
+        req.destroy = vi.fn();
+        setTimeout(() => {
+          req.emit("error", new Error("Network error"));
+        }, 0);
+        return req as ReturnType<typeof https.get>;
+      });
+
+      const version = await getLatestVersion();
+      expect(version).toBeNull();
+    });
+
+    it("should return null on timeout", async () => {
+      vi.mocked(https.get).mockImplementation(() => {
+        const req = new EventEmitter() as EventEmitter & {
+          setTimeout: (ms: number, cb: () => void) => void;
+          destroy: () => void;
+        };
+        req.destroy = vi.fn();
+        req.setTimeout = (_ms: number, cb: () => void) => {
+          setTimeout(cb, 0);
+        };
+        return req as ReturnType<typeof https.get>;
+      });
+
+      const version = await getLatestVersion();
+      expect(version).toBeNull();
+    });
+  });
+
+  describe("checkAndUpgrade", () => {
+    let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleSpy.mockRestore();
+    });
+
+    it("should return false and warn when version check fails", async () => {
+      vi.mocked(https.get).mockImplementation(() => {
+        const req = new EventEmitter() as EventEmitter & {
+          setTimeout: (ms: number, cb: () => void) => void;
+          destroy: () => void;
+        };
+        req.setTimeout = vi.fn();
+        req.destroy = vi.fn();
+        setTimeout(() => {
+          req.emit("error", new Error("Network error"));
+        }, 0);
+        return req as ReturnType<typeof https.get>;
+      });
+
+      const result = await checkAndUpgrade("4.10.0", "test prompt");
+
+      expect(result).toBe(false);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Warning: Could not check for updates"),
+      );
+    });
+
+    it("should return false when already on latest version", async () => {
+      const mockResponse = new EventEmitter();
+
+      vi.mocked(https.get).mockImplementation((_url, callback) => {
+        const cb = callback as (res: typeof mockResponse) => void;
+        setTimeout(() => {
+          cb(mockResponse);
+          mockResponse.emit("data", Buffer.from('{"version":"4.10.0"}'));
+          mockResponse.emit("end");
+        }, 0);
+        const req = new EventEmitter() as EventEmitter & {
+          setTimeout: (ms: number, cb: () => void) => void;
+          destroy: () => void;
+        };
+        req.setTimeout = vi.fn();
+        req.destroy = vi.fn();
+        return req as ReturnType<typeof https.get>;
+      });
+
+      const result = await checkAndUpgrade("4.10.0", "test prompt");
+
+      expect(result).toBe(false);
+      // Should not log EA notice
+      expect(consoleSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("Early Access"),
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/lib/update-checker.ts
+++ b/turbo/apps/cli/src/lib/update-checker.ts
@@ -132,7 +132,7 @@ export async function checkAndUpgrade(
   // Upgrade failed - show manual instructions
   console.log();
   console.log(chalk.red("Upgrade failed. Please run manually:"));
-  console.log(chalk.cyan(`  sudo npm install -g ${PACKAGE_NAME}@latest`));
+  console.log(chalk.cyan(`  npm install -g ${PACKAGE_NAME}@latest`));
   console.log();
   console.log("Then re-run:");
   console.log(chalk.cyan(`  ${buildRerunCommand(prompt)}`));

--- a/turbo/apps/cli/src/lib/update-checker.ts
+++ b/turbo/apps/cli/src/lib/update-checker.ts
@@ -7,10 +7,28 @@ const NPM_REGISTRY_URL = `https://registry.npmjs.org/${encodeURIComponent(PACKAG
 const TIMEOUT_MS = 5000;
 
 /**
+ * Escape a string for use in shell command display
+ * Uses double quotes and escapes internal double quotes
+ */
+export function escapeForShell(str: string): string {
+  return `"${str.replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Build the re-run command string
+ */
+export function buildRerunCommand(prompt: string | undefined): string {
+  if (prompt) {
+    return `vm0 cook ${escapeForShell(prompt)}`;
+  }
+  return "vm0 cook";
+}
+
+/**
  * Fetch the latest version of the package from npm registry
  * Returns null if the request fails or times out
  */
-function getLatestVersion(): Promise<string | null> {
+export function getLatestVersion(): Promise<string | null> {
   return new Promise((resolve) => {
     const req = https.get(NPM_REGISTRY_URL, (res) => {
       let data = "";
@@ -44,7 +62,7 @@ function getLatestVersion(): Promise<string | null> {
  * Execute npm install -g @vm0/cli@latest
  * Returns true on success, false on failure
  */
-function performUpgrade(): Promise<boolean> {
+export function performUpgrade(): Promise<boolean> {
   return new Promise((resolve) => {
     const npm = process.platform === "win32" ? "npm.cmd" : "npm";
     const child = spawn(npm, ["install", "-g", `${PACKAGE_NAME}@latest`], {
@@ -60,24 +78,6 @@ function performUpgrade(): Promise<boolean> {
       resolve(false);
     });
   });
-}
-
-/**
- * Escape a string for use in shell command display
- * Uses double quotes and escapes internal double quotes
- */
-function escapeForShell(str: string): string {
-  return `"${str.replace(/"/g, '\\"')}"`;
-}
-
-/**
- * Build the re-run command string
- */
-function buildRerunCommand(prompt: string | undefined): string {
-  if (prompt) {
-    return `vm0 cook ${escapeForShell(prompt)}`;
-  }
-  return "vm0 cook";
 }
 
 /**

--- a/turbo/apps/cli/src/lib/update-checker.ts
+++ b/turbo/apps/cli/src/lib/update-checker.ts
@@ -1,0 +1,140 @@
+import https from "https";
+import { spawn } from "child_process";
+import chalk from "chalk";
+
+const PACKAGE_NAME = "@vm0/cli";
+const NPM_REGISTRY_URL = `https://registry.npmjs.org/${encodeURIComponent(PACKAGE_NAME)}/latest`;
+const TIMEOUT_MS = 5000;
+
+/**
+ * Fetch the latest version of the package from npm registry
+ * Returns null if the request fails or times out
+ */
+function getLatestVersion(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const req = https.get(NPM_REGISTRY_URL, (res) => {
+      let data = "";
+
+      res.on("data", (chunk: Buffer) => {
+        data += chunk.toString();
+      });
+
+      res.on("end", () => {
+        try {
+          const json = JSON.parse(data) as { version?: string };
+          resolve(json.version ?? null);
+        } catch {
+          resolve(null);
+        }
+      });
+    });
+
+    req.on("error", () => {
+      resolve(null);
+    });
+
+    req.setTimeout(TIMEOUT_MS, () => {
+      req.destroy();
+      resolve(null);
+    });
+  });
+}
+
+/**
+ * Execute npm install -g @vm0/cli@latest
+ * Returns true on success, false on failure
+ */
+function performUpgrade(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+    const child = spawn(npm, ["install", "-g", `${PACKAGE_NAME}@latest`], {
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    });
+
+    child.on("close", (code) => {
+      resolve(code === 0);
+    });
+
+    child.on("error", () => {
+      resolve(false);
+    });
+  });
+}
+
+/**
+ * Escape a string for use in shell command display
+ * Uses double quotes and escapes internal double quotes
+ */
+function escapeForShell(str: string): string {
+  return `"${str.replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Build the re-run command string
+ */
+function buildRerunCommand(prompt: string | undefined): string {
+  if (prompt) {
+    return `vm0 cook ${escapeForShell(prompt)}`;
+  }
+  return "vm0 cook";
+}
+
+/**
+ * Check for updates and perform upgrade if needed
+ * Returns true if caller should exit (upgrade happened or failed)
+ * Returns false if caller should continue (no update needed or check failed)
+ */
+export async function checkAndUpgrade(
+  currentVersion: string,
+  prompt: string | undefined,
+): Promise<boolean> {
+  const latestVersion = await getLatestVersion();
+
+  // If we couldn't check, warn and continue
+  if (latestVersion === null) {
+    console.log(chalk.yellow("Warning: Could not check for updates"));
+    console.log();
+    return false;
+  }
+
+  // If already on latest, continue
+  if (latestVersion === currentVersion) {
+    return false;
+  }
+
+  // New version available - show EA notice
+  console.log(chalk.yellow("vm0 is currently in Early Access (EA)."));
+  console.log(
+    chalk.yellow(
+      `Current version: ${currentVersion} -> Latest version: ${latestVersion}`,
+    ),
+  );
+  console.log(
+    chalk.yellow(
+      "Please always use the latest version for best compatibility.",
+    ),
+  );
+  console.log();
+
+  // Perform upgrade
+  console.log("Upgrading...");
+  const success = await performUpgrade();
+
+  if (success) {
+    console.log(chalk.green(`Upgraded to ${latestVersion}`));
+    console.log();
+    console.log("To continue, run:");
+    console.log(chalk.cyan(`  ${buildRerunCommand(prompt)}`));
+    return true;
+  }
+
+  // Upgrade failed - show manual instructions
+  console.log();
+  console.log(chalk.red("Upgrade failed. Please run manually:"));
+  console.log(chalk.cyan(`  sudo npm install -g ${PACKAGE_NAME}@latest`));
+  console.log();
+  console.log("Then re-run:");
+  console.log(chalk.cyan(`  ${buildRerunCommand(prompt)}`));
+  return true;
+}


### PR DESCRIPTION
## Summary

- Add automatic version checking and upgrade functionality to the `cook` command for EA (Early Access) period
- When a newer version is available on npm registry, the CLI will auto-upgrade before continuing
- Uses zero external dependencies (native Node.js `https` and `child_process` modules)

## Changes

| File | Description |
|------|-------------|
| `turbo/apps/cli/src/lib/update-checker.ts` | New module for version checking and upgrade logic |
| `turbo/apps/cli/src/commands/cook.ts` | Integration at the start of cook action |

## Behavior

**When upgrade needed:**
```
vm0 is currently in Early Access (EA).
Current version: 4.10.0 -> Latest version: 4.11.0
Please always use the latest version for best compatibility.

Upgrading...
Upgraded to 4.11.0

To continue, run:
  vm0 cook "your prompt here"
```

**When network fails:**
```
Warning: Could not check for updates
[continues with cook normally]
```

**When upgrade fails (permission):**
```
Upgrade failed. Please run manually:
  sudo npm install -g @vm0/cli@latest

Then re-run:
  vm0 cook "your prompt here"
```

## Test plan

- [x] Lint passes
- [x] Type check passes  
- [x] All existing tests pass
- [ ] Manual test: cook when already on latest version (should continue normally)
- [ ] Manual test: cook when older version (should upgrade and exit)

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)