### PR TITLE
feat(ci): add cron simulator for sandbox heartbeat timeout detection

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -205,6 +205,7 @@ jobs:
             SECRETS_ENCRYPTION_KEY=${{ secrets.CI_SECRETS_ENCRYPTION_KEY }}
             USE_MOCK_CLAUDE=true
             DEBUG=*
+            CRON_SECRET=${{ secrets.CRON_SECRET }}
           meta-branch: ${{ github.head_ref }}
           meta-pr: ${{ github.event.pull_request.number }}
 
@@ -291,9 +292,27 @@ jobs:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
+      - name: Start Cron Simulator
+        run: |
+          chmod +x ./e2e/scripts/cron-simulator.sh
+          ./e2e/scripts/cron-simulator.sh "$VM0_API_URL" 60 &
+          echo "CRON_SIMULATOR_PID=$!" >> $GITHUB_ENV
+        env:
+          VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
       - name: Run CLI E2E Tests
         run: ./e2e/test/libs/bats/bin/bats -j 4 --no-parallelize-within-files ./e2e/tests/**/*.bats
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           USE_MOCK_CLAUDE: "true"
+
+      - name: Stop Cron Simulator
+        if: always()
+        run: |
+          if [ -n "$CRON_SIMULATOR_PID" ]; then
+            kill "$CRON_SIMULATOR_PID" 2>/dev/null || true
+            echo "Cron simulator stopped"
+          fi

--- a/e2e/scripts/cron-simulator.sh
+++ b/e2e/scripts/cron-simulator.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Cron simulator for CI environments
+# Simulates Vercel's cron job behavior by periodically calling the cleanup-sandboxes endpoint
+# This is needed because Vercel cron jobs only run on production deployments, not preview deployments
+#
+# Usage: ./cron-simulator.sh <api_url> [interval_seconds]
+# Example: ./cron-simulator.sh "https://my-preview.vercel.app" 60
+
+set -euo pipefail
+
+API_URL="${1:?Error: API_URL is required as first argument}"
+INTERVAL="${2:-60}"
+
+echo "Starting cron simulator..."
+echo "  API URL: ${API_URL}"
+echo "  Interval: ${INTERVAL}s"
+
+while true; do
+  echo "[$(date -Iseconds)] Calling cleanup-sandboxes endpoint..."
+
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer ${CRON_SECRET:-}" \
+    -H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET:-}" \
+    "${API_URL}/api/cron/cleanup-sandboxes") || true
+
+  echo "[$(date -Iseconds)] Response status: ${HTTP_STATUS}"
+
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary

- Add a background cron simulator to enable sandbox heartbeat timeout detection in CI E2E tests
- Vercel cron jobs only run on production deployments, so preview deployments need this workaround
- The simulator calls `/api/cron/cleanup-sandboxes` every 60 seconds (matching production)

## Changes

- **New file**: `e2e/scripts/cron-simulator.sh` - Script that periodically calls the cleanup endpoint
- **Modified**: `.github/workflows/turbo.yml`:
  - Add `CRON_SECRET` to preview deployment environment variables
  - Add "Start Cron Simulator" step before E2E tests (runs in background)
  - Add "Stop Cron Simulator" step after E2E tests (with `if: always()`)

## Test plan

- [ ] CI workflow runs successfully with the cron simulator
- [ ] Cron simulator logs show periodic calls to cleanup-sandboxes endpoint
- [ ] E2E tests pass as before

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)