### PR TITLE
feat: add scope/namespace system for resource isolation

### DIFF
--- a/e2e/tests/02-commands/t19-vm0-scope.bats
+++ b/e2e/tests/02-commands/t19-vm0-scope.bats
@@ -91,6 +91,68 @@ teardown() {
 }
 
 # ============================================
+# @scope/name Image Reference Tests
+# ============================================
+
+@test "vm0 compose with @scope/name validates format" {
+    # Create a test config with @scope/name format
+    TEST_DIR="$(mktemp -d)"
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  test-agent:
+    provider: claude-code
+    image: "@invalid/missing-image"
+EOF
+
+    # Should fail because the scope or image doesn't exist, not because of format
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_failure
+    # Should show scope/image not found error, not a format error
+    assert_output --partial "not found"
+
+    rm -rf "$TEST_DIR"
+}
+
+@test "vm0 compose with invalid @scope format fails" {
+    TEST_DIR="$(mktemp -d)"
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  test-agent:
+    provider: claude-code
+    image: "@no-slash-here"
+EOF
+
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_failure
+    # Should fail due to invalid scoped reference format
+
+    rm -rf "$TEST_DIR"
+}
+
+@test "vm0 run with @scope/name shows appropriate error for missing scope" {
+    TEST_DIR="$(mktemp -d)"
+    mkdir -p "$TEST_DIR/artifact"
+    cd "$TEST_DIR/artifact"
+    $CLI_COMMAND artifact init >/dev/null 2>&1 || true
+    $CLI_COMMAND artifact push >/dev/null 2>&1 || true
+
+    # Try to run with a non-existent scope
+    run $CLI_COMMAND run "@nonexistent-scope/test-image" \
+        --artifact-name "e2e-scope-test-$(date +%s)" \
+        "echo hello"
+
+    # Should fail with scope not found
+    assert_failure
+    assert_output --partial "not found"
+
+    rm -rf "$TEST_DIR"
+}
+
+# ============================================
 # Note: We don't test scope creation/update in E2E
 # because it would permanently change the test user's scope.
 # Those flows are tested in unit/integration tests.

--- a/e2e/tests/02-commands/t19-vm0-scope.bats
+++ b/e2e/tests/02-commands/t19-vm0-scope.bats
@@ -73,19 +73,22 @@ teardown() {
 }
 
 @test "vm0 scope set rejects reserved vm0 prefix" {
-    run $CLI_COMMAND scope set "vm0test"
+    # Use --force in case user already has a scope from prior tests
+    run $CLI_COMMAND scope set "vm0test" --force
     assert_failure
     assert_output --partial "reserved"
 }
 
 @test "vm0 scope set rejects reserved system slug" {
-    run $CLI_COMMAND scope set "system"
+    # Use --force in case user already has a scope from prior tests
+    run $CLI_COMMAND scope set "system" --force
     assert_failure
     assert_output --partial "reserved"
 }
 
 @test "vm0 scope set rejects slug with invalid characters" {
-    run $CLI_COMMAND scope set "Test_Slug"
+    # Use --force in case user already has a scope from prior tests
+    run $CLI_COMMAND scope set "Test_Slug" --force
     assert_failure
     # Should fail validation (uppercase or underscore)
 }

--- a/e2e/tests/02-commands/t19-vm0-scope.bats
+++ b/e2e/tests/02-commands/t19-vm0-scope.bats
@@ -231,11 +231,11 @@ EOF
     run $CLI_COMMAND scope set "$SCOPE_SLUG" --force
     assert_success
 
-    # Build an image
+    # Build an image using E2B base image (has required packages pre-installed)
     TEST_DIR="$(mktemp -d)"
     cat > "$TEST_DIR/Dockerfile" <<EOF
-FROM alpine:latest
-RUN echo "test image"
+FROM e2bdev/code-interpreter:latest
+RUN echo "scope-test-marker" > /tmp/scope-test.txt
 EOF
 
     IMAGE_NAME="scope-test-img"

--- a/e2e/tests/02-commands/t19-vm0-scope.bats
+++ b/e2e/tests/02-commands/t19-vm0-scope.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+# Test VM0 scope commands
+# Tests the CLI for managing user scopes/namespaces
+#
+# This test covers issue #628: scope/namespace system
+
+load '../../helpers/setup'
+
+setup() {
+    # Generate a unique slug for this test run to avoid conflicts
+    export TEST_SLUG="e2e-test-$(date +%s)"
+}
+
+teardown() {
+    # No cleanup needed - scopes are user-specific
+    true
+}
+
+# ============================================
+# CLI Help Tests (fast, no network)
+# ============================================
+
+@test "vm0 scope --help shows available subcommands" {
+    run $CLI_COMMAND scope --help
+    assert_success
+    assert_output --partial "status"
+    assert_output --partial "set"
+}
+
+@test "vm0 scope status --help shows usage" {
+    run $CLI_COMMAND scope status --help
+    assert_success
+    assert_output --partial "View current scope status"
+}
+
+@test "vm0 scope set --help shows usage" {
+    run $CLI_COMMAND scope set --help
+    assert_success
+    assert_output --partial "Set your scope slug"
+    assert_output --partial "--force"
+    assert_output --partial "--display-name"
+}
+
+# ============================================
+# Scope Status Tests (requires network)
+# ============================================
+
+@test "vm0 scope status shows scope info or setup instructions" {
+    run $CLI_COMMAND scope status
+
+    # Either shows scope info or tells user to set one up
+    # Both are valid responses
+    if [[ $status -eq 0 ]]; then
+        # User has a scope configured
+        assert_output --partial "Scope Information"
+        assert_output --partial "@"
+    else
+        # User has no scope configured
+        assert_output --partial "No scope configured"
+        assert_output --partial "vm0 scope set"
+    fi
+}
+
+# ============================================
+# Scope Set Validation Tests (no destructive changes)
+# ============================================
+
+@test "vm0 scope set rejects slug that is too short" {
+    run $CLI_COMMAND scope set "ab"
+    assert_failure
+    # Should fail validation before even trying to create
+}
+
+@test "vm0 scope set rejects reserved vm0 prefix" {
+    run $CLI_COMMAND scope set "vm0test"
+    assert_failure
+    assert_output --partial "reserved"
+}
+
+@test "vm0 scope set rejects reserved system slug" {
+    run $CLI_COMMAND scope set "system"
+    assert_failure
+    assert_output --partial "reserved"
+}
+
+@test "vm0 scope set rejects slug with invalid characters" {
+    run $CLI_COMMAND scope set "Test_Slug"
+    assert_failure
+    # Should fail validation (uppercase or underscore)
+}
+
+# ============================================
+# Note: We don't test scope creation/update in E2E
+# because it would permanently change the test user's scope.
+# Those flows are tested in unit/integration tests.
+# ============================================

--- a/e2e/tests/02-commands/t19-vm0-scope.bats
+++ b/e2e/tests/02-commands/t19-vm0-scope.bats
@@ -153,7 +153,102 @@ EOF
 }
 
 # ============================================
-# Note: We don't test scope creation/update in E2E
-# because it would permanently change the test user's scope.
-# Those flows are tested in unit/integration tests.
+# Scope Creation and Update Tests (CI has isolated DB)
 # ============================================
