### PR TITLE
feat(runner): add API connectivity health check

### DIFF
--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -243,6 +243,16 @@
       failed_when: pm2_status.stdout != "online"
       become: no
 
+    - name: Verify runner can connect to API
+      command: node index.js status --config ./runner.yaml
+      args:
+        chdir: "{{ runner_base_dir }}"
+      become: no
+      register: status_check
+      retries: 3
+      delay: 5
+      until: status_check.rc == 0
+
     - name: Display deployment summary
       debug:
         msg: |

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -248,6 +248,7 @@
       args:
         chdir: "{{ runner_base_dir }}"
       become: no
+      environment: "{{ extra_env }}"
       register: status_check
       retries: 3
       delay: 5

--- a/turbo/apps/runner/src/commands/status.ts
+++ b/turbo/apps/runner/src/commands/status.ts
@@ -1,8 +1,32 @@
 import { Command } from "commander";
+import { loadConfig } from "../lib/config.js";
+import { pollForJob } from "../lib/api.js";
 
 export const statusCommand = new Command("status")
-  .description("Show runner status")
-  .action(() => {
-    console.log("Status command not yet implemented");
-    process.exit(0);
+  .description("Check runner connectivity to API")
+  .option("--config <path>", "Config file path", "./runner.yaml")
+  .action(async (options: { config: string }): Promise<void> => {
+    try {
+      const config = loadConfig(options.config);
+
+      console.log(`Checking connectivity to ${config.server.url}...`);
+      console.log(`Runner group: ${config.group}`);
+
+      // Make a test poll request to verify connectivity and authentication
+      await pollForJob(config.server, config.group);
+
+      console.log("");
+      console.log("✓ Runner can connect to API");
+      console.log(`  API: ${config.server.url}`);
+      console.log(`  Group: ${config.group}`);
+      console.log(`  Auth: OK`);
+      process.exit(0);
+    } catch (error) {
+      console.error("");
+      console.error("✗ Runner cannot connect to API");
+      console.error(
+        `  Error: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+      process.exit(1);
+    }
   });


### PR DESCRIPTION
## Summary

Fixes the gap where runner deployment could succeed but runner fails to poll for jobs.

**Problem:** Current health check passes before the first poll request:
- Waits for "Press Ctrl+C to stop" (printed BEFORE polling starts)
- Checks PM2 status is "online" (only means process is running)

**Solution:** Implement `vm0-runner status` command that makes a test poll request.

## Changes

1. **`turbo/apps/runner/src/commands/status.ts`** - Implement status command that:
   - Loads runner config
   - Makes a single poll request to the API
   - Returns exit code 0 if success, 1 if failure
   - Prints clear success/failure message

2. **`ansible/playbooks/deploy-runner.yml`** - Add health check step after PM2 starts:
   - Calls `node index.js status --config ./runner.yaml`
   - Retries 3 times with 5s delay
   - Fails deployment if runner cannot connect to API

## Test plan

- [ ] CI passes (build, lint, type-check)
- [ ] E2E tests pass (deploy-runner job will now verify API connectivity)
- [ ] Manual test: deploy with wrong API URL should fail at new health check step

🤖 Generated with [Claude Code](https://claude.com/claude-code)