### PR TITLE
chore: update docker image tags to 20260116

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:20260115",
+  "image": "ghcr.io/vm0-ai/vm0-dev:20260116",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -12,7 +12,7 @@ jobs:
   cleanup-runner:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     steps:
       - uses: actions/checkout@v4
 
@@ -99,7 +99,7 @@ jobs:
   cleanup-database:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,7 +41,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     permissions:
       contents: read
     steps:
@@ -71,7 +71,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     permissions:
       contents: read
       deployments: write
@@ -120,7 +120,7 @@ jobs:
     if: ${{ needs.release-please.outputs.docs_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     permissions:
       contents: read
       deployments: write
@@ -144,7 +144,7 @@ jobs:
     if: ${{ needs.release-please.outputs.platform_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     permissions:
       contents: read
       deployments: write
@@ -231,7 +231,7 @@ jobs:
     if: ${{ needs.release-please.outputs.runner_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     permissions:
       contents: read
     steps:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -23,7 +23,7 @@ jobs:
   change-detection:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     # Run for all events, but only do actual detection for PRs
     outputs:
       web-changed: ${{ steps.detect.outputs.web-changed }}
@@ -134,7 +134,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
@@ -160,7 +160,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     services:
       postgres:
         image: postgres:17-alpine
@@ -202,7 +202,7 @@ jobs:
   deploy-web:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [change-detection]
     # Deploy if:
     # - It's a PR and web, CLI, runner, platform, or e2e changed (all need web deployment for E2E tests)
@@ -264,7 +264,7 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [change-detection]
     # Only deploy if it's a PR and docs changed
     if: github.event_name == 'pull_request' && needs.change-detection.outputs.docs-changed == 'true'
@@ -292,7 +292,7 @@ jobs:
   deploy-platform:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [change-detection, deploy-web]
     # Only deploy if it's a PR and platform changed
     if: github.event_name == 'pull_request' && needs.change-detection.outputs.platform-changed == 'true'
@@ -323,7 +323,7 @@ jobs:
   e2e-auth:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [deploy-web]
     if: needs.deploy-web.outputs.preview-url != ''
     steps:
@@ -370,7 +370,7 @@ jobs:
   api-e2e-test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [e2e-auth, deploy-web]
     if: needs.deploy-web.outputs.preview-url != ''
     timeout-minutes: 5
@@ -398,7 +398,7 @@ jobs:
   cli-e2e-01-serial:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [e2e-auth, deploy-web, lint, test]
     if: needs.deploy-web.outputs.preview-url != ''
     timeout-minutes: 5
@@ -459,7 +459,7 @@ jobs:
   cli-e2e-02-parallel:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [cli-e2e-01-serial, deploy-web]
     if: needs.deploy-web.outputs.preview-url != ''
     timeout-minutes: 8
@@ -523,7 +523,7 @@ jobs:
   cli-e2e-03-runner:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [cli-e2e-01-serial, deploy-web, deploy-runner-start]
     if: needs.deploy-web.outputs.preview-url != ''
     timeout-minutes: 8
@@ -589,7 +589,7 @@ jobs:
   deploy-runner-prepare:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [change-detection]
     if: |
       (github.event_name == 'pull_request' && (needs.change-detection.outputs.cli-changed == 'true' || needs.change-detection.outputs.web-changed == 'true' || needs.change-detection.outputs.runner-changed == 'true' || needs.change-detection.outputs.e2e-changed == 'true')) ||
@@ -787,7 +787,7 @@ jobs:
   deploy-runner-benchmark:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [deploy-runner-prepare]
     if: needs.deploy-runner-prepare.outputs.runner-host != ''
     steps:
@@ -827,7 +827,7 @@ jobs:
   deploy-runner-start:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260115
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [change-detection, deploy-web, deploy-runner-prepare]
     if: needs.deploy-web.outputs.preview-url != '' && needs.deploy-runner-prepare.outputs.runner-host != ''
     outputs:


### PR DESCRIPTION
## Summary
- Update vm0-dev image tag from 20260115 to 20260116 in devcontainer
- Update vm0-toolchain image tag from 20260115 to 20260116 in all CI workflows

## Test plan
- [ ] Verify devcontainer builds successfully with new image
- [ ] CI pipeline passes with updated toolchain images

🤖 Generated with [Claude Code](https://claude.com/claude-code)