### PR TITLE
chore(devcontainer): update image tag to 0218375

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:b9e1383",
+  "image": "ghcr.io/vm0-ai/vm0-dev:0218375",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"


### PR DESCRIPTION
## Summary
- Update devcontainer image from `b9e1383` to `0218375`
- New image includes `wget`, required for Antigravity IDE to download the remote server binary

## Context
PR #1255 added wget to the Dockerfile but the devcontainer.json image tag was not updated in main. This fixes the dev container startup failure:
```
Error need wget to download server binary
```

## Test plan
- [ ] Rebuild dev container and verify it starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)