### PR TITLE
feat(image): support @vm0/claude-code format for system images

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ version: "1.0"
 agents:
   my-agent:
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
     volumes:
       - claude-files:/home/user/.config/claude
@@ -267,7 +267,7 @@ agents:
   my-agent:
     description: "Agent description"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
     volumes:
       - my-volume:/home/user/data

--- a/e2e/fixtures/configs/vm0-env-expansion.yaml
+++ b/e2e/fixtures/configs/vm0-env-expansion.yaml
@@ -4,7 +4,7 @@ agents:
   vm0-env-expansion:
     description: "Test agent for environment variable expansion"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
     environment:
       TEST_VAR: "${{ vars.testVar }}"

--- a/e2e/fixtures/configs/vm0-network-security.yaml
+++ b/e2e/fixtures/configs/vm0-network-security.yaml
@@ -4,6 +4,6 @@ agents:
   vm0-network-security:
     description: "Test agent with network security (proxy mode)"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     beta_network_security: true
     working_dir: /home/user/workspace

--- a/e2e/fixtures/configs/vm0-standard.yaml
+++ b/e2e/fixtures/configs/vm0-standard.yaml
@@ -4,7 +4,7 @@ agents:
   vm0-standard:
     description: "Test agent with standard config"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     volumes:
       - claude-files:/home/user/.config/claude
     working_dir: /home/user/workspace

--- a/e2e/fixtures/configs/vm0-template-validation.yaml
+++ b/e2e/fixtures/configs/vm0-template-validation.yaml
@@ -4,7 +4,7 @@ agents:
   vm0-template-validation:
     description: "Test agent for template variable validation"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
     volumes:
       - user-data:/home/user/data

--- a/e2e/fixtures/configs/vm0-versioning.yaml
+++ b/e2e/fixtures/configs/vm0-versioning.yaml
@@ -4,5 +4,5 @@ agents:
   vm0-versioning:
     description: "Test agent for version testing"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace

--- a/e2e/fixtures/configs/vm0-volume-override.yaml
+++ b/e2e/fixtures/configs/vm0-volume-override.yaml
@@ -4,7 +4,7 @@ agents:
   vm0-volume-override:
     description: "Test agent with volume for override testing"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     volumes:
       - test-volume:/home/user/data
       - claude-files:/home/user/.config/claude

--- a/e2e/tests/02-commands/t07-vm0-volume-version-override.bats
+++ b/e2e/tests/02-commands/t07-vm0-volume-version-override.bats
@@ -38,7 +38,7 @@ agents:
   vm0-volume-override:
     description: "Test agent with volume for override testing"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     volumes:
       - test-volume:/home/user/data
       - claude-files:/home/user/.config/claude

--- a/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
+++ b/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
@@ -27,7 +27,7 @@ agents:
   $AGENT_NAME:
     description: "Test agent for version display"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -50,7 +50,7 @@ agents:
   $AGENT_NAME:
     description: "Test agent for deduplication"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -90,7 +90,7 @@ agents:
   $AGENT_NAME:
     description: "Initial description"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -108,7 +108,7 @@ agents:
   $AGENT_NAME:
     description: "Updated description"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -139,7 +139,7 @@ agents:
   $AGENT_NAME:
     description: "Deterministic test"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -156,7 +156,7 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     working_dir: /home/user/workspace
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     provider: claude-code
     description: "Deterministic test"
 EOF
@@ -191,7 +191,7 @@ agents:
   $AGENT_NAME:
     description: "Version 1"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -209,7 +209,7 @@ agents:
   $AGENT_NAME:
     description: "Version 2"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -244,7 +244,7 @@ agents:
   $AGENT_NAME:
     description: "Latest version test"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -277,7 +277,7 @@ agents:
   $AGENT_NAME:
     description: "Error test"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -304,7 +304,7 @@ agents:
   $AGENT_NAME:
     description: "Backward compatibility test"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 

