### PR TITLE
ci: split v1 api e2e tests into separate job with shared auth

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -298,14 +298,84 @@ jobs:
           meta-branch: ${{ github.head_ref }}
           meta-pr: ${{ github.event.pull_request.number }}
 
+  # Authenticate for E2E tests (shared by cli-e2e and api-e2e)
+  e2e-auth:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:829341a
+    needs: [deploy-web]
+    if: needs.deploy-web.outputs.preview-url != ''
+    outputs:
+      vm0-token: ${{ steps.auth.outputs.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Setup pnpm global directory
+        run: |
+          mkdir -p $HOME/.local/share/pnpm
+          pnpm config set global-bin-dir $HOME/.local/share/pnpm
+          echo "$HOME/.local/share/pnpm" >> $GITHUB_PATH
+
+      - name: Build CLI
+        run: cd turbo && pnpm --filter @vm0/cli build
+
+      - name: Setup CLI globally
+        run: cd turbo/apps/cli && pnpm link --global
+
+      - name: Install E2E dependencies
+        run: cd e2e && npm install
+
+      - name: Install Playwright browsers
+        run: cd e2e && npx playwright install chromium
+
+      - name: Authenticate and output token
+        id: auth
+        run: |
+          echo "Authenticating CLI with ${{ needs.deploy-web.outputs.preview-url }}"
+          cd e2e && npm run auth
+          # Extract token and output it (masked for security)
+          TOKEN=$(cat ~/.vm0/config.json | jq -r '.token')
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> $GITHUB_OUTPUT
+        env:
+          VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
+          CLERK_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+  # Run API E2E tests (lightweight, fast)
+  api-e2e:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:829341a
+    needs: [e2e-auth, deploy-web]
+    if: needs.deploy-web.outputs.preview-url != '' && needs.e2e-auth.outputs.vm0-token != ''
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive # For BATS test framework
+
+      - name: Run API E2E Tests
+        run: |
+          echo "=== Running API E2E Tests ==="
+          ./e2e/test/libs/bats/bin/bats -T ./e2e/tests/api/*.bats
+        env:
+          VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
+          VM0_TOKEN: ${{ needs.e2e-auth.outputs.vm0-token }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
   # Run CLI E2E tests
   cli-e2e:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:829341a
-    needs: [change-detection, deploy-web, deploy-runner, lint, test]
+    needs: [change-detection, deploy-web, deploy-runner, e2e-auth, lint, test]
     # Runs when all dependencies succeed and preview-url is available
-    if: needs.deploy-web.outputs.preview-url != ''
+    if: needs.deploy-web.outputs.preview-url != '' && needs.e2e-auth.outputs.vm0-token != ''
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -328,21 +398,10 @@ jobs:
       - name: Install GNU parallel for bats
         run: apt-get update && apt-get install -y parallel
 
-      - name: Install E2E dependencies
-        run: cd e2e && npm install
-
-      - name: Install Playwright browsers
-        run: cd e2e && npx playwright install chromium
-
-      - name: Authenticate CLI
+      - name: Setup authentication
         run: |
-          echo "Authenticating CLI with ${{ needs.deploy-web.outputs.preview-url }}"
-          cd e2e && npm run auth
-        env:
-          VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
-          CLERK_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          mkdir -p ~/.vm0
+          echo '{"token":"${{ needs.e2e-auth.outputs.vm0-token }}"}' > ~/.vm0/config.json
 
       - name: Setup VM0 test volumes
         run: ./e2e/scripts/setup-vm0-volumes.sh

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -305,8 +305,6 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:829341a
     needs: [deploy-web]
     if: needs.deploy-web.outputs.preview-url != ''
-    outputs:
-      vm0-token: ${{ steps.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -331,20 +329,22 @@ jobs:
       - name: Install Playwright browsers
         run: cd e2e && npx playwright install chromium
 
-      - name: Authenticate and output token
-        id: auth
+      - name: Authenticate CLI
         run: |
           echo "Authenticating CLI with ${{ needs.deploy-web.outputs.preview-url }}"
           cd e2e && npm run auth
-          # Extract token and output it (masked for security)
-          TOKEN=$(cat ~/.vm0/config.json | jq -r '.token')
-          echo "::add-mask::$TOKEN"
-          echo "token=$TOKEN" >> $GITHUB_OUTPUT
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           CLERK_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Upload auth config
+        uses: actions/upload-artifact@v4
+        with:
+          name: vm0-auth-config
+          path: ~/.vm0/config.json
+          retention-days: 1
 
   # Run API E2E tests (lightweight, fast)
   api-e2e:
@@ -352,12 +352,18 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:829341a
     needs: [e2e-auth, deploy-web]
-    if: needs.deploy-web.outputs.preview-url != '' && needs.e2e-auth.outputs.vm0-token != ''
+    if: needs.deploy-web.outputs.preview-url != ''
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive # For BATS test framework
+
+      - name: Download auth config
+        uses: actions/download-artifact@v4
+        with:
+          name: vm0-auth-config
+          path: ~/.vm0
 
       - name: Run API E2E Tests
         run: |
@@ -365,7 +371,6 @@ jobs:
           ./e2e/test/libs/bats/bin/bats -T ./e2e/tests/api/*.bats
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
-          VM0_TOKEN: ${{ needs.e2e-auth.outputs.vm0-token }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
   # Run CLI E2E tests
@@ -375,7 +380,7 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:829341a
     needs: [change-detection, deploy-web, deploy-runner, e2e-auth, lint, test]
     # Runs when all dependencies succeed and preview-url is available
-    if: needs.deploy-web.outputs.preview-url != '' && needs.e2e-auth.outputs.vm0-token != ''
+    if: needs.deploy-web.outputs.preview-url != ''
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -398,10 +403,11 @@ jobs:
       - name: Install GNU parallel for bats
         run: apt-get update && apt-get install -y parallel
 
-      - name: Setup authentication
-        run: |
-          mkdir -p ~/.vm0
-          echo '{"token":"${{ needs.e2e-auth.outputs.vm0-token }}"}' > ~/.vm0/config.json
+      - name: Download auth config
+        uses: actions/download-artifact@v4
+        with:
+          name: vm0-auth-config
+          path: ~/.vm0
 
       - name: Setup VM0 test volumes
         run: ./e2e/scripts/setup-vm0-volumes.sh

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -339,12 +339,11 @@ jobs:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
-      - name: Upload auth config
-        uses: actions/upload-artifact@v4
+      - name: Save auth config to cache
+        uses: actions/cache/save@v4
         with:
-          name: vm0-auth-config
-          path: ~/.vm0/config.json
-          retention-days: 1
+          path: ~/.vm0
+          key: e2e-auth-${{ github.run_id }}
 
   # Run API E2E tests (lightweight, fast)
   api-e2e:
@@ -359,11 +358,12 @@ jobs:
         with:
           submodules: recursive # For BATS test framework
 
-      - name: Download auth config
-        uses: actions/download-artifact@v4
+      - name: Restore auth config from cache
+        uses: actions/cache/restore@v4
         with:
-          name: vm0-auth-config
           path: ~/.vm0
+          key: e2e-auth-${{ github.run_id }}
+          fail-on-cache-miss: true
 
       - name: Run API E2E Tests
         run: |
@@ -403,11 +403,12 @@ jobs:
       - name: Install GNU parallel for bats
         run: apt-get update && apt-get install -y parallel
 
-      - name: Download auth config
-        uses: actions/download-artifact@v4
+      - name: Restore auth config from cache
+        uses: actions/cache/restore@v4
         with:
-          name: vm0-auth-config
           path: ~/.vm0
+          key: e2e-auth-${{ github.run_id }}
+          fail-on-cache-miss: true
 
       - name: Setup VM0 test volumes
         run: ./e2e/scripts/setup-vm0-volumes.sh

--- a/e2e/tests/api/public-api-v1.bats
+++ b/e2e/tests/api/public-api-v1.bats
@@ -103,4 +103,3 @@ setup() {
     result=$(api_get "/v1/volumes")
     echo "$result" | jq -e '.pagination' > /dev/null
 }
-


### PR DESCRIPTION
## Summary

- Split V1 API E2E tests from CLI E2E into a separate `api-e2e` job
- Create shared `e2e-auth` job that generates token once for both jobs
- Move API tests to dedicated `e2e/tests/api/` directory

## New CI Architecture

```
deploy-web
    |
    v
e2e-auth  (generates token once, masks it for security)
    |
+---+---+
|       |
v       v
cli-e2e  api-e2e  (both receive token, run in parallel)
```

## Changes

| File | Action |
|------|--------|
| `e2e/tests/api/public-api-v1.bats` | Created (moved from 02-parallel) |
| `e2e/tests/02-parallel/t30-public-api-v1.bats` | Deleted |
| `.github/workflows/turbo.yml` | Added `e2e-auth` and `api-e2e` jobs |

## Benefits

- **Faster feedback**: API tests complete independently (~5min timeout vs 20min)
- **No duplication**: Auth runs once, shared by both jobs
- **Parallel execution**: `cli-e2e` and `api-e2e` run simultaneously after auth
- **Cleaner separation**: API tests isolated from CLI test infrastructure

## Test plan

- [ ] `e2e-auth` job successfully generates and outputs masked token
- [ ] `api-e2e` job receives token and all API tests pass
- [ ] `cli-e2e` job receives token and all CLI tests pass
- [ ] Both jobs run in parallel after auth completes

Closes #1127

🤖 Generated with [Claude Code](https://claude.ai/code)