### PR TITLE
fix: add missing foreign key constraint on agent_runs.scheduleId

### DIFF
--- a/turbo/apps/web/src/db/migrations/0053_add_schedule_id_fk.sql
+++ b/turbo/apps/web/src/db/migrations/0053_add_schedule_id_fk.sql
@@ -1,0 +1,6 @@
+-- Add foreign key constraint on agent_runs.schedule_id
+-- References agent_schedules.id with ON DELETE SET NULL behavior
+ALTER TABLE "agent_runs"
+ADD CONSTRAINT "agent_runs_schedule_id_agent_schedules_id_fk"
+FOREIGN KEY ("schedule_id") REFERENCES "agent_schedules"("id")
+ON DELETE SET NULL;

--- a/turbo/apps/web/src/db/schema/agent-run.ts
+++ b/turbo/apps/web/src/db/schema/agent-run.ts
@@ -1,4 +1,5 @@
 import {
+  type AnyPgColumn,
   pgTable,
   uuid,
   varchar,
@@ -8,6 +9,7 @@ import {
   index,
 } from "drizzle-orm/pg-core";
 import { agentComposeVersions } from "./agent-compose";
+import { agentSchedules } from "./agent-schedule";
 
 /**
  * Agent Runs table
@@ -24,8 +26,10 @@ export const agentRuns = pgTable(
       .notNull(),
     resumedFromCheckpointId: uuid("resumed_from_checkpoint_id"),
     // References agent_schedules.id if this run was triggered by a schedule
-    // No FK constraint to avoid circular dependency with agent_schedules
-    scheduleId: uuid("schedule_id"),
+    scheduleId: uuid("schedule_id").references(
+      (): AnyPgColumn => agentSchedules.id,
+      { onDelete: "set null" },
+    ),
     status: varchar("status", { length: 20 }).notNull(),
     prompt: text("prompt").notNull(),
     vars: jsonb("vars"),


### PR DESCRIPTION
## Summary

Add FK constraint from `agent_runs.scheduleId` to `agent_schedules.id` using Drizzle's `AnyPgColumn` type to resolve the circular dependency issue.

## Changes

- Import `AnyPgColumn` and `agentSchedules` in `agent-run.ts` schema
- Add `.references()` with `onDelete: "set null"` behavior
- Create migration 0053 to add the FK constraint to the database

## Technical Details

The circular dependency between `agent_runs` and `agent_schedules` was previously worked around by omitting the FK constraint on `scheduleId`. Drizzle ORM supports this use case via the `AnyPgColumn` type, allowing us to properly define the FK relationship.

## Migration

The migration adds the FK constraint with `ON DELETE SET NULL` behavior, ensuring that when a schedule is deleted, the associated runs keep their data but their `scheduleId` becomes NULL.

Closes #1387

🤖 Generated with [Claude Code](https://claude.com/claude-code)