### PR TITLE
fix(cli): default to production images when NODE_ENV is not set

### DIFF
--- a/turbo/apps/cli/src/lib/__tests__/provider-config.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/provider-config.test.ts
@@ -96,5 +96,22 @@ describe("provider-config", () => {
     it("returns undefined for unknown provider", () => {
       expect(getDefaultImage("unknown")).toBeUndefined();
     });
+
+    describe("default behavior (NODE_ENV undefined or unrecognized)", () => {
+      it("returns production image for claude-code when NODE_ENV is undefined", () => {
+        delete process.env.NODE_ENV;
+        expect(getDefaultImage("claude-code")).toBe("vm0/claude-code:latest");
+      });
+
+      it("returns production image for codex when NODE_ENV is undefined", () => {
+        delete process.env.NODE_ENV;
+        expect(getDefaultImage("codex")).toBe("vm0/codex:latest");
+      });
+
+      it("returns production image for claude-code when NODE_ENV is unrecognized", () => {
+        process.env.NODE_ENV = "staging";
+        expect(getDefaultImage("claude-code")).toBe("vm0/claude-code:latest");
+      });
+    });
   });
 });

--- a/turbo/apps/cli/src/lib/provider-config.ts
+++ b/turbo/apps/cli/src/lib/provider-config.ts
@@ -68,8 +68,9 @@ export function getDefaultImage(provider: string): string | undefined {
   const defaults = PROVIDER_DEFAULTS[provider];
   if (!defaults) return undefined;
 
-  // Only use production image when NODE_ENV is explicitly "production"
-  // All other cases (development, test, undefined) use dev image
-  const isProduction = process.env.NODE_ENV === "production";
-  return isProduction ? defaults.image.production : defaults.image.development;
+  // Use dev image only when NODE_ENV is explicitly "development" or "test"
+  // All other cases (production, undefined, etc.) use production image
+  const isDevelopment =
+    process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
+  return isDevelopment ? defaults.image.development : defaults.image.production;
 }


### PR DESCRIPTION
## Summary

- Change the default image selection logic to use production images (`:latest`) by default
- Only use development images (`:dev`) when `NODE_ENV` is explicitly set to `"development"` or `"test"`
- Add tests for undefined and unrecognized `NODE_ENV` values

## Root Cause

The previous logic checked `process.env.NODE_ENV === "production"` to determine whether to use production images. Since `NODE_ENV` is typically unset when running CLI tools globally, users always got dev images by default.

## Solution

Invert the logic to check for development mode instead:

```typescript
// Before
const isProduction = process.env.NODE_ENV === "production";
return isProduction ? defaults.image.production : defaults.image.development;

// After  
const isDevelopment = process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
return isDevelopment ? defaults.image.development : defaults.image.production;
```

## Test plan

- [x] Existing tests pass (production, development, test NODE_ENV values)
- [x] New test for undefined NODE_ENV returns production image
- [x] New test for unrecognized NODE_ENV (e.g., "staging") returns production image
- [ ] Manual test: `vm0 compose vm0.yaml` shows `:latest` image

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)