### PR TITLE
feat(ci): add ci/cd integration for app subproject

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,7 @@ jobs:
       web_release_created: ${{ steps.release.outputs['turbo/apps/web--release_created'] }}
       docs_release_created: ${{ steps.release.outputs['turbo/apps/docs--release_created'] }}
       runner_release_created: ${{ steps.release.outputs['turbo/apps/runner--release_created'] }}
+      app_release_created: ${{ steps.release.outputs['turbo/apps/app--release_created'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -132,6 +133,30 @@ jobs:
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_DOCS }}
           environment: production
           deployment-env: docs
+
+  # Deploy app (Vite SPA) to production
+  deploy-app-production:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.app_release_created == 'true' }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:829341a
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Deploy App to Vercel Production
+        id: deploy
+        uses: ./.github/actions/vercel-deploy
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_APP }}
+          environment: production
+          deployment-env: app
 
   publish-npm:
     needs: release-please

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -26,6 +26,7 @@ jobs:
       docs-changed: ${{ steps.detect.outputs.docs-changed }}
       cli-changed: ${{ steps.detect.outputs.cli-changed }}
       runner-changed: ${{ steps.detect.outputs.runner-changed }}
+      app-changed: ${{ steps.detect.outputs.app-changed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,6 +45,7 @@ jobs:
             echo "docs-changed=false" >> $GITHUB_OUTPUT
             echo "cli-changed=true" >> $GITHUB_OUTPUT
             echo "runner-changed=false" >> $GITHUB_OUTPUT
+            echo "app-changed=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -54,6 +56,7 @@ jobs:
             echo "docs-changed=true" >> $GITHUB_OUTPUT
             echo "cli-changed=true" >> $GITHUB_OUTPUT
             echo "runner-changed=true" >> $GITHUB_OUTPUT
+            echo "app-changed=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -110,6 +113,16 @@ jobs:
           else
             echo "Changes detected in runner app"
             echo "runner-changed=true" >> $GITHUB_OUTPUT
+          fi
+
+          # Check app (Vite SPA)
+          cd /__w/vm0/vm0/turbo/apps/app
+          if npx turbo-ignore 2>/dev/null; then
+            echo "No changes detected in app"
+            echo "app-changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected in app"
+            echo "app-changed=true" >> $GITHUB_OUTPUT
           fi
 
   lint:
@@ -250,6 +263,34 @@ jobs:
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_DOCS }}
           environment: preview
           deployment-env: docs
