### PR TITLE
fix(ci): use correct production API URL for runner deployment

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -249,6 +249,6 @@ jobs:
             --private-key ~/.ssh/prod-runner.pem \
             -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
             -e "official_runner_secret=${OFFICIAL_RUNNER_SECRET}" \
-            -e "api_url=https://app.vm0.dev" \
+            -e "api_url=https://www.vm0.ai" \
             -e "runner_bundle_path=/tmp/vm0-runner-bundle.tar.gz" \
             -v

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -17,7 +17,7 @@
 #   ansible-playbook -i "host1,host2," playbooks/deploy-runner.yml \
 #     -e "ansible_user=ubuntu" \
 #     -e "official_runner_secret=xxx" \
-#     -e "api_url=https://app.vm0.dev" \
+#     -e "api_url=https://www.vm0.ai" \
 #     -e "enable_drain=true"
 #
 # Required Variables:

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,4 +1,5 @@
 // VM0 Runner - Self-hosted runner for the VM0 platform
+// Connects to the VM0 API to poll and execute agent jobs
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { statusCommand } from "./commands/status.js";


### PR DESCRIPTION
## Summary
- Change `api_url` from `https://app.vm0.dev` to `https://www.vm0.ai` for production runner deployment

## Problem
The production runner was configured with the wrong API URL (`app.vm0.dev` instead of `www.vm0.ai`), causing it to receive HTML error pages instead of JSON responses when polling for jobs.

## Files Changed
- `.github/workflows/release-please.yml` - Fix production deployment URL
- `ansible/playbooks/deploy-runner.yml` - Fix example comment

## Test plan
- [ ] CI passes
- [ ] After merge, manually update runner on production machine or wait for next runner release

🤖 Generated with [Claude Code](https://claude.com/claude-code)