### PR TITLE
fix(web): add module documentation to trigger production deployment

### DIFF
--- a/turbo/apps/web/src/lib/auth/runner-auth.ts
+++ b/turbo/apps/web/src/lib/auth/runner-auth.ts
@@ -1,3 +1,10 @@
+/**
+ * Runner authentication module
+ *
+ * Handles authentication for runner endpoints (poll, claim).
+ * Supports official runners (vm0_official_*) and user runners (vm0_live_*).
+ */
+
 import { headers } from "next/headers";
 import { eq, and, gt } from "drizzle-orm";
 import { initServices } from "../init-services";


### PR DESCRIPTION
## Summary
- Add file header comment to runner-auth module to trigger a web release

## Why is this needed?
The production web app was deployed on 2026-01-06 10:25:39 UTC, but the `OFFICIAL_RUNNER_SECRET` environment variable was only added to the deployment configuration on 2026-01-07 03:42:37 UTC (in PR #935).

This means the production web app is currently running without `OFFICIAL_RUNNER_SECRET`, causing the official runner to receive HTML error pages instead of JSON responses when polling for jobs.

## Test plan
- [ ] CI passes
- [ ] After merge, verify web deployment runs in release-please workflow
- [ ] Verify official runner can poll successfully after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)