### PR TITLE
fix(docs): add plausible initialization script

### DIFF
--- a/turbo/apps/docs/src/app/layout.tsx
+++ b/turbo/apps/docs/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "@/app/global.css";
 import { RootProvider } from "fumadocs-ui/provider";
 import { Noto_Sans } from "next/font/google";
+import Script from "next/script";
 import { PlausibleTracker } from "@/components/plausible-tracker";
 
 const notoSans = Noto_Sans({
@@ -12,11 +13,18 @@ export default function Layout({ children }: LayoutProps<"/">) {
   return (
     <html lang="en" className={notoSans.className} suppressHydrationWarning>
       <head>
-        <script
-          defer
-          data-domain="vm0.ai"
+        <Script
           src="https://plausible.io/js/pa-eEj_2G8vS8xPlTUzW2A3U.js"
-        ></script>
+          data-domain="vm0.ai"
+          strategy="afterInteractive"
+          async
+        />
+        <Script id="plausible-init" strategy="afterInteractive">
+          {`
+            window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+            plausible.init({domain:"vm0.ai"})
+          `}
+        </Script>
       </head>
       <body className="flex flex-col min-h-screen">
         <RootProvider>

--- a/turbo/apps/docs/src/components/plausible-tracker.tsx
+++ b/turbo/apps/docs/src/components/plausible-tracker.tsx
@@ -26,7 +26,10 @@ function PlausibleTrackerInner() {
     }
 
     // Track pageview on route change
-    if (typeof window !== "undefined" && window.plausible) {
+    if (
+      typeof window !== "undefined" &&
+      typeof window.plausible === "function"
+    ) {
       const url =
         pathname + (searchParams?.toString() ? `?${searchParams}` : "");
       window.plausible("pageview", { u: url });


### PR DESCRIPTION
## Summary

- Add Plausible initialization script to docs site
- Switch from native `<script>` tag to Next.js `<Script>` component
- Fix client-side navigation tracking

## Problem

User reported that Plausible analytics only showed **entry pages** but not subsequent page visits when navigating within the docs site. After investigation, we found that:

1. The main website (vm0.ai) has a Plausible initialization script that creates `window.plausible` as a function queue
2. The docs site (docs.vm0.ai) was missing this initialization script
3. Without the init script, `window.plausible` wasn't properly initialized, causing the PlausibleTracker component to fail silently

## Solution

Added the same Plausible initialization configuration used in the main website:

```tsx
<Script
  src="https://plausible.io/js/pa-eEj_2G8vS8xPlTUzW2A3U.js"
  data-domain="vm0.ai"
  strategy="afterInteractive"
  async
/>
<Script id="plausible-init" strategy="afterInteractive">
  {`
    window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)};
    plausible.init({domain:"vm0.ai"})
  `}
</Script>
```

This ensures:
- `window.plausible` is immediately available as a function
- Calls are queued if the main script hasn't loaded yet
- Queued calls execute once the script loads
- PlausibleTracker component can reliably track client-side navigation

## Changes

- Imported Next.js `Script` component
- Replaced native `<script>` tag with `<Script>` component
- Added `plausible-init` script for proper initialization
- Used `strategy="afterInteractive"` to match main website config

## Test Plan

- [ ] Build passes
- [ ] Deploy to production
- [ ] Clear browser cache and visit docs.vm0.ai
- [ ] Navigate between multiple doc pages
- [ ] Verify network requests to `plausible.io/api/event` for each navigation
- [ ] Check Plausible dashboard shows all visited pages, not just entry page

## Related PRs

- #886 - Initial PlausibleTracker with Suspense
- #888 - Added useRef to prevent double counting
- #891 - Added function type check

🤖 Generated with [Claude Code](https://claude.com/claude-code)