### PR TITLE
refactor(platform): use @clerk/clerk-js/headless to reduce bundle size

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
@@ -21,7 +21,7 @@ interface MockClerkType {
 }
 
 // Setup Clerk mock BEFORE importing auth module
-vi.mock("@clerk/clerk-js", () => {
+vi.mock("@clerk/clerk-js/headless", () => {
   return {
     Clerk: function MockClerk() {
       const listeners: (() => void)[] = [];

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -1,4 +1,4 @@
-import { Clerk } from "@clerk/clerk-js";
+import { Clerk } from "@clerk/clerk-js/headless";
 import { command, computed, state } from "ccstate";
 
 const reload$ = state(0);

--- a/turbo/apps/platform/src/signals/test-utils.ts
+++ b/turbo/apps/platform/src/signals/test-utils.ts
@@ -92,7 +92,7 @@ export class MockClerk {
 }
 
 export function setupMock() {
-  vi.mock("@clerk/clerk-js", () => ({
+  vi.mock("@clerk/clerk-js/headless", () => ({
     Clerk: MockClerk,
   }));
 }


### PR DESCRIPTION
## Summary
- Switch from `@clerk/clerk-js` to `@clerk/clerk-js/headless`
- Update mock paths in test files to match new import

## Why
The platform only uses core Clerk functionality (auth state, token retrieval) without any UI components. The full `@clerk/clerk-js` package brings in many unnecessary dependencies:

- 32 @clerk related packages
- @coinbase/wallet-sdk (Coinbase wallet)
- @solana/* (Solana blockchain)
- @stripe/stripe-js (Stripe payments)
- @emotion/* (CSS-in-JS)
- react-native

## Changes
| File | Change |
|------|--------|
| `src/signals/auth.ts` | Import from `@clerk/clerk-js/headless` |
| `src/signals/test-utils.ts` | Update mock path |
| `src/signals/__tests__/fetch.test.ts` | Update mock path |

## Test plan
- [x] TypeScript type checking passes
- [x] All 63 tests pass
- [ ] CI pipeline passes

Closes #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)