### PR TITLE
test: migrate cli and runner tests to msw

### DIFF
--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -28,22 +28,23 @@
     "@ts-rest/core": "3.53.0-rc.1",
     "@vm0/core": "workspace:*",
     "chalk": "^5.6.0",
-    "zod": "^4.1.12",
     "commander": "^14.0.0",
     "dotenv": "^17.2.1",
     "prompts": "^2.4.2",
     "tar": "^7.5.2",
-    "yaml": "^2.3.4"
+    "yaml": "^2.3.4",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
-    "oxlint": "^1.14.0",
     "@types/prompts": "^2.4.9",
     "@types/tar": "^6.1.13",
     "@vm0/eslint-config": "workspace:*",
     "@vm0/typescript-config": "workspace:*",
     "eslint": "^9.34.0",
     "json": "^11.0.0",
+    "msw": "^2.12.7",
+    "oxlint": "^1.14.0",
     "tsup": "^8.5.0",
     "typescript": "5.9.2",
     "vitest": "^3.2.4"

--- a/turbo/apps/cli/src/lib/api/__tests__/api-client.test.ts
+++ b/turbo/apps/cli/src/lib/api/__tests__/api-client.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
 import { apiClient } from "../api-client";
 import * as config from "../config";
 
@@ -8,31 +10,13 @@ vi.mock("../config", () => ({
   getToken: vi.fn(),
 }));
 
-/**
- * Create a mock Response that ts-rest can work with
- * ts-rest needs headers.get() to read content-type
- */
-function createMockResponse(body: unknown, status: number) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    headers: new Headers({ "content-type": "application/json" }),
-    json: async () => body,
-  } as Response;
-}
-
 describe("ApiClient", () => {
-  const mockFetch = vi.fn();
-  const originalFetch = global.fetch;
-
   beforeEach(() => {
-    global.fetch = mockFetch;
     vi.mocked(config.getApiUrl).mockResolvedValue("http://localhost:3000");
     vi.mocked(config.getToken).mockResolvedValue("test-token");
   });
 
   afterEach(() => {
-    global.fetch = originalFetch;
     vi.clearAllMocks();
   });
 
@@ -45,21 +29,21 @@ describe("ApiClient", () => {
         action: "created" as const,
       };
 
-      mockFetch.mockResolvedValue(createMockResponse(mockResponse, 201));
+      let capturedRequest: Request | undefined;
+      server.use(
+        http.post("http://localhost:3000/api/agent/composes", async ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json(mockResponse, { status: 201 });
+        }),
+      );
 
       const result = await apiClient.createOrUpdateCompose({
         content: mockConfig,
       });
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        "http://localhost:3000/api/agent/composes",
-        expect.objectContaining({
-          method: "POST",
-          headers: expect.objectContaining({
-            authorization: "Bearer test-token",
-          }),
-        }),
-      );
+      expect(capturedRequest?.url).toBe("http://localhost:3000/api/agent/composes");
+      expect(capturedRequest?.method).toBe("POST");
+      expect(capturedRequest?.headers.get("authorization")).toBe("Bearer test-token");
 
       expect(result).toEqual(mockResponse);
     });
