### PR TITLE
fix(storybook): rename package to avoid release-please circular dependency

### DIFF
--- a/turbo/apps/storybook/package.json
+++ b/turbo/apps/storybook/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "storybook",
+  "name": "@vm0/storybook",
   "version": "0.0.1",
   "private": true,
   "type": "module",

--- a/turbo/apps/storybook/vercel.json
+++ b/turbo/apps/storybook/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "cd ../.. && pnpm run build --filter=storybook",
+  "buildCommand": "cd ../.. && pnpm run build --filter=@vm0/storybook",
   "installCommand": "cd ../.. && pnpm install",
   "outputDirectory": "storybook-static"
 }


### PR DESCRIPTION
## Summary
- Renames storybook package from `storybook` to `@vm0/storybook`
- Fixes release-please circular dependency detection error: `storybook -> storybook`

## Problem
The release-please workflow was failing with:
```
release-please failed: found cycle in dependency graph: storybook -> storybook
```

This occurred because the package name `storybook` conflicts with the npm package `storybook` in devDependencies.

## Solution
Renamed the package to `@vm0/storybook` following the project's package naming convention.

## Test plan
- [ ] Verify release-please workflow succeeds after merge
- [ ] Verify storybook build still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)