### PR TITLE
feat: add scope support to agent compose

### DIFF
--- a/e2e/tests/02-commands/t22-vm0-compose-scope.bats
+++ b/e2e/tests/02-commands/t22-vm0-compose-scope.bats
@@ -1,0 +1,395 @@
+#!/usr/bin/env bats
+
+# Test VM0 compose with scope support
+# Tests the scope/name:version naming convention for agent composes
+#
+# This test covers issue #757: Add scope support to agent compose
+
+load '../../helpers/setup'
+
+setup() {
+    # Create temporary test directory
+    export TEST_DIR="$(mktemp -d)"
+    # Use UUID for reliable uniqueness in parallel test runs
+    export AGENT_NAME="e2e-scope-compose-$(cat /proc/sys/kernel/random/uuid | head -c 8)"
+    export ARTIFACT_NAME="e2e-scope-artifact-$(date +%s)"
+}
+
+teardown() {
+    # Clean up temporary directory
+    [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ] && rm -rf "$TEST_DIR"
+}
+
+# ============================================
+# vm0 compose displays scope/name format
+# ============================================
+
+@test "vm0 compose displays scope/name format in output" {
+    echo "# Creating config file..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent for scope display"
+    provider: claude-code
+    image: "vm0/claude-code:dev"
+    working_dir: /home/user/workspace
+EOF
+
+    echo "# Running vm0 compose..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Verifying output contains scope/name format..."
+    # Output should show something like "Compose created: user-abc12345/e2e-scope-compose-xxxx"
+    assert_output --regexp "Compose (created|version exists): [a-z0-9-]+/$AGENT_NAME"
+
+    echo "# Verifying output contains version..."
+    assert_output --partial "Version:"
+    assert_output --regexp "Version:[ ]+[0-9a-f]{8}"
+}
+
+@test "vm0 compose shows scope/name:version in run instructions" {
+    echo "# Creating config file..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent for run instructions"
+    provider: claude-code
+    image: "vm0/claude-code:dev"
+    working_dir: /home/user/workspace
+EOF
+
+    echo "# Running vm0 compose..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Verifying run instructions include scope/name:version format..."
+    # Output should show: vm0 run scope/name:version
+    assert_output --regexp "vm0 run [a-z0-9-]+/$AGENT_NAME:[0-9a-f]{8}"
+}
+
+# ============================================
+# vm0 run with scope/name format
+# ============================================
+
+@test "vm0 run with scope/name format resolves agent correctly" {
+    echo "# Step 1: Get user's scope..."
+    run $CLI_COMMAND scope status
+    if [[ $status -ne 0 ]]; then
+        echo "# No scope found, skipping test"
+        skip "User has no scope configured"
+    fi
+
+    # Extract scope slug from output
+    USER_SCOPE=$(echo "$output" | grep -oP 'Slug:\s+\K[a-z0-9-]+' | head -1)
+    echo "# User scope: $USER_SCOPE"
+
+    [ -n "$USER_SCOPE" ] || {
+        echo "# Failed to extract user scope"
+        skip "Could not extract user scope"
+    }
+
+    echo "# Step 2: Creating agent config..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent for scope/name run"
+    provider: claude-code
+    image: "vm0/claude-code:dev"
+    working_dir: /home/user/workspace
+EOF
+
+    echo "# Step 3: Composing agent..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Step 4: Setting up artifact..."
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    echo "# Step 5: Running with scope/name format..."
+    run $CLI_COMMAND run "$USER_SCOPE/$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "echo hello from scope test"
+    assert_success
+}
+
+@test "vm0 run with scope/name:version format works correctly" {
+    echo "# Step 1: Get user's scope..."
+    run $CLI_COMMAND scope status
+    if [[ $status -ne 0 ]]; then
+        skip "User has no scope configured"
+    fi
+
+    USER_SCOPE=$(echo "$output" | grep -oP 'Slug:\s+\K[a-z0-9-]+' | head -1)
+    [ -n "$USER_SCOPE" ] || skip "Could not extract user scope"
+    echo "# User scope: $USER_SCOPE"
+
+    echo "# Step 2: Creating agent config..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent for scope/name:version run"
+    provider: claude-code
+    image: "vm0/claude-code:dev"
+    working_dir: /home/user/workspace
+EOF
+
+    echo "# Step 3: Composing agent..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    # Extract version ID from compose output
+    VERSION_ID=$(echo "$output" | grep -oP 'Version:\s+\K[0-9a-f]+')
+    echo "# Version ID: $VERSION_ID"
+
+    [ -n "$VERSION_ID" ] || {
+        echo "# Failed to extract version ID from output:"
+        echo "$output"
+        return 1
+    }
+
+    echo "# Step 4: Setting up artifact..."
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    echo "# Step 5: Running with scope/name:version format..."
+    run $CLI_COMMAND run "$USER_SCOPE/$AGENT_NAME:$VERSION_ID" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "echo hello from versioned scope test"
+    assert_success
+}
+
+@test "vm0 run with scope/name:latest works correctly" {
+    echo "# Step 1: Get user's scope..."
+    run $CLI_COMMAND scope status
+    if [[ $status -ne 0 ]]; then
+        skip "User has no scope configured"
+    fi
+
+    USER_SCOPE=$(echo "$output" | grep -oP 'Slug:\s+\K[a-z0-9-]+' | head -1)
+    [ -n "$USER_SCOPE" ] || skip "Could not extract user scope"
+    echo "# User scope: $USER_SCOPE"
+
+    echo "# Step 2: Creating agent config..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent for scope/name:latest"
+    provider: claude-code
+    image: "vm0/claude-code:dev"
+    working_dir: /home/user/workspace
+EOF
+
+    echo "# Step 3: Composing agent..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Step 4: Setting up artifact..."
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    echo "# Step 5: Running with scope/name:latest format..."
+    run $CLI_COMMAND run "$USER_SCOPE/$AGENT_NAME:latest" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "echo hello from latest scope test"
+    assert_success
+}
+
+# ============================================
+# Error handling tests
+# ============================================
+
+@test "vm0 run with non-existent scope shows error" {
+    echo "# Trying to run with a non-existent scope..."
+    run $CLI_COMMAND run "nonexistent-scope-xyz123/$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "echo hello"
+
+    assert_failure
+    # Should show scope not found error
+    assert_output --partial "not found"
+}
+
+@test "vm0 run with non-existent agent in valid scope shows error" {
+    echo "# Step 1: Get user's scope..."
+    run $CLI_COMMAND scope status
+    if [[ $status -ne 0 ]]; then
+        skip "User has no scope configured"
+    fi
+
+    USER_SCOPE=$(echo "$output" | grep -oP 'Slug:\s+\K[a-z0-9-]+' | head -1)
+    [ -n "$USER_SCOPE" ] || skip "Could not extract user scope"
+    echo "# User scope: $USER_SCOPE"
+
+    echo "# Step 2: Trying to run non-existent agent..."
+    run $CLI_COMMAND run "$USER_SCOPE/nonexistent-agent-xyz123" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "echo hello"
+
+    assert_failure
+    # Should show agent not found error
+    assert_output --partial "not found"
+}
+
+@test "vm0 run with scope/name:nonexistent-version shows error" {
+    echo "# Step 1: Get user's scope..."
+    run $CLI_COMMAND scope status
+    if [[ $status -ne 0 ]]; then
+        skip "User has no scope configured"
+    fi
+
+    USER_SCOPE=$(echo "$output" | grep -oP 'Slug:\s+\K[a-z0-9-]+' | head -1)
+    [ -n "$USER_SCOPE" ] || skip "Could not extract user scope"
+    echo "# User scope: $USER_SCOPE"
+
+    echo "# Step 2: Creating agent config..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent for version error"
+    provider: claude-code
+    image: "vm0/claude-code:dev"
+    working_dir: /home/user/workspace
+EOF
+
+    echo "# Step 3: Composing agent..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Step 4: Trying to run with non-existent version..."
+    run $CLI_COMMAND run "$USER_SCOPE/$AGENT_NAME:deadbeef" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "echo hello"
+
+    assert_failure
+    # Should show version not found error
+    assert_output --partial "Version not found"
+}
+
+# ============================================
+# Cross-scope isolation tests
+# ============================================
+
+@test "vm0 run cannot access agent from different scope" {
+    echo "# Creating agent config..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent for scope isolation"
+    provider: claude-code
+    image: "vm0/claude-code:dev"
+    working_dir: /home/user/workspace
+EOF
+
+    echo "# Composing agent in user's scope..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Trying to access agent with wrong scope prefix..."
+    # Use a different scope that doesn't exist
+    run $CLI_COMMAND run "other-user-scope/$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "echo hello"
+
+    assert_failure
+    # Should fail because the scope doesn't exist or agent isn't in that scope
+    assert_output --partial "not found"
+}
+
+# ============================================
+# Backward compatibility tests
+# ============================================
+
+@test "vm0 run without scope prefix still works (backward compatible)" {
+    echo "# Step 1: Creating agent config..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent for backward compatibility"
+    provider: claude-code
+    image: "vm0/claude-code:dev"
+    working_dir: /home/user/workspace
+EOF
+
+    echo "# Step 2: Composing agent..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Step 3: Setting up artifact..."
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    echo "# Step 4: Running without scope prefix (should use user's default scope)..."
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "echo hello from backward compat test"
+    assert_success
+}
+
+@test "vm0 run with name:version (no scope) still works" {
+    echo "# Step 1: Creating agent config..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent for name:version format"
+    provider: claude-code
+    image: "vm0/claude-code:dev"
+    working_dir: /home/user/workspace
+EOF
+
+    echo "# Step 2: Composing agent..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    # Extract version ID
+    VERSION_ID=$(echo "$output" | grep -oP 'Version:\s+\K[0-9a-f]+')
+    echo "# Version ID: $VERSION_ID"
+    [ -n "$VERSION_ID" ] || {
+        echo "# Failed to extract version ID"
+        return 1
+    }
+
+    echo "# Step 3: Setting up artifact..."
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init >/dev/null
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    echo "# Step 4: Running with name:version format (no scope prefix)..."
+    run $CLI_COMMAND run "$AGENT_NAME:$VERSION_ID" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "echo hello from name:version test"
+    assert_success
+}

