### PR TITLE
feat: add docs link to main website navigation

### DIFF
--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -61,6 +61,14 @@ export default function Navbar() {
             style={{ display: "flex", gap: "32px" }}
           >
             <a
+              href="https://docs.vm0.ai"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="nav-link"
+            >
+              {t("docs")}
+            </a>
+            <a
               href="https://blog.vm0.ai"
               target="_blank"
               rel="noopener noreferrer"
@@ -124,6 +132,15 @@ export default function Navbar() {
       <div className={`mobile-menu ${mobileMenuOpen ? "open" : ""}`}>
         <div className="mobile-menu-content">
           <div className="mobile-menu-links">
+            <a
+              href="https://docs.vm0.ai"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mobile-menu-link"
+              onClick={() => setMobileMenuOpen(false)}
+            >
+              {t("docs")}
+            </a>
             <a
               href="https://blog.vm0.ai"
               target="_blank"

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -78,6 +78,7 @@
     "button": "Warteliste beitreten"
   },
   "nav": {
+    "docs": "Docs",
     "blog": "Blog",
     "cookbooks": "Kochbücher",
     "skills": "Skills",

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -78,6 +78,7 @@
     "button": "Join waitlist"
   },
   "nav": {
+    "docs": "Docs",
     "blog": "Blog",
     "cookbooks": "Cookbooks",
     "skills": "Skills",

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -78,6 +78,7 @@
     "button": "Unirse a lista de espera"
   },
   "nav": {
+    "docs": "Docs",
     "blog": "Blog",
     "cookbooks": "Recetas",
     "skills": "Skills",

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -78,6 +78,7 @@
     "button": "ウェイトリストに参加"
   },
   "nav": {
+    "docs": "ドキュメント",
     "blog": "ブログ",
     "cookbooks": "クックブック",
     "skills": "Skills",


### PR DESCRIPTION
## Summary
Adds "Docs" link to the main website navigation (vm0.ai) in both desktop and mobile views.

## Changes
- Added docs link to desktop navigation (first position before blog)
- Added docs link to mobile menu
- Added translations for all supported languages (en, de, es, ja)
- Links point to https://docs.vm0.ai

## Test plan
- [x] Verify docs link appears in desktop navigation
- [x] Verify docs link appears in mobile responsive menu
- [x] Verify translations work for all languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>