### PR TITLE
feat: migrate sandbox telemetry metrics and network logs to axiom

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/route.ts
@@ -3,27 +3,23 @@ import { TsRestResponse } from "@ts-rest/serverless";
 import { runMetricsContract } from "@vm0/core";
 import { initServices } from "../../../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../../../src/db/schema/agent-run";
-import { sandboxTelemetry } from "../../../../../../../src/db/schema/sandbox-telemetry";
-import { eq, gt, and, asc } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { getUserId } from "../../../../../../../src/lib/auth/get-user-id";
+import {
+  queryAxiom,
+  getDatasetName,
+  DATASETS,
+} from "../../../../../../../src/lib/axiom";
 
-/**
- * Metric entry structure
- */
-interface MetricEntry {
-  ts: string;
+interface AxiomMetricEvent {
+  _time: string;
+  runId: string;
+  userId: string;
   cpu: number;
   mem_used: number;
   mem_total: number;
   disk_used: number;
   disk_total: number;
-}
-
-/**
- * Telemetry data structure stored in JSONB
- */
-interface TelemetryData {
-  metrics?: MetricEntry[];
 }
 
 const router = tsr.router(runMetricsContract, {
@@ -58,31 +54,44 @@ const router = tsr.router(runMetricsContract, {
 
     const { since, limit } = query;
 
-    // Build query conditions
-    const conditions = [eq(sandboxTelemetry.runId, params.id)];
-    if (since !== undefined) {
-      conditions.push(gt(sandboxTelemetry.createdAt, new Date(since)));
+    // Build APL query for Axiom
+    const dataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_METRICS);
+    const sinceFilter = since
+      ? `| where _time > datetime("${new Date(since).toISOString()}")`
+      : "";
+    const apl = `['${dataset}']
+| where runId == "${params.id}"
+${sinceFilter}
+| order by _time asc
+| limit ${limit + 1}`;
+
+    // Query Axiom for metrics
+    const events = await queryAxiom<AxiomMetricEvent>(apl);
+
+    // If Axiom is not configured or query failed, return empty
+    if (events === null) {
+      return {
+        status: 200 as const,
+        body: {
+          metrics: [],
+          hasMore: false,
+        },
+      };
     }
 
-    // Query all telemetry records (we need to extract metrics from them)
-    const telemetryRecords = await globalThis.services.db
-      .select()
-      .from(sandboxTelemetry)
-      .where(and(...conditions))
-      .orderBy(asc(sandboxTelemetry.createdAt));
+    // Check if there are more records
+    const hasMore = events.length > limit;
+    const records = hasMore ? events.slice(0, limit) : events;
 
-    // Collect all metrics entries
-    const allMetrics: MetricEntry[] = [];
-    for (const record of telemetryRecords) {
-      const data = record.data as TelemetryData;
-      if (data.metrics) {
-        allMetrics.push(...data.metrics);
-      }
-    }
-
-    // Apply limit to metrics
-    const hasMore = allMetrics.length > limit;
-    const metrics = hasMore ? allMetrics.slice(0, limit) : allMetrics;
+    // Transform to API response format
+    const metrics = records.map((e) => ({
+      ts: e._time,
+      cpu: e.cpu,
+      mem_used: e.mem_used,
+      mem_total: e.mem_total,
+      disk_used: e.disk_used,
+      disk_total: e.disk_total,
+    }));
 
     return {
       status: 200 as const,


### PR DESCRIPTION
## Summary

Completes the migration of sandbox telemetry to Axiom by moving metrics and network logs out of PostgreSQL.

- Update telemetry webhook to ingest metrics and network logs to Axiom using fire-and-forget pattern
- Remove PostgreSQL insert for metrics/network (all telemetry now in Axiom)
- Update metrics API to query from Axiom using APL
- Update network logs API to query from Axiom using APL  
- Add comprehensive tests for new Axiom-based APIs
- Apply secret masking to network logs URLs before Axiom ingest

Follows the pattern established in PR #706 for system logs.

## Test plan

- [x] All unit tests pass (60 telemetry-related tests)
- [x] Type checking passes
- [x] Linting passes
- [ ] E2E tests for `vm0 logs --metrics` and `vm0 logs --network`

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)