### PR TITLE
refactor(runner): rename job id terminology to run id

### DIFF
--- a/turbo/apps/runner/src/commands/kill.ts
+++ b/turbo/apps/runner/src/commands/kill.ts
@@ -31,7 +31,7 @@ interface CleanupResult {
 }
 
 export const killCommand = new Command("kill")
-  .description("Force terminate a job and clean up all resources")
+  .description("Force terminate a run and clean up all resources")
   .argument("<run-id>", "Run ID (full UUID or short 8-char vmId)")
   .option("--config <path>", "Config file path", "./runner.yaml")
   .option("--force", "Skip confirmation prompt")
@@ -49,7 +49,7 @@ export const killCommand = new Command("kill")
         // Resolve run ID
         const { vmId, runId } = resolveRunId(runIdArg, statusFilePath);
 
-        console.log(`Killing job ${vmId}...`);
+        console.log(`Killing run ${vmId}...`);
 
         // Find resources
         const proc = findProcessByVmId(vmId);
@@ -185,10 +185,10 @@ export const killCommand = new Command("kill")
 
         console.log("");
         if (allSuccess) {
-          console.log(`Job ${vmId} killed successfully.`);
+          console.log(`Run ${vmId} killed successfully.`);
           process.exit(0);
         } else {
-          console.log(`Job ${vmId} cleanup completed with errors.`);
+          console.log(`Run ${vmId} cleanup completed with errors.`);
           process.exit(1);
         }
       } catch (error) {

--- a/turbo/apps/runner/src/commands/kill.ts
+++ b/turbo/apps/runner/src/commands/kill.ts
@@ -18,8 +18,8 @@ import { deleteTapDevice } from "../lib/firecracker/network.js";
 
 interface RunnerStatus {
   mode: string;
-  active_jobs: number;
-  active_job_ids: string[];
+  active_runs: number;
+  active_run_ids: string[];
   started_at: string;
   updated_at: string;
 }
@@ -32,12 +32,12 @@ interface CleanupResult {
 
 export const killCommand = new Command("kill")
   .description("Force terminate a job and clean up all resources")
-  .argument("<job-id>", "Job ID (full runId UUID or short 8-char vmId)")
+  .argument("<run-id>", "Run ID (full UUID or short 8-char vmId)")
   .option("--config <path>", "Config file path", "./runner.yaml")
   .option("--force", "Skip confirmation prompt")
   .action(
     async (
-      jobId: string,
+      runIdArg: string,
       options: { config: string; force?: boolean },
     ): Promise<void> => {
       try {
@@ -46,8 +46,8 @@ export const killCommand = new Command("kill")
         const statusFilePath = join(configDir, "status.json");
         const workspacesDir = join(configDir, "workspaces");
 
-        // Resolve job ID
-        const { vmId, runId } = resolveJobId(jobId, statusFilePath);
+        // Resolve run ID
+        const { vmId, runId } = resolveRunId(runIdArg, statusFilePath);
 
         console.log(`Killing job ${vmId}...`);
 
@@ -147,17 +147,17 @@ export const killCommand = new Command("kill")
             const status: RunnerStatus = JSON.parse(
               readFileSync(statusFilePath, "utf-8"),
             ) as RunnerStatus;
-            const oldCount = status.active_jobs;
-            status.active_job_ids = status.active_job_ids.filter(
-              (id) => id !== runId,
+            const oldCount = status.active_runs;
+            status.active_run_ids = status.active_run_ids.filter(
+              (id: string) => id !== runId,
             );
-            status.active_jobs = status.active_job_ids.length;
+            status.active_runs = status.active_run_ids.length;
             status.updated_at = new Date().toISOString();
             writeFileSync(statusFilePath, JSON.stringify(status, null, 2));
             results.push({
               step: "status.json",
               success: true,
-              message: `Updated (active_jobs: ${oldCount} -> ${status.active_jobs})`,
+              message: `Updated (active_runs: ${oldCount} -> ${status.active_runs})`,
             });
           } catch (error) {
             results.push({
@@ -200,7 +200,7 @@ export const killCommand = new Command("kill")
     },
   );
 
-function resolveJobId(
+function resolveRunId(
   input: string,
   statusFilePath: string,
 ): { vmId: string; runId: string | null } {
@@ -214,7 +214,9 @@ function resolveJobId(
       const status: RunnerStatus = JSON.parse(
         readFileSync(statusFilePath, "utf-8"),
       ) as RunnerStatus;
-      const match = status.active_job_ids.find((id) => id.startsWith(input));
+      const match = status.active_run_ids.find((id: string) =>
+        id.startsWith(input),
+      );
       if (match) {
         return { vmId: input, runId: match };
       }

--- a/turbo/apps/runner/src/commands/start.ts
+++ b/turbo/apps/runner/src/commands/start.ts
@@ -40,8 +40,8 @@ type RunnerMode = "running" | "draining" | "stopped";
 
 interface RunnerStatus {
   mode: RunnerMode;
-  active_jobs: number;
-  active_job_ids: string[];
+  active_runs: number;
+  active_run_ids: string[];
   started_at: string;
   updated_at: string;
 }
@@ -57,8 +57,8 @@ function writeStatusFile(
 ): void {
   const status: RunnerStatus = {
     mode,
-    active_jobs: activeJobs.size,
-    active_job_ids: Array.from(activeJobs),
+    active_runs: activeJobs.size,
+    active_run_ids: Array.from(activeJobs),
     started_at: startedAt.toISOString(),
     updated_at: new Date().toISOString(),
   };

--- a/turbo/apps/runner/src/commands/start.ts
+++ b/turbo/apps/runner/src/commands/start.ts
@@ -32,8 +32,8 @@ import {
   shutdownMetrics,
 } from "../lib/metrics/index.js";
 
-// Track active jobs for concurrency management
-const activeJobs = new Set<string>();
+// Track active runs for concurrency management
+const activeRuns = new Set<string>();
 
 // Runner mode for maintenance/drain support
 type RunnerMode = "running" | "draining" | "stopped";
@@ -57,8 +57,8 @@ function writeStatusFile(
 ): void {
   const status: RunnerStatus = {
     mode,
-    active_runs: activeJobs.size,
-    active_run_ids: Array.from(activeJobs),
+    active_runs: activeRuns.size,
+    active_run_ids: Array.from(activeRuns),
     started_at: startedAt.toISOString(),
     updated_at: new Date().toISOString(),
   };
@@ -239,7 +239,7 @@ export const startCommand = new Command("start")
         if (state.mode === "running") {
           console.log("\n[Maintenance] Entering drain mode...");
           console.log(
-            `[Maintenance] Active jobs: ${activeJobs.size} (will wait for completion)`,
+            `[Maintenance] Active jobs: ${activeRuns.size} (will wait for completion)`,
           );
           state.mode = "draining";
           updateStatus();
@@ -253,7 +253,7 @@ export const startCommand = new Command("start")
       while (running) {
         // In drain mode, don't poll for new jobs - just wait for active jobs to complete
         if (state.mode === "draining") {
-          if (activeJobs.size === 0) {
+          if (activeRuns.size === 0) {
             console.log("[Maintenance] All jobs completed, exiting drain mode");
             running = false;
             break;
@@ -267,7 +267,7 @@ export const startCommand = new Command("start")
         }
 
         // Check concurrency limit - skip poll if at capacity
-        if (activeJobs.size >= config.sandbox.max_concurrent) {
+        if (activeRuns.size >= config.sandbox.max_concurrent) {
           // Wait for any job to complete before polling again
           if (jobPromises.size > 0) {
             await Promise.race(jobPromises);
@@ -301,7 +301,7 @@ export const startCommand = new Command("start")
             console.log(`Claimed job: ${context.runId}`);
 
             // Track and execute in background
-            activeJobs.add(context.runId);
+            activeRuns.add(context.runId);
             updateStatus(); // Update status when job starts
 
             const jobPromise: Promise<void> = executeJob(context, config)
@@ -312,7 +312,7 @@ export const startCommand = new Command("start")
                 );
               })
               .finally(() => {
-                activeJobs.delete(context.runId);
+                activeRuns.delete(context.runId);
                 jobPromises.delete(jobPromise);
                 updateStatus(); // Update status when job completes
               });


### PR DESCRIPTION
## Summary

- Rename RunnerStatus fields: `active_jobs` to `active_runs`, `active_job_ids` to `active_run_ids`
- Update kill command: `<job-id>` arg to `<run-id>`, `resolveJobId()` to `resolveRunId()`
- Update doctor command: show full run id (no truncation), Jobs to Runs section
- Update warning messages to use "Run" instead of "Job"

## Test plan

- [x] Type check passes
- [x] Tests pass (156 tests)
- [x] Lint passes
- [ ] Verify doctor shows full runId
- [ ] Verify kill command works with both full UUID and short vmId
- [ ] Verify status.json uses new field names

## Breaking Change

`status.json` format changes:
```json
// Before
{ "active_jobs": 1, "active_job_ids": ["uuid..."] }

// After
{ "active_runs": 1, "active_run_ids": ["uuid..."] }
```

Closes #1354

🤖 Generated with [Claude Code](https://claude.com/claude-code)