### PR TITLE
feat(cli): add Dockerfile pre-validation in vm0 image build

### DIFF
--- a/e2e/tests/02-commands/t20-vm0-image-versioning.bats
+++ b/e2e/tests/02-commands/t20-vm0-image-versioning.bats
@@ -104,13 +104,9 @@ teardown() {
     local DOCKERFILE1="${TEST_TMP_DIR}/Dockerfile.v1"
     local DOCKERFILE2="${TEST_TMP_DIR}/Dockerfile.v2"
     echo 'FROM e2bdev/code-interpreter:latest
-USER root
-RUN echo "version-1" > /tmp/version.txt
-USER user' > "$DOCKERFILE1"
+RUN echo "version-1" > /tmp/version.txt' > "$DOCKERFILE1"
     echo 'FROM e2bdev/code-interpreter:latest
-USER root
-RUN echo "version-2" > /tmp/version.txt
-USER user' > "$DOCKERFILE2"
+RUN echo "version-2" > /tmp/version.txt' > "$DOCKERFILE2"
 
     # Build first version
     run $CLI_COMMAND image build --file "$DOCKERFILE1" --name "$MULTI_VER_IMAGE"
@@ -171,13 +167,9 @@ USER user' > "$DOCKERFILE2"
     local DOCKERFILE1="${TEST_TMP_DIR}/Dockerfile.del1"
     local DOCKERFILE2="${TEST_TMP_DIR}/Dockerfile.del2"
     echo 'FROM e2bdev/code-interpreter:latest
-USER root
-RUN echo "delete-test-v1" > /tmp/version.txt
-USER user' > "$DOCKERFILE1"
+RUN echo "delete-test-v1" > /tmp/version.txt' > "$DOCKERFILE1"
     echo 'FROM e2bdev/code-interpreter:latest
-USER root
-RUN echo "delete-test-v2" > /tmp/version.txt
-USER user' > "$DOCKERFILE2"
+RUN echo "delete-test-v2" > /tmp/version.txt' > "$DOCKERFILE2"
 
     # Build two different versions
     run $CLI_COMMAND image build --file "$DOCKERFILE1" --name "$TEST_IMAGE_NAME"
@@ -229,13 +221,9 @@ USER user' > "$DOCKERFILE2"
     local DOCKERFILE1="${TEST_TMP_DIR}/Dockerfile.latest1"
     local DOCKERFILE2="${TEST_TMP_DIR}/Dockerfile.latest2"
     echo 'FROM e2bdev/code-interpreter:latest
-USER root
-RUN echo "latest-test-v1" > /tmp/version.txt
-USER user' > "$DOCKERFILE1"
+RUN echo "latest-test-v1" > /tmp/version.txt' > "$DOCKERFILE1"
     echo 'FROM e2bdev/code-interpreter:latest
-USER root
-RUN echo "latest-test-v2" > /tmp/version.txt
-USER user' > "$DOCKERFILE2"
+RUN echo "latest-test-v2" > /tmp/version.txt' > "$DOCKERFILE2"
 
     # Build two different versions
     run $CLI_COMMAND image build --file "$DOCKERFILE1" --name "$TEST_IMAGE_NAME"

--- a/turbo/apps/cli/src/commands/image/__tests__/build.test.ts
+++ b/turbo/apps/cli/src/commands/image/__tests__/build.test.ts
@@ -1,0 +1,465 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { buildCommand } from "../build";
+import * as fs from "fs/promises";
+import { existsSync } from "fs";
+import { apiClient } from "../../../lib/api-client";
+
+// Mock dependencies
+vi.mock("fs/promises");
+vi.mock("fs");
+vi.mock("../../../lib/api-client");
+
+describe("image build command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("file validation", () => {
+    it("should exit with error if Dockerfile does not exist", async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      await expect(async () => {
+        await buildCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          "Dockerfile",
+          "-n",
+          "my-image",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Dockerfile not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("name validation", () => {
+    beforeEach(() => {
+      vi.mocked(existsSync).mockReturnValue(true);
+    });
+
+    it("should exit with error for invalid name format", async () => {
+      await expect(async () => {
+        await buildCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          "Dockerfile",
+          "-n",
+          "ab", // too short
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid name format"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should exit with error for vm0- prefix", async () => {
+      await expect(async () => {
+        await buildCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          "Dockerfile",
+          "-n",
+          "vm0-my-image",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0-"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("dockerfile validation", () => {
+    beforeEach(() => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(apiClient.getScope).mockResolvedValue({
+        id: "scope-123",
+        slug: "testorg",
+        type: "personal",
+        displayName: "Test Org",
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      });
+    });
+
+    it("should reject Dockerfile with COPY instruction", async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(`FROM node:24
+COPY package.json .
+RUN npm install`);
+
+      await expect(async () => {
+        await buildCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          "Dockerfile",
+          "-n",
+          "my-image",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Dockerfile validation failed"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unsupported instruction: COPY"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject Dockerfile with ADD instruction", async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(`FROM node:24
+ADD https://example.com/file.tar.gz /tmp/
+RUN tar -xzf /tmp/file.tar.gz`);
+
+      await expect(async () => {
+        await buildCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          "Dockerfile",
+          "-n",
+          "my-image",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unsupported instruction: ADD"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject Dockerfile with WORKDIR instruction", async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(`FROM node:24
+WORKDIR /app
+RUN npm install`);
+
+      await expect(async () => {
+        await buildCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          "Dockerfile",
+          "-n",
+          "my-image",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unsupported instruction: WORKDIR"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject Dockerfile with USER instruction", async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(`FROM node:24
+USER node
+RUN npm install`);
+
+      await expect(async () => {
+        await buildCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          "Dockerfile",
+          "-n",
+          "my-image",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unsupported instruction: USER"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject Dockerfile with ENV instruction", async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(`FROM node:24
+ENV NODE_ENV=production
+RUN npm install`);
+
+      await expect(async () => {
+        await buildCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          "Dockerfile",
+          "-n",
+          "my-image",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unsupported instruction: ENV"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject Dockerfile with CMD instruction", async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(`FROM node:24
+RUN npm install
+CMD ["node", "index.js"]`);
+
+      await expect(async () => {
+        await buildCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          "Dockerfile",
+          "-n",
+          "my-image",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unsupported instruction: CMD"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject Dockerfile with ENTRYPOINT instruction", async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(`FROM node:24
+RUN npm install
+ENTRYPOINT ["node"]`);
+
+      await expect(async () => {
+        await buildCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          "Dockerfile",
+          "-n",
+          "my-image",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unsupported instruction: ENTRYPOINT"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject Dockerfile with EXPOSE instruction", async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(`FROM node:24
+EXPOSE 3000
+RUN npm install`);
+
+      await expect(async () => {
+        await buildCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          "Dockerfile",
+          "-n",
+          "my-image",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unsupported instruction: EXPOSE"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject Dockerfile with VOLUME instruction", async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(`FROM node:24
+VOLUME /data
+RUN npm install`);
+
+      await expect(async () => {
+        await buildCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          "Dockerfile",
+          "-n",
+          "my-image",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unsupported instruction: VOLUME"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject Dockerfile with multiple unsupported instructions", async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(`FROM node:24
+WORKDIR /app
+COPY . .
+ENV NODE_ENV=production
+RUN npm install`);
+
+      await expect(async () => {
+        await buildCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          "Dockerfile",
+          "-n",
+          "my-image",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unsupported instruction: WORKDIR"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unsupported instruction: COPY"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unsupported instruction: ENV"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should show helpful message when validation fails", async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(`FROM node:24
+COPY package.json .
+RUN npm install`);
+
+      await expect(async () => {
+        await buildCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          "Dockerfile",
+          "-n",
+          "my-image",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("only supports FROM and RUN instructions"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("pre-install environment dependencies"),
+      );
+    });
+
+    it("should accept valid Dockerfile with only FROM and RUN", async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(`FROM node:24
+RUN apt-get update && apt-get install -y git
+RUN npm install -g @anthropic-ai/claude-code@latest`);
+      vi.mocked(apiClient.createImage).mockResolvedValue({
+        imageId: "img-123",
+        buildId: "bld-456",
+        alias: "my-image",
+        versionId: "abc123def456",
+      });
+      vi.mocked(apiClient.get).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          status: "ready",
+          logs: [],
+          logsOffset: 0,
+        }),
+      } as Response);
+
+      await buildCommand.parseAsync([
+        "node",
+        "cli",
+        "-f",
+        "Dockerfile",
+        "-n",
+        "my-image",
+      ]);
+
+      expect(apiClient.createImage).toHaveBeenCalled();
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Image built"),
+      );
+    });
+
+    it("should accept Dockerfile with comments and empty lines", async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(`# This is a comment
+FROM node:24
+
+# Install dependencies
+RUN npm install`);
+      vi.mocked(apiClient.createImage).mockResolvedValue({
+        imageId: "img-123",
+        buildId: "bld-456",
+        alias: "my-image",
+        versionId: "abc123def456",
+      });
+      vi.mocked(apiClient.get).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          status: "ready",
+          logs: [],
+          logsOffset: 0,
+        }),
+      } as Response);
+
+      await buildCommand.parseAsync([
+        "node",
+        "cli",
+        "-f",
+        "Dockerfile",
+        "-n",
+        "my-image",
+      ]);
+
+      expect(apiClient.createImage).toHaveBeenCalled();
+    });
+
+    it("should accept Dockerfile with multi-line RUN", async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(`FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y \\
+    git \\
+    curl \\
+    python3 \\
+    python3-pip \\
+    && rm -rf /var/lib/apt/lists/`);
+      vi.mocked(apiClient.createImage).mockResolvedValue({
+        imageId: "img-123",
+        buildId: "bld-456",
+        alias: "my-image",
+        versionId: "abc123def456",
+      });
+      vi.mocked(apiClient.get).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          status: "ready",
+          logs: [],
+          logsOffset: 0,
+        }),
+      } as Response);
+
+      await buildCommand.parseAsync([
+        "node",
+        "cli",
+        "-f",
+        "Dockerfile",
+        "-n",
+        "my-image",
+      ]);
+
+      expect(apiClient.createImage).toHaveBeenCalled();
+    });
+  });
+});

--- a/turbo/apps/cli/src/lib/__tests__/dockerfile-validator.spec.ts
+++ b/turbo/apps/cli/src/lib/__tests__/dockerfile-validator.spec.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { validateDockerfile } from "../dockerfile-validator";
+
+describe("validateDockerfile", () => {
+  it("should accept valid Dockerfile with only FROM and RUN", () => {
+    const dockerfile = `FROM node:24
+RUN apt-get update && apt-get install -y git
+RUN npm install -g @anthropic-ai/claude-code@latest`;
+
+    const result = validateDockerfile(dockerfile);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should accept multi-line RUN with backslash", () => {
+    const dockerfile = `FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y \\
+    git \\
+    curl \\
+    python3`;
+
+    const result = validateDockerfile(dockerfile);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should accept comments and empty lines", () => {
+    const dockerfile = `# This is a comment
+FROM node:24
+
+# Another comment
+RUN npm install`;
+
+    const result = validateDockerfile(dockerfile);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should accept parser directives", () => {
+    const dockerfile = `# syntax=docker/dockerfile:1
+FROM node:24
+RUN npm install`;
+
+    const result = validateDockerfile(dockerfile);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should reject COPY instruction", () => {
+    const dockerfile = `FROM node:24
+COPY package.json .
+RUN npm install`;
+
+    const result = validateDockerfile(dockerfile);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Unsupported instruction: COPY (line 2)");
+  });
+
+  it("should reject multiple unsupported instructions", () => {
+    const dockerfile = `FROM node:24
+WORKDIR /app
+COPY . .
+ENV NODE_ENV=production
+RUN npm install`;
+
+    const result = validateDockerfile(dockerfile);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(3);
+    expect(result.errors).toContain(
+      "Unsupported instruction: WORKDIR (line 2)",
+    );
+    expect(result.errors).toContain("Unsupported instruction: COPY (line 3)");
+    expect(result.errors).toContain("Unsupported instruction: ENV (line 4)");
+  });
+
+  it("should handle case-insensitive instructions", () => {
+    const dockerfile = `from node:24
+run npm install`;
+
+    const result = validateDockerfile(dockerfile);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should reject ADD instruction", () => {
+    const dockerfile = `FROM node:24
+ADD https://example.com/file.tar.gz /tmp/
+RUN tar -xzf /tmp/file.tar.gz`;
+
+    const result = validateDockerfile(dockerfile);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Unsupported instruction: ADD (line 2)");
+  });
+
+  it("should reject CMD instruction", () => {
+    const dockerfile = `FROM node:24
+RUN npm install
+CMD ["node", "index.js"]`;
+
+    const result = validateDockerfile(dockerfile);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Unsupported instruction: CMD (line 3)");
+  });
+
+  it("should reject ENTRYPOINT instruction", () => {
+    const dockerfile = `FROM node:24
+RUN npm install
+ENTRYPOINT ["node"]`;
+
+    const result = validateDockerfile(dockerfile);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "Unsupported instruction: ENTRYPOINT (line 3)",
+    );
+  });
+
+  it("should reject USER instruction", () => {
+    const dockerfile = `FROM node:24
+USER node
+RUN npm install`;
+
+    const result = validateDockerfile(dockerfile);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Unsupported instruction: USER (line 2)");
+  });
+
+  it("should reject EXPOSE instruction", () => {
+    const dockerfile = `FROM node:24
+EXPOSE 3000
+RUN npm install`;
+
+    const result = validateDockerfile(dockerfile);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Unsupported instruction: EXPOSE (line 2)");
+  });
+
+  it("should reject VOLUME instruction", () => {
+    const dockerfile = `FROM node:24
+VOLUME /data
+RUN npm install`;
+
+    const result = validateDockerfile(dockerfile);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Unsupported instruction: VOLUME (line 2)");
+  });
+
+  it("should reject ARG instruction", () => {
+    const dockerfile = `FROM node:24
+ARG VERSION=1.0
+RUN npm install`;
+
+    const result = validateDockerfile(dockerfile);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Unsupported instruction: ARG (line 2)");
+  });
+
+  it("should reject LABEL instruction", () => {
+    const dockerfile = `FROM node:24
+LABEL maintainer="test@example.com"
+RUN npm install`;
+
+    const result = validateDockerfile(dockerfile);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Unsupported instruction: LABEL (line 2)");
+  });
+});

--- a/turbo/apps/cli/src/lib/dockerfile-validator.ts
+++ b/turbo/apps/cli/src/lib/dockerfile-validator.ts
@@ -1,0 +1,57 @@
+/**
+ * Validates Dockerfile content for vm0 image build.
+ * Only FROM and RUN instructions are allowed.
+ */
+
+const ALLOWED_INSTRUCTIONS = new Set(["FROM", "RUN"]);
+
+export interface DockerfileValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/**
+ * Validate Dockerfile content.
+ * Returns validation result with list of errors if any unsupported instructions found.
+ */
+export function validateDockerfile(
+  content: string,
+): DockerfileValidationResult {
+  const errors: string[] = [];
+  const lines = content.split("\n");
+  let inContinuation = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    const trimmed = line.trim();
+
+    // Skip empty lines (only if not in continuation)
+    if (!inContinuation && !trimmed) continue;
+
+    // Skip comments (only if not in continuation)
+    if (!inContinuation && trimmed.startsWith("#")) continue;
+
+    // If in continuation, just check if it ends
+    if (inContinuation) {
+      inContinuation = trimmed.endsWith("\\");
+      continue;
+    }
+
+    // Extract instruction name (first word before space)
+    const match = trimmed.match(/^([A-Za-z]+)\s/);
+    if (match) {
+      const instruction = match[1]!.toUpperCase();
+      if (!ALLOWED_INSTRUCTIONS.has(instruction)) {
+        errors.push(`Unsupported instruction: ${instruction} (line ${i + 1})`);
+      }
+    }
+
+    // Check for continuation
+    inContinuation = trimmed.endsWith("\\");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}


### PR DESCRIPTION
## Summary

Add pre-validation for Dockerfile content in `vm0 image build` command to enforce supported instructions.

- Only `FROM` and `RUN` instructions are allowed
- Clear error messages for unsupported instructions
- Handles multi-line RUN commands with backslash continuation

## Changes

- **New:** `turbo/apps/cli/src/lib/dockerfile-validator.ts` - Validation logic
- **Modified:** `turbo/apps/cli/src/commands/image/build.ts` - Integration
- **New:** Unit tests and CLI e2e tests (32 test cases)

## Example Error Output

```
✗ Dockerfile validation failed

  Unsupported instruction: COPY (line 2)
  Unsupported instruction: WORKDIR (line 3)

  vm0 image build only supports FROM and RUN instructions.
  The purpose is to pre-install environment dependencies.
```

## Test plan

- [x] Unit tests for dockerfile-validator (15 tests)
- [x] CLI e2e tests for build command (17 tests)
- [x] Lint check passes
- [x] Type check passes

Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)