### PR TITLE
fix(storage): allow empty artifact push to update remote HEAD

### DIFF
--- a/codereviews/20251219/commit-list.md
+++ b/codereviews/20251219/commit-list.md
@@ -1,0 +1,9 @@
+# PR #618 Code Review - Commit List
+
+**PR Title:** fix(storage): allow empty artifact push to update remote HEAD
+**Author:** lancy
+**URL:** https://github.com/vm0-ai/vm0/pull/618
+
+## Commits
+
+- [x] [053f6a2d](review-pr618.md) - fix(storage): allow empty artifact push to update remote HEAD

--- a/codereviews/20251219/review-pr618.md
+++ b/codereviews/20251219/review-pr618.md
@@ -1,0 +1,108 @@
+# Code Review: PR #618
+
+**Commit:** 053f6a2d - fix(storage): allow empty artifact push to update remote HEAD
+**Files Changed:** 3
+
+## Summary
+
+This PR fixes issue #617 where pushing an empty artifact folder didn't update the remote HEAD. The fix correctly skips archive verification and upload for empty artifacts (fileCount === 0).
+
+## Review Criteria Analysis
+
+### 1. Mock Implementations and Alternatives
+**Status:** ✅ No issues
+
+No new mocks introduced. The existing test infrastructure is properly utilized.
+
+### 2. Test Coverage and Quality
+**Status:** ✅ Good
+
+- Added comprehensive E2E test in `t09-vm0-artifact-empty.bats`
+- Test covers the exact bug scenario: push with files first, then push empty, verify pull gets empty
+- Test properly cleans up temporary directories
+- Assertions verify both push success and pull correctness
+
+### 3. Error Handling Patterns
+**Status:** ✅ Good
+
+- The duplicate check for `prepareResult.uploads` in direct-upload.ts is correct
+- Moving the check inside the `if (files.length > 0)` block and adding another before manifest upload maintains proper error handling
+- No unnecessary try/catch blocks added
+
+### 4. Interface Changes and API Design
+**Status:** ✅ No breaking changes
+
+- Server-side change is backwards compatible (old clients uploading empty archives still work)
+- Client-side change is an optimization (skips unnecessary work for empty artifacts)
+- API contract unchanged
+
+### 5. Timer and Delay Usage
+**Status:** ✅ No issues
+
+No timers or delays introduced.
+
+### 6. Dynamic Import Patterns
+**Status:** ✅ No issues
+
+No dynamic imports introduced.
+
+## Code Quality Assessment
+
+### Server Changes (`commit/route.ts`)
+
+```typescript
+const fileCount = files.length;
+
+const [manifestExists, archiveExists] = await Promise.all([
+  s3ObjectExists(bucketName, manifestKey),
+  fileCount > 0
+    ? s3ObjectExists(bucketName, archiveKey)
+    : Promise.resolve(true),
+]);
+```
+
+**Analysis:**
+- Clean conditional logic for S3 verification
+- `Promise.resolve(true)` is appropriate for the short-circuit case
+- Variable `fileCount` is computed once and reused (moved up from later in the function)
+- Good inline comment explaining the rationale
+
+### Client Changes (`direct-upload.ts`)
+
+**Analysis:**
+- Clean separation of archive upload logic
+- Proper guard for `prepareResult.uploads` before manifest upload
+- Maintains the same error message for consistency
+
+### E2E Test Quality
+
+**Analysis:**
+- Test name clearly describes the scenario
+- Comment references the issue number for traceability
+- Proper cleanup with `rm -rf "$NEW_DIR"`
+- Verifies both version change and content correctness
+
+## Potential Improvements (Minor)
+
+1. **Consider adding a unit test for the commit endpoint** with empty artifact scenario in `route.test.ts` (not just E2E) for faster feedback during development.
+
+2. **Progress message for empty artifacts**: Currently silent when skipping archive upload. Consider:
+   ```typescript
+   } else {
+     onProgress?.("Empty artifact, skipping archive upload...");
+   }
+   ```
+   This would provide better user feedback.
+
+## Verdict
+
+**✅ APPROVED**
+
+This is a well-implemented fix with:
+- Clear root cause identification
+- Minimal, focused changes
+- Good test coverage (E2E)
+- Backwards compatibility maintained
+- No code smells introduced
+
+The fix correctly addresses the issue where empty artifacts weren't updating the remote HEAD because the commit endpoint required an archive that was never uploaded.

