### PR TITLE
refactor(runner): decompose executor.ts into functional modules

### DIFF
--- a/turbo/apps/runner/src/lib/executor-env.ts
+++ b/turbo/apps/runner/src/lib/executor-env.ts
@@ -1,0 +1,91 @@
+/**
+ * Executor Environment
+ *
+ * Environment variable building for agent execution in Firecracker VMs.
+ */
+
+import type { ExecutionContext } from "./api.js";
+
+/**
+ * Path to environment JSON file in VM
+ * Used by run-agent.py to load environment variables
+ */
+export const ENV_JSON_PATH = "/tmp/vm0-env.json";
+
+/**
+ * Path to the proxy CA certificate on the runner host (cert only, no private key)
+ */
+export const PROXY_CA_CERT_PATH = "/opt/vm0-runner/proxy/mitmproxy-ca-cert.pem";
+
+/**
+ * Build environment variables for the agent execution
+ */
+export function buildEnvironmentVariables(
+  context: ExecutionContext,
+  apiUrl: string,
+): Record<string, string> {
+  const envVars: Record<string, string> = {
+    VM0_API_URL: apiUrl,
+    VM0_RUN_ID: context.runId,
+    VM0_API_TOKEN: context.sandboxToken,
+    VM0_PROMPT: context.prompt,
+    VM0_WORKING_DIR: context.workingDir,
+    CLI_AGENT_TYPE: context.cliAgentType || "claude-code",
+  };
+
+  // Add Vercel bypass if available
+  const vercelBypass = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (vercelBypass) {
+    envVars.VERCEL_PROTECTION_BYPASS = vercelBypass;
+  }
+
+  // Pass USE_MOCK_CLAUDE from host environment for testing
+  const useMockClaude = process.env.USE_MOCK_CLAUDE;
+  if (useMockClaude) {
+    envVars.USE_MOCK_CLAUDE = useMockClaude;
+  }
+
+  // Add artifact configuration if present
+  if (context.storageManifest?.artifact) {
+    const artifact = context.storageManifest.artifact;
+    envVars.VM0_ARTIFACT_DRIVER = "vas";
+    envVars.VM0_ARTIFACT_MOUNT_PATH = artifact.mountPath;
+    envVars.VM0_ARTIFACT_VOLUME_NAME = artifact.vasStorageName;
+    envVars.VM0_ARTIFACT_VERSION_ID = artifact.vasVersionId;
+  }
+
+  // Add resume session ID if present
+  if (context.resumeSession) {
+    envVars.VM0_RESUME_SESSION_ID = context.resumeSession.sessionId;
+  }
+
+  // Add user environment variables
+  if (context.environment) {
+    Object.assign(envVars, context.environment);
+  }
+
+  // Add secret values for masking (base64 encoded, comma separated)
+  if (context.secretValues && context.secretValues.length > 0) {
+    envVars.VM0_SECRET_VALUES = context.secretValues
+      .map((v) => Buffer.from(v).toString("base64"))
+      .join(",");
+  }
+
+  // Add user-defined vars
+  if (context.vars) {
+    for (const [key, value] of Object.entries(context.vars)) {
+      envVars[key] = value;
+    }
+  }
+
+  // For MITM mode, tell Node.js to trust the proxy CA certificate
+  // This is required because mitmproxy intercepts HTTPS traffic and re-signs
+  // certificates with its own CA. Without this, Node.js will reject the connection.
+  // Note: Python and curl automatically use the system CA bundle after update-ca-certificates.
+  if (context.experimentalFirewall?.experimental_mitm) {
+    envVars.NODE_EXTRA_CA_CERTS =
+      "/usr/local/share/ca-certificates/vm0-proxy-ca.crt";
+  }
+
+  return envVars;
+}

