### PR TITLE
fix(ci): add shell: bash to cleanup runner step

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Cleanup runner on metal hosts
         if: steps.check.outputs.should-cleanup == 'true'
+        shell: bash
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,5 +1,5 @@
 // VM0 Runner - Self-hosted runner for the VM0 platform
-// Connects to the VM0 API server to poll and execute jobs in isolated Firecracker microVMs
+// Polls the VM0 API server and executes jobs in isolated Firecracker microVMs
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { statusCommand } from "./commands/status.js";


### PR DESCRIPTION
## Summary

Add `shell: bash` to the cleanup runner step in cleanup.yml.

## Problem

The cleanup step uses bash-specific syntax:
- `<<<` (here-string)  
- `read -ra` (array assignment)

These don't work with the default `sh` shell in containers, causing:
```
Syntax error: redirection unexpected
```

## Solution

Add `shell: bash` to the step to ensure bash syntax works correctly.

## Test plan

- [ ] Merge this PR
- [ ] Verify cleanup workflow runs successfully on PR close

🤖 Generated with [Claude Code](https://claude.com/claude-code)