### PR TITLE
test: baseline pr to investigate flaky cli-e2e-02-parallel

### DIFF
--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,5 +1,5 @@
 // VM0 Runner - Self-hosted runner for the VM0 platform
-// Connects to the VM0 API server to poll and execute jobs in Firecracker microVMs
+// Connects to the VM0 API server to poll and execute agent jobs in Firecracker microVMs
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { statusCommand } from "./commands/status.js";


### PR DESCRIPTION
## Summary

Minimal comment change to trigger full CI and investigate if `cli-e2e-02-parallel` failure is a flaky test issue unrelated to code changes.

## Purpose

- Create a baseline to determine if the flaky test is reproducible
- No actual code changes - only a comment modification
- Helps isolate whether the issue is in the test infrastructure or test code

## Related

- Bug issue: #1149
- Previous observation: PR #1139

🤖 Generated with [Claude Code](https://claude.com/claude-code)