### PR TITLE
fix: verify S3 files exist during deduplication to prevent 404 errors

### DIFF
--- a/turbo/apps/web/app/api/storages/commit/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/commit/__tests__/route.test.ts
@@ -432,4 +432,70 @@ describe("POST /api/storages/commit", () => {
     expect(json.success).toBe(true);
     expect(json.deduplicated).toBe(true);
   });
+
+  it("should return 409 when version exists but S3 files are missing", async () => {
+    // This test verifies the fix for issue #658:
+    // Commit should fail with 409 if S3 files are missing for existing version
+    const s3Mock = await import("../../../../../src/lib/s3/s3-client");
+    const verifyS3FilesMock = vi.mocked(s3Mock.verifyS3FilesExist);
+
+    // Mock S3 files as missing for existing version
+    verifyS3FilesMock.mockResolvedValueOnce(false);
+
+    const { POST } = await import("../route");
+    const storageName = `${TEST_PREFIX}s3missing`;
+
+    // Create storage
+    const [storage] = await globalThis.services.db
+      .insert(storages)
+      .values({
+        userId: TEST_USER_ID,
+        name: storageName,
+        type: "volume",
+        s3Prefix: `${TEST_USER_ID}/volume/${storageName}`,
+        size: 100,
+        fileCount: 1,
+      })
+      .returning();
+
+    const files = [
+      {
+        path: "test.txt",
+        hash: "s3missing_hash_abcdef1234567890abcdef",
+        size: 100,
+      },
+    ];
+    const versionId = computeContentHashFromHashes(storage!.id, files);
+
+    // Create version record (simulating DB has record but S3 files deleted)
+    await globalThis.services.db.insert(storageVersions).values({
+      id: versionId,
+      storageId: storage!.id,
+      s3Key: `${TEST_USER_ID}/volume/${storageName}/${versionId}`,
+      size: 100,
+      fileCount: 1,
+      createdBy: TEST_USER_ID,
+    });
+
+    // Commit should fail because S3 files are missing
+    const request = new Request("http://localhost:3000/api/storages/commit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        storageName,
+        storageType: "volume",
+        versionId,
+        files,
+      }),
+    });
+
+    const response = await POST(
+      request as unknown as import("next/server").NextRequest,
+    );
+    expect(response.status).toBe(409);
+
+    const json = await response.json();
+    expect(json.error.code).toBe("S3_FILES_MISSING");
+    expect(json.error.message).toContain("S3 files missing");
+  });
 });

