### PR TITLE
feat(lifecycle): add postCreateCommand hook and hardcode working_dir

### DIFF
--- a/e2e/fixtures/configs/vm0-env-expansion.yaml
+++ b/e2e/fixtures/configs/vm0-env-expansion.yaml
@@ -5,7 +5,6 @@ agents:
     description: "Test agent for environment variable expansion"
     provider: claude-code
     image: "vm0/claude-code:dev"
-    working_dir: /home/user/workspace
     environment:
       TEST_VAR: "${{ vars.testVar }}"
       TEST_SECRET: "${{ secrets.TEST_SECRET }}"

--- a/e2e/fixtures/configs/vm0-template-validation.yaml
+++ b/e2e/fixtures/configs/vm0-template-validation.yaml
@@ -5,7 +5,6 @@ agents:
     description: "Test agent for template variable validation"
     provider: claude-code
     image: "vm0/claude-code:dev"
-    working_dir: /home/user/workspace
     volumes:
       - user-data:/home/user/data
 

--- a/e2e/fixtures/configs/vm0-versioning.yaml
+++ b/e2e/fixtures/configs/vm0-versioning.yaml
@@ -5,4 +5,3 @@ agents:
     description: "Test agent for version testing"
     provider: claude-code
     image: "vm0/claude-code:dev"
-    working_dir: /home/user/workspace

--- a/e2e/fixtures/configs/vm0-volume-override.yaml
+++ b/e2e/fixtures/configs/vm0-volume-override.yaml
@@ -8,7 +8,6 @@ agents:
     volumes:
       - test-volume:/home/user/data
       - claude-files:/home/user/.claude
-    working_dir: /home/user/workspace
 
 volumes:
   test-volume:

--- a/turbo/apps/cli/src/lib/yaml-validator.ts
+++ b/turbo/apps/cli/src/lib/yaml-validator.ts
@@ -149,22 +149,20 @@ export function validateAgentCompose(config: unknown): {
     };
   }
 
