### PR TITLE
fix(ci): fix SSH key handling in cleanup.yml

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -5,8 +5,91 @@ on:
     types: [closed]
 
 jobs:
-  # Note: Runner cleanup is now handled by the cleanup-runner job in turbo.yml
-  # which runs immediately after tests complete (not on PR close)
+  cleanup-runner:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:4f3a2d7
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check if cleanup needed
+        id: check
+        env:
+          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
+          SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
+        run: |
+          if [ -z "$SSH_KEY" ] || [ -z "$METAL_HOSTS" ]; then
+            echo "Metal secrets not available, skipping runner cleanup"
+            echo "should-cleanup=false" >> $GITHUB_OUTPUT
+          else
+            echo "should-cleanup=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup SSH key
+        if: steps.check.outputs.should-cleanup == 'true'
+        env:
+          SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
+        run: |
+          SSH_DIR="$HOME/.ssh"
+          SSH_KEY_FILE="$SSH_DIR/metal.pem"
+          mkdir -p "$SSH_DIR"
+          echo "$SSH_KEY" > "$SSH_KEY_FILE"
+          chmod 600 "$SSH_KEY_FILE"
+          echo "SSH key file created at $SSH_KEY_FILE ($(wc -c < "$SSH_KEY_FILE") bytes)"
+
+      - name: Cleanup runner on metal hosts
+        if: steps.check.outputs.should-cleanup == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
+          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
+        run: |
+          SSH_KEY_FILE="$HOME/.ssh/metal.pem"
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $SSH_KEY_FILE"
+
+          # Parse hosts into array
+          IFS=',' read -ra HOSTS <<< "$METAL_HOSTS"
+          echo "Checking ${#HOSTS[@]} metal hosts for PR $PR_NUMBER..."
+
+          # Check each host for this PR's lock or runner directory
+          for host in "${HOSTS[@]}"; do
+            echo ""
+            echo "Checking host: $host"
+
+            # Check if lock exists for this PR
+            lock_pr=$(ssh $SSH_OPTS ${METAL_USER}@${host} "cat /opt/vm0-runner/.lock/pr 2>/dev/null" || echo "")
+
+            # Also check if runner directory exists for this PR
+            runner_exists=$(ssh $SSH_OPTS ${METAL_USER}@${host} "test -d /opt/vm0-runner/pr-${PR_NUMBER} && echo 'yes'" || echo "")
+
+            if [ "$lock_pr" = "$PR_NUMBER" ] || [ "$runner_exists" = "yes" ]; then
+              echo "Found PR $PR_NUMBER on $host, cleaning up..."
+
+              # Run Ansible cleanup
+              cd ansible
+              ansible-playbook \
+                -i "${host}," \
+                playbooks/cleanup-runner.yml \
+                --private-key "$SSH_KEY_FILE" \
+                -e "ansible_user=${METAL_USER}" \
+                -e "pr_number=${PR_NUMBER}" \
+                -v || true
+              cd ..
+
+              # Release lock if it belongs to this PR
+              if [ "$lock_pr" = "$PR_NUMBER" ]; then
+                ssh $SSH_OPTS ${METAL_USER}@${host} "rm -rf /opt/vm0-runner/.lock" || true
+                echo "Released lock on $host"
+              fi
+
+              echo "Cleanup complete on $host"
+            else
+              echo "PR $PR_NUMBER not found on $host (lock_pr='$lock_pr', runner_exists='$runner_exists')"
+            fi
+          done
+
+          echo ""
+          echo "Cleanup complete"
 
   cleanup-database:
     runs-on: ubuntu-latest

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -5,84 +5,8 @@ on:
     types: [closed]
 
 jobs:
