### PR TITLE
feat: add --debug-no-mock-claude flag for real Claude E2E tests

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -527,6 +527,7 @@ jobs:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           USE_MOCK_CLAUDE: "true"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
       - name: Stop Cron Simulator
         if: always()

--- a/e2e/tests/02-parallel/t27-real-claude-smoke.bats
+++ b/e2e/tests/02-parallel/t27-real-claude-smoke.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+
+setup() {
+    # Create temporary test directory
+    export TEST_DIR="$(mktemp -d)"
+    # Use unique names with timestamp to avoid conflicts in parallel runs
+    export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
+    export AGENT_NAME="e2e-real-claude-${UNIQUE_ID}"
+}
+
+teardown() {
+    # Clean up temporary directory
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
+}
+
+@test "real claude executes simple prompt with --debug-no-mock-claude" {
+    # Skip if ANTHROPIC_API_KEY is not set
+    if [ -z "$ANTHROPIC_API_KEY" ]; then
+        skip "ANTHROPIC_API_KEY not set - required for real Claude test"
+    fi
+
+    # Skip if not authenticated (requires VM0_TOKEN or logged in)
+    if $CLI_COMMAND auth status 2>&1 | grep -q "Not authenticated"; then
+        skip "Not authenticated - run 'vm0 auth login' first"
+    fi
+
+    cd "$TEST_DIR"
+
+    echo "# Step 1: Create vm0.yaml config..."
+    cat > vm0.yaml <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Real Claude smoke test"
+    provider: claude-code
+    image: "vm0/claude-code:dev"
+    working_dir: /home/user/workspace
+    environment:
+      ANTHROPIC_API_KEY: \${{ secrets.ANTHROPIC_API_KEY }}
+EOF
+
+    echo "# Step 2: Create .env file with API key..."
+    cat > .env <<EOF
+ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
+EOF
+
+    echo "# Step 3: Run cook with --debug-no-mock-claude flag..."
+    # Use a simple prompt that Claude can execute quickly
+    # Timeout after 120 seconds to catch hangs
+    run timeout 120 $CLI_COMMAND cook --debug-no-mock-claude "echo 'hello from real claude' && exit 0"
+
+    echo "# Step 4: Verify run completed..."
+    # Should succeed and produce JSONL output
+    assert_success
+
+    echo "# Step 5: Check for expected output markers..."
+    # Should see init event
+    assert_output --partial "[init]"
+    # Should complete successfully
+    assert_output --partial "Run completed successfully"
+}

--- a/e2e/tests/02-parallel/t27-real-claude-smoke.bats
+++ b/e2e/tests/02-parallel/t27-real-claude-smoke.bats
@@ -18,14 +18,14 @@ teardown() {
 }
 
 @test "real claude executes simple prompt with --debug-no-mock-claude" {
-    # Skip if ANTHROPIC_API_KEY is not set
+    # Fail if ANTHROPIC_API_KEY is not set (required for this test)
     if [ -z "$ANTHROPIC_API_KEY" ]; then
-        skip "ANTHROPIC_API_KEY not set - required for real Claude test"
+        fail "ANTHROPIC_API_KEY not set - required for real Claude test"
     fi
 
-    # Skip if not authenticated (requires VM0_TOKEN or logged in)
+    # Fail if not authenticated
     if $CLI_COMMAND auth status 2>&1 | grep -q "Not authenticated"; then
-        skip "Not authenticated - run 'vm0 auth login' first"
+        fail "Not authenticated - run 'vm0 auth login' first"
     fi
 
     cd "$TEST_DIR"
@@ -50,17 +50,9 @@ ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
 EOF
 
     echo "# Step 3: Run cook with --debug-no-mock-claude flag..."
-    # Use a simple prompt that Claude can execute quickly
-    # Timeout after 120 seconds to catch hangs
-    run timeout 120 $CLI_COMMAND cook --debug-no-mock-claude "echo 'hello from real claude' && exit 0"
+    run timeout 120 $CLI_COMMAND cook --debug-no-mock-claude "1+1=?"
 
-    echo "# Step 4: Verify run completed..."
-    # Should succeed and produce JSONL output
+    echo "# Step 4: Verify run completed with result..."
     assert_success
-
-    echo "# Step 5: Check for expected output markers..."
-    # Should see init event
-    assert_output --partial "[init]"
-    # Should complete successfully
-    assert_output --partial "Run completed successfully"
+    assert_output --partial "[result]"
 }

--- a/turbo/apps/cli/src/commands/run.ts
+++ b/turbo/apps/cli/src/commands/run.ts
@@ -344,6 +344,7 @@ const runCmd = new Command()
     "Resume from conversation ID (for fine-grained control)",
   )
   .option("-v, --verbose", "Show verbose output with timing information")
