### PR TITLE
chore: remove debug log for vercel automation bypass secret in cli-e2e

### DIFF
--- a/e2e/tests/02-parallel/t30-public-api-v1.bats
+++ b/e2e/tests/02-parallel/t30-public-api-v1.bats
@@ -10,11 +10,9 @@ api_get() {
     local endpoint="$1"
     local result
 
-    # Debug: verify bypass secret is available
+    # Warn if bypass secret is not available
     if [[ -z "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
         echo "# WARNING: VERCEL_AUTOMATION_BYPASS_SECRET is empty in api_get()" >&3
-    else
-        echo "# DEBUG: VERCEL_AUTOMATION_BYPASS_SECRET length: ${#VERCEL_AUTOMATION_BYPASS_SECRET}" >&3
     fi
 
     result=$(curl -s \


### PR DESCRIPTION
## Summary

- Remove the debug log that outputs the length of `VERCEL_AUTOMATION_BYPASS_SECRET` in CLI E2E tests
- Keep the WARNING message for when the secret is empty (useful for troubleshooting)

Closes #1051

## Test plan

- [ ] Verify CI passes (lint, test, deploy, cli-e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)