### PR TITLE
feat(docs): add claude model selection guide as first vendor

### DIFF
--- a/turbo/apps/docs/content/docs/index.mdx
+++ b/turbo/apps/docs/content/docs/index.mdx
@@ -37,9 +37,9 @@ Welcome to VM0 documentation. Get started with building AI agents.
     description="Enhance your agent with Firecrawl and Tavily for better research"
   />
   <Card
-    title="Custom Container Image"
+    title="Syncing Reports to GitHub"
     href="/docs/tutorial/custom-image"
-    description="Create a custom image with GitHub CLI and automate repository commits"
+    description="Enable your agent to automatically commit research reports to GitHub repositories"
   />
 </Cards>
 

--- a/turbo/apps/docs/content/docs/index.mdx
+++ b/turbo/apps/docs/content/docs/index.mdx
@@ -17,9 +17,9 @@ Welcome to VM0 documentation. Get started with building AI agents.
 
 <Cards>
   <Card
-    title="Deep Research Agent"
+    title="Overview"
     href="/docs/tutorial/deep-research-agent"
-    description="Build a deep research agent series"
+    description="Create an AI agent that conducts comprehensive research and syncs reports to GitHub"
   />
   <Card
     title="My First Agent"
@@ -29,17 +29,17 @@ Welcome to VM0 documentation. Get started with building AI agents.
   <Card
     title="Writing Instructions"
     href="/docs/tutorial/writing-instructions"
-    description="Define workflows with custom instructions"
+    description="Define your deep research agent's workflow with custom instructions"
   />
   <Card
     title="Adding Research Capabilities"
     href="/docs/tutorial/research-capabilities"
-    description="Enhance your agent with Firecrawl and Tavily"
+    description="Enhance your agent with Firecrawl and Tavily for better research"
   />
   <Card
     title="Custom Container Image"
     href="/docs/tutorial/custom-image"
-    description="Create custom images with GitHub CLI"
+    description="Create a custom image with GitHub CLI and automate repository commits"
   />
 </Cards>
 
@@ -77,9 +77,9 @@ Welcome to VM0 documentation. Get started with building AI agents.
     description="Persistent storage for agent files"
   />
   <Card
-    title="Environment Variable"
+    title="Environment Variables"
     href="/docs/core-concept/environment-variable"
-    description="Configure secrets and variables"
+    description="Configure secrets and variables for VM0 agents"
   />
 </Cards>
 
@@ -89,17 +89,17 @@ Welcome to VM0 documentation. Get started with building AI agents.
   <Card
     title="Run Agent"
     href="/docs/usage/run-agent"
-    description="Execute agent sessions"
+    description="Execute agents with vm0 run command"
   />
   <Card
     title="Debugging"
     href="/docs/usage/debugging"
-    description="Debug and troubleshoot agents"
+    description="Debug agent runs with checkpoints and logs"
   />
   <Card
     title="GitHub Actions"
     href="/docs/usage/github-actions"
-    description="CI/CD integration"
+    description="Automate agent deployment with GitHub Actions"
   />
 </Cards>
 
@@ -109,37 +109,37 @@ Welcome to VM0 documentation. Get started with building AI agents.
   <Card
     title="Overview"
     href="/docs/model-selection"
-    description="Configure LLM providers"
+    description="Configure different LLM providers for your agents"
   />
   <Card
     title="Claude"
     href="/docs/model-selection/claude"
-    description="Anthropic Claude models with full model control"
+    description="Use Claude models with full control over Opus, Sonnet, and Haiku selection"
   />
   <Card
     title="OpenRouter"
     href="/docs/model-selection/openrouter"
-    description="Multiple model providers"
+    description="Use multiple model providers through OpenRouter"
   />
   <Card
-    title="Moonshot"
+    title="Moonshot (Kimi)"
     href="/docs/model-selection/moonshot"
-    description="Kimi models"
+    description="Use Kimi K2 model with VM0"
   />
   <Card
     title="MiniMax"
     href="/docs/model-selection/minimax"
-    description="MiniMax models"
+    description="Use MiniMax M2.1 model with VM0"
   />
   <Card
     title="DeepSeek"
     href="/docs/model-selection/deepseek"
