### PR TITLE
feat(cli): implement vm0 cook continue/resume/logs subcommands

### DIFF
--- a/e2e/tests/02-commands/t14-vm0-cook-continue.bats
+++ b/e2e/tests/02-commands/t14-vm0-cook-continue.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+
+setup() {
+    # Create temporary test directory
+    export TEST_DIR="$(mktemp -d)"
+    # Backup existing cook state if any
+    export COOK_STATE_BACKUP=""
+    if [ -f "$HOME/.vm0/cook.json" ]; then
+        COOK_STATE_BACKUP="$(cat "$HOME/.vm0/cook.json")"
+    fi
+    # Clear cook state for clean tests
+    rm -f "$HOME/.vm0/cook.json"
+}
+
+teardown() {
+    # Clean up temporary directory
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
+    # Restore cook state if backed up
+    if [ -n "$COOK_STATE_BACKUP" ]; then
+        echo "$COOK_STATE_BACKUP" > "$HOME/.vm0/cook.json"
+    else
+        rm -f "$HOME/.vm0/cook.json"
+    fi
+}
+
+@test "cook logs fails gracefully without prior run" {
+    # Ensure no cook state exists
+    rm -f "$HOME/.vm0/cook.json"
+
+    run $CLI_COMMAND cook logs
+    assert_failure
+    assert_output --partial "No previous run found"
+    assert_output --partial "Run 'vm0 cook <prompt>' first"
+}
+
+@test "cook continue fails gracefully without prior run" {
+    # Ensure no cook state exists
+    rm -f "$HOME/.vm0/cook.json"
+
+    run $CLI_COMMAND cook continue "test prompt"
+    assert_failure
+    assert_output --partial "No previous session found"
+    assert_output --partial "Run 'vm0 cook <prompt>' first"
+}
+
+@test "cook resume fails gracefully without prior run" {
+    # Ensure no cook state exists
+    rm -f "$HOME/.vm0/cook.json"
+
+    run $CLI_COMMAND cook resume "test prompt"
+    assert_failure
+    assert_output --partial "No previous checkpoint found"
+    assert_output --partial "Run 'vm0 cook <prompt>' first"
+}
+
+@test "cook logs shows tutorial-style command hint" {
+    # Create a mock cook state with a run ID
+    mkdir -p "$HOME/.vm0"
+    echo '{"lastRunId": "test-run-id-12345678-1234-1234-1234-123456789012"}' > "$HOME/.vm0/cook.json"
+
+    # This will fail because the run ID doesn't exist, but we can check the command hint
+    run $CLI_COMMAND cook logs
+    # The command should show the tutorial-style output before failing
+    assert_output --partial "> vm0 logs test-run-id-12345678-1234-1234-1234-123456789012"
+}
+
+@test "cook continue shows tutorial-style command hint" {
+    # Create a mock cook state with a session ID
+    mkdir -p "$HOME/.vm0"
+    echo '{"lastSessionId": "test-session-12345678-1234-1234-1234-123456789012"}' > "$HOME/.vm0/cook.json"
+
+    # This will fail because the session ID doesn't exist, but we can check the command hint
+    run $CLI_COMMAND cook continue "test prompt"
+    # The command should show the tutorial-style output before failing
+    assert_output --partial "> vm0 run continue test-session-12345678-1234-1234-1234-123456789012"
+}
+
+@test "cook resume shows tutorial-style command hint" {
+    # Create a mock cook state with a checkpoint ID
+    mkdir -p "$HOME/.vm0"
+    echo '{"lastCheckpointId": "test-checkpoint-1234-1234-1234-1234-123456789012"}' > "$HOME/.vm0/cook.json"
+
+    # This will fail because the checkpoint ID doesn't exist, but we can check the command hint
+    run $CLI_COMMAND cook resume "test prompt"
+    # The command should show the tutorial-style output before failing
+    assert_output --partial "> vm0 run resume test-checkpoint-1234-1234-1234-1234-123456789012"
+}
+
+@test "cook subcommands help is available" {
+    run $CLI_COMMAND cook --help
+    assert_success
+    assert_output --partial "logs"
+    assert_output --partial "continue"
+    assert_output --partial "resume"
+    assert_output --partial "View logs from the last cook run"
+    assert_output --partial "Continue from the last session"
+    assert_output --partial "Resume from the last checkpoint"
+}

