### PR TITLE
fix(ci): add core build step to publish-npm job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -189,8 +189,11 @@ jobs:
       - name: Use latest npm for OIDC support
         run: npm install -g npm@latest
 
+      - name: Build Core Package
+        run: cd turbo && pnpm turbo run build --filter=@vm0/core
+
       - name: Build CLI
-        run: cd turbo && pnpm -F @vm0/cli build
+        run: cd turbo && pnpm --filter @vm0/cli build
 
       - name: Publish to npm with OIDC
         run: cd turbo/apps/cli/dist && npm publish --access public


### PR DESCRIPTION
## Summary

- Added "Build Core Package" step to the `publish-npm` job
- This fixes the CLI publish failing because `@vm0/cli` depends on `@vm0/core`

## Root Cause

Same issue as #1306 for `publish-runner-npm` - the `pnpm -F @vm0/cli build` command doesn't build dependencies, so `@vm0/core` needs to be built first.

## Changes

```yaml
# Added before Build CLI step
- name: Build Core Package
  run: cd turbo && pnpm turbo run build --filter=@vm0/core
```

## Related

- Fixes the failure in https://github.com/vm0-ai/vm0/actions/runs/21128735086/job/60755014715
- Same fix as #1306 for publish-runner-npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)