+  .option("--debug-no-mock-claude")
   .action(
     async (
       identifier: string,
@@ -356,6 +357,7 @@ const runCmd = new Command()
         volumeVersion: Record<string, string>;
         conversation?: string;
         verbose?: boolean;
+        debugNoMockClaude?: boolean;
       },
     ) => {
       const startTimestamp = new Date(); // Capture command start time for elapsed calculation
@@ -495,6 +497,7 @@ const runCmd = new Command()
               ? options.volumeVersion
               : undefined,
           conversationId: options.conversation,
+          debugNoMockClaude: options.debugNoMockClaude || undefined,
         });
 
         // 4. Check for immediate failure (e.g., missing secrets)
@@ -576,6 +579,7 @@ runCmd
     {},
   )
   .option("-v, --verbose", "Show verbose output with timing information")
+  .option("--debug-no-mock-claude")
   .action(
     async (
       checkpointId: string,
@@ -584,6 +588,7 @@ runCmd
         vars: Record<string, string>;
         secrets: Record<string, string>;
         verbose?: boolean;
+        debugNoMockClaude?: boolean;
       },
       command: { optsWithGlobals: () => Record<string, unknown> },
     ) => {
@@ -596,6 +601,7 @@ runCmd
         secrets: Record<string, string>;
         volumeVersion: Record<string, string>;
         verbose?: boolean;
+        debugNoMockClaude?: boolean;
       };
 
       const verbose = options.verbose || allOpts.verbose;
@@ -661,6 +667,8 @@ runCmd
             Object.keys(allOpts.volumeVersion).length > 0
               ? allOpts.volumeVersion
               : undefined,
+          debugNoMockClaude:
+            options.debugNoMockClaude || allOpts.debugNoMockClaude || undefined,
         });
 
         // 4. Check for immediate failure (e.g., missing secrets)
@@ -734,6 +742,7 @@ runCmd
     {},
   )
   .option("-v, --verbose", "Show verbose output with timing information")
+  .option("--debug-no-mock-claude")
   .action(
     async (
       agentSessionId: string,
@@ -742,6 +751,7 @@ runCmd
         vars: Record<string, string>;
         secrets: Record<string, string>;
         verbose?: boolean;
+        debugNoMockClaude?: boolean;
       },
       command: { optsWithGlobals: () => Record<string, unknown> },
     ) => {
@@ -754,6 +764,7 @@ runCmd
         secrets: Record<string, string>;
         volumeVersion: Record<string, string>;
         verbose?: boolean;
+        debugNoMockClaude?: boolean;
       };
 
       const verbose = options.verbose || allOpts.verbose;
@@ -819,6 +830,8 @@ runCmd
             Object.keys(allOpts.volumeVersion).length > 0
               ? allOpts.volumeVersion
               : undefined,
+          debugNoMockClaude:
+            options.debugNoMockClaude || allOpts.debugNoMockClaude || undefined,
         });
 
         // 4. Check for immediate failure (e.g., missing secrets)