+
+@test "vm0 scope set creates new scope successfully" {
+    # First check if user already has a scope
+    run $CLI_COMMAND scope status
+
+    if [[ $status -eq 0 ]]; then
+        # User already has scope, need to update with --force
+        run $CLI_COMMAND scope set "$TEST_SLUG" --force
+    else
+        # No scope yet, create new one
+        run $CLI_COMMAND scope set "$TEST_SLUG"
+    fi
+
+    assert_success
+    assert_output --partial "@$TEST_SLUG"
+}
+
+@test "vm0 scope status shows newly created scope" {
+    # Ensure scope exists first
+    run $CLI_COMMAND scope status
+    if [[ $status -ne 0 ]]; then
+        $CLI_COMMAND scope set "$TEST_SLUG" >/dev/null 2>&1
+    fi
+
+    run $CLI_COMMAND scope status
+    assert_success
+    assert_output --partial "Scope Information"
+    assert_output --partial "@"
+}
+
+@test "vm0 scope set requires --force to update existing scope" {
+    # Ensure scope exists
+    run $CLI_COMMAND scope status
+    if [[ $status -ne 0 ]]; then
+        $CLI_COMMAND scope set "$TEST_SLUG" >/dev/null 2>&1
+    fi
+
+    # Try to update without --force (should fail)
+    NEW_SLUG="e2e-update-$(date +%s)"
+    run $CLI_COMMAND scope set "$NEW_SLUG"
+    assert_failure
+    assert_output --partial "--force"
+}
+
+@test "vm0 scope set updates scope with --force flag" {
+    # Ensure scope exists
+    run $CLI_COMMAND scope status
+    if [[ $status -ne 0 ]]; then
+        $CLI_COMMAND scope set "$TEST_SLUG" >/dev/null 2>&1
+    fi
+
+    # Update with --force
+    NEW_SLUG="e2e-force-$(date +%s)"
+    run $CLI_COMMAND scope set "$NEW_SLUG" --force
+    assert_success
+    assert_output --partial "@$NEW_SLUG"
+}
+
+@test "vm0 scope set with --display-name sets custom name" {
+    # Update scope with display name
+    NEW_SLUG="e2e-display-$(date +%s)"
+    run $CLI_COMMAND scope set "$NEW_SLUG" --display-name "My Test Scope" --force
+    assert_success
+    assert_output --partial "@$NEW_SLUG"
+}
+
+# ============================================
+# Full Image Build + @scope/name Workflow Tests
+# ============================================
+
+@test "vm0 image build creates image with scope association" {
+    # Ensure user has a scope
+    SCOPE_SLUG="e2e-img-$(date +%s)"
+    run $CLI_COMMAND scope set "$SCOPE_SLUG" --force
+    assert_success
+
+    # Build an image
+    TEST_DIR="$(mktemp -d)"
+    cat > "$TEST_DIR/Dockerfile" <<EOF
+FROM alpine:latest
+RUN echo "test image"
+EOF
+
+    IMAGE_NAME="scope-test-img"
+    run $CLI_COMMAND image build --file "$TEST_DIR/Dockerfile" --name "$IMAGE_NAME" --delete-existing
+    assert_success
+    assert_output --partial "Building image"
+    assert_output --partial "Build ID"
+
+    rm -rf "$TEST_DIR"
+}
+
+@test "vm0 image list shows images after build" {
+    run $CLI_COMMAND image list
+    assert_success
+    # Should show at least one image (from previous test or existing)
+}