+          meta-branch: ${{ github.head_ref }}
+          meta-pr: ${{ github.event.pull_request.number }}
+
+  # Deploy app (Vite SPA)
+  deploy-app:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:829341a
+    needs: [change-detection]
+    # Only deploy if it's a PR and app changed
+    if: github.event_name == 'pull_request' && needs.change-detection.outputs.app-changed == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Deploy App to Vercel
+        id: deploy
+        uses: ./.github/actions/vercel-deploy
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_APP }}
+          environment: preview
+          deployment-env: app
           meta-branch: ${{ github.head_ref }}
           meta-pr: ${{ github.event.pull_request.number }}
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"turbo/apps/cli":"4.35.3","turbo/packages/core":"3.0.2","turbo/apps/web":"8.1.1","turbo/apps/docs":"0.13.9","turbo/apps/runner":"2.2.0"}
+{"turbo/apps/cli":"4.35.3","turbo/packages/core":"3.0.2","turbo/apps/web":"8.1.1","turbo/apps/docs":"0.13.9","turbo/apps/runner":"2.2.0","turbo/apps/app":"0.1.0"}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,9 @@
         },
         "turbo/apps/runner": {
             "releaseType": "node"
+        },
+        "turbo/apps/app": {
+            "releaseType": "node"
         }
     },
     "plugins": [

--- a/turbo/apps/app/docs/VERCEL_SETUP.md
+++ b/turbo/apps/app/docs/VERCEL_SETUP.md
@@ -1,0 +1,80 @@
+# Vercel Setup for App Subproject
+
+This document describes how to set up the Vercel project for the `turbo/apps/app` subproject.
+
+## Prerequisites
+
+- Access to the Vercel team dashboard
+- Admin access to GitHub repository settings
+
+## Step 1: Create Vercel Project
+
+1. Go to Vercel Dashboard
+2. Click "Add New Project"
+3. Import from GitHub repository
+4. Configure the following settings:
+
+| Setting          | Value                                 |
+| ---------------- | ------------------------------------- |
+| Framework Preset | Vite                                  |
+| Root Directory   | `turbo/apps/app`                      |
+| Build Command    | `cd ../.. && pnpm build --filter=app` |
+| Output Directory | `dist`                                |
+| Install Command  | `cd ../.. && pnpm install`            |
+
+## Step 2: Configure GitHub Repository Variable
+
+1. Go to GitHub repository Settings > Secrets and variables > Actions > Variables
+2. Add new repository variable:
+   - Name: `VERCEL_PROJECT_ID_APP`
+   - Value: (copy from Vercel project settings)
+
+To find the Vercel Project ID:
+
+1. Go to Vercel project settings
+2. Navigate to "General" tab
+3. Copy the "Project ID" value
+
+## Step 3: Verify SPA Configuration
+
+The app already includes `vercel.json` with SPA rewrites:
+
+```json
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}
+```
+
+This ensures client-side routing works correctly.
+
+## Step 4: Test Deployment
+
+1. Create a PR with changes to `turbo/apps/app`
+2. Verify the `deploy-app` job triggers in CI
+3. Check that preview URL is posted to PR
+
+## Environment Variables (Optional)
+
+For future features, these variables may be needed:
+
+| Variable                     | Description          | Required            |
+| ---------------------------- | -------------------- | ------------------- |
+| `VITE_CLERK_PUBLISHABLE_KEY` | Clerk authentication | For auth feature    |
+| `VITE_API_URL`               | Backend API URL      | For API integration |
+
+## Troubleshooting
+
+### Build Fails
+
+- Ensure pnpm workspace is correctly configured
+- Check that `@vm0/core` and `@vm0/ui` packages are built first
+
+### Preview URL Not Posted
+
+- Verify `VERCEL_PROJECT_ID_APP` is set correctly
+- Check `VERCEL_TOKEN` and `VERCEL_TEAM_ID` secrets/variables exist
+
+### 404 on Client-Side Routes
+
+- Verify `vercel.json` is in the app root directory
+- Check that rewrites are correctly configured

--- a/turbo/apps/app/src/views/home/home-page.tsx
+++ b/turbo/apps/app/src/views/home/home-page.tsx
@@ -3,7 +3,7 @@ export function HomePage() {
     <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50">
       <div className="text-center">
         <h1 className="mb-4 text-4xl font-bold text-gray-900">VM0 App</h1>
-        <p className="text-lg text-gray-600">Welcome to the VM0 application.</p>
+        <p className="text-lg text-gray-600">Welcome to the VM0 application</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Add `app-changed` detection to change-detection job in turbo.yml
- Add `deploy-app` preview job for PR deployments
- Add app to Release Please configuration
- Add `deploy-app-production` job for production releases
- Add Vercel setup documentation

This is **Phase 1** of Issue #978 implementation.

## Manual Steps Required

After merging, the following manual steps are needed:

1. Create Vercel project for `turbo/apps/app` (see `turbo/apps/app/docs/VERCEL_SETUP.md`)
2. Add `VERCEL_PROJECT_ID_APP` to GitHub repository variables

## Test Plan

- [ ] Verify `app-changed` detection works by checking workflow logs
- [ ] Verify preview deployment triggers when app files change
- [ ] Verify production deployment triggers on app release (after Release Please creates release)

Closes #978 (Phase 1)

🤖 Generated with [Claude Code](https://claude.ai/code)