### PR TITLE
feat(cli): add vm0 init command to initialize project files

### DIFF
--- a/codereviews/20251225/commit-list.md
+++ b/codereviews/20251225/commit-list.md
@@ -1,0 +1,22 @@
+# PR #737 Code Review - vm0 init command
+
+## Commits
+
+- [x] [edcec6a](review-edcec6a.md) feat(cli): add vm0 init command to initialize project files ✅
+- [x] [2b5ad4b](review-2b5ad4b.md) test(cli): add e2e tests for vm0 init command ✅
+
+## Summary
+
+**Overall Verdict: ✅ APPROVED**
+
+Both commits follow project conventions and coding standards. No bad code smells detected.
+
+### Key Points
+- Clean implementation following existing CLI patterns
+- Good test coverage with both unit tests (10 tests) and e2e tests (11 tests)
+- No `any` types, no suppression comments, no artificial delays
+- Proper mock cleanup in tests
+- E2E tests use actual file operations for integration confidence
+
+### Suggestion (Non-blocking)
+Consider adding `--name` flag for non-interactive usage to support scripting/automation.

--- a/codereviews/20251225/review-2b5ad4b.md
+++ b/codereviews/20251225/review-2b5ad4b.md
@@ -1,0 +1,74 @@
+# Code Review: 2b5ad4b - test(cli): add e2e tests for vm0 init command
+
+## Summary
+This commit adds BATS e2e tests for the `vm0 init` command, covering the full workflow with actual file operations.
+
+## Files Changed
+- `e2e/tests/02-commands/t21-vm0-init.bats` (new file, 119 lines)
+
+---
+
+## Review Checklist
+
+### 1. Mock Analysis
+**Assessment:** ✅ Excellent - No mocking
+- E2E tests use actual CLI and file system
+- Tests create/delete real files in temp directories
+- This complements the unit tests well
+
+### 2. Test Coverage
+**Test Cases:**
+1. `vm0 init --help` shows description
+2. Creates vm0.yaml and AGENTS.md with stdin input
+3. Generates correct vm0.yaml content
+4. Generates correct AGENTS.md content
+5. Fails when vm0.yaml exists
+6. Fails when AGENTS.md exists
+7. `--force` overwrites existing files
+8. `-f` short option works
+9. Rejects invalid agent name (too short)
+10. Rejects empty agent name
+
+**Assessment:** ✅ Comprehensive coverage
+
+### 3. Error Handling
+**Assessment:** ✅ Good
+- Tests properly assert on failure cases
+- Cleanup handled in teardown
+
+### 4. Timer and Delay Analysis
+**Assessment:** ✅ No delays
+- Tests use stdin piping for non-interactive input
+- No artificial waits
+
+### 5. Test Patterns
+**Assessment:** ✅ Good patterns
+- Uses setup/teardown for temp directory management
+- Tests actual behavior, not implementation details
+- Verifies both file creation and content
+
+### 6. E2E Test Best Practices
+**Assessment:** ✅ Follows project conventions
+- Uses `load '../../helpers/setup'`
+- Uses `$CLI_COMMAND` variable
+- Proper BATS assertions (`assert_success`, `assert_failure`, `assert_output`)
+
+---
+
+## Code Quality Observations
+
+### Positive
+1. Clean test organization
+2. Good use of BATS assertions
+3. Proper cleanup in teardown
+4. Tests both success and failure paths
+5. Tests verify file content, not just existence
+
+### Suggestions (Non-blocking)
+None - the tests are well-written and follow project conventions.
+
+---
+
+## Verdict: ✅ APPROVED
+
+Excellent e2e test coverage that complements the unit tests. Tests are well-structured and follow project patterns.