--- a/turbo/apps/cli/src/commands/__tests__/compose.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/compose.test.ts
@@ -213,7 +213,7 @@ describe("compose command", () => {
         expect.stringContaining("Compose created: test-agent"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Compose ID: cmp-123"),
+        expect.stringContaining("Version: a1b2c3d4"),
       );
     });
 

--- a/turbo/apps/cli/src/commands/__tests__/compose.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/compose.test.ts
@@ -71,6 +71,14 @@ describe("compose command", () => {
           "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6",
         action: "created",
       });
+      vi.mocked(apiClient.getScope).mockResolvedValue({
+        id: "scope-123",
+        slug: "user-abc12345",
+        type: "personal",
+        displayName: null,
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+      });
 
       await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
 
@@ -114,6 +122,14 @@ describe("compose command", () => {
         versionId:
           "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6",
         action: "created",
+      });
+      vi.mocked(apiClient.getScope).mockResolvedValue({
+        id: "scope-123",
+        slug: "user-abc12345",
+        type: "personal",
+        displayName: null,
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
       });
 
       await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
@@ -162,6 +178,14 @@ describe("compose command", () => {
           "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6",
         action: "created",
       });
+      vi.mocked(apiClient.getScope).mockResolvedValue({
+        id: "scope-123",
+        slug: "user-abc12345",
+        type: "personal",
+        displayName: null,
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+      });
 
       await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
 
