### PR TITLE
feat(proxy): add platform.vm7.ai reverse proxy for app

### DIFF
--- a/turbo/apps/app/vite.config.ts
+++ b/turbo/apps/app/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     port: 3002,
     strictPort: true,
     host: true,
+    allowedHosts: ["platform.vm7.ai"],
   },
   build: {
     outDir: "dist",

--- a/turbo/packages/proxy/Caddyfile
+++ b/turbo/packages/proxy/Caddyfile
@@ -21,6 +21,12 @@ docs.vm7.ai:8443 {
   reverse_proxy localhost:3001
 }
 
+# Platform application (app)
+platform.vm7.ai:8443 {
+  tls ../../../.certs/platform.vm7.ai.pem ../../../.certs/platform.vm7.ai-key.pem
+  reverse_proxy localhost:3002
+}
+
 # HTTP redirects to HTTPS
 http://vm7.ai:8080 {
   redir https://www.vm7.ai:8443{uri} permanent
@@ -32,4 +38,8 @@ http://www.vm7.ai:8080 {
 
 http://docs.vm7.ai:8080 {
   redir https://docs.vm7.ai:8443{uri} permanent
+}
+
+http://platform.vm7.ai:8080 {
+  redir https://platform.vm7.ai:8443{uri} permanent
 }


### PR DESCRIPTION
## Summary
- Add platform.vm7.ai:8443 reverse proxy configuration pointing to app (localhost:3002)
- Add HTTP to HTTPS redirect for platform.vm7.ai
- Configure Vite allowedHosts to permit requests from platform.vm7.ai domain

## Test plan
- [ ] Start dev server with `/dev-start`
- [ ] Access https://platform.vm7.ai:8443 and verify app loads correctly
- [ ] Verify HTTP redirect works from http://platform.vm7.ai:8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)