### PR TITLE
feat(cli): add status command for volume and artifact

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/artifact-status.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/artifact-status.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { statusCommand } from "../artifact/status";
+import * as storageUtils from "../../lib/storage-utils";
+import { apiClient } from "../../lib/api-client";
+
+// Mock dependencies
+vi.mock("../../lib/storage-utils");
+vi.mock("../../lib/api-client");
+
+describe("artifact status command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("local config validation", () => {
+    it("should exit with error if no config exists", async () => {
+      vi.mocked(storageUtils.readStorageConfig).mockResolvedValue(null);
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No artifact initialized"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 artifact init"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should exit with error if config type is volume", async () => {
+      vi.mocked(storageUtils.readStorageConfig).mockResolvedValue({
+        name: "test-volume",
+        type: "volume",
+      });
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("initialized as a volume"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 volume status"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("remote status check", () => {
+    beforeEach(() => {
+      vi.mocked(storageUtils.readStorageConfig).mockResolvedValue({
+        name: "test-artifact",
+        type: "artifact",
+      });
+    });
+
+    it("should show start message", async () => {
+      vi.mocked(apiClient.get).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            versionId:
+              "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4",
+            fileCount: 100,
+            size: 1024000,
+          }),
+      } as Response);
+
+      await statusCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Checking artifact: test-artifact"),
+      );
+    });
+
+    it("should exit with error if remote returns 404", async () => {
+      vi.mocked(apiClient.get).mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: () =>
+          Promise.resolve({
+            error: { message: "Storage not found" },
+          }),
+      } as Response);
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not found on remote"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 artifact push"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should display version info when remote exists", async () => {
+      vi.mocked(apiClient.get).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            versionId:
+              "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4",
+            fileCount: 100,
+            size: 1024000,
+          }),
+      } as Response);
+
+      await statusCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Found"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Version: a1b2c3d4"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Files: 100"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Size:"),
+      );
+    });
+
+    it("should display empty indicator for empty storage", async () => {
+      vi.mocked(apiClient.get).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            versionId:
+              "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4",
+            fileCount: 0,
+            size: 0,
+            empty: true,
+          }),
+      } as Response);
+
+      await statusCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Found (empty)"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Version: a1b2c3d4"),
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    beforeEach(() => {
+      vi.mocked(storageUtils.readStorageConfig).mockResolvedValue({
+        name: "test-artifact",
+        type: "artifact",
+      });
+    });
+
+    it("should handle API errors", async () => {
+      vi.mocked(apiClient.get).mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () =>
+          Promise.resolve({
+            error: { message: "Internal server error" },
+          }),
+      } as Response);
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Status check failed"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle network errors", async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new Error("Network error"));
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Status check failed"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Network error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/__tests__/volume-status.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/volume-status.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { statusCommand } from "../volume/status";
+import * as storageUtils from "../../lib/storage-utils";
+import { apiClient } from "../../lib/api-client";
+
+// Mock dependencies
+vi.mock("../../lib/storage-utils");
+vi.mock("../../lib/api-client");
+
+describe("volume status command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("local config validation", () => {
+    it("should exit with error if no config exists", async () => {
+      vi.mocked(storageUtils.readStorageConfig).mockResolvedValue(null);
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No volume initialized"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 volume init"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should exit with error if config type is artifact", async () => {
+      vi.mocked(storageUtils.readStorageConfig).mockResolvedValue({
+        name: "test-artifact",
+        type: "artifact",
+      });
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("initialized as an artifact"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 artifact status"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("remote status check", () => {
+    beforeEach(() => {
+      vi.mocked(storageUtils.readStorageConfig).mockResolvedValue({
+        name: "test-volume",
+        type: "volume",
+      });
+    });
+
+    it("should show start message", async () => {
+      vi.mocked(apiClient.get).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            versionId:
+              "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4",
+            fileCount: 100,
+            size: 1024000,
+          }),
+      } as Response);
+
+      await statusCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Checking volume: test-volume"),
+      );
+    });
+
+    it("should exit with error if remote returns 404", async () => {
+      vi.mocked(apiClient.get).mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: () =>
+          Promise.resolve({
+            error: { message: "Storage not found" },
+          }),
+      } as Response);
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not found on remote"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 volume push"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should display version info when remote exists", async () => {
+      vi.mocked(apiClient.get).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            versionId:
+              "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4",
+            fileCount: 100,
+            size: 1024000,
+          }),
+      } as Response);
+
+      await statusCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Found"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Version: a1b2c3d4"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Files: 100"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Size:"),
+      );
+    });
+
+    it("should display empty indicator for empty storage", async () => {
+      vi.mocked(apiClient.get).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            versionId:
+              "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4",
+            fileCount: 0,
+            size: 0,
+            empty: true,
+          }),
+      } as Response);
+
+      await statusCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Found (empty)"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Version: a1b2c3d4"),
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    beforeEach(() => {
+      vi.mocked(storageUtils.readStorageConfig).mockResolvedValue({
+        name: "test-volume",
+        type: "volume",
+      });
+    });
+
+    it("should handle API errors", async () => {
+      vi.mocked(apiClient.get).mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () =>
+          Promise.resolve({
+            error: { message: "Internal server error" },
+          }),
+      } as Response);
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Status check failed"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle network errors", async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new Error("Network error"));
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Status check failed"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Network error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/artifact/index.ts
+++ b/turbo/apps/cli/src/commands/artifact/index.ts
@@ -2,10 +2,12 @@ import { Command } from "commander";
 import { initCommand } from "./init";
 import { pushCommand } from "./push";
 import { pullCommand } from "./pull";
