### PR TITLE
feat(metrics): add sandbox internal metrics for operation timing

### DIFF
--- a/turbo/apps/web/src/lib/metrics/index.ts
+++ b/turbo/apps/web/src/lib/metrics/index.ts
@@ -4,4 +4,8 @@ export {
   flushMetrics,
   shutdownMetrics,
 } from "./provider";
-export { recordApiRequest, recordSandboxOperation } from "./instruments";
+export {
+  recordApiRequest,
+  recordSandboxOperation,
+  recordSandboxInternalOperation,
+} from "./instruments";

--- a/turbo/packages/core/src/contracts/webhooks.ts
+++ b/turbo/packages/core/src/contracts/webhooks.ts
@@ -260,6 +260,17 @@ const metricDataSchema = z.object({
 });
 
 /**
+ * Sandbox operation schema for internal sandbox operations (init, storage, cli, checkpoint, cleanup)
+ */
+const sandboxOperationSchema = z.object({
+  ts: z.string(),
+  action_type: z.string(),
+  duration_ms: z.number(),
+  success: z.boolean(),
+  error: z.string().optional(),
+});
+
+/**
  * Network log entry schema (from mitmproxy addon)
  *
  * Supports two modes:
@@ -289,7 +300,7 @@ const networkLogSchema = z.object({
 export const webhookTelemetryContract = c.router({
   /**
    * POST /api/webhooks/agent/telemetry
-   * Receive telemetry data (system log, metrics, and network logs) from sandbox
+   * Receive telemetry data (system log, metrics, network logs, and sandbox operations) from sandbox
    */
   send: {
     method: "POST",
@@ -299,6 +310,7 @@ export const webhookTelemetryContract = c.router({
       systemLog: z.string().optional(),
       metrics: z.array(metricDataSchema).optional(),
       networkLogs: z.array(networkLogSchema).optional(),
+      sandboxOperations: z.array(sandboxOperationSchema).optional(),
     }),
     responses: {
       200: z.object({

--- a/turbo/packages/core/src/sandbox/scripts/lib/common.py.ts
+++ b/turbo/packages/core/src/sandbox/scripts/lib/common.py.ts
@@ -77,6 +77,10 @@ NETWORK_LOG_FILE = f"/tmp/vm0-network-{RUN_ID}.jsonl"
 TELEMETRY_LOG_POS_FILE = f"/tmp/vm0-telemetry-log-pos-{RUN_ID}.txt"
 TELEMETRY_METRICS_POS_FILE = f"/tmp/vm0-telemetry-metrics-pos-{RUN_ID}.txt"
 TELEMETRY_NETWORK_POS_FILE = f"/tmp/vm0-telemetry-network-pos-{RUN_ID}.txt"
+TELEMETRY_SANDBOX_OPS_POS_FILE = f"/tmp/vm0-telemetry-sandbox-ops-pos-{RUN_ID}.txt"
+
+# Sandbox operations log file (JSONL format)
+SANDBOX_OPS_LOG_FILE = f"/tmp/vm0-sandbox-ops-{RUN_ID}.jsonl"
 
 # Metrics collection configuration
 METRICS_INTERVAL = 5  # seconds
@@ -90,4 +94,34 @@ def validate_config() -> bool:
     if not WORKING_DIR:
         raise ValueError("VM0_WORKING_DIR is required but not set")
     return True
+
+def record_sandbox_op(
+    action_type: str,
+    duration_ms: int,
+    success: bool,
+    error: str = None
+) -> None:
+    """
+    Record a sandbox operation to JSONL file for telemetry upload.
+
+    Args:
+        action_type: Operation name (e.g., "init_total", "storage_download", "cli_execution")
+        duration_ms: Duration in milliseconds
+        success: Whether the operation succeeded
+        error: Optional error message if failed
+    """
+    from datetime import datetime, timezone
+    import json
+
+    entry = {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+        "action_type": action_type,
+        "duration_ms": duration_ms,
+        "success": success,
+    }
+    if error:
+        entry["error"] = error
+
+    with open(SANDBOX_OPS_LOG_FILE, "a") as f:
+        f.write(json.dumps(entry) + "\\n")
 `;


### PR DESCRIPTION
## Summary
- Add OpenTelemetry metrics for sandbox internal operations with counter/histogram instruments
- Data flows from Python scripts → webhook → Axiom `sandbox-metric-{env}` dataset
- Labels: `action_type`, `sandbox_type` (no user dimension labels per requirements)

## Changes
- **Server-side**: Add sandbox metrics MeterProvider with separate Axiom exporter, `recordSandboxInternalOperation()` function
- **Contract**: Add `sandboxOperations` schema to `webhookTelemetryContract`
- **Python scripts**: Add `record_sandbox_op()` for timing instrumentation across run-agent, download, checkpoint, and direct_upload scripts

## Instrumented Operations
- Init phase: `heartbeat_start`, `metrics_collector_start`, `telemetry_upload_start`, `working_dir_setup`, `codex_login`, `init_total`
- Execution: `cli_execution`
- Download: `storage_download`, `artifact_download`, `download_total`
- Checkpoint: `session_id_read`, `session_history_read`, `checkpoint_api_call`, `checkpoint_total`
- Direct upload: `artifact_hash_compute`, `artifact_prepare_api`, `artifact_archive_create`, `artifact_s3_upload`, `artifact_commit_api`
- Cleanup: `final_telemetry_upload`, `complete_api_call`

## Test plan
- [x] Lint passes
- [x] Type check passes for web/core packages
- [ ] Verify metrics appear in Axiom dashboard after sandbox run

Closes #1174

🤖 Generated with [Claude Code](https://claude.ai/code)