### PR TITLE
feat(web): remove cookbooks from navigation

### DIFF
--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -76,9 +76,6 @@ export default function Navbar() {
             >
               {t("blog")}
             </a>
-            <Link href="/cookbooks" className="nav-link">
-              {t("cookbooks")}
-            </Link>
             <Link href="/skills" className="nav-link">
               {t("skills")}
             </Link>
@@ -150,13 +147,6 @@ export default function Navbar() {
             >
               {t("blog")}
             </a>
-            <Link
-              href="/cookbooks"
-              className="mobile-menu-link"
-              onClick={() => setMobileMenuOpen(false)}
-            >
-              {t("cookbooks")}
-            </Link>
             <Link
               href="/skills"
               className="mobile-menu-link"


### PR DESCRIPTION
## Summary
Remove Cookbooks link from the main website navigation to streamline the user experience.

## Changes
- ❌ Remove Cookbooks link from desktop navigation
- ❌ Remove Cookbooks link from mobile menu

## Motivation
Simplify the navigation menu by removing the Cookbooks entry, allowing users to focus on the core offerings: Docs, Blog, Skills, and GitHub.

## Files Changed
- `turbo/apps/web/app/components/Navbar.tsx` - Updated navigation structure

## Testing
- [x] Desktop navigation displays correctly
- [x] Mobile menu displays correctly
- [x] TypeScript type checking passes
- [x] ESLint passes with no warnings
- [x] Pre-commit hooks pass

## Visual Changes
**Before:** Docs | Blog | Cookbooks | Skills | GitHub
**After:** Docs | Blog | Skills | GitHub

## Related
Note: The Cookbooks page (`/cookbooks`) and all its functionality remain intact. This change only removes the navigation entry point. Users can still access the page directly via URL.