### PR TITLE
refactor: migrate session & scope endpoints to ts-rest (phase 4)

### DIFF
--- a/turbo/apps/cli/src/lib/api/api-client.ts
+++ b/turbo/apps/cli/src/lib/api/api-client.ts
@@ -6,6 +6,9 @@ import {
   runMetricsContract,
   runAgentEventsContract,
   runNetworkLogsContract,
+  sessionsByIdContract,
+  checkpointsByIdContract,
+  scopeContract,
   type ApiErrorResponse,
 } from "@vm0/core";
 import { getApiUrl, getToken } from "./config";
@@ -423,17 +426,24 @@ class ApiClient {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
-    const response = await fetch(`${baseUrl}/api/scope`, {
-      method: "GET",
-      headers,
+    // Create ts-rest client with config
+    const client = initClient(scopeContract, {
+      baseUrl,
+      baseHeaders: headers,
+      jsonQuery: true,
     });
 
-    if (!response.ok) {
-      const error = (await response.json()) as ApiError;
-      throw new Error(error.error?.message || "Failed to get scope");
+    const result = await client.get();
+
+    // ts-rest returns discriminated union based on status code
+    if (result.status === 200) {
+      return result.body;
     }
 
-    return (await response.json()) as ScopeResponse;
+    // Error cases
+    const errorBody = result.body as ApiErrorResponse;
+    const message = errorBody.error?.message || "Failed to get scope";
+    throw new Error(message);
   }
 
   /**
@@ -446,18 +456,24 @@ class ApiClient {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
-    const response = await fetch(`${baseUrl}/api/scope`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(body),
+    // Create ts-rest client with config
+    const client = initClient(scopeContract, {
+      baseUrl,
+      baseHeaders: headers,
+      jsonQuery: true,
     });
 
-    if (!response.ok) {
-      const error = (await response.json()) as ApiError;
-      throw new Error(error.error?.message || "Failed to create scope");
+    const result = await client.create({ body });
+
+    // ts-rest returns discriminated union based on status code
+    if (result.status === 201) {
+      return result.body;
     }
 
-    return (await response.json()) as ScopeResponse;
+    // Error cases
+    const errorBody = result.body as ApiErrorResponse;
+    const message = errorBody.error?.message || "Failed to create scope";
+    throw new Error(message);
   }
 
   /**
@@ -470,18 +486,24 @@ class ApiClient {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
-    const response = await fetch(`${baseUrl}/api/scope`, {
-      method: "PUT",
-      headers,
-      body: JSON.stringify(body),
+    // Create ts-rest client with config
+    const client = initClient(scopeContract, {
+      baseUrl,
+      baseHeaders: headers,
+      jsonQuery: true,
     });
 
-    if (!response.ok) {
-      const error = (await response.json()) as ApiError;
-      throw new Error(error.error?.message || "Failed to update scope");
+    const result = await client.update({ body });
+
+    // ts-rest returns discriminated union based on status code
+    if (result.status === 200) {
+      return result.body;
     }
 
-    return (await response.json()) as ScopeResponse;
+    // Error cases
+    const errorBody = result.body as ApiErrorResponse;
+    const message = errorBody.error?.message || "Failed to update scope";
+    throw new Error(message);
   }
 
   /**
@@ -492,19 +514,27 @@ class ApiClient {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
-    const response = await fetch(`${baseUrl}/api/agent/sessions/${sessionId}`, {
-      method: "GET",
-      headers,
+    // Create ts-rest client with config
+    const client = initClient(sessionsByIdContract, {
+      baseUrl,
+      baseHeaders: headers,
+      jsonQuery: true,
     });
 
-    if (!response.ok) {
-      const error = (await response.json()) as ApiError;
-      throw new Error(
-        error.error?.message || `Session not found: ${sessionId}`,
-      );
+    const result = await client.getById({
+      params: { id: sessionId },
+    });
+
+    // ts-rest returns discriminated union based on status code
+    if (result.status === 200) {
+      return result.body;
     }
 
-    return (await response.json()) as GetSessionResponse;
+    // Error cases
+    const errorBody = result.body as ApiErrorResponse;
+    const message =
+      errorBody.error?.message || `Session not found: ${sessionId}`;
+    throw new Error(message);
   }
 
   /**
@@ -515,22 +545,27 @@ class ApiClient {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
-    const response = await fetch(
-      `${baseUrl}/api/agent/checkpoints/${checkpointId}`,
-      {
-        method: "GET",
-        headers,
-      },
-    );
+    // Create ts-rest client with config
+    const client = initClient(checkpointsByIdContract, {
+      baseUrl,
+      baseHeaders: headers,
+      jsonQuery: true,
+    });
 
-    if (!response.ok) {
-      const error = (await response.json()) as ApiError;
-      throw new Error(
-        error.error?.message || `Checkpoint not found: ${checkpointId}`,
-      );
+    const result = await client.getById({
+      params: { id: checkpointId },
+    });
+
+    // ts-rest returns discriminated union based on status code
+    if (result.status === 200) {
+      return result.body;
     }
 
-    return (await response.json()) as GetCheckpointResponse;
+    // Error cases
+    const errorBody = result.body as ApiErrorResponse;
+    const message =
+      errorBody.error?.message || `Checkpoint not found: ${checkpointId}`;
+    throw new Error(message);
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR migrates the session and scope-related API endpoints from raw fetch to ts-rest client as part of Phase 4 of the ts-rest migration (issue #1182).

### Changes

**Session Endpoints:**
- Migrate `getSession()` to ts-rest using `sessionsByIdContract`
- Migrate `getCheckpoint()` to ts-rest using `checkpointsByIdContract`

**Scope Endpoints:**
- Migrate `getScope()` to ts-rest using `scopeContract`
- Migrate `createScope()` to ts-rest using `scopeContract`
- Migrate `updateScope()` to ts-rest using `scopeContract`

All endpoints now use ts-rest client with proper status code checking and error handling.

### Test Plan

- [x] All 544 tests pass
- [x] Type check passes
- [x] Lint passes
- [x] Maintains backward compatibility - same public API signatures

### Progress

- ✅ Phase 1: createRun endpoint (PR #1216)
- ✅ Phase 2: Events & telemetry endpoints (PR #1257)
- ✅ Phase 3: Compose endpoints (PR #1266)
- ✅ Phase 4: Session & scope endpoints (this PR)
- ⏳ Phase 5: Generic methods & cleanup

Closes #1182 (Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)