### PR TITLE
feat(platform): migrate phase 2 infrastructure from uspark workspace

### DIFF
--- a/turbo/apps/platform/custom-eslint/__tests__/no-catch-abort.test.ts
+++ b/turbo/apps/platform/custom-eslint/__tests__/no-catch-abort.test.ts
@@ -1,0 +1,74 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { describe, it, afterAll } from "vitest";
+import rule from "../rules/no-catch-abort.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-catch-abort", rule, {
+  valid: [
+    {
+      code: `
+        try {
+          foo()
+        } catch (e) {
+          throwIfAbort(e)
+        }
+      `,
+    },
+    {
+      code: `
+        try {
+          foo()
+        } catch (e) {
+          throwIfAbort(e)
+          console.log(e)
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        try {
+          foo()
+        } catch {}
+      `,
+      errors: [{ messageId: "noCatchAbort" }],
+    },
+    {
+      code: `
+        try {
+          foo()
+        } catch (e) {
+          throwIfAbort()
+        }
+      `,
+      errors: [{ messageId: "noCatchAbort" }],
+    },
+    {
+      code: `
+        try {
+          foo()
+        } catch (e) {
+          throwIfAbort(error)
+        }
+      `,
+      errors: [{ messageId: "noCatchAbort" }],
+    },
+    {
+      code: `
+        try {
+          foo()
+        } catch (e) {
+          console.log(e)
+          throwIfAbort(e)
+        }
+      `,
+      errors: [{ messageId: "noCatchAbort" }],
+    },
+  ],
+});

