### PR TITLE
fix(docs): remove plausibletracker to test automatic spa tracking

### DIFF
--- a/turbo/apps/docs/src/app/layout.tsx
+++ b/turbo/apps/docs/src/app/layout.tsx
@@ -2,7 +2,6 @@ import "@/app/global.css";
 import { RootProvider } from "fumadocs-ui/provider";
 import { Noto_Sans } from "next/font/google";
 import Script from "next/script";
-import { PlausibleTracker } from "@/components/plausible-tracker";
 
 const notoSans = Noto_Sans({
   subsets: ["latin"],
@@ -15,6 +14,7 @@ export default function Layout({ children }: LayoutProps<"/">) {
       <head>
         <Script
           src="https://plausible.io/js/pa-eEj_2G8vS8xPlTUzW2A3U.js"
+          data-domain="vm0.ai"
           strategy="afterInteractive"
           async
         />
@@ -26,10 +26,7 @@ export default function Layout({ children }: LayoutProps<"/">) {
         </Script>
       </head>
       <body className="flex flex-col min-h-screen">
-        <RootProvider>
-          <PlausibleTracker />
-          {children}
-        </RootProvider>
+        <RootProvider>{children}</RootProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Remove PlausibleTracker component to test Plausible's automatic SPA tracking
- Keep both data-domain and plausible.init() for now

## Purpose
This is a **diagnostic PR** to determine:
1. Can Plausible automatically track client-side navigation without PlausibleTracker?
2. Is the duplicate pageview issue caused by PlausibleTracker conflicting with automatic tracking?

## Current Configuration
- ✅ Script with `data-domain="vm0.ai"` (automatic tracking enabled)
- ✅ `plausible.init({domain:"vm0.ai"})` (manual initialization)
- ❌ PlausibleTracker component (removed)

## Expected Results

### If Plausible CAN auto-track navigation:
- Initial load: 1 pageview ✓
- Client-side navigation: Automatically tracked ✓
- No duplicate counting ✓
- **Solution**: Remove PlausibleTracker permanently

### If Plausible CANNOT auto-track navigation:
- Initial load: 1 pageview ✓
- Client-side navigation: NOT tracked ✗
- **Next step**: Keep PlausibleTracker but fix the duplicate issue differently

## Test Plan
- [ ] Deploy and test in production
- [ ] Initial load: Check only 1 pageview in Network tab
- [ ] Navigate to another page (click link in nav)
- [ ] Check if navigation is tracked in Plausible dashboard
- [ ] Check if visitor count is correct (1, not 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)