### PR TITLE
docs: add troubleshooting tip for pre-commit hook and lint oom issues

### DIFF
--- a/.claude/commands/pr-create.md
+++ b/.claude/commands/pr-create.md
@@ -158,3 +158,8 @@ gh pr view --json url -q .url
    gh pr checks
    gh pr status
    ```
+
+6. If pre-commit hook hangs or lint runs out of memory (OOM), try clearing and reinstalling dependencies:
+   ```bash
+   cd turbo && rm -rf node_modules && pnpm install
+   ```


### PR DESCRIPTION
## Summary
- Add tip #6 to pr-create command documentation
- Documents workaround for pre-commit hook hangs and lint OOM issues
- Solution: `cd turbo && rm -rf node_modules && pnpm install`

## Test plan
- [x] Documentation change only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)