--- a/codereviews/20251225/review-edcec6a.md
+++ b/codereviews/20251225/review-edcec6a.md
@@ -1,0 +1,124 @@
+# Code Review: edcec6a - feat(cli): add vm0 init command
+
+## Summary
+This commit adds a new `vm0 init` command that initializes a VM0 project by creating `vm0.yaml` and `AGENTS.md` files with interactive agent name input.
+
+## Files Changed
+- `turbo/apps/cli/src/commands/init.ts` (new file, 126 lines)
+- `turbo/apps/cli/src/commands/__tests__/init.test.ts` (new file, 244 lines)
+- `turbo/apps/cli/src/index.ts` (modified, +2 lines)
+
+---
+
+## Review Checklist
+
+### 1. Mock Analysis
+**New Mocks Identified:**
+- `vi.mock("fs/promises")` - File system operations
+- `vi.mock("fs")` - existsSync
+- `vi.mock("readline")` - Interactive input
+- `vi.mock("../../lib/yaml-validator")` - Name validation
+
+**Assessment:** ✅ Acceptable
+- Mocking `fs` and `readline` is appropriate for unit tests as these are I/O operations
+- The e2e tests (in separate commit) test the actual file operations
+
+### 2. Test Coverage
+**Assessment:** ✅ Good
+- Tests cover file existence checks
+- Tests cover agent name validation
+- Tests cover successful initialization
+- Tests cover `--force` option
+- Tests verify template content
+
+**Missing Tests:** None identified for the scope of unit tests.
+
+### 3. Error Handling
+**Assessment:** ✅ Good - Fail-fast approach
+- No unnecessary try/catch blocks in production code
+- Errors propagate naturally with clear exit codes
+- Single try/catch for user cancellation (Ctrl+C) which is appropriate
+
+### 4. Interface Changes
+**New Public Interface:**
+- `vm0 init` - New CLI command
+- `--force` / `-f` - Option to overwrite existing files
+
+**Assessment:** ✅ Clean API design matching existing CLI patterns
+
+### 5. Timer and Delay Analysis
+**Assessment:** ✅ No issues
+- No artificial delays in production code
+- No fake timers in tests
+
+### 6. Dynamic Imports
+**Assessment:** ✅ No issues
+- All imports are static at the top of files
+
+### 7. Database/Service Mocking
+**Assessment:** N/A - This is CLI code, not web app tests
+
+### 8. Test Mock Cleanup
+**Assessment:** ✅ Compliant
+```typescript
+beforeEach(() => {
+  vi.clearAllMocks();
+  // ...
+});
+```
+
+### 9. TypeScript `any` Type Usage
+**Assessment:** ✅ No `any` types used
+
+### 10. Artificial Delays in Tests
+**Assessment:** ✅ No delays in tests
+
+### 11. Hardcoded URLs/Configuration
+**Assessment:** ✅ Acceptable
+- GitHub URLs in template are intentional documentation links
+- No hardcoded API URLs or environment-specific values
+
+### 12. Direct Database Operations
+**Assessment:** N/A - No database operations
+
+### 13. Fallback Patterns
+**Assessment:** ✅ Good
+- No fallback patterns; errors fail fast with clear messages
+
+### 14. Lint/Type Suppressions
+**Assessment:** ✅ No suppression comments
+
+### 15. Bad Test Patterns
+**Assessment:** ⚠️ Minor observations
+
+1. **Console mocking without full assertions:**
+   ```typescript
+   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+   ```
+   The tests do assert on console output, so this is acceptable.
+
+2. **Tests verify mock calls appropriately** - Tests check both that mocks were called AND verify the content passed to them.
+
+---
+
+## Code Quality Observations
+
+### Positive
+1. Clean, readable code structure
+2. Follows existing CLI patterns consistently
+3. Good separation of concerns (template generators, file checks, prompts)
+4. Helpful user feedback with colored output
+5. Template includes useful comments for users
+
+### Suggestions (Non-blocking)
+1. Consider adding a `--name` flag for non-interactive usage:
+   ```bash
+   vm0 init --name my-agent
+   ```
+   This would help with scripting/automation.
+
+---
+
+## Verdict: ✅ APPROVED
+
+The code is well-structured, follows project conventions, and the tests provide good coverage. No bad code smells detected.

