### PR TITLE
feat(docs): add essential SEO configuration

### DIFF
--- a/turbo/apps/docs/src/app/layout.tsx
+++ b/turbo/apps/docs/src/app/layout.tsx
@@ -2,11 +2,25 @@ import "@/app/global.css";
 import { RootProvider } from "fumadocs-ui/provider";
 import { Noto_Sans } from "next/font/google";
 import Script from "next/script";
+import type { Metadata } from "next";
 
 const notoSans = Noto_Sans({
   subsets: ["latin"],
   weight: ["400", "700"],
 });
+
+export const metadata: Metadata = {
+  metadataBase: new URL("https://docs.vm0.ai"),
+  title: {
+    default: "VM0 Documentation",
+    template: "%s | VM0 Docs",
+  },
+  description: "Build agents and automate workflows with natural language",
+  robots: {
+    index: true,
+    follow: true,
+  },
+};
 
 export default function Layout({ children }: LayoutProps<"/">) {
   return (

--- a/turbo/apps/docs/src/app/robots.ts
+++ b/turbo/apps/docs/src/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/"],
+      },
+    ],
+    sitemap: "https://docs.vm0.ai/sitemap.xml",
+  };
+}

--- a/turbo/apps/docs/src/app/sitemap.ts
+++ b/turbo/apps/docs/src/app/sitemap.ts
@@ -1,0 +1,16 @@
+import { MetadataRoute } from "next";
+import { source } from "@/lib/source";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = "https://docs.vm0.ai";
+
+  const pages = source.getPages();
+
+  const urls: MetadataRoute.Sitemap = pages.map((page) => ({
+    url: `${baseUrl}${page.url}`,
+    changeFrequency: "weekly",
+    priority: page.slugs.length === 0 ? 1.0 : 0.8,
+  }));
+
+  return urls;
+}


### PR DESCRIPTION
## Summary

Adds essential SEO configuration for docs.vm0.ai to enable proper search engine indexing:

- Create `robots.ts` - allows crawling, blocks `/api/`, references sitemap
- Create `sitemap.ts` - dynamically generates sitemap from all ~108 documentation pages using Fumadocs source API
- Add root metadata to `layout.tsx` - configures `metadataBase`, title template, description, and robots directives

## Changes

| File | Change |
|------|--------|
| `turbo/apps/docs/src/app/robots.ts` | New - robots.txt configuration |
| `turbo/apps/docs/src/app/sitemap.ts` | New - dynamic sitemap generation |
| `turbo/apps/docs/src/app/layout.tsx` | Modified - added metadata export |

## Test Plan

- [x] `pnpm turbo run lint` passes
- [x] `pnpm check-types` passes for docs app
- [x] `pnpm build` succeeds (108 static pages generated)
- [ ] Verify `/robots.txt` returns valid content after deployment
- [ ] Verify `/sitemap.xml` lists all documentation pages after deployment
- [ ] Verify page titles include " | VM0 Docs" suffix

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)