### PR TITLE
docs: update init command example prompt

### DIFF
--- a/turbo/apps/cli/src/commands/init.ts
+++ b/turbo/apps/cli/src/commands/init.ts
@@ -132,6 +132,7 @@ export const initCommand = new Command()
     );
     console.log(`  2. Set the environment variable (or add to .env file):`);
     console.log(chalk.dim(`     export CLAUDE_CODE_OAUTH_TOKEN=<your-token>`));
-    console.log(`  3. Run your agent: ${chalk.cyan(`vm0 cook "let's start working."`)}`);
-
+    console.log(
+      `  3. Run your agent: ${chalk.cyan(`vm0 cook "let's start working."`)}`,
+    );
   });

--- a/turbo/apps/cli/src/commands/init.ts
+++ b/turbo/apps/cli/src/commands/init.ts
@@ -132,5 +132,6 @@ export const initCommand = new Command()
     );
     console.log(`  2. Set the environment variable (or add to .env file):`);
     console.log(chalk.dim(`     export CLAUDE_CODE_OAUTH_TOKEN=<your-token>`));
-    console.log(`  3. Run your agent: ${chalk.cyan('vm0 cook "your prompt"')}`);
+    console.log(`  3. Run your agent: ${chalk.cyan(`vm0 cook "let's start working."`)}`);
+
   });


### PR DESCRIPTION
## Summary
- Update the example prompt in `vm0 init` output from "your prompt" to "let's start working."

## Test plan
- [ ] Run `vm0 init` and verify the new example prompt is displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)