### PR TITLE
feat(ci): add core build step to deploy-runner-production job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -241,10 +241,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
 
+      - name: Build Core Package
+        run: cd turbo && pnpm turbo run build --filter=@vm0/core
+
       - name: Build runner bundle
         run: |
           # Build runner (use subshell to preserve working directory)
-          (cd turbo && pnpm -F @vm0/runner build)
+          (cd turbo && pnpm --filter @vm0/runner build)
 
           # Create staging directory with built files
           STAGING_DIR="/tmp/vm0-runner-bundle"

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,4 +1,4 @@
-// VM0 Runner - Self-hosted runner that polls the API server and executes agent jobs in isolated Firecracker microVMs
+// VM0 Runner - Self-hosted runner that polls the VM0 API server and executes agent jobs in isolated Firecracker microVMs
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { statusCommand } from "./commands/status.js";


### PR DESCRIPTION
## Summary
- Fix deploy-runner-production job failure by adding Build Core Package step
- Matches the pattern used in turbo.yml

## Problem
The `deploy-runner-production` job was failing with:
```
Could not resolve "./dist/bundled"
packages/core/src/sandbox/scripts/index.ts:17:7
```

Same root cause as #1304 - `pnpm --filter @vm0/runner build` was used without first building `@vm0/core`.

## Solution
Add the same pattern used in `turbo.yml`:
```yaml
- name: Build Core Package
  run: cd turbo && pnpm turbo run build --filter=@vm0/core

- name: Build runner bundle
  run: (cd turbo && pnpm --filter @vm0/runner build)
```

## Test plan
- [ ] CI workflow runs successfully
- [ ] Runner deploys correctly on next release

🤖 Generated with [Claude Code](https://claude.ai/code)