-    description="DeepSeek models"
+    description="Use DeepSeek models with VM0"
   />
   <Card
-    title="Z.AI"
+    title="Z.AI (GLM)"
     href="/docs/model-selection/zai"
-    description="GLM models"
+    description="Use GLM models with VM0"
   />
 </Cards>
 
@@ -149,42 +149,42 @@ Welcome to VM0 documentation. Get started with building AI agents.
   <Card
     title="GitHub"
     href="/docs/integration/github"
-    description="Code hosting"
+    description="Interact with GitHub repositories, issues, and pull requests"
   />
   <Card
     title="Slack"
     href="/docs/integration/slack"
-    description="Team communication"
+    description="Send messages and interact with Slack workspaces"
   />
   <Card
     title="Discord"
     href="/docs/integration/discord"
-    description="Community platform"
+    description="Send messages and manage Discord servers"
   />
   <Card
     title="Notion"
     href="/docs/integration/notion"
-    description="Documentation"
+    description="Create and manage Notion pages and databases"
   />
   <Card
     title="Linear"
     href="/docs/integration/linear"
-    description="Issue tracking"
+    description="Manage issues and projects in Linear"
   />
   <Card
     title="Jira"
     href="/docs/integration/jira"
-    description="Project management"
+    description="Project management and issue tracking"
   />
   <Card
     title="Supabase"
     href="/docs/integration/supabase"
-    description="Backend as a service"
+    description="PostgreSQL database with REST API"
   />
   <Card
     title="Firecrawl"
     href="/docs/integration/firecrawl"
-    description="Web scraping"
+    description="Web scraping and crawling with Firecrawl API"
   />
 </Cards>
 

--- a/turbo/apps/docs/content/docs/index.mdx
+++ b/turbo/apps/docs/content/docs/index.mdx
@@ -13,6 +13,36 @@ Welcome to VM0 documentation. Get started with building AI agents.
   />
 </Cards>
 
+## Tutorial
+
+<Cards>
+  <Card
+    title="Deep Research Agent"
+    href="/docs/tutorial/deep-research-agent"
+    description="Build a deep research agent series"
+  />
+  <Card
+    title="My First Agent"
+    href="/docs/tutorial/my-first-agent"
+    description="Set up and run your first agent in 5 minutes"
+  />
+  <Card
+    title="Writing Instructions"
+    href="/docs/tutorial/writing-instructions"
+    description="Define workflows with custom instructions"
+  />
+  <Card
+    title="Adding Research Capabilities"
+    href="/docs/tutorial/research-capabilities"
+    description="Enhance your agent with Firecrawl and Tavily"
+  />
+  <Card
+    title="Custom Container Image"
+    href="/docs/tutorial/custom-image"
+    description="Create custom images with GitHub CLI"
+  />
+</Cards>
+
 ## Core Concepts
 
 <Cards>

--- a/turbo/apps/docs/content/docs/index.mdx
+++ b/turbo/apps/docs/content/docs/index.mdx
@@ -82,6 +82,11 @@ Welcome to VM0 documentation. Get started with building AI agents.
     description="Configure LLM providers"
   />
   <Card
+    title="Claude"
+    href="/docs/model-selection/claude"
+    description="Anthropic Claude models with full model control"
+  />
+  <Card
     title="OpenRouter"
     href="/docs/model-selection/openrouter"
     description="Multiple model providers"

