### PR TITLE
test: fix ap-4 violation in proxy-manager test by removing internal vm-registry mock

### DIFF
--- a/turbo/apps/runner/src/lib/proxy/__tests__/proxy-manager.test.ts
+++ b/turbo/apps/runner/src/lib/proxy/__tests__/proxy-manager.test.ts
@@ -6,13 +6,6 @@ import { ProxyManager, DEFAULT_PROXY_CONFIG } from "../proxy-manager";
 // Mock modules
 vi.mock("fs");
 vi.mock("child_process");
-vi.mock("../vm-registry", () => ({
-  getVMRegistry: vi.fn(() => ({
-    register: vi.fn(),
-    unregister: vi.fn(),
-  })),
-  DEFAULT_REGISTRY_PATH: "/tmp/vm0-vm-registry.json",
-}));
 
 describe("ProxyManager", () => {
   let proxyManager: ProxyManager;


### PR DESCRIPTION
## Summary

- Remove `vi.mock("../vm-registry")` from proxy-manager test
- Mock was unused since tests don't exercise `ProxyManager.start()` method
- Violates AP-4 (mocking internal code) testing principle
- All 11 tests continue to pass

## Test Plan

- ✅ Verified all proxy-manager tests pass after removing mock
- ✅ Ran: `pnpm --filter @vm0/runner test src/lib/proxy/__tests__/proxy-manager.test.ts`
- ✅ Result: 11 tests passed

## Related

Fixes #1362 (Phase 3 AP-4 review task)
Parent issue: #1335

🤖 Generated with [Claude Code](https://claude.com/claude-code)