@@ -179,6 +203,14 @@ describe("compose command", () => {
       });
       vi.mocked(yamlValidator.validateAgentCompose).mockReturnValue({
         valid: true,
+      });
+      vi.mocked(apiClient.getScope).mockResolvedValue({
+        id: "scope-123",
+        slug: "user-abc12345",
+        type: "personal",
+        displayName: null,
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
       });
     });
 
@@ -210,7 +242,7 @@ describe("compose command", () => {
       await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Compose created: test-agent"),
+        expect.stringContaining("Compose created: user-abc12345/test-agent"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("Version: a1b2c3d4"),
@@ -229,7 +261,9 @@ describe("compose command", () => {
       await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Compose version exists: test-agent"),
+        expect.stringContaining(
+          "Compose version exists: user-abc12345/test-agent",
+        ),
       );
     });
 
@@ -245,7 +279,7 @@ describe("compose command", () => {
       await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("vm0 run test"),
+        expect.stringContaining("vm0 run user-abc12345/test"),
       );
     });
   });

--- a/turbo/apps/cli/src/commands/compose.ts
+++ b/turbo/apps/cli/src/commands/compose.ts
@@ -198,20 +198,12 @@ export const composeCommand = new Command()
         content: config,
       });
 
-      // Get user's scope for display
-      let scopeSlug: string | undefined;
-      try {
-        const scopeResponse = await apiClient.getScope();
-        scopeSlug = scopeResponse.slug;
-      } catch {
-        // Scope might not be available, continue without it
-      }
+      // Get user's scope for display (must exist if compose succeeded)
+      const scopeResponse = await apiClient.getScope();
 
       // 6. Display result
       const shortVersionId = response.versionId.slice(0, 8);
-      const displayName = scopeSlug
-        ? `${scopeSlug}/${response.name}`
-        : response.name;
+      const displayName = `${scopeResponse.slug}/${response.name}`;
 
       if (response.action === "created") {
         console.log(chalk.green(`✓ Compose created: ${displayName}`));

--- a/turbo/apps/cli/src/commands/compose.ts
+++ b/turbo/apps/cli/src/commands/compose.ts
@@ -198,21 +198,33 @@ export const composeCommand = new Command()
         content: config,
       });
 
