### PR TITLE
feat(schedule): add vm0 schedule init interactive wizard

### DIFF
--- a/turbo/apps/cli/src/commands/schedule/__tests__/init.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/init.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import {
+  generateCronExpression,
+  detectTimezone,
+  extractVarsAndSecrets,
+  validateTimeFormat,
+} from "../../../lib/schedule-utils";
+
+// Mock fs module for file-based tests
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  };
+});
+
+describe("schedule init utilities", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("generateCronExpression", () => {
+    it("should generate daily cron expression", () => {
+      expect(generateCronExpression("daily", "09:00")).toBe("0 9 * * *");
+      expect(generateCronExpression("daily", "14:30")).toBe("30 14 * * *");
+      expect(generateCronExpression("daily", "00:00")).toBe("0 0 * * *");
+      expect(generateCronExpression("daily", "23:59")).toBe("59 23 * * *");
+    });
+
+    it("should generate weekly cron expression", () => {
+      // Monday = 1
+      expect(generateCronExpression("weekly", "09:00", 1)).toBe("0 9 * * 1");
+      // Sunday = 0
+      expect(generateCronExpression("weekly", "10:30", 0)).toBe("30 10 * * 0");
+      // Friday = 5
+      expect(generateCronExpression("weekly", "17:00", 5)).toBe("0 17 * * 5");
+    });
+
+    it("should generate monthly cron expression", () => {
+      expect(generateCronExpression("monthly", "09:00", 1)).toBe("0 9 1 * *");
+      expect(generateCronExpression("monthly", "12:00", 15)).toBe("0 12 15 * *");
+      expect(generateCronExpression("monthly", "23:00", 31)).toBe("0 23 31 * *");
+    });
+
+    it("should use default day when not provided", () => {
+      // Weekly defaults to Monday (1)
+      expect(generateCronExpression("weekly", "09:00")).toBe("0 9 * * 1");
+      // Monthly defaults to 1st
+      expect(generateCronExpression("monthly", "09:00")).toBe("0 9 1 * *");
+    });
+  });
+
+  describe("detectTimezone", () => {
+    it("should return a valid IANA timezone", () => {
+      const tz = detectTimezone();
+      expect(tz).toBeTruthy();
+      expect(typeof tz).toBe("string");
+      // Should be a valid timezone that Intl can recognize
+      expect(() => {
+        Intl.DateTimeFormat(undefined, { timeZone: tz });
+      }).not.toThrow();
+    });
+  });
+
+  describe("validateTimeFormat", () => {
+    it("should accept valid time formats", () => {
+      expect(validateTimeFormat("09:00")).toBe(true);
+      expect(validateTimeFormat("9:00")).toBe(true);
+      expect(validateTimeFormat("00:00")).toBe(true);
+      expect(validateTimeFormat("23:59")).toBe(true);
+      expect(validateTimeFormat("12:30")).toBe(true);
+    });
+
+    it("should reject invalid time formats", () => {
+      expect(validateTimeFormat("9")).toBe("Invalid format. Use HH:MM (e.g., 09:00)");
+      expect(validateTimeFormat("900")).toBe("Invalid format. Use HH:MM (e.g., 09:00)");
+      expect(validateTimeFormat("9:0")).toBe("Invalid format. Use HH:MM (e.g., 09:00)");
+      expect(validateTimeFormat("")).toBe("Invalid format. Use HH:MM (e.g., 09:00)");
+    });
+
+    it("should reject out of range hours", () => {
+      expect(validateTimeFormat("24:00")).toBe("Hour must be 0-23");
+      expect(validateTimeFormat("25:00")).toBe("Hour must be 0-23");
+    });
+
+    it("should reject out of range minutes", () => {
+      expect(validateTimeFormat("09:60")).toBe("Minute must be 0-59");
+      expect(validateTimeFormat("09:99")).toBe("Minute must be 0-59");
+    });
+  });
+
+  describe("extractVarsAndSecrets", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("should return empty arrays when vm0.yaml does not exist", () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const result = extractVarsAndSecrets();
+      expect(result).toEqual({ vars: [], secrets: [] });
+    });
+
+    it("should extract experimental_vars and experimental_secrets", () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(`
+version: "1.0"
+agents:
+  my-agent:
+    provider: anthropic
+    experimental_vars:
+      - API_KEY
+      - BASE_URL
+    experimental_secrets:
+      - DATABASE_URL
+      - API_SECRET
+`);
+
+      const result = extractVarsAndSecrets();
+      expect(result.vars).toContain("API_KEY");
+      expect(result.vars).toContain("BASE_URL");
+      expect(result.secrets).toContain("DATABASE_URL");
+      expect(result.secrets).toContain("API_SECRET");
+    });
+
+    it("should extract vars and secrets from environment patterns", () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(`
+version: "1.0"
+agents:
+  my-agent:
+    provider: anthropic
+    environment:
+      MY_VAR: "\${{ vars.MY_VAR }}"
+      MY_SECRET: "\${{ secrets.MY_SECRET }}"
+      ANOTHER: "\${{ vars.ANOTHER }}"
+`);
+
+      const result = extractVarsAndSecrets();
+      expect(result.vars).toContain("MY_VAR");
+      expect(result.vars).toContain("ANOTHER");
+      expect(result.secrets).toContain("MY_SECRET");
+    });
+
+    it("should not duplicate variable names", () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(`
+version: "1.0"
+agents:
+  my-agent:
+    provider: anthropic
+    experimental_vars:
+      - API_KEY
+    environment:
+      KEY1: "\${{ vars.API_KEY }}"
+      KEY2: "\${{ vars.API_KEY }}"
+`);
+
+      const result = extractVarsAndSecrets();
+      // API_KEY should only appear once
+      expect(result.vars.filter((v) => v === "API_KEY")).toHaveLength(1);
+    });
+
+    it("should handle parse errors gracefully", () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue("invalid: yaml: content:");
+
+      const result = extractVarsAndSecrets();
+      expect(result).toEqual({ vars: [], secrets: [] });
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/schedule/__tests__/init.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/init.test.ts
@@ -42,8 +42,12 @@ describe("schedule init utilities", () => {
 
     it("should generate monthly cron expression", () => {
       expect(generateCronExpression("monthly", "09:00", 1)).toBe("0 9 1 * *");
-      expect(generateCronExpression("monthly", "12:00", 15)).toBe("0 12 15 * *");
-      expect(generateCronExpression("monthly", "23:00", 31)).toBe("0 23 31 * *");
+      expect(generateCronExpression("monthly", "12:00", 15)).toBe(
+        "0 12 15 * *",
+      );
+      expect(generateCronExpression("monthly", "23:00", 31)).toBe(
+        "0 23 31 * *",
+      );
     });
 
     it("should use default day when not provided", () => {
@@ -76,10 +80,18 @@ describe("schedule init utilities", () => {
     });
 
     it("should reject invalid time formats", () => {
-      expect(validateTimeFormat("9")).toBe("Invalid format. Use HH:MM (e.g., 09:00)");
-      expect(validateTimeFormat("900")).toBe("Invalid format. Use HH:MM (e.g., 09:00)");
-      expect(validateTimeFormat("9:0")).toBe("Invalid format. Use HH:MM (e.g., 09:00)");
-      expect(validateTimeFormat("")).toBe("Invalid format. Use HH:MM (e.g., 09:00)");
+      expect(validateTimeFormat("9")).toBe(
+        "Invalid format. Use HH:MM (e.g., 09:00)",
+      );
+      expect(validateTimeFormat("900")).toBe(
+        "Invalid format. Use HH:MM (e.g., 09:00)",
+      );
+      expect(validateTimeFormat("9:0")).toBe(
+        "Invalid format. Use HH:MM (e.g., 09:00)",
+      );
+      expect(validateTimeFormat("")).toBe(
+        "Invalid format. Use HH:MM (e.g., 09:00)",
+      );
     });
 
     it("should reject out of range hours", () => {

--- a/turbo/apps/cli/src/commands/schedule/__tests__/init.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/init.test.ts
@@ -5,7 +5,7 @@ import {
   detectTimezone,
   extractVarsAndSecrets,
   validateTimeFormat,
-} from "../../../lib/schedule-utils";
+} from "../../../lib/domain/schedule-utils";
 
 // Mock fs module for file-based tests
 vi.mock("fs", async () => {

--- a/turbo/apps/cli/src/commands/schedule/index.ts
+++ b/turbo/apps/cli/src/commands/schedule/index.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { initCommand } from "./init";
 import { deployCommand } from "./deploy";
 import { listCommand } from "./list";
 import { statusCommand } from "./status";
@@ -9,6 +10,7 @@ import { disableCommand } from "./disable";
 export const scheduleCommand = new Command()
   .name("schedule")
   .description("Manage agent schedules")
+  .addCommand(initCommand)
   .addCommand(deployCommand)
   .addCommand(listCommand)
   .addCommand(statusCommand)

--- a/turbo/apps/cli/src/commands/schedule/init.ts
+++ b/turbo/apps/cli/src/commands/schedule/init.ts
@@ -79,15 +79,9 @@ export const initCommand = new Command()
   .name("init")
   .description("Create a schedule.yaml interactively")
   .option("-n, --name <name>", "Schedule name")
-  .option(
-    "-f, --frequency <type>",
-    "Frequency: daily|weekly|monthly|once",
-  )
+  .option("-f, --frequency <type>", "Frequency: daily|weekly|monthly|once")
   .option("-t, --time <HH:MM>", "Time to run (24-hour format)")
-  .option(
-    "-d, --day <day>",
-    "Day of week (mon-sun) or day of month (1-31)",
-  )
+  .option("-d, --day <day>", "Day of week (mon-sun) or day of month (1-31)")
   .option("-z, --timezone <tz>", "IANA timezone")
   .option("-p, --prompt <text>", "Prompt to run")
   .option("--no-vars", "Don't include vars from vm0.yaml")
@@ -139,7 +133,9 @@ export const initCommand = new Command()
         let scheduleName = options.name;
         if (!scheduleName) {
           if (!isInteractive()) {
-            console.error(chalk.red("✗ --name is required in non-interactive mode"));
+            console.error(
+              chalk.red("✗ --name is required in non-interactive mode"),
+            );
             process.exit(1);
           }
           scheduleName = await promptText(
@@ -194,11 +190,7 @@ export const initCommand = new Command()
             }
           } else if (isInteractive()) {
             if (frequency === "weekly") {
-              day = await promptSelect(
-                "Day of week",
-                DAY_OF_WEEK_CHOICES,
-                0,
-              );
+              day = await promptSelect("Day of week", DAY_OF_WEEK_CHOICES, 0);
               if (day === undefined) {
                 console.log(chalk.dim("Cancelled"));
                 return;
@@ -257,7 +249,11 @@ export const initCommand = new Command()
               console.error(chalk.red("✗ --time is required (HH:MM format)"));
               process.exit(1);
             }
-            time = await promptText("Time (HH:MM)", "09:00", validateTimeFormat);
+            time = await promptText(
+              "Time (HH:MM)",
+              "09:00",
+              validateTimeFormat,
+            );
             if (!time) {
               console.log(chalk.dim("Cancelled"));
               return;
@@ -378,11 +374,8 @@ export const initCommand = new Command()
         if (atTime) {
           scheduleYaml.schedules[scheduleName]!.on.at = atTime;
         } else if (time && frequency !== "once") {
-          scheduleYaml.schedules[scheduleName]!.on.cron = generateCronExpression(
-            frequency,
-            time,
-            day,
-          );
+          scheduleYaml.schedules[scheduleName]!.on.cron =
+            generateCronExpression(frequency, time, day);
         }
 
         // Add vars and secrets

--- a/turbo/apps/cli/src/commands/schedule/init.ts
+++ b/turbo/apps/cli/src/commands/schedule/init.ts
@@ -1,0 +1,408 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { existsSync, writeFileSync } from "fs";
+import { stringify as stringifyYaml } from "yaml";
+import {
+  isInteractive,
+  promptText,
+  promptConfirm,
+  promptSelect,
+} from "../../lib/prompt-utils";
+import {
+  loadAgentName,
+  generateCronExpression,
+  detectTimezone,
+  extractVarsAndSecrets,
+  validateTimeFormat,
+  type ScheduleFrequency,
+} from "../../lib/schedule-utils";
+
+const SCHEDULE_FILE = "schedule.yaml";
+
+const FREQUENCY_CHOICES = [
+  { title: "Daily", value: "daily" as const, description: "Run every day" },
+  {
+    title: "Weekly",
+    value: "weekly" as const,
+    description: "Run once per week",
+  },
+  {
+    title: "Monthly",
+    value: "monthly" as const,
+    description: "Run once per month",
+  },
+  {
+    title: "One-time",
+    value: "once" as const,
+    description: "Run once at specific time",
+  },
+];
+
+const DAY_OF_WEEK_CHOICES = [
+  { title: "Monday", value: 1 },
+  { title: "Tuesday", value: 2 },
+  { title: "Wednesday", value: 3 },
+  { title: "Thursday", value: 4 },
+  { title: "Friday", value: 5 },
+  { title: "Saturday", value: 6 },
+  { title: "Sunday", value: 0 },
+];
+
+/**
+ * Parse day option for weekly (mon-sun) or monthly (1-31)
+ */
+function parseDayOption(
+  day: string,
+  frequency: ScheduleFrequency,
+): number | undefined {
+  if (frequency === "weekly") {
+    const dayMap: Record<string, number> = {
+      sun: 0,
+      mon: 1,
+      tue: 2,
+      wed: 3,
+      thu: 4,
+      fri: 5,
+      sat: 6,
+    };
+    return dayMap[day.toLowerCase()];
+  } else if (frequency === "monthly") {
+    const num = parseInt(day, 10);
+    if (num >= 1 && num <= 31) {
+      return num;
+    }
+  }
+  return undefined;
+}
+
+export const initCommand = new Command()
+  .name("init")
+  .description("Create a schedule.yaml interactively")
+  .option("-n, --name <name>", "Schedule name")
+  .option(
+    "-f, --frequency <type>",
+    "Frequency: daily|weekly|monthly|once",
+  )
+  .option("-t, --time <HH:MM>", "Time to run (24-hour format)")
+  .option(
+    "-d, --day <day>",
+    "Day of week (mon-sun) or day of month (1-31)",
+  )
+  .option("-z, --timezone <tz>", "IANA timezone")
+  .option("-p, --prompt <text>", "Prompt to run")
+  .option("--no-vars", "Don't include vars from vm0.yaml")
+  .option("--force", "Overwrite existing schedule.yaml")
+  .action(
+    async (options: {
+      name?: string;
+      frequency?: string;
+      time?: string;
+      day?: string;
+      timezone?: string;
+      prompt?: string;
+      vars: boolean;
+      force?: boolean;
+    }) => {
+      try {
+        // 1. Check vm0.yaml exists
+        const { agentName, error } = loadAgentName();
+        if (error) {
+          console.error(chalk.red(`✗ Invalid vm0.yaml: ${error}`));
+          process.exit(1);
+        }
+        if (!agentName) {
+          console.error(chalk.red("✗ No vm0.yaml found"));
+          console.error(
+            chalk.dim("  Run this command from an agent directory"),
+          );
+          process.exit(1);
+        }
+
+        // 2. Check if schedule.yaml exists
+        if (existsSync(SCHEDULE_FILE) && !options.force) {
+          if (!isInteractive()) {
+            console.error(chalk.red("✗ schedule.yaml already exists"));
+            console.error(chalk.dim("  Use --force to overwrite"));
+            process.exit(1);
+          }
+          const overwrite = await promptConfirm(
+            "schedule.yaml exists. Overwrite?",
+            false,
+          );
+          if (!overwrite) {
+            console.log(chalk.dim("Cancelled"));
+            return;
+          }
+        }
+
+        // 3. Gather schedule name
+        let scheduleName = options.name;
+        if (!scheduleName) {
+          if (!isInteractive()) {
+            console.error(chalk.red("✗ --name is required in non-interactive mode"));
+            process.exit(1);
+          }
+          scheduleName = await promptText(
+            "Schedule name",
+            `${agentName}-schedule`,
+          );
+          if (!scheduleName) {
+            console.log(chalk.dim("Cancelled"));
+            return;
+          }
+        }
+
+        // 4. Gather frequency
+        let frequency: ScheduleFrequency | undefined = options.frequency as
+          | ScheduleFrequency
+          | undefined;
+        if (
+          !frequency ||
+          !["daily", "weekly", "monthly", "once"].includes(frequency)
+        ) {
+          if (!isInteractive()) {
+            console.error(
+              chalk.red(
+                "✗ --frequency is required (daily|weekly|monthly|once)",
+              ),
+            );
+            process.exit(1);
+          }
+          frequency = await promptSelect<ScheduleFrequency>(
+            "Schedule frequency",
+            FREQUENCY_CHOICES,
+            0,
+          );
+          if (!frequency) {
+            console.log(chalk.dim("Cancelled"));
+            return;
+          }
+        }
+
+        // 5. Gather day (for weekly/monthly)
+        let day: number | undefined;
+        if (frequency === "weekly" || frequency === "monthly") {
+          if (options.day) {
+            day = parseDayOption(options.day, frequency);
+            if (day === undefined) {
+              console.error(
+                chalk.red(
+                  `✗ Invalid day: ${options.day}. Use mon-sun for weekly or 1-31 for monthly.`,
+                ),
+              );
+              process.exit(1);
+            }
+          } else if (isInteractive()) {
+            if (frequency === "weekly") {
+              day = await promptSelect(
+                "Day of week",
+                DAY_OF_WEEK_CHOICES,
+                0,
+              );
+              if (day === undefined) {
+                console.log(chalk.dim("Cancelled"));
+                return;
+              }
+            } else {
+              // Monthly - prompt for day number
+              const dayStr = await promptText("Day of month (1-31)", "1");
+              if (!dayStr) {
+                console.log(chalk.dim("Cancelled"));
+                return;
+              }
+              day = parseInt(dayStr, 10);
+              if (isNaN(day) || day < 1 || day > 31) {
+                console.error(chalk.red("✗ Day must be between 1 and 31"));
+                process.exit(1);
+              }
+            }
+          } else {
+            console.error(chalk.red("✗ --day is required for weekly/monthly"));
+            process.exit(1);
+          }
+        }
+
+        // 6. Gather time (for cron schedules)
+        let time: string | undefined = options.time;
+        let atTime: string | undefined;
+
+        if (frequency === "once") {
+          // One-time schedule needs ISO timestamp
+          if (!isInteractive()) {
+            console.error(
+              chalk.red("✗ One-time schedules require interactive mode"),
+            );
+            console.error(
+              chalk.dim("  Use cron frequency for non-interactive mode"),
+            );
+            process.exit(1);
+          }
+          const dateStr = await promptText(
+            "Date and time (YYYY-MM-DD HH:MM)",
+            new Date(Date.now() + 24 * 60 * 60 * 1000)
+              .toISOString()
+              .slice(0, 16)
+              .replace("T", " "),
+          );
+          if (!dateStr) {
+            console.log(chalk.dim("Cancelled"));
+            return;
+          }
+          // Convert to ISO
+          atTime = new Date(dateStr.replace(" ", "T") + ":00Z").toISOString();
+        } else {
+          // Cron schedule needs time
+          if (!time) {
+            if (!isInteractive()) {
+              console.error(chalk.red("✗ --time is required (HH:MM format)"));
+              process.exit(1);
+            }
+            time = await promptText("Time (HH:MM)", "09:00", validateTimeFormat);
+            if (!time) {
+              console.log(chalk.dim("Cancelled"));
+              return;
+            }
+          } else {
+            const validation = validateTimeFormat(time);
+            if (validation !== true) {
+              console.error(chalk.red(`✗ Invalid time: ${validation}`));
+              process.exit(1);
+            }
+          }
+        }
+
+        // 7. Gather timezone
+        const detectedTimezone = detectTimezone();
+        let timezone = options.timezone;
+        if (!timezone) {
+          if (isInteractive()) {
+            timezone = await promptText("Timezone", detectedTimezone);
+            if (!timezone) {
+              console.log(chalk.dim("Cancelled"));
+              return;
+            }
+          } else {
+            timezone = detectedTimezone;
+          }
+        }
+
+        // 8. Gather prompt
+        let promptText_ = options.prompt;
+        if (!promptText_) {
+          if (!isInteractive()) {
+            console.error(chalk.red("✗ --prompt is required"));
+            process.exit(1);
+          }
+          promptText_ = await promptText("Prompt to run");
+          if (!promptText_) {
+            console.log(chalk.dim("Cancelled"));
+            return;
+          }
+        }
+
+        // 9. Extract vars and secrets
+        let vars: Record<string, string> | undefined;
+        let secrets: Record<string, string> | undefined;
+
+        if (options.vars) {
+          const extracted = extractVarsAndSecrets();
+
+          if (extracted.vars.length > 0 || extracted.secrets.length > 0) {
+            let includeVars = true;
+            if (isInteractive()) {
+              const varList = [
+                ...extracted.vars.map((v) => `vars.${v}`),
+                ...extracted.secrets.map((s) => `secrets.${s}`),
+              ];
+              includeVars =
+                (await promptConfirm(
+                  `Include ${varList.length} variable(s) from vm0.yaml? (${varList.join(", ")})`,
+                  true,
+                )) ?? true;
+            }
+
+            if (includeVars) {
+              if (extracted.vars.length > 0) {
+                vars = {};
+                for (const v of extracted.vars) {
+                  vars[v] = `\${${v}}`;
+                }
+              }
+              if (extracted.secrets.length > 0) {
+                secrets = {};
+                for (const s of extracted.secrets) {
+                  secrets[s] = `\${${s}}`;
+                }
+              }
+            }
+          }
+        }
+
+        // 10. Build schedule.yaml content
+        interface ScheduleYaml {
+          version: "1.0";
+          schedules: Record<
+            string,
+            {
+              on: {
+                cron?: string;
+                at?: string;
+                timezone: string;
+              };
+              run: {
+                agent: string;
+                prompt: string;
+                vars?: Record<string, string>;
+                secrets?: Record<string, string>;
+              };
+            }
+          >;
+        }
+
+        const scheduleYaml: ScheduleYaml = {
+          version: "1.0",
+          schedules: {
+            [scheduleName]: {
+              on: {
+                timezone,
+              },
+              run: {
+                agent: agentName,
+                prompt: promptText_,
+              },
+            },
+          },
+        };
+
+        // Add trigger
+        if (atTime) {
+          scheduleYaml.schedules[scheduleName]!.on.at = atTime;
+        } else if (time && frequency !== "once") {
+          scheduleYaml.schedules[scheduleName]!.on.cron = generateCronExpression(
+            frequency,
+            time,
+            day,
+          );
+        }
+
+        // Add vars and secrets
+        if (vars && Object.keys(vars).length > 0) {
+          scheduleYaml.schedules[scheduleName]!.run.vars = vars;
+        }
+        if (secrets && Object.keys(secrets).length > 0) {
+          scheduleYaml.schedules[scheduleName]!.run.secrets = secrets;
+        }
+
+        // 11. Write file
+        writeFileSync(SCHEDULE_FILE, stringifyYaml(scheduleYaml));
+        console.log(chalk.green(`✓ Created ${SCHEDULE_FILE}`));
+        console.log(chalk.dim("  Deploy with: vm0 schedule deploy"));
+      } catch (error) {
+        console.error(chalk.red("✗ Failed to create schedule.yaml"));
+        if (error instanceof Error) {
+          console.error(chalk.dim(`  ${error.message}`));
+        }
+        process.exit(1);
+      }
+    },
+  );

--- a/turbo/apps/cli/src/commands/schedule/init.ts
+++ b/turbo/apps/cli/src/commands/schedule/init.ts
@@ -7,7 +7,7 @@ import {
   promptText,
   promptConfirm,
   promptSelect,
-} from "../../lib/prompt-utils";
+} from "../../lib/utils/prompt-utils";
 import {
   loadAgentName,
   generateCronExpression,
@@ -15,7 +15,7 @@ import {
   extractVarsAndSecrets,
   validateTimeFormat,
   type ScheduleFrequency,
-} from "../../lib/schedule-utils";
+} from "../../lib/domain/schedule-utils";
 
 const SCHEDULE_FILE = "schedule.yaml";
 

--- a/turbo/apps/cli/src/lib/domain/schedule-utils.ts
+++ b/turbo/apps/cli/src/lib/domain/schedule-utils.ts
@@ -84,3 +84,140 @@ export function formatDateTime(dateStr: string | null): string {
 
   return `${formatted} (${relative})`;
 }
+
+/**
+ * Frequency type for schedule wizard
+ */
+export type ScheduleFrequency = "daily" | "weekly" | "monthly" | "once";
+
+/**
+ * Generate cron expression from user-friendly inputs
+ * @param frequency - Schedule frequency type
+ * @param time - Time in HH:MM format (24-hour)
+ * @param day - Day of week (0-6, Sun=0) for weekly, or day of month (1-31) for monthly
+ * @returns Cron expression string
+ */
+export function generateCronExpression(
+  frequency: Exclude<ScheduleFrequency, "once">,
+  time: string,
+  day?: number,
+): string {
+  const [hourStr, minuteStr] = time.split(":");
+  const hour = parseInt(hourStr ?? "0", 10);
+  const minute = parseInt(minuteStr ?? "0", 10);
+
+  switch (frequency) {
+    case "daily":
+      return `${minute} ${hour} * * *`;
+    case "weekly":
+      return `${minute} ${hour} * * ${day ?? 1}`;
+    case "monthly":
+      return `${minute} ${hour} ${day ?? 1} * *`;
+  }
+}
+
+/**
+ * Detect system timezone using Intl API
+ * @returns IANA timezone identifier (e.g., "America/New_York")
+ */
+export function detectTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+/**
+ * Agent configuration within vm0.yaml
+ */
+interface AgentConfig {
+  experimental_vars?: string[];
+  experimental_secrets?: string[];
+  environment?: Record<string, string>;
+}
+
+/**
+ * Result of extracting vars and secrets from vm0.yaml
+ */
+export interface VarsAndSecrets {
+  vars: string[];
+  secrets: string[];
+}
+
+/**
+ * Extract variable and secret names from vm0.yaml
+ * Looks for experimental_vars, experimental_secrets, and ${{ vars.X }}, ${{ secrets.X }} patterns
+ */
+export function extractVarsAndSecrets(): VarsAndSecrets {
+  const result: VarsAndSecrets = { vars: [], secrets: [] };
+
+  if (!existsSync(CONFIG_FILE)) {
+    return result;
+  }
+
+  try {
+    const content = readFileSync(CONFIG_FILE, "utf8");
+    const config = parseYaml(content) as AgentComposeConfig;
+
+    // Get first agent's config
+    const agents = Object.values(config.agents || {}) as AgentConfig[];
+    const agent = agents[0];
+    if (!agent) {
+      return result;
+    }
+
+    // Collect from experimental_vars and experimental_secrets
+    if (agent.experimental_vars) {
+      result.vars.push(...agent.experimental_vars);
+    }
+    if (agent.experimental_secrets) {
+      result.secrets.push(...agent.experimental_secrets);
+    }
+
+    // Parse environment for ${{ vars.X }} and ${{ secrets.X }} patterns
+    if (agent.environment) {
+      for (const value of Object.values(agent.environment)) {
+        // Match ${{ vars.NAME }}
+        const varsMatches = value.matchAll(/\$\{\{\s*vars\.(\w+)\s*\}\}/g);
+        for (const match of varsMatches) {
+          if (match[1] && !result.vars.includes(match[1])) {
+            result.vars.push(match[1]);
+          }
+        }
+
+        // Match ${{ secrets.NAME }}
+        const secretsMatches = value.matchAll(/\$\{\{\s*secrets\.(\w+)\s*\}\}/g);
+        for (const match of secretsMatches) {
+          if (match[1] && !result.secrets.includes(match[1])) {
+            result.secrets.push(match[1]);
+          }
+        }
+      }
+    }
+
+    return result;
+  } catch {
+    return result;
+  }
+}
+
+/**
+ * Validate time format (HH:MM, 24-hour)
+ * @param time - Time string to validate
+ * @returns true if valid, error message if invalid
+ */
+export function validateTimeFormat(time: string): boolean | string {
+  const match = time.match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) {
+    return "Invalid format. Use HH:MM (e.g., 09:00)";
+  }
+
+  const hour = parseInt(match[1]!, 10);
+  const minute = parseInt(match[2]!, 10);
+
+  if (hour < 0 || hour > 23) {
+    return "Hour must be 0-23";
+  }
+  if (minute < 0 || minute > 59) {
+    return "Minute must be 0-59";
+  }
+
+  return true;
+}

--- a/turbo/apps/cli/src/lib/domain/schedule-utils.ts
+++ b/turbo/apps/cli/src/lib/domain/schedule-utils.ts
@@ -183,7 +183,9 @@ export function extractVarsAndSecrets(): VarsAndSecrets {
         }
 
         // Match ${{ secrets.NAME }}
-        const secretsMatches = value.matchAll(/\$\{\{\s*secrets\.(\w+)\s*\}\}/g);
+        const secretsMatches = value.matchAll(
+          /\$\{\{\s*secrets\.(\w+)\s*\}\}/g,
+        );
         for (const match of secretsMatches) {
           if (match[1] && !result.secrets.includes(match[1])) {
             result.secrets.push(match[1]);

--- a/turbo/apps/cli/src/lib/utils/prompt-utils.ts
+++ b/turbo/apps/cli/src/lib/utils/prompt-utils.ts
@@ -75,3 +75,47 @@ export async function promptConfirm(
 
   return response.value;
 }
+
+/**
+ * Choice option for select prompts
+ */
+export interface SelectChoice<T> {
+  title: string;
+  value: T;
+  description?: string;
+}
+
+/**
+ * Prompt for selecting from a list of options
+ * @param message - The prompt message
+ * @param choices - Array of choices with title, value, and optional description
+ * @param initial - Index of the default selection (0-based)
+ * @returns The selected value, or undefined if cancelled or non-interactive
+ */
+export async function promptSelect<T>(
+  message: string,
+  choices: SelectChoice<T>[],
+  initial?: number,
+): Promise<T | undefined> {
+  // In non-interactive mode, return undefined immediately
+  if (!isInteractive()) {
+    return undefined;
+  }
+
+  const response = await prompts(
+    {
+      type: "select",
+      name: "value",
+      message,
+      choices,
+      initial,
+    },
+    {
+      onCancel: () => {
+        return false;
+      },
+    },
+  );
+
+  return response.value;
+}


### PR DESCRIPTION
## Summary

- Add `vm0 schedule init` interactive wizard to create `schedule.yaml` without knowing raw cron syntax
- Frequency selection: daily, weekly, monthly, one-time
- Auto-detect system timezone using Intl API
- Extract vars/secrets from vm0.yaml
- Flag support for non-interactive mode (`--name`, `--frequency`, `--time`, etc.)

## Changes

- `turbo/apps/cli/src/commands/schedule/init.ts` - Main init command
- `turbo/apps/cli/src/lib/prompt-utils.ts` - Add `promptSelect` utility
- `turbo/apps/cli/src/lib/schedule-utils.ts` - Add cron generation, timezone detection, var extraction
- `turbo/apps/cli/src/commands/schedule/__tests__/init.test.ts` - Unit tests (14 tests)

## Usage

```bash
# Interactive mode
vm0 schedule init

# Non-interactive mode (all options via flags)
vm0 schedule init --name daily-report --frequency daily --time 09:00 \
  --timezone UTC --prompt "Run daily task" --no-vars
```

## Test plan

- [x] Unit tests for cron generation (daily/weekly/monthly)
- [x] Unit tests for timezone detection
- [x] Unit tests for time validation
- [x] Unit tests for var/secret extraction from vm0.yaml
- [x] Lint and type check pass
- [ ] Manual testing of interactive wizard

Closes #1186

🤖 Generated with [Claude Code](https://claude.com/claude-code)