### PR TITLE
feat: add blog.vm0.ai to sitemap with multilingual support

### DIFF
--- a/turbo/apps/web/app/sitemap.ts
+++ b/turbo/apps/web/app/sitemap.ts
@@ -2,6 +2,7 @@ import { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = "https://vm0.ai";
+  const blogUrl = "https://blog.vm0.ai";
   const locales = ["en", "de", "es", "ja"];
 
   const routes = [
@@ -34,6 +35,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const urls: MetadataRoute.Sitemap = [];
 
+  // Add main site URLs with locales
   routes.forEach((route) => {
     locales.forEach((locale) => {
       urls.push({
@@ -42,6 +44,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
         changeFrequency: route.changeFrequency,
         priority: route.priority,
       });
+    });
+  });
+
+  // Add blog URLs with locales
+  locales.forEach((locale) => {
+    urls.push({
+      url: `${blogUrl}/${locale}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.8,
     });
   });
 


### PR DESCRIPTION
## Summary

Add blog.vm0.ai to the main site's sitemap with full multilingual support.

## Changes

- Add blog URLs for all supported locales (en, de, es, ja)
- Set blog priority to 0.8 with weekly update frequency
- Maintain existing main site URLs with locale support

## Sitemap Structure

**Main Site (20 URLs):**
- Home page × 4 languages
- Cookbooks × 4 languages
- Skills × 4 languages
- Sign-up × 4 languages
- Sign-in × 4 languages

**Blog (4 URLs):**
- https://blog.vm0.ai/en
- https://blog.vm0.ai/de
- https://blog.vm0.ai/es
- https://blog.vm0.ai/ja

**Total: 24 URLs in sitemap**

## SEO Impact

- Improves blog discoverability across all supported languages
- Maintains proper priority hierarchy (blog: 0.8, main pages: 0.9-1.0)
- Weekly update frequency for blog content

🤖 Generated with [Claude Code](https://claude.com/claude-code)