### PR TITLE
feat(site): improve robots.txt with crawl delay and host directive

### DIFF
--- a/turbo/apps/site/app/robots.ts
+++ b/turbo/apps/site/app/robots.ts
@@ -7,8 +7,10 @@ export default function robots(): MetadataRoute.Robots {
         userAgent: "*",
         allow: "/",
         disallow: ["/api/", "/cli-auth/"],
+        crawlDelay: 1,
       },
     ],
     sitemap: "https://vm0.ai/sitemap.xml",
+    host: "https://vm0.ai",
   };
 }


### PR DESCRIPTION
## Summary
- Add crawl delay of 1 second to reduce server load from search engine crawlers
- Specify canonical host directive to help search engines identify the primary domain

## Test plan
- [x] TypeScript type checking passes
- [x] Linting passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)