### PR TITLE
fix(devcontainer): trust host mkcert CA for HTTPS development

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -70,29 +70,33 @@ if [ ! -L "$HOME/.mozilla" ]; then
   echo "✓ Linked ~/.mozilla to project directory"
 fi
 
-# Install mkcert CA if certificates exist
-if [ -d "$WORKSPACE_DIR/.certs" ] && [ "$(ls -A $WORKSPACE_DIR/.certs 2>/dev/null)" ]; then
-  echo "🔐 Installing mkcert CA..."
+# Install host mkcert CA if certificates exist
+# The rootCA.pem is generated on the host machine and shared via .certs/
+if [ -f "$WORKSPACE_DIR/.certs/rootCA.pem" ]; then
+  echo "🔐 Installing host mkcert CA..."
+  HOST_CA="$WORKSPACE_DIR/.certs/rootCA.pem"
 
-  if command -v mkcert &> /dev/null; then
-    CAROOT=$(mkcert -CAROOT)
+  # Install to system trust store (for curl, Node.js, etc.)
+  sudo cp "$HOST_CA" /usr/local/share/ca-certificates/mkcert-host-ca.crt
+  sudo update-ca-certificates 2>/dev/null
+  echo "✓ Host CA installed to system trust store"
 
-    # Install to system trust store (for curl, Node.js, etc.)
-    TRUST_STORES=system mkcert -install
-    echo "✓ mkcert CA installed to system trust store"
-
-    # Install to NSS for browsers (Chrome/Firefox)
-    # Use certutil directly since mkcert doesn't handle symlinks well
-    if [ -f "$CAROOT/rootCA.pem" ] && [ -f "$NSS_DIR/cert9.db" ]; then
-      PWFILE=$(mktemp)
-      echo "" > "$PWFILE"
-      certutil -d sql:"$NSS_DIR" -A -t "C,," -n "mkcert" -i "$CAROOT/rootCA.pem" -f "$PWFILE"
-      rm -f "$PWFILE"
-      echo "✓ mkcert CA installed to NSS database"
-    fi
+  # Install to Chromium NSS database (~/.pki/nssdb)
+  CHROMIUM_NSS="$HOME/.pki/nssdb"
+  if [ -d "$CHROMIUM_NSS" ]; then
+    certutil -d sql:"$CHROMIUM_NSS" -A -t "C,," -n "mkcert-host" -i "$HOST_CA" 2>/dev/null || true
+    echo "✓ Host CA installed to Chromium NSS database"
   fi
+
+  # Install to Firefox NSS database
+  if [ -f "$NSS_DIR/cert9.db" ]; then
+    certutil -d sql:"$NSS_DIR" -A -t "C,," -n "mkcert-host" -i "$HOST_CA" 2>/dev/null || true
+    echo "✓ Host CA installed to Firefox NSS database"
+  fi
+elif [ -d "$WORKSPACE_DIR/.certs" ] && [ "$(ls -A $WORKSPACE_DIR/.certs 2>/dev/null)" ]; then
+  echo "⚠️  Certificates found but no rootCA.pem. Run 'scripts/generate-certs.sh' on host to include CA."
 else
-  echo "ℹ️  No certificates found. Run 'npm run generate-certs' to create them."
+  echo "ℹ️  No certificates found. Run 'scripts/generate-certs.sh' on host to create them."
 fi
 
 echo "✅ Dev container setup complete!"

--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -34,6 +34,14 @@ mkcert -install
 # Create .certs directory in git root if it doesn't exist
 CERTS_DIR="${GIT_ROOT}/.certs"
 mkdir -p "$CERTS_DIR"
+
+# Copy root CA to .certs for devcontainer trust
+CAROOT=$(mkcert -CAROOT)
+if [ -f "$CAROOT/rootCA.pem" ]; then
+  cp "$CAROOT/rootCA.pem" "$CERTS_DIR/"
+  echo -e "${GREEN}✓ Copied rootCA.pem to ${CERTS_DIR}/${NC}"
+fi
+
 cd "$CERTS_DIR"
 
 # Generate certificates for each domain (skip if already exists)


### PR DESCRIPTION
## Summary
- Update `generate-certs.sh` to copy `rootCA.pem` to `.certs/`
- Update `setup.sh` to install host CA instead of devcontainer's own CA
- Install CA to system trust store and Chromium/Firefox NSS databases

## Problem
When certificates are generated on the host machine (macOS), they are signed by the host's mkcert CA. However, the devcontainer has its own separate mkcert CA, so HTTPS connections fail with `ERR_CERT_AUTHORITY_INVALID`.

## Solution
1. `generate-certs.sh` now copies the host's `rootCA.pem` to `.certs/`
2. `setup.sh` detects and installs this host CA into the devcontainer's trust stores

This allows tools like Playwright (used by agent-browser) to access local HTTPS dev servers without certificate errors.

## Test plan
- [ ] Run `scripts/generate-certs.sh` on host
- [ ] Rebuild devcontainer or run `.devcontainer/setup.sh`
- [ ] Verify `curl https://www.vm7.ai:8443` works
- [ ] Verify `agent-browser open https://www.vm7.ai:8443` works

🤖 Generated with [Claude Code](https://claude.ai/code)