### PR TITLE
fix: include _time field in axiom query results

### DIFF
--- a/turbo/apps/web/src/lib/axiom/client.ts
+++ b/turbo/apps/web/src/lib/axiom/client.ts
@@ -63,7 +63,11 @@ export async function queryAxiom<T = Record<string, unknown>>(
 
   try {
     const result = await client.query(apl);
-    return result.matches?.map((m: Entry) => m.data as T) ?? [];
+    // Axiom stores _time separately from data, merge them for the response
+    return (
+      result.matches?.map((m: Entry) => ({ _time: m._time, ...m.data }) as T) ??
+      []
+    );
   } catch (error) {
     log.error("Axiom query failed:", error);
     return null;


### PR DESCRIPTION
## Summary
- Fix `vm0 logs --metrics` displaying `[undefined]` instead of timestamps
- Axiom stores `_time` separately from event data, so it was missing from query results

## Test plan
- [x] Existing metrics route tests pass (9/9)
- [ ] Verify `vm0 logs --metrics` shows proper timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)