### PR TITLE
refactor: remove deprecated experimental_network_security feature

### DIFF
--- a/turbo/apps/cli/src/commands/agents/inspect.ts
+++ b/turbo/apps/cli/src/commands/agents/inspect.ts
@@ -17,7 +17,6 @@ interface AgentDefinition {
   volumes?: string[];
   working_dir?: string;
   environment?: Record<string, string>;
-  experimental_network_security?: boolean;
   instructions?: string;
   skills?: string[];
   experimental_runner?: {
@@ -122,11 +121,6 @@ function formatComposeOutput(
     // Show runner configuration if defined
     if (agent.experimental_runner) {
       console.log(`    Runner: ${agent.experimental_runner.group}`);
-    }
-
-    // Show network security mode if enabled
-    if (agent.experimental_network_security) {
-      console.log(`    Network Security: enabled`);
     }
   }
 }

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -292,7 +292,7 @@ async function showNetworkLogs(
   if (response.networkLogs.length === 0) {
     console.log(
       chalk.yellow(
-        "No network logs found for this run. Network logs are only captured when experimental_network_security is enabled on an experimental_runner.",
+        "No network logs found for this run. Network logs are only captured when experimental_firewall is enabled on a self-hosted runner.",
       ),
     );
     return;

--- a/turbo/apps/cli/src/lib/source-derivation.ts
+++ b/turbo/apps/cli/src/lib/source-derivation.ts
@@ -19,7 +19,6 @@ interface AgentDefinition {
   volumes?: string[];
   working_dir?: string;
   environment?: Record<string, string>;
-  experimental_network_security?: boolean;
   instructions?: string;
   skills?: string[];
   experimental_runner?: {

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -56,13 +56,6 @@ export interface AgentDefinition {
   working_dir?: string; // Optional when provider supports auto-config
   environment?: Record<string, string>; // Environment variables using ${{ vars.X }}, ${{ secrets.X }} syntax
   /**
-   * Enable network security mode for secrets.
-   * When true, secrets are encrypted into proxy tokens and all traffic
-   * is routed through mitmproxy -> VM0 Proxy for decryption.
-   * Default: false (plaintext secrets in env vars)
-   */
-  experimental_network_security?: boolean;
-  /**
    * Path to instructions file (e.g., AGENTS.md).
    * Auto-uploaded as volume and mounted at /home/user/.claude/CLAUDE.md
    */

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -99,13 +99,6 @@ const agentDefinitionSchema = z.object({
   working_dir: z.string().optional(), // Optional when provider supports auto-config
   environment: z.record(z.string(), z.string()).optional(),
   /**
-   * Enable network security mode for secrets.
-   * When true, secrets are encrypted into proxy tokens and all traffic
-   * is routed through mitmproxy -> VM0 Proxy for decryption.
-   * Default: false (plaintext secrets in env vars)
-   */
-  experimental_network_security: z.boolean().optional().default(false),
-  /**
    * Path to instructions file (e.g., AGENTS.md).
    * Auto-uploaded as volume and mounted at /home/user/.claude/CLAUDE.md
    */

--- a/turbo/packages/core/src/sandbox/scripts/lib/common.py.ts
+++ b/turbo/packages/core/src/sandbox/scripts/lib/common.py.ts
@@ -44,9 +44,6 @@ PROXY_URL = f"{API_URL}/api/webhooks/agent/proxy"
 STORAGE_PREPARE_URL = f"{API_URL}/api/webhooks/agent/storages/prepare"
 STORAGE_COMMIT_URL = f"{API_URL}/api/webhooks/agent/storages/commit"
 
-# Proxy configuration (for experimental_network_security feature)
-PROXY_ENABLED = os.environ.get("VM0_PROXY_ENABLED", "false").lower() == "true"
-
 # Heartbeat configuration
 HEARTBEAT_INTERVAL = 60  # seconds
 

--- a/turbo/packages/core/src/sandbox/scripts/run-agent.py.ts
+++ b/turbo/packages/core/src/sandbox/scripts/run-agent.py.ts
@@ -31,7 +31,7 @@ sys.path.insert(0, "/usr/local/bin/vm0-agent/lib")
 from common import (
     WORKING_DIR, PROMPT, RESUME_SESSION_ID, COMPLETE_URL, RUN_ID,
     EVENT_ERROR_FLAG, HEARTBEAT_URL, HEARTBEAT_INTERVAL, AGENT_LOG_FILE,
-    PROXY_ENABLED, CLI_AGENT_TYPE, OPENAI_MODEL, validate_config
+    CLI_AGENT_TYPE, OPENAI_MODEL, validate_config
 )
 from log import log_info, log_error, log_warn
 from events import send_event
@@ -119,12 +119,6 @@ def _run() -> tuple[int, str]:
     init_start_time = time.time()
 
     log_info(f"Working directory: {WORKING_DIR}")
-
-    # Log proxy mode status
-    # NOTE: Proxy setup is done as root by e2b-service.ts BEFORE this script starts
-    # This ensures mitmproxy is running and nftables rules are in place
-    if PROXY_ENABLED:
-        log_info("Network security mode enabled (proxy configured by e2b-service)")
 
     # Start heartbeat thread
     heartbeat_thread = threading.Thread(target=heartbeat_loop, daemon=True)


### PR DESCRIPTION
## Summary

- Remove dead code for `experimental_network_security` feature from CLI, core, and web packages
- Update `vm0 logs --network` error message to reference `experimental_firewall` instead
- Feature was never fully implemented and has been replaced by `experimental_firewall`

## Changes

- **CLI logs command**: Updated error message to reference `experimental_firewall`
- **CLI inspect command**: Removed type field and display code
- **CLI source-derivation**: Removed type field
- **Core composes schema**: Removed Zod schema field
- **Web agent-compose types**: Removed type field
- **Core sandbox scripts**: Removed `PROXY_ENABLED` variable and usage

## Test plan

- [x] Type checks pass for CLI, core, web packages
- [x] Lint checks pass for CLI, core, web packages
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)