### PR TITLE
fix(e2e): use millisecond timestamp + random for unique test names

### DIFF
--- a/e2e/tests/01-serial/ser-t02-vm0-scope.bats
+++ b/e2e/tests/01-serial/ser-t02-vm0-scope.bats
@@ -9,7 +9,7 @@ load '../../helpers/setup'
 
 setup() {
     # Generate a unique slug for this test run to avoid conflicts
-    export TEST_SLUG="e2e-test-$(date +%s)"
+    export TEST_SLUG="e2e-test-$(date +%s%3N)-$RANDOM"
 }
 
 teardown() {
@@ -151,7 +151,7 @@ EOF
 
     # Try to run with a non-existent scope
     run $CLI_COMMAND run "nonexistent-scope/test-image" \
-        --artifact-name "e2e-scope-test-$(date +%s)" \
+        --artifact-name "e2e-scope-test-$(date +%s%3N)-$RANDOM" \
         "echo hello"
 
     # Should fail with scope not found
@@ -202,7 +202,7 @@ EOF
     fi
 
     # Try to update without --force (should fail)
-    NEW_SLUG="e2e-update-$(date +%s)"
+    NEW_SLUG="e2e-update-$(date +%s%3N)-$RANDOM"
     run $CLI_COMMAND scope set "$NEW_SLUG"
     assert_failure
     assert_output --partial "--force"
@@ -216,7 +216,7 @@ EOF
     fi
 
     # Update with --force
-    NEW_SLUG="e2e-force-$(date +%s)"
+    NEW_SLUG="e2e-force-$(date +%s%3N)-$RANDOM"
     run $CLI_COMMAND scope set "$NEW_SLUG" --force
     assert_success
     assert_output --partial "$NEW_SLUG"
@@ -224,7 +224,7 @@ EOF
 
 @test "vm0 scope set with --display-name sets custom name" {
     # Update scope with display name
-    NEW_SLUG="e2e-display-$(date +%s)"
+    NEW_SLUG="e2e-display-$(date +%s%3N)-$RANDOM"
     run $CLI_COMMAND scope set "$NEW_SLUG" --display-name "My Test Scope" --force
     assert_success
     assert_output --partial "$NEW_SLUG"

--- a/e2e/tests/02-parallel/t03-artifacts.bats
+++ b/e2e/tests/02-parallel/t03-artifacts.bats
@@ -6,7 +6,7 @@ setup() {
     # Create temporary test directory
     export TEST_ARTIFACT_DIR="$(mktemp -d)"
     # Use unique test artifact name with timestamp to avoid conflicts
-    export ARTIFACT_NAME="e2e-test-artifact-$(date +%s)"
+    export ARTIFACT_NAME="e2e-test-artifact-$(date +%s%3N)-$RANDOM"
 }
 
 teardown() {

--- a/e2e/tests/02-parallel/t03-volumes.bats
+++ b/e2e/tests/02-parallel/t03-volumes.bats
@@ -6,7 +6,7 @@ setup() {
     # Create temporary test directory
     export TEST_VOLUME_DIR="$(mktemp -d)"
     # Use unique test volume name with timestamp to avoid conflicts
-    export VOLUME_NAME="e2e-test-volume-$(date +%s)"
+    export VOLUME_NAME="e2e-test-volume-$(date +%s%3N)-$RANDOM"
 }
 
 teardown() {

--- a/e2e/tests/02-parallel/t04-vm0-artifact-checkpoint.bats
+++ b/e2e/tests/02-parallel/t04-vm0-artifact-checkpoint.bats
@@ -16,7 +16,7 @@ setup() {
     # Create temporary test directory
     export TEST_ARTIFACT_DIR="$(mktemp -d)"
     # Use unique test artifact name with timestamp
-    export ARTIFACT_NAME="e2e-checkpoint-art-$(date +%s)"
+    export ARTIFACT_NAME="e2e-checkpoint-art-$(date +%s%3N)-$RANDOM"
     # Create inline config with unique agent name
     export TEST_CONFIG="$(mktemp --suffix=.yaml)"
     cat > "$TEST_CONFIG" <<EOF

--- a/e2e/tests/02-parallel/t05-vm0-artifact-mount.bats
+++ b/e2e/tests/02-parallel/t05-vm0-artifact-mount.bats
@@ -13,7 +13,7 @@ AGENT_NAME="e2e-t05"
 
 setup() {
     export TEST_ARTIFACT_DIR="$(mktemp -d)"
-    export ARTIFACT_NAME="e2e-mount-test-$(date +%s)"
+    export ARTIFACT_NAME="e2e-mount-test-$(date +%s%3N)-$RANDOM"
     # Create inline config with unique agent name
     export TEST_CONFIG="$(mktemp --suffix=.yaml)"
     cat > "$TEST_CONFIG" <<EOF

--- a/e2e/tests/02-parallel/t06-vm0-agent-session.bats
+++ b/e2e/tests/02-parallel/t06-vm0-agent-session.bats
@@ -17,7 +17,7 @@ setup() {
     # Create temporary test directory
     export TEST_ARTIFACT_DIR="$(mktemp -d)"
     # Use unique test artifact name with timestamp
-    export ARTIFACT_NAME="e2e-session-art-$(date +%s)"
+    export ARTIFACT_NAME="e2e-session-art-$(date +%s%3N)-$RANDOM"
     # Create inline config with unique agent name
     export TEST_CONFIG="$(mktemp --suffix=.yaml)"
     cat > "$TEST_CONFIG" <<EOF

--- a/e2e/tests/02-parallel/t07-vm0-volume-version-override.bats
+++ b/e2e/tests/02-parallel/t07-vm0-volume-version-override.bats
@@ -16,7 +16,7 @@ setup() {
     # Use unique test names with timestamp
     # Volume name must match the config's volume name for --volume-version to work
     export VOLUME_NAME="test-volume"
-    export ARTIFACT_NAME="e2e-art-override-$(date +%s)"
+    export ARTIFACT_NAME="e2e-art-override-$(date +%s%3N)-$RANDOM"
     export TEST_CONFIG="${TEST_ROOT}/fixtures/configs/vm0-volume-override.yaml"
 }
 

--- a/e2e/tests/02-parallel/t08-vm0-conversation-fork.bats
+++ b/e2e/tests/02-parallel/t08-vm0-conversation-fork.bats
@@ -17,7 +17,7 @@ setup() {
     # Create temporary test directory
     export TEST_ARTIFACT_DIR="$(mktemp -d)"
     # Use unique test artifact name with timestamp
-    export ARTIFACT_NAME="e2e-conversation-$(date +%s)"
+    export ARTIFACT_NAME="e2e-conversation-$(date +%s%3N)-$RANDOM"
     # Create inline config with unique agent name
     export TEST_CONFIG="$(mktemp --suffix=.yaml)"
     cat > "$TEST_CONFIG" <<EOF

--- a/e2e/tests/02-parallel/t09-vm0-artifact-empty.bats
+++ b/e2e/tests/02-parallel/t09-vm0-artifact-empty.bats
@@ -12,7 +12,7 @@ AGENT_NAME="e2e-t09"
 
 setup() {
     export TEST_ARTIFACT_DIR="$(mktemp -d)"
-    export ARTIFACT_NAME="e2e-empty-artifact-$(date +%s)"
+    export ARTIFACT_NAME="e2e-empty-artifact-$(date +%s%3N)-$RANDOM"
     # Create inline config with unique agent name
     export TEST_CONFIG="$(mktemp --suffix=.yaml)"
     cat > "$TEST_CONFIG" <<EOF

--- a/e2e/tests/02-parallel/t10-vm0-error-messages.bats
+++ b/e2e/tests/02-parallel/t10-vm0-error-messages.bats
@@ -15,7 +15,7 @@ setup() {
     # Create temporary test directory
     export TEST_ARTIFACT_DIR="$(mktemp -d)"
     # Use unique test artifact name with timestamp
-    export ARTIFACT_NAME="e2e-error-test-$(date +%s)"
+    export ARTIFACT_NAME="e2e-error-test-$(date +%s%3N)-$RANDOM"
     # Create inline config with unique agent name
     export TEST_CONFIG="$(mktemp --suffix=.yaml)"
     cat > "$TEST_CONFIG" <<EOF

--- a/e2e/tests/02-parallel/t11-vm0-compose-versioning.bats
+++ b/e2e/tests/02-parallel/t11-vm0-compose-versioning.bats
@@ -181,7 +181,7 @@ EOF
 # ============================================
 
 @test "vm0 run with version specifier runs specific version" {
-    export ARTIFACT_NAME="e2e-versioning-artifact-$(date +%s)"
+    export ARTIFACT_NAME="e2e-versioning-artifact-$(date +%s%3N)-$RANDOM"
 
     echo "# Creating initial config..."
     cat > "$TEST_DIR/vm0.yaml" <<EOF
@@ -234,7 +234,7 @@ EOF
 }
 
 @test "vm0 run with :latest tag runs HEAD version" {
-    export ARTIFACT_NAME="e2e-versioning-latest-$(date +%s)"
+    export ARTIFACT_NAME="e2e-versioning-latest-$(date +%s%3N)-$RANDOM"
 
     echo "# Creating config..."
     cat > "$TEST_DIR/vm0.yaml" <<EOF
@@ -267,7 +267,7 @@ EOF
 }
 
 @test "vm0 run with nonexistent version shows error" {
-    export ARTIFACT_NAME="e2e-versioning-error-$(date +%s)"
+    export ARTIFACT_NAME="e2e-versioning-error-$(date +%s%3N)-$RANDOM"
 
     echo "# Creating config..."
     cat > "$TEST_DIR/vm0.yaml" <<EOF
@@ -294,7 +294,7 @@ EOF
 }
 
 @test "vm0 run without version specifier runs HEAD (backward compatible)" {
-    export ARTIFACT_NAME="e2e-versioning-compat-$(date +%s)"
+    export ARTIFACT_NAME="e2e-versioning-compat-$(date +%s%3N)-$RANDOM"
 
     echo "# Creating config..."
     cat > "$TEST_DIR/vm0.yaml" <<EOF

--- a/e2e/tests/02-parallel/t12-vm0-env-expansion.bats
+++ b/e2e/tests/02-parallel/t12-vm0-env-expansion.bats
@@ -4,7 +4,7 @@ load '../../helpers/setup'
 
 setup() {
     export TEST_CONFIG="${TEST_ROOT}/fixtures/configs/vm0-env-expansion.yaml"
-    export UNIQUE_ID="$(date +%s)"
+    export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
     export SECRET_VALUE="secret-value-${UNIQUE_ID}"
     export VAR_VALUE="var-value-${UNIQUE_ID}"
     export ARTIFACT_NAME="e2e-env-test-${UNIQUE_ID}"

--- a/e2e/tests/02-parallel/t13-vm0-cook.bats
+++ b/e2e/tests/02-parallel/t13-vm0-cook.bats
@@ -6,7 +6,7 @@ setup() {
     # Create temporary test directory
     export TEST_DIR="$(mktemp -d)"
     # Use unique names with timestamp to avoid conflicts
-    export AGENT_NAME="e2e-cook-$(date +%s)"
+    export AGENT_NAME="e2e-cook-$(date +%s%3N)-$RANDOM"
 }
 
 teardown() {

--- a/e2e/tests/02-parallel/t15-vm0-telemetry.bats
+++ b/e2e/tests/02-parallel/t15-vm0-telemetry.bats
@@ -15,7 +15,7 @@ AGENT_NAME="e2e-t15"
 
 setup() {
     export TEST_ARTIFACT_DIR="$(mktemp -d)"
-    export ARTIFACT_NAME="e2e-telemetry-test-$(date +%s)"
+    export ARTIFACT_NAME="e2e-telemetry-test-$(date +%s%3N)-$RANDOM"
     # Create inline config with unique agent name
     export TEST_CONFIG="$(mktemp --suffix=.yaml)"
     cat > "$TEST_CONFIG" <<EOF

--- a/e2e/tests/02-parallel/t16-vm0-network-logs.bats
+++ b/e2e/tests/02-parallel/t16-vm0-network-logs.bats
@@ -12,7 +12,7 @@ load '../../helpers/setup'
 
 setup() {
     export TEST_ARTIFACT_DIR="$(mktemp -d)"
-    export ARTIFACT_NAME="e2e-network-logs-test-$(date +%s)"
+    export ARTIFACT_NAME="e2e-network-logs-test-$(date +%s%3N)-$RANDOM"
     export TEST_CONFIG="${TEST_ROOT}/fixtures/configs/vm0-network-security.yaml"
 }
 

--- a/e2e/tests/02-parallel/t17-vm0-simplified-compose.bats
+++ b/e2e/tests/02-parallel/t17-vm0-simplified-compose.bats
@@ -6,8 +6,8 @@ setup() {
     # Create temporary test directory for dynamic configs
     export TEST_DIR="$(mktemp -d)"
     # Use unique agent name with timestamp to avoid conflicts
-    export AGENT_NAME="e2e-simplified-$(date +%s)"
-    export ARTIFACT_NAME="e2e-simplified-artifact-$(date +%s)"
+    export AGENT_NAME="e2e-simplified-$(date +%s%3N)-$RANDOM"
+    export ARTIFACT_NAME="e2e-simplified-artifact-$(date +%s%3N)-$RANDOM"
 }
 
 teardown() {

--- a/e2e/tests/02-parallel/t22-vm0-compose-scope.bats
+++ b/e2e/tests/02-parallel/t22-vm0-compose-scope.bats
@@ -12,7 +12,7 @@ setup() {
     export TEST_DIR="$(mktemp -d)"
     # Use UUID for reliable uniqueness in parallel test runs
     export AGENT_NAME="e2e-scope-compose-$(cat /proc/sys/kernel/random/uuid | head -c 8)"
-    export ARTIFACT_NAME="e2e-scope-artifact-$(date +%s)"
+    export ARTIFACT_NAME="e2e-scope-artifact-$(date +%s%3N)-$RANDOM"
 }
 
 teardown() {

--- a/e2e/tests/02-parallel/t22-vm0-experimental-shorthand.bats
+++ b/e2e/tests/02-parallel/t22-vm0-experimental-shorthand.bats
@@ -5,7 +5,7 @@ load '../../helpers/setup'
 setup() {
     # Create temporary test directory for dynamic configs
     export TEST_DIR="$(mktemp -d)"
-    export UNIQUE_ID="$(date +%s)"
+    export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
     export AGENT_NAME="e2e-exp-shorthand-${UNIQUE_ID}"
     export ARTIFACT_NAME="e2e-exp-shorthand-artifact-${UNIQUE_ID}"
 }

--- a/e2e/tests/02-parallel/t24-vm0-skill-frontmatter.bats
+++ b/e2e/tests/02-parallel/t24-vm0-skill-frontmatter.bats
@@ -5,7 +5,7 @@ load '../../helpers/setup'
 setup() {
     # Create temporary test directory for dynamic configs
     export TEST_DIR="$(mktemp -d)"
-    export UNIQUE_ID="$(date +%s)"
+    export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
     export AGENT_NAME="e2e-skill-frontmatter-${UNIQUE_ID}"
     export ARTIFACT_NAME="e2e-skill-frontmatter-artifact-${UNIQUE_ID}"
 }

--- a/e2e/tests/02-parallel/t25-vm0-list-clone.bats
+++ b/e2e/tests/02-parallel/t25-vm0-list-clone.bats
@@ -7,7 +7,7 @@ load '../../helpers/setup'
 setup() {
     # Create temporary test directory
     export TEST_DIR="$(mktemp -d)"
-    export UNIQUE_ID="$(date +%s)"
+    export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
     export ARTIFACT_NAME="e2e-list-artifact-${UNIQUE_ID}"
     export VOLUME_NAME="e2e-list-volume-${UNIQUE_ID}"
 }


### PR DESCRIPTION
## Summary

- Replace second-level timestamp `$(date +%s)` with millisecond timestamp plus random number `$(date +%s%3N)-$RANDOM`
- Prevents name collisions when parallel tests run within the same second
- Addresses potential race conditions in CI where multiple test jobs could create storages with identical names

## Changes

**Before:** `e2e-empty-artifact-1767171389`
**After:** `e2e-empty-artifact-1767171502718-28875`

## Test plan

- [ ] CI E2E tests pass without name collision errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)