### PR TITLE
fix(cli): update network logs error message to reference experimental_runner

### DIFF
--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -292,7 +292,7 @@ async function showNetworkLogs(
   if (response.networkLogs.length === 0) {
     console.log(
       chalk.yellow(
-        "No network logs found for this run. Network logs are only captured when experimental_firewall is enabled on a self-hosted runner.",
+        "No network logs found for this run. Network logs are only captured when experimental_firewall is enabled on an experimental_runner.",
       ),
     );
     return;


### PR DESCRIPTION
## Summary

- Update CLI logs command error message from "self-hosted runner" to "experimental_runner" for consistency with product terminology

## Test plan

- [ ] Run `vm0 logs <run-id> --network` on a run without network logs to verify the updated message

🤖 Generated with [Claude Code](https://claude.com/claude-code)