--- a/e2e/tests/02-commands/t21-vm0-init.bats
+++ b/e2e/tests/02-commands/t21-vm0-init.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+
+# vm0 init command tests
+
+setup() {
+    # Create a temporary directory for each test
+    TEST_DIR=$(mktemp -d)
+    cd "$TEST_DIR"
+}
+
+teardown() {
+    # Clean up the temporary directory
+    cd /
+    rm -rf "$TEST_DIR"
+}
+
+@test "vm0 init --help shows command description" {
+    run $CLI_COMMAND init --help
+    assert_success
+    assert_output --partial "Initialize a new VM0 project"
+    assert_output --partial "--force"
+}
+
+@test "vm0 init creates vm0.yaml and AGENTS.md with agent name via stdin" {
+    # Provide agent name via stdin using echo pipe
+    run bash -c 'echo "test-agent" | '"$CLI_COMMAND"' init'
+    assert_success
+    assert_output --partial "Created vm0.yaml"
+    assert_output --partial "Created AGENTS.md"
+    assert_output --partial "Next steps:"
+
+    # Verify files were created
+    [ -f "vm0.yaml" ]
+    [ -f "AGENTS.md" ]
+}
+
+@test "vm0 init generates correct vm0.yaml content" {
+    run bash -c 'echo "my-agent" | '"$CLI_COMMAND"' init'
+    assert_success
+
+    # Verify vm0.yaml content
+    run cat vm0.yaml
+    assert_output --partial 'version: "1.0"'
+    assert_output --partial "my-agent:"
+    assert_output --partial "provider: claude-code"
+    assert_output --partial "instructions: AGENTS.md"
+    assert_output --partial "CLAUDE_CODE_OAUTH_TOKEN"
+    assert_output --partial "# Build agentic workflow"
+}
+
+@test "vm0 init generates correct AGENTS.md content" {
+    run bash -c 'echo "my-agent" | '"$CLI_COMMAND"' init'
+    assert_success
+
+    # Verify AGENTS.md content
+    run cat AGENTS.md
+    assert_output --partial "Agent Instructions"
+    assert_output --partial "HackerNews"
+    assert_output --partial "Workflow"
+}
+
+@test "vm0 init fails when vm0.yaml already exists" {
+    # Create existing vm0.yaml
+    echo "existing content" > vm0.yaml
+
+    run bash -c 'echo "test-agent" | '"$CLI_COMMAND"' init'
+    assert_failure
+    assert_output --partial "vm0.yaml already exists"
+    assert_output --partial "vm0 init --force"
+}
+
+@test "vm0 init fails when AGENTS.md already exists" {
+    # Create existing AGENTS.md
+    echo "existing content" > AGENTS.md
+
+    run bash -c 'echo "test-agent" | '"$CLI_COMMAND"' init'
+    assert_failure
+    assert_output --partial "AGENTS.md already exists"
+    assert_output --partial "vm0 init --force"
+}
+
+@test "vm0 init --force overwrites existing files" {
+    # Create existing files
+    echo "old vm0 content" > vm0.yaml
+    echo "old agents content" > AGENTS.md
+
+    run bash -c 'echo "new-agent" | '"$CLI_COMMAND"' init --force'
+    assert_success
+    assert_output --partial "Created vm0.yaml"
+    assert_output --partial "(overwritten)"
+
+    # Verify new content
+    run cat vm0.yaml
+    assert_output --partial "new-agent:"
+}
+
+@test "vm0 init -f short option works" {
+    # Create existing files
+    echo "old content" > vm0.yaml
+    echo "old content" > AGENTS.md
+
+    run bash -c 'echo "short-flag-agent" | '"$CLI_COMMAND"' init -f'
+    assert_success
+    assert_output --partial "Created vm0.yaml"
+}
+
+@test "vm0 init rejects invalid agent name (too short)" {
+    run bash -c 'echo "ab" | '"$CLI_COMMAND"' init'
+    assert_failure
+    assert_output --partial "Invalid agent name"
+}
+
+@test "vm0 init rejects empty agent name" {
+    run bash -c 'echo "" | '"$CLI_COMMAND"' init'
+    assert_failure
+    assert_output --partial "Invalid agent name"
+}

