### PR TITLE
docs: add test anti-pattern guidelines to bad-smell.md

### DIFF
--- a/specs/bad-smell.md
+++ b/specs/bad-smell.md
@@ -6,7 +6,76 @@ This document defines code quality issues and anti-patterns to identify during c
 - Identify new mock implementations
 - Suggest non-mock alternatives where possible
 - List all new mocks for user review
-- Flag fetch API mocking in tests (should use MSW for network mocking instead)
+- **NEVER mock fetch API directly** - always use MSW (Mock Service Worker) instead
+
+### Never Mock Fetch - Always Use MSW
+
+**PROHIBITION: Direct fetch mocking is not allowed**
+
+Tests should NEVER mock the global `fetch` function using `vi.fn()`, `vi.stubGlobal()`, or direct assignment to `window.fetch`. Always use **MSW (Mock Service Worker)** for network mocking.
+
+**Why direct fetch mocking is harmful:**
+- Doesn't accurately represent real HTTP behavior (headers, status codes, streaming)
+- Doesn't test request/response serialization
+- Makes tests brittle and tied to implementation details
+- Misses request URL construction bugs
+- Doesn't verify request headers, body formatting, or HTTP methods
+- MSW provides realistic HTTP mocking with better ergonomics
+
+**Prohibited patterns:**
+```typescript
+// ❌ Bad: Direct fetch mocking with vi.fn()
+const mockFetch = vi.fn().mockResolvedValue(new Response());
+vi.stubGlobal("fetch", mockFetch);
+
+// ❌ Bad: Direct window.fetch assignment
+window.fetch = vi.fn().mockResolvedValue({
+  json: () => Promise.resolve({ data: "test" }),
+});
+
+// ❌ Bad: Using vi.spyOn on global fetch
+vi.spyOn(global, "fetch").mockResolvedValue(
+  new Response(JSON.stringify({ data: "test" }))
+);
+```
+
+**Correct approach - Use MSW:**
+```typescript
+// ✅ Good: Use MSW for HTTP mocking
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+const server = setupServer(
+  http.get('https://api.example.com/users', () => {
+    return HttpResponse.json({ users: [{ id: 1, name: 'Test' }] });
+  }),
+
+  http.post('https://api.example.com/users', async ({ request }) => {
+    const body = await request.json();
+    return HttpResponse.json({ id: 2, ...body }, { status: 201 });
+  })
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+it('should fetch users from API', async () => {
+  const users = await fetchUsers();
+  expect(users).toHaveLength(1);
+  expect(users[0].name).toBe('Test');
+});
+```
+
+**Benefits of MSW:**
+- Realistic HTTP behavior (status codes, headers, streaming)
+- Tests actual request construction (URL, headers, body)
+- Declarative API handlers (easier to read and maintain)
+- Works in both Node.js tests and browser
+- Catches request formatting bugs
+- Better error simulation (network errors, timeouts)
+
+**Exception**: For platform signal tests (fetch.test.ts), direct fetch mocking is acceptable when testing the fetch wrapper itself, not actual HTTP calls.
 
 ## 2. Test Coverage
 - Evaluate test quality and completeness
