### PR TITLE
feat(cli): improve setup-token output with human-readable format

### DIFF
--- a/e2e/tests/02-commands/t18-vm0-auth.bats
+++ b/e2e/tests/02-commands/t18-vm0-auth.bats
@@ -19,12 +19,15 @@ load '../../helpers/setup'
     assert_output --partial "Output auth token for CI/CD environments"
 }
 
-@test "vm0 auth setup-token outputs token when authenticated" {
+@test "vm0 auth setup-token outputs token with human-readable format when authenticated" {
     # This test assumes the CLI is already authenticated (done in CI setup)
     run $CLI_COMMAND auth setup-token
     assert_success
-    # Token should start with vm0_live_ prefix
-    assert_output --regexp '^vm0_live_'
+    # Check for human-readable output format
+    assert_output --partial "Authentication token exported successfully"
+    assert_output --partial "Your token:"
+    assert_output --partial "vm0_live_"
+    assert_output --partial "export VM0_TOKEN=<token>"
 }
 
 @test "vm0 auth status shows authenticated status" {

--- a/turbo/apps/cli/src/lib/__tests__/auth.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/auth.test.ts
@@ -38,23 +38,30 @@ describe("auth", () => {
   });
 
   describe("setupToken", () => {
-    it("should output token when authenticated via config file", async () => {
+    it("should output token with human-readable format when authenticated via config file", async () => {
       await mkdir(CONFIG_DIR, { recursive: true });
       await config.saveConfig({ token: "vm0_live_test123" });
       const consoleSpy = vi.spyOn(console, "log");
 
       await setupToken();
 
-      expect(consoleSpy).toHaveBeenCalledWith("vm0_live_test123");
+      const logCalls = consoleSpy.mock.calls.flat().join(" ");
+      expect(logCalls).toContain("Authentication token exported successfully");
+      expect(logCalls).toContain("Your token:");
+      expect(logCalls).toContain("vm0_live_test123");
+      expect(logCalls).toContain("export VM0_TOKEN=<token>");
     });
 
-    it("should output token when authenticated via VM0_TOKEN env var", async () => {
+    it("should output token with human-readable format when authenticated via VM0_TOKEN env var", async () => {
       process.env.VM0_TOKEN = "vm0_live_envtoken456";
       const consoleSpy = vi.spyOn(console, "log");
 
       await setupToken();
 
-      expect(consoleSpy).toHaveBeenCalledWith("vm0_live_envtoken456");
+      const logCalls = consoleSpy.mock.calls.flat().join(" ");
+      expect(logCalls).toContain("Authentication token exported successfully");
+      expect(logCalls).toContain("vm0_live_envtoken456");
+      expect(logCalls).toContain("export VM0_TOKEN=<token>");
     });
 
     it("should exit with error and show instructions when not authenticated", async () => {

--- a/turbo/apps/cli/src/lib/auth.ts
+++ b/turbo/apps/cli/src/lib/auth.ts
@@ -200,5 +200,13 @@ export async function setupToken(): Promise<void> {
     process.exit(1);
   }
 
+  console.log(chalk.green("✓ Authentication token exported successfully!"));
+  console.log("");
+  console.log("Your token:");
+  console.log("");
   console.log(token);
+  console.log("");
+  console.log(
+    `Use this token by setting: ${chalk.cyan("export VM0_TOKEN=<token>")}`,
+  );
 }


### PR DESCRIPTION
## Summary

- Improve `vm0 auth setup-token` command output to be more user-friendly
- Add success message, visual separation, and usage hint

## Before

```
vm0_live_xxx...
```

## After

```
✓ Authentication token exported successfully!

Your token:

vm0_live_xxx...

Use this token by setting: export VM0_TOKEN=<token>
```

## Changes

- Add success message with checkmark
- Display token with visual separation  
- Add usage hint showing `export VM0_TOKEN=<token>`
- Update unit tests and e2e tests

Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)