### PR TITLE
fix(docs): correct model selection link path

### DIFF
--- a/turbo/apps/docs/content/docs/quick-start.mdx
+++ b/turbo/apps/docs/content/docs/quick-start.mdx
@@ -49,7 +49,7 @@ claude setup-token
 echo "CLAUDE_CODE_OAUTH_TOKEN=<your-token>" > .env
 ```
 
-You can also use other LLM providers instead of Claude, like Moonshot (Kimi), MiniMax, DeepSeek, Z.AI (GLM), or OpenRouter. See [Model Selection](/docs/usage/model-selection) for configuration options.
+You can also use other LLM providers instead of Claude, like Moonshot (Kimi), MiniMax, DeepSeek, Z.AI (GLM), or OpenRouter. See [Model Selection](/docs/model-selection) for configuration options.
 
 ## Run Your Agent
 
@@ -74,5 +74,5 @@ This command displays the agent's execution logs in real-time. When the agent fi
   <Card title="Container Image" href="/docs/core-concept/container-image" />
   <Card title="Run & Debug Agent" href="/docs/usage/run-agent" />
   <Card title="GitHub Actions" href="/docs/usage/github-actions" />
-  <Card title="Model Selection" href="/docs/usage/model-selection" />
+  <Card title="Model Selection" href="/docs/model-selection" />
 </Cards>


### PR DESCRIPTION
## Summary

Fix 404 links to Model Selection in quick-start.mdx.

Changed `/docs/usage/model-selection` → `/docs/model-selection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)