### PR TITLE
chore: disable unused claude code plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,10 @@
 {
   "enabledPlugins": {
-    "pr-review-toolkit@claude-plugins-official": true,
-    "code-simplifier@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": false,
+    "code-simplifier@claude-plugins-official": false,
     "frontend-design@claude-plugins-official": true,
-    "code-review@claude-plugins-official": true,
-    "security-guidance@claude-plugins-official": true,
+    "code-review@claude-plugins-official": false,
+    "security-guidance@claude-plugins-official": false,
     "typescript-lsp@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary

- Disable pr-review-toolkit plugin (not actively used)
- Disable code-simplifier plugin (not actively used)
- Disable code-review plugin (not actively used)
- Disable security-guidance plugin (not actively used)

This reduces overhead and keeps only essential plugins enabled (frontend-design and typescript-lsp).

## Test plan

- [x] Format checks passed
- [x] Lint checks passed
- [x] Tests passed (2 pre-existing flaky tests on main branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)