### PR TITLE
refactor(cli): split api-client.ts into domain modules

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/usage.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/usage.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../mocks/server";
 import { usageCommand } from "../usage";
-import { apiClient } from "../../lib/api/api-client";
+import * as config from "../../lib/api/config";
 
-// Mock dependencies
-vi.mock("../../lib/api/api-client");
+// Mock the config module for auth
+vi.mock("../../lib/api/config", () => ({
+  getApiUrl: vi.fn(),
+  getToken: vi.fn(),
+}));
 
 describe("usage command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
@@ -16,6 +21,8 @@ describe("usage command", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(config.getApiUrl).mockResolvedValue("http://localhost:3000");
+    vi.mocked(config.getToken).mockResolvedValue("test-token");
   });
 
   afterEach(() => {
@@ -26,28 +33,27 @@ describe("usage command", () => {
 
   describe("default behavior", () => {
     it("should fetch usage with default 7 day range", async () => {
-      vi.mocked(apiClient.getUsage).mockResolvedValue({
-        period: {
-          start: "2026-01-12T00:00:00.000Z",
-          end: "2026-01-19T00:00:00.000Z",
-        },
-        summary: {
-          total_runs: 10,
-          total_run_time_ms: 600000, // 10 minutes
-        },
-        daily: [
-          { date: "2026-01-18", run_count: 5, run_time_ms: 300000 },
-          { date: "2026-01-17", run_count: 3, run_time_ms: 180000 },
-          { date: "2026-01-16", run_count: 2, run_time_ms: 120000 },
-        ],
-      });
+      server.use(
+        http.get("http://localhost:3000/api/usage", () => {
+          return HttpResponse.json({
+            period: {
+              start: "2026-01-12T00:00:00.000Z",
+              end: "2026-01-19T00:00:00.000Z",
+            },
+            summary: {
+              total_runs: 10,
+              total_run_time_ms: 600000, // 10 minutes
+            },
+            daily: [
+              { date: "2026-01-18", run_count: 5, run_time_ms: 300000 },
+              { date: "2026-01-17", run_count: 3, run_time_ms: 180000 },
+              { date: "2026-01-16", run_count: 2, run_time_ms: 120000 },
+            ],
+          });
+        }),
+      );
 
       await usageCommand.parseAsync(["node", "cli"]);
-
-      expect(apiClient.getUsage).toHaveBeenCalledWith({
-        startDate: expect.any(String),
-        endDate: expect.any(String),
-      });
 
       // Check output contains expected header and data
       expect(mockConsoleLog).toHaveBeenCalledWith(
@@ -56,19 +62,23 @@ describe("usage command", () => {
     });
 
     it("should display daily breakdown with formatted durations", async () => {
-      vi.mocked(apiClient.getUsage).mockResolvedValue({
-        period: {
-          start: "2026-01-12T00:00:00.000Z",
-          end: "2026-01-19T00:00:00.000Z",
-        },
-        summary: {
-          total_runs: 10,
-          total_run_time_ms: 600000,
-        },
-        daily: [
-          { date: "2026-01-18", run_count: 5, run_time_ms: 300000 }, // 5m
-        ],
-      });
+      server.use(
+        http.get("http://localhost:3000/api/usage", () => {
+          return HttpResponse.json({
+            period: {
+              start: "2026-01-12T00:00:00.000Z",
+              end: "2026-01-19T00:00:00.000Z",
+            },
+            summary: {
+              total_runs: 10,
+              total_run_time_ms: 600000,
+            },
+            daily: [
+              { date: "2026-01-18", run_count: 5, run_time_ms: 300000 }, // 5m
+            ],
+          });
+        }),
+      );
 
       await usageCommand.parseAsync(["node", "cli"]);
 
@@ -81,36 +91,45 @@ describe("usage command", () => {
 
   describe("--since option", () => {
     it("should accept ISO date format", async () => {
-      vi.mocked(apiClient.getUsage).mockResolvedValue({
-        period: {
-          start: "2026-01-15T00:00:00.000Z",
-          end: "2026-01-19T00:00:00.000Z",
-        },
-        summary: { total_runs: 5, total_run_time_ms: 300000 },
-        daily: [],
-      });
+      let capturedUrl: string | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/usage", ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({
+            period: {
+              start: "2026-01-15T00:00:00.000Z",
+              end: "2026-01-19T00:00:00.000Z",
+            },
+            summary: { total_runs: 5, total_run_time_ms: 300000 },
+            daily: [],
+          });
+        }),
+      );
 
       await usageCommand.parseAsync(["node", "cli", "--since", "2026-01-15"]);
 
-      expect(apiClient.getUsage).toHaveBeenCalledWith({
-        startDate: expect.stringContaining("2026-01-15"),
-        endDate: expect.any(String),
-      });
+      expect(capturedUrl).toContain("start_date");
+      expect(capturedUrl).toContain("2026-01-15");
     });
 
     it("should accept relative format (7d)", async () => {
-      vi.mocked(apiClient.getUsage).mockResolvedValue({
-        period: {
-          start: "2026-01-12T00:00:00.000Z",
-          end: "2026-01-19T00:00:00.000Z",
-        },
-        summary: { total_runs: 5, total_run_time_ms: 300000 },
-        daily: [],
-      });
+      server.use(
+        http.get("http://localhost:3000/api/usage", () => {
+          return HttpResponse.json({
+            period: {
+              start: "2026-01-12T00:00:00.000Z",
+              end: "2026-01-19T00:00:00.000Z",
+            },
+            summary: { total_runs: 5, total_run_time_ms: 300000 },
+            daily: [],
+          });
+        }),
+      );
 
       await usageCommand.parseAsync(["node", "cli", "--since", "7d"]);
 
-      expect(apiClient.getUsage).toHaveBeenCalled();
+      // Test passes if no error is thrown
+      expect(mockConsoleLog).toHaveBeenCalled();
     });
 
     it("should reject invalid --since format", async () => {
@@ -127,21 +146,25 @@ describe("usage command", () => {
 
   describe("--until option", () => {
     it("should accept ISO date format", async () => {
-      vi.mocked(apiClient.getUsage).mockResolvedValue({
-        period: {
-          start: "2026-01-10T00:00:00.000Z",
-          end: "2026-01-17T00:00:00.000Z",
-        },
-        summary: { total_runs: 5, total_run_time_ms: 300000 },
-        daily: [],
-      });
+      let capturedUrl: string | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/usage", ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({
+            period: {
+              start: "2026-01-10T00:00:00.000Z",
+              end: "2026-01-17T00:00:00.000Z",
+            },
+            summary: { total_runs: 5, total_run_time_ms: 300000 },
+            daily: [],
+          });
+        }),
+      );
 
       await usageCommand.parseAsync(["node", "cli", "--until", "2026-01-17"]);
 
-      expect(apiClient.getUsage).toHaveBeenCalledWith({
-        startDate: expect.any(String),
-        endDate: expect.stringContaining("2026-01-17"),
-      });
+      expect(capturedUrl).toContain("end_date");
+      expect(capturedUrl).toContain("2026-01-17");
     });
 
     it("should reject invalid --until format", async () => {
@@ -196,9 +219,7 @@ describe("usage command", () => {
 
   describe("error handling", () => {
     it("should handle authentication errors", async () => {
-      vi.mocked(apiClient.getUsage).mockRejectedValue(
-        new Error("Not authenticated"),
-      );
+      vi.mocked(config.getToken).mockResolvedValue(undefined);
 
       await expect(async () => {
         await usageCommand.parseAsync(["node", "cli"]);
@@ -214,8 +235,13 @@ describe("usage command", () => {
     });
 
     it("should handle API errors", async () => {
-      vi.mocked(apiClient.getUsage).mockRejectedValue(
-        new Error("Server error"),
+      server.use(
+        http.get("http://localhost:3000/api/usage", () => {
+          return HttpResponse.json(
+            { error: { message: "Server error", code: "SERVER_ERROR" } },
+            { status: 500 },
+          );
+        }),
       );
 
       await expect(async () => {
@@ -229,14 +255,19 @@ describe("usage command", () => {
     });
 
     it("should handle unexpected errors", async () => {
-      vi.mocked(apiClient.getUsage).mockRejectedValue("Non-error object");
+      server.use(
+        http.get("http://localhost:3000/api/usage", () => {
+          return HttpResponse.error();
+        }),
+      );
 
       await expect(async () => {
         await usageCommand.parseAsync(["node", "cli"]);
       }).rejects.toThrow("process.exit called");
 
+      // Network error from HttpResponse.error() manifests as "Failed to fetch"
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("unexpected error"),
+        expect.stringContaining("Failed to fetch"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
@@ -244,17 +275,21 @@ describe("usage command", () => {
 
   describe("output formatting", () => {
     it("should fill in missing dates with zero values", async () => {
-      vi.mocked(apiClient.getUsage).mockResolvedValue({
-        period: {
-          start: "2026-01-15T00:00:00.000Z",
-          end: "2026-01-19T00:00:00.000Z",
-        },
-        summary: { total_runs: 2, total_run_time_ms: 120000 },
-        daily: [
-          // Only one day has data, others should be filled with zeros
-          { date: "2026-01-17", run_count: 2, run_time_ms: 120000 },
-        ],
-      });
+      server.use(
+        http.get("http://localhost:3000/api/usage", () => {
+          return HttpResponse.json({
+            period: {
+              start: "2026-01-15T00:00:00.000Z",
+              end: "2026-01-19T00:00:00.000Z",
+            },
+            summary: { total_runs: 2, total_run_time_ms: 120000 },
+            daily: [
+              // Only one day has data, others should be filled with zeros
+              { date: "2026-01-17", run_count: 2, run_time_ms: 120000 },
+            ],
+          });
+        }),
+      );
 
       await usageCommand.parseAsync(["node", "cli"]);
 
@@ -264,14 +299,18 @@ describe("usage command", () => {
     });
 
     it("should display '-' for zero run time", async () => {
-      vi.mocked(apiClient.getUsage).mockResolvedValue({
-        period: {
-          start: "2026-01-15T00:00:00.000Z",
-          end: "2026-01-19T00:00:00.000Z",
-        },
-        summary: { total_runs: 0, total_run_time_ms: 0 },
-        daily: [],
-      });
+      server.use(
+        http.get("http://localhost:3000/api/usage", () => {
+          return HttpResponse.json({
+            period: {
+              start: "2026-01-15T00:00:00.000Z",
+              end: "2026-01-19T00:00:00.000Z",
+            },
+            summary: { total_runs: 0, total_run_time_ms: 0 },
+            daily: [],
+          });
+        }),
+      );
 
       await usageCommand.parseAsync(["node", "cli"]);
 

--- a/turbo/apps/cli/src/commands/__tests__/volume-status.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/volume-status.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../mocks/server";
 import { statusCommand } from "../volume/status";
 import * as storageUtils from "../../lib/storage/storage-utils";
-import { apiClient } from "../../lib/api/api-client";
+import * as config from "../../lib/api/config";
 
 // Mock dependencies
 vi.mock("../../lib/storage/storage-utils");
-vi.mock("../../lib/api/api-client");
+vi.mock("../../lib/api/config", () => ({
+  getApiUrl: vi.fn(),
+  getToken: vi.fn(),
+}));
 
 describe("volume status command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
@@ -18,6 +23,8 @@ describe("volume status command", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(config.getApiUrl).mockResolvedValue("http://localhost:3000");
+    vi.mocked(config.getToken).mockResolvedValue("test-token");
   });
 
   afterEach(() => {
@@ -72,13 +79,17 @@ describe("volume status command", () => {
     });
 
     it("should show start message", async () => {
-      vi.mocked(apiClient.getStorageDownload).mockResolvedValue({
-        versionId:
-          "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4",
-        url: "https://example.com/download",
-        fileCount: 100,
-        size: 1024000,
-      });
+      server.use(
+        http.get("http://localhost:3000/api/storages/download", () => {
+          return HttpResponse.json({
+            versionId:
+              "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4",
+            url: "https://example.com/download",
+            fileCount: 100,
+            size: 1024000,
+          });
+        }),
+      );
 
       await statusCommand.parseAsync(["node", "cli"]);
 
@@ -88,8 +99,18 @@ describe("volume status command", () => {
     });
 
     it("should exit with error if remote returns 404", async () => {
-      vi.mocked(apiClient.getStorageDownload).mockRejectedValue(
-        new Error('Storage "test-volume" not found'),
+      server.use(
+        http.get("http://localhost:3000/api/storages/download", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: 'Storage "test-volume" not found',
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        }),
       );
 
       await expect(async () => {
@@ -106,13 +127,17 @@ describe("volume status command", () => {
     });
 
     it("should display version info when remote exists", async () => {
-      vi.mocked(apiClient.getStorageDownload).mockResolvedValue({
-        versionId:
-          "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4",
-        url: "https://example.com/download",
-        fileCount: 100,
-        size: 1024000,
-      });
+      server.use(
+        http.get("http://localhost:3000/api/storages/download", () => {
+          return HttpResponse.json({
+            versionId:
+              "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4",
+            url: "https://example.com/download",
+            fileCount: 100,
+            size: 1024000,
+          });
+        }),
+      );
 
       await statusCommand.parseAsync(["node", "cli"]);
 
@@ -131,13 +156,17 @@ describe("volume status command", () => {
     });
 
     it("should display empty indicator for empty storage", async () => {
-      vi.mocked(apiClient.getStorageDownload).mockResolvedValue({
-        versionId:
-          "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4",
-        empty: true,
-        fileCount: 0,
-        size: 0,
-      });
+      server.use(
+        http.get("http://localhost:3000/api/storages/download", () => {
+          return HttpResponse.json({
+            versionId:
+              "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4",
+            empty: true,
+            fileCount: 0,
+            size: 0,
+          });
+        }),
+      );
 
       await statusCommand.parseAsync(["node", "cli"]);
 
@@ -159,8 +188,18 @@ describe("volume status command", () => {
     });
 
     it("should handle API errors", async () => {
-      vi.mocked(apiClient.getStorageDownload).mockRejectedValue(
-        new Error("Internal server error"),
+      server.use(
+        http.get("http://localhost:3000/api/storages/download", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
       );
 
       await expect(async () => {
@@ -174,8 +213,13 @@ describe("volume status command", () => {
     });
 
     it("should handle network errors", async () => {
-      vi.mocked(apiClient.getStorageDownload).mockRejectedValue(
-        new Error("Network error"),
+      server.use(
+        http.get("http://localhost:3000/api/storages/download", () => {
+          return HttpResponse.json(
+            { error: { message: "Network error", code: "SERVER_ERROR" } },
+            { status: 500 },
+          );
+        }),
       );
 
       await expect(async () => {

--- a/turbo/apps/cli/src/commands/agent/inspect.ts
+++ b/turbo/apps/cli/src/commands/agent/inspect.ts
@@ -1,6 +1,10 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient, type GetComposeResponse } from "../../lib/api/api-client";
+import {
+  getComposeByName,
+  getComposeVersion,
+  type GetComposeResponse,
+} from "../../lib/api";
 import {
   deriveComposeVariableSources,
   type AgentVariableSources,
@@ -156,7 +160,7 @@ export const inspectCommand = new Command()
         // Get compose by name
         let compose: GetComposeResponse;
         try {
-          compose = await apiClient.getComposeByName(name, options.scope);
+          compose = await getComposeByName(name, options.scope);
         } catch (error) {
           if (error instanceof Error && error.message.includes("not found")) {
             console.error(chalk.red(`✗ Agent compose not found: ${name}`));
@@ -174,10 +178,7 @@ export const inspectCommand = new Command()
           if (version.length < 64) {
             // Resolve the version prefix
             try {
-              const versionInfo = await apiClient.getComposeVersion(
-                compose.id,
-                version,
-              );
+              const versionInfo = await getComposeVersion(compose.id, version);
               resolvedVersionId = versionInfo.versionId;
             } catch (error) {
               if (

--- a/turbo/apps/cli/src/commands/agent/list.ts
+++ b/turbo/apps/cli/src/commands/agent/list.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient, type ApiError } from "../../lib/api/api-client";
+import { httpGet, type ApiError } from "../../lib/api";
 import { formatRelativeTime } from "../../lib/utils/file-utils";
 
 /**
@@ -28,7 +28,7 @@ export const listCommand = new Command()
         ? `/api/agent/composes/list?scope=${encodeURIComponent(options.scope)}`
         : "/api/agent/composes/list";
 
-      const response = await apiClient.get(url);
+      const response = await httpGet(url);
 
       if (!response.ok) {
         const error = (await response.json()) as ApiError;

--- a/turbo/apps/cli/src/commands/artifact/list.ts
+++ b/turbo/apps/cli/src/commands/artifact/list.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient } from "../../lib/api/api-client";
+import { listStorages } from "../../lib/api";
 import { formatBytes, formatRelativeTime } from "../../lib/utils/file-utils";
 
 export const listCommand = new Command()
@@ -10,7 +10,7 @@ export const listCommand = new Command()
   .action(async () => {
     try {
       // Call API
-      const items = await apiClient.listStorages({ type: "artifact" });
+      const items = await listStorages({ type: "artifact" });
 
       if (items.length === 0) {
         console.log(chalk.dim("No artifacts found"));

--- a/turbo/apps/cli/src/commands/artifact/pull.ts
+++ b/turbo/apps/cli/src/commands/artifact/pull.ts
@@ -5,7 +5,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as tar from "tar";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
-import { apiClient } from "../../lib/api/api-client";
+import { getStorageDownload } from "../../lib/api";
 import { listTarFiles, removeExtraFiles } from "../../lib/utils/file-utils";
 import { handleEmptyStorageResponse } from "../../lib/storage/pull-utils";
 
@@ -55,7 +55,7 @@ export const pullCommand = new Command()
       // Get download URL from API
       console.log(chalk.dim("Getting download URL..."));
 
-      const downloadInfo = await apiClient.getStorageDownload({
+      const downloadInfo = await getStorageDownload({
         name: config.name,
         type: "artifact",
         version: versionId,

--- a/turbo/apps/cli/src/commands/artifact/status.ts
+++ b/turbo/apps/cli/src/commands/artifact/status.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
-import { apiClient } from "../../lib/api/api-client";
+import { getStorageDownload } from "../../lib/api";
 
 /**
  * Format bytes to human-readable format
@@ -43,7 +43,7 @@ export const statusCommand = new Command()
       console.log(`Checking artifact: ${config.name}`);
 
       // Call API
-      const info = await apiClient.getStorageDownload({
+      const info = await getStorageDownload({
         name: config.name,
         type: "artifact",
       });

--- a/turbo/apps/cli/src/commands/compose.ts
+++ b/turbo/apps/cli/src/commands/compose.ts
@@ -10,7 +10,7 @@ import {
   extractVariableReferences,
   groupVariablesBySource,
 } from "@vm0/core";
-import { apiClient } from "../lib/api/api-client";
+import { getComposeByName, createOrUpdateCompose, getScope } from "../lib/api";
 import { validateAgentCompose } from "../lib/domain/yaml-validator";
 import {
   getProviderDefaults,
@@ -249,7 +249,7 @@ export const composeCommand = new Command()
       // Fetch HEAD version to compare secrets (for smart confirmation)
       let headSecrets = new Set<string>();
       try {
-        const existingCompose = await apiClient.getComposeByName(agentName);
+        const existingCompose = await getComposeByName(agentName);
         if (existingCompose.content) {
           headSecrets = getSecretsFromComposeContent(existingCompose.content);
         }
@@ -336,12 +336,12 @@ export const composeCommand = new Command()
       // 5. Call API
       console.log("Uploading compose...");
 
-      const response = await apiClient.createOrUpdateCompose({
+      const response = await createOrUpdateCompose({
         content: config,
       });
 
       // Get user's scope for display (must exist if compose succeeded)
-      const scopeResponse = await apiClient.getScope();
+      const scopeResponse = await getScope();
 
       // 6. Display result
       const shortVersionId = response.versionId.slice(0, 8);

--- a/turbo/apps/cli/src/commands/credential/delete.ts
+++ b/turbo/apps/cli/src/commands/credential/delete.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient } from "../../lib/api/api-client";
+import { getCredential, deleteCredential } from "../../lib/api";
 
 export const deleteCommand = new Command()
   .name("delete")
@@ -11,7 +11,7 @@ export const deleteCommand = new Command()
     try {
       // Verify credential exists first
       try {
-        await apiClient.getCredential(name);
+        await getCredential(name);
       } catch {
         console.error(chalk.red(`✗ Credential "${name}" not found`));
         process.exit(1);
@@ -43,7 +43,7 @@ export const deleteCommand = new Command()
         }
       }
 
-      await apiClient.deleteCredential(name);
+      await deleteCredential(name);
       console.log(chalk.green(`✓ Credential "${name}" deleted`));
     } catch (error) {
       if (error instanceof Error) {

--- a/turbo/apps/cli/src/commands/credential/list.ts
+++ b/turbo/apps/cli/src/commands/credential/list.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient } from "../../lib/api/api-client";
+import { listCredentials } from "../../lib/api";
 
 export const listCommand = new Command()
   .name("list")
@@ -8,7 +8,7 @@ export const listCommand = new Command()
   .option("--json", "Output in JSON format")
   .action(async (options: { json?: boolean }) => {
     try {
-      const result = await apiClient.listCredentials();
+      const result = await listCredentials();
 
       if (options.json) {
         console.log(JSON.stringify(result.credentials, null, 2));

--- a/turbo/apps/cli/src/commands/credential/set.ts
+++ b/turbo/apps/cli/src/commands/credential/set.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient } from "../../lib/api/api-client";
+import { setCredential } from "../../lib/api";
 
 export const setCommand = new Command()
   .name("set")
@@ -11,7 +11,7 @@ export const setCommand = new Command()
   .action(
     async (name: string, value: string, options: { description?: string }) => {
       try {
-        const credential = await apiClient.setCredential({
+        const credential = await setCredential({
           name,
           value,
           description: options.description,

--- a/turbo/apps/cli/src/commands/run/continue.ts
+++ b/turbo/apps/cli/src/commands/run/continue.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient } from "../../lib/api/api-client";
+import { getSession, createRun } from "../../lib/api";
 import { EventRenderer } from "../../lib/events/event-renderer";
 import {
   collectKeyValue,
@@ -81,7 +81,7 @@ export const continueCommand = new Command()
 
         // 2. Fetch session info to get required secret names
         // This allows loading secrets from environment variables
-        const sessionInfo = await apiClient.getSession(agentSessionId);
+        const sessionInfo = await getSession(agentSessionId);
         const requiredSecretNames = sessionInfo.secretNames || [];
 
         // 3. Load secrets from CLI options + environment variables
@@ -117,7 +117,7 @@ export const continueCommand = new Command()
         }
 
         // 5. Call unified API with sessionId
-        const response = await apiClient.createRun({
+        const response = await createRun({
           sessionId: agentSessionId,
           prompt,
           vars: Object.keys(vars).length > 0 ? vars : undefined,

--- a/turbo/apps/cli/src/commands/run/resume.ts
+++ b/turbo/apps/cli/src/commands/run/resume.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient } from "../../lib/api/api-client";
+import { getCheckpoint, createRun } from "../../lib/api";
 import { EventRenderer } from "../../lib/events/event-renderer";
 import {
   collectKeyValue,
@@ -79,7 +79,7 @@ export const resumeCommand = new Command()
 
         // 2. Fetch checkpoint info to get required secret names
         // This allows loading secrets from environment variables
-        const checkpointInfo = await apiClient.getCheckpoint(checkpointId);
+        const checkpointInfo = await getCheckpoint(checkpointId);
         const requiredSecretNames =
           checkpointInfo.agentComposeSnapshot.secretNames || [];
 
@@ -115,7 +115,7 @@ export const resumeCommand = new Command()
         }
 
         // 5. Call unified API with checkpointId
-        const response = await apiClient.createRun({
+        const response = await createRun({
           checkpointId,
           prompt,
           vars: Object.keys(vars).length > 0 ? vars : undefined,

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -1,6 +1,11 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient } from "../../lib/api/api-client";
+import {
+  getComposeById,
+  getComposeByName,
+  getComposeVersion,
+  createRun,
+} from "../../lib/api";
 import { EventRenderer } from "../../lib/events/event-renderer";
 import {
   collectKeyValue,
@@ -84,7 +89,7 @@ export const mainRunCommand = new Command()
           if (verbose) {
             console.log(chalk.dim(`  Using compose ID: ${identifier}`));
           }
-          const compose = await apiClient.getComposeById(name);
+          const compose = await getComposeById(name);
           composeId = compose.id;
           composeContent = compose.content;
         } else {
@@ -93,7 +98,7 @@ export const mainRunCommand = new Command()
             const displayRef = scope ? `${scope}/${name}` : name;
             console.log(chalk.dim(`  Resolving agent: ${displayRef}`));
           }
-          const compose = await apiClient.getComposeByName(name, scope);
+          const compose = await getComposeByName(name, scope);
           composeId = compose.id;
           composeContent = compose.content;
           if (verbose) {
@@ -110,10 +115,7 @@ export const mainRunCommand = new Command()
             console.log(chalk.dim(`  Resolving version: ${version}`));
           }
           try {
-            const versionInfo = await apiClient.getComposeVersion(
-              composeId,
-              version,
-            );
+            const versionInfo = await getComposeVersion(composeId, version);
             agentComposeVersionId = versionInfo.versionId;
             if (verbose) {
               console.log(
@@ -189,7 +191,7 @@ export const mainRunCommand = new Command()
         }
 
         // 6. Call unified API (server handles all variable expansion)
-        const response = await apiClient.createRun({
+        const response = await createRun({
           // Use agentComposeVersionId if resolved, otherwise use agentComposeId (resolves to HEAD)
           ...(agentComposeVersionId
             ? { agentComposeVersionId }

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { config as dotenvConfig } from "dotenv";
-import { apiClient } from "../../lib/api/api-client";
+import { getEvents } from "../../lib/api";
 import { parseEvent } from "../../lib/events/event-parser-factory";
 import { EventRenderer } from "../../lib/events/event-renderer";
 import { CodexEventRenderer } from "../../lib/events/codex-event-renderer";
@@ -194,7 +194,7 @@ export async function pollEvents(
   const verbose = options.verbose;
 
   while (!complete) {
-    const response = await apiClient.getEvents(runId, {
+    const response = await getEvents(runId, {
       since: nextSequence,
     });
 

--- a/turbo/apps/cli/src/commands/schedule/delete.ts
+++ b/turbo/apps/cli/src/commands/schedule/delete.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import * as readline from "readline";
-import { apiClient } from "../../lib/api/api-client";
+import { getComposeByName, deleteSchedule } from "../../lib/api";
 import {
   loadAgentName,
   loadScheduleName,
@@ -71,7 +71,7 @@ export const deleteCommand = new Command()
       // Get compose ID
       let composeId: string;
       try {
-        const compose = await apiClient.getComposeByName(agentName);
+        const compose = await getComposeByName(agentName);
         composeId = compose.id;
       } catch {
         console.error(chalk.red(`✗ Agent not found: ${agentName}`));
@@ -89,7 +89,7 @@ export const deleteCommand = new Command()
       }
 
       // Call API
-      await apiClient.deleteSchedule({ name, composeId });
+      await deleteSchedule({ name, composeId });
 
       console.log(chalk.green(`✓ Deleted schedule ${chalk.cyan(name)}`));
     } catch (error) {

--- a/turbo/apps/cli/src/commands/schedule/deploy.ts
+++ b/turbo/apps/cli/src/commands/schedule/deploy.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { existsSync, readFileSync } from "fs";
 import { parse as parseYaml } from "yaml";
-import { apiClient } from "../../lib/api/api-client";
+import { getComposeByName, deploySchedule } from "../../lib/api";
 import { scheduleYamlSchema, type ScheduleDefinition } from "@vm0/core";
 import { toISODateTime } from "../../lib/domain/schedule-utils";
 
@@ -133,7 +133,7 @@ export const deployCommand = new Command()
           ? namePart.split(":")[0]!
           : namePart;
 
-        const compose = await apiClient.getComposeByName(agentName);
+        const compose = await getComposeByName(agentName);
         composeId = compose.id;
       } catch {
         console.error(chalk.red(`✗ Agent not found: ${agentRef}`));
@@ -164,7 +164,7 @@ export const deployCommand = new Command()
       };
 
       // Call API
-      const deployResult = await apiClient.deploySchedule(body);
+      const deployResult = await deploySchedule(body);
 
       // Display result
       if (deployResult.created) {

--- a/turbo/apps/cli/src/commands/schedule/disable.ts
+++ b/turbo/apps/cli/src/commands/schedule/disable.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient } from "../../lib/api/api-client";
+import { getComposeByName, disableSchedule } from "../../lib/api";
 import {
   loadAgentName,
   loadScheduleName,
@@ -51,7 +51,7 @@ export const disableCommand = new Command()
       // Get compose ID
       let composeId: string;
       try {
-        const compose = await apiClient.getComposeByName(agentName);
+        const compose = await getComposeByName(agentName);
         composeId = compose.id;
       } catch {
         console.error(chalk.red(`✗ Agent not found: ${agentName}`));
@@ -60,7 +60,7 @@ export const disableCommand = new Command()
       }
 
       // Call API
-      await apiClient.disableSchedule({ name, composeId });
+      await disableSchedule({ name, composeId });
 
       console.log(chalk.green(`✓ Disabled schedule ${chalk.cyan(name)}`));
     } catch (error) {

--- a/turbo/apps/cli/src/commands/schedule/enable.ts
+++ b/turbo/apps/cli/src/commands/schedule/enable.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient } from "../../lib/api/api-client";
+import { getComposeByName, enableSchedule } from "../../lib/api";
 import {
   loadAgentName,
   loadScheduleName,
@@ -51,7 +51,7 @@ export const enableCommand = new Command()
       // Get compose ID
       let composeId: string;
       try {
-        const compose = await apiClient.getComposeByName(agentName);
+        const compose = await getComposeByName(agentName);
         composeId = compose.id;
       } catch {
         console.error(chalk.red(`✗ Agent not found: ${agentName}`));
@@ -60,7 +60,7 @@ export const enableCommand = new Command()
       }
 
       // Call API
-      await apiClient.enableSchedule({ name, composeId });
+      await enableSchedule({ name, composeId });
 
       console.log(chalk.green(`✓ Enabled schedule ${chalk.cyan(name)}`));
     } catch (error) {

--- a/turbo/apps/cli/src/commands/schedule/list.ts
+++ b/turbo/apps/cli/src/commands/schedule/list.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient } from "../../lib/api/api-client";
+import { listSchedules } from "../../lib/api";
 import { formatRelativeTime } from "../../lib/domain/schedule-utils";
 
 export const listCommand = new Command()
@@ -9,7 +9,7 @@ export const listCommand = new Command()
   .description("List all schedules")
   .action(async () => {
     try {
-      const result = await apiClient.listSchedules();
+      const result = await listSchedules();
 
       if (result.schedules.length === 0) {
         console.log(chalk.dim("No schedules found"));

--- a/turbo/apps/cli/src/commands/schedule/status.ts
+++ b/turbo/apps/cli/src/commands/schedule/status.ts
@@ -1,6 +1,10 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient } from "../../lib/api/api-client";
+import {
+  getComposeByName,
+  getScheduleByName,
+  listScheduleRuns,
+} from "../../lib/api";
 import {
   loadAgentName,
   loadScheduleName,
@@ -104,7 +108,7 @@ export const statusCommand = new Command()
       // Get compose ID
       let composeId: string;
       try {
-        const compose = await apiClient.getComposeByName(agentName);
+        const compose = await getComposeByName(agentName);
         composeId = compose.id;
       } catch {
         console.error(chalk.red(`✗ Agent not found: ${agentName}`));
@@ -113,7 +117,7 @@ export const statusCommand = new Command()
       }
 
       // Get schedule details
-      const schedule = await apiClient.getScheduleByName({ name, composeId });
+      const schedule = await getScheduleByName({ name, composeId });
 
       // Print header
       console.log();
@@ -195,7 +199,7 @@ export const statusCommand = new Command()
       );
       if (limit > 0) {
         try {
-          const { runs } = await apiClient.listScheduleRuns({
+          const { runs } = await listScheduleRuns({
             name,
             composeId,
             limit,

--- a/turbo/apps/cli/src/commands/scope/set.ts
+++ b/turbo/apps/cli/src/commands/scope/set.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient } from "../../lib/api/api-client";
+import { getScope, createScope, updateScope } from "../../lib/api";
 
 export const setCommand = new Command()
   .name("set")
@@ -17,7 +17,7 @@ export const setCommand = new Command()
         // First check if user already has a scope
         let existingScope;
         try {
-          existingScope = await apiClient.getScope();
+          existingScope = await getScope();
         } catch (error) {
           // Only swallow "No scope configured" errors - that's the expected case for new users
           // All other errors (network, auth, etc.) should propagate to the outer handler
@@ -48,11 +48,11 @@ export const setCommand = new Command()
             process.exit(1);
           }
 
-          scope = await apiClient.updateScope({ slug, force: true });
+          scope = await updateScope({ slug, force: true });
           console.log(chalk.green(`✓ Scope updated to ${scope.slug}`));
         } else {
           // Create new scope
-          scope = await apiClient.createScope({
+          scope = await createScope({
             slug,
             displayName: options.displayName,
           });

--- a/turbo/apps/cli/src/commands/scope/status.ts
+++ b/turbo/apps/cli/src/commands/scope/status.ts
@@ -1,13 +1,13 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient } from "../../lib/api/api-client";
+import { getScope } from "../../lib/api";
 
 export const statusCommand = new Command()
   .name("status")
   .description("View current scope status")
   .action(async () => {
     try {
-      const scope = await apiClient.getScope();
+      const scope = await getScope();
 
       console.log(chalk.bold("Scope Information:"));
       console.log(`  Slug: ${chalk.green(scope.slug)}`);

--- a/turbo/apps/cli/src/commands/usage.ts
+++ b/turbo/apps/cli/src/commands/usage.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient } from "../lib/api/api-client";
+import { getUsage } from "../lib/api";
 import { parseTime } from "../lib/utils/time-parser";
 import { formatDuration } from "../lib/utils/duration-formatter";
 
@@ -155,7 +155,7 @@ export const usageCommand = new Command()
       }
 
       // Fetch usage data
-      const usage = await apiClient.getUsage({
+      const usage = await getUsage({
         startDate: startDate.toISOString(),
         endDate: endDate.toISOString(),
       });

--- a/turbo/apps/cli/src/commands/volume/list.ts
+++ b/turbo/apps/cli/src/commands/volume/list.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { apiClient } from "../../lib/api/api-client";
+import { listStorages } from "../../lib/api";
 import { formatBytes, formatRelativeTime } from "../../lib/utils/file-utils";
 
 export const listCommand = new Command()
@@ -10,7 +10,7 @@ export const listCommand = new Command()
   .action(async () => {
     try {
       // Call API
-      const items = await apiClient.listStorages({ type: "volume" });
+      const items = await listStorages({ type: "volume" });
 
       if (items.length === 0) {
         console.log(chalk.dim("No volumes found"));

--- a/turbo/apps/cli/src/commands/volume/pull.ts
+++ b/turbo/apps/cli/src/commands/volume/pull.ts
@@ -5,7 +5,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as tar from "tar";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
-import { apiClient } from "../../lib/api/api-client";
+import { getStorageDownload } from "../../lib/api";
 import { listTarFiles, removeExtraFiles } from "../../lib/utils/file-utils";
 import { handleEmptyStorageResponse } from "../../lib/storage/pull-utils";
 
@@ -45,7 +45,7 @@ export const pullCommand = new Command()
       // Get download URL from API
       console.log(chalk.dim("Getting download URL..."));
 
-      const downloadInfo = await apiClient.getStorageDownload({
+      const downloadInfo = await getStorageDownload({
         name: config.name,
         type: "volume",
         version: versionId,

--- a/turbo/apps/cli/src/commands/volume/status.ts
+++ b/turbo/apps/cli/src/commands/volume/status.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
-import { apiClient } from "../../lib/api/api-client";
+import { getStorageDownload } from "../../lib/api";
 
 /**
  * Format bytes to human-readable format
@@ -43,7 +43,7 @@ export const statusCommand = new Command()
       console.log(`Checking volume: ${config.name}`);
 
       // Call API
-      const info = await apiClient.getStorageDownload({
+      const info = await getStorageDownload({
         name: config.name,
         type: "volume",
       });

--- a/turbo/apps/cli/src/lib/api/core/client-factory.ts
+++ b/turbo/apps/cli/src/lib/api/core/client-factory.ts
@@ -1,0 +1,62 @@
+import { getApiUrl, getToken } from "../config";
+import type { ApiErrorResponse } from "@vm0/core";
+
+/**
+ * Get authentication headers for API requests
+ */
+export async function getHeaders(): Promise<Record<string, string>> {
+  const token = await getToken();
+  if (!token) {
+    throw new Error("Not authenticated. Run: vm0 auth login");
+  }
+
+  // Note: Don't set Content-Type here - ts-rest automatically adds it for requests with body.
+  // Setting Content-Type for bodyless requests (GET, DELETE) can cause server-side parsing issues.
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+
+  // Add Vercel bypass secret if available (for CI/preview deployments)
+  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (bypassSecret) {
+    headers["x-vercel-protection-bypass"] = bypassSecret;
+  }
+
+  return headers;
+}
+
+/**
+ * Get base URL for API requests
+ */
+export async function getBaseUrl(): Promise<string> {
+  const apiUrl = await getApiUrl();
+  if (!apiUrl) {
+    throw new Error("API URL not configured");
+  }
+  return apiUrl;
+}
+
+/**
+ * Configuration for ts-rest client initialization
+ */
+export async function getClientConfig(): Promise<{
+  baseUrl: string;
+  baseHeaders: Record<string, string>;
+  jsonQuery: true;
+}> {
+  const baseUrl = await getBaseUrl();
+  const baseHeaders = await getHeaders();
+  return { baseUrl, baseHeaders, jsonQuery: true };
+}
+
+/**
+ * Handle API error responses and throw appropriate error
+ */
+export function handleError(
+  result: { body: unknown },
+  defaultMessage: string,
+): never {
+  const errorBody = result.body as ApiErrorResponse;
+  const message = errorBody.error?.message || defaultMessage;
+  throw new Error(message);
+}

--- a/turbo/apps/cli/src/lib/api/core/http.ts
+++ b/turbo/apps/cli/src/lib/api/core/http.ts
@@ -1,0 +1,37 @@
+import { getBaseUrl } from "./client-factory";
+import { getToken } from "../config";
+
+/**
+ * Get headers for raw HTTP requests (used for non-ts-rest endpoints)
+ */
+async function getRawHeaders(): Promise<Record<string, string>> {
+  const token = await getToken();
+  if (!token) {
+    throw new Error("Not authenticated. Run: vm0 auth login");
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+
+  // Add Vercel bypass secret if available
+  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (bypassSecret) {
+    headers["x-vercel-protection-bypass"] = bypassSecret;
+  }
+
+  return headers;
+}
+
+/**
+ * Generic GET request
+ */
+export async function httpGet(path: string): Promise<Response> {
+  const baseUrl = await getBaseUrl();
+  const headers = await getRawHeaders();
+
+  return fetch(`${baseUrl}${path}`, {
+    method: "GET",
+    headers,
+  });
+}

--- a/turbo/apps/cli/src/lib/api/core/types.ts
+++ b/turbo/apps/cli/src/lib/api/core/types.ts
@@ -1,0 +1,70 @@
+// Re-export types from @vm0/core with CLI naming conventions
+import type {
+  RunResult as CoreRunResult,
+  EventsResponse,
+  SessionResponse,
+  CheckpointResponse,
+  ComposeResponse,
+  ScopeResponse as CoreScopeResponse,
+  ApiErrorResponse,
+  ScheduleResponse,
+  ScheduleListResponse,
+  DeployScheduleResponse,
+  ScheduleRunsResponse,
+  CredentialResponse,
+  CredentialListResponse,
+} from "@vm0/core";
+
+// Re-export types with CLI naming conventions for backward compatibility
+export type RunResult = CoreRunResult;
+export type ApiError = ApiErrorResponse;
+export type ScopeResponse = CoreScopeResponse;
+export type GetSessionResponse = SessionResponse;
+export type GetCheckpointResponse = CheckpointResponse;
+export type GetComposeResponse = ComposeResponse;
+export type GetEventsResponse = EventsResponse;
+
+// Re-export @vm0/core types for domain modules
+export type {
+  ScheduleResponse,
+  ScheduleListResponse,
+  DeployScheduleResponse,
+  ScheduleRunsResponse,
+  CredentialResponse,
+  CredentialListResponse,
+};
+
+// Usage API types
+export interface UsageResponse {
+  period: { start: string; end: string };
+  summary: { total_runs: number; total_run_time_ms: number };
+  daily: Array<{ date: string; run_count: number; run_time_ms: number }>;
+}
+
+// CLI-specific types (not in @vm0/core or have different structure)
+export interface CreateComposeResponse {
+  composeId: string;
+  name: string;
+  versionId: string;
+  action: "created" | "existing";
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+// RunStatus is inlined here to avoid importing the full type
+type RunStatus = "pending" | "running" | "completed" | "failed" | "timeout";
+
+export interface CreateRunResponse {
+  runId: string;
+  status: RunStatus;
+  sandboxId?: string;
+  output?: string;
+  error?: string;
+  executionTimeMs?: number;
+  createdAt: string;
+}
+
+export interface GetComposeVersionResponse {
+  versionId: string;
+  tag?: string;
+}

--- a/turbo/apps/cli/src/lib/api/domains/composes.ts
+++ b/turbo/apps/cli/src/lib/api/domains/composes.ts
@@ -1,0 +1,92 @@
+import { initClient } from "@ts-rest/core";
+import {
+  composesMainContract,
+  composesByIdContract,
+  composesVersionsContract,
+  agentComposeContentSchema,
+  type ApiErrorResponse,
+} from "@vm0/core";
+import type { z } from "zod";
+import { getClientConfig, handleError } from "../core/client-factory";
+import type {
+  GetComposeResponse,
+  CreateComposeResponse,
+  GetComposeVersionResponse,
+} from "../core/types";
+
+export async function getComposeByName(
+  name: string,
+  scope?: string,
+): Promise<GetComposeResponse> {
+  const config = await getClientConfig();
+  const client = initClient(composesMainContract, config);
+
+  const result = await client.getByName({
+    query: { name, scope },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  const errorBody = result.body as ApiErrorResponse;
+  const message = errorBody.error?.message || `Compose not found: ${name}`;
+  throw new Error(message);
+}
+
+export async function getComposeById(id: string): Promise<GetComposeResponse> {
+  const config = await getClientConfig();
+  const client = initClient(composesByIdContract, config);
+
+  const result = await client.getById({
+    params: { id },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  const errorBody = result.body as ApiErrorResponse;
+  const message = errorBody.error?.message || `Compose not found: ${id}`;
+  throw new Error(message);
+}
+
+/**
+ * Resolve a version specifier to a full version ID
+ * Supports: "latest", full hash (64 chars), or hash prefix (8+ chars)
+ */
+export async function getComposeVersion(
+  composeId: string,
+  version: string,
+): Promise<GetComposeVersionResponse> {
+  const config = await getClientConfig();
+  const client = initClient(composesVersionsContract, config);
+
+  const result = await client.resolveVersion({
+    query: { composeId, version },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, `Version not found: ${version}`);
+}
+
+export async function createOrUpdateCompose(body: {
+  content: unknown;
+}): Promise<CreateComposeResponse> {
+  const config = await getClientConfig();
+  const client = initClient(composesMainContract, config);
+
+  const result = await client.create({
+    body: body as { content: z.infer<typeof agentComposeContentSchema> },
+  });
+
+  // Both 200 and 201 are success cases
+  if (result.status === 200 || result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to create compose");
+}

--- a/turbo/apps/cli/src/lib/api/domains/composes.ts
+++ b/turbo/apps/cli/src/lib/api/domains/composes.ts
@@ -4,7 +4,6 @@ import {
   composesByIdContract,
   composesVersionsContract,
   agentComposeContentSchema,
-  type ApiErrorResponse,
 } from "@vm0/core";
 import type { z } from "zod";
 import { getClientConfig, handleError } from "../core/client-factory";
@@ -29,9 +28,7 @@ export async function getComposeByName(
     return result.body;
   }
 
-  const errorBody = result.body as ApiErrorResponse;
-  const message = errorBody.error?.message || `Compose not found: ${name}`;
-  throw new Error(message);
+  handleError(result, `Compose not found: ${name}`);
 }
 
 export async function getComposeById(id: string): Promise<GetComposeResponse> {
@@ -46,9 +43,7 @@ export async function getComposeById(id: string): Promise<GetComposeResponse> {
     return result.body;
   }
 
-  const errorBody = result.body as ApiErrorResponse;
-  const message = errorBody.error?.message || `Compose not found: ${id}`;
-  throw new Error(message);
+  handleError(result, `Compose not found: ${id}`);
 }
 
 /**

--- a/turbo/apps/cli/src/lib/api/domains/credentials.ts
+++ b/turbo/apps/cli/src/lib/api/domains/credentials.ts
@@ -1,0 +1,76 @@
+import { initClient } from "@ts-rest/core";
+import { credentialsMainContract, credentialsByNameContract } from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+import type { CredentialResponse, CredentialListResponse } from "../core/types";
+
+/**
+ * List credentials (metadata only, no values)
+ */
+export async function listCredentials(): Promise<CredentialListResponse> {
+  const config = await getClientConfig();
+  const client = initClient(credentialsMainContract, config);
+
+  const result = await client.list();
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list credentials");
+}
+
+/**
+ * Get credential by name (metadata only, no value)
+ */
+export async function getCredential(name: string): Promise<CredentialResponse> {
+  const config = await getClientConfig();
+  const client = initClient(credentialsByNameContract, config);
+
+  const result = await client.get({
+    params: { name },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, `Credential "${name}" not found`);
+}
+
+/**
+ * Set (create or update) a credential
+ */
+export async function setCredential(body: {
+  name: string;
+  value: string;
+  description?: string;
+}): Promise<CredentialResponse> {
+  const config = await getClientConfig();
+  const client = initClient(credentialsMainContract, config);
+
+  const result = await client.set({ body });
+
+  if (result.status === 200 || result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to set credential");
+}
+
+/**
+ * Delete a credential by name
+ */
+export async function deleteCredential(name: string): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(credentialsByNameContract, config);
+
+  const result = await client.delete({
+    params: { name },
+  });
+
+  if (result.status === 204) {
+    return;
+  }
+
+  handleError(result, `Credential "${name}" not found`);
+}

--- a/turbo/apps/cli/src/lib/api/domains/runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/runs.ts
@@ -1,0 +1,61 @@
+import { initClient } from "@ts-rest/core";
+import { runsMainContract, runEventsContract } from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+import type { CreateRunResponse, GetEventsResponse } from "../core/types";
+
+/**
+ * Create a run with unified request format
+ * Supports new runs, checkpoint resume, and session continue
+ * Note: Environment variables are expanded server-side from vars
+ */
+export async function createRun(body: {
+  // Shortcuts (mutually exclusive)
+  checkpointId?: string;
+  sessionId?: string;
+  // Base parameters
+  agentComposeId?: string;
+  agentComposeVersionId?: string;
+  conversationId?: string;
+  artifactName?: string;
+  artifactVersion?: string;
+  vars?: Record<string, string>;
+  secrets?: Record<string, string>;
+  volumeVersions?: Record<string, string>;
+  // Debug flag (internal use only)
+  debugNoMockClaude?: boolean;
+  // Required
+  prompt: string;
+}): Promise<CreateRunResponse> {
+  const config = await getClientConfig();
+  const client = initClient(runsMainContract, config);
+
+  const result = await client.create({ body });
+
+  if (result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to create run");
+}
+
+export async function getEvents(
+  runId: string,
+  options?: { since?: number; limit?: number },
+): Promise<GetEventsResponse> {
+  const config = await getClientConfig();
+  const client = initClient(runEventsContract, config);
+
+  const result = await client.getEvents({
+    params: { id: runId },
+    query: {
+      since: options?.since ?? 0,
+      limit: options?.limit ?? 100,
+    },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to fetch events");
+}

--- a/turbo/apps/cli/src/lib/api/domains/schedules.ts
+++ b/turbo/apps/cli/src/lib/api/domains/schedules.ts
@@ -1,0 +1,172 @@
+import { initClient } from "@ts-rest/core";
+import {
+  schedulesMainContract,
+  schedulesByNameContract,
+  schedulesEnableContract,
+  scheduleRunsContract,
+} from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+import type {
+  ScheduleResponse,
+  ScheduleListResponse,
+  DeployScheduleResponse,
+  ScheduleRunsResponse,
+} from "../core/types";
+
+/**
+ * Deploy schedule (create or update)
+ */
+export async function deploySchedule(body: {
+  name: string;
+  cronExpression?: string;
+  atTime?: string;
+  timezone?: string;
+  prompt: string;
+  vars?: Record<string, string>;
+  secrets?: Record<string, string>;
+  artifactName?: string;
+  artifactVersion?: string;
+  volumeVersions?: Record<string, string>;
+  composeId: string;
+}): Promise<DeployScheduleResponse> {
+  const config = await getClientConfig();
+  const client = initClient(schedulesMainContract, config);
+
+  const result = await client.deploy({ body });
+
+  if (result.status === 200 || result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to deploy schedule");
+}
+
+/**
+ * List all schedules
+ */
+export async function listSchedules(): Promise<ScheduleListResponse> {
+  const config = await getClientConfig();
+  const client = initClient(schedulesMainContract, config);
+
+  const result = await client.list();
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list schedules");
+}
+
+/**
+ * Get schedule by name
+ */
+export async function getScheduleByName(params: {
+  name: string;
+  composeId: string;
+}): Promise<ScheduleResponse> {
+  const config = await getClientConfig();
+  const client = initClient(schedulesByNameContract, config);
+
+  const result = await client.getByName({
+    params: { name: params.name },
+    query: { composeId: params.composeId },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, `Schedule "${params.name}" not found`);
+}
+
+/**
+ * Delete schedule by name
+ */
+export async function deleteSchedule(params: {
+  name: string;
+  composeId: string;
+}): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(schedulesByNameContract, config);
+
+  const result = await client.delete({
+    params: { name: params.name },
+    query: { composeId: params.composeId },
+  });
+
+  if (result.status === 204) {
+    return;
+  }
+
+  handleError(result, `Schedule "${params.name}" not found on remote`);
+}
+
+/**
+ * Enable schedule
+ */
+export async function enableSchedule(params: {
+  name: string;
+  composeId: string;
+}): Promise<ScheduleResponse> {
+  const config = await getClientConfig();
+  const client = initClient(schedulesEnableContract, config);
+
+  const result = await client.enable({
+    params: { name: params.name },
+    body: { composeId: params.composeId },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, `Failed to enable schedule "${params.name}"`);
+}
+
+/**
+ * Disable schedule
+ */
+export async function disableSchedule(params: {
+  name: string;
+  composeId: string;
+}): Promise<ScheduleResponse> {
+  const config = await getClientConfig();
+  const client = initClient(schedulesEnableContract, config);
+
+  const result = await client.disable({
+    params: { name: params.name },
+    body: { composeId: params.composeId },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, `Failed to disable schedule "${params.name}"`);
+}
+
+/**
+ * List recent runs for a schedule
+ */
+export async function listScheduleRuns(params: {
+  name: string;
+  composeId: string;
+  limit?: number;
+}): Promise<ScheduleRunsResponse> {
+  const config = await getClientConfig();
+  const client = initClient(scheduleRunsContract, config);
+
+  const result = await client.listRuns({
+    params: { name: params.name },
+    query: {
+      composeId: params.composeId,
+      limit: params.limit ?? 5,
+    },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, `Failed to list runs for schedule "${params.name}"`);
+}

--- a/turbo/apps/cli/src/lib/api/domains/scopes.ts
+++ b/turbo/apps/cli/src/lib/api/domains/scopes.ts
@@ -1,0 +1,58 @@
+import { initClient } from "@ts-rest/core";
+import { scopeContract } from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+import type { ScopeResponse } from "../core/types";
+
+/**
+ * Get current user's scope
+ */
+export async function getScope(): Promise<ScopeResponse> {
+  const config = await getClientConfig();
+  const client = initClient(scopeContract, config);
+
+  const result = await client.get();
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to get scope");
+}
+
+/**
+ * Create user's scope
+ */
+export async function createScope(body: {
+  slug: string;
+  displayName?: string;
+}): Promise<ScopeResponse> {
+  const config = await getClientConfig();
+  const client = initClient(scopeContract, config);
+
+  const result = await client.create({ body });
+
+  if (result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to create scope");
+}
+
+/**
+ * Update user's scope slug
+ */
+export async function updateScope(body: {
+  slug: string;
+  force?: boolean;
+}): Promise<ScopeResponse> {
+  const config = await getClientConfig();
+  const client = initClient(scopeContract, config);
+
+  const result = await client.update({ body });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to update scope");
+}

--- a/turbo/apps/cli/src/lib/api/domains/sessions.ts
+++ b/turbo/apps/cli/src/lib/api/domains/sessions.ts
@@ -1,0 +1,52 @@
+import { initClient } from "@ts-rest/core";
+import {
+  sessionsByIdContract,
+  checkpointsByIdContract,
+  type ApiErrorResponse,
+} from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+import type { GetSessionResponse, GetCheckpointResponse } from "../core/types";
+
+/**
+ * Get session by ID
+ * Used by run continue to fetch session info including secretNames
+ */
+export async function getSession(
+  sessionId: string,
+): Promise<GetSessionResponse> {
+  const config = await getClientConfig();
+  const client = initClient(sessionsByIdContract, config);
+
+  const result = await client.getById({
+    params: { id: sessionId },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  const errorBody = result.body as ApiErrorResponse;
+  const message = errorBody.error?.message || `Session not found: ${sessionId}`;
+  throw new Error(message);
+}
+
+/**
+ * Get checkpoint by ID
+ * Used by run resume to fetch checkpoint info including secretNames
+ */
+export async function getCheckpoint(
+  checkpointId: string,
+): Promise<GetCheckpointResponse> {
+  const config = await getClientConfig();
+  const client = initClient(checkpointsByIdContract, config);
+
+  const result = await client.getById({
+    params: { id: checkpointId },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, `Checkpoint not found: ${checkpointId}`);
+}

--- a/turbo/apps/cli/src/lib/api/domains/storages.ts
+++ b/turbo/apps/cli/src/lib/api/domains/storages.ts
@@ -1,0 +1,128 @@
+import { initClient } from "@ts-rest/core";
+import {
+  storagesPrepareContract,
+  storagesCommitContract,
+  storagesDownloadContract,
+  storagesListContract,
+} from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+/**
+ * Prepare storage for direct S3 upload
+ */
+export async function prepareStorage(body: {
+  storageName: string;
+  storageType: "volume" | "artifact";
+  files: Array<{ path: string; hash: string; size: number }>;
+  force?: boolean;
+}): Promise<{
+  versionId: string;
+  existing: boolean;
+  uploads?: {
+    archive: { key: string; presignedUrl: string };
+    manifest: { key: string; presignedUrl: string };
+  };
+}> {
+  const config = await getClientConfig();
+  const client = initClient(storagesPrepareContract, config);
+
+  const result = await client.prepare({ body });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to prepare storage");
+}
+
+/**
+ * Commit storage after S3 upload
+ */
+export async function commitStorage(body: {
+  storageName: string;
+  storageType: "volume" | "artifact";
+  versionId: string;
+  files: Array<{ path: string; hash: string; size: number }>;
+}): Promise<{
+  success: true;
+  versionId: string;
+  storageName: string;
+  size: number;
+  fileCount: number;
+  deduplicated?: boolean;
+}> {
+  const config = await getClientConfig();
+  const client = initClient(storagesCommitContract, config);
+
+  const result = await client.commit({ body });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to commit storage");
+}
+
+/**
+ * Get download URL for storage (volume or artifact)
+ */
+export async function getStorageDownload(query: {
+  name: string;
+  type: "volume" | "artifact";
+  version?: string;
+}): Promise<
+  | {
+      url: string;
+      versionId: string;
+      fileCount: number;
+      size: number;
+    }
+  | {
+      empty: true;
+      versionId: string;
+      fileCount: 0;
+      size: 0;
+    }
+> {
+  const config = await getClientConfig();
+  const client = initClient(storagesDownloadContract, config);
+
+  const result = await client.download({
+    query: {
+      name: query.name,
+      type: query.type,
+      version: query.version,
+    },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, `Storage "${query.name}" not found`);
+}
+
+/**
+ * List storages (volumes or artifacts)
+ */
+export async function listStorages(query: {
+  type: "volume" | "artifact";
+}): Promise<
+  Array<{
+    name: string;
+    size: number;
+    fileCount: number;
+    updatedAt: string;
+  }>
+> {
+  const config = await getClientConfig();
+  const client = initClient(storagesListContract, config);
+
+  const result = await client.list({ query });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, `Failed to list ${query.type}s`);
+}

--- a/turbo/apps/cli/src/lib/api/domains/usage.ts
+++ b/turbo/apps/cli/src/lib/api/domains/usage.ts
@@ -1,0 +1,30 @@
+import { getBaseUrl, getHeaders } from "../core/client-factory";
+import type { UsageResponse } from "../core/types";
+
+/**
+ * Get usage statistics
+ */
+export async function getUsage(options: {
+  startDate: string;
+  endDate: string;
+}): Promise<UsageResponse> {
+  const baseUrl = await getBaseUrl();
+  const headers = await getHeaders();
+
+  const params = new URLSearchParams({
+    start_date: options.startDate,
+    end_date: options.endDate,
+  });
+
+  const response = await fetch(`${baseUrl}/api/usage?${params}`, {
+    method: "GET",
+    headers,
+  });
+
+  if (!response.ok) {
+    const error = (await response.json()) as { error?: { message?: string } };
+    throw new Error(error.error?.message || "Failed to fetch usage data");
+  }
+
+  return response.json() as Promise<UsageResponse>;
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -1,0 +1,52 @@
+// Core types (only export what's actually used)
+export type { ApiError, GetComposeResponse, RunResult } from "./core/types";
+
+// HTTP utilities (only export what's actually used)
+export { httpGet } from "./core/http";
+
+// Domain modules - Composes
+export {
+  getComposeByName,
+  getComposeById,
+  getComposeVersion,
+  createOrUpdateCompose,
+} from "./domains/composes";
+
+// Domain modules - Runs
+export { createRun, getEvents } from "./domains/runs";
+
+// Domain modules - Sessions
+export { getSession, getCheckpoint } from "./domains/sessions";
+
+// Domain modules - Scopes
+export { getScope, createScope, updateScope } from "./domains/scopes";
+
+// Domain modules - Storages
+export {
+  prepareStorage,
+  commitStorage,
+  getStorageDownload,
+  listStorages,
+} from "./domains/storages";
+
+// Domain modules - Schedules
+export {
+  deploySchedule,
+  listSchedules,
+  getScheduleByName,
+  deleteSchedule,
+  enableSchedule,
+  disableSchedule,
+  listScheduleRuns,
+} from "./domains/schedules";
+
+// Domain modules - Credentials
+export {
+  listCredentials,
+  getCredential,
+  setCredential,
+  deleteCredential,
+} from "./domains/credentials";
+
+// Domain modules - Usage
+export { getUsage } from "./domains/usage";

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -10,7 +10,7 @@
 
 import chalk from "chalk";
 import type { ParsedEvent } from "./claude-event-parser";
-import type { RunResult } from "../api/api-client";
+import type { RunResult } from "../api";
 import { getProviderDisplayName, isSupportedProvider } from "@vm0/core";
 
 /**

--- a/turbo/apps/cli/src/lib/storage/clone-utils.ts
+++ b/turbo/apps/cli/src/lib/storage/clone-utils.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as tar from "tar";
 import { writeStorageConfig, type StorageType } from "./storage-utils";
-import { apiClient } from "../api/api-client";
+import { getStorageDownload } from "../api";
 import { listTarFiles, formatBytes } from "../utils/file-utils";
 
 interface CloneOptions {
@@ -38,7 +38,7 @@ export async function cloneStorage(
   // Check if storage exists on remote
   console.log(chalk.dim(`Checking remote ${typeLabel}...`));
 
-  const downloadInfo = await apiClient.getStorageDownload({
+  const downloadInfo = await getStorageDownload({
     name,
     type,
     version: options.version,

--- a/turbo/apps/cli/src/lib/storage/direct-upload.ts
+++ b/turbo/apps/cli/src/lib/storage/direct-upload.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import * as tar from "tar";
-import { apiClient } from "../api/api-client";
+import { prepareStorage, commitStorage } from "../api";
 import { excludeVm0Filter } from "../utils/file-utils";
 
 /**
@@ -274,7 +274,7 @@ export async function directUpload(
 
   // Step 3: Call prepare endpoint
   onProgress?.("Preparing upload...");
-  const prepareResult = await apiClient.prepareStorage({
+  const prepareResult = await prepareStorage({
     storageName,
     storageType,
     files: fileEntries,
@@ -286,7 +286,7 @@ export async function directUpload(
   if (prepareResult.existing) {
     onProgress?.("Version exists, updating HEAD...");
 
-    const commitResult = await apiClient.commitStorage({
+    const commitResult = await commitStorage({
       storageName,
       storageType,
       versionId: prepareResult.versionId,
@@ -333,7 +333,7 @@ export async function directUpload(
 
   // Step 7: Commit the upload
   onProgress?.("Committing...");
-  const commitResult = await apiClient.commitStorage({
+  const commitResult = await commitStorage({
     storageName,
     storageType,
     versionId: prepareResult.versionId,


### PR DESCRIPTION
## Summary

- Refactored monolithic `api-client.ts` (1378 lines) into domain-driven modular architecture
- Created new API module structure: `core/` (client-factory, http, types) and `domains/` (composes, runs, sessions, scopes, storages, schedules, credentials, usage)
- Migrated all command files to use new modular API imports
- Migrated test files to MSW for HTTP-level mocking (AP-4 compliance)
- Removed unused telemetry functions and simplified exports

## Test plan

- [x] All 576 CLI tests pass
- [x] Type checking passes
- [x] Linting passes
- [x] Knip finds no unused code

Closes #1381
Supersedes #1389

🤖 Generated with [Claude Code](https://claude.com/claude-code)