### PR TITLE
feat(ci): use turbo for runner npm build to resolve dependency chain

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -220,7 +220,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Build Runner
-        run: cd turbo && pnpm -F @vm0/runner build
+        run: cd turbo && pnpm turbo run build --filter=@vm0/runner
 
       - name: Publish to npm with OIDC
         run: cd turbo/apps/runner/dist && npm publish --access public

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,4 +1,4 @@
-// VM0 Runner - Polls the API server and executes jobs in isolated Firecracker microVMs
+// VM0 Runner - Self-hosted runner that polls the API server and executes agent jobs in isolated Firecracker microVMs
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { statusCommand } from "./commands/status.js";

--- a/turbo/apps/runner/src/lib/__tests__/executor-preflight.test.ts
+++ b/turbo/apps/runner/src/lib/__tests__/executor-preflight.test.ts
@@ -152,6 +152,37 @@ describe("runPreflightCheck", () => {
     expect(result.error).toContain("TLS certificate error");
     expect(result.error).toContain("unable to get local issuer certificate");
   });
+
+  it("includes Vercel bypass header when bypassSecret is provided", async () => {
+    mockSsh.exec.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    await runPreflightCheck(
+      mockSsh as unknown as Parameters<typeof runPreflightCheck>[0],
+      "https://api.example.com",
+      "run-123",
+      "token-456",
+      "bypass-secret-789",
+    );
+
+    expect(mockSsh.exec).toHaveBeenCalledOnce();
+    const [curlCmd] = mockSsh.exec.mock.calls[0] as [string, number];
+    expect(curlCmd).toContain("x-vercel-protection-bypass: bypass-secret-789");
+  });
+
+  it("does not include Vercel bypass header when bypassSecret is not provided", async () => {
+    mockSsh.exec.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    await runPreflightCheck(
+      mockSsh as unknown as Parameters<typeof runPreflightCheck>[0],
+      "https://api.example.com",
+      "run-123",
+      "token-456",
+    );
+
+    expect(mockSsh.exec).toHaveBeenCalledOnce();
+    const [curlCmd] = mockSsh.exec.mock.calls[0] as [string, number];
+    expect(curlCmd).not.toContain("x-vercel-protection-bypass");
+  });
 });
 
 describe("reportPreflightFailure", () => {
@@ -230,6 +261,48 @@ describe("reportPreflightFailure", () => {
     );
 
     consoleSpy.mockRestore();
+  });
+
+  it("includes Vercel bypass header when bypassSecret is provided", async () => {
+    const mockFetch = global.fetch as ReturnType<typeof vi.fn>;
+    mockFetch.mockResolvedValue({ ok: true });
+
+    await reportPreflightFailure(
+      "https://api.example.com",
+      "run-123",
+      "token-456",
+      "Test error message",
+      "bypass-secret-789",
+    );
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+
+    expect(options.headers).toEqual({
+      "Content-Type": "application/json",
+      Authorization: "Bearer token-456",
+      "x-vercel-protection-bypass": "bypass-secret-789",
+    });
+  });
+
+  it("does not include Vercel bypass header when bypassSecret is not provided", async () => {
+    const mockFetch = global.fetch as ReturnType<typeof vi.fn>;
+    mockFetch.mockResolvedValue({ ok: true });
+
+    await reportPreflightFailure(
+      "https://api.example.com",
+      "run-123",
+      "token-456",
+      "Test error message",
+    );
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+
+    expect(options.headers).toEqual({
+      "Content-Type": "application/json",
+      Authorization: "Bearer token-456",
+    });
   });
 });
 

