### PR TITLE
docs: add infrastructure and architecture documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,6 @@
 
 **Supported**: Claude Code, Codex · **Coming soon**: Gemini CLI, DeepAgent CLI, OpenCode
 
-## 📚 Technical Documentation
-
-- **[Architecture Documentation](./docs/architecture.md)** - Comprehensive technical reference covering sandbox technologies (E2B, Firecracker), infrastructure components, network architecture, and deployment models
-- **[Agent Creator Guide](./docs/agent-creator.md)** - Learn how to build your first agent
-- **[Issue Workflow Guide](./docs/issue-workflow.md)** - GitHub issue workflow automation
-
-For user-facing guides and tutorials, visit [docs.vm0.ai](https://docs.vm0.ai).
-
 ## 🚀 [Quick Start](https://docs.vm0.ai/docs/quick-start)
 
 From zero to workflow agent in 5 minutes
@@ -53,6 +45,12 @@ vm0 init
 cat AGENTS.md # check the workflow which your agent will run
 vm0 cook "run your workflow"
 ```
+
+## 📚 Documentation
+
+- **[Architecture Documentation](./docs/architecture.md)** - Comprehensive technical reference covering sandbox technologies (E2B, Firecracker), infrastructure components and network architecture
+
+For user-facing guides and tutorials, visit [docs.vm0.ai](https://docs.vm0.ai).
 
 ## 🤝 Contribute
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@
 
 **Supported**: Claude Code, Codex · **Coming soon**: Gemini CLI, DeepAgent CLI, OpenCode
 
+## 📚 Technical Documentation
+
+- **[Architecture Documentation](./docs/architecture.md)** - Comprehensive technical reference covering sandbox technologies (E2B, Firecracker), infrastructure components, network architecture, and deployment models
+- **[Agent Creator Guide](./docs/agent-creator.md)** - Learn how to build your first agent
+- **[Issue Workflow Guide](./docs/issue-workflow.md)** - GitHub issue workflow automation
+
+For user-facing guides and tutorials, visit [docs.vm0.ai](https://docs.vm0.ai).
+
 ## 🚀 [Quick Start](https://docs.vm0.ai/docs/quick-start)
 
 From zero to workflow agent in 5 minutes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -245,8 +245,6 @@ sandbox:
 8. Webhook reports progress
 9. VM terminated on completion
 
-**Code**: `turbo/apps/runner/src/lib/executor.ts`, `turbo/apps/runner/src/lib/firecracker/`
-
 ---
 
 ### Cloudflare R2 Object Storage
@@ -274,42 +272,9 @@ Sandboxes download directly from R2 (no proxy through VM0 API):
 3. Sandbox's `download.mjs` script fetches from R2
 4. Parallel downloads for multiple archives
 
-**Code**: `turbo/apps/web/src/lib/s3/s3-client.ts`
-
 ---
 
 ## References
-
-### Codebase
-
-**E2B Integration**:
-- `turbo/apps/web/src/lib/e2b/e2b-service.ts`
-
-**Firecracker Runner**:
-- `turbo/apps/runner/src/lib/firecracker/vm.ts` - VM lifecycle
-- `turbo/apps/runner/src/lib/firecracker/network.ts` - Network setup
-- `turbo/apps/runner/src/lib/firecracker/client.ts` - API client
-- `turbo/apps/runner/src/lib/executor.ts` - Job execution
-- `turbo/apps/runner/src/lib/config.ts` - Configuration
-
-**Storage**:
-- `turbo/apps/web/src/lib/storage/storage-service.ts`
-- `turbo/apps/web/src/lib/s3/s3-client.ts`
-
-**Orchestration**:
-- `turbo/apps/web/src/lib/run/executors/`
-- `turbo/apps/web/src/db/schema/runner-job-queue.ts`
-- `turbo/apps/web/app/api/runners/poll/route.ts`
-
-**Network**:
-- `turbo/apps/runner/src/lib/proxy/proxy-manager.ts`
-- `turbo/apps/runner/src/lib/proxy/mitm-addon-script.ts`
-
-**Deployment**:
-- `turbo/apps/runner/scripts/deploy/install-firecracker.sh`
-- `turbo/apps/runner/scripts/deploy/build-rootfs.sh`
-- `turbo/apps/runner/scripts/deploy/Dockerfile`
-- `ansible/playbooks/deploy-runner.yml`
 
 ### External
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,325 @@
+# VM0 Architecture
+
+## Table of Contents
+
+- [Overview](#overview)
+- [System Architecture](#system-architecture)
+  - [Compute](#compute)
+  - [Storage](#storage)
+  - [Orchestration](#orchestration)
+- [Infrastructure](#infrastructure)
+  - [E2B Sandbox Backend](#e2b-sandbox-backend)
+  - [Firecracker Sandbox Backend](#firecracker-sandbox-backend)
+  - [Cloudflare R2 Object Storage](#cloudflare-r2-object-storage)
+- [References](#references)
+
+---
+
+## Overview
+
+VM0 is a platform for running AI agent workflows in isolated sandbox environments. The platform consists of three core subsystems:
+
+1. **Compute**: Sandbox execution (E2B or Firecracker microVMs)
+2. **Storage**: User data persistence (Cloudflare R2)
+3. **Orchestration**: Job queue and runner coordination (PostgreSQL)
+
+### High-Level Architecture
+
+**Execution Flow**:
+```
+User CLI/API Request
+  ↓
+Web API (Next.js)
+  ↓
+Executor Selection (E2B or Runner)
+  ↓
+Compute Layer (Sandbox)
+  ↓ (downloads from)
+Storage Layer (R2)
+  ↓ (reports via webhooks)
+Web API
+  ↓
+User receives results
+```
+
+---
+
+## System Architecture
+
+### Compute
+
+The compute layer executes agent workflows in isolated sandbox environments.
+
+#### Two Execution Backends
+
+**1. E2B (Default)**
+- Third-party managed sandbox service (e2b.dev)
+- Container-based isolation
+- Template system for environment configuration
+- 24-hour timeout (production), 1-hour (development)
+- Fire-and-forget execution with webhook callbacks
+
+**2. Firecracker (Experimental)**
+- Self-hosted microVMs on bare metal Linux
+- Hardware-level isolation via KVM
+- 3-5 second boot time
+- Network namespace isolation per VM
+- Requires runner infrastructure
+
+#### Executor Selection
+
+```
+if experimental_runner.group specified:
+  → Queue job in runner_job_queue
+  → Firecracker runner polls and executes
+else:
+  → Execute immediately via E2B
+```
+
+---
+
+### Storage
+
+The storage layer persists user data (volumes, artifacts, session state) in Cloudflare R2.
+
+#### Storage Types
+
+**Volumes**: Read-only data mounted at specified paths
+- Examples: Code repositories, dependencies, reference data
+- Defined in `vm0.yaml`
+
+**Artifacts**: Read-write working directory
+- Agent output, modified files, generated assets
+- Versioned after each run
+- Used for checkpoints and resume
+
+#### Data Flow
+
+**Upload**:
+```
+CLI → tar.gz archive → presigned PUT URL → R2
+Database records: storage_id, version_id, s3_key
+```
+
+**Download**:
+```
+Server → presigned GET URL (1h expiration)
+  ↓
+Storage manifest JSON → Sandbox
+  ↓
+Sandbox downloads directly from R2 (no API proxy)
+  ↓
+Extracts to mount paths
+```
+
+---
+
+### Orchestration
+
+The orchestration layer coordinates job execution between web API and runners.
+
+**Runner Behavior**:
+1. Poll `/api/runners/poll` every 5 seconds (configurable)
+2. Receive pending job: `{ runId, prompt, agentComposeVersionId }`
+3. Claim job atomically via `/api/runners/claim` (sets `claimed_at`)
+4. Execute in Firecracker VM
+5. Report completion via webhook
+6. Job deleted from queue
+
+#### Runner Groups
+
+**Format**: `{scope}/{name}`
+- Official: `vm0/*` (e.g., `vm0/production`) - VM0-managed runners
+- User: `{userid}/*` (e.g., `user123/private`) - Self-hosted runners
+
+**Authentication**:
+- Official runners: HMAC signature using `OFFICIAL_RUNNER_SECRET`
+- User runners: JWT bearer token with userId claim
+
+---
+
+## Infrastructure
+
+### E2B Sandbox Backend
+
+E2B (e2b.dev) is a third-party managed sandbox service that provides containerized execution environments.
+
+#### Integration
+
+- SDK: `@e2b/code-interpreter`
+- Template: Specified via `E2B_TEMPLATE_NAME` environment variable or `agent.image` in `vm0.yaml`
+- Authentication: `E2B_API_KEY`
+
+#### Execution Flow
+
+1. Create sandbox with environment variables
+2. Upload Python/Node.js scripts via tar bundle
+3. Download storages from R2 via presigned URLs
+4. Restore session history (for resume)
+5. Start agent CLI in background (nohup)
+6. Webhook reports progress and completion
+
+---
+
+### Firecracker Sandbox Backend
+
+Firecracker is an open-source VMM (Virtual Machine Monitor) developed by AWS that creates lightweight microVMs using Linux KVM.
+
+#### Infrastructure Requirements
+
+**Hardware**:
+- Bare metal Linux server
+- KVM support: `/dev/kvm` device
+- Cannot run on cloud VMs (nested virtualization limitations)
+
+**Software**:
+- Firecracker v1.10.1 binary
+- Linux kernel v6.1.102 (for microVM)
+- Node.js 24.x, pnpm, pm2
+- mitmproxy (network observability)
+- Docker (rootfs build only)
+
+#### Architecture
+
+**Runner Application**: Separate Node.js application in `turbo/apps/runner/`
+
+**VM Configuration**:
+```yaml
+# runner.yaml
+firecracker:
+  binary: /usr/local/bin/firecracker
+  kernel: /opt/firecracker/vmlinux
+  rootfs: /opt/firecracker/rootfs.squashfs
+
+sandbox:
+  vcpu: 2
+  memory_mb: 2048
+  max_concurrent: 1
+```
+
+#### Storage Architecture
+
+**Shared Read-Only Base**:
+- Squashfs rootfs (~500MB-1GB compressed)
+- Location: `/opt/firecracker/rootfs.squashfs`
+- Shared across all VMs
+- Built from Dockerfile via `build-rootfs.sh`
+
+**Per-VM Writable Overlay**:
+- Sparse ext4 (2GB, allocates on write)
+- Location: `/tmp/vm0-vm-{vmId}/overlay.ext4`
+- Combined with base via overlayfs (custom init script)
+- Enables instant boot without rootfs copy
+
+#### Network Architecture
+
+**Isolation**: Each VM in separate network namespace
+
+**TAP Device**: One per VM
+- Name: `vm0tap{vmId}` (e.g., `vm0tap12345678`)
+- Layer 2 Ethernet virtualization
+- Bridges host and guest
+
+**IP Allocation**: 172.16.x.x/30 subnets
+- Host IP: .1 (e.g., 172.16.161.177)
+- Guest IP: .2 (e.g., 172.16.161.178)
+- 4 IPs total per VM: network, host, guest, broadcast
+
+**Internet Access**: NAT via iptables on runner host
+
+**HTTP Proxy**: mitmproxy at host:8080
+- Intercepts all HTTP/HTTPS traffic
+- Logs requests/responses
+- Firewall enforcement (experimental)
+- CA certificate injected into VM trust store
+
+#### Execution Flow
+
+1. Runner polls for jobs (5s interval)
+2. Creates Firecracker VM (3-5s boot)
+3. SSH to VM (using runner's key)
+4. Upload scripts, configure DNS, install proxy CA
+5. Preflight check (curl to heartbeat endpoint)
+6. Download storages from R2
+7. Start agent CLI in background
+8. Webhook reports progress
+9. VM terminated on completion
+
+**Code**: `turbo/apps/runner/src/lib/executor.ts`, `turbo/apps/runner/src/lib/firecracker/`
+
+---
+
+### Cloudflare R2 Object Storage
+
+Cloudflare R2 is S3-compatible object storage with zero egress fees.
+
+#### Configuration
+
+- Endpoint: `https://{R2_ACCOUNT_ID}.r2.cloudflarestorage.com`
+- Bucket: `R2_USER_STORAGES_BUCKET_NAME`
+- SDK: `@aws-sdk/client-s3` with S3-compatible API
+- Region: Auto (global)
+
+#### Storage Format
+
+- Archives: tar.gz compressed
+- S3 keys: Content-addressed by SHA-256 hash
+- Presigned URLs: 1-hour expiration for GET/PUT
+
+#### Direct Download
+
+Sandboxes download directly from R2 (no proxy through VM0 API):
+1. VM0 API generates presigned GET URLs
+2. Storage manifest JSON uploaded to sandbox
+3. Sandbox's `download.mjs` script fetches from R2
+4. Parallel downloads for multiple archives
+
+**Code**: `turbo/apps/web/src/lib/s3/s3-client.ts`
+
+---
+
+## References
+
+### Codebase
+
+**E2B Integration**:
+- `turbo/apps/web/src/lib/e2b/e2b-service.ts`
+
+**Firecracker Runner**:
+- `turbo/apps/runner/src/lib/firecracker/vm.ts` - VM lifecycle
+- `turbo/apps/runner/src/lib/firecracker/network.ts` - Network setup
+- `turbo/apps/runner/src/lib/firecracker/client.ts` - API client
+- `turbo/apps/runner/src/lib/executor.ts` - Job execution
+- `turbo/apps/runner/src/lib/config.ts` - Configuration
+
+**Storage**:
+- `turbo/apps/web/src/lib/storage/storage-service.ts`
+- `turbo/apps/web/src/lib/s3/s3-client.ts`
+
+**Orchestration**:
+- `turbo/apps/web/src/lib/run/executors/`
+- `turbo/apps/web/src/db/schema/runner-job-queue.ts`
+- `turbo/apps/web/app/api/runners/poll/route.ts`
+
+**Network**:
+- `turbo/apps/runner/src/lib/proxy/proxy-manager.ts`
+- `turbo/apps/runner/src/lib/proxy/mitm-addon-script.ts`
+
+**Deployment**:
+- `turbo/apps/runner/scripts/deploy/install-firecracker.sh`
+- `turbo/apps/runner/scripts/deploy/build-rootfs.sh`
+- `turbo/apps/runner/scripts/deploy/Dockerfile`
+- `ansible/playbooks/deploy-runner.yml`
+
+### External
+
+- [Firecracker](https://github.com/firecracker-microvm/firecracker)
+- [E2B](https://e2b.dev)
+- [Cloudflare R2](https://developers.cloudflare.com/r2/)
+- [mitmproxy](https://mitmproxy.org/)
+
+### Community
+
+- [Documentation](https://docs.vm0.ai)
+- [Discord](https://discord.gg/WMpAmHFfp6)
+- [GitHub](https://github.com/vm0-ai/vm0)


### PR DESCRIPTION
## Summary

- Add comprehensive architecture documentation at `docs/architecture.md`
- Document VM0's three core subsystems: Compute, Storage, and Orchestration
- Explain E2B and Firecracker sandbox backends with infrastructure requirements
- Update README.md to link to architecture documentation

## Key Sections

- **System Architecture**: Overview of Compute, Storage, and Orchestration layers
- **Infrastructure**: Detailed information on E2B, Firecracker, and Cloudflare R2
- **References**: Codebase files and external documentation links

This addresses HN feedback about infrastructure transparency by providing technical details on where and how sandboxes are deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)