### PR TITLE
refactor(scope): remove @ prefix from scoped image references

### DIFF
--- a/e2e/fixtures/configs/vm0-env-expansion.yaml
+++ b/e2e/fixtures/configs/vm0-env-expansion.yaml
@@ -4,7 +4,7 @@ agents:
   vm0-env-expansion:
     description: "Test agent for environment variable expansion"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
     environment:
       TEST_VAR: "${{ vars.testVar }}"

--- a/e2e/fixtures/configs/vm0-network-security.yaml
+++ b/e2e/fixtures/configs/vm0-network-security.yaml
@@ -4,6 +4,6 @@ agents:
   vm0-network-security:
     description: "Test agent with network security (proxy mode)"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     beta_network_security: true
     working_dir: /home/user/workspace

--- a/e2e/fixtures/configs/vm0-standard.yaml
+++ b/e2e/fixtures/configs/vm0-standard.yaml
@@ -4,7 +4,7 @@ agents:
   vm0-standard:
     description: "Test agent with standard config"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace

--- a/e2e/fixtures/configs/vm0-template-validation.yaml
+++ b/e2e/fixtures/configs/vm0-template-validation.yaml
@@ -4,7 +4,7 @@ agents:
   vm0-template-validation:
     description: "Test agent for template variable validation"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
     volumes:
       - user-data:/home/user/data

--- a/e2e/fixtures/configs/vm0-versioning.yaml
+++ b/e2e/fixtures/configs/vm0-versioning.yaml
@@ -4,5 +4,5 @@ agents:
   vm0-versioning:
     description: "Test agent for version testing"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace

--- a/e2e/fixtures/configs/vm0-volume-override.yaml
+++ b/e2e/fixtures/configs/vm0-volume-override.yaml
@@ -4,7 +4,7 @@ agents:
   vm0-volume-override:
     description: "Test agent with volume for override testing"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     volumes:
       - test-volume:/home/user/data
       - claude-files:/home/user/.claude

--- a/e2e/tests/02-commands/t07-vm0-volume-version-override.bats
+++ b/e2e/tests/02-commands/t07-vm0-volume-version-override.bats
@@ -38,7 +38,7 @@ agents:
   vm0-volume-override:
     description: "Test agent with volume for override testing"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     volumes:
       - test-volume:/home/user/data
       - claude-files:/home/user/.config/claude

--- a/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
+++ b/e2e/tests/02-commands/t11-vm0-compose-versioning.bats
@@ -27,7 +27,7 @@ agents:
   $AGENT_NAME:
     description: "Test agent for version display"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -50,7 +50,7 @@ agents:
   $AGENT_NAME:
     description: "Test agent for deduplication"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -90,7 +90,7 @@ agents:
   $AGENT_NAME:
     description: "Initial description"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -108,7 +108,7 @@ agents:
   $AGENT_NAME:
     description: "Updated description"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -139,7 +139,7 @@ agents:
   $AGENT_NAME:
     description: "Deterministic test"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -156,7 +156,7 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     working_dir: /home/user/workspace
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     provider: claude-code
     description: "Deterministic test"
 EOF
@@ -191,7 +191,7 @@ agents:
   $AGENT_NAME:
     description: "Version 1"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -209,7 +209,7 @@ agents:
   $AGENT_NAME:
     description: "Version 2"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -244,7 +244,7 @@ agents:
   $AGENT_NAME:
     description: "Latest version test"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -277,7 +277,7 @@ agents:
   $AGENT_NAME:
     description: "Error test"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -304,7 +304,7 @@ agents:
   $AGENT_NAME:
     description: "Backward compatibility test"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 

--- a/e2e/tests/02-commands/t12-vm0-env-expansion.bats
+++ b/e2e/tests/02-commands/t12-vm0-env-expansion.bats
@@ -202,7 +202,7 @@ agents:
   multi-secrets:
     description: "Test agent with multiple secrets"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
     environment:
       SECRET_A: "\${{ secrets.SECRET_A }}"

--- a/e2e/tests/02-commands/t13-vm0-cook.bats
+++ b/e2e/tests/02-commands/t13-vm0-cook.bats
@@ -32,7 +32,7 @@ agents:
   $AGENT_NAME:
     description: "E2E test agent for cook command"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     volumes:
       - test-volume:/home/user/data
     working_dir: /home/user/workspace
@@ -109,7 +109,7 @@ agents:
   $AGENT_NAME:
     description: "E2E test agent for env check"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
     environment:
       API_KEY: \${{ vars.E2E_TEST_API_KEY }}
@@ -152,7 +152,7 @@ agents:
   $AGENT_NAME:
     description: "E2E test agent for env check"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
     environment:
       API_KEY: \${{ vars.E2E_TEST_VAR }}
@@ -183,7 +183,7 @@ agents:
   $AGENT_NAME:
     description: "E2E test agent for env check"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
     environment:
       EXISTING_VAR: \${{ vars.EXISTING_VAR }}

--- a/e2e/tests/02-commands/t17-vm0-simplified-compose.bats
+++ b/e2e/tests/02-commands/t17-vm0-simplified-compose.bats
@@ -28,7 +28,7 @@ agents:
   $AGENT_NAME:
     description: "Test agent with provider auto-config"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
 EOF
 
     echo "# Running vm0 compose..."
@@ -90,7 +90,7 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     beta_system_prompt: AGENTS.md
 EOF
 
@@ -119,7 +119,7 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     beta_system_prompt: AGENTS.md
 EOF
 
