### PR TITLE
feat(runner): increase default max_concurrent from 4 to 8

### DIFF
--- a/ansible/playbooks/templates/runner.yaml.j2
+++ b/ansible/playbooks/templates/runner.yaml.j2
@@ -9,7 +9,7 @@ server:
   token: vm0_official_{{ official_runner_secret }}
 
 sandbox:
-  max_concurrent: {{ max_concurrent | default(4) }}
+  max_concurrent: {{ max_concurrent | default(8) }}
   vcpu: {{ vcpu | default(2) }}
   memory_mb: {{ memory_mb | default(1024) }}
   poll_interval_ms: {{ poll_interval_ms | default(5000) }}


### PR DESCRIPTION
## Summary

- Increases the default `max_concurrent` sandbox limit from 4 to 8 in the Ansible runner template
- The 1:1 vCPU to pCPU ratio (8 VMs × 2 vCPU = 16 vCPU on 16-core host) is conservative - AWS runs Firecracker at 10x overcommitment in production
- Doubles sandbox capacity on the bare metal host

## Test plan

- [ ] Deploy to staging runner and verify 8 concurrent sandboxes can run
- [ ] Monitor CPU utilization under load

🤖 Generated with [Claude Code](https://claude.ai/code)