### PR TITLE
refactor(cli): simplify color scheme

### DIFF
--- a/e2e/tests/02-commands/t20-vm0-image-versioning.bats
+++ b/e2e/tests/02-commands/t20-vm0-image-versioning.bats
@@ -46,7 +46,7 @@ teardown() {
 # Version Listing
 # ============================================
 
-@test "vm0 image list shows versions with (latest) marker" {
+@test "vm0 image list shows versions with latest marker" {
     # First build an image to ensure we have at least one
     run $CLI_COMMAND image build --file "$TEST_DOCKERFILE" --name "$TEST_IMAGE_NAME" --delete-existing
     assert_success
@@ -56,8 +56,8 @@ teardown() {
     assert_success
     # Should show the image name
     assert_output --partial "$TEST_IMAGE_NAME"
-    # Ready images should have (latest) marker
-    assert_output --partial "(latest)"
+    # Ready images should have latest marker (cyan colored, no parentheses)
+    assert_output --partial "latest"
 }
 
 @test "vm0 image versions lists versions for specific image" {
@@ -70,8 +70,8 @@ teardown() {
     assert_success
     # Should show the image name
     assert_output --partial "$TEST_IMAGE_NAME"
-    # Should show (latest) marker
-    assert_output --partial "(latest)"
+    # Should show latest marker (cyan colored, no parentheses)
+    assert_output --partial "latest"
     # Should show usage hints
     assert_output --partial "pin to specific version"
 }

--- a/turbo/apps/cli/src/commands/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/run.test.ts
@@ -1169,7 +1169,7 @@ describe("run command", () => {
       // Errors bubble up to main command handler which displays generic "Run failed" message
       expect(mockConsoleError).toHaveBeenCalledWith(chalk.red("✗ Run failed"));
       expect(mockConsoleError).toHaveBeenCalledWith(
-        chalk.gray("  Network error"),
+        chalk.dim("  Network error"),
       );
     });
 

--- a/turbo/apps/cli/src/commands/artifact/init.ts
+++ b/turbo/apps/cli/src/commands/artifact/init.ts
@@ -31,13 +31,13 @@ export const initCommand = new Command()
             ),
           );
           console.log(
-            chalk.gray(
+            chalk.dim(
               "  To change type, delete .vm0/storage.yaml and reinitialize",
             ),
           );
         }
         console.log(
-          chalk.gray(`Config file: ${path.join(cwd, ".vm0", "storage.yaml")}`),
+          chalk.dim(`Config file: ${path.join(cwd, ".vm0", "storage.yaml")}`),
         );
         return;
       }
@@ -49,12 +49,12 @@ export const initCommand = new Command()
       if (!isValidStorageName(artifactName)) {
         console.error(chalk.red(`✗ Invalid artifact name: "${dirName}"`));
         console.error(
-          chalk.gray(
+          chalk.dim(
             "  Artifact names must be 3-64 characters, lowercase alphanumeric with hyphens",
           ),
         );
         console.error(
-          chalk.gray("  Example: my-project, user-workspace, code-artifact"),
+          chalk.dim("  Example: my-project, user-workspace, code-artifact"),
         );
         process.exit(1);
       }
@@ -64,14 +64,14 @@ export const initCommand = new Command()
 
       console.log(chalk.green(`✓ Initialized artifact: ${artifactName}`));
       console.log(
-        chalk.gray(
+        chalk.dim(
           `✓ Config saved to ${path.join(cwd, ".vm0", "storage.yaml")}`,
         ),
       );
     } catch (error) {
       console.error(chalk.red("✗ Failed to initialize artifact"));
       if (error instanceof Error) {
-        console.error(chalk.gray(`  ${error.message}`));
+        console.error(chalk.dim(`  ${error.message}`));
       }
       process.exit(1);
     }

--- a/turbo/apps/cli/src/commands/artifact/pull.ts
+++ b/turbo/apps/cli/src/commands/artifact/pull.ts
@@ -43,7 +43,7 @@ export const pullCommand = new Command()
       const config = await readStorageConfig(cwd);
       if (!config) {
         console.error(chalk.red("✗ No artifact initialized in this directory"));
-        console.error(chalk.gray("  Run: vm0 artifact init"));
+        console.error(chalk.dim("  Run: vm0 artifact init"));
         process.exit(1);
       }
 
@@ -53,22 +53,18 @@ export const pullCommand = new Command()
             `✗ This directory is initialized as a volume, not an artifact`,
           ),
         );
-        console.error(chalk.gray("  Use: vm0 volume pull"));
+        console.error(chalk.dim("  Use: vm0 volume pull"));
         process.exit(1);
       }
 
       if (versionId) {
-        console.log(
-          chalk.cyan(
-            `Pulling artifact: ${config.name} (version: ${versionId})`,
-          ),
-        );
+        console.log(`Pulling artifact: ${config.name} (version: ${versionId})`);
       } else {
-        console.log(chalk.cyan(`Pulling artifact: ${config.name}`));
+        console.log(`Pulling artifact: ${config.name}`);
       }
 
       // Get download URL from API
-      console.log(chalk.gray("Getting download URL..."));
+      console.log(chalk.dim("Getting download URL..."));
 
       let url = `/api/storages/download?name=${encodeURIComponent(config.name)}&type=artifact`;
       if (versionId) {
@@ -81,12 +77,12 @@ export const pullCommand = new Command()
         if (response.status === 404) {
           console.error(chalk.red(`✗ Artifact "${config.name}" not found`));
           console.error(
-            chalk.gray(
+            chalk.dim(
               "  Make sure the artifact name is correct in .vm0/storage.yaml",
             ),
           );
           console.error(
-            chalk.gray("  Or push the artifact first with: vm0 artifact push"),
+            chalk.dim("  Or push the artifact first with: vm0 artifact push"),
           );
         } else {
           const error = (await response.json()) as ApiError;
@@ -108,7 +104,7 @@ export const pullCommand = new Command()
       }
 
       // Download directly from S3
-      console.log(chalk.gray("Downloading from S3..."));
+      console.log(chalk.dim("Downloading from S3..."));
       const s3Response = await fetch(downloadInfo.url);
 
       if (!s3Response.ok) {
@@ -127,7 +123,7 @@ export const pullCommand = new Command()
       await fs.promises.writeFile(tarPath, tarBuffer);
 
       // Get remote files list for sync
-      console.log(chalk.gray("Syncing local files..."));
+      console.log(chalk.dim("Syncing local files..."));
       const remoteFiles = await listTarFiles(tarPath);
       const remoteFilesSet = new Set(
         remoteFiles.map((f) => f.replace(/\\/g, "/")),
@@ -142,7 +138,7 @@ export const pullCommand = new Command()
       }
 
       // Extract tar.gz
-      console.log(chalk.gray("Extracting files..."));
+      console.log(chalk.dim("Extracting files..."));
       await tar.extract({
         file: tarPath,
         cwd: cwd,
@@ -157,7 +153,7 @@ export const pullCommand = new Command()
     } catch (error) {
       console.error(chalk.red("✗ Pull failed"));
       if (error instanceof Error) {
-        console.error(chalk.gray(`  ${error.message}`));
+        console.error(chalk.dim(`  ${error.message}`));
       }
       process.exit(1);
     }

--- a/turbo/apps/cli/src/commands/artifact/push.ts
+++ b/turbo/apps/cli/src/commands/artifact/push.ts
@@ -29,7 +29,7 @@ export const pushCommand = new Command()
       const config = await readStorageConfig(cwd);
       if (!config) {
         console.error(chalk.red("✗ No artifact initialized in this directory"));
-        console.error(chalk.gray("  Run: vm0 artifact init"));
+        console.error(chalk.dim("  Run: vm0 artifact init"));
         process.exit(1);
       }
 
@@ -39,16 +39,16 @@ export const pushCommand = new Command()
             `✗ This directory is initialized as a volume, not an artifact`,
           ),
         );
-        console.error(chalk.gray("  Use: vm0 volume push"));
+        console.error(chalk.dim("  Use: vm0 volume push"));
         process.exit(1);
       }
 
-      console.log(chalk.cyan(`Pushing artifact: ${config.name}`));
+      console.log(`Pushing artifact: ${config.name}`);
 
       // Perform direct S3 upload
       const result = await directUpload(config.name, "artifact", cwd, {
         onProgress: (message) => {
-          console.log(chalk.gray(message));
+          console.log(chalk.dim(message));
         },
         force: options.force,
       });
@@ -63,13 +63,13 @@ export const pushCommand = new Command()
       } else {
         console.log(chalk.green("✓ Upload complete"));
       }
