### PR TITLE
refactor: centralize oxlint configuration to reduce duplication

### DIFF
--- a/turbo/.oxlintrc.json
+++ b/turbo/.oxlintrc.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oxc-project/oxlint/main/npm/oxlint/configuration_schema.json",
+  "rules": {
+    "import/no-cycle": "error",
+    "import/no-self-import": "error",
+    "import/no-duplicates": "error",
+    "import/no-default-export": "error",
+    "import/no-named-default": "error",
+    "import/first": "error",
+    "import/no-amd": "error",
+    "import/no-commonjs": "error"
+  }
+}

--- a/turbo/apps/cli/.oxlintrc.json
+++ b/turbo/apps/cli/.oxlintrc.json
@@ -1,13 +1,4 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxlint/main/npm/oxlint/configuration_schema.json",
-  "rules": {
-    "import/no-cycle": "error",
-    "import/no-self-import": "error",
-    "import/no-duplicates": "error",
-    "import/no-default-export": "error",
-    "import/no-named-default": "error",
-    "import/first": "error",
-    "import/no-amd": "error",
-    "import/no-commonjs": "error"
-  }
+  "extends": ["../../.oxlintrc.json"]
 }

--- a/turbo/apps/docs/.oxlintrc.json
+++ b/turbo/apps/docs/.oxlintrc.json
@@ -1,13 +1,4 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxlint/main/npm/oxlint/configuration_schema.json",
-  "rules": {
-    "import/no-cycle": "error",
-    "import/no-self-import": "error",
-    "import/no-duplicates": "error",
-    "import/no-default-export": "error",
-    "import/no-named-default": "error",
-    "import/first": "error",
-    "import/no-amd": "error",
-    "import/no-commonjs": "error"
-  }
+  "extends": ["../../.oxlintrc.json"]
 }

--- a/turbo/apps/platform/.oxlintrc.json
+++ b/turbo/apps/platform/.oxlintrc.json
@@ -1,13 +1,4 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxlint/main/npm/oxlint/configuration_schema.json",
-  "rules": {
-    "import/no-cycle": "error",
-    "import/no-self-import": "error",
-    "import/no-duplicates": "error",
-    "import/no-default-export": "error",
-    "import/no-named-default": "error",
-    "import/first": "error",
-    "import/no-amd": "error",
-    "import/no-commonjs": "error"
-  }
+  "extends": ["../../.oxlintrc.json"]
 }

--- a/turbo/apps/runner/.oxlintrc.json
+++ b/turbo/apps/runner/.oxlintrc.json
@@ -1,13 +1,4 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxlint/main/npm/oxlint/configuration_schema.json",
-  "rules": {
-    "import/no-cycle": "error",
-    "import/no-self-import": "error",
-    "import/no-duplicates": "error",
-    "import/no-default-export": "error",
-    "import/no-named-default": "error",
-    "import/first": "error",
-    "import/no-amd": "error",
-    "import/no-commonjs": "error"
-  }
+  "extends": ["../../.oxlintrc.json"]
 }

--- a/turbo/apps/web/.oxlintrc.json
+++ b/turbo/apps/web/.oxlintrc.json
@@ -1,13 +1,4 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxlint/main/npm/oxlint/configuration_schema.json",
-  "rules": {
-    "import/no-cycle": "error",
-    "import/no-self-import": "error",
-    "import/no-duplicates": "error",
-    "import/no-default-export": "error",
-    "import/no-named-default": "error",
-    "import/first": "error",
-    "import/no-amd": "error",
-    "import/no-commonjs": "error"
-  }
+  "extends": ["../../.oxlintrc.json"]
 }

--- a/turbo/packages/core/.oxlintrc.json
+++ b/turbo/packages/core/.oxlintrc.json
@@ -1,13 +1,4 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxlint/main/npm/oxlint/configuration_schema.json",
-  "rules": {
-    "import/no-cycle": "error",
-    "import/no-self-import": "error",
-    "import/no-duplicates": "error",
-    "import/no-default-export": "error",
-    "import/no-named-default": "error",
-    "import/first": "error",
-    "import/no-amd": "error",
-    "import/no-commonjs": "error"
-  }
+  "extends": ["../../.oxlintrc.json"]
 }

--- a/turbo/packages/ui/.oxlintrc.json
+++ b/turbo/packages/ui/.oxlintrc.json
@@ -1,13 +1,4 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxlint/main/npm/oxlint/configuration_schema.json",
-  "rules": {
-    "import/no-cycle": "error",
-    "import/no-self-import": "error",
-    "import/no-duplicates": "error",
-    "import/no-default-export": "error",
-    "import/no-named-default": "error",
-    "import/first": "error",
-    "import/no-amd": "error",
-    "import/no-commonjs": "error"
-  }
+  "extends": ["../../.oxlintrc.json"]
 }


### PR DESCRIPTION
## Summary
- Move shared oxlint import rules to root `turbo/.oxlintrc.json`
- Update all 7 packages to extend from base config using `"extends"`
- Eliminate duplicate rule definitions across packages

## Benefits
- **DRY principle**: Rules defined once in root config
- **Easier maintenance**: Future rule updates only need one file change
- **Consistency**: All packages guaranteed to use identical rules
- **Flexibility**: Packages can still override or add specific rules if needed

## Technical Details
Uses oxlint's `extends` feature to inherit configuration from parent file. Each package now has minimal config:
```json
{
  "extends": ["../../.oxlintrc.json"]
}
```

Base config contains all 8 import rules previously duplicated across packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)