--- a/turbo/apps/platform/custom-eslint/__tests__/test-context-in-hooks.test.ts
+++ b/turbo/apps/platform/custom-eslint/__tests__/test-context-in-hooks.test.ts
@@ -1,0 +1,70 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { describe, it, afterAll } from "vitest";
+import rule from "../rules/test-context-in-hooks.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("test-context-in-hooks", rule, {
+  valid: [
+    {
+      name: "testContext called at top level without destructuring",
+      code: `
+        const context = testContext()
+      `,
+    },
+    {
+      name: "testContext destructured in it",
+      code: `
+        it('should work', () => {
+          const { store, signal } = testContext()
+        })
+      `,
+    },
+    {
+      name: "testContext destructured in test",
+      code: `
+        test('should work', () => {
+          const { store, signal } = testContext()
+        })
+      `,
+    },
+    {
+      name: "testContext destructured in beforeEach",
+      code: `
+        beforeEach(() => {
+          const { store, signal } = testContext()
+        })
+      `,
+    },
+    {
+      name: "testContext destructured in afterEach",
+      code: `
+        afterEach(() => {
+          const { store } = testContext()
+        })
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "testContext destructured at top level",
+      code: `
+        const { store, signal } = testContext()
+      `,
+      errors: [{ messageId: "testContextDestructuringOutsideHook" }],
+    },
+    {
+      name: "testContext destructured in describe but not in hook",
+      code: `
+        describe('test suite', () => {
+          const { store, signal } = testContext()
+        })
+      `,
+      errors: [{ messageId: "testContextDestructuringOutsideHook" }],
+    },
+  ],
+});

--- a/turbo/apps/platform/custom-eslint/index.ts
+++ b/turbo/apps/platform/custom-eslint/index.ts
@@ -6,12 +6,24 @@
  * - no-export-state: Don't export state() directly
  * - signal-check-await: Check AbortSignal after await in commands
  * - tsx-in-views: TSX files only allowed in views/
+ * - no-catch-abort: Enforce throwIfAbort in catch blocks
+ * - no-package-variable: Prevent mutable vars at package scope
+ * - no-get-signal: Prevent getting AbortSignal from state
+ * - test-context-in-hooks: Ensure testContext() in test hooks
+ * - computed-const-args-package-scope: Enforce package scope for constant functions
+ * - no-store-in-params: Prevent Store type in function params
  */
 
 import signalDollarSuffix from "./rules/signal-dollar-suffix.ts";
 import noExportState from "./rules/no-export-state.ts";
 import signalCheckAwait from "./rules/signal-check-await.ts";
 import tsxInViews from "./rules/tsx-in-views.ts";
+import noCatchAbort from "./rules/no-catch-abort.ts";
+import noPackageVariable from "./rules/no-package-variable.ts";
+import noGetSignal from "./rules/no-get-signal.ts";
+import testContextInHooks from "./rules/test-context-in-hooks.ts";
+import computedConstArgsPackageScope from "./rules/computed-const-args-package-scope.ts";
+import noStoreInParams from "./rules/no-store-in-params.ts";
 
 const plugin = {
   meta: {
@@ -23,6 +35,12 @@ const plugin = {
     "no-export-state": noExportState,
     "signal-check-await": signalCheckAwait,
     "tsx-in-views": tsxInViews,
+    "no-catch-abort": noCatchAbort,
+    "no-package-variable": noPackageVariable,
+    "no-get-signal": noGetSignal,
+    "test-context-in-hooks": testContextInHooks,
+    "computed-const-args-package-scope": computedConstArgsPackageScope,
+    "no-store-in-params": noStoreInParams,
   },
 };
 

--- a/turbo/apps/platform/custom-eslint/rules/computed-const-args-package-scope.ts
+++ b/turbo/apps/platform/custom-eslint/rules/computed-const-args-package-scope.ts
@@ -1,0 +1,443 @@
+/**
+ * ESLint rule: computed-const-args-package-scope
+ *
+ * Enforces that functions returning constant types (like Computed/Command)
+ * with literal arguments must be called at package scope, not at runtime.
+ *
+ * Good:
+ *   const theme$ = localStorageSignal('theme'); // At package scope
+ *
+ * Bad:
+ *   function setup() {
+ *     const theme$ = localStorageSignal('theme'); // Inside function
+ *   }
+ */
+
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  type TSESTree,
+} from "@typescript-eslint/utils";
+import {
+  SyntaxKind,
+  TypeFlags,
+  type Type,
+  type TypeChecker,
+} from "typescript";
+import { createRule, isMutableObjectType } from "../utils.ts";
+
+// Performance optimization: Cache results to avoid repeated type checking
+// Note: WeakMap is used so memory is automatically freed when nodes are garbage collected
+const enumMemberCache = new WeakMap<TSESTree.MemberExpression, boolean>();
+const constantReturnTypeCache = new WeakMap<Type, boolean>();
+
+function isEnumMember(
+  node: TSESTree.MemberExpression,
+  checker: TypeChecker,
+  services: import("@typescript-eslint/utils").ParserServicesWithTypeInformation,
+): boolean {
+  // Check cache first
+  const cached = enumMemberCache.get(node);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  if (
+    node.object.type !== AST_NODE_TYPES.Identifier ||
+    node.property.type !== AST_NODE_TYPES.Identifier
+  ) {
+    enumMemberCache.set(node, false);
+    return false;
+  }
+
+  try {
+    // Check if the object refers to an enum
+    const objectTsNode = services.esTreeNodeToTSNodeMap.get(node.object);
+    const objectSymbol = checker.getSymbolAtLocation(objectTsNode);
+
+    if (objectSymbol?.valueDeclaration?.kind === SyntaxKind.EnumDeclaration) {
+      enumMemberCache.set(node, true);
+      return true;
+    }
+
+    // Also check the type of the member expression result
+    const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+    const type = checker.getTypeAtLocation(tsNode);
+
+    // Check if it's a literal type (which enum members are)
+    const isLiteralType =
+      type.flags &
+      (TypeFlags.String |
+        TypeFlags.Number |
+        TypeFlags.Boolean |
+        TypeFlags.StringLiteral |
+        TypeFlags.NumberLiteral |
+        TypeFlags.BooleanLiteral);
+
+    if (isLiteralType) {
+      // Additional check: is the object a known enum-like identifier?
+      const objectName = node.object.name;
+      const result = objectName
+        ? /^[A-Z][a-zA-Z]*Key$|^[A-Z][a-zA-Z]*Type$|^[A-Z][a-zA-Z]*$/.test(
+            objectName,
+          )
+        : false;
+      enumMemberCache.set(node, result);
+      return result;
+    }
+  } catch {
+    // If type checking fails, fall back to heuristic
+    const objectName = node.object.name;
+    const result = objectName
+      ? /^[A-Z][a-zA-Z]*Key$|^[A-Z][a-zA-Z]*Type$|^[A-Z][a-zA-Z]*$/.test(
+          objectName,
+        )
+      : false;
+    enumMemberCache.set(node, result);
+    return result;
+  }
+
+  enumMemberCache.set(node, false);
+  return false;
+}
+
+function isConstantValue(
+  node: TSESTree.Node,
+  checker?: TypeChecker,
+  services?: import("@typescript-eslint/utils").ParserServicesWithTypeInformation,
+): boolean {
+  if (node.type === AST_NODE_TYPES.Literal) {
+    return true;
+  }
+  if (node.type === AST_NODE_TYPES.TemplateLiteral) {
+    return node.expressions.length === 0;
+  }
+  if (node.type === AST_NODE_TYPES.UnaryExpression) {
+    return (
+      node.operator === "-" && isConstantValue(node.argument, checker, services)
+    );
+  }
+  if (node.type === AST_NODE_TYPES.ArrayExpression) {
+    return node.elements.every(
+      (el) => el && isConstantValue(el, checker, services),
+    );
+  }
+  if (node.type === AST_NODE_TYPES.ObjectExpression) {
+    return node.properties.every((prop) => {
+      if (prop.type === AST_NODE_TYPES.Property) {
+        return isConstantValue(prop.value, checker, services);
+      }
+      return false;
+    });
+  }
+  if (node.type === AST_NODE_TYPES.Identifier) {
+    return false;
+  }
+  if (node.type === AST_NODE_TYPES.MemberExpression) {
+    // Handle enum member access like LocalStorageKey.Theme
+    if (checker && services) {
+      return isEnumMember(node, checker, services);
+    }
+    return false;
+  }
+  if (
+    node.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+    node.type === AST_NODE_TYPES.FunctionExpression
+  ) {
+    if (
+      node.type === AST_NODE_TYPES.ArrowFunctionExpression &&
+      node.expression
+    ) {
+      // For arrow functions with expression body: () => 42
+      return isConstantValue(node.body, checker, services);
+    }
+    if (
+      node.body.type === AST_NODE_TYPES.BlockStatement &&
+      node.body.body.length === 1 &&
+      node.body.body[0].type === AST_NODE_TYPES.ReturnStatement &&
+      node.body.body[0].argument
+    ) {
+      return isConstantValue(node.body.body[0].argument, checker, services);
+    }
+    return false;
+  }
+  return false;
+}
+
+function hasOnlyConstantArguments(
+  node: TSESTree.CallExpression,
+  checker: TypeChecker,
+  services: import("@typescript-eslint/utils").ParserServicesWithTypeInformation,
+): boolean {
+  return node.arguments.every((arg) => {
+    if (arg.type === AST_NODE_TYPES.SpreadElement) {
+      return false;
+    }
+    return isConstantValue(arg, checker, services);
+  });
+}
+
+function isInPackageScope(node: TSESTree.Node): boolean {
+  let current: TSESTree.Node | undefined = node.parent;
+
+  while (current) {
+    if (
+      current.type === AST_NODE_TYPES.FunctionDeclaration ||
+      current.type === AST_NODE_TYPES.FunctionExpression ||
+      current.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+      current.type === AST_NODE_TYPES.MethodDefinition ||
+      current.type === AST_NODE_TYPES.ClassDeclaration ||
+      current.type === AST_NODE_TYPES.ClassExpression
+    ) {
+      return false;
+    }
+    if (current.type === AST_NODE_TYPES.Program) {
+      return true;
+    }
+    current = current.parent;
+  }
+
+  return true;
+}
+
+function getFunctionName(node: TSESTree.CallExpression): string {
+  if (node.callee.type === AST_NODE_TYPES.Identifier) {
+    return node.callee.name;
+  } else if (
+    node.callee.type === AST_NODE_TYPES.MemberExpression &&
+    node.callee.property.type === AST_NODE_TYPES.Identifier
+  ) {
+    return node.callee.property.name;
+  }
+  return "<anonymous>";
+}
+
+function isComputedOrCommandType(typeString: string): boolean {
+  return (
+    typeString.startsWith("Computed<") ||
+    typeString === "Computed" ||
+    typeString.startsWith("Command<") ||
+    typeString === "Command"
+  );
+}
+
+function checkObjectProperties(type: Type, checker: TypeChecker): boolean {
+  const properties = checker.getPropertiesOfType(type);
+
+  // Optimization: Skip objects with too many properties (likely not signal containers)
+  if (properties.length > 20) {
+    return false;
+  }
+
+  if (properties.length === 0) {
+    return false;
+  }
+
+  // Check only first few properties for performance
+  const propertiesToCheck = properties.slice(0, 10);
+  for (const property of propertiesToCheck) {
+    try {
+      // Quick check: if property name ends with $, it's likely a signal
+      if (property.name.endsWith("$")) {
+        return true;
+      }
+
+      const declaration =
+        property.valueDeclaration ?? property.declarations?.[0];
+      if (!declaration) {
+        continue;
+      }
+      const propertyType = checker.getTypeOfSymbolAtLocation(
+        property,
+        declaration,
+      );
+      const propertyTypeString = checker.typeToString(propertyType);
+
+      // If any property is Computed/Command, consider this type relevant
+      if (isComputedOrCommandType(propertyTypeString)) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
+export default createRule({
+  name: "computed-const-args-package-scope",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Enforce that functions returning constant types with literal arguments must be called at package scope",
+      recommended: true,
+      requiresTypeChecking: true,
+    },
+    schema: [],
+    messages: {
+      mustBePackageScope:
+        'Function "{{name}}" returns constant type and has only literal arguments. It must be called at package scope, not at runtime.',
+    },
+  },
+  create(context) {
+    const services = ESLintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    // Store deferred call expression checks until we finish processing all function declarations
+    const deferredCallChecks: {
+      node: TSESTree.CallExpression;
+      functionName: string;
+      returnsConstant: boolean;
+    }[] = [];
+
+    // Track functions that return constant types and are defined at package scope
+    const packageScopeConstantFunctions = new Set<string>();
+
+    function isConstantReturnType(type: Type): boolean {
+      // Check cache first
+      const cached = constantReturnTypeCache.get(type);
+      if (cached !== undefined) {
+        return cached;
+      }
+
+      const typeString = checker.typeToString(type);
+
+      // Fast path: Check if it's directly Computed/Command type (string check is fast)
+      if (isComputedOrCommandType(typeString)) {
+        constantReturnTypeCache.set(type, true);
+        return true;
+      }
+
+      // Primary condition: if it's not mutable, it's constant (covers all immutable types)
+      if (!isMutableObjectType(type, services, checker)) {
+        constantReturnTypeCache.set(type, true);
+        return true;
+      }
+
+      // Special handling for objects that contain Computed/Command properties (even if mutable)
+      // This maintains backward compatibility for signal-containing objects
+      const hasSignalProperties = checkObjectProperties(type, checker);
+      constantReturnTypeCache.set(type, hasSignalProperties);
+      return hasSignalProperties;
+    }
+
+    function functionReturnsConstant(node: TSESTree.CallExpression): boolean {
+      // Early return for known non-constant functions
+      if (node.callee.type === AST_NODE_TYPES.Identifier) {
+        const name = node.callee.name;
+        // Common functions that definitely don't return constants
+        const nonConstantFunctions = [
+          "setTimeout",
+          "setInterval",
+          "setImmediate",
+          "fetch",
+          "Promise",
+          "XMLHttpRequest",
+          "addEventListener",
+          "removeEventListener",
+          "Math.random",
+          "Date.now",
+          "performance.now",
+          "requestAnimationFrame",
+          "requestIdleCallback",
+        ];
+        if (nonConstantFunctions.includes(name)) {
+          return false;
+        }
+      }
+
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      const type = checker.getTypeAtLocation(tsNode);
+
+      // Check if the call expression returns a constant type
+      return isConstantReturnType(type);
+    }
+
+    function processDeferredCallChecks() {
+      for (const {
+        node,
+        functionName,
+        returnsConstant,
+      } of deferredCallChecks) {
+        // Skip if it doesn't return constant
+        if (!returnsConstant) {
+          continue;
+        }
+
+        // Only check calls to package-scope defined functions or 'computed'
+        if (
+          functionName !== "computed" &&
+          !packageScopeConstantFunctions.has(functionName)
+        ) {
+          continue;
+        }
+
+        // Check if all arguments are constants
+        if (!hasOnlyConstantArguments(node, checker, services)) {
+          continue;
+        }
+
+        // Skip no-argument functions (factory functions, utility functions)
+        // These are often legitimately called at runtime to create new instances
+        if (node.arguments.length === 0) {
+          continue;
+        }
+
+        // Check if the call is at package scope
+        if (!isInPackageScope(node)) {
+          context.report({
+            node,
+            messageId: "mustBePackageScope",
+            data: {
+              name: functionName,
+            },
+          });
+        }
+      }
+    }
+
+    return {
+      // Track function declarations that return constant types at package scope
+      FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
+        // Only track functions at package scope
+        if (!isInPackageScope(node) || !node.id) {
+          return;
+        }
+
+        // Check if this function returns a constant type (immutable or signal-containing)
+        const hasConstantReturn = node.body.body.some((stmt) => {
+          if (stmt.type === AST_NODE_TYPES.ReturnStatement && stmt.argument) {
+            // Check call expressions, object expressions, and other return types
+            const tsNode = services.esTreeNodeToTSNodeMap.get(stmt.argument);
+            const type = checker.getTypeAtLocation(tsNode);
+            return isConstantReturnType(type);
+          }
+          return false;
+        });
+
+        if (hasConstantReturn) {
+          packageScopeConstantFunctions.add(node.id.name);
+        }
+      },
+
+      CallExpression(node: TSESTree.CallExpression) {
+        // Get the function name
+        const functionName = getFunctionName(node);
+
+        // Check if this function call returns a constant type and store the result
+        const returnsConstant = functionReturnsConstant(node);
+
+        // Defer the check - we'll process it later when we know all function definitions
+        deferredCallChecks.push({ node, functionName, returnsConstant });
+      },
+
+      // Process all deferred checks after we've seen all function declarations
+      "Program:exit"() {
+        processDeferredCallChecks();
+        // WeakMap automatically handles memory cleanup when nodes are garbage collected
+      },
+    };
+  },
+});

--- a/turbo/apps/platform/custom-eslint/rules/computed-const-args-package-scope.ts
+++ b/turbo/apps/platform/custom-eslint/rules/computed-const-args-package-scope.ts
@@ -18,12 +18,7 @@ import {
   ESLintUtils,
   type TSESTree,
 } from "@typescript-eslint/utils";
-import {
-  SyntaxKind,
-  TypeFlags,
-  type Type,
-  type TypeChecker,
-} from "typescript";
+import { SyntaxKind, TypeFlags, type Type, type TypeChecker } from "typescript";
 import { createRule, isMutableObjectType } from "../utils.ts";
 
 // Performance optimization: Cache results to avoid repeated type checking

--- a/turbo/apps/platform/custom-eslint/rules/no-catch-abort.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-catch-abort.ts
@@ -1,0 +1,91 @@
+/**
+ * ESLint rule: no-catch-abort
+ *
+ * Enforces that catch blocks start with throwIfAbort(e) to properly
+ * re-throw AbortError and not swallow cancellation signals.
+ *
+ * Good:
+ *   try {
+ *     await fetch(url);
+ *   } catch (e) {
+ *     throwIfAbort(e);
+ *     // handle other errors
+ *   }
+ *
+ * Bad:
+ *   try {
+ *     await fetch(url);
+ *   } catch (e) {
+ *     console.error(e); // Missing throwIfAbort
+ *   }
+ */
+
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { createRule } from "../utils.ts";
+
+function checkCatchClauseHasThrowIfAbort(node: TSESTree.CatchClause): boolean {
+  if (!node.param || node.param.type !== AST_NODE_TYPES.Identifier) {
+    return true;
+  }
+
+  if (node.body.body.length === 0) {
+    return true;
+  }
+
+  const firstStatement = node.body.body[0];
+
+  if (firstStatement.type !== AST_NODE_TYPES.ExpressionStatement) {
+    return true;
+  }
+
+  if (firstStatement.expression.type !== AST_NODE_TYPES.CallExpression) {
+    return true;
+  }
+
+  const callExpr = firstStatement.expression;
+  if (
+    callExpr.callee.type !== AST_NODE_TYPES.Identifier ||
+    callExpr.callee.name !== "throwIfAbort"
+  ) {
+    return true;
+  }
+
+  if (
+    callExpr.arguments.length !== 1 ||
+    callExpr.arguments[0].type !== AST_NODE_TYPES.Identifier ||
+    callExpr.arguments[0].name !== node.param.name
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+export default createRule({
+  name: "no-catch-abort",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Enforce throwIfAbort in catch block",
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      noCatchAbort:
+        "throwIfAbort should be the first statement in catch block.",
+    },
+  },
+  create(context) {
+    return {
+      CatchClause: (block) => {
+        if (checkCatchClauseHasThrowIfAbort(block)) {
+          context.report({
+            node: block,
+            messageId: "noCatchAbort",
+          });
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/platform/custom-eslint/rules/no-get-signal.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-get-signal.ts
@@ -1,0 +1,136 @@
+/**
+ * ESLint rule: no-get-signal
+ *
+ * Prevents getting AbortSignal from state/computed.
+ * AbortSignal should be passed as parameter, not stored in state.
+ *
+ * Good:
+ *   command(async ({ get }, signal: AbortSignal) => {
+ *     // use signal directly
+ *   })
+ *
+ * Bad:
+ *   const signal$ = state<AbortSignal>(new AbortController().signal);
+ *   command(({ get }) => {
+ *     const signal = get(signal$); // BAD - getting signal from state
+ *   })
+ */
+
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  type TSESTree,
+} from "@typescript-eslint/utils";
+import type { Type } from "typescript";
+import { createRule } from "../utils.ts";
+
+export default createRule({
+  name: "no-get-signal",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "AbortSignal should not be get by state, use signal parameter instead.",
+      recommended: true,
+      requiresTypeChecking: true,
+    },
+    schema: [],
+    messages: {
+      noGetSignal:
+        "AbortSignal should not be get by state, use signal parameter instead.",
+    },
+  },
+  create(context) {
+    const services = ESLintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    const typeCache = new WeakMap<Type, boolean>();
+
+    function isSignalType(type: Type): boolean {
+      const cached = typeCache.get(type);
+      if (cached !== undefined) {
+        return cached;
+      }
+
+      const typeString = checker.typeToString(type);
+
+      const isStateOrComputed = /^(State|Computed)<.*>$/.test(typeString);
+
+      if (isStateOrComputed) {
+        const symbol = type.getSymbol();
+        if (symbol) {
+          const declarations = symbol.getDeclarations();
+          if (declarations?.length) {
+            const sourceFile = declarations[0].getSourceFile();
+            const result = sourceFile.fileName.includes("ccstate");
+            typeCache.set(type, result);
+            return result;
+          }
+        }
+      }
+
+      typeCache.set(type, false);
+      return false;
+    }
+
+    function hasDirectAbortSignalGeneric(type: Type): boolean {
+      const typeString = checker.typeToString(type);
+
+      // Matches：
+      // State<AbortSignal>
+      // Computed<AbortSignal>
+      // State<AbortSignal | undefined>
+      // Computed<AbortSignal | undefined>
+      // State<Map<string, AbortSignal>>
+      // Computed<Map<string, AbortSignal>>
+      // State<Map<string, AbortSignal | undefined>>
+      // Computed<Map<string, AbortSignal | undefined>>
+      // Does not match:
+      // State<Map<string, Command<void, [AbortSignal]>>>
+      const directAbortSignalPattern =
+        /^(State|Computed)<(AbortSignal(\s*\|\s*undefined)?|undefined\s*\|\s*AbortSignal|Map<[^,]+,\s*(AbortSignal(\s*\|\s*undefined)?|undefined\s*\|\s*AbortSignal)>)>$/;
+      return directAbortSignalPattern.test(typeString);
+    }
+
+    function isStoreGet(node: TSESTree.CallExpression): boolean {
+      if (node.callee.type === AST_NODE_TYPES.MemberExpression) {
+        const object = node.callee.object;
+        const property = node.callee.property;
+
+        return (
+          object.type === AST_NODE_TYPES.Identifier &&
+          object.name === "store" &&
+          property.type === AST_NODE_TYPES.Identifier &&
+          property.name === "get"
+        );
+      }
+      return false;
+    }
+
+    return {
+      CallExpression(node: TSESTree.CallExpression) {
+        if (isStoreGet(node)) {
+          return;
+        }
+
+        if (
+          node.callee.type === AST_NODE_TYPES.Identifier &&
+          node.callee.name === "get" &&
+          node.arguments.length > 0
+        ) {
+          const firstArg = node.arguments[0];
+          const tsNode = services.esTreeNodeToTSNodeMap.get(firstArg);
+          const type = checker.getTypeAtLocation(tsNode);
+
+          if (isSignalType(type) && hasDirectAbortSignalGeneric(type)) {
+            context.report({
+              node,
+              messageId: "noGetSignal",
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/platform/custom-eslint/rules/no-package-variable.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-package-variable.ts
@@ -1,0 +1,212 @@
+/**
+ * ESLint rule: no-package-variable
+ *
+ * Prevents mutable variables at package (module) scope.
+ * Use signals (state/computed) for module-level state instead.
+ *
+ * Good:
+ *   const count$ = state(0);
+ *   const config = Object.freeze({ key: 'value' });
+ *
+ * Bad:
+ *   let counter = 0;
+ *   const items = [];
+ *   const cache = new Map();
+ */
+
+import type { TypeOrValueSpecifier } from "@typescript-eslint/type-utils";
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  type ParserServicesWithTypeInformation,
+  type TSESTree,
+} from "@typescript-eslint/utils";
+import type { TypeChecker } from "typescript";
+import { createRule, isMutableObjectType } from "../utils.ts";
+
+interface Options {
+  allowedMutableTypes?: TypeOrValueSpecifier[];
+}
+
+function isPackageScope(node: TSESTree.Node): boolean {
+  let parent = node.parent;
+  while (parent) {
+    if (
+      parent.type === AST_NODE_TYPES.FunctionDeclaration ||
+      parent.type === AST_NODE_TYPES.FunctionExpression ||
+      parent.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+      parent.type === AST_NODE_TYPES.BlockStatement ||
+      parent.type === AST_NODE_TYPES.ClassDeclaration
+    ) {
+      return false;
+    }
+    parent = parent.parent;
+  }
+  return true;
+}
+
+function checkObjectPattern(
+  node: TSESTree.ObjectPattern,
+  services: ParserServicesWithTypeInformation,
+  checker: TypeChecker,
+  allowedMutableTypes: TypeOrValueSpecifier[] = [],
+): boolean {
+  for (const property of node.properties) {
+    if (
+      property.type === AST_NODE_TYPES.Property &&
+      property.value.type === AST_NODE_TYPES.Identifier
+    ) {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(property.value);
+      const type = checker.getTypeAtLocation(tsNode);
+
+      if (isMutableObjectType(type, services, checker, allowedMutableTypes)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function checkIdentifier(
+  node: TSESTree.Identifier,
+  services: ParserServicesWithTypeInformation,
+  checker: TypeChecker,
+  allowedMutableTypes: TypeOrValueSpecifier[] = [],
+): boolean {
+  const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+  const type = checker.getTypeAtLocation(tsNode);
+
+  return isMutableObjectType(type, services, checker, allowedMutableTypes);
+}
+
+function checkArrayPattern(
+  node: TSESTree.ArrayPattern,
+  services: ParserServicesWithTypeInformation,
+  checker: TypeChecker,
+  allowedMutableTypes: TypeOrValueSpecifier[] = [],
+): boolean {
+  for (const element of node.elements) {
+    if (!element || element.type !== AST_NODE_TYPES.Identifier) {
+      continue;
+    }
+    const tsNode = services.esTreeNodeToTSNodeMap.get(element);
+    const type = checker.getTypeAtLocation(tsNode);
+
+    if (isMutableObjectType(type, services, checker, allowedMutableTypes)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function checkDeclarator(
+  declarator: TSESTree.VariableDeclarator,
+  services: ParserServicesWithTypeInformation,
+  checker: TypeChecker,
+  allowedMutableTypes: TypeOrValueSpecifier[] = [],
+): boolean {
+  if (declarator.id.type === AST_NODE_TYPES.ObjectPattern) {
+    return checkObjectPattern(
+      declarator.id,
+      services,
+      checker,
+      allowedMutableTypes,
+    );
+  }
+  if (declarator.id.type === AST_NODE_TYPES.ArrayPattern) {
+    return checkArrayPattern(
+      declarator.id,
+      services,
+      checker,
+      allowedMutableTypes,
+    );
+  }
+  return checkIdentifier(
+    declarator.id,
+    services,
+    checker,
+    allowedMutableTypes,
+  );
+}
+
+export default createRule<[Options] | [], "noPackageVariable">({
+  name: "no-package-variable",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Prevent using package scope variables",
+      recommended: true,
+      requiresTypeChecking: true,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowedMutableTypes: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                from: {
+                  type: "string",
+                  enum: ["file", "lib", "package"],
+                },
+                name: {
+                  type: "string",
+                },
+                package: {
+                  type: "string",
+                },
+              },
+              required: ["from", "name"],
+              additionalProperties: false,
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noPackageVariable:
+        "Variable & mutable object is not allowed in package scope, use signals instead.",
+    },
+  },
+  create(context) {
+    const options = context.options[0];
+    const allowedMutableTypes = options?.allowedMutableTypes ?? [];
+    const services = ESLintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    return {
+      VariableDeclaration(node: TSESTree.VariableDeclaration) {
+        if (!isPackageScope(node)) {
+          return;
+        }
+
+        if (node.kind !== "const") {
+          context.report({
+            node,
+            messageId: "noPackageVariable",
+          });
+          return;
+        }
+
+        for (const declarator of node.declarations) {
+          if (!declarator.init) {
+            continue;
+          }
+
+          if (
+            checkDeclarator(declarator, services, checker, allowedMutableTypes)
+          ) {
+            context.report({
+              node: declarator,
+              messageId: "noPackageVariable",
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/platform/custom-eslint/rules/no-package-variable.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-package-variable.ts
@@ -121,12 +121,7 @@ function checkDeclarator(
       allowedMutableTypes,
     );
   }
-  return checkIdentifier(
-    declarator.id,
-    services,
-    checker,
-    allowedMutableTypes,
-  );
+  return checkIdentifier(declarator.id, services, checker, allowedMutableTypes);
 }
 
 export default createRule<[Options] | [], "noPackageVariable">({

--- a/turbo/apps/platform/custom-eslint/rules/no-store-in-params.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-store-in-params.ts
@@ -1,0 +1,199 @@
+/**
+ * ESLint rule: no-store-in-params
+ *
+ * Prevents Store type in function parameters.
+ * Store should be accessed through signals, not passed around.
+ *
+ * Good:
+ *   command(({ get, set }) => { ... });
+ *
+ * Bad:
+ *   function processStore(store: Store) { ... }
+ */
+
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  type TSESTree,
+} from "@typescript-eslint/utils";
+import type { Type } from "typescript";
+import { createRule } from "../utils.ts";
+
+export default createRule({
+  name: "no-store-in-params",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Prevent Store type in function parameters",
+      recommended: true,
+      requiresTypeChecking: true,
+    },
+    schema: [],
+    messages: {
+      noStoreInParams:
+        "Function parameters should not accept Store type: {{param}}",
+      noStoreInObjectParams:
+        "Function parameters should not contain Store type in object properties: {{param}}.{{property}}",
+    },
+  },
+
+  create(context) {
+    const services = ESLintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    function isStoreType(type: Type): boolean {
+      const typeString = checker.typeToString(type);
+      if (!typeString.includes("Store")) {
+        return false;
+      }
+
+      const symbol = type.getSymbol();
+      if (!symbol || symbol.getName() !== "Store") {
+        return false;
+      }
+      const declarations = symbol.getDeclarations();
+      if (!declarations?.length) {
+        return false;
+      }
+      const sourceFile = declarations[0].getSourceFile();
+      return sourceFile.fileName.includes("ccstate");
+    }
+
+    function checkTypeRecursively(
+      type: Type,
+      paramName: string,
+      node: TSESTree.Node,
+      path: string[] = [],
+      visitedTypes = new Set<Type>(),
+    ): void {
+      if (visitedTypes.has(type)) {
+        return;
+      }
+      visitedTypes.add(type);
+
+      if (path.length > 3) {
+        return;
+      }
+      if (isStoreType(type)) {
+        if (path.length === 0) {
+          context.report({
+            node,
+            messageId: "noStoreInParams",
+            data: { param: paramName },
+          });
+        } else {
+          context.report({
+            node,
+            messageId: "noStoreInObjectParams",
+            data: {
+              param: paramName,
+              property: path.join("."),
+            },
+          });
+        }
+        return;
+      }
+      if (type.isUnion() || type.isIntersection()) {
+        for (const subType of type.types) {
+          checkTypeRecursively(subType, paramName, node, path, visitedTypes);
+        }
+        return;
+      }
+      const typeAsString = checker.typeToString(type);
+      if (
+        typeAsString.includes("Store[]") ||
+        typeAsString.includes("Array<Store")
+      ) {
+        const numberIndexType = checker.getIndexTypeOfType(
+          type,
+          1 /* IndexKind.Number */,
+        );
+        if (numberIndexType) {
+          checkTypeRecursively(
+            numberIndexType,
+            paramName,
+            node,
+            [...path, "[]"],
+            visitedTypes,
+          );
+        }
+        return;
+      }
+
+      if (
+        path.length <= 1 &&
+        (type.isClassOrInterface() ||
+          type.getFlags() & 524_288) /* TypeFlags.Object */
+      ) {
+        const properties = type.getProperties();
+        const propsToCheck = properties.slice(0, 10);
+        for (const prop of propsToCheck) {
+          const propDeclaration = prop.valueDeclaration;
+          if (propDeclaration) {
+            const propType = checker.getTypeOfSymbolAtLocation(
+              prop,
+              propDeclaration,
+            );
+            const propTypeString = checker.typeToString(propType);
+            if (propTypeString.includes("Store")) {
+              checkTypeRecursively(
+                propType,
+                paramName,
+                node,
+                [...path, prop.getName()],
+                visitedTypes,
+              );
+            }
+          }
+        }
+      }
+    }
+
+    function checkParameter(param: TSESTree.Parameter) {
+      if (param.type !== AST_NODE_TYPES.Identifier) {
+        return;
+      }
+      const tsNode = services.esTreeNodeToTSNodeMap.get(param);
+      const type = checker.getTypeAtLocation(tsNode);
+
+      const typeFlags = type.getFlags();
+      if (
+        typeFlags &
+        (16 /* TypeFlags.Boolean */ |
+          32 /* TypeFlags.String */ |
+          64 /* TypeFlags.Number */ |
+          1024 /* TypeFlags.Null */ |
+          2048 /* TypeFlags.Undefined */ |
+          4096) /* TypeFlags.Void */
+      ) {
+        return;
+      }
+      checkTypeRecursively(type, param.name, param);
+    }
+
+    function checkFunctionParams(params: TSESTree.Parameter[]) {
+      for (const param of params) {
+        checkParameter(param);
+      }
+    }
+
+    return {
+      "FunctionDeclaration, ArrowFunctionExpression"(
+        node: TSESTree.FunctionDeclaration | TSESTree.ArrowFunctionExpression,
+      ) {
+        checkFunctionParams(node.params);
+      },
+      "FunctionExpression:not(MethodDefinition > FunctionExpression)"(
+        node: TSESTree.FunctionExpression,
+      ) {
+        checkFunctionParams(node.params);
+      },
+      MethodDefinition(node) {
+        if (node.value.type === AST_NODE_TYPES.FunctionExpression) {
+          checkFunctionParams(node.value.params);
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/platform/custom-eslint/rules/test-context-in-hooks.ts
+++ b/turbo/apps/platform/custom-eslint/rules/test-context-in-hooks.ts
@@ -1,0 +1,95 @@
+/**
+ * ESLint rule: test-context-in-hooks
+ *
+ * Prevents destructuring testContext() return value outside test hooks.
+ * This ensures proper test isolation and cleanup.
+ *
+ * Good:
+ *   const context = testContext();
+ *   it('should work', () => {
+ *     const { store, signal } = context;
+ *   });
+ *
+ * Bad:
+ *   const { store, signal } = testContext(); // Destructuring at top level
+ */
+
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { createRule } from "../utils.ts";
+
+export default createRule({
+  name: "test-context-in-hooks",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Prevent destructuring testContext() outside test hooks",
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      testContextDestructuringOutsideHook:
+        "Destructuring testContext() return value must happen within test hooks",
+    },
+  },
+  create(context) {
+    const testHooks = new Set([
+      "it",
+      "test",
+      "beforeEach",
+      "afterEach",
+      "beforeAll",
+      "afterAll",
+    ]);
+    let currentTestHookDepth = 0;
+
+    function isInTestHook(): boolean {
+      return currentTestHookDepth > 0;
+    }
+
+    function isTestContextCall(node: TSESTree.CallExpression): boolean {
+      return (
+        node.callee.type === AST_NODE_TYPES.Identifier &&
+        node.callee.name === "testContext" &&
+        node.arguments.length === 0
+      );
+    }
+
+    return {
+      // Track when we enter/exit test hooks
+      CallExpression(node: TSESTree.CallExpression) {
+        if (
+          node.callee.type === AST_NODE_TYPES.Identifier &&
+          testHooks.has(node.callee.name)
+        ) {
+          currentTestHookDepth++;
+        }
+      },
+
+      "CallExpression:exit"(node: TSESTree.CallExpression) {
+        if (
+          node.callee.type === AST_NODE_TYPES.Identifier &&
+          testHooks.has(node.callee.name)
+        ) {
+          currentTestHookDepth--;
+        }
+      },
+
+      // Only check for destructuring assignment from testContext()
+      VariableDeclarator(node: TSESTree.VariableDeclarator) {
+        if (
+          node.init &&
+          node.init.type === AST_NODE_TYPES.CallExpression &&
+          isTestContextCall(node.init) &&
+          !isInTestHook() &&
+          node.id.type === AST_NODE_TYPES.ObjectPattern
+        ) {
+          context.report({
+            node,
+            messageId: "testContextDestructuringOutsideHook",
+          });
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/platform/custom-eslint/utils.ts
+++ b/turbo/apps/platform/custom-eslint/utils.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared utilities for custom ESLint rules.
+ */
+
+import {
+  isTypeReadonly,
+  type TypeOrValueSpecifier,
+} from "@typescript-eslint/type-utils";
+import {
+  ESLintUtils,
+  type ParserServicesWithTypeInformation,
+} from "@typescript-eslint/utils";
+import type { Type, TypeChecker } from "typescript";
+
+interface RuleDocs {
+  description: string;
+  recommended?: boolean;
+  requiresTypeChecking?: boolean;
+}
+
+export const createRule = ESLintUtils.RuleCreator<RuleDocs>(
+  (name) =>
+    `https://github.com/anthropics/vm0/blob/main/docs/eslint/${name}.md`,
+);
+
+function isEmptyObjectLiteral(type: Type, checker: TypeChecker): boolean {
+  return checker.typeToString(type) === "{}";
+}
+
+export function isMutableObjectType(
+  type: Type,
+  services: ParserServicesWithTypeInformation,
+  checker: TypeChecker,
+  allowedMutableTypes: TypeOrValueSpecifier[] = [],
+): boolean {
+  return (
+    !isTypeReadonly(services.program, type, {
+      allow: allowedMutableTypes,
+    }) || isEmptyObjectLiteral(type, checker)
+  );
+}

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -18,13 +18,41 @@ export default [
     rules: {
       ...pluginReactHooks.configs.recommended.rules,
       "react/react-in-jsx-scope": "off",
+      // Non-type-aware rules
       "ccstate/signal-dollar-suffix": "error",
       "ccstate/no-export-state": "error",
       "ccstate/signal-check-await": "error",
       "ccstate/tsx-in-views": "error",
+      "ccstate/no-catch-abort": "error",
+      "ccstate/test-context-in-hooks": "error",
+    },
+  },
+  // Type-aware rules (only for TypeScript files)
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "ccstate/no-package-variable": [
+        "error",
+        {
+          allowedMutableTypes: [
+            { from: "package", name: "State", package: "ccstate" },
+            { from: "package", name: "Computed", package: "ccstate" },
+            { from: "package", name: "Command", package: "ccstate" },
+          ],
+        },
+      ],
+      "ccstate/no-get-signal": "error",
+      "ccstate/computed-const-args-package-scope": "error",
+      "ccstate/no-store-in-params": "error",
     },
   },
   {
-    ignores: ["dist/**"],
+    ignores: ["dist/**", "vite.config.ts", "vitest.config.ts"],
   },
 ];

