### PR TITLE
feat(web): add instatus status widget to landing page

### DIFF
--- a/turbo/apps/docs/src/app/layout.tsx
+++ b/turbo/apps/docs/src/app/layout.tsx
@@ -41,6 +41,10 @@ export default function Layout({ children }: LayoutProps<"/">) {
       </head>
       <body className="flex flex-col min-h-screen">
         <RootProvider>{children}</RootProvider>
+        <Script
+          src="https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en"
+          strategy="lazyOnload"
+        />
       </body>
     </html>
   );

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -11,5 +11,9 @@
   </head>
   <body>
     <div id="root"></div>
+    <script
+      src="https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en"
+      defer
+    ></script>
   </body>
 </html>

--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import Image from "next/image";
+import Script from "next/script";
 import { useTranslations } from "next-intl";
 import Navbar from "./Navbar";
 import Footer from "./Footer";
@@ -701,6 +702,12 @@ export default function LandingPage() {
       </section>
 
       <Footer />
+
+      {/* Instatus Status Widget */}
+      <Script
+        src="https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en"
+        strategy="lazyOnload"
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Add Instatus status page widget to the landing page
- Widget displays system status from status.vm0.ai
- Uses `next/script` with `lazyOnload` strategy for optimal performance

## Test plan
- [ ] Verify widget appears on landing page
- [ ] Confirm widget loads without blocking page render
- [ ] Check status.vm0.ai connection works

🤖 Generated with [Claude Code](https://claude.ai/code)