### PR TITLE
fix(sandbox): use ignore for stdin to prevent claude code hang

### DIFF
--- a/turbo/packages/core/src/sandbox/scripts/src/run-agent.ts
+++ b/turbo/packages/core/src/sandbox/scripts/src/run-agent.ts
@@ -320,8 +320,10 @@ async function run(): Promise<[number, string]> {
     }
 
     // Spawn process
+    // Use "ignore" for stdin since we don't send any input to Claude Code
+    // Using "pipe" without closing it would cause Claude Code to hang waiting for EOF
     const proc = spawn(cmdExe, cmd.slice(1), {
-      stdio: ["pipe", "pipe", "pipe"],
+      stdio: ["ignore", "pipe", "pipe"],
     });
 
     // Create promise to track process exit - register handlers BEFORE reading streams


### PR DESCRIPTION
## Summary

- Fixed Claude Code hanging in sandbox by changing stdin from `pipe` to `ignore`
- Root cause: We spawned Claude Code with `stdio: ["pipe", "pipe", "pipe"]` but never wrote to or closed stdin, causing Claude Code to hang waiting for EOF

## Root Cause Analysis

When spawning a process with `stdio: ["pipe", "pipe", "pipe"]`:
1. stdin is connected to a pipe
2. If we never write to it AND never close it, the child process may wait for input or EOF
3. Claude Code detected stdin was a pipe (not TTY) and waited for EOF before proceeding

## Fix

Changed `stdio` from `["pipe", "pipe", "pipe"]` to `["ignore", "pipe", "pipe"]` since we don't need to send any input to Claude Code.

## Testing

- Verified in E2B sandbox that Claude Code process was hanging on `epoll` (waiting for I/O)
- Confirmed `CLAUDE_CODE_OAUTH_TOKEN` was correctly passed to the process
- Manual execution of `claude --print ...` worked fine, indicating the issue was with how we spawned the process

🤖 Generated with [Claude Code](https://claude.com/claude-code)