### PR TITLE
fix(runner): use pm2 jlist for reliable PID detection

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -472,7 +472,7 @@ jobs:
           chmod 600 ~/.ssh/metal.pem
 
           # Run Ansible playbook for CI deployment
-          # Note: enable_drain must be passed as JSON to preserve boolean type
+          # Enable drain mode to test the same code path as production
           cd ansible
           ansible-playbook \
             -i "${METAL_HOST}," \
@@ -485,7 +485,7 @@ jobs:
             -e "official_runner_secret=${OFFICIAL_RUNNER_SECRET}" \
             -e "api_url=${PREVIEW_URL}" \
             -e "runner_bundle_path=/tmp/vm0-runner-bundle.tar.gz" \
-            -e '{"enable_drain": false}' \
+            -e '{"enable_drain": true, "drain_timeout": 300}' \
             -e '{"extra_env": {"VERCEL_AUTOMATION_BYPASS_SECRET": "'"${VERCEL_BYPASS}"'", "USE_MOCK_CLAUDE": "true"}}' \
             -v
 

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -73,7 +73,7 @@
     # Phase 2: Stop existing runner
     # ========================================
     - name: Check if runner is currently running
-      command: pm2 pid {{ pm2_process_name }}
+      shell: pm2 jlist 2>/dev/null | jq -r '.[] | select(.name=="{{ pm2_process_name }}") | .pid // empty'
       register: pm2_pid
       ignore_errors: yes
       changed_when: false
@@ -81,7 +81,7 @@
 
     # Production: Drain before stopping (wait for active jobs)
     - name: Enter maintenance mode (stop polling, wait for active jobs)
-      when: enable_drain and pm2_pid.rc == 0 and pm2_pid.stdout != ""
+      when: enable_drain and pm2_pid.stdout | regex_search('^[0-9]+$')
       block:
         - name: Signal runner to enter drain mode
           command: kill -USR1 {{ pm2_pid.stdout }}
@@ -124,7 +124,7 @@
 
     # CI: Just stop without drain (no long-running jobs)
     - name: Stop runner without drain
-      when: not enable_drain and pm2_pid.rc == 0 and pm2_pid.stdout != ""
+      when: not enable_drain and pm2_pid.stdout | regex_search('^[0-9]+$')
       command: pm2 delete {{ pm2_process_name }}
       ignore_errors: yes
       become: no

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,4 +1,4 @@
-// VM0 Runner - Self-hosted runner for VM0 platform
+// VM0 Runner - Self-hosted runner for the VM0 platform
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { statusCommand } from "./commands/status.js";


### PR DESCRIPTION
## Summary
- Fix production deployment failure caused by `pm2 pid` outputting banner text
- Use `pm2 jlist | jq` to reliably extract numeric PID
- **Enable drain mode in CI** to test the same code path as production

## Root Cause
When PM2 daemon starts for the first time, `pm2 pid <name>` outputs a large banner:
```
-------------
__/\\\\\\____/\\...
PM2 is a Production Process Manager...
-------------
[PM2] Spawning PM2 daemon...
```

This entire output was being passed to `kill -USR1`, causing:
```
kill: invalid argument
```

## Fix
1. Changed PID detection from `pm2 pid` to `pm2 jlist | jq` for reliable numeric output
2. **Changed CI to use `enable_drain: true`** so drain logic is tested before production
3. Set CI drain_timeout to 300s (5 min) vs production 86400s (24h)

## Changes
| Setting | Before | After |
|---------|--------|-------|
| PID detection | `pm2 pid` (unreliable) | `pm2 jlist \| jq` (reliable) |
| CI drain mode | `false` (skipped) | `true` (tested) |
| CI drain timeout | N/A | 300s |

## Test plan
- [ ] CI passes with drain mode enabled
- [ ] Production deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)