### PR TITLE
fix(lefthook): disable parallel execution to prevent turbo cache deadlock

### DIFF
--- a/turbo/lefthook.yml
+++ b/turbo/lefthook.yml
@@ -1,5 +1,4 @@
 pre-commit:
-  parallel: true
   commands:
     lint:
       root: turbo/


### PR DESCRIPTION
## Summary

- Remove `parallel: true` from lefthook pre-commit config to prevent turbo cache lock contention
- Two turbo processes (lint + check-types) running in parallel can cause indefinite hangs during "Finishing writing to cache" phase

## Root Cause

When lefthook runs lint and check-types in parallel, both spawn turbo processes that compete for the same cache. This occasionally causes deadlocks where the process hangs indefinitely.

## Trade-off

Serial execution is slightly slower (~7s vs ~5s with cache hit), but eliminates the intermittent timeout issue.

## Test plan

- [x] Verified pre-commit hook completes successfully in serial mode
- [x] Tested with cache miss scenario - no hang observed

🤖 Generated with [Claude Code](https://claude.ai/code)