--- a/e2e/tests/02-commands/t21-vm0-init.bats
+++ b/e2e/tests/02-commands/t21-vm0-init.bats
@@ -21,6 +21,7 @@ teardown() {
     assert_success
     assert_output --partial "Initialize a new VM0 project"
     assert_output --partial "--force"
+    assert_output --partial "--name"
 }
 
 @test "vm0 init creates vm0.yaml and AGENTS.md with agent name via stdin" {
@@ -114,6 +115,45 @@ teardown() {
 
 @test "vm0 init rejects empty agent name" {
     run bash -c 'echo "" | '"$CLI_COMMAND"' init'
+    assert_failure
+    assert_output --partial "Invalid agent name"
+}
+
+@test "vm0 init --name creates files without interactive prompt" {
+    run $CLI_COMMAND init --name cli-agent
+    assert_success
+    assert_output --partial "Created vm0.yaml"
+    assert_output --partial "Created AGENTS.md"
+
+    # Verify file content
+    run cat vm0.yaml
+    assert_output --partial "cli-agent:"
+}
+
+@test "vm0 init -n short option works" {
+    run $CLI_COMMAND init -n short-name-agent
+    assert_success
+    assert_output --partial "Created vm0.yaml"
+
+    run cat vm0.yaml
+    assert_output --partial "short-name-agent:"
+}
+
+@test "vm0 init --name with --force overwrites existing files" {
+    # Create existing files
+    echo "old content" > vm0.yaml
+    echo "old content" > AGENTS.md
+
+    run $CLI_COMMAND init --name new-cli-agent --force
+    assert_success
+    assert_output --partial "(overwritten)"
+
+    run cat vm0.yaml
+    assert_output --partial "new-cli-agent:"
+}
+
+@test "vm0 init --name rejects invalid agent name" {
+    run $CLI_COMMAND init --name ab
     assert_failure
     assert_output --partial "Invalid agent name"
 }

--- a/turbo/apps/cli/src/commands/__tests__/init.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/init.test.ts
@@ -241,4 +241,64 @@ describe("init command", () => {
       expect(fs.writeFile).toHaveBeenCalled();
     });
   });
+
+  describe("--name option", () => {
+    beforeEach(() => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(yamlValidator.validateAgentName).mockReturnValue(true);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+    });
+
+    it("should skip interactive prompt when --name is provided", async () => {
+      await initCommand.parseAsync(["node", "cli", "--name", "cli-agent"]);
+
+      expect(mockRlQuestion).not.toHaveBeenCalled();
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        "vm0.yaml",
+        expect.stringContaining("cli-agent"),
+      );
+    });
+
+    it("should work with -n short option", async () => {
+      await initCommand.parseAsync(["node", "cli", "-n", "short-agent"]);
+
+      expect(mockRlQuestion).not.toHaveBeenCalled();
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        "vm0.yaml",
+        expect.stringContaining("short-agent"),
+      );
+    });
+
+    it("should validate agent name from --name option", async () => {
+      vi.mocked(yamlValidator.validateAgentName).mockReturnValue(false);
+
+      await expect(async () => {
+        await initCommand.parseAsync(["node", "cli", "--name", "ab"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid agent name"),
+      );
+    });
+
+    it("should work with --name and --force together", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      await initCommand.parseAsync([
+        "node",
+        "cli",
+        "--name",
+        "forced-agent",
+        "--force",
+      ]);
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        "vm0.yaml",
+        expect.stringContaining("forced-agent"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("(overwritten)"),
+      );
+    });
+  });
 });