+import { statusCommand } from "./status";
 
 export const artifactCommand = new Command()
   .name("artifact")
   .description("Manage cloud artifacts (work products)")
   .addCommand(initCommand)
   .addCommand(pushCommand)
-  .addCommand(pullCommand);
+  .addCommand(pullCommand)
+  .addCommand(statusCommand);

--- a/turbo/apps/cli/src/commands/artifact/status.ts
+++ b/turbo/apps/cli/src/commands/artifact/status.ts
@@ -1,0 +1,90 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { readStorageConfig } from "../../lib/storage-utils";
+import { apiClient, type ApiError } from "../../lib/api-client";
+
+/**
+ * Format bytes to human-readable format
+ */
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
+}
+
+/**
+ * Status response from /api/storages/download
+ */
+interface StatusResponse {
+  url?: string;
+  empty?: boolean;
+  versionId: string;
+  fileCount: number;
+  size: number;
+}
+
+export const statusCommand = new Command()
+  .name("status")
+  .description("Show status of cloud artifact")
+  .action(async () => {
+    try {
+      const cwd = process.cwd();
+
+      // Read config
+      const config = await readStorageConfig(cwd);
+      if (!config) {
+        console.error(chalk.red("✗ No artifact initialized in this directory"));
+        console.error(chalk.gray("  Run: vm0 artifact init"));
+        process.exit(1);
+      }
+
+      if (config.type !== "artifact") {
+        console.error(
+          chalk.red(
+            "✗ This directory is initialized as a volume, not an artifact",
+          ),
+        );
+        console.error(chalk.gray("  Use: vm0 volume status"));
+        process.exit(1);
+      }
+
+      // Start message
+      console.log(chalk.cyan(`Checking artifact: ${config.name}`));
+
+      // Call API
+      const url = `/api/storages/download?name=${encodeURIComponent(config.name)}&type=artifact`;
+      const response = await apiClient.get(url);
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          console.error(chalk.red("✗ Not found on remote"));
+          console.error(chalk.gray("  Run: vm0 artifact push"));
+        } else {
+          const error = (await response.json()) as ApiError;
+          throw new Error(error.error?.message || "Status check failed");
+        }
+        process.exit(1);
+      }
+
+      const info = (await response.json()) as StatusResponse;
+      const shortVersion = info.versionId.slice(0, 8);
+
+      if (info.empty) {
+        console.log(chalk.green("✓ Found (empty)"));
+        console.log(chalk.gray(`  Version: ${shortVersion}`));
+      } else {
+        console.log(chalk.green("✓ Found"));
+        console.log(chalk.gray(`  Version: ${shortVersion}`));
+        console.log(chalk.gray(`  Files: ${info.fileCount.toLocaleString()}`));
+        console.log(chalk.gray(`  Size: ${formatBytes(info.size)}`));
+      }
+    } catch (error) {
+      console.error(chalk.red("✗ Status check failed"));
+      if (error instanceof Error) {
+        console.error(chalk.gray(`  ${error.message}`));
+      }
+      process.exit(1);
+    }
+  });

