### PR TITLE
fix(runner): set NODE_EXTRA_CA_CERTS for network security mode

### DIFF
--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -112,6 +112,14 @@ function buildEnvironmentVariables(
     }
   }
 
+  // For network security mode, tell Node.js to trust the proxy CA certificate
+  // This is required because mitmproxy intercepts HTTPS traffic and re-signs
+  // certificates with its own CA. Without this, Node.js will reject the connection.
+  if (context.experimentalNetworkSecurity) {
+    envVars.NODE_EXTRA_CA_CERTS =
+      "/usr/local/share/ca-certificates/vm0-proxy-ca.crt";
+  }
+
   return envVars;
 }
 

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -112,12 +112,20 @@ function buildEnvironmentVariables(
     }
   }
 
-  // For network security mode, tell Node.js to trust the proxy CA certificate
+  // For network security mode, configure CA certificates so all tools trust the proxy
   // This is required because mitmproxy intercepts HTTPS traffic and re-signs
-  // certificates with its own CA. Without this, Node.js will reject the connection.
+  // certificates with its own CA. The system CA bundle at /etc/ssl/certs/ca-certificates.crt
+  // is updated by update-ca-certificates to include the mitmproxy CA.
   if (context.experimentalNetworkSecurity) {
-    envVars.NODE_EXTRA_CA_CERTS =
-      "/usr/local/share/ca-certificates/vm0-proxy-ca.crt";
+    const systemCaBundle = "/etc/ssl/certs/ca-certificates.crt";
+    // Node.js (Claude Code)
+    envVars.NODE_EXTRA_CA_CERTS = systemCaBundle;
+    // Python requests library
+    envVars.REQUESTS_CA_BUNDLE = systemCaBundle;
+    // Python ssl module
+    envVars.SSL_CERT_FILE = systemCaBundle;
+    // curl
+    envVars.CURL_CA_BUNDLE = systemCaBundle;
   }
 
   return envVars;

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -112,20 +112,13 @@ function buildEnvironmentVariables(
     }
   }
 
-  // For network security mode, configure CA certificates so all tools trust the proxy
+  // For network security mode, tell Node.js to trust the proxy CA certificate
   // This is required because mitmproxy intercepts HTTPS traffic and re-signs
-  // certificates with its own CA. The system CA bundle at /etc/ssl/certs/ca-certificates.crt
-  // is updated by update-ca-certificates to include the mitmproxy CA.
+  // certificates with its own CA. Without this, Node.js will reject the connection.
+  // Note: Python and curl automatically use the system CA bundle after update-ca-certificates.
   if (context.experimentalNetworkSecurity) {
-    const systemCaBundle = "/etc/ssl/certs/ca-certificates.crt";
-    // Node.js (Claude Code)
-    envVars.NODE_EXTRA_CA_CERTS = systemCaBundle;
-    // Python requests library
-    envVars.REQUESTS_CA_BUNDLE = systemCaBundle;
-    // Python ssl module
-    envVars.SSL_CERT_FILE = systemCaBundle;
-    // curl
-    envVars.CURL_CA_BUNDLE = systemCaBundle;
+    envVars.NODE_EXTRA_CA_CERTS =
+      "/usr/local/share/ca-certificates/vm0-proxy-ca.crt";
   }
 
   return envVars;


### PR DESCRIPTION
## Summary
- Fix SSL connection error when `experimental_network_security` is enabled
- Set `NODE_EXTRA_CA_CERTS` environment variable to trust mitmproxy CA certificate

## Problem
When `experimental_network_security` is enabled, mitmproxy intercepts HTTPS traffic and re-signs certificates with its own CA. Node.js (which runs Claude Code) needs to be told to trust this CA certificate.

Without this environment variable, Node.js rejects the SSL connection with:
```
[text] API Error: Connection error.
```

## Solution
Add `NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/vm0-proxy-ca.crt` to the VM environment when network security mode is enabled.

## Test plan
- [ ] Deploy runner with this fix
- [ ] Run `vm0 cook` with `experimental_network_security: true`
- [ ] Verify Claude API calls succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)