### PR TITLE
ci: add docs-writer agent workflows with proper working directory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish Agent
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.vm0/agents/docs-writer/**'
+
+defaults:
+  run:
+    working-directory: .vm0/agents/docs-writer
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish Agent
+        uses: vm0-ai/compose-action@v1
+        id: compose
+        with:
+          vm0-token: ${{ secrets.VM0_TOKEN }}
+          working-directory: .vm0/agents/docs-writer
+
+      - name: Show Results
+        run: |
+          echo "Agent: ${{ steps.compose.outputs.name }}"
+          echo "Compose ID: ${{ steps.compose.outputs.compose-id }}"
+          echo "Version: ${{ steps.compose.outputs.version-id }}"
+          echo "Action: ${{ steps.compose.outputs.action }}"

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,0 +1,32 @@
+name: Run Agent
+
+on:
+  # Uncomment to enable scheduled runs:
+  # schedule:
+  #   - cron: '0 1 * * *'  # Daily at 9:00 AM UTC+8
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: 'Prompt for the agent'
+        required: false
+        default: 'do the job'
+
+defaults:
+  run:
+    working-directory: .vm0/agents/docs-writer
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Agent
+        uses: vm0-ai/run-action@v1
+        with:
+          agent: docs-writer
+          prompt: ${{ github.event.inputs.prompt || 'do the job' }}
+          silent: true
+          vm0-token: ${{ secrets.VM0_TOKEN }}
+          working-directory: .vm0/agents/docs-writer
+          secrets: |
+            GH_ISSUE_WRITER_TOKEN=${{ secrets.GH_ISSUE_WRITER_TOKEN }}
+            MINIMAX_API_KEY=${{ secrets.MINIMAX_API_KEY }}

--- a/.vm0/agents/docs-writer/AGENTS.md
+++ b/.vm0/agents/docs-writer/AGENTS.md
@@ -1,5 +1,5 @@
-0. check gh auth status with GH_TOKEN variable
-1. git clone vm0-ai/vm0-skills, and create a issue under vm0-ai/vm0, title may be auto update document
-2. for each skill, create a subagent to check if this skill is not existed or updated of https://github.com/vm0-ai/vm0/tree/main/turbo/apps/docs/content/docs/integration/SKILL_NAME.mdx, if so, write a comment in that issue with updated skill document
-3. for each model vendor under https://github.com/vm0-ai/vm0/tree/main/turbo/apps/docs/content/docs/model-selection, create a subagent to check is there any env change or new model that https://github.com/vm0-ai/vm0/tree/main/turbo/apps/docs/content/docs/integration/SKILL_NAME.mdx, if so, write a comment in that issue with updated document
-4. update issue content for summary, generate a prompt for claude code to update docs from vm0-ai/vm0-skills
+0. Check gh auth status with GH_TOKEN environment variable
+1. Git clone vm0-ai/vm0-skills, then create an issue under vm0-ai/vm0 with title "Auto Update Documentation"
+2. For each model vendor under vm0/turbo/apps/docs/content/docs/model-selection/, create a subagent to check if there are any env variable changes or new models in vm0-skills that are not reflected in the docs. If so, update issue with the updated model documentation.
+3. For each skill in vm0-skills, create a subagent to check if the corresponding doc at vm0/turbo/apps/docs/content/docs/integration/SKILL_NAME.mdx is missing or outdated. If so, update the issue with the updated skill documentation.
+4. Generate a prompt for Claude Code to batch update docs in vm0-ai/vm0 based on vm0-ai/vm0-skills.

--- a/.vm0/agents/docs-writer/AGENTS.md
+++ b/.vm0/agents/docs-writer/AGENTS.md
@@ -1,0 +1,5 @@
+0. check gh auth status with GH_TOKEN variable
+1. git clone vm0-ai/vm0-skills, and create a issue under vm0-ai/vm0, title may be auto update document
+2. for each skill, create a subagent to check if this skill is not existed or updated of https://github.com/vm0-ai/vm0/tree/main/turbo/apps/docs/content/docs/integration/SKILL_NAME.mdx, if so, write a comment in that issue with updated skill document
+3. for each model vendor under https://github.com/vm0-ai/vm0/tree/main/turbo/apps/docs/content/docs/model-selection, create a subagent to check is there any env change or new model that https://github.com/vm0-ai/vm0/tree/main/turbo/apps/docs/content/docs/integration/SKILL_NAME.mdx, if so, write a comment in that issue with updated document
+4. update issue content for summary, generate a prompt for claude code to update docs from vm0-ai/vm0-skills

--- a/.vm0/agents/docs-writer/vm0.yaml
+++ b/.vm0/agents/docs-writer/vm0.yaml
@@ -1,0 +1,19 @@
+version: "1.0"
+
+agents:
+  docs-writer:
+    provider: claude-code
+    instructions: AGENTS.md
+    skills:
+      - https://github.com/vm0-ai/vm0-skills/tree/main/github
+    environment:
+      GH_TOKEN: "${{ secrets.GH_ISSUE_WRITER_TOKEN }}"
+      ANTHROPIC_BASE_URL: "https://api.minimax.io/anthropic"
+      ANTHROPIC_AUTH_TOKEN: "${{ secrets.MINIMAX_API_KEY }}"
+      API_TIMEOUT_MS: "3000000"
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
+      ANTHROPIC_MODEL: "MiniMax-M2.1"
+      ANTHROPIC_SMALL_FAST_MODEL: "MiniMax-M2.1"
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "MiniMax-M2.1"
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "MiniMax-M2.1"
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: "MiniMax-M2.1"


### PR DESCRIPTION
## Summary
- Add `publish.yml` workflow triggered on `.vm0/agents/docs-writer/**` changes
- Add `run.yml` workflow for manual agent execution
- Configure `working-directory` for both workflows and actions

## Test plan
- [ ] Verify publish workflow triggers only on docs-writer directory changes
- [ ] Verify run workflow can be manually triggered
- [ ] Confirm working-directory is correctly set for actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)