### PR TITLE
fix(storybook): switch to @tailwindcss/vite for proper CSS processing

### DIFF
--- a/turbo/apps/storybook/.storybook/main.ts
+++ b/turbo/apps/storybook/.storybook/main.ts
@@ -10,12 +10,15 @@ const config: StorybookConfig = {
   docs: {
     autodocs: "tag",
   },
-  viteFinal: (config) => {
-    config.server = {
-      ...config.server,
-      allowedHosts: ["storybook.vm7.ai"],
-    };
-    return config;
+  async viteFinal(config) {
+    const { mergeConfig } = await import("vite");
+    const { default: tailwindcss } = await import("@tailwindcss/vite");
+    return mergeConfig(config, {
+      plugins: [tailwindcss()],
+      server: {
+        allowedHosts: ["storybook.vm7.ai"],
+      },
+    });
   },
 };
 

--- a/turbo/apps/storybook/package.json
+++ b/turbo/apps/storybook/package.json
@@ -21,15 +21,14 @@
     "@storybook/react": "^8.6.12",
     "@storybook/react-vite": "^8.6.12",
     "@storybook/test": "^8.6.12",
-    "@tailwindcss/postcss": "^4.1.3",
+    "@tailwindcss/vite": "^4.1.8",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
     "@vm0/eslint-config": "workspace:*",
     "@vm0/typescript-config": "workspace:*",
     "eslint": "^9.34.0",
-    "postcss": "^8.5.3",
     "storybook": "^8.6.12",
-    "tailwindcss": "^4.1.3",
+    "tailwindcss": "^4.1.8",
     "typescript": "5.9.2",
     "vite": "^6.3.5"
   }

--- a/turbo/apps/storybook/postcss.config.js
+++ b/turbo/apps/storybook/postcss.config.js
@@ -1,5 +1,0 @@
-import tailwindcss from "@tailwindcss/postcss";
-
-export default {
-  plugins: [tailwindcss],
-};

--- a/turbo/apps/storybook/src/styles.css
+++ b/turbo/apps/storybook/src/styles.css
@@ -1,2 +1,5 @@
 @import "tailwindcss";
 @import "@vm0/ui/styles/globals.css";
+
+/* Tell Tailwind to scan UI package components for class usage */
+@source "../../../packages/ui/src/**/*.tsx";

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -322,9 +322,9 @@ importers:
       '@storybook/test':
         specifier: ^8.6.12
         version: 8.6.15(storybook@8.6.15(bufferutil@4.1.0)(prettier@3.6.2)(utf-8-validate@5.0.10))
-      '@tailwindcss/postcss':
-        specifier: ^4.1.3
-        version: 4.1.12
+      '@tailwindcss/vite':
+        specifier: ^4.1.8
+        version: 4.1.18(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       '@types/react':
         specifier: ^19.1.12
         version: 19.1.12
@@ -340,14 +340,11 @@ importers:
       eslint:
         specifier: ^9.34.0
         version: 9.34.0(jiti@2.6.1)
-      postcss:
-        specifier: ^8.5.3
-        version: 8.5.6
       storybook:
         specifier: ^8.6.12
         version: 8.6.15(bufferutil@4.1.0)(prettier@3.6.2)(utf-8-validate@5.0.10)
       tailwindcss:
-        specifier: ^4.1.3
+        specifier: ^4.1.8
         version: 4.1.18
       typescript:
         specifier: 5.9.2
@@ -12056,6 +12053,13 @@ snapshots:
       tailwindcss: 4.1.18
       vite: 6.4.1(@types/node@22.18.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
+  '@tailwindcss/vite@4.1.18(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
+    dependencies:
+      '@tailwindcss/node': 4.1.18
+      '@tailwindcss/oxide': 4.1.18
+      tailwindcss: 4.1.18
+      vite: 6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+
   '@tanstack/query-core@5.87.4': {}
 
   '@testing-library/dom@10.4.0':
@@ -12712,7 +12716,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.18.0)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@2.0.5':
     dependencies:


### PR DESCRIPTION
## Summary
- Replace `@tailwindcss/postcss` with `@tailwindcss/vite` plugin
- Configure Tailwind via `viteFinal` using dynamic imports (required for ESM compatibility)
- Remove obsolete `postcss.config.js`
- Update `tailwindcss` to v4.1.8 to match platform app

## Problem
Button components in Storybook were missing background and border colors because `@tailwindcss/postcss` wasn't properly integrated with Storybook's Vite builder.

## Solution
Switch to `@tailwindcss/vite` plugin and configure it through Storybook's `viteFinal` hook, matching the pattern used in the platform app.

## Test plan
- [x] Storybook dev server starts without errors
- [x] Storybook build completes successfully
- [ ] All button variants display correct background/border colors
- [ ] Theme switching works correctly (light/dark)

Closes #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)