### PR TITLE
docs(api): change api host from www.vm0.ai to api.vm0.ai

### DIFF
--- a/turbo/apps/docs/content/docs/reference/api/agents.mdx
+++ b/turbo/apps/docs/content/docs/reference/api/agents.mdx
@@ -24,14 +24,14 @@ Returns a paginated list of your agents.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/agents \
+curl https://api.vm0.ai/v1/agents \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
 Filter by name:
 
 ```bash
-curl "https://www.vm0.ai/v1/agents?name=my-agent" \
+curl "https://api.vm0.ai/v1/agents?name=my-agent" \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -81,7 +81,7 @@ Creates a new agent with the specified configuration.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/agents \
+curl https://api.vm0.ai/v1/agents \
   -H "Authorization: Bearer vm0_live_xxx" \
   -H "Content-Type: application/json" \
   -d '{
@@ -138,7 +138,7 @@ Retrieves an agent and its current configuration.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/agents/ag_abc123 \
+curl https://api.vm0.ai/v1/agents/ag_abc123 \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -188,7 +188,7 @@ Updates an agent's configuration. Creates a new version if the config changes.
 ### Request
 
 ```bash
-curl -X PUT https://www.vm0.ai/v1/agents/ag_abc123 \
+curl -X PUT https://api.vm0.ai/v1/agents/ag_abc123 \
   -H "Authorization: Bearer vm0_live_xxx" \
   -H "Content-Type: application/json" \
   -d '{
@@ -237,7 +237,7 @@ Deletes an agent and all its versions.
 ### Request
 
 ```bash
-curl -X DELETE https://www.vm0.ai/v1/agents/ag_abc123 \
+curl -X DELETE https://api.vm0.ai/v1/agents/ag_abc123 \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -271,7 +271,7 @@ Returns a paginated list of all versions for an agent.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/agents/ag_abc123/versions \
+curl https://api.vm0.ai/v1/agents/ag_abc123/versions \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 

--- a/turbo/apps/docs/content/docs/reference/api/artifacts.mdx
+++ b/turbo/apps/docs/content/docs/reference/api/artifacts.mdx
@@ -23,7 +23,7 @@ Returns a paginated list of your artifacts.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/artifacts \
+curl https://api.vm0.ai/v1/artifacts \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -68,7 +68,7 @@ Creates a new empty artifact container.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/artifacts \
+curl https://api.vm0.ai/v1/artifacts \
   -H "Authorization: Bearer vm0_live_xxx" \
   -H "Content-Type: application/json" \
   -d '{"name": "research-output"}'
@@ -108,7 +108,7 @@ Retrieves artifact details including current version information.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/artifacts/art_abc123 \
+curl https://api.vm0.ai/v1/artifacts/art_abc123 \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -154,7 +154,7 @@ Deletes an artifact and all its versions.
 ### Request
 
 ```bash
-curl -X DELETE https://www.vm0.ai/v1/artifacts/art_abc123 \
+curl -X DELETE https://api.vm0.ai/v1/artifacts/art_abc123 \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -181,7 +181,7 @@ Returns a paginated list of all versions for an artifact.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/artifacts/art_abc123/versions \
+curl https://api.vm0.ai/v1/artifacts/art_abc123/versions \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -238,7 +238,7 @@ Gets presigned URLs for direct file upload.
 #### Request
 
 ```bash
-curl https://www.vm0.ai/v1/artifacts/art_abc123/upload \
+curl https://api.vm0.ai/v1/artifacts/art_abc123/upload \
   -H "Authorization: Bearer vm0_live_xxx" \
   -H "Content-Type: application/json" \
   -d '{
@@ -299,7 +299,7 @@ Finalizes the upload and creates a new artifact version.
 #### Request
 
 ```bash
-curl https://www.vm0.ai/v1/artifacts/art_abc123/commit \
+curl https://api.vm0.ai/v1/artifacts/art_abc123/commit \
   -H "Authorization: Bearer vm0_live_xxx" \
   -H "Content-Type: application/json" \
   -d '{"upload_session_id": "sess_upload_xyz789"}'
