### PR TITLE
feat(billing): integrate clerk billing mvp

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@clerk/clerk-js": "^5.92.1",
+    "@clerk/clerk-react": "^5.59.4",
     "@vm0/ui": "workspace:*",
     "ccstate": "^5.0.0",
     "ccstate-react": "^5.0.0",

--- a/turbo/apps/platform/src/signals/layout/navigation.ts
+++ b/turbo/apps/platform/src/signals/layout/navigation.ts
@@ -37,8 +37,8 @@ export const NAVIGATION_CONFIG = [
 ] as const satisfies readonly NavGroup[];
 
 // Footer navigation items (non-grouped)
+// Note: "Bill" is handled separately via SubscriptionDetailsButton in sidebar.tsx
 export const FOOTER_NAV_ITEMS = [
-  { id: "bill", label: "Bill", icon: "Receipt", path: "/" },
   { id: "docs", label: "Documentation", icon: "HelpCircle", path: "/" },
 ] as const satisfies readonly NavItem[];
 

--- a/turbo/apps/platform/src/views/layout/clerk-provider.tsx
+++ b/turbo/apps/platform/src/views/layout/clerk-provider.tsx
@@ -1,0 +1,32 @@
+import {
+  ClerkProvider as BaseClerkProvider,
+  type ClerkProviderProps as BaseClerkProviderProps,
+} from "@clerk/clerk-react";
+import { useLoadable } from "ccstate-react";
+import type { ReactNode } from "react";
+import { clerk$ } from "../../signals/auth.ts";
+
+interface ClerkProviderProps {
+  children: ReactNode;
+}
+
+export function ClerkProvider({ children }: ClerkProviderProps) {
+  const clerkLoadable = useLoadable(clerk$);
+
+  if (clerkLoadable.state !== "hasData") {
+    return null;
+  }
+
+  const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string;
+
+  // Type assertion needed due to @clerk/shared version mismatch between
+  // @clerk/clerk-js and @clerk/clerk-react packages
+  return (
+    <BaseClerkProvider
+      Clerk={clerkLoadable.data as unknown as BaseClerkProviderProps["Clerk"]}
+      publishableKey={publishableKey}
+    >
+      {children}
+    </BaseClerkProvider>
+  );
+}

--- a/turbo/apps/platform/src/views/layout/sidebar.tsx
+++ b/turbo/apps/platform/src/views/layout/sidebar.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../signals/layout/navigation.ts";
 import { clerk$, user$ } from "../../signals/auth.ts";
 import { NavLink } from "./nav-link.tsx";
