### PR TITLE
feat(docs): simplify quick start run agent section

### DIFF
--- a/turbo/apps/docs/content/docs/quick-start.mdx
+++ b/turbo/apps/docs/content/docs/quick-start.mdx
@@ -53,23 +53,11 @@ You can also use other LLM providers instead of Claude, like Moonshot (Kimi), Mi
 
 ## Run Your Agent
 
-Before running your agent, check what it does by reviewing the instructions:
+Start the agent with a prompt:
 
 ```bash
-cat AGENTS.md
+vm0 cook "let's start working."
 ```
-
-By default, your agent is a **HackerNews AI content curator** that reads top articles, extracts AI-related content, and creates summaries.
-
-Now run your agent with a prompt that matches this workflow:
-
-```bash
-vm0 cook "Summarize today's AI news from HackerNews"
-```
-
-<Callout type="tip">
-  **Understanding the workflow:** `AGENTS.md` defines what your agent can do (its capabilities and workflow).
-</Callout>
 
 This command displays the agent's execution logs in real-time. When the agent finishes, any files it created or modified will be downloaded to the `artifact` directory in your project.
 


### PR DESCRIPTION
## Summary
Revert the Quick Start "Run Your Agent" section back to the simpler, more concise version.

## Changes
- Remove `cat AGENTS.md` step
- Remove detailed explanation about HackerNews AI curator
- Remove Callout tip box
- Simplify the example prompt from "Summarize today's AI news from HackerNews" to "let's start working."

## Rationale
The previous version was too prescriptive and assumed users would always start with the default HackerNews agent. The simpler version is more flexible and lets users focus on the core command without extra context.

## Before
```markdown
## Run Your Agent

Before running your agent, check what it does by reviewing the instructions:

```bash
cat AGENTS.md
```

By default, your agent is a **HackerNews AI content curator**...
```

## After
```markdown
## Run Your Agent

Start the agent with a prompt:

```bash
vm0 cook "let's start working."
```
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)