### PR TITLE
docs: update cli e2e timeout from 20 to 8 minutes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,7 @@ If tests timeout, investigate why:
 
 ### CLI E2E Timeout
 
-The `cli-e2e` job has a **20-minute timeout**. If tests exceed this limit, GitHub Actions will **cancel** the job (not fail). **Cancelled status is NOT acceptable for merge** - treat it as a failure and investigate the cause.
+The `cli-e2e` jobs have a **maximum 8-minute timeout** (5 minutes for serial tests, 8 minutes for parallel/runner tests). If tests exceed this limit, GitHub Actions will **cancel** the job (not fail). **Cancelled status is NOT acceptable for merge** - treat it as a failure and investigate the cause.
 
 ### Merge Requirements
 


### PR DESCRIPTION
## Summary
- Update CLAUDE.md to reflect the current CLI E2E timeout configuration
- The CLI E2E tests have been split into multiple phases with shorter timeouts:
  - Serial tests: 5 minutes
  - Parallel/runner tests: 8 minutes

## Test plan
- [x] Documentation change only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)