### PR TITLE
feat(core): add ts-rest contracts for storage direct upload endpoints

### DIFF
--- a/codereviews/20251227/commit-list.md
+++ b/codereviews/20251227/commit-list.md
@@ -1,0 +1,6 @@
+# PR #779 Code Review - Storage ts-rest Contracts
+
+## Commits
+
+- [x] [`d2d455f6`](review-d2d455f6.md) - feat(core): add ts-rest contracts for storage direct upload endpoints
+- [x] [`ebef5f23`](review-ebef5f23.md) - refactor(web): convert storage routes to ts-rest pattern

--- a/codereviews/20251227/review-d2d455f6.md
+++ b/codereviews/20251227/review-d2d455f6.md
@@ -1,0 +1,68 @@
+# Review: d2d455f6 - feat(core): add ts-rest contracts for storage direct upload endpoints
+
+## Summary
+This commit adds type-safe ts-rest contracts for storage direct upload endpoints, including CLI endpoints (prepare, commit, download) and webhook endpoints for sandbox use.
+
+## Files Changed
+- `turbo/packages/core/src/contracts/storages.ts` - New schemas and contracts for CLI endpoints
+- `turbo/packages/core/src/contracts/webhooks.ts` - New contracts for webhook endpoints
+- `turbo/packages/core/src/contracts/index.ts` - Export updates
+
+## Analysis
+
+### 1. Mock Analysis
+**No mocks introduced** - This commit only adds contract definitions with no mock implementations.
+
+### 2. Test Coverage
+**N/A** - This is a contract definition commit. Tests are in the second commit.
+
+### 3. Error Handling
+**Good** - Consistent error schemas using `apiErrorSchema` across all endpoints:
+- 400 (BAD_REQUEST)
+- 401 (UNAUTHORIZED)
+- 404 (NOT_FOUND)
+- 409 (S3_FILES_MISSING) - specific to commit endpoint
+- 500 (INTERNAL_ERROR)
+
+### 4. Interface Changes
+**New interfaces added:**
+
+Shared schemas:
+- `fileEntryWithHashSchema` - File entry with SHA-256 hash validation (64 chars)
+- `storageChangesSchema` - Incremental upload change tracking
+- `presignedUploadSchema` - Presigned URL structure
+
+CLI contracts:
+- `storagesPrepareContract` - POST /api/storages/prepare
+- `storagesCommitContract` - POST /api/storages/commit
+- `storagesDownloadContract` - GET /api/storages/download
+
+Webhook contracts:
+- `webhookStoragesPrepareContract` - POST /api/webhooks/agent/storages/prepare
+- `webhookStoragesCommitContract` - POST /api/webhooks/agent/storages/commit
+
+**Design Notes:**
+- CLI contracts have optional `runId` for sandbox auth
+- Webhook contracts require `runId` (enforced via schema)
+- Download contract uses `z.union()` to handle both normal and empty responses
+
+### 5. Timer and Delay Analysis
+**None** - No timers or delays introduced.
+
+### 6. Dynamic Imports
+**None** - All imports are static.
+
+## Observations
+
+### Positives
+1. Clear schema separation between shared schemas and endpoint-specific contracts
+2. Good JSDoc documentation explaining each contract's purpose
+3. Proper reuse of schemas between CLI and webhook contracts
+4. Type exports for all contracts enable type-safe client usage
+
+### Minor Notes
+1. The `storagesDownloadContract` uses `z.union()` for the 200 response - this is appropriate for handling both normal downloads and empty artifact responses
+2. The webhook contracts properly distinguish from CLI contracts by requiring `runId` instead of making it optional
+
+## Verdict
+**APPROVED** - Well-structured contract definitions following project patterns. No issues found.

--- a/codereviews/20251227/review-ebef5f23.md
+++ b/codereviews/20251227/review-ebef5f23.md
@@ -1,0 +1,125 @@
+# Review: ebef5f23 - refactor(web): convert storage routes to ts-rest pattern
+
+## Summary
+This commit converts storage API routes from inline types (Pattern B) to ts-rest contracts (Pattern A), including CLI and webhook endpoints. Tests were updated to use `NextRequest` (required by ts-rest) and fix hash values to match SHA-256 validation (64 chars).
+
+## Files Changed
+- `turbo/apps/web/app/api/storages/prepare/route.ts` - Converted to ts-rest
+- `turbo/apps/web/app/api/storages/commit/route.ts` - Converted to ts-rest
+- `turbo/apps/web/app/api/storages/download/route.ts` - Converted to ts-rest
+- `turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts` - Converted to ts-rest
+- `turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts` - Converted to ts-rest
+- `turbo/apps/web/app/api/storages/*/__tests__/route.test.ts` - Test updates
+
+## Analysis
+
+### 1. Mock Analysis
+**Existing mocks only** - Tests use appropriate mocks for:
+- `getUserId` - Auth mocking
+- `generatePresignedPutUrl`/`generatePresignedUrl` - S3 URL generation
+- `s3ObjectExists`, `verifyS3FilesExist` - S3 verification
+- `downloadManifest` - Manifest retrieval
+
+**Assessment:** These mocks are appropriate for isolating external dependencies (S3, auth). Tests use real database connections per project guidelines.
+
+### 2. Test Coverage
+Tests cover:
+- Authentication (401 scenarios)
+- Validation (400 scenarios - missing fields, invalid types)
+- Not found (404 scenarios)
+- Business logic (version creation, deduplication, HEAD updates)
+- Edge cases (empty artifacts, S3 files missing, concurrent commits)
+
+**Assessment:** Good coverage with meaningful tests. Tests verify actual behavior, not just status codes.
+
+### 3. Error Handling
+**Pattern used:** Custom `errorHandler` function for each route
+
+```typescript
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (err && typeof err === "object" && "bodyError" in err && "queryError" in err) {
+    // Handle Zod validation errors
+    ...
+  }
+  // Log and return generic error
+  log.error("...", err);
+  return TsRestResponse.fromJson({...}, { status: 500 });
+}
+```
+
+**Assessment:**
+- Appropriate error handler that converts Zod validation errors to API format
+- Falls back to 500 for unexpected errors
+- Logs errors for debugging
+
+### 4. Interface Changes
+**Breaking changes: None** - The API surface remains identical, only the implementation pattern changed:
+- Same HTTP methods
+- Same request/response shapes
+- Same status codes
+
+### 5. Timer and Delay Analysis
+**None** - No timers, delays, or fake timers in the code.
+
+### 6. Dynamic Imports
+**Tests use dynamic imports** - Tests use `await import("../route")` pattern:
+```typescript
+const { POST } = await import("../route");
+```
+
+**Assessment:** This is acceptable for tests because:
+1. It allows tests to import after mocks are set up
+2. It's the standard pattern for testing Next.js API routes
+3. Not prohibited by project guidelines (which focus on production code)
+
+### 7. Database/Service Mocking
+**Good:** Tests do NOT mock `globalThis.services`. They use real database connections as required by project guidelines.
+
+### 8. Test Mock Cleanup
+**Good:** All test files call `vi.clearAllMocks()` in `beforeEach` hooks.
+
+### 9. TypeScript Types
+**Good:** No `any` types introduced. Proper type narrowing used throughout:
+```typescript
+const validationError = err as {
+  bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
+  queryError: { issues: Array<{ path: string[]; message: string }> } | null;
+};
+```
+
+### 10. Lint/Type Suppressions
+**Good:** No `eslint-disable`, `@ts-ignore`, or other suppression comments.
+
+## Observations
+
+### Positives
+1. Consistent pattern across all converted routes
+2. Tests properly updated to work with ts-rest (NextRequest, 64-char hashes)
+3. Good separation between CLI and webhook authentication patterns
+4. Defense-in-depth S3 verification maintained
+
+### Code Patterns
+The conversion follows a consistent pattern:
+```typescript
+import { createHandler, tsr, TsRestResponse } from "...";
+import { someContract } from "@vm0/core";
+
+const router = tsr.router(someContract, {
+  methodName: async ({ body/query }) => {
+    // Business logic
+    return { status: 200 as const, body: {...} };
+  },
+});
+
+function errorHandler(err: unknown): TsRestResponse | void { ... }
+
+const handler = createHandler(someContract, router, { errorHandler });
+export { handler as POST/GET };
+```
+
+### Minor Notes
+1. Tests still include some error status tests (401, 400, 404) - acceptable since they verify the route integration works correctly
+2. Some test hash values changed from short strings to 64-char strings to match schema validation
+
+## Verdict
+**APPROVED** - Clean conversion to ts-rest pattern with no regressions. Tests properly updated. Follows project coding standards.

--- a/turbo/apps/web/app/api/storages/commit/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/commit/__tests__/route.test.ts
@@ -98,16 +98,19 @@ describe("POST /api/storages/commit", () => {
 
     const { POST } = await import("../route");
 
-    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        storageName: "test",
-        storageType: "volume",
-        versionId: "abc123",
-        files: [],
-      }),
-    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/storages/commit",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageName: "test",
+          storageType: "volume",
+          versionId: "abc123",
+          files: [],
+        }),
+      },
+    );
 
     const response = await POST(request);
     expect(response.status).toBe(401);
@@ -116,15 +119,18 @@ describe("POST /api/storages/commit", () => {
   it("should return 400 when storageName is missing", async () => {
     const { POST } = await import("../route");
 
-    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        storageType: "volume",
-        versionId: "abc123",
-        files: [],
-      }),
-    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/storages/commit",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageType: "volume",
+          versionId: "abc123",
+          files: [],
+        }),
+      },
+    );
 
     const response = await POST(request);
     expect(response.status).toBe(400);
@@ -133,16 +139,19 @@ describe("POST /api/storages/commit", () => {
   it("should return 404 when storage does not exist", async () => {
     const { POST } = await import("../route");
 
-    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        storageName: "nonexistent-storage",
-        storageType: "volume",
-        versionId: "abc123",
-        files: [],
-      }),
-    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/storages/commit",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageName: "nonexistent-storage",
+          storageType: "volume",
+          versionId: "abc123",
+          files: [],
+        }),
+      },
+    );
 
     const response = await POST(request);
     expect(response.status).toBe(404);
@@ -162,16 +171,19 @@ describe("POST /api/storages/commit", () => {
       fileCount: 0,
     });
 
-    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        storageName,
-        storageType: "volume",
-        versionId: "wrong_version_id",
-        files: [{ path: "test.txt", hash: "a".repeat(64), size: 100 }],
-      }),
-    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/storages/commit",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageName,
+          storageType: "volume",
+          versionId: "wrong_version_id",
+          files: [{ path: "test.txt", hash: "a".repeat(64), size: 100 }],
+        }),
+      },
+    );
 
     const response = await POST(request);
     expect(response.status).toBe(400);
@@ -204,16 +216,19 @@ describe("POST /api/storages/commit", () => {
     const files = [{ path: "test.txt", hash: "b".repeat(64), size: 100 }];
     const versionId = computeContentHashFromHashes(storage!.id, files);
 
-    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        storageName,
-        storageType: "volume",
-        versionId,
-        files,
-      }),
-    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/storages/commit",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageName,
+          storageType: "volume",
+          versionId,
+          files,
+        }),
+      },
+    );
 
     const response = await POST(request);
     expect(response.status).toBe(400);
@@ -252,16 +267,19 @@ describe("POST /api/storages/commit", () => {
     ];
     const versionId = computeContentHashFromHashes(storage!.id, files);
 
-    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        storageName,
-        storageType: "artifact",
-        versionId,
-        files,
-      }),
-    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/storages/commit",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageName,
+          storageType: "artifact",
+          versionId,
+          files,
+        }),
+      },
+    );
 
     const response = await POST(request);
     expect(response.status).toBe(200);
@@ -325,16 +343,19 @@ describe("POST /api/storages/commit", () => {
     const files: { path: string; hash: string; size: number }[] = [];
     const versionId = computeContentHashFromHashes(storage!.id, files);
 
-    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        storageName,
-        storageType: "artifact",
-        versionId,
-        files,
-      }),
-    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/storages/commit",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageName,
+          storageType: "artifact",
+          versionId,
+          files,
+        }),
+      },
+    );
 
     const response = await POST(request);
     expect(response.status).toBe(200);
