### PR TITLE
feat(api): add name query parameter to GET /v1/agents

### DIFF
--- a/turbo/apps/web/app/v1/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/v1/agents/__tests__/route.test.ts
@@ -175,6 +175,64 @@ describe("Public API v1 - Agents Endpoints", () => {
       expect(response.status).toBe(200);
       expect(data.data.length).toBeLessThanOrEqual(1);
     });
+
+    it("should filter by name when name parameter provided", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/v1/agents?name=test-agent-v1",
+      );
+
+      const response = await listAgents(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data).toBeInstanceOf(Array);
+      expect(data.data.length).toBe(1);
+      expect(data.data[0].name).toBe("test-agent-v1");
+      expect(data.pagination.has_more).toBe(false);
+    });
+
+    it("should return empty array when name not found", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/v1/agents?name=nonexistent-agent",
+      );
+
+      const response = await listAgents(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data).toBeInstanceOf(Array);
+      expect(data.data.length).toBe(0);
+      expect(data.pagination.has_more).toBe(false);
+      expect(data.pagination.next_cursor).toBeNull();
+    });
+
+    it("should filter by name case-insensitively", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/v1/agents?name=TEST-AGENT-V1",
+      );
+
+      const response = await listAgents(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data).toBeInstanceOf(Array);
+      expect(data.data.length).toBe(1);
+      expect(data.data[0].name).toBe("test-agent-v1");
+    });
+
+    it("should filter by name combined with limit", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/v1/agents?name=test-agent-v1&limit=10",
+      );
+
+      const response = await listAgents(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data).toBeInstanceOf(Array);
+      expect(data.data.length).toBe(1);
+      expect(data.data[0].name).toBe("test-agent-v1");
+    });
   });
 
   describe("GET /v1/agents/:id - Get Agent", () => {

--- a/turbo/apps/web/app/v1/agents/route.ts
+++ b/turbo/apps/web/app/v1/agents/route.ts
@@ -60,6 +60,11 @@ const router = tsr.router(publicAgentsListContract, {
     // Build query conditions
     const conditions = [eq(agentComposes.scopeId, userScope.id)];
 
+    // Filter by name if provided (case-insensitive - normalize to lowercase)
+    if (query.name) {
+      conditions.push(eq(agentComposes.name, query.name.toLowerCase()));
+    }
+
     // Handle cursor-based pagination
     if (query.cursor) {
       conditions.push(gt(agentComposes.id, query.cursor));

--- a/turbo/packages/core/src/contracts/public/agents.ts
+++ b/turbo/packages/core/src/contracts/public/agents.ts
@@ -89,20 +89,30 @@ export const updateAgentRequestSchema = z.object({
 export type UpdateAgentRequest = z.infer<typeof updateAgentRequestSchema>;
 
 /**
+ * Agent list query parameters
+ */
+export const agentListQuerySchema = listQuerySchema.extend({
+  name: z.string().optional(),
+});
+
+export type AgentListQuery = z.infer<typeof agentListQuerySchema>;
+
+/**
  * Agents list contract - GET /v1/agents
  */
 export const publicAgentsListContract = c.router({
   list: {
     method: "GET",
     path: "/v1/agents",
-    query: listQuerySchema,
+    query: agentListQuerySchema,
     responses: {
       200: paginatedAgentsSchema,
       401: publicApiErrorSchema,
       500: publicApiErrorSchema,
     },
     summary: "List agents",
-    description: "List all agents in the current scope with pagination",
+    description:
+      "List all agents in the current scope with pagination. Use the `name` query parameter to filter by agent name.",
   },
   create: {
     method: "POST",

--- a/turbo/packages/core/src/contracts/public/index.ts
+++ b/turbo/packages/core/src/contracts/public/index.ts
@@ -49,6 +49,7 @@ export {
   paginatedAgentVersionsSchema,
   createAgentRequestSchema,
   updateAgentRequestSchema,
+  agentListQuerySchema,
   // Contracts
   publicAgentsListContract,
   publicAgentByIdContract,
@@ -59,6 +60,7 @@ export {
   type AgentVersion,
   type CreateAgentRequest,
   type UpdateAgentRequest,
+  type AgentListQuery,
   type PublicAgentsListContract,
   type PublicAgentByIdContract,
   type PublicAgentVersionsContract,


### PR DESCRIPTION
## Summary

Add optional `name` query parameter to `GET /v1/agents` endpoint to enable filtering by agent name. This allows curl/automation users to look up agents by name without listing all agents.

**Example usage:**
```bash
curl "https://api.vm0.com/v1/agents?name=my-agent" \
  -H "Authorization: Bearer vm0_live_xxx"
```

## Changes

- Add `agentListQuerySchema` with optional `name` field in contracts
- Implement case-insensitive name filtering (normalized to lowercase)
- Return empty array when name not found (consistent with filtered list behavior)
- Add unit tests for name filtering scenarios

## Test plan

- [x] Filter by name - found (returns matching agent)
- [x] Filter by name - not found (returns empty array)
- [x] Filter by name - case insensitive
- [x] Filter by name - combined with limit parameter
- [x] All existing tests pass

Closes #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)