### PR TITLE
refactor: remove excessive defensive try-catch blocks

### DIFF
--- a/turbo/apps/cli/src/commands/compose.ts
+++ b/turbo/apps/cli/src/commands/compose.ts
@@ -167,25 +167,17 @@ export const composeCommand = new Command()
         const instructionsPath = agent.instructions as string;
         const provider = agent.provider as string | undefined;
         console.log(`Uploading instructions: ${instructionsPath}`);
-        try {
-          const result = await uploadInstructions(
-            agentName,
-            instructionsPath,
-            basePath,
-            provider,
-          );
-          console.log(
-            chalk.green(
-              `✓ Instructions ${result.action === "deduplicated" ? "(unchanged)" : "uploaded"}: ${result.versionId.slice(0, 8)}`,
-            ),
-          );
-        } catch (error) {
-          console.error(chalk.red(`✗ Failed to upload instructions`));
-          if (error instanceof Error) {
-            console.error(chalk.dim(`  ${error.message}`));
-          }
-          process.exit(1);
-        }
+        const result = await uploadInstructions(
+          agentName,
+          instructionsPath,
+          basePath,
+          provider,
+        );
+        console.log(
+          chalk.green(
+            `✓ Instructions ${result.action === "deduplicated" ? "(unchanged)" : "uploaded"}: ${result.versionId.slice(0, 8)}`,
+          ),
+        );
       }
 
       // Upload skills if specified and collect their frontmatter
@@ -194,22 +186,14 @@ export const composeCommand = new Command()
         const skillUrls = agent.skills as string[];
         console.log(`Uploading ${skillUrls.length} skill(s)...`);
         for (const skillUrl of skillUrls) {
-          try {
-            console.log(chalk.dim(`  Downloading: ${skillUrl}`));
-            const result = await uploadSkill(skillUrl);
-            skillResults.push(result);
-            console.log(
-              chalk.green(
-                `  ✓ Skill ${result.action === "deduplicated" ? "(unchanged)" : "uploaded"}: ${result.skillName} (${result.versionId.slice(0, 8)})`,
-              ),
-            );
-          } catch (error) {
-            console.error(chalk.red(`✗ Failed to upload skill: ${skillUrl}`));
-            if (error instanceof Error) {
-              console.error(chalk.dim(`  ${error.message}`));
-            }
-            process.exit(1);
-          }
+          console.log(chalk.dim(`  Downloading: ${skillUrl}`));
+          const result = await uploadSkill(skillUrl);
+          skillResults.push(result);
+          console.log(
+            chalk.green(
+              `  ✓ Skill ${result.action === "deduplicated" ? "(unchanged)" : "uploaded"}: ${result.skillName} (${result.versionId.slice(0, 8)})`,
+            ),
+          );
         }
       }
 

