### PR TITLE
fix(ci): use pr-isolated paths for runner scripts

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -29,8 +29,9 @@ jobs:
           SSH_OPTS="-o StrictHostKeyChecking=no -i ~/.ssh/metal.pem"
           SSH_TARGET="${METAL_USER}@${METAL_HOST}"
 
+          RUNNER_DIR="/opt/vm0-runner/pr-${PR_NUMBER}"
           echo "Cleaning up runner for PR #${PR_NUMBER}..."
-          ssh $SSH_OPTS "$SSH_TARGET" "/opt/vm0-runner/scripts/cleanup-runner.sh '${PR_NUMBER}'"
+          ssh $SSH_OPTS "$SSH_TARGET" "${RUNNER_DIR}/deploy-runner/cleanup-runner.sh '${PR_NUMBER}'"
 
   cleanup-database:
     runs-on: ubuntu-latest

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -422,12 +422,13 @@ jobs:
         if: always() && needs.deploy-runner.outputs.runner-deployed == 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUNNER_DIR: ${{ needs.deploy-runner.outputs.runner-dir }}
           METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
           METAL_HOST: ${{ secrets.CI_AWS_METAL_RUNNER_HOST }}
         run: |
           SSH_OPTS="-o StrictHostKeyChecking=no -i /tmp/.ssh/metal.pem"
           SSH_TARGET="${METAL_USER}@${METAL_HOST}"
-          ssh $SSH_OPTS "$SSH_TARGET" "/opt/vm0-runner/scripts/stop-runner.sh '${PR_NUMBER}' --show-logs"
+          ssh $SSH_OPTS "$SSH_TARGET" "${RUNNER_DIR}/deploy-runner/stop-runner.sh '${PR_NUMBER}' --show-logs"
 
       - name: Stop Cron Simulator
         if: always()
@@ -514,10 +515,10 @@ jobs:
           scp $SSH_OPTS /tmp/vm0-runner-bundle.tar.gz "${SSH_TARGET}:/tmp/"
           ssh $SSH_OPTS "$SSH_TARGET" "rm -rf ${RUNNER_DIR}/* && tar -xzf /tmp/vm0-runner-bundle.tar.gz -C /tmp && cp -r /tmp/vm0-runner-bundle/* ${RUNNER_DIR}/ && rm -rf /tmp/vm0-runner-bundle /tmp/vm0-runner-bundle.tar.gz"
 
-          # Copy deploy scripts to Metal (PR-specific and global location)
+          # Copy deploy scripts to Metal (PR-specific location only for isolation)
           echo "Copying deploy scripts to Metal..."
           scp $SSH_OPTS -r turbo/scripts/deploy-runner "${SSH_TARGET}:${RUNNER_DIR}/"
-          ssh $SSH_OPTS "$SSH_TARGET" "sudo mkdir -p /opt/vm0-runner/scripts && sudo cp ${RUNNER_DIR}/deploy-runner/*.sh /opt/vm0-runner/scripts/ && sudo chmod +x /opt/vm0-runner/scripts/*.sh"
+          ssh $SSH_OPTS "$SSH_TARGET" "chmod +x ${RUNNER_DIR}/deploy-runner/*.sh"
 
           # Install Firecracker if not present (global, one-time)
           echo "Checking/Installing Firecracker..."


### PR DESCRIPTION
## Summary

Follow-up to #914. Make runner scripts PR-isolated instead of using global location.

**Changes:**
- Remove global script copy to `/opt/vm0-runner/scripts/` in deploy-runner
- Update `stop-runner` call to use `${RUNNER_DIR}/deploy-runner/stop-runner.sh`
- Update `cleanup-runner` call to use `${RUNNER_DIR}/deploy-runner/cleanup-runner.sh`

## Why this matters

Previously, scripts were copied to a global location which meant:
- PR-A's scripts could affect PR-B's runner
- No isolation between PRs

Now each PR uses its own copy of scripts from its runner directory.

## Test plan
- [ ] Merge this PR
- [ ] Next PR with runner changes will use isolated scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)