### PR TITLE
fix(cli): use ppid to isolate cook state per terminal

### DIFF
--- a/turbo/apps/cli/src/lib/__tests__/cook-state.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/cook-state.test.ts
@@ -28,13 +28,19 @@ describe("cook-state", () => {
       expect(state).toEqual({});
     });
 
-    it("returns parsed state from file", async () => {
+    it("returns state for current PPID", async () => {
+      const mockPpid = String(process.ppid);
       vi.mocked(existsSync).mockReturnValue(true);
       vi.mocked(fs.readFile).mockResolvedValue(
         JSON.stringify({
-          lastRunId: "run-123",
-          lastSessionId: "session-456",
-          lastCheckpointId: "checkpoint-789",
+          ppid: {
+            [mockPpid]: {
+              lastRunId: "run-123",
+              lastSessionId: "session-456",
+              lastCheckpointId: "checkpoint-789",
+              lastActiveAt: Date.now(),
+            },
+          },
         }),
       );
 
@@ -45,6 +51,43 @@ describe("cook-state", () => {
         lastRunId: "run-123",
         lastSessionId: "session-456",
         lastCheckpointId: "checkpoint-789",
+      });
+    });
+
+    it("returns empty object for different PPID", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          ppid: {
+            "99999": {
+              lastRunId: "run-123",
+              lastActiveAt: Date.now(),
+            },
+          },
+        }),
+      );
+
+      const { loadCookState } = await import("../cook-state");
+      const state = await loadCookState();
+
+      expect(state).toEqual({});
+    });
+
+    it("migrates old format to current PPID", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          lastRunId: "old-run",
+          lastSessionId: "old-session",
+        }),
+      );
+
+      const { loadCookState } = await import("../cook-state");
+      const state = await loadCookState();
+
+      expect(state).toEqual({
+        lastRunId: "old-run",
+        lastSessionId: "old-session",
       });
     });
 
@@ -73,12 +116,43 @@ describe("cook-state", () => {
       });
     });
 
-    it("merges with existing state", async () => {
+    it("saves state under current PPID with timestamp", async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue();
+
+      const { saveCookState } = await import("../cook-state");
+      await saveCookState({ lastRunId: "new-run" });
+
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0]!;
+      const written = JSON.parse(writeCall[1] as string) as {
+        ppid: Record<string, { lastRunId: string; lastActiveAt: number }>;
+      };
+      const ppidEntry = written.ppid[String(process.ppid)];
+
+      expect(ppidEntry).toMatchObject({
+        lastRunId: "new-run",
+      });
+      expect(ppidEntry?.lastActiveAt).toBeDefined();
+    });
+
+    it("cleans up entries older than 48 hours", async () => {
+      const now = Date.now();
+      const oldTimestamp = now - 49 * 60 * 60 * 1000; // 49 hours ago
+
       vi.mocked(existsSync).mockReturnValue(true);
       vi.mocked(fs.readFile).mockResolvedValue(
         JSON.stringify({
-          lastRunId: "old-run",
-          lastSessionId: "old-session",
+          ppid: {
+            "old-ppid": {
+              lastRunId: "old-run",
+              lastActiveAt: oldTimestamp,
+            },
+            "recent-ppid": {
+              lastRunId: "recent-run",
+              lastActiveAt: now - 1000, // 1 second ago
+            },
+          },
         }),
       );
       vi.mocked(fs.mkdir).mockResolvedValue(undefined);
@@ -87,21 +161,47 @@ describe("cook-state", () => {
       const { saveCookState } = await import("../cook-state");
       await saveCookState({ lastRunId: "new-run" });
 
-      expect(fs.writeFile).toHaveBeenCalledWith(
-        "/home/testuser/.vm0/cook.json",
-        JSON.stringify(
-          {
-            lastRunId: "new-run",
-            lastSessionId: "old-session",
-          },
-          null,
-          2,
-        ),
-        "utf8",
-      );
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0]!;
+      const written = JSON.parse(writeCall[1] as string) as {
+        ppid: Record<string, unknown>;
+      };
+
+      expect(written.ppid["old-ppid"]).toBeUndefined();
+      expect(written.ppid["recent-ppid"]).toBeDefined();
     });
 
-    it("overwrites existing keys", async () => {
+    it("merges with existing entry for same PPID", async () => {
+      const mockPpid = String(process.ppid);
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          ppid: {
+            [mockPpid]: {
+              lastRunId: "old-run",
+              lastSessionId: "old-session",
+              lastActiveAt: Date.now() - 1000,
+            },
+          },
+        }),
+      );
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue();
+
+      const { saveCookState } = await import("../cook-state");
+      await saveCookState({ lastRunId: "new-run" });
+
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0]!;
+      const written = JSON.parse(writeCall[1] as string) as {
+        ppid: Record<string, { lastRunId: string; lastSessionId: string }>;
+      };
+
+      expect(written.ppid[mockPpid]).toMatchObject({
+        lastRunId: "new-run",
+        lastSessionId: "old-session", // preserved from existing
+      });
+    });
+
+    it("migrates old format on save", async () => {
       vi.mocked(existsSync).mockReturnValue(true);
       vi.mocked(fs.readFile).mockResolvedValue(
         JSON.stringify({
@@ -116,23 +216,27 @@ describe("cook-state", () => {
       const { saveCookState } = await import("../cook-state");
       await saveCookState({
         lastRunId: "new-run",
-        lastSessionId: "new-session",
-        lastCheckpointId: "new-checkpoint",
       });
 
-      expect(fs.writeFile).toHaveBeenCalledWith(
-        "/home/testuser/.vm0/cook.json",
-        JSON.stringify(
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0]!;
+      const written = JSON.parse(writeCall[1] as string) as {
+        ppid: Record<
+          string,
           {
-            lastRunId: "new-run",
-            lastSessionId: "new-session",
-            lastCheckpointId: "new-checkpoint",
-          },
-          null,
-          2,
-        ),
-        "utf8",
-      );
+            lastRunId: string;
+            lastSessionId: string;
+            lastCheckpointId: string;
+          }
+        >;
+      };
+
+      // Should have ppid structure now
+      expect(written.ppid).toBeDefined();
+      expect(written.ppid[String(process.ppid)]).toMatchObject({
+        lastRunId: "new-run",
+        lastSessionId: "old-session",
+        lastCheckpointId: "old-checkpoint",
+      });
     });
   });
 });

