### PR TITLE
ci: add lint and test as dependencies for cli-e2e job

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -257,7 +257,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:829341a
-    needs: [change-detection, deploy-web, deploy-runner]
+    needs: [change-detection, deploy-web, deploy-runner, lint, test]
     # Run if:
     # - It's a PR, (CLI or web) changed, and web deployment succeeded
     # - It's a workflow_dispatch with run_cli_e2e enabled and web deployment succeeded


### PR DESCRIPTION
## Summary

- Add `lint` and `test` jobs as dependencies for `cli-e2e` only
- `deploy-web` continues to run in parallel with lint/test for faster CI
- E2E tests only run after all quality checks pass

## Before

```
lint ─────────────────────────────────────────────► (no downstream)
test ─────────────────────────────────────────────► (no downstream)
change-detection ──► deploy-web ──► deploy-runner ──► cli-e2e
```

Lint/test failures did not block cli-e2e, wasting E2E test resources.

## After

```
lint ─────────────────────────────────────────────┐
test ─────────────────────────────────────────────┤
change-detection ──► deploy-web ──► deploy-runner ┼──► cli-e2e
                                                  └────────────┘
```

- `deploy-web` runs in parallel with lint/test (no slowdown)
- `cli-e2e` waits for lint, test, AND deploy-web/deploy-runner to complete
- If lint or test fails, cli-e2e is skipped (saves ~6+ minutes)

## Context

Observed in [run #20741917977](https://github.com/vm0-ai/vm0/actions/runs/20741917977) where lint and test failed but cli-e2e ran anyway.

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Confirm cli-e2e is skipped when lint fails
- [ ] Confirm cli-e2e is skipped when test fails
- [ ] Confirm normal flow works when all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)