--- a/turbo/apps/docs/content/docs/model-selection/claude.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/claude.mdx
@@ -1,0 +1,137 @@
+---
+title: Claude
+description: Use Claude models with full control over Opus, Sonnet, and Haiku selection
+---
+
+Use Claude models with Claude Code. This gives you full control over model selection for different tasks and provides access to the latest Claude models.
+
+## Configuration
+
+Configure your agent to use specific Claude models by setting environment variables:
+
+```yaml title="vm0.yaml"
+version: "1.0"
+
+agents:
+  my-agent:
+    provider: claude-code
+    environment:
+      # Required: Claude Code OAuth token
+      CLAUDE_CODE_OAUTH_TOKEN: "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}" # [!code highlight]
+
+      # Optional: Configure specific models for each tier
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-5-20251101" # [!code highlight]
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-5-20250929" # [!code highlight]
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001" # [!code highlight]
+      CLAUDE_CODE_SUBAGENT_MODEL: "claude-sonnet-4-5-20250929" # [!code highlight]
+```
+
+## Environment Variables
+
+### Required
+
+| Name                      | Description                           |
+| ------------------------- | ------------------------------------- |
+| `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token from `claude setup-token` |
+
+Get your OAuth token by running `claude setup-token` in your terminal.
+
+### Optional Model Configuration
+
+These environment variables allow you to specify which Claude model to use for different tasks:
+
+| Variable                          | Description                                           | Default                      |
+| --------------------------------- | ----------------------------------------------------- | ---------------------------- |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL`    | Model for `opus`, or `opusplan` when Plan Mode is active | Latest Opus model            |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL`  | Model for `sonnet`, or `opusplan` when Plan Mode is inactive | Latest Sonnet model       |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL`   | Model for `haiku`, or background functionality        | Latest Haiku model           |
+| `CLAUDE_CODE_SUBAGENT_MODEL`      | Model for subagents                                   | Latest Sonnet model          |
+
+<Callout type="info">
+  If you don't specify these variables, Claude Code will automatically use the latest available models for each tier.
+</Callout>
+
+## Available Models
+
+See the complete list of available Claude models and their specifications in the [Anthropic documentation](https://docs.anthropic.com/en/docs/about-claude/models).
+
+<Callout type="warning">
+  You must use the **full model name** (e.g., `claude-sonnet-4-5-20250929`) in the environment variables, not aliases like `opus`, `sonnet`, or `haiku`.
+</Callout>
+
+## Usage Examples
+
+### Use Latest Models (Default)
+
+If you don't specify model environment variables, Claude Code automatically uses the latest models:
+
+```yaml title="vm0.yaml"
+version: "1.0"
+
+agents:
+  my-agent:
+    provider: claude-code
+    environment:
+      CLAUDE_CODE_OAUTH_TOKEN: "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
+```
+
+### Use All Opus Models
+
+For maximum intelligence across all tasks:
+
+```yaml title="vm0.yaml"
+version: "1.0"
+
+agents:
+  my-agent:
+    provider: claude-code
+    environment:
+      CLAUDE_CODE_OAUTH_TOKEN: "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-5-20251101" # [!code highlight]
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-opus-4-5-20251101" # [!code highlight]
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-opus-4-5-20251101" # [!code highlight]
+      CLAUDE_CODE_SUBAGENT_MODEL: "claude-opus-4-5-20251101" # [!code highlight]
+```
+
+### Use All Sonnet Models
+
+For balanced performance and cost:
+
+```yaml title="vm0.yaml"
+version: "1.0"
+
+agents:
+  my-agent:
+    provider: claude-code
+    environment:
+      CLAUDE_CODE_OAUTH_TOKEN: "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-sonnet-4-5-20250929" # [!code highlight]
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-5-20250929" # [!code highlight]
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-sonnet-4-5-20250929" # [!code highlight]
+      CLAUDE_CODE_SUBAGENT_MODEL: "claude-sonnet-4-5-20250929" # [!code highlight]
+```
+
+### Use All Haiku Models
+
+For maximum speed and cost-efficiency:
+
+```yaml title="vm0.yaml"
+version: "1.0"
+
+agents:
+  my-agent:
+    provider: claude-code
+    environment:
+      CLAUDE_CODE_OAUTH_TOKEN: "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-haiku-4-5-20251001" # [!code highlight]
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-haiku-4-5-20251001" # [!code highlight]
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001" # [!code highlight]
+      CLAUDE_CODE_SUBAGENT_MODEL: "claude-haiku-4-5-20251001" # [!code highlight]
+```
+
+## Resources
+
+- [Claude Code Documentation](https://code.claude.com/docs/en/model-config) - Model configuration guide
+- [Claude API Documentation](https://docs.anthropic.com/en/api/getting-started)
+- [Model Comparison](https://docs.anthropic.com/en/docs/about-claude/models)
+- [Pricing](https://www.anthropic.com/pricing)

--- a/turbo/apps/docs/content/docs/model-selection/index.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/index.mdx
@@ -63,9 +63,9 @@ agents:
       ANTHROPIC_MODEL: "model-name" # [!code highlight]
 ```
 
-### Supported Providers
+**Supported Providers:**
 
-- [Claude (Anthropic)](/docs/model-selection/claude)
+- [Claude](/docs/model-selection/claude)
 - [OpenRouter](/docs/model-selection/openrouter)
 - [Moonshot (Kimi)](/docs/model-selection/moonshot)
 - [MiniMax](/docs/model-selection/minimax)

--- a/turbo/apps/docs/content/docs/model-selection/index.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/index.mdx
@@ -65,6 +65,7 @@ agents:
 
 ### Supported Providers
 
+- [Claude (Anthropic)](/docs/model-selection/claude)
 - [OpenRouter](/docs/model-selection/openrouter)
 - [Moonshot (Kimi)](/docs/model-selection/moonshot)
 - [MiniMax](/docs/model-selection/minimax)

--- a/turbo/apps/docs/content/docs/model-selection/meta.json
+++ b/turbo/apps/docs/content/docs/model-selection/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Model Selection",
-  "pages": ["index", "openrouter", "moonshot", "minimax", "deepseek", "zai"]
+  "pages": ["index", "claude", "openrouter", "moonshot", "minimax", "deepseek", "zai"]
 }

--- a/turbo/apps/docs/content/docs/model-selection/meta.json
+++ b/turbo/apps/docs/content/docs/model-selection/meta.json
@@ -1,4 +1,12 @@
 {
   "title": "Model Selection",
-  "pages": ["index", "claude", "openrouter", "moonshot", "minimax", "deepseek", "zai"]
+  "pages": [
+    "index",
+    "claude",
+    "openrouter",
+    "moonshot",
+    "minimax",
+    "deepseek",
+    "zai"
+  ]
 }

--- a/turbo/apps/docs/content/docs/tutorial/custom-image.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/custom-image.mdx
@@ -1,6 +1,6 @@
 ---
-title: Custom Container Image
-description: Create a custom image with GitHub CLI and automate repository commits
+title: Syncing Reports to GitHub
+description: Enable your agent to automatically commit research reports to GitHub repositories
 ---
 
 Now let's take your research agent to the next level by making it automatically commit research reports to a GitHub repository. To do this, we need to install the GitHub CLI tool in the agent's sandbox environment.


### PR DESCRIPTION
## Summary
- Add Claude as the first vendor in the model selection documentation
- Document CLAUDE_CODE_OAUTH_TOKEN authentication
- Add environment variables for controlling Opus, Sonnet, and Haiku model selection
- Include usage examples for different model configurations
- Add missing Tutorial section to docs homepage to match sidebar navigation
- Sync all homepage card titles and descriptions with actual page content
- Improve tutorial naming to emphasize agent capabilities over implementation details

## Changes
- Created `/docs/model-selection/claude.mdx` with comprehensive Claude configuration guide
- Updated `/docs/model-selection/meta.json` to add Claude as first item
- Updated `/docs/model-selection/index.mdx` to list Claude as first supported provider
- Added Tutorial section to `/docs/index.mdx` with all 5 tutorial pages
- Updated all card titles and descriptions in `/docs/index.mdx` to match actual page frontmatter
- Renamed "Custom Container Image" to "Syncing Reports to GitHub" for consistency

## Documentation Improvements
- **Model Selection**: Configuration examples using CLAUDE_CODE_OAUTH_TOKEN, model selection with ANTHROPIC_DEFAULT_OPUS_MODEL, ANTHROPIC_DEFAULT_SONNET_MODEL, ANTHROPIC_DEFAULT_HAIKU_MODEL, usage examples for Opus, Sonnet, and Haiku models, links to official Claude Code and Anthropic documentation
- **Homepage Structure**: Tutorial section now appears on docs homepage matching sidebar structure
- **Content Consistency**: All card titles and descriptions now perfectly match the actual page content for Tutorial, Core Concepts, Usage, Model Selection, Integrations, and Reference sections
- **Tutorial Naming**: Tutorial titles now consistently emphasize agent capabilities ("Adding Research Capabilities", "Syncing Reports to GitHub") rather than technical implementation details

🤖 Generated with [Claude Code](https://claude.com/claude-code)