### PR TITLE
fix(ansible): kill pm2 daemon after adding user to kvm group

### DIFF
--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -268,6 +268,14 @@
       meta: reset_connection
       when: kvm_group_result.changed
 
+    # Kill PM2 daemon so it restarts with new group membership
+    # PM2 child processes inherit the daemon's groups, not the shell's groups
+    - name: Kill PM2 daemon to pick up kvm group
+      command: pm2 kill
+      become: no
+      ignore_errors: yes
+      when: kvm_group_result.changed
+
     # ========================================
     # Phase 5: Configure and Start
     # ========================================

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,6 +1,7 @@
 // VM0 Runner - Self-hosted runner for the VM0 platform
 // Connects to the VM0 API server to poll and execute agent jobs
 // Supports drain mode for zero-downtime deployments via SIGUSR1 signal
+// Requires kvm group membership for Firecracker VM execution
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { statusCommand } from "./commands/status.js";


### PR DESCRIPTION
## Summary

- Kill PM2 daemon after adding user to kvm group so child processes inherit the new group membership

## Problem

When a user is added to the kvm group, the change only takes effect for **new login sessions**. If PM2 daemon is already running, child processes inherit the daemon's groups (without kvm), not the new shell's groups.

This caused CI timeouts on `dev-1.aws.vm3.ai` where Firecracker VMs failed to start with:
```
Error creating KVM object: Permission denied (os error 13)
Make sure the user launching the firecracker process is configured on the /dev/kvm file's ACL.
```

### Evidence

| Host | Process Groups | KVM Group (993) |
|------|---------------|-----------------|
| dev-1.aws.vm3.ai | `4 24 27 30 104 1000` | ❌ **MISSING** |
| dev-2.aws.vm3.ai | `4 24 27 30 104 993 1000` | ✅ Present |
| dev-3.aws.vm3.ai | `4 24 27 30 104 993 1000` | ✅ Present |
| dev-4.aws.vm3.ai | `4 24 27 30 104 993 1000` | ✅ Present |

## Solution

Kill PM2 daemon after adding the user to kvm group. When PM2 restarts (via `pm2 start`), it picks up the new group membership.

```yaml
- name: Kill PM2 daemon to pick up kvm group
  command: pm2 kill
  become: no
  ignore_errors: yes
  when: kvm_group_result.changed
```

## Test plan

- [x] Manual fix on dev-1: Killed PM2, restarted runner, PR 1067 and PR 1080 cli-e2e passed
- [ ] Deploy to a fresh host and verify kvm group is present in runner process

Fixes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)