--- a/e2e/tests/02-commands/t09-vm0-artifact-empty.bats
+++ b/e2e/tests/02-commands/t09-vm0-artifact-empty.bats
@@ -76,6 +76,52 @@ teardown() {
     assert_output --partial "nested file"
 }
 
+@test "Push empty artifact after non-empty updates HEAD correctly" {
+    # This test verifies the fix for issue #617:
+    # Push with files first, then push empty, and verify pull gets empty artifact
+    mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+
+    # First push with files
+    echo "version 1 with files" > data.txt
+    mkdir -p subdir
+    echo "nested file" > subdir/nested.txt
+    run $CLI_COMMAND artifact push
+    assert_success
+    VERSION1=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
+
+    # Remove all files (make it empty)
+    rm -rf data.txt subdir
+
+    # Push empty artifact
+    run $CLI_COMMAND artifact push
+    assert_success
+    assert_output --partial "No files found (empty artifact)"
+    VERSION2=$(echo "$output" | grep -oP 'Version: \K[0-9a-f]+')
+
+    # Verify versions are different
+    [ "$VERSION1" != "$VERSION2" ]
+
+    # Pull in a different directory to verify HEAD was updated to empty
+    NEW_DIR="$(mktemp -d)"
+    cd "$NEW_DIR"
+    mkdir -p .vm0
+    cat > .vm0/storage.yaml <<EOF
+name: $ARTIFACT_NAME
+type: artifact
+EOF
+
+    run $CLI_COMMAND artifact pull
+    assert_success
+
+    # Verify we got empty artifact (not the old files)
+    local file_count=$(find . -type f ! -path './.vm0/*' | wc -l)
+    [ "$file_count" -eq 0 ]
+
+    rm -rf "$NEW_DIR"
+}
+
 @test "VM0 artifact pull succeeds after agent removes all files" {
     # Create artifact with files
     mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"

--- a/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
+++ b/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
@@ -5,8 +5,8 @@ load '../../helpers/setup'
 setup() {
     # Create temporary test directory for dynamic configs
     export TEST_DIR="$(mktemp -d)"
-    # Use unique agent name with timestamp to avoid conflicts
-    export AGENT_NAME="e2e-versioning-$(date +%s)"
+    # Use UUID for reliable uniqueness in parallel test runs
+    export AGENT_NAME="e2e-versioning-$(cat /proc/sys/kernel/random/uuid | head -c 8)"
 }
 
 teardown() {


### PR DESCRIPTION
## Summary

- Fix bug where pushing an empty artifact folder didn't update the remote HEAD
- Server now skips archive verification when `fileCount === 0`
- Client now skips archive upload when `files.length === 0`
- Add E2E test for the push empty after non-empty scenario

## Root Cause

The commit endpoint (`/api/storages/commit`) required both `manifest.json` and `archive.tar.gz` to exist in S3 for all commits. For empty artifacts, the archive was either not uploaded or failed verification, causing the commit to return 400 and HEAD never getting updated.

## Changes

| File | Change |
|------|--------|
| `turbo/apps/web/app/api/storages/commit/route.ts` | Skip archive check when fileCount=0 |
| `turbo/apps/cli/src/lib/direct-upload.ts` | Skip archive upload when files.length=0 |
| `e2e/tests/02-commands/t09-vm0-artifact-empty.bats` | Add test for push empty after non-empty |

## Test Plan

- [x] Existing storage tests pass
- [x] Existing CLI direct-upload tests pass
- [x] New E2E test for empty artifact push after non-empty
- [ ] Manual test: Push artifact with files, then push empty, verify pull gets empty

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)