### PR TITLE
fix(runner): handle pretty-printed JSON in drain script

### DIFF
--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -95,9 +95,9 @@
 
             while [ $elapsed -lt $timeout ]; do
               if [ -f "$status_file" ]; then
-                # Check mode and active_jobs from JSON
-                mode=$(cat "$status_file" | grep -o '"mode":"[^"]*"' | cut -d'"' -f4)
-                active=$(cat "$status_file" | grep -o '"active_jobs":[0-9]*' | grep -o '[0-9]*')
+                # Check mode and active_jobs from JSON (handle pretty-printed format with spaces)
+                mode=$(cat "$status_file" | grep -o '"mode": *"[^"]*"' | cut -d'"' -f4)
+                active=$(cat "$status_file" | grep -o '"active_jobs": *[0-9]*' | grep -o '[0-9]*')
 
                 if [ "$active" = "0" ]; then
                   echo "Drain complete: no active jobs (mode: $mode)"

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,5 +1,6 @@
 // VM0 Runner - Self-hosted runner for the VM0 platform
 // Connects to the VM0 API server to poll and execute agent jobs
+// Supports drain mode for zero-downtime deployments via SIGUSR1 signal
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { statusCommand } from "./commands/status.js";


### PR DESCRIPTION
## Summary

Fixes drain script that was stuck indefinitely during production runner deployment.

**Root cause:** The drain script's grep patterns expected compact JSON format (`"active_jobs":0`) but status.json is pretty-printed with spaces (`"active_jobs": 0`). This caused grep to fail silently, leaving `active_jobs` empty, which didn't match "0", so drain waited forever.

## Changes

- Update grep patterns in Ansible drain script to allow optional spaces after colons
- Add comment to runner to trigger release

## Test plan

- [ ] CI passes
- [ ] After merge, monitor deploy-runner-production job
- [ ] Drain should complete immediately (no active jobs on production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)