### PR TITLE
refactor: migrate compose, session & scope endpoints to ts-rest (phases 3-4)

### DIFF
--- a/turbo/apps/cli/src/lib/api/api-client.ts
+++ b/turbo/apps/cli/src/lib/api/api-client.ts
@@ -222,7 +222,7 @@ class ApiClient {
     });
 
     const result = await client.create({
-      body,
+      body: body as any,
     });
 
     // ts-rest returns discriminated union based on status code

--- a/turbo/apps/cli/src/lib/api/api-client.ts
+++ b/turbo/apps/cli/src/lib/api/api-client.ts
@@ -9,6 +9,9 @@ import {
   composesMainContract,
   composesByIdContract,
   composesVersionsContract,
+  sessionsByIdContract,
+  checkpointsByIdContract,
+  scopeContract,
   type ApiErrorResponse,
 } from "@vm0/core";
 import { getApiUrl, getToken } from "./config";
@@ -455,17 +458,24 @@ class ApiClient {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
-    const response = await fetch(`${baseUrl}/api/scope`, {
-      method: "GET",
-      headers,
+    // Create ts-rest client with config
+    const client = initClient(scopeContract, {
+      baseUrl,
+      baseHeaders: headers,
+      jsonQuery: true,
     });
 
-    if (!response.ok) {
-      const error = (await response.json()) as ApiError;
-      throw new Error(error.error?.message || "Failed to get scope");
+    const result = await client.get();
+
+    // ts-rest returns discriminated union based on status code
+    if (result.status === 200) {
+      return result.body;
     }
 
-    return (await response.json()) as ScopeResponse;
+    // Error cases
+    const errorBody = result.body as ApiErrorResponse;
+    const message = errorBody.error?.message || "Failed to get scope";
+    throw new Error(message);
   }
 
   /**
@@ -478,18 +488,24 @@ class ApiClient {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
-    const response = await fetch(`${baseUrl}/api/scope`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(body),
+    // Create ts-rest client with config
+    const client = initClient(scopeContract, {
+      baseUrl,
+      baseHeaders: headers,
+      jsonQuery: true,
     });
 
-    if (!response.ok) {
-      const error = (await response.json()) as ApiError;
-      throw new Error(error.error?.message || "Failed to create scope");
+    const result = await client.create({ body });
+
+    // ts-rest returns discriminated union based on status code
+    if (result.status === 201) {
+      return result.body;
     }
 
-    return (await response.json()) as ScopeResponse;
+    // Error cases
+    const errorBody = result.body as ApiErrorResponse;
+    const message = errorBody.error?.message || "Failed to create scope";
+    throw new Error(message);
   }
 
   /**
@@ -502,18 +518,24 @@ class ApiClient {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
-    const response = await fetch(`${baseUrl}/api/scope`, {
-      method: "PUT",
-      headers,
-      body: JSON.stringify(body),
+    // Create ts-rest client with config
+    const client = initClient(scopeContract, {
+      baseUrl,
+      baseHeaders: headers,
+      jsonQuery: true,
     });
 
-    if (!response.ok) {
-      const error = (await response.json()) as ApiError;
-      throw new Error(error.error?.message || "Failed to update scope");
+    const result = await client.update({ body });
+
+    // ts-rest returns discriminated union based on status code
+    if (result.status === 200) {
+      return result.body;
     }
 
-    return (await response.json()) as ScopeResponse;
+    // Error cases
+    const errorBody = result.body as ApiErrorResponse;
+    const message = errorBody.error?.message || "Failed to update scope";
+    throw new Error(message);
   }
 
   /**
@@ -524,19 +546,27 @@ class ApiClient {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
-    const response = await fetch(`${baseUrl}/api/agent/sessions/${sessionId}`, {
-      method: "GET",
-      headers,
+    // Create ts-rest client with config
+    const client = initClient(sessionsByIdContract, {
+      baseUrl,
+      baseHeaders: headers,
+      jsonQuery: true,
     });
 
-    if (!response.ok) {
-      const error = (await response.json()) as ApiError;
-      throw new Error(
-        error.error?.message || `Session not found: ${sessionId}`,
-      );
+    const result = await client.getById({
+      params: { id: sessionId },
+    });
+
+    // ts-rest returns discriminated union based on status code
+    if (result.status === 200) {
+      return result.body;
     }
 
-    return (await response.json()) as GetSessionResponse;
+    // Error cases
+    const errorBody = result.body as ApiErrorResponse;
+    const message =
+      errorBody.error?.message || `Session not found: ${sessionId}`;
+    throw new Error(message);
   }
 
   /**
@@ -547,22 +577,27 @@ class ApiClient {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
-    const response = await fetch(
-      `${baseUrl}/api/agent/checkpoints/${checkpointId}`,
-      {
-        method: "GET",
-        headers,
-      },
-    );
+    // Create ts-rest client with config
+    const client = initClient(checkpointsByIdContract, {
+      baseUrl,
+      baseHeaders: headers,
+      jsonQuery: true,
+    });
 
-    if (!response.ok) {
-      const error = (await response.json()) as ApiError;
-      throw new Error(
-        error.error?.message || `Checkpoint not found: ${checkpointId}`,
-      );
+    const result = await client.getById({
+      params: { id: checkpointId },
+    });
+
+    // ts-rest returns discriminated union based on status code
+    if (result.status === 200) {
+      return result.body;
     }
 
-    return (await response.json()) as GetCheckpointResponse;
+    // Error cases
+    const errorBody = result.body as ApiErrorResponse;
+    const message =
+      errorBody.error?.message || `Checkpoint not found: ${checkpointId}`;
+    throw new Error(message);
   }
 
   /**

--- a/turbo/apps/cli/src/lib/api/api-client.ts
+++ b/turbo/apps/cli/src/lib/api/api-client.ts
@@ -12,8 +12,10 @@ import {
   sessionsByIdContract,
   checkpointsByIdContract,
   scopeContract,
+  agentComposeContentSchema,
   type ApiErrorResponse,
 } from "@vm0/core";
+import type { z } from "zod";
 import { getApiUrl, getToken } from "./config";
 
 // Import types from @vm0/core contracts
@@ -222,7 +224,7 @@ class ApiClient {
     });
 
     const result = await client.create({
-      body: body as any,
+      body: body as { content: z.infer<typeof agentComposeContentSchema> },
     });
 
     // ts-rest returns discriminated union based on status code

--- a/turbo/apps/cli/src/lib/api/api-client.ts
+++ b/turbo/apps/cli/src/lib/api/api-client.ts
@@ -6,6 +6,9 @@ import {
   runMetricsContract,
   runAgentEventsContract,
   runNetworkLogsContract,
+  composesMainContract,
+  composesByIdContract,
+  composesVersionsContract,
   type ApiErrorResponse,
 } from "@vm0/core";
 import { getApiUrl, getToken } from "./config";
@@ -114,42 +117,55 @@ class ApiClient {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
-    const params = new URLSearchParams({ name });
-    if (scope) {
-      params.append("scope", scope);
-    }
+    // Create ts-rest client with config
+    const client = initClient(composesMainContract, {
+      baseUrl,
+      baseHeaders: headers,
+      jsonQuery: true,
+    });
 
-    const response = await fetch(
-      `${baseUrl}/api/agent/composes?${params.toString()}`,
-      {
-        method: "GET",
-        headers,
+    const result = await client.getByName({
+      query: {
+        name,
+        scope,
       },
-    );
+    });
 
-    if (!response.ok) {
-      const error = (await response.json()) as ApiError;
-      throw new Error(error.error?.message || `Compose not found: ${name}`);
+    // ts-rest returns discriminated union based on status code
+    if (result.status === 200) {
+      return result.body;
     }
 
-    return (await response.json()) as GetComposeResponse;
+    // Error cases
+    const errorBody = result.body as ApiErrorResponse;
+    const message = errorBody.error?.message || `Compose not found: ${name}`;
+    throw new Error(message);
   }
 
   async getComposeById(id: string): Promise<GetComposeResponse> {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
-    const response = await fetch(`${baseUrl}/api/agent/composes/${id}`, {
-      method: "GET",
-      headers,
+    // Create ts-rest client with config
+    const client = initClient(composesByIdContract, {
+      baseUrl,
+      baseHeaders: headers,
+      jsonQuery: true,
     });
 
-    if (!response.ok) {
-      const error = (await response.json()) as ApiError;
-      throw new Error(error.error?.message || `Compose not found: ${id}`);
+    const result = await client.getById({
+      params: { id },
+    });
+
+    // ts-rest returns discriminated union based on status code
+    if (result.status === 200) {
+      return result.body;
     }
 
-    return (await response.json()) as GetComposeResponse;
+    // Error cases
+    const errorBody = result.body as ApiErrorResponse;
+    const message = errorBody.error?.message || `Compose not found: ${id}`;
+    throw new Error(message);
   }
 
   /**
@@ -163,23 +179,30 @@ class ApiClient {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
-    // Quote the version as JSON string to prevent ts-rest's jsonQuery from
-    // parsing hex strings like "52999e37" as scientific notation numbers
-    const quotedVersion = JSON.stringify(version);
-    const response = await fetch(
-      `${baseUrl}/api/agent/composes/versions?composeId=${encodeURIComponent(composeId)}&version=${encodeURIComponent(quotedVersion)}`,
-      {
-        method: "GET",
-        headers,
-      },
-    );
+    // Create ts-rest client with config
+    // Note: jsonQuery: true handles scientific notation edge cases automatically
+    const client = initClient(composesVersionsContract, {
+      baseUrl,
+      baseHeaders: headers,
+      jsonQuery: true,
+    });
 
-    if (!response.ok) {
-      const error = (await response.json()) as ApiError;
-      throw new Error(error.error?.message || `Version not found: ${version}`);
+    const result = await client.resolveVersion({
+      query: {
+        composeId,
+        version,
+      },
+    });
+
+    // ts-rest returns discriminated union based on status code
+    if (result.status === 200) {
+      return result.body;
     }
 
-    return (await response.json()) as GetComposeVersionResponse;
+    // Error cases
+    const errorBody = result.body as ApiErrorResponse;
+    const message = errorBody.error?.message || `Version not found: ${version}`;
+    throw new Error(message);
   }
 
   async createOrUpdateCompose(body: {
@@ -188,18 +211,27 @@ class ApiClient {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
-    const response = await fetch(`${baseUrl}/api/agent/composes`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(body),
+    // Create ts-rest client with config
+    const client = initClient(composesMainContract, {
+      baseUrl,
+      baseHeaders: headers,
+      jsonQuery: true,
     });
 
-    if (!response.ok) {
-      const error = (await response.json()) as ApiError;
-      throw new Error(error.error?.message || "Failed to create compose");
+    const result = await client.create({
+      body,
+    });
+
+    // ts-rest returns discriminated union based on status code
+    // Both 200 and 201 are success cases
+    if (result.status === 200 || result.status === 201) {
+      return result.body;
     }
 
-    return (await response.json()) as CreateComposeResponse;
+    // Error cases
+    const errorBody = result.body as ApiErrorResponse;
+    const message = errorBody.error?.message || "Failed to create compose";
+    throw new Error(message);
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR migrates the compose, session, and scope-related API endpoints from raw fetch to ts-rest client as part of Phases 3-4 of the ts-rest migration (issue #1182).

### Phase 3: Compose Endpoints

- Migrate `getComposeByName()` to ts-rest using `composesMainContract`
- Migrate `getComposeById()` to ts-rest using `composesByIdContract`  
- Migrate `getComposeVersion()` to ts-rest using `composesVersionsContract`
- Migrate `createOrUpdateCompose()` to ts-rest using `composesMainContract`

### Phase 4: Session & Scope Endpoints

**Session Endpoints:**
- Migrate `getSession()` to ts-rest using `sessionsByIdContract`
- Migrate `getCheckpoint()` to ts-rest using `checkpointsByIdContract`

**Scope Endpoints:**
- Migrate `getScope()` to ts-rest using `scopeContract`
- Migrate `createScope()` to ts-rest using `scopeContract`
- Migrate `updateScope()` to ts-rest using `scopeContract`

All endpoints now use ts-rest client with proper status code checking and error handling.

### Test Plan

- [x] All 544 tests pass
- [x] Type check passes
- [x] Lint passes
- [x] Maintains backward compatibility - same public API signatures
- [x] ts-rest's jsonQuery handles scientific notation edge cases automatically

### Progress

- ✅ Phase 1: createRun endpoint (PR #1216 - merged)
- ✅ Phase 2: Events & telemetry endpoints (PR #1257 - merged)
- ✅ Phase 3-4: Compose, session & scope endpoints (this PR)
- ⏳ Phase 5: Generic methods & cleanup

Closes #1182 (Phases 3-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)