### PR TITLE
feat(cli): add usage command to view daily run statistics

### DIFF
--- a/e2e/tests/02-parallel/t28-vm0-usage.bats
+++ b/e2e/tests/02-parallel/t28-vm0-usage.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+
+# Usage command tests
+
+@test "vm0 usage --help shows command description" {
+    run $CLI_COMMAND usage --help
+    assert_success
+    assert_output --partial "View usage statistics"
+    assert_output --partial "--since"
+    assert_output --partial "--until"
+}
+
+@test "vm0 usage returns usage data with default 7 day range" {
+    run $CLI_COMMAND usage
+    assert_success
+    # Should show header with date range
+    assert_output --partial "Usage Summary"
+    # Should show column headers
+    assert_output --partial "DATE"
+    assert_output --partial "RUNS"
+    assert_output --partial "RUN TIME"
+    # Should show total row
+    assert_output --partial "TOTAL"
+}
+
+@test "vm0 usage --since accepts relative date format" {
+    run $CLI_COMMAND usage --since 7d
+    assert_success
+    assert_output --partial "Usage Summary"
+    assert_output --partial "TOTAL"
+}
+
+@test "vm0 usage --since accepts ISO date format" {
+    # Use a date 5 days ago to stay within 30 day limit
+    local since_date=$(date -d "5 days ago" +%Y-%m-%d 2>/dev/null || date -v-5d +%Y-%m-%d)
+    run $CLI_COMMAND usage --since "$since_date"
+    assert_success
+    assert_output --partial "Usage Summary"
+}
+
+@test "vm0 usage --until accepts ISO date format" {
+    local until_date=$(date +%Y-%m-%d)
+    local since_date=$(date -d "3 days ago" +%Y-%m-%d 2>/dev/null || date -v-3d +%Y-%m-%d)
+    run $CLI_COMMAND usage --since "$since_date" --until "$until_date"
+    assert_success
+    assert_output --partial "Usage Summary"
+}
+
+@test "vm0 usage rejects invalid --since format" {
+    run $CLI_COMMAND usage --since "invalid-date"
+    assert_failure
+    assert_output --partial "Invalid --since format"
+}
+
+@test "vm0 usage rejects invalid --until format" {
+    run $CLI_COMMAND usage --until "not-a-date"
+    assert_failure
+    assert_output --partial "Invalid --until format"
+}
+
+@test "vm0 usage rejects --since after --until" {
+    local today=$(date +%Y-%m-%d)
+    local yesterday=$(date -d "1 day ago" +%Y-%m-%d 2>/dev/null || date -v-1d +%Y-%m-%d)
+    run $CLI_COMMAND usage --since "$today" --until "$yesterday"
+    assert_failure
+    assert_output --partial "--since must be before --until"
+}
+
+@test "vm0 usage rejects range exceeding 30 days" {
+    local today=$(date +%Y-%m-%d)
+    local long_ago=$(date -d "40 days ago" +%Y-%m-%d 2>/dev/null || date -v-40d +%Y-%m-%d)
+    run $CLI_COMMAND usage --since "$long_ago" --until "$today"
+    assert_failure
+    assert_output --partial "exceeds maximum of 30 days"
+}
+
+@test "vm0 usage shows dash for zero run time" {
+    # With a very short time range where no runs occurred,
+    # the TOTAL should show 0 runs with "-" for time
+    # This test verifies the formatting works correctly
+    run $CLI_COMMAND usage
+    assert_success
+    # Output should be well-formatted regardless of data
+    assert_output --partial "TOTAL"
+}

