### PR TITLE
ci: split cli-e2e-test into three parallel jobs

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -309,7 +309,7 @@ jobs:
           meta-branch: ${{ github.head_ref }}
           meta-pr: ${{ github.event.pull_request.number }}
 
-  # Authenticate for E2E tests (shared by cli-e2e-test and api-e2e-test)
+  # Authenticate for E2E tests (shared by cli-e2e jobs and api-e2e-test)
   e2e-auth:
     runs-on: ubuntu-latest
     container:
@@ -384,19 +384,18 @@ jobs:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
-  # Run CLI E2E tests
-  cli-e2e-test:
+  # Run CLI E2E tests - Phase 1: Serial tests (establishes e2e-stable scope)
+  cli-e2e-01-serial:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:829341a
-    needs: [change-detection, deploy-web, deploy-runner-start, e2e-auth, lint, test]
-    # Runs when all dependencies succeed and preview-url is available
+    needs: [e2e-auth, deploy-web, lint, test]
     if: needs.deploy-web.outputs.preview-url != ''
-    timeout-minutes: 20
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive # For BATS test framework
+          submodules: recursive
       - uses: ./.github/actions/toolchain-init
 
       - name: Setup pnpm global directory
@@ -410,9 +409,6 @@ jobs:
 
       - name: Setup CLI globally
         run: cd turbo/apps/cli && pnpm link --global
-
-      - name: Install GNU parallel for bats
-        run: apt-get update && apt-get install -y parallel
 
       - name: Restore auth config from cache
         uses: actions/cache/restore@v4
@@ -437,57 +433,139 @@ jobs:
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
-      - name: Run CLI E2E Tests
+      - name: Run Serial E2E Tests
         run: |
-          # Track exit codes
-          RUNNER_EXIT=0
-          SERIAL_EXIT=0
-          PARALLEL_EXIT=0
-
-          # Step 1: Run serial tests sequentially (establishes e2e-stable scope)
-          # MUST run first so runner can use e2e-stable scope
           echo "=== Running Serial E2E Tests ==="
