### PR TITLE
test: replace https module mocks with msw

### DIFF
--- a/turbo/apps/cli/src/mocks/handlers/index.ts
+++ b/turbo/apps/cli/src/mocks/handlers/index.ts
@@ -1,3 +1,4 @@
 import { apiHandlers } from "./api-handlers";
+import { npmRegistryHandlers } from "./npm-registry-handlers";
 
-export const handlers = [...apiHandlers];
+export const handlers = [...apiHandlers, ...npmRegistryHandlers];

--- a/turbo/apps/cli/src/mocks/handlers/npm-registry-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/npm-registry-handlers.ts
@@ -1,0 +1,7 @@
+import { http, HttpResponse } from "msw";
+
+export const npmRegistryHandlers = [
+  http.get("https://registry.npmjs.org/*/latest", () => {
+    return HttpResponse.json({ version: "4.11.0" });
+  }),
+];


### PR DESCRIPTION
## Summary
- Replace `vi.mock("https")` with MSW handlers for testing consistency
- Refactor `getLatestVersion()` from Node.js `https.get()` to `fetch()` for MSW compatibility
- Create `npm-registry-handlers.ts` with wildcard URL pattern matching (`*/latest`)
- Remove timeout test as requested
- Simplify test code by removing ~70 lines of EventEmitter mock code

## Changes
- **New**: `apps/cli/src/mocks/handlers/npm-registry-handlers.ts`
- **Modified**: `apps/cli/src/lib/utils/update-checker.ts` (https → fetch)
- **Modified**: `apps/cli/src/lib/utils/__tests__/update-checker.test.ts` (vi.mock → MSW)
- **Modified**: `apps/cli/src/mocks/handlers/index.ts` (register handlers)

## Test Results
- ✅ All 22 tests pass in `update-checker.test.ts`
- ✅ Removed 1 timeout test (22 tests total, down from 23)
- ✅ All lint, type check, and knip checks pass

## Key Discovery
MSW handlers must use wildcard patterns or URL-encoded strings when matching external URLs with special characters. Used `https://registry.npmjs.org/*/latest` to match the encoded URL `https://registry.npmjs.org/%40vm0%2Fcli/latest`.

Fixes #1405

🤖 Generated with [Claude Code](https://claude.com/claude-code)