### PR TITLE
feat(cli): show tutorial-style manual commands in vm0 cook output

### DIFF
--- a/e2e/tests/02-commands/t13-vm0-cook.bats
+++ b/e2e/tests/02-commands/t13-vm0-cook.bats
@@ -55,11 +55,11 @@ EOF
     assert_output --partial "Reading config: vm0.yaml"
     assert_output --partial "Config validated"
     assert_output --partial "Processing volumes"
-    assert_output --partial "test-volume"
-    assert_output --partial "Pushed"
+    assert_output --partial "cd test-volume"
+    assert_output --partial "vm0 volume push"
     assert_output --partial "Processing artifact"
-    assert_output --partial "Uploading compose"
-    assert_output --partial "Compose uploaded"
+    assert_output --partial "Composing agent"
+    assert_output --partial "vm0 compose vm0.yaml"
 
     echo "# Step 5: Verify volume was initialized..."
     [ -f "test-volume/.vm0/storage.yaml" ]
@@ -81,7 +81,7 @@ EOF
     # Check for "Run completed successfully" which indicates run finished
     if echo "$output" | grep -q "Run completed successfully"; then
         if echo "$output" | grep -q "Pulling updated artifact"; then
-            assert_output --partial "Artifact pulled"
+            assert_output --partial "vm0 artifact pull"
             echo "# Auto-pull triggered successfully"
         else
             echo "# Artifact version unchanged - no pull needed"
@@ -169,7 +169,8 @@ EOF
 
     echo "# Step 4: Verify normal cook output..."
     assert_output --partial "Config validated"
-    assert_output --partial "Compose uploaded"
+    assert_output --partial "Composing agent"
+    assert_output --partial "vm0 compose vm0.yaml"
 }
 
 @test "cook command appends to existing .env file without overwriting" {


### PR DESCRIPTION
## Summary

- Transforms `vm0 cook` into a tutorial tool that shows equivalent manual commands before each step
- Adds `printCommand()` helper for consistent `> command` format
- Only displays commands that are actually executed (conditional operations like `mkdir` and `init` only shown when needed)
- Removes success/failure indicators (✓/✗)
- Renames "Uploading compose" to "Composing agent" with colon formatting

## Expected Output

```
Processing artifact:
> mkdir artifact
> cd artifact
> vm0 artifact init
> vm0 artifact push
> cd ..

Composing agent:
> vm0 compose vm0.yaml

Running agent:
> vm0 run intro --artifact-name artifact "echo hello world"

Pulling updated artifact:
> cd artifact
> vm0 artifact pull e5215be8
> cd ..
```

## Test plan

- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint --filter=@vm0/cli`)
- [x] Unit tests pass (`pnpm vitest run apps/cli/src/commands/__tests__/cook.test.ts`)
- [ ] Manual test: `vm0 cook` without prompt
- [ ] Manual test: `vm0 cook "test prompt"` with full workflow

Closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)