### PR TITLE
chore: upgrade claude code cli to 2.1.12

### DIFF
--- a/turbo/apps/runner/scripts/deploy/Dockerfile
+++ b/turbo/apps/runner/scripts/deploy/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean
 
 # Install Claude Code CLI globally (matching e2b template)
-RUN npm install -g @anthropic-ai/claude-code@latest
+RUN npm install -g @anthropic-ai/claude-code@2.1.12
 
 # Install Codex CLI globally (matching e2b template)
 # See: turbo/scripts/e2b/vm0-codex/template.ts

--- a/turbo/scripts/e2b/vm0-claude-code-github/template.ts
+++ b/turbo/scripts/e2b/vm0-claude-code-github/template.ts
@@ -12,7 +12,7 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "ripgrep", "jq", "file"])
-  .npmInstall("@anthropic-ai/claude-code@2.1.2", { g: true })
+  .npmInstall("@anthropic-ai/claude-code@2.1.12", { g: true })
   // Install GitHub CLI
   // https://github.com/cli/cli/blob/trunk/docs/install_linux.md
   .runCmd(

--- a/turbo/scripts/e2b/vm0-claude-code/template.ts
+++ b/turbo/scripts/e2b/vm0-claude-code/template.ts
@@ -11,4 +11,4 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "ripgrep", "jq", "file"])
-  .npmInstall("@anthropic-ai/claude-code@2.1.2", { g: true });
+  .npmInstall("@anthropic-ai/claude-code@2.1.12", { g: true });


### PR DESCRIPTION
## Summary
- Upgrade Claude Code CLI from 2.1.2 to 2.1.12 in E2B templates
- Pin Runner Dockerfile from `@latest` to `@2.1.12` for version consistency

## Changes
- `turbo/scripts/e2b/vm0-claude-code/template.ts`: `2.1.2` → `2.1.12`
- `turbo/scripts/e2b/vm0-claude-code-github/template.ts`: `2.1.2` → `2.1.12`
- `turbo/apps/runner/scripts/deploy/Dockerfile`: `@latest` → `@2.1.12`

## Test plan
- [ ] Merge to main triggers E2B template rebuild via `e2b-template.yml`
- [ ] Verify new sandbox runs with updated Claude Code CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)