### PR TITLE
ci: add typescript type checking to pre-commit hooks

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -135,8 +135,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
 
+      # Run lint, check-types, and prettier directly (not via lefthook)
+      # lefthook's turbo filter uses git diff which doesn't work in CI
       - name: Lint
-        run: lefthook run pre-commit --all-files
+        working-directory: turbo
+        run: pnpm lint
+
+      - name: Type Check
+        working-directory: turbo
+        run: pnpm check-types
+
+      - name: Prettier
+        working-directory: turbo
+        run: pnpm prettier --check .
 
   test:
     runs-on: ubuntu-latest

--- a/turbo/apps/docs/src/app/(home)/layout.tsx
+++ b/turbo/apps/docs/src/app/(home)/layout.tsx
@@ -1,6 +1,6 @@
 import { HomeLayout } from "fumadocs-ui/layouts/home";
 import { baseOptions } from "@/lib/layout.shared";
 
-export default function Layout({ children }: LayoutProps<"/">) {
+export default function Layout({ children }: { children: React.ReactNode }) {
   return <HomeLayout {...baseOptions()}>{children}</HomeLayout>;
 }

--- a/turbo/apps/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/turbo/apps/docs/src/app/docs/[[...slug]]/page.tsx
@@ -10,7 +10,11 @@ import { notFound } from "next/navigation";
 import { createRelativeLink } from "fumadocs-ui/mdx";
 import { getMDXComponents } from "@/mdx-components";
 
-export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
+interface PageProps {
+  params: Promise<{ slug?: string[] }>;
+}
+
+export default async function Page(props: PageProps) {
   const params = await props.params;
   const page = source.getPage(params.slug);
   if (!page) notFound();
@@ -37,9 +41,7 @@ export async function generateStaticParams() {
   return source.generateParams();
 }
 
-export async function generateMetadata(
-  props: PageProps<"/docs/[[...slug]]">,
-): Promise<Metadata> {
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const params = await props.params;
   const page = source.getPage(params.slug);
   if (!page) notFound();

--- a/turbo/apps/docs/src/app/docs/layout.tsx
+++ b/turbo/apps/docs/src/app/docs/layout.tsx
@@ -2,7 +2,7 @@ import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { baseOptions } from "@/lib/layout.shared";
 import { source } from "@/lib/source";
 
-export default function Layout({ children }: LayoutProps<"/docs">) {
+export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <DocsLayout tree={source.pageTree} {...baseOptions()}>
       {children}

--- a/turbo/apps/docs/src/app/layout.tsx
+++ b/turbo/apps/docs/src/app/layout.tsx
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
   },
 };
 
-export default function Layout({ children }: LayoutProps<"/">) {
+export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={notoSans.className} suppressHydrationWarning>
       <head>

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -1,7 +1,11 @@
 import { command } from "ccstate";
 import { setupClerk$ } from "./auth.ts";
 import { setRootSignal$ } from "./root-signal.ts";
-import { initRoutes$, setupAuthPageWrapper, setupPageWrapper } from "./route.ts";
+import {
+  initRoutes$,
+  setupAuthPageWrapper,
+  setupPageWrapper,
+} from "./route.ts";
 import { setupHomePage$ } from "./home/home-page.ts";
 import { setupLogsPage$ } from "./logs-page/logs-page.ts";
 

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -1,7 +1,7 @@
 import { command } from "ccstate";
 import { setupClerk$ } from "./auth.ts";
 import { setRootSignal$ } from "./root-signal.ts";
-import { initRoutes$, setupAuthPageWrapper } from "./route.ts";
+import { initRoutes$, setupAuthPageWrapper, setupPageWrapper } from "./route.ts";
 import { setupHomePage$ } from "./home/home-page.ts";
 import { setupLogsPage$ } from "./logs-page/logs-page.ts";
 

--- a/turbo/apps/platform/src/signals/layout/navigation.ts
+++ b/turbo/apps/platform/src/signals/layout/navigation.ts
@@ -46,6 +46,14 @@ export const FOOTER_NAV_ITEMS = [
 export const activeNavItem$ = computed((get) => {
   const pathname = get(pathname$);
 
+  // Check Get Started item
+  if (
+    pathname === GET_STARTED_ITEM.path ||
+    pathname.startsWith(GET_STARTED_ITEM.path + "/")
+  ) {
+    return GET_STARTED_ITEM.id;
+  }
+
   // Check main navigation
   for (const group of NAVIGATION_CONFIG) {
     for (const item of group.items) {

--- a/turbo/apps/platform/src/types/navigation.ts
+++ b/turbo/apps/platform/src/types/navigation.ts
@@ -1,9 +1,19 @@
 import type { RoutePath } from "./route.ts";
 
+export type NavIconName =
+  | "Bot"
+  | "CircleDot"
+  | "FileBarChart"
+  | "List"
+  | "KeyRound"
+  | "Receipt"
+  | "HelpCircle"
+  | "Rocket";
+
 export interface NavItem {
   id: string;
   label: string;
-  icon: string;
+  icon: NavIconName;
   path: RoutePath;
 }
 

--- a/turbo/lefthook.yml
+++ b/turbo/lefthook.yml
@@ -3,7 +3,8 @@ pre-commit:
   commands:
     lint:
       root: turbo/
-      run: pnpm lint
+      # Only lint packages affected by staged changes (much faster than full lint)
+      run: pnpm turbo run lint --filter='...[HEAD]'
       glob: "turbo/**/*.{js,ts,tsx,jsx,mjs,cjs}"
     prettier:
       root: turbo/
@@ -11,5 +12,6 @@ pre-commit:
       glob: "turbo/**/*"
     check-types:
       root: turbo/
-      run: pnpm check-types
+      # Only type-check packages affected by staged changes (much faster than full check)
+      run: pnpm turbo run check-types --filter='...[HEAD]'
       glob: "turbo/**/*.{ts,tsx}"

--- a/turbo/lefthook.yml
+++ b/turbo/lefthook.yml
@@ -9,3 +9,7 @@ pre-commit:
       root: turbo/
       run: pnpm prettier --list-different --ignore-unknown {staged_files}
       glob: "turbo/**/*"
+    check-types:
+      root: turbo/
+      run: pnpm check-types
+      glob: "turbo/**/*.{ts,tsx}"


### PR DESCRIPTION
## Summary
- Add `check-types` command to lefthook.yml pre-commit hooks to run TypeScript type checking
- Fix missing `setupPageWrapper` import in `bootstrap.ts`
- Fix `NavIconName` type to be a union of valid icon names instead of `string`
- Add `GET_STARTED_ITEM` to `activeNavItem$` computed signal to fix type comparison error

This PR closes a CI gap where TypeScript type errors could slip through because:
1. `vite build` uses esbuild/SWC for transpilation (no type checking)
2. ESLint doesn't catch missing import errors
3. There was no `tsc --noEmit` step in the lint pipeline

Now `pnpm check-types` runs as part of pre-commit hooks, ensuring type errors are caught before code is committed.

## Test plan
- [x] Verified `pnpm check-types` passes
- [x] Verified `pnpm lint` passes
- [x] Verified `pnpm --filter @vm0/platform test` passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)