+import { ClerkProvider } from "./clerk-provider.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
 
 export function Sidebar() {
@@ -81,12 +82,14 @@ export function Sidebar() {
       <div className="p-2">
         <div className="flex flex-col gap-1">
           {/* Bill button - opens subscription management modal */}
-          <SubscriptionDetailsButton>
-            <button className="flex w-full items-center gap-2 p-2 h-9 rounded-lg text-sidebar-foreground hover:bg-sidebar-accent transition-colors">
-              <Receipt className="h-4 w-4 shrink-0" />
-              <span className="text-sm leading-5">Bill</span>
-            </button>
-          </SubscriptionDetailsButton>
+          <ClerkProvider>
+            <SubscriptionDetailsButton>
+              <button className="flex w-full items-center gap-2 p-2 h-9 rounded-lg text-sidebar-foreground hover:bg-sidebar-accent transition-colors">
+                <Receipt className="h-4 w-4 shrink-0" />
+                <span className="text-sm leading-5">Bill</span>
+              </button>
+            </SubscriptionDetailsButton>
+          </ClerkProvider>
           {FOOTER_NAV_ITEMS.map((item) => (
             <NavLink
               key={item.id}

--- a/turbo/apps/platform/src/views/layout/sidebar.tsx
+++ b/turbo/apps/platform/src/views/layout/sidebar.tsx
@@ -1,5 +1,6 @@
 import { useGet, useLoadable } from "ccstate-react";
-import { MoreVertical } from "lucide-react";
+import { MoreVertical, Receipt } from "lucide-react";
+import { SubscriptionDetailsButton } from "@clerk/clerk-react/experimental";
 import {
   NAVIGATION_CONFIG,
   FOOTER_NAV_ITEMS,
@@ -79,6 +80,13 @@ export function Sidebar() {
       {/* Footer navigation - padding: 8px, gap: 4px */}
       <div className="p-2">
         <div className="flex flex-col gap-1">
+          {/* Bill button - opens subscription management modal */}
+          <SubscriptionDetailsButton>
+            <button className="flex w-full items-center gap-2 p-2 h-9 rounded-lg text-sidebar-foreground hover:bg-sidebar-accent transition-colors">
+              <Receipt className="h-4 w-4 shrink-0" />
+              <span className="text-sm leading-5">Bill</span>
+            </button>
+          </SubscriptionDetailsButton>
           {FOOTER_NAV_ITEMS.map((item) => (
             <NavLink
               key={item.id}

--- a/turbo/apps/platform/src/views/logs-page/__tests__/logs-page.test.tsx
+++ b/turbo/apps/platform/src/views/logs-page/__tests__/logs-page.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createStore } from "ccstate";
+import { StoreProvider } from "ccstate-react";
+import { LogsPage } from "../logs-page.tsx";
+
+// Mock clerk-js
+vi.mock("@clerk/clerk-js", () => ({
+  Clerk: vi.fn().mockImplementation(() => ({
+    load: vi.fn().mockResolvedValue(undefined),
+    user: {
+      id: "test-user",
+      fullName: "Test User",
+      primaryEmailAddress: { emailAddress: "test@example.com" },
+      imageUrl: "https://example.com/avatar.png",
+    },
+    addListener: vi.fn().mockReturnValue(() => {}),
+    openUserProfile: vi.fn(),
+  })),
+}));
+
+describe("logs page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render the logs page", () => {
+    const store = createStore();
+
+    render(
+      <StoreProvider value={store}>
+        <LogsPage />
+      </StoreProvider>,
+    );
+
+    // Check that the page title is rendered (h1 element)
+    expect(
+      screen.getByRole("heading", { name: "Logs", level: 1 }),
+    ).toBeInTheDocument();
+  });
+});

--- a/turbo/apps/web/app/[locale]/pricing/PricingClient.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/PricingClient.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { PricingTable } from "@clerk/nextjs";
+import { useTranslations } from "next-intl";
+import Navbar from "../../components/Navbar";
+import Footer from "../../components/Footer";
+
+export default function PricingClient() {
+  const t = useTranslations("pricing");
+
+  return (
+    <>
+      <Navbar />
+      <main
+        style={{
+          minHeight: "100vh",
+          paddingTop: "80px",
+        }}
+      >
+        <div className="container">
+          <section
+            style={{
+              textAlign: "center",
+              padding: "60px 20px",
+            }}
+          >
+            <h1
+              style={{
+                fontSize: "3rem",
+                fontWeight: 700,
+                marginBottom: "16px",
+                background: "linear-gradient(135deg, #fff 0%, #a0a0a0 100%)",
+                WebkitBackgroundClip: "text",
+                WebkitTextFillColor: "transparent",
+                backgroundClip: "text",
+              }}
+            >
+              {t("title")}
+            </h1>
+            <p
+              style={{
+                fontSize: "1.25rem",
+                color: "var(--text-secondary, #888)",
+                maxWidth: "600px",
+                margin: "0 auto",
+              }}
+            >
+              {t("subtitle")}
+            </p>
+          </section>
+          <section
+            style={{
+              padding: "40px 20px 80px",
+              display: "flex",
+              justifyContent: "center",
+            }}
+          >
+            <PricingTable />
+          </section>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/turbo/apps/web/app/[locale]/pricing/page.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/page.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from "next";
+import PricingClient from "./PricingClient";
+
+export const metadata: Metadata = {
+  title: "Pricing - VM0",
+  description:
+    "Choose the right plan for your needs. Start free and upgrade as you grow.",
+  openGraph: {
+    title: "Pricing - VM0",
+    description:
+      "Choose the right plan for your needs. Start free and upgrade as you grow.",
+    type: "website",
+  },
+};
+
+export default function PricingPage() {
+  return <PricingClient />;
+}

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
@@ -7,7 +7,8 @@ import {
   afterAll,
   vi,
 } from "vitest";
-import { GET, filterConsecutiveEvents } from "../route";
+import { GET } from "../route";
+import { filterConsecutiveEvents } from "../filter-events";
 import { POST as createCompose } from "../../../../composes/route";
 import { initServices } from "../../../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../../../src/db/schema/agent-run";

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/filter-events.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/filter-events.ts
@@ -1,0 +1,42 @@
+interface AxiomAgentEvent {
+  _time: string;
+  runId: string;
+  userId: string;
+  sequenceNumber: number;
+  eventType: string;
+  eventData: Record<string, unknown>;
+}
+
+/**
+ * Filter events to only include consecutive sequence numbers starting from `since + 1`.
+ * This handles Axiom's eventual consistency where events may become queryable out of order.
+ *
+ * Example:
+ * - Input: events=[seq=1, seq=2, seq=4, seq=5], since=0
+ * - Output: [seq=1, seq=2] (truncated at gap before seq=4)
+ *
+ * @param events - Events sorted by sequenceNumber ascending
+ * @param since - The last sequence number already processed
+ * @returns Consecutive events starting from since+1
+ */
+export function filterConsecutiveEvents(
+  events: AxiomAgentEvent[],
+  since: number,
+): AxiomAgentEvent[] {
+  const consecutiveEvents: AxiomAgentEvent[] = [];
+  let expectedSeq = since + 1;
+
+  for (const event of events) {
+    if (event.sequenceNumber === expectedSeq) {
+      consecutiveEvents.push(event);
+      expectedSeq++;
+    } else {
+      // Gap detected, stop here
+      break;
+    }
+  }
+
+  return consecutiveEvents;
+}
+
+export type { AxiomAgentEvent };

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
@@ -19,47 +19,7 @@ import type {
   RunResult,
   RunState,
 } from "../../../../../../src/lib/run/types";
-
-interface AxiomAgentEvent {
-  _time: string;
-  runId: string;
-  userId: string;
-  sequenceNumber: number;
-  eventType: string;
-  eventData: Record<string, unknown>;
-}
-
-/**
- * Filter events to only include consecutive sequence numbers starting from `since + 1`.
- * This handles Axiom's eventual consistency where events may become queryable out of order.
- *
- * Example:
- * - Input: events=[seq=1, seq=2, seq=4, seq=5], since=0
- * - Output: [seq=1, seq=2] (truncated at gap before seq=4)
- *
- * @param events - Events sorted by sequenceNumber ascending
- * @param since - The last sequence number already processed
- * @returns Consecutive events starting from since+1
- */
-export function filterConsecutiveEvents(
-  events: AxiomAgentEvent[],
-  since: number,
-): AxiomAgentEvent[] {
-  const consecutiveEvents: AxiomAgentEvent[] = [];
-  let expectedSeq = since + 1;
-
-  for (const event of events) {
-    if (event.sequenceNumber === expectedSeq) {
-      consecutiveEvents.push(event);
-      expectedSeq++;
-    } else {
-      // Gap detected, stop here
-      break;
-    }
-  }
-
-  return consecutiveEvents;
-}
+import { filterConsecutiveEvents, type AxiomAgentEvent } from "./filter-events";
 
 const router = tsr.router(runEventsContract, {
   getEvents: async ({ params, query }) => {

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -82,6 +82,9 @@ export default function Navbar() {
             <Link href="/glossary" className="nav-link">
               {t("glossary")}
             </Link>
+            <Link href="/pricing" className="nav-link">
+              {t("pricing")}
+            </Link>
             <a
               href="https://github.com/vm0-ai/vm0"
               target="_blank"
@@ -163,6 +166,13 @@ export default function Navbar() {
               onClick={() => setMobileMenuOpen(false)}
             >
               {t("glossary")}
+            </Link>
+            <Link
+              href="/pricing"
+              className="mobile-menu-link"
+              onClick={() => setMobileMenuOpen(false)}
+            >
+              {t("pricing")}
             </Link>
             <a
               href="https://github.com/vm0-ai/vm0"

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -82,9 +82,14 @@
     "blog": "Blog",
     "skills": "Skills",
     "glossary": "Glossar",
+    "pricing": "Preise",
     "github": "GitHub",
     "contact": "Demo vereinbaren",
     "joinWaitlist": "Warteliste beitreten"
+  },
+  "pricing": {
+    "title": "Wählen Sie Ihren Plan",
+    "subtitle": "Starten Sie kostenlos und skalieren Sie nach Bedarf. Keine Kreditkarte erforderlich."
   },
   "footer": {
     "tagline": "Die moderne Laufzeitumgebung für agentenbasierte Entwicklung",

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -82,9 +82,14 @@
     "blog": "Blog",
     "skills": "Skills",
     "glossary": "Glossary",
+    "pricing": "Pricing",
     "github": "GitHub",
     "contact": "Schedule a demo",
     "joinWaitlist": "Join waitlist"
+  },
+  "pricing": {
+    "title": "Choose Your Plan",
+    "subtitle": "Start free and scale as you grow. No credit card required."
   },
   "footer": {
     "tagline": "Build agents and automate workflows with natural language",

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -82,9 +82,14 @@
     "blog": "Blog",
     "skills": "Skills",
     "glossary": "Glosario",
+    "pricing": "Precios",
     "github": "GitHub",
     "contact": "Agendar demo",
     "joinWaitlist": "Unirse a lista de espera"
+  },
+  "pricing": {
+    "title": "Elige Tu Plan",
+    "subtitle": "Comienza gratis y escala según crezcas. Sin tarjeta de crédito."
   },
   "footer": {
     "tagline": "El tiempo de ejecución moderno para desarrollo nativo de agentes",

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -82,9 +82,14 @@
     "blog": "ブログ",
     "skills": "Skills",
     "glossary": "用語集",
+    "pricing": "料金",
     "github": "GitHub",
     "contact": "デモを予約",
     "joinWaitlist": "ウェイトリストに参加"
+  },
+  "pricing": {
+    "title": "プランを選択",
+    "subtitle": "無料から始めて、必要に応じて拡張。クレジットカード不要。"
   },
   "footer": {
     "tagline": "エージェントネイティブ開発のための最新ランタイム",

--- a/turbo/apps/web/middleware.ts
+++ b/turbo/apps/web/middleware.ts
@@ -9,6 +9,7 @@ const isPublicRoute = createRouteMatcher([
   "/:locale",
   "/:locale/skills",
   "/:locale/glossary",
+  "/:locale/pricing",
   "/:locale/terms-of-use",
   "/:locale/privacy-policy",
   "/sign-in(.*)",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       '@clerk/clerk-js':
         specifier: ^5.92.1
         version: 5.119.0(@types/react@19.1.12)(bs58@5.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@19.2.1))(zod@4.1.12)
+      '@clerk/clerk-react':
+        specifier: ^5.59.4
+        version: 5.59.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@vm0/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -955,6 +958,13 @@ packages:
       react: ^18.0.0 || ^19.0.0 || ^19.0.0-0
       react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-0
 
+  '@clerk/clerk-react@5.59.4':
+    resolution: {integrity: sha512-CNr9n7uJT4cRx+cc3fzWr4l4x47+3S5j32HPOP5oUGeIF8O0QHHaoIQ8BHc3lnr4zJJpZxAyrLfwYPv3krtYIw==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
   '@clerk/localizations@3.34.0':
     resolution: {integrity: sha512-LGlxDuwFRfJnUttbHYTShqklGVqbXSp7B5zjir31pPQG1MrJS5LjVx8M0E9i0OZEHec8SU/4EoCOMX07Dk6Jfw==}
     engines: {node: '>=18.17.0'}
@@ -981,6 +991,18 @@ packages:
 
   '@clerk/shared@3.42.0':
     resolution: {integrity: sha512-sJUur/7jnHHlAsdoDosxpOmfV05VR7K5rvqlFskj3GaAMFEJrvdOztw0hmhBGVSWiCpjTZfdGITegton8mo7mQ==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@clerk/shared@3.43.0':
+    resolution: {integrity: sha512-pj8jgV5TX7l0ClHMvDLG7Ensp1BwA63LNvOE2uLwRV4bx3j9s4oGHy5bZlLBoOxdvRPCMpQksHi/O0x1Y+obdw==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -7113,6 +7135,7 @@ packages:
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   test-exclude@7.0.1:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
@@ -8467,6 +8490,13 @@ snapshots:
       react-dom: 19.2.1(react@19.2.1)
       tslib: 2.8.1
 
+  '@clerk/clerk-react@5.59.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@clerk/shared': 3.43.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      tslib: 2.8.1
+
   '@clerk/localizations@3.34.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@clerk/types': 4.101.10(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -8499,6 +8529,18 @@ snapshots:
       react-dom: 19.2.1(react@19.2.1)
 
   '@clerk/shared@3.42.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      csstype: 3.1.3
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.9.0
+      swr: 2.3.4(react@19.2.1)
+    optionalDependencies:
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+
+  '@clerk/shared@3.43.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       csstype: 3.1.3
       dequal: 2.0.3
@@ -11442,7 +11484,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.18.0)(typescript@5.9.2))(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:


### PR DESCRIPTION
## Summary
- Add pricing page to web app (`/pricing`) with Clerk `<PricingTable />` component
- Add "Pricing" link to Navbar (desktop and mobile navigation)
- Integrate `<SubscriptionDetailsButton>` in platform sidebar for "Bill" action
- Add i18n support for pricing page across all 4 locales (en, de, es, ja)

## Additional Fixes
- Refactor `filterConsecutiveEvents` to separate file to fix pre-existing Next.js route type error

## Technical Details
- Web app uses `@clerk/nextjs` PricingTable component
- Platform uses `@clerk/clerk-react/experimental` SubscriptionDetailsButton
- Both apps share the same Clerk authentication

## Clerk Dashboard Setup Required
After merging, the following manual configuration is needed in [Clerk Dashboard](https://dashboard.clerk.com):
1. Enable Billing feature
2. Create subscription plans
3. Connect Stripe account

## Test plan
- [ ] Verify `/pricing` page loads correctly with PricingTable
- [ ] Verify Pricing link appears in Navbar
- [ ] Verify "Bill" button in platform sidebar opens subscription details modal
- [ ] Run `pnpm check-types` - all packages pass
- [ ] Run `pnpm vitest` - all tests pass

Closes #1100

🤖 Generated with [Claude Code](https://claude.com/claude-code)