### PR TITLE
feat(web): remove pricing link from navigation

### DIFF
--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -82,9 +82,6 @@ export default function Navbar() {
             <Link href="/glossary" className="nav-link">
               {t("glossary")}
             </Link>
-            <Link href="/pricing" className="nav-link">
-              {t("pricing")}
-            </Link>
             <a
               href="https://github.com/vm0-ai/vm0"
               target="_blank"
@@ -166,13 +163,6 @@ export default function Navbar() {
               onClick={() => setMobileMenuOpen(false)}
             >
               {t("glossary")}
-            </Link>
-            <Link
-              href="/pricing"
-              className="mobile-menu-link"
-              onClick={() => setMobileMenuOpen(false)}
-            >
-              {t("pricing")}
             </Link>
             <a
               href="https://github.com/vm0-ai/vm0"


### PR DESCRIPTION
## Summary
Remove pricing navigation item from both desktop and mobile menus as it is no longer needed on the vm0 website.

## Changes
- Removed pricing link from desktop navigation bar
- Removed pricing link from mobile menu

## Test plan
- [ ] Verify pricing link is removed from desktop navigation
- [ ] Verify pricing link is removed from mobile menu
- [ ] Verify all other navigation links still work correctly
- [ ] Test navigation on both desktop and mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)