### PR TITLE
feat(web): add debug configuration status utility

### DIFF
--- a/turbo/apps/web/src/lib/logger.ts
+++ b/turbo/apps/web/src/lib/logger.ts
@@ -219,3 +219,19 @@ export async function flushLogs(): Promise<void> {
     console.error("[logger] Failed to flush logs to Axiom:", e);
   }
 }
+
+/**
+ * Get current debug configuration status.
+ * Useful for diagnostics and debugging logger behavior.
+ */
+export function getDebugConfig(): {
+  patterns: string[];
+  autoEnabled: boolean;
+  axiomEnabled: boolean;
+} {
+  return {
+    patterns: getDebugPatterns(),
+    autoEnabled: isAutoDebugEnabled(),
+    axiomEnabled: axiomLogger !== null,
+  };
+}


### PR DESCRIPTION
## Summary
- Added `getDebugConfig()` utility function to logger module
- Returns current debug configuration including patterns, auto-enable status, and Axiom integration status
- Useful for diagnostics and debugging logger behavior

## Test plan
- [ ] Verify function exports correctly from logger module
- [ ] Test that function returns expected configuration shape
- [ ] Confirm no breaking changes to existing logger functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)