### PR TITLE
perf(web): skip eslint during vercel build

### DIFF
--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -3,6 +3,11 @@ import createNextIntlPlugin from "next-intl/plugin";
 const withNextIntl = createNextIntlPlugin("./i18n.ts");
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  eslint: {
+    // CI already runs lint separately, skip during Vercel build to save time and memory
+    ignoreDuringBuilds: true,
+  },
+};
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Summary
- Skip ESLint during `next build` on Vercel since CI already runs lint separately via turbo
- Saves ~7 seconds and ~237MB memory per deployment

## Test plan
- [x] Verify lint still runs in CI `lint` job
- [ ] Verify Vercel build succeeds without running lint

🤖 Generated with [Claude Code](https://claude.ai/code)