### PR TITLE
test: extract clerk mock helper to reduce test duplication (pilot)

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/__tests__/route.test.ts
@@ -24,11 +24,6 @@ vi.mock("next/headers", () => ({
   headers: vi.fn(),
 }));
 
-// Mock Clerk auth
-vi.mock("@clerk/nextjs/server", () => ({
-  auth: vi.fn(),
-}));
-
 // Mock Axiom module
 vi.mock("../../../../../../../../src/lib/axiom", () => ({
   queryAxiom: vi.fn(),
@@ -45,11 +40,13 @@ vi.mock("../../../../../../../../src/lib/axiom", () => ({
 }));
 
 import { headers } from "next/headers";
-import { auth } from "@clerk/nextjs/server";
 import { queryAxiom } from "../../../../../../../../src/lib/axiom";
+import {
+  mockClerk,
+  clearClerkMock,
+} from "../../../../../../../../src/__tests__/clerk-mock";
 
 const mockHeaders = vi.mocked(headers);
-const mockAuth = vi.mocked(auth);
 const mockQueryAxiom = vi.mocked(queryAxiom);
 
 /**
@@ -101,9 +98,7 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
     vi.clearAllMocks();
     initServices();
 
-    mockAuth.mockResolvedValue({
-      userId: testUserId,
-    } as unknown as Awaited<ReturnType<typeof auth>>);
+    mockClerk({ userId: testUserId });
 
     mockHeaders.mockResolvedValue({
       get: vi.fn().mockReturnValue(null),
@@ -177,6 +172,8 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
   });
 
   afterEach(async () => {
+    clearClerkMock();
+
     await globalThis.services.db
       .delete(agentRuns)
       .where(eq(agentRuns.id, testRunId));
@@ -196,9 +193,7 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
 
   describe("Authentication", () => {
     it("should reject request without authentication", async () => {
-      mockAuth.mockResolvedValue({
-        userId: null,
-      } as unknown as Awaited<ReturnType<typeof auth>>);
+      mockClerk({ userId: null });
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/metrics`,

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -1,0 +1,44 @@
+import { vi } from "vitest";
+import { auth } from "@clerk/nextjs/server";
+
+/**
+ * Mock Clerk auth for testing
+ *
+ * @example
+ * ```typescript
+ * import { mockClerk, clearClerkMock } from '@/__tests__/clerk-mock';
+ *
+ * beforeEach(() => {
+ *   mockClerk({ userId: 'test-user-123' });
+ * });
+ *
+ * afterEach(() => {
+ *   clearClerkMock();
+ * });
+ *
+ * it('should reject unauthenticated request', () => {
+ *   mockClerk({ userId: null });
+ *   // ...
+ * });
+ * ```
+ */
+
+const mockAuth = vi.mocked(auth);
+
+/**
+ * Configure Clerk auth mock
+ * @param options - Auth configuration
+ * @param options.userId - User ID to return, or null for unauthenticated
+ */
+export function mockClerk(options: { userId: string | null }) {
+  mockAuth.mockResolvedValue({
+    userId: options.userId,
+  } as Awaited<ReturnType<typeof auth>>);
+}
+
+/**
+ * Clear all Clerk mock calls and reset to default state
+ */
+export function clearClerkMock() {
+  mockAuth.mockClear();
+}


### PR DESCRIPTION
## Summary

This is the **Phase 1.1 pilot** for issue #1412 - extracting test helper functions to reduce duplication.

We're starting conservatively with a Clerk auth mock helper to validate the approach before broader rollout.

### Changes

- ✅ Created `src/__tests__/clerk-mock.ts` with `mockClerk()` and `clearClerkMock()` helpers
- ✅ Updated 3 telemetry test files to use the new helper:
  - `app/api/agent/runs/[id]/telemetry/metrics/__tests__/route.test.ts`
  - `app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts`
  - `app/api/agent/runs/[id]/telemetry/system-log/__tests__/route.test.ts`
- ✅ Removed redundant local Clerk mock declarations
- ✅ Simplified beforeEach/afterEach mock setup

### Results

- **31 lines reduced** across 3 test files (46 deletions, 15 insertions)
- **All 27 tests passing** ✓
- Cleaner, more maintainable test code
- No change in test behavior or execution time

### Example Change

**Before:**
```typescript
// Local mock declaration (5 lines)
vi.mock("@clerk/nextjs/server", () => ({
  auth: vi.fn(),
}));
import { auth } from "@clerk/nextjs/server";
const mockAuth = vi.mocked(auth);

beforeEach(() => {
  mockAuth.mockResolvedValue({
    userId: testUserId,
  } as unknown as Awaited<ReturnType<typeof auth>>);
});

it("should reject unauthenticated request", async () => {
  mockAuth.mockResolvedValue({
    userId: null,
  } as unknown as Awaited<ReturnType<typeof auth>>);
  // ...
});
```

**After:**
```typescript
import { mockClerk, clearClerkMock } from '@/__tests__/clerk-mock';

beforeEach(() => {
  mockClerk({ userId: testUserId });
});

afterEach(() => {
  clearClerkMock();
});

it("should reject unauthenticated request", async () => {
  mockClerk({ userId: null });
  // ...
});
```

### Next Steps

If this pilot is successful:
1. Roll out to remaining **13 files** that use Clerk mocks (~150-200 line reduction)
2. Create similar helpers for other external dependencies (Axiom, headers, etc.)
3. Continue with Phase 2 (fixture factories) per the plan in #1412

### Test Plan

- [x] Run all 3 updated test files - all 27 tests passing
- [x] Verify no behavior changes
- [x] Check code formatting
- [ ] Wait for CI checks to pass

Closes #1412 (pilot phase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)