-      console.log(chalk.gray(`  Version: ${shortVersion}`));
-      console.log(chalk.gray(`  Files: ${result.fileCount.toLocaleString()}`));
-      console.log(chalk.gray(`  Size: ${formatBytes(result.size)}`));
+      console.log(chalk.dim(`  Version: ${shortVersion}`));
+      console.log(chalk.dim(`  Files: ${result.fileCount.toLocaleString()}`));
+      console.log(chalk.dim(`  Size: ${formatBytes(result.size)}`));
     } catch (error) {
       console.error(chalk.red("✗ Push failed"));
       if (error instanceof Error) {
-        console.error(chalk.gray(`  ${error.message}`));
+        console.error(chalk.dim(`  ${error.message}`));
       }
       process.exit(1);
     }

--- a/turbo/apps/cli/src/commands/artifact/status.ts
+++ b/turbo/apps/cli/src/commands/artifact/status.ts
@@ -36,7 +36,7 @@ export const statusCommand = new Command()
       const config = await readStorageConfig(cwd);
       if (!config) {
         console.error(chalk.red("✗ No artifact initialized in this directory"));
-        console.error(chalk.gray("  Run: vm0 artifact init"));
+        console.error(chalk.dim("  Run: vm0 artifact init"));
         process.exit(1);
       }
 
@@ -46,12 +46,12 @@ export const statusCommand = new Command()
             "✗ This directory is initialized as a volume, not an artifact",
           ),
         );
-        console.error(chalk.gray("  Use: vm0 volume status"));
+        console.error(chalk.dim("  Use: vm0 volume status"));
         process.exit(1);
       }
 
       // Start message
-      console.log(chalk.cyan(`Checking artifact: ${config.name}`));
+      console.log(`Checking artifact: ${config.name}`);
 
       // Call API
       const url = `/api/storages/download?name=${encodeURIComponent(config.name)}&type=artifact`;
@@ -60,7 +60,7 @@ export const statusCommand = new Command()
       if (!response.ok) {
         if (response.status === 404) {
           console.error(chalk.red("✗ Not found on remote"));
-          console.error(chalk.gray("  Run: vm0 artifact push"));
+          console.error(chalk.dim("  Run: vm0 artifact push"));
         } else {
           const error = (await response.json()) as ApiError;
           throw new Error(error.error?.message || "Status check failed");
@@ -73,17 +73,17 @@ export const statusCommand = new Command()
 
       if (info.empty) {
         console.log(chalk.green("✓ Found (empty)"));
-        console.log(chalk.gray(`  Version: ${shortVersion}`));
+        console.log(chalk.dim(`  Version: ${shortVersion}`));
       } else {
         console.log(chalk.green("✓ Found"));
-        console.log(chalk.gray(`  Version: ${shortVersion}`));
-        console.log(chalk.gray(`  Files: ${info.fileCount.toLocaleString()}`));
-        console.log(chalk.gray(`  Size: ${formatBytes(info.size)}`));
+        console.log(chalk.dim(`  Version: ${shortVersion}`));
+        console.log(chalk.dim(`  Files: ${info.fileCount.toLocaleString()}`));
+        console.log(chalk.dim(`  Size: ${formatBytes(info.size)}`));
       }
     } catch (error) {
       console.error(chalk.red("✗ Status check failed"));
       if (error instanceof Error) {
-        console.error(chalk.gray(`  ${error.message}`));
+        console.error(chalk.dim(`  ${error.message}`));
       }
       process.exit(1);
     }

--- a/turbo/apps/cli/src/commands/compose.ts
+++ b/turbo/apps/cli/src/commands/compose.ts
@@ -31,7 +31,7 @@ export const composeCommand = new Command()
       } catch (error) {
         console.error(chalk.red("✗ Invalid YAML format"));
         if (error instanceof Error) {
-          console.error(chalk.gray(`  ${error.message}`));
+          console.error(chalk.dim(`  ${error.message}`));
         }
         process.exit(1);
       }