@@ -72,7 +56,11 @@ describe("ApiClient", () => {
         createdAt: "2025-01-01T00:00:00Z",
       };
 
-      mockFetch.mockResolvedValue(createMockResponse(mockResponse, 201));
+      server.use(
+        http.post("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockResponse, { status: 201 });
+        }),
+      );
 
       const result = await apiClient.createOrUpdateCompose({
         content: { version: "1", agents: { main: { provider: "claude" } } },
@@ -91,7 +79,11 @@ describe("ApiClient", () => {
         updatedAt: "2025-01-01T00:00:00Z",
       };
 
-      mockFetch.mockResolvedValue(createMockResponse(mockResponse, 200));
+      server.use(
+        http.post("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockResponse, { status: 200 });
+        }),
+      );
 
       const result = await apiClient.createOrUpdateCompose({
         content: { version: "1", agents: { main: { provider: "claude" } } },
@@ -121,13 +113,15 @@ describe("ApiClient", () => {
     });
 
     it("should throw error on HTTP error response", async () => {
-      mockFetch.mockResolvedValue(
-        createMockResponse(
-          {
-            error: { message: "Invalid compose", code: "INVALID_COMPOSE" },
-          },
-          400,
-        ),
+      server.use(
+        http.post("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(
+            {
+              error: { message: "Invalid compose", code: "INVALID_COMPOSE" },
+            },
+            { status: 400 },
+          );
+        }),
       );
 
       await expect(
@@ -138,13 +132,15 @@ describe("ApiClient", () => {
     });
 
     it("should throw default error message when API error has no message", async () => {
-      mockFetch.mockResolvedValue(
-        createMockResponse(
-          {
-            error: { message: "", code: "ERROR" },
-          },
-          400,
-        ),
+      server.use(
+        http.post("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(
+            {
+              error: { message: "", code: "ERROR" },
+            },
+            { status: 400 },
+          );
+        }),
       );
 
       await expect(
@@ -168,21 +164,20 @@ describe("ApiClient", () => {
         createdAt: "2025-01-01T00:00:00Z",
       };
 
-      mockFetch.mockResolvedValue(createMockResponse(mockResponse, 201));
+      let capturedRequest: Request | undefined;
+      server.use(
+        http.post("http://localhost:3000/api/agent/runs", async ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json(mockResponse, { status: 201 });
+        }),
+      );
 
       const result = await apiClient.createRun(mockRequest);
 
-      // Verify fetch was called with correct URL and headers
-      expect(mockFetch).toHaveBeenCalledWith(
-        "http://localhost:3000/api/agent/runs",
-        expect.objectContaining({
-          method: "POST",
-          headers: expect.objectContaining({
-            authorization: "Bearer test-token",
-            "content-type": "application/json",
-          }),
-        }),
-      );
+      expect(capturedRequest?.url).toBe("http://localhost:3000/api/agent/runs");
+      expect(capturedRequest?.method).toBe("POST");
+      expect(capturedRequest?.headers.get("authorization")).toBe("Bearer test-token");
+      expect(capturedRequest?.headers.get("content-type")).toBe("application/json");
 
       expect(result).toEqual(mockResponse);
     });
@@ -195,25 +190,25 @@ describe("ApiClient", () => {
         artifactName: "my-artifact",
       };
 
-      mockFetch.mockResolvedValue(
-        createMockResponse(
-          {
-            runId: "run-456",
-            status: "pending",
-            createdAt: "2025-01-01T00:00:00Z",
-          },
-          201,
-        ),
+      let capturedRequest: Request | undefined;
+      server.use(
+        http.post("http://localhost:3000/api/agent/runs", async ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json(
+            {
+              runId: "run-456",
+              status: "pending",
+              createdAt: "2025-01-01T00:00:00Z",
+            },
+            { status: 201 },
+          );
+        }),
       );
 
       await apiClient.createRun(mockRequest);
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          body: JSON.stringify(mockRequest),
-        }),
-      );
+      const body = await capturedRequest?.text();
+      expect(body).toBe(JSON.stringify(mockRequest));
     });
 
     it("should return completed run response", async () => {
@@ -226,7 +221,11 @@ describe("ApiClient", () => {
         createdAt: "2025-01-01T00:00:00Z",
       };
 
-      mockFetch.mockResolvedValue(createMockResponse(mockResponse, 201));
+      server.use(
+        http.post("http://localhost:3000/api/agent/runs", () => {
+          return HttpResponse.json(mockResponse, { status: 201 });
+        }),
+      );
 
       const result = await apiClient.createRun({
         agentComposeId: "cmp-123",
@@ -247,7 +246,11 @@ describe("ApiClient", () => {
         createdAt: "2025-01-01T00:00:00Z",
       };
 
-      mockFetch.mockResolvedValue(createMockResponse(mockResponse, 201));
+      server.use(
+        http.post("http://localhost:3000/api/agent/runs", () => {
+          return HttpResponse.json(mockResponse, { status: 201 });
+        }),
+      );
 
       const result = await apiClient.createRun({
         agentComposeId: "cmp-123",
@@ -284,11 +287,13 @@ describe("ApiClient", () => {
     });
 
     it("should throw error on HTTP error response", async () => {
-      mockFetch.mockResolvedValue(
-        createMockResponse(
-          { error: { message: "Compose not found", code: "NOT_FOUND" } },
-          404,
-        ),
+      server.use(
+        http.post("http://localhost:3000/api/agent/runs", () => {
+          return HttpResponse.json(
+            { error: { message: "Compose not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
       );
 
       await expect(
@@ -301,8 +306,10 @@ describe("ApiClient", () => {
     });
 
     it("should throw default error message when API error has no message", async () => {
-      mockFetch.mockResolvedValue(
-        createMockResponse({ error: { message: "", code: "ERROR" } }, 400),
+      server.use(
+        http.post("http://localhost:3000/api/agent/runs", () => {
+          return HttpResponse.json({ error: { message: "", code: "ERROR" } }, { status: 400 });
+        }),
       );
 
       await expect(
@@ -323,19 +330,21 @@ describe("ApiClient", () => {
         nextSequence: 0,
       };
 
-      mockFetch.mockResolvedValue(createMockResponse(mockResponse, 200));
+      let capturedRequest: Request | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", async ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json(mockResponse, { status: 200 });
+        }),
+      );
 
       const result = await apiClient.getEvents("run-123");
 
-      expect(mockFetch).toHaveBeenCalledWith(
+      expect(capturedRequest?.url).toBe(
         "http://localhost:3000/api/agent/runs/run-123/events?since=0&limit=100",
-        expect.objectContaining({
-          method: "GET",
-          headers: expect.objectContaining({
-            authorization: "Bearer test-token",
-          }),
-        }),
       );
+      expect(capturedRequest?.method).toBe("GET");
+      expect(capturedRequest?.headers.get("authorization")).toBe("Bearer test-token");
 
       expect(result).toEqual(mockResponse);
     });
@@ -354,13 +363,18 @@ describe("ApiClient", () => {
         nextSequence: 5,
       };
 
-      mockFetch.mockResolvedValue(createMockResponse(mockResponse, 200));
+      let capturedRequest: Request | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", async ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json(mockResponse, { status: 200 });
+        }),
+      );
 
       const result = await apiClient.getEvents("run-123", { since: 4 });
 
-      expect(mockFetch).toHaveBeenCalledWith(
+      expect(capturedRequest?.url).toBe(
         "http://localhost:3000/api/agent/runs/run-123/events?since=4&limit=100",
-        expect.any(Object),
       );
 
       expect(result.events).toHaveLength(1);
@@ -374,13 +388,18 @@ describe("ApiClient", () => {
         nextSequence: 0,
       };
 
-      mockFetch.mockResolvedValue(createMockResponse(mockResponse, 200));
+      let capturedRequest: Request | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", async ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json(mockResponse, { status: 200 });
+        }),
+      );
 
       await apiClient.getEvents("run-123", { limit: 50 });
 
-      expect(mockFetch).toHaveBeenCalledWith(
+      expect(capturedRequest?.url).toBe(
         "http://localhost:3000/api/agent/runs/run-123/events?since=0&limit=50",
-        expect.any(Object),
       );
     });
 
@@ -391,16 +410,21 @@ describe("ApiClient", () => {
         nextSequence: 150,
       };
 
-      mockFetch.mockResolvedValue(createMockResponse(mockResponse, 200));
+      let capturedRequest: Request | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", async ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json(mockResponse, { status: 200 });
+        }),
+      );
 
       const result = await apiClient.getEvents("run-123", {
         since: 100,
         limit: 50,
       });
 
-      expect(mockFetch).toHaveBeenCalledWith(
+      expect(capturedRequest?.url).toBe(
         "http://localhost:3000/api/agent/runs/run-123/events?since=100&limit=50",
-        expect.any(Object),
       );
 
       expect(result.hasMore).toBe(true);
@@ -427,7 +451,11 @@ describe("ApiClient", () => {
         nextSequence: 2,
       };
 
-      mockFetch.mockResolvedValue(createMockResponse(mockResponse, 200));
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+          return HttpResponse.json(mockResponse, { status: 200 });
+        }),
+      );
 
       const result = await apiClient.getEvents("run-123");
 
@@ -463,33 +491,33 @@ describe("ApiClient", () => {
     });
 
     it("should throw error on HTTP error response", async () => {
-      mockFetch.mockResolvedValue(
-        createMockResponse(
-          {
-            error: { message: "Run not found", code: "NOT_FOUND" },
-          },
-          404,
-        ),
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+          return HttpResponse.json(
+            {
+              error: { message: "Run not found", code: "NOT_FOUND" },
+            },
+            { status: 404 },
+          );
+        }),
       );
 
-      await expect(apiClient.getEvents("run-123")).rejects.toThrow(
-        "Run not found",
-      );
+      await expect(apiClient.getEvents("run-123")).rejects.toThrow("Run not found");
     });
 
     it("should throw default error message when API error has no message", async () => {
-      mockFetch.mockResolvedValue(
-        createMockResponse(
-          {
-            error: { message: "", code: "ERROR" },
-          },
-          500,
-        ),
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+          return HttpResponse.json(
+            {
+              error: { message: "", code: "ERROR" },
+            },
+            { status: 500 },
+          );
+        }),
       );
 
-      await expect(apiClient.getEvents("run-123")).rejects.toThrow(
-        "Failed to fetch events",
-      );
+      await expect(apiClient.getEvents("run-123")).rejects.toThrow("Failed to fetch events");
     });
   });
 
@@ -499,45 +527,51 @@ describe("ApiClient", () => {
       // ts-rest with jsonQuery automatically quotes these to prevent misinterpretation
       const scientificNotationVersion = "52999e37";
 
-      mockFetch.mockResolvedValue(
-        createMockResponse({ versionId: "full-hash-123" }, 200),
+      let capturedRequest: Request | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes/versions", async ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json({ versionId: "full-hash-123" }, { status: 200 });
+        }),
       );
 
-      await apiClient.getComposeVersion(
-        "compose-123",
-        scientificNotationVersion,
-      );
+      await apiClient.getComposeVersion("compose-123", scientificNotationVersion);
 
       // ts-rest quotes the value to prevent scientific notation parsing
       const expectedUrl = `http://localhost:3000/api/agent/composes/versions?composeId=compose-123&version=${encodeURIComponent(JSON.stringify(scientificNotationVersion))}`;
-      expect(mockFetch).toHaveBeenCalledWith(expectedUrl, expect.any(Object));
+      expect(capturedRequest?.url).toBe(expectedUrl);
     });
 
     it("should handle normal hex versions", async () => {
       const normalVersion = "a1b2c3d4";
 
-      mockFetch.mockResolvedValue(
-        createMockResponse({ versionId: "full-hash-456" }, 200),
+      let capturedRequest: Request | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes/versions", async ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json({ versionId: "full-hash-456" }, { status: 200 });
+        }),
       );
 
       await apiClient.getComposeVersion("compose-123", normalVersion);
 
       const expectedUrl = `http://localhost:3000/api/agent/composes/versions?composeId=compose-123&version=${normalVersion}`;
-      expect(mockFetch).toHaveBeenCalledWith(expectedUrl, expect.any(Object));
+      expect(capturedRequest?.url).toBe(expectedUrl);
     });
 
     it("should handle 'latest' tag", async () => {
-      mockFetch.mockResolvedValue(
-        createMockResponse(
-          { versionId: "head-version-id", tag: "latest" },
-          200,
-        ),
+      let capturedRequest: Request | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes/versions", async ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json({ versionId: "head-version-id", tag: "latest" }, { status: 200 });
+        }),
       );
 
       await apiClient.getComposeVersion("compose-123", "latest");
 
       const expectedUrl = `http://localhost:3000/api/agent/composes/versions?composeId=compose-123&version=latest`;
-      expect(mockFetch).toHaveBeenCalledWith(expectedUrl, expect.any(Object));
+      expect(capturedRequest?.url).toBe(expectedUrl);
     });
 
     it("should throw error when not authenticated", async () => {
@@ -549,18 +583,20 @@ describe("ApiClient", () => {
     });
 
     it("should throw error on version not found", async () => {
-      mockFetch.mockResolvedValue(
-        createMockResponse(
-          {
-            error: { message: "Version not found: abc123", code: "NOT_FOUND" },
-          },
-          404,
-        ),
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes/versions", () => {
+          return HttpResponse.json(
+            {
+              error: { message: "Version not found: abc123", code: "NOT_FOUND" },
+            },
+            { status: 404 },
+          );
+        }),
       );
 
-      await expect(
-        apiClient.getComposeVersion("compose-123", "abc123"),
-      ).rejects.toThrow("Version not found: abc123");
+      await expect(apiClient.getComposeVersion("compose-123", "abc123")).rejects.toThrow(
+        "Version not found: abc123",
+      );
     });
   });
 });