--- a/turbo/apps/cli/src/commands/volume/index.ts
+++ b/turbo/apps/cli/src/commands/volume/index.ts
@@ -2,10 +2,12 @@ import { Command } from "commander";
 import { initCommand } from "./init";
 import { pushCommand } from "./push";
 import { pullCommand } from "./pull";
+import { statusCommand } from "./status";
 
 export const volumeCommand = new Command()
   .name("volume")
   .description("Manage cloud volumes")
   .addCommand(initCommand)
   .addCommand(pushCommand)
-  .addCommand(pullCommand);
+  .addCommand(pullCommand)
+  .addCommand(statusCommand);

--- a/turbo/apps/cli/src/commands/volume/status.ts
+++ b/turbo/apps/cli/src/commands/volume/status.ts
@@ -1,0 +1,90 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { readStorageConfig } from "../../lib/storage-utils";
+import { apiClient, type ApiError } from "../../lib/api-client";
+
+/**
+ * Format bytes to human-readable format
+ */
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
+}
+
+/**
+ * Status response from /api/storages/download
+ */
+interface StatusResponse {
+  url?: string;
+  empty?: boolean;
+  versionId: string;
+  fileCount: number;
+  size: number;
+}
+
+export const statusCommand = new Command()
+  .name("status")
+  .description("Show status of cloud volume")
+  .action(async () => {
+    try {
+      const cwd = process.cwd();
+
+      // Read config
+      const config = await readStorageConfig(cwd);
+      if (!config) {
+        console.error(chalk.red("✗ No volume initialized in this directory"));
+        console.error(chalk.gray("  Run: vm0 volume init"));
+        process.exit(1);
+      }
+
+      if (config.type !== "volume") {
+        console.error(
+          chalk.red(
+            "✗ This directory is initialized as an artifact, not a volume",
+          ),
+        );
+        console.error(chalk.gray("  Use: vm0 artifact status"));
+        process.exit(1);
+      }
+
+      // Start message
+      console.log(chalk.cyan(`Checking volume: ${config.name}`));
+
+      // Call API
+      const url = `/api/storages/download?name=${encodeURIComponent(config.name)}&type=volume`;
+      const response = await apiClient.get(url);
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          console.error(chalk.red("✗ Not found on remote"));
+          console.error(chalk.gray("  Run: vm0 volume push"));
+        } else {
+          const error = (await response.json()) as ApiError;
+          throw new Error(error.error?.message || "Status check failed");
+        }
+        process.exit(1);
+      }
+
+      const info = (await response.json()) as StatusResponse;
+      const shortVersion = info.versionId.slice(0, 8);
+
+      if (info.empty) {
+        console.log(chalk.green("✓ Found (empty)"));
+        console.log(chalk.gray(`  Version: ${shortVersion}`));
+      } else {
+        console.log(chalk.green("✓ Found"));
+        console.log(chalk.gray(`  Version: ${shortVersion}`));
+        console.log(chalk.gray(`  Files: ${info.fileCount.toLocaleString()}`));
+        console.log(chalk.gray(`  Size: ${formatBytes(info.size)}`));
+      }
+    } catch (error) {
+      console.error(chalk.red("✗ Status check failed"));
+      if (error instanceof Error) {
+        console.error(chalk.gray(`  ${error.message}`));
+      }
+      process.exit(1);
+    }
+  });


### PR DESCRIPTION
## Summary

- Add `vm0 artifact status` command to check artifact storage status
- Add `vm0 volume status` command to check volume storage status
- Display version ID, file count, and size when remote storage exists
- Show appropriate messages for uninitialized or missing storage

## Output Examples

**Success:**
```
Checking artifact: my-project
✓ Found
  Version: abc12345
  Files: 1,234
  Size: 456.78 MB
```

**Not found:**
```
Checking artifact: my-project
✗ Not found on remote
  Run: vm0 artifact push
```

**Not initialized:**
```
✗ No artifact initialized in this directory
  Run: vm0 artifact init
```

## Test plan

- [x] Unit tests for artifact status command
- [x] Unit tests for volume status command
- [x] Type checking passes
- [x] Linting passes
- [ ] Manual testing with real storage

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)