-  cleanup-runner:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:4f3a2d7
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Check if cleanup needed
-        id: check
-        env:
-          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
-          SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
-        run: |
-          if [ -z "$SSH_KEY" ] || [ -z "$METAL_HOSTS" ]; then
-            echo "Metal secrets not available, skipping runner cleanup"
-            echo "should-cleanup=false" >> $GITHUB_OUTPUT
-          else
-            echo "should-cleanup=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Cleanup Runner with Ansible (Brute Force)
-        if: steps.check.outputs.should-cleanup == 'true'
-        shell: bash
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
-          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
-          SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
-        run: |
-          # Setup SSH key
-          mkdir -p ~/.ssh
-          echo "$SSH_KEY" > ~/.ssh/metal.pem
-          chmod 600 ~/.ssh/metal.pem
-          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i ~/.ssh/metal.pem"
-
-          # Parse hosts into array
-          IFS=',' read -ra HOSTS <<< "$METAL_HOSTS"
-          echo "Checking ${#HOSTS[@]} metal hosts for PR $PR_NUMBER..."
-
-          # Check each host for this PR's lock or runner directory
-          for host in "${HOSTS[@]}"; do
-            echo ""
-            echo "Checking host: $host"
-
-            # Check if lock exists for this PR
-            lock_pr=$(ssh $SSH_OPTS ${METAL_USER}@${host} "cat /opt/vm0-runner/.lock/pr 2>/dev/null" || echo "")
-
-            # Also check if runner directory exists for this PR
-            runner_exists=$(ssh $SSH_OPTS ${METAL_USER}@${host} "test -d /opt/vm0-runner/pr-${PR_NUMBER} && echo 'yes'" || echo "")
-
-            if [ "$lock_pr" = "$PR_NUMBER" ] || [ "$runner_exists" = "yes" ]; then
-              echo "Found PR $PR_NUMBER on $host, cleaning up..."
-
-              # Run Ansible cleanup
-              cd ansible
-              ansible-playbook \
-                -i "${host}," \
-                playbooks/cleanup-runner.yml \
-                --private-key ~/.ssh/metal.pem \
-                -e "ansible_user=${METAL_USER}" \
-                -e "pr_number=${PR_NUMBER}" \
-                -v || true
-              cd ..
-
-              # Release lock if it belongs to this PR
-              if [ "$lock_pr" = "$PR_NUMBER" ]; then
-                ssh $SSH_OPTS ${METAL_USER}@${host} "rm -rf /opt/vm0-runner/.lock" || true
-                echo "Released lock on $host"
-              fi
-
-              echo "Cleanup complete on $host"
-            else
-              echo "PR $PR_NUMBER not found on $host (lock_pr='$lock_pr', runner_exists='$runner_exists')"
-            fi
-          done
-
-          echo ""
-          echo "Brute force cleanup complete"
+  # Note: Runner cleanup is now handled by the cleanup-runner job in turbo.yml
+  # which runs immediately after tests complete (not on PR close)
 
   cleanup-database:
     runs-on: ubuntu-latest

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -833,54 +833,21 @@ jobs:
           echo "runner-deployed=true" >> $GITHUB_OUTPUT
           echo "Runner started at ${RUNNER_DIR} on ${RUNNER_HOST}"
 
-  # Cleanup runner after cli-e2e-03-runner completes (or fails/times out)
-  # Stops PM2 process, removes runner directory, and releases host lock
-  cleanup-runner:
+  # Release runner host lock after cli-e2e-03-runner completes (or fails/times out)
+  # Note: Runner cleanup happens in cleanup.yml when PR is closed (to allow reruns)
+  unlock-runner-host:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:4f3a2d7
     needs: [deploy-runner-prepare, cli-e2e-03-runner]
     if: always() && needs.deploy-runner-prepare.outputs.runner-host != ''
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup SSH key
+      - name: Unlock runner host
         env:
+          RUNNER_HOST: ${{ needs.deploy-runner-prepare.outputs.runner-host }}
+          METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
           SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
         run: |
-          SSH_DIR="$HOME/.ssh"
-          SSH_KEY_FILE="$SSH_DIR/runner.pem"
-          mkdir -p "$SSH_DIR"
-          if [ -z "$SSH_KEY" ]; then
-            echo "ERROR: SSH_KEY secret is empty!"
-            exit 1
-          fi
-          echo "$SSH_KEY" > "$SSH_KEY_FILE"
-          chmod 600 "$SSH_KEY_FILE"
-          echo "SSH key file created at $SSH_KEY_FILE ($(wc -c < "$SSH_KEY_FILE") bytes)"
-
-      - name: Cleanup runner
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          RUNNER_HOST: ${{ needs.deploy-runner-prepare.outputs.runner-host }}
-          METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
-        run: |
-          echo "Cleaning up runner for PR $PR_NUMBER on $RUNNER_HOST"
-          cd ansible
-          ansible-playbook \
-            -i "${RUNNER_HOST}," \
-            playbooks/cleanup-runner.yml \
-            --private-key "$HOME/.ssh/runner.pem" \
-            -e "ansible_user=${METAL_USER}" \
-            -e "pr_number=${PR_NUMBER}" \
-            -v
-
-      - name: Release lock
-        if: always()
-        env:
-          RUNNER_HOST: ${{ needs.deploy-runner-prepare.outputs.runner-host }}
-          METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
-        run: |
-          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
-          ssh $SSH_OPTS ${METAL_USER}@${RUNNER_HOST} "rm -rf /opt/vm0-runner/.lock" || true
-          echo "Lock released on $RUNNER_HOST"
+          mkdir -p "$HOME/.ssh"
+          echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
+          chmod 600 "$HOME/.ssh/runner.pem"
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i "$HOME/.ssh/runner.pem" ${METAL_USER}@${RUNNER_HOST} "rm -rf /opt/vm0-runner/.lock" || true
+          echo "Unlocked runner host: $RUNNER_HOST"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -833,20 +833,54 @@ jobs:
           echo "runner-deployed=true" >> $GITHUB_OUTPUT
           echo "Runner started at ${RUNNER_DIR} on ${RUNNER_HOST}"
 
