### PR TITLE
feat(image): enforce lowercase image names for Docker compatibility

### DIFF
--- a/turbo/apps/cli/src/lib/__tests__/yaml-validator.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/yaml-validator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   validateAgentName,
+  normalizeAgentName,
   validateAgentCompose,
   validateGitHubTreeUrl,
 } from "../yaml-validator";
@@ -73,6 +74,31 @@ describe("validateAgentName", () => {
     it("should reject name with only hyphen", () => {
       expect(validateAgentName("-")).toBe(false);
     });
+  });
+});
+
+describe("normalizeAgentName", () => {
+  it("should normalize valid name to lowercase", () => {
+    expect(normalizeAgentName("My-Agent")).toBe("my-agent");
+  });
+
+  it("should normalize uppercase name to lowercase", () => {
+    expect(normalizeAgentName("MY-AGENT")).toBe("my-agent");
+  });
+
+  it("should keep lowercase name unchanged", () => {
+    expect(normalizeAgentName("my-agent")).toBe("my-agent");
+  });
+
+  it("should normalize mixed case with numbers", () => {
+    expect(normalizeAgentName("My-Agent-123")).toBe("my-agent-123");
+  });
+
+  it("should return null for invalid name format", () => {
+    expect(normalizeAgentName("ab")).toBeNull(); // too short
+    expect(normalizeAgentName("-agent")).toBeNull(); // starts with hyphen
+    expect(normalizeAgentName("agent-")).toBeNull(); // ends with hyphen
+    expect(normalizeAgentName("my_agent")).toBeNull(); // invalid character
   });
 });
 

--- a/turbo/apps/cli/src/lib/yaml-validator.ts
+++ b/turbo/apps/cli/src/lib/yaml-validator.ts
@@ -13,6 +13,17 @@ export function validateAgentName(name: string): boolean {
 }
 
 /**
+ * Normalizes agent name to lowercase
+ * Returns null if the name format is invalid
+ */
+export function normalizeAgentName(name: string): string | null {
+  if (!validateAgentName(name)) {
+    return null;
+  }
+  return name.toLowerCase();
+}
+
+/**
  * Validates GitHub tree URL format for beta_system_skills
  * Expected format: https://github.com/{owner}/{repo}/tree/{branch}/{path}
  */

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -162,6 +162,9 @@ const router = tsr.router(composesMainContract, {
       };
     }
 
