### PR TITLE
fix(ci): add web deployment dependency for platform deployments

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -137,7 +137,7 @@ jobs:
 
   # Deploy platform (Vite SPA) to production
   deploy-platform-production:
-    needs: release-please
+    needs: [release-please, deploy-web-production]
     if: ${{ needs.release-please.outputs.platform_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -284,7 +284,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:829341a
-    needs: [change-detection]
+    needs: [change-detection, deploy-web]
     # Only deploy if it's a PR and platform changed
     if: github.event_name == 'pull_request' && needs.change-detection.outputs.platform-changed == 'true'
     permissions:


### PR DESCRIPTION
## Summary
- Add `deploy-web-production` to `deploy-platform-production`'s `needs` array in `release-please.yml`
- Add `deploy-web` to `deploy-platform`'s `needs` array in `turbo.yml`

Platform (Vite SPA) depends on web (Next.js backend) via `VITE_API_URL`. This ensures platform deploys only after web is ready, preventing API mismatches during simultaneous releases.

When web deployment is skipped (e.g., platform-only release), GitHub Actions allows the dependent job to proceed normally.

## Test plan
- [ ] Verify CI passes on this PR
- [ ] On next simultaneous web+platform release, confirm platform waits for web

🤖 Generated with [Claude Code](https://claude.ai/claude-code)