### PR TITLE
refactor: rename beta_network_security to experimental_network_security

### DIFF
--- a/e2e/fixtures/configs/vm0-network-security.yaml
+++ b/e2e/fixtures/configs/vm0-network-security.yaml
@@ -5,5 +5,5 @@ agents:
     description: "Test agent with network security (proxy mode)"
     provider: claude-code
     image: "vm0/claude-code:dev"
-    beta_network_security: true
+    experimental_network_security: true
     working_dir: /home/user/workspace

--- a/e2e/tests/02-commands/t16-vm0-network-logs.bats
+++ b/e2e/tests/02-commands/t16-vm0-network-logs.bats
@@ -2,7 +2,7 @@
 
 # Test VM0 network logs with network security mode
 # This test verifies that:
-# 1. Agent runs with beta_network_security enabled capture network traffic
+# 1. Agent runs with experimental_network_security enabled capture network traffic
 # 2. The vm0 logs --network command retrieves network logs
 # 3. Network logs contain expected fields (method, url, status, latency)
 #

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -174,7 +174,7 @@ export class E2BService {
       // Enable proxy mode for network security
       // When true, mitmproxy will be set up to intercept traffic
       // and decrypt vm0_enc_ tokens before forwarding to APIs
-      if (context.betaNetworkSecurity) {
+      if (context.experimentalNetworkSecurity) {
         sandboxEnvVars.VM0_PROXY_ENABLED = "true";
         // Set SSL certificate environment variables for mitmproxy CA
         // These ensure Python's requests/urllib and other libraries trust the proxy CA
@@ -265,7 +265,7 @@ export class E2BService {
       await this.startAgentExecution(
         sandbox,
         context.runId,
-        context.betaNetworkSecurity || false,
+        context.experimentalNetworkSecurity || false,
       );
       log.debug(`[${context.runId}] Agent execution command sent`);
 

--- a/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
+++ b/turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts
@@ -44,7 +44,7 @@ PROXY_URL = f"{API_URL}/api/webhooks/agent/proxy"
 STORAGE_PREPARE_URL = f"{API_URL}/api/webhooks/agent/storages/prepare"
 STORAGE_COMMIT_URL = f"{API_URL}/api/webhooks/agent/storages/commit"
 
-# Proxy configuration (for beta_network_security feature)
+# Proxy configuration (for experimental_network_security feature)
 PROXY_ENABLED = os.environ.get("VM0_PROXY_ENABLED", "false").lower() == "true"
 
 # Heartbeat configuration

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -68,7 +68,7 @@ export interface ExecutionContext {
 
   // Network security mode - when true, secrets are encrypted into proxy tokens
   // and traffic is routed through mitmproxy -> VM0 Proxy for decryption
-  betaNetworkSecurity?: boolean;
+  experimentalNetworkSecurity?: boolean;
 
   // Resume-specific (optional)
   resumeSession?: ResumeSession;

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -28,7 +28,7 @@ export interface AgentDefinition {
    * is routed through mitmproxy -> VM0 Proxy for decryption.
    * Default: false (plaintext secrets in env vars)
    */
-  beta_network_security?: boolean;
+  experimental_network_security?: boolean;
   /**
    * Path to instructions file (e.g., AGENTS.md).
    * Auto-uploaded as volume and mounted at /home/user/.claude/CLAUDE.md

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -43,7 +43,7 @@ const agentDefinitionSchema = z.object({
    * is routed through mitmproxy -> VM0 Proxy for decryption.
    * Default: false (plaintext secrets in env vars)
    */
-  beta_network_security: z.boolean().optional().default(false),
+  experimental_network_security: z.boolean().optional().default(false),
   /**
    * Path to instructions file (e.g., AGENTS.md).
    * Auto-uploaded as volume and mounted at /home/user/.claude/CLAUDE.md


### PR DESCRIPTION
## Summary

Rename the `beta_network_security` configuration field to `experimental_network_security` for consistency with other experimental features in the project.

## Changes

- **Schema**: `beta_network_security` → `experimental_network_security` (composes.ts, agent-compose.ts)
- **Types**: `betaNetworkSecurity` → `experimentalNetworkSecurity` (types.ts, run-service.ts, e2b-service.ts)
- **Comments**: Updated all related comments in Python scripts and test files
- **E2E Tests**: Updated test configuration

## Files Modified

| File | Changes |
|------|---------|
| `turbo/packages/core/src/contracts/composes.ts` | Schema field rename |
| `turbo/apps/web/src/types/agent-compose.ts` | Interface field rename |
| `turbo/apps/web/src/lib/run/types.ts` | ExecutionContext field rename |
| `turbo/apps/web/src/lib/run/run-service.ts` | Variable and comment updates |
| `turbo/apps/web/src/lib/e2b/e2b-service.ts` | Variable updates |
| `turbo/apps/web/src/lib/e2b/scripts/lib/common.py.ts` | Comment update |
| `e2e/fixtures/configs/vm0-network-security.yaml` | Config field rename |
| `e2e/tests/02-commands/t16-vm0-network-logs.bats` | Comment update |

## Breaking Change

This is a **breaking change**. Users with existing `agent.yaml` configurations must update their files:

```yaml
# Before
agents:
  my-agent:
    beta_network_security: true

# After
agents:
  my-agent:
    experimental_network_security: true
```

## Test Plan

- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Format applied (`pnpm format`)
- [x] Unit tests pass (pre-existing flaky test unrelated to changes)

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)