### PR TITLE
fix(ci): use PR number for cleanup workflow concurrency group

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -5,7 +5,7 @@ on:
     types: [closed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -15,8 +15,8 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: ${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.head_ref != '' }}
 
 jobs:
   # Detect changes in apps to optimize CI pipeline


### PR DESCRIPTION
## Summary

- Unify concurrency group for `turbo.yml` and `cleanup.yml` using `${{ github.head_ref || github.ref }}`
- Both workflows now share the same concurrency group for the same PR branch

## Problem

The cleanup workflow was using `github.ref` as the concurrency group key, which for `pull_request_target` events resolves to the base branch (main), not the PR's head branch. This caused:

1. All cleanup workflows targeting main shared the same concurrency group
2. When multiple PRs closed simultaneously, cleanups cancelled each other
3. Runner resources were left orphaned

Additionally, `turbo.yml` and `cleanup.yml` were in separate concurrency groups, so:
- If user closed PR then reopened it, cleanup would continue running
- New turbo runs couldn't cancel the cleanup that was cleaning up resources the user needed

## Solution

Both workflows now use:
```yaml
concurrency:
  group: ${{ github.head_ref || github.ref }}
  cancel-in-progress: true  # (conditional for turbo.yml)
```

This ensures:
- Same PR branch → same concurrency group (turbo and cleanup coordinate)
- Different PR branches → different groups (no interference)
- Non-PR events (push to main) → fallback to `github.ref`

## Behavior after fix

| Scenario | Behavior |
|----------|----------|
| Two PRs close simultaneously | Each has own group, both cleanups run ✓ |
| PR closed, then reopened + push | New turbo cancels in-progress cleanup ✓ |
| Push to main | Separate group, no cancellation ✓ |

## Test plan

- [ ] Verify workflow syntax is valid (Actions tab shows no errors)
- [ ] Close a PR and verify cleanup runs
- [ ] (Optional) Close two PRs simultaneously, verify both cleanups complete

Fixes #1232

🤖 Generated with [Claude Code](https://claude.com/claude-code)