### PR TITLE
feat(ci): add site production deployment to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       cli_release_created: ${{ steps.release.outputs['turbo/apps/cli--release_created'] }}
       web_release_created: ${{ steps.release.outputs['turbo/apps/web--release_created'] }}
+      site_release_created: ${{ steps.release.outputs['turbo/apps/site--release_created'] }}
       docs_release_created: ${{ steps.release.outputs['turbo/apps/docs--release_created'] }}
       runner_release_created: ${{ steps.release.outputs['turbo/apps/runner--release_created'] }}
       platform_release_created: ${{ steps.release.outputs['turbo/apps/platform--release_created'] }}
@@ -137,6 +138,34 @@ jobs:
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_DOCS }}
           environment: production
           deployment-env: docs
+
+  # Deploy site app to production
+  deploy-site-production:
+    needs: [release-please, deploy-web-production]
+    if: ${{ needs.release-please.outputs.site_release_created == 'true' }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260116
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Deploy Site to Vercel Production
+        id: deploy
+        uses: ./.github/actions/vercel-deploy
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_SITE }}
+          environment: production
+          deployment-env: site
+          environment-variables: |
+            WEB_APP_URL=https://www.vm0.ai
+            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+            CLERK_SECRET_KEY=${{ secrets.CLERK_SECRET_KEY }}
 
   # Deploy platform (Vite SPA) to production
   deploy-platform-production:


### PR DESCRIPTION
## Summary
Add site application to the release-please production deployment workflow to enable automatic deployment when site releases are created.

## Changes
- Add `site_release_created` output to track site releases in release-please job
- Add `deploy-site-production` job to deploy site to Vercel production
- Configure site deployment to depend on web deployment (requires WEB_APP_URL)
- Include required environment variables:
  - `WEB_APP_URL=https://www.vm0.ai` (production web URL)
  - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
  - `CLERK_SECRET_KEY`

## Why
Currently, site has release configuration in `release-please-config.json` and gets included in release PRs, but lacks production deployment automation. This ensures site is automatically deployed to production when a new version is released, matching the workflow for web, docs, and platform apps.

## Test plan
- [ ] Verify workflow syntax is correct
- [ ] Confirm site deployment triggers when site has a release
- [ ] Validate environment variables are properly configured
- [ ] Check deployment depends on web deployment completing first

🤖 Generated with [Claude Code](https://claude.com/claude-code)