### PR TITLE
feat(cli): improve schedule status UX with local timezone and full run IDs

### DIFF
--- a/turbo/apps/cli/src/lib/domain/schedule-utils.ts
+++ b/turbo/apps/cli/src/lib/domain/schedule-utils.ts
@@ -70,16 +70,22 @@ export function formatRelativeTime(dateStr: string | null): string {
 
 /**
  * Format a date string with both absolute and relative time
- * e.g., "2025-01-14 09:00:00 UTC (in 2h)"
+ * e.g., "2025-01-14 09:00 (in 2h)"
+ * Uses local timezone, but doesn't include timezone in output (shown separately)
  */
 export function formatDateTime(dateStr: string | null): string {
   if (!dateStr) return "-";
 
   const date = new Date(dateStr);
-  const formatted = date
-    .toISOString()
-    .replace("T", " ")
-    .replace(/\.\d+Z$/, " UTC");
+
+  // Format: YYYY-MM-DD HH:MM (no seconds, no timezone - shown separately)
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+
+  const formatted = `${year}-${month}-${day} ${hours}:${minutes}`;
   const relative = formatRelativeTime(dateStr);
 
   return `${formatted} (${relative})`;


### PR DESCRIPTION
## Summary

Improves `vm0 schedule status` command UX by addressing issues raised in #1237:

- Display times in user's local timezone with `YYYY-MM-DD HH:MM` format (no seconds)
- Add dedicated `Timezone:` line showing CLI's IANA timezone (e.g., `Asia/Shanghai`)
- Show full run IDs without truncation or brackets for easy copy-paste to `vm0 logs`
- Add header row for Recent Runs table (`RUN ID`, `STATUS`, `CREATED`)
- Reorganize output into logical groups (run config → time schedule → recent runs)
- Remove unnecessary `Created:` and `ID:` metadata lines

### Before
```
Schedule: my-schedule
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Status:         enabled
Agent:          my-agent (lancy)
Trigger:        0 9 * * * (UTC)
Next Run:       2026-01-15 01:00:00 UTC (in 2h)
Prompt:         let's start working.

Recent Runs:
  [7734edaa] completed  2026-01-14 23:00:00 UTC (2h ago)

Created:  2026-01-14 06:26:24 UTC
ID:       550e8400-e29b-41d4-a716-446655440000
```

### After
```
Schedule: my-schedule
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Status:         enabled
Agent:          my-agent (lancy)
Prompt:         let's start working.

Trigger:        0 9 * * *
Timezone:       Asia/Shanghai
Next Run:       2026-01-15 09:00 (in 2h)

Recent Runs:
RUN ID                                STATUS     CREATED
7734edaa-1234-5678-90ab-cdef12345678  completed  2026-01-15 07:00 (2h ago)
```

## Test plan

- [ ] Run `vm0 schedule status <name>` and verify output format
- [ ] Verify timestamps are in local timezone
- [ ] Verify full run ID can be copied and used with `vm0 logs <id>`

Closes #1237

🤖 Generated with [Claude Code](https://claude.ai/code)