### PR TITLE
fix(docs): remove data-domain to prevent duplicate pageview tracking

### DIFF
--- a/turbo/apps/docs/src/app/layout.tsx
+++ b/turbo/apps/docs/src/app/layout.tsx
@@ -21,7 +21,8 @@ export default function Layout({ children }: LayoutProps<"/">) {
         />
         <Script id="plausible-init" strategy="afterInteractive">
           {`
-            window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)};
+            window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+            plausible.init({domain:"vm0.ai"})
           `}
         </Script>
       </head>

--- a/turbo/apps/docs/src/app/layout.tsx
+++ b/turbo/apps/docs/src/app/layout.tsx
@@ -15,7 +15,6 @@ export default function Layout({ children }: LayoutProps<"/">) {
       <head>
         <Script
           src="https://plausible.io/js/pa-eEj_2G8vS8xPlTUzW2A3U.js"
-          data-domain="vm0.ai"
           strategy="afterInteractive"
           async
         />

--- a/turbo/apps/docs/src/components/plausible-tracker.tsx
+++ b/turbo/apps/docs/src/components/plausible-tracker.tsx
@@ -16,12 +16,22 @@ function PlausibleTrackerInner() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isFirstRender = useRef(true);
+  const lastTrackedPath = useRef<string>("");
 
   useEffect(() => {
     // Skip tracking on initial mount - Plausible's script handles that
-    // Only track subsequent client-side navigation
     if (isFirstRender.current) {
       isFirstRender.current = false;
+      lastTrackedPath.current =
+        pathname + (searchParams?.toString() ? `?${searchParams}` : "");
+      return;
+    }
+
+    const currentPath =
+      pathname + (searchParams?.toString() ? `?${searchParams}` : "");
+
+    // Only track if path actually changed
+    if (currentPath === lastTrackedPath.current) {
       return;
     }
 
@@ -30,9 +40,8 @@ function PlausibleTrackerInner() {
       typeof window !== "undefined" &&
       typeof window.plausible === "function"
     ) {
-      const url =
-        pathname + (searchParams?.toString() ? `?${searchParams}` : "");
-      window.plausible("pageview", { u: url });
+      window.plausible("pageview", { u: currentPath });
+      lastTrackedPath.current = currentPath;
     }
   }, [pathname, searchParams]);
 


### PR DESCRIPTION
## Summary
- Remove `data-domain` attribute from Plausible script tag in docs site
- Fixes duplicate pageview tracking where each navigation triggered 2 events

## Problem
When clicking navigation links, Plausible was sending **2 pageview events**:
1. One from the Plausible script's automatic tracking (enabled by `data-domain`)
2. One from the `PlausibleTracker` component's manual tracking

This caused:
- Duplicate visitor counting (Visitors = 2 instead of 1)
- Duplicate pageview counting on navigation

## Solution
Use manual mode only (`plausible.init()` + `PlausibleTracker`):
- Initial page load: Plausible script auto-tracks after `init()` is called
- Client-side navigation: Only `PlausibleTracker` sends pageview events
- No duplicate tracking

## Test plan
- [ ] Deploy and test in production
- [ ] Visit docs site in incognito mode
- [ ] Check Network tab shows only 1 pageview event on initial load
- [ ] Navigate to another page, verify only 1 pageview event
- [ ] Check Plausible dashboard shows correct visitor count (1, not 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)