@@ -399,16 +420,19 @@ describe("POST /api/storages/commit", () => {
       .where(eq(storages.id, storage!.id));
 
     // Commit again
-    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        storageName,
-        storageType: "volume",
-        versionId,
-        files,
-      }),
-    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/storages/commit",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageName,
+          storageType: "volume",
+          versionId,
+          files,
+        }),
+      },
+    );
 
     const response = await POST(request);
     expect(response.status).toBe(200);
@@ -463,16 +487,19 @@ describe("POST /api/storages/commit", () => {
     });
 
     // Commit should fail because S3 files are missing
-    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        storageName,
-        storageType: "volume",
-        versionId,
-        files,
-      }),
-    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/storages/commit",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageName,
+          storageType: "volume",
+          versionId,
+          files,
+        }),
+      },
+    );
 
     const response = await POST(request);
     expect(response.status).toBe(409);
@@ -546,16 +573,19 @@ describe("POST /api/storages/commit", () => {
         },
       ) as typeof originalTransaction;
 
-    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        storageName,
-        storageType: "artifact",
-        versionId,
-        files,
-      }),
-    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/storages/commit",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageName,
+          storageType: "artifact",
+          versionId,
+          files,
+        }),
+      },
+    );
 
     const response = await POST(request);
 

