### PR TITLE
ci(e2e): parallelize runner deployment with web deployment

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -456,17 +456,19 @@ jobs:
           NUM_HOSTS=${#HOSTS[@]}
           echo "Found $NUM_HOSTS runner hosts"
 
-          # Setup SSH
-          mkdir -p ~/.ssh
+          # Setup SSH (use $HOME instead of ~ for proper expansion in container)
+          SSH_DIR="$HOME/.ssh"
+          SSH_KEY_FILE="$SSH_DIR/runner.pem"
+          mkdir -p "$SSH_DIR"
           if [ -z "$SSH_KEY" ]; then
             echo "ERROR: SSH_KEY secret is empty!"
             exit 1
           fi
-          echo "$SSH_KEY" > ~/.ssh/runner.pem
-          chmod 600 ~/.ssh/runner.pem
-          echo "SSH key file created ($(wc -c < ~/.ssh/runner.pem) bytes)"
+          echo "$SSH_KEY" > "$SSH_KEY_FILE"
+          chmod 600 "$SSH_KEY_FILE"
+          echo "SSH key file created at $SSH_KEY_FILE ($(wc -c < "$SSH_KEY_FILE") bytes)"
 
-          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i ~/.ssh/runner.pem"
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $SSH_KEY_FILE"
 
           # Function to check if host is available (lock doesn't exist or is stale)
           check_and_acquire() {
@@ -599,9 +601,9 @@ jobs:
           RUNNER_DIR="/opt/vm0-runner/pr-${PR_NUMBER}"
           PROXY_PORT=$((8080 + PR_NUMBER % 1000))
 
-          mkdir -p ~/.ssh
-          echo "$SSH_KEY" > ~/.ssh/runner.pem
-          chmod 600 ~/.ssh/runner.pem
+          mkdir -p "$HOME/.ssh"
+          echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
+          chmod 600 "$HOME/.ssh/runner.pem"
 
           echo "Preparing runner on host: ${RUNNER_HOST}"
 
@@ -610,7 +612,7 @@ jobs:
             -i "${RUNNER_HOST}," \
             playbooks/deploy-runner.yml \
             --tags prepare \
-            --private-key ~/.ssh/runner.pem \
+            --private-key "$HOME/.ssh/runner.pem" \
             -e "ansible_user=${METAL_USER}" \
             -e "runner_base_dir=${RUNNER_DIR}" \
             -e "pm2_process_name=vm0-runner-pr-${PR_NUMBER}" \
@@ -654,9 +656,9 @@ jobs:
           PREVIEW_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
-          mkdir -p ~/.ssh
-          echo "$SSH_KEY" > ~/.ssh/runner.pem
-          chmod 600 ~/.ssh/runner.pem
+          mkdir -p "$HOME/.ssh"
+          echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
+          chmod 600 "$HOME/.ssh/runner.pem"
 
           echo "Starting runner on host: ${RUNNER_HOST}"
 
@@ -665,7 +667,7 @@ jobs:
             -i "${RUNNER_HOST}," \
             playbooks/deploy-runner.yml \
             --tags start \
-            --private-key ~/.ssh/runner.pem \
+            --private-key "$HOME/.ssh/runner.pem" \
             -e "ansible_user=${METAL_USER}" \
             -e "runner_base_dir=${RUNNER_DIR}" \
             -e "runner_group=vm0/development-pr-${PR_NUMBER}" \
@@ -690,8 +692,8 @@ jobs:
           METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
           SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
         run: |
-          mkdir -p ~/.ssh
-          echo "$SSH_KEY" > ~/.ssh/runner.pem
-          chmod 600 ~/.ssh/runner.pem
-          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i ~/.ssh/runner.pem ${METAL_USER}@${RUNNER_HOST} "rm -rf /opt/vm0-runner/.lock" || true
+          mkdir -p "$HOME/.ssh"
+          echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
+          chmod 600 "$HOME/.ssh/runner.pem"
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i "$HOME/.ssh/runner.pem" ${METAL_USER}@${RUNNER_HOST} "rm -rf /opt/vm0-runner/.lock" || true
           echo "Unlocked runner host: $RUNNER_HOST"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -299,11 +299,11 @@ jobs:
           meta-pr: ${{ github.event.pull_request.number }}
 
   # Run CLI E2E tests
-  cli-e2e:
+  cli-e2e-test:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:829341a
-    needs: [change-detection, deploy-web, deploy-runner, lint, test]
+    needs: [change-detection, deploy-web, deploy-runner-start, lint, test]
     # Runs when all dependencies succeed and preview-url is available
     if: needs.deploy-web.outputs.preview-url != ''
     timeout-minutes: 20
@@ -426,16 +426,22 @@ jobs:
             echo "Cron simulator stopped"
           fi
 
-  # Lock runner host before deployment (PR-specific isolation)
-  lock-runner-host:
+  # Prepare runner: lock host, build bundle, install deps (runs parallel with deploy-web)
+  deploy-runner-prepare:
     runs-on: ubuntu-latest
-    needs: [change-detection, deploy-web]
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:829341a
+    needs: [change-detection]
     if: |
-      (github.event_name == 'pull_request' && (needs.change-detection.outputs.cli-changed == 'true' || needs.change-detection.outputs.web-changed == 'true' || needs.change-detection.outputs.runner-changed == 'true' || needs.change-detection.outputs.e2e-changed == 'true') && needs.deploy-web.outputs.preview-url != '') ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_cli_e2e == 'true' && needs.deploy-web.outputs.preview-url != '')
+      (github.event_name == 'pull_request' && (needs.change-detection.outputs.cli-changed == 'true' || needs.change-detection.outputs.web-changed == 'true' || needs.change-detection.outputs.runner-changed == 'true' || needs.change-detection.outputs.e2e-changed == 'true')) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_cli_e2e == 'true')
     outputs:
       runner-host: ${{ steps.lock.outputs.host }}
