### PR TITLE
fix(docs): correct image format in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ version: "1.0"
 agents:
   my-agent:
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: vm0/claude-code:latest
     working_dir: /home/user/workspace
     volumes:
       - claude-files:/home/user/.config/claude
@@ -267,7 +267,7 @@ agents:
   my-agent:
     description: "Agent description"
     provider: claude-code
-    image: "@vm0/claude-code:dev"
+    image: vm0/claude-code:latest
     working_dir: /home/user/workspace
     volumes:
       - my-volume:/home/user/data


### PR DESCRIPTION
## Summary
- Fix incorrect image format `@vm0/claude-code:dev` → `vm0/claude-code:latest`
- The `@` prefix was never supported in the codebase
- Use `:latest` tag for production examples

## Test plan
- [x] Verify format matches E2E fixtures and provider-config.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)