### PR TITLE
feat(public-api): add tokens api for self-service token management (#997)

### DIFF
--- a/turbo/apps/web/app/v1/tokens/[id]/route.ts
+++ b/turbo/apps/web/app/v1/tokens/[id]/route.ts
@@ -1,0 +1,133 @@
+/**
+ * Public API v1 - Token by ID Endpoints
+ *
+ * GET /v1/tokens/:id - Get token details (without secret)
+ * DELETE /v1/tokens/:id - Revoke token
+ */
+import { initServices } from "../../../../src/lib/init-services";
+import {
+  createPublicApiHandler,
+  tsr,
+} from "../../../../src/lib/public-api/handler";
+import { publicTokenByIdContract } from "@vm0/core";
+import {
+  authenticatePublicApi,
+  isAuthSuccess,
+} from "../../../../src/lib/public-api/auth";
+import { cliTokens } from "../../../../src/db/schema/cli-tokens";
+import { eq, and } from "drizzle-orm";
+
+/**
+ * Extract token prefix for display (first 12 chars)
+ */
+function getTokenPrefix(token: string): string {
+  return token.substring(0, 16) + "...";
+}
+
+const router = tsr.router(publicTokenByIdContract, {
+  get: async ({ params }) => {
+    initServices();
+
+    const auth = await authenticatePublicApi();
+    if (!isAuthSuccess(auth)) {
+      return {
+        status: 401 as const,
+        body: {
+          error: {
+            type: "authentication_error" as const,
+            code: "invalid_api_key",
+            message: "Invalid API key provided",
+          },
+        },
+      };
+    }
+
+    // Find token by ID, ensuring it belongs to user
+    const [token] = await globalThis.services.db
+      .select()
+      .from(cliTokens)
+      .where(
+        and(eq(cliTokens.id, params.id), eq(cliTokens.userId, auth.userId)),
+      )
+      .limit(1);
+
+    if (!token) {
+      return {
+        status: 404 as const,
+        body: {
+          error: {
+            type: "not_found_error" as const,
+            code: "resource_not_found",
+            message: `No such token: '${params.id}'`,
+          },
+        },
+      };
+    }
+
+    return {
+      status: 200 as const,
+      body: {
+        id: token.id,
+        name: token.name,
+        token_prefix: getTokenPrefix(token.token),
+        last_used_at: token.lastUsedAt?.toISOString() ?? null,
+        expires_at: token.expiresAt.toISOString(),
+        created_at: token.createdAt.toISOString(),
+      },
+    };
+  },
+
+  delete: async ({ params }) => {
+    initServices();
+
+    const auth = await authenticatePublicApi();
+    if (!isAuthSuccess(auth)) {
+      return {
+        status: 401 as const,
+        body: {
+          error: {
+            type: "authentication_error" as const,
+            code: "invalid_api_key",
+            message: "Invalid API key provided",
+          },
+        },
+      };
+    }
+
+    // Find token by ID, ensuring it belongs to user
+    const [token] = await globalThis.services.db
+      .select()
+      .from(cliTokens)
+      .where(
+        and(eq(cliTokens.id, params.id), eq(cliTokens.userId, auth.userId)),
+      )
+      .limit(1);
+
+    if (!token) {
+      return {
+        status: 404 as const,
+        body: {
+          error: {
+            type: "not_found_error" as const,
+            code: "resource_not_found",
+            message: `No such token: '${params.id}'`,
+          },
+        },
+      };
+    }
+
+    // Delete the token
+    await globalThis.services.db
+      .delete(cliTokens)
+      .where(eq(cliTokens.id, token.id));
+
+    return {
+      status: 204 as const,
+      body: undefined,
+    };
+  },
+});
+
+const handler = createPublicApiHandler(publicTokenByIdContract, router);
+
+export { handler as GET, handler as DELETE };

--- a/turbo/apps/web/app/v1/tokens/__tests__/route.test.ts
+++ b/turbo/apps/web/app/v1/tokens/__tests__/route.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET as listTokens, POST as createToken } from "../route";
+import { GET as getToken, DELETE as deleteToken } from "../[id]/route";
+import { initServices } from "../../../../src/lib/init-services";
+import { cliTokens } from "../../../../src/db/schema/cli-tokens";
+import { eq } from "drizzle-orm";
+import { randomUUID } from "crypto";
+
+/**
+ * Helper to create a NextRequest for testing.
+ */
+function createTestRequest(
+  url: string,
+  options?: {
+    method?: string;
+    body?: string;
+    headers?: Record<string, string>;
+  },
+): NextRequest {
+  return new NextRequest(url, {
+    method: options?.method ?? "GET",
+    headers: options?.headers ?? {},
+    body: options?.body,
+  });
+}
+
+// Mock the auth module
+let mockUserId = "test-user-tokens-api";
+vi.mock("../../../../src/lib/auth/get-user-id", () => ({
+  getUserId: async () => mockUserId,
+}));
+
+describe("Public API v1 - Tokens Endpoints", () => {
+  const testUserId = "test-user-tokens-api";
+  let createdTokenId: string;
+
+  beforeAll(async () => {
+    initServices();
+
+    // Clean up any existing test data
+    await globalThis.services.db
+      .delete(cliTokens)
+      .where(eq(cliTokens.userId, testUserId));
+  });
+
+  afterAll(async () => {
+    // Cleanup: Delete test data
+    await globalThis.services.db
+      .delete(cliTokens)
+      .where(eq(cliTokens.userId, testUserId));
+  });
+
+  describe("POST /v1/tokens - Create Token", () => {
+    it("should create a new token", async () => {
+      const request = createTestRequest("http://localhost:3000/v1/tokens", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "Test Token",
+          expires_in_days: 30,
+        }),
+      });
+
+      const response = await createToken(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.id).toBeDefined();
+      expect(data.name).toBe("Test Token");
+      expect(data.token).toBeDefined();
+      expect(data.token).toMatch(/^vm0_live_[a-f0-9]+$/);
+      expect(data.token_prefix).toBeDefined();
+      expect(data.expires_at).toBeDefined();
+      expect(data.created_at).toBeDefined();
+
+      createdTokenId = data.id;
+    });
+
+    it("should create token with default expiry", async () => {
+      const request = createTestRequest("http://localhost:3000/v1/tokens", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "Default Expiry Token",
+        }),
+      });
+
+      const response = await createToken(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.name).toBe("Default Expiry Token");
+
+      // Default expiry is 90 days
+      const expiresAt = new Date(data.expires_at);
+      const now = new Date();
+      const diffDays = Math.floor(
+        (expiresAt.getTime() - now.getTime()) / (1000 * 60 * 60 * 24),
+      );
+      expect(diffDays).toBeGreaterThanOrEqual(89);
+      expect(diffDays).toBeLessThanOrEqual(91);
+    });
+
+    it("should return 401 for unauthenticated request", async () => {
+      mockUserId = "";
+
+      const request = createTestRequest("http://localhost:3000/v1/tokens", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "Unauthorized Token",
+        }),
+      });
+
+      const response = await createToken(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.type).toBe("authentication_error");
+
+      mockUserId = testUserId;
+    });
+  });
+
+  describe("GET /v1/tokens - List Tokens", () => {
+    it("should list user tokens", async () => {
+      const request = createTestRequest("http://localhost:3000/v1/tokens");
+
+      const response = await listTokens(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data).toBeDefined();
+      expect(Array.isArray(data.data)).toBe(true);
+      expect(data.data.length).toBeGreaterThanOrEqual(1);
+      expect(data.pagination).toBeDefined();
+
+      // Token value should NOT be included in list response
+      expect(data.data[0].token).toBeUndefined();
+      expect(data.data[0].token_prefix).toBeDefined();
+    });
+
+    it("should support pagination with limit", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/v1/tokens?limit=1",
+      );
+
+      const response = await listTokens(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data.length).toBe(1);
+      expect(data.pagination.has_more).toBe(true);
+    });
+
+    it("should return 401 for unauthenticated request", async () => {
+      mockUserId = "";
+
+      const request = createTestRequest("http://localhost:3000/v1/tokens");
+
+      const response = await listTokens(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.type).toBe("authentication_error");
+
+      mockUserId = testUserId;
+    });
+  });
+
+  describe("GET /v1/tokens/:id - Get Token", () => {
+    it("should get token details", async () => {
+      const request = createTestRequest(
+        `http://localhost:3000/v1/tokens/${createdTokenId}`,
+      );
+
+      const response = await getToken(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.id).toBe(createdTokenId);
+      expect(data.name).toBe("Test Token");
+      expect(data.token_prefix).toBeDefined();
+      // Token value should NOT be included
+      expect(data.token).toBeUndefined();
+    });
+
+    it("should return 404 for non-existent token", async () => {
+      const fakeId = randomUUID();
+      const request = createTestRequest(
+        `http://localhost:3000/v1/tokens/${fakeId}`,
+      );
+
+      const response = await getToken(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.type).toBe("not_found_error");
+      expect(data.error.code).toBe("resource_not_found");
+    });
+
+    it("should return 404 for other user token", async () => {
+      // Create a token for another user
+      const otherUserId = "other-user-id";
+      const otherToken = await globalThis.services.db
+        .insert(cliTokens)
+        .values({
+          token: `vm0_live_${randomUUID().replace(/-/g, "")}`,
+          userId: otherUserId,
+          name: "Other User Token",
+          expiresAt: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000),
+        })
+        .returning();
+
+      const request = createTestRequest(
+        `http://localhost:3000/v1/tokens/${otherToken[0]!.id}`,
+      );
+
+      const response = await getToken(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.type).toBe("not_found_error");
+
+      // Cleanup
+      await globalThis.services.db
+        .delete(cliTokens)
+        .where(eq(cliTokens.userId, otherUserId));
+    });
+  });
+
+  describe("DELETE /v1/tokens/:id - Revoke Token", () => {
+    it("should delete token", async () => {
+      // Create a token to delete
+      const tokenRequest = createTestRequest(
+        "http://localhost:3000/v1/tokens",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Token to Delete",
+          }),
+        },
+      );
+
+      const createResponse = await createToken(tokenRequest);
+      const createdData = await createResponse.json();
+      const tokenToDeleteId = createdData.id;
+
+      // Delete the token
+      const deleteRequest = createTestRequest(
+        `http://localhost:3000/v1/tokens/${tokenToDeleteId}`,
+        { method: "DELETE" },
+      );
+
+      const deleteResponse = await deleteToken(deleteRequest);
+
+      expect(deleteResponse.status).toBe(204);
+
+      // Verify it's gone
+      const getRequest = createTestRequest(
+        `http://localhost:3000/v1/tokens/${tokenToDeleteId}`,
+      );
+
+      const getResponse = await getToken(getRequest);
+
+      expect(getResponse.status).toBe(404);
+    });
+
+    it("should return 404 for non-existent token", async () => {
+      const fakeId = randomUUID();
+      const request = createTestRequest(
+        `http://localhost:3000/v1/tokens/${fakeId}`,
+        { method: "DELETE" },
+      );
+
+      const response = await deleteToken(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.type).toBe("not_found_error");
+    });
+  });
+
+  describe("Error Response Format", () => {
+    it("should return Stripe-style error format", async () => {
+      mockUserId = "";
+
+      const request = createTestRequest("http://localhost:3000/v1/tokens");
+      const response = await listTokens(request);
+      const data = await response.json();
+
+      expect(data.error).toBeDefined();
+      expect(data.error.type).toBeDefined();
+      expect(data.error.code).toBeDefined();
+      expect(data.error.message).toBeDefined();
+
+      mockUserId = testUserId;
+    });
+  });
+});

