### PR TITLE
fix(devcontainer): add wget for antigravity server installation

### DIFF
--- a/.docker/toolchain/Dockerfile
+++ b/.docker/toolchain/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
     gnupg \
     lsb-release \
     ca-certificates \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 22


### PR DESCRIPTION
## Summary
- Add `wget` to the dev container base image dependencies
- Required by Antigravity IDE to download the remote server binary when connecting to dev containers

## Problem
When using Antigravity with dev containers, the connection fails with:
```
Error need wget to download server binary
```

## Test plan
- [ ] Pipeline builds the new image successfully
- [ ] After image update, Antigravity can connect to dev container without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)