### PR TITLE
fix(toolchain): use pip3 instead of pipx for ansible installation

### DIFF
--- a/.docker/toolchain/Dockerfile
+++ b/.docker/toolchain/Dockerfile
@@ -28,11 +28,11 @@ RUN curl -sL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-am
 RUN npm install -g pnpm@10.15.0 lefthook@1.12.3 vercel@48.11.0 neonctl@2.15.0
 
 # Install Ansible for runner deployment
-# Using pipx for isolated installation (same pattern as mitmproxy in deploy scripts)
+# Using pip3 to ensure all ansible commands (ansible, ansible-playbook, etc.) are available
 RUN apt-get update && apt-get install -y \
-    pipx \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/* \
-    && PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install ansible
+    && pip3 install ansible
 
 # Install Playwright system dependencies for Chromium
 # This is needed for e2e tests in CI


### PR DESCRIPTION
## Summary

Fix the toolchain Docker image to use `pip3` instead of `pipx` for Ansible installation.

## Problem

The previous PR (#1135) used `pipx install ansible` which only exposes the main `ansible` command. However, our CI workflows need `ansible-playbook` which is a separate entry point that pipx doesn't expose by default.

## Solution

Use `pip3 install ansible` instead, which installs all Ansible commands (ansible, ansible-playbook, ansible-galaxy, etc.) into PATH.

## Test Plan

- [ ] Docker Build workflow passes
- [ ] After merge, Docker Publish will create new image
- [ ] New image tag can be used in PR #1139

🤖 Generated with [Claude Code](https://claude.com/claude-code)