### PR TITLE
fix: return provider in events APIs for correct rendering

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/run.test.ts
@@ -85,6 +85,7 @@ describe("run command", () => {
         hasMore: false,
         nextSequence: 1,
         run: { status: "completed" },
+        provider: "claude-code",
       });
 
       await runCommand.parseAsync([
@@ -151,6 +152,7 @@ describe("run command", () => {
         hasMore: false,
         nextSequence: 1,
         run: { status: "completed" },
+        provider: "claude-code",
       });
 
       await runCommand.parseAsync([
@@ -245,6 +247,7 @@ describe("run command", () => {
         hasMore: false,
         nextSequence: 1,
         run: { status: "completed" },
+        provider: "claude-code",
       });
 
       await runCommand.parseAsync([
@@ -310,6 +313,7 @@ describe("run command", () => {
         hasMore: false,
         nextSequence: 1,
         run: { status: "completed" },
+        provider: "claude-code",
       });
 
       await runCommand.parseAsync([
@@ -398,6 +402,7 @@ describe("run command", () => {
         hasMore: false,
         nextSequence: 1,
         run: { status: "completed" },
+        provider: "claude-code",
       });
     });
 
@@ -568,6 +573,7 @@ describe("run command", () => {
         hasMore: false,
         nextSequence: 1,
         run: { status: "running" },
+        provider: "claude-code",
       });
     });
 
@@ -594,6 +600,7 @@ describe("run command", () => {
             artifact: {},
           },
         },
+        provider: "claude-code",
       });
 
       await runCommand.parseAsync([
@@ -637,6 +644,7 @@ describe("run command", () => {
             artifact: {},
           },
         },
+        provider: "claude-code",
       });
 
       await runCommand.parseAsync([
@@ -676,6 +684,7 @@ describe("run command", () => {
             artifact: {},
           },
         },
+        provider: "claude-code",
       });
 
       await runCommand.parseAsync([
@@ -851,6 +860,7 @@ describe("run command", () => {
           hasMore: false,
           nextSequence: 1,
           run: { status: "running" },
+          provider: "claude-code",
         })
         .mockResolvedValueOnce({
           events: [
@@ -888,6 +898,7 @@ describe("run command", () => {
               artifact: {},
             },
           },
+          provider: "claude-code",
         });
 
       await runCommand.parseAsync([
@@ -953,6 +964,7 @@ describe("run command", () => {
             artifact: {},
           },
         },
+        provider: "claude-code",
       });
 
       await runCommand.parseAsync([
@@ -1019,6 +1031,7 @@ describe("run command", () => {
             artifact: {},
           },
         },
+        provider: "claude-code",
       });
 
       await runCommand.parseAsync([
@@ -1098,6 +1111,7 @@ describe("run command", () => {
             artifact: {},
           },
         },
+        provider: "claude-code",
       });
 
       await runCommand.parseAsync([
@@ -1137,6 +1151,7 @@ describe("run command", () => {
           hasMore: false,
           nextSequence: 1,
           run: { status: "running" },
+          provider: "claude-code",
         })
         .mockRejectedValueOnce(new Error("Network error"));
 
@@ -1174,6 +1189,7 @@ describe("run command", () => {
         hasMore: false,
         nextSequence: 0,
         run: { status: "failed", error: "Agent crashed" },
+        provider: "claude-code",
       });
 
       await expect(async () => {
@@ -1210,6 +1226,7 @@ describe("run command", () => {
         hasMore: false,
         nextSequence: 0,
         run: { status: "timeout" },
+        provider: "claude-code",
       });
 
       await expect(async () => {
@@ -1252,6 +1269,7 @@ describe("run command", () => {
             artifact: {},
           },
         },
+        provider: "claude-code",
       });
 
       await runCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -182,15 +182,15 @@ async function pollEvents(
       since: nextSequence,
     });
 
-    // Render agent events (use appropriate renderer for Claude Code or Codex)
+    // Render agent events (use appropriate renderer based on provider from API)
     for (const event of response.events) {
       const eventData = event.eventData as Record<string, unknown>;
 
-      // Use Codex renderer for Codex events
-      if (CodexEventRenderer.isCodexEvent(eventData)) {
+      if (response.provider === "codex") {
+        // Use Codex renderer for Codex provider
         CodexEventRenderer.render(eventData);
       } else {
-        // Use Claude Code renderer
+        // Use Claude Code renderer (default)
         const parsed = parseEvent(eventData);
         if (parsed) {
           EventRenderer.render(parsed, {

--- a/turbo/apps/cli/src/lib/api-client.ts
+++ b/turbo/apps/cli/src/lib/api-client.ts
@@ -93,6 +93,8 @@ export interface GetEventsResponse {
   nextSequence: number;
   /** Run state information (replaces previous vm0_* events) */
   run: RunState;
+  /** Provider type from compose configuration */
+  provider: string;
 }
 
 export interface GetComposeVersionResponse {
@@ -134,6 +136,8 @@ export interface RunEvent {
 export interface GetAgentEventsResponse {
   events: RunEvent[];
   hasMore: boolean;
+  /** Provider type from compose configuration */
+  provider: string;
 }
 
 export interface NetworkLogEntry {

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
@@ -740,4 +740,142 @@ describe("GET /api/agent/runs/:id/events", () => {
       expect(data.run.result).toBeUndefined();
     });
   });
+
+  // ============================================
+  // Provider Field Tests
+  // ============================================
+
+  describe("Provider Field", () => {
+    it("should return default provider 'claude-code' for compose without provider", async () => {
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${testRunId}/events`,
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.provider).toBe("claude-code");
+    });
+
+    it("should return 'codex' provider when compose has codex provider", async () => {
+      // Create a compose with codex provider
+      const codexComposeId = randomUUID();
+      const codexVersionId =
+        randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
+      const codexRunId = randomUUID();
+
+      await globalThis.services.db.insert(agentComposes).values({
+        id: codexComposeId,
+        userId: testUserId,
+        name: "codex-agent",
+        headVersionId: codexVersionId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await globalThis.services.db.insert(agentComposeVersions).values({
+        id: codexVersionId,
+        composeId: codexComposeId,
+        content: {
+          agent: {
+            provider: "codex",
+            model: "codex",
+          },
+        },
+        createdBy: testUserId,
+        createdAt: new Date(),
+      });
+
+      await globalThis.services.db.insert(agentRuns).values({
+        id: codexRunId,
+        userId: testUserId,
+        agentComposeVersionId: codexVersionId,
+        status: "running",
+        prompt: "Test prompt",
+        createdAt: new Date(),
+      });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${codexRunId}/events`,
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.provider).toBe("codex");
+
+      // Clean up
+      await globalThis.services.db
+        .delete(agentRuns)
+        .where(eq(agentRuns.id, codexRunId));
+      await globalThis.services.db
+        .delete(agentComposeVersions)
+        .where(eq(agentComposeVersions.id, codexVersionId));
+      await globalThis.services.db
+        .delete(agentComposes)
+        .where(eq(agentComposes.id, codexComposeId));
+    });
+
+    it("should return explicit provider from compose configuration", async () => {
+      // Create a compose with explicit claude-code provider
+      const explicitComposeId = randomUUID();
+      const explicitVersionId =
+        randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
+      const explicitRunId = randomUUID();
+
+      await globalThis.services.db.insert(agentComposes).values({
+        id: explicitComposeId,
+        userId: testUserId,
+        name: "explicit-agent",
+        headVersionId: explicitVersionId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await globalThis.services.db.insert(agentComposeVersions).values({
+        id: explicitVersionId,
+        composeId: explicitComposeId,
+        content: {
+          agent: {
+            provider: "claude-code",
+            model: "claude-3-5-sonnet-20241022",
+          },
+        },
+        createdBy: testUserId,
+        createdAt: new Date(),
+      });
+
+      await globalThis.services.db.insert(agentRuns).values({
+        id: explicitRunId,
+        userId: testUserId,
+        agentComposeVersionId: explicitVersionId,
+        status: "running",
+        prompt: "Test prompt",
+        createdAt: new Date(),
+      });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${explicitRunId}/events`,
+      );
+
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.provider).toBe("claude-code");
+
+      // Clean up
+      await globalThis.services.db
+        .delete(agentRuns)
+        .where(eq(agentRuns.id, explicitRunId));
+      await globalThis.services.db
+        .delete(agentComposeVersions)
+        .where(eq(agentComposeVersions.id, explicitVersionId));
+      await globalThis.services.db
+        .delete(agentComposes)
+        .where(eq(agentComposes.id, explicitComposeId));
+    });
+  });
 });

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -110,6 +110,7 @@ const eventsResponseSchema = z.object({
   hasMore: z.boolean(),
   nextSequence: z.number(),
   run: runStateSchema,
+  provider: z.string(),
 });
 
 /**
@@ -220,6 +221,7 @@ const metricsResponseSchema = z.object({
 const agentEventsResponseSchema = z.object({
   events: z.array(runEventSchema),
   hasMore: z.boolean(),
+  provider: z.string(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Add `provider` field to both events APIs (`/api/agent/runs/:id/events` for `vm0 run` and `/api/agent/runs/:id/telemetry/agent` for `vm0 logs`)
- Query compose version in both backend APIs to get provider from `content.agent.provider`
- Update `vm0 run` to use API provider instead of client-side detection via `isCodexEvent()`
- Update `vm0 logs` to use API provider for renderer selection
- Add unit tests for provider field in both APIs

## Test plan

- [x] Type checks pass
- [x] Lint checks pass
- [x] Unit tests for events API pass (21 tests)
- [x] Unit tests for telemetry/agent API pass (13 tests)
- [x] Unit tests for CLI run command pass (28 tests)
- [ ] `vm0 run` with Codex agent displays events correctly
- [ ] `vm0 run` with Claude Code agent works (no regression)
- [ ] `vm0 logs <codex-run-id>` displays Codex events correctly
- [ ] `vm0 logs <claude-code-run-id>` works (no regression)

Fixes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)