### PR TITLE
docs: simplify readme with new tagline and clearer capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,34 +41,25 @@
 ```bash
 npm install -g @vm0/cli
 vm0 auth login
-mkdir my-agent && cd my-agent
-vm0 init
 ```
 
-Set up your token ([instructions](https://docs.vm0.ai/docs/quick-start#initialize-token)), then:
-
 ```bash
+mkdir my-agent && cd my-agent
+vm0 init
 cat > AGENTS.md << 'EOF'
-# Agent Instructions
-
-You are a HackerNews AI content curator.
-
-## Workflow
-
+# Workflow
 1. Go to HackerNews and read the top 10 articles
 2. Find and extract AI-related content from these articles
 3. Summarize the findings into a X (Twitter) post format
 4. Write the summary to content.md
 EOF
 
-vm0 cook "let's start working"
+vm0 cook "follow your workflow"
 ```
-
-> VM0 is in beta. [Join the waitlist](https://www.vm0.ai/sign-up) to get access. For full documentation, visit [docs.vm0.ai](https://docs.vm0.ai/docs).
 
 ## Resources
 
-[Documentation](https://docs.vm0.ai) · [Cookbooks](https://github.com/vm0-ai/vm0-cookbooks) · [Skills](https://github.com/vm0-ai/vm0-skills) · [Discord](https://discord.gg/WMpAmHFfp6)
+[Documentation](https://docs.vm0.ai) · [Skills](https://github.com/vm0-ai/vm0-skills) · [Discord](https://discord.gg/WMpAmHFfp6)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 **Supported**: Claude Code, Codex · **Coming soon**: Gemini CLI, self-hosted runner
 
-## Quick Start
+## [Quick Start](https://docs.vm0.ai/docs/quick-start)
 
 ```bash
 npm install -g @vm0/cli

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-<p align="center">
+<p>
   <img src="https://github.com/vm0-ai/vm0/blob/main/turbo/apps/web/public/assets/Logo_VM0_combo_black_bg.svg" alt="VM0 Logo" width="120" />
 </p>
 
-<p align="center">
+<p>
   <a href="https://deepwiki.com/vm0-ai/vm0">
     <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" />
   </a>
@@ -14,16 +14,16 @@
   </a>
 </p>
 
-<p align="center">
-  <strong>Skill workflows, while you sleep</strong>
-</p>
-
-<p align="center">
+<p>
   <a href="https://www.vm0.ai">Website</a> •
   <a href="https://docs.vm0.ai">Documentation</a> •
   <a href="https://www.vm0.ai/sign-up">Join Waitlist</a> •
   <a href="https://discord.gg/WMpAmHFfp6">Discord</a>
 </p>
+
+---
+
+![Alt](https://repobeats.axiom.co/api/embed/ef46db5e11f5146fcc8af07077a79d789efdfbe5.svg "Repobeats analytics image")
 
 ---
 
@@ -49,8 +49,6 @@ vm0 init
 cat AGENTS.md # check the workflow which your agent will run
 vm0 cook "run your workflow"
 ```
-
-![Alt](https://repobeats.axiom.co/api/embed/ef46db5e11f5146fcc8af07077a79d789efdfbe5.svg "Repobeats analytics image")
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
 
 <p align="center">
   <a href="https://www.vm0.ai">Website</a> •
+  <a href="https://docs.vm0.ai">Documentation</a> •
   <a href="https://www.vm0.ai/sign-up">Join Waitlist</a> •
   <a href="https://discord.gg/WMpAmHFfp6">Discord</a> •
-  <a href="mailto:ethan@vm0.ai">Contact</a>
 </p>
 
 ---
@@ -50,7 +50,7 @@ vm0 cook "run your workflow"
 
 ## Resources
 
-[Documentation](https://docs.vm0.ai) · [Skills](https://github.com/vm0-ai/vm0-skills) · [Discord](https://discord.gg/WMpAmHFfp6)
+[Skills](https://github.com/vm0-ai/vm0-skills)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="https://www.vm0.ai">Website</a> •
   <a href="https://docs.vm0.ai">Documentation</a> •
   <a href="https://www.vm0.ai/sign-up">Join Waitlist</a> •
-  <a href="https://discord.gg/WMpAmHFfp6">Discord</a> •
+  <a href="https://discord.gg/WMpAmHFfp6">Discord</a>
 </p>
 
 ---
@@ -38,7 +38,7 @@
 
 ## [Quick Start](https://docs.vm0.ai/docs/quick-start)
 
-From zero to agent in 5 minutes
+From zero to workflow agent in 5 minutes
 
 ```bash
 npm install -g @vm0/cli
@@ -49,6 +49,8 @@ vm0 init
 cat AGENTS.md # check the workflow which your agent will run
 vm0 cook "run your workflow"
 ```
+
+![Alt](https://repobeats.axiom.co/api/embed/ef46db5e11f5146fcc8af07077a79d789efdfbe5.svg "Repobeats analytics image")
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -44,17 +44,13 @@ vm0 auth login
 ```
 
 ```bash
-mkdir my-agent && cd my-agent
-vm0 init
-cat > AGENTS.md << 'EOF'
+cat << 'EOF' | vm0 cook -
 # Workflow
 1. Go to HackerNews and read the top 10 articles
 2. Find and extract AI-related content from these articles
 3. Summarize the findings into a X (Twitter) post format
 4. Write the summary to content.md
 EOF
-
-vm0 cook "follow your workflow"
 ```
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -48,10 +48,6 @@ cat AGENTS.md # check the workflow which your agent will run
 vm0 cook "run your workflow"
 ```
 
-## Resources
-
-[Skills](https://github.com/vm0-ai/vm0-skills)
-
 ## License
 
 See [LICENSE](./LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <strong>Build agents and automate workflows with natural language</strong>
+  <strong>Skill workflows, while you sleep</strong>
 </p>
 
 <p align="center">
@@ -27,76 +27,35 @@
 
 ---
 
-## What is VM0?
+## What You Get
 
-VM0 helps you build agents and automated workflows using natural language.
+- **Cloud sandbox** — Run Claude Code or Codex agents in isolated containers
+- **60+ skills** — GitHub, Slack, Notion, Firecrawl, and [more](https://github.com/vm0-ai/vm0-skills)
+- **Persistence** — Continue chat, resume, fork, and version your workflow sessions
+- **Observability** — Logs, metrics, and network visibility for every run
 
-It also provides a full agent runtime with:
-- Secure cloud sandbox: isolated execution environments for running agents safely
-- Versioned storage: track, reproduce, and roll back agent state and artifacts
-- Persistent execution: resume, fork, and iterate on agent runs with full history
-- Complete observability: logs, metrics, and network visibility for every run
-
-You can build and extend agents using:
-- Natural language workflows: define agent behavior in plain text, without complex graphs or pipelines
-- Pluggable skills: add capabilities through reusable [agent skills](https://github.com/vm0-ai/vm0-skills)
-  
-**Supported agents:**
-- Claude Code
-- OpenAI Codex (in beta)
-- Gemini CLI (coming soon)
-- More coming soon...
-
-## Installation
-
-```bash
-npm install -g @vm0/cli
-```
-
-> VM0 is in beta. [Join the waitlist](https://www.vm0.ai/sign-up) to get access.
+**Supported**: Claude Code, Codex (beta) · **Coming soon**: Gemini CLI, self-hosted runner
 
 ## Quick Start
 
 ```bash
-# 1. Login
+npm install -g @vm0/cli
 vm0 auth login
-
-# 2. Create project directory
 mkdir my-agent && cd my-agent
-
-# 3. Initialize project
 vm0 init
-
-# 4. Get Claude Code token and save to .env
-claude setup-token
-echo "CLAUDE_CODE_OAUTH_TOKEN=<your-token>" > .env
-
-# 5. Run your agent
-vm0 cook "let's start working."
-# Agent follows AGENTS.md: curates AI news from HackerNews and writes to content.md
 ```
 
-### What just happened?
+Set up your token ([instructions](https://docs.vm0.ai/docs/quick-start#initialize-token)), then:
 
-- `vm0 init` created `vm0.yaml` (agent config) and `AGENTS.md` (agent instructions)
-- `vm0 cook` initialized storage, composed the agent, and ran your prompt
-- Results are in the `artifact/` directory
+```bash
+vm0 cook "let's start working"
+```
 
-### Next steps
-
-- Edit `AGENTS.md` to customize agent instructions
-- Edit `vm0.yaml` to configure [agent skills](https://github.com/vm0-ai/vm0-skills)
-
-> For full documentation, visit [docs.vm0.ai](https://docs.vm0.ai/docs).
+> VM0 is in beta. [Join the waitlist](https://www.vm0.ai/sign-up) to get access. For full documentation, visit [docs.vm0.ai](https://docs.vm0.ai/docs).
 
 ## Resources
 
-- [vm0-cookbooks](https://github.com/vm0-ai/vm0-cookbooks) - Ready-to-run examples
-- [vm0-skills](https://github.com/vm0-ai/vm0-skills) - Agent skills library
-- [Contributing guide](./CONTRIBUTING.md) - Development setup
-- [Website](https://www.vm0.ai) - Official website
-- [Discord](https://discord.gg/WMpAmHFfp6) - Join our community
-- [Email](mailto:ethan@vm0.ai) - Questions and support
+[Documentation](https://docs.vm0.ai) · [Cookbooks](https://github.com/vm0-ai/vm0-cookbooks) · [Skills](https://github.com/vm0-ai/vm0-skills) · [Discord](https://discord.gg/WMpAmHFfp6)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@
 
 ## Skill workflows, while you sleep
 
-- **Cloud sandbox** — Run Claude Code or Codex agents in isolated containers
-- **60+ skills** — GitHub, Slack, Notion, Firecrawl, and [more](https://github.com/vm0-ai/vm0-skills)
-- **Persistence** — Continue chat, resume, fork, and version your workflow sessions
-- **Observability** — Logs, metrics, and network visibility for every run
+- **Cloud sandbox**, run Claude Code or Codex agents in isolated containers
+- **60+ skills**, GitHub, Slack, Notion, Firecrawl, and [more](https://github.com/vm0-ai/vm0-skills)
+- **Persistence**, continue chat, resume, fork, and version your workflow sessions
+- **Observability**, logs, metrics, and network visibility for every run
 
 **Supported**: Claude Code, Codex · **Coming soon**: Gemini CLI, self-hosted runner
 

--- a/README.md
+++ b/README.md
@@ -41,16 +41,11 @@
 ```bash
 npm install -g @vm0/cli
 vm0 auth login
-```
+mkdir my-agent && cd my-agent
 
-```bash
-cat << 'EOF' | vm0 cook -
-# Workflow
-1. Go to HackerNews and read the top 10 articles
-2. Find and extract AI-related content from these articles
-3. Summarize the findings into a X (Twitter) post format
-4. Write the summary to content.md
-EOF
+vm0 init
+cat AGENTS.md # check the workflow which your agent will run
+vm0 cook "run your workflow"
 ```
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 - **Persistence** — Continue chat, resume, fork, and version your workflow sessions
 - **Observability** — Logs, metrics, and network visibility for every run
 
-**Supported**: Claude Code, Codex (beta) · **Coming soon**: Gemini CLI, self-hosted runner
+**Supported**: Claude Code, Codex · **Coming soon**: Gemini CLI, self-hosted runner
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ vm0 init
 Set up your token ([instructions](https://docs.vm0.ai/docs/quick-start#initialize-token)), then:
 
 ```bash
+cat > AGENTS.md << 'EOF'
+# Agent Instructions
+
+You are a HackerNews AI content curator.
+
+## Workflow
+
+1. Go to HackerNews and read the top 10 articles
+2. Find and extract AI-related content from these articles
+3. Summarize the findings into a X (Twitter) post format
+4. Write the summary to content.md
+EOF
+
 vm0 cook "let's start working"
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@
 
 ## [Quick Start](https://docs.vm0.ai/docs/quick-start)
 
+From zero to agent in 5 minutes
+
 ```bash
 npm install -g @vm0/cli
 vm0 auth login

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 - **Persistence**, continue chat, resume, fork, and version your workflow sessions
 - **Observability**, logs, metrics, and network visibility for every run
 
-**Supported**: Claude Code, Codex · **Coming soon**: Gemini CLI, self-hosted runner
+**Supported**: Claude Code, Codex · **Coming soon**: Gemini CLI, DeepAgent CLI, OpenCode
 
 ## [Quick Start](https://docs.vm0.ai/docs/quick-start)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ---
 
-## What You Get
+## Skill workflows, while you sleep
 
 - **Cloud sandbox** — Run Claude Code or Codex agents in isolated containers
 - **60+ skills** — GitHub, Slack, Notion, Firecrawl, and [more](https://github.com/vm0-ai/vm0-skills)


### PR DESCRIPTION
## Summary

- Update tagline to "Skill workflows, while you sleep"
- Replace verbose "What is VM0?" with concise "What You Get" section
- Add status line: Supported / Coming soon (Gemini CLI, self-hosted runner)
- Simplify Quick Start with link to docs for token setup
- Condense Resources to single line

## Changes

| Section | Before | After |
|---------|--------|-------|
| Lines | 103 | 62 (-40%) |
| Tagline | "Build agents and automate workflows with natural language" | "Skill workflows, while you sleep" |
| What is VM0? | 18 lines | Removed |
| What You Get | N/A | 8 lines (new) |
| Quick Start | 18 lines | 12 lines |
| What just happened? | 5 lines | Removed |
| Resources | 8 lines | 1 line |

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify all links work
- [ ] Review tagline and messaging

Closes #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)