### PR TITLE
feat(cli): replace --limit with --tail and --head flags for logs command

### DIFF
--- a/e2e/tests/02-parallel/t14-vm0-cook-continue.bats
+++ b/e2e/tests/02-parallel/t14-vm0-cook-continue.bats
@@ -109,5 +109,6 @@ teardown() {
     assert_output --partial "--metrics"
     assert_output --partial "--network"
     assert_output --partial "--since"
-    assert_output --partial "--limit"
+    assert_output --partial "--tail"
+    assert_output --partial "--head"
 }

--- a/e2e/tests/02-parallel/t15-vm0-telemetry.bats
+++ b/e2e/tests/02-parallel/t15-vm0-telemetry.bats
@@ -113,7 +113,7 @@ teardown() {
 
     # Step 6: Verify --system option shows system logs
     echo "# Step 6: Testing --system option..."
-    run $CLI_COMMAND logs "$RUN_ID" --system --limit 100
+    run $CLI_COMMAND logs "$RUN_ID" --system --tail 100
 
     assert_success
     # System log should contain sandbox log entries with INFO level
@@ -124,7 +124,7 @@ teardown() {
 
     # Step 7: Verify --metrics option shows resource metrics
     echo "# Step 7: Testing --metrics option..."
-    run $CLI_COMMAND logs "$RUN_ID" --metrics --limit 100
+    run $CLI_COMMAND logs "$RUN_ID" --metrics --tail 100
 
     assert_success
     # Metrics should contain CPU, memory, and disk information
@@ -133,14 +133,14 @@ teardown() {
     assert_output --partial "Disk:"
     echo "# Metrics contain expected resource data"
 
-    # Step 8: Verify --limit option limits output
-    echo "# Step 8: Testing --limit option..."
-    run $CLI_COMMAND logs "$RUN_ID" --limit 2
+    # Step 8: Verify --tail option limits output
+    echo "# Step 8: Testing --tail option..."
+    run $CLI_COMMAND logs "$RUN_ID" --tail 2
 
     assert_success
-    # With limit=2, should see at most 2 events
-    # If more exist, should see "Use --limit to see more"
-    echo "# Limit option works correctly"
+    # With tail=2, should see at most 2 events
+    # If more exist, should see "Use --tail to see more"
+    echo "# Tail option works correctly"
 
     # Step 9: Verify mutually exclusive options are enforced
     echo "# Step 9: Testing mutually exclusive options..."

--- a/e2e/tests/02-parallel/t16-vm0-network-logs.bats
+++ b/e2e/tests/02-parallel/t16-vm0-network-logs.bats
@@ -64,7 +64,7 @@ teardown() {
 
     # Step 4: Verify vm0 logs --network command retrieves network logs
     echo "# Step 4: Fetching network logs..."
-    run $CLI_COMMAND logs "$RUN_ID" --network --limit 100
+    run $CLI_COMMAND logs "$RUN_ID" --network --tail 100
 
     assert_success
 
@@ -112,7 +112,7 @@ teardown() {
 
     # Step 8: Verify -n short option works
     echo "# Step 8: Testing -n short option..."
-    run $CLI_COMMAND logs "$RUN_ID" -n --limit 10
+    run $CLI_COMMAND logs "$RUN_ID" -n --tail 10
 
     assert_success
     echo "# -n short option works correctly"

--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -537,7 +537,8 @@ cookCmd
     "--since <time>",
     "Show logs since timestamp (e.g., 5m, 2h, 1d, 2024-01-15T10:30:00Z)",
   )
-  .option("--limit <n>", "Maximum number of entries to show (default: 5)")
+  .option("--tail <n>", "Show last N entries (default: 5, max: 100)")
+  .option("--head <n>", "Show first N entries (max: 100)")
   .action(
     async (options: {
       agent?: boolean;
@@ -545,7 +546,8 @@ cookCmd
       metrics?: boolean;
       network?: boolean;
       since?: string;
-      limit?: string;
+      tail?: string;
+      head?: string;
     }) => {
       const state = await loadCookState();
       if (!state.lastRunId) {
@@ -578,9 +580,13 @@ cookCmd
         args.push("--since", options.since);
         displayArgs.push(`--since ${options.since}`);
       }
-      if (options.limit) {
-        args.push("--limit", options.limit);
-        displayArgs.push(`--limit ${options.limit}`);
+      if (options.tail) {
+        args.push("--tail", options.tail);
+        displayArgs.push(`--tail ${options.tail}`);
+      }
+      if (options.head) {
+        args.push("--head", options.head);
+        displayArgs.push(`--head ${options.head}`);
       }
 
       printCommand(displayArgs.join(" "));

--- a/turbo/apps/cli/src/lib/api-client.ts
+++ b/turbo/apps/cli/src/lib/api-client.ts
@@ -361,7 +361,7 @@ class ApiClient {
 
   async getSystemLog(
     runId: string,
-    options?: { since?: number; limit?: number },
+    options?: { since?: number; limit?: number; order?: "asc" | "desc" },
   ): Promise<GetSystemLogResponse> {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
@@ -372,6 +372,9 @@ class ApiClient {
     }
     if (options?.limit !== undefined) {
       params.set("limit", String(options.limit));
+    }
+    if (options?.order !== undefined) {
+      params.set("order", options.order);
     }
 
     const queryString = params.toString();
@@ -392,7 +395,7 @@ class ApiClient {
 
   async getMetrics(
     runId: string,
-    options?: { since?: number; limit?: number },
+    options?: { since?: number; limit?: number; order?: "asc" | "desc" },
   ): Promise<GetMetricsResponse> {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
@@ -403,6 +406,9 @@ class ApiClient {
     }
     if (options?.limit !== undefined) {
       params.set("limit", String(options.limit));
+    }
+    if (options?.order !== undefined) {
+      params.set("order", options.order);
     }
 
     const queryString = params.toString();
@@ -423,7 +429,7 @@ class ApiClient {
 
   async getAgentEvents(
     runId: string,
-    options?: { since?: number; limit?: number },
+    options?: { since?: number; limit?: number; order?: "asc" | "desc" },
   ): Promise<GetAgentEventsResponse> {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
@@ -434,6 +440,9 @@ class ApiClient {
     }
     if (options?.limit !== undefined) {
       params.set("limit", String(options.limit));
+    }
+    if (options?.order !== undefined) {
+      params.set("order", options.order);
     }
 
     const queryString = params.toString();
@@ -454,7 +463,7 @@ class ApiClient {
 
   async getNetworkLogs(
     runId: string,
-    options?: { since?: number; limit?: number },
+    options?: { since?: number; limit?: number; order?: "asc" | "desc" },
   ): Promise<GetNetworkLogsResponse> {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
@@ -465,6 +474,9 @@ class ApiClient {
     }
     if (options?.limit !== undefined) {
       params.set("limit", String(options.limit));
+    }
+    if (options?.order !== undefined) {
+      params.set("order", options.order);
     }
 
     const queryString = params.toString();

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/route.ts
@@ -68,7 +68,7 @@ const router = tsr.router(runAgentEventsContract, {
     } | null;
     const provider = composeContent?.agent?.provider ?? "claude-code";
 
-    const { since, limit } = query;
+    const { since, limit, order } = query;
 
     // Build APL query for Axiom
     const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
@@ -78,7 +78,7 @@ const router = tsr.router(runAgentEventsContract, {
     const apl = `['${dataset}']
 | where runId == "${params.id}"
 ${sinceFilter}
-| order by _time asc
+| order by _time ${order}
 | limit ${limit + 1}`;
 
     // Query Axiom for agent events

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/route.ts
@@ -55,7 +55,7 @@ const router = tsr.router(runMetricsContract, {
       };
     }
 
-    const { since, limit } = query;
+    const { since, limit, order } = query;
 
     // Build APL query for Axiom
     const dataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_METRICS);
@@ -65,7 +65,7 @@ const router = tsr.router(runMetricsContract, {
     const apl = `['${dataset}']
 | where runId == "${params.id}"
 ${sinceFilter}
-| order by _time asc
+| order by _time ${order}
 | limit ${limit + 1}`;
 
     // Query Axiom for metrics

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
@@ -56,7 +56,7 @@ const router = tsr.router(runNetworkLogsContract, {
       };
     }
 
-    const { since, limit } = query;
+    const { since, limit, order } = query;
 
     // Build APL query for Axiom
     const dataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_NETWORK);
@@ -66,7 +66,7 @@ const router = tsr.router(runNetworkLogsContract, {
     const apl = `['${dataset}']
 | where runId == "${params.id}"
 ${sinceFilter}
-| order by _time asc
+| order by _time ${order}
 | limit ${limit + 1}`;
 
     // Query Axiom for network logs

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/route.ts
@@ -51,7 +51,7 @@ const router = tsr.router(runSystemLogContract, {
       };
     }
 
-    const { since, limit } = query;
+    const { since, limit, order } = query;
 
     // Build APL query for Axiom
     const dataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_SYSTEM);
@@ -61,7 +61,7 @@ const router = tsr.router(runSystemLogContract, {
     const apl = `['${dataset}']
 | where runId == "${params.id}"
 ${sinceFilter}
-| order by _time asc
+| order by _time ${order}
 | limit ${limit + 1}`;
 
     // Query Axiom for system logs

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -294,6 +294,7 @@ export const runSystemLogContract = c.router({
     query: z.object({
       since: z.coerce.number().optional(),
       limit: z.coerce.number().min(1).max(100).default(5),
+      order: z.enum(["asc", "desc"]).default("desc"),
     }),
     responses: {
       200: systemLogResponseSchema,
@@ -321,6 +322,7 @@ export const runMetricsContract = c.router({
     query: z.object({
       since: z.coerce.number().optional(),
       limit: z.coerce.number().min(1).max(100).default(5),
+      order: z.enum(["asc", "desc"]).default("desc"),
     }),
     responses: {
       200: metricsResponseSchema,
@@ -348,6 +350,7 @@ export const runAgentEventsContract = c.router({
     query: z.object({
       since: z.coerce.number().optional(),
       limit: z.coerce.number().min(1).max(100).default(5),
+      order: z.enum(["asc", "desc"]).default("desc"),
     }),
     responses: {
       200: agentEventsResponseSchema,
@@ -375,6 +378,7 @@ export const runNetworkLogsContract = c.router({
     query: z.object({
       since: z.coerce.number().optional(),
       limit: z.coerce.number().min(1).max(100).default(5),
+      order: z.enum(["asc", "desc"]).default("desc"),
     }),
     responses: {
       200: networkLogsResponseSchema,


### PR DESCRIPTION
## Summary

- Replace the ambiguous `--limit` flag with explicit `--tail` and `--head` flags that match industry conventions
- Default behavior is now `--tail 5` (show last 5 entries)
- Display order is always chronological (oldest → newest within returned set)

## Changes

| File | Change |
|------|--------|
| `packages/core/src/contracts/runs.ts` | Add `order` parameter to 4 telemetry schemas |
| 4 server endpoint files | Use dynamic order in APL queries |
| `apps/cli/src/lib/api-client.ts` | Pass `order` parameter to telemetry methods |
| `apps/cli/src/commands/logs/index.ts` | Replace `--limit` with `--tail`/`--head`, add reversal logic |

## New Behavior

| Command | Result |
|---------|--------|
| `vm0 logs <run-id>` | Last 5 entries (default) |
| `vm0 logs <run-id> --tail 20` | Last 20 entries |
| `vm0 logs <run-id> --head 20` | First 20 entries |
| `vm0 logs <run-id> --since 5m` | Last 5 entries since 5 min ago |

## Test plan

- [x] Type checking passes
- [x] Linting passes
- [x] All 1196 tests pass
- [ ] Manual testing with real agent runs

Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)