### PR TITLE
fix(ci): add buildkit cache retry mechanism for runner deployment

### DIFF
--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -300,10 +300,18 @@
           }}
       tags: [prepare]
 
-    - name: Build rootfs
-      command: "{{ runner_base_dir }}/deploy-runner/build-rootfs.sh {{ rootfs_path }}"
+    - name: Build rootfs with retry on cache failure
       when: rootfs_needs_rebuild
       tags: [prepare]
+      block:
+        - name: Build rootfs
+          command: "{{ runner_base_dir }}/deploy-runner/build-rootfs.sh {{ rootfs_path }}"
+      rescue:
+        - name: Clear Docker buildkit cache after failure
+          command: docker builder prune -f
+
+        - name: Retry rootfs build after cache cleanup
+          command: "{{ runner_base_dir }}/deploy-runner/build-rootfs.sh {{ rootfs_path }}"
 
     - name: Store rootfs hash
       copy:

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,4 +1,5 @@
 // VM0 Runner - Self-hosted runner that polls the VM0 API server and executes agent jobs in isolated Firecracker microVMs
+// Deployment: Added buildkit cache retry mechanism (issue #1328)
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { doctorCommand } from "./commands/doctor.js";


### PR DESCRIPTION
## Summary

- Add block/rescue pattern to Ansible playbook for rootfs builds
- On first failure, clear Docker buildkit cache and retry
- Add comment to runner index.ts to trigger runner deployment in CI

## Problem

Runner deployment failed due to Docker buildkit cache corruption with error:
```
ERROR: failed to prepare extraction snapshot: parent snapshot does not exist: not found
```

This occurs when builds are interrupted (CI timeout, cancellation) leaving corrupted cache layers.

## Solution

Implement **Approach A: Reactive Recovery** from the deep-dive analysis:
1. First build attempt uses cache (fast path)
2. On failure, clear buildkit cache with `docker builder prune -f`
3. Retry build (will be slower but guaranteed clean)

## Changes

| File | Change |
|------|--------|
| `ansible/playbooks/deploy-runner.yml` | Add block/rescue around rootfs build task |
| `turbo/apps/runner/src/index.ts` | Add comment to trigger runner deployment |

## Test plan

- [ ] Verify normal builds complete on first try using cache
- [ ] Verify corrupted cache scenario: build fails, clears cache, retries, succeeds
- [ ] Verify real build errors fail on both attempts with actual error

Closes #1328

---
🤖 Generated with [Claude Code](https://claude.ai/code)