### PR TITLE
chore: add claude code settings for turbo workspace

### DIFF
--- a/turbo/.claude/settings.json
+++ b/turbo/.claude/settings.json
@@ -1,0 +1,39 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue create:*)",
+      "Skill(issue-todo)",
+      "Skill(issue-todo:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue comment:*)",
+      "Bash(gh issue edit:*)",
+      "Bash(pnpm -F platform test)",
+      "Bash(pnpm check-types:*)",
+      "Bash(pnpm -F platform exec tsc:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(git merge:*)",
+      "Bash(pnpm --filter @vm0/platform build:*)",
+      "Bash(pnpm --filter @vm0/platform check-types:*)",
+      "Bash(pnpm lint:*)",
+      "Bash(pnpm test:*)",
+      "Bash(pnpm --filter @vm0/platform test:*)",
+      "Bash(git checkout:*)",
+      "Bash(git reset:*)",
+      "Bash(gh run view:*)",
+      "Bash(pnpm --filter docs check-types:*)",
+      "Bash(git add:*)",
+      "Bash(time pnpm check-types:*)",
+      "Bash(time pnpm lint:*)",
+      "Bash(pnpm turbo run check-types:*)",
+      "Bash(time pnpm turbo run check-types:*)",
+      "Bash(pnpm prettier:*)",
+      "Bash(gh pr merge:*)",
+      "Bash(gh pr view:*)"
+    ],
+    "additionalDirectories": [
+      "/workspaces/vm0/scripts"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` with pre-approved permissions for common development commands
- Includes permissions for git, pnpm, gh CLI operations used during development

🤖 Generated with [Claude Code](https://claude.com/claude-code)