### PR TITLE
fix(storybook): add storybook.vm7.ai to vite allowed hosts

### DIFF
--- a/turbo/apps/storybook/.storybook/main.ts
+++ b/turbo/apps/storybook/.storybook/main.ts
@@ -10,6 +10,13 @@ const config: StorybookConfig = {
   docs: {
     autodocs: "tag",
   },
+  viteFinal: (config) => {
+    config.server = {
+      ...config.server,
+      allowedHosts: ["storybook.vm7.ai"],
+    };
+    return config;
+  },
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- Add `storybook.vm7.ai` to Vite's `allowedHosts` configuration in Storybook
- Fixes 403 errors when accessing Storybook dev server from the custom hostname

## Test plan
- [ ] Access Storybook at `storybook.vm7.ai` and verify no 403 errors
- [ ] Verify Storybook loads correctly with all assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)