### PR TITLE
fix(runner): standardize file header comment

### DIFF
--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,4 +1,4 @@
-// vm0-runner CLI entrypoint - Self-hosted runner for VM0 platform
+// VM0 Runner - Self-hosted runner for VM0 platform
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { statusCommand } from "./commands/status.js";


### PR DESCRIPTION
## Summary
- Standardize file header comment to use consistent project naming
- Triggers runner 2.1.2 release to deploy with Dockerfile fix from #943

## Context
PR #943 fixed the ansible playbook to copy the Dockerfile, but since the ansible changes were outside `turbo/apps/runner/`, no new runner release was triggered. This change triggers a new release so the fixed ansible playbook will be used in the deployment.

## Test plan
- [ ] CI passes
- [ ] Runner 2.1.2 release created
- [ ] Production deployment succeeds with Dockerfile properly copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)