### PR TITLE
fix(runner): prevent ip address collision in parallel vm creation

### DIFF
--- a/turbo/apps/runner/src/commands/start.ts
+++ b/turbo/apps/runner/src/commands/start.ts
@@ -17,6 +17,7 @@ import {
   checkNetworkPrerequisites,
   setupBridge,
   cleanupOrphanedProxyRules,
+  flushBridgeArpCache,
 } from "../lib/firecracker/network.js";
 import { cleanupOrphanedAllocations } from "../lib/firecracker/ip-pool.js";
 import {
@@ -151,6 +152,11 @@ export const startCommand = new Command("start")
       // Set up bridge network
       console.log("Setting up network bridge...");
       await setupBridge();
+
+      // Flush bridge ARP cache to clear stale entries from previous runs
+      // This prevents routing issues when IPs are reused with different MACs
+      console.log("Flushing bridge ARP cache...");
+      await flushBridgeArpCache();
 
       // Clean up orphaned proxy rules from previous runs
       // This handles rules left behind after crashes or SIGKILL

--- a/turbo/apps/runner/src/commands/start.ts
+++ b/turbo/apps/runner/src/commands/start.ts
@@ -18,6 +18,7 @@ import {
   setupBridge,
   cleanupOrphanedProxyRules,
 } from "../lib/firecracker/network.js";
+import { cleanupOrphanedAllocations } from "../lib/firecracker/ip-pool.js";
 import {
   initProxyManager,
   initVMRegistry,
@@ -155,6 +156,11 @@ export const startCommand = new Command("start")
       // This handles rules left behind after crashes or SIGKILL
       console.log("Cleaning up orphaned proxy rules...");
       await cleanupOrphanedProxyRules(config.name);
+
+      // Clean up orphaned IP allocations from previous runs
+      // This reconciles the IP registry with actual TAP devices
+      console.log("Cleaning up orphaned IP allocations...");
+      await cleanupOrphanedAllocations();
 
       // Initialize proxy for network security mode
       // The proxy is always started but only used when experimentalFirewall is enabled

--- a/turbo/apps/runner/src/commands/start.ts
+++ b/turbo/apps/runner/src/commands/start.ts
@@ -16,6 +16,7 @@ import { executeJob as executeJobInVM } from "../lib/executor.js";
 import {
   checkNetworkPrerequisites,
   setupBridge,
+  cleanupOrphanedProxyRules,
 } from "../lib/firecracker/network.js";
 import {
   initProxyManager,
@@ -149,6 +150,11 @@ export const startCommand = new Command("start")
       // Set up bridge network
       console.log("Setting up network bridge...");
       await setupBridge();
+
+      // Clean up orphaned proxy rules from previous runs
+      // This handles rules left behind after crashes or SIGKILL
+      console.log("Cleaning up orphaned proxy rules...");
+      await cleanupOrphanedProxyRules(config.name);
 
       // Initialize proxy for network security mode
       // The proxy is always started but only used when experimentalFirewall is enabled

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -241,7 +241,7 @@ export async function executeJob(
 
       // Set up per-VM iptables rules to redirect this VM's traffic to mitmproxy
       // This must be done before the VM makes any network requests
-      await setupVMProxyRules(guestIp, config.proxy.port);
+      await setupVMProxyRules(guestIp, config.proxy.port, config.name);
 
       // Register VM in the proxy registry with firewall rules
       getVMRegistry().register(guestIp, context.runId, context.sandboxToken, {
@@ -474,7 +474,7 @@ export async function executeJob(
 
       // Remove per-VM iptables rules first
       try {
-        await removeVMProxyRules(guestIp, config.proxy.port);
+        await removeVMProxyRules(guestIp, config.proxy.port, config.name);
       } catch (err) {
         console.error(
           `[Executor] Failed to remove VM proxy rules: ${err instanceof Error ? err.message : "Unknown error"}`,

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -299,16 +299,6 @@ export async function executeJob(
     // This verifies VM can reach VM0 API - if not, we report failure immediately
     // Skip in benchmark mode since it doesn't use API
     if (!options.benchmarkMode) {
-      // Debug: test basic network connectivity before preflight
-      // Note: ssh.exec runs commands inside the VM, not on the host
-      log(`[Executor] Testing network connectivity for ${guestIp}...`);
-      const networkTestCmd =
-        "curl -sf --connect-timeout 5 --max-time 10 https://www.google.com -o /dev/null -w '%{http_code}'";
-      const pingResult = await ssh.exec(networkTestCmd, 15000);
-      log(
-        `[Executor] Network test: exit=${pingResult.exitCode} stdout='${pingResult.stdout.trim()}' stderr='${pingResult.stderr.trim()}'`,
-      );
-
       log(`[Executor] Running preflight connectivity check...`);
       const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
       const preflight = await runPreflightCheck(

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -299,6 +299,16 @@ export async function executeJob(
     // This verifies VM can reach VM0 API - if not, we report failure immediately
     // Skip in benchmark mode since it doesn't use API
     if (!options.benchmarkMode) {
+      // Debug: test basic network connectivity before preflight
+      // Note: ssh.exec runs commands inside the VM, not on the host
+      log(`[Executor] Testing network connectivity for ${guestIp}...`);
+      const networkTestCmd =
+        "curl -sf --connect-timeout 5 --max-time 10 https://www.google.com -o /dev/null -w '%{http_code}'";
+      const pingResult = await ssh.exec(networkTestCmd, 15000);
+      log(
+        `[Executor] Network test: exit=${pingResult.exitCode} stdout='${pingResult.stdout.trim()}' stderr='${pingResult.stderr.trim()}'`,
+      );
+
       log(`[Executor] Running preflight connectivity check...`);
       const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
       const preflight = await runPreflightCheck(

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/ip-pool.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/ip-pool.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+
+// Type for IP registry
+interface IPAllocation {
+  vmId: string;
+  tapDevice: string;
+  allocatedAt: string;
+}
+interface IPRegistry {
+  allocations: Record<string, IPAllocation>;
+}
+
+// Track mock exec results - this will be used by both callback and promisified versions
+let mockExecStdout = "";
+let mockExecStderr = "";
+
+// Mock the modules - vi.mock is hoisted so this runs first
+vi.mock("node:fs");
+vi.mock("node:child_process", () => {
+  // Use the well-known symbol for custom promisify
+  const kCustomPromisifiedSymbol = Symbol.for("nodejs.util.promisify.custom");
+
+  const execMock = vi.fn(
+    (
+      _cmd: string,
+      callback?: (error: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      if (callback) {
+        callback(null, mockExecStdout, mockExecStderr);
+      }
+      return {} as unknown;
+    },
+  );
+
+  // Add custom promisify implementation that returns { stdout, stderr }
+  (execMock as unknown as Record<symbol, unknown>)[kCustomPromisifiedSymbol] =
+    vi.fn(async () => ({ stdout: mockExecStdout, stderr: mockExecStderr }));
+
+  return { exec: execMock };
+});
+
+// Import after mocking
+import {
+  allocateIP,
+  releaseIP,
+  cleanupOrphanedAllocations,
+} from "../ip-pool.js";
+
+const mockFs = vi.mocked(fs);
+
+describe("IP Pool Manager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default mocks for ensureRunDir
+    mockFs.existsSync.mockReturnValue(true);
+
+    // Reset default exec result
+    mockExecStdout = "";
+    mockExecStderr = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("allocateIP", () => {
+    it("should allocate first available IP (172.16.0.2) when pool is empty", async () => {
+      // Mock empty registry
+      mockFs.existsSync.mockImplementation((path) => {
+        if (String(path).includes("ip-registry.json")) return false;
+        if (String(path).includes("lock.active")) return false;
+        return true; // VM0_RUN_DIR exists
+      });
+
+      // Mock successful lock acquisition
+      mockFs.writeFileSync.mockImplementation(() => undefined);
+      mockFs.unlinkSync.mockImplementation(() => undefined);
+
+      const ip = await allocateIP("test-vm-1234");
+
+      expect(ip).toBe("172.16.0.2");
+    });
+
+    it("should allocate next available IP when some are already allocated", async () => {
+      const existingRegistry = {
+        allocations: {
+          "172.16.0.2": {
+            vmId: "existing-vm",
+            tapDevice: "tapexistin",
+            allocatedAt: new Date().toISOString(),
+          },
+        },
+      };
+
+      mockFs.existsSync.mockImplementation((path) => {
+        if (String(path).includes("ip-registry.json")) return true;
+        if (String(path).includes("lock.active")) return false;
+        return true;
+      });
+
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(existingRegistry));
+      mockFs.writeFileSync.mockImplementation(() => undefined);
+      mockFs.unlinkSync.mockImplementation(() => undefined);
+
+      const ip = await allocateIP("new-vm-5678");
+
+      expect(ip).toBe("172.16.0.3");
+    });
+
+    it("should throw when no IPs are available", async () => {
+      // Create a registry with all IPs allocated
+      const allocations: Record<
+        string,
+        { vmId: string; tapDevice: string; allocatedAt: string }
+      > = {};
+      for (let i = 2; i <= 254; i++) {
+        allocations[`172.16.0.${i}`] = {
+          vmId: `vm-${i}`,
+          tapDevice: `tapvm${i}`,
+          allocatedAt: new Date().toISOString(),
+        };
+      }
+      const fullRegistry = { allocations };
+
+      mockFs.existsSync.mockImplementation((path) => {
+        if (String(path).includes("ip-registry.json")) return true;
+        if (String(path).includes("lock.active")) return false;
+        return true;
+      });
+
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(fullRegistry));
+      mockFs.writeFileSync.mockImplementation(() => undefined);
+      mockFs.unlinkSync.mockImplementation(() => undefined);
+
+      await expect(allocateIP("overflow-vm")).rejects.toThrow(
+        "No free IP addresses available in pool",
+      );
+    });
+
+    it("should use first 8 chars of vmId for TAP device name", async () => {
+      mockFs.existsSync.mockImplementation((path) => {
+        if (String(path).includes("ip-registry.json")) return false;
+        if (String(path).includes("lock.active")) return false;
+        return true;
+      });
+
+      let writtenRegistry: IPRegistry | null = null;
+      mockFs.writeFileSync.mockImplementation((_path, content) => {
+        if (String(_path).includes("ip-registry.json")) {
+          writtenRegistry = JSON.parse(content as string) as IPRegistry;
+        }
+      });
+      mockFs.unlinkSync.mockImplementation(() => undefined);
+
+      await allocateIP("abcdefghijklmnop");
+
+      expect(writtenRegistry!.allocations["172.16.0.2"]?.tapDevice).toBe(
+        "tapabcdefgh",
+      );
+    });
+  });
+
+  describe("releaseIP", () => {
+    it("should remove IP from registry when released", async () => {
+      const existingRegistry = {
+        allocations: {
+          "172.16.0.2": {
+            vmId: "test-vm",
+            tapDevice: "taptest-vm",
+            allocatedAt: new Date().toISOString(),
+          },
+        },
+      };
+
+      mockFs.existsSync.mockImplementation((path) => {
+        if (String(path).includes("ip-registry.json")) return true;
+        if (String(path).includes("lock.active")) return false;
+        return true;
+      });
+
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(existingRegistry));
+
+      let writtenRegistry: IPRegistry | null = null;
+      mockFs.writeFileSync.mockImplementation((_path, content) => {
+        if (String(_path).includes("ip-registry.json")) {
+          writtenRegistry = JSON.parse(content as string) as IPRegistry;
+        }
+      });
+      mockFs.unlinkSync.mockImplementation(() => undefined);
+
+      await releaseIP("172.16.0.2");
+
+      expect(writtenRegistry!.allocations["172.16.0.2"]).toBeUndefined();
+    });
+
+    it("should handle releasing IP that was not allocated", async () => {
+      const existingRegistry = { allocations: {} };
+
+      mockFs.existsSync.mockImplementation((path) => {
+        if (String(path).includes("ip-registry.json")) return true;
+        if (String(path).includes("lock.active")) return false;
+        return true;
+      });
+
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(existingRegistry));
+      mockFs.writeFileSync.mockImplementation(() => undefined);
+      mockFs.unlinkSync.mockImplementation(() => undefined);
+
+      // Should not throw
+      await expect(releaseIP("172.16.0.99")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("cleanupOrphanedAllocations", () => {
+    it("should remove allocations without active TAP devices", async () => {
+      const oldAllocation = new Date(Date.now() - 60000).toISOString(); // 60 seconds ago
+      const existingRegistry = {
+        allocations: {
+          "172.16.0.2": {
+            vmId: "orphan-vm",
+            tapDevice: "taporphanv",
+            allocatedAt: oldAllocation,
+          },
+        },
+      };
+
+      mockFs.existsSync.mockImplementation((path) => {
+        if (String(path).includes("ip-registry.json")) return true;
+        if (String(path).includes("lock.active")) return false;
+        return true;
+      });
+
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(existingRegistry));
+
+      // Mock exec for TAP device scan - return empty (no TAP devices)
+      // mockExecStdout/Stderr are already empty by default
+
+      let writtenRegistry: IPRegistry | null = null;
+      mockFs.writeFileSync.mockImplementation((_path, content) => {
+        if (String(_path).includes("ip-registry.json")) {
+          writtenRegistry = JSON.parse(content as string) as IPRegistry;
+        }
+      });
+      mockFs.unlinkSync.mockImplementation(() => undefined);
+
+      await cleanupOrphanedAllocations();
+
+      // Orphan should be removed
+      expect(writtenRegistry!.allocations["172.16.0.2"]).toBeUndefined();
+    });
+
+    it("should keep allocations within grace period even without TAP device", async () => {
+      const recentAllocation = new Date().toISOString(); // Just now
+      const existingRegistry = {
+        allocations: {
+          "172.16.0.2": {
+            vmId: "new-vm",
+            tapDevice: "tapnew-vm",
+            allocatedAt: recentAllocation,
+          },
+        },
+      };
+
+      mockFs.existsSync.mockImplementation((path) => {
+        if (String(path).includes("ip-registry.json")) return true;
+        if (String(path).includes("lock.active")) return false;
+        return true;
+      });
+
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(existingRegistry));
+
+      // Mock exec for TAP device scan - return empty (no TAP devices)
+      // mockExecStdout/Stderr are already empty by default
+
+      let writtenRegistry: IPRegistry | null = null;
+      mockFs.writeFileSync.mockImplementation((_path, content) => {
+        if (String(_path).includes("ip-registry.json")) {
+          writtenRegistry = JSON.parse(content as string) as IPRegistry;
+        }
+      });
+      mockFs.unlinkSync.mockImplementation(() => undefined);
+
+      await cleanupOrphanedAllocations();
+
+      // Recent allocation should be kept (within grace period)
+      // Note: writtenRegistry might be null if no write happened (no changes)
+      // In this case, the allocation should still exist
+      expect(writtenRegistry).toBeNull(); // No write because nothing changed
+    });
+
+    it("should keep allocations with active TAP devices", async () => {
+      const oldAllocation = new Date(Date.now() - 60000).toISOString();
+      // Use hex-compatible vmId since TAP device regex expects [a-f0-9]+
+      const existingRegistry = {
+        allocations: {
+          "172.16.0.2": {
+            vmId: "a1b2c3d4e5f6",
+            tapDevice: "tapa1b2c3d4",
+            allocatedAt: oldAllocation,
+          },
+        },
+      };
+
+      mockFs.existsSync.mockImplementation((path) => {
+        if (String(path).includes("ip-registry.json")) return true;
+        if (String(path).includes("lock.active")) return false;
+        return true;
+      });
+
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(existingRegistry));
+
+      // Mock exec for TAP device scan - return active TAP device
+      mockExecStdout =
+        "5: tapa1b2c3d4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500";
+
+      let writtenRegistry: IPRegistry | null = null;
+      mockFs.writeFileSync.mockImplementation((_path, content) => {
+        if (String(_path).includes("ip-registry.json")) {
+          writtenRegistry = JSON.parse(content as string) as IPRegistry;
+        }
+      });
+      mockFs.unlinkSync.mockImplementation(() => undefined);
+
+      await cleanupOrphanedAllocations();
+
+      // No changes should be written since TAP exists
+      expect(writtenRegistry).toBeNull();
+    });
+  });
+
+  describe("IP range validation", () => {
+    it("should allocate IPs in range 172.16.0.2 to 172.16.0.254", async () => {
+      // First IP should be .2 (not .1 which is the gateway)
+      mockFs.existsSync.mockImplementation((path) => {
+        if (String(path).includes("ip-registry.json")) return false;
+        if (String(path).includes("lock.active")) return false;
+        return true;
+      });
+
+      mockFs.writeFileSync.mockImplementation(() => undefined);
+      mockFs.unlinkSync.mockImplementation(() => undefined);
+
+      const ip = await allocateIP("test-vm");
+
+      expect(ip).toBe("172.16.0.2");
+      expect(ip).not.toBe("172.16.0.1"); // Gateway
+      expect(ip).not.toBe("172.16.0.0"); // Network
+      expect(ip).not.toBe("172.16.0.255"); // Broadcast
+    });
+  });
+});

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/network-cleanup.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/network-cleanup.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Track mock exec state - the mock will read from these
+interface ExecResponse {
+  stdout: string;
+  stderr: string;
+}
+type CommandHandler = (cmd: string) => ExecResponse | Promise<ExecResponse>;
+let commandHandler: CommandHandler = () => ({ stdout: "", stderr: "" });
+
+// Mock the modules - vi.mock is hoisted so this runs first
+vi.mock("node:child_process", () => {
+  // Use the well-known symbol for custom promisify
+  const kCustomPromisifiedSymbol = Symbol.for("nodejs.util.promisify.custom");
+
+  const execMock = vi.fn(
+    (
+      _cmd: string,
+      callback?: (error: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      const result = commandHandler(_cmd);
+      if (result instanceof Promise) {
+        result
+          .then((r) => callback?.(null, r.stdout, r.stderr))
+          .catch(() => {}); // Mock doesn't need error handling
+      } else {
+        callback?.(null, result.stdout, result.stderr);
+      }
+      return {} as unknown;
+    },
+  );
+
+  // Add custom promisify implementation
+  (execMock as unknown as Record<symbol, unknown>)[kCustomPromisifiedSymbol] =
+    vi.fn(async (cmd: string) => commandHandler(cmd));
+
+  return { exec: execMock };
+});
+
+// Import after mocking
+import { flushBridgeArpCache, cleanupOrphanedProxyRules } from "../network.js";
+
+describe("Network Cleanup Functions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset to default handler
+    commandHandler = () => ({ stdout: "", stderr: "" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("flushBridgeArpCache", () => {
+    it("should skip if bridge does not exist", async () => {
+      // Bridge check throws error (bridge doesn't exist)
+      commandHandler = (cmd) => {
+        if (cmd.includes("ip link show")) {
+          // bridgeExists() returns false when this command fails
+          throw new Error("Device does not exist");
+        }
+        return { stdout: "", stderr: "" };
+      };
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await flushBridgeArpCache();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Bridge does not exist, skipping ARP flush",
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("should skip if no ARP entries exist", async () => {
+      commandHandler = (cmd) => {
+        if (cmd.includes("ip link show")) {
+          return { stdout: "vm0br0", stderr: "" }; // Bridge exists
+        }
+        if (cmd.includes("ip neigh show")) {
+          return { stdout: "", stderr: "" }; // No ARP entries
+        }
+        return { stdout: "", stderr: "" };
+      };
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await flushBridgeArpCache();
+
+      expect(consoleSpy).toHaveBeenCalledWith("No ARP entries on bridge");
+      consoleSpy.mockRestore();
+    });
+
+    it("should clear ARP entries when they exist", async () => {
+      const deletedIps: string[] = [];
+
+      commandHandler = (cmd) => {
+        if (cmd.includes("ip link show")) {
+          return { stdout: "vm0br0", stderr: "" };
+        }
+        if (cmd.includes("ip neigh show")) {
+          return {
+            stdout:
+              "172.16.0.2 lladdr 02:00:00:12:34:56 REACHABLE\n172.16.0.3 lladdr 02:00:00:ab:cd:ef STALE",
+            stderr: "",
+          };
+        }
+        if (cmd.includes("ip neigh del")) {
+          const match = cmd.match(/ip neigh del (\d+\.\d+\.\d+\.\d+)/);
+          if (match?.[1]) {
+            deletedIps.push(match[1]);
+          }
+        }
+        return { stdout: "", stderr: "" };
+      };
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await flushBridgeArpCache();
+
+      expect(deletedIps).toContain("172.16.0.2");
+      expect(deletedIps).toContain("172.16.0.3");
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Cleared 2 ARP entries from bridge",
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("should handle ARP read failure gracefully", async () => {
+      // Bridge exists but ip neigh show fails
+      commandHandler = (cmd) => {
+        if (cmd.includes("ip link show")) {
+          return { stdout: "vm0br0", stderr: "" }; // Bridge exists
+        }
+        if (cmd.includes("ip neigh show")) {
+          throw new Error("Permission denied");
+        }
+        return { stdout: "", stderr: "" };
+      };
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      // Should not throw
+      await expect(flushBridgeArpCache()).resolves.toBeUndefined();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Warning: Could not flush ARP cache"),
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("cleanupOrphanedProxyRules", () => {
+    it("should skip if no orphaned rules exist", async () => {
+      commandHandler = (cmd) => {
+        if (cmd.includes("-S PREROUTING")) {
+          return { stdout: "-A PREROUTING -j ACCEPT", stderr: "" };
+        }
+        return { stdout: "", stderr: "" };
+      };
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await cleanupOrphanedProxyRules("test-runner");
+
+      expect(consoleSpy).toHaveBeenCalledWith("No orphaned proxy rules found");
+      consoleSpy.mockRestore();
+    });
+
+    it("should delete orphaned rules for the runner", async () => {
+      const deletedRules: string[] = [];
+
+      commandHandler = (cmd) => {
+        if (cmd.includes("-S PREROUTING")) {
+          return {
+            stdout: `-A PREROUTING -s 172.16.0.2/32 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 3000 -m comment --comment "vm0:runner:test-runner"
+-A PREROUTING -s 172.16.0.3/32 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 3001 -m comment --comment "vm0:runner:test-runner"
+-A PREROUTING -s 172.16.0.4/32 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 3002 -m comment --comment "vm0:runner:other-runner"`,
+            stderr: "",
+          };
+        }
+        if (cmd.includes("-D PREROUTING")) {
+          deletedRules.push(cmd);
+        }
+        return { stdout: "", stderr: "" };
+      };
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await cleanupOrphanedProxyRules("test-runner");
+
+      // Should delete the 2 rules for test-runner, not the one for other-runner
+      expect(deletedRules.length).toBe(2);
+      expect(deletedRules[0]).toContain("172.16.0.2");
+      expect(deletedRules[1]).toContain("172.16.0.3");
+      expect(deletedRules.some((r) => r.includes("172.16.0.4"))).toBe(false);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Found 2 orphaned rule(s) to clean up",
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("should handle iptables command failure gracefully", async () => {
+      commandHandler = () => {
+        throw new Error("iptables not available");
+      };
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      // Should not throw
+      await expect(
+        cleanupOrphanedProxyRules("test-runner"),
+      ).resolves.toBeUndefined();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Warning: Could not clean up orphaned rules"),
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("should continue deleting even if one rule fails", async () => {
+      let deleteCallCount = 0;
+
+      commandHandler = (cmd) => {
+        if (cmd.includes("-S PREROUTING")) {
+          return {
+            stdout: `-A PREROUTING -s 172.16.0.2/32 -m comment --comment "vm0:runner:test-runner"
+-A PREROUTING -s 172.16.0.3/32 -m comment --comment "vm0:runner:test-runner"`,
+            stderr: "",
+          };
+        }
+        if (cmd.includes("-D PREROUTING")) {
+          deleteCallCount++;
+          if (deleteCallCount === 1) {
+            throw new Error("Rule already gone");
+          }
+        }
+        return { stdout: "", stderr: "" };
+      };
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await cleanupOrphanedProxyRules("test-runner");
+
+      // Should attempt to delete both rules even if first fails
+      expect(deleteCallCount).toBe(2);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to delete rule"),
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
+++ b/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
@@ -184,12 +184,14 @@ export async function allocateIP(vmId: string): Promise<string> {
   // We use atomic file operations to ensure exclusivity
   const lockMarker = path.join(VM0_RUN_DIR, "ip-pool.lock.active");
   const startTime = Date.now();
+  let lockAcquired = false;
 
   // Wait for lock
   while (Date.now() - startTime < LOCK_TIMEOUT_MS) {
     try {
       // Try to create lock file exclusively
       fs.writeFileSync(lockMarker, process.pid.toString(), { flag: "wx" });
+      lockAcquired = true;
       break;
     } catch {
       // Lock exists, check if it's stale (process dead)
@@ -214,7 +216,7 @@ export async function allocateIP(vmId: string): Promise<string> {
     }
   }
 
-  if (!fs.existsSync(lockMarker)) {
+  if (!lockAcquired) {
     throw new Error(
       `Failed to acquire IP pool lock after ${LOCK_TIMEOUT_MS}ms`,
     );
@@ -270,11 +272,13 @@ export async function releaseIP(ip: string): Promise<void> {
 
   const lockMarker = path.join(VM0_RUN_DIR, "ip-pool.lock.active");
   const startTime = Date.now();
+  let lockAcquired = false;
 
   // Wait for lock
   while (Date.now() - startTime < LOCK_TIMEOUT_MS) {
     try {
       fs.writeFileSync(lockMarker, process.pid.toString(), { flag: "wx" });
+      lockAcquired = true;
       break;
     } catch {
       try {
@@ -295,7 +299,7 @@ export async function releaseIP(ip: string): Promise<void> {
     }
   }
 
-  if (!fs.existsSync(lockMarker)) {
+  if (!lockAcquired) {
     throw new Error(
       `Failed to acquire IP pool lock after ${LOCK_TIMEOUT_MS}ms`,
     );

--- a/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
+++ b/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
@@ -38,6 +38,13 @@ const LOCK_TIMEOUT_MS = 10000;
 const LOCK_RETRY_INTERVAL_MS = 100;
 
 /**
+ * Grace period for new allocations (in milliseconds)
+ * Entries newer than this are kept during reconciliation even if TAP doesn't exist yet.
+ * This handles the window between IP allocation and TAP device creation.
+ */
+const ALLOCATION_GRACE_PERIOD_MS = 30000; // 30 seconds
+
+/**
  * Registry entry for an allocated IP
  */
 interface IPAllocation {
@@ -120,6 +127,7 @@ async function scanTapDevices(): Promise<Map<string, string>> {
  * Reconcile the registry with actual TAP device state
  * - Remove entries for IPs whose TAP devices no longer exist
  * - This handles crash recovery where VMs were killed but registry wasn't updated
+ * - Entries within the grace period are kept even if TAP doesn't exist yet
  */
 function reconcileRegistry(
   registry: IPRegistry,
@@ -127,10 +135,21 @@ function reconcileRegistry(
 ): IPRegistry {
   const reconciled: IPRegistry = { allocations: {} };
   const activeTapNames = new Set(activeTaps.keys());
+  const now = Date.now();
 
   for (const [ip, allocation] of Object.entries(registry.allocations)) {
-    // Keep allocation only if its TAP device still exists
+    // Check if this allocation is within the grace period
+    const allocatedTime = new Date(allocation.allocatedAt).getTime();
+    const isWithinGracePeriod =
+      now - allocatedTime < ALLOCATION_GRACE_PERIOD_MS;
+
+    // Keep allocation if:
+    // 1. Its TAP device exists, OR
+    // 2. It's within the grace period (TAP might not be created yet)
     if (activeTapNames.has(allocation.tapDevice)) {
+      reconciled.allocations[ip] = allocation;
+    } else if (isWithinGracePeriod) {
+      // Keep recent allocation - TAP might be in process of being created
       reconciled.allocations[ip] = allocation;
     } else {
       console.log(

--- a/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
+++ b/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
@@ -162,6 +162,38 @@ function writeRegistry(registry: IPRegistry): void {
 }
 
 /**
+ * Get all current IP allocations (for diagnostic purposes)
+ *
+ * This returns the current state of the IP registry without modifying it.
+ * Used by the doctor command to display allocated IPs.
+ *
+ * @returns Map of IP addresses to their allocation info
+ */
+export function getAllocations(): Map<
+  string,
+  { vmId: string; tapDevice: string; allocatedAt: string }
+> {
+  const registry = readRegistry();
+  return new Map(Object.entries(registry.allocations));
+}
+
+/**
+ * Get IP allocation for a specific VM ID (for diagnostic purposes)
+ *
+ * @param vmId The VM identifier to look up
+ * @returns The allocated IP or undefined if not found
+ */
+export function getIPForVm(vmId: string): string | undefined {
+  const registry = readRegistry();
+  for (const [ip, allocation] of Object.entries(registry.allocations)) {
+    if (allocation.vmId === vmId) {
+      return ip;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Scan TAP devices on the bridge to get actual state
  * Returns a map of TAP device names to their associated vmIds (derived from TAP name)
  */

--- a/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
+++ b/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
@@ -243,13 +243,11 @@ export async function allocateIP(vmId: string): Promise<string> {
 
   try {
     // Read current registry
-    let registry = readRegistry();
+    const registry = readRegistry();
 
-    // Scan actual TAP devices
-    const activeTaps = await scanTapDevices();
-
-    // Reconcile registry with actual state (self-healing)
-    registry = reconcileRegistry(registry, activeTaps);
+    // Note: Reconciliation with TAP devices is intentionally NOT done during
+    // allocateIP() to avoid race conditions. The reconciliation happens only
+    // at runner startup via cleanupOrphanedAllocations().
 
     // Find a free IP
     const ip = findFreeIP(registry);
@@ -343,6 +341,96 @@ export async function releaseIP(ip: string): Promise<void> {
       );
     } else {
       console.log(`[IP Pool] IP ${ip} was not in registry, nothing to release`);
+    }
+  } finally {
+    try {
+      fs.unlinkSync(lockMarker);
+    } catch {
+      // Ignore errors on unlock
+    }
+  }
+}
+
+/**
+ * Clean up orphaned IP allocations on runner startup
+ *
+ * This reconciles the IP registry with actual TAP devices on the bridge.
+ * It removes allocations for IPs whose TAP devices no longer exist (crashed VMs).
+ *
+ * IMPORTANT: This should ONLY be called at runner startup, never during
+ * the allocateIP() hot path, to avoid race conditions where:
+ * 1. Process A allocates IP, registry updated
+ * 2. Process B calls allocateIP, scans TAPs, doesn't see A's TAP yet
+ * 3. Process B reconciles and removes A's allocation
+ * 4. Process B allocates the same IP -> collision!
+ */
+export async function cleanupOrphanedAllocations(): Promise<void> {
+  await ensureRunDir();
+
+  const lockMarker = path.join(VM0_RUN_DIR, "ip-pool.lock.active");
+  const startTime = Date.now();
+  let lockAcquired = false;
+
+  // Wait for lock
+  while (Date.now() - startTime < LOCK_TIMEOUT_MS) {
+    try {
+      fs.writeFileSync(lockMarker, process.pid.toString(), { flag: "wx" });
+      lockAcquired = true;
+      break;
+    } catch {
+      try {
+        const pidStr = fs.readFileSync(lockMarker, "utf-8");
+        const pid = parseInt(pidStr, 10);
+        try {
+          process.kill(pid, 0);
+        } catch {
+          fs.unlinkSync(lockMarker);
+          continue;
+        }
+      } catch {
+        // Can't read lock file, retry
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, LOCK_RETRY_INTERVAL_MS),
+      );
+    }
+  }
+
+  if (!lockAcquired) {
+    throw new Error(
+      `Failed to acquire IP pool lock after ${LOCK_TIMEOUT_MS}ms`,
+    );
+  }
+
+  try {
+    console.log("[IP Pool] Cleaning up orphaned allocations...");
+
+    // Read current registry
+    const registry = readRegistry();
+    const beforeCount = Object.keys(registry.allocations).length;
+
+    if (beforeCount === 0) {
+      console.log("[IP Pool] No allocations in registry, nothing to clean up");
+      return;
+    }
+
+    // Scan actual TAP devices on the bridge
+    const activeTaps = await scanTapDevices();
+    console.log(
+      `[IP Pool] Found ${activeTaps.size} active TAP device(s) on bridge`,
+    );
+
+    // Reconcile registry with actual state
+    const reconciled = reconcileRegistry(registry, activeTaps);
+    const afterCount = Object.keys(reconciled.allocations).length;
+
+    if (afterCount !== beforeCount) {
+      writeRegistry(reconciled);
+      console.log(
+        `[IP Pool] Cleaned up ${beforeCount - afterCount} orphaned allocation(s)`,
+      );
+    } else {
+      console.log("[IP Pool] No orphaned allocations found");
     }
   } finally {
     try {

--- a/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
+++ b/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
@@ -259,6 +259,13 @@ export async function allocateIP(vmId: string): Promise<string> {
       );
     }
 
+    // Debug: log current allocation state
+    const allocatedCount = Object.keys(registry.allocations).length;
+    const allocatedIPs = Object.keys(registry.allocations).sort();
+    console.log(
+      `[IP Pool] Current state: ${allocatedCount} IPs allocated [${allocatedIPs.join(", ")}], assigning ${ip}`,
+    );
+
     // Add allocation to registry
     registry.allocations[ip] = {
       vmId,

--- a/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
+++ b/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
@@ -1,0 +1,324 @@
+/**
+ * IP Pool Manager for Firecracker VMs
+ *
+ * Provides race-safe IP allocation using file-based locking (B) combined with
+ * TAP device enumeration for self-healing (C). This ensures:
+ * - No IP collisions during parallel VM creation
+ * - Automatic recovery from crashes by reconciling with actual TAP devices
+ *
+ * IP range: 172.16.0.2 - 172.16.0.254 (253 addresses)
+ * 172.16.0.1 is reserved for the bridge gateway
+ */
+
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const execAsync = promisify(exec);
+
+/**
+ * Configuration constants
+ */
+const VM0_RUN_DIR = "/var/run/vm0";
+const REGISTRY_FILE_PATH = path.join(VM0_RUN_DIR, "ip-registry.json");
+const BRIDGE_NAME = "vm0br0";
+
+/**
+ * IP range constants
+ */
+const IP_PREFIX = "172.16.0.";
+const IP_START = 2; // First usable IP (172.16.0.2)
+const IP_END = 254; // Last usable IP (172.16.0.254)
+
+/**
+ * Lock timeout in milliseconds
+ */
+const LOCK_TIMEOUT_MS = 10000;
+const LOCK_RETRY_INTERVAL_MS = 100;
+
+/**
+ * Registry entry for an allocated IP
+ */
+interface IPAllocation {
+  vmId: string;
+  tapDevice: string;
+  allocatedAt: string;
+}
+
+/**
+ * IP Registry structure
+ */
+interface IPRegistry {
+  allocations: Record<string, IPAllocation>;
+}
+
+/**
+ * Ensure the vm0 run directory exists
+ */
+async function ensureRunDir(): Promise<void> {
+  if (!fs.existsSync(VM0_RUN_DIR)) {
+    await execAsync(`sudo mkdir -p ${VM0_RUN_DIR}`);
+    await execAsync(`sudo chmod 777 ${VM0_RUN_DIR}`);
+  }
+}
+
+/**
+ * Read the IP registry from file
+ */
+function readRegistry(): IPRegistry {
+  try {
+    if (fs.existsSync(REGISTRY_FILE_PATH)) {
+      const content = fs.readFileSync(REGISTRY_FILE_PATH, "utf-8");
+      return JSON.parse(content) as IPRegistry;
+    }
+  } catch {
+    // Registry file doesn't exist or is corrupted, start fresh
+  }
+  return { allocations: {} };
+}
+
+/**
+ * Write the IP registry to file
+ */
+function writeRegistry(registry: IPRegistry): void {
+  fs.writeFileSync(REGISTRY_FILE_PATH, JSON.stringify(registry, null, 2));
+}
+
+/**
+ * Scan TAP devices on the bridge to get actual state
+ * Returns a map of TAP device names to their associated vmIds (derived from TAP name)
+ */
+async function scanTapDevices(): Promise<Map<string, string>> {
+  const tapDevices = new Map<string, string>();
+
+  try {
+    // List all interfaces attached to the bridge
+    const { stdout } = await execAsync(
+      `ip link show master ${BRIDGE_NAME} 2>/dev/null || true`,
+    );
+
+    // Parse output to find TAP devices (format: "X: tapXXXXXXXX: <FLAGS>...")
+    const lines = stdout.split("\n");
+    for (const line of lines) {
+      const match = line.match(/^\d+:\s+(tap[a-f0-9]+):/);
+      if (match && match[1]) {
+        const tapName = match[1];
+        // Extract vmId from TAP name (tap + first 8 chars of vmId)
+        const vmIdPrefix = tapName.substring(3); // Remove "tap" prefix
+        tapDevices.set(tapName, vmIdPrefix);
+      }
+    }
+  } catch {
+    // Bridge doesn't exist or command failed, return empty map
+  }
+
+  return tapDevices;
+}
+
+/**
+ * Reconcile the registry with actual TAP device state
+ * - Remove entries for IPs whose TAP devices no longer exist
+ * - This handles crash recovery where VMs were killed but registry wasn't updated
+ */
+function reconcileRegistry(
+  registry: IPRegistry,
+  activeTaps: Map<string, string>,
+): IPRegistry {
+  const reconciled: IPRegistry = { allocations: {} };
+  const activeTapNames = new Set(activeTaps.keys());
+
+  for (const [ip, allocation] of Object.entries(registry.allocations)) {
+    // Keep allocation only if its TAP device still exists
+    if (activeTapNames.has(allocation.tapDevice)) {
+      reconciled.allocations[ip] = allocation;
+    } else {
+      console.log(
+        `[IP Pool] Removing stale allocation for ${ip} (TAP ${allocation.tapDevice} no longer exists)`,
+      );
+    }
+  }
+
+  return reconciled;
+}
+
+/**
+ * Find the first available IP in the range
+ */
+function findFreeIP(registry: IPRegistry): string | null {
+  const allocatedIPs = new Set(Object.keys(registry.allocations));
+
+  for (let octet = IP_START; octet <= IP_END; octet++) {
+    const ip = `${IP_PREFIX}${octet}`;
+    if (!allocatedIPs.has(ip)) {
+      return ip;
+    }
+  }
+
+  return null; // No free IPs available
+}
+
+/**
+ * Allocate an IP address for a VM
+ *
+ * This is the main entry point for IP allocation. It:
+ * 1. Acquires an exclusive lock to prevent race conditions
+ * 2. Reads the current registry
+ * 3. Scans actual TAP devices for self-healing
+ * 4. Reconciles registry with actual state
+ * 5. Finds and allocates a free IP
+ * 6. Updates the registry
+ * 7. Releases the lock
+ *
+ * @param vmId The VM identifier
+ * @returns The allocated IP address
+ * @throws Error if no free IPs are available or lock cannot be acquired
+ */
+export async function allocateIP(vmId: string): Promise<string> {
+  await ensureRunDir();
+
+  // TAP device name uses first 8 chars of vmId
+  const tapDevice = `tap${vmId.substring(0, 8)}`;
+
+  // Simple file-based locking using a marker file
+  // We use atomic file operations to ensure exclusivity
+  const lockMarker = path.join(VM0_RUN_DIR, "ip-pool.lock.active");
+  const startTime = Date.now();
+
+  // Wait for lock
+  while (Date.now() - startTime < LOCK_TIMEOUT_MS) {
+    try {
+      // Try to create lock file exclusively
+      fs.writeFileSync(lockMarker, process.pid.toString(), { flag: "wx" });
+      break;
+    } catch {
+      // Lock exists, check if it's stale (process dead)
+      try {
+        const pidStr = fs.readFileSync(lockMarker, "utf-8");
+        const pid = parseInt(pidStr, 10);
+        // Check if process is still alive
+        try {
+          process.kill(pid, 0);
+          // Process exists, wait and retry
+        } catch {
+          // Process doesn't exist, remove stale lock
+          fs.unlinkSync(lockMarker);
+          continue;
+        }
+      } catch {
+        // Can't read lock file, retry
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, LOCK_RETRY_INTERVAL_MS),
+      );
+    }
+  }
+
+  if (!fs.existsSync(lockMarker)) {
+    throw new Error(
+      `Failed to acquire IP pool lock after ${LOCK_TIMEOUT_MS}ms`,
+    );
+  }
+
+  try {
+    // Read current registry
+    let registry = readRegistry();
+
+    // Scan actual TAP devices
+    const activeTaps = await scanTapDevices();
+
+    // Reconcile registry with actual state (self-healing)
+    registry = reconcileRegistry(registry, activeTaps);
+
+    // Find a free IP
+    const ip = findFreeIP(registry);
+    if (!ip) {
+      throw new Error(
+        "No free IP addresses available in pool (172.16.0.2-254)",
+      );
+    }
+
+    // Add allocation to registry
+    registry.allocations[ip] = {
+      vmId,
+      tapDevice,
+      allocatedAt: new Date().toISOString(),
+    };
+
+    // Write updated registry
+    writeRegistry(registry);
+
+    console.log(`[IP Pool] Allocated ${ip} for VM ${vmId} (TAP ${tapDevice})`);
+    return ip;
+  } finally {
+    // Release lock
+    try {
+      fs.unlinkSync(lockMarker);
+    } catch {
+      // Ignore errors on unlock
+    }
+  }
+}
+
+/**
+ * Release an IP address back to the pool
+ *
+ * @param ip The IP address to release
+ */
+export async function releaseIP(ip: string): Promise<void> {
+  await ensureRunDir();
+
+  const lockMarker = path.join(VM0_RUN_DIR, "ip-pool.lock.active");
+  const startTime = Date.now();
+
+  // Wait for lock
+  while (Date.now() - startTime < LOCK_TIMEOUT_MS) {
+    try {
+      fs.writeFileSync(lockMarker, process.pid.toString(), { flag: "wx" });
+      break;
+    } catch {
+      try {
+        const pidStr = fs.readFileSync(lockMarker, "utf-8");
+        const pid = parseInt(pidStr, 10);
+        try {
+          process.kill(pid, 0);
+        } catch {
+          fs.unlinkSync(lockMarker);
+          continue;
+        }
+      } catch {
+        // Can't read lock file, retry
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, LOCK_RETRY_INTERVAL_MS),
+      );
+    }
+  }
+
+  if (!fs.existsSync(lockMarker)) {
+    throw new Error(
+      `Failed to acquire IP pool lock after ${LOCK_TIMEOUT_MS}ms`,
+    );
+  }
+
+  try {
+    const registry = readRegistry();
+
+    if (registry.allocations[ip]) {
+      const allocation = registry.allocations[ip];
+      delete registry.allocations[ip];
+      writeRegistry(registry);
+      console.log(
+        `[IP Pool] Released ${ip} (was allocated to VM ${allocation.vmId})`,
+      );
+    } else {
+      console.log(`[IP Pool] IP ${ip} was not in registry, nothing to release`);
+    }
+  } finally {
+    try {
+      fs.unlinkSync(lockMarker);
+    } catch {
+      // Ignore errors on unlock
+    }
+  }
+}

--- a/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
+++ b/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
@@ -71,6 +71,75 @@ async function ensureRunDir(): Promise<void> {
 }
 
 /**
+ * Execute a function while holding an exclusive lock on the IP pool
+ *
+ * This helper provides file-based locking to prevent race conditions during
+ * concurrent IP operations. It:
+ * 1. Acquires an exclusive lock using atomic file creation
+ * 2. Detects and cleans up stale locks from dead processes
+ * 3. Executes the provided callback
+ * 4. Releases the lock in a finally block
+ *
+ * @param fn The function to execute while holding the lock
+ * @returns The result of the callback function
+ * @throws Error if lock cannot be acquired within timeout
+ */
+async function withLock<T>(fn: () => Promise<T>): Promise<T> {
+  await ensureRunDir();
+
+  const lockMarker = path.join(VM0_RUN_DIR, "ip-pool.lock.active");
+  const startTime = Date.now();
+  let lockAcquired = false;
+
+  // Wait for lock
+  while (Date.now() - startTime < LOCK_TIMEOUT_MS) {
+    try {
+      // Try to create lock file exclusively (atomic operation)
+      fs.writeFileSync(lockMarker, process.pid.toString(), { flag: "wx" });
+      lockAcquired = true;
+      break;
+    } catch {
+      // Lock exists, check if it's stale (process dead)
+      try {
+        const pidStr = fs.readFileSync(lockMarker, "utf-8");
+        const pid = parseInt(pidStr, 10);
+        // Check if process is still alive
+        try {
+          process.kill(pid, 0);
+          // Process exists, wait and retry
+        } catch {
+          // Process doesn't exist, remove stale lock
+          fs.unlinkSync(lockMarker);
+          continue;
+        }
+      } catch {
+        // Can't read lock file, retry
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, LOCK_RETRY_INTERVAL_MS),
+      );
+    }
+  }
+
+  if (!lockAcquired) {
+    throw new Error(
+      `Failed to acquire IP pool lock after ${LOCK_TIMEOUT_MS}ms`,
+    );
+  }
+
+  try {
+    return await fn();
+  } finally {
+    // Release lock
+    try {
+      fs.unlinkSync(lockMarker);
+    } catch {
+      // Ignore errors on unlock
+    }
+  }
+}
+
+/**
  * Read the IP registry from file
  */
 function readRegistry(): IPRegistry {
@@ -194,54 +263,10 @@ function findFreeIP(registry: IPRegistry): string | null {
  * @throws Error if no free IPs are available or lock cannot be acquired
  */
 export async function allocateIP(vmId: string): Promise<string> {
-  await ensureRunDir();
-
   // TAP device name uses first 8 chars of vmId
   const tapDevice = `tap${vmId.substring(0, 8)}`;
 
-  // Simple file-based locking using a marker file
-  // We use atomic file operations to ensure exclusivity
-  const lockMarker = path.join(VM0_RUN_DIR, "ip-pool.lock.active");
-  const startTime = Date.now();
-  let lockAcquired = false;
-
-  // Wait for lock
-  while (Date.now() - startTime < LOCK_TIMEOUT_MS) {
-    try {
-      // Try to create lock file exclusively
-      fs.writeFileSync(lockMarker, process.pid.toString(), { flag: "wx" });
-      lockAcquired = true;
-      break;
-    } catch {
-      // Lock exists, check if it's stale (process dead)
-      try {
-        const pidStr = fs.readFileSync(lockMarker, "utf-8");
-        const pid = parseInt(pidStr, 10);
-        // Check if process is still alive
-        try {
-          process.kill(pid, 0);
-          // Process exists, wait and retry
-        } catch {
-          // Process doesn't exist, remove stale lock
-          fs.unlinkSync(lockMarker);
-          continue;
-        }
-      } catch {
-        // Can't read lock file, retry
-      }
-      await new Promise((resolve) =>
-        setTimeout(resolve, LOCK_RETRY_INTERVAL_MS),
-      );
-    }
-  }
-
-  if (!lockAcquired) {
-    throw new Error(
-      `Failed to acquire IP pool lock after ${LOCK_TIMEOUT_MS}ms`,
-    );
-  }
-
-  try {
+  return withLock(async () => {
     // Read current registry
     const registry = readRegistry();
 
@@ -276,14 +301,7 @@ export async function allocateIP(vmId: string): Promise<string> {
 
     console.log(`[IP Pool] Allocated ${ip} for VM ${vmId} (TAP ${tapDevice})`);
     return ip;
-  } finally {
-    // Release lock
-    try {
-      fs.unlinkSync(lockMarker);
-    } catch {
-      // Ignore errors on unlock
-    }
-  }
+  });
 }
 
 /**
@@ -292,44 +310,7 @@ export async function allocateIP(vmId: string): Promise<string> {
  * @param ip The IP address to release
  */
 export async function releaseIP(ip: string): Promise<void> {
-  await ensureRunDir();
-
-  const lockMarker = path.join(VM0_RUN_DIR, "ip-pool.lock.active");
-  const startTime = Date.now();
-  let lockAcquired = false;
-
-  // Wait for lock
-  while (Date.now() - startTime < LOCK_TIMEOUT_MS) {
-    try {
-      fs.writeFileSync(lockMarker, process.pid.toString(), { flag: "wx" });
-      lockAcquired = true;
-      break;
-    } catch {
-      try {
-        const pidStr = fs.readFileSync(lockMarker, "utf-8");
-        const pid = parseInt(pidStr, 10);
-        try {
-          process.kill(pid, 0);
-        } catch {
-          fs.unlinkSync(lockMarker);
-          continue;
-        }
-      } catch {
-        // Can't read lock file, retry
-      }
-      await new Promise((resolve) =>
-        setTimeout(resolve, LOCK_RETRY_INTERVAL_MS),
-      );
-    }
-  }
-
-  if (!lockAcquired) {
-    throw new Error(
-      `Failed to acquire IP pool lock after ${LOCK_TIMEOUT_MS}ms`,
-    );
-  }
-
-  try {
+  return withLock(async () => {
     const registry = readRegistry();
 
     if (registry.allocations[ip]) {
@@ -342,13 +323,7 @@ export async function releaseIP(ip: string): Promise<void> {
     } else {
       console.log(`[IP Pool] IP ${ip} was not in registry, nothing to release`);
     }
-  } finally {
-    try {
-      fs.unlinkSync(lockMarker);
-    } catch {
-      // Ignore errors on unlock
-    }
-  }
+  });
 }
 
 /**
@@ -365,44 +340,7 @@ export async function releaseIP(ip: string): Promise<void> {
  * 4. Process B allocates the same IP -> collision!
  */
 export async function cleanupOrphanedAllocations(): Promise<void> {
-  await ensureRunDir();
-
-  const lockMarker = path.join(VM0_RUN_DIR, "ip-pool.lock.active");
-  const startTime = Date.now();
-  let lockAcquired = false;
-
-  // Wait for lock
-  while (Date.now() - startTime < LOCK_TIMEOUT_MS) {
-    try {
-      fs.writeFileSync(lockMarker, process.pid.toString(), { flag: "wx" });
-      lockAcquired = true;
-      break;
-    } catch {
-      try {
-        const pidStr = fs.readFileSync(lockMarker, "utf-8");
-        const pid = parseInt(pidStr, 10);
-        try {
-          process.kill(pid, 0);
-        } catch {
-          fs.unlinkSync(lockMarker);
-          continue;
-        }
-      } catch {
-        // Can't read lock file, retry
-      }
-      await new Promise((resolve) =>
-        setTimeout(resolve, LOCK_RETRY_INTERVAL_MS),
-      );
-    }
-  }
-
-  if (!lockAcquired) {
-    throw new Error(
-      `Failed to acquire IP pool lock after ${LOCK_TIMEOUT_MS}ms`,
-    );
-  }
-
-  try {
+  return withLock(async () => {
     console.log("[IP Pool] Cleaning up orphaned allocations...");
 
     // Read current registry
@@ -432,11 +370,5 @@ export async function cleanupOrphanedAllocations(): Promise<void> {
     } else {
       console.log("[IP Pool] No orphaned allocations found");
     }
-  } finally {
-    try {
-      fs.unlinkSync(lockMarker);
-    } catch {
-      // Ignore errors on unlock
-    }
-  }
+  });
 }

--- a/turbo/apps/runner/src/lib/firecracker/network.ts
+++ b/turbo/apps/runner/src/lib/firecracker/network.ts
@@ -558,6 +558,59 @@ export async function findOrphanedIptablesRules(
 }
 
 /**
+ * Flush all ARP cache entries on the VM bridge
+ *
+ * This is called at runner startup to clear any stale ARP entries from
+ * previous runs. Stale entries can cause routing issues when IPs are
+ * reused by new VMs with different MAC addresses.
+ */
+export async function flushBridgeArpCache(): Promise<void> {
+  console.log(`Flushing ARP cache on bridge ${BRIDGE_NAME}...`);
+
+  try {
+    // Check if bridge exists first
+    if (!(await bridgeExists())) {
+      console.log("Bridge does not exist, skipping ARP flush");
+      return;
+    }
+
+    // Get all ARP entries on the bridge
+    const { stdout } = await execAsync(
+      `ip neigh show dev ${BRIDGE_NAME} 2>/dev/null || true`,
+    );
+
+    if (!stdout.trim()) {
+      console.log("No ARP entries on bridge");
+      return;
+    }
+
+    // Parse ARP entries and delete each one
+    // Format: "172.16.0.2 lladdr 02:00:00:xx:xx:xx REACHABLE"
+    const lines = stdout.split("\n").filter((line) => line.trim());
+    let cleared = 0;
+
+    for (const line of lines) {
+      const match = line.match(/^(\d+\.\d+\.\d+\.\d+)\s/);
+      if (match && match[1]) {
+        const ip = match[1];
+        try {
+          await execCommand(`ip neigh del ${ip} dev ${BRIDGE_NAME}`, true);
+          cleared++;
+        } catch {
+          // Entry might already be gone
+        }
+      }
+    }
+
+    console.log(`Cleared ${cleared} ARP entries from bridge`);
+  } catch (error) {
+    console.log(
+      `Warning: Could not flush ARP cache: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
+}
+
+/**
  * Clean up orphaned proxy rules for a specific runner on startup
  *
  * This function removes all iptables rules tagged with this runner's name.

--- a/turbo/apps/runner/src/lib/firecracker/network.ts
+++ b/turbo/apps/runner/src/lib/firecracker/network.ts
@@ -276,6 +276,18 @@ export async function deleteTapDevice(
     console.log(`TAP device ${tapDevice} deleted`);
   }
 
+  // Clear ARP cache entry for the VM's IP to prevent stale MAC associations
+  // This ensures that when the same IP is reused by a new VM with a different MAC,
+  // the host will properly learn the new MAC via ARP instead of using cached entries
+  if (guestIp) {
+    try {
+      await execCommand(`ip neigh del ${guestIp} dev ${BRIDGE_NAME}`, true);
+      console.log(`ARP entry cleared for ${guestIp}`);
+    } catch {
+      // ARP entry might not exist, that's fine
+    }
+  }
+
   // Release IP back to the pool if provided
   if (guestIp) {
     await releaseIP(guestIp);

--- a/turbo/apps/runner/src/lib/firecracker/network.ts
+++ b/turbo/apps/runner/src/lib/firecracker/network.ts
@@ -10,6 +10,7 @@
 
 import { execSync, exec } from "node:child_process";
 import { promisify } from "node:util";
+import { allocateIP, releaseIP } from "./ip-pool.js";
 
 const execAsync = promisify(exec);
 
@@ -34,7 +35,7 @@ const BRIDGE_CIDR = "172.16.0.0/24";
 
 /**
  * Simple hash function to convert a string to a number
- * Used for generating unique MAC/IP from string vmId
+ * Used for generating unique MAC addresses from string vmId
  */
 function hashString(str: string): number {
   let hash = 0;
@@ -58,17 +59,6 @@ export function generateMacAddress(vmId: string): string {
   const b2 = (hash >> 8) & 0xff;
   const b3 = hash & 0xff;
   return `02:00:00:${b1.toString(16).padStart(2, "0")}:${b2.toString(16).padStart(2, "0")}:${b3.toString(16).padStart(2, "0")}`;
-}
-
-/**
- * Generate an IP address for a VM within the bridge subnet
- * VM IPs start at 172.16.0.2 (172.16.0.1 is the bridge)
- */
-export function generateGuestIp(vmId: string): string {
-  // Guest IPs: 172.16.0.2 - 172.16.0.254
-  const hash = hashString(vmId);
-  const lastOctet = (hash % 253) + 2;
-  return `172.16.0.${lastOctet}`;
 }
 
 /**
@@ -225,12 +215,15 @@ async function tapDeviceExists(tapDevice: string): Promise<boolean> {
 
 /**
  * Create and configure a TAP device for a VM
+ * Uses the IP pool manager for race-safe IP allocation
  */
 export async function createTapDevice(vmId: string): Promise<VMNetworkConfig> {
   // TAP device name limited to 15 chars, use "tap" + first 8 chars of vmId
   const tapDevice = `tap${vmId.substring(0, 8)}`;
   const guestMac = generateMacAddress(vmId);
-  const guestIp = generateGuestIp(vmId);
+
+  // Allocate IP from pool (race-safe with file locking)
+  const guestIp = await allocateIP(vmId);
 
   console.log(`Creating TAP device ${tapDevice} for VM ${vmId}...`);
 
@@ -266,16 +259,27 @@ export async function createTapDevice(vmId: string): Promise<VMNetworkConfig> {
 }
 
 /**
- * Delete a TAP device
+ * Delete a TAP device and optionally release its IP back to the pool
+ *
+ * @param tapDevice The TAP device name to delete
+ * @param guestIp Optional IP address to release back to the pool
  */
-export async function deleteTapDevice(tapDevice: string): Promise<void> {
+export async function deleteTapDevice(
+  tapDevice: string,
+  guestIp?: string,
+): Promise<void> {
   // Only attempt delete if device exists
   if (!(await tapDeviceExists(tapDevice))) {
     console.log(`TAP device ${tapDevice} does not exist, skipping delete`);
-    return;
+  } else {
+    await execCommand(`ip link delete ${tapDevice}`);
+    console.log(`TAP device ${tapDevice} deleted`);
   }
-  await execCommand(`ip link delete ${tapDevice}`);
-  console.log(`TAP device ${tapDevice} deleted`);
+
+  // Release IP back to the pool if provided
+  if (guestIp) {
+    await releaseIP(guestIp);
+  }
 }
 
 /**
@@ -328,26 +332,32 @@ export function checkNetworkPrerequisites(): { ok: boolean; errors: string[] } {
  * Set up iptables DNAT rules to redirect a specific VM's traffic to the proxy
  * Only VMs with network security enabled should have their traffic intercepted.
  *
+ * Rules are tagged with a comment for easy identification and cleanup.
+ * This follows the industry standard pattern used by Docker, Kubernetes, and firewalld.
+ *
  * @param vmIp The VM's IP address (e.g., "172.16.0.42")
  * @param proxyPort The port mitmproxy is listening on (e.g., 8080)
+ * @param runnerName The runner name for comment tagging (used for cleanup)
  */
 export async function setupVMProxyRules(
   vmIp: string,
   proxyPort: number,
+  runnerName: string,
 ): Promise<void> {
+  const comment = `vm0:runner:${runnerName}`;
   console.log(
-    `Setting up proxy rules for VM ${vmIp} -> localhost:${proxyPort}`,
+    `Setting up proxy rules for VM ${vmIp} -> localhost:${proxyPort} (comment: ${comment})`,
   );
 
   // Redirect HTTP (port 80) from this specific VM to proxy
   try {
     await execCommand(
-      `iptables -t nat -C PREROUTING -s ${vmIp} -p tcp --dport 80 -j REDIRECT --to-port ${proxyPort}`,
+      `iptables -t nat -C PREROUTING -s ${vmIp} -p tcp --dport 80 -j REDIRECT --to-port ${proxyPort} -m comment --comment "${comment}"`,
     );
     console.log(`Proxy rule for ${vmIp}:80 already exists`);
   } catch {
     await execCommand(
-      `iptables -t nat -A PREROUTING -s ${vmIp} -p tcp --dport 80 -j REDIRECT --to-port ${proxyPort}`,
+      `iptables -t nat -A PREROUTING -s ${vmIp} -p tcp --dport 80 -j REDIRECT --to-port ${proxyPort} -m comment --comment "${comment}"`,
     );
     console.log(`Proxy rule for ${vmIp}:80 added`);
   }
@@ -355,12 +365,12 @@ export async function setupVMProxyRules(
   // Redirect HTTPS (port 443) from this specific VM to proxy
   try {
     await execCommand(
-      `iptables -t nat -C PREROUTING -s ${vmIp} -p tcp --dport 443 -j REDIRECT --to-port ${proxyPort}`,
+      `iptables -t nat -C PREROUTING -s ${vmIp} -p tcp --dport 443 -j REDIRECT --to-port ${proxyPort} -m comment --comment "${comment}"`,
     );
     console.log(`Proxy rule for ${vmIp}:443 already exists`);
   } catch {
     await execCommand(
-      `iptables -t nat -A PREROUTING -s ${vmIp} -p tcp --dport 443 -j REDIRECT --to-port ${proxyPort}`,
+      `iptables -t nat -A PREROUTING -s ${vmIp} -p tcp --dport 443 -j REDIRECT --to-port ${proxyPort} -m comment --comment "${comment}"`,
     );
     console.log(`Proxy rule for ${vmIp}:443 added`);
   }
@@ -373,17 +383,20 @@ export async function setupVMProxyRules(
  *
  * @param vmIp The VM's IP address
  * @param proxyPort The port mitmproxy is listening on (e.g., 8080)
+ * @param runnerName The runner name for comment matching
  */
 export async function removeVMProxyRules(
   vmIp: string,
   proxyPort: number,
+  runnerName: string,
 ): Promise<void> {
+  const comment = `vm0:runner:${runnerName}`;
   console.log(`Removing proxy rules for VM ${vmIp}...`);
 
   // Remove HTTP rule
   try {
     await execCommand(
-      `iptables -t nat -D PREROUTING -s ${vmIp} -p tcp --dport 80 -j REDIRECT --to-port ${proxyPort}`,
+      `iptables -t nat -D PREROUTING -s ${vmIp} -p tcp --dport 80 -j REDIRECT --to-port ${proxyPort} -m comment --comment "${comment}"`,
     );
     console.log(`Proxy rule for ${vmIp}:80 removed`);
   } catch {
@@ -393,7 +406,7 @@ export async function removeVMProxyRules(
   // Remove HTTPS rule
   try {
     await execCommand(
-      `iptables -t nat -D PREROUTING -s ${vmIp} -p tcp --dport 443 -j REDIRECT --to-port ${proxyPort}`,
+      `iptables -t nat -D PREROUTING -s ${vmIp} -p tcp --dport 443 -j REDIRECT --to-port ${proxyPort} -m comment --comment "${comment}"`,
     );
     console.log(`Proxy rule for ${vmIp}:443 removed`);
   } catch {
@@ -530,4 +543,56 @@ export async function findOrphanedIptablesRules(
   }
 
   return orphaned;
+}
+
+/**
+ * Clean up orphaned proxy rules for a specific runner on startup
+ *
+ * This function removes all iptables rules tagged with this runner's name.
+ * It's called on runner startup to clean up rules left by previous runs
+ * that may have crashed or been killed without proper cleanup.
+ *
+ * @param runnerName The runner name to clean up rules for
+ */
+export async function cleanupOrphanedProxyRules(
+  runnerName: string,
+): Promise<void> {
+  const comment = `vm0:runner:${runnerName}`;
+  console.log(`Cleaning up orphaned proxy rules for runner '${runnerName}'...`);
+
+  try {
+    // List all PREROUTING rules in save format (-S gives us the exact command syntax)
+    const rules = await execCommand("iptables -t nat -S PREROUTING", false);
+
+    // Find rules with our runner's comment
+    const ourRules = rules.split("\n").filter((rule) => rule.includes(comment));
+
+    if (ourRules.length === 0) {
+      console.log("No orphaned proxy rules found");
+      return;
+    }
+
+    console.log(`Found ${ourRules.length} orphaned rule(s) to clean up`);
+
+    // Delete each rule (convert -A to -D)
+    for (const rule of ourRules) {
+      const deleteRule = rule.replace("-A ", "-D ");
+      try {
+        await execCommand(`iptables -t nat ${deleteRule}`);
+        console.log(`Deleted orphaned rule: ${rule.substring(0, 80)}...`);
+      } catch {
+        console.log(
+          `Failed to delete rule (may already be gone): ${rule.substring(0, 80)}...`,
+        );
+      }
+    }
+
+    console.log("Orphaned proxy rules cleanup complete");
+  } catch (error) {
+    // If iptables command fails, log but continue
+    // This could happen if iptables is not available or we don't have permissions
+    console.log(
+      `Warning: Could not clean up orphaned rules: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
 }

--- a/turbo/apps/runner/src/lib/firecracker/network.ts
+++ b/turbo/apps/runner/src/lib/firecracker/network.ts
@@ -214,6 +214,46 @@ async function tapDeviceExists(tapDevice: string): Promise<boolean> {
 }
 
 /**
+ * Clear any stale iptables rules for a specific IP
+ *
+ * This is called when a new VM is assigned an IP to ensure no leftover
+ * REDIRECT rules from previous VMs interfere with network connectivity.
+ */
+async function clearStaleIptablesRulesForIP(ip: string): Promise<void> {
+  try {
+    // Get all PREROUTING rules
+    const { stdout } = await execAsync(
+      "sudo iptables -t nat -S PREROUTING 2>/dev/null || true",
+    );
+
+    // Find any rules that reference this IP
+    const lines = stdout.split("\n");
+    const rulesForIP = lines.filter((line) => line.includes(`-s ${ip}`));
+
+    if (rulesForIP.length === 0) {
+      return;
+    }
+
+    console.log(
+      `Clearing ${rulesForIP.length} stale iptables rule(s) for IP ${ip}`,
+    );
+
+    // Delete each rule
+    for (const rule of rulesForIP) {
+      // Convert -A to -D for deletion
+      const deleteRule = rule.replace("-A ", "-D ");
+      try {
+        await execCommand(`iptables -t nat ${deleteRule}`);
+      } catch {
+        // Rule might already be gone
+      }
+    }
+  } catch {
+    // Ignore errors - this is defensive cleanup
+  }
+}
+
+/**
  * Create and configure a TAP device for a VM
  * Uses the IP pool manager for race-safe IP allocation
  */
@@ -224,6 +264,10 @@ export async function createTapDevice(vmId: string): Promise<VMNetworkConfig> {
 
   // Allocate IP from pool (race-safe with file locking)
   const guestIp = await allocateIP(vmId);
+
+  // Clear any stale iptables rules for this IP from previous VMs
+  // This prevents leftover REDIRECT rules from interfering with network
+  await clearStaleIptablesRulesForIP(guestIp);
 
   console.log(`Creating TAP device ${tapDevice} for VM ${vmId}...`);
 

--- a/turbo/apps/runner/src/lib/firecracker/vm.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vm.ts
@@ -311,9 +311,12 @@ export class FirecrackerVM {
       this.process = null;
     }
 
-    // Delete TAP device
+    // Delete TAP device and release IP back to pool
     if (this.networkConfig) {
-      await deleteTapDevice(this.networkConfig.tapDevice);
+      await deleteTapDevice(
+        this.networkConfig.tapDevice,
+        this.networkConfig.guestIp,
+      );
       this.networkConfig = null;
     }
 


### PR DESCRIPTION
## Summary

- Implement race-safe IP Pool Manager using file-based locking (prevents collision during parallel VM creation)
- Add TAP device enumeration for self-healing (automatically recovers from crashes by reconciling with actual TAP devices)
- Add iptables comment tagging with runner name for cleanup (follows industry standard pattern used by Docker, Kubernetes)
- Add startup cleanup for orphaned proxy rules from previous crashed runs

Fixes #1329

## Implementation Details

### IP Pool Manager (`ip-pool.ts`)
- File-based exclusive locking via `/var/run/vm0/ip-pool.lock.active`
- Registry file at `/var/run/vm0/ip-registry.json` tracks allocations
- IP range: 172.16.0.2 - 172.16.0.254 (253 addresses)
- On each allocation: scan TAP devices and reconcile stale entries (self-healing)

### iptables Comment Tagging
- All proxy rules tagged with `vm0:runner:{runnerName}` comment
- On runner startup, cleanup rules matching our runner name
- Prevents rule accumulation after crashes/SIGKILL

## Test plan
- [x] All 110 existing tests pass
- [x] Lint, type-check, format checks pass
- [ ] Manual testing with parallel VM creation
- [ ] Verify IP registry works correctly with file locking
- [ ] Verify cleanup removes orphaned rules on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)