### PR TITLE
fix(docs): change Plausible domain to vm0.ai for unified tracking

### DIFF
--- a/turbo/apps/docs/src/app/layout.tsx
+++ b/turbo/apps/docs/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function Layout({ children }: LayoutProps<"/">) {
       <head>
         <script
           defer
-          data-domain="docs.vm0.ai"
+          data-domain="vm0.ai"
           src="https://plausible.io/js/script.js"
         ></script>
       </head>


### PR DESCRIPTION
## Summary
Change Plausible `data-domain` from `docs.vm0.ai` to `vm0.ai` to track all traffic under the main vm0.ai website.

## Problem
Currently docs analytics are configured to track under a separate `docs.vm0.ai` website in Plausible, requiring separate dashboard management.

## Solution
Use `data-domain="vm0.ai"` to consolidate all traffic (main site + docs) into a single Plausible website.

## Changes
```diff
- data-domain="docs.vm0.ai"
+ data-domain="vm0.ai"
```

## Result
- Unified analytics dashboard for all vm0.ai properties
- Docs traffic visible in vm0.ai Plausible website under `/docs/*` paths
- No need to manage separate Plausible website for docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>