### PR TITLE
docs: add agent instruction note in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ echo "CLAUDE_CODE_OAUTH_TOKEN=<your-token>" > .env
 
 # 5. Run your agent
 vm0 cook "let's start working."
+# Agent follows AGENTS.md: curates AI news from HackerNews and writes to content.md
 ```
 
 ### What just happened?


### PR DESCRIPTION
## Summary

Add a comment after the `vm0 cook` command in Quick Start explaining what the default agent does based on the AGENTS.md template.

```bash
# 5. Run your agent
vm0 cook "let's start working."
# Agent follows AGENTS.md: curates AI news from HackerNews and writes to content.md
```

This helps users understand what will happen when they run the example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)