### PR TITLE
fix(ci): update ansible callback to use builtin default with yaml format

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -9,7 +9,8 @@ gather_facts = True
 pipelining = True
 
 # Output formatting
-stdout_callback = yaml
+stdout_callback = ansible.builtin.default
+callback_result_format = yaml
 callback_whitelist = profile_tasks
 
 [ssh_connection]


### PR DESCRIPTION
## Summary

- Replace deprecated `community.general.yaml` callback with `ansible.builtin.default` + `callback_result_format=yaml`
- Fixes cleanup-runner job failures caused by callback plugin removal in community.general 12.0.0

## Root Cause

The `community.general.yaml` callback plugin was removed in `community.general` version 12.0.0 (released November 3, 2025). Since `ubuntu-latest` switched to Ubuntu 24.04 (Python 3.12+) in January 2025, `pip install ansible` now installs Ansible 13.x which bundles community.general 12.0.0+.

## Test plan

- [ ] Merge this PR and verify cleanup-runner job succeeds on subsequent PR closures
- [ ] Verify deploy-runner in turbo.yml continues to work (uses toolchain container with older Python)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)