### PR TITLE
fix(cli): update credential command hints to use experimental prefix

### DIFF
--- a/e2e/tests/02-parallel/t29-vm0-credential.bats
+++ b/e2e/tests/02-parallel/t29-vm0-credential.bats
@@ -11,13 +11,13 @@ setup() {
 
 teardown() {
     # Clean up test credential if it exists
-    $CLI_COMMAND credential delete "$TEST_CRED_NAME" 2>/dev/null || true
+    $CLI_COMMAND credential delete -y "$TEST_CRED_NAME" 2>/dev/null || true
 }
 
 @test "vm0 credential --help shows command description" {
     run $CLI_COMMAND credential --help
     assert_success
-    assert_output --partial "Manage credentials"
+    assert_output --partial "Manage stored credentials"
     assert_output --partial "list"
     assert_output --partial "set"
     assert_output --partial "delete"
@@ -120,8 +120,8 @@ teardown() {
     # Create a credential
     $CLI_COMMAND credential set "$TEST_CRED_NAME" "to-be-deleted"
 
-    # Delete it
-    run $CLI_COMMAND credential delete "$TEST_CRED_NAME"
+    # Delete it (use -y to skip confirmation)
+    run $CLI_COMMAND credential delete -y "$TEST_CRED_NAME"
     assert_success
     assert_output --partial "Credential \"$TEST_CRED_NAME\" deleted"
 
@@ -135,14 +135,14 @@ teardown() {
 }
 
 @test "vm0 credential delete fails for non-existent credential" {
-    run $CLI_COMMAND credential delete "NONEXISTENT_CRED_$(date +%s)"
+    run $CLI_COMMAND credential delete -y "NONEXISTENT_CRED_$(date +%s)"
     assert_failure
     assert_output --partial "not found"
 }
 
 @test "vm0 credential list shows empty state message" {
     # Delete any existing test credentials first
-    $CLI_COMMAND credential delete "$TEST_CRED_NAME" 2>/dev/null || true
+    $CLI_COMMAND credential delete -y "$TEST_CRED_NAME" 2>/dev/null || true
 
     # List credentials - might have other credentials from other tests
     # Just verify the command works

--- a/e2e/tests/02-parallel/t29-vm0-credential.bats
+++ b/e2e/tests/02-parallel/t29-vm0-credential.bats
@@ -11,11 +11,11 @@ setup() {
 
 teardown() {
     # Clean up test credential if it exists
-    $CLI_COMMAND credential delete -y "$TEST_CRED_NAME" 2>/dev/null || true
+    $CLI_COMMAND experimental-credential delete -y "$TEST_CRED_NAME" 2>/dev/null || true
 }
 
-@test "vm0 credential --help shows command description" {
-    run $CLI_COMMAND credential --help
+@test "vm0 experimental-credential --help shows command description" {
+    run $CLI_COMMAND experimental-credential --help
     assert_success
     assert_output --partial "Manage stored credentials"
     assert_output --partial "list"
@@ -23,15 +23,15 @@ teardown() {
     assert_output --partial "delete"
 }
 
-@test "vm0 credential list --help shows options" {
-    run $CLI_COMMAND credential list --help
+@test "vm0 experimental-credential list --help shows options" {
+    run $CLI_COMMAND experimental-credential list --help
     assert_success
     assert_output --partial "List all credentials"
     assert_output --partial "--json"
 }
 
-@test "vm0 credential set --help shows usage" {
-    run $CLI_COMMAND credential set --help
+@test "vm0 experimental-credential set --help shows usage" {
+    run $CLI_COMMAND experimental-credential set --help
     assert_success
     assert_output --partial "Create or update a credential"
     assert_output --partial "<name>"
@@ -39,94 +39,94 @@ teardown() {
     assert_output --partial "--description"
 }
 
-@test "vm0 credential delete --help shows usage" {
-    run $CLI_COMMAND credential delete --help
+@test "vm0 experimental-credential delete --help shows usage" {
+    run $CLI_COMMAND experimental-credential delete --help
     assert_success
     assert_output --partial "Delete a credential"
     assert_output --partial "<name>"
 }
 
-@test "vm0 credential set creates a credential" {
-    run $CLI_COMMAND credential set "$TEST_CRED_NAME" "test-secret-value"
+@test "vm0 experimental-credential set creates a credential" {
+    run $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "test-secret-value"
     assert_success
     assert_output --partial "Credential \"$TEST_CRED_NAME\" saved"
     assert_output --partial "Use in vm0.yaml"
     assert_output --partial "\${{ credentials.$TEST_CRED_NAME }}"
 }
 
-@test "vm0 credential set with description" {
-    run $CLI_COMMAND credential set "$TEST_CRED_NAME" "test-value" --description "Test credential for E2E"
+@test "vm0 experimental-credential set with description" {
+    run $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "test-value" --description "Test credential for E2E"
     assert_success
     assert_output --partial "Credential \"$TEST_CRED_NAME\" saved"
 }
 
-@test "vm0 credential list shows created credential" {
+@test "vm0 experimental-credential list shows created credential" {
     # First create a credential
-    $CLI_COMMAND credential set "$TEST_CRED_NAME" "secret-value" --description "E2E test"
+    $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "secret-value" --description "E2E test"
 
     # Then list credentials
-    run $CLI_COMMAND credential list
+    run $CLI_COMMAND experimental-credential list
     assert_success
     assert_output --partial "$TEST_CRED_NAME"
     assert_output --partial "E2E test"
     assert_output --partial "credential(s)"
 }
 
-@test "vm0 credential list --json outputs valid JSON" {
+@test "vm0 experimental-credential list --json outputs valid JSON" {
     # First create a credential
-    $CLI_COMMAND credential set "$TEST_CRED_NAME" "secret-value"
+    $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "secret-value"
 
     # List in JSON format
-    run $CLI_COMMAND credential list --json
+    run $CLI_COMMAND experimental-credential list --json
     assert_success
 
     # Verify JSON is valid and contains our credential
     echo "$output" | jq -e ".[] | select(.name == \"$TEST_CRED_NAME\")"
 }
 
-@test "vm0 credential set rejects lowercase names" {
-    run $CLI_COMMAND credential set "my_api_key" "value"
+@test "vm0 experimental-credential set rejects lowercase names" {
+    run $CLI_COMMAND experimental-credential set "my_api_key" "value"
     assert_failure
     assert_output --partial "must contain only uppercase"
 }
 
-@test "vm0 credential set rejects names starting with numbers" {
-    run $CLI_COMMAND credential set "123_KEY" "value"
+@test "vm0 experimental-credential set rejects names starting with numbers" {
+    run $CLI_COMMAND experimental-credential set "123_KEY" "value"
     assert_failure
     assert_output --partial "must contain only uppercase"
 }
 
-@test "vm0 credential set rejects names with dashes" {
-    run $CLI_COMMAND credential set "MY-API-KEY" "value"
+@test "vm0 experimental-credential set rejects names with dashes" {
+    run $CLI_COMMAND experimental-credential set "MY-API-KEY" "value"
     assert_failure
     assert_output --partial "must contain only uppercase"
 }
 
-@test "vm0 credential set updates existing credential" {
+@test "vm0 experimental-credential set updates existing credential" {
     # Create initial credential
-    $CLI_COMMAND credential set "$TEST_CRED_NAME" "initial-value"
+    $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "initial-value"
 
     # Update it
-    run $CLI_COMMAND credential set "$TEST_CRED_NAME" "updated-value" --description "Updated"
+    run $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "updated-value" --description "Updated"
     assert_success
     assert_output --partial "Credential \"$TEST_CRED_NAME\" saved"
 
     # Verify description was updated
-    run $CLI_COMMAND credential list
+    run $CLI_COMMAND experimental-credential list
     assert_output --partial "Updated"
 }
 
-@test "vm0 credential delete removes credential" {
+@test "vm0 experimental-credential delete removes credential" {
     # Create a credential
-    $CLI_COMMAND credential set "$TEST_CRED_NAME" "to-be-deleted"
+    $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "to-be-deleted"
 
     # Delete it (use -y to skip confirmation)
-    run $CLI_COMMAND credential delete -y "$TEST_CRED_NAME"
+    run $CLI_COMMAND experimental-credential delete -y "$TEST_CRED_NAME"
     assert_success
     assert_output --partial "Credential \"$TEST_CRED_NAME\" deleted"
 
     # Verify it's gone
-    run $CLI_COMMAND credential list --json
+    run $CLI_COMMAND experimental-credential list --json
     assert_success
     # Should not contain our credential
     if echo "$output" | jq -e ".[] | select(.name == \"$TEST_CRED_NAME\")" >/dev/null 2>&1; then
@@ -134,19 +134,19 @@ teardown() {
     fi
 }
 
-@test "vm0 credential delete fails for non-existent credential" {
-    run $CLI_COMMAND credential delete -y "NONEXISTENT_CRED_$(date +%s)"
+@test "vm0 experimental-credential delete fails for non-existent credential" {
+    run $CLI_COMMAND experimental-credential delete -y "NONEXISTENT_CRED_$(date +%s)"
     assert_failure
     assert_output --partial "not found"
 }
 
-@test "vm0 credential list shows empty state message" {
+@test "vm0 experimental-credential list shows empty state message" {
     # Delete any existing test credentials first
-    $CLI_COMMAND credential delete -y "$TEST_CRED_NAME" 2>/dev/null || true
+    $CLI_COMMAND experimental-credential delete -y "$TEST_CRED_NAME" 2>/dev/null || true
 
     # List credentials - might have other credentials from other tests
     # Just verify the command works
-    run $CLI_COMMAND credential list
+    run $CLI_COMMAND experimental-credential list
     assert_success
     # Should either show credentials or "No credentials found"
     [[ "$output" =~ "Credentials:" ]] || [[ "$output" =~ "No credentials found" ]]

--- a/e2e/tests/02-parallel/t29-vm0-credential.bats
+++ b/e2e/tests/02-parallel/t29-vm0-credential.bats
@@ -1,0 +1,153 @@
+#!/usr/bin/env bats
+
+load '../../helpers/setup'
+
+# Credential command tests
+
+# Generate unique credential name for each test run to avoid conflicts
+setup() {
+    export TEST_CRED_NAME="E2E_TEST_CRED_$(date +%s%3N)_$RANDOM"
+}
+
+teardown() {
+    # Clean up test credential if it exists
+    $CLI_COMMAND credential delete "$TEST_CRED_NAME" 2>/dev/null || true
+}
+
+@test "vm0 credential --help shows command description" {
+    run $CLI_COMMAND credential --help
+    assert_success
+    assert_output --partial "Manage credentials"
+    assert_output --partial "list"
+    assert_output --partial "set"
+    assert_output --partial "delete"
+}
+
+@test "vm0 credential list --help shows options" {
+    run $CLI_COMMAND credential list --help
+    assert_success
+    assert_output --partial "List all credentials"
+    assert_output --partial "--json"
+}
+
+@test "vm0 credential set --help shows usage" {
+    run $CLI_COMMAND credential set --help
+    assert_success
+    assert_output --partial "Create or update a credential"
+    assert_output --partial "<name>"
+    assert_output --partial "<value>"
+    assert_output --partial "--description"
+}
+
+@test "vm0 credential delete --help shows usage" {
+    run $CLI_COMMAND credential delete --help
+    assert_success
+    assert_output --partial "Delete a credential"
+    assert_output --partial "<name>"
+}
+
+@test "vm0 credential set creates a credential" {
+    run $CLI_COMMAND credential set "$TEST_CRED_NAME" "test-secret-value"
+    assert_success
+    assert_output --partial "Credential \"$TEST_CRED_NAME\" saved"
+    assert_output --partial "Use in vm0.yaml"
+    assert_output --partial "\${{ credentials.$TEST_CRED_NAME }}"
+}
+
+@test "vm0 credential set with description" {
+    run $CLI_COMMAND credential set "$TEST_CRED_NAME" "test-value" --description "Test credential for E2E"
+    assert_success
+    assert_output --partial "Credential \"$TEST_CRED_NAME\" saved"
+}
+
+@test "vm0 credential list shows created credential" {
+    # First create a credential
+    $CLI_COMMAND credential set "$TEST_CRED_NAME" "secret-value" --description "E2E test"
+
+    # Then list credentials
+    run $CLI_COMMAND credential list
+    assert_success
+    assert_output --partial "$TEST_CRED_NAME"
+    assert_output --partial "E2E test"
+    assert_output --partial "credential(s)"
+}
+
+@test "vm0 credential list --json outputs valid JSON" {
+    # First create a credential
+    $CLI_COMMAND credential set "$TEST_CRED_NAME" "secret-value"
+
+    # List in JSON format
+    run $CLI_COMMAND credential list --json
+    assert_success
+
+    # Verify JSON is valid and contains our credential
+    echo "$output" | jq -e ".[] | select(.name == \"$TEST_CRED_NAME\")"
+}
+
+@test "vm0 credential set rejects lowercase names" {
+    run $CLI_COMMAND credential set "my_api_key" "value"
+    assert_failure
+    assert_output --partial "must contain only uppercase"
+}
+
+@test "vm0 credential set rejects names starting with numbers" {
+    run $CLI_COMMAND credential set "123_KEY" "value"
+    assert_failure
+    assert_output --partial "must contain only uppercase"
+}
+
+@test "vm0 credential set rejects names with dashes" {
+    run $CLI_COMMAND credential set "MY-API-KEY" "value"
+    assert_failure
+    assert_output --partial "must contain only uppercase"
+}
+
+@test "vm0 credential set updates existing credential" {
+    # Create initial credential
+    $CLI_COMMAND credential set "$TEST_CRED_NAME" "initial-value"
+
+    # Update it
+    run $CLI_COMMAND credential set "$TEST_CRED_NAME" "updated-value" --description "Updated"
+    assert_success
+    assert_output --partial "Credential \"$TEST_CRED_NAME\" saved"
+
+    # Verify description was updated
+    run $CLI_COMMAND credential list
+    assert_output --partial "Updated"
+}
+
+@test "vm0 credential delete removes credential" {
+    # Create a credential
+    $CLI_COMMAND credential set "$TEST_CRED_NAME" "to-be-deleted"
+
+    # Delete it
+    run $CLI_COMMAND credential delete "$TEST_CRED_NAME"
+    assert_success
+    assert_output --partial "Credential \"$TEST_CRED_NAME\" deleted"
+
+    # Verify it's gone
+    run $CLI_COMMAND credential list --json
+    assert_success
+    # Should not contain our credential
+    if echo "$output" | jq -e ".[] | select(.name == \"$TEST_CRED_NAME\")" >/dev/null 2>&1; then
+        fail "Credential should have been deleted"
+    fi
+}
+
+@test "vm0 credential delete fails for non-existent credential" {
+    run $CLI_COMMAND credential delete "NONEXISTENT_CRED_$(date +%s)"
+    assert_failure
+    assert_output --partial "not found"
+}
+
+@test "vm0 credential list shows empty state message" {
+    # Delete any existing test credentials first
+    $CLI_COMMAND credential delete "$TEST_CRED_NAME" 2>/dev/null || true
+
+    # List credentials - might have other credentials from other tests
+    # Just verify the command works
+    run $CLI_COMMAND credential list
+    assert_success
+    # Should either show credentials or "No credentials found"
+    [[ "$output" =~ "Credentials:" ]] || [[ "$output" =~ "No credentials found" ]]
+}

--- a/turbo/apps/cli/src/commands/__tests__/cook.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/cook.test.ts
@@ -67,6 +67,7 @@ describe("cook command - environment variable check", () => {
         env: [],
         vars: [mockRefs[0]!, mockRefs[2]!],
         secrets: [mockRefs[1]!],
+        credentials: [],
       });
 
       // The actual function is internal, so we verify the logic through integration

--- a/turbo/apps/cli/src/commands/__tests__/setup-github.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/setup-github.test.ts
@@ -30,6 +30,7 @@ describe("setup-github command", () => {
       env: [],
       vars: [],
       secrets: [],
+      credentials: [],
     });
   });
 
@@ -246,6 +247,7 @@ agents:
             fullMatch: "${{ secrets.API_KEY }}",
           },
         ],
+        credentials: [],
       });
 
       await setupGithubCommand.parseAsync(["node", "cli", "--skip-secrets"]);
@@ -270,6 +272,7 @@ agents:
           { source: "vars", name: "REGION", fullMatch: "${{ vars.REGION }}" },
         ],
         secrets: [],
+        credentials: [],
       });
 
       await setupGithubCommand.parseAsync(["node", "cli", "--skip-secrets"]);
@@ -544,6 +547,7 @@ agents:
             fullMatch: `\${{ secrets.${TEST_SECRET} }}`,
           },
         ],
+        credentials: [],
       });
       vi.mocked(spawnSync).mockReturnValue({
         status: 0,
@@ -646,6 +650,7 @@ agents:
             fullMatch: "${{ secrets.MISSING_SECRET }}",
           },
         ],
+        credentials: [],
       });
 
       await setupGithubCommand.parseAsync(["node", "cli", "--yes"]);

--- a/turbo/apps/cli/src/commands/credential/delete.ts
+++ b/turbo/apps/cli/src/commands/credential/delete.ts
@@ -1,0 +1,60 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { apiClient } from "../../lib/api/api-client";
+
+export const deleteCommand = new Command()
+  .name("delete")
+  .description("Delete a credential")
+  .argument("<name>", "Credential name to delete")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(async (name: string, options: { yes?: boolean }) => {
+    try {
+      // Verify credential exists first
+      try {
+        await apiClient.getCredential(name);
+      } catch {
+        console.error(chalk.red(`✗ Credential "${name}" not found`));
+        process.exit(1);
+      }
+
+      // Confirm deletion unless --yes is passed
+      if (!options.yes) {
+        const readline = await import("readline");
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
+
+        const confirmed = await new Promise<boolean>((resolve) => {
+          rl.question(
+            chalk.yellow(
+              `Are you sure you want to delete credential "${name}"? (y/N) `,
+            ),
+            (answer) => {
+              rl.close();
+              resolve(answer.toLowerCase() === "y");
+            },
+          );
+        });
+
+        if (!confirmed) {
+          console.log(chalk.dim("Cancelled."));
+          return;
+        }
+      }
+
+      await apiClient.deleteCredential(name);
+      console.log(chalk.green(`✓ Credential "${name}" deleted`));
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes("Not authenticated")) {
+          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
+        } else {
+          console.error(chalk.red(`✗ ${error.message}`));
+        }
+      } else {
+        console.error(chalk.red("✗ An unexpected error occurred"));
+      }
+      process.exit(1);
+    }
+  });

--- a/turbo/apps/cli/src/commands/credential/index.ts
+++ b/turbo/apps/cli/src/commands/credential/index.ts
@@ -4,8 +4,8 @@ import { setCommand } from "./set";
 import { deleteCommand } from "./delete";
 
 export const credentialCommand = new Command()
-  .name("credential")
-  .description("Manage stored credentials for agent runs")
+  .name("experimental-credential")
+  .description("[Experimental] Manage stored credentials for agent runs")
   .addCommand(listCommand)
   .addCommand(setCommand)
   .addCommand(deleteCommand);

--- a/turbo/apps/cli/src/commands/credential/index.ts
+++ b/turbo/apps/cli/src/commands/credential/index.ts
@@ -1,0 +1,11 @@
+import { Command } from "commander";
+import { listCommand } from "./list";
+import { setCommand } from "./set";
+import { deleteCommand } from "./delete";
+
+export const credentialCommand = new Command()
+  .name("credential")
+  .description("Manage stored credentials for agent runs")
+  .addCommand(listCommand)
+  .addCommand(setCommand)
+  .addCommand(deleteCommand);

--- a/turbo/apps/cli/src/commands/credential/list.ts
+++ b/turbo/apps/cli/src/commands/credential/list.ts
@@ -19,7 +19,9 @@ export const listCommand = new Command()
         console.log(chalk.dim("No credentials found."));
         console.log();
         console.log("To add a credential:");
-        console.log(chalk.cyan("  vm0 credential set MY_API_KEY <value>"));
+        console.log(
+          chalk.cyan("  vm0 experimental-credential set MY_API_KEY <value>"),
+        );
         return;
       }
 

--- a/turbo/apps/cli/src/commands/credential/list.ts
+++ b/turbo/apps/cli/src/commands/credential/list.ts
@@ -1,0 +1,55 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { apiClient } from "../../lib/api/api-client";
+
+export const listCommand = new Command()
+  .name("list")
+  .description("List all credentials")
+  .option("--json", "Output in JSON format")
+  .action(async (options: { json?: boolean }) => {
+    try {
+      const result = await apiClient.listCredentials();
+
+      if (options.json) {
+        console.log(JSON.stringify(result.credentials, null, 2));
+        return;
+      }
+
+      if (result.credentials.length === 0) {
+        console.log(chalk.dim("No credentials found."));
+        console.log();
+        console.log("To add a credential:");
+        console.log(chalk.cyan("  vm0 credential set MY_API_KEY <value>"));
+        return;
+      }
+
+      console.log(chalk.bold("Credentials:"));
+      console.log();
+
+      for (const credential of result.credentials) {
+        console.log(`  ${chalk.cyan(credential.name)}`);
+        if (credential.description) {
+          console.log(`    ${chalk.dim(credential.description)}`);
+        }
+        console.log(
+          `    ${chalk.dim(`Updated: ${new Date(credential.updatedAt).toLocaleString()}`)}`,
+        );
+        console.log();
+      }
+
+      console.log(
+        chalk.dim(`Total: ${result.credentials.length} credential(s)`),
+      );
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes("Not authenticated")) {
+          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
+        } else {
+          console.error(chalk.red(`✗ ${error.message}`));
+        }
+      } else {
+        console.error(chalk.red("✗ An unexpected error occurred"));
+      }
+      process.exit(1);
+    }
+  });

--- a/turbo/apps/cli/src/commands/credential/set.ts
+++ b/turbo/apps/cli/src/commands/credential/set.ts
@@ -1,0 +1,47 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { apiClient } from "../../lib/api/api-client";
+
+export const setCommand = new Command()
+  .name("set")
+  .description("Create or update a credential")
+  .argument("<name>", "Credential name (uppercase, e.g., MY_API_KEY)")
+  .argument("<value>", "Credential value")
+  .option("-d, --description <description>", "Optional description")
+  .action(
+    async (name: string, value: string, options: { description?: string }) => {
+      try {
+        const credential = await apiClient.setCredential({
+          name,
+          value,
+          description: options.description,
+        });
+
+        console.log(chalk.green(`✓ Credential "${credential.name}" saved`));
+        console.log();
+        console.log("Use in vm0.yaml:");
+        console.log(chalk.cyan(`  environment:`));
+        console.log(chalk.cyan(`    ${name}: \${{ credentials.${name} }}`));
+      } catch (error) {
+        if (error instanceof Error) {
+          if (error.message.includes("Not authenticated")) {
+            console.error(
+              chalk.red("✗ Not authenticated. Run: vm0 auth login"),
+            );
+          } else if (error.message.includes("must contain only uppercase")) {
+            console.error(chalk.red(`✗ ${error.message}`));
+            console.log();
+            console.log("Examples of valid credential names:");
+            console.log(chalk.dim("  MY_API_KEY"));
+            console.log(chalk.dim("  GITHUB_TOKEN"));
+            console.log(chalk.dim("  AWS_ACCESS_KEY_ID"));
+          } else {
+            console.error(chalk.red(`✗ ${error.message}`));
+          }
+        } else {
+          console.error(chalk.red("✗ An unexpected error occurred"));
+        }
+        process.exit(1);
+      }
+    },
+  );

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -19,6 +19,7 @@ import { initCommand } from "./commands/init";
 import { setupGithubCommand } from "./commands/setup-github";
 import { scheduleCommand } from "./commands/schedule";
 import { usageCommand } from "./commands/usage";
+import { credentialCommand } from "./commands/credential";
 
 const program = new Command();
 
@@ -86,6 +87,7 @@ program.addCommand(initCommand);
 program.addCommand(setupGithubCommand);
 program.addCommand(scheduleCommand);
 program.addCommand(usageCommand);
+program.addCommand(credentialCommand);
 
 export { program };
 

--- a/turbo/apps/web/app/api/credentials/[name]/route.ts
+++ b/turbo/apps/web/app/api/credentials/[name]/route.ts
@@ -1,0 +1,117 @@
+import {
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../../../../src/lib/ts-rest-handler";
+import {
+  credentialsByNameContract,
+  createErrorResponse,
+  ApiError,
+} from "@vm0/core";
+import { initServices } from "../../../../src/lib/init-services";
+import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import {
+  getCredential,
+  deleteCredential,
+} from "../../../../src/lib/credential/credential-service";
+import { logger } from "../../../../src/lib/logger";
+import { NotFoundError } from "../../../../src/lib/errors";
+
+const log = logger("api:credentials");
+
+const router = tsr.router(credentialsByNameContract, {
+  /**
+   * GET /api/credentials/:name - Get a credential by name
+   */
+  get: async ({ params }) => {
+    initServices();
+
+    const userId = await getUserId();
+    if (!userId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+
+    const credential = await getCredential(userId, params.name);
+    if (!credential) {
+      return createErrorResponse(
+        "NOT_FOUND",
+        `Credential "${params.name}" not found`,
+      );
+    }
+
+    return {
+      status: 200 as const,
+      body: {
+        id: credential.id,
+        name: credential.name,
+        description: credential.description,
+        createdAt: credential.createdAt.toISOString(),
+        updatedAt: credential.updatedAt.toISOString(),
+      },
+    };
+  },
+
+  /**
+   * DELETE /api/credentials/:name - Delete a credential
+   */
+  delete: async ({ params }) => {
+    initServices();
+
+    const userId = await getUserId();
+    if (!userId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+
+    log.debug("deleting credential", { userId, name: params.name });
+
+    try {
+      await deleteCredential(userId, params.name);
+
+      return {
+        status: 204 as const,
+        body: undefined,
+      };
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        return createErrorResponse("NOT_FOUND", error.message);
+      }
+      throw error;
+    }
+  },
+});
+
+/**
+ * Custom error handler for credentials by name API
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  // Handle ts-rest RequestValidationError
+  if (err && typeof err === "object" && "pathParamsError" in err) {
+    const validationError = err as {
+      pathParamsError: {
+        issues: Array<{ path: string[]; message: string }>;
+      } | null;
+    };
+
+    // Handle path params validation errors
+    if (validationError.pathParamsError) {
+      const issue = validationError.pathParamsError.issues[0];
+      if (issue) {
+        const message = issue.message;
+
+        return TsRestResponse.fromJson(
+          { error: { message, code: ApiError.BAD_REQUEST.code } },
+          { status: ApiError.BAD_REQUEST.status },
+        );
+      }
+    }
+  }
+
+  // Let other errors propagate
+  return undefined;
+}
+
+const handler = createHandler(credentialsByNameContract, router, {
+  errorHandler,
+});
+
+export { handler as GET, handler as DELETE };

--- a/turbo/apps/web/app/api/credentials/route.ts
+++ b/turbo/apps/web/app/api/credentials/route.ts
@@ -1,0 +1,125 @@
+import {
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../../../src/lib/ts-rest-handler";
+import {
+  credentialsMainContract,
+  createErrorResponse,
+  ApiError,
+} from "@vm0/core";
+import { initServices } from "../../../src/lib/init-services";
+import { getUserId } from "../../../src/lib/auth/get-user-id";
+import {
+  listCredentials,
+  setCredential,
+} from "../../../src/lib/credential/credential-service";
+import { logger } from "../../../src/lib/logger";
+import { BadRequestError } from "../../../src/lib/errors";
+
+const log = logger("api:credentials");
+
+const router = tsr.router(credentialsMainContract, {
+  /**
+   * GET /api/credentials - List all credentials
+   */
+  list: async () => {
+    initServices();
+
+    const userId = await getUserId();
+    if (!userId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+
+    const credentials = await listCredentials(userId);
+
+    return {
+      status: 200 as const,
+      body: {
+        credentials: credentials.map((c) => ({
+          id: c.id,
+          name: c.name,
+          description: c.description,
+          createdAt: c.createdAt.toISOString(),
+          updatedAt: c.updatedAt.toISOString(),
+        })),
+      },
+    };
+  },
+
+  /**
+   * PUT /api/credentials - Create or update a credential
+   */
+  set: async ({ body }) => {
+    initServices();
+
+    const userId = await getUserId();
+    if (!userId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+
+    const { name, value, description } = body;
+
+    log.debug("setting credential", { userId, name });
+
+    try {
+      const credential = await setCredential(userId, name, value, description);
+
+      return {
+        status: 200 as const,
+        body: {
+          id: credential.id,
+          name: credential.name,
+          description: credential.description,
+          createdAt: credential.createdAt.toISOString(),
+          updatedAt: credential.updatedAt.toISOString(),
+        },
+      };
+    } catch (error) {
+      if (error instanceof BadRequestError) {
+        return createErrorResponse("BAD_REQUEST", error.message);
+      }
+      throw error;
+    }
+  },
+});
+
+/**
+ * Custom error handler for credentials API
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  // Handle ts-rest RequestValidationError
+  if (
+    err &&
+    typeof err === "object" &&
+    "bodyError" in err &&
+    "queryError" in err
+  ) {
+    const validationError = err as {
+      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
+      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
+    };
+
+    // Handle body validation errors
+    if (validationError.bodyError) {
+      const issue = validationError.bodyError.issues[0];
+      if (issue) {
+        const message = issue.message;
+
+        return TsRestResponse.fromJson(
+          { error: { message, code: ApiError.BAD_REQUEST.code } },
+          { status: ApiError.BAD_REQUEST.status },
+        );
+      }
+    }
+  }
+
+  // Let other errors propagate
+  return undefined;
+}
+
+const handler = createHandler(credentialsMainContract, router, {
+  errorHandler,
+});
+
+export { handler as GET, handler as PUT };

--- a/turbo/apps/web/src/db/db.ts
+++ b/turbo/apps/web/src/db/db.ts
@@ -14,6 +14,7 @@ import * as sandboxTelemetrySchema from "./schema/sandbox-telemetry";
 import * as scopeSchema from "./schema/scope";
 import * as runnerSchema from "./schema/runner-job-queue";
 import * as agentScheduleSchema from "./schema/agent-schedule";
+import * as credentialSchema from "./schema/credential";
 
 export const schema = {
   ...userSchema,
@@ -32,4 +33,5 @@ export const schema = {
   ...scopeSchema,
   ...runnerSchema,
   ...agentScheduleSchema,
+  ...credentialSchema,
 };

--- a/turbo/apps/web/src/db/migrations/0052_add_credentials.sql
+++ b/turbo/apps/web/src/db/migrations/0052_add_credentials.sql
@@ -1,0 +1,16 @@
+-- Create credentials table for storing third-party service credentials
+CREATE TABLE "credentials" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "scope_id" uuid NOT NULL REFERENCES "scopes"("id") ON DELETE CASCADE,
+  "name" varchar(255) NOT NULL,
+  "encrypted_value" text NOT NULL,
+  "description" text,
+  "created_at" timestamp NOT NULL DEFAULT now(),
+  "updated_at" timestamp NOT NULL DEFAULT now()
+);
+
+-- Credential name unique within scope
+CREATE UNIQUE INDEX "idx_credentials_scope_name" ON "credentials"("scope_id", "name");
+
+-- Index for listing credentials by scope
+CREATE INDEX "idx_credentials_scope" ON "credentials"("scope_id");

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -358,6 +358,20 @@
       "when": 1767500000000,
       "tag": "0050_add_agent_schedules",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1767600000000,
+      "tag": "0051_add_performance_indexes",
+      "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1767700000000,
+      "tag": "0052_add_credentials",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/credential.ts
+++ b/turbo/apps/web/src/db/schema/credential.ts
@@ -1,0 +1,36 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  varchar,
+  timestamp,
+  uniqueIndex,
+  index,
+} from "drizzle-orm/pg-core";
+import { scopes } from "./scope";
+
+/**
+ * Credentials table
+ * Stores encrypted third-party service credentials at scope level
+ * Values encrypted with AES-256-GCM using SECRETS_ENCRYPTION_KEY
+ *
+ * Scoped to user's personal scope initially, supports organization scopes in future
+ */
+export const credentials = pgTable(
+  "credentials",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    scopeId: uuid("scope_id")
+      .references(() => scopes.id, { onDelete: "cascade" })
+      .notNull(),
+    name: varchar("name", { length: 255 }).notNull(),
+    encryptedValue: text("encrypted_value").notNull(),
+    description: text("description"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("idx_credentials_scope_name").on(table.scopeId, table.name),
+    index("idx_credentials_scope").on(table.scopeId),
+  ],
+);

--- a/turbo/apps/web/src/lib/credential/__tests__/credential-service.spec.ts
+++ b/turbo/apps/web/src/lib/credential/__tests__/credential-service.spec.ts
@@ -1,7 +1,15 @@
 /**
  * @vitest-environment node
  */
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from "vitest";
 import {
   validateCredentialName,
   listCredentials,
@@ -18,6 +26,10 @@ import { eq } from "drizzle-orm";
 import { BadRequestError, NotFoundError } from "../../errors";
 
 describe("Credential Service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe("validateCredentialName", () => {
     it("should accept valid names", () => {
       expect(() => validateCredentialName("MY_API_KEY")).not.toThrow();

--- a/turbo/apps/web/src/lib/credential/__tests__/credential-service.spec.ts
+++ b/turbo/apps/web/src/lib/credential/__tests__/credential-service.spec.ts
@@ -1,0 +1,235 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  validateCredentialName,
+  listCredentials,
+  getCredential,
+  getCredentialValue,
+  getCredentialValues,
+  setCredential,
+  deleteCredential,
+} from "../credential-service";
+import { initServices } from "../../init-services";
+import { credentials } from "../../../db/schema/credential";
+import { scopes } from "../../../db/schema/scope";
+import { eq } from "drizzle-orm";
+import { BadRequestError, NotFoundError } from "../../errors";
+
+describe("Credential Service", () => {
+  describe("validateCredentialName", () => {
+    it("should accept valid names", () => {
+      expect(() => validateCredentialName("MY_API_KEY")).not.toThrow();
+      expect(() => validateCredentialName("GITHUB_TOKEN")).not.toThrow();
+      expect(() => validateCredentialName("AWS_ACCESS_KEY_ID")).not.toThrow();
+      expect(() => validateCredentialName("A")).not.toThrow();
+      expect(() => validateCredentialName("A1B2C3")).not.toThrow();
+      expect(() => validateCredentialName("KEY_123")).not.toThrow();
+    });
+
+    it("should reject empty names", () => {
+      expect(() => validateCredentialName("")).toThrow(BadRequestError);
+    });
+
+    it("should reject names that are too long", () => {
+      const longName = "A".repeat(256);
+      expect(() => validateCredentialName(longName)).toThrow(BadRequestError);
+    });
+
+    it("should reject lowercase letters", () => {
+      expect(() => validateCredentialName("my_api_key")).toThrow(
+        BadRequestError,
+      );
+      expect(() => validateCredentialName("MyApiKey")).toThrow(BadRequestError);
+    });
+
+    it("should reject names starting with numbers", () => {
+      expect(() => validateCredentialName("123_KEY")).toThrow(BadRequestError);
+    });
+
+    it("should reject invalid characters", () => {
+      expect(() => validateCredentialName("MY-API-KEY")).toThrow(
+        BadRequestError,
+      );
+      expect(() => validateCredentialName("MY.API.KEY")).toThrow(
+        BadRequestError,
+      );
+      expect(() => validateCredentialName("MY API KEY")).toThrow(
+        BadRequestError,
+      );
+    });
+  });
+
+  describe("Database Operations", () => {
+    const testUserId = "test-credential-service-user";
+    const testSlug = `test-cred-scope-${Date.now()}`;
+    let testScopeId: string;
+
+    beforeAll(async () => {
+      initServices();
+
+      // Create a test scope
+      const [scope] = await globalThis.services.db
+        .insert(scopes)
+        .values({
+          slug: testSlug,
+          type: "personal",
+          ownerId: testUserId,
+        })
+        .returning();
+
+      testScopeId = scope!.id;
+    });
+
+    afterAll(async () => {
+      // Cleanup test credentials and scope
+      await globalThis.services.db
+        .delete(credentials)
+        .where(eq(credentials.scopeId, testScopeId));
+      await globalThis.services.db
+        .delete(scopes)
+        .where(eq(scopes.id, testScopeId));
+    });
+
+    describe("setCredential", () => {
+      it("should create a credential successfully", async () => {
+        const credential = await setCredential(
+          testUserId,
+          "TEST_API_KEY",
+          "secret-value-123",
+          "Test API key",
+        );
+
+        expect(credential).toBeDefined();
+        expect(credential.name).toBe("TEST_API_KEY");
+        expect(credential.description).toBe("Test API key");
+        expect(credential.id).toBeDefined();
+      });
+
+      it("should update existing credential", async () => {
+        // Create initial credential
+        const initial = await setCredential(
+          testUserId,
+          "UPDATE_TEST_KEY",
+          "initial-value",
+        );
+
+        // Update the credential
+        const updated = await setCredential(
+          testUserId,
+          "UPDATE_TEST_KEY",
+          "updated-value",
+          "Updated description",
+        );
+
+        expect(updated.id).toBe(initial.id);
+        expect(updated.description).toBe("Updated description");
+        expect(updated.updatedAt.getTime()).toBeGreaterThan(
+          initial.updatedAt.getTime(),
+        );
+      });
+
+      it("should reject invalid credential names", async () => {
+        await expect(
+          setCredential(testUserId, "invalid-name", "value"),
+        ).rejects.toThrow(BadRequestError);
+      });
+    });
+
+    describe("listCredentials", () => {
+      it("should list all credentials for user", async () => {
+        // Ensure we have at least one credential
+        await setCredential(testUserId, "LIST_TEST_KEY", "value");
+
+        const result = await listCredentials(testUserId);
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result.some((c) => c.name === "LIST_TEST_KEY")).toBe(true);
+      });
+
+      it("should return empty array for user without scope", async () => {
+        const result = await listCredentials("nonexistent-user-12345");
+        expect(result).toEqual([]);
+      });
+
+      it("should not return credential values", async () => {
+        const result = await listCredentials(testUserId);
+
+        for (const credential of result) {
+          expect(credential).not.toHaveProperty("value");
+          expect(credential).not.toHaveProperty("encryptedValue");
+        }
+      });
+    });
+
+    describe("getCredential", () => {
+      it("should return credential metadata", async () => {
+        await setCredential(testUserId, "GET_TEST_KEY", "secret-value");
+
+        const credential = await getCredential(testUserId, "GET_TEST_KEY");
+
+        expect(credential).toBeDefined();
+        expect(credential!.name).toBe("GET_TEST_KEY");
+        expect(credential).not.toHaveProperty("value");
+      });
+
+      it("should return null for nonexistent credential", async () => {
+        const credential = await getCredential(
+          testUserId,
+          "NONEXISTENT_KEY_12345",
+        );
+        expect(credential).toBeNull();
+      });
+    });
+
+    describe("getCredentialValue", () => {
+      it("should return decrypted credential value", async () => {
+        const secretValue = "my-super-secret-value";
+        await setCredential(testUserId, "VALUE_TEST_KEY", secretValue);
+
+        const value = await getCredentialValue(testScopeId, "VALUE_TEST_KEY");
+
+        expect(value).toBe(secretValue);
+      });
+
+      it("should return null for nonexistent credential", async () => {
+        const value = await getCredentialValue(
+          testScopeId,
+          "NONEXISTENT_KEY_12345",
+        );
+        expect(value).toBeNull();
+      });
+    });
+
+    describe("getCredentialValues", () => {
+      it("should return all credential values as a map", async () => {
+        await setCredential(testUserId, "BATCH_KEY_1", "value1");
+        await setCredential(testUserId, "BATCH_KEY_2", "value2");
+
+        const values = await getCredentialValues(testScopeId);
+
+        expect(values.BATCH_KEY_1).toBe("value1");
+        expect(values.BATCH_KEY_2).toBe("value2");
+      });
+    });
+
+    describe("deleteCredential", () => {
+      it("should delete credential successfully", async () => {
+        await setCredential(testUserId, "DELETE_TEST_KEY", "value");
+
+        await deleteCredential(testUserId, "DELETE_TEST_KEY");
+
+        const credential = await getCredential(testUserId, "DELETE_TEST_KEY");
+        expect(credential).toBeNull();
+      });
+
+      it("should throw NotFoundError for nonexistent credential", async () => {
+        await expect(
+          deleteCredential(testUserId, "NONEXISTENT_DELETE_KEY"),
+        ).rejects.toThrow(NotFoundError);
+      });
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/credential/credential-service.ts
+++ b/turbo/apps/web/src/lib/credential/credential-service.ts
@@ -1,0 +1,244 @@
+import { eq, and } from "drizzle-orm";
+import { credentials } from "../../db/schema/credential";
+import { encryptCredentialValue, decryptCredentialValue } from "../crypto";
+import { BadRequestError, NotFoundError } from "../errors";
+import { logger } from "../logger";
+import { getUserScopeByClerkId } from "../scope/scope-service";
+
+const log = logger("service:credential");
+
+/**
+ * Credential name validation regex
+ * Rules:
+ * - 1-255 characters
+ * - uppercase letters, numbers, and underscores only
+ * - must start with a letter
+ */
+const NAME_REGEX = /^[A-Z][A-Z0-9_]*$/;
+
+/**
+ * Validate credential name format
+ */
+export function validateCredentialName(name: string): void {
+  if (name.length === 0 || name.length > 255) {
+    throw new BadRequestError(
+      "Credential name must be between 1 and 255 characters",
+    );
+  }
+
+  if (!NAME_REGEX.test(name)) {
+    throw new BadRequestError(
+      "Credential name must contain only uppercase letters, numbers, and underscores, and must start with a letter (e.g., MY_API_KEY)",
+    );
+  }
+}
+
+interface CredentialInfo {
+  id: string;
+  name: string;
+  description: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * List all credentials for a user's scope (metadata only, no values)
+ */
+export async function listCredentials(
+  clerkUserId: string,
+): Promise<CredentialInfo[]> {
+  const scope = await getUserScopeByClerkId(clerkUserId);
+  if (!scope) {
+    return [];
+  }
+
+  const result = await globalThis.services.db
+    .select({
+      id: credentials.id,
+      name: credentials.name,
+      description: credentials.description,
+      createdAt: credentials.createdAt,
+      updatedAt: credentials.updatedAt,
+    })
+    .from(credentials)
+    .where(eq(credentials.scopeId, scope.id))
+    .orderBy(credentials.name);
+
+  return result;
+}
+
+/**
+ * Get a credential by name for a user's scope (metadata only)
+ */
+export async function getCredential(
+  clerkUserId: string,
+  name: string,
+): Promise<CredentialInfo | null> {
+  const scope = await getUserScopeByClerkId(clerkUserId);
+  if (!scope) {
+    return null;
+  }
+
+  const result = await globalThis.services.db
+    .select({
+      id: credentials.id,
+      name: credentials.name,
+      description: credentials.description,
+      createdAt: credentials.createdAt,
+      updatedAt: credentials.updatedAt,
+    })
+    .from(credentials)
+    .where(and(eq(credentials.scopeId, scope.id), eq(credentials.name, name)))
+    .limit(1);
+
+  return result[0] ?? null;
+}
+
+/**
+ * Get decrypted credential value by name
+ * Used internally for variable expansion during agent execution
+ */
+export async function getCredentialValue(
+  scopeId: string,
+  name: string,
+): Promise<string | null> {
+  const result = await globalThis.services.db
+    .select({
+      encryptedValue: credentials.encryptedValue,
+    })
+    .from(credentials)
+    .where(and(eq(credentials.scopeId, scopeId), eq(credentials.name, name)))
+    .limit(1);
+
+  if (!result[0]) {
+    return null;
+  }
+
+  const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
+  return decryptCredentialValue(result[0].encryptedValue, encryptionKey);
+}
+
+/**
+ * Get all credential values for a scope as a map
+ * Used for batch credential resolution during variable expansion
+ */
+export async function getCredentialValues(
+  scopeId: string,
+): Promise<Record<string, string>> {
+  const result = await globalThis.services.db
+    .select({
+      name: credentials.name,
+      encryptedValue: credentials.encryptedValue,
+    })
+    .from(credentials)
+    .where(eq(credentials.scopeId, scopeId));
+
+  const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
+  const values: Record<string, string> = {};
+
+  for (const row of result) {
+    values[row.name] = decryptCredentialValue(
+      row.encryptedValue,
+      encryptionKey,
+    );
+  }
+
+  return values;
+}
+
+/**
+ * Create or update a credential (upsert)
+ */
+export async function setCredential(
+  clerkUserId: string,
+  name: string,
+  value: string,
+  description?: string,
+): Promise<CredentialInfo> {
+  validateCredentialName(name);
+
+  const scope = await getUserScopeByClerkId(clerkUserId);
+  if (!scope) {
+    throw new BadRequestError(
+      "You need to configure a scope first. Run `vm0 scope create` to set up your scope.",
+    );
+  }
+
+  const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
+  const encryptedValue = encryptCredentialValue(value, encryptionKey);
+
+  log.debug("setting credential", { scopeId: scope.id, name });
+
+  // Check if credential exists
+  const existing = await globalThis.services.db
+    .select({ id: credentials.id })
+    .from(credentials)
+    .where(and(eq(credentials.scopeId, scope.id), eq(credentials.name, name)))
+    .limit(1);
+
+  if (existing[0]) {
+    // Update existing credential
+    const [updated] = await globalThis.services.db
+      .update(credentials)
+      .set({
+        encryptedValue,
+        description: description ?? null,
+        updatedAt: new Date(),
+      })
+      .where(eq(credentials.id, existing[0].id))
+      .returning({
+        id: credentials.id,
+        name: credentials.name,
+        description: credentials.description,
+        createdAt: credentials.createdAt,
+        updatedAt: credentials.updatedAt,
+      });
+
+    log.debug("credential updated", { credentialId: updated!.id, name });
+    return updated!;
+  }
+
+  // Create new credential
+  const [created] = await globalThis.services.db
+    .insert(credentials)
+    .values({
+      scopeId: scope.id,
+      name,
+      encryptedValue,
+      description: description ?? null,
+    })
+    .returning({
+      id: credentials.id,
+      name: credentials.name,
+      description: credentials.description,
+      createdAt: credentials.createdAt,
+      updatedAt: credentials.updatedAt,
+    });
+
+  log.debug("credential created", { credentialId: created!.id, name });
+  return created!;
+}
+
+/**
+ * Delete a credential by name
+ */
+export async function deleteCredential(
+  clerkUserId: string,
+  name: string,
+): Promise<void> {
+  const scope = await getUserScopeByClerkId(clerkUserId);
+  if (!scope) {
+    throw new NotFoundError("Credential not found");
+  }
+
+  const result = await globalThis.services.db
+    .delete(credentials)
+    .where(and(eq(credentials.scopeId, scope.id), eq(credentials.name, name)))
+    .returning({ id: credentials.id });
+
+  if (result.length === 0) {
+    throw new NotFoundError(`Credential "${name}" not found`);
+  }
+
+  log.debug("credential deleted", { scopeId: scope.id, name });
+}

--- a/turbo/apps/web/src/lib/crypto/index.ts
+++ b/turbo/apps/web/src/lib/crypto/index.ts
@@ -1,1 +1,6 @@
-export { encryptSecretsMap, decryptSecretsMap } from "./secrets-encryption";
+export {
+  encryptSecretsMap,
+  decryptSecretsMap,
+  encryptCredentialValue,
+  decryptCredentialValue,
+} from "./secrets-encryption";

--- a/turbo/apps/web/src/lib/crypto/secrets-encryption.ts
+++ b/turbo/apps/web/src/lib/crypto/secrets-encryption.ts
@@ -218,3 +218,96 @@ export function decryptSecretsMap(
 
   return JSON.parse(decrypted.toString("utf8"));
 }
+
+/**
+ * Encrypt a single credential value using AES-256-GCM
+ * Returns base64-encoded ciphertext in format: iv:authTag:encryptedData
+ */
+export function encryptCredentialValue(
+  value: string,
+  encryptionKey: string | undefined,
+): string {
+  if (!encryptionKey) {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error("SECRETS_ENCRYPTION_KEY must be set in production");
+    }
+    log.debug(
+      "SECRETS_ENCRYPTION_KEY not configured, using unencrypted storage (dev mode)",
+    );
+    return JSON.stringify({ unencrypted: true, data: value });
+  }
+
+  const key = Buffer.from(encryptionKey, "hex");
+  if (key.length !== 32) {
+    throw new Error("SECRETS_ENCRYPTION_KEY must be 32 bytes (64 hex chars)");
+  }
+
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+
+  const encrypted = Buffer.concat([
+    cipher.update(value, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return [
+    iv.toString("base64"),
+    authTag.toString("base64"),
+    encrypted.toString("base64"),
+  ].join(":");
+}
+
+/**
+ * Decrypt a single credential value encrypted with AES-256-GCM
+ * Input format: iv:authTag:encryptedData (all base64)
+ */
+export function decryptCredentialValue(
+  encryptedData: string,
+  encryptionKey: string | undefined,
+): string {
+  // Check for unencrypted data (fallback when key not configured)
+  try {
+    const parsed = JSON.parse(encryptedData);
+    if (parsed.unencrypted === true) {
+      return parsed.data as string;
+    }
+  } catch {
+    // Not JSON, continue with decryption
+  }
+
+  if (!encryptionKey) {
+    throw new Error(
+      "SECRETS_ENCRYPTION_KEY not configured but encrypted data found",
+    );
+  }
+
+  const key = Buffer.from(encryptionKey, "hex");
+  if (key.length !== 32) {
+    throw new Error("SECRETS_ENCRYPTION_KEY must be 32 bytes (64 hex chars)");
+  }
+
+  const parts = encryptedData.split(":");
+  if (parts.length !== 3) {
+    throw new Error("Invalid encrypted credential format");
+  }
+
+  const [ivBase64, authTagBase64, dataBase64] = parts;
+  const iv = Buffer.from(ivBase64!, "base64");
+  const authTag = Buffer.from(authTagBase64!, "base64");
+  const encrypted = Buffer.from(dataBase64!, "base64");
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+  decipher.setAuthTag(authTag);
+
+  const decrypted = Buffer.concat([
+    decipher.update(encrypted),
+    decipher.final(),
+  ]);
+
+  return decrypted.toString("utf8");
+}

--- a/turbo/apps/web/src/lib/run/environment/expand-environment.ts
+++ b/turbo/apps/web/src/lib/run/environment/expand-environment.ts
@@ -124,7 +124,7 @@ export function expandEnvironmentFromCompose(
     );
     if (missingCredentials.length > 0) {
       throw new BadRequestError(
-        `Missing required credentials: ${missingCredentials.join(", ")}. Use 'vm0 credential set ${missingCredentials[0]}=<value>' to add them.`,
+        `Missing required credentials: ${missingCredentials.join(", ")}. Use 'vm0 experimental-credential set ${missingCredentials[0]} <value>' to add them.`,
       );
     }
 

--- a/turbo/packages/core/src/contracts/credentials.ts
+++ b/turbo/packages/core/src/contracts/credentials.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+/**
+ * Credential name validation
+ * Rules:
+ * - 1-255 characters
+ * - uppercase letters, numbers, and underscores only
+ * - must start with a letter
+ * Examples: MY_API_KEY, GITHUB_TOKEN, AWS_ACCESS_KEY_ID
+ */
+export const credentialNameSchema = z
+  .string()
+  .min(1, "Credential name is required")
+  .max(255, "Credential name must be at most 255 characters")
+  .regex(
+    /^[A-Z][A-Z0-9_]*$/,
+    "Credential name must contain only uppercase letters, numbers, and underscores, and must start with a letter (e.g., MY_API_KEY)",
+  );
+
+/**
+ * Credential metadata response (value is never returned)
+ */
+export const credentialResponseSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  description: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type CredentialResponse = z.infer<typeof credentialResponseSchema>;
+
+/**
+ * List credentials response
+ */
+export const credentialListResponseSchema = z.object({
+  credentials: z.array(credentialResponseSchema),
+});
+
+export type CredentialListResponse = z.infer<
+  typeof credentialListResponseSchema
+>;
+
+/**
+ * Set credential request (create or update)
+ */
+export const setCredentialRequestSchema = z.object({
+  name: credentialNameSchema,
+  value: z.string().min(1, "Credential value is required"),
+  description: z.string().max(1000).optional(),
+});
+
+export type SetCredentialRequest = z.infer<typeof setCredentialRequestSchema>;
+
+/**
+ * Credentials contract for /api/credentials
+ */
+export const credentialsMainContract = c.router({
+  /**
+   * GET /api/credentials
+   * List all credentials for the current user's scope (metadata only)
+   */
+  list: {
+    method: "GET",
+    path: "/api/credentials",
+    responses: {
+      200: credentialListResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "List all credentials (metadata only)",
+  },
+
+  /**
+   * PUT /api/credentials
+   * Create or update a credential
+   */
+  set: {
+    method: "PUT",
+    path: "/api/credentials",
+    body: setCredentialRequestSchema,
+    responses: {
+      200: credentialResponseSchema,
+      201: credentialResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Create or update a credential",
+  },
+});
+
+export type CredentialsMainContract = typeof credentialsMainContract;
+
+/**
+ * Credentials by name contract for /api/credentials/[name]
+ */
+export const credentialsByNameContract = c.router({
+  /**
+   * GET /api/credentials/:name
+   * Get a credential by name (metadata only)
+   */
+  get: {
+    method: "GET",
+    path: "/api/credentials/:name",
+    pathParams: z.object({
+      name: credentialNameSchema,
+    }),
+    responses: {
+      200: credentialResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get credential metadata by name",
+  },
+
+  /**
+   * DELETE /api/credentials/:name
+   * Delete a credential by name
+   */
+  delete: {
+    method: "DELETE",
+    path: "/api/credentials/:name",
+    pathParams: z.object({
+      name: credentialNameSchema,
+    }),
+    responses: {
+      204: z.undefined(),
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Delete a credential",
+  },
+});
+
+export type CredentialsByNameContract = typeof credentialsByNameContract;

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -163,6 +163,19 @@ export {
   type UpdateScopeRequest,
 } from "./scopes";
 export {
+  credentialsMainContract,
+  credentialsByNameContract,
+  credentialNameSchema,
+  credentialResponseSchema,
+  credentialListResponseSchema,
+  setCredentialRequestSchema,
+  type CredentialsMainContract,
+  type CredentialsByNameContract,
+  type CredentialResponse,
+  type CredentialListResponse,
+  type SetCredentialRequest,
+} from "./credentials";
+export {
   sessionsByIdContract,
   checkpointsByIdContract,
   sessionResponseSchema,


### PR DESCRIPTION
## Summary
- Update error messages and hints to use the new `vm0 experimental-credential` command name
- Fixed 2 locations:
  - `list.ts`: Empty state hint message
  - `expand-environment.ts`: Missing credentials error message

## Test plan
- [x] Run `vm0 experimental-credential list` with no credentials - should show correct hint
- [x] Run agent with missing credentials - should show correct error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)