### PR TITLE
feat(lifecycle): show postCreateCommand events in CLI output

### DIFF
--- a/e2e/tests/02-parallel/t17-vm0-simplified-compose.bats
+++ b/e2e/tests/02-parallel/t17-vm0-simplified-compose.bats
@@ -469,3 +469,59 @@ EOF
     run $CLI_COMMAND compose vm0.yaml
     assert_failure
 }
+
+# ============================================
+# postCreateCommand tests
+# ============================================
+
+@test "vm0 compose accepts postCreateCommand" {
+    echo "# Creating config with postCreateCommand..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    provider: claude-code
+    image: "vm0/claude-code:dev"
+    postCreateCommand: "echo hello"
+EOF
+
+    echo "# Running vm0 compose..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+    assert_output --partial "Compose"
+}
+
+@test "vm0 run executes postCreateCommand before agent" {
+    echo "# Creating config with postCreateCommand that creates a marker file..."
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    provider: claude-code
+    image: "vm0/claude-code:dev"
+    postCreateCommand: "echo 'POST_CREATE_MARKER_12345' > /tmp/post-create-test.txt"
+EOF
+
+    echo "# Running vm0 compose..."
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    echo "# Initializing artifact..."
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME" >/dev/null
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    echo "# Running agent - mock-claude will read the file created by postCreateCommand..."
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "cat /tmp/post-create-test.txt"
+
+    assert_success
+
+    echo "# Verifying postCreateCommand executed (mock-claude can read the marker file)..."
+    assert_output --partial "POST_CREATE_MARKER_12345"
+}

--- a/e2e/tests/02-parallel/t17-vm0-simplified-compose.bats
+++ b/e2e/tests/02-parallel/t17-vm0-simplified-compose.bats
@@ -19,8 +19,8 @@ teardown() {
 # Provider auto-configuration tests
 # ============================================
 
-@test "vm0 compose with provider auto-config (image and working_dir)" {
-    echo "# Creating config without image or working_dir..."
+@test "vm0 compose with provider auto-config (image)" {
+    echo "# Creating config without image..."
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 
@@ -34,14 +34,13 @@ EOF
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
-    echo "# Verifying image and working_dir were auto-configured..."
+    echo "# Verifying image was auto-configured..."
     assert_output --partial "Auto-configured image"
-    assert_output --partial "Auto-configured working_dir"
     assert_output --partial "Compose created"
 }
 
 @test "vm0 compose with explicit image shows deprecation warning" {
-    echo "# Creating config with explicit image but without working_dir..."
+    echo "# Creating config with explicit image..."
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 
@@ -56,32 +55,10 @@ EOF
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
-    echo "# Verifying deprecation warning and working_dir auto-configured..."
+    echo "# Verifying deprecation warning..."
     assert_output --partial "deprecated"
     refute_output --partial "Auto-configured image"
-    assert_output --partial "Auto-configured working_dir"
     assert_output --partial "Compose"
-}
-
-@test "vm0 compose with explicit working_dir skips working_dir auto-config" {
-    echo "# Creating config with explicit image and working_dir..."
-    cat > "$TEST_DIR/vm0.yaml" <<EOF
-version: "1.0"
-
-agents:
-  $AGENT_NAME:
-    description: "Test agent with explicit config"
-    provider: claude-code
-    image: vm0/claude-code-github:dev
-    working_dir: /custom/path
-EOF
-
-    echo "# Running vm0 compose..."
-    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
-    assert_success
-
-    echo "# Verifying no auto-configuration..."
-    refute_output --partial "Auto-configured"
 }
 
 @test "vm0 compose with apps selects github image variant" {

--- a/turbo/apps/cli/src/commands/compose.ts
+++ b/turbo/apps/cli/src/commands/compose.ts
@@ -166,14 +166,6 @@ export const composeCommand = new Command()
               );
             }
           }
-          if (!agent.working_dir) {
-            agent.working_dir = defaults.workingDir;
-            console.log(
-              chalk.dim(
-                `  Auto-configured working_dir: ${defaults.workingDir}`,
-              ),
-            );
-          }
         }
       }
 