@@ -74,14 +74,14 @@ export const composeCommand = new Command()
             if (defaultImage) {
               agent.image = defaultImage;
               console.log(
-                chalk.gray(`  Auto-configured image: ${defaultImage}`),
+                chalk.dim(`  Auto-configured image: ${defaultImage}`),
               );
             }
           }
           if (!agent.working_dir) {
             agent.working_dir = defaults.workingDir;
             console.log(
-              chalk.gray(
+              chalk.dim(
                 `  Auto-configured working_dir: ${defaults.workingDir}`,
               ),
             );
@@ -93,7 +93,7 @@ export const composeCommand = new Command()
       if (agent.instructions) {
         const instructionsPath = agent.instructions as string;
         const provider = agent.provider as string | undefined;
-        console.log(chalk.blue(`Uploading instructions: ${instructionsPath}`));
+        console.log(`Uploading instructions: ${instructionsPath}`);
         try {
           const result = await uploadInstructions(
             agentName,
@@ -109,7 +109,7 @@ export const composeCommand = new Command()
         } catch (error) {
           console.error(chalk.red(`✗ Failed to upload instructions`));
           if (error instanceof Error) {
-            console.error(chalk.gray(`  ${error.message}`));
+            console.error(chalk.dim(`  ${error.message}`));
           }
           process.exit(1);
         }
@@ -118,10 +118,10 @@ export const composeCommand = new Command()
       // Upload skills if specified
       if (agent.skills && Array.isArray(agent.skills)) {
         const skillUrls = agent.skills as string[];
-        console.log(chalk.blue(`Uploading ${skillUrls.length} skill(s)...`));
+        console.log(`Uploading ${skillUrls.length} skill(s)...`);
         for (const skillUrl of skillUrls) {
           try {
-            console.log(chalk.gray(`  Downloading: ${skillUrl}`));
+            console.log(chalk.dim(`  Downloading: ${skillUrl}`));
             const result = await uploadSkill(skillUrl);
             console.log(
               chalk.green(
@@ -131,7 +131,7 @@ export const composeCommand = new Command()
           } catch (error) {
             console.error(chalk.red(`✗ Failed to upload skill: ${skillUrl}`));
             if (error instanceof Error) {
-              console.error(chalk.gray(`  ${error.message}`));
+              console.error(chalk.dim(`  ${error.message}`));
             }
             process.exit(1);
           }
@@ -139,7 +139,7 @@ export const composeCommand = new Command()
       }
 
       // 5. Call API
-      console.log(chalk.blue("Uploading compose..."));
+      console.log("Uploading compose...");
 
       const response = await apiClient.createOrUpdateCompose({
         content: config,
@@ -153,8 +153,8 @@ export const composeCommand = new Command()
         console.log(chalk.green(`✓ Compose version exists: ${response.name}`));
       }
 
-      console.log(chalk.gray(`  Compose ID: ${response.composeId}`));
-      console.log(chalk.gray(`  Version:    ${shortVersionId}`));
+      console.log(chalk.dim(`  Compose ID: ${response.composeId}`));
+      console.log(chalk.dim(`  Version:    ${shortVersionId}`));
       console.log();
       console.log("  Run your agent:");
       console.log(
@@ -168,10 +168,10 @@ export const composeCommand = new Command()
           console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
         } else if (error.message.includes("Failed to create compose")) {
           console.error(chalk.red("✗ Failed to create compose"));
-          console.error(chalk.gray(`  ${error.message}`));
+          console.error(chalk.dim(`  ${error.message}`));
         } else {
           console.error(chalk.red("✗ Failed to create compose"));
-          console.error(chalk.gray(`  ${error.message}`));
+          console.error(chalk.dim(`  ${error.message}`));
         }
       } else {
         console.error(chalk.red("✗ An unexpected error occurred"));

--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -281,7 +281,7 @@ async function autoPullArtifact(
 
   if (serverVersion && existsSync(artifactDir)) {
     console.log();
-    console.log(chalk.blue("Pulling updated artifact:"));
+    console.log(chalk.bold("Pulling updated artifact:"));
     printCommand(`cd ${ARTIFACT_DIR}`);
     printCommand(`vm0 artifact pull ${serverVersion}`);
 
@@ -294,7 +294,7 @@ async function autoPullArtifact(
     } catch (error) {
       console.error(chalk.red(`✗ Artifact pull failed`));
       if (error instanceof Error) {
-        console.error(chalk.gray(`  ${error.message}`));
+        console.error(chalk.dim(`  ${error.message}`));
       }
       // Don't exit - the run succeeded, pull is optional
     }
@@ -319,7 +319,7 @@ cookCmd
     const cwd = process.cwd();
 
     // Step 1: Read and parse config
-    console.log(chalk.blue(`Reading config: ${CONFIG_FILE}`));
+    console.log(chalk.bold(`Reading config: ${CONFIG_FILE}`));
 
     if (!existsSync(CONFIG_FILE)) {
       console.error(chalk.red(`✗ Config file not found: ${CONFIG_FILE}`));
@@ -333,7 +333,7 @@ cookCmd
     } catch (error) {
       console.error(chalk.red("✗ Invalid YAML format"));
       if (error instanceof Error) {
-        console.error(chalk.gray(`  ${error.message}`));
+        console.error(chalk.dim(`  ${error.message}`));
       }
       process.exit(1);
     }
@@ -376,7 +376,7 @@ cookCmd
     // Step 2: Process volumes
     if (config.volumes && Object.keys(config.volumes).length > 0) {
       console.log();
-      console.log(chalk.blue("Processing volumes:"));
+      console.log(chalk.bold("Processing volumes:"));
 
       for (const volumeConfig of Object.values(config.volumes)) {
         const volumeDir = path.join(cwd, volumeConfig.name);
@@ -414,7 +414,7 @@ cookCmd
         } catch (error) {
           console.error(chalk.red(`✗ Failed`));
           if (error instanceof Error) {
-            console.error(chalk.gray(`  ${error.message}`));
+            console.error(chalk.dim(`  ${error.message}`));
           }
           process.exit(1);
         }
@@ -423,7 +423,7 @@ cookCmd
 
     // Step 3: Process artifact
     console.log();
-    console.log(chalk.blue("Processing artifact:"));
+    console.log(chalk.bold("Processing artifact:"));
 
     const artifactDir = path.join(cwd, ARTIFACT_DIR);
 
@@ -457,14 +457,14 @@ cookCmd
     } catch (error) {
       console.error(chalk.red(`✗ Failed`));
       if (error instanceof Error) {
-        console.error(chalk.gray(`  ${error.message}`));
+        console.error(chalk.dim(`  ${error.message}`));
       }
       process.exit(1);
     }
 
     // Step 4: Compose agent
     console.log();
-    console.log(chalk.blue("Composing agent:"));
+    console.log(chalk.bold("Composing agent:"));
     printCommand(`vm0 compose ${CONFIG_FILE}`);
 
     try {
@@ -475,7 +475,7 @@ cookCmd
     } catch (error) {
       console.error(chalk.red(`✗ Compose failed`));
       if (error instanceof Error) {
-        console.error(chalk.gray(`  ${error.message}`));
+        console.error(chalk.dim(`  ${error.message}`));
       }
       process.exit(1);
     }
@@ -483,7 +483,7 @@ cookCmd
     // Step 5: Run agent (if prompt provided)
     if (prompt) {
       console.log();
-      console.log(chalk.blue("Running agent:"));
+      console.log(chalk.bold("Running agent:"));
       printCommand(
         `vm0 run ${agentName} --artifact-name ${ARTIFACT_DIR} "${prompt}"`,
       );
@@ -550,7 +550,7 @@ cookCmd
       const state = await loadCookState();
       if (!state.lastRunId) {
         console.error(chalk.red("✗ No previous run found"));
-        console.error(chalk.gray("  Run 'vm0 cook <prompt>' first"));
+        console.error(chalk.dim("  Run 'vm0 cook <prompt>' first"));
         process.exit(1);
       }
 
@@ -599,7 +599,7 @@ cookCmd
     const state = await loadCookState();
     if (!state.lastSessionId) {
       console.error(chalk.red("✗ No previous session found"));
-      console.error(chalk.gray("  Run 'vm0 cook <prompt>' first"));
+      console.error(chalk.dim("  Run 'vm0 cook <prompt>' first"));
       process.exit(1);
     }
 
@@ -645,7 +645,7 @@ cookCmd
     const state = await loadCookState();
     if (!state.lastCheckpointId) {
       console.error(chalk.red("✗ No previous checkpoint found"));
-      console.error(chalk.gray("  Run 'vm0 cook <prompt>' first"));
+      console.error(chalk.dim("  Run 'vm0 cook <prompt>' first"));
       process.exit(1);
     }
 

--- a/turbo/apps/cli/src/commands/image/build.ts
+++ b/turbo/apps/cli/src/commands/image/build.ts
@@ -84,7 +84,7 @@ export const buildCommand = new Command()
           process.exit(1);
         }
 
-        console.log(chalk.blue(`Building image: ${scope.slug}/${name}`));
+        console.log(chalk.bold(`Building image: ${scope.slug}/${name}`));
         console.log();
 
         // Start build
@@ -95,7 +95,7 @@ export const buildCommand = new Command()
         });
         const { imageId, buildId, versionId } = buildInfo;
 
-        console.log(chalk.gray(`  Build ID: ${buildId}`));
+        console.log(chalk.dim(`  Build ID: ${buildId}`));
         console.log();
 
         // Poll for status
@@ -120,7 +120,7 @@ export const buildCommand = new Command()
 
           // Print new logs
           for (const log of statusData.logs) {
-            console.log(chalk.gray(`  ${log}`));
+            console.log(chalk.dim(`  ${log}`));
           }
 
           logsOffset = statusData.logsOffset;

--- a/turbo/apps/cli/src/commands/image/delete.ts
+++ b/turbo/apps/cli/src/commands/image/delete.ts
@@ -123,7 +123,7 @@ export const deleteCommand = new Command()
           });
 
           if (answer.toLowerCase() !== "y" && answer.toLowerCase() !== "yes") {
-            console.log(chalk.gray("Cancelled."));
+            console.log(chalk.dim("Cancelled."));
             return;
           }
         }

--- a/turbo/apps/cli/src/commands/image/list.ts
+++ b/turbo/apps/cli/src/commands/image/list.ts
@@ -37,7 +37,7 @@ export const listCommand = new Command()
       const { images } = data;
 
       if (images.length === 0) {
-        console.log(chalk.gray("No images found."));
+        console.log(chalk.dim("No images found."));
         console.log();
         console.log("Build your first image:");
         console.log(
@@ -67,11 +67,11 @@ export const listCommand = new Command()
 
       // Table header
       console.log(
-        chalk.gray(
+        chalk.dim(
           `${"NAME".padEnd(40)} ${"STATUS".padEnd(12)} ${"CREATED".padEnd(20)}`,
         ),
       );
-      console.log(chalk.gray("-".repeat(72)));
+      console.log(chalk.dim("-".repeat(72)));
 
       for (const image of images) {
         const statusColor =
@@ -93,7 +93,7 @@ export const listCommand = new Command()
             image.status === "ready" &&
             latestVersions.get(image.alias) === image.versionId
           ) {
-            displayName = `${displayName} ${chalk.cyan("(latest)")}`;
+            displayName = `${displayName} ${chalk.cyan("latest")}`;
           }
         }
 
@@ -107,7 +107,7 @@ export const listCommand = new Command()
       }
 
       console.log();
-      console.log(chalk.gray(`Total: ${images.length} version(s)`));
+      console.log(chalk.dim(`Total: ${images.length} version(s)`));
     } catch (error) {
       if (error instanceof Error) {
         if (error.message.includes("Not authenticated")) {

--- a/turbo/apps/cli/src/commands/image/versions.ts
+++ b/turbo/apps/cli/src/commands/image/versions.ts
@@ -52,11 +52,11 @@ export const versionsCommand = new Command()
 
       // Table header
       console.log(
-        chalk.gray(
+        chalk.dim(
           `${"VERSION".padEnd(20)} ${"STATUS".padEnd(12)} ${"CREATED".padEnd(24)}`,
         ),
       );
-      console.log(chalk.gray("-".repeat(56)));
+      console.log(chalk.dim("-".repeat(56)));
 
       for (const version of versions) {
         const statusColor =
@@ -76,7 +76,7 @@ export const versionsCommand = new Command()
           version.status === "ready" &&
           version.versionId === latestVersionId
         ) {
-          versionDisplay = `${versionDisplay} ${chalk.cyan("(latest)")}`;
+          versionDisplay = `${versionDisplay} ${chalk.cyan("latest")}`;
         }
 
         console.log(
@@ -89,14 +89,14 @@ export const versionsCommand = new Command()
       }
 
       console.log();
-      console.log(chalk.gray(`Total: ${versions.length} version(s)`));
+      console.log(chalk.dim(`Total: ${versions.length} version(s)`));
       console.log();
-      console.log(chalk.gray("Usage:"));
-      console.log(chalk.gray(`  image: "${name}"              # uses latest`));
+      console.log(chalk.dim("Usage:"));
+      console.log(chalk.dim(`  image: "${name}"              # uses latest`));
       if (latestVersionId) {
         const shortVersion = formatVersionIdForDisplay(latestVersionId);
         console.log(
-          chalk.gray(
+          chalk.dim(
             `  image: "${name}:${shortVersion}"   # pin to specific version`,
           ),
         );

--- a/turbo/apps/cli/src/commands/init.ts
+++ b/turbo/apps/cli/src/commands/init.ts
@@ -99,9 +99,9 @@ export const initCommand = new Command()
     if (!agentName || !validateAgentName(agentName)) {
       console.log(chalk.red("✗ Invalid agent name"));
       console.log(
-        chalk.gray("  Must be 3-64 characters, alphanumeric and hyphens only"),
+        chalk.dim("  Must be 3-64 characters, alphanumeric and hyphens only"),
       );
-      console.log(chalk.gray("  Must start and end with letter or number"));
+      console.log(chalk.dim("  Must start and end with letter or number"));
       process.exit(1);
     }
 
@@ -126,6 +126,6 @@ export const initCommand = new Command()
       `  1. Get your Claude Code token: ${chalk.cyan("claude setup-token")}`,
     );
     console.log(`  2. Set the environment variable (or add to .env file):`);
-    console.log(chalk.gray(`     export CLAUDE_CODE_OAUTH_TOKEN=<your-token>`));
+    console.log(chalk.dim(`     export CLAUDE_CODE_OAUTH_TOKEN=<your-token>`));
     console.log(`  3. Run your agent: ${chalk.cyan('vm0 cook "your prompt"')}`);
   });

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -63,7 +63,7 @@ function formatNetworkLog(entry: NetworkLogEntry): string {
     latencyColor = chalk.red;
   }
 
-  return `[${entry.timestamp}] ${chalk.cyan(entry.method.padEnd(6))} ${statusColor(entry.status)} ${latencyColor(entry.latency_ms + "ms")} ${formatBytes(entry.request_size)}/${formatBytes(entry.response_size)} ${chalk.gray(entry.url)}`;
+  return `[${entry.timestamp}] ${entry.method.padEnd(6)} ${statusColor(entry.status)} ${latencyColor(entry.latency_ms + "ms")} ${formatBytes(entry.request_size)}/${formatBytes(entry.response_size)} ${chalk.dim(entry.url)}`;
 }
 
 /**
@@ -203,7 +203,7 @@ async function showAgentEvents(
   if (response.hasMore) {
     console.log();
     console.log(
-      chalk.gray(
+      chalk.dim(
         `Showing ${response.events.length} events. Use --limit to see more.`,
       ),
     );
@@ -229,7 +229,7 @@ async function showSystemLog(
   if (response.hasMore) {
     console.log();
     console.log(
-      chalk.gray("More log entries available. Use --limit to see more."),
+      chalk.dim("More log entries available. Use --limit to see more."),
     );
   }
 }
@@ -255,7 +255,7 @@ async function showMetrics(
   if (response.hasMore) {
     console.log();
     console.log(
-      chalk.gray(
+      chalk.dim(
         `Showing ${response.metrics.length} metrics. Use --limit to see more.`,
       ),
     );
@@ -287,7 +287,7 @@ async function showNetworkLogs(
   if (response.hasMore) {
     console.log();
     console.log(
-      chalk.gray(
+      chalk.dim(
         `Showing ${response.networkLogs.length} network logs. Use --limit to see more.`,
       ),
     );
@@ -307,7 +307,7 @@ function handleError(error: unknown, runId: string): void {
       console.error(chalk.red(error.message));
     } else {
       console.error(chalk.red("Failed to fetch logs"));
-      console.error(chalk.gray(`  ${error.message}`));
+      console.error(chalk.dim(`  ${error.message}`));
     }
   } else {
     console.error(chalk.red("An unexpected error occurred"));

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -448,9 +448,7 @@ const runCmd = new Command()
           );
           if (secrets) {
             console.log(
-              chalk.dim(
-                `  Loaded secrets: ${Object.keys(secrets).join(", ")}`,
-              ),
+              chalk.dim(`  Loaded secrets: ${Object.keys(secrets).join(", ")}`),
             );
           }
         }

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -231,7 +231,7 @@ async function pollEvents(
       complete = true;
       console.error(chalk.red("\n✗ Run timed out"));
       console.error(
-        chalk.gray(`  (use "vm0 logs ${runId} --system" to view system logs)`),
+        chalk.dim(`  (use "vm0 logs ${runId} --system" to view system logs)`),
       );
       result = { succeeded: false, runId };
     }
@@ -252,14 +252,14 @@ function logVerbosePreFlight(
   action: string,
   details: Array<{ label: string; value: string | undefined }>,
 ): void {
-  console.log(chalk.blue(`\n${action}...`));
+  console.log(`\n${action}...`);
   for (const { label, value } of details) {
     if (value !== undefined) {
-      console.log(chalk.gray(`  ${label}: ${value}`));
+      console.log(chalk.dim(`  ${label}: ${value}`));
     }
   }
   console.log();
-  console.log(chalk.blue("Executing in sandbox..."));
+  console.log("Executing in sandbox...");
   console.log();
 }
 
@@ -356,7 +356,7 @@ const runCmd = new Command()
         if (isUUID(name)) {
           // It's a UUID compose ID - fetch compose to get content
           if (verbose) {
-            console.log(chalk.gray(`  Using compose ID: ${identifier}`));
+            console.log(chalk.dim(`  Using compose ID: ${identifier}`));
           }
           try {
             const compose = await apiClient.getComposeById(name);
@@ -371,20 +371,20 @@ const runCmd = new Command()
         } else {
           // It's an agent name - resolve to compose ID
           if (verbose) {
-            console.log(chalk.gray(`  Resolving agent name: ${name}`));
+            console.log(chalk.dim(`  Resolving agent name: ${name}`));
           }
           try {
             const compose = await apiClient.getComposeByName(name);
             composeId = compose.id;
             composeContent = compose.content;
             if (verbose) {
-              console.log(chalk.gray(`  Resolved to compose ID: ${composeId}`));
+              console.log(chalk.dim(`  Resolved to compose ID: ${composeId}`));
             }
           } catch (error) {
             if (error instanceof Error) {
               console.error(chalk.red(`✗ Agent not found: ${name}`));
               console.error(
-                chalk.gray(
+                chalk.dim(
                   "  Make sure you've composed the agent with: vm0 compose",
                 ),
               );
@@ -399,7 +399,7 @@ const runCmd = new Command()
         if (version && version !== "latest") {
           // Resolve version hash to full version ID
           if (verbose) {
-            console.log(chalk.gray(`  Resolving version: ${version}`));
+            console.log(chalk.dim(`  Resolving version: ${version}`));
           }
           try {
             const versionInfo = await apiClient.getComposeVersion(
@@ -409,7 +409,7 @@ const runCmd = new Command()
             agentComposeVersionId = versionInfo.versionId;
             if (verbose) {
               console.log(
-                chalk.gray(
+                chalk.dim(
                   `  Resolved to version ID: ${agentComposeVersionId.slice(0, 8)}...`,
                 ),
               );
@@ -418,7 +418,7 @@ const runCmd = new Command()
             if (error instanceof Error) {
               console.error(chalk.red(`✗ Version not found: ${version}`));
               console.error(
-                chalk.gray("  Make sure the version hash is correct."),
+                chalk.dim("  Make sure the version hash is correct."),
               );
             }
             process.exit(1);
@@ -434,21 +434,21 @@ const runCmd = new Command()
         const secrets = loadValues(options.secrets, secretNames);
 
         if (verbose && varNames.length > 0) {
-          console.log(chalk.gray(`  Required vars: ${varNames.join(", ")}`));
+          console.log(chalk.dim(`  Required vars: ${varNames.join(", ")}`));
           if (vars) {
             console.log(
-              chalk.gray(`  Loaded vars: ${Object.keys(vars).join(", ")}`),
+              chalk.dim(`  Loaded vars: ${Object.keys(vars).join(", ")}`),
             );
           }
         }
 
         if (verbose && secretNames.length > 0) {
           console.log(
-            chalk.gray(`  Required secrets: ${secretNames.join(", ")}`),
+            chalk.dim(`  Required secrets: ${secretNames.join(", ")}`),
           );
           if (secrets) {
             console.log(
-              chalk.gray(
+              chalk.dim(
                 `  Loaded secrets: ${Object.keys(secrets).join(", ")}`,
               ),
             );
@@ -509,7 +509,7 @@ const runCmd = new Command()
         if (response.status === "failed") {
           console.error(chalk.red("✗ Run preparation failed"));
           if (response.error) {
-            console.error(chalk.gray(`  ${response.error}`));
+            console.error(chalk.dim(`  ${response.error}`));
           }
           process.exit(1);
         }
@@ -538,13 +538,13 @@ const runCmd = new Command()
           } else if (error.message.includes("not found")) {
             console.error(chalk.red(`✗ Agent not found: ${identifier}`));
             console.error(
-              chalk.gray(
+              chalk.dim(
                 "  Make sure you've composed the agent with: vm0 compose",
               ),
             );
           } else {
             console.error(chalk.red("✗ Run failed"));
-            console.error(chalk.gray(`  ${error.message}`));
+            console.error(chalk.dim(`  ${error.message}`));
           }
         } else {
           console.error(chalk.red("✗ An unexpected error occurred"));
@@ -591,7 +591,7 @@ runCmd
           console.error(
             chalk.red(`✗ Invalid checkpoint ID format: ${checkpointId}`),
           );
-          console.error(chalk.gray("  Checkpoint ID must be a valid UUID"));
+          console.error(chalk.dim("  Checkpoint ID must be a valid UUID"));
           process.exit(1);
         }
 
@@ -624,7 +624,7 @@ runCmd
         if (response.status === "failed") {
           console.error(chalk.red("✗ Run preparation failed"));
           if (response.error) {
-            console.error(chalk.gray(`  ${response.error}`));
+            console.error(chalk.dim(`  ${response.error}`));
           }
           process.exit(1);
         }
@@ -654,7 +654,7 @@ runCmd
             console.error(chalk.red(`✗ Checkpoint not found: ${checkpointId}`));
           } else {
             console.error(chalk.red("✗ Resume failed"));
-            console.error(chalk.gray(`  ${error.message}`));
+            console.error(chalk.dim(`  ${error.message}`));
           }
         } else {
           console.error(chalk.red("✗ An unexpected error occurred"));
@@ -703,7 +703,7 @@ runCmd
           console.error(
             chalk.red(`✗ Invalid agent session ID format: ${agentSessionId}`),
           );
-          console.error(chalk.gray("  Agent session ID must be a valid UUID"));
+          console.error(chalk.dim("  Agent session ID must be a valid UUID"));
           process.exit(1);
         }
 
@@ -737,7 +737,7 @@ runCmd
         if (response.status === "failed") {
           console.error(chalk.red("✗ Run preparation failed"));
           if (response.error) {
-            console.error(chalk.gray(`  ${response.error}`));
+            console.error(chalk.dim(`  ${response.error}`));
           }
           process.exit(1);
         }
@@ -769,7 +769,7 @@ runCmd
             );
           } else {
             console.error(chalk.red("✗ Continue failed"));
-            console.error(chalk.gray(`  ${error.message}`));
+            console.error(chalk.dim(`  ${error.message}`));
           }
         } else {
           console.error(chalk.red("✗ An unexpected error occurred"));

--- a/turbo/apps/cli/src/commands/scope/status.ts
+++ b/turbo/apps/cli/src/commands/scope/status.ts
@@ -9,7 +9,7 @@ export const statusCommand = new Command()
     try {
       const scope = await apiClient.getScope();
 
-      console.log(chalk.cyan("Scope Information:"));
+      console.log(chalk.bold("Scope Information:"));
       console.log(`  Slug: ${chalk.green(scope.slug)}`);
       console.log(`  Type: ${scope.type}`);
       if (scope.displayName) {
@@ -29,7 +29,7 @@ export const statusCommand = new Command()
           console.log(chalk.cyan("  vm0 scope set <slug>"));
           console.log();
           console.log("Example:");
-          console.log(chalk.gray("  vm0 scope set myusername"));
+          console.log(chalk.dim("  vm0 scope set myusername"));
         } else {
           console.error(chalk.red(`✗ ${error.message}`));
         }

--- a/turbo/apps/cli/src/commands/volume/init.ts
+++ b/turbo/apps/cli/src/commands/volume/init.ts
@@ -22,7 +22,7 @@ export const initCommand = new Command()
           chalk.yellow(`Volume already initialized: ${existingConfig.name}`),
         );
         console.log(
-          chalk.gray(`Config file: ${path.join(cwd, ".vm0", "storage.yaml")}`),
+          chalk.dim(`Config file: ${path.join(cwd, ".vm0", "storage.yaml")}`),
         );
         return;
       }
@@ -34,12 +34,12 @@ export const initCommand = new Command()
       if (!isValidStorageName(volumeName)) {
         console.error(chalk.red(`✗ Invalid volume name: "${dirName}"`));
         console.error(
-          chalk.gray(
+          chalk.dim(
             "  Volume names must be 3-64 characters, lowercase alphanumeric with hyphens",
           ),
         );
         console.error(
-          chalk.gray("  Example: my-dataset, user-data-v2, training-set-2024"),
+          chalk.dim("  Example: my-dataset, user-data-v2, training-set-2024"),
         );
         process.exit(1);
       }
@@ -49,14 +49,14 @@ export const initCommand = new Command()
 
       console.log(chalk.green(`✓ Initialized volume: ${volumeName}`));
       console.log(
-        chalk.gray(
+        chalk.dim(
           `✓ Config saved to ${path.join(cwd, ".vm0", "storage.yaml")}`,
         ),
       );
     } catch (error) {
       console.error(chalk.red("✗ Failed to initialize volume"));
       if (error instanceof Error) {
-        console.error(chalk.gray(`  ${error.message}`));
+        console.error(chalk.dim(`  ${error.message}`));
       }
       process.exit(1);
     }

--- a/turbo/apps/cli/src/commands/volume/pull.ts
+++ b/turbo/apps/cli/src/commands/volume/pull.ts
@@ -43,20 +43,18 @@ export const pullCommand = new Command()
       const config = await readStorageConfig(cwd);
       if (!config) {
         console.error(chalk.red("✗ No volume initialized in this directory"));
-        console.error(chalk.gray("  Run: vm0 volume init"));
+        console.error(chalk.dim("  Run: vm0 volume init"));
         process.exit(1);
       }
 
       if (versionId) {
-        console.log(
-          chalk.cyan(`Pulling volume: ${config.name} (version: ${versionId})`),
-        );
+        console.log(`Pulling volume: ${config.name} (version: ${versionId})`);
       } else {
-        console.log(chalk.cyan(`Pulling volume: ${config.name}`));
+        console.log(`Pulling volume: ${config.name}`);
       }
 
       // Get download URL from API
-      console.log(chalk.gray("Getting download URL..."));
+      console.log(chalk.dim("Getting download URL..."));
 
       let url = `/api/storages/download?name=${encodeURIComponent(config.name)}&type=volume`;
       if (versionId) {
@@ -69,12 +67,12 @@ export const pullCommand = new Command()
         if (response.status === 404) {
           console.error(chalk.red(`✗ Volume "${config.name}" not found`));
           console.error(
-            chalk.gray(
+            chalk.dim(
               "  Make sure the volume name is correct in .vm0/storage.yaml",
             ),
           );
           console.error(
-            chalk.gray("  Or push the volume first with: vm0 volume push"),
+            chalk.dim("  Or push the volume first with: vm0 volume push"),
           );
         } else {
           const error = (await response.json()) as ApiError;
@@ -96,7 +94,7 @@ export const pullCommand = new Command()
       }
 
       // Download directly from S3
-      console.log(chalk.gray("Downloading from S3..."));
+      console.log(chalk.dim("Downloading from S3..."));
       const s3Response = await fetch(downloadInfo.url);
 
       if (!s3Response.ok) {
@@ -115,7 +113,7 @@ export const pullCommand = new Command()
       await fs.promises.writeFile(tarPath, tarBuffer);
 
       // Get remote files list for sync
-      console.log(chalk.gray("Syncing local files..."));
+      console.log(chalk.dim("Syncing local files..."));
       const remoteFiles = await listTarFiles(tarPath);
       const remoteFilesSet = new Set(
         remoteFiles.map((f) => f.replace(/\\/g, "/")),
@@ -130,7 +128,7 @@ export const pullCommand = new Command()
       }
 
       // Extract tar.gz
-      console.log(chalk.gray("Extracting files..."));
+      console.log(chalk.dim("Extracting files..."));
       await tar.extract({
         file: tarPath,
         cwd: cwd,
@@ -145,7 +143,7 @@ export const pullCommand = new Command()
     } catch (error) {
       console.error(chalk.red("✗ Pull failed"));
       if (error instanceof Error) {
-        console.error(chalk.gray(`  ${error.message}`));
+        console.error(chalk.dim(`  ${error.message}`));
       }
       process.exit(1);
     }

--- a/turbo/apps/cli/src/commands/volume/push.ts
+++ b/turbo/apps/cli/src/commands/volume/push.ts
@@ -29,16 +29,16 @@ export const pushCommand = new Command()
       const config = await readStorageConfig(cwd);
       if (!config) {
         console.error(chalk.red("✗ No volume initialized in this directory"));
-        console.error(chalk.gray("  Run: vm0 volume init"));
+        console.error(chalk.dim("  Run: vm0 volume init"));
         process.exit(1);
       }
 
-      console.log(chalk.cyan(`Pushing volume: ${config.name}`));
+      console.log(`Pushing volume: ${config.name}`);
 
       // Perform direct S3 upload
       const result = await directUpload(config.name, "volume", cwd, {
         onProgress: (message) => {
-          console.log(chalk.gray(message));
+          console.log(chalk.dim(message));
         },
         force: options.force,
       });
@@ -53,13 +53,13 @@ export const pushCommand = new Command()
       } else {
         console.log(chalk.green("✓ Upload complete"));
       }
-      console.log(chalk.gray(`  Version: ${shortVersion}`));
-      console.log(chalk.gray(`  Files: ${result.fileCount.toLocaleString()}`));
-      console.log(chalk.gray(`  Size: ${formatBytes(result.size)}`));
+      console.log(chalk.dim(`  Version: ${shortVersion}`));
+      console.log(chalk.dim(`  Files: ${result.fileCount.toLocaleString()}`));
+      console.log(chalk.dim(`  Size: ${formatBytes(result.size)}`));
     } catch (error) {
       console.error(chalk.red("✗ Push failed"));
       if (error instanceof Error) {
-        console.error(chalk.gray(`  ${error.message}`));
+        console.error(chalk.dim(`  ${error.message}`));
       }
       process.exit(1);
     }

--- a/turbo/apps/cli/src/commands/volume/status.ts
+++ b/turbo/apps/cli/src/commands/volume/status.ts
@@ -36,7 +36,7 @@ export const statusCommand = new Command()
       const config = await readStorageConfig(cwd);
       if (!config) {
         console.error(chalk.red("✗ No volume initialized in this directory"));
-        console.error(chalk.gray("  Run: vm0 volume init"));
+        console.error(chalk.dim("  Run: vm0 volume init"));
         process.exit(1);
       }
 
@@ -46,12 +46,12 @@ export const statusCommand = new Command()
             "✗ This directory is initialized as an artifact, not a volume",
           ),
         );
-        console.error(chalk.gray("  Use: vm0 artifact status"));
+        console.error(chalk.dim("  Use: vm0 artifact status"));
         process.exit(1);
       }
 
       // Start message
-      console.log(chalk.cyan(`Checking volume: ${config.name}`));
+      console.log(`Checking volume: ${config.name}`);
 
       // Call API
       const url = `/api/storages/download?name=${encodeURIComponent(config.name)}&type=volume`;
@@ -60,7 +60,7 @@ export const statusCommand = new Command()
       if (!response.ok) {
         if (response.status === 404) {
           console.error(chalk.red("✗ Not found on remote"));
-          console.error(chalk.gray("  Run: vm0 volume push"));
+          console.error(chalk.dim("  Run: vm0 volume push"));
         } else {
           const error = (await response.json()) as ApiError;
           throw new Error(error.error?.message || "Status check failed");
@@ -73,17 +73,17 @@ export const statusCommand = new Command()
 
       if (info.empty) {
         console.log(chalk.green("✓ Found (empty)"));
-        console.log(chalk.gray(`  Version: ${shortVersion}`));
+        console.log(chalk.dim(`  Version: ${shortVersion}`));
       } else {
         console.log(chalk.green("✓ Found"));
-        console.log(chalk.gray(`  Version: ${shortVersion}`));
-        console.log(chalk.gray(`  Files: ${info.fileCount.toLocaleString()}`));
-        console.log(chalk.gray(`  Size: ${formatBytes(info.size)}`));
+        console.log(chalk.dim(`  Version: ${shortVersion}`));
+        console.log(chalk.dim(`  Files: ${info.fileCount.toLocaleString()}`));
+        console.log(chalk.dim(`  Size: ${formatBytes(info.size)}`));
       }
     } catch (error) {
       console.error(chalk.red("✗ Status check failed"));
       if (error instanceof Error) {
-        console.error(chalk.gray(`  ${error.message}`));
+        console.error(chalk.dim(`  ${error.message}`));
       }
       process.exit(1);
     }

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -25,7 +25,7 @@ program
   .command("info")
   .description("Display environment information")
   .action(async () => {
-    console.log(chalk.cyan("System Information:"));
+    console.log(chalk.bold("System Information:"));
     console.log(`Node Version: ${process.version}`);
     console.log(`Platform: ${process.platform}`);
     console.log(`Architecture: ${process.arch}`);

--- a/turbo/apps/cli/src/lib/auth.ts
+++ b/turbo/apps/cli/src/lib/auth.ts
@@ -85,7 +85,7 @@ function delay(ms: number): Promise<void> {
 export async function authenticate(apiUrl?: string): Promise<void> {
   // Use provided apiUrl or get from config/env (with fallback to production)
   const targetApiUrl = apiUrl ?? (await getApiUrl());
-  console.log(chalk.blue("Initiating authentication..."));
+  console.log("Initiating authentication...");
 
   // Request device code
   const deviceAuth = await requestDeviceCode(targetApiUrl);
@@ -100,7 +100,7 @@ export async function authenticate(apiUrl?: string): Promise<void> {
     `\nThe code expires in ${Math.floor(deviceAuth.expires_in / 60)} minutes.`,
   );
 
-  console.log(chalk.blue("\nWaiting for authentication..."));
+  console.log("\nWaiting for authentication...");
 
   // Poll for token
   const startTime = Date.now();
@@ -135,7 +135,7 @@ export async function authenticate(apiUrl?: string): Promise<void> {
 
     if (tokenResult.error === "authorization_pending") {
       // Still waiting for user to authenticate
-      process.stdout.write(chalk.gray("."));
+      process.stdout.write(chalk.dim("."));
       continue;
     }
 
@@ -181,7 +181,7 @@ export async function checkAuthStatus(): Promise<void> {
 
   // Also check for environment variable
   if (process.env.VM0_TOKEN) {
-    console.log(chalk.blue("Using token from VM0_TOKEN environment variable"));
+    console.log("Using token from VM0_TOKEN environment variable");
   }
 }
 

--- a/turbo/apps/cli/src/lib/codex-event-renderer.ts
+++ b/turbo/apps/cli/src/lib/codex-event-renderer.ts
@@ -139,8 +139,7 @@ export class CodexEventRenderer {
               ? chalk.dim(` ... (${lines.length - 3} more lines)`)
               : "";
           console.log(
-            "[output]" +
-              (exitCode !== 0 ? chalk.red(` exit=${exitCode}`) : ""),
+            "[output]" + (exitCode !== 0 ? chalk.red(` exit=${exitCode}`) : ""),
           );
           if (preview) {
             console.log("  " + preview + more);

--- a/turbo/apps/cli/src/lib/codex-event-renderer.ts
+++ b/turbo/apps/cli/src/lib/codex-event-renderer.ts
@@ -83,7 +83,7 @@ export class CodexEventRenderer {
   }
 
   private static renderThreadStarted(event: CodexEvent): void {
-    console.log(chalk.cyan("[thread.started]") + ` ${event.thread_id}`);
+    console.log("[thread.started]" + ` ${event.thread_id}`);
   }
 
   private static renderTurnCompleted(event: CodexEvent): void {
@@ -93,8 +93,8 @@ export class CodexEventRenderer {
       const cached = event.usage.cached_input_tokens || 0;
       const cachedStr = cached ? ` (${cached} cached)` : "";
       console.log(
-        chalk.cyan("[turn.completed]") +
-          chalk.gray(` ${input} in / ${output} out${cachedStr}`),
+        "[turn.completed]" +
+          chalk.dim(` ${input} in / ${output} out${cachedStr}`),
       );
     }
   }
@@ -114,20 +114,20 @@ export class CodexEventRenderer {
 
     // Reasoning (thinking)
     if (itemType === "reasoning" && item.text) {
-      console.log(chalk.magenta("[reasoning]") + ` ${item.text}`);
+      console.log("[reasoning]" + ` ${item.text}`);
       return;
     }
 
     // Agent message
     if (itemType === "agent_message" && item.text) {
-      console.log(chalk.blue("[message]") + ` ${item.text}`);
+      console.log("[message]" + ` ${item.text}`);
       return;
     }
 
     // Command execution
     if (itemType === "command_execution") {
       if (eventType === "item.started" && item.command) {
-        console.log(chalk.yellow("[exec]") + ` ${item.command}`);
+        console.log("[exec]" + ` ${item.command}`);
       } else if (eventType === "item.completed") {
         const output = item.aggregated_output || "";
         const exitCode = item.exit_code ?? 0;
@@ -136,10 +136,10 @@ export class CodexEventRenderer {
           const preview = lines.slice(0, 3).join("\n  ");
           const more =
             lines.length > 3
-              ? chalk.gray(` ... (${lines.length - 3} more lines)`)
+              ? chalk.dim(` ... (${lines.length - 3} more lines)`)
               : "";
           console.log(
-            chalk.gray("[output]") +
+            "[output]" +
               (exitCode !== 0 ? chalk.red(` exit=${exitCode}`) : ""),
           );
           if (preview) {
@@ -172,7 +172,7 @@ export class CodexEventRenderer {
     ) {
       const action = itemType.replace("file_", "");
       if (eventType === "item.started" && item.path) {
-        console.log(chalk.blue(`[${action}]`) + ` ${item.path}`);
+        console.log(`[${action}]` + ` ${item.path}`);
       }
       return;
     }

--- a/turbo/apps/cli/src/lib/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/event-renderer.ts
@@ -134,18 +134,14 @@ export class EventRenderer {
       if (result.artifact && Object.keys(result.artifact).length > 0) {
         console.log(`  Artifact:`);
         for (const [name, version] of Object.entries(result.artifact)) {
-          console.log(
-            `    ${name}: ${chalk.dim(this.formatVersion(version))}`,
-          );
+          console.log(`    ${name}: ${chalk.dim(this.formatVersion(version))}`);
         }
       }
 
       if (result.volumes && Object.keys(result.volumes).length > 0) {
         console.log(`  Volumes:`);
         for (const [name, version] of Object.entries(result.volumes)) {
-          console.log(
-            `    ${name}: ${chalk.dim(this.formatVersion(version))}`,
-          );
+          console.log(`    ${name}: ${chalk.dim(this.formatVersion(version))}`);
         }
       }
     }
@@ -180,9 +176,7 @@ export class EventRenderer {
     const displayName = isSupportedProvider(providerStr)
       ? getProviderDisplayName(providerStr)
       : providerStr;
-    console.log(
-      prefix + "[init]" + suffix + ` Starting ${displayName} agent`,
-    );
+    console.log(prefix + "[init]" + suffix + ` Starting ${displayName} agent`);
     console.log(`  Session: ${chalk.dim(String(event.data.sessionId || ""))}`);
     if (event.data.model) {
       console.log(`  Model: ${chalk.dim(String(event.data.model))}`);

--- a/turbo/apps/cli/src/lib/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/event-renderer.ts
@@ -41,12 +41,12 @@ export class EventRenderer {
    * Called immediately after run is created, before polling events
    */
   static renderRunStarted(info: RunStartedInfo): void {
-    console.log(chalk.blue("▶ Run started"));
-    console.log(`  Run ID:   ${chalk.gray(info.runId)}`);
+    console.log(chalk.bold("▶ Run started"));
+    console.log(`  Run ID:   ${chalk.dim(info.runId)}`);
     if (info.sandboxId) {
-      console.log(`  Sandbox:  ${chalk.gray(info.sandboxId)}`);
+      console.log(`  Sandbox:  ${chalk.dim(info.sandboxId)}`);
     }
-    console.log(chalk.gray(`  (use "vm0 logs ${info.runId}" to view logs)`));
+    console.log(chalk.dim(`  (use "vm0 logs ${info.runId}" to view logs)`));
     console.log();
   }
 
@@ -88,7 +88,7 @@ export class EventRenderer {
     const elapsedSuffix =
       options?.verbose && options?.previousTimestamp
         ? " " +
-          chalk.gray(
+          chalk.dim(
             this.formatElapsed(options.previousTimestamp, event.timestamp),
           )
         : "";
@@ -126,16 +126,16 @@ export class EventRenderer {
     console.log(chalk.green("✓ Run completed successfully"));
 
     if (result) {
-      console.log(`  Checkpoint:    ${chalk.gray(result.checkpointId)}`);
-      console.log(`  Session:       ${chalk.gray(result.agentSessionId)}`);
-      console.log(`  Conversation:  ${chalk.gray(result.conversationId)}`);
+      console.log(`  Checkpoint:    ${chalk.dim(result.checkpointId)}`);
+      console.log(`  Session:       ${chalk.dim(result.agentSessionId)}`);
+      console.log(`  Conversation:  ${chalk.dim(result.conversationId)}`);
 
       // Render artifact and volumes
       if (result.artifact && Object.keys(result.artifact).length > 0) {
         console.log(`  Artifact:`);
         for (const [name, version] of Object.entries(result.artifact)) {
           console.log(
-            `    ${name}: ${chalk.gray(this.formatVersion(version))}`,
+            `    ${name}: ${chalk.dim(this.formatVersion(version))}`,
           );
         }
       }
@@ -144,7 +144,7 @@ export class EventRenderer {
         console.log(`  Volumes:`);
         for (const [name, version] of Object.entries(result.volumes)) {
           console.log(
-            `    ${name}: ${chalk.gray(this.formatVersion(version))}`,
+            `    ${name}: ${chalk.dim(this.formatVersion(version))}`,
           );
         }
       }
@@ -153,7 +153,7 @@ export class EventRenderer {
     // Show total time in verbose mode
     if (options?.verbose && options?.startTimestamp) {
       const totalTime = this.formatTotalTime(options.startTimestamp, now);
-      console.log(`  Total time:    ${chalk.gray(totalTime)}`);
+      console.log(`  Total time:    ${chalk.dim(totalTime)}`);
     }
   }
 
@@ -167,7 +167,7 @@ export class EventRenderer {
     console.log(chalk.red("✗ Run failed"));
     console.log(`  Error: ${chalk.red(error || "Unknown error")}`);
     console.log(
-      chalk.gray(`  (use "vm0 logs ${runId} --system" to view system logs)`),
+      chalk.dim(`  (use "vm0 logs ${runId} --system" to view system logs)`),
     );
   }
 
@@ -181,14 +181,14 @@ export class EventRenderer {
       ? getProviderDisplayName(providerStr)
       : providerStr;
     console.log(
-      prefix + chalk.cyan("[init]") + suffix + ` Starting ${displayName} agent`,
+      prefix + "[init]" + suffix + ` Starting ${displayName} agent`,
     );
-    console.log(`  Session: ${chalk.gray(String(event.data.sessionId || ""))}`);
+    console.log(`  Session: ${chalk.dim(String(event.data.sessionId || ""))}`);
     if (event.data.model) {
-      console.log(`  Model: ${chalk.gray(String(event.data.model))}`);
+      console.log(`  Model: ${chalk.dim(String(event.data.model))}`);
     }
     console.log(
-      `  Tools: ${chalk.gray(
+      `  Tools: ${chalk.dim(
         Array.isArray(event.data.tools)
           ? event.data.tools.join(", ")
           : String(event.data.tools || ""),
@@ -202,7 +202,7 @@ export class EventRenderer {
     suffix: string,
   ): void {
     const text = String(event.data.text || "");
-    console.log(prefix + chalk.blue("[text]") + suffix + " " + text);
+    console.log(prefix + "[text]" + suffix + " " + text);
   }
 
   private static renderToolUse(
@@ -211,7 +211,7 @@ export class EventRenderer {
     suffix: string,
   ): void {
     const tool = String(event.data.tool || "");
-    console.log(prefix + chalk.yellow("[tool_use]") + suffix + " " + tool);
+    console.log(prefix + "[tool_use]" + suffix + " " + tool);
 
     // Show full input without truncation
     const input = event.data.input as Record<string, unknown>;
@@ -222,7 +222,7 @@ export class EventRenderer {
             typeof value === "object"
               ? JSON.stringify(value, null, 2)
               : String(value);
-          console.log(`  ${key}: ${chalk.gray(displayValue)}`);
+          console.log(`  ${key}: ${chalk.dim(displayValue)}`);
         }
       }
     }
@@ -241,7 +241,7 @@ export class EventRenderer {
 
     // Show full result without truncation
     const result = String(event.data.result || "");
-    console.log(`  ${chalk.gray(result)}`);
+    console.log(`  ${chalk.dim(result)}`);
   }
 
   private static renderResult(
@@ -257,13 +257,13 @@ export class EventRenderer {
 
     const durationMs = Number(event.data.durationMs || 0);
     const durationSec = (durationMs / 1000).toFixed(1);
-    console.log(`  Duration: ${chalk.gray(durationSec + "s")}`);
+    console.log(`  Duration: ${chalk.dim(durationSec + "s")}`);
 
     const cost = Number(event.data.cost || 0);
-    console.log(`  Cost: ${chalk.gray("$" + cost.toFixed(4))}`);
+    console.log(`  Cost: ${chalk.dim("$" + cost.toFixed(4))}`);
 
     const numTurns = Number(event.data.numTurns || 0);
-    console.log(`  Turns: ${chalk.gray(String(numTurns))}`);
+    console.log(`  Turns: ${chalk.dim(String(numTurns))}`);
 
     const usage = event.data.usage as Record<string, unknown>;
     if (usage && typeof usage === "object") {
@@ -278,7 +278,7 @@ export class EventRenderer {
       };
 
       console.log(
-        `  Tokens: ${chalk.gray(
+        `  Tokens: ${chalk.dim(
           `input=${formatTokens(inputTokens)} output=${formatTokens(outputTokens)}`,
         )}`,
       );

--- a/turbo/apps/cli/src/lib/pull-utils.ts
+++ b/turbo/apps/cli/src/lib/pull-utils.ts
@@ -18,7 +18,7 @@ export interface EmptyStorageResult {
 export async function handleEmptyStorageResponse(
   cwd: string,
 ): Promise<EmptyStorageResult> {
-  console.log(chalk.gray("Syncing local files..."));
+  console.log(chalk.dim("Syncing local files..."));
 
   // Sync to empty state - remove all local files
   const removedCount = await removeExtraFiles(cwd, new Set());

--- a/turbo/apps/cli/src/lib/update-checker.ts
+++ b/turbo/apps/cli/src/lib/update-checker.ts
@@ -158,7 +158,7 @@ export async function checkAndUpgrade(
   console.log();
   console.log(chalk.red("Upgrade failed. Please run manually:"));
   console.log(chalk.cyan(`  npm install -g ${PACKAGE_NAME}@latest`));
-  console.log(chalk.gray("  # or"));
+  console.log(chalk.dim("  # or"));
   console.log(chalk.cyan(`  pnpm add -g ${PACKAGE_NAME}@latest`));
   console.log();
   console.log("Then re-run:");


### PR DESCRIPTION
## Summary
- Remove `blue` color, use `bold` for titles instead
- Remove `magenta` color from event rendering (default color now)
- Replace `gray` with `dim` for metadata and secondary information
- Keep `cyan` only for interactive prompts, command suggestions, and `latest` marker
- Change `(latest)` to `latest` (remove parentheses since color already distinguishes it)

## Final Color Scheme
| Color | Usage |
|-------|-------|
| `red` | Errors, failures |
| `green` | Success, completion |
| `yellow` | Warnings, in-progress |
| `cyan` | Interactive prompts, command suggestions, `latest` marker |
| `bold` | Titles, emphasis |
| `dim` | Metadata, secondary info |

## Test plan
- [x] Lint passes
- [x] Type check passes
- [x] All 453 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)