### PR TITLE
chore: enable knip in CI and clean up unused code

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -139,7 +139,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
 
-      # Run lint, check-types, and prettier directly (not via lefthook)
+      # Run lint, check-types, prettier and knip directly (not via lefthook)
       # lefthook's turbo filter uses git diff which doesn't work in CI
       - name: Lint
         working-directory: turbo
@@ -152,6 +152,10 @@ jobs:
       - name: Prettier
         working-directory: turbo
         run: pnpm prettier --check .
+
+      - name: Knip
+        working-directory: turbo
+        run: pnpm knip
 
   test:
     runs-on: ubuntu-latest

--- a/turbo/apps/cli/src/lib/domain/github-skills.ts
+++ b/turbo/apps/cli/src/lib/domain/github-skills.ts
@@ -97,33 +97,6 @@ export async function downloadGitHubSkill(
 }
 
 /**
- * Download multiple skills in parallel
- *
- * @param skillUrls - Array of GitHub tree URLs
- * @param destDir - Destination directory for downloaded skills
- * @returns Map of skill URL to local path
- */
-export async function downloadSkills(
-  skillUrls: string[],
-  destDir: string,
-): Promise<Map<string, string>> {
-  const results = new Map<string, string>();
-
-  // Create destination directory
-  await fs.mkdir(destDir, { recursive: true });
-
-  // Download skills in parallel
-  const downloads = skillUrls.map(async (url) => {
-    const parsed = parseGitHubTreeUrl(url);
-    const skillPath = await downloadGitHubSkill(parsed, destDir);
-    results.set(url, skillPath);
-  });
-
-  await Promise.all(downloads);
-  return results;
-}
-
-/**
  * Validate that a downloaded skill has the required SKILL.md file
  *
  * @param skillDir - Path to the downloaded skill directory

--- a/turbo/apps/cli/src/lib/domain/provider-config.ts
+++ b/turbo/apps/cli/src/lib/domain/provider-config.ts
@@ -102,7 +102,7 @@ const PROVIDER_APPS_IMAGES: Record<
  * @param appString - App string in format "app" or "app:tag"
  * @returns Object with app name and tag (defaults to "latest")
  */
