### PR TITLE
fix(runner): connect as user instead of root via ssh

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -518,14 +518,35 @@ jobs:
           ssh $SSH_OPTS "$SSH_TARGET" "cd ${RUNNER_DIR}/deploy-runner && ./install-firecracker.sh"
 
           # Build rootfs from Dockerfile (global, shared across all PRs)
-          # Only rebuild if not exists or FORCE_REBUILD_ROOTFS is set
+          # Rebuild if: rootfs doesn't exist, or Dockerfile changed (based on hash)
           GLOBAL_ROOTFS="/opt/firecracker/rootfs.ext4"
+          ROOTFS_HASH_FILE="/opt/firecracker/rootfs.hash"
+          DOCKERFILE_HASH=$(sha256sum turbo/scripts/deploy-runner/Dockerfile | cut -d' ' -f1)
           echo "Checking global rootfs at ${GLOBAL_ROOTFS}..."
-          if ssh $SSH_OPTS "$SSH_TARGET" "[ -f ${GLOBAL_ROOTFS} ]"; then
-            echo "Global rootfs already exists, skipping build"
+          echo "Current Dockerfile hash: ${DOCKERFILE_HASH}"
+
+          NEEDS_REBUILD="false"
+          if ! ssh $SSH_OPTS "$SSH_TARGET" "[ -f ${GLOBAL_ROOTFS} ]"; then
+            echo "Rootfs does not exist, will build"
+            NEEDS_REBUILD="true"
+          elif ! ssh $SSH_OPTS "$SSH_TARGET" "[ -f ${ROOTFS_HASH_FILE} ]"; then
+            echo "Rootfs hash file does not exist, will rebuild to track changes"
+            NEEDS_REBUILD="true"
           else
+            REMOTE_HASH=$(ssh $SSH_OPTS "$SSH_TARGET" "cat ${ROOTFS_HASH_FILE}")
+            if [ "${DOCKERFILE_HASH}" != "${REMOTE_HASH}" ]; then
+              echo "Dockerfile changed (${REMOTE_HASH} -> ${DOCKERFILE_HASH}), will rebuild"
+              NEEDS_REBUILD="true"
+            else
+              echo "Rootfs up to date (hash: ${DOCKERFILE_HASH})"
+            fi
+          fi
+
+          if [ "${NEEDS_REBUILD}" = "true" ]; then
             echo "Building global rootfs from Dockerfile..."
             ssh $SSH_OPTS "$SSH_TARGET" "cd ${RUNNER_DIR}/deploy-runner && ./build-rootfs.sh ${GLOBAL_ROOTFS}"
+            ssh $SSH_OPTS "$SSH_TARGET" "echo '${DOCKERFILE_HASH}' | sudo tee ${ROOTFS_HASH_FILE}"
+            echo "Rootfs built and hash saved"
           fi
 
           echo "Runner deployed to ${RUNNER_DIR} for PR #${PR_NUMBER}"

--- a/turbo/scripts/deploy-runner/Dockerfile
+++ b/turbo/scripts/deploy-runner/Dockerfile
@@ -50,7 +50,9 @@ RUN npm install -g @anthropic-ai/claude-code@latest
 # Create 'user' account (UID 1000) matching E2B sandbox default
 # - Home directory at /home/user
 # - Add to sudo group for privileged operations
-RUN useradd -m -u 1000 -s /bin/bash user \
+# Note: node:24-bookworm-slim has 'node' user at UID 1000, so we delete it first
+RUN userdel -r node 2>/dev/null || true \
+    && useradd -m -u 1000 -s /bin/bash user \
     && usermod -aG sudo user \
     && echo 'user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
     && passwd -d user

--- a/turbo/scripts/deploy-runner/Dockerfile
+++ b/turbo/scripts/deploy-runner/Dockerfile
@@ -47,12 +47,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Claude Code CLI globally (matching e2b template)
 RUN npm install -g @anthropic-ai/claude-code@latest
 
+# Create 'user' account (UID 1000) matching E2B sandbox default
+# - Home directory at /home/user
+# - Add to sudo group for privileged operations
+RUN useradd -m -u 1000 -s /bin/bash user \
+    && usermod -aG sudo user \
+    && echo 'user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    && passwd -d user
+
 # Configure SSH server for VM communication
-# - Allow root login with empty password (acceptable for ephemeral sandboxes)
+# - Allow root and user login with empty password (acceptable for ephemeral sandboxes)
 # - Disable DNS lookup for faster connections
-# - Create required directories
-RUN mkdir -p /run/sshd /root/.ssh \
-    && chmod 700 /root/.ssh \
+# - Create required directories for both root and user
+RUN mkdir -p /run/sshd /root/.ssh /home/user/.ssh \
+    && chmod 700 /root/.ssh /home/user/.ssh \
+    && chown user:user /home/user/.ssh \
     && sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config \
     && sed -i 's/#PermitEmptyPasswords.*/PermitEmptyPasswords yes/' /etc/ssh/sshd_config \
     && sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config \
@@ -71,9 +80,6 @@ RUN systemctl enable ssh
 
 # Create working directory for agent scripts
 RUN mkdir -p /opt/vm0-scripts/lib
-
-# Create user working directory (common sandbox working dir)
-RUN mkdir -p /home/user && chmod 755 /home/user
 
 # Set default target for systemd
 RUN systemctl set-default multi-user.target


### PR DESCRIPTION
## Summary
- Change SSH connection to use 'user' account instead of 'root' to match E2B behavior
- Claude Code refuses to run with `--dangerously-skip-permissions` when it detects root privileges
- Connect as non-root user and use sudo for privileged operations (DNS config, script upload)
- Add `writeFileWithSudo` method to SSHClient for writing to privileged locations

## Test plan
- [ ] Verify runner can connect to VM via SSH as user
- [ ] Verify DNS configuration is set correctly using sudo
- [ ] Verify scripts are uploaded to /usr/local/bin using sudo
- [ ] Verify Claude Code runs without root permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)