### PR TITLE
fix(runner): configure SSH keep-alive for long-running drain operations

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -13,4 +13,5 @@ stdout_callback = yaml
 callback_whitelist = profile_tasks
 
 [ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no
+# Keep SSH connection alive during long operations (drain can take hours)
+ssh_args = -o ControlMaster=auto -o ControlPersist=3600s -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,5 +1,5 @@
 // VM0 Runner - Self-hosted runner for the VM0 platform
-// Connects to the VM0 API to poll and execute agent jobs
+// Connects to the VM0 API server to poll and execute agent jobs
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { statusCommand } from "./commands/status.js";


### PR DESCRIPTION
## Summary
The production deployment failed because SSH connection dropped during the drain wait phase (~5 minutes).

## Root Cause
- `ControlPersist=60s` was too short for drain operations that can take hours
- No SSH keep-alive was configured

## Fix
- `ServerAliveInterval=30`: Send keep-alive every 30 seconds
- `ServerAliveCountMax=10`: Allow up to 10 missed responses before disconnect
- `ControlPersist=3600s`: Keep connection alive for 1 hour

## Failed Job
https://github.com/vm0-ai/vm0/actions/runs/20779249774/job/59672568129