### PR TITLE
ci: add concurrency config to cancel outdated workflow runs

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [closed]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cleanup-runner:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,10 @@ on:
       - '.docker/toolchain/**'
       - '.github/workflows/docker-*.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,6 +8,10 @@ on:
       - '.docker/toolchain/**'
       - '.github/workflows/docker-*.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/e2b-template.yml
+++ b/.github/workflows/e2b-template.yml
@@ -16,6 +16,10 @@ on:
       - "turbo/scripts/e2b/vm0-codex/**"
       - ".github/workflows/e2b-template.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-e2b-template:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - '.vm0/agents/docs-writer/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: .vm0/agents/docs-writer

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: 'do the job'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: .vm0/agents/docs-writer

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -14,6 +14,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Detect changes in apps to optimize CI pipeline
   change-detection:


### PR DESCRIPTION
## Summary
- Add `concurrency` configuration to all 8 GitHub Actions workflow files
- When a new commit is pushed to the same PR, previous running workflows will be automatically cancelled

## Changes
Added the following config to each workflow file:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Files modified:
- `.github/workflows/turbo.yml`
- `.github/workflows/docker-build.yml`
- `.github/workflows/docker-publish.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/run.yml`
- `.github/workflows/e2b-template.yml`
- `.github/workflows/cleanup.yml`
- `.github/workflows/release-please.yml`

## Test plan
- [ ] Verify workflows still trigger correctly on PR creation
- [ ] Verify pushing new commits cancels previous running workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)