### PR TITLE
fix(web): add authorization check for scope access in composes list

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -7,6 +7,7 @@ import { eq, desc } from "drizzle-orm";
 import {
   getUserScopeByClerkId,
   getScopeBySlug,
+  canAccessScope,
 } from "../../../../../src/lib/scope/scope-service";
 
 const router = tsr.router(composesListContract, {
@@ -38,6 +39,21 @@ const router = tsr.router(composesListContract, {
           },
         };
       }
+
+      // Check if user has access to this scope
+      const hasAccess = await canAccessScope(userId, scope.id);
+      if (!hasAccess) {
+        return {
+          status: 403 as const,
+          body: {
+            error: {
+              message: "You don't have access to this scope",
+              code: "FORBIDDEN",
+            },
+          },
+        };
+      }
+
       scopeId = scope.id;
     } else {
       const userScope = await getUserScopeByClerkId(userId);


### PR DESCRIPTION
## Summary

- Add `canAccessScope` check when user specifies a scope parameter in the composes list endpoint
- Return 403 Forbidden if user doesn't have access to the requested scope
- Add unit test for unauthorized scope access scenario

## Problem

The list endpoint (`/api/agent/composes/list`) checked if a scope exists but didn't verify if the user has permission to access that scope. A user could potentially list composes from any scope by providing its slug.

## Solution

After finding the scope by slug, call `canAccessScope(userId, scope.id)` to verify the user has access. If not, return 403 Forbidden.

## Test plan

- [x] Added unit test: "should return 403 when user tries to access another user's scope"
- [x] All existing tests pass
- [x] Lint and type checks pass

Closes #1007

🤖 Generated with [Claude Code](https://claude.ai/code)