--- a/turbo/apps/cli/src/lib/api/__tests__/api-client.test.ts
+++ b/turbo/apps/cli/src/lib/api/__tests__/api-client.test.ts
@@ -31,19 +31,26 @@ describe("ApiClient", () => {
 
       let capturedRequest: Request | undefined;
       server.use(
-        http.post("http://localhost:3000/api/agent/composes", async ({ request }) => {
-          capturedRequest = request;
-          return HttpResponse.json(mockResponse, { status: 201 });
-        }),
+        http.post(
+          "http://localhost:3000/api/agent/composes",
+          async ({ request }) => {
+            capturedRequest = request;
+            return HttpResponse.json(mockResponse, { status: 201 });
+          },
+        ),
       );
 
       const result = await apiClient.createOrUpdateCompose({
         content: mockConfig,
       });
 
-      expect(capturedRequest?.url).toBe("http://localhost:3000/api/agent/composes");
+      expect(capturedRequest?.url).toBe(
+        "http://localhost:3000/api/agent/composes",
+      );
       expect(capturedRequest?.method).toBe("POST");
-      expect(capturedRequest?.headers.get("authorization")).toBe("Bearer test-token");
+      expect(capturedRequest?.headers.get("authorization")).toBe(
+        "Bearer test-token",
+      );
 
       expect(result).toEqual(mockResponse);
     });
