### PR TITLE
feat(sandbox): add storage phase logging with mount verification

### DIFF
--- a/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
+++ b/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
@@ -180,10 +180,11 @@ describe("E2B Service - mocked unit tests", () => {
       expect(result.error).toBeUndefined();
 
       // Verify sandbox methods were called
-      // Optimized: commands.run called only 2 times:
-      // 1. tar extract (mkdir + tar xf + chmod in single command)
-      // 2. execute with background:true
-      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(2);
+      // commands.run called 3 times:
+      // 1. log file initialization (echo header > log file)
+      // 2. tar extract (mkdir + tar xf + chmod in single command)
+      // 3. execute with background:true
+      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(3);
       // Sandbox is NOT killed - it continues running (fire-and-forget)
       expect(mockSandbox.kill).not.toHaveBeenCalled();
 
@@ -237,9 +238,9 @@ describe("E2B Service - mocked unit tests", () => {
 
       // Verify both sandboxes were created (but NOT cleaned up - fire-and-forget)
       expect(Sandbox.create).toHaveBeenCalledTimes(2);
-      // Optimized: Each sandbox only 2 commands.run calls (tar extract + execute)
-      expect(mockSandbox1.commands.run).toHaveBeenCalledTimes(2);
-      expect(mockSandbox2.commands.run).toHaveBeenCalledTimes(2);
+      // Each sandbox: 3 commands.run calls (log init + tar extract + execute)
+      expect(mockSandbox1.commands.run).toHaveBeenCalledTimes(3);
+      expect(mockSandbox2.commands.run).toHaveBeenCalledTimes(3);
       // Sandboxes NOT killed - they continue running
       expect(mockSandbox1.kill).not.toHaveBeenCalled();
       expect(mockSandbox2.kill).not.toHaveBeenCalled();
@@ -269,8 +270,8 @@ describe("E2B Service - mocked unit tests", () => {
 
       // Verify sandbox was created (but NOT cleaned up - fire-and-forget)
       expect(Sandbox.create).toHaveBeenCalledTimes(1);
-      // Optimized: 2 commands.run calls (tar extract + execute)
-      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(2);
+      // 3 commands.run calls (log init + tar extract + execute)
+      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(3);
       expect(mockSandbox.kill).not.toHaveBeenCalled();
     });
 
@@ -303,8 +304,8 @@ describe("E2B Service - mocked unit tests", () => {
 
       // Verify sandbox was created (but NOT cleaned up - fire-and-forget)
       expect(Sandbox.create).toHaveBeenCalledTimes(1);
-      // Optimized: 2 commands.run calls (tar extract + execute)
-      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(2);
+      // 3 commands.run calls (log init + tar extract + execute)
+      expect(mockSandbox.commands.run).toHaveBeenCalledTimes(3);
       expect(mockSandbox.kill).not.toHaveBeenCalled();
     });
 

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -238,7 +238,11 @@ export class E2BService {
       // Download storages directly to sandbox via presigned URLs
       // Scripts are already available from uploadAllScripts()
       log.debug(`[${context.runId}] Downloading storages to sandbox...`);
-      await this.downloadStoragesDirectly(sandbox, storageManifest);
+      await this.downloadStoragesDirectly(
+        sandbox,
+        storageManifest,
+        context.runId,
+      );
       log.debug(`[${context.runId}] Storages downloaded successfully`);
 
       // Restore session history for resume
@@ -609,14 +613,15 @@ export class E2BService {
     // Start Python script in background using nohup to ignore SIGHUP signal
     // This prevents the process from being killed when E2B connection is closed
     // NOTE: Scripts already uploaded via uploadAllScripts(), do not pass envs here
-    // Redirect output to per-run log file in /tmp with vm0- prefix
+    // Append output to per-run log file in /tmp with vm0- prefix (file created by downloadStoragesDirectly)
     //
     // NOTE: Agent runs as E2B default user ('user').
     // When network security is enabled, proxy setup is done as root before this.
     // mitmproxy also runs as root, and nftables skips root's traffic (meta skuid 0)
     // to avoid redirect loops.
     // Use python3 -u for unbuffered stdout/stderr to ensure logs are written immediately
-    const cmd = `nohup python3 -u ${SCRIPT_PATHS.runAgent} > /tmp/vm0-main-${runId}.log 2>&1 &`;
+    // Use >> to append to log file (header and Storage phase already written by downloadStoragesDirectly)
+    const cmd = `nohup python3 -u ${SCRIPT_PATHS.runAgent} >> /tmp/vm0-main-${runId}.log 2>&1 &`;
     log.debug(`[${runId}] Executing background command: ${cmd}`);
     await sandbox.commands.run(cmd);
     log.debug(`[${runId}] Background command returned successfully`);
@@ -627,13 +632,26 @@ export class E2BService {
    * This method uploads a manifest file and runs a download script inside the sandbox
    * NOTE: Scripts must be uploaded first via uploadAllScripts()
    *
+   * Logs are written to the main system log file for visibility in `vm0 logs --system`
+   *
    * @param sandbox - E2B sandbox instance
    * @param manifest - Storage manifest with presigned URLs
+   * @param runId - Run ID for log file naming
    */
   private async downloadStoragesDirectly(
     sandbox: Sandbox,
     manifest: StorageManifest,
+    runId: string,
   ): Promise<void> {
+    const logFile = `/tmp/vm0-main-${runId}.log`;
+
+    // Initialize log file with run header
+    // This creates the file before download.py runs so logs can be appended
+    const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+    await sandbox.commands.run(
+      `echo "[${timestamp}] [INFO] [sandbox:run-agent] ▶ VM0 Sandbox ${runId}" > ${logFile}`,
+    );
+
     const totalArchives =
       manifest.storages.filter((s) => s.archiveUrl).length +
       (manifest.artifact?.archiveUrl ? 1 : 0);
@@ -659,10 +677,12 @@ export class E2BService {
     await sandbox.files.write(manifestPath, arrayBuffer);
     log.debug(`Uploaded storage manifest to ${manifestPath}`);
 
-    // Execute download script (scripts already uploaded via uploadAllScripts)
+    // Execute download script with output redirected to log file
+    // LOG_SCRIPT_NAME=download sets the script name in log output
+    // python3 -u ensures unbuffered output for real-time logging
     const downloadStart = Date.now();
     const result = await sandbox.commands.run(
-      `python3 ${SCRIPT_PATHS.download} ${manifestPath}`,
+      `LOG_SCRIPT_NAME=download python3 -u ${SCRIPT_PATHS.download} ${manifestPath} >> ${logFile} 2>&1`,
       {
         timeoutMs: 300000, // 5 minute timeout for downloads
       },
@@ -671,8 +691,11 @@ export class E2BService {
     const downloadTimeMs = Date.now() - downloadStart;
 
     if (result.exitCode !== 0) {
-      log.error(`Storage download failed: ${result.stderr}`);
-      throw new Error(`Storage download failed: ${result.stderr}`);
+      // On failure, read the log file for error details
+      const logResult = await sandbox.commands.run(`cat ${logFile}`);
+      const errorDetails = logResult.stdout || result.stderr || "Unknown error";
+      log.error(`Storage download failed: ${errorDetails}`);
+      throw new Error(`Storage download failed: ${errorDetails}`);
     }
 
     log.debug(

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/download.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/download.py.ts
@@ -1,11 +1,13 @@
 /**
  * Download storages script for E2B sandbox (Python)
  * Downloads tar.gz archives directly from S3 using presigned URLs
+ * Includes mount verification with ls -la output
  */
 export const DOWNLOAD_SCRIPT = `#!/usr/bin/env python3
 """
 Download storages script for E2B sandbox.
 Downloads tar.gz archives directly from S3 using presigned URLs.
+Includes lifecycle logging and mount verification.
 
 Usage: python download.py <manifest_path>
 """
@@ -14,13 +16,67 @@ import sys
 import json
 import tarfile
 import tempfile
+import time
+import subprocess
 
 # Add lib to path for imports
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from common import validate_config
 from log import log_info, log_error
-from http_client import http_download
+
+
+def format_size(size_bytes: int) -> str:
+    """Format bytes as human-readable size."""
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    elif size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    elif size_bytes < 1024 * 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+    else:
+        return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
+
+
+def verify_mount(mount_path: str, name: str, max_lines: int = 20) -> None:
+    """
+    Verify mount by listing directory contents.
+
+    Args:
+        mount_path: Path to verify
+        name: Display name (volume name or 'artifact')
+        max_lines: Maximum lines to display from ls -la
+    """
+    log_info(f"  {name}: {mount_path}")
+
+    if not os.path.exists(mount_path):
+        log_info(f"    (directory does not exist)")
+        return
+
+    try:
+        result = subprocess.run(
+            ['ls', '-la', mount_path],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+
+        lines = result.stdout.strip().split('\\n') if result.stdout.strip() else []
+
+        if not lines:
+            log_info(f"    (empty directory)")
+            return
+
+        # Show lines up to max_lines
+        for line in lines[:max_lines]:
+            log_info(f"    {line}")
+
+        if len(lines) > max_lines:
+            log_info(f"    ... and {len(lines) - max_lines} more entries")
+
+    except subprocess.TimeoutExpired:
+        log_info(f"    (ls timed out)")
+    except Exception as e:
+        log_info(f"    (error: {e})")
 
 
 def download_storage(mount_path: str, archive_url: str) -> bool:
@@ -34,7 +90,8 @@ def download_storage(mount_path: str, archive_url: str) -> bool:
     Returns:
         True on success, False on failure
     """
-    log_info(f"Downloading storage to {mount_path}")
+    # Import http_download here to avoid circular import at module load
+    from http_client import http_download
 
     # Create temp file for download
     temp_tar = tempfile.mktemp(suffix=".tar.gz", prefix="storage-")
@@ -54,9 +111,8 @@ def download_storage(mount_path: str, archive_url: str) -> bool:
                 tar.extractall(path=mount_path)
         except tarfile.ReadError:
             # Empty or invalid archive - not a fatal error
-            log_info(f"Archive appears empty for {mount_path}")
+            log_info(f"  (archive empty for {mount_path})")
 
-        log_info(f"Successfully extracted to {mount_path}")
         return True
 
     finally:
@@ -79,7 +135,9 @@ def main():
         log_error(f"Manifest file not found: {manifest_path}")
         sys.exit(1)
 
-    log_info(f"Starting storage download from manifest: {manifest_path}")
+    # Lifecycle: Storage phase start
+    log_info("▷ Storage")
+    start_time = time.time()
 
     # Load manifest
     try:
@@ -87,6 +145,8 @@ def main():
             manifest = json.load(f)
     except (IOError, json.JSONDecodeError) as e:
         log_error(f"Failed to load manifest: {e}")
+        duration = int(time.time() - start_time)
+        log_info(f"✗ Storage failed ({duration}s)")
         sys.exit(1)
 
     # Count total storages
@@ -96,25 +156,64 @@ def main():
     storage_count = len(storages)
     has_artifact = artifact is not None
 
-    log_info(f"Found {storage_count} storages, artifact: {has_artifact}")
+    if storage_count == 0 and not has_artifact:
+        log_info("No storages configured")
+        duration = int(time.time() - start_time)
+        log_info(f"✓ Storage complete ({duration}s)")
+        return
 
-    # Process storages
+    log_info(f"Found {storage_count} volume(s), artifact: {has_artifact}")
+
+    # Download phase
+    download_failed = False
+
     for storage in storages:
+        name = storage.get("name", "unnamed")
         mount_path = storage.get("mountPath")
         archive_url = storage.get("archiveUrl")
+        archive_size = storage.get("archiveSize", 0)
+
+        size_str = format_size(archive_size) if archive_size else "unknown size"
 
         if archive_url and archive_url != "null":
-            download_storage(mount_path, archive_url)
+            log_info(f"Downloading volume '{name}' to {mount_path} ({size_str})")
+            if not download_storage(mount_path, archive_url):
+                download_failed = True
 
-    # Process artifact
     if artifact:
         artifact_mount = artifact.get("mountPath")
         artifact_url = artifact.get("archiveUrl")
+        artifact_size = artifact.get("archiveSize", 0)
+
+        size_str = format_size(artifact_size) if artifact_size else "unknown size"
 
         if artifact_url and artifact_url != "null":
-            download_storage(artifact_mount, artifact_url)
+            log_info(f"Downloading artifact to {artifact_mount} ({size_str})")
+            if not download_storage(artifact_mount, artifact_url):
+                download_failed = True
 
-    log_info("All storages downloaded successfully")
+    if download_failed:
+        duration = int(time.time() - start_time)
+        log_info(f"✗ Storage failed ({duration}s)")
+        sys.exit(1)
+
+    # Verification phase
+    log_info("Verifying mounts...")
+
+    for storage in storages:
+        name = storage.get("name", "unnamed")
+        mount_path = storage.get("mountPath")
+        if mount_path:
+            verify_mount(mount_path, name)
+
+    if artifact:
+        artifact_mount = artifact.get("mountPath")
+        if artifact_mount:
+            verify_mount(artifact_mount, "artifact")
+
+    # Lifecycle: Storage phase complete
+    duration = int(time.time() - start_time)
+    log_info(f"✓ Storage complete ({duration}s)")
 
 
 if __name__ == "__main__":

--- a/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/run-agent.py.ts
@@ -111,8 +111,8 @@ def _run() -> tuple[int, str]:
     # Validate configuration - raises ValueError if invalid
     validate_config()
 
-    # Lifecycle: Header
-    log_info(f"▶ VM0 Sandbox {RUN_ID}")
+    # NOTE: Header "▶ VM0 Sandbox {RUN_ID}" is now written by e2b-service.ts
+    # in downloadStoragesDirectly() before this script runs
 
     # Lifecycle: Initialization
     log_info("▷ Initialization")


### PR DESCRIPTION
## Summary

- Add a unified "Storage" lifecycle phase to sandbox logs
- Initialize log file with run header before download starts
- Show download progress for each volume/artifact with size
- Verify mounts with `ls -la` output after extraction
- Use consistent lifecycle indicators (▷, ✓, ✗)

## Changes

- `e2b-service.ts`: Initialize log file, redirect download.py output to log file
- `download.py.ts`: Add lifecycle pattern, verify_mount function, and format_size helper
- `run-agent.py.ts`: Remove duplicate header (now written by e2b-service)
- `e2b-service.test.ts`: Update expected commands.run call count (2 → 3)

## Expected Log Output

```
[2024-12-22T09:30:00Z] [INFO] [sandbox:run-agent] ▶ VM0 Sandbox abc123
[2024-12-22T09:30:00Z] [INFO] [sandbox:download] ▷ Storage
[2024-12-22T09:30:00Z] [INFO] [sandbox:download] Found 1 volume(s), artifact: True
[2024-12-22T09:30:00Z] [INFO] [sandbox:download] Downloading volume 'data' to /home/user/data (1.2 MB)
[2024-12-22T09:30:01Z] [INFO] [sandbox:download] Downloading artifact to /home/user/workspace (256 KB)
[2024-12-22T09:30:02Z] [INFO] [sandbox:download] Verifying mounts...
[2024-12-22T09:30:02Z] [INFO] [sandbox:download]   data: /home/user/data
[2024-12-22T09:30:02Z] [INFO] [sandbox:download]     total 24K
[2024-12-22T09:30:02Z] [INFO] [sandbox:download]     -rw-r--r-- 1 user user 15K Dec 22 09:30 dataset.csv
[2024-12-22T09:30:02Z] [INFO] [sandbox:download]   artifact: /home/user/workspace
[2024-12-22T09:30:02Z] [INFO] [sandbox:download]     total 8K
[2024-12-22T09:30:02Z] [INFO] [sandbox:download]     drwxr-xr-x 2 user user 4.0K Dec 22 09:30 src
[2024-12-22T09:30:02Z] [INFO] [sandbox:download] ✓ Storage complete (2s)
[2024-12-22T09:30:02Z] [INFO] [sandbox:run-agent] ▷ Initialization
...
```

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] e2b-service tests updated and pass
- [ ] Manual testing with `vm0 logs --system` to verify output

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)