--- a/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { setCommand } from "../set";
+import { apiClient } from "../../../lib/api-client";
+
+// Mock dependencies
+vi.mock("../../../lib/api-client");
+
+describe("scope set command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("authentication", () => {
+    it("should exit with error if not authenticated", async () => {
+      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.createScope).mockRejectedValue(
+        new Error("Not authenticated"),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "testslug"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 auth login"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("create new scope", () => {
+    it("should create scope successfully", async () => {
+      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.createScope).mockResolvedValue({
+        id: "test-id",
+        slug: "testslug",
+        type: "personal",
+        displayName: null,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      });
+
+      await setCommand.parseAsync(["node", "cli", "testslug"]);
+
+      expect(apiClient.createScope).toHaveBeenCalledWith({
+        slug: "testslug",
+        displayName: undefined,
+      });
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Scope created: @testslug"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("@testslug/<image-name>"),
+      );
+    });
+
+    it("should create scope with display name", async () => {
+      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.createScope).mockResolvedValue({
+        id: "test-id",
+        slug: "testslug",
+        type: "personal",
+        displayName: "Test Display",
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      });
+
+      await setCommand.parseAsync([
+        "node",
+        "cli",
+        "testslug",
+        "--display-name",
+        "Test Display",
+      ]);
+
+      expect(apiClient.createScope).toHaveBeenCalledWith({
+        slug: "testslug",
+        displayName: "Test Display",
+      });
+    });
+  });
+
+  describe("update existing scope", () => {
+    it("should require --force to update existing scope", async () => {
+      vi.mocked(apiClient.getScope).mockResolvedValue({
+        id: "test-id",
+        slug: "oldslug",
+        type: "personal",
+        displayName: null,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      });
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "newslug"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("already have a scope: @oldslug"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--force"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should update scope with --force", async () => {
+      vi.mocked(apiClient.getScope).mockResolvedValue({
+        id: "test-id",
+        slug: "oldslug",
+        type: "personal",
+        displayName: null,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      });
+      vi.mocked(apiClient.updateScope).mockResolvedValue({
+        id: "test-id",
+        slug: "newslug",
+        type: "personal",
+        displayName: null,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      });
+
+      await setCommand.parseAsync(["node", "cli", "newslug", "--force"]);
+
+      expect(apiClient.updateScope).toHaveBeenCalledWith({
+        slug: "newslug",
+        force: true,
+      });
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Scope updated to @newslug"),
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle slug already taken", async () => {
+      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.createScope).mockRejectedValue(
+        new Error("Scope already exists"),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "takenslug"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("already taken"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle reserved slug", async () => {
+      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.createScope).mockRejectedValue(
+        new Error('Scope slug "vm0" is reserved'),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "vm0"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("reserved"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle vm0 prefix rejection", async () => {
+      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.createScope).mockRejectedValue(
+        new Error('Scope slug "vm0test" is reserved'),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "vm0test"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("reserved"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle unexpected errors", async () => {
+      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.createScope).mockRejectedValue(
+        new Error("Unexpected error"),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "testslug"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unexpected error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle non-Error exceptions", async () => {
+      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.createScope).mockRejectedValue("Unknown error");
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "testslug"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("unexpected error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/scope/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/status.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { statusCommand } from "../status";
+import { apiClient } from "../../../lib/api-client";
+
+// Mock dependencies
+vi.mock("../../../lib/api-client");
+
+describe("scope status command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("authentication", () => {
+    it("should exit with error if not authenticated", async () => {
+      vi.mocked(apiClient.getScope).mockRejectedValue(
+        new Error("Not authenticated"),
+      );
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 auth login"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("no scope configured", () => {
+    it("should show helpful message when user has no scope", async () => {
+      vi.mocked(apiClient.getScope).mockRejectedValue(
+        new Error("No scope configured"),
+      );
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("No scope configured"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 scope set"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("scope display", () => {
+    it("should display scope information", async () => {
+      vi.mocked(apiClient.getScope).mockResolvedValue({
+        id: "test-id",
+        slug: "testuser",
+        type: "personal",
+        displayName: "Test User",
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      });
+
+      await statusCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Scope Information"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("@testuser"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("personal"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Test User"),
+      );
+    });
+
+    it("should handle scope without display name", async () => {
+      vi.mocked(apiClient.getScope).mockResolvedValue({
+        id: "test-id",
+        slug: "testuser",
+        type: "personal",
+        displayName: null,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      });
+
+      await statusCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("@testuser"),
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle unexpected errors", async () => {
+      vi.mocked(apiClient.getScope).mockRejectedValue(
+        new Error("Network error"),
+      );
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Network error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle non-Error exceptions", async () => {
+      vi.mocked(apiClient.getScope).mockRejectedValue("Unknown error");
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("unexpected error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/scope/index.ts
+++ b/turbo/apps/cli/src/commands/scope/index.ts
@@ -1,0 +1,9 @@
+import { Command } from "commander";
+import { statusCommand } from "./status";
+import { setCommand } from "./set";
+
+export const scopeCommand = new Command()
+  .name("scope")
+  .description("Manage your scope (namespace for images)")
+  .addCommand(statusCommand)
+  .addCommand(setCommand);

--- a/turbo/apps/cli/src/commands/scope/set.ts
+++ b/turbo/apps/cli/src/commands/scope/set.ts
@@ -1,0 +1,87 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { apiClient } from "../../lib/api-client";
+
+export const setCommand = new Command()
+  .name("set")
+  .description("Set your scope slug")
+  .argument("<slug>", "The scope slug (e.g., your username)")
+  .option("--force", "Force change existing scope (may break references)")
+  .option("--display-name <name>", "Display name for the scope")
+  .action(
+    async (
+      slug: string,
+      options: { force?: boolean; displayName?: string },
+    ) => {
+      try {
+        // First check if user already has a scope
+        let existingScope;
+        try {
+          existingScope = await apiClient.getScope();
+        } catch {
+          // No existing scope - that's fine
+        }
+
+        let scope;
+        if (existingScope) {
+          // User already has a scope - update it
+          if (!options.force) {
+            console.error(
+              chalk.yellow(`You already have a scope: @${existingScope.slug}`),
+            );
+            console.error();
+            console.error("To change your scope, use --force:");
+            console.error(chalk.cyan(`  vm0 scope set ${slug} --force`));
+            console.error();
+            console.error(
+              chalk.yellow(
+                "Warning: Changing your scope may break existing image references.",
+              ),
+            );
+            process.exit(1);
+          }
+
+          scope = await apiClient.updateScope({ slug, force: true });
+          console.log(chalk.green(`✓ Scope updated to @${scope.slug}`));
+        } else {
+          // Create new scope
+          scope = await apiClient.createScope({
+            slug,
+            displayName: options.displayName,
+          });
+          console.log(chalk.green(`✓ Scope created: @${scope.slug}`));
+        }
+
+        console.log();
+        console.log("Your images will now be namespaced as:");
+        console.log(chalk.cyan(`  @${scope.slug}/<image-name>`));
+      } catch (error) {
+        if (error instanceof Error) {
+          if (error.message.includes("Not authenticated")) {
+            console.error(
+              chalk.red("✗ Not authenticated. Run: vm0 auth login"),
+            );
+          } else if (error.message.includes("already exists")) {
+            console.error(
+              chalk.red(
+                `✗ Scope "${slug}" is already taken. Please choose a different slug.`,
+              ),
+            );
+          } else if (error.message.includes("reserved")) {
+            console.error(chalk.red(`✗ ${error.message}`));
+          } else if (error.message.includes("vm0")) {
+            console.error(
+              chalk.red(
+                "✗ Scope slugs cannot start with 'vm0' (reserved for system use)",
+              ),
+            );
+          } else {
+            console.error(chalk.red(`✗ ${error.message}`));
+          }
+        } else {
+          console.error(chalk.red("✗ An unexpected error occurred"));
+        }
+        process.exit(1);
+      }
+    },
+  );

--- a/turbo/apps/cli/src/commands/scope/status.ts
+++ b/turbo/apps/cli/src/commands/scope/status.ts
@@ -1,0 +1,41 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { apiClient } from "../../lib/api-client";
+
+export const statusCommand = new Command()
+  .name("status")
+  .description("View current scope status")
+  .action(async () => {
+    try {
+      const scope = await apiClient.getScope();
+
+      console.log(chalk.cyan("Scope Information:"));
+      console.log(`  Slug: ${chalk.green("@" + scope.slug)}`);
+      console.log(`  Type: ${scope.type}`);
+      if (scope.displayName) {
+        console.log(`  Display Name: ${scope.displayName}`);
+      }
+      console.log(
+        `  Created: ${new Date(scope.createdAt).toLocaleDateString()}`,
+      );
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes("Not authenticated")) {
+          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
+        } else if (error.message.includes("No scope configured")) {
+          console.log(chalk.yellow("No scope configured."));
+          console.log();
+          console.log("Set your scope with:");
+          console.log(chalk.cyan("  vm0 scope set <slug>"));
+          console.log();
+          console.log("Example:");
+          console.log(chalk.gray("  vm0 scope set myusername"));
+        } else {
+          console.error(chalk.red(`✗ ${error.message}`));
+        }
+      } else {
+        console.error(chalk.red("✗ An unexpected error occurred"));
+      }
+      process.exit(1);
+    }
+  });

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -9,6 +9,7 @@ import { artifactCommand } from "./commands/artifact";
 import { cookCommand } from "./commands/cook";
 import { imageCommand } from "./commands/image";
 import { logsCommand } from "./commands/logs";
+import { scopeCommand } from "./commands/scope";
 
 const program = new Command();
 
@@ -63,7 +64,7 @@ authCommand
     await setupToken();
   });
 
-// Register compose, run, volume, artifact, cook, image, and logs commands
+// Register compose, run, volume, artifact, cook, image, logs, and scope commands
 program.addCommand(composeCommand);
 program.addCommand(runCommand);
 program.addCommand(volumeCommand);
@@ -71,6 +72,7 @@ program.addCommand(artifactCommand);
 program.addCommand(cookCommand);
 program.addCommand(imageCommand);
 program.addCommand(logsCommand);
+program.addCommand(scopeCommand);
 
 export { program };
 

--- a/turbo/apps/cli/src/lib/api-client.ts
+++ b/turbo/apps/cli/src/lib/api-client.ts
@@ -157,6 +157,15 @@ export interface CreateImageResponse {
   alias: string;
 }
 
+export interface ScopeResponse {
+  id: string;
+  slug: string;
+  type: "personal" | "organization" | "system";
+  displayName: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 class ApiClient {
   private async getHeaders(): Promise<Record<string, string>> {
     const token = await getToken();
@@ -516,6 +525,74 @@ class ApiClient {
     }
 
     return (await response.json()) as CreateImageResponse;
+  }
+
+  /**
+   * Get current user's scope
+   */
+  async getScope(): Promise<ScopeResponse> {
+    const baseUrl = await this.getBaseUrl();
+    const headers = await this.getHeaders();
+
+    const response = await fetch(`${baseUrl}/api/scope`, {
+      method: "GET",
+      headers,
+    });
+
+    if (!response.ok) {
+      const error = (await response.json()) as ApiError;
+      throw new Error(error.error?.message || "Failed to get scope");
+    }
+
+    return (await response.json()) as ScopeResponse;
+  }
+
+  /**
+   * Create user's scope
+   */
+  async createScope(body: {
+    slug: string;
+    displayName?: string;
+  }): Promise<ScopeResponse> {
+    const baseUrl = await this.getBaseUrl();
+    const headers = await this.getHeaders();
+
+    const response = await fetch(`${baseUrl}/api/scope`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const error = (await response.json()) as ApiError;
+      throw new Error(error.error?.message || "Failed to create scope");
+    }
+
+    return (await response.json()) as ScopeResponse;
+  }
+
+  /**
+   * Update user's scope slug
+   */
+  async updateScope(body: {
+    slug: string;
+    force?: boolean;
+  }): Promise<ScopeResponse> {
+    const baseUrl = await this.getBaseUrl();
+    const headers = await this.getHeaders();
+
+    const response = await fetch(`${baseUrl}/api/scope`, {
+      method: "PUT",
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const error = (await response.json()) as ApiError;
+      throw new Error(error.error?.message || "Failed to update scope");
+    }
+
+    return (await response.json()) as ScopeResponse;
   }
 
   /**

--- a/turbo/apps/web/app/api/scope/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/route.test.ts
@@ -1,0 +1,232 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, POST, PUT } from "../route";
+import { initServices } from "../../../../src/lib/init-services";
+import { scopes } from "../../../../src/db/schema/scope";
+import { eq } from "drizzle-orm";
+
+// Mock the auth module
+let mockUserId: string | null = "test-user-scope-api";
+vi.mock("../../../../src/lib/auth/get-user-id", () => ({
+  getUserId: async () => mockUserId,
+}));
+
+describe("/api/scope", () => {
+  const testUserId = "test-user-scope-api";
+  const testUserId2 = "test-user-scope-api-2";
+
+  beforeAll(() => {
+    initServices();
+  });
+
+  afterAll(async () => {
+    // Cleanup: Delete all test scopes
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.ownerId, testUserId));
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.ownerId, testUserId2));
+  });
+
+  describe("GET /api/scope", () => {
+    it("should require authentication", async () => {
+      mockUserId = null;
+
+      const request = new NextRequest("http://localhost:3000/api/scope", {
+        method: "GET",
+      });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.message).toContain("Not authenticated");
+
+      mockUserId = testUserId;
+    });
+
+    it("should return 404 if user has no scope", async () => {
+      mockUserId = "user-with-no-scope";
+
+      const request = new NextRequest("http://localhost:3000/api/scope", {
+        method: "GET",
+      });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.message).toContain("No scope configured");
+
+      mockUserId = testUserId;
+    });
+  });
+
+  describe("POST /api/scope", () => {
+    it("should require authentication", async () => {
+      mockUserId = null;
+
+      const request = new NextRequest("http://localhost:3000/api/scope", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: "test-scope" }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.message).toContain("Not authenticated");
+
+      mockUserId = testUserId;
+    });
+
+    it("should create a scope successfully", async () => {
+      const slug = `api-test-${Date.now()}`;
+
+      const request = new NextRequest("http://localhost:3000/api/scope", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug, displayName: "Test Scope" }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.slug).toBe(slug);
+      expect(data.displayName).toBe("Test Scope");
+      expect(data.type).toBe("personal");
+      expect(data.id).toBeDefined();
+    });
+
+    it("should reject duplicate scope creation for same user", async () => {
+      const slug = `dup-test-${Date.now()}`;
+
+      // Create first scope
+      const request1 = new NextRequest("http://localhost:3000/api/scope", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug }),
+      });
+      await POST(request1);
+
+      // Try to create another scope for same user
+      const request2 = new NextRequest("http://localhost:3000/api/scope", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: `${slug}-2` }),
+      });
+
+      const response = await POST(request2);
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data.error.message).toContain("already have a scope");
+    });
+
+    it("should reject invalid slug format", async () => {
+      mockUserId = testUserId2; // Use different user without scope
+
+      const request = new NextRequest("http://localhost:3000/api/scope", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: "AB" }), // Too short
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+
+      mockUserId = testUserId;
+    });
+
+    it("should reject reserved slugs", async () => {
+      mockUserId = testUserId2; // Use different user without scope
+
+      const request = new NextRequest("http://localhost:3000/api/scope", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: "vm0" }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain("reserved");
+
+      mockUserId = testUserId;
+    });
+  });
+
+  describe("PUT /api/scope", () => {
+    it("should require authentication", async () => {
+      mockUserId = null;
+
+      const request = new NextRequest("http://localhost:3000/api/scope", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: "new-slug", force: true }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.message).toContain("Not authenticated");
+
+      mockUserId = testUserId;
+    });
+
+    it("should require force flag to update", async () => {
+      const request = new NextRequest("http://localhost:3000/api/scope", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: "new-slug", force: false }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain("--force");
+    });
+
+    it("should update scope slug with force flag", async () => {
+      const newSlug = `updated-${Date.now()}`;
+
+      const request = new NextRequest("http://localhost:3000/api/scope", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: newSlug, force: true }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.slug).toBe(newSlug);
+    });
+  });
+
+  describe("GET /api/scope (after scope created)", () => {
+    it("should return user's scope", async () => {
+      const request = new NextRequest("http://localhost:3000/api/scope", {
+        method: "GET",
+      });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.type).toBe("personal");
+      expect(data.id).toBeDefined();
+      expect(data.slug).toBeDefined();
+    });
+  });
+});

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -1,0 +1,206 @@
+import { createNextHandler, tsr } from "@ts-rest/serverless/next";
+import { TsRestResponse } from "@ts-rest/serverless";
+import { scopeContract, createErrorResponse, ApiError } from "@vm0/core";
+import { initServices } from "../../../src/lib/init-services";
+import { getUserId } from "../../../src/lib/auth/get-user-id";
+import {
+  getUserScopeByClerkId,
+  createUserScope,
+  updateScopeSlug,
+} from "../../../src/lib/scope/scope-service";
+import { logger } from "../../../src/lib/logger";
+import {
+  BadRequestError,
+  ForbiddenError,
+  NotFoundError,
+} from "../../../src/lib/errors";
+
+const log = logger("api:scope");
+
+const router = tsr.router(scopeContract, {
+  /**
+   * GET /api/scope - Get current user's scope
+   */
+  get: async () => {
+    initServices();
+
+    const userId = await getUserId();
+    if (!userId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+
+    const scope = await getUserScopeByClerkId(userId);
+    if (!scope) {
+      return createErrorResponse(
+        "NOT_FOUND",
+        "No scope configured. Set your scope with: vm0 scope set <slug>",
+      );
+    }
+
+    return {
+      status: 200 as const,
+      body: {
+        id: scope.id,
+        slug: scope.slug,
+        type: scope.type,
+        displayName: scope.displayName,
+        createdAt: scope.createdAt.toISOString(),
+        updatedAt: scope.updatedAt.toISOString(),
+      },
+    };
+  },
+
+  /**
+   * POST /api/scope - Create user's scope
+   */
+  create: async ({ body }) => {
+    initServices();
+
+    const userId = await getUserId();
+    if (!userId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+
+    const { slug, displayName } = body;
+
+    log.debug("creating user scope", { userId, slug });
+
+    try {
+      const scope = await createUserScope(userId, slug, displayName);
+
+      return {
+        status: 201 as const,
+        body: {
+          id: scope.id,
+          slug: scope.slug,
+          type: scope.type,
+          displayName: scope.displayName,
+          createdAt: scope.createdAt.toISOString(),
+          updatedAt: scope.updatedAt.toISOString(),
+        },
+      };
+    } catch (error) {
+      if (error instanceof BadRequestError) {
+        // Check if it's a conflict error (user already has scope)
+        if (error.message.includes("already have a scope")) {
+          return {
+            status: 409 as const,
+            body: {
+              error: { message: error.message, code: "CONFLICT" },
+            },
+          };
+        }
+        return createErrorResponse("BAD_REQUEST", error.message);
+      }
+      throw error;
+    }
+  },
+
+  /**
+   * PUT /api/scope - Update user's scope slug
+   */
+  update: async ({ body }) => {
+    initServices();
+
+    const userId = await getUserId();
+    if (!userId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+
+    const { slug, force } = body;
+
+    log.debug("updating user scope", { userId, slug, force });
+
+    // First get user's current scope
+    const existingScope = await getUserScopeByClerkId(userId);
+    if (!existingScope) {
+      return createErrorResponse(
+        "NOT_FOUND",
+        "No scope configured. Set your scope with: vm0 scope set <slug>",
+      );
+    }
+
+    try {
+      const scope = await updateScopeSlug(
+        existingScope.id,
+        slug,
+        userId,
+        force,
+      );
+
+      return {
+        status: 200 as const,
+        body: {
+          id: scope.id,
+          slug: scope.slug,
+          type: scope.type,
+          displayName: scope.displayName,
+          createdAt: scope.createdAt.toISOString(),
+          updatedAt: scope.updatedAt.toISOString(),
+        },
+      };
+    } catch (error) {
+      if (error instanceof BadRequestError) {
+        // Check if it's a conflict error (slug already exists)
+        if (error.message.includes("already exists")) {
+          return {
+            status: 409 as const,
+            body: {
+              error: { message: error.message, code: "CONFLICT" },
+            },
+          };
+        }
+        return createErrorResponse("BAD_REQUEST", error.message);
+      }
+      if (error instanceof ForbiddenError) {
+        return createErrorResponse("FORBIDDEN", error.message);
+      }
+      if (error instanceof NotFoundError) {
+        return createErrorResponse("NOT_FOUND", error.message);
+      }
+      throw error;
+    }
+  },
+});
+
+/**
+ * Custom error handler for scope API
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  // Handle ts-rest RequestValidationError
+  if (
+    err &&
+    typeof err === "object" &&
+    "bodyError" in err &&
+    "queryError" in err
+  ) {
+    const validationError = err as {
+      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
+      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
+    };
+
+    // Handle body validation errors
+    if (validationError.bodyError) {
+      const issue = validationError.bodyError.issues[0];
+      if (issue) {
+        const message = issue.message;
+
+        return TsRestResponse.fromJson(
+          { error: { message, code: ApiError.BAD_REQUEST.code } },
+          { status: ApiError.BAD_REQUEST.status },
+        );
+      }
+    }
+  }
+
+  // Let other errors propagate
+  return undefined;
+}
+
+const handler = createNextHandler(scopeContract, router, {
+  handlerType: "app-router",
+  jsonQuery: true,
+  errorHandler,
+});
+
+export { handler as GET, handler as POST, handler as PUT };

--- a/turbo/apps/web/src/db/db.ts
+++ b/turbo/apps/web/src/db/db.ts
@@ -11,6 +11,7 @@ import * as storageSchema from "./schema/storage";
 import * as blobSchema from "./schema/blob";
 import * as imageSchema from "./schema/image";
 import * as sandboxTelemetrySchema from "./schema/sandbox-telemetry";
+import * as scopeSchema from "./schema/scope";
 
 export const schema = {
   ...userSchema,
@@ -26,4 +27,5 @@ export const schema = {
   ...blobSchema,
   ...imageSchema,
   ...sandboxTelemetrySchema,
+  ...scopeSchema,
 };

--- a/turbo/apps/web/src/db/migrations/0037_add_scopes_table.sql
+++ b/turbo/apps/web/src/db/migrations/0037_add_scopes_table.sql
@@ -1,0 +1,25 @@
+-- Add scopes table for namespace isolation
+-- Phase 1 of scope system implementation (Issue #628)
+
+-- Create scope type enum
+CREATE TYPE scope_type AS ENUM ('personal', 'organization', 'system');
+
+-- Create scopes table
+CREATE TABLE IF NOT EXISTS "scopes" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "slug" varchar(64) NOT NULL UNIQUE,
+  "type" scope_type NOT NULL DEFAULT 'personal',
+  "owner_id" text,
+  "display_name" varchar(128),
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- Create indexes
+CREATE INDEX IF NOT EXISTS "idx_scopes_owner" ON "scopes" USING btree ("owner_id");
+CREATE INDEX IF NOT EXISTS "idx_scopes_type" ON "scopes" USING btree ("type");
+
+-- Seed vm0 system scope
+INSERT INTO "scopes" ("slug", "type", "display_name")
+VALUES ('vm0', 'system', 'VM0 System')
+ON CONFLICT ("slug") DO NOTHING;

--- a/turbo/apps/web/src/db/migrations/0038_add_scope_id_to_users.sql
+++ b/turbo/apps/web/src/db/migrations/0038_add_scope_id_to_users.sql
@@ -1,0 +1,7 @@
+-- Add scope_id to users table
+-- Links users to their personal scope
+
+ALTER TABLE "users" ADD COLUMN "scope_id" uuid REFERENCES "scopes"("id");
+
+-- Create index for scope lookups
+CREATE INDEX IF NOT EXISTS "idx_users_scope" ON "users" USING btree ("scope_id");

--- a/turbo/apps/web/src/db/migrations/0039_expand_e2b_alias.sql
+++ b/turbo/apps/web/src/db/migrations/0039_expand_e2b_alias.sql
@@ -1,0 +1,5 @@
+-- Expand e2b_alias column to 256 characters
+-- New format: scope-{scopeId}-image-{name}-version-{hash}
+-- Requires more space than the previous 128 character limit
+
+ALTER TABLE "images" ALTER COLUMN "e2b_alias" TYPE varchar(256);

--- a/turbo/apps/web/src/db/migrations/0040_add_scope_id_to_images.sql
+++ b/turbo/apps/web/src/db/migrations/0040_add_scope_id_to_images.sql
@@ -1,0 +1,7 @@
+-- Add scope_id to images table
+-- Links images to their owning scope for namespace isolation
+
+ALTER TABLE "images" ADD COLUMN "scope_id" uuid REFERENCES "scopes"("id");
+
+-- Create index for scope lookups
+CREATE INDEX IF NOT EXISTS "idx_images_scope" ON "images" USING btree ("scope_id");

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -260,6 +260,34 @@
       "when": 1766100000000,
       "tag": "0036_storage_name_256",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1766200000000,
+      "tag": "0037_add_scopes_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1766300000000,
+      "tag": "0038_add_scope_id_to_users",
+      "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1766400000000,
+      "tag": "0039_expand_e2b_alias",
+      "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1766500000000,
+      "tag": "0040_add_scope_id_to_images",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/image.ts
+++ b/turbo/apps/web/src/db/schema/image.ts
@@ -5,7 +5,9 @@ import {
   varchar,
   timestamp,
   uniqueIndex,
+  index,
 } from "drizzle-orm/pg-core";
+import { scopes } from "./scope";
 
 /**
  * Image build status:
@@ -24,8 +26,9 @@ export const images = pgTable(
   {
     id: uuid("id").defaultRandom().primaryKey(),
     userId: text("user_id").notNull(),
+    scopeId: uuid("scope_id").references(() => scopes.id), // Scope FK (nullable for migration)
     alias: varchar("alias", { length: 64 }).notNull(), // User-specified name
-    e2bAlias: varchar("e2b_alias", { length: 128 }).notNull(), // E2B template name: user-{userId}-{alias}
+    e2bAlias: varchar("e2b_alias", { length: 256 }).notNull(), // E2B template name: scope-{scopeId}-image-{name}-version-{hash}
     e2bTemplateId: varchar("e2b_template_id", { length: 64 }), // E2B template ID (set after build completes)
     e2bBuildId: varchar("e2b_build_id", { length: 64 }).notNull(), // E2B build ID for status polling
     status: varchar("status", { length: 16 }).notNull().default("building"),
@@ -38,5 +41,6 @@ export const images = pgTable(
       table.userId,
       table.alias,
     ),
+    scopeIdx: index("idx_images_scope").on(table.scopeId),
   }),
 );

--- a/turbo/apps/web/src/db/schema/scope.ts
+++ b/turbo/apps/web/src/db/schema/scope.ts
@@ -1,0 +1,44 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  varchar,
+  timestamp,
+  pgEnum,
+  index,
+} from "drizzle-orm/pg-core";
+
+/**
+ * Scope types:
+ * - "personal": Individual user's scope
+ * - "organization": Organization/team scope (future)
+ * - "system": System-level scope (e.g., vm0)
+ */
+export const scopeTypeEnum = pgEnum("scope_type", [
+  "personal",
+  "organization",
+  "system",
+]);
+
+export type ScopeType = "personal" | "organization" | "system";
+
+/**
+ * Scopes table
+ * Provides namespace isolation for resources (images, storages, etc.)
+ */
+export const scopes = pgTable(
+  "scopes",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    slug: varchar("slug", { length: 64 }).notNull().unique(),
+    type: scopeTypeEnum("type").notNull().default("personal"),
+    ownerId: text("owner_id"), // Clerk user ID, null for system scopes
+    displayName: varchar("display_name", { length: 128 }),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    ownerIdx: index("idx_scopes_owner").on(table.ownerId),
+    typeIdx: index("idx_scopes_type").on(table.type),
+  }),
+);

--- a/turbo/apps/web/src/db/schema/user.ts
+++ b/turbo/apps/web/src/db/schema/user.ts
@@ -1,7 +1,15 @@
-import { pgTable, uuid, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, uuid, timestamp, index } from "drizzle-orm/pg-core";
+import { scopes } from "./scope";
 
-export const users = pgTable("users", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at").defaultNow().notNull(),
-});
+export const users = pgTable(
+  "users",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    scopeId: uuid("scope_id").references(() => scopes.id),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    scopeIdx: index("idx_users_scope").on(table.scopeId),
+  }),
+);

--- a/turbo/apps/web/src/lib/image/__tests__/image-service.spec.ts
+++ b/turbo/apps/web/src/lib/image/__tests__/image-service.spec.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it } from "vitest";
-import { generateE2bAlias, isSystemTemplate } from "../image-service";
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import {
+  generateE2bAlias,
+  isSystemTemplate,
+  resolveImageAlias,
+  getImageByScopeAndAlias,
+} from "../image-service";
+import { initServices } from "../../init-services";
+import { createUserScope } from "../../scope/scope-service";
+import { images } from "../../../db/schema/image";
+import { scopes } from "../../../db/schema/scope";
+import { eq } from "drizzle-orm";
 
 describe("Image Service", () => {
   describe("generateE2bAlias", () => {
@@ -42,6 +55,145 @@ describe("Image Service", () => {
     it("should be case sensitive", () => {
       expect(isSystemTemplate("VM0-test")).toBe(false);
       expect(isSystemTemplate("Vm0-test")).toBe(false);
+    });
+  });
+
+  describe("resolveImageAlias with @scope/name", () => {
+    const testUserId = "test-image-resolve-user";
+    const testScopeSlug = `img-test-${Date.now()}`;
+    let testScopeId: string;
+
+    beforeAll(async () => {
+      initServices();
+
+      // Create test scope for the user
+      const scope = await createUserScope(testUserId, testScopeSlug);
+      testScopeId = scope.id;
+
+      // Create a test image with scopeId
+      await globalThis.services.db.insert(images).values({
+        userId: testUserId,
+        scopeId: testScopeId,
+        alias: "test-image",
+        e2bAlias: `user-${testUserId}-test-image`,
+        e2bTemplateId: "test-template-id",
+        e2bBuildId: "test-build-id",
+        status: "ready",
+      });
+
+      // Create a building image
+      await globalThis.services.db.insert(images).values({
+        userId: testUserId,
+        scopeId: testScopeId,
+        alias: "building-image",
+        e2bAlias: `user-${testUserId}-building-image`,
+        e2bTemplateId: "build-template-id",
+        e2bBuildId: "build-build-id",
+        status: "building",
+      });
+    });
+
+    afterAll(async () => {
+      // Cleanup test data
+      await globalThis.services.db
+        .delete(images)
+        .where(eq(images.userId, testUserId));
+      await globalThis.services.db
+        .delete(scopes)
+        .where(eq(scopes.ownerId, testUserId));
+    });
+
+    it("should resolve @scope/name format to e2bAlias", async () => {
+      const result = await resolveImageAlias(
+        testUserId,
+        `@${testScopeSlug}/test-image`,
+      );
+      expect(result.templateName).toBe(`user-${testUserId}-test-image`);
+      expect(result.isUserImage).toBe(true);
+    });
+
+    it("should throw NotFoundError for non-existent scope", async () => {
+      await expect(
+        resolveImageAlias(testUserId, "@nonexistent-scope/test-image"),
+      ).rejects.toThrow('Scope "@nonexistent-scope" not found');
+    });
+
+    it("should throw NotFoundError for non-existent image in scope", async () => {
+      await expect(
+        resolveImageAlias(testUserId, `@${testScopeSlug}/nonexistent`),
+      ).rejects.toThrow(`not found`);
+    });
+
+    it("should throw BadRequestError for image not ready", async () => {
+      await expect(
+        resolveImageAlias(testUserId, `@${testScopeSlug}/building-image`),
+      ).rejects.toThrow("not ready");
+    });
+
+    it("should pass through vm0- prefixed system templates", async () => {
+      const result = await resolveImageAlias(testUserId, "vm0-claude-code");
+      expect(result.templateName).toBe("vm0-claude-code");
+      expect(result.isUserImage).toBe(false);
+    });
+
+    it("should resolve plain alias via legacy lookup", async () => {
+      const result = await resolveImageAlias(testUserId, "test-image");
+      expect(result.templateName).toBe(`user-${testUserId}-test-image`);
+      expect(result.isUserImage).toBe(true);
+    });
+  });
+
+  describe("getImageByScopeAndAlias", () => {
+    const testUserId = "test-getimage-user";
+    const testScopeSlug = `getimg-test-${Date.now()}`;
+    let testScopeId: string;
+
+    beforeAll(async () => {
+      initServices();
+
+      // Create test scope
+      const scope = await createUserScope(testUserId, testScopeSlug);
+      testScopeId = scope.id;
+
+      // Create test image
+      await globalThis.services.db.insert(images).values({
+        userId: testUserId,
+        scopeId: testScopeId,
+        alias: "scoped-image",
+        e2bAlias: `user-${testUserId}-scoped-image`,
+        e2bTemplateId: "scoped-template-id",
+        e2bBuildId: "scoped-build-id",
+        status: "ready",
+      });
+    });
+
+    afterAll(async () => {
+      await globalThis.services.db
+        .delete(images)
+        .where(eq(images.userId, testUserId));
+      await globalThis.services.db
+        .delete(scopes)
+        .where(eq(scopes.ownerId, testUserId));
+    });
+
+    it("should return image when found by scopeId and alias", async () => {
+      const image = await getImageByScopeAndAlias(testScopeId, "scoped-image");
+      expect(image).toBeDefined();
+      expect(image!.alias).toBe("scoped-image");
+      expect(image!.scopeId).toBe(testScopeId);
+    });
+
+    it("should return null for non-existent alias", async () => {
+      const image = await getImageByScopeAndAlias(testScopeId, "nonexistent");
+      expect(image).toBeNull();
+    });
+
+    it("should return null for non-existent scopeId", async () => {
+      const image = await getImageByScopeAndAlias(
+        "00000000-0000-0000-0000-000000000000",
+        "scoped-image",
+      );
+      expect(image).toBeNull();
     });
   });
 });

--- a/turbo/apps/web/src/lib/image/image-service.ts
+++ b/turbo/apps/web/src/lib/image/image-service.ts
@@ -5,6 +5,7 @@ import { images } from "../../db/schema/image";
 import { scopes } from "../../db/schema/scope";
 import { BadRequestError, NotFoundError, ForbiddenError } from "../errors";
 import { logger } from "../logger";
+import { getUserScopeByClerkId } from "../scope/scope-service";
 import type { ImageStatusEnum } from "../../db/schema/image";
 
 const log = logger("service:image");
@@ -142,7 +143,11 @@ export async function buildImage(
 ): Promise<BuildResult> {
   const e2bAlias = generateE2bAlias(userId, alias);
 
-  log.debug("starting image build", { userId, alias, e2bAlias });
+  // Get user's scope if they have one (for @scope/name resolution)
+  const userScope = await getUserScopeByClerkId(userId);
+  const scopeId = userScope?.id ?? null;
+
+  log.debug("starting image build", { userId, alias, e2bAlias, scopeId });
 
   // Create template from Dockerfile content
   const template = Template().fromDockerfile(dockerfile);
@@ -181,6 +186,7 @@ export async function buildImage(
     .insert(images)
     .values({
       userId,
+      scopeId,
       alias,
       e2bAlias,
       e2bTemplateId: buildInfo.templateId,
@@ -190,6 +196,7 @@ export async function buildImage(
     .onConflictDoUpdate({
       target: [images.userId, images.alias],
       set: {
+        scopeId,
         e2bAlias,
         e2bTemplateId: buildInfo.templateId,
         e2bBuildId: buildInfo.buildId,

--- a/turbo/apps/web/src/lib/image/image-service.ts
+++ b/turbo/apps/web/src/lib/image/image-service.ts
@@ -2,11 +2,59 @@ import { eq, and, desc } from "drizzle-orm";
 import { ApiClient, ConnectionConfig, Template, BuildError } from "e2b";
 
 import { images } from "../../db/schema/image";
+import { scopes } from "../../db/schema/scope";
 import { BadRequestError, NotFoundError, ForbiddenError } from "../errors";
 import { logger } from "../logger";
 import type { ImageStatusEnum } from "../../db/schema/image";
 
 const log = logger("service:image");
+
+/**
+ * Check if an image alias is a legacy system template (starts with vm0-)
+ */
+function isLegacySystemTemplate(reference: string): boolean {
+  return reference.startsWith("vm0-");
+}
+
+/**
+ * Parse a scoped reference string (@scope/name format)
+ */
+function parseScopedReference(reference: string): {
+  scope: string;
+  name: string;
+} {
+  if (!reference.startsWith("@")) {
+    throw new Error(
+      `Invalid scoped reference: must start with @ (got "${reference}")`,
+    );
+  }
+
+  const withoutAt = reference.slice(1);
+  const slashIndex = withoutAt.indexOf("/");
+
+  if (slashIndex === -1) {
+    throw new Error(
+      `Invalid scoped reference: missing / separator (got "${reference}")`,
+    );
+  }
+
+  const scope = withoutAt.slice(0, slashIndex);
+  const name = withoutAt.slice(slashIndex + 1);
+
+  if (!scope) {
+    throw new Error(
+      `Invalid scoped reference: empty scope (got "${reference}")`,
+    );
+  }
+
+  if (!name) {
+    throw new Error(
+      `Invalid scoped reference: empty name (got "${reference}")`,
+    );
+  }
+
+  return { scope, name };
+}
 
 /**
  * Generate E2B alias from userId and user-specified alias
@@ -20,7 +68,31 @@ export function generateE2bAlias(userId: string, alias: string): string {
  * Check if an image alias is a system template (starts with vm0-)
  */
 export function isSystemTemplate(alias: string): boolean {
-  return alias.startsWith("vm0-");
+  return isLegacySystemTemplate(alias);
+}
+
+/**
+ * Get scope by slug
+ */
+async function getScopeBySlug(slug: string) {
+  const result = await globalThis.services.db
+    .select()
+    .from(scopes)
+    .where(eq(scopes.slug, slug))
+    .limit(1);
+  return result[0] ?? null;
+}
+
+/**
+ * Get image by scope ID and alias
+ */
+export async function getImageByScopeAndAlias(scopeId: string, alias: string) {
+  const result = await globalThis.services.db
+    .select()
+    .from(images)
+    .where(and(eq(images.scopeId, scopeId), eq(images.alias, alias)))
+    .limit(1);
+  return result[0] ?? null;
 }
 
 /**
@@ -229,8 +301,10 @@ export async function getImageByBuildId(buildId: string) {
 
 /**
  * Resolve an image alias to E2B template name
- * - System templates (vm0-*): return as-is
- * - User templates: lookup in DB and return e2bAlias
+ * Supports multiple formats:
+ * - Legacy vm0-* prefix: passthrough directly (system templates)
+ * - @scope/name format: explicit scope resolution
+ * - Plain name: lookup by userId (legacy) or user's scope
  * @throws NotFoundError if user image not found
  * @throws BadRequestError if user image is not ready
  */
@@ -238,12 +312,50 @@ export async function resolveImageAlias(
   userId: string,
   alias: string,
 ): Promise<{ templateName: string; isUserImage: boolean }> {
-  // System templates bypass DB lookup
+  // 1. Legacy vm0-* system templates: passthrough directly
   if (isSystemTemplate(alias)) {
     return { templateName: alias, isUserImage: false };
   }
 
-  // User template - must exist in DB
+  // 2. Try to parse as scoped reference (@scope/name format)
+  if (alias.startsWith("@")) {
+    try {
+      const parsed = parseScopedReference(alias);
+
+      // Lookup scope by slug
+      const scope = await getScopeBySlug(parsed.scope);
+      if (!scope) {
+        throw new NotFoundError(`Scope "@${parsed.scope}" not found`);
+      }
+
+      // Lookup image by scope and name
+      const image = await getImageByScopeAndAlias(scope.id, parsed.name);
+      if (!image) {
+        throw new NotFoundError(
+          `Image "@${parsed.scope}/${parsed.name}" not found`,
+        );
+      }
+
+      if (image.status !== "ready") {
+        throw new BadRequestError(
+          `Image "@${parsed.scope}/${parsed.name}" is not ready (status: ${image.status})`,
+        );
+      }
+
+      return { templateName: image.e2bAlias, isUserImage: true };
+    } catch (error) {
+      // If parsing fails, fall through to legacy lookup
+      if (error instanceof NotFoundError || error instanceof BadRequestError) {
+        throw error;
+      }
+      log.debug("Failed to parse scoped reference, falling back to legacy", {
+        alias,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  // 3. Legacy lookup by userId (for backward compatibility)
   const image = await getImageByAlias(userId, alias);
 
   if (!image) {

--- a/turbo/apps/web/src/lib/scope/__tests__/scope-service.spec.ts
+++ b/turbo/apps/web/src/lib/scope/__tests__/scope-service.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  validateScopeSlug,
+  getScopeBySlug,
+  getScopeById,
+  createScope,
+  createUserScope,
+  getUserScopeByClerkId,
+} from "../scope-service";
+import { initServices } from "../../init-services";
+import { scopes } from "../../../db/schema/scope";
+import { eq } from "drizzle-orm";
+import { BadRequestError } from "../../errors";
+
+describe("Scope Service", () => {
+  describe("validateScopeSlug", () => {
+    it("should accept valid slugs", () => {
+      expect(() => validateScopeSlug("myslug")).not.toThrow();
+      expect(() => validateScopeSlug("my-slug")).not.toThrow();
+      expect(() => validateScopeSlug("my-long-slug-123")).not.toThrow();
+      expect(() => validateScopeSlug("abc")).not.toThrow();
+      expect(() => validateScopeSlug("a1b2c3")).not.toThrow();
+    });
+
+    it("should reject slugs that are too short", () => {
+      expect(() => validateScopeSlug("ab")).toThrow(BadRequestError);
+      expect(() => validateScopeSlug("a")).toThrow(BadRequestError);
+      expect(() => validateScopeSlug("")).toThrow(BadRequestError);
+    });
+
+    it("should reject slugs that are too long", () => {
+      const longSlug = "a".repeat(65);
+      expect(() => validateScopeSlug(longSlug)).toThrow(BadRequestError);
+    });
+
+    it("should reject slugs with uppercase letters", () => {
+      expect(() => validateScopeSlug("MySlug")).toThrow(BadRequestError);
+      expect(() => validateScopeSlug("MYSLUG")).toThrow(BadRequestError);
+    });
+
+    it("should reject slugs with invalid characters", () => {
+      expect(() => validateScopeSlug("my_slug")).toThrow(BadRequestError);
+      expect(() => validateScopeSlug("my.slug")).toThrow(BadRequestError);
+      expect(() => validateScopeSlug("my slug")).toThrow(BadRequestError);
+      expect(() => validateScopeSlug("my@slug")).toThrow(BadRequestError);
+    });
+
+    it("should reject slugs starting with hyphen", () => {
+      expect(() => validateScopeSlug("-myslug")).toThrow(BadRequestError);
+    });
+
+    it("should reject slugs ending with hyphen", () => {
+      expect(() => validateScopeSlug("myslug-")).toThrow(BadRequestError);
+    });
+
+    it("should reject reserved slugs", () => {
+      expect(() => validateScopeSlug("vm0")).toThrow(BadRequestError);
+      expect(() => validateScopeSlug("system")).toThrow(BadRequestError);
+      expect(() => validateScopeSlug("admin")).toThrow(BadRequestError);
+      expect(() => validateScopeSlug("api")).toThrow(BadRequestError);
+      expect(() => validateScopeSlug("app")).toThrow(BadRequestError);
+      expect(() => validateScopeSlug("www")).toThrow(BadRequestError);
+    });
+
+    it("should reject slugs starting with vm0", () => {
+      expect(() => validateScopeSlug("vm0test")).toThrow(BadRequestError);
+      expect(() => validateScopeSlug("vm0-custom")).toThrow(BadRequestError);
+    });
+  });
+
+  describe("Database Operations", () => {
+    const testUserId = "test-scope-service-user";
+    const testSlug = `test-scope-${Date.now()}`;
+
+    beforeAll(() => {
+      initServices();
+    });
+
+    afterAll(async () => {
+      // Cleanup test scopes
+      await globalThis.services.db
+        .delete(scopes)
+        .where(eq(scopes.ownerId, testUserId));
+    });
+
+    describe("createScope", () => {
+      it("should create a scope successfully", async () => {
+        const scope = await createScope(
+          testSlug,
+          "personal",
+          testUserId,
+          "Test Scope",
+        );
+
+        expect(scope).toBeDefined();
+        expect(scope.slug).toBe(testSlug);
+        expect(scope.type).toBe("personal");
+        expect(scope.ownerId).toBe(testUserId);
+        expect(scope.displayName).toBe("Test Scope");
+        expect(scope.id).toBeDefined();
+      });
+
+      it("should reject duplicate slugs", async () => {
+        await expect(
+          createScope(`${testSlug}-dup`, "personal", testUserId),
+        ).resolves.toBeDefined();
+
+        await expect(
+          createScope(`${testSlug}-dup`, "personal", testUserId),
+        ).rejects.toThrow("already exists");
+      });
+    });
+
+    describe("getScopeBySlug", () => {
+      it("should return scope when found", async () => {
+        const slug = `test-get-${Date.now()}`;
+        await createScope(slug, "personal", testUserId);
+
+        const scope = await getScopeBySlug(slug);
+        expect(scope).toBeDefined();
+        expect(scope!.slug).toBe(slug);
+      });
+
+      it("should return null when not found", async () => {
+        const scope = await getScopeBySlug("nonexistent-scope-12345");
+        expect(scope).toBeNull();
+      });
+    });
+
+    describe("getScopeById", () => {
+      it("should return scope when found", async () => {
+        const slug = `test-getid-${Date.now()}`;
+        const created = await createScope(slug, "personal", testUserId);
+
+        const scope = await getScopeById(created.id);
+        expect(scope).toBeDefined();
+        expect(scope!.id).toBe(created.id);
+      });
+
+      it("should return null when not found", async () => {
+        const scope = await getScopeById(
+          "00000000-0000-0000-0000-000000000000",
+        );
+        expect(scope).toBeNull();
+      });
+    });
+
+    describe("getUserScopeByClerkId", () => {
+      it("should return user's personal scope", async () => {
+        const userId = `test-user-${Date.now()}`;
+        const slug = `user-scope-${Date.now()}`;
+        await createScope(slug, "personal", userId);
+
+        const scope = await getUserScopeByClerkId(userId);
+        expect(scope).toBeDefined();
+        expect(scope!.ownerId).toBe(userId);
+        expect(scope!.type).toBe("personal");
+      });
+
+      it("should return null if user has no scope", async () => {
+        const scope = await getUserScopeByClerkId("nonexistent-user-12345");
+        expect(scope).toBeNull();
+      });
+    });
+
+    describe("createUserScope", () => {
+      it("should create personal scope for user", async () => {
+        const userId = `test-create-user-${Date.now()}`;
+        const slug = `user-create-${Date.now()}`;
+
+        const scope = await createUserScope(userId, slug, "My Personal Scope");
+
+        expect(scope).toBeDefined();
+        expect(scope.slug).toBe(slug);
+        expect(scope.type).toBe("personal");
+        expect(scope.ownerId).toBe(userId);
+        expect(scope.displayName).toBe("My Personal Scope");
+      });
+
+      it("should reject if user already has a scope", async () => {
+        const userId = `test-duplicate-user-${Date.now()}`;
+        const slug1 = `user-dup1-${Date.now()}`;
+        const slug2 = `user-dup2-${Date.now()}`;
+
+        await createUserScope(userId, slug1);
+
+        await expect(createUserScope(userId, slug2)).rejects.toThrow(
+          "already have a scope",
+        );
+      });
+    });
+  });
+});

--- a/turbo/packages/core/src/__tests__/scope-reference.spec.ts
+++ b/turbo/packages/core/src/__tests__/scope-reference.spec.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseScopedReference,
+  formatScopedReference,
+  isLegacySystemTemplate,
+  resolveImageReference,
+  generateScopedE2bAlias,
+  computeDockerfileVersionHash,
+} from "../scope-reference";
+
+describe("parseScopedReference", () => {
+  it("parses valid @scope/name format", () => {
+    const result = parseScopedReference("@myorg/my-image");
+    expect(result).toEqual({ scope: "myorg", name: "my-image" });
+  });
+
+  it("parses scope with numbers", () => {
+    const result = parseScopedReference("@user123/image-v2");
+    expect(result).toEqual({ scope: "user123", name: "image-v2" });
+  });
+
+  it("throws for missing @ prefix", () => {
+    expect(() => parseScopedReference("myorg/my-image")).toThrow(
+      "must start with @",
+    );
+  });
+
+  it("throws for missing / separator", () => {
+    expect(() => parseScopedReference("@myorg")).toThrow("missing / separator");
+  });
+
+  it("throws for empty scope", () => {
+    expect(() => parseScopedReference("@/my-image")).toThrow("empty scope");
+  });
+
+  it("throws for empty name", () => {
+    expect(() => parseScopedReference("@myorg/")).toThrow("empty name");
+  });
+});
+
+describe("formatScopedReference", () => {
+  it("formats scope and name correctly", () => {
+    expect(formatScopedReference("myorg", "my-image")).toBe("@myorg/my-image");
+  });
+
+  it("handles special characters in name", () => {
+    expect(formatScopedReference("user", "image-v2")).toBe("@user/image-v2");
+  });
+});
+
+describe("isLegacySystemTemplate", () => {
+  it("returns true for vm0- prefix", () => {
+    expect(isLegacySystemTemplate("vm0-claude-code")).toBe(true);
+    expect(isLegacySystemTemplate("vm0-base")).toBe(true);
+  });
+
+  it("returns false for non-vm0 prefix", () => {
+    expect(isLegacySystemTemplate("my-image")).toBe(false);
+    expect(isLegacySystemTemplate("@scope/vm0-image")).toBe(false);
+    expect(isLegacySystemTemplate("vm1-image")).toBe(false);
+  });
+});
+
+describe("resolveImageReference", () => {
+  it("passes through legacy vm0-* templates", () => {
+    const result = resolveImageReference("vm0-claude-code");
+    expect(result).toEqual({
+      name: "vm0-claude-code",
+      isLegacy: true,
+    });
+  });
+
+  it("legacy templates don't require userScopeSlug", () => {
+    const result = resolveImageReference("vm0-base");
+    expect(result.isLegacy).toBe(true);
+  });
+
+  it("parses explicit @scope/name format", () => {
+    const result = resolveImageReference("@myorg/my-image");
+    expect(result).toEqual({
+      scope: "myorg",
+      name: "my-image",
+      isLegacy: false,
+    });
+  });
+
+  it("explicit scope doesn't require userScopeSlug", () => {
+    const result = resolveImageReference("@other/image");
+    expect(result.scope).toBe("other");
+  });
+
+  it("uses user scope for implicit references", () => {
+    const result = resolveImageReference("my-image", "myuser");
+    expect(result).toEqual({
+      scope: "myuser",
+      name: "my-image",
+      isLegacy: false,
+    });
+  });
+
+  it("throws for implicit reference without userScopeSlug", () => {
+    expect(() => resolveImageReference("my-image")).toThrow(
+      "Please set up your scope first",
+    );
+  });
+});
+
+describe("generateScopedE2bAlias", () => {
+  it("generates correct format", () => {
+    const result = generateScopedE2bAlias(
+      "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "my-image",
+      "deadbeef",
+    );
+    expect(result).toBe(
+      "scope-a1b2c3d4-e5f6-7890-abcd-ef1234567890-image-my-image-version-deadbeef",
+    );
+  });
+
+  it("sanitizes uppercase characters", () => {
+    const result = generateScopedE2bAlias("A1B2C3D4", "MyImage", "DEADBEEF");
+    expect(result).toBe("scope-a1b2c3d4-image-myimage-version-deadbeef");
+  });
+
+  it("sanitizes invalid characters in name", () => {
+    const result = generateScopedE2bAlias(
+      "12345678",
+      "my_image@v1",
+      "abcd1234",
+    );
+    expect(result).toBe("scope-12345678-image-my-image-v1-version-abcd1234");
+  });
+});
+
+describe("computeDockerfileVersionHash", () => {
+  it("returns 8 character hash", async () => {
+    const result = await computeDockerfileVersionHash("FROM ubuntu:22.04");
+    expect(result).toHaveLength(8);
+    expect(result).toMatch(/^[a-f0-9]{8}$/);
+  });
+
+  it("returns consistent hash for same content", async () => {
+    const dockerfile = "FROM node:18\nRUN npm install";
+    const hash1 = await computeDockerfileVersionHash(dockerfile);
+    const hash2 = await computeDockerfileVersionHash(dockerfile);
+    expect(hash1).toBe(hash2);
+  });
+
+  it("returns different hash for different content", async () => {
+    const hash1 = await computeDockerfileVersionHash("FROM ubuntu:22.04");
+    const hash2 = await computeDockerfileVersionHash("FROM ubuntu:24.04");
+    expect(hash1).not.toBe(hash2);
+  });
+});

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -127,3 +127,16 @@ export {
   type ProxyError,
   type ProxyErrorCode as ProxyErrorCodeType,
 } from "./proxy";
+export {
+  scopeContract,
+  scopeTypeSchema,
+  scopeSlugSchema,
+  scopeResponseSchema,
+  createScopeRequestSchema,
+  updateScopeRequestSchema,
+  type ScopeContract,
+  type ScopeTypeContract,
+  type ScopeResponse,
+  type CreateScopeRequest,
+  type UpdateScopeRequest,
+} from "./scopes";

--- a/turbo/packages/core/src/contracts/scopes.ts
+++ b/turbo/packages/core/src/contracts/scopes.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+/**
+ * Scope type enum
+ */
+export const scopeTypeSchema = z.enum(["personal", "organization", "system"]);
+export type ScopeTypeContract = z.infer<typeof scopeTypeSchema>;
+
+/**
+ * Scope slug validation
+ * - 3-64 characters (or 1-2 for single/double char slugs)
+ * - lowercase letters, numbers, and hyphens only
+ * - must start and end with alphanumeric
+ */
+export const scopeSlugSchema = z
+  .string()
+  .min(3, "Scope slug must be at least 3 characters")
+  .max(64, "Scope slug must be at most 64 characters")
+  .regex(
+    /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]{1,2}$/,
+    "Scope slug must contain only lowercase letters, numbers, and hyphens, and must start and end with an alphanumeric character",
+  )
+  .refine(
+    (slug) => !slug.startsWith("vm0"),
+    "Scope slug cannot start with 'vm0' (reserved)",
+  )
+  .transform((s) => s.toLowerCase());
+
+/**
+ * Scope response schema
+ */
+export const scopeResponseSchema = z.object({
+  id: z.string().uuid(),
+  slug: z.string(),
+  type: scopeTypeSchema,
+  displayName: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type ScopeResponse = z.infer<typeof scopeResponseSchema>;
+
+/**
+ * Create scope request schema
+ */
+export const createScopeRequestSchema = z.object({
+  slug: scopeSlugSchema,
+  displayName: z.string().max(128).optional(),
+});
+
+export type CreateScopeRequest = z.infer<typeof createScopeRequestSchema>;
+
+/**
+ * Update scope request schema
+ */
+export const updateScopeRequestSchema = z.object({
+  slug: scopeSlugSchema,
+  force: z.boolean().optional().default(false),
+});
+
+export type UpdateScopeRequest = z.infer<typeof updateScopeRequestSchema>;
+
+/**
+ * Scope contract for /api/scope
+ */
+export const scopeContract = c.router({
+  /**
+   * GET /api/scope
+   * Get current user's scope
+   */
+  get: {
+    method: "GET",
+    path: "/api/scope",
+    responses: {
+      200: scopeResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get current user's scope",
+  },
+
+  /**
+   * POST /api/scope
+   * Create user's scope
+   */
+  create: {
+    method: "POST",
+    path: "/api/scope",
+    body: createScopeRequestSchema,
+    responses: {
+      201: scopeResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      409: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Create user's scope",
+  },
+
+  /**
+   * PUT /api/scope
+   * Update user's scope slug
+   */
+  update: {
+    method: "PUT",
+    path: "/api/scope",
+    body: updateScopeRequestSchema,
+    responses: {
+      200: scopeResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Update user's scope slug",
+  },
+});
+
+export type ScopeContract = typeof scopeContract;

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./variable-expander";
 export * from "./contracts";
+export * from "./scope-reference";


### PR DESCRIPTION
## Summary

Implements Issue #628 - a scope/namespace system for VM0 resources that enables:

- **Namespace isolation** via scopes (personal, organization, system types)
- **`@scope/name` reference format** for explicit scope resolution
- **Implicit scope resolution** for unscoped resource names
- **Legacy compatibility** with `vm0-*` system templates

### Changes by Phase

**Phase 1: Database Schema**
- Add `scopes` table with `personal`/`organization`/`system` types
- Add `scope_id` FK to `users` and `images` tables  
- Expand `e2b_alias` from 128 to 256 characters for future extensibility
- Seed `vm0` system scope on migration

**Phase 2: Scope Service**
- Create `scope-service.ts` with CRUD operations
- Add `scope-reference.ts` in `@vm0/core` for reference parsing

**Phase 3: API & CLI**
- Add `/api/scope` endpoint (GET/POST/PUT)
- Add CLI commands: `vm0 scope status`, `vm0 scope set <slug> [--force]`
- Add scopes contract in `@vm0/core`

**Phase 4: Image Integration**
- Support `@scope/name` format in `resolveImageAlias`
- Maintain backward compatibility with legacy `vm0-*` passthrough

## Test plan

- [x] All 808 tests pass
- [x] Type checking passes
- [x] Lint passes
- [x] 22 new tests for scope-reference parsing
- [ ] CI pipeline verification

Closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)