--- a/turbo/apps/web/app/v1/tokens/route.ts
+++ b/turbo/apps/web/app/v1/tokens/route.ts
@@ -1,0 +1,166 @@
+/**
+ * Public API v1 - Tokens Endpoints
+ *
+ * GET /v1/tokens - List user's API tokens
+ * POST /v1/tokens - Create new API token
+ */
+import { initServices } from "../../../src/lib/init-services";
+import {
+  createPublicApiHandler,
+  tsr,
+} from "../../../src/lib/public-api/handler";
+import { publicTokensListContract } from "@vm0/core";
+import {
+  authenticatePublicApi,
+  isAuthSuccess,
+} from "../../../src/lib/public-api/auth";
+import { cliTokens } from "../../../src/db/schema/cli-tokens";
+import { eq, and, desc, gt } from "drizzle-orm";
+import { randomBytes } from "crypto";
+
+/**
+ * Generate a new API token with prefix
+ * Format: vm0_live_<32 random bytes in hex>
+ */
+function generateApiToken(): string {
+  const randomPart = randomBytes(32).toString("hex");
+  return `vm0_live_${randomPart}`;
+}
+
+/**
+ * Extract token prefix for display (first 12 chars)
+ */
+function getTokenPrefix(token: string): string {
+  return token.substring(0, 16) + "...";
+}
+
+const router = tsr.router(publicTokensListContract, {
+  list: async ({ query }) => {
+    initServices();
+
+    const auth = await authenticatePublicApi();
+    if (!isAuthSuccess(auth)) {
+      return {
+        status: 401 as const,
+        body: {
+          error: {
+            type: "authentication_error" as const,
+            code: "invalid_api_key",
+            message: "Invalid API key provided",
+          },
+        },
+      };
+    }
+
+    // Build query conditions - filter by user
+    const conditions = [eq(cliTokens.userId, auth.userId)];
+
+    // Handle cursor-based pagination
+    if (query.cursor) {
+      conditions.push(gt(cliTokens.id, query.cursor));
+    }
+
+    const limit = query.limit ?? 20;
+
+    // Fetch tokens
+    const tokens = await globalThis.services.db
+      .select()
+      .from(cliTokens)
+      .where(and(...conditions))
+      .orderBy(desc(cliTokens.createdAt))
+      .limit(limit + 1);
+
+    // Determine pagination info
+    const hasMore = tokens.length > limit;
+    const data = hasMore ? tokens.slice(0, limit) : tokens;
+    const nextCursor =
+      hasMore && data.length > 0 ? data[data.length - 1]!.id : null;
+
+    return {
+      status: 200 as const,
+      body: {
+        data: data.map((token) => ({
+          id: token.id,
+          name: token.name,
+          token_prefix: getTokenPrefix(token.token),
+          last_used_at: token.lastUsedAt?.toISOString() ?? null,
+          expires_at: token.expiresAt.toISOString(),
+          created_at: token.createdAt.toISOString(),
+        })),
+        pagination: {
+          has_more: hasMore,
+          next_cursor: nextCursor,
+        },
+      },
+    };
+  },
+
+  create: async ({ body }) => {
+    initServices();
+
+    const auth = await authenticatePublicApi();
+    if (!isAuthSuccess(auth)) {
+      return {
+        status: 401 as const,
+        body: {
+          error: {
+            type: "authentication_error" as const,
+            code: "invalid_api_key",
+            message: "Invalid API key provided",
+          },
+        },
+      };
+    }
+
+    const { name, expires_in_days } = body;
+
+    // Calculate expiry date (default 90 days)
+    const expiryDays = expires_in_days ?? 90;
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + expiryDays);
+
+    // Generate new token
+    const token = generateApiToken();
+
+    // Insert token into database
+    const [newToken] = await globalThis.services.db
+      .insert(cliTokens)
+      .values({
+        token,
+        userId: auth.userId,
+        name,
+        expiresAt,
+      })
+      .returning();
+
+    if (!newToken) {
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            type: "invalid_request_error" as const,
+            code: "internal_error",
+            message: "Failed to create token",
+          },
+        },
+      };
+    }
+
+    return {
+      status: 201 as const,
+      body: {
+        id: newToken.id,
+        name: newToken.name,
+        token_prefix: getTokenPrefix(newToken.token),
+        token, // Full token value - only returned on creation!
+        last_used_at: null,
+        expires_at: newToken.expiresAt.toISOString(),
+        created_at: newToken.createdAt.toISOString(),
+      },
+    };
+  },
+});
+
+const handler = createPublicApiHandler(publicTokensListContract, router);
+
+export { handler as GET, handler as POST };

