### PR TITLE
feat: remove v1 API create and delete endpoints for agents, volumes, artifacts

### DIFF
--- a/turbo/apps/web/app/v1/agents/[id]/route.ts
+++ b/turbo/apps/web/app/v1/agents/[id]/route.ts
@@ -3,7 +3,6 @@
  *
  * GET /v1/agents/:id - Get agent details
  * PUT /v1/agents/:id - Update agent
- * DELETE /v1/agents/:id - Delete agent
  */
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -212,77 +211,8 @@ const router = tsr.router(publicAgentByIdContract, {
       },
     };
   },
-
-  delete: async ({ params }) => {
-    initServices();
-
-    const auth = await authenticatePublicApi();
-    if (!isAuthSuccess(auth)) {
-      return {
-        status: 401 as const,
-        body: {
-          error: {
-            type: "authentication_error" as const,
-            code: "invalid_api_key",
-            message: "Invalid API key provided",
-          },
-        },
-      };
-    }
-
-    // Get user's scope
-    const userScope = await getUserScopeByClerkId(auth.userId);
-    if (!userScope) {
-      return {
-        status: 401 as const,
-        body: {
-          error: {
-            type: "authentication_error" as const,
-            code: "invalid_api_key",
-            message:
-              "Please set up your scope first. Login again with: vm0 login",
-          },
-        },
-      };
-    }
-
-    // Find agent by ID, ensuring it belongs to user's scope
-    const [agent] = await globalThis.services.db
-      .select()
-      .from(agentComposes)
-      .where(
-        and(
-          eq(agentComposes.id, params.id),
-          eq(agentComposes.scopeId, userScope.id),
-        ),
-      )
-      .limit(1);
-
-    if (!agent) {
-      return {
-        status: 404 as const,
-        body: {
-          error: {
-            type: "not_found_error" as const,
-            code: "resource_not_found",
-            message: `No such agent: '${params.id}'`,
-          },
-        },
-      };
-    }
-
-    // Delete the agent (cascade will delete versions due to FK constraint)
-    await globalThis.services.db
-      .delete(agentComposes)
-      .where(eq(agentComposes.id, agent.id));
-
-    return {
-      status: 204 as const,
-      body: undefined,
-    };
-  },
 });
 
 const handler = createPublicApiHandler(publicAgentByIdContract, router);
 
-export { handler as GET, handler as PUT, handler as DELETE };
+export { handler as GET, handler as PUT };

--- a/turbo/apps/web/app/v1/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/v1/agents/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { NextRequest } from "next/server";
-import { GET as listAgents, POST as createAgent } from "../route";
+import { GET as listAgents } from "../route";
 import {
   GET as getAgent,
   PUT as updateAgent,
@@ -8,10 +8,15 @@ import {
 } from "../[id]/route";
 import { GET as listVersions } from "../[id]/versions/route";
 import { initServices } from "../../../../src/lib/init-services";
-import { agentComposes } from "../../../../src/db/schema/agent-compose";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../src/db/schema/agent-compose";
 import { scopes } from "../../../../src/db/schema/scope";
 import { eq } from "drizzle-orm";
 import { randomUUID } from "crypto";
+import { computeComposeVersionId } from "../../../../src/lib/agent-compose/content-hash";
+import type { AgentComposeYaml } from "../../../../src/types/agent-compose";
 
 /**
  * Helper to create a NextRequest for testing.
@@ -31,8 +36,43 @@ function createTestRequest(
   });
 }
 
+/**
+ * Helper to create an agent directly in the database for testing.
+ */
+async function createTestAgent(
+  userId: string,
+  scopeId: string,
+  name: string,
+  config: AgentComposeYaml,
+): Promise<{ id: string; versionId: string }> {
+  const versionId = computeComposeVersionId(config);
+
+  const [created] = await globalThis.services.db
+    .insert(agentComposes)
+    .values({
+      userId,
+      scopeId,
+      name,
+    })
+    .returning();
+
+  await globalThis.services.db.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId: created!.id,
+    content: config,
+    createdBy: userId,
+  });
+
+  await globalThis.services.db
+    .update(agentComposes)
+    .set({ headVersionId: versionId })
+    .where(eq(agentComposes.id, created!.id));
+
+  return { id: created!.id, versionId };
+}
+
 // Mock the auth module
