### PR TITLE
feat(toolchain): pre-install ansible for runner deployment

### DIFF
--- a/.docker/toolchain/Dockerfile
+++ b/.docker/toolchain/Dockerfile
@@ -27,6 +27,13 @@ RUN curl -sL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-am
 # Install global npm packages for CI/CD
 RUN npm install -g pnpm@10.15.0 lefthook@1.12.3 vercel@48.11.0 neonctl@2.15.0
 
+# Install Ansible for runner deployment
+# Using pipx for isolated installation (same pattern as mitmproxy in deploy scripts)
+RUN apt-get update && apt-get install -y \
+    pipx \
+    && rm -rf /var/lib/apt/lists/* \
+    && PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install ansible
+
 # Install Playwright system dependencies for Chromium
 # This is needed for e2e tests in CI
 RUN npx playwright install-deps chromium


### PR DESCRIPTION
## Summary

- Pre-install Ansible in the toolchain Docker image using pipx
- Eliminates ~38 second runtime installation overhead in deploy-runner jobs (26% of job time)

## Changes

- Add Ansible installation to `.docker/toolchain/Dockerfile` using pipx for isolated installation
- Uses same pattern as mitmproxy installation in deploy scripts

## Next Steps (after this PR merges)

After this PR is merged and the new toolchain image is published, a follow-up PR will:
1. Update workflow files to use the new image tag
2. Remove the "Install Ansible" steps from:
   - `turbo.yml` (deploy-runner job)
   - `release-please.yml` (deploy-runner-production job)

## Test Plan

- [ ] Docker build workflow passes (triggered automatically on this PR)
- [ ] Verify `ansible --version` is available in the built image

Closes #1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)