@@ -241,7 +241,7 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     beta_system_prompt: AGENTS.md
 EOF
 
@@ -322,7 +322,7 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     beta_system_skills:
       - https://example.com/not-a-github-url
 EOF
@@ -341,7 +341,7 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     beta_system_prompt: ""
 EOF
 
@@ -359,7 +359,7 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: "vm0/claude-code:dev"
     beta_system_prompt: nonexistent-file.md
 EOF
 

--- a/e2e/tests/02-commands/t19-vm0-scope.bats
+++ b/e2e/tests/02-commands/t19-vm0-scope.bats
@@ -54,7 +54,7 @@ teardown() {
     if [[ $status -eq 0 ]]; then
         # User has a scope configured
         assert_output --partial "Scope Information"
-        assert_output --partial "@"
+        assert_output --partial "Slug:"
     else
         # User has no scope configured
         assert_output --partial "No scope configured"
@@ -94,11 +94,11 @@ teardown() {
 }
 
 # ============================================
-# @scope/name Image Reference Tests
+# scope/name Image Reference Tests
 # ============================================
 
-@test "vm0 compose with @scope/name validates format" {
-    # Create a test config with @scope/name format
+@test "vm0 compose with scope/name validates format" {
+    # Create a test config with scope/name format
     TEST_DIR="$(mktemp -d)"
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
@@ -106,7 +106,7 @@ version: "1.0"
 agents:
   test-agent:
     provider: claude-code
-    image: "@invalid/missing-image"
+    image: "invalid/missing-image"
 EOF
 
     # Should fail because the scope or image doesn't exist, not because of format
@@ -118,7 +118,7 @@ EOF
     rm -rf "$TEST_DIR"
 }
 
-@test "vm0 compose with invalid @scope format fails" {
+@test "vm0 compose with plain image name that does not exist fails" {
     TEST_DIR="$(mktemp -d)"
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
@@ -126,17 +126,17 @@ version: "1.0"
 agents:
   test-agent:
     provider: claude-code
-    image: "@no-slash-here"
+    image: "no-slash-here"
 EOF
 
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_failure
-    # Should fail due to invalid scoped reference format
+    # Should fail due to image not found (plain name without slash is a user image lookup)
 
     rm -rf "$TEST_DIR"
 }
 
-@test "vm0 run with @scope/name shows appropriate error for missing scope" {
+@test "vm0 run with scope/name shows appropriate error for missing scope" {
     TEST_DIR="$(mktemp -d)"
     mkdir -p "$TEST_DIR/artifact"
     cd "$TEST_DIR/artifact"
@@ -144,7 +144,7 @@ EOF
     $CLI_COMMAND artifact push >/dev/null 2>&1 || true
 
     # Try to run with a non-existent scope
-    run $CLI_COMMAND run "@nonexistent-scope/test-image" \
+    run $CLI_COMMAND run "nonexistent-scope/test-image" \
         --artifact-name "e2e-scope-test-$(date +%s)" \
         "echo hello"
 
@@ -172,7 +172,7 @@ EOF
     fi
 
     assert_success
-    assert_output --partial "@$TEST_SLUG"
+    assert_output --partial "$TEST_SLUG"
 }
 
 @test "vm0 scope status shows newly created scope" {
@@ -185,7 +185,7 @@ EOF
     run $CLI_COMMAND scope status
     assert_success
     assert_output --partial "Scope Information"
-    assert_output --partial "@"
+    assert_output --partial "Slug:"
 }
 
 @test "vm0 scope set requires --force to update existing scope" {
@@ -213,7 +213,7 @@ EOF
     NEW_SLUG="e2e-force-$(date +%s)"
     run $CLI_COMMAND scope set "$NEW_SLUG" --force
     assert_success
-    assert_output --partial "@$NEW_SLUG"
+    assert_output --partial "$NEW_SLUG"
 }
 
 @test "vm0 scope set with --display-name sets custom name" {
@@ -221,7 +221,7 @@ EOF
     NEW_SLUG="e2e-display-$(date +%s)"
     run $CLI_COMMAND scope set "$NEW_SLUG" --display-name "My Test Scope" --force
     assert_success
-    assert_output --partial "@$NEW_SLUG"
+    assert_output --partial "$NEW_SLUG"
 }
 
 # ============================================

--- a/e2e/tests/02-commands/t20-vm0-image-versioning.bats
+++ b/e2e/tests/02-commands/t20-vm0-image-versioning.bats
@@ -35,8 +35,7 @@ teardown() {
     run $CLI_COMMAND image build --file "$TEST_DOCKERFILE" --name "$TEST_IMAGE_NAME" --delete-existing
 
     assert_success
-    # Should show the @scope/name:version format
-    assert_output --partial "@"
+    # Should show the scope/name:version format
     assert_output --partial "/"
     assert_output --partial ":"
     # Should show success message

--- a/turbo/apps/cli/src/commands/image/build.ts
+++ b/turbo/apps/cli/src/commands/image/build.ts
@@ -62,7 +62,7 @@ export const buildCommand = new Command()
         // Read Dockerfile content
         const dockerfile = await readFile(file, "utf8");
 
-        console.log(chalk.blue(`Building image: @${scope.slug}/${name}`));
+        console.log(chalk.blue(`Building image: ${scope.slug}/${name}`));
         console.log();
 
         // Start build
@@ -114,9 +114,7 @@ export const buildCommand = new Command()
         if (status === "ready") {
           const shortVersion = formatVersionIdForDisplay(versionId);
           console.log(
-            chalk.green(
-              `✓ Image built: @${scope.slug}/${name}:${shortVersion}`,
-            ),
+            chalk.green(`✓ Image built: ${scope.slug}/${name}:${shortVersion}`),
           );
         } else {
           console.error(chalk.red(`✗ Build failed`));

--- a/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
@@ -64,10 +64,10 @@ describe("scope set command", () => {
         displayName: undefined,
       });
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Scope created: @testslug"),
+        expect.stringContaining("Scope created: testslug"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("@testslug/<image-name>"),
+        expect.stringContaining("testslug/<image-name>"),
       );
     });
 
@@ -113,7 +113,7 @@ describe("scope set command", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("already have a scope: @oldslug"),
+        expect.stringContaining("already have a scope: oldslug"),
       );
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("--force"),
@@ -146,7 +146,7 @@ describe("scope set command", () => {
         force: true,
       });
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Scope updated to @newslug"),
+        expect.stringContaining("Scope updated to newslug"),
       );
     });
   });

