### PR TITLE
fix(runner): move mitmproxy CA to per-runner directory to fix race condition

### DIFF
--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -341,6 +341,16 @@
       when: not proxy_ca_file.stat.exists
       tags: [prepare]
 
+    - name: Fix proxy CA certificate ownership
+      file:
+        path: "{{ runner_base_dir }}/proxy"
+        state: directory
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        recurse: yes
+      when: not proxy_ca_file.stat.exists
+      tags: [prepare]
+
     - name: Ensure user is in kvm group for Firecracker
       user:
         name: "{{ ansible_user }}"

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -321,44 +321,24 @@
       when: rootfs_needs_rebuild
       tags: [prepare]
 
-    - name: Check if proxy CA certificate exists
-      stat:
-        path: "{{ runner_base_dir }}/deploy-runner/proxy-ca/mitmproxy-ca.pem"
-      register: proxy_ca_file
-      tags: [prepare]
-
-    - name: Generate proxy CA certificate if not exists
-      command: "{{ runner_base_dir }}/deploy-runner/generate-proxy-ca.sh {{ runner_base_dir }}/deploy-runner/proxy-ca"
-      when: not proxy_ca_file.stat.exists
-      tags: [prepare]
-
-    - name: Ensure proxy CA directory exists
+    - name: Ensure per-runner proxy directory exists
       file:
-        path: /opt/vm0-runner/proxy
+        path: "{{ runner_base_dir }}/proxy"
         state: directory
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
         mode: '0755'
       tags: [prepare]
 
-    - name: Copy proxy CA (cert+key) for mitmproxy
-      copy:
-        src: "{{ runner_base_dir }}/deploy-runner/proxy-ca/mitmproxy-ca.pem"
-        dest: /opt/vm0-runner/proxy/mitmproxy-ca.pem
-        owner: "{{ ansible_user }}"
-        group: "{{ ansible_user }}"
-        mode: '0600'
-        remote_src: yes
+    - name: Check if proxy CA certificate exists
+      stat:
+        path: "{{ runner_base_dir }}/proxy/mitmproxy-ca.pem"
+      register: proxy_ca_file
       tags: [prepare]
 
-    - name: Copy proxy CA certificate (cert only) for VM installation
-      copy:
-        src: "{{ runner_base_dir }}/deploy-runner/proxy-ca/mitmproxy-ca-cert.pem"
-        dest: /opt/vm0-runner/proxy/mitmproxy-ca-cert.pem
-        owner: "{{ ansible_user }}"
-        group: "{{ ansible_user }}"
-        mode: '0644'
-        remote_src: yes
+    - name: Generate proxy CA certificate if not exists
+      command: "{{ runner_base_dir }}/deploy-runner/generate-proxy-ca.sh {{ runner_base_dir }}/proxy"
+      when: not proxy_ca_file.stat.exists
       tags: [prepare]
 
     - name: Ensure user is in kvm group for Firecracker

--- a/ansible/playbooks/templates/runner.yaml.j2
+++ b/ansible/playbooks/templates/runner.yaml.j2
@@ -21,3 +21,4 @@ firecracker:
 
 proxy:
   port: {{ proxy_port | default(8080) }}
+  ca_dir: {{ runner_base_dir }}/proxy

--- a/turbo/apps/runner/src/__tests__/config.test.ts
+++ b/turbo/apps/runner/src/__tests__/config.test.ts
@@ -25,6 +25,9 @@ describe("RunnerConfig Schema", () => {
         kernel: "/opt/vmlinux",
         rootfs: "/opt/rootfs.squashfs",
       },
+      proxy: {
+        ca_dir: "/opt/runner/proxy",
+      },
     };
 
     const result = runnerConfigSchema.safeParse(config);
@@ -50,6 +53,9 @@ describe("RunnerConfig Schema", () => {
         kernel: "/opt/vmlinux",
         rootfs: "/opt/rootfs.squashfs",
       },
+      proxy: {
+        ca_dir: "/opt/runner/proxy",
+      },
     };
 
     const result = runnerConfigSchema.parse(config);
@@ -72,6 +78,9 @@ describe("RunnerConfig Schema", () => {
         kernel: "/opt/vmlinux",
         rootfs: "/opt/rootfs.squashfs",
       },
+      proxy: {
+        ca_dir: "/opt/runner/proxy",
+      },
     };
 
     const result = runnerConfigSchema.safeParse(config);
@@ -92,6 +101,9 @@ describe("RunnerConfig Schema", () => {
         kernel: "/opt/vmlinux",
         rootfs: "/opt/rootfs.squashfs",
       },
+      proxy: {
+        ca_dir: "/opt/runner/proxy",
+      },
     };
 
     const result = runnerConfigSchema.safeParse(config);