--- a/turbo/apps/runner/src/lib/__tests__/executor-preflight.test.ts
+++ b/turbo/apps/runner/src/lib/__tests__/executor-preflight.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  runPreflightCheck,
+  reportPreflightFailure,
+  CURL_ERROR_MESSAGES,
+} from "../executor";
+
+/**
+ * Unit tests for preflight connectivity check functions
+ */
+
+// Mock SSH client type matching SSHClient interface
+interface MockSSHClient {
+  exec: ReturnType<typeof vi.fn>;
+}
+
+describe("runPreflightCheck", () => {
+  let mockSsh: MockSSHClient;
+
+  beforeEach(() => {
+    mockSsh = {
+      exec: vi.fn(),
+    };
+  });
+
+  it("returns success when curl succeeds", async () => {
+    mockSsh.exec.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    const result = await runPreflightCheck(
+      mockSsh as unknown as Parameters<typeof runPreflightCheck>[0],
+      "https://api.example.com",
+      "run-123",
+      "token-456",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+
+    // Verify curl command was called with correct URL
+    expect(mockSsh.exec).toHaveBeenCalledOnce();
+    const curlCmd = mockSsh.exec.mock.calls[0]?.[0] as string;
+    expect(curlCmd).toContain(
+      "https://api.example.com/api/webhooks/agent/heartbeat",
+    );
+    expect(curlCmd).toContain("Bearer token-456");
+    expect(curlCmd).toContain("run-123");
+  });
+
+  it("returns DNS error for exit code 6", async () => {
+    mockSsh.exec.mockResolvedValue({ exitCode: 6, stdout: "", stderr: "" });
+
+    const result = await runPreflightCheck(
+      mockSsh as unknown as Parameters<typeof runPreflightCheck>[0],
+      "https://api.example.com",
+      "run-123",
+      "token-456",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("DNS resolution failed");
+    expect(result.error).toContain("VM cannot reach VM0 API");
+  });
+
+  it("returns connection refused error for exit code 7", async () => {
+    mockSsh.exec.mockResolvedValue({ exitCode: 7, stdout: "", stderr: "" });
+
+    const result = await runPreflightCheck(
+      mockSsh as unknown as Parameters<typeof runPreflightCheck>[0],
+      "https://api.example.com",
+      "run-123",
+      "token-456",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Connection refused");
+  });
+
+  it("returns timeout error for exit code 28", async () => {
+    mockSsh.exec.mockResolvedValue({ exitCode: 28, stdout: "", stderr: "" });
+
+    const result = await runPreflightCheck(
+      mockSsh as unknown as Parameters<typeof runPreflightCheck>[0],
+      "https://api.example.com",
+      "run-123",
+      "token-456",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Connection timeout");
+  });
+
+  it("returns TLS error for exit code 60", async () => {
+    mockSsh.exec.mockResolvedValue({ exitCode: 60, stdout: "", stderr: "" });
+
+    const result = await runPreflightCheck(
+      mockSsh as unknown as Parameters<typeof runPreflightCheck>[0],
+      "https://api.example.com",
+      "run-123",
+      "token-456",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("TLS certificate error");
+  });
+
+  it("returns HTTP error for exit code 22", async () => {
+    mockSsh.exec.mockResolvedValue({ exitCode: 22, stdout: "", stderr: "" });
+
+    const result = await runPreflightCheck(
+      mockSsh as unknown as Parameters<typeof runPreflightCheck>[0],
+      "https://api.example.com",
+      "run-123",
+      "token-456",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("HTTP error from server");
+  });
+
+  it("returns generic error for unknown exit code", async () => {
+    mockSsh.exec.mockResolvedValue({ exitCode: 99, stdout: "", stderr: "" });
+
+    const result = await runPreflightCheck(
+      mockSsh as unknown as Parameters<typeof runPreflightCheck>[0],
+      "https://api.example.com",
+      "run-123",
+      "token-456",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("curl exit code 99");
+  });
+
+  it("includes stderr in error message when available", async () => {
+    mockSsh.exec.mockResolvedValue({
+      exitCode: 60,
+      stdout: "",
+      stderr: "SSL certificate problem: unable to get local issuer certificate",
+    });
+
+    const result = await runPreflightCheck(
+      mockSsh as unknown as Parameters<typeof runPreflightCheck>[0],
+      "https://api.example.com",
+      "run-123",
+      "token-456",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("TLS certificate error");
+    expect(result.error).toContain("unable to get local issuer certificate");
+  });
+});
+
+describe("reportPreflightFailure", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("calls complete API with correct parameters", async () => {
+    const mockFetch = global.fetch as ReturnType<typeof vi.fn>;
+    mockFetch.mockResolvedValue({ ok: true });
+
+    await reportPreflightFailure(
+      "https://api.example.com",
+      "run-123",
+      "token-456",
+      "Test error message",
+    );
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe("https://api.example.com/api/webhooks/agent/complete");
+    expect(options.method).toBe("POST");
+    expect(options.headers).toEqual({
+      "Content-Type": "application/json",
+      Authorization: "Bearer token-456",
+    });
+
+    const body = JSON.parse(options.body as string);
+    expect(body.runId).toBe("run-123");
+    expect(body.exitCode).toBe(1);
+    expect(body.error).toBe("Test error message");
+  });
+
+  it("logs error when API returns non-ok response", async () => {
+    const mockFetch = global.fetch as ReturnType<typeof vi.fn>;
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await reportPreflightFailure(
+      "https://api.example.com",
+      "run-123",
+      "token-456",
+      "Test error",
+    );
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[Executor] Failed to report preflight failure: HTTP 500",
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it("logs error when fetch throws", async () => {
+    const mockFetch = global.fetch as ReturnType<typeof vi.fn>;
+    mockFetch.mockRejectedValue(new Error("Network error"));
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await reportPreflightFailure(
+      "https://api.example.com",
+      "run-123",
+      "token-456",
+      "Test error",
+    );
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[Executor] Failed to report preflight failure: Error: Network error",
+    );
+
+    consoleSpy.mockRestore();
+  });
+});
+
+describe("CURL_ERROR_MESSAGES", () => {
+  it("contains expected error codes", () => {
+    expect(CURL_ERROR_MESSAGES[6]).toBe("DNS resolution failed");
+    expect(CURL_ERROR_MESSAGES[7]).toBe("Connection refused");
+    expect(CURL_ERROR_MESSAGES[28]).toBe("Connection timeout");
+    expect(CURL_ERROR_MESSAGES[60]).toBe(
+      "TLS certificate error (proxy CA not trusted)",
+    );
+    expect(CURL_ERROR_MESSAGES[22]).toBe("HTTP error from server");
+  });
+});

--- a/turbo/apps/runner/src/lib/__tests__/executor-preflight.test.ts
+++ b/turbo/apps/runner/src/lib/__tests__/executor-preflight.test.ts
@@ -36,14 +36,17 @@ describe("runPreflightCheck", () => {
     expect(result.success).toBe(true);
     expect(result.error).toBeUndefined();
 
-    // Verify curl command was called with correct URL
+    // Verify curl command was called with correct URL and timeout
     expect(mockSsh.exec).toHaveBeenCalledOnce();
-    const curlCmd = mockSsh.exec.mock.calls[0]?.[0] as string;
+    const [curlCmd, timeout] = mockSsh.exec.mock.calls[0] as [string, number];
     expect(curlCmd).toContain(
       "https://api.example.com/api/webhooks/agent/heartbeat",
     );
     expect(curlCmd).toContain("Bearer token-456");
     expect(curlCmd).toContain("run-123");
+    expect(curlCmd).toContain("--connect-timeout 5");
+    expect(curlCmd).toContain("--max-time 10");
+    expect(timeout).toBe(20000); // 20 second SSH timeout
   });
 
   it("returns DNS error for exit code 6", async () => {

--- a/turbo/apps/runner/src/lib/__tests__/executor-preflight.test.ts
+++ b/turbo/apps/runner/src/lib/__tests__/executor-preflight.test.ts
@@ -18,6 +18,7 @@ describe("runPreflightCheck", () => {
   let mockSsh: MockSSHClient;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     mockSsh = {
       exec: vi.fn(),
     };
@@ -189,6 +190,7 @@ describe("reportPreflightFailure", () => {
   const originalFetch = global.fetch;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     global.fetch = vi.fn();
   });
 

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -402,6 +402,113 @@ async function installProxyCA(ssh: SSHClient): Promise<void> {
 }
 
 /**
+ * Preflight check result
+ */
+interface PreflightResult {
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Map curl exit codes to meaningful error messages
+ * Exported for testing
+ */
+export const CURL_ERROR_MESSAGES: Record<number, string> = {
+  6: "DNS resolution failed",
+  7: "Connection refused",
+  28: "Connection timeout",
+  60: "TLS certificate error (proxy CA not trusted)",
+  22: "HTTP error from server",
+};
+
+/**
+ * Preflight connectivity check - verify VM can reach VM0 API
+ * Run this AFTER network is configured but BEFORE starting agent
+ *
+ * This function uses ssh.exec() to run curl inside the VM (not on the host).
+ * The curl command is hardcoded with no user input interpolation, so shell
+ * injection is not a concern here.
+ *
+ * @param ssh - SSH client connected to the VM
+ * @param apiUrl - VM0 API URL to test
+ * @param runId - Run ID for the heartbeat request
+ * @param sandboxToken - Authentication token for the API
+ * @returns PreflightResult indicating success or failure with error message
+ */
+export async function runPreflightCheck(
+  ssh: SSHClient,
+  apiUrl: string,
+  runId: string,
+  sandboxToken: string,
+): Promise<PreflightResult> {
+  const heartbeatUrl = `${apiUrl}/api/webhooks/agent/heartbeat`;
+
+  // Build curl command to send test heartbeat from inside VM
+  // -s: silent mode (no progress bar)
+  // -f: fail silently on HTTP errors (returns exit code 22)
+  // --max-time: timeout in seconds
+  // Note: This runs inside the VM via SSH, not on the runner host
+  const curlCmd = `curl -sf --max-time 10 "${heartbeatUrl}" -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${sandboxToken}" -d '{"runId":"${runId}"}'`;
+
+  const result = await ssh.exec(curlCmd);
+
+  if (result.exitCode === 0) {
+    return { success: true };
+  }
+
+  // Map curl exit code to meaningful error message
+  const errorDetail =
+    CURL_ERROR_MESSAGES[result.exitCode] ?? `curl exit code ${result.exitCode}`;
+  const stderrInfo = result.stderr?.trim() ? ` (${result.stderr.trim()})` : "";
+
+  return {
+    success: false,
+    error: `Preflight check failed: ${errorDetail}${stderrInfo} - VM cannot reach VM0 API at ${apiUrl}`,
+  };
+}
+
+/**
+ * Report preflight failure to complete API
+ * This allows CLI to see the error immediately instead of waiting forever
+ *
+ * @param apiUrl - VM0 API URL
+ * @param runId - Run ID to mark as failed
+ * @param sandboxToken - Authentication token
+ * @param error - Error message to report
+ */
+export async function reportPreflightFailure(
+  apiUrl: string,
+  runId: string,
+  sandboxToken: string,
+  error: string,
+): Promise<void> {
+  const completeUrl = `${apiUrl}/api/webhooks/agent/complete`;
+
+  try {
+    const response = await fetch(completeUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${sandboxToken}`,
+      },
+      body: JSON.stringify({
+        runId,
+        exitCode: 1,
+        error,
+      }),
+    });
+
+    if (!response.ok) {
+      console.error(
+        `[Executor] Failed to report preflight failure: HTTP ${response.status}`,
+      );
+    }
+  } catch (err) {
+    console.error(`[Executor] Failed to report preflight failure: ${err}`);
+  }
+}
+
+/**
  * Configure DNS in the VM
  * Systemd-resolved may overwrite /etc/resolv.conf at boot,
  * so we need to ensure DNS servers are configured after SSH is ready.
@@ -544,6 +651,37 @@ export async function executeJob(
       `[Executor] Writing env JSON (${envJson.length} bytes) to ${ENV_JSON_PATH}`,
     );
     await ssh.writeFile(ENV_JSON_PATH, envJson);
+
+    // Run preflight connectivity check before starting agent
+    // This verifies VM can reach VM0 API - if not, we report failure immediately
+    // Skip in benchmark mode since it doesn't use API
+    if (!options.benchmarkMode) {
+      log(`[Executor] Running preflight connectivity check...`);
+      const preflight = await runPreflightCheck(
+        ssh,
+        config.server.url,
+        context.runId,
+        context.sandboxToken,
+      );
+
+      if (!preflight.success) {
+        log(`[Executor] Preflight check failed: ${preflight.error}`);
+
+        // Report failure via complete API so CLI sees it immediately
+        await reportPreflightFailure(
+          config.server.url,
+          context.runId,
+          context.sandboxToken,
+          preflight.error!,
+        );
+
+        return {
+          exitCode: 1,
+          error: preflight.error,
+        };
+      }
+      log(`[Executor] Preflight check passed`);
+    }
 
     // Execute agent or direct command based on mode
     const systemLogFile = `/tmp/vm0-main-${context.runId}.log`;

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -433,6 +433,7 @@ export const CURL_ERROR_MESSAGES: Record<number, string> = {
  * @param apiUrl - VM0 API URL to test
  * @param runId - Run ID for the heartbeat request
  * @param sandboxToken - Authentication token for the API
+ * @param bypassSecret - Optional Vercel automation bypass secret for preview deployments
  * @returns PreflightResult indicating success or failure with error message
  */
 export async function runPreflightCheck(
@@ -440,6 +441,7 @@ export async function runPreflightCheck(
   apiUrl: string,
   runId: string,
   sandboxToken: string,
+  bypassSecret?: string,
 ): Promise<PreflightResult> {
   const heartbeatUrl = `${apiUrl}/api/webhooks/agent/heartbeat`;
 
@@ -449,7 +451,10 @@ export async function runPreflightCheck(
   // --connect-timeout: max time for connection phase
   // --max-time: total max time for the request
   // Note: This runs inside the VM via SSH, not on the runner host
-  const curlCmd = `curl -sf --connect-timeout 5 --max-time 10 "${heartbeatUrl}" -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${sandboxToken}" -d '{"runId":"${runId}"}'`;
+  const bypassHeader = bypassSecret
+    ? ` -H "x-vercel-protection-bypass: ${bypassSecret}"`
+    : "";
+  const curlCmd = `curl -sf --connect-timeout 5 --max-time 10 "${heartbeatUrl}" -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${sandboxToken}"${bypassHeader} -d '{"runId":"${runId}"}'`;
 
   // Use 20 second timeout for SSH exec (curl has 10s max-time, plus buffer for SSH overhead)
   const result = await ssh.exec(curlCmd, 20000);
@@ -477,22 +482,31 @@ export async function runPreflightCheck(
  * @param runId - Run ID to mark as failed
  * @param sandboxToken - Authentication token
  * @param error - Error message to report
+ * @param bypassSecret - Optional Vercel automation bypass secret for preview deployments
  */
 export async function reportPreflightFailure(
   apiUrl: string,
   runId: string,
   sandboxToken: string,
   error: string,
+  bypassSecret?: string,
 ): Promise<void> {
   const completeUrl = `${apiUrl}/api/webhooks/agent/complete`;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${sandboxToken}`,
+  };
+
+  // Add Vercel bypass header for preview deployments
+  if (bypassSecret) {
+    headers["x-vercel-protection-bypass"] = bypassSecret;
+  }
 
   try {
     const response = await fetch(completeUrl, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${sandboxToken}`,
-      },
+      headers,
       body: JSON.stringify({
         runId,
         exitCode: 1,
@@ -659,11 +673,13 @@ export async function executeJob(
     // Skip in benchmark mode since it doesn't use API
     if (!options.benchmarkMode) {
       log(`[Executor] Running preflight connectivity check...`);
+      const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
       const preflight = await runPreflightCheck(
         ssh,
         config.server.url,
         context.runId,
         context.sandboxToken,
+        bypassSecret,
       );
 
       if (!preflight.success) {
@@ -675,6 +691,7 @@ export async function executeJob(
           context.runId,
           context.sandboxToken,
           preflight.error!,
+          bypassSecret,
         );
 
         return {

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -446,11 +446,13 @@ export async function runPreflightCheck(
   // Build curl command to send test heartbeat from inside VM
   // -s: silent mode (no progress bar)
   // -f: fail silently on HTTP errors (returns exit code 22)
-  // --max-time: timeout in seconds
+  // --connect-timeout: max time for connection phase
+  // --max-time: total max time for the request
   // Note: This runs inside the VM via SSH, not on the runner host
-  const curlCmd = `curl -sf --max-time 10 "${heartbeatUrl}" -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${sandboxToken}" -d '{"runId":"${runId}"}'`;
+  const curlCmd = `curl -sf --connect-timeout 5 --max-time 10 "${heartbeatUrl}" -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${sandboxToken}" -d '{"runId":"${runId}"}'`;
 
-  const result = await ssh.exec(curlCmd);
+  // Use 20 second timeout for SSH exec (curl has 10s max-time, plus buffer for SSH overhead)
+  const result = await ssh.exec(curlCmd, 20000);
 
   if (result.exitCode === 0) {
     return { success: true };


### PR DESCRIPTION
## Summary
- Fix runner npm build failure by using turbo instead of pnpm filter
- Ensures @vm0/core is built before @vm0/runner to generate required `dist/bundled` file

## Problem
The `publish-runner-npm` job was failing with:
```
Could not resolve "./dist/bundled"
packages/core/src/sandbox/scripts/index.ts:17:7
```

This happened because `pnpm -F @vm0/runner build` bypasses turbo's dependency resolution. The runner imports script constants from `@vm0/core`, which requires `@vm0/core` to be built first.

## Solution
Change from:
```yaml
run: cd turbo && pnpm -F @vm0/runner build
```

To:
```yaml
run: cd turbo && pnpm turbo run build --filter=@vm0/runner
```

This leverages turbo's `^build` dependency chain configured in `turbo.json`.

## Test plan
- [ ] CI workflow runs successfully
- [ ] Runner npm package publishes correctly on next release

🤖 Generated with [Claude Code](https://claude.ai/code)