### PR TITLE
feat(docs): add client-side route tracking for plausible analytics

### DIFF
--- a/turbo/apps/docs/src/app/layout.tsx
+++ b/turbo/apps/docs/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "@/app/global.css";
 import { RootProvider } from "fumadocs-ui/provider";
 import { Noto_Sans } from "next/font/google";
+import { PlausibleTracker } from "@/components/plausible-tracker";
 
 const notoSans = Noto_Sans({
   subsets: ["latin"],
@@ -18,7 +19,10 @@ export default function Layout({ children }: LayoutProps<"/">) {
         ></script>
       </head>
       <body className="flex flex-col min-h-screen">
-        <RootProvider>{children}</RootProvider>
+        <RootProvider>
+          <PlausibleTracker />
+          {children}
+        </RootProvider>
       </body>
     </html>
   );

--- a/turbo/apps/docs/src/components/plausible-tracker.tsx
+++ b/turbo/apps/docs/src/components/plausible-tracker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, Suspense } from "react";
 
 declare global {
   interface Window {
@@ -12,7 +12,7 @@ declare global {
   }
 }
 
-export function PlausibleTracker() {
+function PlausibleTrackerInner() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
@@ -26,4 +26,12 @@ export function PlausibleTracker() {
   }, [pathname, searchParams]);
 
   return null;
+}
+
+export function PlausibleTracker() {
+  return (
+    <Suspense fallback={null}>
+      <PlausibleTrackerInner />
+    </Suspense>
+  );
 }

--- a/turbo/apps/docs/src/components/plausible-tracker.tsx
+++ b/turbo/apps/docs/src/components/plausible-tracker.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+declare global {
+  interface Window {
+    plausible?: (
+      event: string,
+      options?: { u?: string; props?: Record<string, string | number> },
+    ) => void;
+  }
+}
+
+export function PlausibleTracker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    // Track pageview on route change
+    if (typeof window !== "undefined" && window.plausible) {
+      const url =
+        pathname + (searchParams?.toString() ? `?${searchParams}` : "");
+      window.plausible("pageview", { u: url });
+    }
+  }, [pathname, searchParams]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Fixes the issue where all doc page visits were being attributed to the homepage in Plausible analytics.

## Changes

- Added `PlausibleTracker` component that listens to Next.js App Router navigation events
- Triggers Plausible pageview events on client-side route changes  
- Integrated the tracker into the root layout

## Technical Details

Next.js App Router uses client-side navigation after the initial page load. The default Plausible script only tracks the initial page load, causing all subsequent navigation to not be recorded. This PR adds a client component that:

1. Uses `usePathname()` and `useSearchParams()` hooks to detect route changes
2. Calls `window.plausible('pageview', { u: url })` when the route changes
3. Properly constructs the URL including search parameters

## Testing

After deployment, each doc subpage visit will be properly recorded in Plausible with the correct path (e.g., `/docs/product-philosophy`, `/docs/quick-start`) instead of all being grouped under `/`.