### PR TITLE
fix: use correct base ref for change detection in pr and merge queue

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -38,8 +38,20 @@ jobs:
         run: |
           echo "Checking for changes..."
 
+          # Determine base ref based on event type
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="${{ github.event.pull_request.base.sha }}"
+            echo "PR mode: comparing against base branch $BASE_REF"
+          elif [ "${{ github.event_name }}" = "merge_group" ]; then
+            BASE_REF="${{ github.event.merge_group.base_sha }}"
+            echo "Merge queue mode: comparing against base $BASE_REF"
+          else
+            BASE_REF="HEAD^"
+            echo "Main push mode: comparing against HEAD^"
+          fi
+
           # Run changed.sh to get all package changes in one go
-          CHANGES_JSON=$(./scripts/changed.sh HEAD^)
+          CHANGES_JSON=$(./scripts/changed.sh $BASE_REF)
 
           # Parse JSON and set outputs for each app
           for app in $(ls turbo/apps); do


### PR DESCRIPTION
## Problem

Currently, change detection uses hardcoded `HEAD^` comparison, which causes incorrect behavior:

**PR scenario:**
- ❌ Current: Compares PR latest commit vs its parent commit
- ✅ Fixed: Compares PR head vs PR base (main)
- **Impact**: PRs with multiple commits or based on old main now get accurate detection

**Merge Queue:**
- ❌ Current: Compares merge commit vs HEAD^
- ✅ Fixed: Compares vs merge queue base
- **Impact**: Correct change detection for merge queue

**Main Push:**
- ✅ Current: Compares new commit vs HEAD^ (already correct)
- ✅ Fixed: Keeps the same behavior

## Solution

Added event-type-aware base ref selection:

```bash
if [ "${{ github.event_name }}" = "pull_request" ]; then
  BASE_REF="${{ github.event.pull_request.base.sha }}"
elif [ "${{ github.event_name }}" = "merge_group" ]; then
  BASE_REF="${{ github.event.merge_group.base_sha }}"
else
  BASE_REF="HEAD^"
fi
```

## Benefits

- ✅ Accurate change detection for PRs (entire branch vs base)
- ✅ Correct merge queue behavior
- ✅ More efficient CI (only runs tests for truly changed packages)
- ✅ Critical for #1460 (enabling main CI)

## Testing

This PR itself will validate:
- Change detection works correctly for PR (compares against main)
- Workflow logs show correct base ref being used

## Files Modified

- `.github/workflows/turbo.yml` (13 insertions, 1 deletion)

Fixes #1464