### PR TITLE
perf(turbo): exclude test files from build inputs

### DIFF
--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -34,7 +34,17 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        ".env*",
+        "!**/__tests__/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.spec.ts",
+        "!**/*.spec.tsx",
+        "!**/vitest.config.ts",
+        "!**/src/test/**"
+      ],
       "outputs": [
         ".next/**",
         "!.next/cache/**",


### PR DESCRIPTION
## Summary

- Exclude test files from Turborepo build task inputs to prevent unnecessary E2E test runs in CI when only test files are modified

## Details

Previously, `$TURBO_DEFAULT$` included all git-tracked files, including test files. This meant that any test file change would:
1. Change the build hash for the affected package
2. Cascade to dependent packages (e.g., core → web → CLI)
3. Trigger `turbo-ignore` to detect changes
4. Run full E2E test suite unnecessarily

This PR adds negative glob patterns to exclude:
- `**/__tests__/**` - Test directories
- `**/*.test.ts`, `**/*.test.tsx` - Test files
- `**/*.spec.ts`, `**/*.spec.tsx` - Spec files
- `**/vitest.config.ts` - Test configuration
- `**/src/test/**` - Test utility directories

## Test plan

- [x] Verified JSON is valid
- [x] Verified test files are excluded from build inputs (64 → 50 files for core)
- [x] Verified build hash is stable when only test files change
- [x] Verified build hash changes when source files change
- [x] Turbo accepts the configuration

🤖 Generated with [Claude Code](https://claude.ai/code)