@@ -166,18 +173,25 @@ describe("ApiClient", () => {
 
       let capturedRequest: Request | undefined;
       server.use(
-        http.post("http://localhost:3000/api/agent/runs", async ({ request }) => {
-          capturedRequest = request;
-          return HttpResponse.json(mockResponse, { status: 201 });
-        }),
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedRequest = request;
+            return HttpResponse.json(mockResponse, { status: 201 });
+          },
+        ),
       );
 
       const result = await apiClient.createRun(mockRequest);
 
       expect(capturedRequest?.url).toBe("http://localhost:3000/api/agent/runs");
       expect(capturedRequest?.method).toBe("POST");
-      expect(capturedRequest?.headers.get("authorization")).toBe("Bearer test-token");
-      expect(capturedRequest?.headers.get("content-type")).toBe("application/json");
+      expect(capturedRequest?.headers.get("authorization")).toBe(
+        "Bearer test-token",
+      );
+      expect(capturedRequest?.headers.get("content-type")).toBe(
+        "application/json",
+      );
 
       expect(result).toEqual(mockResponse);
     });
@@ -192,17 +206,20 @@ describe("ApiClient", () => {
 
       let capturedRequest: Request | undefined;
       server.use(
-        http.post("http://localhost:3000/api/agent/runs", async ({ request }) => {
-          capturedRequest = request;
-          return HttpResponse.json(
-            {
-              runId: "run-456",
-              status: "pending",
-              createdAt: "2025-01-01T00:00:00Z",
-            },
-            { status: 201 },
-          );
-        }),
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedRequest = request;
+            return HttpResponse.json(
+              {
+                runId: "run-456",
+                status: "pending",
+                createdAt: "2025-01-01T00:00:00Z",
+              },
+              { status: 201 },
+            );
+          },
+        ),
       );
 
       await apiClient.createRun(mockRequest);
