### PR TITLE
feat: add context fork to query-axiom-logs and agent-browser skills

### DIFF
--- a/.claude/skills/agent-browser/SKILL.md
+++ b/.claude/skills/agent-browser/SKILL.md
@@ -1,10 +1,20 @@
 ---
 name: agent-browser
 description: Automates browser interactions for web testing, form filling, screenshots, and data extraction. Use when the user needs to navigate websites, interact with web pages, fill forms, take screenshots, test web applications, or extract information from web pages.
-allowed-tools: Bash(agent-browser:*)
+context: fork
+agent: general-purpose
+allowed-tools: Bash(agent-browser:*), Read, Write
 ---
 
 # Browser Automation with agent-browser
+
+You are a browser automation specialist. Your role is to automate web interactions using the agent-browser tool for testing, data extraction, and web application validation.
+
+## Your Task
+
+Execute the following browser automation request: $ARGUMENTS
+
+Use the agent-browser commands and workflows below to accomplish this task.
 
 ## Quick start
 

--- a/.claude/skills/query-axiom-logs/SKILL.md
+++ b/.claude/skills/query-axiom-logs/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: Query Axiom Logs
 description: Query logs from Axiom for debugging (read-only, no ingestion allowed)
+context: fork
+agent: Explore
+allowed-tools: Bash(axiom:*, source:*), Read
 ---
 
 # Query Axiom Logs
 
-Query logs and telemetry data from Axiom for debugging purposes.
+You are a log analysis specialist for the vm0 project. Your role is to query and analyze logs from Axiom for debugging purposes.
 
 **IMPORTANT: This skill is READ-ONLY. Never ingest or write data to Axiom.**
+
+## Your Task
+
+Execute the following request: $ARGUMENTS
+
+Query logs and telemetry data from Axiom using the guidelines and examples below.
 
 ## Environment Setup
 


### PR DESCRIPTION
## Summary

Enable isolated subagent execution for `query-axiom-logs` and `agent-browser` skills by adding `context: fork` configuration.

## Changes

### query-axiom-logs
- Added `context: fork` to run in isolated environment
- Specified `agent: Explore` for read-only operations
- Added `allowed-tools: Bash(axiom:*, source:*), Read` for security
- Added clear role definition as "log analysis specialist"
- Added `$ARGUMENTS` placeholder for dynamic task injection

### agent-browser
- Added `context: fork` to run in isolated environment  
- Specified `agent: general-purpose` for browser automation
- Added `allowed-tools: Bash(agent-browser:*), Read, Write` to support screenshots/recordings
- Added clear role definition as "browser automation specialist"
- Added `$ARGUMENTS` placeholder for dynamic task injection

## Benefits

- **Isolation**: Skills run in dedicated environments without accessing conversation history
- **Safety**: Prevents context pollution and unintended side effects
- **Performance**: Specialized agents optimize for specific use cases
- **Security**: Explicit tool restrictions via `allowed-tools`
- **Backward compatible**: Usage remains the same for users

## Testing

Skills can be tested with:
```bash
/query-axiom-logs "find errors in last hour"
/agent-browser "open example.com and take screenshot"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)