### PR TITLE
fix: disable DTS generation in watch mode to prevent memory crashes

### DIFF
--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -75,6 +75,28 @@ else
   GENERATED_COUNT=$((GENERATED_COUNT + 1))
 fi
 
+# Platform app
+if [ -f "platform.vm7.ai.pem" ] && [ -f "platform.vm7.ai-key.pem" ]; then
+  echo -e "  - platform.vm7.ai ${YELLOW}(skipped - already exists)${NC}"
+  SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+else
+  echo "  - platform.vm7.ai"
+  mkcert -cert-file platform.vm7.ai.pem -key-file platform.vm7.ai-key.pem \
+    "platform.vm7.ai" "localhost" "127.0.0.1" "::1"
+  GENERATED_COUNT=$((GENERATED_COUNT + 1))
+fi
+
+# Storybook app
+if [ -f "storybook.vm7.ai.pem" ] && [ -f "storybook.vm7.ai-key.pem" ]; then
+  echo -e "  - storybook.vm7.ai ${YELLOW}(skipped - already exists)${NC}"
+  SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+else
+  echo "  - storybook.vm7.ai"
+  mkcert -cert-file storybook.vm7.ai.pem -key-file storybook.vm7.ai-key.pem \
+    "storybook.vm7.ai" "localhost" "127.0.0.1" "::1"
+  GENERATED_COUNT=$((GENERATED_COUNT + 1))
+fi
+
 if [ $GENERATED_COUNT -gt 0 ]; then
   echo -e "${GREEN}✓ Generated ${GENERATED_COUNT} certificate(s) in ${CERTS_DIR}/${NC}"
 else

--- a/turbo/apps/cli/tsup.config.ts
+++ b/turbo/apps/cli/tsup.config.ts
@@ -8,7 +8,9 @@ const pkg = JSON.parse(readFileSync("./package.json", "utf-8")) as {
 export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm"],
-  dts: true,
+  // Skip DTS generation in watch mode to avoid memory issues
+  // DTS files are still generated during production builds
+  dts: !process.argv.includes("--watch"),
   sourcemap: true,
   clean: true,
   shims: true,

--- a/turbo/apps/runner/tsup.config.ts
+++ b/turbo/apps/runner/tsup.config.ts
@@ -8,7 +8,9 @@ const pkg = JSON.parse(readFileSync("./package.json", "utf-8")) as {
 export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm"],
-  dts: true,
+  // Skip DTS generation in watch mode to avoid memory issues
+  // DTS files are still generated during production builds
+  dts: !process.argv.includes("--watch"),
   sourcemap: true,
   clean: true,
   shims: true,

--- a/turbo/apps/storybook/package.json
+++ b/turbo/apps/storybook/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "storybook dev -p 6006",
+    "dev": "storybook dev -p 6006 --no-open",
     "build": "storybook build",
     "lint": "eslint . --max-warnings 0",
     "check-types": "tsc --noEmit"

--- a/turbo/packages/proxy/Caddyfile
+++ b/turbo/packages/proxy/Caddyfile
@@ -27,6 +27,12 @@ platform.vm7.ai:8443 {
   reverse_proxy localhost:3002
 }
 
+# Storybook application
+storybook.vm7.ai:8443 {
+  tls ../../../.certs/storybook.vm7.ai.pem ../../../.certs/storybook.vm7.ai-key.pem
+  reverse_proxy localhost:6006
+}
+
 # HTTP redirects to HTTPS
 http://vm7.ai:8080 {
   redir https://www.vm7.ai:8443{uri} permanent
@@ -42,4 +48,8 @@ http://docs.vm7.ai:8080 {
 
 http://platform.vm7.ai:8080 {
   redir https://platform.vm7.ai:8443{uri} permanent
+}
+
+http://storybook.vm7.ai:8080 {
+  redir https://storybook.vm7.ai:8443{uri} permanent
 }

--- a/turbo/packages/proxy/scripts/check-certs.js
+++ b/turbo/packages/proxy/scripts/check-certs.js
@@ -12,6 +12,10 @@ const requiredCerts = [
   "www.vm7.ai-key.pem",
   "docs.vm7.ai.pem",
   "docs.vm7.ai-key.pem",
+  "platform.vm7.ai.pem",
+  "platform.vm7.ai-key.pem",
+  "storybook.vm7.ai.pem",
+  "storybook.vm7.ai-key.pem",
 ];
 
 console.log("🔍 Checking SSL certificates...\n");

--- a/turbo/packages/proxy/scripts/start-caddy.js
+++ b/turbo/packages/proxy/scripts/start-caddy.js
@@ -54,11 +54,15 @@ caddy.on("exit", (code) => {
 setTimeout(() => {
   console.log("\n✅ Caddy is running!");
   console.log("\n📱 Available at:");
-  console.log("   Web:  https://www.vm7.ai:8443");
-  console.log("   Docs: https://docs.vm7.ai:8443");
+  console.log("   Web:       https://www.vm7.ai:8443");
+  console.log("   Docs:      https://docs.vm7.ai:8443");
+  console.log("   Platform:  https://platform.vm7.ai:8443");
+  console.log("   Storybook: https://storybook.vm7.ai:8443");
   console.log("\n💡 Make sure your applications are running:");
-  console.log("   Web:  pnpm --filter web dev (port 3000)");
-  console.log("   Docs: pnpm --filter docs dev (port 3001)");
+  console.log("   Web:       pnpm --filter web dev (port 3000)");
+  console.log("   Docs:      pnpm --filter docs dev (port 3001)");
+  console.log("   Platform:  pnpm --filter @vm0/platform dev (port 3002)");
+  console.log("   Storybook: pnpm --filter @vm0/storybook dev (port 6006)");
   console.log("\n🛑 Press Ctrl+C to stop Caddy\n");
 }, 1000);
 


### PR DESCRIPTION
## Summary

- Skip DTS generation in CLI and runner tsup configs during `--watch` mode to prevent memory crashes
- Add Storybook support to Caddy proxy configuration with SSL certificates
- Add `--no-open` flag to Storybook dev script for headless environments

## Changes

| File | Change |
|------|--------|
| `turbo/apps/cli/tsup.config.ts` | Disable DTS in watch mode |
| `turbo/apps/runner/tsup.config.ts` | Disable DTS in watch mode |
| `turbo/packages/proxy/Caddyfile` | Add storybook.vm7.ai proxy |
| `turbo/packages/proxy/scripts/check-certs.js` | Add platform/storybook cert checks |
| `turbo/packages/proxy/scripts/start-caddy.js` | Update available URLs output |
| `scripts/generate-certs.sh` | Add platform/storybook certificate generation |
| `turbo/apps/storybook/package.json` | Add --no-open flag |

## Root Cause

The dev server crashed with `ERR_WORKER_OUT_OF_MEMORY` because tsup's DTS generation uses worker threads that exhaust memory when running concurrently with Next.js, Vite, and Storybook.

## Solution

Disable DTS generation during watch mode (`pnpm dev`) since `.d.ts` files are only needed for production builds. DTS files are still generated during `pnpm build`.

## Test Plan

- [ ] `pnpm dev` runs all 7 services without memory errors
- [ ] `pnpm build` still generates DTS files in `dist/`
- [ ] `https://storybook.vm7.ai:8443` loads Storybook via Caddy proxy

Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)