-      // 6. Display result
-      const shortVersionId = response.versionId.slice(0, 8);
-      if (response.action === "created") {
-        console.log(chalk.green(`✓ Compose created: ${response.name}`));
-      } else {
-        console.log(chalk.green(`✓ Compose version exists: ${response.name}`));
+      // Get user's scope for display
+      let scopeSlug: string | undefined;
+      try {
+        const scopeResponse = await apiClient.getScope();
+        scopeSlug = scopeResponse.slug;
+      } catch {
+        // Scope might not be available, continue without it
       }
 
-      console.log(chalk.dim(`  Compose ID: ${response.composeId}`));
-      console.log(chalk.dim(`  Version:    ${shortVersionId}`));
+      // 6. Display result
+      const shortVersionId = response.versionId.slice(0, 8);
+      const displayName = scopeSlug
+        ? `${scopeSlug}/${response.name}`
+        : response.name;
+
+      if (response.action === "created") {
+        console.log(chalk.green(`✓ Compose created: ${displayName}`));
+      } else {
+        console.log(chalk.green(`✓ Compose version exists: ${displayName}`));
+      }
+
+      console.log(chalk.dim(`  Version: ${shortVersionId}`));
       console.log();
       console.log("  Run your agent:");
       console.log(
         chalk.cyan(
-          `    vm0 run ${response.name} --artifact-name <artifact> "your prompt"`,
+          `    vm0 run ${displayName}:${shortVersionId} --artifact-name <artifact> "your prompt"`,
         ),
       );
     } catch (error) {

--- a/turbo/apps/cli/src/lib/api-client.ts
+++ b/turbo/apps/cli/src/lib/api-client.ts
@@ -182,12 +182,20 @@ class ApiClient {
     return apiUrl;
   }
 
-  async getComposeByName(name: string): Promise<GetComposeResponse> {
+  async getComposeByName(
+    name: string,
+    scope?: string,
+  ): Promise<GetComposeResponse> {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
+    const params = new URLSearchParams({ name });
+    if (scope) {
+      params.append("scope", scope);
+    }
+
     const response = await fetch(
-      `${baseUrl}/api/agent/composes?name=${encodeURIComponent(name)}`,
+      `${baseUrl}/api/agent/composes?${params.toString()}`,
       {
         method: "GET",
         headers,

--- a/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
@@ -220,12 +220,8 @@ describe("GET /api/agent/composes?name=<name>", () => {
     await globalThis.services.db
       .delete(agentComposes)
       .where(eq(agentComposes.userId, user2Id));
-    await globalThis.services.db
-      .delete(scopes)
-      .where(eq(scopes.id, scope1Id));
-    await globalThis.services.db
-      .delete(scopes)
-      .where(eq(scopes.id, scope2Id));
+    await globalThis.services.db.delete(scopes).where(eq(scopes.id, scope1Id));
+    await globalThis.services.db.delete(scopes).where(eq(scopes.id, scope2Id));
 
     // Reset mockUserId
     mockUserId = "test-user-get-by-name";

--- a/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
@@ -6,7 +6,9 @@ import { NextRequest } from "next/server";
 import { GET, POST } from "../route";
 import { initServices } from "../../../../../src/lib/init-services";
 import { agentComposes } from "../../../../../src/db/schema/agent-compose";
+import { scopes } from "../../../../../src/db/schema/scope";
 import { eq } from "drizzle-orm";
+import { randomUUID } from "crypto";
 
 /**
  * Helper to create a NextRequest for testing.
@@ -35,9 +37,27 @@ vi.mock("../../../../../src/lib/auth/get-user-id", () => ({
 
 describe("GET /api/agent/composes?name=<name>", () => {
   const testUserId = "test-user-get-by-name";
+  const testScopeId = randomUUID();
 
-  beforeAll(() => {
+  beforeAll(async () => {
     initServices();
+
+    // Clean up any existing test data
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.userId, testUserId));
+
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, testScopeId));
+
+    // Create test scope for the user (required for compose creation)
+    await globalThis.services.db.insert(scopes).values({
+      id: testScopeId,
+      slug: `test-${testScopeId.slice(0, 8)}`,
+      type: "personal",
+      ownerId: testUserId,
+    });
   });
 
   afterAll(async () => {
@@ -45,6 +65,10 @@ describe("GET /api/agent/composes?name=<name>", () => {
     await globalThis.services.db
       .delete(agentComposes)
       .where(eq(agentComposes.userId, testUserId));
+
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, testScopeId));
   });
 
   it("should return compose when name exists", async () => {
@@ -128,8 +152,30 @@ describe("GET /api/agent/composes?name=<name>", () => {
   });
 
   it("should only return compose for authenticated user", async () => {
+    // Create scopes for isolated users
+    const user1Id = "user-1-isolation";
+    const user2Id = "user-2-isolation";
+    const scope1Id = randomUUID();
+    const scope2Id = randomUUID();
+
+    // Create scope for user 1
+    await globalThis.services.db.insert(scopes).values({
+      id: scope1Id,
+      slug: `test-${scope1Id.slice(0, 8)}`,
+      type: "personal",
+      ownerId: user1Id,
+    });
+
+    // Create scope for user 2
+    await globalThis.services.db.insert(scopes).values({
+      id: scope2Id,
+      slug: `test-${scope2Id.slice(0, 8)}`,
+      type: "personal",
+      ownerId: user2Id,
+    });
+
     // Create compose as user 1
-    mockUserId = "user-1-isolation";
+    mockUserId = user1Id;
     const config = {
       version: "1.0",
       agents: {
@@ -155,7 +201,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
     expect(createResponse.status).toBe(201);
 
     // Try to get it as user 2
-    mockUserId = "user-2-isolation";
+    mockUserId = user2Id;
     const getRequest = createTestRequest(
       "http://localhost:3000/api/agent/composes?name=test-user-isolation",
       { method: "GET" },
@@ -168,13 +214,18 @@ describe("GET /api/agent/composes?name=<name>", () => {
     expect(getData.error.message).toContain("Agent compose not found");
 
     // Cleanup
-    mockUserId = "user-1-isolation";
     await globalThis.services.db
       .delete(agentComposes)
-      .where(eq(agentComposes.userId, "user-1-isolation"));
+      .where(eq(agentComposes.userId, user1Id));
     await globalThis.services.db
       .delete(agentComposes)
-      .where(eq(agentComposes.userId, "user-2-isolation"));
+      .where(eq(agentComposes.userId, user2Id));
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, scope1Id));
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, scope2Id));
 
     // Reset mockUserId
     mockUserId = "test-user-get-by-name";

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
@@ -19,6 +19,7 @@ import {
   agentComposeVersions,
 } from "../../../../../../../src/db/schema/agent-compose";
 import { cliTokens } from "../../../../../../../src/db/schema/cli-tokens";
+import { scopes } from "../../../../../../../src/db/schema/scope";
 import { eq } from "drizzle-orm";
 import { randomUUID } from "crypto";
 import {
@@ -76,6 +77,7 @@ function createAxiomAgentEvent(overrides: {
 describe("GET /api/agent/runs/:id/events", () => {
   // Generate unique IDs for this test run to avoid conflicts
   const testUserId = `test-user-${Date.now()}-${process.pid}`;
+  const testScopeId = randomUUID();
   const testAgentName = `test-agent-run-events-${Date.now()}`;
   const testRunId = randomUUID(); // UUID for agent run
   let testVersionId: string;
@@ -118,6 +120,16 @@ describe("GET /api/agent/runs/:id/events", () => {
     await globalThis.services.db
       .delete(agentComposes)
       .where(eq(agentComposes.userId, testUserId));
+
+    await globalThis.services.db.delete(scopes).where(eq(scopes.id, testScopeId));
+
+    // Create test scope for the user (required for compose creation)
+    await globalThis.services.db.insert(scopes).values({
+      id: testScopeId,
+      slug: `test-${testScopeId.slice(0, 8)}`,
+      type: "personal",
+      ownerId: testUserId,
+    });
 
     // Create test compose via API endpoint
     const config = createDefaultComposeConfig(testAgentName);
@@ -216,13 +228,23 @@ describe("GET /api/agent/runs/:id/events", () => {
       const otherUserId = `other-user-${Date.now()}-${process.pid}`;
       const otherRunId = randomUUID();
       const otherComposeId = randomUUID();
+      const otherScopeId = randomUUID();
       const otherVersionId =
         randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
+
+      // Create scope for other user
+      await globalThis.services.db.insert(scopes).values({
+        id: otherScopeId,
+        slug: `test-${otherScopeId.slice(0, 8)}`,
+        type: "personal",
+        ownerId: otherUserId,
+      });
 
       // Create config for other user
       await globalThis.services.db.insert(agentComposes).values({
         id: otherComposeId,
         userId: otherUserId,
+        scopeId: otherScopeId,
         name: "other-agent",
         headVersionId: otherVersionId,
         createdAt: new Date(),
@@ -706,6 +728,7 @@ describe("GET /api/agent/runs/:id/events", () => {
       await globalThis.services.db.insert(agentComposes).values({
         id: codexComposeId,
         userId: testUserId,
+        scopeId: testScopeId,
         name: "codex-agent",
         headVersionId: codexVersionId,
         createdAt: new Date(),
@@ -768,6 +791,7 @@ describe("GET /api/agent/runs/:id/events", () => {
       await globalThis.services.db.insert(agentComposes).values({
         id: explicitComposeId,
         userId: testUserId,
+        scopeId: testScopeId,
         name: "explicit-agent",
         headVersionId: explicitVersionId,
         createdAt: new Date(),

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
@@ -121,7 +121,9 @@ describe("GET /api/agent/runs/:id/events", () => {
       .delete(agentComposes)
       .where(eq(agentComposes.userId, testUserId));
 
-    await globalThis.services.db.delete(scopes).where(eq(scopes.id, testScopeId));
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, testScopeId));
 
     // Create test scope for the user (required for compose creation)
     await globalThis.services.db.insert(scopes).values({

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/__tests__/route.test.ts
@@ -19,6 +19,7 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../../../../../src/db/schema/agent-compose";
+import { scopes } from "../../../../../../../src/db/schema/scope";
 import { eq } from "drizzle-orm";
 import { randomUUID } from "crypto";
 
@@ -49,6 +50,7 @@ function createTestRequest(url: string): NextRequest {
 describe("GET /api/agent/runs/:id/telemetry", () => {
   // Generate unique IDs for this test run to avoid conflicts
   const testUserId = `test-user-${Date.now()}-${process.pid}`;
+  const testScopeId = randomUUID();
   const testRunId = randomUUID();
   const testComposeId = randomUUID();
   const testVersionId =
@@ -88,10 +90,23 @@ describe("GET /api/agent/runs/:id/telemetry", () => {
       .delete(agentComposes)
       .where(eq(agentComposes.id, testComposeId));
 
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, testScopeId));
+
+    // Create test scope
+    await globalThis.services.db.insert(scopes).values({
+      id: testScopeId,
+      slug: `test-${testScopeId.slice(0, 8)}`,
+      type: "personal",
+      ownerId: testUserId,
+    });
+
     // Create test agent config
     await globalThis.services.db.insert(agentComposes).values({
       id: testComposeId,
       userId: testUserId,
+      scopeId: testScopeId,
       name: "test-agent",
       headVersionId: testVersionId,
       createdAt: new Date(),
@@ -194,15 +209,25 @@ describe("GET /api/agent/runs/:id/telemetry", () => {
 
     it("should reject request for run owned by different user", async () => {
       const otherUserId = `other-user-${Date.now()}-${process.pid}`;
+      const otherScopeId = randomUUID();
       const otherRunId = randomUUID();
       const otherComposeId = randomUUID();
       const otherVersionId =
         randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
 
+      // Create scope for other user
+      await globalThis.services.db.insert(scopes).values({
+        id: otherScopeId,
+        slug: `test-${otherScopeId.slice(0, 8)}`,
+        type: "personal",
+        ownerId: otherUserId,
+      });
+
       // Create config for other user
       await globalThis.services.db.insert(agentComposes).values({
         id: otherComposeId,
         userId: otherUserId,
+        scopeId: otherScopeId,
         name: "other-agent",
         headVersionId: otherVersionId,
         createdAt: new Date(),
@@ -256,6 +281,9 @@ describe("GET /api/agent/runs/:id/telemetry", () => {
       await globalThis.services.db
         .delete(agentComposes)
         .where(eq(agentComposes.id, otherComposeId));
+      await globalThis.services.db
+        .delete(scopes)
+        .where(eq(scopes.id, otherScopeId));
     });
   });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts
@@ -18,6 +18,7 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../../../../../../src/db/schema/agent-compose";
+import { scopes } from "../../../../../../../../src/db/schema/scope";
 import { eq } from "drizzle-orm";
 import { randomUUID } from "crypto";
 
@@ -91,6 +92,7 @@ function createAxiomNetworkEvent(
 
 describe("GET /api/agent/runs/:id/telemetry/network", () => {
   const testUserId = `test-user-${Date.now()}-${process.pid}`;
+  const testScopeId = randomUUID();
   const testRunId = randomUUID();
   const testComposeId = randomUUID();
   const testVersionId =
@@ -124,10 +126,23 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
       .delete(agentComposes)
       .where(eq(agentComposes.id, testComposeId));
 
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, testScopeId));
+
+    // Create test scope
+    await globalThis.services.db.insert(scopes).values({
+      id: testScopeId,
+      slug: `test-${testScopeId.slice(0, 8)}`,
+      type: "personal",
+      ownerId: testUserId,
+    });
+
     // Create test agent compose
     await globalThis.services.db.insert(agentComposes).values({
       id: testComposeId,
       userId: testUserId,
+      scopeId: testScopeId,
       name: "test-agent",
       headVersionId: testVersionId,
       createdAt: new Date(),
@@ -216,14 +231,23 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
 
     it("should reject request for run owned by different user", async () => {
       const otherUserId = `other-user-${Date.now()}-${process.pid}`;
+      const otherScopeId = randomUUID();
       const otherRunId = randomUUID();
       const otherComposeId = randomUUID();
       const otherVersionId =
         randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
 
+      await globalThis.services.db.insert(scopes).values({
+        id: otherScopeId,
+        slug: `test-${otherScopeId.slice(0, 8)}`,
+        type: "personal",
+        ownerId: otherUserId,
+      });
+
       await globalThis.services.db.insert(agentComposes).values({
         id: otherComposeId,
         userId: otherUserId,
+        scopeId: otherScopeId,
         name: "other-agent",
         headVersionId: otherVersionId,
         createdAt: new Date(),
@@ -275,6 +299,9 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
       await globalThis.services.db
         .delete(agentComposes)
         .where(eq(agentComposes.id, otherComposeId));
+      await globalThis.services.db
+        .delete(scopes)
+        .where(eq(scopes.id, otherScopeId));
     });
   });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/__tests__/route.test.ts
@@ -18,6 +18,7 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../../../../../../src/db/schema/agent-compose";
+import { scopes } from "../../../../../../../../src/db/schema/scope";
 import { eq } from "drizzle-orm";
 import { randomUUID } from "crypto";
 
@@ -57,6 +58,7 @@ function createTestRequest(url: string): NextRequest {
 
 describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
   const testUserId = `test-user-${Date.now()}-${process.pid}`;
+  const testScopeId = randomUUID();
   const testRunId = randomUUID();
   const testComposeId = randomUUID();
   const testVersionId =
@@ -90,10 +92,23 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
       .delete(agentComposes)
       .where(eq(agentComposes.id, testComposeId));
 
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, testScopeId));
+
+    // Create test scope
+    await globalThis.services.db.insert(scopes).values({
+      id: testScopeId,
+      slug: `test-${testScopeId.slice(0, 8)}`,
+      type: "personal",
+      ownerId: testUserId,
+    });
+
     // Create test agent compose
     await globalThis.services.db.insert(agentComposes).values({
       id: testComposeId,
       userId: testUserId,
+      scopeId: testScopeId,
       name: "test-agent",
       headVersionId: testVersionId,
       createdAt: new Date(),
@@ -182,14 +197,23 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
 
     it("should reject request for run owned by different user", async () => {
       const otherUserId = `other-user-${Date.now()}-${process.pid}`;
+      const otherScopeId = randomUUID();
       const otherRunId = randomUUID();
       const otherComposeId = randomUUID();
       const otherVersionId =
         randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
 
+      await globalThis.services.db.insert(scopes).values({
+        id: otherScopeId,
+        slug: `test-${otherScopeId.slice(0, 8)}`,
+        type: "personal",
+        ownerId: otherUserId,
+      });
+
       await globalThis.services.db.insert(agentComposes).values({
         id: otherComposeId,
         userId: otherUserId,
+        scopeId: otherScopeId,
         name: "other-agent",
         headVersionId: otherVersionId,
         createdAt: new Date(),
@@ -241,6 +265,9 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
       await globalThis.services.db
         .delete(agentComposes)
         .where(eq(agentComposes.id, otherComposeId));
+      await globalThis.services.db
+        .delete(scopes)
+        .where(eq(scopes.id, otherScopeId));
     });
   });
 

--- a/turbo/apps/web/src/db/migrations/0045_create_default_scopes_for_existing_users.sql
+++ b/turbo/apps/web/src/db/migrations/0045_create_default_scopes_for_existing_users.sql
@@ -1,0 +1,16 @@
+-- Create default scopes for existing users who don't have one
+-- Uses random slug generation (migration doesn't need determinism)
+-- Format: user-{8 hex chars} e.g., user-a1b2c3d4
+
+INSERT INTO "scopes" ("slug", "type", "owner_id")
+SELECT
+  'user-' || left(md5(random()::text), 8),
+  'personal',
+  ct.user_id
+FROM (
+  SELECT DISTINCT user_id FROM cli_tokens
+  WHERE user_id NOT IN (
+    SELECT owner_id FROM scopes WHERE owner_id IS NOT NULL
+  )
+) ct
+ON CONFLICT ("slug") DO NOTHING;

--- a/turbo/apps/web/src/db/migrations/0046_add_scope_id_to_agent_composes.sql
+++ b/turbo/apps/web/src/db/migrations/0046_add_scope_id_to_agent_composes.sql
@@ -1,0 +1,29 @@
+-- Add scope support to agent_composes table
+-- Follows the same pattern as images table
+
+-- Step 1: Add scope_id column (nullable initially)
+ALTER TABLE "agent_composes" ADD COLUMN "scope_id" uuid REFERENCES "scopes"("id");
+--> statement-breakpoint
+
+-- Step 2: Create index for scope lookups
+CREATE INDEX IF NOT EXISTS "idx_agent_composes_scope" ON "agent_composes" USING btree ("scope_id");
+--> statement-breakpoint
+
+-- Step 3: Populate scope_id from user's personal scope
+UPDATE "agent_composes" ac
+SET "scope_id" = s.id
+FROM "scopes" s
+WHERE s.owner_id = ac.user_id AND s.type = 'personal';
+--> statement-breakpoint
+
+-- Step 4: Make scope_id NOT NULL (all rows should have scope now)
+ALTER TABLE "agent_composes" ALTER COLUMN "scope_id" SET NOT NULL;
+--> statement-breakpoint
+
+-- Step 5: Drop old unique index
+DROP INDEX IF EXISTS "idx_agent_composes_user_name";
+--> statement-breakpoint
+
+-- Step 6: Create new unique index on (scope_id, name)
+CREATE UNIQUE INDEX "idx_agent_composes_scope_name"
+  ON "agent_composes" ("scope_id", "name");

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -316,6 +316,20 @@
       "when": 1766900000000,
       "tag": "0044_add_session_history_hash",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1767000000000,
+      "tag": "0045_create_default_scopes_for_existing_users",
+      "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1767100000000,
+      "tag": "0046_add_scope_id_to_agent_composes",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/agent-compose.ts
+++ b/turbo/apps/web/src/db/schema/agent-compose.ts
@@ -8,6 +8,7 @@ import {
   uniqueIndex,
   index,
 } from "drizzle-orm/pg-core";
+import { scopes } from "./scope";
 
 /**
  * Agent Composes table
@@ -18,16 +19,20 @@ export const agentComposes = pgTable(
   {
     id: uuid("id").defaultRandom().primaryKey(),
     userId: text("user_id").notNull(), // Clerk user ID
+    scopeId: uuid("scope_id")
+      .notNull()
+      .references(() => scopes.id), // Scope reference
     name: varchar("name", { length: 64 }).notNull(), // Agent name from compose
     headVersionId: varchar("head_version_id", { length: 64 }), // Points to latest version hash
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => ({
-    userNameIdx: uniqueIndex("idx_agent_composes_user_name").on(
-      table.userId,
+    scopeNameIdx: uniqueIndex("idx_agent_composes_scope_name").on(
+      table.scopeId,
       table.name,
     ),
+    scopeIdx: index("idx_agent_composes_scope").on(table.scopeId),
   }),
 );
 

--- a/turbo/apps/web/src/lib/run/__tests__/run-service.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-service.test.ts
@@ -62,7 +62,9 @@ describe("run-service", () => {
     agentSessionService = agentSessionModule.agentSessionService;
 
     // Create test scope for the user (required for compose creation)
-    await globalThis.services.db.delete(scopes).where(eq(scopes.id, TEST_SCOPE_ID));
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, TEST_SCOPE_ID));
     await globalThis.services.db.insert(scopes).values({
       id: TEST_SCOPE_ID,
       slug: `test-${TEST_SCOPE_ID.slice(0, 8)}`,

--- a/turbo/apps/web/src/lib/run/__tests__/run-service.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-service.test.ts
@@ -19,6 +19,8 @@ import {
 import { agentRuns } from "../../../db/schema/agent-run";
 import { conversations } from "../../../db/schema/conversation";
 import { checkpoints } from "../../../db/schema/checkpoint";
+import { scopes } from "../../../db/schema/scope";
+import { randomUUID } from "crypto";
 
 // Mock e2b-service to prevent env() access during module load
 vi.mock("../../e2b", () => ({
@@ -41,8 +43,9 @@ let NotFoundError: typeof import("../../errors").NotFoundError;
 let UnauthorizedError: typeof import("../../errors").UnauthorizedError;
 let agentSessionService: typeof import("../../agent-session").agentSessionService;
 
-// Test user ID for isolation
+// Test user ID and scope for isolation
 const TEST_USER_ID = "test-user-run-service";
+const TEST_SCOPE_ID = randomUUID();
 
 describe("run-service", () => {
   beforeAll(async () => {
@@ -57,6 +60,15 @@ describe("run-service", () => {
 
     const agentSessionModule = await import("../../agent-session");
     agentSessionService = agentSessionModule.agentSessionService;
+
+    // Create test scope for the user (required for compose creation)
+    await globalThis.services.db.delete(scopes).where(eq(scopes.id, TEST_SCOPE_ID));
+    await globalThis.services.db.insert(scopes).values({
+      id: TEST_SCOPE_ID,
+      slug: `test-${TEST_SCOPE_ID.slice(0, 8)}`,
+      type: "personal",
+      ownerId: TEST_USER_ID,
+    });
   });
 
   beforeEach(async () => {
@@ -244,6 +256,7 @@ describe("run-service", () => {
             .insert(agentComposes)
             .values({
               userId: TEST_USER_ID,
+              scopeId: TEST_SCOPE_ID,
               name: "test-compose-run-service",
             })
             .returning();

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { eq, and } from "drizzle-orm";
 import { scopes } from "../../db/schema/scope";
 import { users } from "../../db/schema/user";
@@ -20,6 +21,18 @@ const RESERVED_SLUGS = ["vm0", "system", "admin", "api", "app", "www"];
  * - must start and end with alphanumeric
  */
 const SLUG_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]{1,2}$/;
+
+/**
+ * Generate a deterministic default scope slug from Clerk user ID.
+ * Format: user-{8 hex chars from SHA-256 hash}
+ *
+ * @param clerkUserId - The Clerk user ID to hash
+ * @returns A slug in format "user-xxxxxxxx" (13 chars total)
+ */
+export function generateDefaultScopeSlug(clerkUserId: string): string {
+  const hash = createHash("sha256").update(clerkUserId).digest("hex");
+  return `user-${hash.slice(0, 8)}`;
+}
 
 /**
  * Validate scope slug format

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -94,14 +94,16 @@ const createComposeResponseSchema = z.object({
  */
 export const composesMainContract = c.router({
   /**
-   * GET /api/agent/composes?name={name}
+   * GET /api/agent/composes?name={name}&scope={scope}
    * Get agent compose by name with HEAD version content
+   * If scope is not provided, uses the authenticated user's default scope
    */
   getByName: {
     method: "GET",
     path: "/api/agent/composes",
     query: z.object({
       name: z.string().min(1, "Missing name query parameter"),
+      scope: z.string().optional(),
     }),
     responses: {
       200: composeResponseSchema,


### PR DESCRIPTION
## Summary

Implements scope support for agent composes, enabling the `scope/name:version` naming convention (e.g., `user-abc123/my-agent:latest`).

### Key Changes

- **Auto-scope creation on login**: Personal scope automatically created on first CLI login using deterministic slug from SHA-256 hash of Clerk user ID (format: `user-{8 hex chars}`)
- **Database migrations**: 
  - Migration 0045: Create scopes for existing users using random slugs
  - Migration 0046: Add `scopeId` to `agent_composes` with unique index on `(scope_id, name)`
- **API changes**: Resolve composes by name within user's scope or specified scope parameter
- **CLI changes**: 
  - Parse `[scope/]name[:version]` format in `vm0 run` command
  - Display `scope/name:version` format in `vm0 compose` output

### Design Decisions

- Follows the proven Image scope pattern already in production
- Scope slugs are deterministic (SHA-256 hash) to ensure consistent user experience across multiple logins
- Migration uses `md5(random())` for existing users (no need for determinism)
- Unique constraint on `(scope_id, name)` allows same compose name in different scopes

## Test Plan

- [x] CLI tests pass for new `scope/name:version` parsing
- [x] Test files updated to create scopes before inserting composes
- [x] Type check passes with new `scopeId` requirement

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)