@@ -110,6 +122,9 @@ describe("RunnerConfig Schema", () => {
         binary: "/usr/bin/firecracker",
         kernel: "/opt/vmlinux",
         rootfs: "/opt/rootfs.squashfs",
+      },
+      proxy: {
+        ca_dir: "/opt/runner/proxy",
       },
     };
 
@@ -130,6 +145,9 @@ describe("RunnerConfig Schema", () => {
         kernel: "/opt/vmlinux",
         rootfs: "/opt/rootfs.squashfs",
       },
+      proxy: {
+        ca_dir: "/opt/runner/proxy",
+      },
     };
 
     const result = runnerConfigSchema.safeParse(config);
@@ -145,6 +163,9 @@ describe("RunnerConfig Schema", () => {
         kernel: "/opt/vmlinux",
         rootfs: "/opt/rootfs.squashfs",
       },
+      proxy: {
+        ca_dir: "/opt/runner/proxy",
+      },
     };
 
     const result = runnerConfigSchema.safeParse(config);
@@ -157,6 +178,28 @@ describe("RunnerConfig Schema", () => {
       group: "scope/name",
       server: {
         url: "not-a-valid-url",
+        token: "test-token",
+      },
+      firecracker: {
+        binary: "/usr/bin/firecracker",
+        kernel: "/opt/vmlinux",
+        rootfs: "/opt/rootfs.squashfs",
+      },
+      proxy: {
+        ca_dir: "/opt/runner/proxy",
+      },
+    };
+
+    const result = runnerConfigSchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject missing proxy ca_dir", () => {
+    const config = {
+      name: "test",
+      group: "scope/name",
+      server: {
+        url: "https://example.com",
         token: "test-token",
       },
       firecracker: {
@@ -201,6 +244,8 @@ firecracker:
   binary: /usr/bin/firecracker
   kernel: /opt/vmlinux
   rootfs: /opt/rootfs.squashfs
+proxy:
+  ca_dir: /opt/runner/proxy
 `;
     fs.writeFileSync(testConfigPath, yamlContent);
 
@@ -208,6 +253,7 @@ firecracker:
     expect(config.name).toBe("test-runner");
     expect(config.group).toBe("e2e/test");
     expect(config.server.url).toBe("https://example.com");
+    expect(config.proxy.ca_dir).toBe("/opt/runner/proxy");
   });
 
   it("should throw error for invalid YAML config", () => {
@@ -221,6 +267,8 @@ firecracker:
   binary: /usr/bin/firecracker
   kernel: /opt/vmlinux
   rootfs: /opt/rootfs.squashfs
+proxy:
+  ca_dir: /opt/runner/proxy
 `;
     fs.writeFileSync(testConfigPath, yamlContent);
 

--- a/turbo/apps/runner/src/commands/start.ts
+++ b/turbo/apps/runner/src/commands/start.ts
@@ -175,6 +175,7 @@ export const startCommand = new Command("start")
       const proxyManager = initProxyManager({
         apiUrl: config.server.url,
         port: config.proxy.port,
+        caDir: config.proxy.ca_dir,
       });
 
       // Try to start proxy - if mitmproxy is not installed, continue without it

--- a/turbo/apps/runner/src/lib/config.ts
+++ b/turbo/apps/runner/src/lib/config.ts
@@ -54,11 +54,10 @@ export const runnerConfigSchema = z.object({
     kernel: z.string().min(1, "Kernel path is required"),
     rootfs: z.string().min(1, "Rootfs path is required"),
   }),
-  proxy: z
-    .object({
-      port: z.number().int().min(1024).max(65535).default(PROXY_DEFAULTS.port),
-    })
-    .default(PROXY_DEFAULTS),
+  proxy: z.object({
+    port: z.number().int().min(1024).max(65535).default(PROXY_DEFAULTS.port),
+    ca_dir: z.string().min(1, "Proxy CA directory is required"),
+  }),
 });
 
 export type RunnerConfig = z.infer<typeof runnerConfigSchema>;
@@ -105,8 +104,9 @@ export const debugConfigSchema = z.object({
   proxy: z
     .object({
       port: z.number().int().min(1024).max(65535).default(PROXY_DEFAULTS.port),
+      ca_dir: z.string().default("/tmp/vm0-proxy"),
     })
-    .default(PROXY_DEFAULTS),
+    .default({ ...PROXY_DEFAULTS, ca_dir: "/tmp/vm0-proxy" }),
 });
 
 type DebugConfig = z.infer<typeof debugConfigSchema>;

--- a/turbo/apps/runner/src/lib/executor-env.ts
+++ b/turbo/apps/runner/src/lib/executor-env.ts
@@ -13,11 +13,6 @@ import type { ExecutionContext } from "./api.js";
 export const ENV_JSON_PATH = "/tmp/vm0-env.json";
 
 /**
- * Path to the proxy CA certificate on the runner host (cert only, no private key)
- */
-export const PROXY_CA_CERT_PATH = "/opt/vm0-runner/proxy/mitmproxy-ca-cert.pem";
-
-/**
  * Build environment variables for the agent execution
  */
 export function buildEnvironmentVariables(

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -253,7 +253,11 @@ export async function executeJob(
       // Install proxy CA certificate only if MITM is enabled
       // For SNI-only mode (filter without MITM), we don't need CA
       if (mitmEnabled) {
-        await installProxyCA(ssh);
+        const caCertPath = path.join(
+          config.proxy.ca_dir,
+          "mitmproxy-ca-cert.pem",
+        );
+        await installProxyCA(ssh, caCertPath);
       }
     }
 

--- a/turbo/apps/runner/src/lib/vm-setup/vm-setup.ts
+++ b/turbo/apps/runner/src/lib/vm-setup/vm-setup.ts
@@ -10,7 +10,6 @@ import type { SSHClient } from "../firecracker/guest.js";
 import type { StorageManifest, ResumeSession } from "../api.js";
 import { getAllScripts } from "../scripts/utils.js";
 import { SCRIPT_PATHS } from "../scripts/index.js";
-import { PROXY_CA_CERT_PATH } from "../executor-env.js";
 
 /**
  * Upload all scripts to VM individually via SSH
@@ -110,16 +109,22 @@ export async function restoreSessionHistory(
 /**
  * Install proxy CA certificate in VM for network security mode
  * This allows the VM to trust the runner's mitmproxy for HTTPS interception
+ *
+ * @param ssh - SSH client connected to the VM
+ * @param caCertPath - Path to the CA certificate file on the runner host
  */
-export async function installProxyCA(ssh: SSHClient): Promise<void> {
+export async function installProxyCA(
+  ssh: SSHClient,
+  caCertPath: string,
+): Promise<void> {
   // Read CA certificate from runner host
-  if (!fs.existsSync(PROXY_CA_CERT_PATH)) {
+  if (!fs.existsSync(caCertPath)) {
     throw new Error(
-      `Proxy CA certificate not found at ${PROXY_CA_CERT_PATH}. Run generate-proxy-ca.sh first.`,
+      `Proxy CA certificate not found at ${caCertPath}. Run generate-proxy-ca.sh first.`,
     );
   }
 
-  const caCert = fs.readFileSync(PROXY_CA_CERT_PATH, "utf-8");
+  const caCert = fs.readFileSync(caCertPath, "utf-8");
   console.log(
     `[Executor] Installing proxy CA certificate (${caCert.length} bytes)`,
   );


### PR DESCRIPTION
## Summary

- Move mitmproxy CA certificate files from shared `/opt/vm0-runner/proxy/` to per-runner `${RUNNER_DIR}/proxy/`
- Add `ca_dir` to runner config schema (required field)
- Update ProxyManager to derive addonPath from caDir
- Eliminate race condition when multiple PRs run E2E tests concurrently

## Details

When multiple PRs run E2E tests concurrently on the same runner host, the mitmproxy CA certificate stored at a shared location could be overwritten by another PR's deployment, causing TLS certificate errors ("proxy CA not trusted").

This PR moves all proxy-related files to a per-runner directory, ensuring complete isolation:

```
${RUNNER_DIR}/proxy/
├── mitmproxy-ca-cert.pem   # CA certificate (for VMs)
├── mitmproxy-ca.pem        # CA cert + key (for mitmproxy)
├── mitmproxy-ca-key.pem    # Private key
└── mitm_addon.py           # Addon script
```

## Files Changed

| File | Change |
|------|--------|
| `config.ts` | Add `ca_dir` to proxy schema (required) |
| `runner.yaml.j2` | Add `ca_dir: {{ runner_base_dir }}/proxy` |
| `proxy-manager.ts` | Use config `caDir`, derive `addonPath` |
| `start.ts` | Pass `caDir` to `initProxyManager` |
| `executor-env.ts` | Remove `PROXY_CA_CERT_PATH` constant |
| `vm-setup.ts` | Accept CA path parameter |
| `executor.ts` | Pass CA path to `installProxyCA` |
| `deploy-runner.yml` | Generate CA in `${RUNNER_DIR}/proxy/` |

## Test plan

- [ ] Unit tests pass (`pnpm turbo run test --filter @vm0/runner`)
- [ ] Lint passes (`pnpm turbo run lint --filter @vm0/runner`)
- [ ] E2E mitm-firewall tests pass (`t09-firewall-mitm.bats`)
- [ ] Verify CA is generated in per-runner directory during deployment

Closes #1397

🤖 Generated with [Claude Code](https://claude.com/claude-code)