### PR TITLE
refactor(platform): remove unnecessary eslint-disable in fetch.ts

### DIFF
--- a/turbo/apps/platform/src/signals/fetch.ts
+++ b/turbo/apps/platform/src/signals/fetch.ts
@@ -68,12 +68,10 @@ export const fetch$ = computed((get) => {
     } else {
       const autoHeaders: Record<string, string> = {};
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { headers, ...restOptions } = options ?? {};
       finalInit = {
         credentials: "include",
         method: "GET",
-        ...restOptions,
+        ...options,
         headers: mergeHeadersWithAutoIds(
           authHeaders,
           options?.headers,

--- a/turbo/apps/platform/src/views/default-error-boundary.tsx
+++ b/turbo/apps/platform/src/views/default-error-boundary.tsx
@@ -6,7 +6,7 @@ interface ErrorFallbackProps {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function DefaultErrorFallback(_: ErrorFallbackProps) {
+export function DefaultErrorFallback(_props: ErrorFallbackProps) {
   return (
     <div className="flex h-screen items-center justify-center bg-white">
       <div className="flex flex-col items-center">


### PR DESCRIPTION
## Summary
- Remove `eslint-disable` for `no-unused-vars` in `fetch.ts` by simplifying code to spread `options` directly instead of unnecessary destructuring
- Rename unused parameter from `_` to `_props` in `default-error-boundary.tsx` for better clarity

## Test plan
- [x] Lint check passes: `npx eslint src/views/default-error-boundary.tsx src/signals/fetch.ts --max-warnings 0`
- [x] Type check passes: `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)