### PR TITLE
fix(ci): remove concurrency from turbo workflow to ensure unlock runs

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -14,10 +14,6 @@ on:
         type: boolean
         default: false
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   # Detect changes in apps to optimize CI pipeline
   change-detection:


### PR DESCRIPTION
## Summary
- Remove `concurrency` configuration from `turbo.yml` workflow
- This ensures `unlock-runner-host` job always executes to release runner locks

## Problem
The turbo workflow uses runner host locking mechanism:
1. `lock-runner-host` acquires a lock before E2E tests
2. `unlock-runner-host` releases the lock after tests complete

With `cancel-in-progress: true`, when a new commit is pushed to the same PR:
- The old workflow is cancelled
- `unlock-runner-host` never runs
- The runner host stays locked until timeout (30 min)

## Solution
Remove concurrency config from turbo.yml only. Other workflows retain it since they don't have cleanup jobs that must always run.

## Test plan
- [ ] Push multiple commits to a PR quickly
- [ ] Verify old workflow is NOT cancelled (expected behavior now)
- [ ] Verify unlock-runner-host executes after cli-e2e completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)