### PR TITLE
fix(cli): suppress dotenv promotional messages

### DIFF
--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -186,7 +186,7 @@ function checkMissingVariables(
   // Load .env file if it exists
   let dotenvValues: Record<string, string> = {};
   if (existsSync(envFilePath)) {
-    const result = dotenvConfig({ path: envFilePath });
+    const result = dotenvConfig({ path: envFilePath, quiet: true });
     if (result.parsed) {
       dotenvValues = result.parsed;
     }

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -96,7 +96,7 @@ function loadValues(
     let dotenvValues: Record<string, string> = {};
 
     if (fs.existsSync(envFilePath)) {
-      const dotenvResult = dotenvConfig({ path: envFilePath });
+      const dotenvResult = dotenvConfig({ path: envFilePath, quiet: true });
       if (dotenvResult.parsed) {
         // Only include keys that are missing
         dotenvValues = Object.fromEntries(


### PR DESCRIPTION
## Summary

- Add `quiet: true` option to `dotenv.config()` calls in CLI commands
- Suppresses promotional tip messages like `[dotenv@17.2.3] injecting env (0) from .env -- tip: ...`

## Test plan

- [ ] Run `vm0 run` with a `.env` file present and verify no dotenv promotional messages appear
- [ ] Run `vm0 cook` with a `.env` file present and verify no dotenv promotional messages appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)