### PR TITLE
fix(devcontainer): install lefthook git hooks on setup

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -95,4 +95,9 @@ else
   echo "ℹ️  No certificates found. Run 'npm run generate-certs' to create them."
 fi
 
+# Install lefthook git hooks for pre-commit checks
+echo "🪝 Installing lefthook git hooks..."
+cd "$WORKSPACE_DIR/turbo" && lefthook install
+echo "✓ Lefthook hooks installed"
+
 echo "✅ Dev container setup complete!"


### PR DESCRIPTION
## Summary

Fix missing lefthook git hooks installation in devcontainer setup.

### Problem

When the devcontainer is created, lefthook binary is installed but **git hooks are not configured**. This causes pre-commit checks (lint, prettier, check-types, knip) to be skipped during local commits, leading to CI failures that could have been caught locally.

### Solution

Add `lefthook install` to `.devcontainer/setup.sh` to automatically install git hooks when the container is created.

### Changes
- Add lefthook install step to setup.sh

### Verification

After this fix, committing will trigger lefthook pre-commit hooks:

```
╭───────────────────────────────────────╮
│ 🥊 lefthook v1.12.3  hook: pre-commit │
╰───────────────────────────────────────╯
│  prettier ❯ 
│  check-types ❯ 
│  lint ❯ 
│  knip ❯ 
```

## Test plan
- [x] Verified `lefthook install` runs successfully
- [x] Verified pre-commit hooks are triggered on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)