### PR TITLE
fix(devcontainer): create pki directory with proper permissions

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -17,8 +17,8 @@ echo "✓ Locale configured"
 
 # Setup directories - fix ownership for all mounted volumes
 # This is the key difference - vm0 fixes all directories at once
-sudo mkdir -p /home/vscode/.local/bin
-sudo chown -R vscode:vscode /home/vscode/.config /home/vscode/.cache /home/vscode/.local
+sudo mkdir -p /home/vscode/.local/bin /home/vscode/.pki/nssdb
+sudo chown -R vscode:vscode /home/vscode/.config /home/vscode/.cache /home/vscode/.local /home/vscode/.pki
 
 # Add local development domains to /etc/hosts
 echo "📝 Adding local domains to /etc/hosts..."


### PR DESCRIPTION
## Summary
- Create `/home/vscode/.pki/nssdb` directory with sudo during devcontainer setup
- Fix ownership of `.pki` directory to prevent permission denied error during mkcert CA installation

## Problem
Dev container build failed with:
```
mkdir: cannot create directory '/home/vscode/.pki/nssdb': Permission denied
```

The script was trying to create the `.pki/nssdb` directory as the vscode user without proper permissions.

## Solution
Create the directory with sudo and fix ownership in the same step as other user directories.

## Test plan
- [ ] Rebuild dev container with `~/.local/bin/dcu`
- [ ] Verify setup completes without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)