@@ -334,7 +334,7 @@ Gets presigned URLs for downloading artifact files.
 ### Request
 
 ```bash
-curl "https://www.vm0.ai/v1/artifacts/art_abc123/download" \
+curl "https://api.vm0.ai/v1/artifacts/art_abc123/download" \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 

--- a/turbo/apps/docs/content/docs/reference/api/index.mdx
+++ b/turbo/apps/docs/content/docs/reference/api/index.mdx
@@ -10,7 +10,7 @@ The VM0 Public API allows you to programmatically manage agents, execute runs, a
 All API requests should be made to:
 
 ```
-https://www.vm0.ai/v1/
+https://api.vm0.ai/v1/
 ```
 
 ## Resources
@@ -62,7 +62,7 @@ vm0_live_<64 hex characters>
 Include your token in the `Authorization` header with the `Bearer` prefix:
 
 ```bash
-curl https://www.vm0.ai/v1/agents \
+curl https://api.vm0.ai/v1/agents \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -87,7 +87,7 @@ vm0 auth setup-token
 You can also create tokens programmatically using an existing token:
 
 ```bash
-curl https://www.vm0.ai/v1/tokens \
+curl https://api.vm0.ai/v1/tokens \
   -H "Authorization: Bearer vm0_live_xxx" \
   -H "Content-Type: application/json" \
   -d '{"name": "my-new-token", "expires_in_days": 90}'
@@ -209,14 +209,14 @@ Paginated responses include a `pagination` object:
 Request the first page without a cursor:
 
 ```bash
-curl "https://www.vm0.ai/v1/agents?limit=10" \
+curl "https://api.vm0.ai/v1/agents?limit=10" \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
 Use the `next_cursor` from the previous response for subsequent pages:
 
 ```bash
-curl "https://www.vm0.ai/v1/agents?limit=10&cursor=eyJpZCI6ImFnX2RlZiJ9" \
+curl "https://api.vm0.ai/v1/agents?limit=10&cursor=eyJpZCI6ImFnX2RlZiJ9" \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 

--- a/turbo/apps/docs/content/docs/reference/api/runs.mdx
+++ b/turbo/apps/docs/content/docs/reference/api/runs.mdx
@@ -39,7 +39,7 @@ Returns a paginated list of runs.
 ### Request
 
 ```bash
-curl "https://www.vm0.ai/v1/runs?status=completed&limit=10" \
+curl "https://api.vm0.ai/v1/runs?status=completed&limit=10" \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -96,7 +96,7 @@ Starts a new agent execution. Returns immediately with run details; the agent ex
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/runs \
+curl https://api.vm0.ai/v1/runs \
   -H "Authorization: Bearer vm0_live_xxx" \
   -H "Content-Type: application/json" \
   -d '{
@@ -147,7 +147,7 @@ Retrieves run details including output and execution metrics.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/runs/run_abc123 \
+curl https://api.vm0.ai/v1/runs/run_abc123 \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -194,7 +194,7 @@ Cancels a pending or running execution.
 ### Request
 
 ```bash
-curl -X POST https://www.vm0.ai/v1/runs/run_abc123/cancel \
+curl -X POST https://api.vm0.ai/v1/runs/run_abc123/cancel \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -227,7 +227,7 @@ Streams real-time events using Server-Sent Events (SSE).
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/runs/run_abc123/events \
+curl https://api.vm0.ai/v1/runs/run_abc123/events \
   -H "Authorization: Bearer vm0_live_xxx" \
   -H "Accept: text/event-stream"
 ```
