### PR TITLE
test: remove unused child_process mock in update-checker.test.ts

### DIFF
--- a/turbo/apps/cli/src/lib/utils/__tests__/update-checker.test.ts
+++ b/turbo/apps/cli/src/lib/utils/__tests__/update-checker.test.ts
@@ -16,11 +16,6 @@ vi.mock("https", () => ({
   },
 }));
 
-// Mock child_process module
-vi.mock("child_process", () => ({
-  spawn: vi.fn(),
-}));
-
 describe("update-checker", () => {
   describe("detectPackageManager", () => {
     const originalArgv = process.argv;


### PR DESCRIPTION
## Summary

Removes the unused `child_process` mock from `update-checker.test.ts`.

## Analysis

The `spawn` mock was defined at lines 19-22 but never used by any of the 23 tests in this file:
- `grep -n spawn` returns only the mock definition itself
- All tests exercise code paths that don't reach `performUpgrade()`
- Tests only cover early-return scenarios (version check failed, already on latest)

## Impact

- ✅ Removes 5 lines of dead code
- ✅ Makes test file cleaner
- ✅ No test behavior changes

## Related

Closes #1410

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)