--- a/turbo/packages/core/src/contracts/public/index.ts
+++ b/turbo/packages/core/src/contracts/public/index.ts
@@ -190,3 +190,21 @@ export {
   type PublicVolumeCommitContract,
   type PublicVolumeDownloadContract,
 } from "./volumes";
+
+// Token contracts
+export {
+  // Schemas
+  publicTokenSchema,
+  publicTokenDetailSchema,
+  paginatedTokensSchema,
+  createTokenRequestSchema,
+  // Contracts
+  publicTokensListContract,
+  publicTokenByIdContract,
+  // Types
+  type PublicToken,
+  type PublicTokenDetail,
+  type CreateTokenRequest,
+  type PublicTokensListContract,
+  type PublicTokenByIdContract,
+} from "./tokens";

--- a/turbo/packages/core/src/contracts/public/tokens.ts
+++ b/turbo/packages/core/src/contracts/public/tokens.ts
@@ -1,0 +1,129 @@
+/**
+ * Public API v1 - Tokens Contract
+ *
+ * Token management endpoints for self-service API token creation and revocation.
+ */
+import { z } from "zod";
+import { initContract } from "../base";
+import {
+  publicApiErrorSchema,
+  createPaginatedResponseSchema,
+  listQuerySchema,
+  timestampSchema,
+} from "./common";
+
+const c = initContract();
+
+/**
+ * Token schema for public API responses (does not include secret)
+ */
+export const publicTokenSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  token_prefix: z.string(), // First 12 chars for identification (e.g., "vm0_live_abc")
+  last_used_at: timestampSchema.nullable(),
+  expires_at: timestampSchema,
+  created_at: timestampSchema,
+});
+
+export type PublicToken = z.infer<typeof publicTokenSchema>;
+
+/**
+ * Token detail schema with full token value (only on creation)
+ */
+export const publicTokenDetailSchema = publicTokenSchema.extend({
+  token: z.string().optional(), // Full token value, only returned on creation
+});
+
+export type PublicTokenDetail = z.infer<typeof publicTokenDetailSchema>;
+
+/**
+ * Paginated tokens response
+ */
+export const paginatedTokensSchema =
+  createPaginatedResponseSchema(publicTokenSchema);
+
+/**
+ * Create token request schema
+ */
+export const createTokenRequestSchema = z.object({
+  name: z.string().min(1, "Name is required").max(100, "Name too long"),
+  expires_in_days: z.number().min(1).max(365).optional(), // null for no expiry (default 90 days)
+});
+
+export type CreateTokenRequest = z.infer<typeof createTokenRequestSchema>;
+
+/**
+ * Tokens List Contract
+ *
+ * GET /v1/tokens - List user's API tokens
+ */
+export const publicTokensListContract = c.router({
+  list: {
+    method: "GET",
+    path: "/v1/tokens",
+    query: listQuerySchema,
+    responses: {
+      200: paginatedTokensSchema,
+      401: publicApiErrorSchema,
+    },
+    summary: "List API tokens",
+    description: "List all API tokens for the authenticated user",
+  },
+  create: {
+    method: "POST",
+    path: "/v1/tokens",
+    body: createTokenRequestSchema,
+    responses: {
+      201: publicTokenDetailSchema, // Includes full token value
+      400: publicApiErrorSchema,
+      401: publicApiErrorSchema,
+    },
+    summary: "Create API token",
+    description:
+      "Create a new API token. The token value is only returned once on creation.",
+  },
+});
+
+export type PublicTokensListContract = typeof publicTokensListContract;
+
+/**
+ * Token by ID Contract
+ *
+ * GET /v1/tokens/:id - Get token details (without secret)
+ * DELETE /v1/tokens/:id - Revoke token
+ */
+export const publicTokenByIdContract = c.router({
+  get: {
+    method: "GET",
+    path: "/v1/tokens/:id",
+    pathParams: z.object({
+      id: z.string(),
+    }),
+    responses: {
+      200: publicTokenSchema, // Does NOT include token value
+      401: publicApiErrorSchema,
+      404: publicApiErrorSchema,
+    },
+    summary: "Get API token",
+    description:
+      "Get details of an API token (does not include the token value)",
+  },
+  delete: {
+    method: "DELETE",
+    path: "/v1/tokens/:id",
+    pathParams: z.object({
+      id: z.string(),
+    }),
+    responses: {
+      204: z.undefined(),
+      401: publicApiErrorSchema,
+      404: publicApiErrorSchema,
+    },
+    summary: "Revoke API token",
+    description:
+      "Permanently revoke an API token. This action cannot be undone.",
+  },
+});
+
+export type PublicTokenByIdContract = typeof publicTokenByIdContract;


