### PR TITLE
refactor(docs): use next typegen for fumadocs type safety

### DIFF
--- a/turbo/apps/docs/package.json
+++ b/turbo/apps/docs/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev --turbo --port 3001",
     "start": "next start",
     "lint": "next lint --max-warnings 0",
-    "check-types": "tsc --noEmit",
+    "check-types": "next typegen && tsc --noEmit",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/turbo/apps/docs/src/app/(home)/layout.tsx
+++ b/turbo/apps/docs/src/app/(home)/layout.tsx
@@ -1,6 +1,6 @@
 import { HomeLayout } from "fumadocs-ui/layouts/home";
 import { baseOptions } from "@/lib/layout.shared";
 
-export default function Layout({ children }: { children: React.ReactNode }) {
+export default function Layout({ children }: LayoutProps<"/">) {
   return <HomeLayout {...baseOptions()}>{children}</HomeLayout>;
 }

--- a/turbo/apps/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/turbo/apps/docs/src/app/docs/[[...slug]]/page.tsx
@@ -10,11 +10,7 @@ import { notFound } from "next/navigation";
 import { createRelativeLink } from "fumadocs-ui/mdx";
 import { getMDXComponents } from "@/mdx-components";
 
-interface PageProps {
-  params: Promise<{ slug?: string[] }>;
-}
-
-export default async function Page(props: PageProps) {
+export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
   const params = await props.params;
   const page = source.getPage(params.slug);
   if (!page) notFound();
@@ -41,7 +37,9 @@ export async function generateStaticParams() {
   return source.generateParams();
 }
 
-export async function generateMetadata(props: PageProps): Promise<Metadata> {
+export async function generateMetadata(
+  props: PageProps<"/docs/[[...slug]]">,
+): Promise<Metadata> {
   const params = await props.params;
   const page = source.getPage(params.slug);
   if (!page) notFound();

--- a/turbo/apps/docs/src/app/docs/layout.tsx
+++ b/turbo/apps/docs/src/app/docs/layout.tsx
@@ -2,7 +2,7 @@ import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { baseOptions } from "@/lib/layout.shared";
 import { source } from "@/lib/source";
 
-export default function Layout({ children }: { children: React.ReactNode }) {
+export default function Layout({ children }: LayoutProps<"/docs">) {
   return (
     <DocsLayout tree={source.pageTree} {...baseOptions()}>
       {children}

--- a/turbo/apps/docs/src/app/layout.tsx
+++ b/turbo/apps/docs/src/app/layout.tsx
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
   },
 };
 
-export default function Layout({ children }: { children: React.ReactNode }) {
+export default function Layout({ children }: LayoutProps<"/">) {
   return (
     <html lang="en" className={notoSans.className} suppressHydrationWarning>
       <head>


### PR DESCRIPTION
## Summary
- Update `check-types` script to run `next typegen` before `tsc --noEmit`
- Restore `LayoutProps<"/">` for root and home layouts
- Restore `LayoutProps<"/docs">` for docs layout  
- Restore `PageProps<"/docs/[[...slug]]">` for docs page
- Remove local `PageProps` interface in favor of generated types

This aligns with the official fumadocs-ui-template pattern while maintaining CI type-check compatibility through Next.js 15.5's `typegen` command.

## Test plan
- [x] Verified `pnpm check-types --filter=docs` passes without prior build
- [x] Verified `pnpm build --filter=docs` succeeds
- [ ] CI pipeline passes

Closes #1145

🤖 Generated with [Claude Code](https://claude.com/claude-code)