### PR TITLE
fix: explicitly set Plausible domain to vm0.ai

### DIFF
--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -136,13 +136,14 @@ export default function RootLayout({
           />
           <Script
             src="https://plausible.io/js/pa-eEj_2G8vS8xPlTUzW2A3U.js"
+            data-domain="vm0.ai"
             strategy="afterInteractive"
             async
           />
           <Script id="plausible-init" strategy="afterInteractive">
             {`
               window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
-              plausible.init()
+              plausible.init({domain:"vm0.ai"})
             `}
           </Script>
         </head>


### PR DESCRIPTION
## Summary
Fix Plausible analytics configuration to explicitly set domain to `vm0.ai` on the main website, ensuring consistent tracking with the blog.

## Problem
- Blog was configured with `data-domain="vm0.ai"` 
- Main site was not explicitly setting domain
- This caused inconsistent tracking and Top Pages not showing up correctly in Plausible dashboard

## Changes
- Add `data-domain="vm0.ai"` to Plausible script tag in main site
- Configure `plausible.init({domain:"vm0.ai"})` to match blog configuration
- Ensures both sites explicitly report to the same Plausible site

## Benefits
✅ Consistent analytics configuration across main site and blog
✅ All traffic from both domains shows up in single vm0.ai dashboard
✅ Top Pages now correctly displays pages from both sites
✅ Can distinguish traffic by page paths:
  - Main site: `/`, `/cookbooks`, `/sign-up`
  - Blog: `/posts/...`

## Test Plan
- [ ] Deploy and verify Plausible script loads on vm0.ai
- [ ] Check browser console for Plausible errors
- [ ] Visit vm0.ai and verify pageview is sent to Plausible
- [ ] Check Plausible dashboard shows vm0.ai pages in Top Pages
- [ ] Verify blog pages also appear in the same dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)