### PR TITLE
chore: remove ignoreExportsUsedInFile and clean up unused exports

### DIFF
--- a/turbo/apps/cli/src/lib/domain/cook-state.ts
+++ b/turbo/apps/cli/src/lib/domain/cook-state.ts
@@ -8,7 +8,7 @@ const COOK_STATE_FILE = join(CONFIG_DIR, "cook.json");
 const STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000; // 48 hours
 
 // Public API interface (unchanged for backward compatibility)
-export interface CookState {
+interface CookState {
   lastRunId?: string;
   lastSessionId?: string;
   lastCheckpointId?: string;

--- a/turbo/apps/cli/src/lib/domain/github-skills.ts
+++ b/turbo/apps/cli/src/lib/domain/github-skills.ts
@@ -17,7 +17,7 @@ const execAsync = promisify(exec);
 export { getInstructionsStorageName };
 
 // Re-export the type with the local name for backwards compatibility
-export type ParsedGitHubUrl = ParsedGitHubTreeUrl;
+type ParsedGitHubUrl = ParsedGitHubTreeUrl;
 
 /**
  * Parse a GitHub tree URL into its components

--- a/turbo/apps/cli/src/lib/domain/provider-config.ts
+++ b/turbo/apps/cli/src/lib/domain/provider-config.ts
@@ -3,7 +3,7 @@
  * When a provider is specified, these defaults can be used if not explicitly set
  */
 
-export interface ProviderDefaults {
+interface ProviderDefaults {
   workingDir: string;
   image: {
     production: string;

--- a/turbo/apps/cli/src/lib/domain/schedule-utils.ts
+++ b/turbo/apps/cli/src/lib/domain/schedule-utils.ts
@@ -7,7 +7,7 @@ const SCHEDULE_FILE = "schedule.yaml";
 /**
  * vm0.yaml structure for agent compose
  */
-export interface AgentComposeConfig {
+interface AgentComposeConfig {
   version: string;
   agents: Record<string, unknown>;
 }
@@ -15,7 +15,7 @@ export interface AgentComposeConfig {
 /**
  * Result of loading agent name from vm0.yaml
  */
-export interface LoadAgentNameResult {
+interface LoadAgentNameResult {
   agentName: string | null;
   error?: string;
 }
@@ -44,7 +44,7 @@ export function loadAgentName(): LoadAgentNameResult {
 /**
  * Result of loading schedule name from schedule.yaml
  */
-export interface LoadScheduleNameResult {
+interface LoadScheduleNameResult {
   scheduleName: string | null;
   error?: string;
 }
@@ -181,7 +181,7 @@ interface AgentConfig {
 /**
  * Result of extracting vars and secrets from vm0.yaml
  */
-export interface VarsAndSecrets {
+interface VarsAndSecrets {
   vars: string[];
   secrets: string[];
 }

--- a/turbo/apps/cli/src/lib/domain/source-derivation.ts
+++ b/turbo/apps/cli/src/lib/domain/source-derivation.ts
@@ -38,7 +38,7 @@ interface AgentComposeContent {
 /**
  * Source of a variable or secret
  */
-export interface VariableSource {
+interface VariableSource {
   /** The variable/secret name */
   name: string;
   /** Source description (e.g., "agent environment" or "skill: openai-skill") */

--- a/turbo/apps/cli/src/lib/domain/yaml-validator.ts
+++ b/turbo/apps/cli/src/lib/domain/yaml-validator.ts
@@ -277,4 +277,3 @@ export function validateAgentCompose(config: unknown): {
 
   return { valid: true };
 }
-

--- a/turbo/apps/cli/src/lib/domain/yaml-validator.ts
+++ b/turbo/apps/cli/src/lib/domain/yaml-validator.ts
@@ -1,10 +1,5 @@
 import { z } from "zod";
-import {
-  agentNameSchema as coreAgentNameSchema,
-  agentDefinitionSchema,
-  volumeConfigSchema,
-  agentComposeContentSchema,
-} from "@vm0/core";
+import { agentDefinitionSchema, volumeConfigSchema } from "@vm0/core";
 import { isProviderSupported } from "./provider-config";
 
 /**
@@ -283,5 +278,3 @@ export function validateAgentCompose(config: unknown): {
   return { valid: true };
 }
 
-// Re-export schemas for potential use by other CLI modules
-export { coreAgentNameSchema, agentComposeContentSchema };

--- a/turbo/apps/cli/src/lib/events/event-parser-factory.ts
+++ b/turbo/apps/cli/src/lib/events/event-parser-factory.ts
@@ -7,9 +7,7 @@ import { ClaudeEventParser, type ParsedEvent } from "./claude-event-parser";
 import { CodexEventParser } from "./codex-event-parser";
 import { getValidatedProvider, type SupportedProvider } from "@vm0/core";
 
-type EventParserType =
-  | typeof ClaudeEventParser
-  | typeof CodexEventParser;
+type EventParserType = typeof ClaudeEventParser | typeof CodexEventParser;
 
 /**
  * Detect the provider type from event data

--- a/turbo/apps/cli/src/lib/events/event-parser-factory.ts
+++ b/turbo/apps/cli/src/lib/events/event-parser-factory.ts
@@ -7,7 +7,7 @@ import { ClaudeEventParser, type ParsedEvent } from "./claude-event-parser";
 import { CodexEventParser } from "./codex-event-parser";
 import { getValidatedProvider, type SupportedProvider } from "@vm0/core";
 
-export type EventParserType =
+type EventParserType =
   | typeof ClaudeEventParser
   | typeof CodexEventParser;
 

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -16,7 +16,7 @@ import { getProviderDisplayName, isSupportedProvider } from "@vm0/core";
 /**
  * Info about a started run
  */
-export interface RunStartedInfo {
+interface RunStartedInfo {
   runId: string;
   sandboxId?: string;
 }

--- a/turbo/apps/cli/src/lib/storage/clone-utils.ts
+++ b/turbo/apps/cli/src/lib/storage/clone-utils.ts
@@ -18,11 +18,11 @@ interface DownloadResponse {
   size: number;
 }
 
-export interface CloneOptions {
+interface CloneOptions {
   version?: string;
 }
 
-export interface CloneResult {
+interface CloneResult {
   success: boolean;
   fileCount: number;
   size: number;

--- a/turbo/apps/cli/src/lib/storage/direct-upload.ts
+++ b/turbo/apps/cli/src/lib/storage/direct-upload.ts
@@ -42,7 +42,7 @@ interface CommitResponse {
 /**
  * Result of direct upload operation
  */
-export interface DirectUploadResult {
+interface DirectUploadResult {
   versionId: string;
   size: number;
   fileCount: number;
@@ -53,7 +53,7 @@ export interface DirectUploadResult {
 /**
  * Progress callback for upload operations
  */
-export type ProgressCallback = (message: string) => void;
+type ProgressCallback = (message: string) => void;
 
 /**
  * Compute SHA-256 hash of file content (for testing with small buffers)
@@ -266,7 +266,7 @@ async function uploadToPresignedUrl(
 /**
  * Options for direct upload
  */
-export interface DirectUploadOptions {
+interface DirectUploadOptions {
   onProgress?: ProgressCallback;
   force?: boolean;
 }

--- a/turbo/apps/cli/src/lib/storage/pull-utils.ts
+++ b/turbo/apps/cli/src/lib/storage/pull-utils.ts
@@ -4,7 +4,7 @@ import { removeExtraFiles } from "../utils/file-utils";
 /**
  * Result of handling an empty storage response (HTTP 204).
  */
-export interface EmptyStorageResult {
+interface EmptyStorageResult {
   removedCount: number;
 }
 

--- a/turbo/apps/cli/src/lib/storage/storage-utils.ts
+++ b/turbo/apps/cli/src/lib/storage/storage-utils.ts
@@ -10,7 +10,7 @@ import path from "path";
  */
 export type StorageType = "volume" | "artifact";
 
-export interface StorageConfig {
+interface StorageConfig {
   name: string;
   type: StorageType;
 }

--- a/turbo/apps/cli/src/lib/storage/system-storage.ts
+++ b/turbo/apps/cli/src/lib/storage/system-storage.ts
@@ -13,7 +13,7 @@ import {
 import { directUpload } from "./direct-upload";
 import { getValidatedProvider } from "@vm0/core";
 
-export interface StorageUploadResult {
+interface StorageUploadResult {
   name: string;
   versionId: string;
   action: "created" | "deduplicated";

--- a/turbo/apps/cli/src/lib/utils/prompt-utils.ts
+++ b/turbo/apps/cli/src/lib/utils/prompt-utils.ts
@@ -79,7 +79,7 @@ export async function promptConfirm(
 /**
  * Choice option for select prompts
  */
-export interface SelectChoice<T> {
+interface SelectChoice<T> {
   title: string;
   value: T;
   description?: string;

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -175,7 +175,7 @@ export const generateRouterPath = <T extends RoutePath>(
   return _path;
 };
 
-export const setupPageWrapper = (
+const setupPageWrapper = (
   fn: Command<Promise<void> | void, [AbortSignal]>,
 ) => {
   return command(async ({ set }, signal: AbortSignal) => {

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -175,9 +175,7 @@ export const generateRouterPath = <T extends RoutePath>(
   return _path;
 };
 
-const setupPageWrapper = (
-  fn: Command<Promise<void> | void, [AbortSignal]>,
-) => {
+const setupPageWrapper = (fn: Command<Promise<void> | void, [AbortSignal]>) => {
   return command(async ({ set }, signal: AbortSignal) => {
     set(setPageSignal$, signal);
     await set(fn, signal);

--- a/turbo/apps/platform/src/types/navigation.ts
+++ b/turbo/apps/platform/src/types/navigation.ts
@@ -1,6 +1,6 @@
 import type { RoutePath } from "./route.ts";
 
-export type NavIconName =
+type NavIconName =
   | "Bot"
   | "CircleDot"
   | "FileBarChart"

--- a/turbo/apps/runner/src/lib/api.ts
+++ b/turbo/apps/runner/src/lib/api.ts
@@ -14,12 +14,12 @@ import type {
 } from "@vm0/core";
 
 // Re-export types for consumers
-export type { Job, ExecutionContext, StorageManifest, ResumeSession };
+export type { ExecutionContext, StorageManifest, ResumeSession };
 
 /**
  * Runner-specific server configuration
  */
-export interface ServerConfig {
+interface ServerConfig {
   url: string;
   token: string;
 }
@@ -112,7 +112,7 @@ export async function claimJob(
   return response.json() as Promise<ExecutionContext>;
 }
 
-export interface CompleteJobResult {
+interface CompleteJobResult {
   success: boolean;
   status: "completed" | "failed";
 }

--- a/turbo/apps/runner/src/lib/config.ts
+++ b/turbo/apps/runner/src/lib/config.ts
@@ -109,7 +109,7 @@ export const debugConfigSchema = z.object({
     .default(PROXY_DEFAULTS),
 });
 
-export type DebugConfig = z.infer<typeof debugConfigSchema>;
+type DebugConfig = z.infer<typeof debugConfigSchema>;
 
 /**
  * Load and validate debug configuration from YAML file

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -37,7 +37,7 @@ import { withSandboxTiming, recordRunnerOperation } from "./metrics/index.js";
 /**
  * Execution result
  */
-export interface ExecutionResult {
+interface ExecutionResult {
   exitCode: number;
   error?: string;
 }
@@ -45,7 +45,7 @@ export interface ExecutionResult {
 /**
  * Execution options for customizing job execution behavior
  */
-export interface ExecutionOptions {
+interface ExecutionOptions {
   /**
    * Benchmark mode for local VM performance testing without API server:
    * - Runs prompt directly as bash command (skips run-agent.py)

--- a/turbo/apps/runner/src/lib/firecracker/client.ts
+++ b/turbo/apps/runner/src/lib/firecracker/client.ts
@@ -10,7 +10,7 @@ import http from "node:http";
 /**
  * Machine configuration for Firecracker VM
  */
-export interface MachineConfig {
+interface MachineConfig {
   vcpu_count: number;
   mem_size_mib: number;
   smt?: boolean; // Simultaneous Multi-Threading (default: false)
@@ -19,7 +19,7 @@ export interface MachineConfig {
 /**
  * Boot source configuration
  */
-export interface BootSource {
+interface BootSource {
   kernel_image_path: string;
   boot_args?: string;
 }
@@ -27,7 +27,7 @@ export interface BootSource {
 /**
  * Drive configuration for block devices
  */
-export interface Drive {
+interface Drive {
   drive_id: string;
   path_on_host: string;
   is_root_device: boolean;
@@ -37,7 +37,7 @@ export interface Drive {
 /**
  * Network interface configuration
  */
-export interface NetworkInterface {
+interface NetworkInterface {
   iface_id: string;
   guest_mac?: string;
   host_dev_name: string;
@@ -46,7 +46,7 @@ export interface NetworkInterface {
 /**
  * Vsock device configuration
  */
-export interface Vsock {
+interface Vsock {
   vsock_id: string;
   guest_cid: number;
   uds_path: string;
@@ -55,7 +55,7 @@ export interface Vsock {
 /**
  * Action types for VM control
  */
-export type ActionType = "InstanceStart" | "SendCtrlAltDel" | "FlushMetrics";
+type ActionType = "InstanceStart" | "SendCtrlAltDel" | "FlushMetrics";
 
 /**
  * Firecracker API Client

--- a/turbo/apps/runner/src/lib/firecracker/vm.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vm.ts
@@ -36,7 +36,7 @@ export interface VMConfig {
 /**
  * VM state
  */
-export type VMState =
+type VMState =
   | "created"
   | "configuring"
   | "running"

--- a/turbo/apps/runner/src/lib/proxy/proxy-manager.ts
+++ b/turbo/apps/runner/src/lib/proxy/proxy-manager.ts
@@ -15,7 +15,7 @@ import { RUNNER_MITM_ADDON_SCRIPT } from "./mitm-addon-script";
 /**
  * Proxy configuration
  */
-export interface ProxyConfig {
+interface ProxyConfig {
   /** Port for mitmproxy to listen on */
   port: number;
   /** Path to the mitmproxy CA directory */

--- a/turbo/apps/runner/src/lib/proxy/vm-registry.ts
+++ b/turbo/apps/runner/src/lib/proxy/vm-registry.ts
@@ -16,7 +16,7 @@ import fs from "fs";
  * - Domain/IP rule: { domain: "*.example.com", action: "ALLOW" }
  * - Terminal rule: { final: "DENY" } - value is the action
  */
-export interface FirewallRule {
+interface FirewallRule {
   domain?: string;
   ip?: string;
   /** Terminal rule - value is the action (ALLOW or DENY) */
@@ -28,7 +28,7 @@ export interface FirewallRule {
 /**
  * VM registration data
  */
-export interface VMRegistration {
+interface VMRegistration {
   runId: string;
   sandboxToken: string;
   registeredAt: number;

--- a/turbo/apps/runner/src/lib/scripts/utils.ts
+++ b/turbo/apps/runner/src/lib/scripts/utils.ts
@@ -23,7 +23,7 @@ import {
   ENV_LOADER_PATH,
 } from "./index.js";
 
-export interface ScriptEntry {
+interface ScriptEntry {
   content: string;
   path: string;
 }

--- a/turbo/apps/web/src/lib/auth/get-sandbox-auth.ts
+++ b/turbo/apps/web/src/lib/auth/get-sandbox-auth.ts
@@ -25,7 +25,7 @@ const log = logger("auth:sandbox");
  *
  * @returns SandboxAuth with userId and runId, or null if not authenticated
  */
-export async function getSandboxAuth(): Promise<SandboxAuth | null> {
+async function getSandboxAuth(): Promise<SandboxAuth | null> {
   const headersList = await headers();
   const authHeader = headersList.get("Authorization");
 

--- a/turbo/apps/web/src/lib/axiom/client.ts
+++ b/turbo/apps/web/src/lib/axiom/client.ts
@@ -11,7 +11,7 @@ let axiomClient: Axiom | null = null;
  * Get the Axiom client singleton.
  * Returns null if AXIOM_TOKEN is not configured.
  */
-export function getAxiomClient(): Axiom | null {
+function getAxiomClient(): Axiom | null {
   const token = process.env.AXIOM_TOKEN;
   if (!token) {
     return null;
@@ -76,7 +76,7 @@ export async function queryAxiom<T = Record<string, unknown>>(
   }
 }
 
-export interface RequestLogEntry {
+interface RequestLogEntry {
   remote_addr: string;
   user_agent: string;
   method: string;
@@ -107,7 +107,7 @@ export function ingestRequestLog(entry: RequestLogEntry): void {
   // Don't await flush - let it batch automatically
 }
 
-export interface SandboxOpLogEntry {
+interface SandboxOpLogEntry {
   source: "web" | "runner" | "sandbox";
   op_type: string;
   sandbox_type: string;

--- a/turbo/apps/web/src/lib/blob/blob-service.ts
+++ b/turbo/apps/web/src/lib/blob/blob-service.ts
@@ -23,7 +23,7 @@ const MAX_CONCURRENT_UPLOADS = 10;
 /**
  * Result of uploading blobs
  */
-export interface BlobUploadResult {
+interface BlobUploadResult {
   /** Map of file path to blob hash */
   hashes: Map<string, string>;
   /** Number of new blobs uploaded */

--- a/turbo/apps/web/src/lib/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/checkpoint/checkpoint-service.ts
@@ -21,7 +21,7 @@ const log = logger("service:checkpoint");
  * Checkpoint Service
  * Manages creation and storage of agent run checkpoints
  */
-export class CheckpointService {
+class CheckpointService {
   /**
    * Create a checkpoint for an agent run
    *

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -50,7 +50,7 @@ function getFirstAgent(
  * Manages E2B sandbox creation and execution
  * Agnostic to run type (new run or resume)
  */
-export class E2BService {
+class E2BService {
   /**
    * Execute an agent run with the given context
    * Works for both new runs and resumed runs

--- a/turbo/apps/web/src/lib/e2b/index.ts
+++ b/turbo/apps/web/src/lib/e2b/index.ts
@@ -1,4 +1,4 @@
-export { e2bService, E2BService } from "./e2b-service";
+export { e2bService } from "./e2b-service";
 export type {
   CreateRunOptions,
   RunResult,

--- a/turbo/apps/web/src/lib/errors.ts
+++ b/turbo/apps/web/src/lib/errors.ts
@@ -2,7 +2,7 @@
  * Custom error classes for API
  */
 
-export class ApiError extends Error {
+class ApiError extends Error {
   constructor(
     public statusCode: number,
     message: string,

--- a/turbo/apps/web/src/lib/proxy/token-service.ts
+++ b/turbo/apps/web/src/lib/proxy/token-service.ts
@@ -16,7 +16,7 @@ export const PROXY_TOKEN_PREFIX = "vm0_enc_";
 /**
  * Token payload structure
  */
-export interface ProxyTokenPayload {
+interface ProxyTokenPayload {
   runId: string;
   userId: string;
   secretName: string;
@@ -27,7 +27,7 @@ export interface ProxyTokenPayload {
 /**
  * Token validation result
  */
-export interface TokenValidationResult {
+interface TokenValidationResult {
   valid: boolean;
   payload?: ProxyTokenPayload;
   error?: string;

--- a/turbo/apps/web/src/lib/public-api/auth.ts
+++ b/turbo/apps/web/src/lib/public-api/auth.ts
@@ -13,7 +13,7 @@ const log = logger("public-api:auth");
 /**
  * Authentication result for public API
  */
-export interface PublicApiAuth {
+interface PublicApiAuth {
   userId: string;
 }
 

--- a/turbo/apps/web/src/lib/public-api/index.ts
+++ b/turbo/apps/web/src/lib/public-api/index.ts
@@ -39,8 +39,4 @@ export {
 } from "./request-id";
 
 // Authentication
-export {
-  authenticatePublicApi,
-  isAuthSuccess,
-  type PublicApiAuth,
-} from "./auth";
+export { authenticatePublicApi, isAuthSuccess } from "./auth";

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -38,7 +38,7 @@ const STORAGE_AUTO_DOMAINS = [
  * Extract and process firewall configuration from agent compose
  * Auto-injects platform and provider domains
  */
-export function processFirewallConfig(
+function processFirewallConfig(
   agentCompose: unknown,
 ): CoreExperimentalFirewall | null {
   const compose = agentCompose as AgentComposeYaml | undefined;
@@ -122,7 +122,7 @@ export function processFirewallConfig(
  * Extract working directory from agent compose config
  * This is required for resume and storage operations
  */
-export function extractWorkingDir(agentCompose: unknown): string {
+function extractWorkingDir(agentCompose: unknown): string {
   const compose = agentCompose as AgentComposeYaml | undefined;
   if (!compose?.agents) {
     throw new BadRequestError(
@@ -142,7 +142,7 @@ export function extractWorkingDir(agentCompose: unknown): string {
 /**
  * Extract CLI agent type from agent compose config
  */
-export function extractCliAgentType(agentCompose: unknown): string {
+function extractCliAgentType(agentCompose: unknown): string {
   const compose = agentCompose as AgentComposeYaml | undefined;
   if (!compose?.agents) return "claude-code";
   const agents = Object.values(compose.agents);
@@ -152,7 +152,7 @@ export function extractCliAgentType(agentCompose: unknown): string {
 /**
  * Resolve runner group from agent compose config
  */
-export function resolveRunnerGroup(agentCompose: unknown): string | null {
+function resolveRunnerGroup(agentCompose: unknown): string | null {
   const compose = agentCompose as AgentComposeYaml | undefined;
   if (!compose?.agents) return null;
   const agents = Object.values(compose.agents);

--- a/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
@@ -70,7 +70,7 @@ function getFirstAgent(
  * Executes agent runs in E2B sandboxes.
  * Receives a PreparedContext with all necessary information pre-computed.
  */
-export class E2BExecutor implements Executor {
+class E2BExecutor implements Executor {
   /**
    * Execute an agent run in E2B sandbox
    *

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -14,7 +14,7 @@ const log = logger("executor:runner");
  * Unlike E2B executor which executes immediately, this executor
  * stores the job in the runner_job_queue for later polling.
  */
-export class RunnerExecutor implements Executor {
+class RunnerExecutor implements Executor {
   /**
    * Queue an agent run for execution by a self-hosted runner
    *

--- a/turbo/apps/web/src/lib/s3/types.ts
+++ b/turbo/apps/web/src/lib/s3/types.ts
@@ -78,7 +78,7 @@ export class S3UploadError extends Error {
 /**
  * File entry with hash for manifest generation
  */
-export interface FileEntryWithHash {
+interface FileEntryWithHash {
   /** Relative path within the storage */
   path: string;
   /** SHA-256 hash of file content */

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -39,7 +39,7 @@ export interface ScheduleResponse {
 /**
  * Run summary for schedule runs list
  */
-export interface RunSummary {
+interface RunSummary {
   id: string;
   status: "pending" | "running" | "completed" | "failed" | "timeout";
   createdAt: string;
@@ -50,7 +50,7 @@ export interface RunSummary {
 /**
  * Deploy schedule request data
  */
-export interface DeployScheduleRequest {
+interface DeployScheduleRequest {
   name: string;
   composeId: string;
   cronExpression?: string;

--- a/turbo/apps/web/src/lib/storage/content-hash.ts
+++ b/turbo/apps/web/src/lib/storage/content-hash.ts
@@ -73,7 +73,7 @@ export const MIN_VERSION_PREFIX_LENGTH = 8;
 /**
  * Default display length for version IDs
  */
-export const DEFAULT_VERSION_DISPLAY_LENGTH = 8;
+const DEFAULT_VERSION_DISPLAY_LENGTH = 8;
 
 /**
  * Full SHA-256 hash length
@@ -109,7 +109,7 @@ export function isValidVersionPrefix(prefix: string): boolean {
  * File entry with pre-computed hash (no content needed)
  * Used for direct upload flow where client computes hashes
  */
-export interface FileEntryWithHash {
+interface FileEntryWithHash {
   /** Relative path within the storage */
   path: string;
   /** SHA-256 hash of file content (computed by client) */

--- a/turbo/apps/web/src/lib/storage/version-resolver.ts
+++ b/turbo/apps/web/src/lib/storage/version-resolver.ts
@@ -13,12 +13,12 @@ import {
 /**
  * Storage version record type
  */
-export type StorageVersion = typeof storageVersions.$inferSelect;
+type StorageVersion = typeof storageVersions.$inferSelect;
 
 /**
  * Result of version resolution - either success with version or error with details
  */
-export type VersionResolutionResult =
+type VersionResolutionResult =
   | { version: StorageVersion }
   | { error: string; status: number };
 

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -124,6 +124,7 @@
     "apps/web/src/lib/logger.ts",
     "apps/web/src/lib/s3/s3-client.ts",
     "apps/web/src/lib/scope/scope-service.ts",
+    "apps/web/src/lib/schedule/schedule-service.ts",
     "apps/web/src/lib/checkpoint/types.ts",
     "apps/web/src/lib/proxy/proxy-service.ts",
     "apps/web/src/lib/storage/types.ts",
@@ -135,6 +136,5 @@
   ],
   "ignoreDependencies": ["@commitlint/cli"],
   "ignoreWorkspaces": [],
-  "ignoreUnresolved": [],
-  "ignoreExportsUsedInFile": true
+  "ignoreUnresolved": []
 }

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -358,13 +358,9 @@ export {
   agentDefinitionSchema,
   agentComposeContentSchema,
   composeResponseSchema,
-  createComposeResponseSchema,
   composeListItemSchema,
 };
 
 // Export inferred types for consumers
 export type ComposeResponse = z.infer<typeof composeResponseSchema>;
-export type CoreCreateComposeResponse = z.infer<
-  typeof createComposeResponseSchema
->;
 export type ComposeListItem = z.infer<typeof composeListItemSchema>;

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -40,7 +40,6 @@ export {
   type SupportedAppTag,
   // Inferred types
   type ComposeResponse,
-  type CoreCreateComposeResponse,
   type ComposeListItem,
 } from "./composes";
 export {


### PR DESCRIPTION
## Summary

Follows up on #1261 to make knip stricter by removing `ignoreExportsUsedInFile` and cleaning up all the issues it reveals.

### Changes
- Remove `ignoreExportsUsedInFile: true` from knip.json for stricter checking
- Remove `export` keyword from 50+ types/interfaces only used internally
- Remove `export` keyword from internal functions
- Clean up unused imports in yaml-validator.ts
- Add schedule-service.ts to ignore list (ScheduleResponse needed for return type inference)

### Impact
This makes knip more strict by detecting exports that are only used within the same file, preventing unnecessary public API surface. All removed exports were verified to be internal-only.

## Test plan
- [x] `pnpm knip` passes
- [x] `pnpm check-types` passes
- [x] `pnpm turbo run lint` passes

Closes #1242

🤖 Generated with [Claude Code](https://claude.com/claude-code)