@@ -308,7 +325,10 @@ describe("ApiClient", () => {
     it("should throw default error message when API error has no message", async () => {
       server.use(
         http.post("http://localhost:3000/api/agent/runs", () => {
-          return HttpResponse.json({ error: { message: "", code: "ERROR" } }, { status: 400 });
+          return HttpResponse.json(
+            { error: { message: "", code: "ERROR" } },
+            { status: 400 },
+          );
         }),
       );
 
@@ -332,10 +352,13 @@ describe("ApiClient", () => {
 
       let capturedRequest: Request | undefined;
       server.use(
-        http.get("http://localhost:3000/api/agent/runs/:id/events", async ({ request }) => {
-          capturedRequest = request;
-          return HttpResponse.json(mockResponse, { status: 200 });
-        }),
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/events",
+          async ({ request }) => {
+            capturedRequest = request;
+            return HttpResponse.json(mockResponse, { status: 200 });
+          },
+        ),
       );
 
       const result = await apiClient.getEvents("run-123");
@@ -344,7 +367,9 @@ describe("ApiClient", () => {
         "http://localhost:3000/api/agent/runs/run-123/events?since=0&limit=100",
       );
       expect(capturedRequest?.method).toBe("GET");
-      expect(capturedRequest?.headers.get("authorization")).toBe("Bearer test-token");
+      expect(capturedRequest?.headers.get("authorization")).toBe(
+        "Bearer test-token",
+      );
 
       expect(result).toEqual(mockResponse);
     });
@@ -365,10 +390,13 @@ describe("ApiClient", () => {
 
       let capturedRequest: Request | undefined;
       server.use(
-        http.get("http://localhost:3000/api/agent/runs/:id/events", async ({ request }) => {
-          capturedRequest = request;
-          return HttpResponse.json(mockResponse, { status: 200 });
-        }),
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/events",
+          async ({ request }) => {
+            capturedRequest = request;
+            return HttpResponse.json(mockResponse, { status: 200 });
+          },
+        ),
       );
 
       const result = await apiClient.getEvents("run-123", { since: 4 });
@@ -390,10 +418,13 @@ describe("ApiClient", () => {
 
       let capturedRequest: Request | undefined;
       server.use(
-        http.get("http://localhost:3000/api/agent/runs/:id/events", async ({ request }) => {
-          capturedRequest = request;
-          return HttpResponse.json(mockResponse, { status: 200 });
-        }),
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/events",
+          async ({ request }) => {
+            capturedRequest = request;
+            return HttpResponse.json(mockResponse, { status: 200 });
+          },
+        ),
       );
 
       await apiClient.getEvents("run-123", { limit: 50 });
@@ -412,10 +443,13 @@ describe("ApiClient", () => {
 
       let capturedRequest: Request | undefined;
       server.use(
-        http.get("http://localhost:3000/api/agent/runs/:id/events", async ({ request }) => {
-          capturedRequest = request;
-          return HttpResponse.json(mockResponse, { status: 200 });
-        }),
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/events",
+          async ({ request }) => {
+            capturedRequest = request;
+            return HttpResponse.json(mockResponse, { status: 200 });
+          },
+        ),
       );
 
       const result = await apiClient.getEvents("run-123", {
@@ -502,7 +536,9 @@ describe("ApiClient", () => {
         }),
       );
 
-      await expect(apiClient.getEvents("run-123")).rejects.toThrow("Run not found");
+      await expect(apiClient.getEvents("run-123")).rejects.toThrow(
+        "Run not found",
+      );
     });
 
     it("should throw default error message when API error has no message", async () => {
@@ -517,7 +553,9 @@ describe("ApiClient", () => {
         }),
       );
 
-      await expect(apiClient.getEvents("run-123")).rejects.toThrow("Failed to fetch events");
+      await expect(apiClient.getEvents("run-123")).rejects.toThrow(
+        "Failed to fetch events",
+      );
     });
   });
 
@@ -529,13 +567,22 @@ describe("ApiClient", () => {
 
       let capturedRequest: Request | undefined;
       server.use(
-        http.get("http://localhost:3000/api/agent/composes/versions", async ({ request }) => {
-          capturedRequest = request;
-          return HttpResponse.json({ versionId: "full-hash-123" }, { status: 200 });
-        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/versions",
+          async ({ request }) => {
+            capturedRequest = request;
+            return HttpResponse.json(
+              { versionId: "full-hash-123" },
+              { status: 200 },
+            );
+          },
+        ),
       );
 
-      await apiClient.getComposeVersion("compose-123", scientificNotationVersion);
+      await apiClient.getComposeVersion(
+        "compose-123",
+        scientificNotationVersion,
+      );
 
       // ts-rest quotes the value to prevent scientific notation parsing
       const expectedUrl = `http://localhost:3000/api/agent/composes/versions?composeId=compose-123&version=${encodeURIComponent(JSON.stringify(scientificNotationVersion))}`;
@@ -547,10 +594,16 @@ describe("ApiClient", () => {
 
       let capturedRequest: Request | undefined;
       server.use(
-        http.get("http://localhost:3000/api/agent/composes/versions", async ({ request }) => {
-          capturedRequest = request;
-          return HttpResponse.json({ versionId: "full-hash-456" }, { status: 200 });
-        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/versions",
+          async ({ request }) => {
+            capturedRequest = request;
+            return HttpResponse.json(
+              { versionId: "full-hash-456" },
+              { status: 200 },
+            );
+          },
+        ),
       );
 
       await apiClient.getComposeVersion("compose-123", normalVersion);
@@ -562,10 +615,16 @@ describe("ApiClient", () => {
     it("should handle 'latest' tag", async () => {
       let capturedRequest: Request | undefined;
       server.use(
-        http.get("http://localhost:3000/api/agent/composes/versions", async ({ request }) => {
-          capturedRequest = request;
-          return HttpResponse.json({ versionId: "head-version-id", tag: "latest" }, { status: 200 });
-        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/versions",
+          async ({ request }) => {
+            capturedRequest = request;
+            return HttpResponse.json(
+              { versionId: "head-version-id", tag: "latest" },
+              { status: 200 },
+            );
+          },
+        ),
       );
 
       await apiClient.getComposeVersion("compose-123", "latest");
@@ -587,16 +646,19 @@ describe("ApiClient", () => {
         http.get("http://localhost:3000/api/agent/composes/versions", () => {
           return HttpResponse.json(
             {
-              error: { message: "Version not found: abc123", code: "NOT_FOUND" },
+              error: {
+                message: "Version not found: abc123",
+                code: "NOT_FOUND",
+              },
             },
             { status: 404 },
           );
         }),
       );
 
-      await expect(apiClient.getComposeVersion("compose-123", "abc123")).rejects.toThrow(
-        "Version not found: abc123",
-      );
+      await expect(
+        apiClient.getComposeVersion("compose-123", "abc123"),
+      ).rejects.toThrow("Version not found: abc123");
     });
   });
 });

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from "msw";
+
+export const apiHandlers = [
+	// POST /api/agent/composes - createOrUpdateCompose
+	http.post("http://localhost:3000/api/agent/composes", () => {
+		return HttpResponse.json(
+			{ composeId: "default", name: "default", action: "created" },
+			{ status: 201 }
+		);
+	}),
+
+	// POST /api/agent/runs - createRun
+	http.post("http://localhost:3000/api/agent/runs", () => {
+		return HttpResponse.json(
+			{ runId: "default", status: "pending", createdAt: new Date().toISOString() },
+			{ status: 201 }
+		);
+	}),
+
+	// GET /api/agent/runs/:id/events - getEvents
+	http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+		return HttpResponse.json({ events: [], hasMore: false, nextSequence: 0 }, { status: 200 });
+	}),
+
+	// GET /api/agent/composes/versions - getComposeVersion
+	http.get("http://localhost:3000/api/agent/composes/versions", () => {
+		return HttpResponse.json({ versionId: "default" }, { status: 200 });
+	}),
+];

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -1,29 +1,36 @@
 import { http, HttpResponse } from "msw";
 
 export const apiHandlers = [
-	// POST /api/agent/composes - createOrUpdateCompose
-	http.post("http://localhost:3000/api/agent/composes", () => {
-		return HttpResponse.json(
-			{ composeId: "default", name: "default", action: "created" },
-			{ status: 201 }
-		);
-	}),
+  // POST /api/agent/composes - createOrUpdateCompose
+  http.post("http://localhost:3000/api/agent/composes", () => {
+    return HttpResponse.json(
+      { composeId: "default", name: "default", action: "created" },
+      { status: 201 },
+    );
+  }),
 
-	// POST /api/agent/runs - createRun
-	http.post("http://localhost:3000/api/agent/runs", () => {
-		return HttpResponse.json(
-			{ runId: "default", status: "pending", createdAt: new Date().toISOString() },
-			{ status: 201 }
-		);
-	}),
+  // POST /api/agent/runs - createRun
+  http.post("http://localhost:3000/api/agent/runs", () => {
+    return HttpResponse.json(
+      {
+        runId: "default",
+        status: "pending",
+        createdAt: new Date().toISOString(),
+      },
+      { status: 201 },
+    );
+  }),
 
-	// GET /api/agent/runs/:id/events - getEvents
-	http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
-		return HttpResponse.json({ events: [], hasMore: false, nextSequence: 0 }, { status: 200 });
-	}),
+  // GET /api/agent/runs/:id/events - getEvents
+  http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+    return HttpResponse.json(
+      { events: [], hasMore: false, nextSequence: 0 },
+      { status: 200 },
+    );
+  }),
 
-	// GET /api/agent/composes/versions - getComposeVersion
-	http.get("http://localhost:3000/api/agent/composes/versions", () => {
-		return HttpResponse.json({ versionId: "default" }, { status: 200 });
-	}),
+  // GET /api/agent/composes/versions - getComposeVersion
+  http.get("http://localhost:3000/api/agent/composes/versions", () => {
+    return HttpResponse.json({ versionId: "default" }, { status: 200 });
+  }),
 ];

--- a/turbo/apps/cli/src/mocks/handlers/index.ts
+++ b/turbo/apps/cli/src/mocks/handlers/index.ts
@@ -1,0 +1,3 @@
+import { apiHandlers } from "./api-handlers";
+
+export const handlers = [...apiHandlers];

--- a/turbo/apps/cli/src/mocks/server.ts
+++ b/turbo/apps/cli/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from "msw/node";
+import { handlers } from "./handlers/index";
+
+export const server = setupServer(...handlers);

--- a/turbo/apps/cli/src/test/setup.ts
+++ b/turbo/apps/cli/src/test/setup.ts
@@ -1,0 +1,11 @@
+import { server } from "../mocks/server";
+import { afterAll, afterEach, beforeAll } from "vitest";
+
+// Start MSW server before all tests
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+
+// Reset handlers after each test
+afterEach(() => server.resetHandlers());
+
+// Close server after all tests
+afterAll(() => server.close());

--- a/turbo/apps/cli/vitest.config.ts
+++ b/turbo/apps/cli/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    setupFiles: ["./src/test/setup.ts"],
   },
 });

