### PR TITLE
refactor(web): remove defensive try-catch blocks

### DIFF
--- a/turbo/apps/web/app/api/auth/me/route.ts
+++ b/turbo/apps/web/app/api/auth/me/route.ts
@@ -2,9 +2,6 @@ import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { authContract } from "@vm0/core";
 import { clerkClient } from "@clerk/nextjs/server";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
-import { logger } from "../../../../src/lib/logger";
-
-const log = logger("api:auth");
 
 const router = tsr.router(authContract, {
   me: async () => {
@@ -19,39 +16,29 @@ const router = tsr.router(authContract, {
       };
     }
 
-    try {
-      const client = await clerkClient();
-      const user = await client.users.getUser(userId);
+    const client = await clerkClient();
+    const user = await client.users.getUser(userId);
 
-      if (!user) {
-        return {
-          status: 404 as const,
-          body: {
-            error: { message: "User not found", code: "NOT_FOUND" },
-          },
-        };
-      }
-
-      const email = user.emailAddresses.find(
-        (e) => e.id === user.primaryEmailAddressId,
-      )?.emailAddress;
-
+    if (!user) {
       return {
-        status: 200 as const,
+        status: 404 as const,
         body: {
-          userId: user.id,
-          email: email || "",
-        },
-      };
-    } catch (error) {
-      log.error("Failed to get user info:", error);
-      return {
-        status: 500 as const,
-        body: {
-          error: { message: "Internal server error", code: "INTERNAL_ERROR" },
+          error: { message: "User not found", code: "NOT_FOUND" },
         },
       };
     }
+
+    const email = user.emailAddresses.find(
+      (e) => e.id === user.primaryEmailAddressId,
+    )?.emailAddress;
+
+    return {
+      status: 200 as const,
+      body: {
+        userId: user.id,
+        email: email || "",
+      },
+    };
   },
 });
 

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/route.ts
@@ -56,44 +56,26 @@ const router = tsr.router(webhookCheckpointsContract, {
     // Note: We don't check run status here because the checkpoint is called from within
     // the sandbox before the E2B service updates the run status to "completed"
 
-    try {
-      // Create checkpoint
-      const result = await checkpointService.createCheckpoint(body);
+    // Create checkpoint
+    const result = await checkpointService.createCheckpoint(body);
 
-      log.debug(
-        `Checkpoint created: ${result.checkpointId}, session: ${result.agentSessionId}, conversation: ${result.conversationId}`,
-      );
+    log.debug(
+      `Checkpoint created: ${result.checkpointId}, session: ${result.agentSessionId}, conversation: ${result.conversationId}`,
+    );
 
-      // Note: vm0_result event is now sent by the complete API
-      // This endpoint only handles checkpoint data persistence
+    // Note: vm0_result event is now sent by the complete API
+    // This endpoint only handles checkpoint data persistence
 
-      return {
-        status: 200 as const,
-        body: {
-          checkpointId: result.checkpointId,
-          agentSessionId: result.agentSessionId,
-          conversationId: result.conversationId,
-          artifact: result.artifact,
-          volumes: result.volumes,
-        },
-      };
-    } catch (error) {
-      log.error("Error:", error);
-
-      // Note: vm0_error event is now sent by the complete API
-      // If checkpoint fails, run-agent.sh will call complete API with exitCode != 0
-
-      return {
-        status: 500 as const,
-        body: {
-          error: {
-            message:
-              error instanceof Error ? error.message : "Internal server error",
-            code: "INTERNAL_ERROR",
-          },
-        },
-      };
-    }
+    return {
+      status: 200 as const,
+      body: {
+        checkpointId: result.checkpointId,
+        agentSessionId: result.agentSessionId,
+        conversationId: result.conversationId,
+        artifact: result.artifact,
+        volumes: result.volumes,
+      },
+    };
   },
 });
 


### PR DESCRIPTION
## Summary

Remove defensive try-catch blocks that violate the project's "Avoid Defensive Programming" principle per Issue #977.

### Files Modified

| File | Changes |
|------|---------|
| `app/api/auth/me/route.ts` | Remove log + return 500 catch |
| `app/api/webhooks/agent/checkpoints/route.ts` | Remove log + return 500 catch |
| `app/api/webhooks/agent/complete/route.ts` | Remove log + return 500 catch **(NEW - not in original issue)** |
| `app/api/web/cookbooks/route.ts` | Remove return null + log + return 500 catches |
| `app/api/web/skills/route.ts` | Remove return null + log + return 500 catches |

### Key Changes

- Errors now propagate to framework error handlers instead of being caught and logged defensively
- `parseCookbookMetadata` and `fetchSkillMetadata` no longer return `null` - they either succeed or throw
- `GET` handlers no longer need to filter out `null` values from `Promise.all` results

### Verification

- ✅ Lint passed
- ✅ Type-check passed
- ✅ Unit tests passed

Closes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)