--- a/e2e/tests/02-commands/t12-vm0-env-expansion.bats
+++ b/e2e/tests/02-commands/t12-vm0-env-expansion.bats
@@ -202,7 +202,7 @@ agents:
   multi-secrets:
     description: "Test agent with multiple secrets"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
     environment:
       SECRET_A: "\${{ secrets.SECRET_A }}"

--- a/e2e/tests/02-commands/t13-vm0-cook.bats
+++ b/e2e/tests/02-commands/t13-vm0-cook.bats
@@ -32,7 +32,7 @@ agents:
   $AGENT_NAME:
     description: "E2E test agent for cook command"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     volumes:
       - test-volume:/home/user/data
     working_dir: /home/user/workspace
@@ -109,7 +109,7 @@ agents:
   $AGENT_NAME:
     description: "E2E test agent for env check"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
     environment:
       API_KEY: \${{ vars.E2E_TEST_API_KEY }}
@@ -152,7 +152,7 @@ agents:
   $AGENT_NAME:
     description: "E2E test agent for env check"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
     environment:
       API_KEY: \${{ vars.E2E_TEST_VAR }}
@@ -183,7 +183,7 @@ agents:
   $AGENT_NAME:
     description: "E2E test agent for env check"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     working_dir: /home/user/workspace
     environment:
       EXISTING_VAR: \${{ vars.EXISTING_VAR }}

--- a/e2e/tests/02-commands/t17-vm0-simplified-compose.bats
+++ b/e2e/tests/02-commands/t17-vm0-simplified-compose.bats
@@ -28,7 +28,7 @@ agents:
   $AGENT_NAME:
     description: "Test agent with provider auto-config"
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
 EOF
 
     echo "# Running vm0 compose..."
@@ -90,7 +90,7 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     beta_system_prompt: AGENTS.md
 EOF
 
@@ -119,7 +119,7 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     beta_system_prompt: AGENTS.md
 EOF
 
@@ -241,7 +241,7 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     beta_system_prompt: AGENTS.md
 EOF
 
@@ -322,7 +322,7 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     beta_system_skills:
       - https://example.com/not-a-github-url
 EOF
@@ -341,7 +341,7 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     beta_system_prompt: ""
 EOF
 
@@ -359,7 +359,7 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     provider: claude-code
-    image: vm0-claude-code-dev
+    image: "@vm0/claude-code:dev"
     beta_system_prompt: nonexistent-file.md
 EOF
 

