### PR TITLE
ci: prevent workflow cancellation on main branch

### DIFF
--- a/.github/workflows/e2b-template.yml
+++ b/.github/workflows/e2b-template.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build-e2b-template:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # Detect changes in apps to optimize CI pipeline


### PR DESCRIPTION
## Summary
- **release-please**: disable `cancel-in-progress` entirely to prevent release workflows from being cancelled
- **turbo**: only cancel in-progress runs on PRs, not on main branch
- **e2b-template**: same as turbo, prevent cancellation on main

## Why
When multiple PRs are merged to main in quick succession, the `cancel-in-progress: true` setting causes later workflow runs to cancel earlier ones. This is problematic for:
- Release workflows that should always complete
- Main branch CI runs that downstream workflows (like release-please) depend on

## Test plan
- [ ] Verify PR workflows still cancel each other (same PR, new push)
- [ ] Verify main branch workflows no longer cancel each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)