### PR TITLE
feat(docs): add deep research agent tutorial series

### DIFF
--- a/turbo/apps/docs/content/docs/meta.json
+++ b/turbo/apps/docs/content/docs/meta.json
@@ -2,6 +2,7 @@
   "pages": [
     "index",
     "quick-start",
+    "tutorial",
     "core-concept",
     "usage",
     "model-selection",

--- a/turbo/apps/docs/content/docs/tutorial/custom-image.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/custom-image.mdx
@@ -1,0 +1,211 @@
+---
+title: Custom Container Image
+description: Create a custom image with GitHub CLI and automate repository commits
+---
+
+Now let's take your research agent to the next level by making it automatically commit research reports to a GitHub repository. To do this, we need to install the GitHub CLI tool in the agent's sandbox environment.
+
+## Prerequisites
+
+You'll need:
+
+- A GitHub account
+- A test repository where the agent can commit reports, create one if you don't have it
+- A GitHub personal access token with `content write` permission, you can create one at [github.com/settings/personal-access-tokens](https://github.com/settings/personal-access-tokens)
+
+You should have also completed the previous sections of this tutorial.
+
+## Step 1: Create a Dockerfile
+
+Create a `Dockerfile` in your project directory:
+
+```dockerfile title="Dockerfile"
+FROM node:20-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    python3 \
+    python3-pip \
+    python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code globally
+RUN npm install -g @anthropic-ai/claude-code
+```
+
+This Dockerfile starts from Node.js 20 slim image, installs system dependencies including Git and Python, adds the GitHub CLI tool, and finally installs Claude Code globally.
+
+<Callout type="info">
+  VM0 Dockerfiles only support `FROM` and `RUN` instructions. This is intentional - custom images are for pre-installing dependencies, not configuring application behavior. Learn more in the [Container Image documentation](/docs/core-concept/container-image).
+</Callout>
+
+## Step 2: Set Your Scope
+
+Before building images, you need to set your scope (your username namespace):
+
+```bash
+vm0 scope set your-username
+```
+
+Replace `your-username` with your preferred namespace. This creates a namespace for your images like `your-username/image-name`.
+
+## Step 3: Build the Image
+
+Build your custom image:
+
+```bash
+vm0 image build -f Dockerfile -n my-researcher-image
+```
+
+You'll see output showing the build progress:
+
+```
+Building image: my-researcher-image
+✓ Validated Dockerfile
+✓ Image built: a1b2c3d4
+✓ Image pushed: your-username/my-researcher-image:a1b2c3d4
+```
+
+This builds your custom image with GitHub CLI installed and pushes it to the VM0 registry.
+
+## Step 4: Update vm0.yaml
+
+Update your `vm0.yaml` to use the custom image and add the GitHub skill:
+
+```yaml title="vm0.yaml"
+version: "1.0"
+
+agents:
+  my-researcher:
+    provider: claude-code
+    image: my-researcher-image # [!code highlight]
+    instructions: AGENTS.md
+    environment:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    skills:
+      - https://github.com/vm0-ai/vm0-skills/tree/main/firecrawl
+      - https://github.com/vm0-ai/vm0-skills/tree/main/tavily
+      - https://github.com/vm0-ai/vm0-skills/tree/main/github # [!code highlight]
+```
+
+The key changes are:
+- Added `image: my-researcher-image` to use your custom image
+- Added the GitHub skill to enable GitHub operations
+
+## Step 5: Update Agent Instructions
+
+Update your `AGENTS.md` to include GitHub workflow:
+
+```markdown title="AGENTS.md"
+# Deep Research Agent
+
+You help me research topics by gathering information from multiple sources and creating a summary report.
+
+## What to do
+
+When I give you a research topic:
+
+1. `gh repo clone your-username/your-repo` as working directory and use `gh auth setup-git` make sure we have write permission
+2. Create a folder based on the research topic to keep things organized
+3. Using tavily figure out 3-5 good sources to look at
+4. Using firecrawl visit each source and grab the important info
+5. For each source, write a research report about what you found from that source
+6. Combine everything into one report called `report.md` that summarizes all the findings
+7. git commit & push
+
+That's it! Keep the files simple and readable.
+```
+
+The key changes are step 1 clones the GitHub repository as the working directory and sets up git authentication for write permission, so all research files are created inside the repo, and step 7 commits and pushes them to GitHub.
+
+## Step 6: Compose Your Agent
+
+Recompose your agent with the new image and skill:
+
+```bash
+vm0 compose vm0.yaml
+```
+
+You'll see output showing the GitHub skill being added:
+
+```
+  Auto-configured working_dir: /home/user/workspace
+Uploading instructions: AGENTS.md
+✓ Instructions uploaded: 1191fd33
+Uploading 3 skill(s)...
+  Downloading: https://github.com/vm0-ai/vm0-skills/tree/main/firecrawl
+  ✓ Skill (unchanged): firecrawl (119bf88e)
+  Downloading: https://github.com/vm0-ai/vm0-skills/tree/main/tavily
+  ✓ Skill (unchanged): tavily (f1cc346f)
+  Downloading: https://github.com/vm0-ai/vm0-skills/tree/main/github
+  ✓ Skill uploaded: github (30aa39f6)
+
+Skills require the following environment variables:
+
+  Secrets:
+    FIRECRAWL_API_KEY        <- firecrawl
+    TAVILY_API_KEY           <- tavily
+    GH_TOKEN                 (new) <- github
+
+? Approve 1 new secret(s)? › (Y/n)
+```
+
+VM0 is asking you to approve the new `GH_TOKEN` secret required by the GitHub skill. Type `y` and press Enter to continue.
+
+## Step 7: Run Your Agent
+
+Now let's run the agent. Since we're using GitHub repository to store research reports, we don't need the artifact parameter:
+
+```bash
+vm0 run my-researcher "research the latest developments in WebAssembly for 2025"
+```
+
+You'll see an error asking for the GitHub token:
+
+```
+✗ Run preparation failed
+  Missing required secrets: GH_TOKEN. Use '--secrets GH_TOKEN=<value>' to provide them.
+```
+
+Open your `.env` file and add the GitHub token:
+
+```bash title=".env"
+FIRECRAWL_API_KEY=fc-xxx
+TAVILY_API_KEY=tvly-xxx
+GH_TOKEN=ghp_xxx
+```
+
+Now run again:
+
+```bash
+vm0 run my-researcher "research the latest developments in WebAssembly for 2025"
+```
+
+After the agent finishes running, visit your GitHub repository. You should see the research report, similar to https://github.com/vm0-ai/tutorial-report/blob/main/webassembly-2025-developments/report.md
+
+## What Just Happened?
+
+You created a custom container image with GitHub CLI pre-installed, and integrated the GitHub skill to access git operations. The custom image approach lets you pre-install any tools or dependencies your agent needs, from programming languages to CLI tools. This eliminates the need to install tools during every run.
+
+<Callout>
+  This is optional. You can commit your changes if you want to save this milestone.
+
+  ```bash
+  git add .
+  git commit -m "feat: add custom image with github cli and auto-commit capability"
+  ```
+</Callout>
+
+## Next Steps
+
+Congratulations! The tutorial ends here. You've built a capable deep research agent. From here, you can visit [Model Selection](/docs/model-selection) to explore cost-effective model alternatives, check out [GitHub Actions integration](/docs/usage/github-actions) to learn how to schedule automated runs, or experiment with your `AGENTS.md` to customize the output format and agent behavior.

--- a/turbo/apps/docs/content/docs/tutorial/deep-research-agent.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/deep-research-agent.mdx
@@ -1,0 +1,27 @@
+---
+title: Overview
+description: Create an AI agent that conducts comprehensive research and syncs reports to GitHub
+---
+
+In this tutorial series, you'll build a powerful deep research agent that can autonomously gather information from multiple sources, analyze content, and sync comprehensive research reports to your GitHub repository.
+
+## What You'll Build
+
+By the end of this tutorial, your agent will be able to:
+
+- Search the web for relevant information using multiple strategies
+- Extract and analyze content from various sources
+- Synthesize findings into well-structured research reports
+- Automatically commit and push reports to your GitHub repository
+- Handle complex research queries that require multiple iterations
+
+## Tutorial Overview
+
+This tutorial is divided into several parts:
+
+1. **My First Agent** - Set up your first agent and verify it works
+2. **Writing Instructions** - Define your agent's research workflow
+3. **Adding Research Capabilities** - Enable web search and content extraction
+4. **GitHub Integration** - Automatically sync reports to your repository
+
+Let's get started!

--- a/turbo/apps/docs/content/docs/tutorial/meta.json
+++ b/turbo/apps/docs/content/docs/tutorial/meta.json
@@ -1,4 +1,10 @@
 {
   "title": "Tutorial",
-  "pages": ["deep-research-agent", "my-first-agent", "writing-instructions"]
+  "pages": [
+    "deep-research-agent",
+    "my-first-agent",
+    "writing-instructions",
+    "research-capabilities",
+    "custom-image"
+  ]
 }

--- a/turbo/apps/docs/content/docs/tutorial/meta.json
+++ b/turbo/apps/docs/content/docs/tutorial/meta.json
@@ -1,0 +1,8 @@
+{
+  "title": "Tutorial",
+  "pages": [
+    "deep-research-agent",
+    "my-first-agent",
+    "writing-instructions"
+  ]
+}

--- a/turbo/apps/docs/content/docs/tutorial/meta.json
+++ b/turbo/apps/docs/content/docs/tutorial/meta.json
@@ -1,8 +1,4 @@
 {
   "title": "Tutorial",
-  "pages": [
-    "deep-research-agent",
-    "my-first-agent",
-    "writing-instructions"
-  ]
+  "pages": ["deep-research-agent", "my-first-agent", "writing-instructions"]
 }

--- a/turbo/apps/docs/content/docs/tutorial/my-first-agent.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/my-first-agent.mdx
@@ -1,0 +1,256 @@
+---
+title: My First Agent
+description: Set up and run your first agent in 5 minutes
+---
+
+In this guide, you'll create your first VM0 agent, configure it, and run it to see how agents work.
+
+## Prerequisites
+
+Before starting, make sure you have:
+- VM0 CLI installed (`npm install -g @vm0/cli`)
+- Authenticated with VM0 (`vm0 auth login`)
+
+## Step 1: Create Your Project
+
+Create a new directory for your research agent:
+
+```bash
+mkdir research-agent
+cd research-agent
+```
+
+## Step 2: Initialize Your Agent
+
+Initialize a new VM0 agent project with a descriptive name:
+
+```bash
+vm0 init -n my-researcher
+```
+
+This command creates two important files:
+
+- **vm0.yaml** - Agent configuration file that defines provider, image, and environment settings
+- **AGENTS.md** - Instructions file that describes what your agent should do
+
+Let's look at what was created:
+
+```yaml title="vm0.yaml"
+version: "1.0"
+
+agents:
+  my-researcher:
+    provider: claude-code
+    # Build agentic workflow using natural language
+    instructions: AGENTS.md
+    # Agent skills - see https://github.com/vm0-ai/vm0-skills for available skills
+    # skills:
+    #   - https://github.com/vm0-ai/vm0-skills/tree/main/github
+    environment:
+      # Get token using: claude setup-token, then add to .env file
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+```
+
+```markdown title="AGENTS.md"
+# Agent Instructions
+
+You are a HackerNews AI content curator.
+
+## Workflow
+
+1. Go to HackerNews and read the top 10 articles
+2. Find and extract AI-related content from these articles
+3. Summarize the findings into a X (Twitter) post format
+4. Write the summary to content.md
+```
+
+The `vm0.yaml` file includes helpful comments showing you where to add skills and how the environment variables work. The `AGENTS.md` file provides a complete example workflow that you can study and customize. We'll modify this in the next part of the tutorial to build our research agent.
+
+## Step 3: Set Up Claude Code Token
+
+Your agent needs authentication to use Claude. Set up your OAuth token:
+
+```bash
+claude setup-token
+```
+
+This will open your browser to authenticate with Claude. After completing authentication, you'll receive a token.
+
+Create a `.env` file in your project directory:
+
+```bash
+echo "CLAUDE_CODE_OAUTH_TOKEN=<your-token>" > .env
+```
+
+<Callout type="info">
+Replace `<your-token>` with the actual token you received from the authentication process.
+</Callout>
+
+<Callout type="tip">
+You can also use other LLM providers instead of Claude, such as Moonshot (Kimi), MiniMax, DeepSeek, Z.AI (GLM), or OpenRouter. See [Model Selection](/docs/model-selection) for configuration options.
+</Callout>
+
+## Step 4: Run Your First Agent
+
+Now let's run your agent and watch it complete the workflow:
+
+```bash
+vm0 cook "let's do it"
+```
+
+You'll see output similar to this:
+
+```
+Reading config: vm0.yaml
+✓ Config validated: 1 agent, 0 volume(s)
+
+Processing artifact:
+> mkdir artifact
+> cd artifact
+> vm0 artifact init --name artifact
+> vm0 artifact push
+> cd ..
+
+Composing agent:
+> vm0 compose vm0.yaml
+  Auto-configured image: vm0/claude-code:latest
+  Auto-configured working_dir: /home/user/workspace
+Uploading instructions: AGENTS.md
+✓ Instructions (unchanged): b2d77a3d
+Uploading compose...
+✓ Compose version exists: your-username/my-researcher
+  Version: e2ec8e50
+
+Running agent:
+> vm0 run my-researcher --artifact-name artifact "let's do it"
+
+▶ Run started
+  Run ID:   56a0d396-7d95-4cde-a44d-232ad6f8a21f
+  Sandbox:  ic63cb57nrddkra94yzg7
+
+[init] Starting Claude Code agent
+  Session: 4b5d44f8-2d5f-494d-b8ce-698eb355096d
+  Model: claude-sonnet-4-5-20250929
+
+[text] I'll help you curate AI content from HackerNews! Let me create a todo list...
+[tool_use] TodoWrite
+[tool_use] WebFetch - https://news.ycombinator.com
+[tool_use] Write - /home/user/workspace/content.md
+
+[result] ✓ completed successfully
+  Duration: 54.0s
+  Cost: $0.1166
+
+✓ Run completed successfully
+
+Pulling updated artifact:
+> cd artifact
+> vm0 artifact pull b5abed3a
+> cd ..
+```
+
+Check your results:
+
+```bash
+ls artifact
+# Output: content.md
+
+cat artifact/content.md
+# You'll see the AI content summary!
+```
+
+<Callout type="success">
+If you see `artifact/content.md` created with HackerNews AI content, congratulations! Your agent is working correctly.
+</Callout>
+
+## What Just Happened?
+
+`vm0 cook` is a convenient command that runs multiple steps automatically. Here's what it did:
+
+### 1. Prepared Artifact Directory
+```bash
+mkdir artifact
+cd artifact
+vm0 artifact init --name artifact
+vm0 artifact push
+cd ..
+```
+This creates a workspace where your agent can save output files. The artifact directory is synced between your local machine and the remote agent.
+
+See [Artifact](/docs/core-concept/artifact) for more information about managing agent output.
+
+### 2. Composed Agent
+```bash
+vm0 compose vm0.yaml
+```
+This step binds your [instructions](/docs/core-concept/instructions), [skills](/docs/core-concept/skills), and [container image](/docs/core-concept/container-image) together to compose your agent.
+
+### 3. Ran Agent
+```bash
+vm0 run my-researcher --artifact-name artifact "let's do it"
+```
+This step creates a remote sandbox environment and executes your prompt using Claude Code with your configured instructions and skills, streaming real-time logs back to you.
+
+In this step, Claude Code follows your prompt "let's do it" along with the instructions in `AGENTS.md` to complete the workflow: fetching content from HackerNews, extracting AI-related articles, and generating the X (Twitter) post summary.
+
+### 4. Downloaded Results
+```bash
+cd artifact && vm0 artifact pull <artifact-version> && cd ..
+```
+Any files the agent created or modified are downloaded to your local `artifact` directory.
+
+## Understanding Your Project Structure
+
+After this step, your project should look like this:
+
+```
+research-agent/
+├── vm0.yaml       # Agent configuration
+├── AGENTS.md      # Agent instructions (system prompt)
+├── .env           # Your secrets (never commit this!)
+└── artifact/      # Output files from agent runs
+    └── content.md # HackerNews AI summary created by agent
+```
+
+## Before Moving On
+
+<Callout type="tip">
+This step is optional. If you're familiar with git and want to track your project changes, follow the steps below. Otherwise, you can skip directly to the next section.
+</Callout>
+
+Let's create a `.gitignore` file and commit your work. This is a good practice to track your project changes.
+
+Create a `.gitignore` file in your project directory:
+
+```bash
+cat > .gitignore << 'EOF'
+# Environment variables (contains secrets)
+.env
+
+# Artifact directory (already persisted in VM0 remote storage)
+artifact/
+EOF
+```
+
+<Callout type="info">
+The `artifact/` directory is automatically synced with VM0's remote storage, so you don't need to commit it to git. The `.env` file contains your API tokens and should never be committed for security reasons.
+</Callout>
+
+Initialize git repository and commit:
+
+```bash
+# Initialize git repository
+git init
+
+# Add files to staging
+git add .gitignore vm0.yaml AGENTS.md
+
+# Commit with a conventional commit message
+git commit -m "chore: initial agent setup with gitignore"
+```
+
+Now your project is tracked in git and sensitive files are protected!
+
+## Next Steps
+
+Continue to the next section to learn how to customize the AGENTS.md instructions and build a deep research agent.

--- a/turbo/apps/docs/content/docs/tutorial/research-capabilities.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/research-capabilities.mdx
@@ -1,0 +1,169 @@
+---
+title: Adding Research Capabilities
+description: Enhance your agent with Firecrawl and Tavily for better research
+---
+
+Now let's give your research agent some superpowers by adding specialized tools for web research.
+
+## Why Add These Tools?
+
+The built-in `WebSearch` and `WebFetch` tools are great for basic tasks, but they have limitations. WebSearch returns snippets and may not always give you full content. WebFetch can struggle with JavaScript-heavy sites or complex page structures.
+
+This is where specialized services come in:
+
+**Firecrawl** is a web scraping service that turns any website into clean, LLM-ready markdown. It handles JavaScript rendering, removes navigation and ads, and extracts just the content you need.
+
+**Tavily** is an AI-powered search API built specifically for LLMs. It understands context better than traditional search and returns highly relevant sources with clean summaries.
+
+Together, they create a powerful workflow: Tavily finds the best sources, and Firecrawl extracts clean content from them.
+
+## Prerequisites
+
+You'll need API keys from both services:
+
+- **Firecrawl API key** from [firecrawl.dev](https://firecrawl.dev) (500 credits/month free)
+- **Tavily API key** from [tavily.com](https://tavily.com) (1,000 credits/month free)
+
+You should have also completed the previous sections of this tutorial.
+
+## Step 1: Add Skills to vm0.yaml
+
+Open your `vm0.yaml` and add the skills section:
+
+```yaml title="vm0.yaml"
+version: "1.0"
+
+agents:
+  my-researcher:
+    provider: claude-code
+    instructions: AGENTS.md
+    environment:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    skills:
+      - https://github.com/vm0-ai/vm0-skills/tree/main/firecrawl
+      - https://github.com/vm0-ai/vm0-skills/tree/main/tavily
+```
+
+The skills section tells VM0 to load these integrations when composing your agent.
+
+<Callout type="info">
+  Learn more about [vm0.yaml configuration](/docs/reference/vm0-yaml) and the [skills system](/docs/core-concept/skills).
+</Callout>
+
+## Step 2: Update Agent Instructions
+
+Now update your `AGENTS.md` to use these new tools:
+
+```markdown title="AGENTS.md"
+# Deep Research Agent
+
+You help me research topics by gathering information from multiple sources and creating a summary report.
+
+## What to do
+
+When I give you a research topic:
+
+1. Create a folder based on the research topic to keep things organized
+2. Using tavily figure out 3-5 good sources to look at
+3. Using firecrawl visit each source and grab the important info
+4. For each source, write a research report about what you found from that source
+5. Combine everything into one report called `report.md` that summarizes all the findings
+
+That's it! Keep the files simple and readable.
+```
+
+The key changes are explicitly telling the agent to use tavily for search and firecrawl for content extraction.
+
+## Step 3: Compose Your Agent
+
+Recompose your agent to include the new skills:
+
+```bash
+vm0 compose vm0.yaml
+```
+
+You'll see output showing the skills being downloaded and uploaded:
+
+```
+  Auto-configured image: vm0/claude-code:latest
+  Auto-configured working_dir: /home/user/workspace
+Uploading instructions: AGENTS.md
+✓ Instructions uploaded: 15f0ffee
+Uploading 2 skill(s)...
+  Downloading: https://github.com/vm0-ai/vm0-skills/tree/main/firecrawl
+  ✓ Skill (unchanged): firecrawl (119bf88e)
+  Downloading: https://github.com/vm0-ai/vm0-skills/tree/main/tavily
+  ✓ Skill uploaded: tavily (f1cc346f)
+
+Skills require the following environment variables:
+
+  Secrets:
+    FIRECRAWL_API_KEY        (new) <- firecrawl
+    TAVILY_API_KEY           (new) <- tavily
+
+? Approve 2 new secret(s)? › (Y/n)
+```
+
+VM0 is asking you to approve the new secrets required by these skills. This is a security confirmation since the secrets are implicitly passed through the skills. Type `y` and press Enter to continue.
+
+## Step 4: Run Your Agent
+
+Let's test it out:
+
+```bash
+vm0 run my-researcher --artifact-name artifact "research the latest developments in WebAssembly for 2025"
+```
+
+You'll see an error asking for the API keys:
+
+```
+✗ Run preparation failed
+  Missing required secrets: TAVILY_API_KEY, FIRECRAWL_API_KEY. Use '--secrets TAVILY_API_KEY=<value>' to provide them.
+```
+
+Open your `.env` file and add the API keys:
+
+```bash title=".env"
+FIRECRAWL_API_KEY=fc-xxx
+TAVILY_API_KEY=tvly-xxx
+```
+
+Now run again:
+
+```bash
+vm0 run my-researcher --artifact-name artifact "research the latest developments in WebAssembly for 2025"
+```
+
+This time it should work! You'll see the agent:
+
+1. Use Tavily to find relevant sources
+2. Use Firecrawl to extract content from each source
+3. Create individual research reports
+4. Combine everything into a final report
+
+The research quality will be noticeably better compared to using basic web tools.
+
+## What Just Happened?
+
+The skills system integrated Firecrawl and Tavily into your agent's capabilities. When you composed the agent, VM0:
+
+1. Downloaded the skill definitions from GitHub
+2. Built the `$HOME/.claude/skills` directory structure to mount into the sandbox
+3. Injected the API keys from your environment into the sandbox securely
+
+During execution, Claude Code could see these tools in its available toolkit and used them according to your instructions. The combination of AI-powered search and clean content extraction produced much higher quality research.
+
+To learn more about how skills are mounted into the sandbox, see the [Volume documentation](/docs/core-concept/volume). For details on how environment variables and secrets work, check the [Environment Variables documentation](/docs/core-concept/environment-variable).
+
+<Callout>
+  This is optional. You can commit your changes if you want to save this milestone.
+
+  ```bash
+  git add .
+  git commit -m "feat: add firecrawl and tavily skills to research agent"
+  ```
+</Callout>
+
+## Next Steps
+
+Your research agent is now much more capable! Next we'll try making the agent automatically commit research records to a GitHub repository. This requires providing git and github cli tools to the agent sandbox. We'll learn how to achieve this by customizing the container image.

--- a/turbo/apps/docs/content/docs/tutorial/writing-instructions.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/writing-instructions.mdx
@@ -1,0 +1,259 @@
+---
+title: Writing Instructions
+description: Define your deep research agent's workflow with custom instructions
+---
+
+Now that you've run your first agent, let's customize it to become a deep research agent that can gather information from multiple sources and create comprehensive reports.
+
+## Prerequisites
+
+Make sure you've completed the previous step and have:
+- A `research-agent/` directory with `vm0.yaml`, `AGENTS.md`, and `.gitignore`
+- Claude Code token configured in `.env`
+- Successfully run `vm0 cook "let's do it"`
+- Committed your initial setup to git
+
+Your project structure should look like this:
+
+```
+research-agent/
+├── vm0.yaml
+├── AGENTS.md
+├── .gitignore
+├── .env
+└── artifact/
+    └── content.md
+```
+
+## Step 1: Design Your Research Workflow
+
+Let's design a simple deep research workflow:
+
+1. **Create a topic folder** to organize output files
+2. **Identify information sources** to research
+3. **Fetch from each source** and gather information
+4. **Save each source separately** as individual files
+5. **Synthesize final report** by combining all sources
+
+## Step 2: Update AGENTS.md
+
+Now let's update the `AGENTS.md` file to implement this workflow. Replace the entire content with:
+
+```markdown title="AGENTS.md"
+# Deep Research Agent
+
+You help me research topics by gathering information from multiple sources and creating a summary report.
+
+## What to do
+
+When I give you a research topic:
+
+1. Create a folder based on the research topic to keep things organized
+2. Figure out 3-5 good sources to look at
+3. Go visit each source and grab the important info
+4. For each source, write a research report about what you found from that source
+5. Combine everything into one report called `report.md` that summarizes all the findings
+
+That's it! Keep the files simple and readable.
+```
+
+Save this file and your research agent instructions are ready!
+
+## Step 3: Compose Your Agent
+
+Now we need to compose (build) the agent with the new instructions:
+
+```bash
+vm0 compose vm0.yaml
+```
+
+You should see output like:
+
+```
+Auto-configured image: vm0/claude-code:latest
+Auto-configured working_dir: /home/user/workspace
+Uploading instructions: AGENTS.md
+✓ Instructions (changed): a3f89b2c
+Uploading compose...
+✓ Compose version exists: your-username/my-researcher
+  Version: f4d29a81
+```
+
+<Callout type="success">
+Notice the instructions hash changed from the previous version. This means your new instructions have been uploaded successfully.
+</Callout>
+
+## Step 4: Run Your Research Agent
+
+Now let's test the research agent:
+
+```bash
+vm0 run my-researcher --artifact-name artifact "AI coding assistants"
+```
+
+You should see the agent create a todo list and start working:
+
+```
+[tool_use] TodoWrite
+  todos: [
+    "Create research folder for AI coding assistants",
+    "Identify 3-5 good sources about AI coding assistants",
+    "Gather information from each source",
+    "Write individual research reports for each source",
+    "Create final combined report (report.md)"
+  ]
+
+[tool_use] Bash
+  command: mkdir -p "ai_coding_assistants_research"
+  description: Create research folder
+```
+
+The agent will then visit multiple sources, gather information, and write individual reports:
+
+```
+[tool_result] Completed
+  File created successfully at: /home/user/workspace/ai_coding_assistants_research/source_1_features_comparison.md
+
+[tool_result] Completed
+  File created successfully at: /home/user/workspace/ai_coding_assistants_research/source_2_tool_comparison.md
+
+[tool_result] Completed
+  File created successfully at: /home/user/workspace/ai_coding_assistants_research/source_3_pair_programming.md
+
+[tool_result] Completed
+  File created successfully at: /home/user/workspace/ai_coding_assistants_research/source_4_enterprise_productivity.md
+```
+
+Finally, it will create the combined report that synthesizes all findings.
+
+When the agent completes, you'll see a summary:
+
+```
+[text] Perfect! I've completed your research on AI coding assistants. Here's what I created:
+
+## Research Complete
+
+I've gathered information from multiple sources and created a comprehensive research report
+in the `ai_coding_assistants_research` folder:
+
+### Files Created:
+
+1. source_1_features_comparison.md
+2. source_2_tool_comparison.md
+3. source_3_pair_programming.md
+4. source_4_enterprise_productivity.md
+5. report.md
+
+[result] ✓ completed successfully
+  Duration: 250.3s
+  Cost: $0.6441
+  Turns: 16
+  Tokens: input=2k output=10k
+```
+
+Check your results:
+
+```bash
+cd artifact && vm0 artifact pull && ls
+# You should see a folder like: ai_coding_assistants_research/
+
+ls ai_coding_assistants_research/
+# You should see files like:
+# source_1_features_comparison.md
+# source_2_tool_comparison.md
+# source_3_pair_programming.md
+# source_4_enterprise_productivity.md
+# report.md
+
+cat ai_coding_assistants_research/report.md
+# View the comprehensive research report
+```
+
+The final report will look something like this:
+
+```markdown
+# AI Coding Assistants: Comprehensive Research Report (2025)
+
+## Executive Summary
+
+AI coding assistants have transformed software development in 2025, with 76% of
+developers using or planning to use AI tools. This report synthesizes research on
+the leading AI coding assistants, their capabilities, enterprise applications, and
+impact on developer productivity.
+
+---
+
+## Market Landscape
+
+### Adoption Statistics
+- **76%** of developers say they use or plan to use AI tools
+- **62%** are already actively using them
+- **82%** of enterprises reportedly use GitHub Copilot
+
+[... detailed findings from each source ...]
+
+---
+
+## Sources
+
+### General Features and Comparison
+- [Best AI Coding Assistants as of December 2025 | Shakudo](...)
+- [20 Best AI Code Assistants Reviewed and Tested [August 2025]](...)
+
+### Tool-Specific Comparisons
+- [GitHub Copilot vs Cursor vs Claude: I Tested All AI Coding Tools](...)
+- [Claude, Cursor, Aider, Cline, Copilot: Which Is the Best One?](...)
+
+### Pair Programming
+- [Pair Programming with AI Coding Agents: Is It Beneficial?](...)
+
+### Enterprise and Productivity
+- [Tabnine AI Code Assistant](...)
+- [Amazon Q Developer – AWS](...)
+```
+
+## What Just Happened?
+
+By modifying `AGENTS.md`, we completely changed how the agent behaves. The agent now implements a deep research workflow: it identifies multiple sources, visits each one, writes individual reports, and synthesizes everything into a comprehensive final report.
+
+The same agent with different instructions does completely different work. The instructions file defines the agent's behavior and workflow.
+
+## Try Different Research Topics
+
+Your agent can now research any topic. Try these:
+
+```bash
+# Technology research
+vm0 run my-researcher --artifact-name artifact "latest developments in quantum computing"
+
+# Market analysis
+vm0 run my-researcher --artifact-name artifact "EV battery market"
+
+# Product comparison
+vm0 run my-researcher --artifact-name artifact "top 5 note-taking apps"
+
+# Academic research
+vm0 run my-researcher --artifact-name artifact "psychological effects of remote work"
+```
+
+## Before Moving On
+
+<Callout type="tip">
+This step is optional. If you're familiar with git and want to track your project changes, follow the steps below. Otherwise, you can skip directly to the next section.
+</Callout>
+
+Let's commit the updated instructions:
+
+```bash
+# Add the modified AGENTS.md
+git add AGENTS.md
+
+# Commit with a conventional commit message
+git commit -m "feat: update instructions for deep research workflow"
+```
+
+Now your changes are saved!
+
+## Next Steps
+
+Great! You've created a functional deep research agent. In the next part, we'll add better web scraping capabilities to improve the quality of information gathering.


### PR DESCRIPTION
This PR adds a comprehensive tutorial series for building a deep research agent.

## What's included

### Tutorial Structure
- **Overview** - Introduction to the tutorial series and what users will build
- **My First Agent** - Getting started guide (init, setup token, first run)
- **Writing Instructions** - Customizing AGENTS.md to build a deep research workflow

### Key Features
- Progressive learning path from basics to advanced
- Real examples with actual command output
- Optional git workflow sections for version control
- Simple, conversational writing style
- No external API dependencies in initial setup

### Tutorial Flow
1. Users create and run a basic HackerNews curator agent
2. Users learn to modify instructions to create a deep research agent
3. Agent researches topics by visiting multiple sources and creating reports
4. Next steps prepared for adding web scraping skills (future PR)

## Changes
- Created  directory
- Added three tutorial pages (overview, my-first-agent, writing-instructions)
- Updated docs navigation to include tutorial section
- Follows project conventions for docs structure and formatting