### PR TITLE
fix: update credential hint messages to use experimental-credential command

### DIFF
--- a/turbo/apps/cli/src/commands/credential/list.ts
+++ b/turbo/apps/cli/src/commands/credential/list.ts
@@ -19,7 +19,9 @@ export const listCommand = new Command()
         console.log(chalk.dim("No credentials found."));
         console.log();
         console.log("To add a credential:");
-        console.log(chalk.cyan("  vm0 credential set MY_API_KEY <value>"));
+        console.log(
+          chalk.cyan("  vm0 experimental-credential set MY_API_KEY <value>"),
+        );
         return;
       }
 

--- a/turbo/apps/web/src/lib/run/environment/expand-environment.ts
+++ b/turbo/apps/web/src/lib/run/environment/expand-environment.ts
@@ -124,7 +124,7 @@ export function expandEnvironmentFromCompose(
     );
     if (missingCredentials.length > 0) {
       throw new BadRequestError(
-        `Missing required credentials: ${missingCredentials.join(", ")}. Use 'vm0 credential set ${missingCredentials[0]}=<value>' to add them.`,
+        `Missing required credentials: ${missingCredentials.join(", ")}. Use 'vm0 experimental-credential set ${missingCredentials[0]} <value>' to add them.`,
       );
     }
 


### PR DESCRIPTION
## Summary
- Updated hint message in CLI `list` command to use `vm0 experimental-credential set` instead of `vm0 credential set`
- Updated error message in environment expansion to use correct command format: `vm0 experimental-credential set <name> <value>` (space-separated, not `=`)

## Files changed
- `turbo/apps/cli/src/commands/credential/list.ts`
- `turbo/apps/web/src/lib/run/environment/expand-environment.ts`

## Test plan
- [x] Verified only 2 files changed
- [x] Pre-commit checks passed (lint, type-check, prettier, knip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)