### PR TITLE
ci: enable debug logs in preview, disable in production

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -113,7 +113,6 @@ jobs:
             AXIOM_DATASET_SUFFIX=prod
             CRON_SECRET=${{ secrets.CRON_SECRET }}
             OFFICIAL_RUNNER_SECRET=${{ secrets.OFFICIAL_RUNNER_SECRET }}
-            DEBUG=*
 
   # Deploy docs app to production
   deploy-docs-production:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -252,6 +252,7 @@ jobs:
             AXIOM_DATASET_SUFFIX=dev
             USE_MOCK_CLAUDE=true
             CRON_SECRET=${{ secrets.CRON_SECRET }}
+            DEBUG=*
           meta-branch: ${{ github.head_ref }}
           meta-pr: ${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
## Summary
- Enable `DEBUG=*` in preview deployments (turbo.yml) for better debugging
- Disable `DEBUG=*` in production deployments (release-please.yml) to reduce log noise and improve performance

## Changes
- ✅ Added `DEBUG=*` to preview environment variables in `.github/workflows/turbo.yml`
- ✅ Removed `DEBUG=*` from production environment variables in `.github/workflows/release-please.yml`

## Result
| Environment | DEBUG Setting | Debug Logs Output |
|-------------|---------------|-------------------|
| Local Dev | Auto `DEBUG=*` (NODE_ENV=development) | ✅ Enabled |
| Preview (PR) | `DEBUG=*` | ✅ Enabled |
| Production | Not set | ❌ Disabled |

This aligns with the logger.ts documentation that states preview deployments should have DEBUG enabled for debugging purposes, while production should remain clean and performant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)