--- a/turbo/apps/cli/src/lib/cook-state.ts
+++ b/turbo/apps/cli/src/lib/cook-state.ts
@@ -5,34 +5,101 @@ import { existsSync } from "fs";
 
 const CONFIG_DIR = join(homedir(), ".vm0");
 const COOK_STATE_FILE = join(CONFIG_DIR, "cook.json");
+const STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000; // 48 hours
 
+// Public API interface (unchanged for backward compatibility)
 export interface CookState {
   lastRunId?: string;
   lastSessionId?: string;
   lastCheckpointId?: string;
 }
 
-export async function loadCookState(): Promise<CookState> {
+// Internal storage structure
+interface CookStateEntry {
+  lastRunId?: string;
+  lastSessionId?: string;
+  lastCheckpointId?: string;
+  lastActiveAt: number;
+}
+
+interface CookStateFile {
+  ppid: Record<string, CookStateEntry>;
+}
+
+/**
+ * Load cook state file with automatic migration from old format
+ */
+async function loadCookStateFile(): Promise<CookStateFile> {
   if (!existsSync(COOK_STATE_FILE)) {
-    return {};
+    return { ppid: {} };
   }
+
   try {
     const content = await readFile(COOK_STATE_FILE, "utf8");
-    return JSON.parse(content) as CookState;
+    const data = JSON.parse(content) as Record<string, unknown>;
+
+    // Detect old format (no ppid field)
+    if (!data.ppid) {
+      // Migrate old data to current PPID
+      const oldState = data as CookState;
+      return {
+        ppid: {
+          [String(process.ppid)]: {
+            lastRunId: oldState.lastRunId,
+            lastSessionId: oldState.lastSessionId,
+            lastCheckpointId: oldState.lastCheckpointId,
+            lastActiveAt: Date.now(),
+          },
+        },
+      };
+    }
+
+    return data as unknown as CookStateFile;
   } catch {
     // If file is corrupted, return empty state
-    return {};
+    return { ppid: {} };
   }
+}
+
+export async function loadCookState(): Promise<CookState> {
+  const file = await loadCookStateFile();
+  const ppid = String(process.ppid);
+  const entry = file.ppid[ppid];
+
+  if (!entry) return {};
+
+  return {
+    lastRunId: entry.lastRunId,
+    lastSessionId: entry.lastSessionId,
+    lastCheckpointId: entry.lastCheckpointId,
+  };
 }
 
 export async function saveCookState(state: CookState): Promise<void> {
   // Ensure config directory exists
   await mkdir(CONFIG_DIR, { recursive: true });
 
-  // Merge with existing state
-  const existing = await loadCookState();
-  const merged = { ...existing, ...state };
+  const file = await loadCookStateFile();
+  const ppid = String(process.ppid);
+  const now = Date.now();
+
+  // Clean up stale entries (older than 48 hours)
+  for (const key of Object.keys(file.ppid)) {
+    const entry = file.ppid[key];
+    if (entry && now - entry.lastActiveAt > STALE_THRESHOLD_MS) {
+      delete file.ppid[key];
+    }
+  }
+
+  // Merge with existing entry for this PPID
+  const existing = file.ppid[ppid];
+  file.ppid[ppid] = {
+    lastRunId: state.lastRunId ?? existing?.lastRunId,
+    lastSessionId: state.lastSessionId ?? existing?.lastSessionId,
+    lastCheckpointId: state.lastCheckpointId ?? existing?.lastCheckpointId,
+    lastActiveAt: now,
+  };
 
   // Write state file
-  await writeFile(COOK_STATE_FILE, JSON.stringify(merged, null, 2), "utf8");
+  await writeFile(COOK_STATE_FILE, JSON.stringify(file, null, 2), "utf8");
 }


### PR DESCRIPTION
## Summary

- Fix race condition in cook state management when running `vm0 cook` in multiple terminals
- Use `process.ppid` (parent process ID) as key to isolate each terminal's state
- Auto-cleanup entries older than 48 hours to prevent file growth
- Backward compatible: automatically migrates old format

## Changes

- Store state under `ppid` key instead of flat structure
- Add `lastActiveAt` timestamp for cleanup tracking
- Clean up stale entries (>48 hours) on each save operation

## Test plan

- [x] Unit tests updated and passing (10 tests)
- [x] Lint passing
- [x] Type check passing
- [x] Backward compatibility: old format auto-migrates

Closes #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)