### PR TITLE
feat(cli): improve setup-token output with human-readable format

### DIFF
--- a/e2e/tests/02-commands/t18-vm0-auth.bats
+++ b/e2e/tests/02-commands/t18-vm0-auth.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+
+# Auth command tests
+
+@test "vm0 auth --help shows available auth commands" {
+    run $CLI_COMMAND auth --help
+    assert_success
+    assert_output --partial "login"
+    assert_output --partial "logout"
+    assert_output --partial "status"
+    assert_output --partial "setup-token"
+}
+
+@test "vm0 auth setup-token --help shows command description" {
+    run $CLI_COMMAND auth setup-token --help
+    assert_success
+    assert_output --partial "Output auth token for CI/CD environments"
+}
+
+@test "vm0 auth setup-token outputs token when authenticated" {
+    # This test assumes the CLI is already authenticated (done in CI setup)
+    run $CLI_COMMAND auth setup-token
+    assert_success
+    # Token should start with vm0_live_ prefix
+    assert_output --regexp '^vm0_live_'
+}
+
+@test "vm0 auth status shows authenticated status" {
+    run $CLI_COMMAND auth status
+    assert_success
+    assert_output --partial "Authenticated"
+}

--- a/e2e/tests/02-commands/t18-vm0-auth.bats
+++ b/e2e/tests/02-commands/t18-vm0-auth.bats
@@ -19,12 +19,15 @@ load '../../helpers/setup'
     assert_output --partial "Output auth token for CI/CD environments"
 }
 
