### PR TITLE
fix(runner): use config server url instead of claim response

### DIFF
--- a/turbo/apps/runner/src/commands/start.ts
+++ b/turbo/apps/runner/src/commands/start.ts
@@ -50,7 +50,7 @@ async function executeJob(
 
     // Report failure to server if VM execution failed before bootstrap
     // Let errors propagate - the caller's .catch() will handle them
-    const result = await completeJob(context, 1, error);
+    const result = await completeJob(config.server.url, context, 1, error);
     console.log(`  Job ${context.runId} reported as ${result.status}`);
   }
 }

--- a/turbo/apps/runner/src/lib/api.ts
+++ b/turbo/apps/runner/src/lib/api.ts
@@ -120,8 +120,10 @@ export interface CompleteJobResult {
 /**
  * Report job completion to the server
  * Uses the sandbox token for authentication
+ * apiUrl comes from runner config, not from execution context
  */
 export async function completeJob(
+  apiUrl: string,
   context: ExecutionContext,
   exitCode: number,
   error?: string,
@@ -137,18 +139,15 @@ export async function completeJob(
     headers["x-vercel-protection-bypass"] = bypassSecret;
   }
 
-  const response = await fetch(
-    `${context.apiUrl}/api/webhooks/agent/complete`,
-    {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        runId: context.runId,
-        exitCode,
-        error,
-      }),
-    },
-  );
+  const response = await fetch(`${apiUrl}/api/webhooks/agent/complete`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      runId: context.runId,
+      exitCode,
+      error,
+    }),
+  });
 
   if (!response.ok) {
     const errorData = (await response.json()) as ApiErrorResponse;

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -50,9 +50,10 @@ function getVmIdFromRunId(runId: string): string {
  */
 function buildEnvironmentVariables(
   context: ExecutionContext,
+  apiUrl: string,
 ): Record<string, string> {
   const envVars: Record<string, string> = {
-    VM0_API_URL: context.apiUrl,
+    VM0_API_URL: apiUrl,
     VM0_RUN_ID: context.runId,
     VM0_API_TOKEN: context.sandboxToken,
     VM0_PROMPT: context.prompt,
@@ -300,7 +301,8 @@ export async function executeJob(
 
     // Build environment variables and write as JSON file in VM
     // Using JSON avoids shell escaping issues entirely - Python loads it directly
-    const envVars = buildEnvironmentVariables(context);
+    // API URL comes from runner config, not from claim response
+    const envVars = buildEnvironmentVariables(context, config.server.url);
     const envJson = JSON.stringify(envVars);
     console.log(
       `[Executor] Writing env JSON (${envJson.length} bytes) to ${ENV_JSON_PATH}`,

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -20,26 +20,6 @@ import { validateRunnerGroupScope } from "../../../../../../src/lib/scope/scope-
 
 const log = logger("api:runners:jobs:claim");
 
-/**
- * Get the API URL for the runner to use when calling webhooks.
- * Uses VM0_API_URL if set, otherwise falls back to VERCEL_URL for preview deployments.
- */
-function getApiUrl(): string {
-  // Explicit configuration takes precedence
-  if (globalThis.services.env.VM0_API_URL) {
-    return globalThis.services.env.VM0_API_URL;
-  }
-
-  // Use Vercel URL for preview deployments
-  const vercelUrl = process.env.VERCEL_URL;
-  if (vercelUrl) {
-    return `https://${vercelUrl}`;
-  }
-
-  // Production fallback
-  return "https://www.vm0.ai";
-}
-
 const router = tsr.router(runnersJobClaimContract, {
   claim: async ({ params }) => {
     initServices();
@@ -167,6 +147,7 @@ const router = tsr.router(runnersJobClaimContract, {
     );
 
     // Return execution context (context already prepared at job creation)
+    // Note: apiUrl is not returned - runner uses its configured server.url
     return {
       status: 200 as const,
       body: {
@@ -177,7 +158,6 @@ const router = tsr.router(runnersJobClaimContract, {
         secretNames: run.secretNames ?? null,
         checkpointId: run.resumedFromCheckpointId ?? null,
         sandboxToken,
-        apiUrl: getApiUrl(),
         // From stored context (prepared at job creation):
         workingDir: storedContext.workingDir,
         storageManifest: storedContext.storageManifest,

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -112,7 +112,6 @@ export const executionContextSchema = z.object({
   secretNames: z.array(z.string()).nullable(),
   checkpointId: z.string().uuid().nullable(),
   sandboxToken: z.string(),
-  apiUrl: z.string(),
   // New fields for E2B parity:
   workingDir: z.string(),
   storageManifest: storageManifestSchema.nullable(),


### PR DESCRIPTION
## Summary

- Remove apiUrl from claim API response
- Runner now uses its configured `server.url` for all API callbacks
- Ensures consistency regardless of where the run was originally created

## Problem

When a run is created through a preview deployment URL but executed by a production runner, the VM would try to call back to the preview URL (which requires Vercel bypass auth), causing 401 errors.

## Solution

The runner's configured `server.url` is now the single source of truth for API callbacks, eliminating any URL mismatch issues.

## Changes

- `packages/core/src/contracts/runners.ts`: Remove `apiUrl` from `ExecutionContext` schema
- `apps/web/app/api/runners/jobs/[id]/claim/route.ts`: Remove `getApiUrl()` function and `apiUrl` from response
- `apps/runner/src/lib/executor.ts`: Pass `config.server.url` to `buildEnvironmentVariables`
- `apps/runner/src/lib/api.ts`: `completeJob` accepts `apiUrl` as first parameter
- `apps/runner/src/commands/start.ts`: Pass `config.server.url` to `completeJob`

## Test plan

- [ ] Deploy runner with production URL config
- [ ] Create run via production CLI
- [ ] Verify VM callbacks use production URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)