### PR TITLE
fix(runner): use sudo for cleanup scripts

### DIFF
--- a/turbo/scripts/deploy-runner/cleanup-runner.sh
+++ b/turbo/scripts/deploy-runner/cleanup-runner.sh
@@ -22,8 +22,8 @@ echo "Cleaning up runner for PR #${PR_NUMBER}..."
 # Stop pm2 process
 pm2 delete "$PROCESS_NAME" 2>/dev/null || true
 
-# Remove runner directory
-rm -rf "$RUNNER_DIR"
+# Remove runner directory (needs sudo as it was created with sudo)
+sudo rm -rf "$RUNNER_DIR"
 
 # Remove log file
 rm -f "$LOG_FILE"

--- a/turbo/scripts/deploy-runner/stop-runner.sh
+++ b/turbo/scripts/deploy-runner/stop-runner.sh
@@ -33,7 +33,7 @@ pm2 delete "$PROCESS_NAME" 2>/dev/null || true
 WORKSPACES_DIR="${RUNNER_DIR}/workspaces"
 if [ -d "$WORKSPACES_DIR" ]; then
   echo "Cleaning up workspaces: $WORKSPACES_DIR"
-  rm -rf "$WORKSPACES_DIR"
+  sudo rm -rf "$WORKSPACES_DIR"
 fi
 
 # Clean up TAP devices that may have been left behind


### PR DESCRIPTION
## Summary

Fix runner cleanup script permission issues and make scripts PR-isolated:

1. **Add sudo to cleanup scripts**:
   - `cleanup-runner.sh` - for removing runner directory
   - `stop-runner.sh` - for removing workspaces directory

2. **Remove global script location** (for PR isolation):
   - Remove copy to `/opt/vm0-runner/scripts/` 
   - Scripts now only exist in PR-specific location

3. **Update script paths**:
   - `turbo.yml` stop-runner: use `${RUNNER_DIR}/deploy-runner/stop-runner.sh`
   - `cleanup.yml`: use `${RUNNER_DIR}/deploy-runner/cleanup-runner.sh`

## Why this matters

Previously, scripts were copied to a global location which meant:
- PR-A's scripts could affect PR-B's runner
- No isolation between PRs

Now scripts are PR-isolated - each PR uses its own copy of scripts from its runner directory.

## Test plan
- [ ] Merge this PR
- [ ] Manually clean up PR 851: `ssh metal "sudo rm -rf /opt/vm0-runner/pr-851"`
- [ ] Future PR deployments should have proper isolation
- [ ] Future PR cleanups should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)