### PR TITLE
fix(runner): copy Dockerfile in ansible deployment

### DIFF
--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -169,6 +169,14 @@
       with_fileglob:
         - "{{ playbook_dir }}/../../turbo/scripts/deploy-runner/*.sh"
 
+    - name: Copy Dockerfile for rootfs build
+      copy:
+        src: "{{ playbook_dir }}/../../turbo/scripts/deploy-runner/Dockerfile"
+        dest: "{{ runner_base_dir }}/deploy-runner/Dockerfile"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0644'
+
     # ========================================
     # Phase 4: Install Dependencies (if needed)
     # ========================================


### PR DESCRIPTION
## Summary
- Fix production deployment failure: `build-rootfs.sh` couldn't find Dockerfile on remote machine
- The ansible playbook only copied `*.sh` files but the Dockerfile is needed for rootfs build

## Root Cause
The ansible playbook used `with_fileglob: *.sh` which doesn't match `Dockerfile`:
```yaml
with_fileglob:
  - "{{ playbook_dir }}/../../turbo/scripts/deploy-runner/*.sh"
```

## Fix
Added a new task to explicitly copy the Dockerfile:
```yaml
- name: Copy Dockerfile for rootfs build
  copy:
    src: "{{ playbook_dir }}/../../turbo/scripts/deploy-runner/Dockerfile"
    dest: "{{ runner_base_dir }}/deploy-runner/Dockerfile"
```

## Test plan
- [ ] Verify ansible playbook deploys successfully to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)