### PR TITLE
fix(ci): handle missing runner directory in cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -31,7 +31,10 @@ jobs:
 
           RUNNER_DIR="/opt/vm0-runner/pr-${PR_NUMBER}"
           echo "Cleaning up runner for PR #${PR_NUMBER}..."
-          ssh $SSH_OPTS "$SSH_TARGET" "${RUNNER_DIR}/deploy-runner/cleanup-runner.sh '${PR_NUMBER}'"
+
+          # Check if runner directory exists before cleanup
+          # (PR may not have deployed a runner if no runner code changes)
+          ssh $SSH_OPTS "$SSH_TARGET" "if [ -d '${RUNNER_DIR}' ]; then ${RUNNER_DIR}/deploy-runner/cleanup-runner.sh '${PR_NUMBER}'; else echo 'No runner directory to clean up (runner was not deployed for this PR)'; fi"
 
   cleanup-database:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Check if runner directory exists before attempting cleanup in cleanup.yml
- PRs that don't deploy a runner (no runner code changes) won't have a directory to clean up
- Fixes cleanup failure for PRs like #915 where deploy-runner job was skipped

## Context
The cleanup workflow was failing with:
```
bash: line 1: /opt/vm0-runner/pr-915/deploy-runner/cleanup-runner.sh: No such file or directory
```

This happened because PR #915 only modified workflow files, so the `deploy-runner` job was skipped and no PR-specific directory was created on the Metal server.

## Test plan
- [ ] Verify cleanup passes for PRs that deployed a runner
- [ ] Verify cleanup passes gracefully for PRs that didn't deploy a runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)