--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -30,6 +30,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@typescript-eslint/rule-tester": "^8.52.0",
+    "@typescript-eslint/type-utils": "^8.52.0",
     "@typescript-eslint/utils": "^8.52.0",
     "@vitejs/plugin-react": "^4.5.1",
     "@vm0/eslint-config": "workspace:*",
@@ -41,6 +42,7 @@
     "oxlint": "^1.14.0",
     "tailwindcss": "^4.1.8",
     "typescript": "^5.9.2",
+    "typescript-eslint": "^8.41.0",
     "vite": "^6.3.5",
     "vitest": "^3.2.4"
   }

--- a/turbo/apps/platform/src/__tests__/polyfill.test.ts
+++ b/turbo/apps/platform/src/__tests__/polyfill.test.ts
@@ -16,7 +16,10 @@ describe("AbortSignal.any polyfill", () => {
       const controller1 = new AbortController();
       const controller2 = new AbortController();
 
-      const combined = AbortSignal.any([controller1.signal, controller2.signal]);
+      const combined = AbortSignal.any([
+        controller1.signal,
+        controller2.signal,
+      ]);
 
       expect(combined.aborted).toBe(false);
     });
@@ -27,7 +30,10 @@ describe("AbortSignal.any polyfill", () => {
 
       controller1.abort("test reason");
 
-      const combined = AbortSignal.any([controller1.signal, controller2.signal]);
+      const combined = AbortSignal.any([
+        controller1.signal,
+        controller2.signal,
+      ]);
 
       expect(combined.aborted).toBe(true);
       expect(combined.reason).toBe("test reason");
@@ -37,7 +43,10 @@ describe("AbortSignal.any polyfill", () => {
       const controller1 = new AbortController();
       const controller2 = new AbortController();
 
-      const combined = AbortSignal.any([controller1.signal, controller2.signal]);
+      const combined = AbortSignal.any([
+        controller1.signal,
+        controller2.signal,
+      ]);
       const abortHandler = vi.fn();
       combined.addEventListener("abort", abortHandler);
 
@@ -72,7 +81,10 @@ describe("AbortSignal.any polyfill", () => {
       const controller1 = new AbortController();
       const controller2 = new AbortController();
 
-      const combined = AbortSignal.any([controller1.signal, controller2.signal]);
+      const combined = AbortSignal.any([
+        controller1.signal,
+        controller2.signal,
+      ]);
       const abortHandler = vi.fn();
       combined.addEventListener("abort", abortHandler);
 

--- a/turbo/apps/platform/src/__tests__/polyfill.test.ts
+++ b/turbo/apps/platform/src/__tests__/polyfill.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+describe("AbortSignal.any polyfill", () => {
+  it("should have AbortSignal.any available", async () => {
+    // Import polyfill to ensure it's loaded
+    await import("../polyfill.ts");
+    expect(typeof AbortSignal.any).toBe("function");
+  });
+
+  describe("combining signals", () => {
+    beforeEach(async () => {
+      await import("../polyfill.ts");
+    });
+
+    it("should return non-aborted signal when none are aborted", () => {
+      const controller1 = new AbortController();
+      const controller2 = new AbortController();
+
+      const combined = AbortSignal.any([controller1.signal, controller2.signal]);
+
+      expect(combined.aborted).toBe(false);
+    });
+
+    it("should return aborted signal when one is already aborted", () => {
+      const controller1 = new AbortController();
+      const controller2 = new AbortController();
+
+      controller1.abort("test reason");
+
+      const combined = AbortSignal.any([controller1.signal, controller2.signal]);
+
+      expect(combined.aborted).toBe(true);
+      expect(combined.reason).toBe("test reason");
+    });
+
+    it("should abort when any signal is aborted later", () => {
+      const controller1 = new AbortController();
+      const controller2 = new AbortController();
+
+      const combined = AbortSignal.any([controller1.signal, controller2.signal]);
+      const abortHandler = vi.fn();
+      combined.addEventListener("abort", abortHandler);
+
+      expect(combined.aborted).toBe(false);
+
+      controller2.abort("second signal aborted");
+
+      expect(combined.aborted).toBe(true);
+      expect(combined.reason).toBe("second signal aborted");
+      expect(abortHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it("should propagate abort reason correctly", () => {
+      const controller = new AbortController();
+      const customError = new Error("Custom abort error");
+
+      controller.abort(customError);
+
+      const combined = AbortSignal.any([controller.signal]);
+
+      expect(combined.aborted).toBe(true);
+      expect(combined.reason).toBe(customError);
+    });
+
+    it("should handle empty signal array", () => {
+      const combined = AbortSignal.any([]);
+
+      expect(combined.aborted).toBe(false);
+    });
+
+    it("should only abort once even if multiple signals abort", () => {
+      const controller1 = new AbortController();
+      const controller2 = new AbortController();
+
+      const combined = AbortSignal.any([controller1.signal, controller2.signal]);
+      const abortHandler = vi.fn();
+      combined.addEventListener("abort", abortHandler);
+
+      controller1.abort("first");
+      controller2.abort("second");
+
+      // Should only be called once (first abort wins)
+      expect(abortHandler).toHaveBeenCalledTimes(1);
+      expect(combined.reason).toBe("first");
+    });
+  });
+});

--- a/turbo/apps/platform/src/main.ts
+++ b/turbo/apps/platform/src/main.ts
@@ -1,3 +1,4 @@
+import "./polyfill.ts";
 import { createStore, type Store } from "ccstate";
 import { createRoot } from "react-dom/client";
 import { bootstrap$ } from "./signals/bootstrap.ts";

--- a/turbo/apps/platform/src/polyfill.ts
+++ b/turbo/apps/platform/src/polyfill.ts
@@ -1,0 +1,32 @@
+// Conditional polyfill for AbortSignal.any()
+// Only activates when native support is missing (older browsers)
+
+if (typeof AbortSignal.any !== "function") {
+  function anySignal(signals: AbortSignal[]): AbortSignal {
+    const controller = new AbortController();
+
+    function onAbort(reason: unknown): void {
+      controller.abort(reason);
+    }
+
+    for (const signal of signals) {
+      if (signal.aborted) {
+        onAbort(signal.reason);
+        break;
+      }
+
+      signal.addEventListener(
+        "abort",
+        (event) => {
+          const target = event.target as AbortSignal;
+          onAbort(target.reason);
+        },
+        { signal: controller.signal },
+      );
+    }
+
+    return controller.signal;
+  }
+
+  AbortSignal.any = anySignal;
+}

--- a/turbo/apps/platform/src/signals/__tests__/route.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/route.test.ts
@@ -1,0 +1,313 @@
+import { command } from "ccstate";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mockLocation } from "../location.ts";
+import {
+  initRoutes$,
+  navigate$,
+  pathname$,
+  pathParams$,
+  searchParams$,
+  updateSearchParams$,
+} from "../route.ts";
+import { testContext } from "./test-helpers.ts";
+
+const context = testContext();
+
+// Helper to create a pushState mock that updates mockLocation
+function createPushStateMock(signal: AbortSignal) {
+  return vi.fn((_data: unknown, _unused: string, url: unknown) => {
+    if (typeof url === "string") {
+      const urlObj = new URL(url, "http://localhost");
+      mockLocation(
+        { pathname: urlObj.pathname, search: urlObj.search },
+        signal,
+      );
+    }
+  });
+}
+
+afterEach(() => {
+  // Reset pushState mock to default after each test
+  vi.mocked(window.history.pushState).mockImplementation(() => {});
+});
+
+describe("route", () => {
+  describe("searchParams$", () => {
+    it("should return current URL search parameters", () => {
+      const { store, signal } = context;
+      mockLocation(
+        { pathname: "/test-path", search: "?key=value&test=123" },
+        signal,
+      );
+
+      const params = store.get(searchParams$);
+      expect(params.get("key")).toBe("value");
+      expect(params.get("test")).toBe("123");
+    });
+
+    it("should return empty URLSearchParams when URL has no search parameters", () => {
+      const { store, signal } = context;
+      mockLocation({ pathname: "/test-path", search: "" }, signal);
+
+      const params = store.get(searchParams$);
+      expect([...params.entries()]).toHaveLength(0);
+    });
+  });
+
+  describe("updateSearchParams$", () => {
+    it("should update URL search parameters", () => {
+      const { store } = context;
+
+      mockLocation({ pathname: "/test-path", search: "" }, context.signal);
+      const params = new URLSearchParams();
+      params.set("foo", "bar");
+      params.set("id", "123");
+
+      store.set(updateSearchParams$, params);
+
+      expect(store.get(pathname$)).toBe("/test-path");
+    });
+  });
+
+  describe("navigate$", () => {
+    it("should navigate to new path", async () => {
+      const { store, signal } = context;
+
+      // Setup pushState mock to update location
+      const pushStateMock = createPushStateMock(signal);
+      vi.mocked(window.history.pushState).mockImplementation(pushStateMock);
+
+      mockLocation({ pathname: "/", search: "" }, signal);
+      const mockSetup = vi.fn();
+
+      // Initialize routes
+      await store.set(
+        initRoutes$,
+        [
+          {
+            path: "/",
+            setup: command(() => void 0),
+          },
+          {
+            path: "/home",
+            setup: command(() => {
+              mockSetup();
+            }),
+          },
+        ],
+        signal,
+      );
+
+      // Navigate to /home
+      await store.set(navigate$, "/home", {}, signal);
+
+      expect(pushStateMock).toHaveBeenCalledWith({}, "", "/home");
+      expect(store.get(pathname$)).toBe("/home");
+      expect(mockSetup).toHaveBeenCalledWith();
+    });
+
+    it("should throw error when navigating to non-existent route", async () => {
+      const { store, signal } = context;
+
+      // Setup pushState mock to update location
+      const pushStateMock = createPushStateMock(signal);
+      vi.mocked(window.history.pushState).mockImplementation(pushStateMock);
+
+      mockLocation({ pathname: "/", search: "" }, signal);
+      const mockSetup$ = command(() => void 0);
+
+      // Initialize routes
+      await store.set(
+        initRoutes$,
+        [
+          {
+            path: "/",
+            setup: command(() => void 0),
+          },
+          { path: "/home", setup: mockSetup$ },
+        ],
+        signal,
+      );
+
+      // Navigate to non-existent path
+      await expect(
+        store.set(navigate$, "/non-existent", {}, signal),
+      ).rejects.toThrow("No route matches");
+    });
+
+    it("should navigate to new path and update search parameters", async () => {
+      const { store, signal } = context;
+
+      // Setup pushState mock to update location
+      const pushStateMock = createPushStateMock(signal);
+      vi.mocked(window.history.pushState).mockImplementation(pushStateMock);
+
+      mockLocation({ pathname: "/", search: "" }, signal);
+      const mockSetup = vi.fn();
+
+      // Initialize routes
+      await store.set(
+        initRoutes$,
+        [
+          {
+            path: "/",
+            setup: command(() => void 0),
+          },
+          {
+            path: "/home",
+            setup: command(() => {
+              mockSetup();
+            }),
+          },
+        ],
+        signal,
+      );
+
+      // Navigate to /home
+      await store.set(
+        navigate$,
+        "/home",
+        { searchParams: new URLSearchParams("foo=bar") },
+        signal,
+      );
+
+      expect(pushStateMock).toHaveBeenCalledWith({}, "", "/home?foo=bar");
+      expect(store.get(pathname$)).toBe("/home");
+      expect(store.get(searchParams$)).toStrictEqual(
+        new URLSearchParams("foo=bar"),
+      );
+      expect(mockSetup).toHaveBeenCalledWith();
+    });
+  });
+
+  describe("initRoutes$", () => {
+    it("should initialize routes and execute setup function of matching route", async () => {
+      const { store, signal } = context;
+      const trace = vi.fn();
+
+      mockLocation({ pathname: "/dashboard", search: "" }, signal);
+      let calledSignal: AbortSignal | undefined;
+
+      await store.set(
+        initRoutes$,
+        [
+          { path: "/", setup: command(() => void 0) },
+          {
+            path: "/dashboard",
+            setup: command((_, signal: AbortSignal) => {
+              trace(signal);
+              calledSignal = signal;
+            }),
+          },
+          { path: "/settings", setup: command(() => void 0) },
+        ],
+        signal,
+      );
+
+      expect(trace).toHaveBeenCalledWith(expect.any(AbortSignal));
+      expect(calledSignal).toBeInstanceOf(AbortSignal);
+      expect(calledSignal?.aborted).toBeFalsy();
+
+      mockLocation({ pathname: "/settings", search: "" }, signal);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+
+      expect(calledSignal?.aborted).toBeTruthy();
+    });
+
+    it("should initialize parameterized routes", async () => {
+      const { store, signal } = context;
+      mockLocation({ pathname: "/dashboard/1/edit", search: "" }, signal);
+
+      const trace = vi.fn();
+
+      await store.set(
+        initRoutes$,
+        [
+          {
+            path: "/dashboard/:id/edit",
+            setup: command((_, signal: AbortSignal) => {
+              trace(signal);
+              return Promise.resolve();
+            }),
+          },
+        ],
+        signal,
+      );
+
+      expect(trace).toHaveBeenCalledWith(expect.any(AbortSignal));
+      expect(store.get(pathParams$)).toHaveProperty("id", "1");
+    });
+
+    it("should navigate to root path when current path has no matching route", async () => {
+      const { store, signal } = context;
+      const trace = vi.fn();
+
+      // Setup pushState mock to update location
+      const pushStateMock = createPushStateMock(signal);
+      vi.mocked(window.history.pushState).mockImplementation(pushStateMock);
+
+      // Start with non-existent path, will be redirected to /
+      mockLocation({ pathname: "/non-existent", search: "" }, signal);
+
+      await store.set(
+        initRoutes$,
+        [
+          {
+            path: "/",
+            setup: command(() => {
+              trace();
+              return Promise.resolve();
+            }),
+          },
+          { path: "/dashboard", setup: command(() => void 0) },
+        ],
+        signal,
+      );
+
+      expect(pushStateMock).toHaveBeenCalledWith({}, "", "/");
+      expect(store.get(pathname$)).toBe("/");
+      expect(trace).toHaveBeenCalledWith();
+    });
+
+    it("should handle popstate events", async () => {
+      const { store, signal } = context;
+      const traceDashboard = vi.fn();
+      const traceSettings = vi.fn();
+
+      mockLocation({ pathname: "/dashboard", search: "" }, signal);
+
+      await store.set(
+        initRoutes$,
+        [
+          { path: "/", setup: command(() => void 0) },
+          {
+            path: "/dashboard",
+            setup: command(() => {
+              traceDashboard();
+              return Promise.resolve();
+            }),
+          },
+          {
+            path: "/settings",
+            setup: command(() => {
+              traceSettings();
+              return Promise.resolve();
+            }),
+          },
+        ],
+        signal,
+      );
+
+      expect(traceDashboard).toHaveBeenCalledTimes(1);
+      expect(traceSettings).toHaveBeenCalledTimes(0);
+
+      // Simulate browser history navigation
+      mockLocation({ pathname: "/settings", search: "" }, signal);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+
+      await vi.waitFor(() => {
+        expect(traceSettings).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/__tests__/route.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 import { command } from "ccstate";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { mockLocation } from "../location.ts";
+import { describe, expect, it, vi } from "vitest";
+import { mockLocation, mockPushState } from "../location.ts";
 import {
   initRoutes$,
   navigate$,
@@ -15,21 +15,20 @@ const context = testContext();
 
 // Helper to create a pushState mock that updates mockLocation
 function createPushStateMock(signal: AbortSignal) {
-  return vi.fn((_data: unknown, _unused: string, url: unknown) => {
-    if (typeof url === "string") {
-      const urlObj = new URL(url, "http://localhost");
-      mockLocation(
-        { pathname: urlObj.pathname, search: urlObj.search },
-        signal,
-      );
-    }
-  });
+  const fn = vi.fn(
+    (_data: unknown, _unused: string, url?: string | URL | null) => {
+      if (typeof url === "string") {
+        const urlObj = new URL(url, "http://localhost");
+        mockLocation(
+          { pathname: urlObj.pathname, search: urlObj.search },
+          signal,
+        );
+      }
+    },
+  ) as unknown as typeof window.history.pushState;
+  mockPushState(fn, signal);
+  return fn;
 }
-
-afterEach(() => {
-  // Reset pushState mock to default after each test
-  vi.mocked(window.history.pushState).mockImplementation(() => {});
-});
 
 describe("route", () => {
   describe("searchParams$", () => {
@@ -72,10 +71,7 @@ describe("route", () => {
   describe("navigate$", () => {
     it("should navigate to new path", async () => {
       const { store, signal } = context;
-
-      // Setup pushState mock to update location
       const pushStateMock = createPushStateMock(signal);
-      vi.mocked(window.history.pushState).mockImplementation(pushStateMock);
 
       mockLocation({ pathname: "/", search: "" }, signal);
       const mockSetup = vi.fn();
@@ -108,10 +104,7 @@ describe("route", () => {
 
     it("should throw error when navigating to non-existent route", async () => {
       const { store, signal } = context;
-
-      // Setup pushState mock to update location
-      const pushStateMock = createPushStateMock(signal);
-      vi.mocked(window.history.pushState).mockImplementation(pushStateMock);
+      createPushStateMock(signal);
 
       mockLocation({ pathname: "/", search: "" }, signal);
       const mockSetup$ = command(() => void 0);
@@ -137,10 +130,7 @@ describe("route", () => {
 
     it("should navigate to new path and update search parameters", async () => {
       const { store, signal } = context;
-
-      // Setup pushState mock to update location
       const pushStateMock = createPushStateMock(signal);
-      vi.mocked(window.history.pushState).mockImplementation(pushStateMock);
 
       mockLocation({ pathname: "/", search: "" }, signal);
       const mockSetup = vi.fn();
@@ -241,10 +231,7 @@ describe("route", () => {
     it("should navigate to root path when current path has no matching route", async () => {
       const { store, signal } = context;
       const trace = vi.fn();
-
-      // Setup pushState mock to update location
       const pushStateMock = createPushStateMock(signal);
-      vi.mocked(window.history.pushState).mockImplementation(pushStateMock);
 
       // Start with non-existent path, will be redirected to /
       mockLocation({ pathname: "/non-existent", search: "" }, signal);

--- a/turbo/apps/platform/src/signals/location.ts
+++ b/turbo/apps/platform/src/signals/location.ts
@@ -1,6 +1,7 @@
 let _pathname: string | undefined = undefined;
 let _search: string | undefined = undefined;
 let _origin: string | undefined = undefined;
+let _pushState: typeof window.history.pushState | undefined = undefined;
 
 export const setPathname = (pathname: string) => {
   _pathname = pathname;
@@ -44,3 +45,25 @@ export const search = () => {
 export const origin = () => {
   return _origin ?? location.origin;
 };
+
+export const pushState = (
+  data: Parameters<typeof window.history.pushState>[0],
+  unused: Parameters<typeof window.history.pushState>[1],
+  url: Parameters<typeof window.history.pushState>[2],
+) => {
+  if (_pushState) {
+    _pushState.call(window.history, data, unused, url);
+  } else {
+    window.history.pushState(data, unused, url);
+  }
+};
+
+export function mockPushState(
+  fn: typeof window.history.pushState | undefined,
+  signal: AbortSignal,
+) {
+  _pushState = fn;
+  signal.addEventListener("abort", () => {
+    _pushState = undefined;
+  });
+}

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -1,17 +1,11 @@
 import { command, computed, state, type Command } from "ccstate";
 import { match } from "path-to-regexp";
 import type { RoutePath } from "../types/route.ts";
+import { clerk$ } from "./auth.ts";
+import { pathname, search } from "./location.ts";
 import { setPageSignal$ } from "./page-signal.ts";
 import { rootSignal$ } from "./root-signal.ts";
 import { detach, onDomEventFn, Reason, resetSignal } from "./utils.ts";
-
-function pathname() {
-  return window.location.pathname;
-}
-
-function search() {
-  return window.location.search;
-}
 
 const reloadPathname$ = state(0);
 
@@ -185,5 +179,25 @@ export const setupPageWrapper = (
   return command(async ({ set }, signal: AbortSignal) => {
     set(setPageSignal$, signal);
     await set(fn, signal);
+  });
+};
+
+/**
+ * Wraps a page setup function with authentication requirement.
+ * Opens sign-in dialog if user is not authenticated.
+ */
+export const setupAuthPageWrapper = (
+  fn: Command<Promise<void> | void, [AbortSignal]>,
+) => {
+  return command(async ({ get, set }, signal: AbortSignal) => {
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+
+    if (!clerk.user) {
+      clerk.openSignIn();
+      return;
+    }
+
+    await set(setupPageWrapper(fn), signal);
   });
 };

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -2,7 +2,7 @@ import { command, computed, state, type Command } from "ccstate";
 import { match } from "path-to-regexp";
 import type { RoutePath } from "../types/route.ts";
 import { clerk$ } from "./auth.ts";
-import { pathname, search } from "./location.ts";
+import { pathname, pushState, search } from "./location.ts";
 import { setPageSignal$ } from "./page-signal.ts";
 import { rootSignal$ } from "./root-signal.ts";
 import { detach, onDomEventFn, Reason, resetSignal } from "./utils.ts";
@@ -22,7 +22,7 @@ export const searchParams$ = computed((get) => {
 export const updateSearchParams$ = command(
   ({ set }, searchParams: URLSearchParams) => {
     const str = searchParams.toString();
-    window.history.pushState({}, "", `${pathname()}${str ? `?${str}` : ""}`);
+    pushState({}, "", `${pathname()}${str ? `?${str}` : ""}`);
     set(reloadPathname$, (x) => x + 1);
   },
 );
@@ -89,7 +89,7 @@ const navigateToDefaultWhenInvalid$ = command(({ get, set }) => {
 
   if (!get(currentRoute$)) {
     set(reloadPathname$, (x) => x + 1);
-    window.history.pushState({}, "", "/");
+    pushState({}, "", "/");
   }
 });
 
@@ -126,7 +126,7 @@ export const navigate$ = command(
     const searchParams = options.searchParams
       ? `?${options.searchParams.toString()}`
       : "";
-    window.history.pushState({}, "", `${pathname}${searchParams}`);
+    pushState({}, "", `${pathname}${searchParams}`);
     set(reloadPathname$, (x) => x + 1);
     await set(loadRoute$, signal);
   },

--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -1,6 +1,9 @@
 import "@testing-library/jest-dom/vitest";
 import { server } from "../mocks/server.ts";
-import { afterAll, afterEach, beforeAll } from "vitest";
+import { afterAll, afterEach, beforeAll, vi } from "vitest";
+
+// Mock window.history.pushState for route tests
+vi.spyOn(window.history, "pushState").mockImplementation(() => {});
 
 // Start MSW server before all tests
 beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));

--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -1,9 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { server } from "../mocks/server.ts";
-import { afterAll, afterEach, beforeAll, vi } from "vitest";
-
-// Mock window.history.pushState for route tests
-vi.spyOn(window.history, "pushState").mockImplementation(() => {});
+import { afterAll, afterEach, beforeAll } from "vitest";
 
 // Start MSW server before all tests
 beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       '@typescript-eslint/rule-tester':
         specifier: ^8.52.0
         version: 8.52.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/type-utils':
+        specifier: ^8.52.0
+        version: 8.52.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2)
       '@typescript-eslint/utils':
         specifier: ^8.52.0
         version: 8.52.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2)
@@ -239,6 +242,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
+      typescript-eslint:
+        specifier: ^8.41.0
+        version: 8.41.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2)
       vite:
         specifier: ^6.3.5
         version: 6.4.1(@types/node@22.18.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
@@ -3962,6 +3968,13 @@ packages:
 
   '@typescript-eslint/type-utils@8.41.0':
     resolution: {integrity: sha512-63qt1h91vg3KsjVVonFJWjgSK7pZHSQFKH6uwqxAH9bBrsyRhO6ONoKyXxyVBzG1lJnFAJcKAcxLS54N1ee1OQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.52.0':
+    resolution: {integrity: sha512-JD3wKBRWglYRQkAtsyGz1AewDu3mTc7NtRjR/ceTyGoPqmdS5oCdx/oZMWD5Zuqmo6/MpsYs0wp6axNt88/2EQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -7976,12 +7989,6 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  ts-api-utils@2.1.0:
-    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      typescript: '>=4.8.4'
-
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -9370,7 +9377,7 @@ snapshots:
       '@babel/parser': 7.28.3
       '@babel/template': 7.27.2
       '@babel/types': 7.28.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12407,7 +12414,7 @@ snapshots:
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.9.2)
+      ts-api-utils: 2.4.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -12418,7 +12425,7 @@ snapshots:
       '@typescript-eslint/types': 8.41.0
       '@typescript-eslint/typescript-estree': 8.41.0(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.41.0
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 9.34.0(jiti@2.6.1)
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -12498,6 +12505,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.52.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.52.0
+      '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.52.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2)
+      debug: 4.4.3
+      eslint: 9.34.0(jiti@2.6.1)
+      ts-api-utils: 2.4.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.41.0': {}
 
   '@typescript-eslint/types@8.52.0': {}
@@ -12508,12 +12527,12 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.41.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.41.0
       '@typescript-eslint/visitor-keys': 8.41.0
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.3
-      ts-api-utils: 2.1.0(typescript@5.9.2)
+      ts-api-utils: 2.4.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -12693,7 +12712,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.18.0)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@2.0.5':
     dependencies:
@@ -13874,7 +13893,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.25.9):
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       esbuild: 0.25.9
     transitivePeerDependencies:
       - supports-color
@@ -17454,10 +17473,6 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
-
-  ts-api-utils@2.1.0(typescript@5.9.2):
-    dependencies:
-      typescript: 5.9.2
 
   ts-api-utils@2.4.0(typescript@5.9.2):
     dependencies:


### PR DESCRIPTION
## Summary
- Add conditional AbortSignal.any polyfill with feature detection
- Migrate 6 ESLint rules from uspark workspace: no-catch-abort, no-package-variable, no-get-signal, test-context-in-hooks, computed-const-args-package-scope, no-store-in-params
- Update route.ts to use location.ts module and add setupAuthPageWrapper for authenticated pages
- Add comprehensive tests for polyfill (7 tests) and route modules (10 tests)

Closes #1031

## Test plan
- [x] All 93 platform tests pass
- [x] Type check passes
- [x] Build succeeds
- [x] New polyfill tests verify conditional activation and signal behavior
- [x] New route tests verify navigation, search params, and popstate handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)