### PR TITLE
feat(platform): require authentication for home page

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -1,13 +1,13 @@
 import { command } from "ccstate";
 import { setupClerk$ } from "./auth.ts";
 import { setRootSignal$ } from "./root-signal.ts";
-import { initRoutes$, setupPageWrapper } from "./route.ts";
+import { initRoutes$, setupAuthPageWrapper } from "./route.ts";
 import { setupHomePage$ } from "./home/home-page.ts";
 
 const ROUTE_CONFIG = [
   {
     path: "/",
-    setup: setupPageWrapper(setupHomePage$),
+    setup: setupAuthPageWrapper(setupHomePage$),
   },
 ] as const;
 


### PR DESCRIPTION
## Summary
- Use `setupAuthPageWrapper` instead of `setupPageWrapper` for the platform home page route
- Unauthenticated users will now see the Clerk sign-in modal when visiting the platform
- This is a minimal change that leverages existing auth infrastructure

## Test plan
- [ ] Visit platform home page without authentication
- [ ] Verify Clerk sign-in modal appears
- [ ] Sign in and verify home page content loads

🤖 Generated with [Claude Code](https://claude.ai/code)