--- a/turbo/apps/web/app/api/storages/commit/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/commit/__tests__/route.test.ts
@@ -26,6 +26,7 @@ vi.mock("../../../../../src/lib/auth/get-user-id", () => ({
 
 vi.mock("../../../../../src/lib/s3/s3-client", () => ({
   s3ObjectExists: vi.fn().mockResolvedValue(true),
+  verifyS3FilesExist: vi.fn().mockResolvedValue(true),
 }));
 
 // Set required environment variables

--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -4,7 +4,10 @@ import { agentRuns } from "../../../../src/db/schema/agent-run";
 import { storages, storageVersions } from "../../../../src/db/schema/storage";
 import { eq, and } from "drizzle-orm";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
-import { s3ObjectExists } from "../../../../src/lib/s3/s3-client";
+import {
+  s3ObjectExists,
+  verifyS3FilesExist,
+} from "../../../../src/lib/s3/s3-client";
 import {
   computeContentHashFromHashes,
   type FileEntryWithHash,
@@ -161,7 +164,36 @@ export async function POST(request: NextRequest) {
       .limit(1);
 
     if (existingVersion) {
-      // Version already exists, update HEAD pointer if needed
+      // Get bucket name for S3 verification
+      const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
+      if (!bucketName) {
+        return errorResponse(
+          "R2_USER_STORAGES_BUCKET_NAME not configured",
+          "INTERNAL_ERROR",
+          500,
+        );
+      }
+
+      // Defense-in-depth: verify S3 files exist before updating HEAD
+      // This catches edge cases where S3 files were deleted between prepare and commit
+      const s3Exists = await verifyS3FilesExist(
+        bucketName,
+        existingVersion.s3Key,
+        existingVersion.fileCount,
+      );
+
+      if (!s3Exists) {
+        log.error(
+          `Version ${versionId} exists in DB but S3 files missing - cannot commit`,
+        );
+        return errorResponse(
+          "S3 files missing for existing version - please retry upload",
+          "S3_FILES_MISSING",
+          409,
+        );
+      }
+
+      // Version already exists with valid S3 files, update HEAD pointer if needed
       if (storage.headVersionId !== versionId) {
         await globalThis.services.db
           .update(storages)

--- a/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
@@ -27,6 +27,7 @@ vi.mock("../../../../../src/lib/s3/s3-client", () => ({
     .fn()
     .mockResolvedValue("https://s3.example.com/presigned-url"),
   downloadManifest: vi.fn().mockResolvedValue({ files: [] }),
+  verifyS3FilesExist: vi.fn().mockResolvedValue(true),
 }));
 
 // Set required environment variables

--- a/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
@@ -296,4 +296,74 @@ describe("POST /api/storages/prepare", () => {
     expect(json1.versionId).toBe(json2.versionId);
     expect(json1.versionId).toHaveLength(64);
   });
+
+  it("should return upload URLs when version exists but S3 files are missing", async () => {
+    // Import mock to control verifyS3FilesExist behavior
+    const s3Mock = await import("../../../../../src/lib/s3/s3-client");
+    const verifyS3FilesMock = vi.mocked(s3Mock.verifyS3FilesExist);
+
+    const { POST } = await import("../route");
+    const storageName = `${TEST_PREFIX}s3missing`;
+
+    // Create storage
+    const [storage] = await globalThis.services.db
+      .insert(storages)
+      .values({
+        userId: TEST_USER_ID,
+        name: storageName,
+        type: "volume",
+        s3Prefix: `${TEST_USER_ID}/volume/${storageName}`,
+        size: 100,
+        fileCount: 1,
+      })
+      .returning();
+
+    // Prepare with files to get the version ID
+    const files = [{ path: "test.txt", hash: "abc123missing", size: 100 }];
+    const request1 = new Request("http://localhost:3000/api/storages/prepare", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ storageName, storageType: "volume", files }),
+    });
+
+    const response1 = await POST(
+      request1 as unknown as import("next/server").NextRequest,
+    );
+    const json1 = await response1.json();
+    const versionId = json1.versionId;
+
+    // Create version record (simulating DB has record but S3 files deleted)
+    await globalThis.services.db.insert(storageVersions).values({
+      id: versionId,
+      storageId: storage!.id,
+      s3Key: `${TEST_USER_ID}/volume/${storageName}/${versionId}`,
+      size: 100,
+      fileCount: 1,
+      createdBy: TEST_USER_ID,
+    });
+
+    // Mock S3 files as missing
+    verifyS3FilesMock.mockResolvedValueOnce(false);
+
+    // Prepare again with same files - should get upload URLs since S3 missing
+    const request2 = new Request("http://localhost:3000/api/storages/prepare", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ storageName, storageType: "volume", files }),
+    });
+
+    const response2 = await POST(
+      request2 as unknown as import("next/server").NextRequest,
+    );
+    expect(response2.status).toBe(200);
+
+    const json2 = await response2.json();
+    expect(json2.versionId).toBe(versionId);
+    // Should NOT return existing: true since S3 files are missing
+    expect(json2.existing).toBe(false);
+    // Should return upload URLs for re-upload
+    expect(json2.uploads).toBeDefined();
+    expect(json2.uploads.archive.presignedUrl).toBeDefined();
+    expect(json2.uploads.manifest.presignedUrl).toBeDefined();
+  });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -10,6 +10,7 @@ import { getSandboxAuthForRun } from "../../../../../../src/lib/auth/get-sandbox
 import {
   generatePresignedPutUrl,
   downloadManifest,
+  verifyS3FilesExist,
 } from "../../../../../../src/lib/s3/s3-client";
 import {
   computeContentHashFromHashes,
@@ -229,6 +230,16 @@ export async function POST(request: NextRequest) {
     const versionId = computeContentHashFromHashes(storage.id, mergedFiles);
     log.debug(`Computed version ID: ${versionId}`);
 
+    // Get bucket name (needed for S3 verification)
+    const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
+    if (!bucketName) {
+      return errorResponse(
+        "R2_USER_STORAGES_BUCKET_NAME not configured",
+        "INTERNAL_ERROR",
+        500,
+      );
+    }
+
     // Check if version already exists (deduplication) - skip if force is true
     if (!force) {
       const [existingVersion] = await globalThis.services.db
@@ -243,25 +254,32 @@ export async function POST(request: NextRequest) {
         .limit(1);
 
       if (existingVersion) {
-        log.debug(`Version ${versionId} already exists, returning existing`);
-        return NextResponse.json({
-          versionId,
-          existing: true,
-        } satisfies PrepareResponse);
+        // Verify S3 files actually exist before returning existing: true
+        // This handles the case where DB record exists but S3 files were deleted
+        const s3Exists = await verifyS3FilesExist(
+          bucketName,
+          existingVersion.s3Key,
+          existingVersion.fileCount,
+        );
+
+        if (s3Exists) {
+          log.debug(
+            `Version ${versionId} exists with S3 files, returning existing`,
+          );
+          return NextResponse.json({
+            versionId,
+            existing: true,
+          } satisfies PrepareResponse);
+        }
+
+        // S3 files missing - treat as new version, will trigger re-upload
+        log.warn(
+          `Version ${versionId} exists in DB but S3 files missing, treating as new`,
+        );
       }
     } else {
       log.debug(
         `Force flag set, skipping deduplication check for ${versionId}`,
-      );
-    }
-
-    // Get bucket name
-    const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
-    if (!bucketName) {
-      return errorResponse(
-        "R2_USER_STORAGES_BUCKET_NAME not configured",
-        "INTERNAL_ERROR",
-        500,
       );
     }
 


### PR DESCRIPTION
## Summary

When deduplication occurs (version already exists in DB), the prepare and commit endpoints now verify that S3 files actually exist before returning success. This prevents 404 errors when pulling artifacts where the DB record exists but S3 files were deleted.

## Changes

- Add `verifyS3FilesExist` utility function to s3-client.ts
- Update prepare endpoints (API + webhook) to check S3 before returning `existing: true`
  - If S3 files missing, treat as new version and return upload URLs (self-healing)
- Update commit endpoints (API + webhook) to verify S3 before updating HEAD (defense-in-depth)
  - If S3 files missing, return 409 Conflict error
- Update tests to mock the new `verifyS3FilesExist` function

## Files Changed

| File | Change |
|------|--------|
| `src/lib/s3/s3-client.ts` | Add `verifyS3FilesExist` utility |
| `app/api/storages/prepare/route.ts` | Add S3 check in dedup path |
| `app/api/storages/commit/route.ts` | Add S3 check for dedup path |
| `app/api/webhooks/agent/storages/prepare/route.ts` | Add S3 check in dedup path |
| `app/api/webhooks/agent/storages/commit/route.ts` | Add S3 check for dedup path |
| `app/api/storages/prepare/__tests__/route.test.ts` | Update mock |
| `app/api/storages/commit/__tests__/route.test.ts` | Update mock |

## Test plan

- [x] All storage endpoint tests pass
- [x] Type check passes
- [x] Lint passes
- [ ] Manual verification with `vm0 cook`

Fixes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)