### PR TITLE
fix(eslint): extend signal-check-await rule and fix logs-page violation

### DIFF
--- a/turbo/apps/platform/custom-eslint/__tests__/signal-check-await.test.ts
+++ b/turbo/apps/platform/custom-eslint/__tests__/signal-check-await.test.ts
@@ -85,5 +85,50 @@ ruleTester.run("signal-check-await", rule, {
         { messageId: "missingSignalCheck" },
       ],
     },
+    // Case 1: signal in destructuring (no type) - SHOULD DETECT ✅
+    {
+      code: `
+        command(async ({ signal }) => {
+          signal.throwIfAborted();
+          const cursor = await getSomething();
+          doSomething(cursor);
+        })
+      `,
+      errors: [{ messageId: "missingSignalCheck" }],
+    },
+    // Case 2: signal in destructuring (with type) - SHOULD DETECT ✅
+    {
+      code: `
+        command(async ({ signal }: { signal: AbortSignal }) => {
+          signal.throwIfAborted();
+          const cursor = await getSomething();
+          doSomething(cursor);
+        })
+      `,
+      errors: [{ messageId: "missingSignalCheck" }],
+    },
+    // Case 3: signal as first standalone parameter - SHOULD DETECT BUT DOESN'T ❌
+    {
+      code: `
+        command(async (signal: AbortSignal) => {
+          signal.throwIfAborted();
+          const cursor = await getSomething();
+          doSomething(cursor);
+        })
+      `,
+      errors: [{ messageId: "missingSignalCheck" }],
+    },
+    // Case 4: signal as second standalone parameter (actual PR 1373 pattern) - SHOULD DETECT BUT DOESN'T ❌
+    {
+      code: `
+        command(async ({ get, set }, signal: AbortSignal) => {
+          signal.throwIfAborted();
+          const cursor = await get(currentCursor$);
+          const newComputed = createLogsFetch(cursor);
+          set(setLogs$, (prev) => [...prev, newComputed]);
+        })
+      `,
+      errors: [{ messageId: "missingSignalCheck" }],
+    },
   ],
 });