--- a/turbo/apps/cli/src/commands/__tests__/usage.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/usage.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { usageCommand } from "../usage";
+import { apiClient } from "../../lib/api/api-client";
+
+// Mock dependencies
+vi.mock("../../lib/api/api-client");
+
+describe("usage command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("default behavior", () => {
+    it("should fetch usage with default 7 day range", async () => {
+      vi.mocked(apiClient.getUsage).mockResolvedValue({
+        period: {
+          start: "2026-01-12T00:00:00.000Z",
+          end: "2026-01-19T00:00:00.000Z",
+        },
+        summary: {
+          total_runs: 10,
+          total_run_time_ms: 600000, // 10 minutes
+        },
+        daily: [
+          { date: "2026-01-18", run_count: 5, run_time_ms: 300000 },
+          { date: "2026-01-17", run_count: 3, run_time_ms: 180000 },
+          { date: "2026-01-16", run_count: 2, run_time_ms: 120000 },
+        ],
+      });
+
+      await usageCommand.parseAsync(["node", "cli"]);
+
+      expect(apiClient.getUsage).toHaveBeenCalledWith({
+        startDate: expect.any(String),
+        endDate: expect.any(String),
+      });
+
+      // Check output contains expected header and data
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Usage Summary"),
+      );
+    });
+
+    it("should display daily breakdown with formatted durations", async () => {
+      vi.mocked(apiClient.getUsage).mockResolvedValue({
+        period: {
+          start: "2026-01-12T00:00:00.000Z",
+          end: "2026-01-19T00:00:00.000Z",
+        },
+        summary: {
+          total_runs: 10,
+          total_run_time_ms: 600000,
+        },
+        daily: [
+          { date: "2026-01-18", run_count: 5, run_time_ms: 300000 }, // 5m
+        ],
+      });
+
+      await usageCommand.parseAsync(["node", "cli"]);
+
+      // Check totals row
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("TOTAL"),
+      );
+    });
+  });
+
+  describe("--since option", () => {
+    it("should accept ISO date format", async () => {
+      vi.mocked(apiClient.getUsage).mockResolvedValue({
+        period: {
+          start: "2026-01-15T00:00:00.000Z",
+          end: "2026-01-19T00:00:00.000Z",
+        },
+        summary: { total_runs: 5, total_run_time_ms: 300000 },
+        daily: [],
+      });
+
+      await usageCommand.parseAsync(["node", "cli", "--since", "2026-01-15"]);
+
+      expect(apiClient.getUsage).toHaveBeenCalledWith({
+        startDate: expect.stringContaining("2026-01-15"),
+        endDate: expect.any(String),
+      });
+    });
+
+    it("should accept relative format (7d)", async () => {
+      vi.mocked(apiClient.getUsage).mockResolvedValue({
+        period: {
+          start: "2026-01-12T00:00:00.000Z",
+          end: "2026-01-19T00:00:00.000Z",
+        },
+        summary: { total_runs: 5, total_run_time_ms: 300000 },
+        daily: [],
+      });
+
+      await usageCommand.parseAsync(["node", "cli", "--since", "7d"]);
+
+      expect(apiClient.getUsage).toHaveBeenCalled();
+    });
+
+    it("should reject invalid --since format", async () => {
+      await expect(async () => {
+        await usageCommand.parseAsync(["node", "cli", "--since", "invalid"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid --since format"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("--until option", () => {
+    it("should accept ISO date format", async () => {
+      vi.mocked(apiClient.getUsage).mockResolvedValue({
+        period: {
+          start: "2026-01-10T00:00:00.000Z",
+          end: "2026-01-17T00:00:00.000Z",
+        },
+        summary: { total_runs: 5, total_run_time_ms: 300000 },
+        daily: [],
+      });
+
+      await usageCommand.parseAsync(["node", "cli", "--until", "2026-01-17"]);
+
+      expect(apiClient.getUsage).toHaveBeenCalledWith({
+        startDate: expect.any(String),
+        endDate: expect.stringContaining("2026-01-17"),
+      });
+    });
+
+    it("should reject invalid --until format", async () => {
+      await expect(async () => {
+        await usageCommand.parseAsync(["node", "cli", "--until", "invalid"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid --until format"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("date range validation", () => {
+    it("should reject --since after --until", async () => {
+      await expect(async () => {
+        await usageCommand.parseAsync([
+          "node",
+          "cli",
+          "--since",
+          "2026-01-20",
+          "--until",
+          "2026-01-15",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--since must be before --until"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject range exceeding 30 days", async () => {
+      await expect(async () => {
+        await usageCommand.parseAsync([
+          "node",
+          "cli",
+          "--since",
+          "2025-12-01",
+          "--until",
+          "2026-01-15",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("exceeds maximum of 30 days"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication errors", async () => {
+      vi.mocked(apiClient.getUsage).mockRejectedValue(
+        new Error("Not authenticated"),
+      );
+
+      await expect(async () => {
+        await usageCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 auth login"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle API errors", async () => {
+      vi.mocked(apiClient.getUsage).mockRejectedValue(
+        new Error("Server error"),
+      );
+
+      await expect(async () => {
+        await usageCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle unexpected errors", async () => {
+      vi.mocked(apiClient.getUsage).mockRejectedValue("Non-error object");
+
+      await expect(async () => {
+        await usageCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("unexpected error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("output formatting", () => {
+    it("should fill in missing dates with zero values", async () => {
+      vi.mocked(apiClient.getUsage).mockResolvedValue({
+        period: {
+          start: "2026-01-15T00:00:00.000Z",
+          end: "2026-01-19T00:00:00.000Z",
+        },
+        summary: { total_runs: 2, total_run_time_ms: 120000 },
+        daily: [
+          // Only one day has data, others should be filled with zeros
+          { date: "2026-01-17", run_count: 2, run_time_ms: 120000 },
+        ],
+      });
+
+      await usageCommand.parseAsync(["node", "cli"]);
+
+      // Should have called console.log multiple times for each day
+      // The missing dates should be filled in
+      expect(mockConsoleLog).toHaveBeenCalled();
+    });
+
+    it("should display '-' for zero run time", async () => {
+      vi.mocked(apiClient.getUsage).mockResolvedValue({
+        period: {
+          start: "2026-01-15T00:00:00.000Z",
+          end: "2026-01-19T00:00:00.000Z",
+        },
+        summary: { total_runs: 0, total_run_time_ms: 0 },
+        daily: [],
+      });
+
+      await usageCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalled();
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/usage.ts
+++ b/turbo/apps/cli/src/commands/usage.ts
@@ -1,0 +1,213 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { apiClient } from "../lib/api/api-client";
+import { parseTime } from "../lib/utils/time-parser";
+import { formatDuration } from "../lib/utils/duration-formatter";
+
+/**
+ * Maximum time range allowed (30 days in milliseconds)
+ */
+const MAX_RANGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Default time range (7 days in milliseconds)
+ */
+const DEFAULT_RANGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Format a date for display (e.g., "Jan 19")
+ */
+function formatDateDisplay(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+/**
+ * Format a date range for the header (e.g., "Jan 13 - Jan 19, 2026")
+ */
+function formatDateRange(start: string, end: string): string {
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+
+  // Subtract 1 day from end since it's exclusive
+  endDate.setDate(endDate.getDate() - 1);
+
+  const startStr = startDate.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+  const endStr = endDate.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return `${startStr} - ${endStr}`;
+}
+
+/**
+ * Fill in missing dates in the daily array
+ */
+function fillMissingDates(
+  daily: Array<{ date: string; run_count: number; run_time_ms: number }>,
+  startDate: Date,
+  endDate: Date,
+): Array<{ date: string; run_count: number; run_time_ms: number }> {
+  const dateMap = new Map<
+    string,
+    { date: string; run_count: number; run_time_ms: number }
+  >();
+
+  // Index existing data by date
+  for (const day of daily) {
+    dateMap.set(day.date, day);
+  }
+
+  // Generate all dates in range
+  const result: Array<{
+    date: string;
+    run_count: number;
+    run_time_ms: number;
+  }> = [];
+  const current = new Date(startDate);
+  current.setUTCHours(0, 0, 0, 0);
+
+  while (current < endDate) {
+    const dateStr = current.toISOString().split("T")[0]!;
+    const existing = dateMap.get(dateStr);
+
+    if (existing) {
+      result.push(existing);
+    } else {
+      result.push({ date: dateStr, run_count: 0, run_time_ms: 0 });
+    }
+
+    current.setDate(current.getDate() + 1);
+  }
+
+  // Sort by date descending (most recent first)
+  result.sort((a, b) => b.date.localeCompare(a.date));
+
+  return result;
+}
+
+export const usageCommand = new Command()
+  .name("usage")
+  .description("View usage statistics")
+  .option("--since <date>", "Start date (ISO format or relative: 7d, 30d)")
+  .option(
+    "--until <date>",
+    "End date (ISO format or relative, defaults to now)",
+  )
+  .action(async (options: { since?: string; until?: string }) => {
+    try {
+      // Calculate date range
+      const now = new Date();
+      let endDate: Date;
+      let startDate: Date;
+
+      if (options.until) {
+        try {
+          const untilMs = parseTime(options.until);
+          endDate = new Date(untilMs);
+        } catch {
+          console.error(
+            chalk.red(
+              "Error: Invalid --until format. Use ISO (2026-01-01) or relative (7d, 30d)",
+            ),
+          );
+          process.exit(1);
+        }
+      } else {
+        endDate = now;
+      }
+
+      if (options.since) {
+        try {
+          const sinceMs = parseTime(options.since);
+          startDate = new Date(sinceMs);
+        } catch {
+          console.error(
+            chalk.red(
+              "Error: Invalid --since format. Use ISO (2026-01-01) or relative (7d, 30d)",
+            ),
+          );
+          process.exit(1);
+        }
+      } else {
+        startDate = new Date(endDate.getTime() - DEFAULT_RANGE_MS);
+      }
+
+      // Validate date range
+      if (startDate >= endDate) {
+        console.error(chalk.red("Error: --since must be before --until"));
+        process.exit(1);
+      }
+
+      const rangeMs = endDate.getTime() - startDate.getTime();
+      if (rangeMs > MAX_RANGE_MS) {
+        console.error(
+          chalk.red(
+            "Error: Time range exceeds maximum of 30 days. Use --until to specify an end date.",
+          ),
+        );
+        process.exit(1);
+      }
+
+      // Fetch usage data
+      const usage = await apiClient.getUsage({
+        startDate: startDate.toISOString(),
+        endDate: endDate.toISOString(),
+      });
+
+      // Fill in missing dates
+      const filledDaily = fillMissingDates(
+        usage.daily,
+        new Date(usage.period.start),
+        new Date(usage.period.end),
+      );
+
+      // Print header
+      console.log();
+      console.log(
+        chalk.bold(
+          `Usage Summary (${formatDateRange(usage.period.start, usage.period.end)})`,
+        ),
+      );
+      console.log();
+
+      // Print column headers
+      console.log(chalk.dim("DATE        RUNS    RUN TIME"));
+
+      // Print each day
+      for (const day of filledDaily) {
+        const dateDisplay = formatDateDisplay(day.date).padEnd(10);
+        const runsDisplay = String(day.run_count).padStart(6);
+        const timeDisplay = formatDuration(day.run_time_ms);
+
+        console.log(`${dateDisplay}${runsDisplay}    ${timeDisplay}`);
+      }
+
+      // Print separator and totals
+      console.log(chalk.dim("─".repeat(29)));
+      const totalRunsDisplay = String(usage.summary.total_runs).padStart(6);
+      const totalTimeDisplay = formatDuration(usage.summary.total_run_time_ms);
+      console.log(
+        `${"TOTAL".padEnd(10)}${totalRunsDisplay}    ${totalTimeDisplay}`,
+      );
+      console.log();
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes("Not authenticated")) {
+          console.error(
+            chalk.red("Error: Not authenticated. Run: vm0 auth login"),
+          );
+        } else {
+          console.error(chalk.red(`Error: ${error.message}`));
+        }
+      } else {
+        console.error(chalk.red("Error: An unexpected error occurred"));
+      }
+      process.exit(1);
+    }
+  });

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -18,6 +18,7 @@ import { agentCommand } from "./commands/agent";
 import { initCommand } from "./commands/init";
 import { setupGithubCommand } from "./commands/setup-github";
 import { scheduleCommand } from "./commands/schedule";
+import { usageCommand } from "./commands/usage";
 
 const program = new Command();
 
@@ -84,6 +85,7 @@ program.addCommand(agentCommand);
 program.addCommand(initCommand);
 program.addCommand(setupGithubCommand);
 program.addCommand(scheduleCommand);
+program.addCommand(usageCommand);
 
 export { program };
 

--- a/turbo/apps/cli/src/lib/api/api-client.ts
+++ b/turbo/apps/cli/src/lib/api/api-client.ts
@@ -1139,6 +1139,39 @@ class ApiClient {
   }
 
   /**
+   * Get usage statistics
+   */
+  async getUsage(options: { startDate: string; endDate: string }): Promise<{
+    period: { start: string; end: string };
+    summary: { total_runs: number; total_run_time_ms: number };
+    daily: Array<{ date: string; run_count: number; run_time_ms: number }>;
+  }> {
+    const baseUrl = await this.getBaseUrl();
+    const headers = await this.getHeaders();
+
+    const params = new URLSearchParams({
+      start_date: options.startDate,
+      end_date: options.endDate,
+    });
+
+    const response = await fetch(`${baseUrl}/api/usage?${params}`, {
+      method: "GET",
+      headers,
+    });
+
+    if (!response.ok) {
+      const error = (await response.json()) as { error?: { message?: string } };
+      throw new Error(error.error?.message || "Failed to fetch usage data");
+    }
+
+    return response.json() as Promise<{
+      period: { start: string; end: string };
+      summary: { total_runs: number; total_run_time_ms: number };
+      daily: Array<{ date: string; run_count: number; run_time_ms: number }>;
+    }>;
+  }
+
+  /**
    * Generic GET request
    */
   async get(path: string): Promise<Response> {

--- a/turbo/apps/cli/src/lib/api/api-client.ts
+++ b/turbo/apps/cli/src/lib/api/api-client.ts
@@ -79,6 +79,13 @@ export type GetCheckpointResponse = CheckpointResponse;
 export type GetComposeResponse = ComposeResponse;
 export type GetEventsResponse = EventsResponse;
 
+// Usage API types
+export interface UsageResponse {
+  period: { start: string; end: string };
+  summary: { total_runs: number; total_run_time_ms: number };
+  daily: Array<{ date: string; run_count: number; run_time_ms: number }>;
+}
+
 // CLI-specific types (not in @vm0/core or have different structure)
 export interface CreateComposeResponse {
   composeId: string;
@@ -1141,11 +1148,10 @@ class ApiClient {
   /**
    * Get usage statistics
    */
-  async getUsage(options: { startDate: string; endDate: string }): Promise<{
-    period: { start: string; end: string };
-    summary: { total_runs: number; total_run_time_ms: number };
-    daily: Array<{ date: string; run_count: number; run_time_ms: number }>;
-  }> {
+  async getUsage(options: {
+    startDate: string;
+    endDate: string;
+  }): Promise<UsageResponse> {
     const baseUrl = await this.getBaseUrl();
     const headers = await this.getHeaders();
 
@@ -1164,11 +1170,7 @@ class ApiClient {
       throw new Error(error.error?.message || "Failed to fetch usage data");
     }
 
-    return response.json() as Promise<{
-      period: { start: string; end: string };
-      summary: { total_runs: number; total_run_time_ms: number };
-      daily: Array<{ date: string; run_count: number; run_time_ms: number }>;
-    }>;
+    return response.json() as Promise<UsageResponse>;
   }
 
   /**

--- a/turbo/apps/cli/src/lib/utils/__tests__/duration-formatter.test.ts
+++ b/turbo/apps/cli/src/lib/utils/__tests__/duration-formatter.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { formatDuration } from "../duration-formatter";
+
+describe("formatDuration", () => {
+  it("formats hours, minutes, and seconds", () => {
+    // 2h 53m 22s = 10402000ms
+    expect(formatDuration(10402000)).toBe("2h 53m 22s");
+  });
+
+  it("formats hours and minutes without seconds", () => {
+    // 2h 30m = 9000000ms
+    expect(formatDuration(9000000)).toBe("2h 30m");
+  });
+
+  it("formats hours and seconds without minutes", () => {
+    // 1h 30s = 3630000ms
+    expect(formatDuration(3630000)).toBe("1h 30s");
+  });
+
+  it("formats hours only", () => {
+    // 2h = 7200000ms
+    expect(formatDuration(7200000)).toBe("2h");
+  });
+
+  it("formats minutes and seconds (< 1 hour)", () => {
+    // 45m 32s = 2732000ms
+    expect(formatDuration(2732000)).toBe("45m 32s");
+  });
+
+  it("formats minutes only", () => {
+    // 15m = 900000ms
+    expect(formatDuration(900000)).toBe("15m");
+  });
+
+  it("formats seconds only (< 1 minute)", () => {
+    // 32s = 32000ms
+    expect(formatDuration(32000)).toBe("32s");
+  });
+
+  it("returns '< 1s' for sub-second durations", () => {
+    expect(formatDuration(500)).toBe("< 1s");
+    expect(formatDuration(999)).toBe("< 1s");
+    expect(formatDuration(1)).toBe("< 1s");
+  });
+
+  it("returns '-' for zero", () => {
+    expect(formatDuration(0)).toBe("-");
+  });
+
+  it("returns '-' for null", () => {
+    expect(formatDuration(null)).toBe("-");
+  });
+
+  it("returns '-' for undefined", () => {
+    expect(formatDuration(undefined)).toBe("-");
+  });
+
+  it("returns '-' for negative values", () => {
+    expect(formatDuration(-1000)).toBe("-");
+  });
+
+  it("handles exactly 1 second", () => {
+    expect(formatDuration(1000)).toBe("1s");
+  });
+
+  it("handles exactly 1 minute", () => {
+    expect(formatDuration(60000)).toBe("1m");
+  });
+
+  it("handles exactly 1 hour", () => {
+    expect(formatDuration(3600000)).toBe("1h");
+  });
+});

--- a/turbo/apps/cli/src/lib/utils/duration-formatter.ts
+++ b/turbo/apps/cli/src/lib/utils/duration-formatter.ts
@@ -1,0 +1,51 @@
+/**
+ * Duration formatter utility for human-readable time display
+ *
+ * Formats milliseconds into readable strings like:
+ * - "2h 53m 22s" (hours + minutes + seconds)
+ * - "45m 32s" (minutes + seconds, < 1 hour)
+ * - "32s" (seconds only, < 1 minute)
+ * - "< 1s" (less than 1 second)
+ * - "-" (zero or null)
+ */
+
+/**
+ * Format duration in milliseconds to human-readable string
+ * @param ms - Duration in milliseconds
+ * @returns Formatted duration string
+ */
+export function formatDuration(ms: number | null | undefined): string {
+  if (ms === null || ms === undefined || ms === 0) {
+    return "-";
+  }
+
+  if (ms < 0) {
+    return "-";
+  }
+
+  const totalSeconds = Math.floor(ms / 1000);
+
+  if (totalSeconds === 0) {
+    return "< 1s";
+  }
+
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const parts: string[] = [];
+
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+
+  if (minutes > 0) {
+    parts.push(`${minutes}m`);
+  }
+
+  if (seconds > 0) {
+    parts.push(`${seconds}s`);
+  }
+
+  return parts.join(" ");
+}

--- a/turbo/apps/web/app/api/usage/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/usage/__tests__/route.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+// Mock the auth module
+let mockUserId: string | null = "test-user-usage-api";
+vi.mock("../../../../src/lib/auth/get-user-id", () => ({
+  getUserId: async () => mockUserId,
+}));
+
+// Mock the init-services module
+vi.mock("../../../../src/lib/init-services", () => ({
+  initServices: vi.fn(),
+}));
+
+// Mock database queries
+const mockDailyResults = [
+  { date: "2026-01-18", run_count: 5, run_time_ms: 300000 },
+  { date: "2026-01-17", run_count: 3, run_time_ms: 180000 },
+];
+
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("drizzle-orm")>();
+  return {
+    ...actual,
+    sql: actual.sql,
+    and: actual.and,
+    gte: actual.gte,
+    lt: actual.lt,
+    eq: actual.eq,
+    isNotNull: actual.isNotNull,
+  };
+});
+
+// Set up mock database
+const mockDb = {
+  select: vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        groupBy: vi.fn(() => ({
+          orderBy: vi.fn(() => Promise.resolve(mockDailyResults)),
+        })),
+      })),
+    })),
+  })),
+};
+
+// Mock globalThis.services
+beforeEach(() => {
+  mockUserId = "test-user-usage-api";
+  (globalThis as Record<string, unknown>).services = {
+    db: mockDb,
+  };
+});
+
+describe("/api/usage", () => {
+  describe("GET /api/usage", () => {
+    it("should require authentication", async () => {
+      mockUserId = null;
+
+      const request = new NextRequest("http://localhost:3000/api/usage", {
+        method: "GET",
+      });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.message).toContain("Not authenticated");
+    });
+
+    it("should return usage data with default 7 day range", async () => {
+      const request = new NextRequest("http://localhost:3000/api/usage", {
+        method: "GET",
+      });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.period).toBeDefined();
+      expect(data.period.start).toBeDefined();
+      expect(data.period.end).toBeDefined();
+      expect(data.summary).toBeDefined();
+      expect(data.summary.total_runs).toBe(8); // 5 + 3
+      expect(data.summary.total_run_time_ms).toBe(480000); // 300000 + 180000
+      expect(data.daily).toBeDefined();
+      expect(Array.isArray(data.daily)).toBe(true);
+    });
+
+    it("should accept custom date range", async () => {
+      const now = new Date();
+      const threeDaysAgo = new Date(now);
+      threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/usage?start_date=${threeDaysAgo.toISOString()}&end_date=${now.toISOString()}`,
+        {
+          method: "GET",
+        },
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.period.start).toBeDefined();
+      expect(data.period.end).toBeDefined();
+    });
+
+    it("should reject invalid start_date format", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/usage?start_date=invalid",
+        {
+          method: "GET",
+        },
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain("Invalid start_date format");
+    });
+
+    it("should reject invalid end_date format", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/usage?end_date=invalid",
+        {
+          method: "GET",
+        },
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain("Invalid end_date format");
+    });
+
+    it("should reject start_date after end_date", async () => {
+      const now = new Date();
+      const yesterday = new Date(now);
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/usage?start_date=${now.toISOString()}&end_date=${yesterday.toISOString()}`,
+        {
+          method: "GET",
+        },
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain(
+        "start_date must be before end_date",
+      );
+    });
+
+    it("should reject range exceeding 30 days", async () => {
+      const now = new Date();
+      const fortyDaysAgo = new Date(now);
+      fortyDaysAgo.setDate(fortyDaysAgo.getDate() - 40);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/usage?start_date=${fortyDaysAgo.toISOString()}&end_date=${now.toISOString()}`,
+        {
+          method: "GET",
+        },
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain("exceeds maximum of 30 days");
+    });
+
+    it("should return daily breakdown with run counts and run times", async () => {
+      const request = new NextRequest("http://localhost:3000/api/usage", {
+        method: "GET",
+      });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+
+      // Check that daily data has expected structure
+      expect(data.daily.length).toBeGreaterThan(0);
+      for (const day of data.daily) {
+        expect(day.date).toBeDefined();
+        expect(typeof day.run_count).toBe("number");
+        expect(typeof day.run_time_ms).toBe("number");
+      }
+    });
+  });
+});

--- a/turbo/apps/web/app/api/usage/route.ts
+++ b/turbo/apps/web/app/api/usage/route.ts
@@ -1,0 +1,178 @@
+import { NextRequest, NextResponse } from "next/server";
+import { initServices } from "../../../src/lib/init-services";
+import { getUserId } from "../../../src/lib/auth/get-user-id";
+import { agentRuns } from "../../../src/db/schema/agent-run";
+import { sql, and, gte, lt, eq, isNotNull } from "drizzle-orm";
+
+/**
+ * Maximum time range allowed for usage queries (30 days in milliseconds)
+ */
+const MAX_RANGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Default time range (7 days in milliseconds)
+ */
+const DEFAULT_RANGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface DailyUsage {
+  date: string;
+  run_count: number;
+  run_time_ms: number;
+}
+
+interface UsageResponse {
+  period: {
+    start: string;
+    end: string;
+  };
+  summary: {
+    total_runs: number;
+    total_run_time_ms: number;
+  };
+  daily: DailyUsage[];
+}
+
+/**
+ * GET /api/usage
+ *
+ * Query parameters:
+ * - start_date: ISO date string (default: 7 days ago)
+ * - end_date: ISO date string (default: now)
+ *
+ * Returns daily aggregated usage statistics for the authenticated user.
+ */
+export async function GET(request: NextRequest) {
+  initServices();
+
+  const userId = await getUserId();
+  if (!userId) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  // Parse query parameters
+  const searchParams = request.nextUrl.searchParams;
+  const startDateParam = searchParams.get("start_date");
+  const endDateParam = searchParams.get("end_date");
+
+  // Calculate date range
+  const now = new Date();
+  let endDate: Date;
+  let startDate: Date;
+
+  if (endDateParam) {
+    endDate = new Date(endDateParam);
+    if (isNaN(endDate.getTime())) {
+      return NextResponse.json(
+        {
+          error: {
+            message: "Invalid end_date format. Use ISO 8601 format.",
+            code: "BAD_REQUEST",
+          },
+        },
+        { status: 400 },
+      );
+    }
+  } else {
+    endDate = now;
+  }
+
+  if (startDateParam) {
+    startDate = new Date(startDateParam);
+    if (isNaN(startDate.getTime())) {
+      return NextResponse.json(
+        {
+          error: {
+            message: "Invalid start_date format. Use ISO 8601 format.",
+            code: "BAD_REQUEST",
+          },
+        },
+        { status: 400 },
+      );
+    }
+  } else {
+    startDate = new Date(endDate.getTime() - DEFAULT_RANGE_MS);
+  }
+
+  // Validate date range
+  if (startDate >= endDate) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "start_date must be before end_date",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const rangeMs = endDate.getTime() - startDate.getTime();
+  if (rangeMs > MAX_RANGE_MS) {
+    return NextResponse.json(
+      {
+        error: {
+          message:
+            "Time range exceeds maximum of 30 days. Use --until to specify an end date.",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  // Query daily aggregation
+  // Using raw SQL for DATE() function and aggregation
+  const dailyResults = await globalThis.services.db
+    .select({
+      date: sql<string>`DATE(${agentRuns.createdAt})`.as("date"),
+      run_count: sql<number>`COUNT(*)::int`.as("run_count"),
+      run_time_ms:
+        sql<number>`COALESCE(SUM(EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000), 0)::bigint`.as(
+          "run_time_ms",
+        ),
+    })
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.userId, userId),
+        gte(agentRuns.createdAt, startDate),
+        lt(agentRuns.createdAt, endDate),
+        isNotNull(agentRuns.completedAt),
+      ),
+    )
+    .groupBy(sql`DATE(${agentRuns.createdAt})`)
+    .orderBy(sql`DATE(${agentRuns.createdAt}) DESC`);
+
+  // Calculate totals
+  let totalRuns = 0;
+  let totalRunTimeMs = 0;
+
+  const daily: DailyUsage[] = dailyResults.map((row) => {
+    const runCount = Number(row.run_count);
+    const runTimeMs = Number(row.run_time_ms);
+    totalRuns += runCount;
+    totalRunTimeMs += runTimeMs;
+    return {
+      date: String(row.date),
+      run_count: runCount,
+      run_time_ms: runTimeMs,
+    };
+  });
+
+  const response: UsageResponse = {
+    period: {
+      start: startDate.toISOString(),
+      end: endDate.toISOString(),
+    },
+    summary: {
+      total_runs: totalRuns,
+      total_run_time_ms: totalRunTimeMs,
+    },
+    daily,
+  };
+
+  return NextResponse.json(response);
+}


### PR DESCRIPTION
## Summary

- Add `vm0 usage` command that displays daily agent run counts and run times for the authenticated user
- The command supports `--since` and `--until` options for date range filtering
- Maximum 30-day time range with clear error messaging
- Tabular output with daily breakdown and totals

## Implementation

- New API endpoint at `/api/usage` with daily aggregation using SQL DATE() grouping
- Duration formatter utility for human-readable time display (e.g., "2h 53m 22s")
- Comprehensive test coverage for CLI, API, and utilities (37 new tests)

## Test plan

- [x] Unit tests for duration formatter (15 tests)
- [x] Unit tests for CLI command (14 tests)
- [x] Unit tests for API endpoint (8 tests)
- [x] All existing tests pass (1754 tests)
- [ ] CI pipeline passes

Closes #1296

🤖 Generated with [Claude Code](https://claude.com/claude-code)