### PR TITLE
fix(runner): ensure user is in kvm group for Firecracker

### DIFF
--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -198,6 +198,17 @@
       command: "{{ runner_base_dir }}/deploy-runner/build-rootfs.sh /opt/firecracker/rootfs.ext4"
       when: not rootfs_file.stat.exists
 
+    - name: Ensure user is in kvm group for Firecracker
+      user:
+        name: "{{ ansible_user }}"
+        groups: kvm
+        append: yes
+      register: kvm_group_result
+
+    - name: Reset connection to pick up new group membership
+      meta: reset_connection
+      when: kvm_group_result.changed
+
     # ========================================
     # Phase 5: Configure and Start
     # ========================================


### PR DESCRIPTION
## Summary
- Add ansible task to ensure the deploy user is in the `kvm` group
- This is required for Firecracker to access `/dev/kvm`
- Reset SSH connection after group changes to pick up new membership

## Root Cause
The production runner was failing with:
```
Error creating KVM object: Permission denied (os error 13)
Make sure the user launching the firecracker process is configured on the /dev/kvm file's ACL.
```

The `ubuntu` user was not in the `kvm` group.

## Test Plan
- [x] Manually fixed on both production servers
- [x] Verified runners can now execute jobs with Firecracker

🤖 Generated with [Claude Code](https://claude.com/claude-code)