### PR TITLE
fix(docs): prevent plausible duplicate visitor counting

### DIFF
--- a/turbo/apps/docs/src/app/layout.tsx
+++ b/turbo/apps/docs/src/app/layout.tsx
@@ -21,7 +21,8 @@ export default function Layout({ children }: LayoutProps<"/">) {
         />
         <Script id="plausible-init" strategy="afterInteractive">
           {`
-            window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)};
+            window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+            plausible.init({domain:"vm0.ai"})
           `}
         </Script>
       </head>

--- a/turbo/apps/docs/src/components/plausible-tracker.tsx
+++ b/turbo/apps/docs/src/components/plausible-tracker.tsx
@@ -16,12 +16,22 @@ function PlausibleTrackerInner() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isFirstRender = useRef(true);
+  const lastTrackedPath = useRef<string>("");
 
   useEffect(() => {
     // Skip tracking on initial mount - Plausible's script handles that
-    // Only track subsequent client-side navigation
     if (isFirstRender.current) {
       isFirstRender.current = false;
+      lastTrackedPath.current =
+        pathname + (searchParams?.toString() ? `?${searchParams}` : "");
+      return;
+    }
+
+    const currentPath =
+      pathname + (searchParams?.toString() ? `?${searchParams}` : "");
+
+    // Only track if path actually changed
+    if (currentPath === lastTrackedPath.current) {
       return;
     }
 
@@ -30,9 +40,8 @@ function PlausibleTrackerInner() {
       typeof window !== "undefined" &&
       typeof window.plausible === "function"
     ) {
-      const url =
-        pathname + (searchParams?.toString() ? `?${searchParams}` : "");
-      window.plausible("pageview", { u: url });
+      window.plausible("pageview", { u: currentPath });
+      lastTrackedPath.current = currentPath;
     }
   }, [pathname, searchParams]);
 


### PR DESCRIPTION
## Summary

Fix duplicate visitor counting while maintaining tracking functionality.

## Problem

User reported that every page visit was being counted **twice (X2)**:
- Single visitor session → Plausible showed **Visitors = 2**
- Each page visit counted twice
- After removing `plausible.init()`, tracking stopped working completely

## Root Cause

Two issues working together:
1. Missing `plausible.init()` call prevents tracking from working
2. `useEffect` triggering multiple times for the same path causes duplicate counting

## Solution

**1. Restore plausible.init() in layout.tsx** (required for tracking):
```tsx
<Script id="plausible-init" strategy="afterInteractive">
  {`
    window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
    plausible.init({domain:"vm0.ai"})
  `}
</Script>
```

**2. Add path deduplication in plausible-tracker.tsx**:
```tsx
const lastTrackedPath = useRef<string>("");

// Only track if path actually changed
if (currentPath === lastTrackedPath.current) {
  return;
}

window.plausible("pageview", { u: currentPath });
lastTrackedPath.current = currentPath;
```

This prevents duplicate pageviews from multiple useEffect triggers while keeping tracking functional.

## Changes

- `apps/docs/src/app/layout.tsx` - Restore plausible.init() call
- `apps/docs/src/components/plausible-tracker.tsx` - Add path deduplication logic

## Test Plan

- [ ] Deploy to production
- [ ] Use incognito browser to visit docs.vm0.ai
- [ ] Navigate to 2-3 different pages in same session
- [ ] Wait 2-3 minutes
- [ ] Check Plausible dashboard:
  - **Expected: Visitors = 1** (not 2!)
  - **Expected: Each page listed once** (not twice!)
  - **Expected: All pages tracked** (not missing!)

## Related PRs

- #886 - Initial PlausibleTracker with Suspense
- #888 - Added useRef to prevent double counting
- #891 - Added function type check
- #893 - Added plausible initialization script
- #895 - Attempted fix (closed due to GitHub cache issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)