### PR TITLE
fix: inherit vars/secrets and compose version in continue/resume runs

### DIFF
--- a/turbo/apps/web/src/db/migrations/0043_add_compose_version_to_sessions.sql
+++ b/turbo/apps/web/src/db/migrations/0043_add_compose_version_to_sessions.sql
@@ -1,0 +1,6 @@
+-- Add agentComposeVersionId and volumeVersions to agent_sessions
+-- These fields preserve the execution context at session creation for reproducibility
+
+ALTER TABLE "agent_sessions"
+  ADD COLUMN "agent_compose_version_id" varchar(255),
+  ADD COLUMN "volume_versions" jsonb;

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1766700000000,
       "tag": "0042_add_image_version_id",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1766800000000,
+      "tag": "0043_add_compose_version_to_sessions",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/lib/agent-session/types.ts
+++ b/turbo/apps/web/src/lib/agent-session/types.ts
@@ -10,10 +10,15 @@ export interface AgentSessionData {
   id: string;
   userId: string;
   agentComposeId: string;
+  // Immutable compose version ID (SHA-256) fixed at session creation
+  // Null for legacy sessions - resolveSession falls back to HEAD
+  agentComposeVersionId: string | null;
   conversationId: string | null;
   artifactName: string | null;
   vars: Record<string, string> | null;
   secrets: Record<string, string> | null;
+  // Volume versions snapshot at session creation
+  volumeVersions: Record<string, string> | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -24,10 +29,14 @@ export interface AgentSessionData {
 export interface CreateAgentSessionInput {
   userId: string;
   agentComposeId: string;
+  // Compose version ID to fix at session creation (for reproducibility)
+  agentComposeVersionId?: string;
   artifactName?: string;
   conversationId?: string;
   vars?: Record<string, string>;
   secrets?: Record<string, string>;
+  // Volume versions to fix at session creation
+  volumeVersions?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #709 - `vm0 run resume` fails with "Missing required variables for environment" while `vm0 run continue` works.

### Root Cause

When using `resume` (checkpoint) or `continue` (session), the vars and secrets from the original run weren't being inherited to the new run record. Additionally, sessions didn't store the compose version ID, causing continued runs to use HEAD version instead of the version that was used to create the session.

### Changes

- **Database schema**: Added `agent_compose_version_id` and `volume_versions` columns to `agent_sessions` table
- **Session service**: Updated to store and retrieve compose version ID and volume versions
- **Run service**: Updated `validateAgentSession` and `resolveSession` to use session's version
- **API route**: Added vars/secrets inheritance from checkpoint and session sources
- **Checkpoint service**: Pass version ID and volume versions when creating/updating sessions

### Behavior Changes

1. **Continue (session)**: New runs inherit vars/secrets from session if not provided in request
2. **Resume (checkpoint)**: New runs inherit vars/secrets from checkpoint if not provided in request
3. **Version pinning**: Sessions now store the compose version ID, ensuring continued runs use the same version
4. **Backwards compatibility**: Legacy sessions without version ID fall back to HEAD version

### Testing

- Added 5 new unit tests for `agentComposeVersionId` and `volumeVersions` functionality
- All 520 existing tests pass

## Test plan

- [x] Unit tests pass for new functionality
- [x] Existing agent session tests pass
- [ ] CI pipeline passes (lint, type-check, build, tests)
- [ ] Manual testing: create session → continue → verify vars inherited
- [ ] Manual testing: create checkpoint → resume → verify vars inherited

🤖 Generated with [Claude Code](https://claude.com/claude-code)