--- a/turbo/apps/cli/src/lib/api/api-client.ts
+++ b/turbo/apps/cli/src/lib/api/api-client.ts
@@ -280,6 +280,8 @@ class ApiClient {
     vars?: Record<string, string>;
     secrets?: Record<string, string>;
     volumeVersions?: Record<string, string>;
+    // Debug flag (internal use only)
+    debugNoMockClaude?: boolean;
     // Required
     prompt: string;
   }): Promise<CreateRunResponse> {

--- a/turbo/apps/runner/src/lib/executor-env.ts
+++ b/turbo/apps/runner/src/lib/executor-env.ts
@@ -39,9 +39,9 @@ export function buildEnvironmentVariables(
     envVars.VERCEL_PROTECTION_BYPASS = vercelBypass;
   }
 
-  // Pass USE_MOCK_CLAUDE from host environment for testing
+  // Pass USE_MOCK_CLAUDE from host environment for testing (skip if debugNoMockClaude is set)
   const useMockClaude = process.env.USE_MOCK_CLAUDE;
-  if (useMockClaude) {
+  if (useMockClaude && !context.debugNoMockClaude) {
     envVars.USE_MOCK_CLAUDE = useMockClaude;
   }
 

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -373,6 +373,7 @@ const router = tsr.router(runsMainContract, {
         agentName: agentComposeName,
         resumedFromCheckpointId: body.checkpointId,
         continuedFromSessionId: body.sessionId,
+        debugNoMockClaude: body.debugNoMockClaude,
       });
 
       // Prepare and dispatch to executor (unified path for E2B and runner)

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -182,6 +182,7 @@ const router = tsr.router(runnersJobClaimContract, {
         secretValues, // Decrypted secrets
         cliAgentType: storedContext.cliAgentType,
         experimentalFirewall: storedContext.experimentalFirewall,
+        debugNoMockClaude: storedContext.debugNoMockClaude,
       },
     };
   },

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -155,8 +155,11 @@ class E2BService {
         sandboxEnvVars.VM0_RESUME_SESSION_ID = context.resumeSession.sessionId;
       }
 
-      // Pass USE_MOCK_CLAUDE for testing (executes prompt as bash instead of calling LLM)
-      if (process.env.USE_MOCK_CLAUDE === "true") {
+      // Pass USE_MOCK_CLAUDE for testing (skip if debugNoMockClaude is set)
+      if (
+        process.env.USE_MOCK_CLAUDE === "true" &&
+        !context.debugNoMockClaude
+      ) {
         sandboxEnvVars.USE_MOCK_CLAUDE = "true";
       }
 

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -38,6 +38,8 @@ export interface BuildContextParams {
   agentName?: string;
   resumedFromCheckpointId?: string;
   continuedFromSessionId?: string;
+  // Debug flag to force real Claude in mock environments (internal use only)
+  debugNoMockClaude?: boolean;
 }
 
 /**
@@ -208,5 +210,7 @@ export async function buildExecutionContext(
     agentName: params.agentName,
     resumedFromCheckpointId: params.resumedFromCheckpointId,
     continuedFromSessionId: params.continuedFromSessionId,
+    // Debug flag
+    debugNoMockClaude: params.debugNoMockClaude,
   };
 }

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -243,6 +243,9 @@ export async function prepareForExecution(
     agentName: context.agentName || null,
     resumedFromCheckpointId: context.resumedFromCheckpointId || null,
     continuedFromSessionId: context.continuedFromSessionId || null,
+
+    // Debug flag
+    debugNoMockClaude: context.debugNoMockClaude || false,
   };
 
   log.debug(`PreparedContext built for run ${context.runId}`);

--- a/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
@@ -254,8 +254,8 @@ class E2BExecutor implements Executor {
       sandboxEnvVars.VM0_RESUME_SESSION_ID = context.resumeSession.sessionId;
     }
 
-    // Pass USE_MOCK_CLAUDE for testing
-    if (process.env.USE_MOCK_CLAUDE === "true") {
+    // Pass USE_MOCK_CLAUDE for testing (skip if debugNoMockClaude is set)
+    if (process.env.USE_MOCK_CLAUDE === "true" && !context.debugNoMockClaude) {
       sandboxEnvVars.USE_MOCK_CLAUDE = "true";
     }
 

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -52,6 +52,7 @@ class RunnerExecutor implements Executor {
       encryptedSecrets,
       cliAgentType: context.cliAgentType,
       experimentalFirewall: context.experimentalFirewall ?? undefined,
+      debugNoMockClaude: context.debugNoMockClaude || undefined,
     };
 
     // Insert into runner job queue

--- a/turbo/apps/web/src/lib/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/run/executors/types.ts
@@ -49,6 +49,9 @@ export interface PreparedContext {
   agentName: string | null;
   resumedFromCheckpointId: string | null;
   continuedFromSessionId: string | null;
+
+  // Debug flag to force real Claude in mock environments (internal use only)
+  debugNoMockClaude: boolean;
 }
 
 /**

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -79,4 +79,7 @@ export interface ExecutionContext {
   agentName?: string;
   resumedFromCheckpointId?: string;
   continuedFromSessionId?: string;
+
+  // Debug flag to force real Claude in mock environments (internal use only)
+  debugNoMockClaude?: boolean;
 }

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -125,6 +125,8 @@ export const storedExecutionContextSchema = z.object({
   encryptedSecrets: z.string().nullable(), // AES-256-GCM encrypted secrets
   cliAgentType: z.string(),
   experimentalFirewall: experimentalFirewallSchema.optional(),
+  // Debug flag to force real Claude in mock environments (internal use only)
+  debugNoMockClaude: z.boolean().optional(),
 });
 
 /**
@@ -147,6 +149,8 @@ export const executionContextSchema = z.object({
   cliAgentType: z.string(),
   // Experimental firewall configuration
   experimentalFirewall: experimentalFirewallSchema.optional(),
+  // Debug flag to force real Claude in mock environments (internal use only)
+  debugNoMockClaude: z.boolean().optional(),
 });
 
 /**

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -33,6 +33,9 @@ const unifiedRunRequestSchema = z.object({
   secrets: z.record(z.string(), z.string()).optional(),
   volumeVersions: z.record(z.string(), z.string()).optional(),
 
+  // Debug flag to force real Claude in mock environments (internal use only)
+  debugNoMockClaude: z.boolean().optional(),
+
   // Required
   prompt: z.string().min(1, "Missing prompt"),
 });


### PR DESCRIPTION
## Summary

- Add hidden `--debug-no-mock-claude` CLI flag that forces real Claude Code execution even when server has `USE_MOCK_CLAUDE=true`
- Pass the flag through the entire stack: CLI → API → server route → run service → executors → sandbox
- When flag is present, skip setting `USE_MOCK_CLAUDE` in sandbox environment variables
- Add E2E test `t27-real-claude-smoke.bats` that uses the flag with a real Anthropic API key
- Update CI workflow to pass `ANTHROPIC_API_KEY` secret to parallel E2E tests

## Test plan

- [ ] Type check passes (all modified packages)
- [ ] Lint passes
- [ ] E2E test with `--debug-no-mock-claude` flag skips when `ANTHROPIC_API_KEY` not set
- [ ] E2E test runs successfully when `ANTHROPIC_API_KEY` is provided in CI
- [ ] Existing mock tests continue to work (USE_MOCK_CLAUDE behavior unchanged when flag not used)

Closes #1322

🤖 Generated with [Claude Code](https://claude.com/claude-code)