--- a/turbo/apps/runner/src/lib/executor-types.ts
+++ b/turbo/apps/runner/src/lib/executor-types.ts
@@ -1,0 +1,42 @@
+/**
+ * Executor Types
+ *
+ * Shared interfaces and types for the job executor.
+ */
+
+/**
+ * Execution result
+ */
+export interface ExecutionResult {
+  exitCode: number;
+  error?: string;
+}
+
+/**
+ * Execution options for customizing job execution behavior
+ */
+export interface ExecutionOptions {
+  /**
+   * Benchmark mode for local VM performance testing without API server:
+   * - Runs prompt directly as bash command (skips run-agent.py)
+   * - Skips network log upload
+   * - Skips telemetry reporting
+   * Used by the benchmark command
+   */
+  benchmarkMode?: boolean;
+
+  /**
+   * Custom logger function for execution output.
+   * If provided, executor will use this instead of console.log.
+   * Useful for adding timestamps or custom prefixes.
+   */
+  logger?: (message: string) => void;
+}
+
+/**
+ * Preflight check result
+ */
+export interface PreflightResult {
+  success: boolean;
+  error?: string;
+}

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -12,7 +12,6 @@
  */
 
 import path from "path";
-import fs from "fs";
 import { FirecrackerVM, type VMConfig } from "./firecracker/vm.js";
 import {
   type SSHClient,
@@ -23,45 +22,27 @@ import {
   setupVMProxyRules,
   removeVMProxyRules,
 } from "./firecracker/network.js";
-import type {
-  ExecutionContext,
-  StorageManifest,
-  ResumeSession,
-} from "./api.js";
+import type { ExecutionContext } from "./api.js";
 import type { RunnerConfig } from "./config.js";
-import { getAllScripts } from "./scripts/utils.js";
 import { SCRIPT_PATHS, ENV_LOADER_PATH } from "./scripts/index.js";
 import { getVMRegistry } from "./proxy/index.js";
 import { withSandboxTiming, recordRunnerOperation } from "./metrics/index.js";
 
-/**
- * Execution result
- */
-interface ExecutionResult {
-  exitCode: number;
-  error?: string;
-}
-
-/**
- * Execution options for customizing job execution behavior
- */
-interface ExecutionOptions {
-  /**
-   * Benchmark mode for local VM performance testing without API server:
-   * - Runs prompt directly as bash command (skips run-agent.py)
-   * - Skips network log upload
-   * - Skips telemetry reporting
-   * Used by the benchmark command
-   */
-  benchmarkMode?: boolean;
-
-  /**
-   * Custom logger function for execution output.
-   * If provided, executor will use this instead of console.log.
-   * Useful for adding timestamps or custom prefixes.
-   */
-  logger?: (message: string) => void;
-}
+// Import from extracted modules
+import type {
+  ExecutionResult,
+  ExecutionOptions,
+  PreflightResult,
+} from "./executor-types.js";
+import { buildEnvironmentVariables, ENV_JSON_PATH } from "./executor-env.js";
+import { uploadNetworkLogs } from "./network-logs/index.js";
+import {
+  uploadScripts,
+  downloadStorages,
+  restoreSessionHistory,
+  installProxyCA,
+  configureDNS,
+} from "./vm-setup/index.js";
 
 /**
  * Extract short VM ID from runId (UUID)
@@ -71,342 +52,6 @@ function getVmIdFromRunId(runId: string): string {
   // runId is a UUID like "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
   // Extract first 8 chars (before first hyphen) for a unique short ID
   return runId.split("-")[0] || runId.substring(0, 8);
-}
-
-/**
- * Build environment variables for the agent execution
- */
-function buildEnvironmentVariables(
-  context: ExecutionContext,
-  apiUrl: string,
-): Record<string, string> {
-  const envVars: Record<string, string> = {
-    VM0_API_URL: apiUrl,
-    VM0_RUN_ID: context.runId,
-    VM0_API_TOKEN: context.sandboxToken,
-    VM0_PROMPT: context.prompt,
-    VM0_WORKING_DIR: context.workingDir,
-    CLI_AGENT_TYPE: context.cliAgentType || "claude-code",
-  };
-
-  // Add Vercel bypass if available
-  const vercelBypass = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (vercelBypass) {
-    envVars.VERCEL_PROTECTION_BYPASS = vercelBypass;
-  }
-
-  // Pass USE_MOCK_CLAUDE from host environment for testing
-  const useMockClaude = process.env.USE_MOCK_CLAUDE;
-  if (useMockClaude) {
-    envVars.USE_MOCK_CLAUDE = useMockClaude;
-  }
-
-  // Add artifact configuration if present
-  if (context.storageManifest?.artifact) {
-    const artifact = context.storageManifest.artifact;
-    envVars.VM0_ARTIFACT_DRIVER = "vas";
-    envVars.VM0_ARTIFACT_MOUNT_PATH = artifact.mountPath;
-    envVars.VM0_ARTIFACT_VOLUME_NAME = artifact.vasStorageName;
-    envVars.VM0_ARTIFACT_VERSION_ID = artifact.vasVersionId;
-  }
-
-  // Add resume session ID if present
-  if (context.resumeSession) {
-    envVars.VM0_RESUME_SESSION_ID = context.resumeSession.sessionId;
-  }
-
-  // Add user environment variables
-  if (context.environment) {
-    Object.assign(envVars, context.environment);
-  }
-
-  // Add secret values for masking (base64 encoded, comma separated)
-  if (context.secretValues && context.secretValues.length > 0) {
-    envVars.VM0_SECRET_VALUES = context.secretValues
-      .map((v) => Buffer.from(v).toString("base64"))
-      .join(",");
-  }
-
-  // Add user-defined vars
-  if (context.vars) {
-    for (const [key, value] of Object.entries(context.vars)) {
-      envVars[key] = value;
-    }
-  }
-
-  // For MITM mode, tell Node.js to trust the proxy CA certificate
-  // This is required because mitmproxy intercepts HTTPS traffic and re-signs
-  // certificates with its own CA. Without this, Node.js will reject the connection.
-  // Note: Python and curl automatically use the system CA bundle after update-ca-certificates.
-  if (context.experimentalFirewall?.experimental_mitm) {
-    envVars.NODE_EXTRA_CA_CERTS =
-      "/usr/local/share/ca-certificates/vm0-proxy-ca.crt";
-  }
-
-  return envVars;
-}
-
-/**
- * Path to environment JSON file in VM
- * Used by run-agent.py to load environment variables
- */
-const ENV_JSON_PATH = "/tmp/vm0-env.json";
-
-/**
- * Network log entry from mitmproxy addon
- *
- * Supports two modes:
- * - sni: SNI-only mode (no HTTPS decryption, only host/port/action)
- * - mitm: MITM mode (full HTTP details including method, status, latency, sizes)
- */
-interface NetworkLogEntry {
-  timestamp: string;
-  // Common fields (all modes)
-  mode?: "mitm" | "sni";
-  action?: "ALLOW" | "DENY";
-  host?: string;
-  port?: number;
-  rule_matched?: string | null;
-  // MITM-only fields (optional)
-  method?: string;
-  url?: string;
-  status?: number;
-  latency_ms?: number;
-  request_size?: number;
-  response_size?: number;
-}
-
-/**
- * Get the network log file path for a run
- */
-function getNetworkLogPath(runId: string): string {
-  return `/tmp/vm0-network-${runId}.jsonl`;
-}
-
-/**
- * Read network logs from the JSONL file
- */
-function readNetworkLogs(runId: string): NetworkLogEntry[] {
-  const logPath = getNetworkLogPath(runId);
-
-  if (!fs.existsSync(logPath)) {
-    return [];
-  }
-
-  try {
-    const content = fs.readFileSync(logPath, "utf-8");
-    const lines = content.split("\n").filter((line) => line.trim());
-    return lines.map((line) => JSON.parse(line) as NetworkLogEntry);
-  } catch (err) {
-    console.error(
-      `[Executor] Failed to read network logs: ${err instanceof Error ? err.message : "Unknown error"}`,
-    );
-    return [];
-  }
-}
-
-/**
- * Delete network log file after upload
- */
-function cleanupNetworkLogs(runId: string): void {
-  const logPath = getNetworkLogPath(runId);
-
-  try {
-    if (fs.existsSync(logPath)) {
-      fs.unlinkSync(logPath);
-    }
-  } catch (err) {
-    console.error(
-      `[Executor] Failed to cleanup network logs: ${err instanceof Error ? err.message : "Unknown error"}`,
-    );
-  }
-}
-
-/**
- * Upload network logs to telemetry endpoint
- */
-async function uploadNetworkLogs(
-  apiUrl: string,
-  sandboxToken: string,
-  runId: string,
-): Promise<void> {
-  const networkLogs = readNetworkLogs(runId);
-
-  if (networkLogs.length === 0) {
-    console.log(`[Executor] No network logs to upload for ${runId}`);
-    return;
-  }
-
-  console.log(
-    `[Executor] Uploading ${networkLogs.length} network log entries for ${runId}`,
-  );
-
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${sandboxToken}`,
-    "Content-Type": "application/json",
-  };
-
-  // Add Vercel bypass secret if available
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  if (bypassSecret) {
-    headers["x-vercel-protection-bypass"] = bypassSecret;
-  }
-
-  const response = await fetch(`${apiUrl}/api/webhooks/agent/telemetry`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      runId,
-      networkLogs,
-    }),
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error(`[Executor] Failed to upload network logs: ${errorText}`);
-    return;
-  }
-
-  console.log(`[Executor] Network logs uploaded successfully for ${runId}`);
-
-  // Cleanup log file after successful upload
-  cleanupNetworkLogs(runId);
-}
-
-/**
- * Upload all scripts to VM individually via SSH
- * Scripts are installed to /usr/local/bin which requires sudo
- */
-async function uploadScripts(ssh: SSHClient): Promise<void> {
-  const scripts = getAllScripts();
-
-  // Create directory (requires sudo for /usr/local/bin)
-  // No lib directory needed - scripts are self-contained ESM bundles
-  await ssh.execOrThrow(`sudo mkdir -p ${SCRIPT_PATHS.baseDir}`);
-
-  // Write each script file individually using sudo tee
-  for (const script of scripts) {
-    await ssh.writeFileWithSudo(script.path, script.content);
-  }
-
-  // Set executable permissions (requires sudo)
-  await ssh.execOrThrow(
-    `sudo chmod +x ${SCRIPT_PATHS.baseDir}/*.mjs 2>/dev/null || true`,
-  );
-}
-
-/**
- * Download storages to VM using storage manifest
- */
-async function downloadStorages(
-  ssh: SSHClient,
-  manifest: StorageManifest,
-): Promise<void> {
-  // Count archives to download
-  const totalArchives =
-    manifest.storages.filter((s) => s.archiveUrl).length +
-    (manifest.artifact?.archiveUrl ? 1 : 0);
-
-  if (totalArchives === 0) {
-    console.log(`[Executor] No archives to download`);
-    return;
-  }
-
-  console.log(`[Executor] Downloading ${totalArchives} archive(s)...`);
-
-  // Write manifest to VM
-  const manifestJson = JSON.stringify(manifest);
-  await ssh.writeFile("/tmp/storage-manifest.json", manifestJson);
-
-  // Run download script
-  const result = await ssh.exec(
-    `node ${SCRIPT_PATHS.download} /tmp/storage-manifest.json`,
-  );
-
-  if (result.exitCode !== 0) {
-    throw new Error(`Storage download failed: ${result.stderr}`);
-  }
-
-  console.log(`[Executor] Storage download completed`);
-}
-
-/**
- * Restore session history for resume functionality
- */
-async function restoreSessionHistory(
-  ssh: SSHClient,
-  resumeSession: ResumeSession,
-  workingDir: string,
-  cliAgentType: string,
-): Promise<void> {
-  const { sessionId, sessionHistory } = resumeSession;
-
-  // Calculate session history path based on CLI agent type
-  let sessionPath: string;
-  if (cliAgentType === "codex") {
-    // Codex uses different path structure - for now use a marker
-    // The checkpoint.py will search for the actual file
-    console.log(
-      `[Executor] Codex resume session will be handled by checkpoint.py`,
-    );
-    return;
-  } else {
-    // Claude Code path: ~/.claude/projects/-{path}/{session_id}.jsonl
-    const projectName = workingDir.replace(/^\//, "").replace(/\//g, "-");
-    sessionPath = `/home/user/.claude/projects/-${projectName}/${sessionId}.jsonl`;
-  }
-
-  console.log(`[Executor] Restoring session history to ${sessionPath}`);
-
-  // Create directory and write file
-  const dirPath = sessionPath.substring(0, sessionPath.lastIndexOf("/"));
-  await ssh.execOrThrow(`mkdir -p "${dirPath}"`);
-  await ssh.writeFile(sessionPath, sessionHistory);
-
-  console.log(
-    `[Executor] Session history restored (${sessionHistory.split("\n").length} lines)`,
-  );
-}
-
-/**
- * Path to the proxy CA certificate on the runner host (cert only, no private key)
- */
-const PROXY_CA_CERT_PATH = "/opt/vm0-runner/proxy/mitmproxy-ca-cert.pem";
-
-/**
- * Install proxy CA certificate in VM for network security mode
- * This allows the VM to trust the runner's mitmproxy for HTTPS interception
- */
-async function installProxyCA(ssh: SSHClient): Promise<void> {
-  // Read CA certificate from runner host
-  if (!fs.existsSync(PROXY_CA_CERT_PATH)) {
-    throw new Error(
-      `Proxy CA certificate not found at ${PROXY_CA_CERT_PATH}. Run generate-proxy-ca.sh first.`,
-    );
-  }
-
-  const caCert = fs.readFileSync(PROXY_CA_CERT_PATH, "utf-8");
-  console.log(
-    `[Executor] Installing proxy CA certificate (${caCert.length} bytes)`,
-  );
-
-  // Write CA cert to VM's CA certificates directory
-  await ssh.writeFileWithSudo(
-    "/usr/local/share/ca-certificates/vm0-proxy-ca.crt",
-    caCert,
-  );
-
-  // Update CA certificates (requires sudo)
-  await ssh.execOrThrow("sudo update-ca-certificates");
-  console.log(`[Executor] Proxy CA certificate installed successfully`);
-}
-
-/**
- * Preflight check result
- */
-interface PreflightResult {
-  success: boolean;
-  error?: string;
 }
 
 /**
@@ -522,24 +167,6 @@ export async function reportPreflightFailure(
   } catch (err) {
     console.error(`[Executor] Failed to report preflight failure: ${err}`);
   }
-}
-
-/**
- * Configure DNS in the VM
- * Systemd-resolved may overwrite /etc/resolv.conf at boot,
- * so we need to ensure DNS servers are configured after SSH is ready.
- * Requires sudo since we're connected as 'user', not root.
- */
-async function configureDNS(ssh: SSHClient): Promise<void> {
-  // Remove any symlink and write static DNS configuration
-  // Use sudo since /etc/resolv.conf requires root access
-  const dnsConfig = `nameserver 8.8.8.8
-nameserver 8.8.4.4
-nameserver 1.1.1.1`;
-
-  await ssh.execOrThrow(
-    `sudo sh -c 'rm -f /etc/resolv.conf && echo "${dnsConfig}" > /etc/resolv.conf'`,
-  );
 }
 
 /**

--- a/turbo/apps/runner/src/lib/network-logs/index.ts
+++ b/turbo/apps/runner/src/lib/network-logs/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Network Logs Module
+ *
+ * Re-exports for network logging functionality.
+ */
+
+export { uploadNetworkLogs } from "./network-logs.js";

--- a/turbo/apps/runner/src/lib/network-logs/network-logs.ts
+++ b/turbo/apps/runner/src/lib/network-logs/network-logs.ts
@@ -1,0 +1,106 @@
+/**
+ * Network Logs
+ *
+ * Functions for reading, uploading, and cleaning up network logs
+ * captured by mitmproxy addon during VM execution.
+ */
+
+import fs from "fs";
+import type { NetworkLogEntry } from "./types.js";
+
+/**
+ * Get the network log file path for a run
+ */
+function getNetworkLogPath(runId: string): string {
+  return `/tmp/vm0-network-${runId}.jsonl`;
+}
+
+/**
+ * Read network logs from the JSONL file
+ */
+function readNetworkLogs(runId: string): NetworkLogEntry[] {
+  const logPath = getNetworkLogPath(runId);
+
+  if (!fs.existsSync(logPath)) {
+    return [];
+  }
+
+  try {
+    const content = fs.readFileSync(logPath, "utf-8");
+    const lines = content.split("\n").filter((line) => line.trim());
+    return lines.map((line) => JSON.parse(line) as NetworkLogEntry);
+  } catch (err) {
+    console.error(
+      `[Executor] Failed to read network logs: ${err instanceof Error ? err.message : "Unknown error"}`,
+    );
+    return [];
+  }
+}
+
+/**
+ * Delete network log file after upload
+ */
+function cleanupNetworkLogs(runId: string): void {
+  const logPath = getNetworkLogPath(runId);
+
+  try {
+    if (fs.existsSync(logPath)) {
+      fs.unlinkSync(logPath);
+    }
+  } catch (err) {
+    console.error(
+      `[Executor] Failed to cleanup network logs: ${err instanceof Error ? err.message : "Unknown error"}`,
+    );
+  }
+}
+
+/**
+ * Upload network logs to telemetry endpoint
+ */
+export async function uploadNetworkLogs(
+  apiUrl: string,
+  sandboxToken: string,
+  runId: string,
+): Promise<void> {
+  const networkLogs = readNetworkLogs(runId);
+
+  if (networkLogs.length === 0) {
+    console.log(`[Executor] No network logs to upload for ${runId}`);
+    return;
+  }
+
+  console.log(
+    `[Executor] Uploading ${networkLogs.length} network log entries for ${runId}`,
+  );
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${sandboxToken}`,
+    "Content-Type": "application/json",
+  };
+
+  // Add Vercel bypass secret if available
+  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (bypassSecret) {
+    headers["x-vercel-protection-bypass"] = bypassSecret;
+  }
+
+  const response = await fetch(`${apiUrl}/api/webhooks/agent/telemetry`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      runId,
+      networkLogs,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error(`[Executor] Failed to upload network logs: ${errorText}`);
+    return;
+  }
+
+  console.log(`[Executor] Network logs uploaded successfully for ${runId}`);
+
+  // Cleanup log file after successful upload
+  cleanupNetworkLogs(runId);
+}

--- a/turbo/apps/runner/src/lib/network-logs/types.ts
+++ b/turbo/apps/runner/src/lib/network-logs/types.ts
@@ -1,0 +1,29 @@
+/**
+ * Network Logs Types
+ *
+ * Type definitions for network logging from mitmproxy addon.
+ */
+
+/**
+ * Network log entry from mitmproxy addon
+ *
+ * Supports two modes:
+ * - sni: SNI-only mode (no HTTPS decryption, only host/port/action)
+ * - mitm: MITM mode (full HTTP details including method, status, latency, sizes)
+ */
+export interface NetworkLogEntry {
+  timestamp: string;
+  // Common fields (all modes)
+  mode?: "mitm" | "sni";
+  action?: "ALLOW" | "DENY";
+  host?: string;
+  port?: number;
+  rule_matched?: string | null;
+  // MITM-only fields (optional)
+  method?: string;
+  url?: string;
+  status?: number;
+  latency_ms?: number;
+  request_size?: number;
+  response_size?: number;
+}

--- a/turbo/apps/runner/src/lib/vm-setup/index.ts
+++ b/turbo/apps/runner/src/lib/vm-setup/index.ts
@@ -1,0 +1,13 @@
+/**
+ * VM Setup Module
+ *
+ * Re-exports for VM setup operations.
+ */
+
+export {
+  uploadScripts,
+  downloadStorages,
+  restoreSessionHistory,
+  installProxyCA,
+  configureDNS,
+} from "./vm-setup.js";

--- a/turbo/apps/runner/src/lib/vm-setup/vm-setup.ts
+++ b/turbo/apps/runner/src/lib/vm-setup/vm-setup.ts
@@ -1,0 +1,154 @@
+/**
+ * VM Setup Operations
+ *
+ * SSH-based setup operations for Firecracker VMs.
+ * These functions configure the VM environment before agent execution.
+ */
+
+import fs from "fs";
+import type { SSHClient } from "../firecracker/guest.js";
+import type { StorageManifest, ResumeSession } from "../api.js";
+import { getAllScripts } from "../scripts/utils.js";
+import { SCRIPT_PATHS } from "../scripts/index.js";
+import { PROXY_CA_CERT_PATH } from "../executor-env.js";
+
+/**
+ * Upload all scripts to VM individually via SSH
+ * Scripts are installed to /usr/local/bin which requires sudo
+ */
+export async function uploadScripts(ssh: SSHClient): Promise<void> {
+  const scripts = getAllScripts();
+
+  // Create directory (requires sudo for /usr/local/bin)
+  // No lib directory needed - scripts are self-contained ESM bundles
+  await ssh.execOrThrow(`sudo mkdir -p ${SCRIPT_PATHS.baseDir}`);
+
+  // Write each script file individually using sudo tee
+  for (const script of scripts) {
+    await ssh.writeFileWithSudo(script.path, script.content);
+  }
+
+  // Set executable permissions (requires sudo)
+  await ssh.execOrThrow(
+    `sudo chmod +x ${SCRIPT_PATHS.baseDir}/*.mjs 2>/dev/null || true`,
+  );
+}
+
+/**
+ * Download storages to VM using storage manifest
+ */
+export async function downloadStorages(
+  ssh: SSHClient,
+  manifest: StorageManifest,
+): Promise<void> {
+  // Count archives to download
+  const totalArchives =
+    manifest.storages.filter((s) => s.archiveUrl).length +
+    (manifest.artifact?.archiveUrl ? 1 : 0);
+
+  if (totalArchives === 0) {
+    console.log(`[Executor] No archives to download`);
+    return;
+  }
+
+  console.log(`[Executor] Downloading ${totalArchives} archive(s)...`);
+
+  // Write manifest to VM
+  const manifestJson = JSON.stringify(manifest);
+  await ssh.writeFile("/tmp/storage-manifest.json", manifestJson);
+
+  // Run download script
+  const result = await ssh.exec(
+    `node ${SCRIPT_PATHS.download} /tmp/storage-manifest.json`,
+  );
+
+  if (result.exitCode !== 0) {
+    throw new Error(`Storage download failed: ${result.stderr}`);
+  }
+
+  console.log(`[Executor] Storage download completed`);
+}
+
+/**
+ * Restore session history for resume functionality
+ */
+export async function restoreSessionHistory(
+  ssh: SSHClient,
+  resumeSession: ResumeSession,
+  workingDir: string,
+  cliAgentType: string,
+): Promise<void> {
+  const { sessionId, sessionHistory } = resumeSession;
+
+  // Calculate session history path based on CLI agent type
+  let sessionPath: string;
+  if (cliAgentType === "codex") {
+    // Codex uses different path structure - for now use a marker
+    // The checkpoint.py will search for the actual file
+    console.log(
+      `[Executor] Codex resume session will be handled by checkpoint.py`,
+    );
+    return;
+  } else {
+    // Claude Code path: ~/.claude/projects/-{path}/{session_id}.jsonl
+    const projectName = workingDir.replace(/^\//, "").replace(/\//g, "-");
+    sessionPath = `/home/user/.claude/projects/-${projectName}/${sessionId}.jsonl`;
+  }
+
+  console.log(`[Executor] Restoring session history to ${sessionPath}`);
+
+  // Create directory and write file
+  const dirPath = sessionPath.substring(0, sessionPath.lastIndexOf("/"));
+  await ssh.execOrThrow(`mkdir -p "${dirPath}"`);
+  await ssh.writeFile(sessionPath, sessionHistory);
+
+  console.log(
+    `[Executor] Session history restored (${sessionHistory.split("\n").length} lines)`,
+  );
+}
+
+/**
+ * Install proxy CA certificate in VM for network security mode
+ * This allows the VM to trust the runner's mitmproxy for HTTPS interception
+ */
+export async function installProxyCA(ssh: SSHClient): Promise<void> {
+  // Read CA certificate from runner host
+  if (!fs.existsSync(PROXY_CA_CERT_PATH)) {
+    throw new Error(
+      `Proxy CA certificate not found at ${PROXY_CA_CERT_PATH}. Run generate-proxy-ca.sh first.`,
+    );
+  }
+
+  const caCert = fs.readFileSync(PROXY_CA_CERT_PATH, "utf-8");
+  console.log(
+    `[Executor] Installing proxy CA certificate (${caCert.length} bytes)`,
+  );
+
+  // Write CA cert to VM's CA certificates directory
+  await ssh.writeFileWithSudo(
+    "/usr/local/share/ca-certificates/vm0-proxy-ca.crt",
+    caCert,
+  );
+
+  // Update CA certificates (requires sudo)
+  await ssh.execOrThrow("sudo update-ca-certificates");
+  console.log(`[Executor] Proxy CA certificate installed successfully`);
+}
+
+/**
+ * Configure DNS in the VM
+ * Systemd-resolved may overwrite /etc/resolv.conf at boot,
+ * so we need to ensure DNS servers are configured after SSH is ready.
+ * Requires sudo since we're connected as 'user', not root.
+ */
+export async function configureDNS(ssh: SSHClient): Promise<void> {
+  // Remove any symlink and write static DNS configuration
+  // Use sudo since /etc/resolv.conf requires root access
+  const dnsConfig = `nameserver 8.8.8.8
+nameserver 8.8.4.4
+nameserver 1.1.1.1`;
+
+  await ssh.execOrThrow(
+    `sudo sh -c 'rm -f /etc/resolv.conf && echo "${dnsConfig}" > /etc/resolv.conf'`,
+  );
+}


### PR DESCRIPTION
## Summary

- Extract helper functions from `executor.ts` (883 lines) into focused modules following the PR #1287 pattern
- Result: `executor.ts` reduced to 509 lines (42% reduction), focusing on orchestration and VM lifecycle management

### New Files Created

| File | Lines | Description |
|------|-------|-------------|
| `executor-types.ts` | 42 | Shared interfaces (ExecutionResult, ExecutionOptions, PreflightResult) |
| `executor-env.ts` | 91 | Environment variable building and path constants |
| `network-logs/index.ts` | 7 | Re-exports |
| `network-logs/types.ts` | 29 | NetworkLogEntry interface |
| `network-logs/network-logs.ts` | 106 | Network log reading, uploading, cleanup |
| `vm-setup/index.ts` | 13 | Re-exports |
| `vm-setup/vm-setup.ts` | 154 | SSH-based VM setup operations |

### What Stays in executor.ts

- `getVmIdFromRunId` - VM ID extraction
- `CURL_ERROR_MESSAGES` - Error message mapping
- `runPreflightCheck` - Preflight connectivity check
- `reportPreflightFailure` - Preflight failure reporting
- `executeJob` - Main orchestration function

Closes #1293

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm turbo run lint --filter=@vm0/runner` passes  
- [x] `pnpm knip` passes (no unused exports)
- [x] `pnpm vitest run apps/runner` passes (110 tests)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)