--- a/turbo/apps/web/app/api/storages/commit/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/commit/__tests__/route.test.ts
@@ -33,6 +33,14 @@ vi.mock("../../../../../src/lib/s3/s3-client", () => ({
 // Set required environment variables
 process.env.R2_USER_STORAGES_BUCKET_NAME = "test-storages-bucket";
 
+// Static imports - mocks are already in place due to hoisting
+import { POST } from "../route";
+import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import {
+  s3ObjectExists,
+  verifyS3FilesExist,
+} from "../../../../../src/lib/s3/s3-client";
+
 // Test constants
 const TEST_USER_ID = "test-user-commit";
 const TEST_PREFIX = "test-commit-";
@@ -91,12 +99,7 @@ describe("POST /api/storages/commit", () => {
   });
 
   it("should return 401 when not authenticated", async () => {
-    const { getUserId } = await import(
-      "../../../../../src/lib/auth/get-user-id"
-    );
     vi.mocked(getUserId).mockResolvedValueOnce(null);
-
-    const { POST } = await import("../route");
 
     const request = new NextRequest(
       "http://localhost:3000/api/storages/commit",
@@ -117,8 +120,6 @@ describe("POST /api/storages/commit", () => {
   });
 
   it("should return 400 when storageName is missing", async () => {
-    const { POST } = await import("../route");
-
     const request = new NextRequest(
       "http://localhost:3000/api/storages/commit",
       {
@@ -137,8 +138,6 @@ describe("POST /api/storages/commit", () => {
   });
 
   it("should return 404 when storage does not exist", async () => {
-    const { POST } = await import("../route");
-
     const request = new NextRequest(
       "http://localhost:3000/api/storages/commit",
       {
@@ -158,7 +157,6 @@ describe("POST /api/storages/commit", () => {
   });
 
   it("should return 400 when versionId does not match computed hash", async () => {
-    const { POST } = await import("../route");
     const storageName = `${TEST_PREFIX}mismatch`;
 
     // Create storage
@@ -192,12 +190,8 @@ describe("POST /api/storages/commit", () => {
   });
 
   it("should return 400 when S3 objects do not exist", async () => {
-    const { s3ObjectExists } = await import(
-      "../../../../../src/lib/s3/s3-client"
-    );
     vi.mocked(s3ObjectExists).mockResolvedValueOnce(false); // manifest doesn't exist
 
-    const { POST } = await import("../route");
     const storageName = `${TEST_PREFIX}missing-s3`;
 
     // Create storage
@@ -237,7 +231,6 @@ describe("POST /api/storages/commit", () => {
   });
 
   it("should create version and update HEAD on successful commit", async () => {
-    const { POST } = await import("../route");
     const storageName = `${TEST_PREFIX}success`;
 
     // Create storage
@@ -317,13 +310,9 @@ describe("POST /api/storages/commit", () => {
   it("should commit empty artifact without requiring archive in S3", async () => {
     // This test verifies the fix for issue #617:
     // Empty artifacts (fileCount === 0) should not require archive.tar.gz in S3
-    const { s3ObjectExists } = await import(
-      "../../../../../src/lib/s3/s3-client"
-    );
     // Mock: manifest exists (only one call expected for empty artifact)
     vi.mocked(s3ObjectExists).mockResolvedValueOnce(true); // manifest exists
 
-    const { POST } = await import("../route");
     const storageName = `${TEST_PREFIX}empty`;
 
     // Create storage
@@ -378,7 +367,6 @@ describe("POST /api/storages/commit", () => {
   });
 
   it("should return deduplicated=true when version already exists", async () => {
-    const { POST } = await import("../route");
     const storageName = `${TEST_PREFIX}idempotent`;
 
     // Create storage
@@ -445,13 +433,9 @@ describe("POST /api/storages/commit", () => {
   it("should return 409 when version exists but S3 files are missing", async () => {
     // This test verifies the fix for issue #658:
     // Commit should fail with 409 if S3 files are missing for existing version
-    const s3Mock = await import("../../../../../src/lib/s3/s3-client");
-    const verifyS3FilesMock = vi.mocked(s3Mock.verifyS3FilesExist);
-
     // Mock S3 files as missing for existing version
-    verifyS3FilesMock.mockResolvedValueOnce(false);
+    vi.mocked(verifyS3FilesExist).mockResolvedValueOnce(false);
 
-    const { POST } = await import("../route");
     const storageName = `${TEST_PREFIX}s3missing`;
 
     // Create storage
@@ -515,7 +499,6 @@ describe("POST /api/storages/commit", () => {
     // the code verifies the version exists before updating HEAD pointer.
     // If the version doesn't exist (concurrent transaction hasn't committed),
     // the commit should fail with a clear error message instead of FK violation.
-    const { POST } = await import("../route");
     const storageName = `${TEST_PREFIX}race-condition`;
 
     // Create storage

--- a/turbo/apps/web/app/api/storages/commit/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/commit/__tests__/route.test.ts
@@ -10,6 +10,7 @@ import {
   beforeAll,
   afterAll,
 } from "vitest";
+import { NextRequest } from "next/server";
 import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -97,7 +98,7 @@ describe("POST /api/storages/commit", () => {
 
     const { POST } = await import("../route");
 
-    const request = new Request("http://localhost:3000/api/storages/commit", {
+    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -108,16 +109,14 @@ describe("POST /api/storages/commit", () => {
       }),
     });
 
-    const response = await POST(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await POST(request);
     expect(response.status).toBe(401);
   });
 
   it("should return 400 when storageName is missing", async () => {
     const { POST } = await import("../route");
 
-    const request = new Request("http://localhost:3000/api/storages/commit", {
+    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -127,16 +126,14 @@ describe("POST /api/storages/commit", () => {
       }),
     });
 
-    const response = await POST(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await POST(request);
     expect(response.status).toBe(400);
   });
 
   it("should return 404 when storage does not exist", async () => {
     const { POST } = await import("../route");
 
-    const request = new Request("http://localhost:3000/api/storages/commit", {
+    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -147,9 +144,7 @@ describe("POST /api/storages/commit", () => {
       }),
     });
 
-    const response = await POST(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await POST(request);
     expect(response.status).toBe(404);
   });
 
@@ -167,20 +162,18 @@ describe("POST /api/storages/commit", () => {
       fileCount: 0,
     });
 
-    const request = new Request("http://localhost:3000/api/storages/commit", {
+    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         storageName,
         storageType: "volume",
         versionId: "wrong_version_id",
-        files: [{ path: "test.txt", hash: "abc123", size: 100 }],
+        files: [{ path: "test.txt", hash: "a".repeat(64), size: 100 }],
       }),
     });
 
-    const response = await POST(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await POST(request);
     expect(response.status).toBe(400);
     const json = await response.json();
     expect(json.error.message).toContain("mismatch");
@@ -208,10 +201,10 @@ describe("POST /api/storages/commit", () => {
       })
       .returning();
 
-    const files = [{ path: "test.txt", hash: "abc123", size: 100 }];
+    const files = [{ path: "test.txt", hash: "b".repeat(64), size: 100 }];
     const versionId = computeContentHashFromHashes(storage!.id, files);
 
-    const request = new Request("http://localhost:3000/api/storages/commit", {
+    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -222,9 +215,7 @@ describe("POST /api/storages/commit", () => {
       }),
     });
 
-    const response = await POST(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await POST(request);
     expect(response.status).toBe(400);
     const json = await response.json();
     expect(json.error.message).toContain("not uploaded");
@@ -250,18 +241,18 @@ describe("POST /api/storages/commit", () => {
     const files = [
       {
         path: "file1.txt",
-        hash: "hash1_abcdef1234567890abcdef1234567890abcdef1234",
+        hash: "e".repeat(64),
         size: 100,
       },
       {
         path: "file2.txt",
-        hash: "hash2_abcdef1234567890abcdef1234567890abcdef1234",
+        hash: "f".repeat(64),
         size: 200,
       },
     ];
     const versionId = computeContentHashFromHashes(storage!.id, files);
 
-    const request = new Request("http://localhost:3000/api/storages/commit", {
+    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -272,9 +263,7 @@ describe("POST /api/storages/commit", () => {
       }),
     });
 
-    const response = await POST(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await POST(request);
     expect(response.status).toBe(200);
 
     const json = await response.json();
@@ -301,10 +290,10 @@ describe("POST /api/storages/commit", () => {
     // Clean up blobs created
     await globalThis.services.db
       .delete(blobs)
-      .where(eq(blobs.hash, files[0]!.hash));
+      .where(eq(blobs.hash, "e".repeat(64)));
     await globalThis.services.db
       .delete(blobs)
-      .where(eq(blobs.hash, files[1]!.hash));
+      .where(eq(blobs.hash, "f".repeat(64)));
   });
 
   it("should commit empty artifact without requiring archive in S3", async () => {
@@ -336,7 +325,7 @@ describe("POST /api/storages/commit", () => {
     const files: { path: string; hash: string; size: number }[] = [];
     const versionId = computeContentHashFromHashes(storage!.id, files);
 
-    const request = new Request("http://localhost:3000/api/storages/commit", {
+    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -347,9 +336,7 @@ describe("POST /api/storages/commit", () => {
       }),
     });
 
-    const response = await POST(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await POST(request);
     expect(response.status).toBe(200);
 
     const json = await response.json();
@@ -389,7 +376,7 @@ describe("POST /api/storages/commit", () => {
     const files = [
       {
         path: "test.txt",
-        hash: "idempotent_hash_abcdef1234567890abcdef",
+        hash: "d".repeat(64),
         size: 100,
       },
     ];
@@ -412,7 +399,7 @@ describe("POST /api/storages/commit", () => {
       .where(eq(storages.id, storage!.id));
 
     // Commit again
-    const request = new Request("http://localhost:3000/api/storages/commit", {
+    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -423,9 +410,7 @@ describe("POST /api/storages/commit", () => {
       }),
     });
 
-    const response = await POST(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await POST(request);
     expect(response.status).toBe(200);
 
     const json = await response.json();
@@ -461,7 +446,7 @@ describe("POST /api/storages/commit", () => {
     const files = [
       {
         path: "test.txt",
-        hash: "s3missing_hash_abcdef1234567890abcdef",
+        hash: "c".repeat(64),
         size: 100,
       },
     ];
@@ -478,7 +463,7 @@ describe("POST /api/storages/commit", () => {
     });
 
     // Commit should fail because S3 files are missing
-    const request = new Request("http://localhost:3000/api/storages/commit", {
+    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -489,9 +474,7 @@ describe("POST /api/storages/commit", () => {
       }),
     });
 
-    const response = await POST(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await POST(request);
     expect(response.status).toBe(409);
 
     const json = await response.json();
@@ -524,7 +507,7 @@ describe("POST /api/storages/commit", () => {
     const files = [
       {
         path: "race.txt",
-        hash: "race_hash_abcdef1234567890abcdef1234567890",
+        hash: "f".repeat(64),
         size: 50,
       },
     ];
@@ -563,7 +546,7 @@ describe("POST /api/storages/commit", () => {
         },
       ) as typeof originalTransaction;
 
-    const request = new Request("http://localhost:3000/api/storages/commit", {
+    const request = new NextRequest("http://localhost:3000/api/storages/commit", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -574,9 +557,7 @@ describe("POST /api/storages/commit", () => {
       }),
     });
 
-    const response = await POST(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await POST(request);
 
     // Should return 500 with clear error message about concurrent transaction
     expect(response.status).toBe(500);

--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -140,7 +140,8 @@ const router = tsr.router(storagesCommitContract, {
           status: 409 as const,
           body: {
             error: {
-              message: "S3 files missing for existing version - please retry upload",
+              message:
+                "S3 files missing for existing version - please retry upload",
               code: "S3_FILES_MISSING",
             },
           },

--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -1,4 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import {
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../../../../src/lib/ts-rest-handler";
+import { storagesCommitContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
 import { storages, storageVersions } from "../../../../src/db/schema/storage";
@@ -8,100 +13,28 @@ import {
   s3ObjectExists,
   verifyS3FilesExist,
 } from "../../../../src/lib/s3/s3-client";
-import {
-  computeContentHashFromHashes,
-  type FileEntryWithHash,
-} from "../../../../src/lib/storage/content-hash";
+import { computeContentHashFromHashes } from "../../../../src/lib/storage/content-hash";
 import { env } from "../../../../src/env";
 import { logger } from "../../../../src/lib/logger";
 
 const log = logger("api:storages:commit");
 
-/**
- * Standard error response format
- */
-function errorResponse(
-  message: string,
-  code: string,
-  status: number,
-): NextResponse {
-  return NextResponse.json({ error: { message, code } }, { status });
-}
-
-/**
- * Request body schema for commit endpoint
- */
-interface CommitRequest {
-  storageName: string;
-  storageType: "volume" | "artifact";
-  versionId: string;
-  files: FileEntryWithHash[];
-  // Sandbox-specific fields (optional)
-  runId?: string;
-  message?: string;
-}
-
-/**
- * Response schema for commit endpoint
- */
-interface CommitResponse {
-  success: boolean;
-  versionId: string;
-  storageName: string;
-  size: number;
-  fileCount: number;
-  deduplicated?: boolean;
-}
-
-/**
- * POST /api/storages/commit
- *
- * Commits a direct S3 upload by:
- * 1. Verifying uploaded files exist in S3 (using HeadObject)
- * 2. Creating blob records in database (with ref counts)
- * 3. Creating storage version record
- * 4. Updating storage HEAD pointer
- *
- * This endpoint is called after the client has uploaded files directly to S3
- * using presigned URLs from the prepare endpoint.
- */
-export async function POST(request: NextRequest) {
-  try {
+const router = tsr.router(storagesCommitContract, {
+  commit: async ({ body }) => {
     initServices();
 
     // Authenticate user
     const userId = await getUserId();
     if (!userId) {
-      return errorResponse("Not authenticated", "UNAUTHORIZED", 401);
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        },
+      };
     }
 
-    // Parse JSON body
-    const body = (await request.json()) as CommitRequest;
     const { storageName, storageType, versionId, files, runId, message } = body;
-
-    // Validate required fields
-    if (!storageName) {
-      return errorResponse("storageName is required", "BAD_REQUEST", 400);
-    }
-
-    if (
-      !storageType ||
-      (storageType !== "volume" && storageType !== "artifact")
-    ) {
-      return errorResponse(
-        "storageType must be 'volume' or 'artifact'",
-        "BAD_REQUEST",
-        400,
-      );
-    }
-
-    if (!versionId) {
-      return errorResponse("versionId is required", "BAD_REQUEST", 400);
-    }
-
-    if (!files || !Array.isArray(files)) {
-      return errorResponse("files array is required", "BAD_REQUEST", 400);
-    }
 
     log.debug(
       `Committing version ${versionId} for "${storageName}" (type: ${storageType}), ${files.length} files`,
@@ -116,7 +49,12 @@ export async function POST(request: NextRequest) {
         .limit(1);
 
       if (!run) {
-        return errorResponse("Agent run not found", "NOT_FOUND", 404);
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Agent run not found", code: "NOT_FOUND" },
+          },
+        };
       }
     }
 
@@ -134,21 +72,29 @@ export async function POST(request: NextRequest) {
       .limit(1);
 
     if (!storage) {
-      return errorResponse(
-        `Storage "${storageName}" not found`,
-        "NOT_FOUND",
-        404,
-      );
+      return {
+        status: 404 as const,
+        body: {
+          error: {
+            message: `Storage "${storageName}" not found`,
+            code: "NOT_FOUND",
+          },
+        },
+      };
     }
 
     // Verify version ID matches computed hash
     const computedVersionId = computeContentHashFromHashes(storage.id, files);
     if (computedVersionId !== versionId) {
-      return errorResponse(
-        "Version ID mismatch - files may have changed",
-        "BAD_REQUEST",
-        400,
-      );
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: "Version ID mismatch - files may have changed",
+            code: "BAD_REQUEST",
+          },
+        },
+      };
     }
 
     // Check if version already exists (idempotency)
@@ -167,11 +113,15 @@ export async function POST(request: NextRequest) {
       // Get bucket name for S3 verification
       const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
       if (!bucketName) {
-        return errorResponse(
-          "R2_USER_STORAGES_BUCKET_NAME not configured",
-          "INTERNAL_ERROR",
-          500,
-        );
+        return {
+          status: 500 as const,
+          body: {
+            error: {
+              message: "R2_USER_STORAGES_BUCKET_NAME not configured",
+              code: "INTERNAL_ERROR",
+            },
+          },
+        };
       }
 
       // Defense-in-depth: verify S3 files exist before updating HEAD
@@ -186,11 +136,15 @@ export async function POST(request: NextRequest) {
         log.error(
           `Version ${versionId} exists in DB but S3 files missing - cannot commit`,
         );
-        return errorResponse(
-          "S3 files missing for existing version - please retry upload",
-          "S3_FILES_MISSING",
-          409,
-        );
+        return {
+          status: 409 as const,
+          body: {
+            error: {
+              message: "S3 files missing for existing version - please retry upload",
+              code: "S3_FILES_MISSING",
+            },
+          },
+        };
       }
 
       // Version already exists with valid S3 files, update HEAD pointer if needed
@@ -205,24 +159,31 @@ export async function POST(request: NextRequest) {
       }
 
       log.debug(`Version ${versionId} already committed, returning success`);
-      return NextResponse.json({
-        success: true,
-        versionId,
-        storageName,
-        size: Number(existingVersion.size),
-        fileCount: existingVersion.fileCount,
-        deduplicated: true,
-      } satisfies CommitResponse);
+      return {
+        status: 200 as const,
+        body: {
+          success: true as const,
+          versionId,
+          storageName,
+          size: Number(existingVersion.size),
+          fileCount: existingVersion.fileCount,
+          deduplicated: true,
+        },
+      };
     }
 
     // Get bucket name
     const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
     if (!bucketName) {
-      return errorResponse(
-        "R2_USER_STORAGES_BUCKET_NAME not configured",
-        "INTERNAL_ERROR",
-        500,
-      );
+      return {
+        status: 500 as const,
+        body: {
+          error: {
+            message: "R2_USER_STORAGES_BUCKET_NAME not configured",
+            code: "INTERNAL_ERROR",
+          },
+        },
+      };
     }
 
     // Verify required S3 objects exist
@@ -241,19 +202,27 @@ export async function POST(request: NextRequest) {
     ]);
 
     if (!manifestExists) {
-      return errorResponse(
-        "Manifest not uploaded - upload failed or incomplete",
-        "BAD_REQUEST",
-        400,
-      );
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: "Manifest not uploaded - upload failed or incomplete",
+            code: "BAD_REQUEST",
+          },
+        },
+      };
     }
 
     if (fileCount > 0 && !archiveExists) {
-      return errorResponse(
-        "Archive not uploaded - upload failed or incomplete",
-        "BAD_REQUEST",
-        400,
-      );
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: "Archive not uploaded - upload failed or incomplete",
+            code: "BAD_REQUEST",
+          },
+        },
+      };
     }
 
     // Calculate totals
@@ -305,19 +274,62 @@ export async function POST(request: NextRequest) {
       `Committed version ${versionId}: ${fileCount} files, ${totalSize} bytes`,
     );
 
-    return NextResponse.json({
-      success: true,
-      versionId,
-      storageName,
-      size: totalSize,
-      fileCount,
-    } satisfies CommitResponse);
-  } catch (error) {
-    log.error("Commit error:", error);
-    return errorResponse(
-      error instanceof Error ? error.message : "Commit failed",
-      "INTERNAL_ERROR",
-      500,
-    );
+    return {
+      status: 200 as const,
+      body: {
+        success: true as const,
+        versionId,
+        storageName,
+        size: totalSize,
+        fileCount,
+      },
+    };
+  },
+});
+
+/**
+ * Custom error handler to convert Zod validation errors to API error format
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (
+    err &&
+    typeof err === "object" &&
+    "bodyError" in err &&
+    "queryError" in err
+  ) {
+    const validationError = err as {
+      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
+      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
+    };
+
+    if (validationError.bodyError) {
+      const issue = validationError.bodyError.issues[0];
+      if (issue) {
+        const path = issue.path.join(".");
+        const message = path ? `${path}: ${issue.message}` : issue.message;
+        return TsRestResponse.fromJson(
+          { error: { message, code: "BAD_REQUEST" } },
+          { status: 400 },
+        );
+      }
+    }
   }
+
+  // Log unexpected errors
+  log.error("Commit error:", err);
+  return TsRestResponse.fromJson(
+    {
+      error: {
+        message: err instanceof Error ? err.message : "Commit failed",
+        code: "INTERNAL_ERROR",
+      },
+    },
+    { status: 500 },
+  );
 }
+
+const handler = createHandler(storagesCommitContract, router, {
+  errorHandler,
+});
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/storages/download/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/download/__tests__/route.test.ts
@@ -32,6 +32,10 @@ vi.mock("../../../../../src/lib/s3/s3-client", () => ({
 // Set required environment variables
 process.env.R2_USER_STORAGES_BUCKET_NAME = "test-storages-bucket";
 
+// Static imports - mocks are already in place due to hoisting
+import { GET } from "../route";
+import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+
 // Test constants
 const TEST_USER_ID = "test-user-download";
 const TEST_PREFIX = "test-download-";
@@ -90,12 +94,7 @@ describe("GET /api/storages/download", () => {
   });
 
   it("should return 401 when not authenticated", async () => {
-    const { getUserId } = await import(
-      "../../../../../src/lib/auth/get-user-id"
-    );
     vi.mocked(getUserId).mockResolvedValueOnce(null);
-
-    const { GET } = await import("../route");
 
     const request = new NextRequest(
       "http://localhost:3000/api/storages/download?name=test&type=volume",
@@ -106,8 +105,6 @@ describe("GET /api/storages/download", () => {
   });
 
   it("should return 400 when name parameter is missing", async () => {
-    const { GET } = await import("../route");
-
     const request = new NextRequest(
       "http://localhost:3000/api/storages/download?type=volume",
     );
@@ -120,8 +117,6 @@ describe("GET /api/storages/download", () => {
   });
 
   it("should return 400 when type parameter is missing", async () => {
-    const { GET } = await import("../route");
-
     const request = new NextRequest(
       "http://localhost:3000/api/storages/download?name=test",
     );
@@ -134,8 +129,6 @@ describe("GET /api/storages/download", () => {
   });
 
   it("should return 400 when type is invalid", async () => {
-    const { GET } = await import("../route");
-
     const request = new NextRequest(
       "http://localhost:3000/api/storages/download?name=test&type=invalid",
     );
@@ -148,8 +141,6 @@ describe("GET /api/storages/download", () => {
   });
 
   it("should return 404 when storage does not exist", async () => {
-    const { GET } = await import("../route");
-
     const request = new NextRequest(
       "http://localhost:3000/api/storages/download?name=nonexistent&type=volume",
     );
@@ -159,7 +150,6 @@ describe("GET /api/storages/download", () => {
   });
 
   it("should return 404 when storage has no versions", async () => {
-    const { GET } = await import("../route");
     const storageName = `${TEST_PREFIX}no-versions`;
 
     // Create storage without versions
@@ -185,7 +175,6 @@ describe("GET /api/storages/download", () => {
   });
 
   it("should return empty=true for empty storage", async () => {
-    const { GET } = await import("../route");
     const storageName = `${TEST_PREFIX}empty`;
     const versionId = "a".repeat(64);
 
@@ -231,7 +220,6 @@ describe("GET /api/storages/download", () => {
   });
 
   it("should return presigned URL for non-empty storage", async () => {
-    const { GET } = await import("../route");
     const storageName = `${TEST_PREFIX}with-files`;
     const versionId = "b".repeat(64);
 
@@ -278,7 +266,6 @@ describe("GET /api/storages/download", () => {
   });
 
   it("should return presigned URL for specific version", async () => {
-    const { GET } = await import("../route");
     const storageName = `${TEST_PREFIX}specific-version`;
     const version1Id = "c".repeat(64);
     const version2Id = "d".repeat(64);

--- a/turbo/apps/web/app/api/storages/download/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/download/__tests__/route.test.ts
@@ -10,6 +10,7 @@ import {
   beforeAll,
   afterAll,
 } from "vitest";
+import { NextRequest } from "next/server";
 import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -96,26 +97,22 @@ describe("GET /api/storages/download", () => {
 
     const { GET } = await import("../route");
 
-    const request = new Request(
+    const request = new NextRequest(
       "http://localhost:3000/api/storages/download?name=test&type=volume",
     );
 
-    const response = await GET(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await GET(request);
     expect(response.status).toBe(401);
   });
 
   it("should return 400 when name parameter is missing", async () => {
     const { GET } = await import("../route");
 
-    const request = new Request(
+    const request = new NextRequest(
       "http://localhost:3000/api/storages/download?type=volume",
     );
 
-    const response = await GET(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await GET(request);
     expect(response.status).toBe(400);
 
     const json = await response.json();
@@ -125,13 +122,11 @@ describe("GET /api/storages/download", () => {
   it("should return 400 when type parameter is missing", async () => {
     const { GET } = await import("../route");
 
-    const request = new Request(
+    const request = new NextRequest(
       "http://localhost:3000/api/storages/download?name=test",
     );
 
-    const response = await GET(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await GET(request);
     expect(response.status).toBe(400);
 
     const json = await response.json();
@@ -141,29 +136,25 @@ describe("GET /api/storages/download", () => {
   it("should return 400 when type is invalid", async () => {
     const { GET } = await import("../route");
 
-    const request = new Request(
+    const request = new NextRequest(
       "http://localhost:3000/api/storages/download?name=test&type=invalid",
     );
 
-    const response = await GET(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await GET(request);
     expect(response.status).toBe(400);
 
     const json = await response.json();
-    expect(json.error.message).toContain("volume");
+    expect(json.error.message).toContain("type");
   });
 
   it("should return 404 when storage does not exist", async () => {
     const { GET } = await import("../route");
 
-    const request = new Request(
+    const request = new NextRequest(
       "http://localhost:3000/api/storages/download?name=nonexistent&type=volume",
     );
 
-    const response = await GET(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await GET(request);
     expect(response.status).toBe(404);
   });
 
@@ -182,13 +173,11 @@ describe("GET /api/storages/download", () => {
       headVersionId: null,
     });
 
-    const request = new Request(
+    const request = new NextRequest(
       `http://localhost:3000/api/storages/download?name=${storageName}&type=volume`,
     );
 
-    const response = await GET(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await GET(request);
     expect(response.status).toBe(404);
 
     const json = await response.json();
@@ -227,13 +216,11 @@ describe("GET /api/storages/download", () => {
       .set({ headVersionId: versionId })
       .where(eq(storages.id, storage!.id));
 
-    const request = new Request(
+    const request = new NextRequest(
       `http://localhost:3000/api/storages/download?name=${storageName}&type=volume`,
     );
 
-    const response = await GET(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await GET(request);
     expect(response.status).toBe(200);
 
     const json = await response.json();
@@ -275,13 +262,11 @@ describe("GET /api/storages/download", () => {
       .set({ headVersionId: versionId })
       .where(eq(storages.id, storage!.id));
 
-    const request = new Request(
+    const request = new NextRequest(
       `http://localhost:3000/api/storages/download?name=${storageName}&type=volume`,
     );
 
-    const response = await GET(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await GET(request);
     expect(response.status).toBe(200);
 
     const json = await response.json();
@@ -336,13 +321,11 @@ describe("GET /api/storages/download", () => {
       .where(eq(storages.id, storage!.id));
 
     // Request specific older version
-    const request = new Request(
+    const request = new NextRequest(
       `http://localhost:3000/api/storages/download?name=${storageName}&type=artifact&version=${version1Id}`,
     );
 
-    const response = await GET(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await GET(request);
     expect(response.status).toBe(200);
 
     const json = await response.json();

--- a/turbo/apps/web/app/api/storages/download/route.ts
+++ b/turbo/apps/web/app/api/storages/download/route.ts
@@ -1,8 +1,13 @@
-import { NextRequest, NextResponse } from "next/server";
+import {
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../../../../src/lib/ts-rest-handler";
+import { storagesDownloadContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
 import { storages, storageVersions } from "../../../../src/db/schema/storage";
 import { eq, and } from "drizzle-orm";
+import { getUserId } from "../../../../src/lib/auth/get-user-id";
 import { generatePresignedUrl } from "../../../../src/lib/s3/s3-client";
 import { env } from "../../../../src/env";
 import { resolveVersionByPrefix } from "../../../../src/lib/storage/version-resolver";
@@ -10,73 +15,22 @@ import { logger } from "../../../../src/lib/logger";
 
 const log = logger("api:storages:download");
 
-/**
- * Helper to create standardized error response
- * Matches apiErrorSchema: { error: { message, code } }
- */
-function errorResponse(
-  message: string,
-  code: string,
-  status: number,
-): NextResponse {
-  return NextResponse.json({ error: { message, code } }, { status });
-}
-
-/**
- * GET /api/storages/download?name=storageName&type=volume&version=versionId
- * Get a presigned URL for downloading a storage archive from S3
- *
- * Query params:
- * - name: string (required, storage name)
- * - type: "volume" | "artifact" (required)
- * - version: string (optional, version ID or prefix)
- *
- * Returns: JSON with presigned S3 URL
- * {
- *   url: string (presigned GET URL, valid for 1 hour)
- *   versionId: string
- *   fileCount: number
- *   size: number
- * }
- *
- * If version is specified, returns URL for that specific version
- * Otherwise, returns URL for the HEAD (latest) version
- *
- * For empty artifacts (fileCount=0), returns empty=true instead of URL
- */
-export async function GET(request: NextRequest) {
-  try {
-    // Initialize services
+const router = tsr.router(storagesDownloadContract, {
+  download: async ({ query }) => {
     initServices();
 
-    // Authenticate
+    // Authenticate user
     const userId = await getUserId();
     if (!userId) {
-      return errorResponse("Not authenticated", "UNAUTHORIZED", 401);
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        },
+      };
     }
 
-    // Get query parameters
-    const { searchParams } = new URL(request.url);
-    const storageName = searchParams.get("name");
-    const storageType = searchParams.get("type");
-    const versionId = searchParams.get("version");
-
-    if (!storageName) {
-      return errorResponse("Missing name parameter", "BAD_REQUEST", 400);
-    }
-
-    if (!storageType) {
-      return errorResponse("Missing type parameter", "BAD_REQUEST", 400);
-    }
-
-    // Validate storage type
-    if (storageType !== "volume" && storageType !== "artifact") {
-      return errorResponse(
-        "Invalid type. Must be 'volume' or 'artifact'",
-        "BAD_REQUEST",
-        400,
-      );
-    }
+    const { name: storageName, type: storageType, version: versionId } = query;
 
     log.debug(
       `Getting download URL for "${storageName}" (type: ${storageType})${versionId ? ` version ${versionId}` : ""} for user ${userId}`,
@@ -96,11 +50,15 @@ export async function GET(request: NextRequest) {
       .limit(1);
 
     if (!storage) {
-      return errorResponse(
-        `Storage "${storageName}" not found`,
-        "NOT_FOUND",
-        404,
-      );
+      return {
+        status: 404 as const,
+        body: {
+          error: {
+            message: `Storage "${storageName}" not found`,
+            code: "NOT_FOUND",
+          },
+        },
+      };
     }
 
     // Determine which version to download
@@ -109,21 +67,30 @@ export async function GET(request: NextRequest) {
       // Resolve version (supports short prefix)
       const resolveResult = await resolveVersionByPrefix(storage.id, versionId);
       if ("error" in resolveResult) {
-        return errorResponse(
-          resolveResult.error,
-          resolveResult.status === 404 ? "NOT_FOUND" : "BAD_REQUEST",
-          resolveResult.status,
-        );
+        const status = resolveResult.status === 404 ? 404 : 400;
+        return {
+          status: status as 400 | 404,
+          body: {
+            error: {
+              message: resolveResult.error,
+              code: status === 404 ? "NOT_FOUND" : "BAD_REQUEST",
+            },
+          },
+        };
       }
       version = resolveResult.version;
     } else {
       // Use HEAD version
       if (!storage.headVersionId) {
-        return errorResponse(
-          `Storage "${storageName}" has no versions`,
-          "NOT_FOUND",
-          404,
-        );
+        return {
+          status: 404 as const,
+          body: {
+            error: {
+              message: `Storage "${storageName}" has no versions`,
+              code: "NOT_FOUND",
+            },
+          },
+        };
       }
 
       // Get HEAD version details
@@ -134,11 +101,15 @@ export async function GET(request: NextRequest) {
         .limit(1);
 
       if (!headVersion) {
-        return errorResponse(
-          `Storage "${storageName}" HEAD version not found`,
-          "NOT_FOUND",
-          404,
-        );
+        return {
+          status: 404 as const,
+          body: {
+            error: {
+              message: `Storage "${storageName}" HEAD version not found`,
+              code: "NOT_FOUND",
+            },
+          },
+        };
       }
       version = headVersion;
     }
@@ -148,22 +119,29 @@ export async function GET(request: NextRequest) {
     // Handle empty artifact case - return empty flag
     if (version.fileCount === 0) {
       log.debug("Empty artifact, returning empty response");
-      return NextResponse.json({
-        empty: true,
-        versionId: version.id,
-        fileCount: 0,
-        size: 0,
-      });
+      return {
+        status: 200 as const,
+        body: {
+          empty: true as const,
+          versionId: version.id,
+          fileCount: 0 as const,
+          size: 0 as const,
+        },
+      };
     }
 
     // Generate presigned URL for archive.tar.gz
     const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
     if (!bucketName) {
-      return errorResponse(
-        "R2_USER_STORAGES_BUCKET_NAME environment variable is not set",
-        "INTERNAL_ERROR",
-        500,
-      );
+      return {
+        status: 500 as const,
+        body: {
+          error: {
+            message: "R2_USER_STORAGES_BUCKET_NAME not configured",
+            code: "INTERNAL_ERROR",
+          },
+        },
+      };
     }
 
     const archiveKey = `${version.s3Key}/archive.tar.gz`;
@@ -172,21 +150,61 @@ export async function GET(request: NextRequest) {
 
     log.debug(`Generated presigned URL for ${archiveKey}`);
 
-    return NextResponse.json({
-      url,
-      versionId: version.id,
-      fileCount: version.fileCount,
-      size: Number(version.size),
-    });
-  } catch (error) {
-    log.error("Download URL generation error:", error);
+    return {
+      status: 200 as const,
+      body: {
+        url,
+        versionId: version.id,
+        fileCount: version.fileCount,
+        size: Number(version.size),
+      },
+    };
+  },
+});
 
-    return errorResponse(
-      error instanceof Error
-        ? error.message
-        : "Failed to generate download URL",
-      "INTERNAL_ERROR",
-      500,
-    );
+/**
+ * Custom error handler to convert Zod validation errors to API error format
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (
+    err &&
+    typeof err === "object" &&
+    "bodyError" in err &&
+    "queryError" in err
+  ) {
+    const validationError = err as {
+      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
+      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
+    };
+
+    if (validationError.queryError) {
+      const issue = validationError.queryError.issues[0];
+      if (issue) {
+        const path = issue.path.join(".");
+        const message = path ? `${path}: ${issue.message}` : issue.message;
+        return TsRestResponse.fromJson(
+          { error: { message, code: "BAD_REQUEST" } },
+          { status: 400 },
+        );
+      }
+    }
   }
+
+  // Log unexpected errors
+  log.error("Download error:", err);
+  return TsRestResponse.fromJson(
+    {
+      error: {
+        message: err instanceof Error ? err.message : "Download failed",
+        code: "INTERNAL_ERROR",
+      },
+    },
+    { status: 500 },
+  );
 }
+
+const handler = createHandler(storagesDownloadContract, router, {
+  errorHandler,
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
@@ -100,15 +100,18 @@ describe("POST /api/storages/prepare", () => {
 
     const { POST } = await import("../route");
 
-    const request = new NextRequest("http://localhost:3000/api/storages/prepare", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        storageName: "test",
-        storageType: "volume",
-        files: [],
-      }),
-    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/storages/prepare",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageName: "test",
+          storageType: "volume",
+          files: [],
+        }),
+      },
+    );
 
     const response = await POST(request);
     expect(response.status).toBe(401);
@@ -117,14 +120,17 @@ describe("POST /api/storages/prepare", () => {
   it("should return 400 when storageName is missing", async () => {
     const { POST } = await import("../route");
 
-    const request = new NextRequest("http://localhost:3000/api/storages/prepare", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        storageType: "volume",
-        files: [],
-      }),
-    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/storages/prepare",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageType: "volume",
+          files: [],
+        }),
+      },
+    );
 
     const response = await POST(request);
     expect(response.status).toBe(400);
@@ -135,15 +141,18 @@ describe("POST /api/storages/prepare", () => {
   it("should return 400 when storageType is invalid", async () => {
     const { POST } = await import("../route");
 
-    const request = new NextRequest("http://localhost:3000/api/storages/prepare", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        storageName: "test",
-        storageType: "invalid",
-        files: [],
-      }),
-    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/storages/prepare",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageName: "test",
+          storageType: "invalid",
+          files: [],
+        }),
+      },
+    );
 
     const response = await POST(request);
     expect(response.status).toBe(400);
@@ -155,15 +164,18 @@ describe("POST /api/storages/prepare", () => {
     const { POST } = await import("../route");
     const storageName = `${TEST_PREFIX}new-storage`;
 
-    const request = new NextRequest("http://localhost:3000/api/storages/prepare", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        storageName,
-        storageType: "volume",
-        files: [{ path: "test.txt", hash: "a".repeat(64), size: 100 }],
-      }),
-    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/storages/prepare",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storageName,
+          storageType: "volume",
+          files: [{ path: "test.txt", hash: "a".repeat(64), size: 100 }],
+        }),
+      },
+    );
 
     const response = await POST(request);
     expect(response.status).toBe(200);
@@ -203,11 +215,14 @@ describe("POST /api/storages/prepare", () => {
 
     // Prepare with same files to get the version ID
     const files = [{ path: "test.txt", hash: "b".repeat(64), size: 100 }];
-    const request1 = new NextRequest("http://localhost:3000/api/storages/prepare", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ storageName, storageType: "volume", files }),
-    });
+    const request1 = new NextRequest(
+      "http://localhost:3000/api/storages/prepare",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ storageName, storageType: "volume", files }),
+      },
+    );
 
     const response1 = await POST(request1);
     const json1 = await response1.json();
@@ -224,11 +239,14 @@ describe("POST /api/storages/prepare", () => {
     });
 
     // Prepare again with same files
-    const request2 = new NextRequest("http://localhost:3000/api/storages/prepare", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ storageName, storageType: "volume", files }),
-    });
+    const request2 = new NextRequest(
+      "http://localhost:3000/api/storages/prepare",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ storageName, storageType: "volume", files }),
+      },
+    );
 
     const response2 = await POST(request2);
     expect(response2.status).toBe(200);
@@ -259,17 +277,23 @@ describe("POST /api/storages/prepare", () => {
     ];
 
     // Make two requests with same files
-    const request1 = new NextRequest("http://localhost:3000/api/storages/prepare", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ storageName, storageType: "artifact", files }),
-    });
+    const request1 = new NextRequest(
+      "http://localhost:3000/api/storages/prepare",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ storageName, storageType: "artifact", files }),
+      },
+    );
 
-    const request2 = new NextRequest("http://localhost:3000/api/storages/prepare", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ storageName, storageType: "artifact", files }),
-    });
+    const request2 = new NextRequest(
+      "http://localhost:3000/api/storages/prepare",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ storageName, storageType: "artifact", files }),
+      },
+    );
 
     const response1 = await POST(request1);
     const response2 = await POST(request2);
@@ -305,11 +329,14 @@ describe("POST /api/storages/prepare", () => {
 
     // Prepare with files to get the version ID
     const files = [{ path: "test.txt", hash: "e".repeat(64), size: 100 }];
-    const request1 = new NextRequest("http://localhost:3000/api/storages/prepare", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ storageName, storageType: "volume", files }),
-    });
+    const request1 = new NextRequest(
+      "http://localhost:3000/api/storages/prepare",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ storageName, storageType: "volume", files }),
+      },
+    );
 
     const response1 = await POST(request1);
     const json1 = await response1.json();
@@ -329,11 +356,14 @@ describe("POST /api/storages/prepare", () => {
     verifyS3FilesMock.mockResolvedValueOnce(false);
 
     // Prepare again with same files - should get upload URLs since S3 missing
-    const request2 = new NextRequest("http://localhost:3000/api/storages/prepare", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ storageName, storageType: "volume", files }),
-    });
+    const request2 = new NextRequest(
+      "http://localhost:3000/api/storages/prepare",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ storageName, storageType: "volume", files }),
+      },
+    );
 
     const response2 = await POST(request2);
     expect(response2.status).toBe(200);

--- a/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
@@ -18,7 +18,7 @@ import {
   storageVersions,
 } from "../../../../../src/db/schema/storage";
 
-// Mock external dependencies
+// Mock external dependencies - vi.mock() is hoisted, so mocks are ready before imports
 vi.mock("../../../../../src/lib/auth/get-user-id", () => ({
   getUserId: vi.fn().mockResolvedValue("test-user-prepare"),
 }));
@@ -33,6 +33,11 @@ vi.mock("../../../../../src/lib/s3/s3-client", () => ({
 
 // Set required environment variables
 process.env.R2_USER_STORAGES_BUCKET_NAME = "test-storages-bucket";
+
+// Static imports - mocks are already in place due to hoisting
+import { POST } from "../route";
+import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import { verifyS3FilesExist } from "../../../../../src/lib/s3/s3-client";
 
 // Test constants
 const TEST_USER_ID = "test-user-prepare";
@@ -92,13 +97,8 @@ describe("POST /api/storages/prepare", () => {
   });
 
   it("should return 401 when not authenticated", async () => {
-    // Override mock to return null
-    const { getUserId } = await import(
-      "../../../../../src/lib/auth/get-user-id"
-    );
+    // Override mock to return null for this test
     vi.mocked(getUserId).mockResolvedValueOnce(null);
-
-    const { POST } = await import("../route");
 
     const request = new NextRequest(
       "http://localhost:3000/api/storages/prepare",
@@ -118,8 +118,6 @@ describe("POST /api/storages/prepare", () => {
   });
 
   it("should return 400 when storageName is missing", async () => {
-    const { POST } = await import("../route");
-
     const request = new NextRequest(
       "http://localhost:3000/api/storages/prepare",
       {
@@ -139,8 +137,6 @@ describe("POST /api/storages/prepare", () => {
   });
 
   it("should return 400 when storageType is invalid", async () => {
-    const { POST } = await import("../route");
-
     const request = new NextRequest(
       "http://localhost:3000/api/storages/prepare",
       {
@@ -161,7 +157,6 @@ describe("POST /api/storages/prepare", () => {
   });
 
   it("should create new storage when it does not exist", async () => {
-    const { POST } = await import("../route");
     const storageName = `${TEST_PREFIX}new-storage`;
 
     const request = new NextRequest(
@@ -197,7 +192,6 @@ describe("POST /api/storages/prepare", () => {
   });
 
   it("should return existing=true when version already exists", async () => {
-    const { POST } = await import("../route");
     const storageName = `${TEST_PREFIX}existing-version`;
 
     // Create storage first
@@ -258,7 +252,6 @@ describe("POST /api/storages/prepare", () => {
   });
 
   it("should compute deterministic version ID from files", async () => {
-    const { POST } = await import("../route");
     const storageName = `${TEST_PREFIX}deterministic`;
 
     // Create storage
@@ -307,11 +300,6 @@ describe("POST /api/storages/prepare", () => {
   });
 
   it("should return upload URLs when version exists but S3 files are missing", async () => {
-    // Import mock to control verifyS3FilesExist behavior
-    const s3Mock = await import("../../../../../src/lib/s3/s3-client");
-    const verifyS3FilesMock = vi.mocked(s3Mock.verifyS3FilesExist);
-
-    const { POST } = await import("../route");
     const storageName = `${TEST_PREFIX}s3missing`;
 
     // Create storage
@@ -353,7 +341,7 @@ describe("POST /api/storages/prepare", () => {
     });
 
     // Mock S3 files as missing
-    verifyS3FilesMock.mockResolvedValueOnce(false);
+    vi.mocked(verifyS3FilesExist).mockResolvedValueOnce(false);
 
     // Prepare again with same files - should get upload URLs since S3 missing
     const request2 = new NextRequest(

--- a/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
@@ -10,6 +10,7 @@ import {
   beforeAll,
   afterAll,
 } from "vitest";
+import { NextRequest } from "next/server";
 import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
@@ -99,7 +100,7 @@ describe("POST /api/storages/prepare", () => {
 
     const { POST } = await import("../route");
 
-    const request = new Request("http://localhost:3000/api/storages/prepare", {
+    const request = new NextRequest("http://localhost:3000/api/storages/prepare", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -109,16 +110,14 @@ describe("POST /api/storages/prepare", () => {
       }),
     });
 
-    const response = await POST(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await POST(request);
     expect(response.status).toBe(401);
   });
 
   it("should return 400 when storageName is missing", async () => {
     const { POST } = await import("../route");
 
-    const request = new Request("http://localhost:3000/api/storages/prepare", {
+    const request = new NextRequest("http://localhost:3000/api/storages/prepare", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -127,9 +126,7 @@ describe("POST /api/storages/prepare", () => {
       }),
     });
 
-    const response = await POST(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await POST(request);
     expect(response.status).toBe(400);
     const json = await response.json();
     expect(json.error.code).toBe("BAD_REQUEST");
@@ -138,7 +135,7 @@ describe("POST /api/storages/prepare", () => {
   it("should return 400 when storageType is invalid", async () => {
     const { POST } = await import("../route");
 
-    const request = new Request("http://localhost:3000/api/storages/prepare", {
+    const request = new NextRequest("http://localhost:3000/api/storages/prepare", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -148,9 +145,7 @@ describe("POST /api/storages/prepare", () => {
       }),
     });
 
-    const response = await POST(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await POST(request);
     expect(response.status).toBe(400);
     const json = await response.json();
     expect(json.error.code).toBe("BAD_REQUEST");
@@ -160,19 +155,17 @@ describe("POST /api/storages/prepare", () => {
     const { POST } = await import("../route");
     const storageName = `${TEST_PREFIX}new-storage`;
 
-    const request = new Request("http://localhost:3000/api/storages/prepare", {
+    const request = new NextRequest("http://localhost:3000/api/storages/prepare", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         storageName,
         storageType: "volume",
-        files: [{ path: "test.txt", hash: "abc123", size: 100 }],
+        files: [{ path: "test.txt", hash: "a".repeat(64), size: 100 }],
       }),
     });
 
-    const response = await POST(
-      request as unknown as import("next/server").NextRequest,
-    );
+    const response = await POST(request);
     expect(response.status).toBe(200);
 
     const json = await response.json();
@@ -209,16 +202,14 @@ describe("POST /api/storages/prepare", () => {
       .returning();
 
     // Prepare with same files to get the version ID
-    const files = [{ path: "test.txt", hash: "abc123def456", size: 100 }];
-    const request1 = new Request("http://localhost:3000/api/storages/prepare", {
+    const files = [{ path: "test.txt", hash: "b".repeat(64), size: 100 }];
+    const request1 = new NextRequest("http://localhost:3000/api/storages/prepare", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ storageName, storageType: "volume", files }),
     });
 
-    const response1 = await POST(
-      request1 as unknown as import("next/server").NextRequest,
-    );
+    const response1 = await POST(request1);
     const json1 = await response1.json();
     const versionId = json1.versionId;
 
@@ -233,15 +224,13 @@ describe("POST /api/storages/prepare", () => {
     });
 
     // Prepare again with same files
-    const request2 = new Request("http://localhost:3000/api/storages/prepare", {
+    const request2 = new NextRequest("http://localhost:3000/api/storages/prepare", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ storageName, storageType: "volume", files }),
     });
 
-    const response2 = await POST(
-      request2 as unknown as import("next/server").NextRequest,
-    );
+    const response2 = await POST(request2);
     expect(response2.status).toBe(200);
 
     const json2 = await response2.json();
@@ -265,29 +254,25 @@ describe("POST /api/storages/prepare", () => {
     });
 
     const files = [
-      { path: "a.txt", hash: "hash1", size: 10 },
-      { path: "b.txt", hash: "hash2", size: 20 },
+      { path: "a.txt", hash: "c".repeat(64), size: 10 },
+      { path: "b.txt", hash: "d".repeat(64), size: 20 },
     ];
 
     // Make two requests with same files
-    const request1 = new Request("http://localhost:3000/api/storages/prepare", {
+    const request1 = new NextRequest("http://localhost:3000/api/storages/prepare", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ storageName, storageType: "artifact", files }),
     });
 
-    const request2 = new Request("http://localhost:3000/api/storages/prepare", {
+    const request2 = new NextRequest("http://localhost:3000/api/storages/prepare", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ storageName, storageType: "artifact", files }),
     });
 
-    const response1 = await POST(
-      request1 as unknown as import("next/server").NextRequest,
-    );
-    const response2 = await POST(
-      request2 as unknown as import("next/server").NextRequest,
-    );
+    const response1 = await POST(request1);
+    const response2 = await POST(request2);
 
     const json1 = await response1.json();
     const json2 = await response2.json();
@@ -319,16 +304,14 @@ describe("POST /api/storages/prepare", () => {
       .returning();
 
     // Prepare with files to get the version ID
-    const files = [{ path: "test.txt", hash: "abc123missing", size: 100 }];
-    const request1 = new Request("http://localhost:3000/api/storages/prepare", {
+    const files = [{ path: "test.txt", hash: "e".repeat(64), size: 100 }];
+    const request1 = new NextRequest("http://localhost:3000/api/storages/prepare", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ storageName, storageType: "volume", files }),
     });
 
-    const response1 = await POST(
-      request1 as unknown as import("next/server").NextRequest,
-    );
+    const response1 = await POST(request1);
     const json1 = await response1.json();
     const versionId = json1.versionId;
 
@@ -346,15 +329,13 @@ describe("POST /api/storages/prepare", () => {
     verifyS3FilesMock.mockResolvedValueOnce(false);
 
     // Prepare again with same files - should get upload URLs since S3 missing
-    const request2 = new Request("http://localhost:3000/api/storages/prepare", {
+    const request2 = new NextRequest("http://localhost:3000/api/storages/prepare", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ storageName, storageType: "volume", files }),
     });
 
-    const response2 = await POST(
-      request2 as unknown as import("next/server").NextRequest,
-    );
+    const response2 = await POST(request2);
     expect(response2.status).toBe(200);
 
     const json2 = await response2.json();

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -101,7 +101,10 @@ const router = tsr.router(storagesPrepareContract, {
       return {
         status: 500 as const,
         body: {
-          error: { message: "Failed to create storage", code: "INTERNAL_ERROR" },
+          error: {
+            message: "Failed to create storage",
+            code: "INTERNAL_ERROR",
+          },
         },
       };
     }

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -1,4 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import {
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../../../../src/lib/ts-rest-handler";
+import { storagesPrepareContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
 import { storages, storageVersions } from "../../../../src/db/schema/storage";
@@ -9,80 +14,27 @@ import {
   downloadManifest,
   verifyS3FilesExist,
 } from "../../../../src/lib/s3/s3-client";
-import {
-  computeContentHashFromHashes,
-  type FileEntryWithHash,
-} from "../../../../src/lib/storage/content-hash";
+import { computeContentHashFromHashes } from "../../../../src/lib/storage/content-hash";
 import { env } from "../../../../src/env";
 import { logger } from "../../../../src/lib/logger";
 
 const log = logger("api:storages:prepare");
 
-/**
- * Standard error response format
- */
-function errorResponse(
-  message: string,
-  code: string,
-  status: number,
-): NextResponse {
-  return NextResponse.json({ error: { message, code } }, { status });
-}
-
-/**
- * Request body schema for prepare endpoint
- */
-interface PrepareRequest {
-  storageName: string;
-  storageType: "volume" | "artifact";
-  files: FileEntryWithHash[];
-  // Force upload even if version already exists
-  force?: boolean;
-  // Sandbox-specific fields (optional)
-  runId?: string;
-  baseVersion?: string;
-  changes?: {
-    added: string[];
-    modified: string[];
-    deleted: string[];
-  };
-}
-
-/**
- * Response schema for prepare endpoint
- */
-interface PrepareResponse {
-  versionId: string;
-  existing: boolean;
-  uploads?: {
-    archive: { key: string; presignedUrl: string };
-    manifest: { key: string; presignedUrl: string };
-  };
-}
-
-/**
- * POST /api/storages/prepare
- *
- * Prepares for a direct S3 upload by:
- * 1. Computing the version ID from file metadata
- * 2. Checking for existing version (deduplication)
- * 3. Generating presigned PUT URLs for new blobs, archive, and manifest
- *
- * This endpoint is used by both CLI and Sandbox clients for large file uploads
- * that would exceed Vercel's 4.5MB request body limit.
- */
-export async function POST(request: NextRequest) {
-  try {
+const router = tsr.router(storagesPrepareContract, {
+  prepare: async ({ body }) => {
     initServices();
 
     // Authenticate user
     const userId = await getUserId();
     if (!userId) {
-      return errorResponse("Not authenticated", "UNAUTHORIZED", 401);
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        },
+      };
     }
 
-    // Parse JSON body
-    const body = (await request.json()) as PrepareRequest;
     const {
       storageName,
       storageType,
@@ -92,26 +44,6 @@ export async function POST(request: NextRequest) {
       baseVersion,
       changes,
     } = body;
-
-    // Validate required fields
-    if (!storageName) {
-      return errorResponse("storageName is required", "BAD_REQUEST", 400);
-    }
-
-    if (
-      !storageType ||
-      (storageType !== "volume" && storageType !== "artifact")
-    ) {
-      return errorResponse(
-        "storageType must be 'volume' or 'artifact'",
-        "BAD_REQUEST",
-        400,
-      );
-    }
-
-    if (!files || !Array.isArray(files)) {
-      return errorResponse("files array is required", "BAD_REQUEST", 400);
-    }
 
     log.debug(
       `Preparing upload for "${storageName}" (type: ${storageType}), ${files.length} files`,
@@ -126,7 +58,12 @@ export async function POST(request: NextRequest) {
         .limit(1);
 
       if (!run) {
-        return errorResponse("Agent run not found", "NOT_FOUND", 404);
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Agent run not found", code: "NOT_FOUND" },
+          },
+        };
       }
     }
 
@@ -161,7 +98,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!storage) {
-      return errorResponse("Failed to create storage", "INTERNAL_ERROR", 500);
+      return {
+        status: 500 as const,
+        body: {
+          error: { message: "Failed to create storage", code: "INTERNAL_ERROR" },
+        },
+      };
     }
 
     // Handle incremental upload - merge files with base version
@@ -197,7 +139,10 @@ export async function POST(request: NextRequest) {
 
           // Start with base manifest files, excluding deleted ones
           const deletedSet = new Set(changes.deleted || []);
-          const baseFilesMap = new Map<string, FileEntryWithHash>();
+          const baseFilesMap = new Map<
+            string,
+            { path: string; hash: string; size: number }
+          >();
 
           for (const file of baseManifest.files) {
             if (!deletedSet.has(file.path) && !currentFilesMap.has(file.path)) {
@@ -226,11 +171,15 @@ export async function POST(request: NextRequest) {
     // Get bucket name (needed for S3 verification)
     const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
     if (!bucketName) {
-      return errorResponse(
-        "R2_USER_STORAGES_BUCKET_NAME not configured",
-        "INTERNAL_ERROR",
-        500,
-      );
+      return {
+        status: 500 as const,
+        body: {
+          error: {
+            message: "R2_USER_STORAGES_BUCKET_NAME not configured",
+            code: "INTERNAL_ERROR",
+          },
+        },
+      };
     }
 
     // Check if version already exists (deduplication) - skip if force is true
@@ -259,10 +208,13 @@ export async function POST(request: NextRequest) {
           log.debug(
             `Version ${versionId} exists with S3 files, returning existing`,
           );
-          return NextResponse.json({
-            versionId,
-            existing: true,
-          } satisfies PrepareResponse);
+          return {
+            status: 200 as const,
+            body: {
+              versionId,
+              existing: true,
+            },
+          };
         }
 
         // S3 files missing - treat as new version, will trigger re-upload
@@ -291,23 +243,64 @@ export async function POST(request: NextRequest) {
       ),
     ]);
 
-    const response: PrepareResponse = {
-      versionId,
-      existing: false,
-      uploads: {
-        archive: { key: archiveKey, presignedUrl: archiveUrl },
-        manifest: { key: manifestKey, presignedUrl: manifestUrl },
+    log.debug(`Prepared upload for version ${versionId}`);
+    return {
+      status: 200 as const,
+      body: {
+        versionId,
+        existing: false,
+        uploads: {
+          archive: { key: archiveKey, presignedUrl: archiveUrl },
+          manifest: { key: manifestKey, presignedUrl: manifestUrl },
+        },
       },
     };
+  },
+});
 
-    log.debug(`Prepared upload for version ${versionId}`);
-    return NextResponse.json(response);
-  } catch (error) {
-    log.error("Prepare error:", error);
-    return errorResponse(
-      error instanceof Error ? error.message : "Prepare failed",
-      "INTERNAL_ERROR",
-      500,
-    );
+/**
+ * Custom error handler to convert Zod validation errors to API error format
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (
+    err &&
+    typeof err === "object" &&
+    "bodyError" in err &&
+    "queryError" in err
+  ) {
+    const validationError = err as {
+      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
+      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
+    };
+
+    if (validationError.bodyError) {
+      const issue = validationError.bodyError.issues[0];
+      if (issue) {
+        const path = issue.path.join(".");
+        const message = path ? `${path}: ${issue.message}` : issue.message;
+        return TsRestResponse.fromJson(
+          { error: { message, code: "BAD_REQUEST" } },
+          { status: 400 },
+        );
+      }
+    }
   }
+
+  // Log unexpected errors
+  log.error("Prepare error:", err);
+  return TsRestResponse.fromJson(
+    {
+      error: {
+        message: err instanceof Error ? err.message : "Prepare failed",
+        code: "INTERNAL_ERROR",
+      },
+    },
+    { status: 500 },
+  );
 }
+
+const handler = createHandler(storagesPrepareContract, router, {
+  errorHandler,
+});
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
@@ -1,4 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import {
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../../../../../../src/lib/ts-rest-handler";
+import { webhookStoragesCommitContract } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import {
@@ -11,107 +16,33 @@ import {
   s3ObjectExists,
   verifyS3FilesExist,
 } from "../../../../../../src/lib/s3/s3-client";
-import {
-  computeContentHashFromHashes,
-  type FileEntryWithHash,
-} from "../../../../../../src/lib/storage/content-hash";
+import { computeContentHashFromHashes } from "../../../../../../src/lib/storage/content-hash";
 import { env } from "../../../../../../src/env";
 import { logger } from "../../../../../../src/lib/logger";
 
 const log = logger("webhook:storages:commit");
 
-/**
- * Standard error response format
- */
-function errorResponse(
-  message: string,
-  code: string,
-  status: number,
-): NextResponse {
-  return NextResponse.json({ error: { message, code } }, { status });
-}
-
-/**
- * Request body schema for commit endpoint
- */
-interface CommitRequest {
-  runId: string; // Required for webhook - verified against JWT token
-  storageName: string;
-  storageType: "volume" | "artifact";
-  versionId: string;
-  files: FileEntryWithHash[];
-  message?: string;
-}
-
-/**
- * Response schema for commit endpoint
- */
-interface CommitResponse {
-  success: boolean;
-  versionId: string;
-  storageName: string;
-  size: number;
-  fileCount: number;
-  deduplicated?: boolean;
-}
-
-/**
- * POST /api/webhooks/agent/storages/commit
- *
- * Webhook version of storage commit endpoint for sandbox use.
- * Uses JWT sandbox token authentication and verifies runId matches token.
- *
- * This endpoint is called after the client has uploaded files directly to S3
- * using presigned URLs from the prepare endpoint.
- */
-export async function POST(request: NextRequest) {
-  try {
+const router = tsr.router(webhookStoragesCommitContract, {
+  commit: async ({ body }) => {
     initServices();
 
-    // Parse JSON body first to get runId for auth verification
-    const body = (await request.json()) as CommitRequest;
     const { runId, storageName, storageType, versionId, files, message } = body;
-
-    // Validate runId is provided
-    if (!runId) {
-      return errorResponse("runId is required", "BAD_REQUEST", 400);
-    }
 
     // Authenticate with sandbox JWT and verify runId matches
     const auth = await getSandboxAuthForRun(runId);
     if (!auth) {
-      return errorResponse(
-        "Not authenticated or runId mismatch",
-        "UNAUTHORIZED",
-        401,
-      );
+      return {
+        status: 401 as const,
+        body: {
+          error: {
+            message: "Not authenticated or runId mismatch",
+            code: "UNAUTHORIZED",
+          },
+        },
+      };
     }
 
     const { userId } = auth;
-
-    // Validate required fields
-    if (!storageName) {
-      return errorResponse("storageName is required", "BAD_REQUEST", 400);
-    }
-
-    if (
-      !storageType ||
-      (storageType !== "volume" && storageType !== "artifact")
-    ) {
-      return errorResponse(
-        "storageType must be 'volume' or 'artifact'",
-        "BAD_REQUEST",
-        400,
-      );
-    }
-
-    if (!versionId) {
-      return errorResponse("versionId is required", "BAD_REQUEST", 400);
-    }
-
-    if (!files || !Array.isArray(files)) {
-      return errorResponse("files array is required", "BAD_REQUEST", 400);
-    }
 
     log.debug(
       `Committing version ${versionId} for "${storageName}" (type: ${storageType}), ${files.length} files, run: ${runId}`,
@@ -125,7 +56,12 @@ export async function POST(request: NextRequest) {
       .limit(1);
 
     if (!run) {
-      return errorResponse("Agent run not found", "NOT_FOUND", 404);
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Agent run not found", code: "NOT_FOUND" },
+        },
+      };
     }
 
     // Find storage
@@ -142,21 +78,29 @@ export async function POST(request: NextRequest) {
       .limit(1);
 
     if (!storage) {
-      return errorResponse(
-        `Storage "${storageName}" not found`,
-        "NOT_FOUND",
-        404,
-      );
+      return {
+        status: 404 as const,
+        body: {
+          error: {
+            message: `Storage "${storageName}" not found`,
+            code: "NOT_FOUND",
+          },
+        },
+      };
     }
 
     // Verify version ID matches computed hash
     const computedVersionId = computeContentHashFromHashes(storage.id, files);
     if (computedVersionId !== versionId) {
-      return errorResponse(
-        "Version ID mismatch - files may have changed",
-        "BAD_REQUEST",
-        400,
-      );
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: "Version ID mismatch - files may have changed",
+            code: "BAD_REQUEST",
+          },
+        },
+      };
     }
 
     // Check if version already exists (idempotency)
@@ -175,11 +119,15 @@ export async function POST(request: NextRequest) {
       // Get bucket name for S3 verification
       const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
       if (!bucketName) {
-        return errorResponse(
-          "R2_USER_STORAGES_BUCKET_NAME not configured",
-          "INTERNAL_ERROR",
-          500,
-        );
+        return {
+          status: 500 as const,
+          body: {
+            error: {
+              message: "R2_USER_STORAGES_BUCKET_NAME not configured",
+              code: "INTERNAL_ERROR",
+            },
+          },
+        };
       }
 
       // Defense-in-depth: verify S3 files exist before updating HEAD
@@ -194,11 +142,15 @@ export async function POST(request: NextRequest) {
         log.error(
           `Version ${versionId} exists in DB but S3 files missing - cannot commit`,
         );
-        return errorResponse(
-          "S3 files missing for existing version - please retry upload",
-          "S3_FILES_MISSING",
-          409,
-        );
+        return {
+          status: 409 as const,
+          body: {
+            error: {
+              message: "S3 files missing for existing version - please retry upload",
+              code: "S3_FILES_MISSING",
+            },
+          },
+        };
       }
 
       // Version already exists with valid S3 files, update HEAD pointer if needed
@@ -213,55 +165,72 @@ export async function POST(request: NextRequest) {
       }
 
       log.debug(`Version ${versionId} already committed, returning success`);
-      return NextResponse.json({
-        success: true,
-        versionId,
-        storageName,
-        size: Number(existingVersion.size),
-        fileCount: existingVersion.fileCount,
-        deduplicated: true,
-      } satisfies CommitResponse);
+      return {
+        status: 200 as const,
+        body: {
+          success: true as const,
+          versionId,
+          storageName,
+          size: Number(existingVersion.size),
+          fileCount: existingVersion.fileCount,
+          deduplicated: true,
+        },
+      };
     }
 
     // Get bucket name
     const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
     if (!bucketName) {
-      return errorResponse(
-        "R2_USER_STORAGES_BUCKET_NAME not configured",
-        "INTERNAL_ERROR",
-        500,
-      );
+      return {
+        status: 500 as const,
+        body: {
+          error: {
+            message: "R2_USER_STORAGES_BUCKET_NAME not configured",
+            code: "INTERNAL_ERROR",
+          },
+        },
+      };
     }
 
     // Verify required S3 objects exist (manifest and archive)
     const s3Key = `${userId}/${storageType}/${storageName}/${versionId}`;
     const manifestKey = `${s3Key}/manifest.json`;
     const archiveKey = `${s3Key}/archive.tar.gz`;
+    const fileCount = files.length;
 
     const [manifestExists, archiveExists] = await Promise.all([
       s3ObjectExists(bucketName, manifestKey),
-      s3ObjectExists(bucketName, archiveKey),
+      fileCount > 0
+        ? s3ObjectExists(bucketName, archiveKey)
+        : Promise.resolve(true),
     ]);
 
     if (!manifestExists) {
-      return errorResponse(
-        "Manifest not uploaded - upload failed or incomplete",
-        "BAD_REQUEST",
-        400,
-      );
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: "Manifest not uploaded - upload failed or incomplete",
+            code: "BAD_REQUEST",
+          },
+        },
+      };
     }
 
-    if (!archiveExists) {
-      return errorResponse(
-        "Archive not uploaded - upload failed or incomplete",
-        "BAD_REQUEST",
-        400,
-      );
+    if (fileCount > 0 && !archiveExists) {
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: "Archive not uploaded - upload failed or incomplete",
+            code: "BAD_REQUEST",
+          },
+        },
+      };
     }
 
     // Calculate totals
     const totalSize = files.reduce((sum, f) => sum + f.size, 0);
-    const fileCount = files.length;
 
     // Use transaction for atomicity
     await globalThis.services.db.transaction(async (tx) => {
@@ -309,19 +278,62 @@ export async function POST(request: NextRequest) {
       `Committed version ${versionId}: ${fileCount} files, ${totalSize} bytes`,
     );
 
-    return NextResponse.json({
-      success: true,
-      versionId,
-      storageName,
-      size: totalSize,
-      fileCount,
-    } satisfies CommitResponse);
-  } catch (error) {
-    log.error("Commit error:", error);
-    return errorResponse(
-      error instanceof Error ? error.message : "Commit failed",
-      "INTERNAL_ERROR",
-      500,
-    );
+    return {
+      status: 200 as const,
+      body: {
+        success: true as const,
+        versionId,
+        storageName,
+        size: totalSize,
+        fileCount,
+      },
+    };
+  },
+});
+
+/**
+ * Custom error handler to convert Zod validation errors to API error format
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (
+    err &&
+    typeof err === "object" &&
+    "bodyError" in err &&
+    "queryError" in err
+  ) {
+    const validationError = err as {
+      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
+      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
+    };
+
+    if (validationError.bodyError) {
+      const issue = validationError.bodyError.issues[0];
+      if (issue) {
+        const path = issue.path.join(".");
+        const message = path ? `${path}: ${issue.message}` : issue.message;
+        return TsRestResponse.fromJson(
+          { error: { message, code: "BAD_REQUEST" } },
+          { status: 400 },
+        );
+      }
+    }
   }
+
+  // Log unexpected errors
+  log.error("Commit error:", err);
+  return TsRestResponse.fromJson(
+    {
+      error: {
+        message: err instanceof Error ? err.message : "Commit failed",
+        code: "INTERNAL_ERROR",
+      },
+    },
+    { status: 500 },
+  );
 }
+
+const handler = createHandler(webhookStoragesCommitContract, router, {
+  errorHandler,
+});
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
@@ -146,7 +146,8 @@ const router = tsr.router(webhookStoragesCommitContract, {
           status: 409 as const,
           body: {
             error: {
-              message: "S3 files missing for existing version - please retry upload",
+              message:
+                "S3 files missing for existing version - please retry upload",
               code: "S3_FILES_MISSING",
             },
           },

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -1,4 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import {
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../../../../../../src/lib/ts-rest-handler";
+import { webhookStoragesPrepareContract } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import {
@@ -12,69 +17,16 @@ import {
   downloadManifest,
   verifyS3FilesExist,
 } from "../../../../../../src/lib/s3/s3-client";
-import {
-  computeContentHashFromHashes,
-  type FileEntryWithHash,
-} from "../../../../../../src/lib/storage/content-hash";
+import { computeContentHashFromHashes } from "../../../../../../src/lib/storage/content-hash";
 import { env } from "../../../../../../src/env";
 import { logger } from "../../../../../../src/lib/logger";
 
 const log = logger("webhook:storages:prepare");
 
-/**
- * Standard error response format
- */
-function errorResponse(
-  message: string,
-  code: string,
-  status: number,
-): NextResponse {
-  return NextResponse.json({ error: { message, code } }, { status });
-}
-
-/**
- * Request body schema for prepare endpoint
- */
-interface PrepareRequest {
-  runId: string; // Required for webhook - verified against JWT token
-  storageName: string;
-  storageType: "volume" | "artifact";
-  files: FileEntryWithHash[];
-  force?: boolean;
-  baseVersion?: string;
-  changes?: {
-    added: string[];
-    modified: string[];
-    deleted: string[];
-  };
-}
-
-/**
- * Response schema for prepare endpoint
- */
-interface PrepareResponse {
-  versionId: string;
-  existing: boolean;
-  uploads?: {
-    archive: { key: string; presignedUrl: string };
-    manifest: { key: string; presignedUrl: string };
-  };
-}
-
-/**
- * POST /api/webhooks/agent/storages/prepare
- *
- * Webhook version of storage prepare endpoint for sandbox use.
- * Uses JWT sandbox token authentication and verifies runId matches token.
- *
- * This endpoint is used by sandbox clients for direct S3 uploads.
- */
-export async function POST(request: NextRequest) {
-  try {
+const router = tsr.router(webhookStoragesPrepareContract, {
+  prepare: async ({ body }) => {
     initServices();
 
-    // Parse JSON body first to get runId for auth verification
-    const body = (await request.json()) as PrepareRequest;
     const {
       runId,
       storageName,
@@ -85,42 +37,21 @@ export async function POST(request: NextRequest) {
       changes,
     } = body;
 
-    // Validate runId is provided
-    if (!runId) {
-      return errorResponse("runId is required", "BAD_REQUEST", 400);
-    }
-
     // Authenticate with sandbox JWT and verify runId matches
     const auth = await getSandboxAuthForRun(runId);
     if (!auth) {
-      return errorResponse(
-        "Not authenticated or runId mismatch",
-        "UNAUTHORIZED",
-        401,
-      );
+      return {
+        status: 401 as const,
+        body: {
+          error: {
+            message: "Not authenticated or runId mismatch",
+            code: "UNAUTHORIZED",
+          },
+        },
+      };
     }
 
     const { userId } = auth;
-
-    // Validate required fields
-    if (!storageName) {
-      return errorResponse("storageName is required", "BAD_REQUEST", 400);
-    }
-
-    if (
-      !storageType ||
-      (storageType !== "volume" && storageType !== "artifact")
-    ) {
-      return errorResponse(
-        "storageType must be 'volume' or 'artifact'",
-        "BAD_REQUEST",
-        400,
-      );
-    }
-
-    if (!files || !Array.isArray(files)) {
-      return errorResponse("files array is required", "BAD_REQUEST", 400);
-    }
 
     log.debug(
       `Preparing upload for "${storageName}" (type: ${storageType}), ${files.length} files, run: ${runId}`,
@@ -134,7 +65,12 @@ export async function POST(request: NextRequest) {
       .limit(1);
 
     if (!run) {
-      return errorResponse("Agent run not found", "NOT_FOUND", 404);
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Agent run not found", code: "NOT_FOUND" },
+        },
+      };
     }
 
     // Find or create storage
@@ -168,7 +104,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!storage) {
-      return errorResponse("Failed to create storage", "INTERNAL_ERROR", 500);
+      return {
+        status: 500 as const,
+        body: {
+          error: { message: "Failed to create storage", code: "INTERNAL_ERROR" },
+        },
+      };
     }
 
     // Handle incremental upload - merge files with base version
@@ -204,7 +145,10 @@ export async function POST(request: NextRequest) {
 
           // Start with base manifest files, excluding deleted ones
           const deletedSet = new Set(changes.deleted || []);
-          const baseFilesMap = new Map<string, FileEntryWithHash>();
+          const baseFilesMap = new Map<
+            string,
+            { path: string; hash: string; size: number }
+          >();
 
           for (const file of baseManifest.files) {
             if (!deletedSet.has(file.path) && !currentFilesMap.has(file.path)) {
@@ -233,11 +177,15 @@ export async function POST(request: NextRequest) {
     // Get bucket name (needed for S3 verification)
     const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
     if (!bucketName) {
-      return errorResponse(
-        "R2_USER_STORAGES_BUCKET_NAME not configured",
-        "INTERNAL_ERROR",
-        500,
-      );
+      return {
+        status: 500 as const,
+        body: {
+          error: {
+            message: "R2_USER_STORAGES_BUCKET_NAME not configured",
+            code: "INTERNAL_ERROR",
+          },
+        },
+      };
     }
 
     // Check if version already exists (deduplication) - skip if force is true
@@ -266,10 +214,13 @@ export async function POST(request: NextRequest) {
           log.debug(
             `Version ${versionId} exists with S3 files, returning existing`,
           );
-          return NextResponse.json({
-            versionId,
-            existing: true,
-          } satisfies PrepareResponse);
+          return {
+            status: 200 as const,
+            body: {
+              versionId,
+              existing: true,
+            },
+          };
         }
 
         // S3 files missing - treat as new version, will trigger re-upload
@@ -298,23 +249,64 @@ export async function POST(request: NextRequest) {
       ),
     ]);
 
-    const response: PrepareResponse = {
-      versionId,
-      existing: false,
-      uploads: {
-        archive: { key: archiveKey, presignedUrl: archiveUrl },
-        manifest: { key: manifestKey, presignedUrl: manifestUrl },
+    log.debug(`Prepared upload for version ${versionId}`);
+    return {
+      status: 200 as const,
+      body: {
+        versionId,
+        existing: false,
+        uploads: {
+          archive: { key: archiveKey, presignedUrl: archiveUrl },
+          manifest: { key: manifestKey, presignedUrl: manifestUrl },
+        },
       },
     };
+  },
+});
 
-    log.debug(`Prepared upload for version ${versionId}`);
-    return NextResponse.json(response);
-  } catch (error) {
-    log.error("Prepare error:", error);
-    return errorResponse(
-      error instanceof Error ? error.message : "Prepare failed",
-      "INTERNAL_ERROR",
-      500,
-    );
+/**
+ * Custom error handler to convert Zod validation errors to API error format
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (
+    err &&
+    typeof err === "object" &&
+    "bodyError" in err &&
+    "queryError" in err
+  ) {
+    const validationError = err as {
+      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
+      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
+    };
+
+    if (validationError.bodyError) {
+      const issue = validationError.bodyError.issues[0];
+      if (issue) {
+        const path = issue.path.join(".");
+        const message = path ? `${path}: ${issue.message}` : issue.message;
+        return TsRestResponse.fromJson(
+          { error: { message, code: "BAD_REQUEST" } },
+          { status: 400 },
+        );
+      }
+    }
   }
+
+  // Log unexpected errors
+  log.error("Prepare error:", err);
+  return TsRestResponse.fromJson(
+    {
+      error: {
+        message: err instanceof Error ? err.message : "Prepare failed",
+        code: "INTERNAL_ERROR",
+      },
+    },
+    { status: 500 },
+  );
 }
+
+const handler = createHandler(webhookStoragesPrepareContract, router, {
+  errorHandler,
+});
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -107,7 +107,10 @@ const router = tsr.router(webhookStoragesPrepareContract, {
       return {
         status: 500 as const,
         body: {
-          error: { message: "Failed to create storage", code: "INTERNAL_ERROR" },
+          error: {
+            message: "Failed to create storage",
+            code: "INTERNAL_ERROR",
+          },
         },
       };
     }

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -68,7 +68,18 @@ export {
   storagesContract,
   storageTypeSchema,
   uploadStorageResponseSchema,
+  // Direct upload schemas (shared with webhooks)
+  fileEntryWithHashSchema,
+  storageChangesSchema,
+  presignedUploadSchema,
+  // Direct upload contracts (CLI endpoints)
+  storagesPrepareContract,
+  storagesCommitContract,
+  storagesDownloadContract,
   type StoragesContract,
+  type StoragesPrepareContract,
+  type StoragesCommitContract,
+  type StoragesDownloadContract,
 } from "./storages";
 export {
   webhookEventsContract,
@@ -78,6 +89,9 @@ export {
   webhookStoragesContract,
   webhookStoragesIncrementalContract,
   webhookTelemetryContract,
+  // Direct upload contracts (Webhook endpoints for sandbox)
+  webhookStoragesPrepareContract,
+  webhookStoragesCommitContract,
   type WebhookEventsContract,
   type WebhookCompleteContract,
   type WebhookCheckpointsContract,
@@ -85,6 +99,8 @@ export {
   type WebhookStoragesContract,
   type WebhookStoragesIncrementalContract,
   type WebhookTelemetryContract,
+  type WebhookStoragesPrepareContract,
+  type WebhookStoragesCommitContract,
 } from "./webhooks";
 export {
   cliAuthDeviceContract,

--- a/turbo/packages/core/src/contracts/storages.ts
+++ b/turbo/packages/core/src/contracts/storages.ts
@@ -91,5 +91,164 @@ export const storagesContract = c.router({
 
 export type StoragesContract = typeof storagesContract;
 
+// ============================================================================
+// Direct Upload Schemas (for CLI and Webhook endpoints)
+// ============================================================================
+
+/**
+ * File entry with hash for content-addressable storage
+ */
+export const fileEntryWithHashSchema = z.object({
+  path: z.string().min(1, "File path is required"),
+  hash: z.string().length(64, "Hash must be SHA-256 (64 hex chars)"),
+  size: z.number().int().min(0, "Size must be non-negative"),
+});
+
+/**
+ * Incremental changes schema for partial uploads
+ */
+export const storageChangesSchema = z.object({
+  added: z.array(z.string()),
+  modified: z.array(z.string()),
+  deleted: z.array(z.string()),
+});
+
+/**
+ * Presigned upload URL schema
+ */
+export const presignedUploadSchema = z.object({
+  key: z.string(),
+  presignedUrl: z.string().url(),
+});
+
+// ============================================================================
+// Direct Upload Contracts (CLI endpoints)
+// ============================================================================
+
+/**
+ * Storage prepare contract for /api/storages/prepare
+ *
+ * Prepares for direct S3 upload by:
+ * 1. Computing content hash from file metadata
+ * 2. Checking for existing version (deduplication)
+ * 3. Generating presigned URLs if upload needed
+ */
+export const storagesPrepareContract = c.router({
+  prepare: {
+    method: "POST",
+    path: "/api/storages/prepare",
+    body: z.object({
+      storageName: z.string().min(1, "Storage name is required"),
+      storageType: storageTypeSchema,
+      files: z.array(fileEntryWithHashSchema),
+      force: z.boolean().optional(),
+      runId: z.string().optional(), // For sandbox auth
+      baseVersion: z.string().optional(), // For incremental uploads
+      changes: storageChangesSchema.optional(),
+    }),
+    responses: {
+      200: z.object({
+        versionId: z.string(),
+        existing: z.boolean(),
+        uploads: z
+          .object({
+            archive: presignedUploadSchema,
+            manifest: presignedUploadSchema,
+          })
+          .optional(),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Prepare for direct S3 upload",
+  },
+});
+
+/**
+ * Storage commit contract for /api/storages/commit
+ *
+ * Commits a direct S3 upload by:
+ * 1. Verifying uploaded files exist in S3
+ * 2. Creating storage version record
+ * 3. Updating storage HEAD pointer
+ */
+export const storagesCommitContract = c.router({
+  commit: {
+    method: "POST",
+    path: "/api/storages/commit",
+    body: z.object({
+      storageName: z.string().min(1, "Storage name is required"),
+      storageType: storageTypeSchema,
+      versionId: z.string().min(1, "Version ID is required"),
+      files: z.array(fileEntryWithHashSchema),
+      runId: z.string().optional(),
+      message: z.string().optional(),
+    }),
+    responses: {
+      200: z.object({
+        success: z.literal(true),
+        versionId: z.string(),
+        storageName: z.string(),
+        size: z.number(),
+        fileCount: z.number(),
+        deduplicated: z.boolean().optional(),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema, // S3 files missing
+      500: apiErrorSchema,
+    },
+    summary: "Commit uploaded storage",
+  },
+});
+
+/**
+ * Storage download contract for /api/storages/download
+ *
+ * Returns presigned URL for downloading storage archive from S3.
+ * Different from storagesContract.download which streams the file directly.
+ */
+export const storagesDownloadContract = c.router({
+  download: {
+    method: "GET",
+    path: "/api/storages/download",
+    query: z.object({
+      name: z.string().min(1, "Storage name is required"),
+      type: storageTypeSchema,
+      version: z.string().optional(),
+    }),
+    responses: {
+      // Normal response with presigned URL
+      200: z.union([
+        z.object({
+          url: z.string().url(),
+          versionId: z.string(),
+          fileCount: z.number(),
+          size: z.number(),
+        }),
+        // Empty artifact response
+        z.object({
+          empty: z.literal(true),
+          versionId: z.string(),
+          fileCount: z.literal(0),
+          size: z.literal(0),
+        }),
+      ]),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get presigned download URL",
+  },
+});
+
+export type StoragesPrepareContract = typeof storagesPrepareContract;
+export type StoragesCommitContract = typeof storagesCommitContract;
+export type StoragesDownloadContract = typeof storagesDownloadContract;
+
 // Export schemas for reuse
 export { storageTypeSchema, uploadStorageResponseSchema };


### PR DESCRIPTION
## Summary

Add type-safe ts-rest contracts for storage direct upload endpoints (CLI and webhook).

### CLI Endpoints (in `storages.ts`)
- `storagesPrepareContract` for `POST /api/storages/prepare`
- `storagesCommitContract` for `POST /api/storages/commit`
- `storagesDownloadContract` for `GET /api/storages/download`

### Webhook Endpoints (in `webhooks.ts`)
- `webhookStoragesPrepareContract` for `POST /api/webhooks/agent/storages/prepare`
- `webhookStoragesCommitContract` for `POST /api/webhooks/agent/storages/commit`

### Shared Schemas (exported from `storages.ts`)
- `fileEntryWithHashSchema` - file entry with SHA-256 hash
- `storageChangesSchema` - incremental upload changes
- `presignedUploadSchema` - presigned S3 URL structure

## Changes

| File | Changes |
|------|---------|
| `storages.ts` | Added shared schemas + 3 CLI contracts |
| `webhooks.ts` | Import shared schemas + 2 webhook contracts |
| `index.ts` | Export all new contracts and schemas |

## Test Plan

- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint --filter=@vm0/core`)
- [ ] CI pipeline passes

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)