### PR TITLE
feat(web): replace Home nav link with Blog link

### DIFF
--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -27,9 +27,14 @@ export default function Navbar() {
             </Link>
           </div>
           <div className="nav-center" style={{ display: "flex", gap: "32px" }}>
-            <Link href="/" className="nav-link">
-              Home
-            </Link>
+            <a
+              href="https://blog.vm0.ai"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="nav-link"
+            >
+              Blog
+            </a>
             <Link href="/cookbooks" className="nav-link">
               Cookbooks
             </Link>


### PR DESCRIPTION
## Summary
- Replace the "Home" navigation link with a "Blog" link pointing to https://blog.vm0.ai
- Opens in a new tab with proper security attributes (target="_blank" rel="noopener noreferrer")

## Changes
- Modified `turbo/apps/web/app/components/Navbar.tsx` to update the navigation link from Home to Blog

## Test plan
- [ ] Verify the Blog link appears in the navigation bar
- [ ] Confirm clicking the Blog link opens https://blog.vm0.ai in a new tab
- [ ] Check that other navigation links still work correctly
- [ ] Ensure responsive design is maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)