--- a/turbo/apps/platform/custom-eslint/rules/signal-check-await.ts
+++ b/turbo/apps/platform/custom-eslint/rules/signal-check-await.ts
@@ -46,6 +46,8 @@ export default createRule<[], MessageIds>({
   create(context) {
     let signalParamName: string | null = null;
     let inCommand = false;
+    let functionDepth = 0;
+    let commandCallback: TSESTree.Node | null = null;
 
     function isCommandCall(node: TSESTree.CallExpression): boolean {
       const callee = node.callee;
@@ -159,6 +161,8 @@ export default createRule<[], MessageIds>({
             if (callback.async) {
               inCommand = true;
               signalParamName = getSignalParamName(callback);
+              functionDepth = 0;
+              commandCallback = callback; // Save reference to command callback
             }
           }
         }
@@ -167,10 +171,35 @@ export default createRule<[], MessageIds>({
         if (isCommandCall(node)) {
           inCommand = false;
           signalParamName = null;
+          functionDepth = 0;
+          commandCallback = null;
+        }
+      },
+      ArrowFunctionExpression(node) {
+        // Track nested async functions inside command (but not the command callback itself)
+        if (inCommand && signalParamName && node.async && node !== commandCallback) {
+          functionDepth++;
+        }
+      },
+      "ArrowFunctionExpression:exit"(node: TSESTree.ArrowFunctionExpression) {
+        if (inCommand && signalParamName && node.async && node !== commandCallback && functionDepth > 0) {
+          functionDepth--;
+        }
+      },
+      FunctionExpression(node) {
+        // Track nested async functions inside command (but not the command callback itself)
+        if (inCommand && signalParamName && node.async && node !== commandCallback) {
+          functionDepth++;
+        }
+      },
+      "FunctionExpression:exit"(node: TSESTree.FunctionExpression) {
+        if (inCommand && signalParamName && node.async && node !== commandCallback && functionDepth > 0) {
+          functionDepth--;
         }
       },
       BlockStatement(node) {
-        if (inCommand && signalParamName) {
+        // Only check await in the command's direct block, not nested functions
+        if (inCommand && signalParamName && functionDepth === 0) {
           checkAwaitInBlock(node.body);
         }
       },

--- a/turbo/apps/platform/custom-eslint/rules/signal-check-await.ts
+++ b/turbo/apps/platform/custom-eslint/rules/signal-check-await.ts
@@ -55,23 +55,31 @@ export default createRule<[], MessageIds>({
     function getSignalParamName(
       node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
     ): string | null {
-      const firstParam = node.params[0];
-      if (!firstParam) {
-        return null;
-      }
+      // 遍历所有参数，不只是第一个
+      for (const param of node.params) {
+        // 情况1: 独立参数 signal: AbortSignal
+        if (param.type === "Identifier" && param.name === "signal") {
+          return "signal";
+        }
 
-      if (firstParam.type === "ObjectPattern") {
-        for (const prop of firstParam.properties) {
-          if (
-            prop.type === "Property" &&
-            prop.key.type === "Identifier" &&
-            prop.key.name === "signal"
-          ) {
-            if (prop.value.type === "Identifier") {
-              return prop.value.name;
-            }
-            return "signal";
+        // 情况2: 解构参数 { signal } 或 { signal: customName }
+        if (param.type !== "ObjectPattern") {
+          continue;
+        }
+
+        for (const prop of param.properties) {
+          if (prop.type !== "Property") {
+            continue;
           }
+          if (prop.key.type !== "Identifier" || prop.key.name !== "signal") {
+            continue;
+          }
+
+          // 找到了 signal 属性
+          if (prop.value.type === "Identifier") {
+            return prop.value.name;
+          }
+          return "signal";
         }
       }
 

--- a/turbo/apps/platform/custom-eslint/rules/signal-check-await.ts
+++ b/turbo/apps/platform/custom-eslint/rules/signal-check-await.ts
@@ -177,23 +177,45 @@ export default createRule<[], MessageIds>({
       },
       ArrowFunctionExpression(node) {
         // Track nested async functions inside command (but not the command callback itself)
-        if (inCommand && signalParamName && node.async && node !== commandCallback) {
+        if (
+          inCommand &&
+          signalParamName &&
+          node.async &&
+          node !== commandCallback
+        ) {
           functionDepth++;
         }
       },
       "ArrowFunctionExpression:exit"(node: TSESTree.ArrowFunctionExpression) {
-        if (inCommand && signalParamName && node.async && node !== commandCallback && functionDepth > 0) {
+        if (
+          inCommand &&
+          signalParamName &&
+          node.async &&
+          node !== commandCallback &&
+          functionDepth > 0
+        ) {
           functionDepth--;
         }
       },
       FunctionExpression(node) {
         // Track nested async functions inside command (but not the command callback itself)
-        if (inCommand && signalParamName && node.async && node !== commandCallback) {
+        if (
+          inCommand &&
+          signalParamName &&
+          node.async &&
+          node !== commandCallback
+        ) {
           functionDepth++;
         }
       },
       "FunctionExpression:exit"(node: TSESTree.FunctionExpression) {
-        if (inCommand && signalParamName && node.async && node !== commandCallback && functionDepth > 0) {
+        if (
+          inCommand &&
+          signalParamName &&
+          node.async &&
+          node !== commandCallback &&
+          functionDepth > 0
+        ) {
           functionDepth--;
         }
       },

--- a/turbo/apps/platform/src/signals/logs-page/logs-signals.ts
+++ b/turbo/apps/platform/src/signals/logs-page/logs-signals.ts
@@ -71,6 +71,7 @@ export const loadMore$ = command(async ({ get, set }, signal: AbortSignal) => {
   signal.throwIfAborted();
 
   const cursor = await get(currentCursor$);
+  signal.throwIfAborted();
 
   // Load next batch with cursor
   const nextBatch$ = computed(async (get) => {


### PR DESCRIPTION
## Summary

Fixes the `signal-check-await` ESLint rule to detect missing signal checks in all command parameter patterns, and fixes the violation found in the logs page.

### Issues Fixed

1. **ESLint rule was too narrow**: Only detected `{ signal }` in first parameter, missing patterns like `({ get, set }, signal: AbortSignal)`
2. **False positives**: Incorrectly flagged await in nested async functions that don't have signal access
3. **Code violation**: `loadMore$` command missing `signal.throwIfAborted()` after await

### Changes

**Commit 1: Extend parameter pattern support**
- Iterate through all parameters, not just the first
- Support both `Identifier` (signal: AbortSignal) and `ObjectPattern` ({ signal })
- Add 4 test cases covering all patterns
- Reduce nesting depth to fix oxlint max-depth violation

**Commit 2: Ignore nested async functions**
- Track function depth to identify nested functions
- Only check await in command's direct body
- Skip await checks in nested functions (e.g., computed callbacks)

**Commit 3: Fix logs-page violation**
- Add missing `signal.throwIfAborted()` after `await get(currentCursor$)` in `loadMore$`

## Test plan

- [x] All 48 custom-eslint tests pass
- [x] Full platform lint passes (0 errors, 0 warnings)
- [x] Rule now correctly detects all signal parameter patterns
- [x] No false positives for nested async functions
- [x] Code violation fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)