### PR TITLE
fix: prevent duplicate "not found" in error messages

### DIFF
--- a/turbo/apps/web/src/lib/agent-session/agent-session-service.ts
+++ b/turbo/apps/web/src/lib/agent-session/agent-session-service.ts
@@ -69,7 +69,7 @@ export class AgentSessionService {
       .returning();
 
     if (!session) {
-      throw new NotFoundError("AgentSession");
+      throw new NotFoundError("AgentSession not found");
     }
 
     return this.mapToAgentSessionData(session);

--- a/turbo/apps/web/src/lib/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/checkpoint/checkpoint-service.ts
@@ -41,7 +41,7 @@ export class CheckpointService {
       .limit(1);
 
     if (!run) {
-      throw new NotFoundError("Agent run");
+      throw new NotFoundError("Agent run not found");
     }
 
     // Fetch agent compose version to get composeId for session
@@ -52,7 +52,7 @@ export class CheckpointService {
       .limit(1);
 
     if (!version) {
-      throw new NotFoundError("Agent compose version");
+      throw new NotFoundError("Agent compose version not found");
     }
 
     log.debug(

--- a/turbo/apps/web/src/lib/errors.ts
+++ b/turbo/apps/web/src/lib/errors.ts
@@ -20,8 +20,8 @@ export class UnauthorizedError extends ApiError {
 }
 
 export class NotFoundError extends ApiError {
-  constructor(resource = "Resource") {
-    super(404, `${resource} not found`, "NOT_FOUND");
+  constructor(message = "Resource not found") {
+    super(404, message, "NOT_FOUND");
   }
 }
 

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -238,7 +238,7 @@ export class RunService {
       .limit(1);
 
     if (!checkpoint) {
-      throw new NotFoundError("Checkpoint");
+      throw new NotFoundError("Checkpoint not found");
     }
 
     // Verify checkpoint belongs to user
@@ -264,7 +264,7 @@ export class RunService {
       .limit(1);
 
     if (!conversation) {
-      throw new NotFoundError("Conversation");
+      throw new NotFoundError("Conversation not found");
     }
 
     // Extract snapshots (artifactSnapshot may be null for runs without artifact)
@@ -291,7 +291,9 @@ export class RunService {
       .limit(1);
 
     if (!version) {
-      throw new NotFoundError(`Agent compose version ${agentComposeVersionId}`);
+      throw new NotFoundError(
+        `Agent compose version ${agentComposeVersionId} not found`,
+      );
     }
     const agentCompose = version.content as AgentComposeYaml;
 
@@ -332,7 +334,7 @@ export class RunService {
       await agentSessionService.getByIdWithConversation(sessionId);
 
     if (!session) {
-      throw new NotFoundError("Agent session");
+      throw new NotFoundError("Agent session not found");
     }
 
     if (session.userId !== userId) {
@@ -359,7 +361,7 @@ export class RunService {
       .limit(1);
 
     if (!compose) {
-      throw new NotFoundError("Agent compose");
+      throw new NotFoundError("Agent compose not found");
     }
 
     if (!compose.headVersionId) {
@@ -376,7 +378,7 @@ export class RunService {
       .limit(1);
 
     if (!version) {
-      throw new NotFoundError("Agent compose version");
+      throw new NotFoundError("Agent compose version not found");
     }
 
     // Decrypt secrets from session (stored encrypted per-value)
@@ -421,7 +423,7 @@ export class RunService {
       .limit(1);
 
     if (!conversation) {
-      throw new NotFoundError("Conversation");
+      throw new NotFoundError("Conversation not found");
     }
 
     // Verify conversation belongs to user
@@ -447,7 +449,7 @@ export class RunService {
       .limit(1);
 
     if (!version) {
-      throw new NotFoundError("Agent compose version");
+      throw new NotFoundError("Agent compose version not found");
     }
 
     return {
@@ -534,7 +536,7 @@ export class RunService {
       .limit(1);
 
     if (!checkpoint) {
-      throw new NotFoundError("Checkpoint");
+      throw new NotFoundError("Checkpoint not found");
     }
 
     // Verify checkpoint belongs to user by checking the associated run
@@ -601,7 +603,7 @@ export class RunService {
       await agentSessionService.getByIdWithConversation(agentSessionId);
 
     if (!session) {
-      throw new NotFoundError("Agent session");
+      throw new NotFoundError("Agent session not found");
     }
 
     // Verify session belongs to user
@@ -738,7 +740,7 @@ export class RunService {
         .limit(1);
 
       if (!version) {
-        throw new NotFoundError("Agent compose version");
+        throw new NotFoundError("Agent compose version not found");
       }
 
       agentCompose = version.content;


### PR DESCRIPTION
## Summary

- Fixed `NotFoundError` class design that was causing duplicate "not found" in error messages
- The class was auto-appending " not found" to the parameter, but callers were passing complete messages
- Result was messages like: `Image "@vm0/test:dev" not found not found`

## Changes

- Modified `NotFoundError` to accept a complete message (consistent with `BadRequestError`)
- Updated all callers that relied on auto-append to include "not found" in their messages

## Test plan

- [x] Type checking passes
- [x] Lint passes
- [x] Unit tests pass for affected services (run-service, image-service, agent-session-service)

🤖 Generated with [Claude Code](https://claude.com/claude-code)