### PR TITLE
fix(cli): hide --debug-no-mock-claude option from help output

### DIFF
--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import chalk from "chalk";
 import { readFile, mkdir, writeFile, appendFile } from "fs/promises";
 import { existsSync, readFileSync } from "fs";
@@ -317,7 +317,7 @@ const cookCmd = new Command()
 cookCmd
   .argument("[prompt]", "Prompt for the agent")
   .option("-y, --yes", "Skip confirmation prompts")
-  .option("--debug-no-mock-claude")
+  .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .action(
     async (
       prompt: string | undefined,
@@ -627,7 +627,7 @@ cookCmd
     "Continue from the last session (latest conversation and artifact)",
   )
   .argument("<prompt>", "Prompt for the continued agent")
-  .option("--debug-no-mock-claude")
+  .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .action(async (prompt: string, options: { debugNoMockClaude?: boolean }) => {
     const state = await loadCookState();
     if (!state.lastSessionId) {
@@ -680,7 +680,7 @@ cookCmd
     "Resume from the last checkpoint (snapshotted conversation and artifact)",
   )
   .argument("<prompt>", "Prompt for the resumed agent")
-  .option("--debug-no-mock-claude")
+  .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .action(async (prompt: string, options: { debugNoMockClaude?: boolean }) => {
     const state = await loadCookState();
     if (!state.lastCheckpointId) {

--- a/turbo/apps/cli/src/commands/run/continue.ts
+++ b/turbo/apps/cli/src/commands/run/continue.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import chalk from "chalk";
 import { getSession, createRun } from "../../lib/api";
 import { EventRenderer } from "../../lib/events/event-renderer";
@@ -43,7 +43,7 @@ export const continueCommand = new Command()
     "--experimental-realtime",
     "Use realtime event streaming instead of polling (experimental)",
   )
-  .option("--debug-no-mock-claude")
+  .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .action(
     async (
       agentSessionId: string,

--- a/turbo/apps/cli/src/commands/run/resume.ts
+++ b/turbo/apps/cli/src/commands/run/resume.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import chalk from "chalk";
 import { getCheckpoint, createRun } from "../../lib/api";
 import { EventRenderer } from "../../lib/events/event-renderer";
@@ -41,7 +41,7 @@ export const resumeCommand = new Command()
     "--experimental-realtime",
     "Use realtime event streaming instead of polling (experimental)",
   )
-  .option("--debug-no-mock-claude")
+  .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .action(
     async (
       checkpointId: string,

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import chalk from "chalk";
 import {
   getComposeById,
@@ -61,7 +61,7 @@ export const mainRunCommand = new Command()
     "--experimental-realtime",
     "Use realtime event streaming instead of polling (experimental)",
   )
-  .option("--debug-no-mock-claude")
+  .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .action(
     async (
       identifier: string,


### PR DESCRIPTION
## Summary

- Fix `--debug-no-mock-claude` option appearing in CLI help output when it should be hidden
- Use Commander.js `.addOption()` with `.hideHelp()` method instead of `.option()` without description

## Changes

Updated 4 files with 6 option definitions to use the correct Commander.js API for hidden options:

| File | Changes |
|------|---------|
| `turbo/apps/cli/src/commands/run/run.ts` | Import `Option`, use `.addOption().hideHelp()` |
| `turbo/apps/cli/src/commands/run/continue.ts` | Import `Option`, use `.addOption().hideHelp()` |
| `turbo/apps/cli/src/commands/run/resume.ts` | Import `Option`, use `.addOption().hideHelp()` |
| `turbo/apps/cli/src/commands/cook.ts` | Import `Option`, use `.addOption().hideHelp()` (3 places) |

## Root Cause

Simply omitting the description parameter in `.option("--debug-no-mock-claude")` does NOT hide the option in Commander.js. The correct approach is:

```typescript
.addOption(new Option("--debug-no-mock-claude").hideHelp())
```

## Test plan

- [x] Verified `vm0 run --help` no longer shows `--debug-no-mock-claude`
- [x] Verified `vm0 cook --help` no longer shows the option
- [x] Verified `vm0 run resume --help` no longer shows the option
- [x] Verified `vm0 run continue --help` no longer shows the option
- [x] All 600 CLI tests pass
- [x] Lint and type checks pass

Fixes #1458

🤖 Generated with [Claude Code](https://claude.ai/code)