--- a/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
@@ -26,7 +26,9 @@ describe("scope set command", () => {
 
   describe("authentication", () => {
     it("should exit with error if not authenticated", async () => {
-      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.getScope).mockRejectedValue(
+        new Error("No scope configured"),
+      );
       vi.mocked(apiClient.createScope).mockRejectedValue(
         new Error("Not authenticated"),
       );
@@ -47,7 +49,9 @@ describe("scope set command", () => {
 
   describe("create new scope", () => {
     it("should create scope successfully", async () => {
-      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.getScope).mockRejectedValue(
+        new Error("No scope configured"),
+      );
       vi.mocked(apiClient.createScope).mockResolvedValue({
         id: "test-id",
         slug: "testslug",
@@ -72,7 +76,9 @@ describe("scope set command", () => {
     });
 
     it("should create scope with display name", async () => {
-      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.getScope).mockRejectedValue(
+        new Error("No scope configured"),
+      );
       vi.mocked(apiClient.createScope).mockResolvedValue({
         id: "test-id",
         slug: "testslug",
@@ -153,7 +159,9 @@ describe("scope set command", () => {
 
   describe("error handling", () => {
     it("should handle slug already taken", async () => {
-      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.getScope).mockRejectedValue(
+        new Error("No scope configured"),
+      );
       vi.mocked(apiClient.createScope).mockRejectedValue(
         new Error("Scope already exists"),
       );
@@ -169,7 +177,9 @@ describe("scope set command", () => {
     });
 
     it("should handle reserved slug", async () => {
-      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.getScope).mockRejectedValue(
+        new Error("No scope configured"),
+      );
       vi.mocked(apiClient.createScope).mockRejectedValue(
         new Error('Scope slug "vm0" is reserved'),
       );
@@ -185,7 +195,9 @@ describe("scope set command", () => {
     });
 
     it("should handle vm0 prefix rejection", async () => {
-      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.getScope).mockRejectedValue(
+        new Error("No scope configured"),
+      );
       vi.mocked(apiClient.createScope).mockRejectedValue(
         new Error('Scope slug "vm0test" is reserved'),
       );
@@ -201,7 +213,9 @@ describe("scope set command", () => {
     });
 
     it("should handle unexpected errors", async () => {
-      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.getScope).mockRejectedValue(
+        new Error("No scope configured"),
+      );
       vi.mocked(apiClient.createScope).mockRejectedValue(
         new Error("Unexpected error"),
       );
@@ -217,7 +231,9 @@ describe("scope set command", () => {
     });
 
     it("should handle non-Error exceptions", async () => {
-      vi.mocked(apiClient.getScope).mockRejectedValue(new Error("Not found"));
+      vi.mocked(apiClient.getScope).mockRejectedValue(
+        new Error("No scope configured"),
+      );
       vi.mocked(apiClient.createScope).mockRejectedValue("Unknown error");
 
       await expect(async () => {

--- a/turbo/apps/cli/src/commands/scope/set.ts
+++ b/turbo/apps/cli/src/commands/scope/set.ts
@@ -18,8 +18,15 @@ export const setCommand = new Command()
         let existingScope;
         try {
           existingScope = await apiClient.getScope();
-        } catch {
-          // No existing scope - that's fine
+        } catch (error) {
+          // Only swallow "No scope configured" errors - that's the expected case for new users
+          // All other errors (network, auth, etc.) should propagate to the outer handler
+          if (
+            !(error instanceof Error) ||
+            !error.message.includes("No scope configured")
+          ) {
+            throw error;
+          }
         }
 
         let scope;

--- a/turbo/apps/cli/src/commands/volume/pull.ts
+++ b/turbo/apps/cli/src/commands/volume/pull.ts
@@ -143,7 +143,11 @@ export const pullCommand = new Command()
     } catch (error) {
       console.error(chalk.red("✗ Pull failed"));
       if (error instanceof Error) {
-        console.error(chalk.dim(`  ${error.message}`));
+        if (error.message.includes("Not authenticated")) {
+          console.error(chalk.dim("  Run: vm0 auth login"));
+        } else {
+          console.error(chalk.dim(`  ${error.message}`));
+        }
       }
       process.exit(1);
     }

--- a/turbo/apps/cli/src/commands/volume/push.ts
+++ b/turbo/apps/cli/src/commands/volume/push.ts
@@ -59,7 +59,11 @@ export const pushCommand = new Command()
     } catch (error) {
       console.error(chalk.red("✗ Push failed"));
       if (error instanceof Error) {
-        console.error(chalk.dim(`  ${error.message}`));
+        if (error.message.includes("Not authenticated")) {
+          console.error(chalk.dim("  Run: vm0 auth login"));
+        } else {
+          console.error(chalk.dim(`  ${error.message}`));
+        }
       }
       process.exit(1);
     }

--- a/turbo/apps/cli/src/commands/volume/status.ts
+++ b/turbo/apps/cli/src/commands/volume/status.ts
@@ -83,7 +83,11 @@ export const statusCommand = new Command()
     } catch (error) {
       console.error(chalk.red("✗ Status check failed"));
       if (error instanceof Error) {
-        console.error(chalk.dim(`  ${error.message}`));
+        if (error.message.includes("Not authenticated")) {
+          console.error(chalk.dim("  Run: vm0 auth login"));
+        } else {
+          console.error(chalk.dim(`  ${error.message}`));
+        }
       }
       process.exit(1);
     }

--- a/turbo/apps/runner/src/commands/start.ts
+++ b/turbo/apps/runner/src/commands/start.ts
@@ -49,15 +49,9 @@ async function executeJob(
     console.error(`  Job ${context.runId} execution failed: ${error}`);
 
     // Report failure to server if VM execution failed before bootstrap
-    try {
-      const result = await completeJob(context, 1, error);
-      console.log(`  Job ${context.runId} reported as ${result.status}`);
-    } catch (reportErr) {
-      console.error(
-        `  Failed to report job ${context.runId} completion:`,
-        reportErr instanceof Error ? reportErr.message : "Unknown error",
-      );
-    }
+    // Let errors propagate - the caller's .catch() will handle them
+    const result = await completeJob(context, 1, error);
+    console.log(`  Job ${context.runId} reported as ${result.status}`);
   }
 }
 

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -353,17 +353,10 @@ export async function executeJob(
       error: errorMsg,
     };
   } finally {
-    // Always cleanup VM
+    // Always cleanup VM - let errors propagate (fail-fast principle)
     if (vm) {
       console.log(`[Executor] Cleaning up VM ${vmId}...`);
-      try {
-        await vm.kill();
-      } catch (error) {
-        console.error(
-          `[Executor] Failed to cleanup VM ${vmId}:`,
-          error instanceof Error ? error.message : error,
-        );
-      }
+      await vm.kill();
     }
   }
 }

--- a/turbo/apps/runner/src/lib/firecracker/guest.ts
+++ b/turbo/apps/runner/src/lib/firecracker/guest.ts
@@ -200,15 +200,10 @@ export class SSHClient {
     intervalMs: number = 2000,
   ): Promise<void> {
     const start = Date.now();
-    let lastError: Error | null = null;
 
     while (Date.now() - start < timeoutMs) {
-      try {
-        if (await this.isReachable()) {
-          return;
-        }
-      } catch (err) {
-        lastError = err instanceof Error ? err : new Error(String(err));
+      if (await this.isReachable()) {
+        return;
       }
 
       // Wait before retry
@@ -223,7 +218,7 @@ export class SSHClient {
     }
 
     throw new Error(
-      `SSH not reachable after ${timeoutMs}ms at ${this.config.host}: ${lastError?.message || "timeout"}`,
+      `SSH not reachable after ${timeoutMs}ms at ${this.config.host}`,
     );
   }
 

--- a/turbo/apps/runner/src/lib/firecracker/vm.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vm.ts
@@ -257,11 +257,13 @@ export class FirecrackerVM {
     try {
       // Send graceful shutdown signal
       if (this.client) {
-        try {
-          await this.client.sendCtrlAltDel();
-        } catch {
-          // API may fail if VM is already stopping
-        }
+        await this.client.sendCtrlAltDel().catch((error: unknown) => {
+          // Expected: API may fail if VM is already stopping
+          console.log(
+            `[VM ${this.config.vmId}] Graceful shutdown signal failed (VM may already be stopping):`,
+            error instanceof Error ? error.message : error,
+          );
+        });
       }
     } finally {
       await this.cleanup();

--- a/turbo/apps/web/app/[locale]/cookbooks/page.tsx
+++ b/turbo/apps/web/app/[locale]/cookbooks/page.tsx
@@ -25,16 +25,11 @@ interface CookbookMetadata {
 }
 
 async function getCookbooks(): Promise<CookbookMetadata[]> {
-  try {
-    // Import the API handler directly for server-side rendering
-    const { GET } = await import("../../api/web/cookbooks/route");
-    const response = await GET();
-    const data = await response.json();
-    return data.cookbooks || [];
-  } catch (error) {
-    console.error("Error fetching cookbooks:", error);
-    return [];
-  }
+  // Import the API handler directly for server-side rendering
+  const { GET } = await import("../../api/web/cookbooks/route");
+  const response = await GET();
+  const data = await response.json();
+  return data.cookbooks || [];
 }
 
 export default async function CookbooksPage() {

--- a/turbo/apps/web/app/[locale]/skills/page.tsx
+++ b/turbo/apps/web/app/[locale]/skills/page.tsx
@@ -25,17 +25,12 @@ interface SkillMetadata {
 }
 
 async function getSkills(): Promise<SkillMetadata[]> {
-  try {
-    // Import the API handler directly for server-side rendering
-    // This avoids issues with VERCEL_URL vs custom domain
-    const { GET } = await import("../../api/web/skills/route");
-    const response = await GET();
-    const data = await response.json();
-    return data.skills || [];
-  } catch (error) {
-    console.error("Error fetching skills:", error);
-    return [];
-  }
+  // Import the API handler directly for server-side rendering
+  // This avoids issues with VERCEL_URL vs custom domain
+  const { GET } = await import("../../api/web/skills/route");
+  const response = await GET();
+  const data = await response.json();
+  return data.skills || [];
 }
 
 export default async function SkillsPage() {

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -192,8 +192,7 @@ const router = tsr.router(webhookCompleteContract, {
         .set({
           status: "failed",
           completedAt: new Date(),
-          error:
-            error instanceof Error ? error.message : "Complete API failed",
+          error: error instanceof Error ? error.message : "Complete API failed",
         })
         .where(eq(agentRuns.id, body.runId));
 

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -185,20 +185,17 @@ const router = tsr.router(webhookCompleteContract, {
     } catch (error) {
       log.error("Error:", error);
 
-      // Try to update run status to failed
-      try {
-        await globalThis.services.db
-          .update(agentRuns)
-          .set({
-            status: "failed",
-            completedAt: new Date(),
-            error:
-              error instanceof Error ? error.message : "Complete API failed",
-          })
-          .where(eq(agentRuns.id, body.runId));
-      } catch {
-        log.error("Failed to update run status after error");
-      }
+      // Update run status to failed - if this fails, let it propagate
+      // since we can't recover from a database error anyway
+      await globalThis.services.db
+        .update(agentRuns)
+        .set({
+          status: "failed",
+          completedAt: new Date(),
+          error:
+            error instanceof Error ? error.message : "Complete API failed",
+        })
+        .where(eq(agentRuns.id, body.runId));
 
       // Still try to kill sandbox on error
       if (sandboxId) {

--- a/turbo/apps/web/src/lib/blob/blob-service.ts
+++ b/turbo/apps/web/src/lib/blob/blob-service.ts
@@ -87,21 +87,10 @@ export class BlobService {
     );
 
     // Step 2: Query database for existing blobs
-    let existingBlobs;
-    try {
-      existingBlobs = await globalThis.services.db
-        .select({ hash: blobs.hash })
-        .from(blobs)
-        .where(inArray(blobs.hash, uniqueHashes));
-    } catch (queryError) {
-      log.error("Failed to query blobs table", {
-        error: queryError,
-        cause: (queryError as { cause?: unknown }).cause,
-        message: (queryError as Error).message,
-        uniqueHashes: uniqueHashes.length,
-      });
-      throw queryError;
-    }
+    const existingBlobs = await globalThis.services.db
+      .select({ hash: blobs.hash })
+      .from(blobs)
+      .where(inArray(blobs.hash, uniqueHashes));
 
     const existingHashSet = new Set(existingBlobs.map((b) => b.hash));
     const newHashes = uniqueHashes.filter((h) => !existingHashSet.has(h));


### PR DESCRIPTION
## Summary

Remove defensive programming anti-patterns per issue #910, following the fail-fast principle.

- **CLI**: Remove nested try-catch blocks in `run.ts`, `compose.ts`; improve error handling in `scope/set.ts` and volume commands
- **Runner**: Remove defensive catches in cleanup/error handling paths
- **Web**: Remove log-and-rethrow patterns in API routes and services

## Changes by Area

### CLI Commands
| File | Change |
|------|--------|
| `run.ts` | Remove 3 nested try-catch blocks covered by outer CLI handler |
| `compose.ts` | Remove 2 nested try-catch blocks for upload operations |
| `scope/set.ts` | Only swallow specific "No scope configured" error, re-throw others |
| `volume/*.ts` | Add consistent auth error hints for better UX |

### Runner
| File | Change |
|------|--------|
| `start.ts` | Remove nested try-catch in completeJob call |
| `executor.ts` | Remove defensive try-catch in finally block cleanup |
| `guest.ts` | Remove redundant try-catch in waitUntilReachable (isReachable never throws) |
| `vm.ts` | Add logging to empty catch block for graceful shutdown |

### Web
| File | Change |
|------|--------|
| `complete/route.ts` | Remove nested try-catch for db status update |
| `blob-service.ts` | Remove log-and-rethrow anti-pattern |

## Test plan

- [x] All lint checks pass
- [x] All type checks pass
- [ ] CI pipeline passes

Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)