### PR DESCRIPTION
## Summary

Implements Phase 4.1 of Issue #997 - Tokens API for self-service token management.

### New Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/v1/tokens` | List user's API tokens |
| POST | `/v1/tokens` | Create new API token |
| GET | `/v1/tokens/:id` | Get token details |
| DELETE | `/v1/tokens/:id` | Revoke token |

### Features

- **Security**: Token value only returned on creation (cannot be retrieved later)
- **Token prefix**: Shows first 16 chars in list/get for identification
- **Configurable expiry**: Default 90 days, can be customized via `expires_in_days`
- **Consistent patterns**: Same auth and error handling as other v1 endpoints

### Test Coverage

12 tests covering:
- Create token (success, default expiry, unauthorized)
- List tokens (pagination, unauthorized)
- Get token (success, not found, other user)
- Delete token (success, not found)
- Error response format

### Files Changed

- `packages/core/src/contracts/public/tokens.ts` - Token contracts
- `packages/core/src/contracts/public/index.ts` - Export tokens
- `apps/web/app/v1/tokens/route.ts` - List/Create handlers
- `apps/web/app/v1/tokens/[id]/route.ts` - Get/Delete handlers
- `apps/web/app/v1/tokens/__tests__/route.test.ts` - Tests

## Test plan

- [x] All 12 new tests pass
- [x] Type check passes
- [x] Lint passes
- [ ] CI pipeline passes

Closes part of #997

🤖 Generated with [Claude Code](https://claude.ai/code)