### PR TITLE
fix(ci): prevent pkill from killing itself in cleanup playbook

### DIFF
--- a/ansible/playbooks/cleanup-runner.yml
+++ b/ansible/playbooks/cleanup-runner.yml
@@ -48,15 +48,27 @@
         msg: "PM2 process {{ 'stopped' if pm2_result.rc == 0 else 'was not running' }}"
 
     # Kill any orphaned node processes
-    - name: Kill any node processes running from runner directory
-      shell: pkill -f "node.*{{ runner_base_dir }}" || true
+    # Note: We use pgrep + kill instead of pkill to avoid pkill matching itself
+    # (pkill -f "pattern" would match the shell process running the pkill command)
+    - name: Find node processes running from runner directory
+      shell: pgrep -f "node.*{{ runner_base_dir }}" || true
+      register: node_pids
+      changed_when: false
+
+    - name: Kill node processes (graceful)
+      shell: kill {{ node_pids.stdout_lines | join(' ') }}
+      when: node_pids.stdout_lines | length > 0
+      ignore_errors: yes
 
     - name: Wait for processes to terminate
       pause:
         seconds: 1
+      when: node_pids.stdout_lines | length > 0
 
-    - name: Force kill remaining processes
-      shell: pkill -9 -f "node.*{{ runner_base_dir }}" || true
+    - name: Force kill remaining node processes
+      shell: kill -9 {{ node_pids.stdout_lines | join(' ') }}
+      when: node_pids.stdout_lines | length > 0
+      ignore_errors: yes
 
     # Clean up files
     - name: Check if runner directory exists


### PR DESCRIPTION
## Summary

- Replace `pkill -f` with `pgrep` + `kill` to prevent self-termination
- Skip kill/pause steps when no processes are found

## Root Cause

`pkill -f "node.*/opt/vm0-runner/pr-970"` matches its own shell process because the command line arguments contain the search pattern. This causes pkill to send SIGTERM to the shell running it, resulting in `rc=-15`.

## Solution

1. Use `pgrep -f` to find matching PIDs (safe - only searches, doesn't kill)
2. Use `kill` with explicit PIDs (no pattern matching in command line)
3. Only run kill steps when processes are actually found

## Test plan

- [ ] Merge and verify cleanup-runner succeeds on next PR closure

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)