### PR TITLE
revert: feat(lifecycle): add postCreateCommand hook and hardcode working_dir (#1077)

### DIFF
--- a/e2e/fixtures/configs/vm0-env-expansion.yaml
+++ b/e2e/fixtures/configs/vm0-env-expansion.yaml
@@ -5,6 +5,7 @@ agents:
     description: "Test agent for environment variable expansion"
     provider: claude-code
     image: "vm0/claude-code:dev"
+    working_dir: /home/user/workspace
     environment:
       TEST_VAR: "${{ vars.testVar }}"
       TEST_SECRET: "${{ secrets.TEST_SECRET }}"

--- a/e2e/fixtures/configs/vm0-template-validation.yaml
+++ b/e2e/fixtures/configs/vm0-template-validation.yaml
@@ -5,6 +5,7 @@ agents:
     description: "Test agent for template variable validation"
     provider: claude-code
     image: "vm0/claude-code:dev"
+    working_dir: /home/user/workspace
     volumes:
       - user-data:/home/user/data
 

--- a/e2e/fixtures/configs/vm0-versioning.yaml
+++ b/e2e/fixtures/configs/vm0-versioning.yaml
@@ -5,3 +5,4 @@ agents:
     description: "Test agent for version testing"
     provider: claude-code
     image: "vm0/claude-code:dev"
+    working_dir: /home/user/workspace

--- a/e2e/fixtures/configs/vm0-volume-override.yaml
+++ b/e2e/fixtures/configs/vm0-volume-override.yaml
@@ -8,6 +8,7 @@ agents:
     volumes:
       - test-volume:/home/user/data
       - claude-files:/home/user/.claude
+    working_dir: /home/user/workspace
 
 volumes:
   test-volume:

--- a/turbo/apps/cli/src/lib/__tests__/yaml-validator.test.ts
+++ b/turbo/apps/cli/src/lib/__tests__/yaml-validator.test.ts
@@ -111,6 +111,7 @@ describe("validateAgentCompose", () => {
           "test-agent": {
             image: "vm0/claude-code:dev",
             provider: "claude-code",
+            working_dir: "/home/user/workspace",
           },
         },
       };
@@ -128,6 +129,7 @@ describe("validateAgentCompose", () => {
             description: "Test description",
             image: "vm0/claude-code:dev",
             provider: "claude-code",
+            working_dir: "/home/user/workspace",
             volumes: ["claude-files:/home/user/.config/claude"],
           },
         },
@@ -150,21 +152,7 @@ describe("validateAgentCompose", () => {
           "My-Test-Agent-123": {
             image: "vm0/claude-code:dev",
             provider: "claude-code",
-          },
-        },
-      };
-
-      const result = validateAgentCompose(config);
-      expect(result.valid).toBe(true);
-    });
-
-    it("should accept config with postCreateCommand", () => {
-      const config = {
-        version: "1.0",
-        agents: {
-          "test-agent": {
-            provider: "claude-code",
-            postCreateCommand: "cloudflared tunnel run my-tunnel",
+            working_dir: "/home/user/workspace",
           },
         },
       };
@@ -199,6 +187,7 @@ describe("validateAgentCompose", () => {
           "test-agent": {
             image: "vm0/claude-code:dev",
             provider: "claude-code",
+            working_dir: "/home/user/workspace",
           },
         },
       };
@@ -247,10 +236,12 @@ describe("validateAgentCompose", () => {
           "agent-1": {
             image: "vm0/claude-code:dev",
             provider: "claude-code",
+            working_dir: "/workspace",
           },
           "agent-2": {
             image: "vm0/claude-code:dev",
             provider: "claude-code",
+            working_dir: "/workspace",
           },
         },
       };
@@ -270,6 +261,7 @@ describe("validateAgentCompose", () => {
             // Too short
             image: "vm0/claude-code:dev",
             provider: "claude-code",
+            working_dir: "/home/user/workspace",
           },
         },
       };
@@ -286,6 +278,7 @@ describe("validateAgentCompose", () => {
           "-invalid": {
             image: "vm0/claude-code:dev",
             provider: "claude-code",
+            working_dir: "/home/user/workspace",
           },
         },
       };
@@ -302,6 +295,7 @@ describe("validateAgentCompose", () => {
           my_agent: {
             image: "vm0/claude-code:dev",
             provider: "claude-code",
+            working_dir: "/home/user/workspace",
           },
         },
       };
@@ -311,12 +305,29 @@ describe("validateAgentCompose", () => {
       expect(result.error).toContain("Invalid agent name format");
     });
 
+    it("should reject config with missing working_dir when provider not supported", () => {
+      const config = {
+        version: "1.0",
+        agents: {
+          "test-agent": {
+            image: "custom-image",
+            provider: "custom-provider",
+          },
+        },
+      };
+
+      const result = validateAgentCompose(config);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("agent.working_dir");
+    });
+
     it("should reject config with missing image when provider not supported", () => {
       const config = {
         version: "1.0",
         agents: {
           "test-agent": {
             provider: "custom-provider",
+            working_dir: "/home/user/workspace",
           },
         },
       };
@@ -332,6 +343,7 @@ describe("validateAgentCompose", () => {
         agents: {
           "test-agent": {
             image: "vm0/claude-code:dev",
+            working_dir: "/home/user/workspace",
           },
         },
       };
@@ -348,6 +360,7 @@ describe("validateAgentCompose", () => {
           "test-agent": {
             image: "vm0/claude-code:dev",
             provider: "claude-code",
+            working_dir: "/home/user/workspace",
             volumes: ["missing-vol:/path"],
           },
         },
@@ -371,6 +384,7 @@ describe("validateAgentCompose", () => {
           "test-agent": {
             image: "vm0/claude-code:dev",
             provider: "claude-code",
+            working_dir: "/home/user/workspace",
             volumes: ["data:/path"],
           },
         },
@@ -393,6 +407,7 @@ describe("validateAgentCompose", () => {
           "test-agent": {
             image: "vm0/claude-code:dev",
             provider: "claude-code",
+            working_dir: "/home/user/workspace",
             volumes: ["data:/path"],
           },
         },
@@ -407,41 +422,24 @@ describe("validateAgentCompose", () => {
       expect(result.valid).toBe(false);
       expect(result.error).toContain("'version' field");
     });
-
-    it("should reject postCreateCommand that is not a string", () => {
-      const config = {
-        version: "1.0",
-        agents: {
-          "test-agent": {
-            provider: "claude-code",
-            postCreateCommand: 123,
-          },
-        },
-      };
-
-      const result = validateAgentCompose(config);
-      expect(result.valid).toBe(false);
-      expect(result.error).toContain("postCreateCommand must be a string");
-    });
-
-    it("should reject empty postCreateCommand", () => {
-      const config = {
-        version: "1.0",
-        agents: {
-          "test-agent": {
-            provider: "claude-code",
-            postCreateCommand: "",
-          },
-        },
-      };
-
-      const result = validateAgentCompose(config);
-      expect(result.valid).toBe(false);
-      expect(result.error).toContain("postCreateCommand cannot be empty");
-    });
   });
 
   describe("provider auto-config", () => {
+    it("should accept config without working_dir when provider is claude-code", () => {
+      const config = {
+        version: "1.0",
+        agents: {
+          "test-agent": {
+            provider: "claude-code",
+            image: "vm0/claude-code:dev",
+          },
+        },
+      };
+
+      const result = validateAgentCompose(config);
+      expect(result.valid).toBe(true);
+    });
+
     it("should accept config without image when provider is claude-code (auto-configurable)", () => {
       const config = {
         version: "1.0",

--- a/turbo/apps/cli/src/lib/yaml-validator.ts
+++ b/turbo/apps/cli/src/lib/yaml-validator.ts
@@ -149,20 +149,22 @@ export function validateAgentCompose(config: unknown): {
     };
   }
 
-  // Validate postCreateCommand if present (must be a non-empty string)
-  if (agent.postCreateCommand !== undefined) {
-    if (typeof agent.postCreateCommand !== "string") {
-      return {
-        valid: false,
-        error: "agent.postCreateCommand must be a string",
-      };
-    }
-    if (agent.postCreateCommand.length === 0) {
-      return {
-        valid: false,
-        error: "agent.postCreateCommand cannot be empty",
-      };
-    }
+  // Check agent.working_dir (optional when provider is supported)
+  if (
+    agent.working_dir !== undefined &&
+    typeof agent.working_dir !== "string"
+  ) {
+    return {
+      valid: false,
+      error: "agent.working_dir must be a string if provided",
+    };
+  }
+  if (!agent.working_dir && !providerIsSupported) {
+    return {
+      valid: false,
+      error:
+        "Missing agent.working_dir (required when provider is not auto-configured)",
+    };
   }
 
   // Validate instructions if present (must be a relative file path)

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -88,11 +88,6 @@ function buildEnvironmentVariables(
     envVars.VM0_ARTIFACT_VERSION_ID = artifact.vasVersionId;
   }
 
-  // Add postCreateCommand lifecycle hook if specified
-  if (context.postCreateCommand) {
-    envVars.VM0_POST_CREATE_COMMAND = context.postCreateCommand;
-  }
-
   // Add resume session ID if present
   if (context.resumeSession) {
     envVars.VM0_RESUME_SESSION_ID = context.resumeSession.sessionId;

--- a/turbo/apps/web/src/lib/agent-compose/__tests__/content-hash.test.ts
+++ b/turbo/apps/web/src/lib/agent-compose/__tests__/content-hash.test.ts
@@ -20,6 +20,7 @@ describe("content-hash", () => {
           "test-agent": {
             image: "test-image",
             provider: "claude-code",
+            working_dir: "/workspace",
           },
         },
       };
@@ -37,6 +38,7 @@ describe("content-hash", () => {
           "my-agent": {
             image: "ubuntu",
             provider: "claude-code",
+            working_dir: "/home",
           },
         },
       };
@@ -47,6 +49,7 @@ describe("content-hash", () => {
           "my-agent": {
             image: "ubuntu",
             provider: "claude-code",
+            working_dir: "/home",
           },
         },
       };
@@ -62,6 +65,7 @@ describe("content-hash", () => {
         version: "1.0",
         agents: {
           agent1: {
+            working_dir: "/workspace",
             image: "test",
             provider: "claude-code",
           },
@@ -71,8 +75,9 @@ describe("content-hash", () => {
       const content2 = {
         agents: {
           agent1: {
-            provider: "claude-code",
             image: "test",
+            provider: "claude-code",
+            working_dir: "/workspace",
           },
         },
         version: "1.0",
@@ -90,6 +95,7 @@ describe("content-hash", () => {
           agent1: {
             image: "image-a",
             provider: "claude-code",
+            working_dir: "/workspace",
           },
         },
       };
@@ -100,6 +106,7 @@ describe("content-hash", () => {
           agent1: {
             image: "image-b",
             provider: "claude-code",
+            working_dir: "/workspace",
           },
         },
       };
@@ -116,6 +123,7 @@ describe("content-hash", () => {
           agent1: {
             image: "test",
             provider: "claude-code",
+            working_dir: "/workspace",
             environment: {
               FOO: "bar",
               BAZ: "qux",
@@ -132,6 +140,7 @@ describe("content-hash", () => {
         version: "1.0",
         agents: {
           agent1: {
+            working_dir: "/workspace",
             provider: "claude-code",
             image: "test",
             environment: {

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -2,6 +2,7 @@ import { Sandbox } from "@e2b/code-interpreter";
 import { e2bConfig } from "./config";
 import type { RunResult } from "./types";
 import { storageService } from "../storage/storage-service";
+import { BadRequestError } from "../errors";
 import { resolveImageAlias } from "../image/image-service";
 import type {
   AgentVolumeConfig,
@@ -75,11 +76,15 @@ export class E2BService {
       | undefined;
 
     try {
-      // Get agent config for provider and image settings
+      // Get mount path from agent compose (used for resume artifact)
+      // working_dir is required - no fallback allowed
       const firstAgent = getFirstAgent(agentComposeYaml);
-
-      // Hardcoded working directory (artifact mount path)
-      const artifactMountPath = "/home/user/workspace";
+      if (!firstAgent?.working_dir) {
+        throw new BadRequestError(
+          "Agent must have working_dir configured (no default allowed)",
+        );
+      }
+      const artifactMountPath = firstAgent.working_dir;
       // Prepare storage manifest with presigned URLs for direct download to sandbox
       // This works for both new runs and resume scenarios
       const storageManifest = await storageService.prepareStorageManifest(
@@ -188,7 +193,7 @@ export class E2BService {
 
       // Set CLI_AGENT_TYPE based on provider (defaults to "claude-code")
       // This is used by run-agent.py to determine which CLI to invoke
-      const provider = firstAgent?.provider || "claude-code";
+      const provider = firstAgent.provider || "claude-code";
       sandboxEnvVars.CLI_AGENT_TYPE = provider;
       log.debug(`CLI_AGENT_TYPE set to: ${provider}`);
 

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -119,27 +119,24 @@ export function processFirewallConfig(
 }
 
 /**
- * Hardcoded working directory for all agents
+ * Extract working directory from agent compose config
+ * This is required for resume and storage operations
  */
-const WORKING_DIR = "/home/user/workspace";
-
-/**
- * Get working directory - now hardcoded for all agents
- * This simplifies configuration and ensures consistency
- */
-export function getWorkingDir(): string {
-  return WORKING_DIR;
-}
-
-/**
- * Extract postCreateCommand from agent compose config
- * Returns null if not specified
- */
-export function extractPostCreateCommand(agentCompose: unknown): string | null {
+export function extractWorkingDir(agentCompose: unknown): string {
   const compose = agentCompose as AgentComposeYaml | undefined;
-  if (!compose?.agents) return null;
+  if (!compose?.agents) {
+    throw new BadRequestError(
+      "Agent must have working_dir configured (no default allowed)",
+    );
+  }
   const agents = Object.values(compose.agents);
-  return agents[0]?.postCreateCommand ?? null;
+  const workingDir = agents[0]?.working_dir;
+  if (!workingDir) {
+    throw new BadRequestError(
+      "Agent must have working_dir configured (no default allowed)",
+    );
+  }
+  return workingDir;
 }
 
 /**
@@ -178,16 +175,15 @@ export async function prepareForExecution(
   log.debug(`Preparing execution context for run ${context.runId}...`);
 
   // Extract configuration from agent compose
-  const workingDir = getWorkingDir();
+  const workingDir = extractWorkingDir(context.agentCompose);
   const cliAgentType = extractCliAgentType(context.agentCompose);
   const runnerGroup = resolveRunnerGroup(context.agentCompose);
-  const postCreateCommand = extractPostCreateCommand(context.agentCompose);
 
   // Process firewall configuration (validates and auto-injects rules)
   const experimentalFirewall = processFirewallConfig(context.agentCompose);
 
   log.debug(
-    `Extracted config: workingDir=${workingDir}, cliAgentType=${cliAgentType}, runnerGroup=${runnerGroup}, firewall=${experimentalFirewall ? "enabled" : "disabled"}, postCreateCommand=${postCreateCommand ? "set" : "none"}`,
+    `Extracted config: workingDir=${workingDir}, cliAgentType=${cliAgentType}, runnerGroup=${runnerGroup}, firewall=${experimentalFirewall ? "enabled" : "disabled"}`,
   );
 
   // Prepare storage manifest with presigned URLs
@@ -220,7 +216,6 @@ export async function prepareForExecution(
     agentCompose: context.agentCompose,
     cliAgentType,
     workingDir,
-    postCreateCommand,
 
     // Storage
     storageManifest,

--- a/turbo/apps/web/src/lib/run/context/index.ts
+++ b/turbo/apps/web/src/lib/run/context/index.ts
@@ -1,6 +1,6 @@
 export {
   prepareForExecution,
-  getWorkingDir,
+  extractWorkingDir,
   extractCliAgentType,
   resolveRunnerGroup,
 } from "./execution-preparer";

--- a/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
@@ -247,11 +247,6 @@ export class E2BExecutor implements Executor {
       sandboxEnvVars.VM0_ARTIFACT_VERSION_ID = artifactForCommand.vasVersionId;
     }
 
-    // Add postCreateCommand lifecycle hook if specified
-    if (context.postCreateCommand) {
-      sandboxEnvVars.VM0_POST_CREATE_COMMAND = context.postCreateCommand;
-    }
-
     // Add user-defined environment variables
     if (context.environment) {
       for (const [key, value] of Object.entries(context.environment)) {

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -52,7 +52,6 @@ export class RunnerExecutor implements Executor {
       encryptedSecrets,
       cliAgentType: context.cliAgentType,
       experimentalFirewall: context.experimentalFirewall ?? undefined,
-      postCreateCommand: context.postCreateCommand,
     };
 
     // Insert into runner job queue

--- a/turbo/apps/web/src/lib/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/run/executors/types.ts
@@ -22,7 +22,6 @@ export interface PreparedContext {
   agentCompose: unknown;
   cliAgentType: string;
   workingDir: string;
-  postCreateCommand: string | null;
 
   // Storage (prepared once, used by both executors)
   storageManifest: StorageManifest | null;

--- a/turbo/apps/web/src/lib/run/index.ts
+++ b/turbo/apps/web/src/lib/run/index.ts
@@ -13,7 +13,7 @@ export type { PreparedContext, ExecutorResult, Executor } from "./executors";
 // Context preparation exports
 export {
   prepareForExecution,
-  getWorkingDir,
+  extractWorkingDir,
   extractCliAgentType,
   resolveRunnerGroup,
 } from "./context";

--- a/turbo/apps/web/src/test/api-test-helpers.ts
+++ b/turbo/apps/web/src/test/api-test-helpers.ts
@@ -52,6 +52,7 @@ export function createDefaultComposeConfig(
       [agentName]: {
         image: "vm0/claude-code:dev",
         provider: "claude-code",
+        working_dir: "/home/user/workspace",
         ...overrides,
       },
     },

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -53,14 +53,8 @@ export interface AgentDefinition {
   image?: string; // Optional when provider supports auto-config
   provider: string;
   volumes?: string[]; // Format: "volume-key:/mount/path"
+  working_dir?: string; // Optional when provider supports auto-config
   environment?: Record<string, string>; // Environment variables using ${{ vars.X }}, ${{ secrets.X }} syntax
-  /**
-   * Command to execute after working directory creation, before CLI agent starts.
-   * Follows Dev Container lifecycle naming convention.
-   * Executes via /bin/bash -c, supports background processes via &.
-   * If command fails (non-zero exit), the entire run fails.
-   */
-  postCreateCommand?: string;
   /**
    * Path to instructions file (e.g., AGENTS.md).
    * Auto-uploaded as volume and mounted at /home/user/.claude/CLAUDE.md

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -125,7 +125,6 @@ export const storedExecutionContextSchema = z.object({
   encryptedSecrets: z.string().nullable(), // AES-256-GCM encrypted secrets
   cliAgentType: z.string(),
   experimentalFirewall: experimentalFirewallSchema.optional(),
-  postCreateCommand: z.string().nullable().optional(), // Lifecycle hook
 });
 
 /**
@@ -148,8 +147,6 @@ export const executionContextSchema = z.object({
   cliAgentType: z.string(),
   // Experimental firewall configuration
   experimentalFirewall: experimentalFirewallSchema.optional(),
-  // Lifecycle hook - command to run after working dir creation
-  postCreateCommand: z.string().nullable().optional(),
 });
 
 /**

--- a/turbo/packages/core/src/sandbox/scripts/lib/common.py.ts
+++ b/turbo/packages/core/src/sandbox/scripts/lib/common.py.ts
@@ -32,9 +32,6 @@ ARTIFACT_MOUNT_PATH = os.environ.get("VM0_ARTIFACT_MOUNT_PATH", "")
 ARTIFACT_VOLUME_NAME = os.environ.get("VM0_ARTIFACT_VOLUME_NAME", "")
 ARTIFACT_VERSION_ID = os.environ.get("VM0_ARTIFACT_VERSION_ID", "")
 
-# Lifecycle hook - command to execute after working directory creation
-POST_CREATE_COMMAND = os.environ.get("VM0_POST_CREATE_COMMAND", "")
-
 # Construct webhook endpoint URLs
 WEBHOOK_URL = f"{API_URL}/api/webhooks/agent/events"
 CHECKPOINT_URL = f"{API_URL}/api/webhooks/agent/checkpoints"

--- a/turbo/packages/core/src/sandbox/scripts/run-agent.py.ts
+++ b/turbo/packages/core/src/sandbox/scripts/run-agent.py.ts
@@ -31,7 +31,7 @@ sys.path.insert(0, "/usr/local/bin/vm0-agent/lib")
 from common import (
     WORKING_DIR, PROMPT, RESUME_SESSION_ID, COMPLETE_URL, RUN_ID,
     EVENT_ERROR_FLAG, HEARTBEAT_URL, HEARTBEAT_INTERVAL, AGENT_LOG_FILE,
-    CLI_AGENT_TYPE, OPENAI_MODEL, POST_CREATE_COMMAND, validate_config
+    CLI_AGENT_TYPE, OPENAI_MODEL, validate_config
 )
 from log import log_info, log_error, log_warn
 from events import send_event
@@ -140,26 +140,6 @@ def _run() -> tuple[int, str]:
         os.chdir(WORKING_DIR)
     except OSError as e:
         raise RuntimeError(f"Failed to create/change to working directory: {WORKING_DIR} - {e}") from e
-
-    # Execute postCreateCommand if specified (lifecycle hook)
-    # This runs after working directory is created but before agent execution
-    if POST_CREATE_COMMAND:
-        log_info(f"Running postCreateCommand: {POST_CREATE_COMMAND}")
-        try:
-            result = subprocess.run(
-                ["/bin/bash", "-c", POST_CREATE_COMMAND],
-                cwd=WORKING_DIR,
-                capture_output=True,
-                text=True
-            )
-            if result.returncode != 0:
-                stderr_output = result.stderr.strip() if result.stderr else "No error output"
-                raise RuntimeError(f"postCreateCommand failed with exit code {result.returncode}: {stderr_output}")
-            if result.stdout:
-                log_info(f"postCreateCommand output: {result.stdout.strip()}")
-            log_info("postCreateCommand completed successfully")
-        except subprocess.SubprocessError as e:
-            raise RuntimeError(f"Failed to execute postCreateCommand: {e}") from e
 
     # Set up Codex configuration if using Codex CLI
     # Claude Code uses ~/.claude by default (no configuration needed)


### PR DESCRIPTION
## Summary
- Revert PR #1077 because it was merged with `cli-e2e` check in CANCELLED status (timeout)
- Per project guidelines: "Cancelled status does NOT satisfy the merge requirement - treat it as a failure"

## Original PR
- #1077 added `postCreateCommand` lifecycle hook and hardcoded `working_dir`
- The `cli-e2e` job timed out after 20 minutes and was cancelled
- The PR was merged despite this, violating CI requirements

## Next Steps
- Once this revert is merged, the original author should investigate why `cli-e2e` timed out
- Fix the underlying issue and re-submit the feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)