### PR TITLE
fix(ci): use subshell to preserve working directory in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -211,8 +211,8 @@ jobs:
 
       - name: Build runner bundle
         run: |
-          # Build runner
-          cd turbo && pnpm -F @vm0/runner build
+          # Build runner (use subshell to preserve working directory)
+          (cd turbo && pnpm -F @vm0/runner build)
 
           # Create staging directory with built files
           STAGING_DIR="/tmp/vm0-runner-bundle"
@@ -221,7 +221,7 @@ jobs:
           cp -r turbo/apps/runner/dist/* "$STAGING_DIR/"
 
           # Install production dependencies
-          cd "$STAGING_DIR" && npm install --omit=dev
+          (cd "$STAGING_DIR" && npm install --omit=dev)
 
           # Create tarball
           tar -czf /tmp/vm0-runner-bundle.tar.gz -C /tmp vm0-runner-bundle


### PR DESCRIPTION
## Summary
Fixes deploy-runner-production failure in release-please workflow.

## Problem
The `cd turbo` command was changing the working directory, causing subsequent `cp` command to fail:
```
cp: cannot stat 'turbo/apps/runner/dist/*': No such file or directory
```

## Solution
Use subshell `(cd ... && cmd)` to preserve the original working directory.

## Changes
- `cd turbo && pnpm build` → `(cd turbo && pnpm build)`
- `cd "$STAGING_DIR" && npm install` → `(cd "$STAGING_DIR" && npm install)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)