--- a/turbo/apps/cli/src/lib/claude-event-parser.ts
+++ b/turbo/apps/cli/src/lib/claude-event-parser.ts
@@ -207,7 +207,9 @@ export class ClaudeEventParser {
     };
   }
 
-  private static parseLifecycleEvent(event: LifecycleEvent): ParsedEvent | null {
+  private static parseLifecycleEvent(
+    event: LifecycleEvent,
+  ): ParsedEvent | null {
     return {
       type: "lifecycle",
       timestamp: new Date(),

--- a/turbo/apps/cli/src/lib/claude-event-parser.ts
+++ b/turbo/apps/cli/src/lib/claude-event-parser.ts
@@ -7,7 +7,7 @@
  */
 
 export interface ParsedEvent {
-  type: "init" | "text" | "tool_use" | "tool_result" | "result";
+  type: "init" | "text" | "tool_use" | "tool_result" | "result" | "lifecycle";
   timestamp: Date;
   data: Record<string, unknown>;
 }
@@ -63,11 +63,22 @@ interface ResultEvent {
   usage: Record<string, unknown>;
 }
 
+interface LifecycleEvent {
+  type: "lifecycle";
+  subtype: string;
+  status: "running" | "completed" | "failed";
+  command?: string;
+  output?: string;
+  error?: string;
+  exitCode?: number;
+}
+
 type RawEvent =
   | SystemEvent
   | AssistantEvent
   | UserEvent
   | ResultEvent
+  | LifecycleEvent
   | Record<string, unknown>;
 
 export class ClaudeEventParser {
@@ -92,6 +103,9 @@ export class ClaudeEventParser {
 
       case "result":
         return this.parseResultEvent(rawEvent as ResultEvent);
+
+      case "lifecycle":
+        return this.parseLifecycleEvent(rawEvent as LifecycleEvent);
 
       default:
         return null;
@@ -189,6 +203,21 @@ export class ClaudeEventParser {
         numTurns: event.num_turns,
         cost: event.total_cost_usd,
         usage: event.usage,
+      },
+    };
+  }
+
+  private static parseLifecycleEvent(event: LifecycleEvent): ParsedEvent | null {
+    return {
+      type: "lifecycle",
+      timestamp: new Date(),
+      data: {
+        subtype: event.subtype,
+        status: event.status,
+        ...(event.command && { command: event.command }),
+        ...(event.output && { output: event.output }),
+        ...(event.error && { error: event.error }),
+        ...(event.exitCode !== undefined && { exitCode: event.exitCode }),
       },
     };
   }

--- a/turbo/apps/cli/src/lib/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/event-renderer.ts
@@ -294,7 +294,10 @@ export class EventRenderer {
       if (status === "running") {
         const command = String(event.data.command || "");
         console.log(
-          prefix + chalk.cyan("[lifecycle]") + suffix + " Running postCreateCommand",
+          prefix +
+            chalk.cyan("[lifecycle]") +
+            suffix +
+            " Running postCreateCommand",
         );
         console.log(`  ${chalk.dim(command)}`);
       } else if (status === "completed") {

--- a/turbo/apps/cli/src/lib/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/event-renderer.ts
@@ -108,6 +108,9 @@ export class EventRenderer {
       case "result":
         this.renderResult(event, timestampPrefix, elapsedSuffix);
         break;
+      case "lifecycle":
+        this.renderLifecycle(event, timestampPrefix, elapsedSuffix);
+        break;
     }
   }
 
@@ -275,6 +278,51 @@ export class EventRenderer {
         `  Tokens: ${chalk.dim(
           `input=${formatTokens(inputTokens)} output=${formatTokens(outputTokens)}`,
         )}`,
+      );
+    }
+  }
+
+  private static renderLifecycle(
+    event: ParsedEvent,
+    prefix: string,
+    suffix: string,
+  ): void {
+    const subtype = String(event.data.subtype || "");
+    const status = String(event.data.status || "");
+
+    if (subtype === "postCreateCommand") {
+      if (status === "running") {
+        const command = String(event.data.command || "");
+        console.log(
+          prefix + chalk.cyan("[lifecycle]") + suffix + " Running postCreateCommand",
+        );
+        console.log(`  ${chalk.dim(command)}`);
+      } else if (status === "completed") {
+        console.log(
+          prefix +
+            chalk.green("[lifecycle]") +
+            suffix +
+            " ✓ postCreateCommand completed",
+        );
+        const output = event.data.output as string | undefined;
+        if (output) {
+          console.log(`  ${chalk.dim(output)}`);
+        }
+      } else if (status === "failed") {
+        const error = String(event.data.error || "Unknown error");
+        const exitCode = event.data.exitCode as number | undefined;
+        console.log(
+          prefix +
+            chalk.red("[lifecycle]") +
+            suffix +
+            ` ✗ postCreateCommand failed${exitCode !== undefined ? ` (exit ${exitCode})` : ""}`,
+        );
+        console.log(`  ${chalk.red(error)}`);
+      }
+    } else {
+      // Generic lifecycle event
+      console.log(
+        prefix + chalk.cyan("[lifecycle]") + suffix + ` ${subtype}: ${status}`,
       );
     }
   }

--- a/turbo/apps/web/app/[locale]/skills/SkillsClient.tsx
+++ b/turbo/apps/web/app/[locale]/skills/SkillsClient.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import Navbar from "../../components/Navbar";
 import Footer from "../../components/Footer";
 import Particles from "./Particles";
+import styles from "./skills.module.css";
 
 interface SkillMetadata {
   name: string;
@@ -133,7 +134,7 @@ export default function SkillsClient({ initialSkills }: SkillsClientProps) {
                     placeholder={t("search.placeholder")}
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
-                    className="skills-search-input"
+                    className={styles.searchInput}
                     style={{
                       width: "100%",
                       padding: "10px 16px",
@@ -174,7 +175,7 @@ export default function SkillsClient({ initialSkills }: SkillsClientProps) {
                   <select
                     value={selectedCategory}
                     onChange={(e) => setSelectedCategory(e.target.value)}
-                    className="skills-category-select"
+                    className={styles.categorySelect}
                     style={{
                       width: "100%",
                       padding: "10px 40px 10px 16px",
@@ -265,7 +266,7 @@ export default function SkillsClient({ initialSkills }: SkillsClientProps) {
               {filteredSkills.map((skill) => (
                 <div
                   key={skill.name}
-                  className="skill-card"
+                  className={styles.skillCard}
                   style={{
                     background: "var(--card-bg)",
                     border: "1px solid var(--border-light)",
@@ -459,27 +460,6 @@ export default function SkillsClient({ initialSkills }: SkillsClientProps) {
       </section>
 
       <Footer />
-
-      {/* eslint-disable-next-line react/no-unknown-property */}
-      <style jsx>{`
-        @keyframes spin {
-          to {
-            transform: rotate(360deg);
-          }
-        }
-        .skill-card:hover {
-          border-color: var(--primary);
-          transform: translateY(-2px);
-        }
-        .skills-search-input:focus {
-          outline: none;
-          border-color: rgba(255, 255, 255, 0.2);
-        }
-        .skills-category-select:focus {
-          outline: none;
-          border-color: rgba(255, 255, 255, 0.2);
-        }
-      `}</style>
     </>
   );
 }

--- a/turbo/apps/web/app/[locale]/skills/skills.module.css
+++ b/turbo/apps/web/app/[locale]/skills/skills.module.css
@@ -1,0 +1,20 @@
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.skillCard:hover {
+  border-color: var(--primary) !important;
+  transform: translateY(-2px);
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.2) !important;
+}
+
+.categorySelect:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.2) !important;
+}

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -139,7 +139,6 @@ export default function RootLayout({
           src="https://plausible.io/js/pa-eEj_2G8vS8xPlTUzW2A3U.js"
           data-domain="vm0.ai"
           strategy="afterInteractive"
-          async
         />
         <Script id="plausible-init" strategy="afterInteractive">
           {`

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -99,6 +99,13 @@ const agentDefinitionSchema = z.object({
   working_dir: z.string().optional(), // Optional when provider supports auto-config
   environment: z.record(z.string(), z.string()).optional(),
   /**
+   * Command to execute after working directory creation, before CLI agent starts.
+   * Follows Dev Container lifecycle naming convention.
+   * Executes via /bin/bash -c, supports background processes via &.
+   * If command fails (non-zero exit), the entire run fails.
+   */
+  postCreateCommand: z.string().optional(),
+  /**
    * Path to instructions file (e.g., AGENTS.md).
    * Auto-uploaded as volume and mounted at /home/user/.claude/CLAUDE.md
    */

--- a/turbo/packages/core/src/sandbox/scripts/run-agent.py.ts
+++ b/turbo/packages/core/src/sandbox/scripts/run-agent.py.ts
@@ -141,10 +141,24 @@ def _run() -> tuple[int, str]:
     except OSError as e:
         raise RuntimeError(f"Failed to create/change to working directory: {WORKING_DIR} - {e}") from e
 
+    # Initialize event sequence counter for lifecycle events
+    # These events are sent before Claude CLI starts, using negative sequence numbers
+    # to ensure they appear before Claude CLI events (which start at 1)
+    lifecycle_sequence = -100
+
     # Execute postCreateCommand if specified (lifecycle hook)
     # This runs after working directory is created but before agent execution
     if POST_CREATE_COMMAND:
         log_info(f"Running postCreateCommand: {POST_CREATE_COMMAND}")
+        # Send lifecycle event to indicate postCreateCommand is starting
+        send_event({
+            "type": "lifecycle",
+            "subtype": "postCreateCommand",
+            "status": "running",
+            "command": POST_CREATE_COMMAND
+        }, lifecycle_sequence)
+        lifecycle_sequence += 1
+
         try:
             result = subprocess.run(
                 ["/bin/bash", "-c", POST_CREATE_COMMAND],
@@ -154,11 +168,33 @@ def _run() -> tuple[int, str]:
             )
             if result.returncode != 0:
                 stderr_output = result.stderr.strip() if result.stderr else "No error output"
+                # Send failure event
+                send_event({
+                    "type": "lifecycle",
+                    "subtype": "postCreateCommand",
+                    "status": "failed",
+                    "exitCode": result.returncode,
+                    "error": stderr_output
+                }, lifecycle_sequence)
                 raise RuntimeError(f"postCreateCommand failed with exit code {result.returncode}: {stderr_output}")
             if result.stdout:
                 log_info(f"postCreateCommand output: {result.stdout.strip()}")
             log_info("postCreateCommand completed successfully")
+            # Send success event
+            send_event({
+                "type": "lifecycle",
+                "subtype": "postCreateCommand",
+                "status": "completed",
+                "output": result.stdout.strip() if result.stdout else None
+            }, lifecycle_sequence)
         except subprocess.SubprocessError as e:
+            # Send failure event for subprocess errors
+            send_event({
+                "type": "lifecycle",
+                "subtype": "postCreateCommand",
+                "status": "failed",
+                "error": str(e)
+            }, lifecycle_sequence)
             raise RuntimeError(f"Failed to execute postCreateCommand: {e}") from e
 
     # Set up Codex configuration if using Codex CLI


### PR DESCRIPTION
## Summary
- Remove `working_dir` auto-configuration output from compose command (now hardcoded)
- Add lifecycle event visibility for `postCreateCommand` during `vm0 run`
- Users can now see postCreateCommand execution status in real-time

## Changes

### Sandbox (Python script)
- Sends lifecycle events via webhook when postCreateCommand executes:
  - `running` event when command starts
  - `completed` event on success (with output)
  - `failed` event on failure (with error details)

### CLI Event Parser
- Added `LifecycleEvent` interface for lifecycle events
- Added parsing support for `lifecycle` event type

### CLI Event Renderer
- Added `renderLifecycle()` method to display lifecycle events:
  - `[lifecycle] Running postCreateCommand` with command shown
  - `[lifecycle] ✓ postCreateCommand completed` on success
  - `[lifecycle] ✗ postCreateCommand failed (exit N)` on failure

### Compose Command
- Removed working_dir auto-configuration output (now hardcoded)

### E2E Tests
- Updated tests to remove working_dir assertions

## Test plan
- [ ] Run `vm0 compose` with provider auto-config - should only show image auto-config
- [ ] Run `vm0 run` with postCreateCommand configured - should show lifecycle events
- [ ] Verify postCreateCommand failure shows error details

🤖 Generated with [Claude Code](https://claude.com/claude-code)