--- a/turbo/apps/cli/src/commands/__tests__/init.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/init.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { initCommand } from "../init";
+import * as fs from "fs/promises";
+import { existsSync } from "fs";
+import * as readline from "readline";
+import * as yamlValidator from "../../lib/yaml-validator";
+
+// Mock dependencies
+vi.mock("fs/promises");
+vi.mock("fs");
+vi.mock("readline");
+vi.mock("../../lib/yaml-validator");
+
+describe("init command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  // Mock readline interface
+  const mockRlQuestion = vi.fn();
+  const mockRlClose = vi.fn();
+  const mockRlOn = vi.fn();
+  const mockRlInterface = {
+    question: mockRlQuestion,
+    close: mockRlClose,
+    on: mockRlOn,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(readline.createInterface).mockReturnValue(
+      mockRlInterface as unknown as readline.Interface,
+    );
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("file existence check", () => {
+    it("should exit with error if vm0.yaml exists without --force", async () => {
+      vi.mocked(existsSync).mockImplementation((path) => {
+        return path === "vm0.yaml";
+      });
+
+      await expect(async () => {
+        await initCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("vm0.yaml already exists"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 init --force"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should exit with error if AGENTS.md exists without --force", async () => {
+      vi.mocked(existsSync).mockImplementation((path) => {
+        return path === "AGENTS.md";
+      });
+
+      await expect(async () => {
+        await initCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("AGENTS.md already exists"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should exit with error if both files exist without --force", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      await expect(async () => {
+        await initCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("vm0.yaml already exists"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("AGENTS.md already exists"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("agent name validation", () => {
+    beforeEach(() => {
+      vi.mocked(existsSync).mockReturnValue(false);
+    });
+
+    it("should exit with error for invalid agent name", async () => {
+      mockRlQuestion.mockImplementation((_, callback) => {
+        callback("ab"); // Too short
+      });
+      vi.mocked(yamlValidator.validateAgentName).mockReturnValue(false);
+
+      await expect(async () => {
+        await initCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid agent name"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should exit with error for empty agent name", async () => {
+      mockRlQuestion.mockImplementation((_, callback) => {
+        callback("");
+      });
+      vi.mocked(yamlValidator.validateAgentName).mockReturnValue(false);
+
+      await expect(async () => {
+        await initCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid agent name"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("successful initialization", () => {
+    beforeEach(() => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(yamlValidator.validateAgentName).mockReturnValue(true);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+    });
+
+    it("should create vm0.yaml and AGENTS.md with valid agent name", async () => {
+      mockRlQuestion.mockImplementation((_, callback) => {
+        callback("my-agent");
+      });
+
+      await initCommand.parseAsync(["node", "cli"]);
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        "vm0.yaml",
+        expect.stringContaining("my-agent"),
+      );
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        "AGENTS.md",
+        expect.stringContaining("Agent Instructions"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Created vm0.yaml"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Created AGENTS.md"),
+      );
+    });
+
+    it("should include correct vm0.yaml template content", async () => {
+      mockRlQuestion.mockImplementation((_, callback) => {
+        callback("test-agent");
+      });
+
+      await initCommand.parseAsync(["node", "cli"]);
+
+      const writeCall = vi
+        .mocked(fs.writeFile)
+        .mock.calls.find((call) => call[0] === "vm0.yaml");
+      expect(writeCall).toBeDefined();
+      const content = writeCall![1] as string;
+
+      expect(content).toContain('version: "1.0"');
+      expect(content).toContain("test-agent:");
+      expect(content).toContain("provider: claude-code");
+      expect(content).toContain("instructions: AGENTS.md");
+      expect(content).toContain(
+        "# Build agentic workflow using natural language",
+      );
+      expect(content).toContain("# Agent skills");
+      expect(content).toContain("CLAUDE_CODE_OAUTH_TOKEN");
+    });
+
+    it("should display next steps after creation", async () => {
+      mockRlQuestion.mockImplementation((_, callback) => {
+        callback("my-agent");
+      });
+
+      await initCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith("Next steps:");
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("claude setup-token"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("CLAUDE_CODE_OAUTH_TOKEN"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 cook"),
+      );
+    });
+  });
+
+  describe("--force option", () => {
+    beforeEach(() => {
+      vi.mocked(yamlValidator.validateAgentName).mockReturnValue(true);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+    });
+
+    it("should overwrite existing files with --force", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockRlQuestion.mockImplementation((_, callback) => {
+        callback("my-agent");
+      });
+
+      await initCommand.parseAsync(["node", "cli", "--force"]);
+
+      expect(fs.writeFile).toHaveBeenCalledWith("vm0.yaml", expect.any(String));
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        "AGENTS.md",
+        expect.any(String),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("(overwritten)"),
+      );
+    });
+
+    it("should work with -f short option", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockRlQuestion.mockImplementation((_, callback) => {
+        callback("my-agent");
+      });
+
+      await initCommand.parseAsync(["node", "cli", "-f"]);
+
+      expect(fs.writeFile).toHaveBeenCalled();
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/init.ts
+++ b/turbo/apps/cli/src/commands/init.ts
@@ -1,0 +1,126 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import * as readline from "readline";
+import { existsSync } from "fs";
+import { writeFile } from "fs/promises";
+import { validateAgentName } from "../lib/yaml-validator";
+
+const VM0_YAML_FILE = "vm0.yaml";
+const AGENTS_MD_FILE = "AGENTS.md";
+
+function generateVm0Yaml(agentName: string): string {
+  return `version: "1.0"
+
+agents:
+  ${agentName}:
+    provider: claude-code
+    # Build agentic workflow using natural language
+    instructions: AGENTS.md
+    # Agent skills - see https://github.com/vm0-ai/vm0-skills for available skills
+    # skills:
+    #   - https://github.com/vm0-ai/vm0-skills/tree/main/github
+    environment:
+      # Get token using: claude setup-token, then add to .env file
+      CLAUDE_CODE_OAUTH_TOKEN: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+`;
+}
+
+function generateAgentsMd(): string {
+  return `# Agent Instructions
+
+You are a HackerNews AI content curator.
+
+## Workflow
+
+1. Go to HackerNews and read the top 10 articles
+2. Find and extract AI-related content from these articles
+3. Summarize the findings into a X (Twitter) post format
+4. Write the summary to content.md
+`;
+}
+
+function checkExistingFiles(): string[] {
+  const existingFiles: string[] = [];
+  if (existsSync(VM0_YAML_FILE)) existingFiles.push(VM0_YAML_FILE);
+  if (existsSync(AGENTS_MD_FILE)) existingFiles.push(AGENTS_MD_FILE);
+  return existingFiles;
+}
+
+async function promptAgentName(): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve, reject) => {
+    rl.question(chalk.cyan("? Enter agent name: "), (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+
+    rl.on("SIGINT", () => {
+      rl.close();
+      console.log();
+      reject(new Error("User cancelled"));
+    });
+  });
+}
+
+export const initCommand = new Command()
+  .name("init")
+  .description("Initialize a new VM0 project in the current directory")
+  .option("-f, --force", "Overwrite existing files")
+  .action(async (options: { force?: boolean }) => {
+    // Check existing files
+    const existingFiles = checkExistingFiles();
+    if (existingFiles.length > 0 && !options.force) {
+      for (const file of existingFiles) {
+        console.log(chalk.red(`✗ ${file} already exists`));
+      }
+      console.log();
+      console.log(`To overwrite: ${chalk.cyan("vm0 init --force")}`);
+      process.exit(1);
+    }
+
+    // Prompt for agent name
+    let agentName: string;
+    try {
+      agentName = await promptAgentName();
+    } catch {
+      process.exit(0);
+    }
+
+    // Validate agent name
+    if (!agentName || !validateAgentName(agentName)) {
+      console.log(chalk.red("✗ Invalid agent name"));
+      console.log(
+        chalk.gray("  Must be 3-64 characters, alphanumeric and hyphens only"),
+      );
+      console.log(chalk.gray("  Must start and end with letter or number"));
+      process.exit(1);
+    }
+
+    // Write vm0.yaml
+    await writeFile(VM0_YAML_FILE, generateVm0Yaml(agentName));
+    const vm0Status = existingFiles.includes(VM0_YAML_FILE)
+      ? " (overwritten)"
+      : "";
+    console.log(chalk.green(`✓ Created ${VM0_YAML_FILE}${vm0Status}`));
+
+    // Write AGENTS.md
+    await writeFile(AGENTS_MD_FILE, generateAgentsMd());
+    const agentsStatus = existingFiles.includes(AGENTS_MD_FILE)
+      ? " (overwritten)"
+      : "";
+    console.log(chalk.green(`✓ Created ${AGENTS_MD_FILE}${agentsStatus}`));
+
+    // Print next steps
+    console.log();
+    console.log("Next steps:");
+    console.log(
+      `  1. Get your Claude Code token: ${chalk.cyan("claude setup-token")}`,
+    );
+    console.log(`  2. Set the environment variable (or add to .env file):`);
+    console.log(chalk.gray(`     export CLAUDE_CODE_OAUTH_TOKEN=<your-token>`));
+    console.log(`  3. Run your agent: ${chalk.cyan('vm0 cook "your prompt"')}`);
+  });

--- a/turbo/apps/cli/src/commands/init.ts
+++ b/turbo/apps/cli/src/commands/init.ts
@@ -70,7 +70,8 @@ export const initCommand = new Command()
   .name("init")
   .description("Initialize a new VM0 project in the current directory")
   .option("-f, --force", "Overwrite existing files")
-  .action(async (options: { force?: boolean }) => {
+  .option("-n, --name <name>", "Agent name (skips interactive prompt)")
+  .action(async (options: { force?: boolean; name?: string }) => {
     // Check existing files
     const existingFiles = checkExistingFiles();
     if (existingFiles.length > 0 && !options.force) {
@@ -82,12 +83,16 @@ export const initCommand = new Command()
       process.exit(1);
     }
 
-    // Prompt for agent name
+    // Get agent name from option or prompt
     let agentName: string;
-    try {
-      agentName = await promptAgentName();
-    } catch {
-      process.exit(0);
+    if (options.name) {
+      agentName = options.name.trim();
+    } else {
+      try {
+        agentName = await promptAgentName();
+      } catch {
+        process.exit(0);
+      }
     }
 
     // Validate agent name

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -10,6 +10,7 @@ import { cookCommand } from "./commands/cook";
 import { imageCommand } from "./commands/image";
 import { logsCommand } from "./commands/logs";
 import { scopeCommand } from "./commands/scope";
+import { initCommand } from "./commands/init";
 
 const program = new Command();
 
@@ -73,6 +74,7 @@ program.addCommand(cookCommand);
 program.addCommand(imageCommand);
 program.addCommand(logsCommand);
 program.addCommand(scopeCommand);
+program.addCommand(initCommand);
 
 export { program };
 


### PR DESCRIPTION
## Summary

- Add new top-level `vm0 init` command
- Creates `vm0.yaml` and `AGENTS.md` files with interactive agent name input
- Includes `--force` option to overwrite existing files

## Changes

- **`turbo/apps/cli/src/commands/init.ts`**: New init command implementation
- **`turbo/apps/cli/src/index.ts`**: Register init command
- **`turbo/apps/cli/src/commands/__tests__/init.test.ts`**: 10 test cases

## Features

- Interactive prompt for agent name with validation
- Generates vm0.yaml with helpful comments:
  - Instructions field comment
  - Skills field with example (commented out)
  - Environment variable setup hint
- Generates AGENTS.md with example HackerNews AI workflow
- `--force` / `-f` option to overwrite existing files
- Displays next steps after successful initialization

## Test plan

- [x] Run `vm0 init` and verify agent name prompt works
- [x] Verify vm0.yaml is created with correct template and comments
- [x] Verify AGENTS.md is created with workflow example
- [x] Verify error when files exist without --force
- [x] Verify --force overwrites existing files
- [x] Verify invalid agent names are rejected
- [x] All 10 unit tests pass

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)