### PR TITLE
fix(docs): skip plausible tracking on initial render

### DIFF
--- a/turbo/apps/docs/src/app/layout.tsx
+++ b/turbo/apps/docs/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "@/app/global.css";
 import { RootProvider } from "fumadocs-ui/provider";
 import { Noto_Sans } from "next/font/google";
+import { PlausibleTracker } from "@/components/plausible-tracker";
 
 const notoSans = Noto_Sans({
   subsets: ["latin"],
@@ -18,7 +19,10 @@ export default function Layout({ children }: LayoutProps<"/">) {
         ></script>
       </head>
       <body className="flex flex-col min-h-screen">
-        <RootProvider>{children}</RootProvider>
+        <RootProvider>
+          <PlausibleTracker />
+          {children}
+        </RootProvider>
       </body>
     </html>
   );

--- a/turbo/apps/docs/src/components/plausible-tracker.tsx
+++ b/turbo/apps/docs/src/components/plausible-tracker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect, Suspense } from "react";
+import { useEffect, useRef, Suspense } from "react";
 
 declare global {
   interface Window {
@@ -15,8 +15,16 @@ declare global {
 function PlausibleTrackerInner() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const isFirstRender = useRef(true);
 
   useEffect(() => {
+    // Skip tracking on initial mount - Plausible's script handles that
+    // Only track subsequent client-side navigation
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
     // Track pageview on route change
     if (typeof window !== "undefined" && window.plausible) {
       const url =

--- a/turbo/apps/docs/src/components/plausible-tracker.tsx
+++ b/turbo/apps/docs/src/components/plausible-tracker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, Suspense } from "react";
 
 declare global {
   interface Window {
@@ -12,7 +12,7 @@ declare global {
   }
 }
 
-export function PlausibleTracker() {
+function PlausibleTrackerInner() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
@@ -26,4 +26,12 @@ export function PlausibleTracker() {
   }, [pathname, searchParams]);
 
   return null;
+}
+
+export function PlausibleTracker() {
+  return (
+    <Suspense fallback={null}>
+      <PlausibleTrackerInner />
+    </Suspense>
+  );
 }

--- a/turbo/apps/docs/src/components/plausible-tracker.tsx
+++ b/turbo/apps/docs/src/components/plausible-tracker.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+declare global {
+  interface Window {
+    plausible?: (
+      event: string,
+      options?: { u?: string; props?: Record<string, string | number> },
+    ) => void;
+  }
+}
+
+export function PlausibleTracker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    // Track pageview on route change
+    if (typeof window !== "undefined" && window.plausible) {
+      const url =
+        pathname + (searchParams?.toString() ? `?${searchParams}` : "");
+      window.plausible("pageview", { u: url });
+    }
+  }, [pathname, searchParams]);
+
+  return null;
+}


### PR DESCRIPTION
## Problem

The PlausibleTracker component was tracking pageviews on initial mount, causing double-tracking:
1. Plausible's script tracks the initial page load
2. Our component also tracked the same page load

This resulted in inflated pageview counts and potentially incorrect analytics data.

## Solution  

Added a `useRef` to track the first render and skip tracking on initial mount. Now:
- Initial page load: Only Plausible's script tracks (as intended)
- Client-side navigation: Our component tracks each route change

## Testing

- ✅ Type check passed
- ✅ Lint passed
- ✅ Build succeeded locally

## Impact

After this fix deploys, Plausible analytics will show accurate pageview counts without double-counting initial page loads.