-export function parseAppString(appString: string): {
+function parseAppString(appString: string): {
   app: string;
   tag: "latest" | "dev";
 } {

--- a/turbo/apps/cli/src/lib/utils/update-checker.ts
+++ b/turbo/apps/cli/src/lib/utils/update-checker.ts
@@ -78,9 +78,7 @@ export function getLatestVersion(): Promise<string | null> {
  * - pnpm: pnpm add -g @vm0/cli@latest
  * Returns true on success, false on failure
  */
-export function performUpgrade(
-  packageManager: PackageManager,
-): Promise<boolean> {
+function performUpgrade(packageManager: PackageManager): Promise<boolean> {
   return new Promise((resolve) => {
     const isWindows = process.platform === "win32";
     const command = isWindows ? `${packageManager}.cmd` : packageManager;

--- a/turbo/apps/runner/src/lib/firecracker/vm.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vm.ts
@@ -358,12 +358,3 @@ export class FirecrackerVM {
     );
   }
 }
-
-/**
- * Create and start a VM with the given configuration
- */
-export async function createVM(config: VMConfig): Promise<FirecrackerVM> {
-  const vm = new FirecrackerVM(config);
-  await vm.start();
-  return vm;
-}

--- a/turbo/apps/runner/src/lib/metrics/index.ts
+++ b/turbo/apps/runner/src/lib/metrics/index.ts
@@ -1,9 +1,3 @@
-export {
-  initMetrics,
-  isMetricsEnabled,
-  getRunnerLabel,
-  flushMetrics,
-  shutdownMetrics,
-} from "./provider";
-export { recordRunnerOperation, recordSandboxOperation } from "./instruments";
+export { initMetrics, flushMetrics, shutdownMetrics } from "./provider";
+export { recordRunnerOperation } from "./instruments";
 export { withRunnerTiming, withSandboxTiming } from "./timing";

--- a/turbo/apps/runner/src/lib/proxy/index.ts
+++ b/turbo/apps/runner/src/lib/proxy/index.ts
@@ -6,20 +6,6 @@
  * - Proxy Manager: Manages mitmproxy lifecycle
  */
 
-export {
-  VMRegistry,
-  type VMRegistration,
-  getVMRegistry,
-  initVMRegistry,
-  DEFAULT_REGISTRY_PATH,
-} from "./vm-registry";
+export { getVMRegistry, initVMRegistry } from "./vm-registry";
 
-export {
-  ProxyManager,
-  type ProxyConfig,
-  getProxyManager,
-  initProxyManager,
-  DEFAULT_PROXY_CONFIG,
-} from "./proxy-manager";
-
-export { RUNNER_MITM_ADDON_SCRIPT } from "./mitm-addon-script";
+export { getProxyManager, initProxyManager } from "./proxy-manager";

--- a/turbo/apps/web/src/lib/agent-session/index.ts
+++ b/turbo/apps/web/src/lib/agent-session/index.ts
@@ -1,10 +1,1 @@
-export {
-  agentSessionService,
-  AgentSessionService,
-} from "./agent-session-service";
-export type {
-  AgentSessionData,
-  AgentSessionWithConversation,
-  CreateAgentSessionInput,
-  UpdateAgentSessionInput,
-} from "./types";
+export { agentSessionService } from "./agent-session-service";

--- a/turbo/apps/web/src/lib/axiom/index.ts
+++ b/turbo/apps/web/src/lib/axiom/index.ts
@@ -1,9 +1,7 @@
 export {
-  getAxiomClient,
   ingestToAxiom,
   queryAxiom,
   ingestRequestLog,
   ingestSandboxOpLog,
 } from "./client";
-export type { RequestLogEntry, SandboxOpLogEntry } from "./client";
 export { getDatasetName, DATASETS } from "./datasets";

--- a/turbo/apps/web/src/lib/checkpoint/index.ts
+++ b/turbo/apps/web/src/lib/checkpoint/index.ts
@@ -4,11 +4,4 @@
  */
 
 export { checkpointService } from "./checkpoint-service";
-export type {
-  CheckpointData,
-  CheckpointRequest,
-  CheckpointResponse,
-  ArtifactSnapshot,
-  AgentComposeSnapshot,
-  ConversationData,
-} from "./types";
+export type { ArtifactSnapshot } from "./types";

--- a/turbo/apps/web/src/lib/crypto/index.ts
+++ b/turbo/apps/web/src/lib/crypto/index.ts
@@ -1,6 +1,1 @@
-export {
-  encryptSecrets,
-  decryptSecrets,
-  encryptSecretsMap,
-  decryptSecretsMap,
-} from "./secrets-encryption";
+export { encryptSecretsMap, decryptSecretsMap } from "./secrets-encryption";

--- a/turbo/apps/web/src/lib/run/context/index.ts
+++ b/turbo/apps/web/src/lib/run/context/index.ts
@@ -1,6 +1,0 @@
-export {
-  prepareForExecution,
-  extractWorkingDir,
-  extractCliAgentType,
-  resolveRunnerGroup,
-} from "./execution-preparer";

--- a/turbo/apps/web/src/lib/run/executors/index.ts
+++ b/turbo/apps/web/src/lib/run/executors/index.ts
@@ -1,3 +1,0 @@
-export { e2bExecutor, E2BExecutor } from "./e2b-executor";
-export { runnerExecutor, RunnerExecutor } from "./runner-executor";
-export type { PreparedContext, ExecutorResult, Executor } from "./types";

--- a/turbo/apps/web/src/lib/run/index.ts
+++ b/turbo/apps/web/src/lib/run/index.ts
@@ -3,17 +3,4 @@
  * Handles creation and resumption of agent runs
  */
 
-export { runService, calculateSessionHistoryPath } from "./run-service";
-export type { ExecutionContext, ResumeSession } from "./types";
-
-// Executor exports
-export { e2bExecutor, runnerExecutor } from "./executors";
-export type { PreparedContext, ExecutorResult, Executor } from "./executors";
-
-// Context preparation exports
-export {
-  prepareForExecution,
-  extractWorkingDir,
-  extractCliAgentType,
-  resolveRunnerGroup,
-} from "./context";
+export { runService } from "./run-service";

--- a/turbo/apps/web/src/lib/s3/s3-client.ts
+++ b/turbo/apps/web/src/lib/s3/s3-client.ts
@@ -363,37 +363,6 @@ export async function deleteS3Objects(
 }
 
 /**
- * Delete all objects under S3 prefix
- * @param s3Uri - S3 URI in format s3://bucket/prefix
- */
-export async function deleteS3Directory(s3Uri: string): Promise<void> {
-  const { bucket, prefix } = parseS3Uri(s3Uri);
-  const client = getS3Client();
-
-  // List all objects under prefix
-  const objects = await listS3Objects(bucket, prefix);
-
-  if (objects.length === 0) {
-    return;
-  }
-
-  // Delete in batches of 1000 (AWS limit)
-  const batchSize = 1000;
-  for (let i = 0; i < objects.length; i += batchSize) {
-    const batch = objects.slice(i, i + batchSize);
-
-    const command = new DeleteObjectsCommand({
-      Bucket: bucket,
-      Delete: {
-        Objects: batch.map((obj) => ({ Key: obj.key })),
-      },
-    });
-
-    await client.send(command);
-  }
-}
-
-/**
  * Get all files in directory recursively
  * @param dirPath - Directory path
  * @returns Array of file paths

--- a/turbo/apps/web/src/lib/schedule/index.ts
+++ b/turbo/apps/web/src/lib/schedule/index.ts
@@ -1,5 +1,1 @@
-export {
-  scheduleService,
-  type ScheduleResponse,
-  type DeployScheduleRequest,
-} from "./schedule-service";
+export { scheduleService } from "./schedule-service";

--- a/turbo/apps/web/src/lib/session-history/index.ts
+++ b/turbo/apps/web/src/lib/session-history/index.ts
@@ -1,4 +1,1 @@
-export {
-  SessionHistoryService,
-  sessionHistoryService,
-} from "./session-history-service";
+export { sessionHistoryService } from "./session-history-service";

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -16,45 +16,49 @@
         "**/*.{test,spec}.{ts,tsx}"
       ],
       "project": ["**/*.{ts,tsx}", "scripts/**/*.ts"],
-      "ignoreDependencies": ["@vm0/ui"],
+      "ignoreDependencies": [
+        "@vm0/ui",
+        "e2b",
+        "@testing-library/react",
+        "@types/tar"
+      ],
       "next": {
         "entry": ["next.config.{js,ts,mjs}"]
       }
     },
     "apps/cli": {
       "entry": [
-        "src/index.ts",
         "src/**/__tests__/**/*.{test,spec}.ts",
         "src/**/*.{test,spec}.ts"
       ],
       "project": ["src/**/*.ts"],
+      "ignoreDependencies": ["@types/tar"],
       "tsup": {
         "config": ["tsup.config.ts"]
       }
     },
     "apps/docs": {
       "entry": ["source.config.ts"],
-      "project": ["**/*.{ts,tsx,mdx,js,mjs}"]
+      "project": ["**/*.{ts,tsx,mdx,js,mjs}"],
+      "ignoreDependencies": ["@vm0/typescript-config"]
     },
     "apps/platform": {
-      "entry": ["src/main.ts", "**/*.{test,spec}.ts?(x)", "src/test/setup.ts"],
+      "entry": ["src/main.ts", "**/*.{test,spec}.ts?(x)"],
       "project": ["**/*.{ts,tsx}"],
-      "ignore": ["eslint.config.js", "custom-eslint/**"],
+      "ignore": ["custom-eslint/**"],
       "ignoreDependencies": [
-        "@typescript-eslint/parser",
         "tailwindcss",
-        "@vm0/ui"
-      ],
-      "eslint": false
+        "@vm0/ui",
+        "@testing-library/react",
+        "typescript-eslint"
+      ]
     },
     "apps/runner": {
       "entry": [
-        "src/index.ts",
-        "scripts/*.ts",
         "src/**/__tests__/**/*.{test,spec}.ts",
         "src/**/*.{test,spec}.ts"
       ],
-      "project": ["src/**/*.ts", "scripts/**/*.ts"],
+      "project": ["src/**/*.ts"],
       "tsup": {
         "config": ["tsup.config.ts"]
       }
@@ -68,11 +72,11 @@
     },
     "packages/ui": {
       "entry": [
-        "src/test/setup.ts",
         "src/**/__tests__/**/*.{test,spec}.{ts,tsx}",
         "src/**/*.{test,spec}.{ts,tsx}"
       ],
-      "project": ["src/**/*.{ts,tsx}"]
+      "project": ["src/**/*.{ts,tsx}"],
+      "ignoreDependencies": ["autoprefixer"]
     },
     "packages/eslint-config": {
       "entry": [],
@@ -85,8 +89,7 @@
     },
     "packages/proxy": {
       "entry": [],
-      "project": ["**/*.{js,json}"],
-      "ignoreBinaries": ["caddy"]
+      "project": ["**/*.{js,json}"]
     }
   },
   "ignore": [
@@ -96,25 +99,42 @@
     "build/**",
     "coverage/**",
     "**/drizzle.config.ts",
-    "**/eslint.config.{js,mjs,cjs}",
     "**/custom-eslint/**",
-    "**/vite.config.ts",
-    "**/vitest.config.ts",
     "apps/docs/src/components/plausible-tracker.tsx",
     "apps/platform/src/mocks/browser.ts",
     "apps/platform/src/signals/test-utils.ts",
+    "apps/platform/src/signals/__tests__/test-helpers.ts",
+    "apps/platform/src/signals/location.ts",
+    "apps/platform/src/signals/log.ts",
+    "apps/platform/src/signals/page-signal.ts",
+    "apps/platform/src/signals/utils.ts",
     "apps/platform/src/views/router/link.tsx",
     "apps/runner/src/lib/firecracker/index.ts",
+    "apps/runner/src/lib/firecracker/guest.ts",
+    "apps/runner/src/lib/firecracker/network.ts",
     "apps/web/src/db/index.ts",
     "apps/web/src/lib/auth/require-user.ts",
     "apps/web/src/lib/e2b/index.ts",
+    "apps/web/src/lib/e2b/types.ts",
     "apps/web/src/lib/public-api/index.ts",
+    "apps/web/src/lib/public-api/errors.ts",
+    "apps/web/src/lib/public-api/handler.ts",
+    "apps/web/src/lib/public-api/request-id.ts",
+    "apps/web/src/lib/image/image-service.ts",
+    "apps/web/src/lib/logger.ts",
+    "apps/web/src/lib/s3/s3-client.ts",
+    "apps/web/src/lib/scope/scope-service.ts",
+    "apps/web/src/lib/checkpoint/types.ts",
+    "apps/web/src/lib/proxy/proxy-service.ts",
+    "apps/web/src/lib/storage/types.ts",
     "apps/web/src/test/setup.ts",
-    "apps/web/src/types/agent-run.ts"
+    "apps/web/src/types/agent-run.ts",
+    "apps/web/src/types/agent-compose.ts",
+    "apps/cli/src/lib/api/api-client.ts",
+    "packages/core/src/contracts/public/agents.ts"
   ],
+  "ignoreDependencies": ["@commitlint/cli"],
   "ignoreWorkspaces": [],
   "ignoreUnresolved": [],
-  "eslint": false,
-  "vite": false,
-  "vitest": false
+  "ignoreExportsUsedInFile": true
 }


### PR DESCRIPTION
- Enable ESLint, Vite, and Vitest plugins in knip.json
- Remove dead code: downloadSkills, createVM, deleteS3Directory
- Remove unnecessary exports: parseAppString, performUpgrade
- Clean up unused barrel exports across multiple packages
- Add remaining unused exports to ignore list for future cleanup
- Add knip check to CI workflow lint job

This reduces false positives from 234 to 0 issues and enables knip enforcement in CI to prevent new unused code accumulation.

partial update #1242,  will finish the ignore part in the next PR