### PR TITLE
fix: add v1 api routes to middleware and e2e tests

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -377,6 +377,12 @@ jobs:
       - name: Install Playwright browsers
         run: cd e2e && npx playwright install chromium
 
+      - name: Wait for Vercel deployment propagation
+        run: |
+          echo "⏳ Waiting 180 seconds for Vercel deployment to propagate to edge nodes..."
+          sleep 180
+          echo "✅ Wait complete, proceeding with tests"
+
       - name: Authenticate CLI
         run: |
           echo "Authenticating CLI with ${{ needs.deploy-web.outputs.preview-url }}"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -377,12 +377,6 @@ jobs:
       - name: Install Playwright browsers
         run: cd e2e && npx playwright install chromium
 
-      - name: Wait for Vercel deployment propagation
-        run: |
-          echo "⏳ Waiting 420 seconds (7 minutes) for Vercel deployment to propagate to edge nodes..."
-          sleep 420
-          echo "✅ Wait complete, proceeding with tests"
-
       - name: Authenticate CLI
         run: |
           echo "Authenticating CLI with ${{ needs.deploy-web.outputs.preview-url }}"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -379,8 +379,8 @@ jobs:
 
       - name: Wait for Vercel deployment propagation
         run: |
-          echo "⏳ Waiting 180 seconds for Vercel deployment to propagate to edge nodes..."
-          sleep 180
+          echo "⏳ Waiting 420 seconds (7 minutes) for Vercel deployment to propagate to edge nodes..."
+          sleep 420
           echo "✅ Wait complete, proceeding with tests"
 
       - name: Authenticate CLI

--- a/e2e/tests/02-parallel/t30-public-api-v1.bats
+++ b/e2e/tests/02-parallel/t30-public-api-v1.bats
@@ -5,6 +5,15 @@ load '../../helpers/setup'
 # Public API v1 E2E Tests
 # Tests verify that API endpoints return valid JSON responses with expected structure
 