+    // Normalize agent name to lowercase for consistent storage
+    const normalizedAgentName = agentName.toLowerCase();
+
     // Validate image access
     const agent = content.agents[agentName];
     if (agent?.image) {
@@ -191,7 +194,7 @@ const router = tsr.router(composesMainContract, {
       .where(
         and(
           eq(agentComposes.userId, userId),
-          eq(agentComposes.name, agentName),
+          eq(agentComposes.name, normalizedAgentName),
         ),
       )
       .limit(1);
@@ -207,7 +210,7 @@ const router = tsr.router(composesMainContract, {
         .insert(agentComposes)
         .values({
           userId,
-          name: agentName,
+          name: normalizedAgentName,
         })
         .returning({ id: agentComposes.id });
 
@@ -258,7 +261,7 @@ const router = tsr.router(composesMainContract, {
         status: 201 as const,
         body: {
           composeId,
-          name: agentName,
+          name: normalizedAgentName,
           versionId,
           action: action as "created" | "existing",
           updatedAt,
@@ -270,7 +273,7 @@ const router = tsr.router(composesMainContract, {
       status: 200 as const,
       body: {
         composeId,
-        name: agentName,
+        name: normalizedAgentName,
         versionId,
         action: action as "created" | "existing",
         updatedAt,

--- a/turbo/packages/core/src/__tests__/scope-reference.spec.ts
+++ b/turbo/packages/core/src/__tests__/scope-reference.spec.ts
@@ -110,6 +110,41 @@ describe("resolveImageReference", () => {
       "Please set up your scope first",
     );
   });
+
+  describe("case normalization", () => {
+    it("normalizes explicit scope and name to lowercase", () => {
+      const result = resolveImageReference("@MyOrg/My-Image");
+      expect(result).toEqual({
+        scope: "myorg",
+        name: "my-image",
+        isLegacy: false,
+      });
+    });
+
+    it("normalizes uppercase scope and name to lowercase", () => {
+      const result = resolveImageReference("@LANCY/MY-IMAGE");
+      expect(result).toEqual({
+        scope: "lancy",
+        name: "my-image",
+        isLegacy: false,
+      });
+    });
+
+    it("normalizes implicit name to lowercase", () => {
+      const result = resolveImageReference("My-Image", "myuser");
+      expect(result).toEqual({
+        scope: "myuser",
+        name: "my-image",
+        isLegacy: false,
+      });
+    });
+
+    it("does not normalize legacy templates", () => {
+      // Legacy templates are passed through as-is
+      const result = resolveImageReference("vm0-claude-code");
+      expect(result.name).toBe("vm0-claude-code");
+    });
+  });
 });
 
 describe("parseImageReferenceWithTag", () => {
@@ -247,6 +282,49 @@ describe("parseImageReferenceWithTag", () => {
       expect(() => parseImageReferenceWithTag(":latest", "myuser")).toThrow(
         "empty name",
       );
+    });
+  });
+
+  describe("case normalization", () => {
+    it("normalizes explicit scope and name to lowercase", () => {
+      const result = parseImageReferenceWithTag("@VM0/Claude-Code:dev");
+      expect(result).toEqual({
+        scope: "vm0",
+        name: "claude-code",
+        tag: "dev",
+        isLegacy: false,
+      });
+    });
+
+    it("normalizes uppercase scope and name to lowercase", () => {
+      const result = parseImageReferenceWithTag("@LANCY/MY-IMAGE");
+      expect(result).toEqual({
+        scope: "lancy",
+        name: "my-image",
+        tag: undefined,
+        isLegacy: false,
+      });
+    });
+
+    it("normalizes implicit name to lowercase", () => {
+      const result = parseImageReferenceWithTag("My-Image:latest", "myuser");
+      expect(result).toEqual({
+        scope: "myuser",
+        name: "my-image",
+        tag: "latest",
+        isLegacy: false,
+      });
+    });
+
+    it("preserves tag case", () => {
+      // Tags should preserve original case (version hashes, etc.)
+      const result = parseImageReferenceWithTag("@myorg/my-image:DeadBeef");
+      expect(result.tag).toBe("DeadBeef");
+    });
+
+    it("does not normalize legacy templates", () => {
+      const result = parseImageReferenceWithTag("vm0-claude-code");
+      expect(result.name).toBe("vm0-claude-code");
     });
   });
 });

--- a/turbo/packages/core/src/contracts/images.ts
+++ b/turbo/packages/core/src/contracts/images.ts
@@ -37,9 +37,10 @@ const createImageRequestSchema = z.object({
       "alias must be 3-64 characters, alphanumeric and hyphens, start/end with alphanumeric",
     )
     .refine(
-      (val) => !val.startsWith("vm0-"),
+      (val) => !val.toLowerCase().startsWith("vm0-"),
       'alias cannot start with "vm0-" (reserved for system templates)',
-    ),
+    )
+    .transform((s) => s.toLowerCase()),
   deleteExisting: z.boolean().optional(),
 });
 

--- a/turbo/packages/core/src/scope-reference.ts
+++ b/turbo/packages/core/src/scope-reference.ts
@@ -197,8 +197,8 @@ export function resolveImageReference(
   if (input.startsWith("@")) {
     const { scope, name } = parseScopedReference(input);
     return {
-      scope,
-      name,
+      scope: scope.toLowerCase(),
+      name: name.toLowerCase(),
       isLegacy: false,
     };
   }
@@ -212,7 +212,7 @@ export function resolveImageReference(
 
   return {
     scope: userScopeSlug,
-    name: input,
+    name: input.toLowerCase(),
     isLegacy: false,
   };
 }
@@ -280,8 +280,8 @@ export function parseImageReferenceWithTag(
     }
 
     return {
-      scope,
-      name,
+      scope: scope.toLowerCase(),
+      name: name.toLowerCase(),
       tag,
       isLegacy: false,
     };
@@ -314,7 +314,7 @@ export function parseImageReferenceWithTag(
 
   return {
     scope: userScopeSlug,
-    name,
+    name: name.toLowerCase(),
     tag,
     isLegacy: false,
   };


### PR DESCRIPTION
## Summary

- Implements case-insensitive image name handling by normalizing all inputs to lowercase before storage and lookup
- Aligns with Docker conventions which require lowercase image names
- Ensures consistency with existing scope slug behavior which already enforces lowercase

## Changes

- **`packages/core/src/contracts/images.ts`**: Add `.transform((s) => s.toLowerCase())` to image alias validation schema
- **`packages/core/src/scope-reference.ts`**: Normalize scope and name to lowercase in `parseImageReferenceWithTag()` and `resolveImageReference()`
- **`apps/cli/src/lib/yaml-validator.ts`**: Add `normalizeAgentName()` function for consistent case handling
- **`apps/web/app/api/agent/composes/route.ts`**: Normalize agent name before storage

## Test plan

- [x] Unit tests for image alias normalization: `My-Image` → `my-image`
- [x] Unit tests for image reference parsing with case normalization
- [x] Unit tests for `normalizeAgentName()` function
- [x] All existing scope-reference tests pass
- [x] All existing yaml-validator tests pass

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)