### PR TITLE
refactor: move sandbox scripts build output to dist directory

### DIFF
--- a/turbo/packages/core/.gitignore
+++ b/turbo/packages/core/.gitignore
@@ -1,3 +1,2 @@
 # Build output for sandbox scripts
 src/sandbox/scripts/dist/
-src/sandbox/scripts/bundled.ts

--- a/turbo/packages/core/scripts/build-sandbox-scripts.ts
+++ b/turbo/packages/core/scripts/build-sandbox-scripts.ts
@@ -4,8 +4,8 @@
  * Bundles TypeScript source files into self-contained ESM modules (.mjs)
  * that can be deployed and executed in E2B sandbox or Firecracker VM.
  *
- * Output:
- * - dist/*.mjs - Bundled scripts for deployment
+ * Output (in src/sandbox/scripts/dist/):
+ * - *.mjs - Bundled scripts for deployment
  * - bundled.ts - Exports bundled JS as string constants for TypeScript imports
  */
 import * as esbuild from "esbuild";
@@ -14,12 +14,12 @@ import * as path from "path";
 
 const SCRIPTS_SRC = "src/sandbox/scripts/src";
 const SCRIPTS_DIST = "src/sandbox/scripts/dist";
-const BUNDLED_TS = "src/sandbox/scripts/bundled.ts";
+const BUNDLED_TS = `${SCRIPTS_DIST}/bundled.ts`;
 
 async function build() {
   console.log("[build-sandbox-scripts] Starting build...");
 
-  // Ensure dist directory exists
+  // Ensure generated/dist directory exists
   fs.mkdirSync(SCRIPTS_DIST, { recursive: true });
 
   // Bundle entry points as ESM with .mjs extension

--- a/turbo/packages/core/src/sandbox/scripts/index.ts
+++ b/turbo/packages/core/src/sandbox/scripts/index.ts
@@ -14,7 +14,7 @@ export {
   DOWNLOAD_SCRIPT,
   MOCK_CLAUDE_SCRIPT,
   ENV_LOADER_SCRIPT,
-} from "./bundled";
+} from "./dist/bundled";
 
 /**
  * Script paths in the E2B sandbox / Firecracker VM (TypeScript/ESM)

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -39,7 +39,6 @@
         ".next/**",
         "!.next/cache/**",
         "dist/**",
-        "src/sandbox/scripts/bundled.ts",
         "src/sandbox/scripts/dist/**"
       ]
     },


### PR DESCRIPTION
## Summary
- Move generated files from scattered locations to `src/sandbox/scripts/dist/`
- Consolidate `bundled.ts` and `.mjs` files in single dist directory
- Update turbo.json outputs and .gitignore accordingly

## Motivation
Follows common industry convention for build artifacts - having all generated files in a `dist/` directory makes the separation between source and generated code clearer.

**Before:**
```
src/sandbox/scripts/
├── bundled.ts        # generated (gitignore)
├── dist/             # generated (gitignore)
│   └── *.mjs
└── src/              # source
```

**After:**
```
src/sandbox/scripts/
├── dist/             # all generated (gitignore)
│   ├── bundled.ts
│   └── *.mjs
└── src/              # source
```

## Test plan
- [x] `pnpm run build` generates files in new location
- [x] `pnpm run check-types` passes
- [x] `pnpm run test` passes (317 tests)
- [x] `pnpm knip` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)