+# Helper function to make authenticated API requests
+api_get() {
+    local endpoint="$1"
+    curl -s \
+        -H "Authorization: Bearer $VM0_TOKEN" \
+        -H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET:-}" \
+        "${VM0_API_URL}${endpoint}"
+}
+
 setup() {
     # Get token from config file if not in environment
     if [[ -z "$VM0_TOKEN" ]]; then
@@ -24,12 +33,12 @@ setup() {
 # ============================================
 
 @test "GET /v1/agents returns data array" {
-    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/agents")
+    result=$(api_get "/v1/agents")
     echo "$result" | jq -e '.data' > /dev/null
 }
 
 @test "GET /v1/agents returns pagination object" {
-    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/agents")
+    result=$(api_get "/v1/agents")
     echo "$result" | jq -e '.pagination' > /dev/null
 }
 
@@ -38,12 +47,12 @@ setup() {
 # ============================================
 
 @test "GET /v1/runs returns data array" {
-    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/runs")
+    result=$(api_get "/v1/runs")
     echo "$result" | jq -e '.data' > /dev/null
 }
 
 @test "GET /v1/runs returns pagination object" {
-    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/runs")
+    result=$(api_get "/v1/runs")
     echo "$result" | jq -e '.pagination' > /dev/null
 }
 
@@ -52,12 +61,12 @@ setup() {
 # ============================================
 
 @test "GET /v1/artifacts returns data array" {
-    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/artifacts")
+    result=$(api_get "/v1/artifacts")
     echo "$result" | jq -e '.data' > /dev/null
 }
 
 @test "GET /v1/artifacts returns pagination object" {
-    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/artifacts")
+    result=$(api_get "/v1/artifacts")
     echo "$result" | jq -e '.pagination' > /dev/null
 }
 
@@ -66,12 +75,12 @@ setup() {
 # ============================================
 
 @test "GET /v1/volumes returns data array" {
-    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/volumes")
+    result=$(api_get "/v1/volumes")
     echo "$result" | jq -e '.data' > /dev/null
 }
 
 @test "GET /v1/volumes returns pagination object" {
-    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/volumes")
+    result=$(api_get "/v1/volumes")
     echo "$result" | jq -e '.pagination' > /dev/null
 }
 
@@ -80,11 +89,11 @@ setup() {
 # ============================================
 
 @test "GET /v1/tokens returns data array" {
-    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/tokens")
+    result=$(api_get "/v1/tokens")
     echo "$result" | jq -e '.data' > /dev/null
 }
 
 @test "GET /v1/tokens returns pagination object" {
-    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/tokens")
+    result=$(api_get "/v1/tokens")
     echo "$result" | jq -e '.pagination' > /dev/null
 }

--- a/e2e/tests/02-parallel/t30-public-api-v1.bats
+++ b/e2e/tests/02-parallel/t30-public-api-v1.bats
@@ -10,18 +10,11 @@ api_get() {
     local endpoint="$1"
     local result
 
-    # Only add Vercel bypass headers if the secret is set and non-empty
-    if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
-        result=$(curl -s \
-            -H "Authorization: Bearer $VM0_TOKEN" \
-            -H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}" \
-            -H "x-vercel-set-bypass-cookie: true" \
-            "${VM0_API_URL}${endpoint}")
-    else
-        result=$(curl -s \
-            -H "Authorization: Bearer $VM0_TOKEN" \
-            "${VM0_API_URL}${endpoint}")
-    fi
+    result=$(curl -s \
+        -H "Authorization: Bearer $VM0_TOKEN" \
+        -H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}" \
+        -H "x-vercel-set-bypass-cookie: true" \
+        "${VM0_API_URL}${endpoint}")
 
     # Debug: show first 200 chars of response if not JSON
     if ! echo "$result" | jq -e '.' > /dev/null 2>&1; then
@@ -31,6 +24,13 @@ api_get() {
 }
 
 setup() {
+    # Verify VERCEL_AUTOMATION_BYPASS_SECRET is set
+    if [[ -z "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
+        echo "ERROR: VERCEL_AUTOMATION_BYPASS_SECRET is not set or empty" >&2
+        echo "This test requires a valid Vercel bypass secret for preview deployments" >&2
+        exit 1
+    fi
+
     # Get token from config file if not in environment
     if [[ -z "$VM0_TOKEN" ]]; then
         VM0_TOKEN=$(cat ~/.vm0/config.json | jq -r '.token')

--- a/e2e/tests/02-parallel/t30-public-api-v1.bats
+++ b/e2e/tests/02-parallel/t30-public-api-v1.bats
@@ -8,10 +8,17 @@ load '../../helpers/setup'
 # Helper function to make authenticated API requests
 api_get() {
     local endpoint="$1"
-    curl -s \
+    local result
+    result=$(curl -s \
         -H "Authorization: Bearer $VM0_TOKEN" \
         -H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET:-}" \
-        "${VM0_API_URL}${endpoint}"
+        -H "x-vercel-set-bypass-cookie: true" \
+        "${VM0_API_URL}${endpoint}")
+    # Debug: show first 200 chars of response if not JSON
+    if ! echo "$result" | jq -e '.' > /dev/null 2>&1; then
+        echo "# Non-JSON response (first 200 chars): ${result:0:200}" >&3
+    fi
+    echo "$result"
 }
 
 setup() {

--- a/e2e/tests/02-parallel/t30-public-api-v1.bats
+++ b/e2e/tests/02-parallel/t30-public-api-v1.bats
@@ -10,6 +10,13 @@ api_get() {
     local endpoint="$1"
     local result
 
+    # Debug: verify bypass secret is available
+    if [[ -z "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
+        echo "# WARNING: VERCEL_AUTOMATION_BYPASS_SECRET is empty in api_get()" >&3
+    else
+        echo "# DEBUG: VERCEL_AUTOMATION_BYPASS_SECRET length: ${#VERCEL_AUTOMATION_BYPASS_SECRET}" >&3
+    fi
+
     result=$(curl -s \
         -H "Authorization: Bearer $VM0_TOKEN" \
         -H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}" \

--- a/e2e/tests/02-parallel/t30-public-api-v1.bats
+++ b/e2e/tests/02-parallel/t30-public-api-v1.bats
@@ -9,11 +9,20 @@ load '../../helpers/setup'
 api_get() {
     local endpoint="$1"
     local result
-    result=$(curl -s \
-        -H "Authorization: Bearer $VM0_TOKEN" \
-        -H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET:-}" \
-        -H "x-vercel-set-bypass-cookie: true" \
-        "${VM0_API_URL}${endpoint}")
+
+    # Only add Vercel bypass headers if the secret is set and non-empty
+    if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
+        result=$(curl -s \
+            -H "Authorization: Bearer $VM0_TOKEN" \
+            -H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}" \
+            -H "x-vercel-set-bypass-cookie: true" \
+            "${VM0_API_URL}${endpoint}")
+    else
+        result=$(curl -s \
+            -H "Authorization: Bearer $VM0_TOKEN" \
+            "${VM0_API_URL}${endpoint}")
+    fi
+
     # Debug: show first 200 chars of response if not JSON
     if ! echo "$result" | jq -e '.' > /dev/null 2>&1; then
         echo "# Non-JSON response (first 200 chars): ${result:0:200}" >&3

--- a/e2e/tests/02-parallel/t30-public-api-v1.bats
+++ b/e2e/tests/02-parallel/t30-public-api-v1.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+
+# Public API v1 E2E Tests
+# Tests verify that API endpoints return valid JSON responses with expected structure
+
+setup() {
+    # Get token from config file if not in environment
+    if [[ -z "$VM0_TOKEN" ]]; then
+        VM0_TOKEN=$(cat ~/.vm0/config.json | jq -r '.token')
+        export VM0_TOKEN
+    fi
+
+    # Ensure API URL is set
+    if [[ -z "$VM0_API_URL" ]]; then
+        VM0_API_URL="https://www.vm0.ai"
+        export VM0_API_URL
+    fi
+}
+
+# ============================================
+# Agents API Tests
+# ============================================
+
+@test "GET /v1/agents returns data array" {
+    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/agents")
+    echo "$result" | jq -e '.data' > /dev/null
+}
+
+@test "GET /v1/agents returns pagination object" {
+    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/agents")
+    echo "$result" | jq -e '.pagination' > /dev/null
+}
+
+# ============================================
+# Runs API Tests
+# ============================================
+
+@test "GET /v1/runs returns data array" {
+    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/runs")
+    echo "$result" | jq -e '.data' > /dev/null
+}
+
+@test "GET /v1/runs returns pagination object" {
+    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/runs")
+    echo "$result" | jq -e '.pagination' > /dev/null
+}
+
+# ============================================
+# Artifacts API Tests
+# ============================================
+
+@test "GET /v1/artifacts returns data array" {
+    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/artifacts")
+    echo "$result" | jq -e '.data' > /dev/null
+}
+
+@test "GET /v1/artifacts returns pagination object" {
+    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/artifacts")
+    echo "$result" | jq -e '.pagination' > /dev/null
+}
+
+# ============================================
+# Volumes API Tests
+# ============================================
+
+@test "GET /v1/volumes returns data array" {
+    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/volumes")
+    echo "$result" | jq -e '.data' > /dev/null
+}
+
+@test "GET /v1/volumes returns pagination object" {
+    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/volumes")
+    echo "$result" | jq -e '.pagination' > /dev/null
+}
+
+# ============================================
+# Tokens API Tests
+# ============================================
+
+@test "GET /v1/tokens returns data array" {
+    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/tokens")
+    echo "$result" | jq -e '.data' > /dev/null
+}
+
+@test "GET /v1/tokens returns pagination object" {
+    result=$(curl -sf -H "Authorization: Bearer $VM0_TOKEN" "${VM0_API_URL}/v1/tokens")
+    echo "$result" | jq -e '.pagination' > /dev/null
+}

--- a/e2e/tests/02-parallel/t30-public-api-v1.bats
+++ b/e2e/tests/02-parallel/t30-public-api-v1.bats
@@ -13,7 +13,6 @@ api_get() {
     result=$(curl -s \
         -H "Authorization: Bearer $VM0_TOKEN" \
         -H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}" \
-        -H "x-vercel-set-bypass-cookie: true" \
         "${VM0_API_URL}${endpoint}")
 
     # Debug: show first 200 chars of response if not JSON

--- a/turbo/apps/web/middleware.ts
+++ b/turbo/apps/web/middleware.ts
@@ -39,12 +39,8 @@ export default clerkMiddleware(async (auth, request: NextRequest) => {
       request.nextUrl.pathname,
     )
   ) {
-    // Handle Public API v1 routes - skip Clerk, handle CORS
-    if (request.nextUrl.pathname.startsWith("/v1/")) {
-      return handleCors(request);
-    }
-
-    if (request.nextUrl.pathname.startsWith("/api/")) {
+    if (request.nextUrl.pathname.startsWith("/api/") ||
+        request.nextUrl.pathname.startsWith("/v1/")) {
       // Check if this might be a CLI token request BEFORE handling CORS
       const authHeader = request.headers.get("Authorization");
       const hasCliToken = authHeader && authHeader.includes("vm0_live_");

--- a/turbo/apps/web/middleware.ts
+++ b/turbo/apps/web/middleware.ts
@@ -30,6 +30,7 @@ export default clerkMiddleware(async (auth, request: NextRequest) => {
   // Skip i18n for API routes, static files, CLI auth, sign-up, and Next.js internals
   if (
     request.nextUrl.pathname.startsWith("/api/") ||
+    request.nextUrl.pathname.startsWith("/v1/") ||
     request.nextUrl.pathname.startsWith("/_next/") ||
     request.nextUrl.pathname.startsWith("/cli-auth") ||
     request.nextUrl.pathname.startsWith("/sign-up") ||
@@ -38,6 +39,11 @@ export default clerkMiddleware(async (auth, request: NextRequest) => {
       request.nextUrl.pathname,
     )
   ) {
+    // Handle Public API v1 routes - skip Clerk, handle CORS
+    if (request.nextUrl.pathname.startsWith("/v1/")) {
+      return handleCors(request);
+    }
+
     if (request.nextUrl.pathname.startsWith("/api/")) {
       // Check if this might be a CLI token request BEFORE handling CORS
       const authHeader = request.headers.get("Authorization");
@@ -72,5 +78,8 @@ export default clerkMiddleware(async (auth, request: NextRequest) => {
 });
 
 export const config = {
-  matcher: ["/((?!_next|_vercel|assets|.*\\..*|api).*)", "/(api|trpc)(.*)"],
+  matcher: [
+    "/((?!_next|_vercel|assets|.*\\..*|api|v1).*)",
+    "/(api|trpc|v1)(.*)",
+  ],
 };

--- a/turbo/apps/web/middleware.ts
+++ b/turbo/apps/web/middleware.ts
@@ -27,7 +27,7 @@ const intlMiddleware = createIntlMiddleware({
 });
 
 export default clerkMiddleware(async (auth, request: NextRequest) => {
-  // Skip i18n for API routes, static files, CLI auth, sign-up, and Next.js internals
+  // Skip i18n for API routes (including /v1), static files, CLI auth, sign-up, and Next.js internals
   if (
     request.nextUrl.pathname.startsWith("/api/") ||
     request.nextUrl.pathname.startsWith("/v1/") ||

--- a/turbo/apps/web/middleware.ts
+++ b/turbo/apps/web/middleware.ts
@@ -77,7 +77,7 @@ export default clerkMiddleware(async (auth, request: NextRequest) => {
 
 export const config = {
   matcher: [
-    "/((?!_next|_vercel|assets|.*\\..*|api|v1|trpc).*)",
-    "/(api|trpc)(.*)",
+    "/((?!_next|_vercel|assets|.*\\..*|api|v1).*)",
+    "/(api|v1|trpc)(.*)",
   ],
 };

--- a/turbo/apps/web/middleware.ts
+++ b/turbo/apps/web/middleware.ts
@@ -39,8 +39,10 @@ export default clerkMiddleware(async (auth, request: NextRequest) => {
       request.nextUrl.pathname,
     )
   ) {
-    if (request.nextUrl.pathname.startsWith("/api/") ||
-        request.nextUrl.pathname.startsWith("/v1/")) {
+    if (
+      request.nextUrl.pathname.startsWith("/api/") ||
+      request.nextUrl.pathname.startsWith("/v1/")
+    ) {
       // Check if this might be a CLI token request BEFORE handling CORS
       const authHeader = request.headers.get("Authorization");
       const hasCliToken = authHeader && authHeader.includes("vm0_live_");

--- a/turbo/apps/web/middleware.ts
+++ b/turbo/apps/web/middleware.ts
@@ -77,7 +77,7 @@ export default clerkMiddleware(async (auth, request: NextRequest) => {
 
 export const config = {
   matcher: [
-    "/((?!_next|_vercel|assets|.*\\..*|api|v1).*)",
-    "/(api|trpc|v1)(.*)",
+    "/((?!_next|_vercel|assets|.*\\..*|api|v1|trpc).*)",
+    "/(api|trpc)(.*)",
   ],
 };


### PR DESCRIPTION
## Summary
- Fix v1 API routes returning HTML instead of JSON by adding `/v1/` to middleware config
- Skip i18n processing and handle CORS for `/v1/*` routes
- Add BATS E2E tests for Public API v1 endpoints (agents, runs, artifacts, volumes, tokens)

## Changes
- `middleware.ts`: Add `/v1/` route handling to skip i18n and handle CORS
- `t30-public-api-v1.bats`: Add E2E tests verifying API response structure

## Test plan
- [ ] CI passes lint, build, and type checks
- [ ] E2E tests run against preview deployment
- [ ] All 10 API endpoint tests pass (5 endpoints × 2 validations)

Closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)