--- a/turbo/apps/cli/src/commands/scope/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/status.test.ts
@@ -81,7 +81,7 @@ describe("scope status command", () => {
         expect.stringContaining("Scope Information"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("@testuser"),
+        expect.stringContaining("testuser"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("personal"),
@@ -104,7 +104,7 @@ describe("scope status command", () => {
       await statusCommand.parseAsync(["node", "cli"]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("@testuser"),
+        expect.stringContaining("testuser"),
       );
     });
   });

--- a/turbo/apps/cli/src/commands/scope/set.ts
+++ b/turbo/apps/cli/src/commands/scope/set.ts
@@ -27,7 +27,7 @@ export const setCommand = new Command()
           // User already has a scope - update it
           if (!options.force) {
             console.error(
-              chalk.yellow(`You already have a scope: @${existingScope.slug}`),
+              chalk.yellow(`You already have a scope: ${existingScope.slug}`),
             );
             console.error();
             console.error("To change your scope, use --force:");
@@ -42,19 +42,19 @@ export const setCommand = new Command()
           }
 
           scope = await apiClient.updateScope({ slug, force: true });
-          console.log(chalk.green(`✓ Scope updated to @${scope.slug}`));
+          console.log(chalk.green(`✓ Scope updated to ${scope.slug}`));
         } else {
           // Create new scope
           scope = await apiClient.createScope({
             slug,
             displayName: options.displayName,
           });
-          console.log(chalk.green(`✓ Scope created: @${scope.slug}`));
+          console.log(chalk.green(`✓ Scope created: ${scope.slug}`));
         }
 
         console.log();
         console.log("Your images will now be namespaced as:");
-        console.log(chalk.cyan(`  @${scope.slug}/<image-name>`));
+        console.log(chalk.cyan(`  ${scope.slug}/<image-name>`));
       } catch (error) {
         if (error instanceof Error) {
           if (error.message.includes("Not authenticated")) {

--- a/turbo/apps/cli/src/commands/scope/status.ts
+++ b/turbo/apps/cli/src/commands/scope/status.ts
@@ -10,7 +10,7 @@ export const statusCommand = new Command()
       const scope = await apiClient.getScope();
 
       console.log(chalk.cyan("Scope Information:"));
-      console.log(`  Slug: ${chalk.green("@" + scope.slug)}`);
+      console.log(`  Slug: ${chalk.green(scope.slug)}`);
       console.log(`  Type: ${scope.type}`);
       if (scope.displayName) {
         console.log(`  Display Name: ${scope.displayName}`);

--- a/turbo/apps/cli/src/lib/__tests__/yaml-validator.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/yaml-validator.test.ts
@@ -109,7 +109,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "test-agent": {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -127,7 +127,7 @@ describe("validateAgentCompose", () => {
         agents: {
           "test-agent": {
             description: "Test description",
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
             volumes: ["claude-files:/home/user/.config/claude"],
@@ -150,7 +150,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "My-Test-Agent-123": {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -185,7 +185,7 @@ describe("validateAgentCompose", () => {
       const config = {
         agents: {
           "test-agent": {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -234,12 +234,12 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "agent-1": {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/workspace",
           },
           "agent-2": {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/workspace",
           },
@@ -259,7 +259,7 @@ describe("validateAgentCompose", () => {
         agents: {
           ab: {
             // Too short
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -276,7 +276,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "-invalid": {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -293,7 +293,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           my_agent: {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -342,7 +342,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "test-agent": {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             working_dir: "/home/user/workspace",
           },
         },
@@ -358,7 +358,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "test-agent": {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
             volumes: ["missing-vol:/path"],
@@ -382,7 +382,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "test-agent": {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
             volumes: ["data:/path"],
@@ -405,7 +405,7 @@ describe("validateAgentCompose", () => {
         version: "1.0",
         agents: {
           "test-agent": {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
             volumes: ["data:/path"],
@@ -431,7 +431,7 @@ describe("validateAgentCompose", () => {
         agents: {
           "test-agent": {
             provider: "claude-code",
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
           },
         },
       };
@@ -461,7 +461,7 @@ describe("validateAgentCompose", () => {
         agents: {
           "test-agent": {
             provider: "claude-code",
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             beta_system_prompt: "AGENTS.md",
           },
         },
@@ -477,7 +477,7 @@ describe("validateAgentCompose", () => {
         agents: {
           "test-agent": {
             provider: "claude-code",
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             beta_system_skills: [
               "https://github.com/vm0-ai/vm0-skills/tree/main/github",
             ],
@@ -495,7 +495,7 @@ describe("validateAgentCompose", () => {
         agents: {
           "test-agent": {
             provider: "claude-code",
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             beta_system_prompt: "",
           },
         },
@@ -512,7 +512,7 @@ describe("validateAgentCompose", () => {
         agents: {
           "test-agent": {
             provider: "claude-code",
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             beta_system_skills: ["https://example.com/not-github"],
           },
         },

--- a/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
@@ -54,7 +54,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
       agents: {
         "test-get-by-name-success": {
           description: "Test description",
-          image: "@vm0/claude-code:dev",
+          image: "vm0/claude-code:dev",
           provider: "claude-code",
           working_dir: "/home/user/workspace",
         },
@@ -135,7 +135,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
       agents: {
         "test-user-isolation": {
           description: "Test",
-          image: "@vm0/claude-code:dev",
+          image: "vm0/claude-code:dev",
           provider: "claude-code",
           working_dir: "/home/user/workspace",
         },
@@ -187,7 +187,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
       agents: {
         "test-agent-with-hyphens": {
           description: "Test description",
-          image: "@vm0/claude-code:dev",
+          image: "vm0/claude-code:dev",
           provider: "claude-code",
           working_dir: "/home/user/workspace",
         },

--- a/turbo/apps/web/app/api/agent/composes/__tests__/upsert.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/upsert.test.ts
@@ -54,7 +54,7 @@ describe("Agent Compose Upsert Behavior", () => {
         version: "1.0",
         agents: {
           "test-agent-create": {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -87,7 +87,7 @@ describe("Agent Compose Upsert Behavior", () => {
         agents: {
           "test-agent-update": {
             description: "Initial description",
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -159,7 +159,7 @@ describe("Agent Compose Upsert Behavior", () => {
         version: "1.0",
         agents: {
           "test-unique-constraint": {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -218,12 +218,12 @@ describe("Agent Compose Upsert Behavior", () => {
         version: "1.0",
         agents: {
           "agent-one": {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
           "agent-two": {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -254,7 +254,7 @@ describe("Agent Compose Upsert Behavior", () => {
         agents: {
           ab: {
             // Too short name
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -282,7 +282,7 @@ describe("Agent Compose Upsert Behavior", () => {
         version: "1.0",
         agents: {
           "my-test-agent-123": {
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },
@@ -317,7 +317,7 @@ describe("Agent Compose Upsert Behavior", () => {
         agents: {
           "test-get-compose": {
             description: "Test",
-            image: "@vm0/claude-code:dev",
+            image: "vm0/claude-code:dev",
             provider: "claude-code",
             working_dir: "/home/user/workspace",
           },

--- a/turbo/apps/web/app/api/agent/composes/versions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/versions/__tests__/route.test.ts
@@ -51,7 +51,7 @@ describe("GET /api/agent/composes/versions", () => {
       agents: {
         "test-version-agent": {
           description: "Test agent for version tests",
-          image: "@vm0/claude-code:dev",
+          image: "vm0/claude-code:dev",
           provider: "claude-code",
           working_dir: "/home/user/workspace",
         },

--- a/turbo/apps/web/src/lib/image/__tests__/image-service.spec.ts
+++ b/turbo/apps/web/src/lib/image/__tests__/image-service.spec.ts
@@ -62,7 +62,7 @@ describe("Image Service", () => {
     });
   });
 
-  describe("resolveImageAlias with @scope/name and tags", () => {
+  describe("resolveImageAlias with scope/name and tags", () => {
     const testUserId = "test-image-resolve-user";
     const testScopeSlug = `img-test-${Date.now()}`;
     let testScopeId: string;
@@ -125,10 +125,10 @@ describe("Image Service", () => {
         .where(eq(scopes.ownerId, testUserId));
     });
 
-    it("should resolve @scope/name to latest version", async () => {
+    it("should resolve scope/name to latest version", async () => {
       const result = await resolveImageAlias(
         testUserId,
-        `@${testScopeSlug}/test-image`,
+        `${testScopeSlug}/test-image`,
       );
       // Should resolve to the newer version (v2)
       expect(result.templateName).toContain(testVersionId2);
@@ -136,19 +136,19 @@ describe("Image Service", () => {
       expect(result.versionId).toBe(testVersionId2);
     });
 
-    it("should resolve @scope/name:latest to latest version", async () => {
+    it("should resolve scope/name:latest to latest version", async () => {
       const result = await resolveImageAlias(
         testUserId,
-        `@${testScopeSlug}/test-image:latest`,
+        `${testScopeSlug}/test-image:latest`,
       );
       expect(result.templateName).toContain(testVersionId2);
       expect(result.versionId).toBe(testVersionId2);
     });
 
-    it("should resolve @scope/name:versionId to specific version", async () => {
+    it("should resolve scope/name:versionId to specific version", async () => {
       const result = await resolveImageAlias(
         testUserId,
-        `@${testScopeSlug}/test-image:${testVersionId1}`,
+        `${testScopeSlug}/test-image:${testVersionId1}`,
       );
       expect(result.templateName).toContain(testVersionId1);
       expect(result.versionId).toBe(testVersionId1);
@@ -156,13 +156,13 @@ describe("Image Service", () => {
 
     it("should throw NotFoundError for non-existent scope", async () => {
       await expect(
-        resolveImageAlias(testUserId, "@nonexistent-scope/test-image"),
-      ).rejects.toThrow('Scope "@nonexistent-scope" not found');
+        resolveImageAlias(testUserId, "nonexistent-scope/test-image"),
+      ).rejects.toThrow('Scope "nonexistent-scope" not found');
     });
 
     it("should throw NotFoundError for non-existent image in scope", async () => {
       await expect(
-        resolveImageAlias(testUserId, `@${testScopeSlug}/nonexistent`),
+        resolveImageAlias(testUserId, `${testScopeSlug}/nonexistent`),
       ).rejects.toThrow(`not found`);
     });
 
@@ -170,7 +170,7 @@ describe("Image Service", () => {
       await expect(
         resolveImageAlias(
           testUserId,
-          `@${testScopeSlug}/test-image:nonexistent`,
+          `${testScopeSlug}/test-image:nonexistent`,
         ),
       ).rejects.toThrow("not found");
     });
@@ -179,7 +179,7 @@ describe("Image Service", () => {
       await expect(
         resolveImageAlias(
           testUserId,
-          `@${testScopeSlug}/building-image:build001`,
+          `${testScopeSlug}/building-image:build001`,
         ),
       ).rejects.toThrow("not ready");
     });

--- a/turbo/apps/web/src/lib/image/image-service.ts
+++ b/turbo/apps/web/src/lib/image/image-service.ts
@@ -56,15 +56,15 @@ export function generateE2bAlias(userId: string, alias: string): string {
 
 /**
  * Check if an image alias is a system template
- * Supports both legacy (vm0-*) and new (@vm0/...) formats
+ * Supports both legacy (vm0-*) and new (vm0/...) formats
  */
 export function isSystemTemplate(alias: string): boolean {
   // Legacy vm0-* format
   if (isLegacySystemTemplate(alias)) {
     return true;
   }
-  // New @vm0/... format (system scope)
-  if (alias.startsWith("@vm0/")) {
+  // New vm0/... format (system scope)
+  if (alias.startsWith("vm0/")) {
     return true;
   }
   return false;
@@ -455,8 +455,8 @@ export async function getImageByBuildId(buildId: string) {
  * Resolve an image alias to E2B template name
  * Supports multiple formats with optional tag:
  * - Legacy vm0-* prefix: passthrough directly (system templates, deprecated)
- * - @vm0/name[:tag] format: system scope with special handling
- * - @scope/name[:tag] format: explicit scope resolution with optional tag
+ * - vm0/name[:tag] format: system scope with special handling
+ * - scope/name[:tag] format: explicit scope resolution with optional tag
  * - name[:tag]: implicit scope (user's scope) with optional tag
  *
  * Tag resolution:
@@ -483,7 +483,7 @@ export async function resolveImageAlias(
     return { templateName: ref.name, isUserImage: false };
   }
 
-  // 2. System scope (@vm0/...) - special handling
+  // 2. System scope (vm0/...) - special handling
   if (ref.scope && isSystemScope(ref.scope)) {
     try {
       const { e2bTemplate } = resolveSystemImageToE2b(ref.name, ref.tag);
@@ -500,12 +500,12 @@ export async function resolveImageAlias(
   const scope = ref.scope ? await getScopeBySlug(ref.scope) : userScope;
 
   if (!scope) {
-    throw new NotFoundError(`Scope "@${ref.scope}" not found`);
+    throw new NotFoundError(`Scope "${ref.scope}" not found`);
   }
 
   // 4. Resolve version based on tag
   let image;
-  const refDisplay = ref.scope ? `@${ref.scope}/${ref.name}` : ref.name;
+  const refDisplay = ref.scope ? `${ref.scope}/${ref.name}` : ref.name;
 
   if (!ref.tag || ref.tag === "latest") {
     // Resolve :latest or no tag to most recent ready version

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -138,7 +138,7 @@ export async function createUserScope(
 
   if (existingScope.length > 0) {
     throw new BadRequestError(
-      `You already have a scope: @${existingScope[0]!.slug}. Use --force to change it.`,
+      `You already have a scope: ${existingScope[0]!.slug}. Use --force to change it.`,
     );
   }
 

--- a/turbo/apps/web/src/test/api-test-helpers.ts
+++ b/turbo/apps/web/src/test/api-test-helpers.ts
@@ -50,7 +50,7 @@ export function createDefaultComposeConfig(
     version: "1.0",
     agents: {
       [agentName]: {
-        image: "@vm0/claude-code:dev",
+        image: "vm0/claude-code:dev",
         provider: "claude-code",
         working_dir: "/home/user/workspace",
         ...overrides,

--- a/turbo/codereviews/20251222/commit-list.md
+++ b/turbo/codereviews/20251222/commit-list.md
@@ -1,0 +1,8 @@
+# Code Review: PR #662 - Enforce Lowercase Image Names
+
+**Date**: 2025-12-22
+**PR**: https://github.com/vm0-ai/vm0/pull/662
+
+## Commits
+
+- [x] [`7213ffd0`](review-7213ffd0.md) - feat(image): enforce lowercase image names for Docker compatibility

--- a/turbo/codereviews/20251222/review-7213ffd0.md
+++ b/turbo/codereviews/20251222/review-7213ffd0.md
@@ -10,14 +10,14 @@ This commit implements case-insensitive image name handling by normalizing all i
 
 ## Files Changed
 
-| File | Changes |
-|------|---------|
-| `apps/cli/src/lib/__tests__/yaml-validator.test.ts` | +26 lines - Added tests for `normalizeAgentName()` |
-| `apps/cli/src/lib/yaml-validator.ts` | +11 lines - Added `normalizeAgentName()` function |
-| `apps/web/app/api/agent/composes/route.ts` | +4/-4 lines - Normalize agent name before storage |
-| `packages/core/src/__tests__/scope-reference.spec.ts` | +78 lines - Added case normalization tests |
-| `packages/core/src/contracts/images.ts` | +3/-2 lines - Added `.transform()` to alias schema |
-| `packages/core/src/scope-reference.ts` | +6/-6 lines - Normalize scope/name in parsers |
+| File                                                  | Changes                                            |
+| ----------------------------------------------------- | -------------------------------------------------- |
+| `apps/cli/src/lib/__tests__/yaml-validator.test.ts`   | +26 lines - Added tests for `normalizeAgentName()` |
+| `apps/cli/src/lib/yaml-validator.ts`                  | +11 lines - Added `normalizeAgentName()` function  |
+| `apps/web/app/api/agent/composes/route.ts`            | +4/-4 lines - Normalize agent name before storage  |
+| `packages/core/src/__tests__/scope-reference.spec.ts` | +78 lines - Added case normalization tests         |
+| `packages/core/src/contracts/images.ts`               | +3/-2 lines - Added `.transform()` to alias schema |
+| `packages/core/src/scope-reference.ts`                | +6/-6 lines - Normalize scope/name in parsers      |
 
 ## Review Findings
 

--- a/turbo/codereviews/20251222/review-7213ffd0.md
+++ b/turbo/codereviews/20251222/review-7213ffd0.md
@@ -1,0 +1,66 @@
+# Code Review: 7213ffd0
+
+**Commit**: feat(image): enforce lowercase image names for Docker compatibility
+**Author**: Lancy
+**Date**: 2025-12-22
+
+## Summary
+
+This commit implements case-insensitive image name handling by normalizing all inputs to lowercase before storage and lookup, aligning with Docker conventions.
+
+## Files Changed
+
+| File | Changes |
+|------|---------|
+| `apps/cli/src/lib/__tests__/yaml-validator.test.ts` | +26 lines - Added tests for `normalizeAgentName()` |
+| `apps/cli/src/lib/yaml-validator.ts` | +11 lines - Added `normalizeAgentName()` function |
+| `apps/web/app/api/agent/composes/route.ts` | +4/-4 lines - Normalize agent name before storage |
+| `packages/core/src/__tests__/scope-reference.spec.ts` | +78 lines - Added case normalization tests |
+| `packages/core/src/contracts/images.ts` | +3/-2 lines - Added `.transform()` to alias schema |
+| `packages/core/src/scope-reference.ts` | +6/-6 lines - Normalize scope/name in parsers |
+
+## Review Findings
+
+### ✅ Positive Observations
+
+1. **Comprehensive test coverage**: New tests cover multiple case normalization scenarios including:
+   - Mixed case to lowercase conversion
+   - Uppercase to lowercase conversion
+   - Already lowercase names (no change)
+   - Invalid name format returns null
+   - Legacy template passthrough (no normalization)
+   - Tag case preservation
+
+2. **Consistent implementation pattern**: Follows the existing scope slug normalization pattern using Zod's `.transform()` method.
+
+3. **Clean, focused changes**: Each file modification is minimal and targeted.
+
+4. **Good defensive programming**: The `normalizeAgentName()` function validates before normalizing, returning `null` for invalid inputs.
+
+5. **Proper test isolation**: Each test case is independent and tests a single behavior.
+
+### ⚠️ Suggestions
+
+1. **Consider normalizing tags too** (Low Priority): The implementation preserves tag case (`DeadBeef`), which is correct for version hashes, but if tags like `Latest` vs `latest` should be equivalent, consider normalizing those too. Current behavior is fine for the stated use case.
+
+2. **Compose route handler consistency**: The `agentName` variable is used to access `content.agents[agentName]` after `normalizedAgentName` is defined. This is correct (the YAML key still has original case), but the variable naming could be clearer (e.g., `originalAgentName`).
+
+### ❌ Issues Found
+
+**None** - The implementation is clean and follows project conventions.
+
+## Code Quality Checklist
+
+- [x] No mocks introduced
+- [x] Test coverage added
+- [x] No unnecessary try/catch blocks
+- [x] No over-engineering
+- [x] No dynamic imports
+- [x] No timer/delay patterns
+- [x] Key interfaces unchanged (backward compatible)
+
+## Verdict
+
+**APPROVED** ✅
+
+This is a well-implemented feature with good test coverage. The changes are minimal, focused, and follow existing patterns in the codebase.

--- a/turbo/packages/core/src/__tests__/scope-reference.spec.ts
+++ b/turbo/packages/core/src/__tests__/scope-reference.spec.ts
@@ -16,42 +16,36 @@ import {
 } from "../scope-reference";
 
 describe("parseScopedReference", () => {
-  it("parses valid @scope/name format", () => {
-    const result = parseScopedReference("@myorg/my-image");
+  it("parses valid scope/name format", () => {
+    const result = parseScopedReference("myorg/my-image");
     expect(result).toEqual({ scope: "myorg", name: "my-image" });
   });
 
   it("parses scope with numbers", () => {
-    const result = parseScopedReference("@user123/image-v2");
+    const result = parseScopedReference("user123/image-v2");
     expect(result).toEqual({ scope: "user123", name: "image-v2" });
   });
 
-  it("throws for missing @ prefix", () => {
-    expect(() => parseScopedReference("myorg/my-image")).toThrow(
-      "must start with @",
-    );
-  });
-
   it("throws for missing / separator", () => {
-    expect(() => parseScopedReference("@myorg")).toThrow("missing / separator");
+    expect(() => parseScopedReference("myorg")).toThrow("missing / separator");
   });
 
   it("throws for empty scope", () => {
-    expect(() => parseScopedReference("@/my-image")).toThrow("empty scope");
+    expect(() => parseScopedReference("/my-image")).toThrow("empty scope");
   });
 
   it("throws for empty name", () => {
-    expect(() => parseScopedReference("@myorg/")).toThrow("empty name");
+    expect(() => parseScopedReference("myorg/")).toThrow("empty name");
   });
 });
 
 describe("formatScopedReference", () => {
   it("formats scope and name correctly", () => {
-    expect(formatScopedReference("myorg", "my-image")).toBe("@myorg/my-image");
+    expect(formatScopedReference("myorg", "my-image")).toBe("myorg/my-image");
   });
 
   it("handles special characters in name", () => {
-    expect(formatScopedReference("user", "image-v2")).toBe("@user/image-v2");
+    expect(formatScopedReference("user", "image-v2")).toBe("user/image-v2");
   });
 });
 
@@ -63,7 +57,7 @@ describe("isLegacySystemTemplate", () => {
 
   it("returns false for non-vm0 prefix", () => {
     expect(isLegacySystemTemplate("my-image")).toBe(false);
-    expect(isLegacySystemTemplate("@scope/vm0-image")).toBe(false);
+    expect(isLegacySystemTemplate("scope/vm0-image")).toBe(false);
     expect(isLegacySystemTemplate("vm1-image")).toBe(false);
   });
 });
@@ -82,8 +76,8 @@ describe("resolveImageReference", () => {
     expect(result.isLegacy).toBe(true);
   });
 
-  it("parses explicit @scope/name format", () => {
-    const result = resolveImageReference("@myorg/my-image");
+  it("parses explicit scope/name format", () => {
+    const result = resolveImageReference("myorg/my-image");
     expect(result).toEqual({
       scope: "myorg",
       name: "my-image",
@@ -92,7 +86,7 @@ describe("resolveImageReference", () => {
   });
 
   it("explicit scope doesn't require userScopeSlug", () => {
-    const result = resolveImageReference("@other/image");
+    const result = resolveImageReference("other/image");
     expect(result.scope).toBe("other");
   });
 
@@ -113,7 +107,7 @@ describe("resolveImageReference", () => {
 
   describe("case normalization", () => {
     it("normalizes explicit scope and name to lowercase", () => {
-      const result = resolveImageReference("@MyOrg/My-Image");
+      const result = resolveImageReference("MyOrg/My-Image");
       expect(result).toEqual({
         scope: "myorg",
         name: "my-image",
@@ -122,7 +116,7 @@ describe("resolveImageReference", () => {
     });
 
     it("normalizes uppercase scope and name to lowercase", () => {
-      const result = resolveImageReference("@LANCY/MY-IMAGE");
+      const result = resolveImageReference("LANCY/MY-IMAGE");
       expect(result).toEqual({
         scope: "lancy",
         name: "my-image",
@@ -163,9 +157,9 @@ describe("parseImageReferenceWithTag", () => {
     });
   });
 
-  describe("explicit @scope/name format", () => {
-    it("parses @scope/name without tag", () => {
-      const result = parseImageReferenceWithTag("@myorg/my-image");
+  describe("explicit scope/name format", () => {
+    it("parses scope/name without tag", () => {
+      const result = parseImageReferenceWithTag("myorg/my-image");
       expect(result).toEqual({
         scope: "myorg",
         name: "my-image",
@@ -174,8 +168,8 @@ describe("parseImageReferenceWithTag", () => {
       });
     });
 
-    it("parses @scope/name:latest", () => {
-      const result = parseImageReferenceWithTag("@myorg/my-image:latest");
+    it("parses scope/name:latest", () => {
+      const result = parseImageReferenceWithTag("myorg/my-image:latest");
       expect(result).toEqual({
         scope: "myorg",
         name: "my-image",
@@ -184,8 +178,8 @@ describe("parseImageReferenceWithTag", () => {
       });
     });
 
-    it("parses @scope/name with version ID", () => {
-      const result = parseImageReferenceWithTag("@myorg/my-image:a1b2c3d4");
+    it("parses scope/name with version ID", () => {
+      const result = parseImageReferenceWithTag("myorg/my-image:a1b2c3d4");
       expect(result).toEqual({
         scope: "myorg",
         name: "my-image",
@@ -195,35 +189,29 @@ describe("parseImageReferenceWithTag", () => {
     });
 
     it("does not require userScopeSlug for explicit scope", () => {
-      const result = parseImageReferenceWithTag("@other/image:v1");
+      const result = parseImageReferenceWithTag("other/image:v1");
       expect(result.scope).toBe("other");
       expect(result.tag).toBe("v1");
     });
 
     it("throws for empty tag after colon", () => {
-      expect(() => parseImageReferenceWithTag("@myorg/my-image:")).toThrow(
+      expect(() => parseImageReferenceWithTag("myorg/my-image:")).toThrow(
         "empty tag after colon",
       );
     });
 
-    it("throws for missing / separator", () => {
-      expect(() => parseImageReferenceWithTag("@myorg")).toThrow(
-        "missing / separator",
-      );
-    });
-
     it("throws for empty scope", () => {
-      expect(() => parseImageReferenceWithTag("@/my-image")).toThrow(
+      expect(() => parseImageReferenceWithTag("/my-image")).toThrow(
         "empty scope",
       );
     });
 
     it("throws for empty name", () => {
-      expect(() => parseImageReferenceWithTag("@myorg/")).toThrow("empty name");
+      expect(() => parseImageReferenceWithTag("myorg/")).toThrow("empty name");
     });
 
     it("throws for empty name with tag", () => {
-      expect(() => parseImageReferenceWithTag("@myorg/:latest")).toThrow(
+      expect(() => parseImageReferenceWithTag("myorg/:latest")).toThrow(
         "empty name",
       );
     });
@@ -287,7 +275,7 @@ describe("parseImageReferenceWithTag", () => {
 
   describe("case normalization", () => {
     it("normalizes explicit scope and name to lowercase", () => {
-      const result = parseImageReferenceWithTag("@VM0/Claude-Code:dev");
+      const result = parseImageReferenceWithTag("VM0/Claude-Code:dev");
       expect(result).toEqual({
         scope: "vm0",
         name: "claude-code",
@@ -297,7 +285,7 @@ describe("parseImageReferenceWithTag", () => {
     });
 
     it("normalizes uppercase scope and name to lowercase", () => {
-      const result = parseImageReferenceWithTag("@LANCY/MY-IMAGE");
+      const result = parseImageReferenceWithTag("LANCY/MY-IMAGE");
       expect(result).toEqual({
         scope: "lancy",
         name: "my-image",
@@ -318,7 +306,7 @@ describe("parseImageReferenceWithTag", () => {
 
     it("preserves tag case", () => {
       // Tags should preserve original case (version hashes, etc.)
-      const result = parseImageReferenceWithTag("@myorg/my-image:DeadBeef");
+      const result = parseImageReferenceWithTag("myorg/my-image:DeadBeef");
       expect(result.tag).toBe("DeadBeef");
     });
 
@@ -408,17 +396,17 @@ describe("isValidSystemTag", () => {
 
 describe("resolveSystemImageToE2b", () => {
   describe("successful conversions", () => {
-    it("converts @vm0/claude-code to vm0-claude-code", () => {
+    it("converts vm0/claude-code to vm0-claude-code", () => {
       const result = resolveSystemImageToE2b("claude-code");
       expect(result.e2bTemplate).toBe("vm0-claude-code");
     });
 
-    it("converts @vm0/claude-code:latest to vm0-claude-code", () => {
+    it("converts vm0/claude-code:latest to vm0-claude-code", () => {
       const result = resolveSystemImageToE2b("claude-code", "latest");
       expect(result.e2bTemplate).toBe("vm0-claude-code");
     });
 
-    it("converts @vm0/claude-code:dev to vm0-claude-code-dev", () => {
+    it("converts vm0/claude-code:dev to vm0-claude-code-dev", () => {
       const result = resolveSystemImageToE2b("claude-code", "dev");
       expect(result.e2bTemplate).toBe("vm0-claude-code-dev");
     });
@@ -427,7 +415,7 @@ describe("resolveSystemImageToE2b", () => {
   describe("error cases", () => {
     it("throws for unknown system image", () => {
       expect(() => resolveSystemImageToE2b("unknown-image")).toThrow(
-        "Unknown system image: @vm0/unknown-image",
+        "Unknown system image: vm0/unknown-image",
       );
     });
 
@@ -449,13 +437,13 @@ describe("getLegacySystemTemplateWarning", () => {
   it("returns warning for vm0-claude-code", () => {
     const warning = getLegacySystemTemplateWarning("vm0-claude-code");
     expect(warning).toContain("deprecated");
-    expect(warning).toContain("@vm0/claude-code");
+    expect(warning).toContain("vm0/claude-code");
   });
 
   it("returns warning for vm0-claude-code-dev", () => {
     const warning = getLegacySystemTemplateWarning("vm0-claude-code-dev");
     expect(warning).toContain("deprecated");
-    expect(warning).toContain("@vm0/claude-code:dev");
+    expect(warning).toContain("vm0/claude-code:dev");
   });
 
   it("returns warning for vm0-github-cli", () => {
@@ -470,8 +458,8 @@ describe("getLegacySystemTemplateWarning", () => {
   });
 
   it("returns undefined for non-legacy formats", () => {
-    expect(getLegacySystemTemplateWarning("@vm0/claude-code")).toBeUndefined();
+    expect(getLegacySystemTemplateWarning("vm0/claude-code")).toBeUndefined();
     expect(getLegacySystemTemplateWarning("my-image")).toBeUndefined();
-    expect(getLegacySystemTemplateWarning("@myorg/image")).toBeUndefined();
+    expect(getLegacySystemTemplateWarning("myorg/image")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Remove `@` prefix from scoped image references to eliminate YAML quoting requirements
- Change format from `"@vm0/claude-code:latest"` to `vm0/claude-code:latest`
- Update detection logic from `startsWith("@")` to `includes("/")` (unambiguous since `/` is not allowed in image names)

## Format Changes

| Type | Before | After |
|------|--------|-------|
| System image | `"@vm0/claude-code:latest"` | `vm0/claude-code:latest` |
| User image | `"@lancy/my-image:v1"` | `lancy/my-image:v1` |
| Implicit (user scope) | `my-image:latest` | `my-image:latest` |
| Legacy system | `vm0-claude-code` | `vm0-claude-code` |

## Files Modified

| Category | Files |
|----------|-------|
| Core | `packages/core/src/scope-reference.ts` |
| CLI | `scope/set.ts`, `scope/status.ts`, `image/build.ts` |
| Web | `scope-service.ts`, `image-service.ts` |
| Tests | ~80 test cases updated |

## Test plan

- [x] All unit tests pass
- [x] Type check passes
- [x] Lint passes
- [ ] CI pipeline passes

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)