### PR TITLE
fix(runner): support SNI-only mode network logs in experimental_firewall

### DIFF
--- a/turbo/apps/cli/src/lib/api-client.ts
+++ b/turbo/apps/cli/src/lib/api-client.ts
@@ -122,14 +122,26 @@ export interface GetAgentEventsResponse {
   provider: string;
 }
 
+/**
+ * Network log entry supports two modes:
+ * - sni: SNI-only mode (no HTTPS decryption, only host/port/action)
+ * - mitm: MITM mode (full HTTP details including method, status, latency, sizes)
+ */
 export interface NetworkLogEntry {
   timestamp: string;
-  method: string;
-  url: string;
-  status: number;
-  latency_ms: number;
-  request_size: number;
-  response_size: number;
+  // Common fields (all modes)
+  mode?: "mitm" | "sni";
+  action?: "ALLOW" | "DENY";
+  host?: string;
+  port?: number;
+  rule_matched?: string | null;
+  // MITM-only fields (optional)
+  method?: string;
+  url?: string;
+  status?: number;
+  latency_ms?: number;
+  request_size?: number;
+  response_size?: number;
 }
 
 export interface GetNetworkLogsResponse {

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -132,15 +132,26 @@ const ENV_JSON_PATH = "/tmp/vm0-env.json";
 
 /**
  * Network log entry from mitmproxy addon
+ *
+ * Supports two modes:
+ * - sni: SNI-only mode (no HTTPS decryption, only host/port/action)
+ * - mitm: MITM mode (full HTTP details including method, status, latency, sizes)
  */
 interface NetworkLogEntry {
   timestamp: string;
-  method: string;
-  url: string;
-  status: number;
-  latency_ms: number;
-  request_size: number;
-  response_size: number;
+  // Common fields (all modes)
+  mode?: "mitm" | "sni";
+  action?: "ALLOW" | "DENY";
+  host?: string;
+  port?: number;
+  rule_matched?: string | null;
+  // MITM-only fields (optional)
+  method?: string;
+  url?: string;
+  status?: number;
+  latency_ms?: number;
+  request_size?: number;
+  response_size?: number;
 }
 
 /**

--- a/turbo/apps/runner/src/lib/proxy/mitm-addon-script.ts
+++ b/turbo/apps/runner/src/lib/proxy/mitm-addon-script.ts
@@ -451,7 +451,7 @@ def response(flow: http.HTTPFlow) -> None:
     if run_id:
         log_entry = {
             "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()),
-            "mode": "mitm" if mitm_enabled else "filter",
+            "mode": "mitm" if mitm_enabled else "sni",
             "action": firewall_action,
             "host": host,
             "port": port,

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
@@ -98,6 +98,7 @@ const router = tsr.router(webhookTelemetryContract, {
     }
 
     // Ingest network logs to Axiom (fire-and-forget)
+    // Supports both SNI-only mode (basic connection info) and MITM mode (full HTTP details)
     if (body.networkLogs && body.networkLogs.length > 0) {
       const axiomDataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_NETWORK);
       // Network logs are already masked by client
@@ -105,6 +106,13 @@ const router = tsr.router(webhookTelemetryContract, {
         _time: netLog.timestamp,
         runId: body.runId,
         userId: auth.userId,
+        // Common fields (all modes)
+        mode: netLog.mode,
+        action: netLog.action,
+        host: netLog.host,
+        port: netLog.port,
+        rule_matched: netLog.rule_matched,
+        // MITM-only fields (may be undefined for SNI-only mode)
         method: netLog.method,
         url: netLog.url,
         status: netLog.status,

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -226,15 +226,26 @@ const agentEventsResponseSchema = z.object({
 
 /**
  * Network log entry schema
+ *
+ * Supports two modes:
+ * - sni: SNI-only mode (no HTTPS decryption, only host/port/action)
+ * - mitm: MITM mode (full HTTP details including method, status, latency, sizes)
  */
 const networkLogEntrySchema = z.object({
   timestamp: z.string(),
-  method: z.string(),
-  url: z.string(),
-  status: z.number(),
-  latency_ms: z.number(),
-  request_size: z.number(),
-  response_size: z.number(),
+  // Common fields (all modes)
+  mode: z.enum(["mitm", "sni"]).optional(),
+  action: z.enum(["ALLOW", "DENY"]).optional(),
+  host: z.string().optional(),
+  port: z.number().optional(),
+  rule_matched: z.string().nullable().optional(),
+  // MITM-only fields (optional)
+  method: z.string().optional(),
+  url: z.string().optional(),
+  status: z.number().optional(),
+  latency_ms: z.number().optional(),
+  request_size: z.number().optional(),
+  response_size: z.number().optional(),
 });
 
 /**

--- a/turbo/packages/core/src/contracts/webhooks.ts
+++ b/turbo/packages/core/src/contracts/webhooks.ts
@@ -261,15 +261,26 @@ const metricDataSchema = z.object({
 
 /**
  * Network log entry schema (from mitmproxy addon)
+ *
+ * Supports two modes:
+ * - sni: SNI-only mode (no HTTPS decryption, only host/port/action)
+ * - mitm: MITM mode (full HTTP details including method, status, latency, sizes)
  */
 const networkLogSchema = z.object({
   timestamp: z.string(),
-  method: z.string(),
-  url: z.string(),
-  status: z.number(),
-  latency_ms: z.number(),
-  request_size: z.number(),
-  response_size: z.number(),
+  // Common fields (all modes)
+  mode: z.enum(["mitm", "sni"]).optional(),
+  action: z.enum(["ALLOW", "DENY"]).optional(),
+  host: z.string().optional(),
+  port: z.number().optional(),
+  rule_matched: z.string().nullable().optional(),
+  // MITM-only fields (optional)
+  method: z.string().optional(),
+  url: z.string().optional(),
+  status: z.number().optional(),
+  latency_ms: z.number().optional(),
+  request_size: z.number().optional(),
+  response_size: z.number().optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Fix network logs not being captured for SNI-only mode (`experimental_firewall.enabled: true` without `experimental_mitm`)
- Update Zod schema to make MITM-specific fields optional
- Add `mode` field to distinguish between `sni` and `mitm` modes
- Update CLI to display both formats appropriately

## Root Cause

The network log schema required all MITM-specific fields (`method`, `url`, `status`, `latency_ms`, etc.), but SNI-only mode logs don't have these fields. This caused Zod validation to fail when uploading SNI-only logs, and network logs were never stored in Axiom.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/contracts/webhooks.ts` | Make MITM fields optional, add common fields |
| `packages/core/src/contracts/runs.ts` | Update response schema to match |
| `apps/runner/src/lib/executor.ts` | Update interface |
| `apps/runner/src/lib/proxy/mitm-addon-script.ts` | Change `filter` to `sni` mode |
| `apps/web/app/api/webhooks/agent/telemetry/route.ts` | Include all fields in Axiom |
| `apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts` | Return all fields |
| `apps/cli/src/commands/logs/index.ts` | Display both formats |
| `apps/cli/src/lib/api-client.ts` | Update interface |

## Test plan

- [ ] Run agent with `experimental_firewall.enabled: true` (SNI-only mode)
- [ ] Run agent with `experimental_firewall.experimental_mitm: true` (MITM mode)
- [ ] Verify `vm0 logs --network` displays logs for both modes

Closes #1063

🤖 Generated with [Claude Code](https://claude.ai/code)