-let mockUserId = "test-user-public-api";
+const mockUserId = "test-user-public-api";
 vi.mock("../../../../src/lib/auth/get-user-id", () => ({
   getUserId: async () => mockUserId,
 }));
@@ -40,6 +80,7 @@ vi.mock("../../../../src/lib/auth/get-user-id", () => ({
 describe("Public API v1 - Agents Endpoints", () => {
   const testUserId = "test-user-public-api";
   const testScopeId = randomUUID();
+  let testAgentId: string;
 
   beforeAll(async () => {
     initServices();
@@ -60,6 +101,23 @@ describe("Public API v1 - Agents Endpoints", () => {
       type: "personal",
       ownerId: testUserId,
     });
+
+    // Create a test agent for use in subsequent tests
+    const { id } = await createTestAgent(
+      testUserId,
+      testScopeId,
+      "test-agent-v1",
+      {
+        version: "1.0",
+        agents: {
+          "test-agent-v1": {
+            image: "vm0/claude-code:dev",
+            provider: "claude-code",
+          },
+        },
+      },
+    );
+    testAgentId = id;
   });
 
   afterAll(async () => {
@@ -71,84 +129,6 @@ describe("Public API v1 - Agents Endpoints", () => {
     await globalThis.services.db
       .delete(scopes)
       .where(eq(scopes.id, testScopeId));
-  });
-
-  describe("POST /v1/agents - Create Agent", () => {
-    it("should create a new agent", async () => {
-      const request = createTestRequest("http://localhost:3000/v1/agents", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: "test-agent-v1",
-          config: {
-            version: "1.0",
-            agents: {
-              "test-agent-v1": {
-                image: "vm0/claude-code:dev",
-                provider: "claude-code",
-              },
-            },
-          },
-        }),
-      });
-
-      const response = await createAgent(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(201);
-      expect(data.id).toBeDefined();
-      expect(data.name).toBe("test-agent-v1");
-      expect(data.current_version_id).toBeDefined();
-      expect(data.created_at).toBeDefined();
-      expect(data.updated_at).toBeDefined();
-    });
-
-    it("should return 409 when agent already exists", async () => {
-      const request = createTestRequest("http://localhost:3000/v1/agents", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: "test-agent-v1",
-          config: {
-            version: "1.0",
-            agents: {
-              "test-agent-v1": {
-                image: "vm0/claude-code:dev",
-                provider: "claude-code",
-              },
-            },
-          },
-        }),
-      });
-
-      const response = await createAgent(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(409);
-      expect(data.error.type).toBe("conflict_error");
-      expect(data.error.code).toBe("resource_already_exists");
-    });
-
-    it("should return 401 for unauthenticated request", async () => {
-      mockUserId = "";
-
-      const request = createTestRequest("http://localhost:3000/v1/agents", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: "test-agent-unauth",
-          config: { version: "1.0", agents: {} },
-        }),
-      });
-
-      const response = await createAgent(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(401);
-      expect(data.error.type).toBe("authentication_error");
-
-      mockUserId = testUserId;
-    });
   });
 
   describe("GET /v1/agents - List Agents", () => {
@@ -178,29 +158,16 @@ describe("Public API v1 - Agents Endpoints", () => {
   });
 
   describe("GET /v1/agents/:id - Get Agent", () => {
-    let agentId: string;
-
-    beforeAll(async () => {
-      // Get agent ID from earlier creation
-      const agents = await globalThis.services.db
-        .select()
-        .from(agentComposes)
-        .where(eq(agentComposes.name, "test-agent-v1"))
-        .limit(1);
-
-      agentId = agents[0]!.id;
-    });
-
     it("should get agent by ID", async () => {
       const request = createTestRequest(
-        `http://localhost:3000/v1/agents/${agentId}`,
+        `http://localhost:3000/v1/agents/${testAgentId}`,
       );
 
       const response = await getAgent(request);
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.id).toBe(agentId);
+      expect(data.id).toBe(testAgentId);
       expect(data.name).toBe("test-agent-v1");
       expect(data.config).toBeDefined();
     });
@@ -221,21 +188,9 @@ describe("Public API v1 - Agents Endpoints", () => {
   });
 
   describe("PUT /v1/agents/:id - Update Agent", () => {
-    let agentId: string;
-
-    beforeAll(async () => {
-      const agents = await globalThis.services.db
-        .select()
-        .from(agentComposes)
-        .where(eq(agentComposes.name, "test-agent-v1"))
-        .limit(1);
-
-      agentId = agents[0]!.id;
-    });
-
     it("should update agent config and create new version", async () => {
       const request = createTestRequest(
-        `http://localhost:3000/v1/agents/${agentId}`,
+        `http://localhost:3000/v1/agents/${testAgentId}`,
         {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
@@ -258,7 +213,7 @@ describe("Public API v1 - Agents Endpoints", () => {
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.id).toBe(agentId);
+      expect(data.id).toBe(testAgentId);
       expect(data.config.version).toBe("1.1");
     });
 
@@ -284,21 +239,9 @@ describe("Public API v1 - Agents Endpoints", () => {
   });
 
   describe("GET /v1/agents/:id/versions - List Agent Versions", () => {
-    let agentId: string;
-
-    beforeAll(async () => {
-      const agents = await globalThis.services.db
-        .select()
-        .from(agentComposes)
-        .where(eq(agentComposes.name, "test-agent-v1"))
-        .limit(1);
-
-      agentId = agents[0]!.id;
-    });
-
     it("should list agent versions", async () => {
       const request = createTestRequest(
-        `http://localhost:3000/v1/agents/${agentId}/versions`,
+        `http://localhost:3000/v1/agents/${testAgentId}/versions`,
       );
 
       const response = await listVersions(request);
@@ -312,7 +255,7 @@ describe("Public API v1 - Agents Endpoints", () => {
       // Each version should have required fields
       const version = data.data[0];
       expect(version.id).toBeDefined();
-      expect(version.agent_id).toBe(agentId);
+      expect(version.agent_id).toBe(testAgentId);
       expect(version.version_number).toBeDefined();
       expect(version.config).toBeDefined();
       expect(version.created_at).toBeDefined();
@@ -336,27 +279,22 @@ describe("Public API v1 - Agents Endpoints", () => {
     let agentIdToDelete: string;
 
     beforeAll(async () => {
-      // Create a new agent to delete
-      const request = createTestRequest("http://localhost:3000/v1/agents", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: "test-agent-delete",
-          config: {
-            version: "1.0",
-            agents: {
-              "test-agent-delete": {
-                image: "vm0/claude-code:dev",
-                provider: "claude-code",
-              },
+      // Create a new agent to delete via direct DB insertion
+      const { id } = await createTestAgent(
+        testUserId,
+        testScopeId,
+        "test-agent-delete",
+        {
+          version: "1.0",
+          agents: {
+            "test-agent-delete": {
+              image: "vm0/claude-code:dev",
+              provider: "claude-code",
             },
           },
-        }),
-      });
-
-      const response = await createAgent(request);
-      const data = await response.json();
-      agentIdToDelete = data.id;
+        },
+      );
+      agentIdToDelete = id;
     });
 
     it("should delete agent", async () => {

--- a/turbo/apps/web/app/v1/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/v1/agents/__tests__/route.test.ts
@@ -1,11 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { GET as listAgents } from "../route";
-import {
-  GET as getAgent,
-  PUT as updateAgent,
-  DELETE as deleteAgent,
-} from "../[id]/route";
+import { GET as getAgent, PUT as updateAgent } from "../[id]/route";
 import { GET as listVersions } from "../[id]/versions/route";
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -268,63 +264,6 @@ describe("Public API v1 - Agents Endpoints", () => {
       );
 
       const response = await listVersions(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(404);
-      expect(data.error.type).toBe("not_found_error");
-    });
-  });
-
-  describe("DELETE /v1/agents/:id - Delete Agent", () => {
-    let agentIdToDelete: string;
-
-    beforeAll(async () => {
-      // Create a new agent to delete via direct DB insertion
-      const { id } = await createTestAgent(
-        testUserId,
-        testScopeId,
-        "test-agent-delete",
-        {
-          version: "1.0",
-          agents: {
-            "test-agent-delete": {
-              image: "vm0/claude-code:dev",
-              provider: "claude-code",
-            },
-          },
-        },
-      );
-      agentIdToDelete = id;
-    });
-
-    it("should delete agent", async () => {
-      const request = createTestRequest(
-        `http://localhost:3000/v1/agents/${agentIdToDelete}`,
-        { method: "DELETE" },
-      );
-
-      const response = await deleteAgent(request);
-
-      expect(response.status).toBe(204);
-
-      // Verify agent is deleted
-      const getRequest = createTestRequest(
-        `http://localhost:3000/v1/agents/${agentIdToDelete}`,
-      );
-
-      const getResponse = await getAgent(getRequest);
-
-      expect(getResponse.status).toBe(404);
-    });
-
-    it("should return 404 for non-existent agent", async () => {
-      const fakeId = randomUUID();
-      const request = createTestRequest(
-        `http://localhost:3000/v1/agents/${fakeId}`,
-        { method: "DELETE" },
-      );
-
-      const response = await deleteAgent(request);
       const data = await response.json();
 
       expect(response.status).toBe(404);

--- a/turbo/apps/web/app/v1/agents/route.ts
+++ b/turbo/apps/web/app/v1/agents/route.ts
@@ -2,7 +2,6 @@
  * Public API v1 - Agents Endpoints
  *
  * GET /v1/agents - List agents
- * POST /v1/agents - Create agent
  */
 import { initServices } from "../../../src/lib/init-services";
 import {
@@ -15,13 +14,8 @@ import {
   isAuthSuccess,
 } from "../../../src/lib/public-api/auth";
 import { getUserScopeByClerkId } from "../../../src/lib/scope/scope-service";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../../src/db/schema/agent-compose";
+import { agentComposes } from "../../../src/db/schema/agent-compose";
 import { eq, and, desc, gt } from "drizzle-orm";
-import { computeComposeVersionId } from "../../../src/lib/agent-compose/content-hash";
-import type { AgentComposeYaml } from "../../../src/types/agent-compose";
 
 const router = tsr.router(publicAgentsListContract, {
   list: async ({ query }) => {
@@ -98,121 +92,8 @@ const router = tsr.router(publicAgentsListContract, {
       },
     };
   },
-
-  create: async ({ body }) => {
-    initServices();
-
-    const auth = await authenticatePublicApi();
-    if (!isAuthSuccess(auth)) {
-      return {
-        status: 401 as const,
-        body: {
-          error: {
-            type: "authentication_error" as const,
-            code: "invalid_api_key",
-            message: "Invalid API key provided",
-          },
-        },
-      };
-    }
-
-    // Get user's scope
-    const userScope = await getUserScopeByClerkId(auth.userId);
-    if (!userScope) {
-      return {
-        status: 401 as const,
-        body: {
-          error: {
-            type: "authentication_error" as const,
-            code: "invalid_api_key",
-            message:
-              "Please set up your scope first. Login again with: vm0 login",
-          },
-        },
-      };
-    }
-
-    const { name, config } = body;
-
-    // Check if agent with this name already exists in user's scope
-    const existing = await globalThis.services.db
-      .select()
-      .from(agentComposes)
-      .where(
-        and(
-          eq(agentComposes.scopeId, userScope.id),
-          eq(agentComposes.name, name),
-        ),
-      )
-      .limit(1);
-
-    if (existing.length > 0) {
-      return {
-        status: 409 as const,
-        body: {
-          error: {
-            type: "conflict_error" as const,
-            code: "resource_already_exists",
-            message: `An agent with this identifier already exists: '${name}'`,
-          },
-        },
-      };
-    }
-
-    // Compute content-addressable version ID
-    const versionId = computeComposeVersionId(config as AgentComposeYaml);
-
-    // Create the agent compose
-    const [created] = await globalThis.services.db
-      .insert(agentComposes)
-      .values({
-        userId: auth.userId,
-        scopeId: userScope.id,
-        name,
-      })
-      .returning();
-
-    if (!created) {
-      return {
-        status: 500 as const,
-        body: {
-          error: {
-            type: "api_error" as const,
-            code: "internal_error",
-            message: "Failed to create agent",
-          },
-        },
-      };
-    }
-
-    // Create the initial version
-    await globalThis.services.db.insert(agentComposeVersions).values({
-      id: versionId,
-      composeId: created.id,
-      content: config,
-      createdBy: auth.userId,
-    });
-
-    // Update HEAD pointer
-    await globalThis.services.db
-      .update(agentComposes)
-      .set({ headVersionId: versionId })
-      .where(eq(agentComposes.id, created.id));
-
-    return {
-      status: 201 as const,
-      body: {
-        id: created.id,
-        name: created.name,
-        current_version_id: versionId,
-        created_at: created.createdAt.toISOString(),
-        updated_at: created.updatedAt.toISOString(),
-        config,
-      },
-    };
-  },
 });
 
 const handler = createPublicApiHandler(publicAgentsListContract, router);
 
-export { handler as GET, handler as POST };
+export { handler as GET };

--- a/turbo/apps/web/app/v1/artifacts/[id]/route.ts
+++ b/turbo/apps/web/app/v1/artifacts/[id]/route.ts
@@ -2,7 +2,6 @@
  * Public API v1 - Artifact by ID Endpoints
  *
  * GET /v1/artifacts/:id - Get artifact details
- * DELETE /v1/artifacts/:id - Delete artifact
  */
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -99,67 +98,8 @@ const router = tsr.router(publicArtifactByIdContract, {
       },
     };
   },
-
-  delete: async ({ params }) => {
-    initServices();
-
-    const auth = await authenticatePublicApi();
-    if (!isAuthSuccess(auth)) {
-      return {
-        status: 401 as const,
-        body: {
-          error: {
-            type: "authentication_error" as const,
-            code: "invalid_api_key",
-            message: "Invalid API key provided",
-          },
-        },
-      };
-    }
-
-    // Find artifact by ID
-    const [artifact] = await globalThis.services.db
-      .select()
-      .from(storages)
-      .where(
-        and(
-          eq(storages.id, params.id),
-          eq(storages.userId, auth.userId),
-          eq(storages.type, STORAGE_TYPE),
-        ),
-      )
-      .limit(1);
-
-    if (!artifact) {
-      return {
-        status: 404 as const,
-        body: {
-          error: {
-            type: "not_found_error" as const,
-            code: "resource_not_found",
-            message: `No such artifact: '${params.id}'`,
-          },
-        },
-      };
-    }
-
-    // Delete all versions first (foreign key constraint)
-    await globalThis.services.db
-      .delete(storageVersions)
-      .where(eq(storageVersions.storageId, artifact.id));
-
-    // Delete the artifact
-    await globalThis.services.db
-      .delete(storages)
-      .where(eq(storages.id, artifact.id));
-
-    return {
-      status: 204 as const,
-      body: undefined,
-    };
-  },
 });
 
 const handler = createPublicApiHandler(publicArtifactByIdContract, router);
 
-export { handler as GET, handler as DELETE };
+export { handler as GET };

--- a/turbo/apps/web/app/v1/artifacts/__tests__/route.test.ts
+++ b/turbo/apps/web/app/v1/artifacts/__tests__/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { GET as listArtifacts, POST as createArtifact } from "../route";
-import { GET as getArtifact, DELETE as deleteArtifact } from "../[id]/route";
+import { GET as getArtifact } from "../[id]/route";
 import { GET as listVersions } from "../[id]/versions/route";
 import { initServices } from "../../../../src/lib/init-services";
 import { storages } from "../../../../src/db/schema/storage";
@@ -215,59 +215,6 @@ describe("Public API v1 - Artifacts Endpoints", () => {
       );
 
       const response = await listVersions(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(404);
-      expect(data.error.type).toBe("not_found_error");
-    });
-  });
-
-  describe("DELETE /v1/artifacts/:id - Delete Artifact", () => {
-    let artifactIdToDelete: string;
-
-    beforeAll(async () => {
-      // Create a new artifact to delete
-      const request = createTestRequest("http://localhost:3000/v1/artifacts", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: "test-artifact-delete",
-        }),
-      });
-
-      const response = await createArtifact(request);
-      const data = await response.json();
-      artifactIdToDelete = data.id;
-    });
-
-    it("should delete artifact", async () => {
-      const request = createTestRequest(
-        `http://localhost:3000/v1/artifacts/${artifactIdToDelete}`,
-        { method: "DELETE" },
-      );
-
-      const response = await deleteArtifact(request);
-
-      expect(response.status).toBe(204);
-
-      // Verify artifact is deleted
-      const getRequest = createTestRequest(
-        `http://localhost:3000/v1/artifacts/${artifactIdToDelete}`,
-      );
-
-      const getResponse = await getArtifact(getRequest);
-
-      expect(getResponse.status).toBe(404);
-    });
-
-    it("should return 404 for non-existent artifact", async () => {
-      const fakeId = randomUUID();
-      const request = createTestRequest(
-        `http://localhost:3000/v1/artifacts/${fakeId}`,
-        { method: "DELETE" },
-      );
-
-      const response = await deleteArtifact(request);
       const data = await response.json();
 
       expect(response.status).toBe(404);

--- a/turbo/apps/web/app/v1/volumes/[id]/route.ts
+++ b/turbo/apps/web/app/v1/volumes/[id]/route.ts
@@ -2,7 +2,6 @@
  * Public API v1 - Volume by ID Endpoints
  *
  * GET /v1/volumes/:id - Get volume details
- * DELETE /v1/volumes/:id - Delete volume
  */
 import { initServices } from "../../../../src/lib/init-services";
 import {
@@ -99,67 +98,8 @@ const router = tsr.router(publicVolumeByIdContract, {
       },
     };
   },
-
-  delete: async ({ params }) => {
-    initServices();
-
-    const auth = await authenticatePublicApi();
-    if (!isAuthSuccess(auth)) {
-      return {
-        status: 401 as const,
-        body: {
-          error: {
-            type: "authentication_error" as const,
-            code: "invalid_api_key",
-            message: "Invalid API key provided",
-          },
-        },
-      };
-    }
-
-    // Find volume by ID
-    const [volume] = await globalThis.services.db
-      .select()
-      .from(storages)
-      .where(
-        and(
-          eq(storages.id, params.id),
-          eq(storages.userId, auth.userId),
-          eq(storages.type, STORAGE_TYPE),
-        ),
-      )
-      .limit(1);
-
-    if (!volume) {
-      return {
-        status: 404 as const,
-        body: {
-          error: {
-            type: "not_found_error" as const,
-            code: "resource_not_found",
-            message: `No such volume: '${params.id}'`,
-          },
-        },
-      };
-    }
-
-    // Delete all versions first (foreign key constraint)
-    await globalThis.services.db
-      .delete(storageVersions)
-      .where(eq(storageVersions.storageId, volume.id));
-
-    // Delete the volume
-    await globalThis.services.db
-      .delete(storages)
-      .where(eq(storages.id, volume.id));
-
-    return {
-      status: 204 as const,
-      body: undefined,
-    };
-  },
 });
 
 const handler = createPublicApiHandler(publicVolumeByIdContract, router);
 
-export { handler as GET, handler as DELETE };
+export { handler as GET };

--- a/turbo/apps/web/app/v1/volumes/__tests__/route.test.ts
+++ b/turbo/apps/web/app/v1/volumes/__tests__/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { GET as listVolumes, POST as createVolume } from "../route";
-import { GET as getVolume, DELETE as deleteVolume } from "../[id]/route";
+import { GET as getVolume } from "../[id]/route";
 import { GET as listVersions } from "../[id]/versions/route";
 import { initServices } from "../../../../src/lib/init-services";
 import { storages } from "../../../../src/db/schema/storage";
@@ -211,59 +211,6 @@ describe("Public API v1 - Volumes Endpoints", () => {
       );
 
       const response = await listVersions(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(404);
-      expect(data.error.type).toBe("not_found_error");
-    });
-  });
-
-  describe("DELETE /v1/volumes/:id - Delete Volume", () => {
-    let volumeIdToDelete: string;
-
-    beforeAll(async () => {
-      // Create a new volume to delete
-      const request = createTestRequest("http://localhost:3000/v1/volumes", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: "test-volume-delete",
-        }),
-      });
-
-      const response = await createVolume(request);
-      const data = await response.json();
-      volumeIdToDelete = data.id;
-    });
-
-    it("should delete volume", async () => {
-      const request = createTestRequest(
-        `http://localhost:3000/v1/volumes/${volumeIdToDelete}`,
-        { method: "DELETE" },
-      );
-
-      const response = await deleteVolume(request);
-
-      expect(response.status).toBe(204);
-
-      // Verify volume is deleted
-      const getRequest = createTestRequest(
-        `http://localhost:3000/v1/volumes/${volumeIdToDelete}`,
-      );
-
-      const getResponse = await getVolume(getRequest);
-
-      expect(getResponse.status).toBe(404);
-    });
-
-    it("should return 404 for non-existent volume", async () => {
-      const fakeId = randomUUID();
-      const request = createTestRequest(
-        `http://localhost:3000/v1/volumes/${fakeId}`,
-        { method: "DELETE" },
-      );
-
-      const response = await deleteVolume(request);
       const data = await response.json();
 
       expect(response.status).toBe(404);

--- a/turbo/packages/core/src/contracts/public/agents.ts
+++ b/turbo/packages/core/src/contracts/public/agents.ts
@@ -63,23 +63,6 @@ export const paginatedAgentVersionsSchema =
   createPaginatedResponseSchema(agentVersionSchema);
 
 /**
- * Create agent request schema
- */
-export const createAgentRequestSchema = z.object({
-  name: z
-    .string()
-    .min(1)
-    .max(100)
-    .regex(
-      /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/,
-      "Name must be lowercase alphanumeric with hyphens, not starting or ending with hyphen",
-    ),
-  config: z.unknown(), // Agent YAML configuration
-});
-
-export type CreateAgentRequest = z.infer<typeof createAgentRequestSchema>;
-
-/**
  * Update agent request schema
  */
 export const updateAgentRequestSchema = z.object({
@@ -103,20 +86,6 @@ export const publicAgentsListContract = c.router({
     },
     summary: "List agents",
     description: "List all agents in the current scope with pagination",
-  },
-  create: {
-    method: "POST",
-    path: "/v1/agents",
-    body: createAgentRequestSchema,
-    responses: {
-      201: publicAgentDetailSchema,
-      400: publicApiErrorSchema,
-      401: publicApiErrorSchema,
-      409: publicApiErrorSchema,
-      500: publicApiErrorSchema,
-    },
-    summary: "Create agent",
-    description: "Create a new agent with the given configuration",
   },
 });
 

--- a/turbo/packages/core/src/contracts/public/agents.ts
+++ b/turbo/packages/core/src/contracts/public/agents.ts
@@ -90,7 +90,7 @@ export const publicAgentsListContract = c.router({
 });
 
 /**
- * Agent by ID contract - GET/PUT/DELETE /v1/agents/:id
+ * Agent by ID contract - GET/PUT /v1/agents/:id
  */
 export const publicAgentByIdContract = c.router({
   get: {
@@ -125,22 +125,6 @@ export const publicAgentByIdContract = c.router({
     summary: "Update agent",
     description:
       "Update agent configuration. Creates a new version if config changes.",
-  },
-  delete: {
-    method: "DELETE",
-    path: "/v1/agents/:id",
-    pathParams: z.object({
-      id: z.string().min(1, "Agent ID is required"),
-    }),
-    body: z.undefined(),
-    responses: {
-      204: z.undefined(),
-      401: publicApiErrorSchema,
-      404: publicApiErrorSchema,
-      500: publicApiErrorSchema,
-    },
-    summary: "Delete agent",
-    description: "Archive an agent (soft delete)",
   },
 });
 

--- a/turbo/packages/core/src/contracts/public/artifacts.ts
+++ b/turbo/packages/core/src/contracts/public/artifacts.ts
@@ -186,7 +186,7 @@ export const publicArtifactsListContract = c.router({
 });
 
 /**
- * Artifact by ID contract - GET/DELETE /v1/artifacts/:id
+ * Artifact by ID contract - GET /v1/artifacts/:id
  */
 export const publicArtifactByIdContract = c.router({
   get: {
@@ -203,22 +203,6 @@ export const publicArtifactByIdContract = c.router({
     },
     summary: "Get artifact",
     description: "Get artifact details by ID",
-  },
-  delete: {
-    method: "DELETE",
-    path: "/v1/artifacts/:id",
-    pathParams: z.object({
-      id: z.string().min(1, "Artifact ID is required"),
-    }),
-    body: z.undefined(),
-    responses: {
-      204: z.undefined(),
-      401: publicApiErrorSchema,
-      404: publicApiErrorSchema,
-      500: publicApiErrorSchema,
-    },
-    summary: "Delete artifact",
-    description: "Delete an artifact and all its versions",
   },
 });
 

--- a/turbo/packages/core/src/contracts/public/index.ts
+++ b/turbo/packages/core/src/contracts/public/index.ts
@@ -47,7 +47,6 @@ export {
   agentVersionSchema,
   paginatedAgentsSchema,
   paginatedAgentVersionsSchema,
-  createAgentRequestSchema,
   updateAgentRequestSchema,
   // Contracts
   publicAgentsListContract,
@@ -57,7 +56,6 @@ export {
   type PublicAgent,
   type PublicAgentDetail,
   type AgentVersion,
-  type CreateAgentRequest,
   type UpdateAgentRequest,
   type PublicAgentsListContract,
   type PublicAgentByIdContract,

--- a/turbo/packages/core/src/contracts/public/volumes.ts
+++ b/turbo/packages/core/src/contracts/public/volumes.ts
@@ -185,7 +185,7 @@ export const publicVolumesListContract = c.router({
 });
 
 /**
- * Volume by ID contract - GET/DELETE /v1/volumes/:id
+ * Volume by ID contract - GET /v1/volumes/:id
  */
 export const publicVolumeByIdContract = c.router({
   get: {
@@ -202,22 +202,6 @@ export const publicVolumeByIdContract = c.router({
     },
     summary: "Get volume",
     description: "Get volume details by ID",
-  },
-  delete: {
-    method: "DELETE",
-    path: "/v1/volumes/:id",
-    pathParams: z.object({
-      id: z.string().min(1, "Volume ID is required"),
-    }),
-    body: z.undefined(),
-    responses: {
-      204: z.undefined(),
-      401: publicApiErrorSchema,
-      404: publicApiErrorSchema,
-      500: publicApiErrorSchema,
-    },
-    summary: "Delete volume",
-    description: "Delete a volume and all its versions",
   },
 });
 


### PR DESCRIPTION
## Summary

- Remove the `POST /v1/agents` endpoint from the public API
- Remove `DELETE` endpoints for agents, volumes, and artifacts from the public API
- The vm0 compose command has become more complex and these endpoints no longer meet requirements
- Resource management (create/delete) continues to work via CLI and Web UI through internal APIs

## Changes

### First commit: Remove POST /v1/agents
- Remove `create` handler from `v1/agents/route.ts` (only keep GET for listing)
- Remove `createAgentRequestSchema` and `CreateAgentRequest` type from contracts
- Remove `create` method from `publicAgentsListContract`
- Update unit tests to use direct DB insertion instead of API calls

### Second commit: Remove DELETE endpoints
- Remove `delete` handler from `agents/[id]/route.ts`
- Remove `delete` handler from `volumes/[id]/route.ts`
- Remove `delete` handler from `artifacts/[id]/route.ts`
- Remove `delete` method from `publicAgentByIdContract`
- Remove `delete` method from `publicVolumeByIdContract`
- Remove `delete` method from `publicArtifactByIdContract`
- Update all related tests

### Remaining endpoints
- `DELETE /v1/tokens/:id` is kept - users need to be able to revoke their API tokens

## Test plan

- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm lint`)
- [ ] CI pipeline passes
- [ ] E2E tests pass

Closes #1058

🤖 Generated with [Claude Code](https://claude.com/claude-code)