-  # Release runner host lock after cli-e2e-03-runner completes (or fails/times out)
-  unlock-runner-host:
+  # Cleanup runner after cli-e2e-03-runner completes (or fails/times out)
+  # Stops PM2 process, removes runner directory, and releases host lock
+  cleanup-runner:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:4f3a2d7
     needs: [deploy-runner-prepare, cli-e2e-03-runner]
     if: always() && needs.deploy-runner-prepare.outputs.runner-host != ''
     steps:
-      - name: Unlock runner host
+      - uses: actions/checkout@v4
+
+      - name: Setup SSH key
+        env:
+          SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
+        run: |
+          SSH_DIR="$HOME/.ssh"
+          SSH_KEY_FILE="$SSH_DIR/runner.pem"
+          mkdir -p "$SSH_DIR"
+          if [ -z "$SSH_KEY" ]; then
+            echo "ERROR: SSH_KEY secret is empty!"
+            exit 1
+          fi
+          echo "$SSH_KEY" > "$SSH_KEY_FILE"
+          chmod 600 "$SSH_KEY_FILE"
+          echo "SSH key file created at $SSH_KEY_FILE ($(wc -c < "$SSH_KEY_FILE") bytes)"
+
+      - name: Cleanup runner
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUNNER_HOST: ${{ needs.deploy-runner-prepare.outputs.runner-host }}
+          METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
+        run: |
+          echo "Cleaning up runner for PR $PR_NUMBER on $RUNNER_HOST"
+          cd ansible
+          ansible-playbook \
+            -i "${RUNNER_HOST}," \
+            playbooks/cleanup-runner.yml \
+            --private-key "$HOME/.ssh/runner.pem" \
+            -e "ansible_user=${METAL_USER}" \
+            -e "pr_number=${PR_NUMBER}" \
+            -v
+
+      - name: Release lock
+        if: always()
         env:
           RUNNER_HOST: ${{ needs.deploy-runner-prepare.outputs.runner-host }}
           METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
-          SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
         run: |
-          mkdir -p "$HOME/.ssh"
-          echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
-          chmod 600 "$HOME/.ssh/runner.pem"
-          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i "$HOME/.ssh/runner.pem" ${METAL_USER}@${RUNNER_HOST} "rm -rf /opt/vm0-runner/.lock" || true
-          echo "Unlocked runner host: $RUNNER_HOST"
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
+          ssh $SSH_OPTS ${METAL_USER}@${RUNNER_HOST} "rm -rf /opt/vm0-runner/.lock" || true
+          echo "Lock released on $RUNNER_HOST"

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,5 +1,5 @@
 // VM0 Runner - Self-hosted runner for the VM0 platform
-// Connects to the VM0 API server to poll and execute jobs in Firecracker microVMs
+// Connects to the VM0 API server to poll and execute jobs in isolated Firecracker microVMs
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { statusCommand } from "./commands/status.js";


### PR DESCRIPTION
## Summary

- Fix SSH key handling in `cleanup.yml` that was causing runner cleanup to silently fail
- Use `$HOME/.ssh/` instead of `~/.ssh/` for proper path expansion in container
- Split SSH setup into separate step with file size validation

## Problem

The `cleanup-runner` job in `cleanup.yml` was failing silently due to SSH key issues:
- Used `~/.ssh/metal.pem` path which didn't expand correctly in container
- No validation that SSH key file was created
- Failed SSH commands returned empty strings, interpreted as "nothing to clean up"

This caused orphaned runners (PM2 processes and directories) to accumulate on metal hosts.

## Solution

Fix SSH handling in `cleanup.yml`:
1. **Setup SSH key** - Separate step using `$HOME/.ssh/` with file size validation
2. **Cleanup runner on metal hosts** - Uses the validated SSH key file

Keep cleanup on PR close (not at test completion) to allow CLI E2E test reruns.

## Test plan

- [ ] Close a PR that deployed a runner
- [ ] Verify `cleanup-runner` job runs successfully (no SSH errors)
- [ ] Check metal host: PM2 process stopped, directory removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)