### PR TITLE
fix(cli): inherit TTY for compose command in cook workflow

### DIFF
--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -47,15 +47,22 @@ function printCommand(cmd: string): void {
 /**
  * Execute a vm0 command in a subprocess
  * Returns stdout on success, throws on failure with stderr
+ *
+ * @param options.silent - If true, capture stdout/stderr (no output to terminal)
  */
 function execVm0Command(
   args: string[],
   options: { cwd?: string; silent?: boolean } = {},
 ): Promise<string> {
   return new Promise((resolve, reject) => {
+    // Determine stdio configuration:
+    // - silent: pipe all (capture output, no terminal interaction)
+    // - default: inherit all (full terminal passthrough, allows prompts)
+    const stdio: "pipe" | "inherit" = options.silent ? "pipe" : "inherit";
+
     const proc = spawn("vm0", args, {
       cwd: options.cwd,
-      stdio: options.silent ? "pipe" : ["inherit", "inherit", "inherit"],
+      stdio,
       shell: process.platform === "win32",
     });
 
@@ -468,9 +475,9 @@ cookCmd
     printCommand(`vm0 compose ${CONFIG_FILE}`);
 
     try {
+      // Use inherit to show compose output and allow confirmation prompts
       await execVm0Command(["compose", CONFIG_FILE], {
         cwd,
-        silent: true,
       });
     } catch (error) {
       console.error(chalk.red(`✗ Compose failed`));


### PR DESCRIPTION
## Summary

- Removed `silent: true` from compose call in cook command to inherit TTY
- This allows prompts library to properly detect TTY and show confirmation prompts when skills with frontmatter variables are being composed
- Fixes bug where `vm0 cook` would fail with "Non-interactive terminal. Use --yes flag to skip confirmation"

## Test plan

- [x] Unit tests pass (`pnpm vitest run src/commands/__tests__/cook.test.ts`)
- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint --filter=@vm0/cli`)
- [ ] E2E test to be added for cook with skills having frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)