-@test "vm0 auth setup-token outputs token when authenticated" {
+@test "vm0 auth setup-token outputs token with human-readable format when authenticated" {
     # This test assumes the CLI is already authenticated (done in CI setup)
     run $CLI_COMMAND auth setup-token
     assert_success
-    # Token should start with vm0_live_ prefix
-    assert_output --regexp '^vm0_live_'
+    # Check for human-readable output format
+    assert_output --partial "Authentication token exported successfully"
+    assert_output --partial "Your token:"
+    assert_output --partial "vm0_live_"
+    assert_output --partial "export VM0_TOKEN=<token>"
 }
 
 @test "vm0 auth status shows authenticated status" {

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -59,9 +59,8 @@ authCommand
 authCommand
   .command("setup-token")
   .description("Output auth token for CI/CD environments")
-  .option("-e, --export", "Output as shell export statement")
-  .action(async (options: { export?: boolean }) => {
-    await setupToken(options);
+  .action(async () => {
+    await setupToken();
   });
 
 // Register compose, run, volume, artifact, cook, image, and logs commands

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { authenticate, logout, checkAuthStatus } from "./lib/auth";
+import { authenticate, logout, checkAuthStatus, setupToken } from "./lib/auth";
 import { getApiUrl } from "./lib/config";
 import { composeCommand } from "./commands/compose";
 import { runCommand } from "./commands/run";
@@ -54,6 +54,14 @@ authCommand
   .description("Show current authentication status")
   .action(async () => {
     await checkAuthStatus();
+  });
+
+authCommand
+  .command("setup-token")
+  .description("Output auth token for CI/CD environments")
+  .option("-e, --export", "Output as shell export statement")
+  .action(async (options: { export?: boolean }) => {
+    await setupToken(options);
   });
 
 // Register compose, run, volume, artifact, cook, image, and logs commands

--- a/turbo/apps/cli/src/lib/__tests__/auth.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/auth.test.ts
@@ -38,23 +38,30 @@ describe("auth", () => {
   });
 
   describe("setupToken", () => {
-    it("should output token when authenticated via config file", async () => {
+    it("should output token with human-readable format when authenticated via config file", async () => {
       await mkdir(CONFIG_DIR, { recursive: true });
       await config.saveConfig({ token: "vm0_live_test123" });
       const consoleSpy = vi.spyOn(console, "log");
 
       await setupToken();
 
-      expect(consoleSpy).toHaveBeenCalledWith("vm0_live_test123");
+      const logCalls = consoleSpy.mock.calls.flat().join(" ");
+      expect(logCalls).toContain("Authentication token exported successfully");
+      expect(logCalls).toContain("Your token:");
+      expect(logCalls).toContain("vm0_live_test123");
+      expect(logCalls).toContain("export VM0_TOKEN=<token>");
     });
 
-    it("should output token when authenticated via VM0_TOKEN env var", async () => {
+    it("should output token with human-readable format when authenticated via VM0_TOKEN env var", async () => {
       process.env.VM0_TOKEN = "vm0_live_envtoken456";
       const consoleSpy = vi.spyOn(console, "log");
 
       await setupToken();
 
-      expect(consoleSpy).toHaveBeenCalledWith("vm0_live_envtoken456");
+      const logCalls = consoleSpy.mock.calls.flat().join(" ");
+      expect(logCalls).toContain("Authentication token exported successfully");
+      expect(logCalls).toContain("vm0_live_envtoken456");
+      expect(logCalls).toContain("export VM0_TOKEN=<token>");
     });
 
     it("should exit with error and show instructions when not authenticated", async () => {

--- a/turbo/apps/cli/src/lib/__tests__/auth.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setupToken } from "../auth";
+import * as config from "../config";
+import { existsSync } from "fs";
+import { unlink, mkdir } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+
+const CONFIG_DIR = join(homedir(), ".vm0");
+const CONFIG_FILE = join(CONFIG_DIR, "config.json");
+
+describe("auth", () => {
+  const originalEnv = { ...process.env };
+  const originalExit = process.exit;
+  const mockExit = vi.fn() as unknown as typeof process.exit;
+
+  beforeEach(async () => {
+    // Clean up any existing test config
+    if (existsSync(CONFIG_FILE)) {
+      await unlink(CONFIG_FILE);
+    }
+    // Reset environment variables
+    delete process.env.VM0_TOKEN;
+    // Mock process.exit
+    process.exit = mockExit;
+  });
+
+  afterEach(async () => {
+    // Restore original env vars
+    process.env = { ...originalEnv };
+    // Restore process.exit
+    process.exit = originalExit;
+    vi.restoreAllMocks();
+    // Clean up test config
+    if (existsSync(CONFIG_FILE)) {
+      await unlink(CONFIG_FILE);
+    }
+  });
+
+  describe("setupToken", () => {
+    it("should output token when authenticated via config file", async () => {
+      await mkdir(CONFIG_DIR, { recursive: true });
+      await config.saveConfig({ token: "vm0_live_test123" });
+      const consoleSpy = vi.spyOn(console, "log");
+
+      await setupToken({});
+
+      expect(consoleSpy).toHaveBeenCalledWith("vm0_live_test123");
+    });
+
+    it("should output token when authenticated via VM0_TOKEN env var", async () => {
+      process.env.VM0_TOKEN = "vm0_live_envtoken456";
+      const consoleSpy = vi.spyOn(console, "log");
+
+      await setupToken({});
+
+      expect(consoleSpy).toHaveBeenCalledWith("vm0_live_envtoken456");
+    });
+
+    it("should output export statement with --export flag", async () => {
+      await mkdir(CONFIG_DIR, { recursive: true });
+      await config.saveConfig({ token: "vm0_live_test123" });
+      const consoleSpy = vi.spyOn(console, "log");
+
+      await setupToken({ export: true });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'export VM0_TOKEN="vm0_live_test123"',
+      );
+    });
+
+    it("should exit with error when not authenticated", async () => {
+      const consoleErrorSpy = vi.spyOn(console, "error");
+
+      await setupToken({});
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/lib/__tests__/auth.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/auth.test.ts
@@ -43,7 +43,7 @@ describe("auth", () => {
       await config.saveConfig({ token: "vm0_live_test123" });
       const consoleSpy = vi.spyOn(console, "log");
 
-      await setupToken({});
+      await setupToken();
 
       expect(consoleSpy).toHaveBeenCalledWith("vm0_live_test123");
     });
@@ -52,27 +52,15 @@ describe("auth", () => {
       process.env.VM0_TOKEN = "vm0_live_envtoken456";
       const consoleSpy = vi.spyOn(console, "log");
 
-      await setupToken({});
+      await setupToken();
 
       expect(consoleSpy).toHaveBeenCalledWith("vm0_live_envtoken456");
-    });
-
-    it("should output export statement with --export flag", async () => {
-      await mkdir(CONFIG_DIR, { recursive: true });
-      await config.saveConfig({ token: "vm0_live_test123" });
-      const consoleSpy = vi.spyOn(console, "log");
-
-      await setupToken({ export: true });
-
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'export VM0_TOKEN="vm0_live_test123"',
-      );
     });
 
     it("should exit with error when not authenticated", async () => {
       const consoleErrorSpy = vi.spyOn(console, "error");
 
-      await setupToken({});
+      await setupToken();
 
       expect(consoleErrorSpy).toHaveBeenCalled();
       expect(mockExit).toHaveBeenCalledWith(1);

--- a/turbo/apps/cli/src/lib/__tests__/auth.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/auth.test.ts
@@ -57,12 +57,17 @@ describe("auth", () => {
       expect(consoleSpy).toHaveBeenCalledWith("vm0_live_envtoken456");
     });
 
-    it("should exit with error when not authenticated", async () => {
+    it("should exit with error and show instructions when not authenticated", async () => {
       const consoleErrorSpy = vi.spyOn(console, "error");
 
       await setupToken();
 
       expect(consoleErrorSpy).toHaveBeenCalled();
+      // Check that helpful instructions are shown
+      const errorCalls = consoleErrorSpy.mock.calls.flat().join(" ");
+      expect(errorCalls).toContain("Not authenticated");
+      expect(errorCalls).toContain("vm0 auth login");
+      expect(errorCalls).toContain("CI/CD");
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });

--- a/turbo/apps/cli/src/lib/auth.ts
+++ b/turbo/apps/cli/src/lib/auth.ts
@@ -1,5 +1,11 @@
 import chalk from "chalk";
-import { saveConfig, clearConfig, loadConfig, getApiUrl } from "./config";
+import {
+  saveConfig,
+  clearConfig,
+  loadConfig,
+  getApiUrl,
+  getToken,
+} from "./config";
 
 /**
  * Build headers with optional Vercel bypass secret
@@ -176,5 +182,21 @@ export async function checkAuthStatus(): Promise<void> {
   // Also check for environment variable
   if (process.env.VM0_TOKEN) {
     console.log(chalk.blue("Using token from VM0_TOKEN environment variable"));
+  }
+}
+
+export async function setupToken(options: { export?: boolean }): Promise<void> {
+  const token = await getToken();
+
+  if (!token) {
+    console.error(chalk.red("Error: Not authenticated."));
+    console.error("Run 'vm0 auth login' first.");
+    process.exit(1);
+  }
+
+  if (options.export) {
+    console.log(`export VM0_TOKEN="${token}"`);
+  } else {
+    console.log(token);
   }
 }

--- a/turbo/apps/cli/src/lib/auth.ts
+++ b/turbo/apps/cli/src/lib/auth.ts
@@ -190,7 +190,13 @@ export async function setupToken(): Promise<void> {
 
   if (!token) {
     console.error(chalk.red("Error: Not authenticated."));
-    console.error("Run 'vm0 auth login' first.");
+    console.error("");
+    console.error("To get a token for CI/CD:");
+    console.error("  1. Run 'vm0 auth login' to authenticate");
+    console.error("  2. Run 'vm0 auth setup-token' to get your token");
+    console.error(
+      "  3. Store the token in your CI/CD secrets (e.g., VM0_TOKEN)",
+    );
     process.exit(1);
   }
 

--- a/turbo/apps/cli/src/lib/auth.ts
+++ b/turbo/apps/cli/src/lib/auth.ts
@@ -185,7 +185,7 @@ export async function checkAuthStatus(): Promise<void> {
   }
 }
 
-export async function setupToken(options: { export?: boolean }): Promise<void> {
+export async function setupToken(): Promise<void> {
   const token = await getToken();
 
   if (!token) {
@@ -194,9 +194,5 @@ export async function setupToken(options: { export?: boolean }): Promise<void> {
     process.exit(1);
   }
 
-  if (options.export) {
-    console.log(`export VM0_TOKEN="${token}"`);
-  } else {
-    console.log(token);
-  }
+  console.log(token);
 }

--- a/turbo/apps/cli/src/lib/auth.ts
+++ b/turbo/apps/cli/src/lib/auth.ts
@@ -200,5 +200,11 @@ export async function setupToken(): Promise<void> {
     process.exit(1);
   }
 
+  console.log(chalk.green("✓ Authentication token exported successfully!"));
+  console.log("");
+  console.log("Your token:");
+  console.log("");
   console.log(token);
+  console.log("");
+  console.log(`Use this token by setting: ${chalk.cyan("export VM0_TOKEN=<token>")}`);
 }


### PR DESCRIPTION
## Summary

- Improve `vm0 auth setup-token` command output to be more user-friendly
- Add success message, visual separation, and usage hint

## Before

```
vm0_live_xxx...
```

## After

```
✓ Authentication token exported successfully!

Your token:

vm0_live_xxx...

Use this token by setting: export VM0_TOKEN=<token>
```

## Changes

- Add success message with checkmark
- Display token with visual separation  
- Add usage hint showing `export VM0_TOKEN=<token>`
- Update unit tests and e2e tests

Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)