### PR TITLE
test: fix ap-4 violations in v1 public API tests (phase 4 pr8)

### DIFF
--- a/turbo/apps/web/app/v1/volumes/__tests__/route.test.ts
+++ b/turbo/apps/web/app/v1/volumes/__tests__/route.test.ts
@@ -27,11 +27,21 @@ function createTestRequest(
   });
 }
 
-// Mock the auth module
-let mockUserId = "test-user-volumes-api";
-vi.mock("../../../../src/lib/auth/get-user-id", () => ({
-  getUserId: async () => mockUserId,
+// Mock Next.js headers() function
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
 }));
+
+// Mock Clerk auth (external SaaS)
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+import { headers } from "next/headers";
+import { auth } from "@clerk/nextjs/server";
+
+const mockHeaders = vi.mocked(headers);
+const mockAuth = vi.mocked(auth);
 
 describe("Public API v1 - Volumes Endpoints", () => {
   const testUserId = "test-user-volumes-api";
@@ -40,6 +50,16 @@ describe("Public API v1 - Volumes Endpoints", () => {
 
   beforeAll(async () => {
     initServices();
+
+    // Mock headers() - return empty headers so auth falls through to Clerk
+    mockHeaders.mockResolvedValue({
+      get: vi.fn().mockReturnValue(null),
+    } as unknown as Headers);
+
+    // Mock Clerk auth to return test user
+    mockAuth.mockResolvedValue({
+      userId: testUserId,
+    } as unknown as Awaited<ReturnType<typeof auth>>);
 
     // Clean up any existing test data
     await globalThis.services.db
@@ -109,7 +129,10 @@ describe("Public API v1 - Volumes Endpoints", () => {
     });
 
     it("should return 401 for unauthenticated request", async () => {
-      mockUserId = "";
+      // Mock Clerk to return no user
+      mockAuth.mockResolvedValueOnce({
+        userId: null,
+      } as unknown as Awaited<ReturnType<typeof auth>>);
 
       const request = createTestRequest("http://localhost:3000/v1/volumes");
 
@@ -118,8 +141,6 @@ describe("Public API v1 - Volumes Endpoints", () => {
 
       expect(response.status).toBe(401);
       expect(data.error.type).toBe("authentication_error");
-
-      mockUserId = testUserId;
     });
   });
 


### PR DESCRIPTION
## Summary

First PR of Phase 4 (final phase) for fixing API route AP-4 violations (#1371). This PR fixes all 3 v1 public API test files that mock `get-user-id`.

## Files Fixed

All 3 v1 public API tests:
1. ✅ `app/v1/agents/__tests__/route.test.ts`
2. ✅ `app/v1/artifacts/__tests__/route.test.ts`
3. ✅ `app/v1/volumes/__tests__/route.test.ts`

## Changes Made

For each file:
- **Removed** internal `get-user-id` mock (AP-4 violation)
- **Added** `@clerk/nextjs/server` mock (external SaaS - correct)
- Use real `getUserId()` function from auth module
- Updated unauthenticated tests to use `mockAuth.mockResolvedValueOnce({ userId: null })`

## Mock Pattern Change

**Before (❌ Wrong)**:
```typescript
// Mock internal get-user-id
let mockUserId = "test-user";
vi.mock("../../../../src/lib/auth/get-user-id", () => ({
  getUserId: async () => mockUserId,
}));

// Test unauthenticated by mutating module state
it("should return 401", () => {
  mockUserId = "";  // ❌ Mutate module state
  // test...
  mockUserId = testUserId;  // ❌ Restore state
});
```

**After (✅ Correct)**:
```typescript
// Mock only external Clerk SDK
vi.mock("@clerk/nextjs/server", () => ({
  auth: vi.fn(),
}));

const mockAuth = vi.mocked(auth);

beforeAll(() => {
  // Default: authenticated user
  mockAuth.mockResolvedValue({ userId: testUserId });
});

// Test unauthenticated with clean override
it("should return 401", () => {
  mockAuth.mockResolvedValueOnce({ userId: null });  // ✅ Clean override
  // test...
  // Auto-resets in next test
});
```

## Test Results

**Local tests**: All 27 tests passing ✅
- v1/agents: 11 tests
- v1/artifacts: 8 tests
- v1/volumes: 8 tests

**Test command used**:
```bash
cd turbo && pnpm format && pnpm test apps/web/app/v1/{agents,artifacts,volumes}/__tests__/route.test.ts
```

## Progress Update

### Completed Phases
- ✅ Phase 1: 6 files (4 PRs) - COMPLETE
- ✅ Phase 2: 3 files (1 PR) - COMPLETE
- ✅ Phase 3: 8 files (2 PRs) - COMPLETE

### Phase 4: Auth Mocks (10 files, 3 PRs)
- ✅ **PR8 (this)**: v1/* (3 files, 27 tests)
- ⏳ PR9: api/agent/composes/* (4 files)
- ⏳ PR10: Remaining files (3 files)

**Total Progress**: 20/28 files fixed (71% complete)

Part of #1371 Phase 4 PR8

🤖 Generated with [Claude Code](https://claude.com/claude-code)