### PR TITLE
test(runner): trigger CI to verify active_runs fix

### DIFF
--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,5 +1,5 @@
-// VM0 Runner - Self-hosted runner that polls the VM0 API server and executes agent jobs in isolated Firecracker microVMs
-// Deployment: Added buildkit cache retry mechanism (issue #1328)
+// VM0 Runner - Self-hosted runner that polls the VM0 API server and executes agent runs in isolated Firecracker microVMs
+// Deployment: Verify active_runs fix in Ansible playbook (#1363)
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { doctorCommand } from "./commands/doctor.js";


### PR DESCRIPTION
## Summary
- Trigger runner deployment CI to verify the active_runs Ansible fix from PR #1363 works correctly
- This is a test PR to confirm the drain script now properly reads `active_runs` from status.json

## Test plan
- [ ] Runner CI pipeline should pass (deploy-runner-prepare, deploy-runner-start, etc.)
- [ ] Drain script should successfully read `active_runs` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)