### PR TITLE
docs: add language requirement to deep-dive commands

### DIFF
--- a/.claude/commands/deep-innovate.md
+++ b/.claude/commands/deep-innovate.md
@@ -6,6 +6,15 @@ description: Deep brainstorming and solution exploration based on research findi
 
 You are entering **Deep Innovate Mode**. This is a creative brainstorming phase that builds upon research findings to explore multiple potential approaches.
 
+## LANGUAGE REQUIREMENT
+
+**All outputs must be written in English.** This includes:
+- The innovation document (`innovate.md`)
+- Solution proposals and trade-off analysis
+- Any discussion or evaluation shared with the user
+
+This ensures consistency with project standards and accessibility for all contributors.
+
 ## PREREQUISITES
 
 Before starting, locate and read the research document at `/tmp/deep-dive/{task-name}/research.md` where `{task-name}` matches the research phase. If no research exists, inform the user and suggest running `/deep-research` first.

--- a/.claude/commands/deep-plan.md
+++ b/.claude/commands/deep-plan.md
@@ -6,6 +6,15 @@ description: Create concrete implementation plan based on research and innovatio
 
 You are entering **Deep Plan Mode**. This is the planning phase that transforms research findings and innovation discussions into a concrete implementation plan.
 
+## LANGUAGE REQUIREMENT
+
+**All outputs must be written in English.** This includes:
+- The plan document (`plan.md`)
+- Task breakdowns and specifications
+- Any discussion or presentation shared with the user
+
+This ensures consistency with project standards and accessibility for all contributors.
+
 ## PREREQUISITES
 
 Before starting:

--- a/.claude/commands/deep-research.md
+++ b/.claude/commands/deep-research.md
@@ -6,6 +6,15 @@ description: Deep research and information gathering before any implementation d
 
 You are entering **Deep Research Mode**. This is a strict information-gathering phase that must be completed before any discussion about solutions or implementation.
 
+## LANGUAGE REQUIREMENT
+
+**All outputs must be written in English.** This includes:
+- The research document (`research.md`)
+- Summaries and findings shared with the user
+- Any analysis or observations
+
+This ensures consistency with project standards and accessibility for all contributors.
+
 ## CRITICAL RESTRICTIONS
 
 **PERMITTED:**


### PR DESCRIPTION
## Summary
- Add explicit English language requirement to `/deep-research`, `/deep-innovate`, and `/deep-plan` slash commands
- Ensures all generated documents and outputs follow project's language standard
- Improves consistency and accessibility for all contributors

## Changes
- `.claude/commands/deep-research.md` - Added LANGUAGE REQUIREMENT section
- `.claude/commands/deep-innovate.md` - Added LANGUAGE REQUIREMENT section
- `.claude/commands/deep-plan.md` - Added LANGUAGE REQUIREMENT section

## Test plan
- [ ] Verify commands still work correctly
- [ ] Confirm outputs are generated in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)