### PR TITLE
feat(docs): add api key instructions and reorder providers

### DIFF
--- a/turbo/apps/docs/content/docs/model-selection/deepseek.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/deepseek.mdx
@@ -5,6 +5,10 @@ description: Use DeepSeek models with VM0
 
 [DeepSeek](https://api-docs.deepseek.com/guides/anthropic_api) provides cost-effective models with strong coding capabilities.
 
+## Get API Key
+
+Visit the [DeepSeek Platform](https://platform.deepseek.com/api_keys) to create and obtain an API Key.
+
 ## Configuration
 
 ```yaml title="vm0.yaml"

--- a/turbo/apps/docs/content/docs/model-selection/index.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/index.mdx
@@ -65,8 +65,8 @@ agents:
 
 ### Supported Providers
 
+- [OpenRouter](/docs/model-selection/openrouter)
 - [Moonshot (Kimi)](/docs/model-selection/moonshot)
 - [MiniMax](/docs/model-selection/minimax)
 - [DeepSeek](/docs/model-selection/deepseek)
 - [Z.AI (GLM)](/docs/model-selection/zai)
-- [OpenRouter](/docs/model-selection/openrouter)

--- a/turbo/apps/docs/content/docs/model-selection/meta.json
+++ b/turbo/apps/docs/content/docs/model-selection/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Model Selection",
-  "pages": ["index", "moonshot", "minimax", "deepseek", "zai", "openrouter"]
+  "pages": ["index", "openrouter", "moonshot", "minimax", "deepseek", "zai"]
 }

--- a/turbo/apps/docs/content/docs/model-selection/minimax.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/minimax.mdx
@@ -5,6 +5,10 @@ description: Use MiniMax M2.1 model with VM0
 
 [MiniMax](https://platform.minimax.io/docs/guides/text-ai-coding-tools) offers the M2.1 model with strong code understanding and multi-turn dialogue capabilities.
 
+## Get API Key
+
+Visit the [MiniMax Coding Plan](https://platform.minimax.io/user-center/payment/coding-plan) page to get your Coding Plan API Key.
+
 ## Configuration
 
 ```yaml title="vm0.yaml"

--- a/turbo/apps/docs/content/docs/model-selection/moonshot.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/moonshot.mdx
@@ -5,6 +5,10 @@ description: Use Kimi K2 model with VM0
 
 [Moonshot](https://platform.moonshot.ai/docs/guide/agent-support) provides the Kimi K2 model with strong reasoning capabilities.
 
+## Get API Key
+
+Visit the [Moonshot Open Platform](https://platform.moonshot.ai/console/api-keys) to create and obtain an API Key.
+
 ## Configuration
 
 ```yaml title="vm0.yaml"
@@ -28,9 +32,3 @@ agents:
 ```bash
 vm0 run my-agent "build a todo app" --secrets MOONSHOT_API_KEY=sk-xxx
 ```
-
-## Available Models
-
-| Model                    | Description          |
-| ------------------------ | -------------------- |
-| `kimi-k2-thinking-turbo` | Fast reasoning model |

--- a/turbo/apps/docs/content/docs/model-selection/zai.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/zai.mdx
@@ -5,6 +5,10 @@ description: Use GLM models with VM0
 
 [Z.AI](https://docs.z.ai/devpack/tool/claude) provides access to GLM models with strong coding capabilities.
 
+## Get API Key
+
+Visit the [Z.AI Open Platform](https://z.ai/manage-apikey/apikey-list) to create and obtain an API Key.
+
 ## Configuration
 
 ```yaml title="vm0.yaml"
@@ -27,5 +31,3 @@ agents:
 ```bash
 vm0 run my-agent "build a todo app" --secrets ZAI_API_KEY=xxx
 ```
-
-Get your API key at [Z.AI Open Platform](https://z.ai/model-api).


### PR DESCRIPTION
## Summary
- Add Get API Key section to moonshot, minimax, deepseek, zai
- Remove Available Models from moonshot
- Move OpenRouter to first in Supported Providers list
- Reorder sidebar to put OpenRouter first

🤖 Generated with [Claude Code](https://claude.com/claude-code)