### PR TITLE
refactor(env): make E2B and R2 environment variables required

### DIFF
--- a/.env.local.tpl
+++ b/.env.local.tpl
@@ -1,14 +1,17 @@
+# Required: Authentication (Clerk)
 CLERK_SECRET_KEY=op://Development/vm0-env-local/clerk_secret_key
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=op://Development/vm0-env-local/clerk_publishable_key
+
+# Required: Sandbox Runtime (E2B)
 E2B_API_KEY=op://Development/vm0-env-local/e2b_api_key
 E2B_TEMPLATE_NAME=vm0-claude-code-dev
 
-# Cloudflare R2 Configuration for Storage
+# Required: Object Storage (Cloudflare R2)
 R2_ACCOUNT_ID=op://Development/vm0-env-local/r2_account_id
 R2_ACCESS_KEY_ID=op://Development/vm0-env-local/r2_access_key_id
 R2_SECRET_ACCESS_KEY=op://Development/vm0-env-local/r2_secret_access_key
 R2_USER_STORAGES_BUCKET_NAME=op://Development/vm0-env-local/r2_user_storages_bucket_name
 
-# Axiom Observability
+# Optional: Observability (Axiom)
 AXIOM_TOKEN=op://Development/vm0-env-local/axiom_token
 AXIOM_DATASET_SUFFIX=dev

--- a/turbo/apps/web/src/env.ts
+++ b/turbo/apps/web/src/env.ts
@@ -12,15 +12,15 @@ function initEnv() {
         .enum(["development", "test", "production"])
         .default("development"),
       CLERK_SECRET_KEY: z.string().min(1),
-      E2B_API_KEY: z.string().min(1).optional(),
-      E2B_TEMPLATE_NAME: z.string().min(1).optional(),
+      E2B_API_KEY: z.string().min(1),
+      E2B_TEMPLATE_NAME: z.string().min(1),
       VM0_API_URL: z.string().url().optional(),
       VERCEL_ENV: z.enum(["production", "preview", "development"]).optional(),
       VERCEL_URL: z.string().optional(),
-      R2_ACCOUNT_ID: z.string().min(1).optional(),
-      R2_ACCESS_KEY_ID: z.string().min(1).optional(),
-      R2_SECRET_ACCESS_KEY: z.string().min(1).optional(),
-      R2_USER_STORAGES_BUCKET_NAME: z.string().min(1).optional(),
+      R2_ACCOUNT_ID: z.string().min(1),
+      R2_ACCESS_KEY_ID: z.string().min(1),
+      R2_SECRET_ACCESS_KEY: z.string().min(1),
+      R2_USER_STORAGES_BUCKET_NAME: z.string().min(1),
       SECRETS_ENCRYPTION_KEY: z.string().length(64).optional(), // 32-byte hex key for AES-256
       OFFICIAL_RUNNER_SECRET: z.string().length(64).optional(), // 32-byte hex key for official runner auth
       AXIOM_TOKEN: z.string().min(1).optional(),

--- a/turbo/apps/web/src/lib/blob/blob-service.ts
+++ b/turbo/apps/web/src/lib/blob/blob-service.ts
@@ -61,11 +61,6 @@ export class BlobService {
     }
 
     const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
-    if (!bucketName) {
-      throw new Error(
-        "R2_USER_STORAGES_BUCKET_NAME environment variable is not set",
-      );
-    }
 
     // Step 1: Compute hashes for all files
     const fileHashes = new Map<string, { hash: string; content: Buffer }>();
@@ -218,12 +213,6 @@ export class BlobService {
    */
   async downloadBlob(hash: string): Promise<Buffer> {
     const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
-    if (!bucketName) {
-      throw new Error(
-        "R2_USER_STORAGES_BUCKET_NAME environment variable is not set",
-      );
-    }
-
     return downloadBlobFromS3(bucketName, hash);
   }
 
@@ -240,12 +229,6 @@ export class BlobService {
     }
 
     const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
-    if (!bucketName) {
-      throw new Error(
-        "R2_USER_STORAGES_BUCKET_NAME environment variable is not set",
-      );
-    }
-
     const result = new Map<string, Buffer>();
     const uniqueHashes = [...new Set(hashes)];
     const limit = pLimit(MAX_CONCURRENT_UPLOADS);

--- a/turbo/apps/web/src/lib/s3/s3-client.ts
+++ b/turbo/apps/web/src/lib/s3/s3-client.ts
@@ -53,16 +53,6 @@ export function parseS3Uri(uri: string): S3Uri {
 function getS3Client(): S3Client {
   const envVars = env();
 
-  if (
-    !envVars.R2_ACCOUNT_ID ||
-    !envVars.R2_ACCESS_KEY_ID ||
-    !envVars.R2_SECRET_ACCESS_KEY
-  ) {
-    throw new Error(
-      "R2 credentials not configured. Set R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, and R2_SECRET_ACCESS_KEY environment variables.",
-    );
-  }
-
   return new S3Client({
     region: "auto",
     endpoint: `https://${envVars.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -119,11 +119,6 @@ export class StorageService {
     log.debug("Preparing storage manifest with presigned URLs...");
 
     const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
-    if (!bucketName) {
-      throw new Error(
-        "R2_USER_STORAGES_BUCKET_NAME environment variable is not set",
-      );
-    }
 
     // For resume scenario, use resumeArtifact; otherwise use artifactName/artifactVersion
     const effectiveArtifactName = resumeArtifact?.artifactName ?? artifactName;


### PR DESCRIPTION
## Summary
- Make E2B and R2 environment variables required instead of optional
- Remove redundant defensive checks since env validation handles missing values
- Update `.env.local.tpl` with clear required/optional labels

## Rationale
E2B and R2 are core services for sandbox runtime and object storage. Previously marked as optional in env schema, but would fail at runtime when features were used. Now fail fast at startup with clear error.

## Test plan
- [ ] Verify app fails to start without E2B/R2 env vars configured
- [ ] Verify app starts normally with all required env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)