### PR TITLE
fix(docs): add function type check for plausible

### DIFF
--- a/turbo/apps/docs/src/components/plausible-tracker.tsx
+++ b/turbo/apps/docs/src/components/plausible-tracker.tsx
@@ -26,7 +26,10 @@ function PlausibleTrackerInner() {
     }
 
     // Track pageview on route change
-    if (typeof window !== "undefined" && window.plausible) {
+    if (
+      typeof window !== "undefined" &&
+      typeof window.plausible === "function"
+    ) {
       const url =
         pathname + (searchParams?.toString() ? `?${searchParams}` : "");
       window.plausible("pageview", { u: url });


### PR DESCRIPTION
## Summary

- Add proper function type check before calling `window.plausible()`
- Prevent `TypeError: window.plausible is not a function` errors

## Problem

The docs site was encountering errors when the Plausible analytics script hadn't fully loaded yet:

```
Uncaught TypeError: window.plausible is not a function
    at layout-5f1b04d702eb9301.js?dpl=dpl_DreGRGBvamUtb7Gw9HYwPkFXMwT6:1:4105
```

The original code only checked `if (window.plausible)` but didn't verify that `plausible` was actually a function before calling it.

## Solution

Changed the type check from:
```tsx
if (typeof window !== "undefined" && window.plausible) {
```

to:
```tsx
if (
  typeof window !== "undefined" &&
  typeof window.plausible === "function"
) {
```

This ensures the Plausible script is fully loaded and `window.plausible` is callable before attempting to track pageviews.

## Test Plan

- [ ] Build passes
- [ ] Deploy to production
- [ ] Verify no TypeErrors in browser console
- [ ] Confirm individual doc pages are tracked correctly in Plausible dashboard

## Related PRs

- #886 - Initial PlausibleTracker implementation with Suspense
- #888 - Added useRef to prevent double counting

🤖 Generated with [Claude Code](https://claude.com/claude-code)