### PR TITLE
fix(runner): sync version with npm registry

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"turbo/apps/cli":"4.33.0","turbo/packages/core":"2.5.0","turbo/apps/web":"7.9.0","turbo/apps/docs":"0.7.0","turbo/apps/runner":"0.2.1"}
+{"turbo/apps/cli":"4.33.0","turbo/packages/core":"2.5.0","turbo/apps/web":"7.9.0","turbo/apps/docs":"0.7.0","turbo/apps/runner":"1.0.0"}

--- a/turbo/apps/runner/package.json
+++ b/turbo/apps/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vm0/runner",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "private": true,
   "description": "Self-hosted runner for VM0 agents",
   "repository": {

--- a/turbo/codereviews/20251230/commit-list-pr803.md
+++ b/turbo/codereviews/20251230/commit-list-pr803.md
@@ -1,0 +1,28 @@
+# PR #803 Code Review - Separate Secrets from Vars
+
+**PR Title:** feat: separate secrets from vars in checkpoint/session system
+**Author:** lancy
+**URL:** https://github.com/vm0-ai/vm0/pull/803
+
+## Commits to Review
+
+- [ ] `9dd1e752` feat(sandbox): add client-side secret masking
+- [ ] `18c36a8d` refactor(types): add secret-names field and deprecate secrets
+- [ ] `93c4c401` feat(db): add secret_names column to agent_runs and agent_sessions
+- [ ] `5ffbddc1` refactor(services): use secret-names instead of secrets
+- [ ] `2b7b39db` refactor(api): store secret-names instead of encrypted secrets
+- [ ] `63c906d8` refactor(webhooks): remove server-side secret masking
+- [ ] `761d9d54` feat(cli): add --vars and --secrets to resume/continue commands
+- [ ] `93015440` fix(db): register migration 0047 in drizzle journal
+- [ ] `f0a85509` test: remove server-side masking tests (now client-side)
+- [ ] `c7d8e2d3` test(e2e): update secrets tests - must be re-provided on continue/resume
+- [ ] `55da8d84` fix(sandbox): pass secret values for client-side masking
+- [ ] `d18c9aac` refactor(db): remove deprecated secrets column from database
+
+## Summary
+
+This PR implements a security improvement where secret values are never stored in the database. Instead:
+
+- Only secret names are stored for validation purposes
+- Secret values must be provided at runtime via `--secrets` flag
+- Client-side masking in the sandbox ensures secrets are masked before being sent to the server

--- a/turbo/codereviews/20251230/review-pr803-secrets-separation.md
+++ b/turbo/codereviews/20251230/review-pr803-secrets-separation.md
@@ -1,0 +1,99 @@
+# PR #803 Code Review - Separate Secrets from Vars
+
+**PR Title:** feat: separate secrets from vars in checkpoint/session system
+**Author:** lancy
+**URL:** https://github.com/vm0-ai/vm0/pull/803
+
+## Review Summary
+
+### Security Improvement ✅
+
+This PR implements a significant security improvement by ensuring **secret values are never persisted to the database**. The changes:
+
+1. Store only `secretNames: string[]` (names for validation) instead of encrypted secret values
+2. Require users to re-provide secrets via `--secrets` flag on `continue`/`resume` operations
+3. Move secret masking from server-side to client-side (in sandbox)
+
+### Commits Reviewed
+
+| Commit     | Description                                                              | Status |
+| ---------- | ------------------------------------------------------------------------ | ------ |
+| `9dd1e752` | feat(sandbox): add client-side secret masking                            | ✅     |
+| `18c36a8d` | refactor(types): add secret-names field and deprecate secrets            | ✅     |
+| `93c4c401` | feat(db): add secret_names column to agent_runs and agent_sessions       | ✅     |
+| `5ffbddc1` | refactor(services): use secret-names instead of secrets                  | ✅     |
+| `2b7b39db` | refactor(api): store secret-names instead of encrypted secrets           | ✅     |
+| `63c906d8` | refactor(webhooks): remove server-side secret masking                    | ✅     |
+| `761d9d54` | feat(cli): add --vars and --secrets to resume/continue commands          | ✅     |
+| `93015440` | fix(db): register migration 0047 in drizzle journal                      | ✅     |
+| `f0a85509` | test: remove server-side masking tests (now client-side)                 | ✅     |
+| `c7d8e2d3` | test(e2e): update secrets tests - must be re-provided on continue/resume | ✅     |
+| `55da8d84` | fix(sandbox): pass secret values for client-side masking                 | ✅     |
+| `d18c9aac` | refactor(db): remove deprecated secrets column from database             | ✅     |
+
+### Code Quality Assessment
+
+#### No Bad Code Smells Found ✅
+
+- **No `any` types** - All TypeScript code uses proper typing
+- **No `eslint-disable` comments** - Code follows lint rules
+- **No `@ts-ignore` or `@ts-nocheck`** - Type checking is maintained
+- **No dynamic imports** - Static imports used throughout
+- **No unnecessary mocks** - Tests use appropriate fixtures
+- **No setTimeout/useFakeTimers misuse** - No timing-related issues
+
+### Architecture Highlights
+
+#### 1. Client-Side Secret Masking (`secret_masker.py.ts`)
+
+The Python masking module is well-designed:
+
+- Pre-computes encoding variants (base64, URL-encoded) for efficient matching
+- Recursively masks secrets in nested data structures
+- Uses global lazy-initialized singleton pattern
+- Minimum secret length (5 chars) prevents false positives
+
+#### 2. Secure Value Passing (`e2b-service.ts:221-233`)
+
+```typescript
+// Pass secret values to sandbox for client-side masking
+// Values are base64 encoded and comma-separated
+if (context.secrets && Object.keys(context.secrets).length > 0) {
+  const secretValues = Object.values(context.secrets);
+  const encodedValues = secretValues.map((v) =>
+    Buffer.from(v).toString("base64"),
+  );
+  sandboxEnvVars.VM0_SECRET_VALUES = encodedValues.join(",");
+}
+```
+
+- Base64 encoding prevents shell injection issues
+- Only values are passed (names are already in environment)
+
+#### 3. Database Schema Changes
+
+Clean schema with proper documentation:
+
+- `secretNames: jsonb("secret_names").$type<string[]>()` - Only names stored
+- Comments explain "values never stored - must be provided at runtime"
+
+#### 4. Migration Strategy
+
+Two-step migration approach:
+
+1. `0047_add_secret_names.sql` - Add new column
+2. `0048_drop_secrets_column.sql` - Remove deprecated column
+
+Uses `DROP COLUMN IF EXISTS` for idempotency.
+
+### Potential Considerations
+
+1. **Breaking Change**: Users must now provide secrets on every continue/resume. This is documented in test updates and is the intended security behavior.
+
+2. **Base64 Encoding**: The comma-separated base64 format works but could theoretically fail if a secret contains encoded commas. The current implementation handles this correctly since base64 output never contains commas.
+
+### Verdict
+
+**APPROVED** ✅
+
+This PR successfully implements the security goal of never storing secret values. The code is clean, well-documented, properly tested, and follows project conventions.

--- a/turbo/codereviews/20251231/commit-list.md
+++ b/turbo/codereviews/20251231/commit-list.md
@@ -1,0 +1,31 @@
+# Code Review: PR #852 - fix(runner): add postbuild script for npm publish
+
+**Date:** 2025-12-31
+**Base Branch:** main
+**Head Branch:** fix/issue-850-runner-postbuild
+
+## Commits
+
+- [x] [194dfa6e](review-194dfa6e.md) - fix(runner): add postbuild script for npm publish - **APPROVED**
+
+## Summary
+
+**Overall Verdict:** APPROVED
+
+This PR adds a `postbuild` script to the runner package to prepare `dist/package.json` for npm publishing. The change:
+
+- Follows the exact pattern established by the CLI package
+- Makes minimal, targeted changes (2 lines in package.json)
+- Has been verified locally with successful build and test runs
+- All CI checks pass
+
+### Key Points
+
+1. **Correct implementation**: The postbuild script properly transforms package.json for publishing:
+   - Removes `private: true`
+   - Removes scripts and devDependencies
+   - Adjusts bin path for dist directory
+
+2. **Consistency**: Uses the same `json` package (v11.0.0) as the CLI
+
+3. **No issues found**: Clean, well-targeted fix with no code smells

--- a/turbo/codereviews/20251231/review-194dfa6e.md
+++ b/turbo/codereviews/20251231/review-194dfa6e.md
@@ -1,0 +1,82 @@
+# Review: 194dfa6e - fix(runner): add postbuild script for npm publish
+
+**Commit:** 194dfa6e20d930bdd8d0636b68d6551355351ed3
+**Author:** Lancy <lancy@vm0.ai>
+**Date:** 2025-12-31
+
+## Summary
+
+This commit adds a `postbuild` script to the runner package to prepare `dist/package.json` for npm publishing, mirroring the CLI package's approach.
+
+## Files Changed
+
+| File                             | Changes  |
+| -------------------------------- | -------- |
+| `turbo/apps/runner/package.json` | +2 lines |
+| `turbo/pnpm-lock.yaml`           | +3 lines |
+
+## Review Checklist
+
+### Code Quality
+
+- [x] **Follows existing patterns**: The postbuild script mirrors the CLI package's approach exactly
+- [x] **No unnecessary complexity**: Simple, single-purpose change
+- [x] **No over-engineering**: Uses existing tooling (`json` package) already in the monorepo
+
+### Specific Changes
+
+#### 1. postbuild script addition
+
+```json
+"postbuild": "cp package.json dist/ && pnpm json -I -f dist/package.json -e 'this.name=\"@vm0/runner\"; delete this.private; delete this.scripts; delete this.devDependencies; this.bin[\"vm0-runner\"]=\"index.js\"; this.files=[\".\"]'"
+```
+
+**Analysis:**
+
+- Correctly copies `package.json` to `dist/`
+- Removes `private: true` (required for npm publish)
+- Removes `scripts` and `devDependencies` (not needed in published package)
+- Adjusts `bin` path from `./dist/index.js` to `index.js` (correct for publish from dist)
+- Sets `files` to `["."]` (correct for publish from dist)
+
+**Comparison with CLI:**
+The CLI has an additional deletion: `delete this.dependencies["@vm0/core"]` because it bundles the `@vm0/core` workspace package. The runner doesn't have this dependency, so it's correctly omitted.
+
+#### 2. json devDependency addition
+
+```json
+"json": "^11.0.0"
+```
+
+**Analysis:**
+
+- Same version as CLI uses
+- Required for the `pnpm json` command in postbuild
+- Correctly added to devDependencies (not runtime dependency)
+
+### Bad Code Smell Analysis
+
+- [x] **No new mocks introduced**: N/A - build script only
+- [x] **No unnecessary try/catch**: N/A - build script only
+- [x] **No timer/delay misuse**: N/A - build script only
+- [x] **No dynamic imports**: N/A - build script only
+- [x] **Interface changes**: None - build configuration only
+
+### Test Coverage
+
+- [x] Existing tests pass (13 tests in runner package)
+- [x] Build verification performed locally
+- [x] `dist/package.json` output verified
+
+## Verdict
+
+**APPROVED**
+
+This is a minimal, well-targeted fix that:
+
+1. Follows the established pattern from the CLI package
+2. Makes no unnecessary changes
+3. Correctly addresses the npm publish failure
+4. Has been verified locally
+
+No issues found.


### PR DESCRIPTION
## Summary

- Sync runner version to 1.0.0 to match what's already on npm
- Next release will be 1.0.1+

## Root Cause

The `@vm0/runner` package was previously published as 1.0.0 on npm, but the repo version was at 0.2.1. npm refuses to publish a lower version as "latest".

## Changes

| File | Change |
|------|--------|
| `.release-please-manifest.json` | `runner: "0.2.1"` → `"1.0.0"` |
| `turbo/apps/runner/package.json` | `version: "0.2.1"` → `"1.0.0"` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)