### PR TITLE
feat(cli): auto-detect schedule name from schedule.yaml

### DIFF
--- a/turbo/apps/cli/src/commands/schedule/delete.ts
+++ b/turbo/apps/cli/src/commands/schedule/delete.ts
@@ -2,7 +2,10 @@ import { Command } from "commander";
 import chalk from "chalk";
 import * as readline from "readline";
 import { apiClient, type ApiError } from "../../lib/api/api-client";
-import { loadAgentName } from "../../lib/domain/schedule-utils";
+import {
+  loadAgentName,
+  loadScheduleName,
+} from "../../lib/domain/schedule-utils";
 
 /**
  * Prompt for confirmation
@@ -25,10 +28,33 @@ export const deleteCommand = new Command()
   .name("delete")
   .alias("rm")
   .description("Delete a schedule")
-  .argument("<name>", "Schedule name to delete")
+  .argument(
+    "[name]",
+    "Schedule name (auto-detected from schedule.yaml if omitted)",
+  )
   .option("-f, --force", "Skip confirmation prompt")
-  .action(async (name: string, options: { force?: boolean }) => {
+  .action(async (nameArg: string | undefined, options: { force?: boolean }) => {
     try {
+      // Auto-detect schedule name if not provided
+      let name = nameArg;
+      if (!name) {
+        const scheduleResult = loadScheduleName();
+        if (scheduleResult.error) {
+          console.error(chalk.red(`✗ ${scheduleResult.error}`));
+          process.exit(1);
+        }
+        if (!scheduleResult.scheduleName) {
+          console.error(chalk.red("✗ Schedule name required"));
+          console.error(
+            chalk.dim(
+              "  Provide name or run from directory with schedule.yaml",
+            ),
+          );
+          process.exit(1);
+        }
+        name = scheduleResult.scheduleName;
+      }
+
       // Load vm0.yaml to get agent name
       const result = loadAgentName();
       if (result.error) {

--- a/turbo/apps/cli/src/commands/schedule/disable.ts
+++ b/turbo/apps/cli/src/commands/schedule/disable.ts
@@ -1,14 +1,40 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { apiClient, type ApiError } from "../../lib/api/api-client";
-import { loadAgentName } from "../../lib/domain/schedule-utils";
+import {
+  loadAgentName,
+  loadScheduleName,
+} from "../../lib/domain/schedule-utils";
 
 export const disableCommand = new Command()
   .name("disable")
   .description("Disable a schedule")
-  .argument("<name>", "Schedule name to disable")
-  .action(async (name: string) => {
+  .argument(
+    "[name]",
+    "Schedule name (auto-detected from schedule.yaml if omitted)",
+  )
+  .action(async (nameArg: string | undefined) => {
     try {
+      // Auto-detect schedule name if not provided
+      let name = nameArg;
+      if (!name) {
+        const scheduleResult = loadScheduleName();
+        if (scheduleResult.error) {
+          console.error(chalk.red(`✗ ${scheduleResult.error}`));
+          process.exit(1);
+        }
+        if (!scheduleResult.scheduleName) {
+          console.error(chalk.red("✗ Schedule name required"));
+          console.error(
+            chalk.dim(
+              "  Provide name or run from directory with schedule.yaml",
+            ),
+          );
+          process.exit(1);
+        }
+        name = scheduleResult.scheduleName;
+      }
+
       // Load vm0.yaml to get agent name
       const result = loadAgentName();
       if (result.error) {

--- a/turbo/apps/cli/src/lib/domain/schedule-utils.ts
+++ b/turbo/apps/cli/src/lib/domain/schedule-utils.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "fs";
 import { parse as parseYaml } from "yaml";
 
 const CONFIG_FILE = "vm0.yaml";
+const SCHEDULE_FILE = "schedule.yaml";
 
 /**
  * vm0.yaml structure for agent compose
@@ -36,6 +37,44 @@ export function loadAgentName(): LoadAgentNameResult {
     return {
       agentName: null,
       error: err instanceof Error ? err.message : "Failed to parse vm0.yaml",
+    };
+  }
+}
+
+/**
+ * Result of loading schedule name from schedule.yaml
+ */
+export interface LoadScheduleNameResult {
+  scheduleName: string | null;
+  error?: string;
+}
+
+/**
+ * Load schedule.yaml and return the first schedule name.
+ * Returns error message if file exists but cannot be parsed.
+ */
+export function loadScheduleName(): LoadScheduleNameResult {
+  if (!existsSync(SCHEDULE_FILE)) {
+    return { scheduleName: null };
+  }
+  try {
+    const content = readFileSync(SCHEDULE_FILE, "utf8");
+    const parsed = parseYaml(content) as {
+      schedules?: Record<string, unknown>;
+    };
+    if (!parsed?.schedules) {
+      return {
+        scheduleName: null,
+        error: "No schedules defined in schedule.yaml",
+      };
+    }
+    const scheduleNames = Object.keys(parsed.schedules);
+    return { scheduleName: scheduleNames[0] || null };
+  } catch (err) {
+    return {
+      scheduleName: null,
+      error:
+        err instanceof Error ? err.message : "Failed to parse schedule.yaml",
     };
   }
 }


### PR DESCRIPTION
## Summary
- Allow `vm0 schedule status|enable|disable|delete` commands to omit the schedule name argument when running from a directory containing `schedule.yaml`
- Auto-detect the first schedule name from the file when not provided
- Follows the same pattern as `loadAgentName()` which reads from `vm0.yaml`

## Test plan
- [ ] Run `vm0 schedule status` in a directory with `schedule.yaml` - should auto-detect schedule name
- [ ] Run `vm0 schedule status` without `schedule.yaml` - should show helpful error message
- [ ] Run `vm0 schedule status explicit-name` - should use the provided name
- [ ] Same behavior for `enable`, `disable`, and `delete` commands

Closes #1251

🤖 Generated with [Claude Code](https://claude.com/claude-code)