### PR TITLE
fix(ci): use per-pr rootfs to prevent cross-pr interference

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -485,6 +485,8 @@ jobs:
             -e "official_runner_secret=${OFFICIAL_RUNNER_SECRET}" \
             -e "api_url=${PREVIEW_URL}" \
             -e "runner_bundle_path=/tmp/vm0-runner-bundle.tar.gz" \
+            -e "rootfs_path=${RUNNER_DIR}/rootfs.ext4" \
+            -e "force_rebuild_rootfs=true" \
             -e '{"enable_drain": true, "drain_timeout": 300}' \
             -e '{"extra_env": {"VERCEL_AUTOMATION_BYPASS_SECRET": "'"${VERCEL_BYPASS}"'", "USE_MOCK_CLAUDE": "true"}}' \
             -v

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -46,6 +46,9 @@
     enable_drain: true
     drain_timeout: 86400  # 24 hours
     extra_env: {}
+    # Rootfs configuration - CI should override for per-PR isolation
+    rootfs_path: /opt/firecracker/rootfs.ext4
+    force_rebuild_rootfs: false
 
   tasks:
     # ========================================
@@ -191,12 +194,12 @@
 
     - name: Check if rootfs exists
       stat:
-        path: /opt/firecracker/rootfs.ext4
+        path: "{{ rootfs_path }}"
       register: rootfs_file
 
     - name: Build rootfs
-      command: "{{ runner_base_dir }}/deploy-runner/build-rootfs.sh /opt/firecracker/rootfs.ext4"
-      when: not rootfs_file.stat.exists
+      command: "{{ runner_base_dir }}/deploy-runner/build-rootfs.sh {{ rootfs_path }}"
+      when: not rootfs_file.stat.exists or force_rebuild_rootfs
 
     - name: Ensure user is in kvm group for Firecracker
       user:

--- a/ansible/playbooks/templates/runner.yaml.j2
+++ b/ansible/playbooks/templates/runner.yaml.j2
@@ -17,4 +17,4 @@ sandbox:
 firecracker:
   binary: /usr/local/bin/firecracker
   kernel: /opt/firecracker/vmlinux
-  rootfs: /opt/firecracker/rootfs.ext4
+  rootfs: {{ rootfs_path | default('/opt/firecracker/rootfs.ext4') }}

--- a/turbo/apps/runner/src/lib/firecracker/vm.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vm.ts
@@ -112,6 +112,7 @@ export class FirecrackerVM {
 
       // Copy rootfs to VM-local path for isolation
       // Each VM needs its own writable copy to prevent corruption
+      // Note: In CI, each PR has its own rootfs at {runner_base_dir}/rootfs.ext4
       console.log(`[VM ${this.config.vmId}] Copying rootfs for isolation...`);
       fs.copyFileSync(this.config.rootfsPath, this.vmRootfsPath);
 


### PR DESCRIPTION
## Summary
- Add `rootfs_path` and `force_rebuild_rootfs` variables to Ansible deploy-runner playbook
- Update runner.yaml.j2 template to use configurable rootfs path with backward-compatible default
- Pass PR-specific rootfs path (`/opt/vm0-runner/pr-{PR_NUMBER}/rootfs.ext4`) in GitHub Actions workflow

## Problem
Previously, all PRs shared a single rootfs at `/opt/firecracker/rootfs.ext4`. If one PR modified `build-rootfs.sh` or `Dockerfile`, it could affect all other PRs on the same metal instance.

## Solution
Each PR now builds its own rootfs in its dedicated directory, ensuring complete isolation between PRs. Production deployments continue to use the global rootfs path.

## Test plan
- [ ] Deploy a PR that modifies the Dockerfile
- [ ] Verify rootfs is built at `/opt/vm0-runner/pr-{PR_NUMBER}/rootfs.ext4`
- [ ] Verify runner.yaml contains correct rootfs path
- [ ] Verify E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)