-  // Check agent.working_dir (optional when provider is supported)
-  if (
-    agent.working_dir !== undefined &&
-    typeof agent.working_dir !== "string"
-  ) {
-    return {
-      valid: false,
-      error: "agent.working_dir must be a string if provided",
-    };
-  }
-  if (!agent.working_dir && !providerIsSupported) {
-    return {
-      valid: false,
-      error:
-        "Missing agent.working_dir (required when provider is not auto-configured)",
-    };
+  // Validate postCreateCommand if present (must be a non-empty string)
+  if (agent.postCreateCommand !== undefined) {
+    if (typeof agent.postCreateCommand !== "string") {
+      return {
+        valid: false,
+        error: "agent.postCreateCommand must be a string",
+      };
+    }
+    if (agent.postCreateCommand.length === 0) {
+      return {
+        valid: false,
+        error: "agent.postCreateCommand cannot be empty",
+      };
+    }
   }
 
   // Validate instructions if present (must be a relative file path)

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -88,6 +88,11 @@ function buildEnvironmentVariables(
     envVars.VM0_ARTIFACT_VERSION_ID = artifact.vasVersionId;
   }
 
+  // Add postCreateCommand lifecycle hook if specified
+  if (context.postCreateCommand) {
+    envVars.VM0_POST_CREATE_COMMAND = context.postCreateCommand;
+  }
+
   // Add resume session ID if present
   if (context.resumeSession) {
     envVars.VM0_RESUME_SESSION_ID = context.resumeSession.sessionId;

--- a/turbo/apps/web/src/lib/agent-compose/__tests__/content-hash.test.ts
+++ b/turbo/apps/web/src/lib/agent-compose/__tests__/content-hash.test.ts
@@ -20,7 +20,6 @@ describe("content-hash", () => {
           "test-agent": {
             image: "test-image",
             provider: "claude-code",
-            working_dir: "/workspace",
           },
         },
       };
@@ -38,7 +37,6 @@ describe("content-hash", () => {
           "my-agent": {
             image: "ubuntu",
             provider: "claude-code",
-            working_dir: "/home",
           },
         },
       };
@@ -49,7 +47,6 @@ describe("content-hash", () => {
           "my-agent": {
             image: "ubuntu",
             provider: "claude-code",
-            working_dir: "/home",
           },
         },
       };
@@ -65,7 +62,6 @@ describe("content-hash", () => {
         version: "1.0",
         agents: {
           agent1: {
-            working_dir: "/workspace",
             image: "test",
             provider: "claude-code",
           },
@@ -75,9 +71,8 @@ describe("content-hash", () => {
       const content2 = {
         agents: {
           agent1: {
-            image: "test",
             provider: "claude-code",
-            working_dir: "/workspace",
+            image: "test",
           },
         },
         version: "1.0",
@@ -95,7 +90,6 @@ describe("content-hash", () => {
           agent1: {
             image: "image-a",
             provider: "claude-code",
-            working_dir: "/workspace",
           },
         },
       };
@@ -106,7 +100,6 @@ describe("content-hash", () => {
           agent1: {
             image: "image-b",
             provider: "claude-code",
-            working_dir: "/workspace",
           },
         },
       };
@@ -123,7 +116,6 @@ describe("content-hash", () => {
           agent1: {
             image: "test",
             provider: "claude-code",
-            working_dir: "/workspace",
             environment: {
               FOO: "bar",
               BAZ: "qux",
@@ -140,7 +132,6 @@ describe("content-hash", () => {
         version: "1.0",
         agents: {
           agent1: {
-            working_dir: "/workspace",
             provider: "claude-code",
             image: "test",
             environment: {

--- a/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
+++ b/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
@@ -99,7 +99,7 @@ describe("E2B Service - mocked unit tests", () => {
   });
 
   /**
-   * Helper function to create a valid agent compose with working_dir
+   * Helper function to create a valid agent compose
    */
   const createValidAgentCompose = (overrides = {}) => ({
     version: "1.0",
@@ -107,7 +107,6 @@ describe("E2B Service - mocked unit tests", () => {
       "test-agent": {
         image: "test-image",
         provider: "claude-code",
-        working_dir: "/workspace",
         ...overrides,
       },
     },
@@ -332,7 +331,7 @@ describe("E2B Service - mocked unit tests", () => {
       expect(mockSandbox.kill).not.toHaveBeenCalled();
     });
 
-    it("should pass working_dir to sandbox when configured", async () => {
+    it("should pass hardcoded working_dir to sandbox", async () => {
       // Arrange
       const mockSandbox = createMockSandbox();
       vi.mocked(Sandbox.create).mockResolvedValue(
@@ -346,10 +345,9 @@ describe("E2B Service - mocked unit tests", () => {
           version: "1.0",
           agents: {
             "test-agent": {
-              description: "Test agent with working dir",
+              description: "Test agent",
               image: "test-image",
               provider: "claude-code",
-              working_dir: "/home/user/workspace",
             },
           },
         },
@@ -363,7 +361,7 @@ describe("E2B Service - mocked unit tests", () => {
       // Assert - fire-and-forget returns "running"
       expect(result.status).toBe("running");
 
-      // Verify sandbox was created with environment variables including working_dir
+      // Verify sandbox was created with hardcoded working_dir
       // NOTE: VM0_WORKING_DIR is passed at sandbox creation time, not via commands.run({ envs })
       // because E2B's background mode doesn't pass envs to the background process
       expect(Sandbox.create).toHaveBeenCalled();
@@ -372,39 +370,6 @@ describe("E2B Service - mocked unit tests", () => {
       expect(createCall?.[1]?.envs?.VM0_WORKING_DIR).toBe(
         "/home/user/workspace",
       );
-    });
-
-    it("should fail when working_dir is not configured", async () => {
-      // Arrange
-      const mockSandbox = createMockSandbox();
-      vi.mocked(Sandbox.create).mockResolvedValue(
-        mockSandbox as unknown as Sandbox,
-      );
-
-      const context: ExecutionContext = {
-        runId: "test-run-007",
-        agentComposeVersionId: "test-version-007",
-        agentCompose: {
-          version: "1.0",
-          agents: {
-            "test-agent": {
-              description: "Test agent without working dir",
-              image: "test-image",
-              provider: "claude-code",
-              working_dir: "",
-            },
-          },
-        },
-        sandboxToken: "vm0_live_test_token",
-        prompt: "Read files",
-      };
-
-      // Act
-      const result = await e2bService.execute(context);
-
-      // Assert - should fail because working_dir is required
-      expect(result.status).toBe("failed");
-      expect(result.error).toContain("working_dir");
     });
   });
 
@@ -482,7 +447,6 @@ describe("E2B Service - mocked unit tests", () => {
               description: "Test agent with custom image",
               image: "custom-template-name",
               provider: "claude-code",
-              working_dir: "/workspace",
             },
           },
         },

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -2,7 +2,6 @@ import { Sandbox } from "@e2b/code-interpreter";
 import { e2bConfig } from "./config";
 import type { RunResult } from "./types";
 import { storageService } from "../storage/storage-service";
-import { BadRequestError } from "../errors";
 import { resolveImageAlias } from "../image/image-service";
 import type {
   AgentVolumeConfig,
@@ -76,15 +75,11 @@ export class E2BService {
       | undefined;
 
     try {
-      // Get mount path from agent compose (used for resume artifact)
-      // working_dir is required - no fallback allowed
+      // Get agent config for provider and image settings
       const firstAgent = getFirstAgent(agentComposeYaml);
-      if (!firstAgent?.working_dir) {
-        throw new BadRequestError(
-          "Agent must have working_dir configured (no default allowed)",
-        );
-      }
-      const artifactMountPath = firstAgent.working_dir;
+
+      // Hardcoded working directory (artifact mount path)
+      const artifactMountPath = "/home/user/workspace";
       // Prepare storage manifest with presigned URLs for direct download to sandbox
       // This works for both new runs and resume scenarios
       const storageManifest = await storageService.prepareStorageManifest(
@@ -193,7 +188,7 @@ export class E2BService {
 
       // Set CLI_AGENT_TYPE based on provider (defaults to "claude-code")
       // This is used by run-agent.py to determine which CLI to invoke
-      const provider = firstAgent.provider || "claude-code";
+      const provider = firstAgent?.provider || "claude-code";
       sandboxEnvVars.CLI_AGENT_TYPE = provider;
       log.debug(`CLI_AGENT_TYPE set to: ${provider}`);
 

--- a/turbo/apps/web/src/lib/run/context/index.ts
+++ b/turbo/apps/web/src/lib/run/context/index.ts
@@ -1,6 +1,6 @@
 export {
   prepareForExecution,
-  extractWorkingDir,
+  getWorkingDir,
   extractCliAgentType,
   resolveRunnerGroup,
 } from "./execution-preparer";

--- a/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
@@ -247,6 +247,11 @@ export class E2BExecutor implements Executor {
       sandboxEnvVars.VM0_ARTIFACT_VERSION_ID = artifactForCommand.vasVersionId;
     }
 
+    // Add postCreateCommand lifecycle hook if specified
+    if (context.postCreateCommand) {
+      sandboxEnvVars.VM0_POST_CREATE_COMMAND = context.postCreateCommand;
+    }
+
     // Add user-defined environment variables
     if (context.environment) {
       for (const [key, value] of Object.entries(context.environment)) {

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -52,6 +52,7 @@ export class RunnerExecutor implements Executor {
       encryptedSecrets,
       cliAgentType: context.cliAgentType,
       experimentalFirewall: context.experimentalFirewall ?? undefined,
+      postCreateCommand: context.postCreateCommand,
     };
 
     // Insert into runner job queue

--- a/turbo/apps/web/src/lib/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/run/executors/types.ts
@@ -22,6 +22,7 @@ export interface PreparedContext {
   agentCompose: unknown;
   cliAgentType: string;
   workingDir: string;
+  postCreateCommand: string | null;
 
   // Storage (prepared once, used by both executors)
   storageManifest: StorageManifest | null;

--- a/turbo/apps/web/src/lib/run/index.ts
+++ b/turbo/apps/web/src/lib/run/index.ts
@@ -13,7 +13,7 @@ export type { PreparedContext, ExecutorResult, Executor } from "./executors";
 // Context preparation exports
 export {
   prepareForExecution,
-  extractWorkingDir,
+  getWorkingDir,
   extractCliAgentType,
   resolveRunnerGroup,
 } from "./context";

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -249,24 +249,10 @@ export class RunService {
   }
 
   /**
-   * Extract working directory from agent config
-   * Throws BadRequestError if working_dir is not configured
+   * Get working directory (hardcoded value)
    */
-  private extractWorkingDir(config: unknown): string {
-    const compose = config as AgentComposeYaml | undefined;
-    if (!compose?.agents) {
-      throw new BadRequestError(
-        "Agent compose must have agents configured with working_dir",
-      );
-    }
-    const agents = Object.values(compose.agents);
-    const firstAgent = agents[0];
-    if (!firstAgent?.working_dir) {
-      throw new BadRequestError(
-        "Agent must have working_dir configured (no default allowed)",
-      );
-    }
-    return firstAgent.working_dir;
+  private getWorkingDir(): string {
+    return "/home/user/workspace";
   }
 
   /**
@@ -357,7 +343,7 @@ export class RunService {
       conversationId: checkpoint.conversationId,
       agentComposeVersionId,
       agentCompose,
-      workingDir: this.extractWorkingDir(agentCompose),
+      workingDir: this.getWorkingDir(),
       conversationData: {
         cliAgentSessionId: conversation.cliAgentSessionId,
         cliAgentSessionHistory: sessionHistory,
@@ -447,7 +433,7 @@ export class RunService {
       conversationId: session.conversationId,
       agentComposeVersionId: versionId,
       agentCompose: version.content,
-      workingDir: this.extractWorkingDir(version.content),
+      workingDir: this.getWorkingDir(),
       conversationData: {
         cliAgentSessionId: session.conversation.cliAgentSessionId,
         cliAgentSessionHistory: sessionHistory,
@@ -517,7 +503,7 @@ export class RunService {
       conversationId,
       agentComposeVersionId,
       agentCompose: version.content,
-      workingDir: this.extractWorkingDir(version.content),
+      workingDir: this.getWorkingDir(),
       conversationData: {
         cliAgentSessionId: conversation.cliAgentSessionId,
         cliAgentSessionHistory: sessionHistory,

--- a/turbo/apps/web/src/test/api-test-helpers.ts
+++ b/turbo/apps/web/src/test/api-test-helpers.ts
@@ -52,7 +52,6 @@ export function createDefaultComposeConfig(
       [agentName]: {
         image: "vm0/claude-code:dev",
         provider: "claude-code",
-        working_dir: "/home/user/workspace",
         ...overrides,
       },
     },

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -53,8 +53,14 @@ export interface AgentDefinition {
   image?: string; // Optional when provider supports auto-config
   provider: string;
   volumes?: string[]; // Format: "volume-key:/mount/path"
-  working_dir?: string; // Optional when provider supports auto-config
   environment?: Record<string, string>; // Environment variables using ${{ vars.X }}, ${{ secrets.X }} syntax
+  /**
+   * Command to execute after working directory creation, before CLI agent starts.
+   * Follows Dev Container lifecycle naming convention.
+   * Executes via /bin/bash -c, supports background processes via &.
+   * If command fails (non-zero exit), the entire run fails.
+   */
+  postCreateCommand?: string;
   /**
    * Path to instructions file (e.g., AGENTS.md).
    * Auto-uploaded as volume and mounted at /home/user/.claude/CLAUDE.md

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -125,6 +125,7 @@ export const storedExecutionContextSchema = z.object({
   encryptedSecrets: z.string().nullable(), // AES-256-GCM encrypted secrets
   cliAgentType: z.string(),
   experimentalFirewall: experimentalFirewallSchema.optional(),
+  postCreateCommand: z.string().nullable().optional(), // Lifecycle hook
 });
 
 /**
@@ -147,6 +148,8 @@ export const executionContextSchema = z.object({
   cliAgentType: z.string(),
   // Experimental firewall configuration
   experimentalFirewall: experimentalFirewallSchema.optional(),
+  // Lifecycle hook - command to run after working dir creation
+  postCreateCommand: z.string().nullable().optional(),
 });
 
 /**

--- a/turbo/packages/core/src/sandbox/scripts/lib/common.py.ts
+++ b/turbo/packages/core/src/sandbox/scripts/lib/common.py.ts
@@ -32,6 +32,9 @@ ARTIFACT_MOUNT_PATH = os.environ.get("VM0_ARTIFACT_MOUNT_PATH", "")
 ARTIFACT_VOLUME_NAME = os.environ.get("VM0_ARTIFACT_VOLUME_NAME", "")
 ARTIFACT_VERSION_ID = os.environ.get("VM0_ARTIFACT_VERSION_ID", "")
 
+# Lifecycle hook - command to execute after working directory creation
+POST_CREATE_COMMAND = os.environ.get("VM0_POST_CREATE_COMMAND", "")
+
 # Construct webhook endpoint URLs
 WEBHOOK_URL = f"{API_URL}/api/webhooks/agent/events"
 CHECKPOINT_URL = f"{API_URL}/api/webhooks/agent/checkpoints"

--- a/turbo/packages/core/src/sandbox/scripts/run-agent.py.ts
+++ b/turbo/packages/core/src/sandbox/scripts/run-agent.py.ts
@@ -31,7 +31,7 @@ sys.path.insert(0, "/usr/local/bin/vm0-agent/lib")
 from common import (
     WORKING_DIR, PROMPT, RESUME_SESSION_ID, COMPLETE_URL, RUN_ID,
     EVENT_ERROR_FLAG, HEARTBEAT_URL, HEARTBEAT_INTERVAL, AGENT_LOG_FILE,
-    CLI_AGENT_TYPE, OPENAI_MODEL, validate_config
+    CLI_AGENT_TYPE, OPENAI_MODEL, POST_CREATE_COMMAND, validate_config
 )
 from log import log_info, log_error, log_warn
 from events import send_event
@@ -140,6 +140,26 @@ def _run() -> tuple[int, str]:
         os.chdir(WORKING_DIR)
     except OSError as e:
         raise RuntimeError(f"Failed to create/change to working directory: {WORKING_DIR} - {e}") from e
+
+    # Execute postCreateCommand if specified (lifecycle hook)
+    # This runs after working directory is created but before agent execution
+    if POST_CREATE_COMMAND:
+        log_info(f"Running postCreateCommand: {POST_CREATE_COMMAND}")
+        try:
+            result = subprocess.run(
+                ["/bin/bash", "-c", POST_CREATE_COMMAND],
+                cwd=WORKING_DIR,
+                capture_output=True,
+                text=True
+            )
+            if result.returncode != 0:
+                stderr_output = result.stderr.strip() if result.stderr else "No error output"
+                raise RuntimeError(f"postCreateCommand failed with exit code {result.returncode}: {stderr_output}")
+            if result.stdout:
+                log_info(f"postCreateCommand output: {result.stdout.strip()}")
+            log_info("postCreateCommand completed successfully")
+        except subprocess.SubprocessError as e:
+            raise RuntimeError(f"Failed to execute postCreateCommand: {e}") from e
 
     # Set up Codex configuration if using Codex CLI
     # Claude Code uses ~/.claude by default (no configuration needed)


### PR DESCRIPTION
## Summary
- Add `postCreateCommand` lifecycle hook that executes user-defined scripts after artifact initialization but before agent starts (e.g., for cloudflared tunnel setup)
- Remove `working_dir` from agent compose configuration and hardcode to `/home/user/workspace` for simplicity and consistency
- Pass `VM0_POST_CREATE_COMMAND` environment variable to sandbox and execute via subprocess in run-agent.py

## Changes
- **Agent Compose Schema**: Added `postCreateCommand?: string` field
- **YAML Validation**: Added validation for postCreateCommand (non-empty string if present)
- **Execution Flow**: 
  - Executors pass `VM0_POST_CREATE_COMMAND` env var
  - `run-agent.py` executes command after working dir creation, before agent starts
  - Non-zero exit code raises RuntimeError
- **Working Dir**: Removed from config, hardcoded to `/home/user/workspace`

## Test plan
- [x] Type checking passes
- [x] Lint passes
- [x] yaml-validator.test.ts passes
- [x] content-hash.test.ts passes

Closes #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)