--- a/turbo/apps/runner/package.json
+++ b/turbo/apps/runner/package.json
@@ -37,11 +37,12 @@
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
-    "oxlint": "^1.14.0",
     "@vm0/eslint-config": "workspace:*",
     "@vm0/typescript-config": "workspace:*",
     "eslint": "^9.34.0",
     "json": "^11.0.0",
+    "msw": "^2.12.7",
+    "oxlint": "^1.14.0",
     "tsup": "^8.5.0",
     "typescript": "5.9.2",
     "vitest": "^3.2.4"

--- a/turbo/apps/runner/src/lib/__tests__/executor-preflight.test.ts
+++ b/turbo/apps/runner/src/lib/__tests__/executor-preflight.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../mocks/server";
 import {
   runPreflightCheck,
   reportPreflightFailure,
@@ -187,56 +189,49 @@ describe("runPreflightCheck", () => {
 });
 
 describe("reportPreflightFailure", () => {
-  const originalFetch = global.fetch;
-
   beforeEach(() => {
     vi.clearAllMocks();
-    global.fetch = vi.fn();
-  });
-
-  afterEach(() => {
-    global.fetch = originalFetch;
   });
 
   it("calls complete API with correct parameters", async () => {
-    const mockFetch = global.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockResolvedValue({ ok: true });
+    let capturedRequest: Request | undefined;
+    server.use(
+      http.post("http://localhost:3000/api/webhooks/agent/complete", async ({ request }) => {
+        capturedRequest = request;
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    );
 
     await reportPreflightFailure(
-      "https://api.example.com",
+      "http://localhost:3000",
       "run-123",
       "token-456",
       "Test error message",
     );
 
-    expect(mockFetch).toHaveBeenCalledOnce();
-    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(capturedRequest?.url).toBe("http://localhost:3000/api/webhooks/agent/complete");
+    expect(capturedRequest?.method).toBe("POST");
+    expect(capturedRequest?.headers.get("Content-Type")).toBe("application/json");
+    expect(capturedRequest?.headers.get("Authorization")).toBe("Bearer token-456");
 
-    expect(url).toBe("https://api.example.com/api/webhooks/agent/complete");
-    expect(options.method).toBe("POST");
-    expect(options.headers).toEqual({
-      "Content-Type": "application/json",
-      Authorization: "Bearer token-456",
+    const body = await capturedRequest?.json();
+    expect(body).toEqual({
+      runId: "run-123",
+      exitCode: 1,
+      error: "Test error message",
     });
-
-    const body = JSON.parse(options.body as string);
-    expect(body.runId).toBe("run-123");
-    expect(body.exitCode).toBe(1);
-    expect(body.error).toBe("Test error message");
   });
 
   it("logs error when API returns non-ok response", async () => {
-    const mockFetch = global.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+    server.use(
+      http.post("http://localhost:3000/api/webhooks/agent/complete", () => {
+        return HttpResponse.json({}, { status: 500 });
+      }),
+    );
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    await reportPreflightFailure(
-      "https://api.example.com",
-      "run-123",
-      "token-456",
-      "Test error",
-    );
+    await reportPreflightFailure("http://localhost:3000", "run-123", "token-456", "Test error");
 
     expect(consoleSpy).toHaveBeenCalledWith(
       "[Executor] Failed to report preflight failure: HTTP 500",
@@ -246,65 +241,64 @@ describe("reportPreflightFailure", () => {
   });
 
   it("logs error when fetch throws", async () => {
-    const mockFetch = global.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockRejectedValue(new Error("Network error"));
+    server.use(
+      http.post("http://localhost:3000/api/webhooks/agent/complete", () => {
+        return HttpResponse.error();
+      }),
+    );
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    await reportPreflightFailure(
-      "https://api.example.com",
-      "run-123",
-      "token-456",
-      "Test error",
-    );
+    await reportPreflightFailure("http://localhost:3000", "run-123", "token-456", "Test error");
 
     expect(consoleSpy).toHaveBeenCalledWith(
-      "[Executor] Failed to report preflight failure: Error: Network error",
+      "[Executor] Failed to report preflight failure: TypeError: Failed to fetch",
     );
 
     consoleSpy.mockRestore();
   });
 
   it("includes Vercel bypass header when bypassSecret is provided", async () => {
-    const mockFetch = global.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockResolvedValue({ ok: true });
+    let capturedRequest: Request | undefined;
+    server.use(
+      http.post("http://localhost:3000/api/webhooks/agent/complete", async ({ request }) => {
+        capturedRequest = request;
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    );
 
     await reportPreflightFailure(
-      "https://api.example.com",
+      "http://localhost:3000",
       "run-123",
       "token-456",
       "Test error message",
       "bypass-secret-789",
     );
 
-    expect(mockFetch).toHaveBeenCalledOnce();
-    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
-
-    expect(options.headers).toEqual({
-      "Content-Type": "application/json",
-      Authorization: "Bearer token-456",
-      "x-vercel-protection-bypass": "bypass-secret-789",
-    });
+    expect(capturedRequest?.headers.get("Content-Type")).toBe("application/json");
+    expect(capturedRequest?.headers.get("Authorization")).toBe("Bearer token-456");
+    expect(capturedRequest?.headers.get("x-vercel-protection-bypass")).toBe("bypass-secret-789");
   });
 
   it("does not include Vercel bypass header when bypassSecret is not provided", async () => {
-    const mockFetch = global.fetch as ReturnType<typeof vi.fn>;
-    mockFetch.mockResolvedValue({ ok: true });
+    let capturedRequest: Request | undefined;
+    server.use(
+      http.post("http://localhost:3000/api/webhooks/agent/complete", async ({ request }) => {
+        capturedRequest = request;
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    );
 
     await reportPreflightFailure(
-      "https://api.example.com",
+      "http://localhost:3000",
       "run-123",
       "token-456",
       "Test error message",
     );
 
-    expect(mockFetch).toHaveBeenCalledOnce();
-    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
-
-    expect(options.headers).toEqual({
-      "Content-Type": "application/json",
-      Authorization: "Bearer token-456",
-    });
+    expect(capturedRequest?.headers.get("Content-Type")).toBe("application/json");
+    expect(capturedRequest?.headers.get("Authorization")).toBe("Bearer token-456");
+    expect(capturedRequest?.headers.get("x-vercel-protection-bypass")).toBeNull();
   });
 });
 

--- a/turbo/apps/runner/src/lib/__tests__/executor-preflight.test.ts
+++ b/turbo/apps/runner/src/lib/__tests__/executor-preflight.test.ts
@@ -196,10 +196,13 @@ describe("reportPreflightFailure", () => {
   it("calls complete API with correct parameters", async () => {
     let capturedRequest: Request | undefined;
     server.use(
-      http.post("http://localhost:3000/api/webhooks/agent/complete", async ({ request }) => {
-        capturedRequest = request;
-        return HttpResponse.json({}, { status: 200 });
-      }),
+      http.post(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        async ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json({}, { status: 200 });
+        },
+      ),
     );
 
     await reportPreflightFailure(
@@ -209,10 +212,16 @@ describe("reportPreflightFailure", () => {
       "Test error message",
     );
 
-    expect(capturedRequest?.url).toBe("http://localhost:3000/api/webhooks/agent/complete");
+    expect(capturedRequest?.url).toBe(
+      "http://localhost:3000/api/webhooks/agent/complete",
+    );
     expect(capturedRequest?.method).toBe("POST");
-    expect(capturedRequest?.headers.get("Content-Type")).toBe("application/json");
-    expect(capturedRequest?.headers.get("Authorization")).toBe("Bearer token-456");
+    expect(capturedRequest?.headers.get("Content-Type")).toBe(
+      "application/json",
+    );
+    expect(capturedRequest?.headers.get("Authorization")).toBe(
+      "Bearer token-456",
+    );
 
     const body = await capturedRequest?.json();
     expect(body).toEqual({
@@ -231,7 +240,12 @@ describe("reportPreflightFailure", () => {
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    await reportPreflightFailure("http://localhost:3000", "run-123", "token-456", "Test error");
+    await reportPreflightFailure(
+      "http://localhost:3000",
+      "run-123",
+      "token-456",
+      "Test error",
+    );
 
     expect(consoleSpy).toHaveBeenCalledWith(
       "[Executor] Failed to report preflight failure: HTTP 500",
@@ -249,7 +263,12 @@ describe("reportPreflightFailure", () => {
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    await reportPreflightFailure("http://localhost:3000", "run-123", "token-456", "Test error");
+    await reportPreflightFailure(
+      "http://localhost:3000",
+      "run-123",
+      "token-456",
+      "Test error",
+    );
 
     expect(consoleSpy).toHaveBeenCalledWith(
       "[Executor] Failed to report preflight failure: TypeError: Failed to fetch",
@@ -261,10 +280,13 @@ describe("reportPreflightFailure", () => {
   it("includes Vercel bypass header when bypassSecret is provided", async () => {
     let capturedRequest: Request | undefined;
     server.use(
-      http.post("http://localhost:3000/api/webhooks/agent/complete", async ({ request }) => {
-        capturedRequest = request;
-        return HttpResponse.json({}, { status: 200 });
-      }),
+      http.post(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        async ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json({}, { status: 200 });
+        },
+      ),
     );
 
     await reportPreflightFailure(
@@ -275,18 +297,27 @@ describe("reportPreflightFailure", () => {
       "bypass-secret-789",
     );
 
-    expect(capturedRequest?.headers.get("Content-Type")).toBe("application/json");
-    expect(capturedRequest?.headers.get("Authorization")).toBe("Bearer token-456");
-    expect(capturedRequest?.headers.get("x-vercel-protection-bypass")).toBe("bypass-secret-789");
+    expect(capturedRequest?.headers.get("Content-Type")).toBe(
+      "application/json",
+    );
+    expect(capturedRequest?.headers.get("Authorization")).toBe(
+      "Bearer token-456",
+    );
+    expect(capturedRequest?.headers.get("x-vercel-protection-bypass")).toBe(
+      "bypass-secret-789",
+    );
   });
 
   it("does not include Vercel bypass header when bypassSecret is not provided", async () => {
     let capturedRequest: Request | undefined;
     server.use(
-      http.post("http://localhost:3000/api/webhooks/agent/complete", async ({ request }) => {
-        capturedRequest = request;
-        return HttpResponse.json({}, { status: 200 });
-      }),
+      http.post(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        async ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json({}, { status: 200 });
+        },
+      ),
     );
 
     await reportPreflightFailure(
@@ -296,9 +327,15 @@ describe("reportPreflightFailure", () => {
       "Test error message",
     );
 
-    expect(capturedRequest?.headers.get("Content-Type")).toBe("application/json");
-    expect(capturedRequest?.headers.get("Authorization")).toBe("Bearer token-456");
-    expect(capturedRequest?.headers.get("x-vercel-protection-bypass")).toBeNull();
+    expect(capturedRequest?.headers.get("Content-Type")).toBe(
+      "application/json",
+    );
+    expect(capturedRequest?.headers.get("Authorization")).toBe(
+      "Bearer token-456",
+    );
+    expect(
+      capturedRequest?.headers.get("x-vercel-protection-bypass"),
+    ).toBeNull();
   });
 });
 

--- a/turbo/apps/runner/src/mocks/handlers/index.ts
+++ b/turbo/apps/runner/src/mocks/handlers/index.ts
@@ -1,0 +1,3 @@
+import { webhookHandlers } from "./webhook-handlers";
+
+export const handlers = [...webhookHandlers];

--- a/turbo/apps/runner/src/mocks/handlers/webhook-handlers.ts
+++ b/turbo/apps/runner/src/mocks/handlers/webhook-handlers.ts
@@ -1,0 +1,8 @@
+import { http, HttpResponse } from "msw";
+
+export const webhookHandlers = [
+	// POST /api/webhooks/agent/complete - reportPreflightFailure
+	http.post("http://localhost:3000/api/webhooks/agent/complete", () => {
+		return HttpResponse.json({}, { status: 200 });
+	}),
+];

--- a/turbo/apps/runner/src/mocks/handlers/webhook-handlers.ts
+++ b/turbo/apps/runner/src/mocks/handlers/webhook-handlers.ts
@@ -1,8 +1,8 @@
 import { http, HttpResponse } from "msw";
 
 export const webhookHandlers = [
-	// POST /api/webhooks/agent/complete - reportPreflightFailure
-	http.post("http://localhost:3000/api/webhooks/agent/complete", () => {
-		return HttpResponse.json({}, { status: 200 });
-	}),
+  // POST /api/webhooks/agent/complete - reportPreflightFailure
+  http.post("http://localhost:3000/api/webhooks/agent/complete", () => {
+    return HttpResponse.json({}, { status: 200 });
+  }),
 ];

--- a/turbo/apps/runner/src/mocks/server.ts
+++ b/turbo/apps/runner/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from "msw/node";
+import { handlers } from "./handlers/index";
+
+export const server = setupServer(...handlers);

--- a/turbo/apps/runner/src/test/setup.ts
+++ b/turbo/apps/runner/src/test/setup.ts
@@ -1,0 +1,11 @@
+import { server } from "../mocks/server";
+import { afterAll, afterEach, beforeAll } from "vitest";
+
+// Start MSW server before all tests
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+
+// Reset handlers after each test
+afterEach(() => server.resetHandlers());
+
+// Close server after all tests
+afterAll(() => server.close());

--- a/turbo/apps/runner/vitest.config.ts
+++ b/turbo/apps/runner/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    setupFiles: ["./src/test/setup.ts"],
   },
 });

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       json:
         specifier: ^11.0.0
         version: 11.0.0
+      msw:
+        specifier: ^2.12.7
+        version: 2.12.7(@types/node@24.3.0)(typescript@5.9.2)
       oxlint:
         specifier: ^1.14.0
         version: 1.38.0
@@ -312,6 +315,9 @@ importers:
       json:
         specifier: ^11.0.0
         version: 11.0.0
+      msw:
+        specifier: ^2.12.7
+        version: 2.12.7(@types/node@24.3.0)(typescript@5.9.2)
       oxlint:
         specifier: ^1.14.0
         version: 1.38.0


### PR DESCRIPTION
## Summary

Replace manual fetch mocking with MSW (Mock Service Worker) in CLI and Runner test files for more realistic and maintainable HTTP mocking.

## Changes

### CLI Workspace (@vm0/cli)
- Migrate `api-client.test.ts` (29 tests) to use MSW for API endpoint mocking
- Set up MSW infrastructure (server, handlers, test setup)
- Remove manual `global.fetch` mocking and `createMockResponse` helper

### Runner Workspace (@vm0/runner)
- Migrate `executor-preflight.test.ts` reportPreflightFailure suite (5 tests) to use MSW for webhook mocking
- Set up MSW infrastructure (server, handlers, test setup)
- Keep SSH-based tests unchanged (they test SSH, not HTTP)

## Benefits

- **More realistic**: Uses proper Request/Response objects instead of manual mocks
- **Better isolation**: Automatic handler reset between tests
- **Cleaner code**: Eliminates manual mock setup/teardown
- **Consistency**: Unified mocking approach across workspaces

## Test Results

✅ All tests passing:
- CLI: 576 tests
- Runner: 156 tests

✅ Lint and type checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)