-          ./e2e/test/libs/bats/bin/bats -T ./e2e/tests/01-serial/*.bats || SERIAL_EXIT=$?
-
-          if [ $SERIAL_EXIT -ne 0 ]; then
-            echo ""
-            echo "❌ Serial tests failed - skipping remaining tests"
-            exit 1
-          fi
+          ./e2e/test/libs/bats/bin/bats -T ./e2e/tests/01-serial/*.bats
           echo "✅ Serial tests passed"
+        env:
+          VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          USE_MOCK_CLAUDE: "true"
 
-          # Step 2: Run parallel tests with -j 10
-          echo ""
+      - name: Stop Cron Simulator
+        if: always()
+        run: |
+          if [ -n "$CRON_SIMULATOR_PID" ]; then
+            kill "$CRON_SIMULATOR_PID" 2>/dev/null || true
+            echo "Cron simulator stopped"
+          fi
+
+  # Run CLI E2E tests - Phase 2: Parallel tests (does NOT need runner)
+  cli-e2e-02-parallel:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:829341a
+    needs: [cli-e2e-01-serial, deploy-web]
+    if: needs.deploy-web.outputs.preview-url != ''
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Setup pnpm global directory
+        run: |
+          mkdir -p $HOME/.local/share/pnpm
+          pnpm config set global-bin-dir $HOME/.local/share/pnpm
+          echo "$HOME/.local/share/pnpm" >> $GITHUB_PATH
+
+      - name: Build CLI
+        run: cd turbo && pnpm --filter @vm0/cli build
+
+      - name: Setup CLI globally
+        run: cd turbo/apps/cli && pnpm link --global
+
+      - name: Install GNU parallel for bats
+        run: apt-get update && apt-get install -y parallel
+
+      - name: Restore auth config from cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.vm0
+          key: e2e-auth-${{ github.run_id }}
+          fail-on-cache-miss: true
+
+      - name: Start Cron Simulator
+        run: |
+          chmod +x ./e2e/scripts/cron-simulator.sh
+          ./e2e/scripts/cron-simulator.sh "$VM0_API_URL" 60 &
+          echo "CRON_SIMULATOR_PID=$!" >> $GITHUB_ENV
+        env:
+          VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Run Parallel E2E Tests
+        run: |
           echo "=== Running Parallel E2E Tests ==="
-          ./e2e/test/libs/bats/bin/bats -T -j 10 --no-parallelize-within-files ./e2e/tests/02-parallel/*.bats || PARALLEL_EXIT=$?
-
-          if [ $PARALLEL_EXIT -ne 0 ]; then
-            echo ""
-            echo "❌ Parallel tests failed - skipping runner tests"
-            exit 1
-          fi
+          ./e2e/test/libs/bats/bin/bats -T -j 10 --no-parallelize-within-files ./e2e/tests/02-parallel/*.bats
           echo "✅ Parallel tests passed"
+        env:
+          VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          USE_MOCK_CLAUDE: "true"
 
-          # Runner is started in deploy-runner job with official token
-          # Set RUNNER_GROUP for runner tests
-          export RUNNER_GROUP="vm0/development-pr-${PR_NUMBER}"
-
-          # Step 3: Run runner tests
-          echo ""
-          echo "=== Running Runner E2E Tests (8 parallel) ==="
-          RUNNER_GROUP="vm0/development-pr-${PR_NUMBER}" ./e2e/test/libs/bats/bin/bats -T -j 8 --no-parallelize-within-files ./e2e/tests/03-experimental-runner/*.bats || RUNNER_EXIT=$?
-
-          # Report results and exit with failure if any suite failed
-          echo ""
-          echo "=== Test Results ==="
-          echo "Serial tests: PASSED"
-          echo "Parallel tests: PASSED"
-          echo "Runner tests: $([ $RUNNER_EXIT -eq 0 ] && echo 'PASSED' || echo 'FAILED')"
-
-          # Exit with failure if runner tests failed
-          if [ $RUNNER_EXIT -ne 0 ]; then
-            exit 1
+      - name: Stop Cron Simulator
+        if: always()
+        run: |
+          if [ -n "$CRON_SIMULATOR_PID" ]; then
+            kill "$CRON_SIMULATOR_PID" 2>/dev/null || true
+            echo "Cron simulator stopped"
           fi
+
+  # Run CLI E2E tests - Phase 3: Runner tests (needs runner deployed)
+  cli-e2e-03-runner:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:829341a
+    needs: [cli-e2e-01-serial, deploy-web, deploy-runner-start]
+    if: needs.deploy-web.outputs.preview-url != ''
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Setup pnpm global directory
+        run: |
+          mkdir -p $HOME/.local/share/pnpm
+          pnpm config set global-bin-dir $HOME/.local/share/pnpm
+          echo "$HOME/.local/share/pnpm" >> $GITHUB_PATH
+
+      - name: Build CLI
+        run: cd turbo && pnpm --filter @vm0/cli build
+
+      - name: Setup CLI globally
+        run: cd turbo/apps/cli && pnpm link --global
+
+      - name: Install GNU parallel for bats
+        run: apt-get update && apt-get install -y parallel
+
+      - name: Restore auth config from cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.vm0
+          key: e2e-auth-${{ github.run_id }}
+          fail-on-cache-miss: true
+
+      - name: Start Cron Simulator
+        run: |
+          chmod +x ./e2e/scripts/cron-simulator.sh
+          ./e2e/scripts/cron-simulator.sh "$VM0_API_URL" 60 &
+          echo "CRON_SIMULATOR_PID=$!" >> $GITHUB_ENV
+        env:
+          VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Run Runner E2E Tests
+        run: |
+          echo "=== Running Runner E2E Tests (8 parallel) ==="
+          RUNNER_GROUP="vm0/development-pr-${PR_NUMBER}" ./e2e/test/libs/bats/bin/bats -T -j 8 --no-parallelize-within-files ./e2e/tests/03-experimental-runner/*.bats
+          echo "✅ Runner tests passed"
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
@@ -761,10 +839,10 @@ jobs:
           echo "runner-deployed=true" >> $GITHUB_OUTPUT
           echo "Runner started at ${RUNNER_DIR} on ${RUNNER_HOST}"
 
-  # Release runner host lock after cli-e2e-test completes (or fails/times out)
+  # Release runner host lock after cli-e2e-03-runner completes (or fails/times out)
   unlock-runner-host:
     runs-on: ubuntu-latest
-    needs: [deploy-runner-prepare, cli-e2e-test]
+    needs: [deploy-runner-prepare, cli-e2e-03-runner]
     if: always() && needs.deploy-runner-prepare.outputs.runner-host != ''
     steps:
       - name: Unlock runner host

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,6 +1,5 @@
 // VM0 Runner - Self-hosted runner for the VM0 platform
 // Connects to the VM0 API server to poll and execute agent jobs in Firecracker microVMs
-// Supports drain mode for zero-downtime deployments via SIGUSR1 signal
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { statusCommand } from "./commands/status.js";


### PR DESCRIPTION
## Summary

- Split the monolithic `cli-e2e-test` job into three separate jobs for better parallelization:
  - `cli-e2e-01-serial`: runs serial tests, establishes e2e-stable scope
  - `cli-e2e-02-parallel`: runs parallel tests (does NOT need runner)
  - `cli-e2e-03-runner`: runs runner tests (needs deploy-runner-start)

- This allows `cli-e2e-02-parallel` to run without waiting for the runner deployment, improving overall CI pipeline throughput

## New Job Dependency Graph

```
e2e-auth
    │
    ▼
cli-e2e-01-serial (01-serial tests, establishes scope)
    │
    ├─────────────────────────────────────┐
    │                                     │
    ▼                                     ▼
cli-e2e-02-parallel              cli-e2e-03-runner
(does NOT need runner)           (needs deploy-runner-start)
```

## Test plan

- [ ] CI pipeline runs successfully
- [ ] All three E2E test jobs complete
- [ ] Runner host is properly unlocked after cli-e2e-03-runner completes

Related to: #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)