### PR TITLE
feat(cli): promote beta features to stable and add image auto-config

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/compose.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/compose.test.ts
@@ -14,10 +14,11 @@ vi.mock("../../lib/api-client");
 vi.mock("../../lib/yaml-validator");
 vi.mock("../../lib/provider-config", () => ({
   getProviderDefaults: vi.fn().mockReturnValue(undefined),
+  getDefaultImage: vi.fn().mockReturnValue(undefined),
 }));
 vi.mock("../../lib/system-storage", () => ({
-  uploadSystemPrompt: vi.fn(),
-  uploadSystemSkill: vi.fn(),
+  uploadInstructions: vi.fn(),
+  uploadSkill: vi.fn(),
 }));
 
 describe("compose command", () => {

--- a/turbo/apps/cli/src/lib/__tests__/github-skills.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/github-skills.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseGitHubTreeUrl,
   getSkillStorageName,
-  getSystemPromptStorageName,
+  getInstructionsStorageName,
 } from "../github-skills";
 
 describe("github-skills", () => {
@@ -73,7 +73,7 @@ describe("github-skills", () => {
       );
       const name = getSkillStorageName(parsed);
 
-      expect(name).toBe("system-skill@vm0-ai/vm0-skills/tree/main/github");
+      expect(name).toBe("agent-skills@vm0-ai/vm0-skills/tree/main/github");
     });
 
     it("should include full path for nested skills", () => {
@@ -83,20 +83,20 @@ describe("github-skills", () => {
       const name = getSkillStorageName(parsed);
 
       expect(name).toBe(
-        "system-skill@vm0-ai/vm0-skills/tree/v1.0/skills/notion",
+        "agent-skills@vm0-ai/vm0-skills/tree/v1.0/skills/notion",
       );
     });
   });
 
-  describe("getSystemPromptStorageName", () => {
+  describe("getInstructionsStorageName", () => {
     it("should generate storage name with @ format", () => {
-      const name = getSystemPromptStorageName("my-agent");
-      expect(name).toBe("system-prompt@my-agent");
+      const name = getInstructionsStorageName("my-agent");
+      expect(name).toBe("agent-instructions@my-agent");
     });
 
     it("should handle agent names with hyphens", () => {
-      const name = getSystemPromptStorageName("my-cool-agent-v2");
-      expect(name).toBe("system-prompt@my-cool-agent-v2");
+      const name = getInstructionsStorageName("my-cool-agent-v2");
+      expect(name).toBe("agent-instructions@my-cool-agent-v2");
     });
   });
 });

--- a/turbo/apps/cli/src/lib/__tests__/yaml-validator.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/yaml-validator.test.ts
@@ -440,29 +440,12 @@ describe("validateAgentCompose", () => {
       expect(result.valid).toBe(true);
     });
 
-    it("should reject config without image even when provider is claude-code", () => {
+    it("should accept config without image when provider is claude-code (auto-configurable)", () => {
       const config = {
         version: "1.0",
         agents: {
           "test-agent": {
             provider: "claude-code",
-          },
-        },
-      };
-
-      const result = validateAgentCompose(config);
-      expect(result.valid).toBe(false);
-      expect(result.error).toContain("agent.image");
-    });
-
-    it("should accept config with beta_system_prompt", () => {
-      const config = {
-        version: "1.0",
-        agents: {
-          "test-agent": {
-            provider: "claude-code",
-            image: "vm0/claude-code:dev",
-            beta_system_prompt: "AGENTS.md",
           },
         },
       };
@@ -471,16 +454,14 @@ describe("validateAgentCompose", () => {
       expect(result.valid).toBe(true);
     });
 
-    it("should accept config with beta_system_skills", () => {
+    it("should accept config with instructions", () => {
       const config = {
         version: "1.0",
         agents: {
           "test-agent": {
             provider: "claude-code",
             image: "vm0/claude-code:dev",
-            beta_system_skills: [
-              "https://github.com/vm0-ai/vm0-skills/tree/main/github",
-            ],
+            instructions: "AGENTS.md",
           },
         },
       };
@@ -489,14 +470,30 @@ describe("validateAgentCompose", () => {
       expect(result.valid).toBe(true);
     });
 
-    it("should reject empty beta_system_prompt", () => {
+    it("should accept config with skills", () => {
       const config = {
         version: "1.0",
         agents: {
           "test-agent": {
             provider: "claude-code",
             image: "vm0/claude-code:dev",
-            beta_system_prompt: "",
+            skills: ["https://github.com/vm0-ai/vm0-skills/tree/main/github"],
+          },
+        },
+      };
+
+      const result = validateAgentCompose(config);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject empty instructions", () => {
+      const config = {
+        version: "1.0",
+        agents: {
+          "test-agent": {
+            provider: "claude-code",
+            image: "vm0/claude-code:dev",
+            instructions: "",
           },
         },
       };
@@ -506,21 +503,21 @@ describe("validateAgentCompose", () => {
       expect(result.error).toContain("cannot be empty");
     });
 
-    it("should reject invalid beta_system_skills URL", () => {
+    it("should reject invalid skill URL", () => {
       const config = {
         version: "1.0",
         agents: {
           "test-agent": {
             provider: "claude-code",
             image: "vm0/claude-code:dev",
-            beta_system_skills: ["https://example.com/not-github"],
+            skills: ["https://example.com/not-github"],
           },
         },
       };
 
       const result = validateAgentCompose(config);
       expect(result.valid).toBe(false);
-      expect(result.error).toContain("Invalid beta_system_skill URL");
+      expect(result.error).toContain("Invalid skill URL");
     });
   });
 });

--- a/turbo/apps/cli/src/lib/github-skills.ts
+++ b/turbo/apps/cli/src/lib/github-skills.ts
@@ -3,8 +3,15 @@ import * as path from "node:path";
 import * as os from "node:os";
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
+import {
+  getInstructionsStorageName,
+  getSkillStorageName as getCoreSkillStorageName,
+} from "@vm0/core";
 
 const execAsync = promisify(exec);
+
+// Re-export from @vm0/core for convenience
+export { getInstructionsStorageName };
 
 /**
  * Parsed GitHub tree URL components
@@ -65,25 +72,14 @@ export function parseGitHubTreeUrl(url: string): ParsedGitHubUrl {
 }
 
 /**
- * Generate the storage name for a system skill
- * Format: system-skill@{fullPath}
+ * Generate the storage name for an agent skill
+ * Format: agent-skills@{fullPath}
  *
  * @param parsed - Parsed GitHub URL
  * @returns Storage name for the skill
  */
 export function getSkillStorageName(parsed: ParsedGitHubUrl): string {
-  return `system-skill@${parsed.fullPath}`;
-}
-
-/**
- * Generate the storage name for a system prompt
- * Format: system-prompt@{composeName}
- *
- * @param composeName - Name of the compose (agent name)
- * @returns Storage name for the system prompt
- */
-export function getSystemPromptStorageName(composeName: string): string {
-  return `system-prompt@${composeName}`;
+  return getCoreSkillStorageName(parsed.fullPath);
 }
 
 /**

--- a/turbo/apps/cli/src/lib/provider-config.ts
+++ b/turbo/apps/cli/src/lib/provider-config.ts
@@ -61,7 +61,8 @@ export function getDefaultImage(provider: string): string | undefined {
   const defaults = PROVIDER_DEFAULTS[provider];
   if (!defaults) return undefined;
 
-  const isCI = process.env.CI === "true";
-  const isDev = process.env.NODE_ENV === "development";
-  return isCI || isDev ? defaults.image.development : defaults.image.production;
+  // Only use production image when NODE_ENV is explicitly "production"
+  // All other cases (development, test, undefined) use dev image
+  const isProduction = process.env.NODE_ENV === "production";
+  return isProduction ? defaults.image.production : defaults.image.development;
 }

--- a/turbo/apps/cli/src/lib/provider-config.ts
+++ b/turbo/apps/cli/src/lib/provider-config.ts
@@ -1,11 +1,14 @@
 /**
- * Provider configuration for auto-resolving working_dir
+ * Provider configuration for auto-resolving working_dir and image
  * When a provider is specified, these defaults can be used if not explicitly set
- * Note: image is always required and must be explicitly configured
  */
 
 export interface ProviderDefaults {
   workingDir: string;
+  image: {
+    production: string;
+    development: string;
+  };
 }
 
 /**
@@ -14,6 +17,10 @@ export interface ProviderDefaults {
 const PROVIDER_DEFAULTS: Record<string, ProviderDefaults> = {
   "claude-code": {
     workingDir: "/home/user/workspace",
+    image: {
+      production: "vm0/claude-code:latest",
+      development: "vm0/claude-code:dev",
+    },
   },
 };
 
@@ -43,4 +50,18 @@ export function isProviderSupported(provider: string): boolean {
  */
 export function getSupportedProviders(): string[] {
   return Object.keys(PROVIDER_DEFAULTS);
+}
+
+/**
+ * Get the default image for a provider based on the current environment
+ * @param provider - The provider name
+ * @returns Default image string or undefined if provider is not recognized
+ */
+export function getDefaultImage(provider: string): string | undefined {
+  const defaults = PROVIDER_DEFAULTS[provider];
+  if (!defaults) return undefined;
+
+  const isCI = process.env.CI === "true";
+  const isDev = process.env.NODE_ENV === "development";
+  return isCI || isDev ? defaults.image.development : defaults.image.production;
 }

--- a/turbo/apps/cli/src/lib/system-storage.ts
+++ b/turbo/apps/cli/src/lib/system-storage.ts
@@ -5,51 +5,51 @@ import {
   parseGitHubTreeUrl,
   downloadGitHubSkill,
   getSkillStorageName,
-  getSystemPromptStorageName,
+  getInstructionsStorageName,
   validateSkillDirectory,
 } from "./github-skills";
 import { directUpload } from "./direct-upload";
 
-export interface SystemStorageUploadResult {
+export interface StorageUploadResult {
   name: string;
   versionId: string;
   action: "created" | "deduplicated";
 }
 
 /**
- * Upload system prompt file as a volume
+ * Upload instructions file as a volume
  *
  * @param agentName - Name of the agent (used for storage name)
- * @param promptFilePath - Path to the system prompt file (AGENTS.md)
+ * @param instructionsFilePath - Path to the instructions file (e.g., AGENTS.md)
  * @param basePath - Base path for resolving relative paths
  * @returns Upload result with storage name and version
  */
-export async function uploadSystemPrompt(
+export async function uploadInstructions(
   agentName: string,
-  promptFilePath: string,
+  instructionsFilePath: string,
   basePath: string,
-): Promise<SystemStorageUploadResult> {
-  const storageName = getSystemPromptStorageName(agentName);
+): Promise<StorageUploadResult> {
+  const storageName = getInstructionsStorageName(agentName);
 
   // Resolve file path relative to base path
-  const absolutePath = path.isAbsolute(promptFilePath)
-    ? promptFilePath
-    : path.join(basePath, promptFilePath);
+  const absolutePath = path.isAbsolute(instructionsFilePath)
+    ? instructionsFilePath
+    : path.join(basePath, instructionsFilePath);
 
-  // Read the prompt file
+  // Read the instructions file
   const content = await fs.readFile(absolutePath, "utf8");
 
   // Create a temporary directory with the file
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vm0-prompt-"));
-  const promptDir = path.join(tmpDir, "prompt");
-  await fs.mkdir(promptDir);
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vm0-instructions-"));
+  const instructionsDir = path.join(tmpDir, "instructions");
+  await fs.mkdir(instructionsDir);
 
-  // Write file as CLAUDE.md (the canonical name for Claude Code system prompts)
-  await fs.writeFile(path.join(promptDir, "CLAUDE.md"), content);
+  // Write file as CLAUDE.md (the canonical name for Claude Code instructions)
+  await fs.writeFile(path.join(instructionsDir, "CLAUDE.md"), content);
 
   try {
     // Use direct upload (bypasses Vercel 4.5MB limit)
-    const result = await directUpload(storageName, "volume", promptDir);
+    const result = await directUpload(storageName, "volume", instructionsDir);
 
     return {
       name: storageName,
@@ -68,9 +68,9 @@ export async function uploadSystemPrompt(
  * @param skillUrl - GitHub tree URL for the skill
  * @returns Upload result with storage name and version
  */
-export async function uploadSystemSkill(
+export async function uploadSkill(
   skillUrl: string,
-): Promise<SystemStorageUploadResult> {
+): Promise<StorageUploadResult> {
   const parsed = parseGitHubTreeUrl(skillUrl);
   const storageName = getSkillStorageName(parsed);
 

--- a/turbo/apps/cli/src/lib/yaml-validator.ts
+++ b/turbo/apps/cli/src/lib/yaml-validator.ts
@@ -24,7 +24,7 @@ export function normalizeAgentName(name: string): string | null {
 }
 
 /**
- * Validates GitHub tree URL format for beta_system_skills
+ * Validates GitHub tree URL format for skills
  * Expected format: https://github.com/{owner}/{repo}/tree/{branch}/{path}
  */
 export function validateGitHubTreeUrl(url: string): boolean {
@@ -133,11 +133,18 @@ export function validateAgentCompose(config: unknown): {
 
   const providerIsSupported = isProviderSupported(agent.provider as string);
 
-  // Check agent.image (always required)
-  if (!agent.image || typeof agent.image !== "string") {
+  // Check agent.image (optional when provider supports auto-config)
+  if (agent.image !== undefined && typeof agent.image !== "string") {
     return {
       valid: false,
-      error: "Missing or invalid agent.image (must be a string)",
+      error: "agent.image must be a string if provided",
+    };
+  }
+  if (!agent.image && !providerIsSupported) {
+    return {
+      valid: false,
+      error:
+        "Missing agent.image (required when provider is not auto-configured)",
     };
   }
 
@@ -159,42 +166,42 @@ export function validateAgentCompose(config: unknown): {
     };
   }
 
-  // Validate beta_system_prompt if present (must be a relative file path)
-  if (agent.beta_system_prompt !== undefined) {
-    if (typeof agent.beta_system_prompt !== "string") {
+  // Validate instructions if present (must be a relative file path)
+  if (agent.instructions !== undefined) {
+    if (typeof agent.instructions !== "string") {
       return {
         valid: false,
         error:
-          "agent.beta_system_prompt must be a string (path to AGENTS.md file)",
+          "agent.instructions must be a string (path to instructions file)",
       };
     }
-    if (agent.beta_system_prompt.length === 0) {
+    if (agent.instructions.length === 0) {
       return {
         valid: false,
-        error: "agent.beta_system_prompt cannot be empty",
+        error: "agent.instructions cannot be empty",
       };
     }
   }
 
-  // Validate beta_system_skills if present (must be array of GitHub tree URLs)
-  if (agent.beta_system_skills !== undefined) {
-    if (!Array.isArray(agent.beta_system_skills)) {
+  // Validate skills if present (must be array of GitHub tree URLs)
+  if (agent.skills !== undefined) {
+    if (!Array.isArray(agent.skills)) {
       return {
         valid: false,
-        error: "agent.beta_system_skills must be an array of GitHub tree URLs",
+        error: "agent.skills must be an array of GitHub tree URLs",
       };
     }
-    for (const skillUrl of agent.beta_system_skills as unknown[]) {
+    for (const skillUrl of agent.skills as unknown[]) {
       if (typeof skillUrl !== "string") {
         return {
           valid: false,
-          error: "Each beta_system_skill must be a string URL",
+          error: "Each skill must be a string URL",
         };
       }
       if (!validateGitHubTreeUrl(skillUrl)) {
         return {
           valid: false,
-          error: `Invalid beta_system_skill URL: ${skillUrl}. Expected format: https://github.com/{owner}/{repo}/tree/{branch}/{path}`,
+          error: `Invalid skill URL: ${skillUrl}. Expected format: https://github.com/{owner}/{repo}/tree/{branch}/{path}`,
         };
       }
     }

--- a/turbo/apps/web/src/lib/storage/types.ts
+++ b/turbo/apps/web/src/lib/storage/types.ts
@@ -67,8 +67,8 @@ export interface AgentVolumeConfig {
     {
       volumes?: string[];
       working_dir?: string; // Optional when provider supports auto-config
-      beta_system_prompt?: string; // Path to system prompt file (stored as system-prompt@{name} volume)
-      beta_system_skills?: string[]; // GitHub tree URLs (stored as system-skill@{path} volumes)
+      instructions?: string; // Path to instructions file (stored as agent-instructions@{name} volume)
+      skills?: string[]; // GitHub tree URLs (stored as agent-skills@{path} volumes)
     }
   >;
   volumes?: Record<string, VolumeConfig>;

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -17,7 +17,7 @@ export interface VolumeConfig {
  */
 export interface AgentDefinition {
   description?: string;
-  image: string;
+  image?: string; // Optional when provider supports auto-config
   provider: string;
   volumes?: string[]; // Format: "volume-key:/mount/path"
   working_dir?: string; // Optional when provider supports auto-config
@@ -30,18 +30,16 @@ export interface AgentDefinition {
    */
   beta_network_security?: boolean;
   /**
-   * Path to system prompt file (e.g., AGENTS.md).
+   * Path to instructions file (e.g., AGENTS.md).
    * Auto-uploaded as volume and mounted at /home/user/.claude/CLAUDE.md
-   * Beta feature: field name may change in future versions.
    */
-  beta_system_prompt?: string;
+  instructions?: string;
   /**
-   * Array of GitHub tree URLs for system skills.
+   * Array of GitHub tree URLs for agent skills.
    * Each skill is auto-downloaded and mounted at /home/user/.claude/skills/{skillName}/
    * Format: https://github.com/{owner}/{repo}/tree/{branch}/{path}
-   * Beta feature: field name may change in future versions.
    */
-  beta_system_skills?: string[];
+  skills?: string[];
 }
 
 export interface AgentComposeYaml {

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -32,7 +32,7 @@ const volumeConfigSchema = z.object({
  */
 const agentDefinitionSchema = z.object({
   description: z.string().optional(),
-  image: z.string().min(1, "Image is required"),
+  image: z.string().optional(), // Optional when provider supports auto-config
   provider: z.string().min(1, "Provider is required"),
   volumes: z.array(z.string()).optional(),
   working_dir: z.string().optional(), // Optional when provider supports auto-config
@@ -45,15 +45,15 @@ const agentDefinitionSchema = z.object({
    */
   beta_network_security: z.boolean().optional().default(false),
   /**
-   * Path to system prompt file (e.g., AGENTS.md).
+   * Path to instructions file (e.g., AGENTS.md).
    * Auto-uploaded as volume and mounted at /home/user/.claude/CLAUDE.md
    */
-  beta_system_prompt: z.string().optional(),
+  instructions: z.string().optional(),
   /**
-   * Array of GitHub tree URLs for system skills.
+   * Array of GitHub tree URLs for agent skills.
    * Each skill is auto-downloaded and mounted at /home/user/.claude/skills/{skillName}/
    */
-  beta_system_skills: z.array(z.string()).optional(),
+  skills: z.array(z.string()).optional(),
 });
 
 /**

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -2,3 +2,4 @@ export * from "./variable-expander";
 export * from "./contracts";
 export * from "./scope-reference";
 export * from "./version-id";
+export * from "./storage-names";

--- a/turbo/packages/core/src/storage-names.ts
+++ b/turbo/packages/core/src/storage-names.ts
@@ -1,0 +1,26 @@
+/**
+ * Storage name generation functions for agent instructions and skills.
+ * These functions create standardized storage names used across CLI and Web packages.
+ */
+
+/**
+ * Generate the storage name for agent instructions.
+ * Format: agent-instructions@{agentName}
+ *
+ * @param agentName - Name of the agent (compose name)
+ * @returns Storage name for the instructions
+ */
+export function getInstructionsStorageName(agentName: string): string {
+  return `agent-instructions@${agentName}`;
+}
+
+/**
+ * Generate the storage name for an agent skill.
+ * Format: agent-skills@{fullPath}
+ *
+ * @param fullPath - Full path from GitHub URL (e.g., "owner/repo/tree/branch/path")
+ * @returns Storage name for the skill
+ */
+export function getSkillStorageName(fullPath: string): string {
+  return `agent-skills@${fullPath}`;
+}

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -2,6 +2,7 @@
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "globalEnv": [
+    "CI",
     "DATABASE_URL",
     "DEBUG",
     "NODE_ENV",

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -2,7 +2,6 @@
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "globalEnv": [
-    "CI",
     "DATABASE_URL",
     "DEBUG",
     "NODE_ENV",


### PR DESCRIPTION
## Summary

- Rename `beta_system_prompt` to `instructions` and `beta_system_skills` to `skills`
- Update storage keys from `system-prompt@{name}` / `system-skill@{path}` to `agent-instructions@{name}` / `agent-skills@{path}`
- Add auto-configure image based on provider (claude-code uses `vm0/claude-code:latest` in production, `:dev` in CI/development)
- Extract storage name generation functions to `@vm0/core` package for shared use
- Make `image` field optional in Zod schema when provider supports auto-config
- Update all related unit tests and E2E tests

## Test plan

- [x] Build all packages successfully
- [x] Pass type checking
- [x] Pass linting
- [x] Pass unit tests for yaml-validator, github-skills, compose command, and storage-resolver
- [x] E2E tests updated in `t17-vm0-simplified-compose.bats`
- [ ] Verify CI pipeline passes

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)