### PR TITLE
fix(docs): remove plausible.init call to prevent duplicate counting

### DIFF
--- a/turbo/apps/docs/src/app/layout.tsx
+++ b/turbo/apps/docs/src/app/layout.tsx
@@ -21,8 +21,7 @@ export default function Layout({ children }: LayoutProps<"/">) {
         />
         <Script id="plausible-init" strategy="afterInteractive">
           {`
-            window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
-            plausible.init({domain:"vm0.ai"})
+            window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)};
           `}
         </Script>
       </head>


### PR DESCRIPTION
## Summary

- Remove `plausible.init({domain:"vm0.ai"})` call that was causing duplicate visitor counting
- Keep only the function queue creation to ensure `window.plausible` is available

## Problem

User discovered that every page visit was being counted **twice (X2)**:
- First UV visit: ✓ tracked
- Subsequent page navigation: ✓ tracked but **X2 (duplicated)**
- After session ends: ✗ new pages not tracked

Testing confirmed:
- Single visitor session → Plausible showed **Visitors = 2**
- Each page visit counted **twice**

## Root Cause

The `plausible.init({domain:"vm0.ai"})` call in the initialization script was:
- Re-initializing Plausible tracking
- Creating duplicate tracking instances
- Causing every pageview to be processed twice

## Solution

Simplified the initialization script to:
```tsx
<Script id="plausible-init" strategy="afterInteractive">
  {`
    window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)};
  `}
</Script>
```

This ensures:
- ✅ `window.plausible` is immediately available (prevents TypeError)
- ✅ Calls are queued before main script loads
- ✅ **No duplicate initialization** - Plausible script handles init properly
- ✅ Each page counted only once

## Changes

**Before:**
```javascript
window.plausible=...||function(){...},plausible.init=...||function(){...};
plausible.init({domain:"vm0.ai"})  // ❌ Causing duplicate counting
```

**After:**
```javascript
window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)};
// ✅ No init call - let Plausible script handle it
```

## Test Plan

- [ ] Deploy to production
- [ ] Use incognito browser to visit docs.vm0.ai
- [ ] Navigate to 2-3 different pages
- [ ] Wait 2-3 minutes
- [ ] Check Plausible dashboard:
  - **Expected: Visitors = 1** (not 2!)
  - **Expected: Each page listed once in Top Pages** (not twice!)

## Related PRs

- #886 - Initial PlausibleTracker with Suspense
- #888 - Added useRef to prevent double counting  
- #891 - Added function type check
- #893 - Added plausible initialization script (introduced the duplicate counting bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)