--- a/turbo/apps/cli/src/lib/__tests__/yaml-validator.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/yaml-validator.test.ts
@@ -83,7 +83,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "test-agent": {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -101,7 +101,7 @@ describe("validateAgentCompose", () => {
         agents: {
           "test-agent": {
             description: "Test description",
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
             volumes: ["claude-files:/home/user/.config/claude"],
@@ -124,7 +124,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "My-Test-Agent-123": {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -159,7 +159,7 @@ describe("validateAgentCompose", () => {
       const config = {
         agents: {
           "test-agent": {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -208,12 +208,12 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "agent-1": {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/workspace",
           },
           "agent-2": {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/workspace",
           },
@@ -233,7 +233,7 @@ describe("validateAgentCompose", () => {
         agents: {
           ab: {
             // Too short
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -250,7 +250,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "-invalid": {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -267,7 +267,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           my_agent: {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -316,7 +316,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "test-agent": {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             working_dir: "/home/user/workspace",
           },
         },
@@ -332,7 +332,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "test-agent": {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
             volumes: ["missing-vol:/path"],
@@ -356,7 +356,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "test-agent": {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
             volumes: ["data:/path"],
@@ -379,7 +379,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "test-agent": {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
             volumes: ["data:/path"],
@@ -405,7 +405,7 @@ describe("validateAgentCompose", () => {
         agents: {
           "test-agent": {
             provider: "claude-code",
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
           },
         },
       };
@@ -435,7 +435,7 @@ describe("validateAgentCompose", () => {
         agents: {
           "test-agent": {
             provider: "claude-code",
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             beta_system_prompt: "AGENTS.md",
           },
         },
@@ -451,7 +451,7 @@ describe("validateAgentCompose", () => {
         agents: {
           "test-agent": {
             provider: "claude-code",
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             beta_system_skills: [
               "https://github.com/vm0-ai/vm0-skills/tree/main/github",
             ],
@@ -469,7 +469,7 @@ describe("validateAgentCompose", () => {
         agents: {
           "test-agent": {
             provider: "claude-code",
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             beta_system_prompt: "",
           },
         },
@@ -486,7 +486,7 @@ describe("validateAgentCompose", () => {
         agents: {
           "test-agent": {
             provider: "claude-code",
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             beta_system_skills: ["https://example.com/not-github"],
           },
         },

--- a/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
@@ -54,7 +54,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
       agents: {
         "test-get-by-name-success": {
           description: "Test description",
-          image: "vm0-claude-code-dev",
+          image: "@vm0/claude-code:dev",
           provider: "claude-code",
           working_dir: "/home/user/workspace",
         },
@@ -135,7 +135,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
       agents: {
         "test-user-isolation": {
           description: "Test",
-          image: "vm0-claude-code-dev",
+          image: "@vm0/claude-code:dev",
           provider: "claude-code",
           working_dir: "/home/user/workspace",
         },
@@ -187,7 +187,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
       agents: {
         "test-agent-with-hyphens": {
           description: "Test description",
-          image: "vm0-claude-code-dev",
+          image: "@vm0/claude-code:dev",
           provider: "claude-code",
           working_dir: "/home/user/workspace",
         },

--- a/turbo/apps/web/app/api/agent/composes/__tests__/upsert.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/upsert.test.ts
@@ -54,7 +54,7 @@ describe("Agent Compose Upsert Behavior", () => {
         version: "1.0",
         agents: {
           "test-agent-create": {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -87,7 +87,7 @@ describe("Agent Compose Upsert Behavior", () => {
         agents: {
           "test-agent-update": {
             description: "Initial description",
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -159,7 +159,7 @@ describe("Agent Compose Upsert Behavior", () => {
         version: "1.0",
         agents: {
           "test-unique-constraint": {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -218,12 +218,12 @@ describe("Agent Compose Upsert Behavior", () => {
         version: "1.0",
         agents: {
           "agent-one": {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
           "agent-two": {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -254,7 +254,7 @@ describe("Agent Compose Upsert Behavior", () => {
         agents: {
           ab: {
             // Too short name
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -282,7 +282,7 @@ describe("Agent Compose Upsert Behavior", () => {
         version: "1.0",
         agents: {
           "my-test-agent-123": {
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -317,7 +317,7 @@ describe("Agent Compose Upsert Behavior", () => {
         agents: {
           "test-get-compose": {
             description: "Test",
-            image: "vm0-claude-code-dev",
+            image: "@vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },

--- a/turbo/apps/web/app/api/agent/composes/versions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/versions/__tests__/route.test.ts
@@ -51,7 +51,7 @@ describe("GET /api/agent/composes/versions", () => {
       agents: {
         "test-version-agent": {
           description: "Test agent for version tests",
-          image: "vm0-claude-code-dev",
+          image: "@vm0/claude-code:dev",
           provider: "claude-code",
           working_dir: "/home/user/workspace",
         },

--- a/turbo/apps/web/src/lib/image/image-service.ts
+++ b/turbo/apps/web/src/lib/image/image-service.ts
@@ -13,6 +13,8 @@ import {
   generateScopedE2bAlias,
   MIN_VERSION_PREFIX_LENGTH,
   isValidVersionPrefix,
+  isSystemScope,
+  resolveSystemImageToE2b,
 } from "@vm0/core";
 
 const log = logger("service:image");
@@ -443,16 +445,18 @@ export async function getImageByBuildId(buildId: string) {
 /**
  * Resolve an image alias to E2B template name
  * Supports multiple formats with optional tag:
- * - Legacy vm0-* prefix: passthrough directly (system templates)
+ * - Legacy vm0-* prefix: passthrough directly (system templates, deprecated)
+ * - @vm0/name[:tag] format: system scope with special handling
  * - @scope/name[:tag] format: explicit scope resolution with optional tag
  * - name[:tag]: implicit scope (user's scope) with optional tag
  *
  * Tag resolution:
  * - No tag or :latest → most recently built ready version
  * - Specific tag (e.g., :a1b2c3d4) → exact version by versionId
+ * - For system scope: only :latest and :dev are supported
  *
  * @throws NotFoundError if user image not found
- * @throws BadRequestError if user image is not ready
+ * @throws BadRequestError if user image is not ready or invalid system tag
  */
 export async function resolveImageAlias(
   userId: string,
@@ -470,14 +474,27 @@ export async function resolveImageAlias(
     return { templateName: ref.name, isUserImage: false };
   }
 
-  // 2. Resolve scope
+  // 2. System scope (@vm0/...) - special handling
+  if (ref.scope && isSystemScope(ref.scope)) {
+    try {
+      const { e2bTemplate } = resolveSystemImageToE2b(ref.name, ref.tag);
+      return { templateName: e2bTemplate, isUserImage: false };
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new BadRequestError(error.message);
+      }
+      throw error;
+    }
+  }
+
+  // 3. Resolve user scope
   const scope = ref.scope ? await getScopeBySlug(ref.scope) : userScope;
 
   if (!scope) {
     throw new NotFoundError(`Scope "@${ref.scope}" not found`);
   }
 
-  // 3. Resolve version based on tag
+  // 4. Resolve version based on tag
   let image;
   const refDisplay = ref.scope ? `@${ref.scope}/${ref.name}` : ref.name;
 

--- a/turbo/apps/web/src/lib/image/image-service.ts
+++ b/turbo/apps/web/src/lib/image/image-service.ts
@@ -55,10 +55,19 @@ export function generateE2bAlias(userId: string, alias: string): string {
 }
 
 /**
- * Check if an image alias is a system template (starts with vm0-)
+ * Check if an image alias is a system template
+ * Supports both legacy (vm0-*) and new (@vm0/...) formats
  */
 export function isSystemTemplate(alias: string): boolean {
-  return isLegacySystemTemplate(alias);
+  // Legacy vm0-* format
+  if (isLegacySystemTemplate(alias)) {
+    return true;
+  }
+  // New @vm0/... format (system scope)
+  if (alias.startsWith("@vm0/")) {
+    return true;
+  }
+  return false;
 }
 
 /**

--- a/turbo/apps/web/src/test/api-test-helpers.ts
+++ b/turbo/apps/web/src/test/api-test-helpers.ts
@@ -50,7 +50,7 @@ export function createDefaultComposeConfig(
     version: "1.0",
     agents: {
       [agentName]: {
-        image: "vm0-claude-code-dev",
+        image: "@vm0/claude-code:dev",
         provider: "claude-code",
         working_dir: "/home/user/workspace",
         ...overrides,


### PR DESCRIPTION
## Summary

Add support for `@vm0/claude-code` format to reference system images, providing consistency with the new `@scope/name` naming convention.

### Changes
- Support `@vm0/claude-code`, `@vm0/claude-code:latest`, `@vm0/claude-code:dev` formats
- System scope uses special conversion logic (not standard E2B alias format)
- Only `:latest` and `:dev` tags supported for system images
- Hash version tags return clear error message
- Legacy `vm0-*` format shows deprecation warning in CLI compose command

### Conversion Rules

| Input | Output |
|-------|--------|
| `@vm0/claude-code` | `vm0-claude-code` |
| `@vm0/claude-code:latest` | `vm0-claude-code` |
| `@vm0/claude-code:dev` | `vm0-claude-code-dev` |
| `@vm0/claude-code:abc123` | Error (hash not supported) |
| `vm0-claude-code` | `vm0-claude-code` + deprecation warning |

## Test plan

- [x] Unit tests for system scope constants and functions
- [x] Unit tests for `resolveSystemImageToE2b()` conversions and errors
- [x] Unit tests for `getLegacySystemTemplateWarning()`
- [x] All existing tests pass
- [ ] Manual testing with compose file using new format

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)