@@ -333,4 +402,389 @@ This document defines code quality issues and anti-patterns to identify during c
       expect(screen.getByTestId("project-form")).toBeVisible();
     });
     ```
+
+## 16. Mocking Internal Code - AP-4 Anti-Pattern (Issue #1335)
+
+Based on systematic review of 70+ test files, tests should **only mock third-party packages from node_modules**, not project internal code.
+
+**Rule**: If it starts with `../../` or `../`, you probably shouldn't mock it.
+
+### What is AP-4?
+
+Tests that mock **project internal code** (database, services, utilities) instead of using real implementations available in vitest.
+
+**CRITICAL: Only mock third-party external services from node_modules!**
+
+### The "Relative Path Rule"
+
+```typescript
+// ✅ GOOD: Third-party package from node_modules
+vi.mock("@clerk/nextjs")
+vi.mock("@aws-sdk/client-s3")
+vi.mock("@e2b/code-interpreter")
+vi.mock("@anthropic-ai/sdk")
+
+// ❌ BAD: Project internal code with relative path
+vi.mock("../../blob/blob-service")        // Internal service!
+vi.mock("../../storage/storage-service")  // Internal service!
+vi.mock("../agent-session-service")       // Internal service!
+vi.mock("../storage-resolver")            // Internal utility!
+
+// ❌ BAD: Project infrastructure
+const mockDb = { select: vi.fn() }        // Mock database!
+globalThis.services.db = mockDb           // Mock database!
+```
+
+### What Counts as AP-4 Violation
+
+**❌ Mocking project database:**
+- `globalThis.services.db` (project PostgreSQL database)
+- Database query methods (select, insert, update, delete)
+
+**❌ Mocking project internal services:**
+- `../../blob/blob-service` (internal service)
+- `../../agent-session/agent-session-service` (internal service)
+- `../../storage/storage-service` (internal service)
+- `../../run/run-service` (internal service)
+- `../../e2b/e2b-service` (internal service)
+- Any relative import path `../../*` or `../*`
+
+**❌ Mocking project infrastructure:**
+- File system operations (use real file system or temp directories)
+- Environment variables (use real env or test config)
+- Internal utilities and helpers
+
+### What is Acceptable to Mock
+
+**✅ Third-party external services (from node_modules):**
+- `@clerk/nextjs` - Authentication SaaS
+- `@aws-sdk/client-s3` - AWS cloud storage
+- `@e2b/code-interpreter` - Sandbox SaaS
+- `@anthropic-ai/sdk` - AI API
+- `@axiomhq/js` - Logging SaaS
+- `@stripe/stripe-js` - Payment API
+- Other third-party packages that require API keys or external infrastructure
+
+**✅ Node.js built-ins:**
+- `fs` - File system operations (when testing file I/O logic)
+- `child_process` - Process spawning
+- Other Node.js core modules
+
+**✅ Next.js framework APIs:**
+- `next/headers` - For mocking request headers in tests
+
+### Bad Example 1 - Mocking Project Database
+
+**File**: `runner-auth.test.ts:38-65`
+
+```typescript
+// ❌ WRONG: Mocking project database
+const mockDb = {
+  select: vi.fn().mockReturnThis(),
+  from: vi.fn().mockReturnThis(),
+  where: vi.fn().mockReturnThis(),
+  limit: vi.fn(),
+  update: vi.fn().mockReturnThis(),
+  set: vi.fn().mockReturnThis(),
+};
+
+beforeEach(() => {
+  (globalThis as any).services = {
+    db: mockDb,  // ❌ Mocking project database
+    env: mockEnv,
+  };
+});
+
+// Test only verifies mock was called
+mockDb.limit.mockResolvedValue([{ token: TEST_CLI_TOKEN, userId: TEST_USER_ID }]);
+const result = await getRunnerAuth();
+expect(mockDb.select).toHaveBeenCalled();  // ❌ Testing mock!
+```
+
+**Why this is wrong:**
+- Tests mock behavior, not actual database logic
+- Misses real database constraints, triggers, and edge cases
+- Brittle - breaks when implementation changes even if behavior is correct
+- False confidence - tests pass but real database issues remain
+
+### Bad Example 2 - Mocking Internal Service
+
+**File**: `session-history-service.test.ts:6-11`
+
+```typescript
+// ❌ WRONG: Mocking project internal service
+vi.mock("../../blob/blob-service", () => ({
+  blobService: {
+    uploadBlobs: vi.fn(),
+    downloadBlob: vi.fn(),
+  },
+}));
+
+it("should save session history", async () => {
+  vi.mocked(blobService.uploadBlobs).mockResolvedValue({
+    hashes: new Map([["session-history-hash.jsonl", mockHash]]),
+  });
+
+  const result = await sessionHistory.store(content);
+
+  expect(blobService.uploadBlobs).toHaveBeenCalled();  // ❌ Testing mock!
+  expect(result).toBe(mockHash);  // ❌ Just echoing mock return value!
+});
+```
+
+**Why this is wrong:**
+- Tests mock orchestration, not real blob storage logic
+- Misses blob deduplication bugs, refCount issues, S3 upload failures
+- Mock behavior may not match actual service behavior
+
+### Bad Example 3 - API Route Mocking Internal Services
+
+**File**: `app/api/agent/runs/__tests__/route.test.ts`
+
+```typescript
+// ❌ WRONG: Mocking multiple internal services
+vi.mock("../../../../../src/lib/run", () => ({
+  runService: {
+    buildExecutionContext: vi.fn().mockResolvedValue({}),
+    prepareAndDispatch: vi.fn().mockResolvedValue({ status: "pending" }),
+  },
+}));
+
+vi.mock("../../../../../src/lib/auth/sandbox-token", () => ({
+  generateSandboxToken: vi.fn().mockResolvedValue("mock-token"),
+}));
+
+vi.mock("../../../../../src/lib/axiom", () => ({
+  queryAxiom: vi.fn().mockResolvedValue([]),
+}));
+
+it("should create a run", async () => {
+  const response = await POST(request);
+  expect(runService.prepareAndDispatch).toHaveBeenCalled();  // ❌ Testing mocks!
+});
+```
+
+**Why this is wrong:**
+- API routes are **main integration points** - should be high-value integration tests
+- Mocking all services means tests only verify mock calls, not actual API logic
+- Misses real service integration bugs, database constraints, transaction issues
+- Currently low-value tests (verify mock orchestration instead of real behavior)
+
+### Good Example 1 - Real Database + Mock External S3 Only
+
+**File**: `blob-service.test.ts:31-53` (Reference example from #1335)
+
+```typescript
+// ✅ Mock third-party external service (AWS S3), NOT internal code
+vi.mock("@aws-sdk/client-s3");
+
+beforeAll(async () => {
+  // ✅ Initialize real database connection
+  initServices();
+  const blobModule = await import("../blob-service");
+  BlobService = blobModule.BlobService;
+});
+
+beforeEach(async () => {
+  // ✅ Clean up test data using real database
+  await globalThis.services.db
+    .delete(blobs)
+    .where(like(blobs.hash, `${TEST_HASH_PREFIX}%`));
+});
+
+it("should upload new blobs to S3 and insert into database", async () => {
+  // ✅ Mock external AWS S3 service
+  vi.mocked(s3Client.uploadS3Buffer).mockResolvedValue(undefined);
+
+  // ✅ Use real blob-service implementation
+  const result = await blobService.uploadBlobs(files);
+
+  // ✅ Verify with real database query
+  const dbBlobs = await globalThis.services.db
+    .select()
+    .from(blobs)
+    .where(eq(blobs.hash, hash1));
+
+  expect(dbBlobs).toHaveLength(1);
+  expect(dbBlobs[0]!.refCount).toBe(1);
+});
+```
+
+**Why this is correct:**
+- Only mocks external AWS S3 service (acceptable per AP-4)
+- Uses real database with `initServices()`
+- Tests actual blob storage logic including deduplication and refCount
+- Verifies real database state, not mocks
+- Catches actual bugs in database constraints and service integration
+
+### Good Example 2 - Real Services + Mock External Auth Only
+
+**File**: `agent-session-service.test.ts:22-132`
+
+```typescript
+// ✅ Mock third-party external service (Clerk)
+vi.mock("@clerk/nextjs", () => ({
+  auth: vi.fn().mockResolvedValue({
+    userId: "test-user-123",
+    sessionId: "test-session-456",
+  }),
+}));
+
+// ✅ Use real database for project data
+beforeAll(() => {
+  initServices();
+});
+
+beforeEach(async () => {
+  // ✅ Clean up test data with real database
+  await globalThis.services.db
+    .delete(agentSessions)
+    .where(eq(agentSessions.userId, TEST_USER_ID));
+});
+
+it("should create user record after Clerk authentication", async () => {
+  // Clerk mock provides auth context
+  const result = await createUserProfile();
+
+  // ✅ Verify with real database
+  const user = await globalThis.services.db
+    .select()
+    .from(users)
+    .where(eq(users.clerkId, "test-user-123"));
+
+  expect(user).toHaveLength(1);
+});
+```
+
+**Why this is correct:**
+- Only mocks external Clerk auth service (third-party SaaS)
+- Uses real database for all data operations
+- Tests actual service integration and business logic
+- Verifies real database constraints and relationships
+
+### Good Example 3 - Only Mock Node.js Built-ins
+
+**File**: `vm-registry.test.ts:6`
+
+```typescript
+// ✅ Only mock Node.js built-in
+vi.mock("fs");
+
+// ✅ NO internal modules mocked!
+
+beforeEach(() => {
+  registry = new VMRegistry(testRegistryPath);
+});
+
+it("should register a VM with correct data", () => {
+  const mockWriteFileSync = vi.mocked(fs.writeFileSync);
+
+  // ✅ Use real VMRegistry implementation
+  registry.register("172.16.0.2", "run-123", "token-abc");
+
+  // ✅ Verify actual atomic write pattern (write to .tmp, then rename)
+  expect(mockWriteFileSync).toHaveBeenCalledWith(
+    testTempPath,
+    expect.any(String),
+    { mode: 0o644 },
+  );
+
+  // ✅ Verify actual data structure
+  const writtenData = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string);
+  expect(writtenData.vms["172.16.0.2"]).toMatchObject({
+    runId: "run-123",
+    sandboxToken: "token-abc",
+  });
+});
+```
+
+**Why this is correct:**
+- Only mocks Node.js built-in `fs` module (acceptable)
+- NO internal modules mocked (correct approach!)
+- Tests actual VMRegistry logic with mocked file I/O
+- Verifies atomic write pattern and data structure
+
+### Summary Table
+
+| What | Mock? | Why |
+|------|-------|-----|
+| `@clerk/nextjs` | ✅ Yes | Third-party SaaS, requires API key |
+| `@aws-sdk/client-s3` | ✅ Yes | Third-party cloud, requires credentials |
+| `@e2b/code-interpreter` | ✅ Yes | Third-party SaaS, requires API key |
+| `@anthropic-ai/sdk` | ✅ Yes | Third-party API, requires API key |
+| `fs`, `child_process` | ✅ Yes | Node.js built-ins for I/O operations |
+| `next/headers` | ✅ Yes | Next.js framework API (test setup) |
+| `globalThis.services.db` | ❌ No | Project database, use real connection |
+| `../../blob/blob-service` | ❌ No | Internal service, use real implementation |
+| `../../storage/*` | ❌ No | Internal service, use real implementation |
+| `../../agent-session/*` | ❌ No | Internal service, use real implementation |
+| `../../run/*` | ❌ No | Internal service, use real implementation |
+| `../storage-resolver` | ❌ No | Internal utility, use real implementation |
+| `../vm-registry` | ❌ No | Internal module, use real implementation |
+
+### When to Use Real Implementations
+
+- Integration tests for services that interact with database
+- Testing internal service interactions and orchestration
+- Testing database constraints, transactions, foreign keys
+- Testing query logic and data transformations
+- API route tests (main integration points)
+- Any test where implementation behavior matters
+
+### When Mocking is Acceptable
+
+- Unit tests for pure functions (no I/O dependencies)
+- **Only mock third-party services from node_modules**
+- Services that require API keys or external infrastructure
+- Services outside our control (Clerk, AWS, E2B, Anthropic, etc.)
+- Node.js built-ins when testing I/O logic (fs, child_process)
+
+### Impact of Fixing AP-4 Violations
+
+**Before (with mocks):**
+- Tests verify mock behavior, not actual implementation
+- Misses real bugs in database constraints, service interactions
+- False confidence - tests pass but real issues remain
+- More brittle - breaks when implementation changes
+
+**After (with real implementations):**
+- Tests verify actual business logic and integration
+- Catches real bugs in database, services, error handling
+- Higher confidence - tests verify real behavior
+- More maintainable - tests verify behavior, not implementation details
+
+### Reference Files (Gold Standards)
+
+Use these as templates when writing tests:
+
+1. **blob-service.test.ts** - Real DB + mock external S3 only
+2. **agent-session-service.test.ts** - Real services + mock Clerk only
+3. **scope-service.spec.ts** - Real database CRUD operations
+4. **proxy-token-service.test.ts** - Pure functions, zero mocks
+5. **scope-reference.spec.ts** - Comprehensive pure function testing
+6. **vm-registry.test.ts** - Correct file I/O testing (mock fs only)
+
+### Common Violations Found (Issue #1335)
+
+**High Priority** (mock database):
+- runner-auth.test.ts (#1336)
+- e2b-service.test.ts (#1344)
+
+**Medium Priority** (mock internal services):
+- storage-service.test.ts (#1358, #1340)
+- run-service.test.ts (#1359)
+- session-history-service.test.ts (#1360)
+- proxy-manager.test.ts (#1362)
+- e2b-service.test.ts (#1344 - also mocks storage-service)
+
+**High Impact** (widespread - 28 files):
+- API route tests (#1371) - Mock get-user-id, runService, sandbox-token, axiom, e2b-service
+
+### Review Statistics (Issue #1335)
+
+- **70+ files reviewed** across 30 tasks
+- **690+ test cases** analyzed
+- **Phase 2 (integration tests)**: 100% clean! 🌟
+- **Overall clean rate**: ~70% (Phase 2 service tests are exemplary)
+- **Main issues**: Auth tests (Phase 1) and API routes (Phase 4)
 


### PR DESCRIPTION
## Summary

Add comprehensive testing guidelines based on systematic review of 70+ test files in issue #1335:

- **Section 1**: Never mock fetch - always use MSW
- **Section 16**: AP-4 anti-pattern - never mock internal code (the "relative path rule")

## Changes

### 1. Never Mock Fetch - Always Use MSW

- Prohibit direct fetch mocking (`vi.stubGlobal`, `window.fetch`, `vi.spyOn`)
- Require MSW for all HTTP mocking
- Include bad/good examples
- Document benefits: realistic HTTP, catches request bugs, better error simulation
- Exception: fetch wrapper tests can mock fetch when testing the wrapper itself

### 2. Mocking Internal Code - AP-4 Anti-Pattern

- **The "Relative Path Rule"**: If it starts with `../../` or `../`, don't mock it
- Only mock: third-party packages from node_modules, Node.js built-ins
- Never mock: project database, internal services, internal utilities
- 3 bad examples with explanations:
  - Mocking project database (runner-auth.test.ts)
  - Mocking internal service (session-history-service.test.ts)  
  - API routes mocking internal services (28 files - widespread)
- 3 good examples (reference files):
  - blob-service.test.ts - Real DB + mock S3 only
  - agent-session-service.test.ts - Real services + mock Clerk only
  - vm-registry.test.ts - Mock fs only, not internal modules
- Summary table: what to mock vs not mock
- 6 reference files as gold standards
- Impact analysis: before/after fixing violations
- Links to all violations found (#1336, #1340, #1344, #1358, #1359, #1360, #1362, #1371)

## Test Plan

- [x] Reviewed specs/bad-smell.md changes
- [x] Verified all examples are clear and actionable
- [x] Confirmed links to issue references work
- [x] Guidelines are comprehensive and cover all findings from #1335

## Related

Closes #1335

🤖 Generated with [Claude Code](https://claude.com/claude-code)