### PR TITLE
fix: sandbox calls commit on deduplication to update HEAD

### DIFF
--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -431,7 +431,7 @@ export const cookCommand = new Command()
         console.log(chalk.blue("Pulling updated artifact..."));
 
         try {
-          await execVm0Command(["artifact", "pull"], {
+          await execVm0Command(["artifact", "pull", serverVersion], {
             cwd: artifactDir,
             silent: true,
           });


### PR DESCRIPTION
## Summary

- Fix sandbox Python script to call commit endpoint even when deduplication occurs
- Update cook auto-pull to pass explicit version for additional robustness

## Problem

When `vm0 cook` runs and the artifact content is deduplicated (same hash as existing version), the sandbox's Python `direct_upload.py.ts` script was returning early without calling the commit endpoint. This left `headVersionId` pointing to an old version, causing subsequent `artifact pull` (without explicit version) to fail with 404.

## Root Cause

The CLI's TypeScript `direct-upload.ts` was fixed in #626 to call commit even on deduplication, but the sandbox's Python script was never updated with the same fix.

## Changes

1. **Primary fix** (`direct_upload.py.ts`): Call commit endpoint even when `prepare` returns `existing=true` to update HEAD pointer
2. **Secondary fix** (`cook.ts`): Pass explicit version to artifact pull for additional robustness

## Test plan

- [ ] Run `vm0 cook` with deduplication scenario
- [ ] Verify auto-pull succeeds
- [ ] Verify manual `vm0 artifact pull` also works

Fixes #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)