### PR TITLE
feat(cli): add setup-github command for github actions workflow initialization

### DIFF
--- a/e2e/tests/02-parallel/t23-vm0-setup-github.bats
+++ b/e2e/tests/02-parallel/t23-vm0-setup-github.bats
@@ -17,9 +17,19 @@ teardown() {
     rm -rf "$TEST_DIR"
 }
 
+# Helper to check if GitHub CLI is installed
+check_gh_installed() {
+    command -v gh >/dev/null 2>&1
+}
+
 # Helper to check if VM0 is authenticated
 check_vm0_auth() {
     $CLI_COMMAND auth status 2>/dev/null | grep -q "Authenticated"
+}
+
+# Combined helper for tests that need both gh and VM0 auth
+check_setup_github_prereqs() {
+    check_gh_installed && check_vm0_auth
 }
 
 @test "vm0 setup-github --help shows command description" {
@@ -32,6 +42,8 @@ check_vm0_auth() {
 }
 
 @test "vm0 setup-github checks prerequisites in order" {
+    check_gh_installed || skip "GitHub CLI (gh) not installed"
+
     # Without vm0.yaml, the command should fail at some prerequisite check
     run $CLI_COMMAND setup-github --skip-secrets
     assert_failure
@@ -40,7 +52,7 @@ check_vm0_auth() {
 }
 
 @test "vm0 setup-github creates workflow files with --skip-secrets" {
-    check_vm0_auth || skip "VM0 not authenticated"
+    check_setup_github_prereqs || skip "Requires gh CLI and VM0 auth"
 
     # First create a vm0.yaml
     $CLI_COMMAND init --name test-setup-agent
@@ -58,7 +70,7 @@ check_vm0_auth() {
 }
 
 @test "vm0 setup-github generates correct publish.yml content" {
-    check_vm0_auth || skip "VM0 not authenticated"
+    check_setup_github_prereqs || skip "Requires gh CLI and VM0 auth"
 
     $CLI_COMMAND init --name my-publish-agent
 
@@ -76,7 +88,7 @@ check_vm0_auth() {
 }
 
 @test "vm0 setup-github generates correct run.yml content with agent name" {
-    check_vm0_auth || skip "VM0 not authenticated"
+    check_setup_github_prereqs || skip "Requires gh CLI and VM0 auth"
 
     $CLI_COMMAND init --name my-run-agent
 
@@ -93,7 +105,7 @@ check_vm0_auth() {
 }
 
 @test "vm0 setup-github warns about existing workflow files" {
-    check_vm0_auth || skip "VM0 not authenticated"
+    check_setup_github_prereqs || skip "Requires gh CLI and VM0 auth"
 
     $CLI_COMMAND init --name test-agent
 
@@ -109,7 +121,7 @@ check_vm0_auth() {
 }
 
 @test "vm0 setup-github --force overwrites existing workflow files" {
-    check_vm0_auth || skip "VM0 not authenticated"
+    check_setup_github_prereqs || skip "Requires gh CLI and VM0 auth"
 
     $CLI_COMMAND init --name test-agent
 
@@ -129,7 +141,7 @@ check_vm0_auth() {
 }
 
 @test "vm0 setup-github -f short option works" {
-    check_vm0_auth || skip "VM0 not authenticated"
+    check_setup_github_prereqs || skip "Requires gh CLI and VM0 auth"
 
     $CLI_COMMAND init --name test-agent
 
@@ -143,7 +155,7 @@ check_vm0_auth() {
 }
 
 @test "vm0 setup-github includes secrets from experimental_secrets" {
-    check_vm0_auth || skip "VM0 not authenticated"
+    check_setup_github_prereqs || skip "Requires gh CLI and VM0 auth"
 
     # Create vm0.yaml with experimental_secrets
     cat > vm0.yaml << 'EOF'
@@ -168,7 +180,7 @@ EOF
 }
 
 @test "vm0 setup-github includes vars from experimental_vars" {
-    check_vm0_auth || skip "VM0 not authenticated"
+    check_setup_github_prereqs || skip "Requires gh CLI and VM0 auth"
 
     # Create vm0.yaml with experimental_vars
     cat > vm0.yaml << 'EOF'
@@ -193,7 +205,7 @@ EOF
 }
 
 @test "vm0 setup-github --yes auto-confirms overwrite prompt" {
-    check_vm0_auth || skip "VM0 not authenticated"
+    check_setup_github_prereqs || skip "Requires gh CLI and VM0 auth"
 
     $CLI_COMMAND init --name test-agent
 
@@ -208,7 +220,7 @@ EOF
 }
 
 @test "vm0 setup-github -y short option works" {
-    check_vm0_auth || skip "VM0 not authenticated"
+    check_setup_github_prereqs || skip "Requires gh CLI and VM0 auth"
 
     $CLI_COMMAND init --name test-agent
 

--- a/e2e/tests/02-parallel/t23-vm0-setup-github.bats
+++ b/e2e/tests/02-parallel/t23-vm0-setup-github.bats
@@ -1,0 +1,221 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+
+# vm0 setup-github command tests
+# NOTE: These tests assume VM0 is authenticated (done in CI setup)
+
+setup() {
+    # Create a temporary directory for each test
+    TEST_DIR=$(mktemp -d)
+    cd "$TEST_DIR"
+}
+
+teardown() {
+    # Clean up the temporary directory
+    cd /
+    rm -rf "$TEST_DIR"
+}
+
+# Helper to check if VM0 is authenticated
+check_vm0_auth() {
+    $CLI_COMMAND auth status 2>/dev/null | grep -q "Authenticated"
+}
+
+@test "vm0 setup-github --help shows command description" {
+    run $CLI_COMMAND setup-github --help
+    assert_success
+    assert_output --partial "Initialize GitHub Actions workflows"
+    assert_output --partial "--force"
+    assert_output --partial "--yes"
+    assert_output --partial "--skip-secrets"
+}
+
+@test "vm0 setup-github checks prerequisites in order" {
+    # Without vm0.yaml, the command should fail at some prerequisite check
+    run $CLI_COMMAND setup-github --skip-secrets
+    assert_failure
+    # Should show prerequisite checking message
+    assert_output --partial "Checking prerequisites"
+}
+
+@test "vm0 setup-github creates workflow files with --skip-secrets" {
+    check_vm0_auth || skip "VM0 not authenticated"
+
+    # First create a vm0.yaml
+    $CLI_COMMAND init --name test-setup-agent
+
+    # Run setup-github with --skip-secrets to avoid gh secret operations
+    run $CLI_COMMAND setup-github --skip-secrets
+    assert_success
+    assert_output --partial "Created .github/workflows/publish.yml"
+    assert_output --partial "Created .github/workflows/run.yml"
+    assert_output --partial "Done (secrets setup skipped)"
+
+    # Verify workflow files were created
+    [ -f ".github/workflows/publish.yml" ]
+    [ -f ".github/workflows/run.yml" ]
+}
+
+@test "vm0 setup-github generates correct publish.yml content" {
+    check_vm0_auth || skip "VM0 not authenticated"
+
+    $CLI_COMMAND init --name my-publish-agent
+
+    run $CLI_COMMAND setup-github --skip-secrets
+    assert_success
+
+    # Verify publish.yml content
+    run cat .github/workflows/publish.yml
+    assert_output --partial "name: Publish Agent"
+    assert_output --partial "branches: [main]"
+    assert_output --partial "vm0.yaml"
+    assert_output --partial "AGENTS.md"
+    assert_output --partial "vm0-ai/compose-action@v1"
+    assert_output --partial "secrets.VM0_TOKEN"
+}
+
+@test "vm0 setup-github generates correct run.yml content with agent name" {
+    check_vm0_auth || skip "VM0 not authenticated"
+
+    $CLI_COMMAND init --name my-run-agent
+
+    run $CLI_COMMAND setup-github --skip-secrets
+    assert_success
+
+    # Verify run.yml content
+    run cat .github/workflows/run.yml
+    assert_output --partial "name: Run Agent"
+    assert_output --partial "workflow_dispatch:"
+    assert_output --partial "agent: my-run-agent"
+    assert_output --partial "vm0-ai/run-action@v1"
+    assert_output --partial "secrets.VM0_TOKEN"
+}
+
+@test "vm0 setup-github warns about existing workflow files" {
+    check_vm0_auth || skip "VM0 not authenticated"
+
+    $CLI_COMMAND init --name test-agent
+
+    # Create existing workflow file
+    mkdir -p .github/workflows
+    echo "existing content" > .github/workflows/publish.yml
+
+    # Run without --force, answer 'n' to overwrite prompt
+    run bash -c 'echo "n" | '"$CLI_COMMAND"' setup-github --skip-secrets'
+    assert_success  # exits with 0 when user declines
+    assert_output --partial "Existing workflow files detected"
+    assert_output --partial "vm0 setup-github --force"
+}
+
+@test "vm0 setup-github --force overwrites existing workflow files" {
+    check_vm0_auth || skip "VM0 not authenticated"
+
+    $CLI_COMMAND init --name test-agent
+
+    # Create existing workflow files
+    mkdir -p .github/workflows
+    echo "old publish content" > .github/workflows/publish.yml
+    echo "old run content" > .github/workflows/run.yml
+
+    run $CLI_COMMAND setup-github --force --skip-secrets
+    assert_success
+    assert_output --partial "Overwrote .github/workflows/publish.yml"
+    assert_output --partial "Overwrote .github/workflows/run.yml"
+
+    # Verify new content
+    run cat .github/workflows/publish.yml
+    assert_output --partial "name: Publish Agent"
+}
+
+@test "vm0 setup-github -f short option works" {
+    check_vm0_auth || skip "VM0 not authenticated"
+
+    $CLI_COMMAND init --name test-agent
+
+    # Create existing workflow file
+    mkdir -p .github/workflows
+    echo "old content" > .github/workflows/publish.yml
+
+    run $CLI_COMMAND setup-github -f --skip-secrets
+    assert_success
+    assert_output --partial "Overwrote"
+}
+
+@test "vm0 setup-github includes secrets from experimental_secrets" {
+    check_vm0_auth || skip "VM0 not authenticated"
+
+    # Create vm0.yaml with experimental_secrets
+    cat > vm0.yaml << 'EOF'
+version: "1.0"
+agents:
+  secret-test-agent:
+    provider: claude-code
+    instructions: AGENTS.md
+    experimental_secrets:
+      - CUSTOM_API_KEY
+      - ANOTHER_SECRET
+EOF
+    echo "# Agent Instructions" > AGENTS.md
+
+    run $CLI_COMMAND setup-github --skip-secrets
+    assert_success
+
+    # Verify run.yml includes the secrets
+    run cat .github/workflows/run.yml
+    assert_output --partial "CUSTOM_API_KEY=\${{ secrets.CUSTOM_API_KEY }}"
+    assert_output --partial "ANOTHER_SECRET=\${{ secrets.ANOTHER_SECRET }}"
+}
+
+@test "vm0 setup-github includes vars from experimental_vars" {
+    check_vm0_auth || skip "VM0 not authenticated"
+
+    # Create vm0.yaml with experimental_vars
+    cat > vm0.yaml << 'EOF'
+version: "1.0"
+agents:
+  vars-test-agent:
+    provider: claude-code
+    instructions: AGENTS.md
+    experimental_vars:
+      - REGION
+      - ENVIRONMENT
+EOF
+    echo "# Agent Instructions" > AGENTS.md
+
+    run $CLI_COMMAND setup-github --skip-secrets
+    assert_success
+
+    # Verify run.yml includes the vars
+    run cat .github/workflows/run.yml
+    assert_output --partial "REGION=\${{ vars.REGION }}"
+    assert_output --partial "ENVIRONMENT=\${{ vars.ENVIRONMENT }}"
+}
+
+@test "vm0 setup-github --yes auto-confirms overwrite prompt" {
+    check_vm0_auth || skip "VM0 not authenticated"
+
+    $CLI_COMMAND init --name test-agent
+
+    # Create existing workflow file
+    mkdir -p .github/workflows
+    echo "old content" > .github/workflows/publish.yml
+
+    # --yes should auto-confirm without prompting
+    run $CLI_COMMAND setup-github --yes --skip-secrets
+    assert_success
+    assert_output --partial "Overwrote .github/workflows/publish.yml"
+}
+
+@test "vm0 setup-github -y short option works" {
+    check_vm0_auth || skip "VM0 not authenticated"
+
+    $CLI_COMMAND init --name test-agent
+
+    mkdir -p .github/workflows
+    echo "old content" > .github/workflows/publish.yml
+
+    run $CLI_COMMAND setup-github -y --skip-secrets
+    assert_success
+    assert_output --partial "Overwrote"
+}

--- a/turbo/apps/cli/src/commands/__tests__/setup-github.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/setup-github.test.ts
@@ -1,0 +1,599 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { setupGithubCommand } from "../setup-github";
+import * as fs from "fs/promises";
+import { existsSync } from "fs";
+import * as readline from "readline";
+import { execSync, spawnSync, SpawnSyncReturns } from "child_process";
+import * as config from "../../lib/config";
+import * as core from "@vm0/core";
+
+// Mock dependencies
+vi.mock("fs/promises");
+vi.mock("fs");
+vi.mock("readline");
+vi.mock("child_process");
+vi.mock("../../lib/config");
+vi.mock("@vm0/core");
+
+describe("setup-github command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  // Mock readline interface
+  const mockRlQuestion = vi.fn();
+  const mockRlClose = vi.fn();
+  const mockRlInterface = {
+    question: mockRlQuestion,
+    close: mockRlClose,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(readline.createInterface).mockReturnValue(
+      mockRlInterface as unknown as readline.Interface,
+    );
+    // Default mocks for core functions
+    vi.mocked(core.extractVariableReferences).mockReturnValue([]);
+    vi.mocked(core.groupVariablesBySource).mockReturnValue({
+      env: [],
+      vars: [],
+      secrets: [],
+    });
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+  });
+
+  describe("prerequisite checks", () => {
+    it("should exit with error if gh CLI is not installed", async () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === "gh --version") {
+          throw new Error("command not found");
+        }
+        return Buffer.from("");
+      });
+
+      await expect(async () => {
+        await setupGithubCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("GitHub CLI (gh) is not installed"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("brew install gh"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should exit with error if gh CLI is not authenticated", async () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === "gh --version") {
+          return Buffer.from("gh version 2.0.0");
+        }
+        if (cmd === "gh auth status") {
+          throw new Error("not authenticated");
+        }
+        return Buffer.from("");
+      });
+
+      await expect(async () => {
+        await setupGithubCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("GitHub CLI is not authenticated"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("gh auth login"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should exit with error if VM0 is not authenticated", async () => {
+      vi.mocked(execSync).mockReturnValue(Buffer.from(""));
+      vi.mocked(config.getToken).mockResolvedValue(undefined);
+
+      await expect(async () => {
+        await setupGithubCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("VM0 not authenticated"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 auth login"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should exit with error if vm0.yaml does not exist", async () => {
+      vi.mocked(execSync).mockReturnValue(Buffer.from(""));
+      vi.mocked(config.getToken).mockResolvedValue("test-token");
+      vi.mocked(existsSync).mockImplementation((path) => {
+        if (path === "vm0.yaml") return false;
+        return false;
+      });
+
+      await expect(async () => {
+        await setupGithubCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("vm0.yaml not found"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 init"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("workflow file generation", () => {
+    beforeEach(() => {
+      // Pass all prerequisites
+      vi.mocked(execSync).mockReturnValue(Buffer.from(""));
+      vi.mocked(config.getToken).mockResolvedValue("test-token");
+      vi.mocked(existsSync).mockImplementation((path) => {
+        if (path === "vm0.yaml") return true;
+        return false;
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(`
+version: "1.0"
+agents:
+  my-test-agent:
+    provider: claude-code
+    instructions: AGENTS.md
+`);
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(spawnSync).mockReturnValue({
+        status: 0,
+      } as SpawnSyncReturns<Buffer>);
+    });
+
+    it("should create publish.yml with correct content", async () => {
+      mockRlQuestion.mockImplementation((_, callback) => {
+        callback("n"); // Skip auto-setup
+      });
+
+      await setupGithubCommand.parseAsync(["node", "cli", "--skip-secrets"]);
+
+      const writeCall = vi
+        .mocked(fs.writeFile)
+        .mock.calls.find((call) => call[0] === ".github/workflows/publish.yml");
+      expect(writeCall).toBeDefined();
+      const content = writeCall![1] as string;
+
+      expect(content).toContain("name: Publish Agent");
+      expect(content).toContain("branches: [main]");
+      expect(content).toContain("vm0.yaml");
+      expect(content).toContain("AGENTS.md");
+      expect(content).toContain("vm0-ai/compose-action@v1");
+      expect(content).toContain("secrets.VM0_TOKEN");
+    });
+
+    it("should create run.yml with agent name", async () => {
+      mockRlQuestion.mockImplementation((_, callback) => {
+        callback("n");
+      });
+
+      await setupGithubCommand.parseAsync(["node", "cli", "--skip-secrets"]);
+
+      const writeCall = vi
+        .mocked(fs.writeFile)
+        .mock.calls.find((call) => call[0] === ".github/workflows/run.yml");
+      expect(writeCall).toBeDefined();
+      const content = writeCall![1] as string;
+
+      expect(content).toContain("name: Run Agent");
+      expect(content).toContain("workflow_dispatch:");
+      expect(content).toContain("agent: my-test-agent");
+      expect(content).toContain("vm0-ai/run-action@v1");
+      expect(content).toContain("secrets.VM0_TOKEN");
+    });
+
+    it("should include detected secrets in run.yml", async () => {
+      vi.mocked(core.extractVariableReferences).mockReturnValue([
+        {
+          source: "secrets",
+          name: "API_KEY",
+          fullMatch: "${{ secrets.API_KEY }}",
+        },
+      ]);
+      vi.mocked(core.groupVariablesBySource).mockReturnValue({
+        env: [],
+        vars: [],
+        secrets: [
+          {
+            source: "secrets",
+            name: "API_KEY",
+            fullMatch: "${{ secrets.API_KEY }}",
+          },
+        ],
+      });
+
+      await setupGithubCommand.parseAsync(["node", "cli", "--skip-secrets"]);
+
+      const writeCall = vi
+        .mocked(fs.writeFile)
+        .mock.calls.find((call) => call[0] === ".github/workflows/run.yml");
+      expect(writeCall).toBeDefined();
+      const content = writeCall![1] as string;
+
+      expect(content).toContain("secrets: |");
+      expect(content).toContain("API_KEY=${{ secrets.API_KEY }}");
+    });
+
+    it("should include detected vars in run.yml", async () => {
+      vi.mocked(core.extractVariableReferences).mockReturnValue([
+        { source: "vars", name: "REGION", fullMatch: "${{ vars.REGION }}" },
+      ]);
+      vi.mocked(core.groupVariablesBySource).mockReturnValue({
+        env: [],
+        vars: [
+          { source: "vars", name: "REGION", fullMatch: "${{ vars.REGION }}" },
+        ],
+        secrets: [],
+      });
+
+      await setupGithubCommand.parseAsync(["node", "cli", "--skip-secrets"]);
+
+      const writeCall = vi
+        .mocked(fs.writeFile)
+        .mock.calls.find((call) => call[0] === ".github/workflows/run.yml");
+      expect(writeCall).toBeDefined();
+      const content = writeCall![1] as string;
+
+      expect(content).toContain("vars: |");
+      expect(content).toContain("REGION=${{ vars.REGION }}");
+    });
+
+    it("should handle experimental_secrets and experimental_vars", async () => {
+      vi.mocked(fs.readFile).mockResolvedValue(`
+version: "1.0"
+agents:
+  my-test-agent:
+    provider: claude-code
+    instructions: AGENTS.md
+    experimental_secrets:
+      - CUSTOM_SECRET
+    experimental_vars:
+      - CUSTOM_VAR
+`);
+
+      await setupGithubCommand.parseAsync(["node", "cli", "--skip-secrets"]);
+
+      const writeCall = vi
+        .mocked(fs.writeFile)
+        .mock.calls.find((call) => call[0] === ".github/workflows/run.yml");
+      expect(writeCall).toBeDefined();
+      const content = writeCall![1] as string;
+
+      expect(content).toContain("CUSTOM_SECRET=${{ secrets.CUSTOM_SECRET }}");
+      expect(content).toContain("CUSTOM_VAR=${{ vars.CUSTOM_VAR }}");
+    });
+  });
+
+  describe("existing file handling", () => {
+    beforeEach(() => {
+      vi.mocked(execSync).mockReturnValue(Buffer.from(""));
+      vi.mocked(config.getToken).mockResolvedValue("test-token");
+      vi.mocked(fs.readFile).mockResolvedValue(`
+version: "1.0"
+agents:
+  my-agent:
+    provider: claude-code
+`);
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+    });
+
+    it("should prompt to overwrite existing files", async () => {
+      vi.mocked(existsSync).mockImplementation((path) => {
+        if (path === "vm0.yaml") return true;
+        if (path === ".github/workflows/publish.yml") return true;
+        return false;
+      });
+
+      mockRlQuestion.mockImplementation((question, callback) => {
+        if (question.includes("Overwrite")) {
+          callback("n"); // No, don't overwrite
+        } else {
+          callback("n");
+        }
+      });
+
+      await expect(async () => {
+        await setupGithubCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Existing workflow files detected"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(0);
+    });
+
+    it("should overwrite files with --force option", async () => {
+      vi.mocked(existsSync).mockImplementation((path) => {
+        if (path === "vm0.yaml") return true;
+        if (path === ".github/workflows/publish.yml") return true;
+        return false;
+      });
+
+      await setupGithubCommand.parseAsync([
+        "node",
+        "cli",
+        "--force",
+        "--skip-secrets",
+      ]);
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        ".github/workflows/publish.yml",
+        expect.any(String),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Overwrote"),
+      );
+    });
+
+    it("should work with -f short option", async () => {
+      vi.mocked(existsSync).mockImplementation((path) => {
+        if (path === "vm0.yaml") return true;
+        if (path === ".github/workflows/publish.yml") return true;
+        return false;
+      });
+
+      await setupGithubCommand.parseAsync([
+        "node",
+        "cli",
+        "-f",
+        "--skip-secrets",
+      ]);
+
+      expect(fs.writeFile).toHaveBeenCalled();
+    });
+  });
+
+  describe("--skip-secrets option", () => {
+    beforeEach(() => {
+      vi.mocked(execSync).mockReturnValue(Buffer.from(""));
+      vi.mocked(config.getToken).mockResolvedValue("test-token");
+      vi.mocked(existsSync).mockImplementation((path) => {
+        if (path === "vm0.yaml") return true;
+        return false;
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(`
+version: "1.0"
+agents:
+  my-agent:
+    provider: claude-code
+`);
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+    });
+
+    it("should skip secrets setup with --skip-secrets", async () => {
+      await setupGithubCommand.parseAsync(["node", "cli", "--skip-secrets"]);
+
+      expect(spawnSync).not.toHaveBeenCalledWith(
+        "gh",
+        expect.arrayContaining(["secret", "set"]),
+        expect.any(Object),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Done (secrets setup skipped)"),
+      );
+    });
+  });
+
+  describe("--yes option", () => {
+    beforeEach(() => {
+      vi.mocked(execSync).mockReturnValue(Buffer.from(""));
+      vi.mocked(config.getToken).mockResolvedValue("test-token");
+      vi.mocked(existsSync).mockImplementation((path) => {
+        if (path === "vm0.yaml") return true;
+        if (path === ".github/workflows/publish.yml") return true;
+        return false;
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(`
+version: "1.0"
+agents:
+  my-agent:
+    provider: claude-code
+`);
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(spawnSync).mockReturnValue({
+        status: 0,
+      } as SpawnSyncReturns<Buffer>);
+    });
+
+    it("should auto-confirm prompts with --yes", async () => {
+      await setupGithubCommand.parseAsync(["node", "cli", "--yes"]);
+
+      // Should not have prompted the user
+      expect(mockRlQuestion).not.toHaveBeenCalled();
+      // Should have proceeded with overwriting and setting secrets
+      expect(fs.writeFile).toHaveBeenCalled();
+    });
+
+    it("should work with -y short option", async () => {
+      await setupGithubCommand.parseAsync(["node", "cli", "-y"]);
+
+      expect(mockRlQuestion).not.toHaveBeenCalled();
+      expect(fs.writeFile).toHaveBeenCalled();
+    });
+  });
+
+  describe("secrets setup", () => {
+    beforeEach(() => {
+      vi.mocked(execSync).mockReturnValue(Buffer.from(""));
+      vi.mocked(config.getToken).mockResolvedValue("test-token");
+      vi.mocked(existsSync).mockImplementation((path) => {
+        if (path === "vm0.yaml") return true;
+        return false;
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(`
+version: "1.0"
+agents:
+  my-agent:
+    provider: claude-code
+`);
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+    });
+
+    it("should set VM0_TOKEN secret when auto-setup is confirmed", async () => {
+      vi.mocked(spawnSync).mockReturnValue({
+        status: 0,
+      } as SpawnSyncReturns<Buffer>);
+
+      await setupGithubCommand.parseAsync(["node", "cli", "--yes"]);
+
+      expect(spawnSync).toHaveBeenCalledWith(
+        "gh",
+        ["secret", "set", "VM0_TOKEN"],
+        expect.objectContaining({
+          input: "test-token",
+        }),
+      );
+    });
+
+    it("should detect secrets from environment variables", async () => {
+      // Use bracket notation to avoid turbo env var lint warnings
+      const TEST_SECRET = "CUSTOM_TEST_SECRET";
+      const originalEnv = process.env[TEST_SECRET];
+      process.env[TEST_SECRET] = "test-secret-value";
+
+      vi.mocked(core.extractVariableReferences).mockReturnValue([
+        {
+          source: "secrets",
+          name: TEST_SECRET,
+          fullMatch: `\${{ secrets.${TEST_SECRET} }}`,
+        },
+      ]);
+      vi.mocked(core.groupVariablesBySource).mockReturnValue({
+        env: [],
+        vars: [],
+        secrets: [
+          {
+            source: "secrets",
+            name: TEST_SECRET,
+            fullMatch: `\${{ secrets.${TEST_SECRET} }}`,
+          },
+        ],
+      });
+      vi.mocked(spawnSync).mockReturnValue({
+        status: 0,
+      } as SpawnSyncReturns<Buffer>);
+
+      await setupGithubCommand.parseAsync(["node", "cli", "--yes"]);
+
+      expect(spawnSync).toHaveBeenCalledWith(
+        "gh",
+        ["secret", "set", TEST_SECRET],
+        expect.objectContaining({
+          input: "test-secret-value",
+        }),
+      );
+
+      process.env[TEST_SECRET] = originalEnv;
+    });
+
+    it("should show manual setup instructions when declining auto-setup", async () => {
+      mockRlQuestion.mockImplementation((question, callback) => {
+        if (question.includes("Set up GitHub secrets")) {
+          callback("n"); // No, don't auto-setup
+        } else {
+          callback("");
+        }
+      });
+
+      await setupGithubCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Configure secrets manually"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("gh secret set VM0_TOKEN"),
+      );
+    });
+
+    it("should handle failed secret setting gracefully", async () => {
+      vi.mocked(spawnSync).mockReturnValue({
+        status: 1,
+      } as SpawnSyncReturns<Buffer>);
+
+      await setupGithubCommand.parseAsync(["node", "cli", "--yes"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("VM0_TOKEN (failed)"),
+      );
+    });
+  });
+
+  describe("display messages", () => {
+    beforeEach(() => {
+      vi.mocked(execSync).mockReturnValue(Buffer.from(""));
+      vi.mocked(config.getToken).mockResolvedValue("test-token");
+      vi.mocked(existsSync).mockImplementation((path) => {
+        if (path === "vm0.yaml") return true;
+        return false;
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(`
+version: "1.0"
+agents:
+  my-agent:
+    provider: claude-code
+`);
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(spawnSync).mockReturnValue({
+        status: 0,
+      } as SpawnSyncReturns<Buffer>);
+    });
+
+    it("should show success message when all secrets are set", async () => {
+      await setupGithubCommand.parseAsync(["node", "cli", "--yes"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("GitHub Actions setup complete"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Commit and push the workflow files"),
+      );
+    });
+
+    it("should show partial success message when some secrets are missing", async () => {
+      vi.mocked(core.extractVariableReferences).mockReturnValue([
+        {
+          source: "secrets",
+          name: "MISSING_SECRET",
+          fullMatch: "${{ secrets.MISSING_SECRET }}",
+        },
+      ]);
+      vi.mocked(core.groupVariablesBySource).mockReturnValue({
+        env: [],
+        vars: [],
+        secrets: [
+          {
+            source: "secrets",
+            name: "MISSING_SECRET",
+            fullMatch: "${{ secrets.MISSING_SECRET }}",
+          },
+        ],
+      });
+
+      await setupGithubCommand.parseAsync(["node", "cli", "--yes"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Setup partially complete"),
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/setup-github.ts
+++ b/turbo/apps/cli/src/commands/setup-github.ts
@@ -1,0 +1,622 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import * as readline from "readline";
+import { existsSync } from "fs";
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { execSync, spawnSync } from "child_process";
+import { parse as parseYaml } from "yaml";
+import { extractVariableReferences, groupVariablesBySource } from "@vm0/core";
+import { getToken } from "../lib/config";
+
+// ============================================================================
+// Prerequisite Checks
+// ============================================================================
+
+function isGhInstalled(): boolean {
+  try {
+    execSync("gh --version", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isGhAuthenticated(): boolean {
+  try {
+    execSync("gh auth status", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function checkPrerequisites(): Promise<string | undefined> {
+  console.log("Checking prerequisites...");
+
+  // 1. Check gh CLI installed
+  if (!isGhInstalled()) {
+    console.log(chalk.red("✗ GitHub CLI (gh) is not installed"));
+    console.log();
+    console.log("GitHub CLI is required for this command.");
+    console.log();
+    console.log(`  macOS:  ${chalk.cyan("brew install gh")}`);
+    console.log(`  Other:  ${chalk.cyan("https://cli.github.com/")}`);
+    console.log();
+    console.log("After installation, run:");
+    console.log(`  ${chalk.cyan("gh auth login")}`);
+    console.log();
+    console.log("Then try again:");
+    console.log(`  ${chalk.cyan("vm0 setup-github")}`);
+    process.exit(1);
+  }
+  console.log(chalk.green("✓ GitHub CLI (gh) is installed"));
+
+  // 2. Check gh authenticated
+  if (!isGhAuthenticated()) {
+    console.log(chalk.red("✗ GitHub CLI is not authenticated"));
+    console.log();
+    console.log("Please authenticate GitHub CLI first:");
+    console.log(`  ${chalk.cyan("gh auth login")}`);
+    console.log();
+    console.log("Then try again:");
+    console.log(`  ${chalk.cyan("vm0 setup-github")}`);
+    process.exit(1);
+  }
+  console.log(chalk.green("✓ GitHub CLI is authenticated"));
+
+  // 3. Check VM0 authenticated
+  const token = await getToken();
+  if (!token) {
+    console.log(chalk.red("✗ VM0 not authenticated"));
+    console.log();
+    console.log("Please authenticate with VM0 first:");
+    console.log(`  ${chalk.cyan("vm0 auth login")}`);
+    console.log();
+    console.log("Then try again:");
+    console.log(`  ${chalk.cyan("vm0 setup-github")}`);
+    process.exit(1);
+  }
+  console.log(chalk.green("✓ VM0 authenticated"));
+
+  // 4. Check vm0.yaml exists
+  if (!existsSync("vm0.yaml")) {
+    console.log(chalk.red("✗ vm0.yaml not found"));
+    console.log();
+    console.log("This command requires a vm0.yaml configuration file.");
+    console.log();
+    console.log("To create one, run:");
+    console.log(`  ${chalk.cyan("vm0 init")}`);
+    console.log();
+    console.log("Then try again:");
+    console.log(`  ${chalk.cyan("vm0 setup-github")}`);
+    process.exit(1);
+  }
+  console.log(chalk.green("✓ vm0.yaml found"));
+
+  return token;
+}
+
+// ============================================================================
+// Workflow File Generation
+// ============================================================================
+
+function generatePublishYaml(): string {
+  return `name: Publish Agent
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'vm0.yaml'
+      - 'AGENTS.md'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish Agent
+        uses: vm0-ai/compose-action@v1
+        id: compose
+        with:
+          vm0-token: \${{ secrets.VM0_TOKEN }}
+
+      - name: Show Results
+        run: |
+          echo "Agent: \${{ steps.compose.outputs.name }}"
+          echo "Compose ID: \${{ steps.compose.outputs.compose-id }}"
+          echo "Version: \${{ steps.compose.outputs.version-id }}"
+          echo "Action: \${{ steps.compose.outputs.action }}"
+`;
+}
+
+function generateRunYaml(
+  agentName: string,
+  secrets: string[],
+  vars: string[],
+): string {
+  // Build secrets section (excluding VM0_TOKEN which is passed separately)
+  const otherSecrets = secrets.filter((s) => s !== "VM0_TOKEN");
+  const secretsLines = otherSecrets
+    .map((s) => `            ${s}=\${{ secrets.${s} }}`)
+    .join("\n");
+
+  // Build vars section
+  const varsLines = vars
+    .map((v) => `            ${v}=\${{ vars.${v} }}`)
+    .join("\n");
+
+  let yaml = `name: Run Agent
+
+on:
+  # Uncomment to enable scheduled runs:
+  # schedule:
+  #   - cron: '0 1 * * *'  # Daily at 9:00 AM UTC+8
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: 'Prompt for the agent'
+        required: false
+        default: 'do the job'
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Agent
+        uses: vm0-ai/run-action@v1
+        with:
+          agent: ${agentName}
+          prompt: \${{ github.event.inputs.prompt || 'do the job' }}
+          silent: true
+          vm0-token: \${{ secrets.VM0_TOKEN }}`;
+
+  if (secretsLines) {
+    yaml += `
+          secrets: |
+${secretsLines}`;
+  }
+
+  if (varsLines) {
+    yaml += `
+          vars: |
+${varsLines}`;
+  }
+
+  yaml += "\n";
+  return yaml;
+}
+
+// ============================================================================
+// Variable Extraction
+// ============================================================================
+
+interface ExtractedVars {
+  secrets: string[];
+  vars: string[];
+}
+
+function extractSecretsAndVars(config: unknown): ExtractedVars {
+  const secrets = new Set<string>();
+  const vars = new Set<string>();
+
+  // Extract from ${{ secrets.X }} and ${{ vars.X }} syntax
+  const refs = extractVariableReferences(config);
+  const grouped = groupVariablesBySource(refs);
+
+  for (const ref of grouped.secrets) {
+    secrets.add(ref.name);
+  }
+  for (const ref of grouped.vars) {
+    vars.add(ref.name);
+  }
+
+  // Extract from experimental_* shorthand
+  const cfg = config as Record<string, unknown>;
+  const agents = cfg.agents as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  if (agents) {
+    const agentConfig = Object.values(agents)[0];
+    if (agentConfig) {
+      const expSecrets = agentConfig.experimental_secrets as
+        | string[]
+        | undefined;
+      const expVars = agentConfig.experimental_vars as string[] | undefined;
+
+      if (expSecrets) {
+        for (const s of expSecrets) {
+          secrets.add(s);
+        }
+      }
+      if (expVars) {
+        for (const v of expVars) {
+          vars.add(v);
+        }
+      }
+    }
+  }
+
+  // Always include VM0_TOKEN in secrets
+  secrets.add("VM0_TOKEN");
+
+  return {
+    secrets: Array.from(secrets).sort(),
+    vars: Array.from(vars).sort(),
+  };
+}
+
+// ============================================================================
+// User Prompts
+// ============================================================================
+
+async function promptYesNo(
+  question: string,
+  defaultYes: boolean,
+): Promise<boolean> {
+  const hint = defaultYes ? "(Y/n)" : "(y/N)";
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(chalk.cyan(`? ${question} ${hint} `), (answer) => {
+      rl.close();
+      const normalized = answer.trim().toLowerCase();
+      if (normalized === "") {
+        resolve(defaultYes);
+      } else {
+        resolve(normalized === "y" || normalized === "yes");
+      }
+    });
+  });
+}
+
+// ============================================================================
+// GitHub Secrets/Variables Setup
+// ============================================================================
+
+function setGitHubSecret(name: string, value: string): boolean {
+  const result = spawnSync("gh", ["secret", "set", name], {
+    input: value,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  return result.status === 0;
+}
+
+function setGitHubVariable(name: string, value: string): boolean {
+  const result = spawnSync("gh", ["variable", "set", name, "--body", value], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  return result.status === 0;
+}
+
+interface SecretStatus {
+  name: string;
+  found: boolean;
+  source?: string;
+  value?: string;
+}
+
+async function detectSecretValues(
+  secrets: string[],
+  vars: string[],
+  vm0Token: string,
+): Promise<{
+  secretStatuses: SecretStatus[];
+  varStatuses: SecretStatus[];
+}> {
+  const secretStatuses: SecretStatus[] = secrets.map((name) => {
+    if (name === "VM0_TOKEN") {
+      return { name, found: true, source: "vm0 auth", value: vm0Token };
+    }
+    const envValue = process.env[name];
+    if (envValue) {
+      return { name, found: true, source: "environment", value: envValue };
+    }
+    return { name, found: false };
+  });
+
+  const varStatuses: SecretStatus[] = vars.map((name) => {
+    const envValue = process.env[name];
+    if (envValue) {
+      return { name, found: true, source: "environment", value: envValue };
+    }
+    return { name, found: false };
+  });
+
+  return { secretStatuses, varStatuses };
+}
+
+function displaySecretsTable(
+  secretStatuses: SecretStatus[],
+  varStatuses: SecretStatus[],
+): void {
+  console.log("┌─────────────────────────────────────────────────────────┐");
+  console.log("│ Detected secrets and variables:                         │");
+  console.log("├─────────────────────────────────────────────────────────┤");
+
+  if (secretStatuses.length > 0) {
+    console.log("│ Secrets:                                                │");
+    for (const s of secretStatuses) {
+      const status = s.found ? chalk.green("✓") : chalk.red("✗");
+      const source = s.found ? `(from ${s.source})` : "not found";
+      const paddedName = (s.name + " ").padEnd(23, ".");
+      console.log(`│   ${status} ${paddedName} ${source.padEnd(19)}│`);
+    }
+  }
+
+  if (varStatuses.length > 0) {
+    console.log("│ Variables:                                              │");
+    for (const v of varStatuses) {
+      const status = v.found ? chalk.green("✓") : chalk.red("✗");
+      const source = v.found ? `(from ${v.source})` : "not found";
+      const paddedName = (v.name + " ").padEnd(23, ".");
+      console.log(`│   ${status} ${paddedName} ${source.padEnd(19)}│`);
+    }
+  }
+
+  console.log("└─────────────────────────────────────────────────────────┘");
+}
+
+function showManualSetupInstructions(secrets: string[], vars: string[]): void {
+  console.log("Skipped automatic setup. Configure secrets manually:");
+  console.log();
+  console.log("  Step 1: Get your VM0 token");
+  console.log(`    ${chalk.cyan("vm0 auth setup-token")}`);
+  console.log();
+  console.log("  Step 2: Set GitHub secrets");
+  for (const s of secrets) {
+    console.log(`    ${chalk.cyan(`gh secret set ${s}`)}`);
+  }
+  if (vars.length > 0) {
+    console.log();
+    console.log("  Step 3: Set GitHub variables");
+    for (const v of vars) {
+      console.log(`    ${chalk.cyan(`gh variable set ${v}`)}`);
+    }
+  }
+}
+
+function showSuccessMessage(): void {
+  console.log("┌─────────────────────────────────────────────────────────┐");
+  console.log("│ ✓ GitHub Actions setup complete!                        │");
+  console.log("├─────────────────────────────────────────────────────────┤");
+  console.log("│ Workflows created:                                      │");
+  console.log("│   • .github/workflows/publish.yml                       │");
+  console.log("│   • .github/workflows/run.yml                           │");
+  console.log("│                                                         │");
+  console.log("│ Next steps:                                             │");
+  console.log("│   1. Commit and push the workflow files                 │");
+  console.log("│   2. Push to main branch to trigger publish             │");
+  console.log("└─────────────────────────────────────────────────────────┘");
+}
+
+function showPartialSuccessMessage(
+  missingSecrets: string[],
+  missingVars: string[],
+): void {
+  console.log("┌─────────────────────────────────────────────────────────┐");
+  console.log("│ ⚠ Setup partially complete                              │");
+  console.log("├─────────────────────────────────────────────────────────┤");
+  console.log("│ Missing secrets - set them manually:                    │");
+  for (const s of missingSecrets) {
+    console.log(`│   gh secret set ${s.padEnd(40)}│`);
+  }
+  for (const v of missingVars) {
+    console.log(`│   gh variable set ${v.padEnd(38)}│`);
+  }
+  console.log("└─────────────────────────────────────────────────────────┘");
+}
+
+function showWorkflowsCreatedMessage(): void {
+  console.log("┌─────────────────────────────────────────────────────────┐");
+  console.log("│ ✓ Workflow files created!                               │");
+  console.log("├─────────────────────────────────────────────────────────┤");
+  console.log("│   • .github/workflows/publish.yml                       │");
+  console.log("│   • .github/workflows/run.yml                           │");
+  console.log("│                                                         │");
+  console.log("│ Next steps:                                             │");
+  console.log("│   1. Set GitHub secrets (see commands above)            │");
+  console.log("│   2. Commit and push the workflow files                 │");
+  console.log("│   3. Push to main branch to trigger publish             │");
+  console.log("└─────────────────────────────────────────────────────────┘");
+}
+
+// ============================================================================
+// Main Command
+// ============================================================================
+
+export const setupGithubCommand = new Command()
+  .name("setup-github")
+  .description("Initialize GitHub Actions workflows for agent deployment")
+  .option("-f, --force", "Overwrite existing workflow files")
+  .option("-y, --yes", "Auto-confirm all prompts")
+  .option("--skip-secrets", "Skip automatic secrets/variables setup")
+  .action(
+    async (options: {
+      force?: boolean;
+      yes?: boolean;
+      skipSecrets?: boolean;
+    }) => {
+      // 1. Check prerequisites
+      const vm0Token = await checkPrerequisites();
+      if (!vm0Token) {
+        process.exit(1);
+      }
+      console.log();
+
+      // 2. Parse vm0.yaml
+      console.log("Analyzing vm0.yaml...");
+      const content = await readFile("vm0.yaml", "utf8");
+      const config = parseYaml(content);
+      const agents = (config as Record<string, unknown>).agents as Record<
+        string,
+        unknown
+      >;
+      const agentName = Object.keys(agents)[0]!;
+      console.log(chalk.green(`✓ Agent: ${agentName}`));
+
+      // 3. Extract secrets and vars
+      const { secrets, vars } = extractSecretsAndVars(config);
+      console.log(
+        chalk.green(
+          `✓ Found ${secrets.length} secrets, ${vars.length} variables`,
+        ),
+      );
+      console.log();
+
+      // 4. Check existing workflow files
+      const publishPath = ".github/workflows/publish.yml";
+      const runPath = ".github/workflows/run.yml";
+      const existingFiles: string[] = [];
+      if (existsSync(publishPath)) existingFiles.push(publishPath);
+      if (existsSync(runPath)) existingFiles.push(runPath);
+
+      if (existingFiles.length > 0 && !options.force) {
+        console.log(chalk.yellow("⚠ Existing workflow files detected:"));
+        for (const file of existingFiles) {
+          console.log(`  • ${file}`);
+        }
+        console.log();
+
+        if (!options.yes) {
+          const overwrite = await promptYesNo(
+            "Overwrite existing files?",
+            false,
+          );
+          if (!overwrite) {
+            console.log();
+            console.log("Aborted. To force overwrite, run:");
+            console.log(`  ${chalk.cyan("vm0 setup-github --force")}`);
+            process.exit(0);
+          }
+        }
+        console.log();
+      }
+
+      // 5. Create workflow files
+      console.log("Creating workflow files...");
+      await mkdir(".github/workflows", { recursive: true });
+
+      await writeFile(publishPath, generatePublishYaml());
+      const publishStatus = existingFiles.includes(publishPath)
+        ? "Overwrote"
+        : "Created";
+      console.log(chalk.green(`✓ ${publishStatus} ${publishPath}`));
+
+      await writeFile(runPath, generateRunYaml(agentName, secrets, vars));
+      const runStatus = existingFiles.includes(runPath)
+        ? "Overwrote"
+        : "Created";
+      console.log(chalk.green(`✓ ${runStatus} ${runPath}`));
+      console.log();
+
+      // 6. Handle secrets/vars setup
+      if (options.skipSecrets) {
+        console.log(chalk.green("✓ Done (secrets setup skipped)"));
+        return;
+      }
+
+      // Detect values
+      const { secretStatuses, varStatuses } = await detectSecretValues(
+        secrets,
+        vars,
+        vm0Token,
+      );
+
+      // Display status table
+      displaySecretsTable(secretStatuses, varStatuses);
+      console.log();
+
+      // Check if any values were found
+      const hasFoundValues =
+        secretStatuses.some((s) => s.found) || varStatuses.some((v) => v.found);
+      if (!hasFoundValues) {
+        console.log("No secret/variable values found in environment.");
+        console.log();
+        showManualSetupInstructions(secrets, vars);
+        console.log();
+        showWorkflowsCreatedMessage();
+        return;
+      }
+
+      // Prompt for auto-setup
+      let shouldSetup = options.yes;
+      if (!shouldSetup) {
+        shouldSetup = await promptYesNo(
+          "Set up GitHub secrets/variables automatically?",
+          true,
+        );
+      }
+
+      if (!shouldSetup) {
+        console.log();
+        showManualSetupInstructions(secrets, vars);
+        console.log();
+        showWorkflowsCreatedMessage();
+        return;
+      }
+
+      // Set secrets
+      console.log();
+      console.log("Setting secrets...");
+      const failedSecrets: string[] = [];
+      for (const s of secretStatuses) {
+        if (s.found && s.value) {
+          const success = setGitHubSecret(s.name, s.value);
+          if (success) {
+            console.log(`  ${chalk.green("✓")} ${s.name}`);
+          } else {
+            console.log(`  ${chalk.red("✗")} ${s.name} (failed)`);
+            failedSecrets.push(s.name);
+          }
+        } else {
+          console.log(
+            `  ${chalk.yellow("⚠")} ${s.name} (skipped - not found)`,
+          );
+        }
+      }
+
+      // Set variables
+      const failedVars: string[] = [];
+      if (varStatuses.length > 0) {
+        console.log();
+        console.log("Setting variables...");
+        for (const v of varStatuses) {
+          if (v.found && v.value) {
+            const success = setGitHubVariable(v.name, v.value);
+            if (success) {
+              console.log(`  ${chalk.green("✓")} ${v.name}`);
+            } else {
+              console.log(`  ${chalk.red("✗")} ${v.name} (failed)`);
+              failedVars.push(v.name);
+            }
+          } else {
+            console.log(
+              `  ${chalk.yellow("⚠")} ${v.name} (skipped - not found)`,
+            );
+          }
+        }
+      }
+
+      // Final summary
+      console.log();
+      const missingSecrets = [
+        ...secretStatuses.filter((s) => !s.found).map((s) => s.name),
+        ...failedSecrets,
+      ];
+      const missingVars = [
+        ...varStatuses.filter((v) => !v.found).map((v) => v.name),
+        ...failedVars,
+      ];
+
+      if (missingSecrets.length === 0 && missingVars.length === 0) {
+        showSuccessMessage();
+      } else {
+        showPartialSuccessMessage(missingSecrets, missingVars);
+      }
+    },
+  );

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -11,6 +11,7 @@ import { imageCommand } from "./commands/image";
 import { logsCommand } from "./commands/logs";
 import { scopeCommand } from "./commands/scope";
 import { initCommand } from "./commands/init";
+import { setupGithubCommand } from "./commands/setup-github";
 
 const program = new Command();
 
@@ -75,6 +76,7 @@ program.addCommand(imageCommand);
 program.addCommand(logsCommand);
 program.addCommand(scopeCommand);
 program.addCommand(initCommand);
+program.addCommand(setupGithubCommand);
 
 export { program };
 


### PR DESCRIPTION
## Summary

Add `vm0 setup-github` command that initializes GitHub Actions workflows for agent repositories:
- Checks prerequisites (gh CLI installation & auth, VM0 auth, vm0.yaml)
- Creates `.github/workflows/publish.yml` (triggers on push to main)
- Creates `.github/workflows/run.yml` (manual/scheduled execution)
- Extracts secrets/vars from vm0.yaml (both explicit `${{ secrets.X }}` and `experimental_*` shorthand)
- Optionally auto-configures GitHub secrets/variables via gh CLI

### Command Options
- `--force/-f`: Overwrite existing workflow files
- `--yes/-y`: Auto-confirm all prompts
- `--skip-secrets`: Skip automatic secrets/variables setup

### Interactive Flow
1. Checks prerequisites and displays status
2. Parses vm0.yaml to detect agent name and required secrets/vars
3. Prompts before overwriting existing files (default: No)
4. Displays detected secrets/vars with sources (env, vm0 auth)
5. Prompts for automatic GitHub setup (default: Yes)
6. Sets secrets/vars via gh CLI and shows final status

## Test plan

- [x] Unit tests added for all key functions (21 tests)
- [x] Tests cover prerequisite checks, workflow generation, variable extraction, and secret setup
- [ ] Manual testing: `vm0 setup-github --help` shows correct options
- [ ] Manual testing: Run in repository with vm0.yaml to verify workflow creation
- [ ] Manual testing: Verify `--skip-secrets` skips automatic setup
- [ ] Manual testing: Verify `--force` overwrites existing files

Closes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)