### PR TITLE
fix(runner): kill direct node processes in cleanup script

### DIFF
--- a/turbo/scripts/deploy-runner/cleanup-runner.sh
+++ b/turbo/scripts/deploy-runner/cleanup-runner.sh
@@ -19,8 +19,18 @@ RUNNER_DIR="/opt/vm0-runner/pr-${PR_NUMBER}"
 
 echo "Cleaning up runner for PR #${PR_NUMBER}..."
 
-# Stop pm2 process
+# Stop pm2 process (if using pm2)
 pm2 delete "$PROCESS_NAME" 2>/dev/null || true
+
+# Kill any node processes running from this runner directory
+# This catches runners started directly (not via pm2)
+pkill -f "node.*${RUNNER_DIR}" 2>/dev/null || true
+
+# Wait a moment for processes to terminate
+sleep 1
+
+# Force kill if still running
+pkill -9 -f "node.*${RUNNER_DIR}" 2>/dev/null || true
 
 # Remove runner directory (needs sudo as it was created with sudo)
 sudo rm -rf "$RUNNER_DIR"


### PR DESCRIPTION
## Summary
- Fix cleanup script to kill node processes started directly (not via pm2)
- This prevents zombie runner processes from remaining after PR cleanup

## Root Cause
PR #851's cleanup failed because:
1. Old script lacked `sudo` for directory removal (fixed in PR #914)
2. Script only killed pm2 processes, but runner was started directly with `node index.js start`

## Changes
- Add `pkill -f "node.*${RUNNER_DIR}"` to kill direct node processes
- Add grace period and force kill fallback

## Test plan
- [ ] Verify cleanup script kills both pm2 and direct node processes
- [ ] Verify directory is properly removed after cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)