### PR TITLE
fix(docs): use custom Plausible script to match main site

### DIFF
--- a/turbo/apps/docs/src/app/layout.tsx
+++ b/turbo/apps/docs/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function Layout({ children }: LayoutProps<"/">) {
         <script
           defer
           data-domain="vm0.ai"
-          src="https://plausible.io/js/script.js"
+          src="https://plausible.io/js/pa-eEj_2G8vS8xPlTUzW2A3U.js"
         ></script>
       </head>
       <body className="flex flex-col min-h-screen">


### PR DESCRIPTION
## Problem
Docs visits are not appearing in Plausible dashboard even though:
- ✅ Plausible API accepts events (202 status)
- ✅ Requests are sent from docs site
- ✅ Main site (vm0.ai) shows data correctly
- ✅ Both use `data-domain="vm0.ai"`

## Root Cause
Main site and docs use **different Plausible scripts**:

**Main site**: `pa-eEj_2G8vS8xPlTUzW2A3U.js` (custom/proxy script)
**Docs**: `script.js` (standard script)

The custom script is likely a Plausible proxy script (to bypass ad blockers) or enterprise version. For unified tracking, both sites must use the **same script**.

## Solution
Change docs to use the same custom Plausible script as main site:

```diff
- src="https://plausible.io/js/script.js"
+ src="https://plausible.io/js/pa-eEj_2G8vS8xPlTUzW2A3U.js"
```

## Result
After deployment, docs visits will appear in the vm0.ai Plausible dashboard alongside main site traffic.

## Test Plan
1. Deploy changes
2. Visit docs.vm0.ai
3. Check Plausible dashboard for vm0.ai
4. Verify docs pageviews appear under `/docs/*` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>