### PR TITLE
fix(metrics): require AXIOM_DATASET_SUFFIX environment variable

### DIFF
--- a/.env.local.tpl
+++ b/.env.local.tpl
@@ -11,3 +11,4 @@ R2_USER_STORAGES_BUCKET_NAME=op://Development/vm0-env-local/r2_user_storages_buc
 
 # Axiom Observability
 AXIOM_TOKEN=op://Development/vm0-env-local/axiom_token
+AXIOM_DATASET_SUFFIX=dev

--- a/turbo/apps/runner/src/commands/start.ts
+++ b/turbo/apps/runner/src/commands/start.ts
@@ -120,10 +120,15 @@ export const startCommand = new Command("start")
       console.log("Config valid");
 
       // Initialize metrics (from AXIOM_TOKEN env var)
-      // Use explicit AXIOM_DATASET_SUFFIX if provided, otherwise infer from NODE_ENV
-      const datasetSuffix =
-        (process.env.AXIOM_DATASET_SUFFIX as "dev" | "prod" | undefined) ??
-        (process.env.NODE_ENV === "production" ? "prod" : "dev");
+      const datasetSuffix = process.env.AXIOM_DATASET_SUFFIX as
+        | "dev"
+        | "prod"
+        | undefined;
+      if (!datasetSuffix) {
+        throw new Error(
+          "AXIOM_DATASET_SUFFIX is required. Set to 'dev' or 'prod'.",
+        );
+      }
       initMetrics({
         serviceName: "vm0-runner",
         runnerLabel: config.name,

--- a/turbo/apps/web/src/lib/init-services.ts
+++ b/turbo/apps/web/src/lib/init-services.ts
@@ -87,17 +87,15 @@ export function initServices(): void {
   if (!_metricsInitialized) {
     _metricsInitialized = true;
     const envVars = _services.env;
-    // Use explicit AXIOM_DATASET_SUFFIX if provided, otherwise infer from environment
-    const datasetSuffix =
-      envVars.AXIOM_DATASET_SUFFIX ??
-      (process.env.VERCEL_ENV === "production" ||
-      process.env.NODE_ENV === "production"
-        ? "prod"
-        : "dev");
+    if (!envVars.AXIOM_DATASET_SUFFIX) {
+      throw new Error(
+        "AXIOM_DATASET_SUFFIX is required. Set to 'dev' or 'prod'.",
+      );
+    }
     initMetrics({
       serviceName: "vm0-web",
       axiomToken: envVars.AXIOM_TOKEN,
-      environment: datasetSuffix,
+      environment: envVars.AXIOM_DATASET_SUFFIX,
     });
   }
 }

--- a/turbo/apps/web/src/test/setup.ts
+++ b/turbo/apps/web/src/test/setup.ts
@@ -21,3 +21,4 @@ vi.mock("@clerk/nextjs/server", () => ({
 process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
   "pk_test_mock_instance.clerk.accounts.dev$";
 process.env.CLERK_SECRET_KEY = "sk_test_mock_secret_key_for_testing";
+process.env.AXIOM_DATASET_SUFFIX = "dev";

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -28,7 +28,8 @@
     "OFFICIAL_RUNNER_SECRET",
     "USE_MOCK_CLAUDE",
     "CRON_SECRET",
-    "AXIOM_TOKEN"
+    "AXIOM_TOKEN",
+    "AXIOM_DATASET_SUFFIX"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary
- Remove fallback logic that inferred dataset suffix from NODE_ENV or VERCEL_ENV
- Both web and runner now fail fast with a clear error if AXIOM_DATASET_SUFFIX is not set
- Prevents metrics from accidentally going to the wrong Axiom dataset

## Test plan
- [ ] Verify web fails to start without AXIOM_DATASET_SUFFIX
- [ ] Verify runner fails to start without AXIOM_DATASET_SUFFIX
- [ ] Verify CI passes with AXIOM_DATASET_SUFFIX=dev set in workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)