@@ -288,7 +288,7 @@ Retrieves unified logs from the run.
 ### Request
 
 ```bash
-curl "https://www.vm0.ai/v1/runs/run_abc123/logs?type=agent&limit=50" \
+curl "https://api.vm0.ai/v1/runs/run_abc123/logs?type=agent&limit=50" \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -338,7 +338,7 @@ Retrieves resource usage metrics for a run.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/runs/run_abc123/metrics \
+curl https://api.vm0.ai/v1/runs/run_abc123/metrics \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 

--- a/turbo/apps/docs/content/docs/reference/api/tokens.mdx
+++ b/turbo/apps/docs/content/docs/reference/api/tokens.mdx
@@ -23,7 +23,7 @@ Returns a paginated list of your API tokens.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/tokens \
+curl https://api.vm0.ai/v1/tokens \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -72,7 +72,7 @@ Creates a new API token.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/tokens \
+curl https://api.vm0.ai/v1/tokens \
   -H "Authorization: Bearer vm0_live_xxx" \
   -H "Content-Type: application/json" \
   -d '{
@@ -114,7 +114,7 @@ Retrieves details of a specific token.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/tokens/tok_abc123 \
+curl https://api.vm0.ai/v1/tokens/tok_abc123 \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -150,7 +150,7 @@ Permanently revokes a token. This action cannot be undone.
 ### Request
 
 ```bash
-curl -X DELETE https://www.vm0.ai/v1/tokens/tok_abc123 \
+curl -X DELETE https://api.vm0.ai/v1/tokens/tok_abc123 \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 

--- a/turbo/apps/docs/content/docs/reference/api/volumes.mdx
+++ b/turbo/apps/docs/content/docs/reference/api/volumes.mdx
@@ -23,7 +23,7 @@ Returns a paginated list of your volumes.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/volumes \
+curl https://api.vm0.ai/v1/volumes \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -68,7 +68,7 @@ Creates a new empty volume container.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/volumes \
+curl https://api.vm0.ai/v1/volumes \
   -H "Authorization: Bearer vm0_live_xxx" \
   -H "Content-Type: application/json" \
   -d '{"name": "training-data"}'
@@ -108,7 +108,7 @@ Retrieves volume details including current version information.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/volumes/vol_abc123 \
+curl https://api.vm0.ai/v1/volumes/vol_abc123 \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -154,7 +154,7 @@ Deletes a volume and all its versions.
 ### Request
 
 ```bash
-curl -X DELETE https://www.vm0.ai/v1/volumes/vol_abc123 \
+curl -X DELETE https://api.vm0.ai/v1/volumes/vol_abc123 \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -181,7 +181,7 @@ Returns a paginated list of all versions for a volume.
 ### Request
 
 ```bash
-curl https://www.vm0.ai/v1/volumes/vol_abc123/versions \
+curl https://api.vm0.ai/v1/volumes/vol_abc123/versions \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
@@ -238,7 +238,7 @@ Gets presigned URLs for direct file upload.
 #### Request
 
 ```bash
-curl https://www.vm0.ai/v1/volumes/vol_abc123/upload \
+curl https://api.vm0.ai/v1/volumes/vol_abc123/upload \
   -H "Authorization: Bearer vm0_live_xxx" \
   -H "Content-Type: application/json" \
   -d '{
@@ -299,7 +299,7 @@ Finalizes the upload and creates a new volume version.
 #### Request
 
 ```bash
-curl https://www.vm0.ai/v1/volumes/vol_abc123/commit \
+curl https://api.vm0.ai/v1/volumes/vol_abc123/commit \
   -H "Authorization: Bearer vm0_live_xxx" \
   -H "Content-Type: application/json" \
   -d '{"upload_session_id": "sess_upload_abc123"}'
@@ -334,7 +334,7 @@ Gets presigned URLs for downloading volume files.
 ### Request
 
 ```bash
-curl "https://www.vm0.ai/v1/volumes/vol_abc123/download" \
+curl "https://api.vm0.ai/v1/volumes/vol_abc123/download" \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 


### PR DESCRIPTION
## Summary
- Change API host from `www.vm0.ai` to `api.vm0.ai` in all API documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)