### PR TITLE
test: replace vi.useFakeTimers with vi.spyOn for Date.now mocking

### DIFF
--- a/turbo/apps/cli/src/lib/utils/__tests__/time-parser.test.ts
+++ b/turbo/apps/cli/src/lib/utils/__tests__/time-parser.test.ts
@@ -4,14 +4,14 @@ import { parseTime, formatTimestamp } from "../time-parser";
 describe("time-parser", () => {
   describe("parseTime", () => {
     describe("relative time", () => {
+      const FIXED_TIME = new Date("2024-01-15T12:00:00Z").getTime();
+
       beforeEach(() => {
-        // Mock Date.now() to return a fixed timestamp
-        vi.useFakeTimers();
-        vi.setSystemTime(new Date("2024-01-15T12:00:00Z"));
+        vi.spyOn(Date, "now").mockReturnValue(FIXED_TIME);
       });
 
       afterEach(() => {
-        vi.useRealTimers();
+        vi.restoreAllMocks();
       });
 
       it("parses seconds", () => {


### PR DESCRIPTION
## Summary

Replace `vi.useFakeTimers()` with `vi.spyOn(Date, 'now')` in time-parser tests to comply with project guidelines that prohibit fake timer usage.

## Changes

- Replace `vi.useFakeTimers()` and `vi.setSystemTime()` with `vi.spyOn(Date, 'now').mockReturnValue()`
- Replace `vi.useRealTimers()` with `vi.restoreAllMocks()` for cleanup
- Keep `vi` import as it's still needed for spyOn
- Maintain all existing test assertions unchanged

## Implementation Details

**Before:**
```typescript
beforeEach(() => {
  vi.useFakeTimers();
  vi.setSystemTime(new Date("2024-01-15T12:00:00Z"));
});

afterEach(() => {
  vi.useRealTimers();
});
```

**After:**
```typescript
const FIXED_TIME = new Date("2024-01-15T12:00:00Z").getTime();

beforeEach(() => {
  vi.spyOn(Date, "now").mockReturnValue(FIXED_TIME);
});

afterEach(() => {
  vi.restoreAllMocks();
});
```

## Why This Approach

- `vi.useFakeTimers()` is prohibited by project guidelines (specs/bad-smell.md)
- `vi.spyOn()` is standard function mocking, not timer manipulation
- Maintains test precision and determinism
- No changes to production code required
- All test assertions remain identical

## Test Coverage

All 13 tests in time-parser.test.ts:
- 5 relative time tests (updated mocking approach)
- 2 Unix timestamp tests (unchanged)
- 3 ISO 8601 tests (unchanged)
- 3 error case tests (unchanged)
- 1 formatTimestamp test (unchanged)

Resolves #1403

🤖 Generated with [Claude Code](https://claude.com/claude-code)