### PR TITLE
ci: parallelize deploy-runner-benchmark and deploy-runner-start

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -824,7 +824,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:4f3a2d7
-    needs: [change-detection, deploy-web, deploy-runner-prepare, deploy-runner-benchmark]
+    needs: [change-detection, deploy-web, deploy-runner-prepare]
     if: needs.deploy-web.outputs.preview-url != '' && needs.deploy-runner-prepare.outputs.runner-host != ''
     outputs:
       runner-deployed: ${{ steps.start.outputs.runner-deployed }}


### PR DESCRIPTION
## Summary

- Remove `deploy-runner-benchmark` from `deploy-runner-start`'s `needs` array to allow parallel execution
- The benchmark job produces no outputs that `deploy-runner-start` consumes - the dependency was purely for sequencing
- Both jobs now run in parallel after `deploy-runner-prepare` completes

**Before:**
```
deploy-runner-prepare → deploy-runner-benchmark → deploy-runner-start
```

**After:**
```
deploy-runner-prepare ─┬─→ deploy-runner-benchmark (parallel)
                       └─→ deploy-runner-start (parallel)
```

## Test plan

- [ ] Verify CI pipeline runs successfully
- [ ] Confirm both jobs start in parallel after `deploy-runner-prepare`
- [ ] Check that `cli-e2e-03-runner` still waits for `deploy-runner-start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)