### PR TITLE
fix(runner): add postbuild script for npm publish

### DIFF
--- a/turbo/apps/runner/package.json
+++ b/turbo/apps/runner/package.json
@@ -17,6 +17,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "postbuild": "cp package.json dist/ && pnpm json -I -f dist/package.json -e 'this.name=\"@vm0/runner\"; delete this.private; delete this.scripts; delete this.devDependencies; this.bin[\"vm0-runner\"]=\"index.js\"; this.files=[\".\"]'",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -33,6 +34,7 @@
     "@vm0/eslint-config": "workspace:*",
     "@vm0/typescript-config": "workspace:*",
     "eslint": "^9.34.0",
+    "json": "^11.0.0",
     "tsup": "^8.5.0",
     "typescript": "5.9.2",
     "vitest": "^3.2.4"

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       eslint:
         specifier: ^9.34.0
         version: 9.34.0(jiti@2.6.1)
+      json:
+        specifier: ^11.0.0
+        version: 11.0.0
       tsup:
         specifier: ^8.5.0
         version: 8.5.0(@swc/core@1.15.7)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)


### PR DESCRIPTION
## Summary

- Add `postbuild` script to runner package to prepare `dist/package.json` for npm publishing
- Add `json` package to devDependencies (same as CLI uses)

This mirrors the CLI package's approach and fixes the npm publish failure.

## Root Cause

The `publish-runner-npm` workflow runs `npm publish` from the `dist/` directory, but the runner package didn't have a `postbuild` script to copy and prepare `package.json` for that directory.

**Failed workflow:** https://github.com/vm0-ai/vm0/actions/runs/20615794809

## Changes

The postbuild script:
- Copies `package.json` to `dist/`
- Removes `private: true`
- Removes `scripts` and `devDependencies`
- Adjusts `bin` path to `index.js`
- Sets `files` to `["."]`

## Test plan

- [x] Local build produces correct `dist/package.json`
- [x] Lint passes
- [x] Type check passes
- [x] Tests pass
- [ ] CI pipeline passes
- [ ] After merge, verify `publish-runner-npm` job succeeds
- [ ] Verify `npm install -g @vm0/runner` works

Fixes #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)