### PR TITLE
feat(cli): forward vm0 logs options in vm0 cook logs

### DIFF
--- a/e2e/tests/02-commands/t14-vm0-cook-continue.bats
+++ b/e2e/tests/02-commands/t14-vm0-cook-continue.bats
@@ -100,3 +100,14 @@ teardown() {
     assert_output --partial "Continue from the last session"
     assert_output --partial "Resume from the last checkpoint"
 }
+
+@test "cook logs supports vm0 logs options" {
+    run $CLI_COMMAND cook logs --help
+    assert_success
+    assert_output --partial "--agent"
+    assert_output --partial "--system"
+    assert_output --partial "--metrics"
+    assert_output --partial "--network"
+    assert_output --partial "--since"
+    assert_output --partial "--limit"
+}


### PR DESCRIPTION
## Summary

- Forward all `vm0 logs` options to `vm0 cook logs` subcommand
- Supports `--agent`, `--system`, `--metrics`, `--network` for log type selection
- Supports `--since` for time filtering
- Supports `--limit` for entry count

## Example

```bash
# Now works:
vm0 cook logs --system
vm0 cook logs --metrics --limit 10
vm0 cook logs --since 5m
```

## Test plan

- [x] E2E test added to verify options are shown in help
- [x] Unit tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)