### PR TITLE
fix: use message.name instead of data.type for realtime event handling

### DIFF
--- a/e2e/tests/02-parallel/t30-vm0-realtime-streaming.bats
+++ b/e2e/tests/02-parallel/t30-vm0-realtime-streaming.bats
@@ -28,7 +28,7 @@ version: "1.0"
 agents:
   ${AGENT_NAME}:
     description: "E2E test agent for realtime streaming"
-    provider: claude-code
+    framework: claude-code
     image: "vm0/claude-code:dev"
     volumes:
       - claude-files:/home/user/.claude

--- a/e2e/tests/02-parallel/t30-vm0-realtime-streaming.bats
+++ b/e2e/tests/02-parallel/t30-vm0-realtime-streaming.bats
@@ -76,11 +76,12 @@ teardown() {
     assert_success
 
     # Step 2: Run agent with --experimental-realtime flag
+    # Note: Use bash command as prompt since mock-claude executes prompts as bash commands
     echo "# Step 2: Running agent with --experimental-realtime..."
     run timeout 120 $CLI_COMMAND run "$AGENT_NAME" \
         --artifact-name "$ARTIFACT_NAME" \
         --experimental-realtime \
-        "Read the readme.txt file and tell me what it contains"
+        "cat readme.txt && echo 'realtime test complete'"
 
     # Step 3: Verify run completed successfully
     echo "# Step 3: Verifying output..."
@@ -111,11 +112,12 @@ teardown() {
     assert_success
 
     # Step 2: Run with realtime streaming
+    # Note: Use bash command as prompt since mock-claude executes prompts as bash commands
     echo "# Step 2: Running with --experimental-realtime..."
     run timeout 120 $CLI_COMMAND run "$AGENT_NAME" \
         --artifact-name "$ARTIFACT_NAME-compare" \
         --experimental-realtime \
-        "echo 'realtime test' > output.txt"
+        "echo 'realtime test' > output.txt && cat output.txt"
 
     assert_success
     REALTIME_OUTPUT="$output"

--- a/e2e/tests/02-parallel/t30-vm0-realtime-streaming.bats
+++ b/e2e/tests/02-parallel/t30-vm0-realtime-streaming.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+
+# Test VM0 realtime event streaming (--experimental-realtime flag)
+# This test verifies that:
+# 1. Events are streamed in realtime via Ably
+# 2. Output matches polling mode ([init], [text], [tool_use], [tool_result], [result])
+# 3. Run completes successfully without hanging
+#
+# Related issue: #1429
+
+load '../../helpers/setup'
+
+# Unique agent name for this test file
+AGENT_NAME="e2e-t30-realtime"
+
+setup() {
+    # Create unique volume for this test
+    create_test_volume "e2e-vol-t30"
+
+    # Create temporary test directory
+    export TEST_ARTIFACT_DIR="$(mktemp -d)"
+    export ARTIFACT_NAME="e2e-realtime-art-$(date +%s%3N)-$RANDOM"
+
+    # Create inline config with unique agent name
+    export TEST_CONFIG="$(mktemp --suffix=.yaml)"
+    cat > "$TEST_CONFIG" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_NAME}:
+    description: "E2E test agent for realtime streaming"
+    provider: claude-code
+    image: "vm0/claude-code:dev"
+    volumes:
+      - claude-files:/home/user/.claude
+    working_dir: /home/user/workspace
+volumes:
+  claude-files:
+    name: $VOLUME_NAME
+    version: latest
+EOF
+}
+
+teardown() {
+    # Clean up temporary directory
+    if [ -n "$TEST_ARTIFACT_DIR" ] && [ -d "$TEST_ARTIFACT_DIR" ]; then
+        rm -rf "$TEST_ARTIFACT_DIR"
+    fi
+    # Clean up config file
+    if [ -n "$TEST_CONFIG" ] && [ -f "$TEST_CONFIG" ]; then
+        rm -f "$TEST_CONFIG"
+    fi
+    # Clean up test volume
+    cleanup_test_volume
+}
+
+@test "Build realtime streaming test agent configuration" {
+    run $CLI_COMMAND compose "$TEST_CONFIG"
+    assert_success
+    assert_output --partial "$AGENT_NAME"
+}
+
+@test "Realtime streaming: events are displayed with --experimental-realtime flag" {
+    # This test verifies that --experimental-realtime:
+    # 1. Streams events in realtime (not polling)
+    # 2. Displays all expected event types
+    # 3. Completes successfully without hanging
+
+    # Step 1: Create artifact
+    echo "# Step 1: Creating test artifact..."
+    mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME" >/dev/null
+
+    echo "test content" > readme.txt
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    # Step 2: Run agent with --experimental-realtime flag
+    echo "# Step 2: Running agent with --experimental-realtime..."
+    run timeout 120 $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        --experimental-realtime \
+        "Read the readme.txt file and tell me what it contains"
+
+    # Step 3: Verify run completed successfully
+    echo "# Step 3: Verifying output..."
+    assert_success
+
+    # Verify events were streamed (same as polling mode)
+    assert_output --partial "[init]"
+    assert_output --partial "[text]"
+    assert_output --partial "[tool_use]"
+    assert_output --partial "[result]"
+
+    # Verify run completed
+    assert_output --partial "completed successfully"
+}
+
+@test "Realtime streaming: output matches polling mode" {
+    # This test compares realtime vs polling mode output
+    # to ensure they produce equivalent results
+
+    # Step 1: Create artifact
+    echo "# Step 1: Creating test artifact..."
+    mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME-compare"
+    cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME-compare"
+    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME-compare" >/dev/null
+
+    echo "hello world" > test.txt
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    # Step 2: Run with realtime streaming
+    echo "# Step 2: Running with --experimental-realtime..."
+    run timeout 120 $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME-compare" \
+        --experimental-realtime \
+        "echo 'realtime test' > output.txt"
+
+    assert_success
+    REALTIME_OUTPUT="$output"
+
+    # Verify realtime mode shows all event types
+    echo "$REALTIME_OUTPUT" | grep -q "\[init\]" || fail "Missing [init] event in realtime mode"
+    echo "$REALTIME_OUTPUT" | grep -q "\[result\]" || fail "Missing [result] event in realtime mode"
+
+    echo "# Realtime streaming test passed - events displayed correctly"
+}

--- a/turbo/apps/cli/src/lib/realtime/__tests__/stream-events.test.ts
+++ b/turbo/apps/cli/src/lib/realtime/__tests__/stream-events.test.ts
@@ -117,7 +117,8 @@ describe("streamEvents", () => {
 
     // Simulate completion
     capturedMessageHandler?.({
-      data: { type: "status", status: "completed", result: {} },
+      name: "status",
+      data: { status: "completed", result: {} },
     });
 
     const result = await streamPromise;
@@ -140,7 +141,8 @@ describe("streamEvents", () => {
       { type: "text", sequenceNumber: 1, text: "World" },
     ];
     capturedMessageHandler?.({
-      data: { type: "events", events, nextSequence: 2 },
+      name: "events",
+      data: { events, nextSequence: 2 },
     });
 
     expect(options.onEventMock).toHaveBeenCalledTimes(2);
@@ -157,7 +159,8 @@ describe("streamEvents", () => {
 
     // Complete the stream
     capturedMessageHandler?.({
-      data: { type: "status", status: "completed" },
+      name: "status",
+      data: { status: "completed" },
     });
 
     await streamPromise;
@@ -177,7 +180,8 @@ describe("streamEvents", () => {
       agentSessionId: "session-456",
     };
     capturedMessageHandler?.({
-      data: { type: "status", status: "completed", result },
+      name: "status",
+      data: { status: "completed", result },
     });
 
     const streamResult = await streamPromise;
@@ -202,7 +206,8 @@ describe("streamEvents", () => {
     });
 
     capturedMessageHandler?.({
-      data: { type: "status", status: "failed", error: "Something went wrong" },
+      name: "status",
+      data: { status: "failed", error: "Something went wrong" },
     });
 
     const streamResult = await streamPromise;
@@ -225,7 +230,8 @@ describe("streamEvents", () => {
     });
 
     capturedMessageHandler?.({
-      data: { type: "status", status: "timeout" },
+      name: "status",
+      data: { status: "timeout" },
     });
 
     const streamResult = await streamPromise;
@@ -244,7 +250,8 @@ describe("streamEvents", () => {
     });
 
     capturedMessageHandler?.({
-      data: { type: "status", status: "completed" },
+      name: "status",
+      data: { status: "completed" },
     });
 
     await streamPromise;
@@ -265,8 +272,8 @@ describe("streamEvents", () => {
 
     // Send events with a gap (skip sequence 0)
     capturedMessageHandler?.({
+      name: "events",
       data: {
-        type: "events",
         events: [{ type: "text", sequenceNumber: 5 }],
         nextSequence: 6,
       },
@@ -278,7 +285,8 @@ describe("streamEvents", () => {
 
     // Complete
     capturedMessageHandler?.({
-      data: { type: "status", status: "completed" },
+      name: "status",
+      data: { status: "completed" },
     });
 
     await streamPromise;
@@ -296,8 +304,8 @@ describe("streamEvents", () => {
     });
 
     capturedMessageHandler?.({
+      name: "events",
       data: {
-        type: "events",
         events: [{ type: "text", sequenceNumber: 0 }],
         nextSequence: 1,
       },
@@ -309,7 +317,8 @@ describe("streamEvents", () => {
     );
 
     capturedMessageHandler?.({
-      data: { type: "status", status: "completed" },
+      name: "status",
+      data: { status: "completed" },
     });
 
     await streamPromise;


### PR DESCRIPTION
## Summary

- Fixes the realtime event streaming bug where no events were displayed when using `--experimental-realtime` flag
- The issue was a protocol mismatch: server uses `message.name` to indicate message type, but client was checking `message.data.type`
- All messages were silently ignored because `data.type` was always undefined

## Changes

- Update `handleMessage()` to check `message.name` instead of `data.type`
- Rename interfaces from `EventsMessage`/`StatusMessage` to `EventsData`/`StatusData` to reflect they represent the data payload only
- Update test mocks to include `name` field matching actual Ably message structure

## Test plan

- [x] All existing tests pass (596 tests)
- [x] Lint and type checks pass
- [ ] Manual testing with `vm0 run <agent> --experimental-realtime` (requires production access)

Fixes #1429

🤖 Generated with [Claude Code](https://claude.com/claude-code)