### PR TITLE
fix(e2b): pin cli versions to prevent cache from blocking updates

### DIFF
--- a/turbo/scripts/e2b/vm0-claude-code-github/template.ts
+++ b/turbo/scripts/e2b/vm0-claude-code-github/template.ts
@@ -12,7 +12,7 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "ripgrep", "jq", "file"])
-  .npmInstall("@anthropic-ai/claude-code@latest", { g: true })
+  .npmInstall("@anthropic-ai/claude-code@2.1.2", { g: true })
   // Install GitHub CLI
   // https://github.com/cli/cli/blob/trunk/docs/install_linux.md
   .runCmd(

--- a/turbo/scripts/e2b/vm0-claude-code/template.ts
+++ b/turbo/scripts/e2b/vm0-claude-code/template.ts
@@ -11,4 +11,4 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "ripgrep", "jq", "file"])
-  .npmInstall("@anthropic-ai/claude-code@latest", { g: true });
+  .npmInstall("@anthropic-ai/claude-code@2.1.2", { g: true });

--- a/turbo/scripts/e2b/vm0-codex/template.ts
+++ b/turbo/scripts/e2b/vm0-codex/template.ts
@@ -11,4 +11,4 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "ripgrep", "jq", "file"])
-  .npmInstall("@openai/codex@latest", { g: true });
+  .npmInstall("@openai/codex@0.79.0", { g: true });


### PR DESCRIPTION
## Summary
- Pin @anthropic-ai/claude-code to `2.1.2` (was `@latest`)
- Pin @openai/codex to `0.79.0` (was `@latest`)

E2B's layer caching is based on command hash, not npm package content. Using `@latest` means the cache never invalidates even when new versions are available on npm. This change pins specific versions so that updating the version number triggers cache invalidation and a fresh build.

## Test plan
- [ ] Verify E2B template build workflow runs and rebuilds the npm layer (should not show CACHED)
- [ ] Verify templates work correctly with pinned versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)