--- a/turbo/apps/cli/src/lib/__tests__/cook-state.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/cook-state.test.ts
@@ -135,29 +135,4 @@ describe("cook-state", () => {
       );
     });
   });
-
-  describe("clearCookState", () => {
-    it("clears state file if it exists", async () => {
-      vi.mocked(existsSync).mockReturnValue(true);
-      vi.mocked(fs.writeFile).mockResolvedValue();
-
-      const { clearCookState } = await import("../cook-state");
-      await clearCookState();
-
-      expect(fs.writeFile).toHaveBeenCalledWith(
-        "/home/testuser/.vm0/cook.json",
-        "{}",
-        "utf8",
-      );
-    });
-
-    it("does nothing if file doesn't exist", async () => {
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      const { clearCookState } = await import("../cook-state");
-      await clearCookState();
-
-      expect(fs.writeFile).not.toHaveBeenCalled();
-    });
-  });
 });

--- a/turbo/apps/cli/src/lib/__tests__/cook-state.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/cook-state.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs/promises";
+import { existsSync } from "fs";
+
+// Mock dependencies
+vi.mock("fs/promises");
+vi.mock("fs");
+vi.mock("os", () => ({
+  homedir: () => "/home/testuser",
+}));
+
+describe("cook-state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  describe("loadCookState", () => {
+    it("returns empty object when file doesn't exist", async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const { loadCookState } = await import("../cook-state");
+      const state = await loadCookState();
+
+      expect(state).toEqual({});
+    });
+
+    it("returns parsed state from file", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          lastRunId: "run-123",
+          lastSessionId: "session-456",
+          lastCheckpointId: "checkpoint-789",
+        }),
+      );
+
+      const { loadCookState } = await import("../cook-state");
+      const state = await loadCookState();
+
+      expect(state).toEqual({
+        lastRunId: "run-123",
+        lastSessionId: "session-456",
+        lastCheckpointId: "checkpoint-789",
+      });
+    });
+
+    it("returns empty object when JSON is corrupted", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue("not valid json {{{");
+
+      const { loadCookState } = await import("../cook-state");
+      const state = await loadCookState();
+
+      expect(state).toEqual({});
+    });
+  });
+
+  describe("saveCookState", () => {
+    it("creates config directory if needed", async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue();
+
+      const { saveCookState } = await import("../cook-state");
+      await saveCookState({ lastRunId: "new-run" });
+
+      expect(fs.mkdir).toHaveBeenCalledWith("/home/testuser/.vm0", {
+        recursive: true,
+      });
+    });
+
+    it("merges with existing state", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          lastRunId: "old-run",
+          lastSessionId: "old-session",
+        }),
+      );
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue();
+
+      const { saveCookState } = await import("../cook-state");
+      await saveCookState({ lastRunId: "new-run" });
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        "/home/testuser/.vm0/cook.json",
+        JSON.stringify(
+          {
+            lastRunId: "new-run",
+            lastSessionId: "old-session",
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+    });
+
+    it("overwrites existing keys", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          lastRunId: "old-run",
+          lastSessionId: "old-session",
+          lastCheckpointId: "old-checkpoint",
+        }),
+      );
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue();
+
+      const { saveCookState } = await import("../cook-state");
+      await saveCookState({
+        lastRunId: "new-run",
+        lastSessionId: "new-session",
+        lastCheckpointId: "new-checkpoint",
+      });
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        "/home/testuser/.vm0/cook.json",
+        JSON.stringify(
+          {
+            lastRunId: "new-run",
+            lastSessionId: "new-session",
+            lastCheckpointId: "new-checkpoint",
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+    });
+  });
+
+  describe("clearCookState", () => {
+    it("clears state file if it exists", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.writeFile).mockResolvedValue();
+
+      const { clearCookState } = await import("../cook-state");
+      await clearCookState();
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        "/home/testuser/.vm0/cook.json",
+        "{}",
+        "utf8",
+      );
+    });
+
+    it("does nothing if file doesn't exist", async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const { clearCookState } = await import("../cook-state");
+      await clearCookState();
+
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/turbo/apps/cli/src/lib/cook-state.ts
+++ b/turbo/apps/cli/src/lib/cook-state.ts
@@ -1,0 +1,44 @@
+import { homedir } from "os";
+import { join } from "path";
+import { readFile, writeFile, mkdir } from "fs/promises";
+import { existsSync } from "fs";
+
+const CONFIG_DIR = join(homedir(), ".vm0");
+const COOK_STATE_FILE = join(CONFIG_DIR, "cook.json");
+
+export interface CookState {
+  lastRunId?: string;
+  lastSessionId?: string;
+  lastCheckpointId?: string;
+}
+
+export async function loadCookState(): Promise<CookState> {
+  if (!existsSync(COOK_STATE_FILE)) {
+    return {};
+  }
+  try {
+    const content = await readFile(COOK_STATE_FILE, "utf8");
+    return JSON.parse(content) as CookState;
+  } catch {
+    // If file is corrupted, return empty state
+    return {};
+  }
+}
+
+export async function saveCookState(state: CookState): Promise<void> {
+  // Ensure config directory exists
+  await mkdir(CONFIG_DIR, { recursive: true });
+
+  // Merge with existing state
+  const existing = await loadCookState();
+  const merged = { ...existing, ...state };
+
+  // Write state file
+  await writeFile(COOK_STATE_FILE, JSON.stringify(merged, null, 2), "utf8");
+}
+
+export async function clearCookState(): Promise<void> {
+  if (existsSync(COOK_STATE_FILE)) {
+    await writeFile(COOK_STATE_FILE, "{}", "utf8");
+  }
+}

--- a/turbo/apps/cli/src/lib/cook-state.ts
+++ b/turbo/apps/cli/src/lib/cook-state.ts
@@ -36,9 +36,3 @@ export async function saveCookState(state: CookState): Promise<void> {
   // Write state file
   await writeFile(COOK_STATE_FILE, JSON.stringify(merged, null, 2), "utf8");
 }
-
-export async function clearCookState(): Promise<void> {
-  if (existsSync(COOK_STATE_FILE)) {
-    await writeFile(COOK_STATE_FILE, "{}", "utf8");
-  }
-}


### PR DESCRIPTION
## Summary

- Add automatic session state management for `vm0 cook` teaching workflow
- Implement `vm0 cook logs` - view logs from last cook run using saved `lastRunId`
- Implement `vm0 cook continue <prompt>` - continue with last session using saved `lastSessionId`
- Implement `vm0 cook resume <prompt>` - resume from last checkpoint using saved `lastCheckpointId`
- Add tutorial-style output showing underlying commands being executed
- State persisted in `~/.vm0/cook.json`

## Changes

- **New**: `cook-state.ts` - State management module for persisting cook session data
- **Modified**: `cook.ts` - Refactored to Commander subcommands, added output parsing and state saving
- **New**: Unit tests for cook-state module and `parseRunIdsFromOutput()` function
- **New**: E2E tests for graceful failure handling

## Test plan

- [x] Unit tests pass (`pnpm vitest`)
- [x] Lint passes (`pnpm lint`)
- [x] Type check passes (`pnpm check-types`)
- [x] E2E tests added for graceful failures (no previous run state)
- [ ] Manual testing: Run `vm0 cook "prompt"` and verify state file created
- [ ] Manual testing: Run `vm0 cook logs` and verify it reads lastRunId
- [ ] Manual testing: Run `vm0 cook continue "prompt"` and verify it reads lastSessionId
- [ ] Manual testing: Run `vm0 cook resume "prompt"` and verify it reads lastCheckpointId

Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)