### PR TITLE
refactor(docker): move typescript tooling to development stage

### DIFF
--- a/.docker/toolchain/Dockerfile
+++ b/.docker/toolchain/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -sL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-am
     && chmod +x /usr/local/bin/jq
 
 # Install global npm packages for CI/CD
-RUN npm install -g pnpm@10.15.0 lefthook@1.12.3 vercel@48.11.0 neonctl@2.15.0 typescript typescript-language-server
+RUN npm install -g pnpm@10.15.0 lefthook@1.12.3 vercel@48.11.0 neonctl@2.15.0
 
 # Install Ansible for runner deployment
 # Using pip3 to ensure all ansible commands (ansible, ansible-playbook, etc.) are available
@@ -113,6 +113,9 @@ RUN curl -fsSL https://downloads.1password.com/linux/keys/1password.asc | gpg --
     && apt-get update \
     && apt-get install -y 1password-cli \
     && rm -rf /var/lib/apt/lists/*
+
+# Install TypeScript tooling for IDE/editor support
+RUN npm install -g typescript typescript-language-server
 
 # Install agent-browser for browser automation
 RUN npm install -g agent-browser \


### PR DESCRIPTION
## Summary
- Move `typescript` and `typescript-language-server` from toolchain stage to development stage
- These are IDE/editor tools not needed in CI, reducing toolchain image size

## Test plan
- [ ] CI passes (toolchain image builds without typescript)
- [ ] Devcontainer works with typescript-language-server for IDE support

🤖 Generated with [Claude Code](https://claude.com/claude-code)