### PR TITLE
ci(storybook): add CI/CD and release-please configuration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,6 +23,7 @@ jobs:
       docs_release_created: ${{ steps.release.outputs['turbo/apps/docs--release_created'] }}
       runner_release_created: ${{ steps.release.outputs['turbo/apps/runner--release_created'] }}
       platform_release_created: ${{ steps.release.outputs['turbo/apps/platform--release_created'] }}
+      storybook_release_created: ${{ steps.release.outputs['turbo/apps/storybook--release_created'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -160,6 +161,30 @@ jobs:
           environment-variables: |
             VITE_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
             VITE_API_URL=https://www.vm0.ai
+
+  # Deploy storybook to production
+  deploy-storybook-production:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.storybook_release_created == 'true' }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:829341a
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Deploy Storybook to Vercel Production
+        id: deploy
+        uses: ./.github/actions/vercel-deploy
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_STORYBOOK }}
+          environment: production
+          deployment-env: storybook
 
   publish-npm:
     needs: release-please

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -27,6 +27,7 @@ jobs:
       cli-changed: ${{ steps.detect.outputs.cli-changed }}
       runner-changed: ${{ steps.detect.outputs.runner-changed }}
       platform-changed: ${{ steps.detect.outputs.platform-changed }}
+      storybook-changed: ${{ steps.detect.outputs.storybook-changed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -46,6 +47,7 @@ jobs:
             echo "cli-changed=true" >> $GITHUB_OUTPUT
             echo "runner-changed=false" >> $GITHUB_OUTPUT
             echo "platform-changed=false" >> $GITHUB_OUTPUT
+            echo "storybook-changed=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -57,6 +59,7 @@ jobs:
             echo "cli-changed=true" >> $GITHUB_OUTPUT
             echo "runner-changed=true" >> $GITHUB_OUTPUT
             echo "platform-changed=true" >> $GITHUB_OUTPUT
+            echo "storybook-changed=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -123,6 +126,16 @@ jobs:
           else
             echo "Changes detected in platform"
             echo "platform-changed=true" >> $GITHUB_OUTPUT
+          fi
+
+          # Check storybook
+          cd /__w/vm0/vm0/turbo/apps/storybook
+          if npx turbo-ignore 2>/dev/null; then
+            echo "No changes detected in storybook"
+            echo "storybook-changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected in storybook"
+            echo "storybook-changed=true" >> $GITHUB_OUTPUT
           fi
 
   lint:
@@ -293,6 +306,34 @@ jobs:
           deployment-env: platform
           environment-variables: |
             VITE_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          meta-branch: ${{ github.head_ref }}
+          meta-pr: ${{ github.event.pull_request.number }}
+
+  # Deploy storybook
+  deploy-storybook:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:829341a
+    needs: [change-detection]
+    # Only deploy if it's a PR and storybook changed
+    if: github.event_name == 'pull_request' && needs.change-detection.outputs.storybook-changed == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Deploy Storybook to Vercel
+        id: deploy
+        uses: ./.github/actions/vercel-deploy
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_STORYBOOK }}
+          environment: preview
+          deployment-env: storybook
           meta-branch: ${{ github.head_ref }}
           meta-pr: ${{ github.event.pull_request.number }}
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"turbo/apps/cli":"4.37.0","turbo/packages/core":"3.2.0","turbo/apps/web":"8.3.0","turbo/apps/docs":"0.13.10","turbo/apps/runner":"2.3.1","turbo/apps/platform":"0.5.0"}
+{"turbo/apps/cli":"4.37.0","turbo/packages/core":"3.2.0","turbo/apps/web":"8.3.0","turbo/apps/docs":"0.13.10","turbo/apps/runner":"2.3.1","turbo/apps/platform":"0.5.0","turbo/apps/storybook":"0.0.1"}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,6 +17,9 @@
         },
         "turbo/apps/platform": {
             "releaseType": "node"
+        },
+        "turbo/apps/storybook": {
+            "releaseType": "node"
         }
     },
     "plugins": [


### PR DESCRIPTION
## Summary

- Add storybook-changed detection to `turbo.yml` change detection job
- Add `deploy-storybook` preview job for PR deployments
- Add storybook to `release-please-config.json` with `releaseType: node`
- Add storybook to `.release-please-manifest.json` with initial version `0.0.1`
- Add `deploy-storybook-production` job to `release-please.yml`

## Related

Completes Phase 5 and Phase 6 of #1013

## Prerequisites

- [x] `VERCEL_PROJECT_ID_STORYBOOK` GitHub variable set to `prj_hp3YXd7HAOVZ6Cb8jAE4nEoebbjl`

## Test plan

- [x] YAML syntax is valid
- [ ] CI pipeline passes
- [ ] Preview deployment triggers on storybook changes
- [ ] Production deployment triggers on storybook release

🤖 Generated with [Claude Code](https://claude.com/claude-code)