+      runner-dir: ${{ steps.prepare.outputs.runner-dir }}
     steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/toolchain-init
+
       - name: Lock runner host
         id: lock
         shell: bash
@@ -563,21 +569,6 @@ jobs:
           echo "All runner hosts are busy. Please try again later or check for stale locks."
           exit 1
 
-  # Deploy runner on locked host
-  deploy-runner:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:829341a
-    needs: [change-detection, deploy-web, lock-runner-host]
-    # Runs whenever lock-runner-host succeeds (no conditional)
-    outputs:
-      runner-deployed: ${{ steps.deploy.outputs.runner-deployed }}
-      runner-dir: ${{ steps.deploy.outputs.runner-dir }}
-      runner-host: ${{ needs.lock-runner-host.outputs.runner-host }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/toolchain-init
-
       - name: Install Ansible
         run: apt-get update && apt-get install -y python3-pip && pip3 install ansible
 
@@ -597,16 +588,13 @@ jobs:
           tar -czf /tmp/vm0-runner-bundle.tar.gz -C /tmp vm0-runner-bundle
           echo "Bundle created: $(ls -lh /tmp/vm0-runner-bundle.tar.gz)"
 
-      - name: Deploy runner with Ansible
-        id: deploy
+      - name: Prepare runner (deploy bundle, install deps)
+        id: prepare
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
-          RUNNER_HOST: ${{ needs.lock-runner-host.outputs.runner-host }}
+          RUNNER_HOST: ${{ steps.lock.outputs.host }}
           SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
-          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-          PREVIEW_URL: ${{ needs.deploy-web.outputs.preview-url }}
-          VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           RUNNER_DIR="/opt/vm0-runner/pr-${PR_NUMBER}"
           PROXY_PORT=$((8080 + PR_NUMBER % 1000))
@@ -615,12 +603,68 @@ jobs:
           echo "$SSH_KEY" > ~/.ssh/runner.pem
           chmod 600 ~/.ssh/runner.pem
 
-          echo "Deploying to runner host: ${RUNNER_HOST}"
+          echo "Preparing runner on host: ${RUNNER_HOST}"
 
           cd ansible
           ansible-playbook \
             -i "${RUNNER_HOST}," \
             playbooks/deploy-runner.yml \
+            --tags prepare \
+            --private-key ~/.ssh/runner.pem \
+            -e "ansible_user=${METAL_USER}" \
+            -e "runner_base_dir=${RUNNER_DIR}" \
+            -e "pm2_process_name=vm0-runner-pr-${PR_NUMBER}" \
+            -e "runner_bundle_path=/tmp/vm0-runner-bundle.tar.gz" \
+            -e "rootfs_path=${RUNNER_DIR}/rootfs.ext4" \
+            -e "force_rebuild_rootfs=true" \
+            -e "proxy_port=${PROXY_PORT}" \
+            -e '{"enable_drain": true, "drain_timeout": 300}' \
+            -v
+
+          echo "runner-dir=${RUNNER_DIR}" >> $GITHUB_OUTPUT
+          echo "Runner prepared at ${RUNNER_DIR} on ${RUNNER_HOST}"
+
+  # Start runner after deploy-web provides preview URL
+  deploy-runner-start:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:829341a
+    needs: [change-detection, deploy-web, deploy-runner-prepare]
+    if: needs.deploy-web.outputs.preview-url != '' && needs.deploy-runner-prepare.outputs.runner-host != ''
+    outputs:
+      runner-deployed: ${{ steps.start.outputs.runner-deployed }}
+      runner-dir: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
+      runner-host: ${{ needs.deploy-runner-prepare.outputs.runner-host }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Install Ansible
+        run: apt-get update && apt-get install -y python3-pip && pip3 install ansible
+
+      - name: Start runner (configure and launch)
+        id: start
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
+          RUNNER_HOST: ${{ needs.deploy-runner-prepare.outputs.runner-host }}
+          RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
+          SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+          PREVIEW_URL: ${{ needs.deploy-web.outputs.preview-url }}
+          VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/runner.pem
+          chmod 600 ~/.ssh/runner.pem
+
+          echo "Starting runner on host: ${RUNNER_HOST}"
+
+          cd ansible
+          ansible-playbook \
+            -i "${RUNNER_HOST}," \
+            playbooks/deploy-runner.yml \
+            --tags start \
             --private-key ~/.ssh/runner.pem \
             -e "ansible_user=${METAL_USER}" \
             -e "runner_base_dir=${RUNNER_DIR}" \
@@ -628,28 +672,21 @@ jobs:
             -e "pm2_process_name=vm0-runner-pr-${PR_NUMBER}" \
             -e "official_runner_secret=${OFFICIAL_RUNNER_SECRET}" \
             -e "api_url=${PREVIEW_URL}" \
-            -e "runner_bundle_path=/tmp/vm0-runner-bundle.tar.gz" \
-            -e "rootfs_path=${RUNNER_DIR}/rootfs.ext4" \
-            -e "force_rebuild_rootfs=true" \
-            -e "proxy_port=${PROXY_PORT}" \
-            -e "max_concurrent=8" \
-            -e '{"enable_drain": true, "drain_timeout": 300}' \
             -e '{"extra_env": {"VERCEL_AUTOMATION_BYPASS_SECRET": "'"${VERCEL_BYPASS}"'", "USE_MOCK_CLAUDE": "true"}}' \
             -v
 
           echo "runner-deployed=true" >> $GITHUB_OUTPUT
-          echo "runner-dir=${RUNNER_DIR}" >> $GITHUB_OUTPUT
-          echo "Runner deployed to ${RUNNER_DIR} on ${RUNNER_HOST}"
+          echo "Runner started at ${RUNNER_DIR} on ${RUNNER_HOST}"
 
-  # Release runner host lock after cli-e2e completes (or fails/times out)
+  # Release runner host lock after cli-e2e-test completes (or fails/times out)
   unlock-runner-host:
     runs-on: ubuntu-latest
-    needs: [lock-runner-host, cli-e2e]
-    if: always() && needs.lock-runner-host.outputs.runner-host != ''
+    needs: [deploy-runner-prepare, cli-e2e-test]
+    if: always() && needs.deploy-runner-prepare.outputs.runner-host != ''
     steps:
       - name: Unlock runner host
         env:
-          RUNNER_HOST: ${{ needs.lock-runner-host.outputs.runner-host }}
+          RUNNER_HOST: ${{ needs.deploy-runner-prepare.outputs.runner-host }}
           METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
           SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
         run: |

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -722,6 +722,8 @@ jobs:
           PREVIEW_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
+          PROXY_PORT=$((8080 + PR_NUMBER % 1000))
+
           mkdir -p "$HOME/.ssh"
           echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
           chmod 600 "$HOME/.ssh/runner.pem"
@@ -740,6 +742,8 @@ jobs:
             -e "pm2_process_name=vm0-runner-pr-${PR_NUMBER}" \
             -e "official_runner_secret=${OFFICIAL_RUNNER_SECRET}" \
             -e "api_url=${PREVIEW_URL}" \
+            -e "rootfs_path=${RUNNER_DIR}/rootfs.ext4" \
+            -e "proxy_port=${PROXY_PORT}" \
             -e '{"extra_env": {"VERCEL_AUTOMATION_BYPASS_SECRET": "'"${VERCEL_BYPASS}"'", "USE_MOCK_CLAUDE": "true"}}' \
             -v
 

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -3,7 +3,7 @@
 # This playbook deploys the VM0 runner to metal instances.
 # Supports both CI (PR testing) and Production deployments.
 #
-# CI Usage (single host, no drain):
+# CI Usage - Full deployment (single host, no drain):
 #   ansible-playbook -i "host," playbooks/deploy-runner.yml \
 #     -e "ansible_user=ubuntu" \
 #     -e "runner_base_dir=/opt/vm0-runner/pr-123" \
@@ -13,6 +13,22 @@
 #     -e "api_url=https://preview-url.vercel.app" \
 #     -e "enable_drain=false"
 #
+# CI Usage - Prepare only (no api_url needed):
+#   ansible-playbook -i "host," playbooks/deploy-runner.yml --tags prepare \
+#     -e "ansible_user=ubuntu" \
+#     -e "runner_base_dir=/opt/vm0-runner/pr-123" \
+#     -e "runner_bundle_path=/tmp/vm0-runner-bundle.tar.gz" \
+#     -e "enable_drain=false"
+#
+# CI Usage - Start only (requires api_url):
+#   ansible-playbook -i "host," playbooks/deploy-runner.yml --tags start \
+#     -e "ansible_user=ubuntu" \
+#     -e "runner_base_dir=/opt/vm0-runner/pr-123" \
+#     -e "runner_group=vm0/development-pr-123" \
+#     -e "pm2_process_name=vm0-runner-pr-123" \
+#     -e "official_runner_secret=xxx" \
+#     -e "api_url=https://preview-url.vercel.app"
+#
 # Production Usage (multiple hosts, with drain):
 #   ansible-playbook -i "host1,host2," playbooks/deploy-runner.yml \
 #     -e "ansible_user=ubuntu" \
@@ -20,10 +36,15 @@
 #     -e "api_url=https://www.vm0.ai" \
 #     -e "enable_drain=true"
 #
+# Tags:
+#   - prepare: Phases 1-4 (stop, deploy bundle, install deps) - no api_url needed
+#   - start: Phases 5-6 (configure, start, health check) - requires api_url
+#   - (no tags): Run all phases
+#
 # Required Variables:
-#   - official_runner_secret: The OFFICIAL_RUNNER_SECRET for authentication
-#   - api_url: The API URL (preview URL for CI, production URL for prod)
-#   - runner_bundle_path: Path to pre-built runner bundle tarball
+#   - For prepare: runner_bundle_path
+#   - For start: official_runner_secret, api_url
+#   - For full: all of the above
 #
 # Optional Variables (with defaults):
 #   - runner_base_dir: Runner installation directory (default: /opt/vm0-runner/production)
@@ -56,23 +77,39 @@
     # ========================================
     # Phase 1: Pre-flight checks
     # ========================================
-    - name: Check required variables
+    - name: Check required variables for prepare phase
+      assert:
+        that:
+          - runner_bundle_path is defined
+        fail_msg: "Required variable for prepare: runner_bundle_path"
+      tags: [prepare]
+
+    - name: Check required variables for start phase
       assert:
         that:
           - official_runner_secret is defined
           - api_url is defined
-          - runner_bundle_path is defined
-        fail_msg: "Required variables: official_runner_secret, api_url, runner_bundle_path"
+        fail_msg: "Required variables for start: official_runner_secret, api_url"
+      tags: [start]
 
-    - name: Display deployment configuration
+    - name: Display prepare configuration
       debug:
         msg: |
-          Deploying runner:
+          Preparing runner:
+          - Directory: {{ runner_base_dir }}
+          - Bundle: {{ runner_bundle_path }}
+          - Drain enabled: {{ enable_drain }}
+      tags: [prepare]
+
+    - name: Display start configuration
+      debug:
+        msg: |
+          Starting runner:
           - Directory: {{ runner_base_dir }}
           - Group: {{ runner_group }}
           - Process: {{ pm2_process_name }}
           - API: {{ api_url }}
-          - Drain enabled: {{ enable_drain }}
+      tags: [start]
 
     # ========================================
     # Phase 2: Stop existing runner
@@ -83,10 +120,12 @@
       ignore_errors: yes
       changed_when: false
       become: no
+      tags: [prepare]
 
     # Production: Drain before stopping (wait for active jobs)
     - name: Enter maintenance mode (stop polling, wait for active jobs)
       when: enable_drain and pm2_pid.stdout | regex_search('^[0-9]+$')
+      tags: [prepare]
       block:
         - name: Signal runner to enter drain mode
           command: kill -USR1 {{ pm2_pid.stdout }}
@@ -133,6 +172,7 @@
       command: pm2 delete {{ pm2_process_name }}
       ignore_errors: yes
       become: no
+      tags: [prepare]
 
     # ========================================
     # Phase 3: Deploy
@@ -144,9 +184,11 @@
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
         mode: '0755'
+      tags: [prepare]
 
     - name: Clean runner directory
       shell: rm -rf {{ runner_base_dir }}/*
+      tags: [prepare]
 
     - name: Extract runner bundle
       unarchive:
@@ -155,6 +197,7 @@
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
         extra_opts: [--strip-components=1]
+      tags: [prepare]
 
     - name: Ensure deploy-runner directory exists
       file:
@@ -163,6 +206,7 @@
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
         mode: '0755'
+      tags: [prepare]
 
     - name: Copy deploy scripts
       copy:
@@ -173,6 +217,7 @@
         mode: '0755'
       with_fileglob:
         - "{{ playbook_dir }}/../../turbo/scripts/deploy-runner/*.sh"
+      tags: [prepare]
 
     - name: Copy Dockerfile for rootfs build
       copy:
@@ -181,6 +226,7 @@
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
         mode: '0644'
+      tags: [prepare]
 
     # ========================================
     # Phase 4: Install Dependencies (if needed)
@@ -189,22 +235,26 @@
       stat:
         path: /usr/local/bin/firecracker
       register: firecracker_bin
+      tags: [prepare]
 
     - name: Install Firecracker
       command: "{{ runner_base_dir }}/deploy-runner/install-firecracker.sh"
       when: not firecracker_bin.stat.exists
+      tags: [prepare]
 
     - name: Check if mitmproxy is installed
       command: mitmdump --version
       register: mitmproxy_check
       ignore_errors: yes
       changed_when: false
+      tags: [prepare]
 
     - name: Install pipx for mitmproxy
       apt:
         name: pipx
         state: present
       when: mitmproxy_check.rc != 0
+      tags: [prepare]
 
     - name: Install mitmproxy via pipx
       command: pipx install mitmproxy
@@ -212,24 +262,29 @@
         PIPX_HOME: /opt/pipx
         PIPX_BIN_DIR: /usr/local/bin
       when: mitmproxy_check.rc != 0
+      tags: [prepare]
 
     - name: Check if rootfs exists
       stat:
         path: "{{ rootfs_path }}"
       register: rootfs_file
+      tags: [prepare]
 
     - name: Build rootfs
       command: "{{ runner_base_dir }}/deploy-runner/build-rootfs.sh {{ rootfs_path }}"
       when: not rootfs_file.stat.exists or force_rebuild_rootfs
+      tags: [prepare]
 
     - name: Check if proxy CA certificate exists
       stat:
         path: "{{ runner_base_dir }}/deploy-runner/proxy-ca/mitmproxy-ca.pem"
       register: proxy_ca_file
+      tags: [prepare]
 
     - name: Generate proxy CA certificate if not exists
       command: "{{ runner_base_dir }}/deploy-runner/generate-proxy-ca.sh {{ runner_base_dir }}/deploy-runner/proxy-ca"
       when: not proxy_ca_file.stat.exists
+      tags: [prepare]
 
     - name: Ensure proxy CA directory exists
       file:
@@ -238,6 +293,7 @@
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
         mode: '0755'
+      tags: [prepare]
 
     - name: Copy proxy CA (cert+key) for mitmproxy
       copy:
@@ -247,6 +303,7 @@
         group: "{{ ansible_user }}"
         mode: '0600'
         remote_src: yes
+      tags: [prepare]
 
     - name: Copy proxy CA certificate (cert only) for VM installation
       copy:
@@ -256,6 +313,7 @@
         group: "{{ ansible_user }}"
         mode: '0644'
         remote_src: yes
+      tags: [prepare]
 
     - name: Ensure user is in kvm group for Firecracker
       user:
@@ -263,10 +321,12 @@
         groups: kvm
         append: yes
       register: kvm_group_result
+      tags: [prepare]
 
     - name: Reset connection to pick up new group membership
       meta: reset_connection
       when: kvm_group_result.changed
+      tags: [prepare]
 
     # Kill PM2 daemon so it restarts with new group membership
     # PM2 child processes inherit the daemon's groups, not the shell's groups
@@ -275,6 +335,7 @@
       become: no
       ignore_errors: yes
       when: kvm_group_result.changed
+      tags: [prepare]
 
     # ========================================
     # Phase 5: Configure and Start
@@ -286,6 +347,7 @@
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
         mode: '0600'
+      tags: [start]
 
     - name: Create PM2 ecosystem file
       template:
@@ -294,6 +356,7 @@
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
         mode: '0644'
+      tags: [start]
 
     - name: Start runner via PM2
       command: pm2 start ecosystem.config.cjs
@@ -301,10 +364,12 @@
         chdir: "{{ runner_base_dir }}"
       become: no
       environment: "{{ extra_env }}"
+      tags: [start]
 
     - name: Save PM2 process list
       command: pm2 save
       become: no
+      tags: [start]
 
     # ========================================
     # Phase 6: Health Check
@@ -314,12 +379,14 @@
         path: /tmp/{{ pm2_process_name }}.log
         search_regex: "Press Ctrl\\+C to stop"
         timeout: 120
+      tags: [start]
 
     - name: Verify runner is polling
       shell: pm2 jlist | jq -r '.[] | select(.name=="{{ pm2_process_name }}") | .pm2_env.status'
       register: pm2_status
       failed_when: pm2_status.stdout != "online"
       become: no
+      tags: [start]
 
     - name: Verify runner can connect to API
       command: node index.js status --config ./runner.yaml
@@ -331,6 +398,7 @@
       retries: 3
       delay: 5
       until: status_check.rc == 0
+      tags: [start]
 
     - name: Display deployment summary
       debug:
@@ -340,3 +408,4 @@
           - Group: {{ runner_group }}
           - API: {{ api_url }}
           - Directory: {{ runner_base_dir }}
+      tags: [start]

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -123,8 +123,9 @@
       tags: [prepare]
 
     # Production: Drain before stopping (wait for active jobs)
+    # Note: regex must match positive integers only (not '0' which would signal process group)
     - name: Enter maintenance mode (stop polling, wait for active jobs)
-      when: enable_drain and pm2_pid.stdout | regex_search('^[0-9]+$')
+      when: enable_drain and pm2_pid.stdout | regex_search('^[1-9][0-9]*$')
       tags: [prepare]
       block:
         - name: Signal runner to enter drain mode
@@ -168,7 +169,7 @@
 
     # CI: Just stop without drain (no long-running jobs)
     - name: Stop runner without drain
-      when: not enable_drain and pm2_pid.stdout | regex_search('^[0-9]+$')
+      when: not enable_drain and pm2_pid.stdout | regex_search('^[1-9][0-9]*$')
       command: pm2 delete {{ pm2_process_name }}
       ignore_errors: yes
       become: no

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,5 +1,5 @@
 // VM0 Runner - Self-hosted runner for the VM0 platform
-// Connects to the VM0 API server to poll and execute agent jobs
+// Connects to the VM0 API server to poll and execute agent jobs in Firecracker microVMs
 // Supports drain mode for zero-downtime deployments via SIGUSR1 signal
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";


### PR DESCRIPTION
## Summary

- Split deploy-runner into `deploy-runner-prepare` and `deploy-runner-start` to enable parallel execution
- `deploy-runner-prepare` now runs in parallel with `deploy-web` (no preview URL needed)
- `deploy-runner-start` runs after both complete (needs preview URL for config)
- Renamed `cli-e2e` to `cli-e2e-test` for clarity
- Added Ansible playbook tags (`prepare`, `start`) for selective phase execution

## New Pipeline Flow

```
change-detection
    │
    ├────────────────────┬───────────────────────┐
    │                    │                       │
    ▼                    ▼                       ▼
deploy-web         deploy-runner-prepare     lint/test
    │                    │
    └─────────┬──────────┘
              │
              ▼
       deploy-runner-start
              │
              ▼
        cli-e2e-test
              │
              ▼
       unlock-runner-host
```

## Expected Results

- Time savings: ~1.5-2 minutes on critical path
- Cleaner job naming with `cli-e2e-test`
- Better separation of concerns between prepare and start phases

## Test plan

- [ ] CI pipeline runs successfully
- [ ] Runner deploys correctly with two-phase approach
- [ ] E2E tests pass
- [ ] Unlock job correctly releases lock after tests

Closes #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)