### PR TITLE
chore(docs): migrate from deprecated provider to framework field

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/setup-github.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/setup-github.test.ts
@@ -188,7 +188,7 @@ describe("setup-github command", () => {
         `version: "1.0"
 agents:
   my-test-agent:
-    provider: claude-code
+    framework: claude-code
     instructions: AGENTS.md
 `,
       );
@@ -299,7 +299,7 @@ agents:
         `version: "1.0"
 agents:
   my-test-agent:
-    provider: claude-code
+    framework: claude-code
     instructions: AGENTS.md
     experimental_secrets:
       - CUSTOM_SECRET
@@ -334,7 +334,7 @@ agents:
         `version: "1.0"
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
 `,
       );
     });
@@ -414,7 +414,7 @@ agents:
         `version: "1.0"
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
 `,
       );
     });
@@ -449,7 +449,7 @@ agents:
         `version: "1.0"
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
 `,
       );
       await fs.mkdir(".github/workflows", { recursive: true });
@@ -499,7 +499,7 @@ agents:
         `version: "1.0"
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
 `,
       );
     });
@@ -601,7 +601,7 @@ agents:
         `version: "1.0"
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
 `,
       );
 
@@ -671,7 +671,7 @@ agents:
         `version: "1.0"
 agents:
   subdir-agent:
-    provider: claude-code
+    framework: claude-code
     instructions: AGENTS.md
 `,
       );
@@ -747,7 +747,7 @@ agents:
         `version: "1.0"
 agents:
   root-agent:
-    provider: claude-code
+    framework: claude-code
     instructions: AGENTS.md
 `,
       );
@@ -795,7 +795,7 @@ agents:
         `version: "1.0"
 agents:
   nested-agent:
-    provider: claude-code
+    framework: claude-code
     instructions: AGENTS.md
 `,
       );

--- a/turbo/apps/docs/content/docs/core-concept/environment-variable.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/environment-variable.mdx
@@ -39,7 +39,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     environment: # [!code highlight]
       # Secrets for sensitive data
       ANTHROPIC_AUTH_TOKEN: "${{ secrets.API_KEY }}" # [!code highlight]

--- a/turbo/apps/docs/content/docs/core-concept/instructions.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/instructions.mdx
@@ -14,7 +14,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     instructions: AGENTS.md # [!code highlight]
 ```
 

--- a/turbo/apps/docs/content/docs/core-concept/skills.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/skills.mdx
@@ -14,7 +14,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills: # [!code highlight]
       - https://github.com/anthropics/skills/tree/main/skills/pdf # [!code highlight]
       - https://github.com/vm0-ai/vm0-skills/tree/main/slack # [!code highlight]

--- a/turbo/apps/docs/content/docs/core-concept/volume.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/volume.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     instructions: AGENTS.md # [!code highlight]
     skills: # [!code highlight]
       - https://github.com/vm0-ai/vm0-skills/tree/main/hackernews # [!code highlight]
@@ -45,7 +45,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     image: vm0/claude-code:latest
     volumes: # [!code highlight]
       - claude-files:/home/user/.claude # [!code highlight]
@@ -95,7 +95,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     instructions: AGENTS.md
     image: vm0/claude-code:latest
     volumes:

--- a/turbo/apps/docs/content/docs/experimental/firewall.mdx
+++ b/turbo/apps/docs/content/docs/experimental/firewall.mdx
@@ -22,7 +22,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     experimental_runner: # [!code highlight]
       group: vm0/production # [!code highlight]
     experimental_firewall: # [!code highlight]

--- a/turbo/apps/docs/content/docs/integration/apify.mdx
+++ b/turbo/apps/docs/content/docs/integration/apify.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/apify # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/axiom.mdx
+++ b/turbo/apps/docs/content/docs/integration/axiom.mdx
@@ -20,7 +20,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/axiom # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/bitrix.mdx
+++ b/turbo/apps/docs/content/docs/integration/bitrix.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/bitrix # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/brave-search.mdx
+++ b/turbo/apps/docs/content/docs/integration/brave-search.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/brave-search # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/bright-data.mdx
+++ b/turbo/apps/docs/content/docs/integration/bright-data.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/bright-data # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/browserbase.mdx
+++ b/turbo/apps/docs/content/docs/integration/browserbase.mdx
@@ -19,7 +19,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/browserbase # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/browserless.mdx
+++ b/turbo/apps/docs/content/docs/integration/browserless.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/browserless # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/chatwoot.mdx
+++ b/turbo/apps/docs/content/docs/integration/chatwoot.mdx
@@ -20,7 +20,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/chatwoot # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/cloudinary.mdx
+++ b/turbo/apps/docs/content/docs/integration/cloudinary.mdx
@@ -20,7 +20,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/cloudinary # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/cronlytic.mdx
+++ b/turbo/apps/docs/content/docs/integration/cronlytic.mdx
@@ -19,7 +19,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/cronlytic # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/deepseek.mdx
+++ b/turbo/apps/docs/content/docs/integration/deepseek.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/deepseek # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/devto.mdx
+++ b/turbo/apps/docs/content/docs/integration/devto.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/dev.to # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/discord-webhook.mdx
+++ b/turbo/apps/docs/content/docs/integration/discord-webhook.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/discord-webhook # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/discord.mdx
+++ b/turbo/apps/docs/content/docs/integration/discord.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/discord # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/elevenlabs.mdx
+++ b/turbo/apps/docs/content/docs/integration/elevenlabs.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/elevenlabs # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/fal-ai.mdx
+++ b/turbo/apps/docs/content/docs/integration/fal-ai.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/fal.ai # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/figma.mdx
+++ b/turbo/apps/docs/content/docs/integration/figma.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/figma # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/firecrawl.mdx
+++ b/turbo/apps/docs/content/docs/integration/firecrawl.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/firecrawl # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/github-copilot.mdx
+++ b/turbo/apps/docs/content/docs/integration/github-copilot.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github-copilot # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/github.mdx
+++ b/turbo/apps/docs/content/docs/integration/github.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/gitlab.mdx
+++ b/turbo/apps/docs/content/docs/integration/gitlab.mdx
@@ -19,7 +19,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/gitlab # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/gmail.mdx
+++ b/turbo/apps/docs/content/docs/integration/gmail.mdx
@@ -29,7 +29,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/gmail # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/google-sheets.mdx
+++ b/turbo/apps/docs/content/docs/integration/google-sheets.mdx
@@ -27,7 +27,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/google-sheets # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/hackernews.mdx
+++ b/turbo/apps/docs/content/docs/integration/hackernews.mdx
@@ -12,7 +12,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/hackernews # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/htmlcsstoimage.mdx
+++ b/turbo/apps/docs/content/docs/integration/htmlcsstoimage.mdx
@@ -19,7 +19,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/htmlcsstoimage # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/imgur.mdx
+++ b/turbo/apps/docs/content/docs/integration/imgur.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/imgur # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/instagram.mdx
+++ b/turbo/apps/docs/content/docs/integration/instagram.mdx
@@ -19,7 +19,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/instagram # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/instantly.mdx
+++ b/turbo/apps/docs/content/docs/integration/instantly.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/instantly # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/intercom.mdx
+++ b/turbo/apps/docs/content/docs/integration/intercom.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/intercom # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/jira.mdx
+++ b/turbo/apps/docs/content/docs/integration/jira.mdx
@@ -20,7 +20,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/jira # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/kommo.mdx
+++ b/turbo/apps/docs/content/docs/integration/kommo.mdx
@@ -19,7 +19,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/kommo # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/lark.mdx
+++ b/turbo/apps/docs/content/docs/integration/lark.mdx
@@ -19,7 +19,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/lark # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/linear.mdx
+++ b/turbo/apps/docs/content/docs/integration/linear.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/linear # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/mercury.mdx
+++ b/turbo/apps/docs/content/docs/integration/mercury.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/mercury # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/minimax.mdx
+++ b/turbo/apps/docs/content/docs/integration/minimax.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/minimax # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/minio.mdx
+++ b/turbo/apps/docs/content/docs/integration/minio.mdx
@@ -20,7 +20,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/minio # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/monday.mdx
+++ b/turbo/apps/docs/content/docs/integration/monday.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/monday # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/notion.mdx
+++ b/turbo/apps/docs/content/docs/integration/notion.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/notion # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/openai.mdx
+++ b/turbo/apps/docs/content/docs/integration/openai.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/openai # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/pdf4me.mdx
+++ b/turbo/apps/docs/content/docs/integration/pdf4me.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/pdf4me # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/pdfco.mdx
+++ b/turbo/apps/docs/content/docs/integration/pdfco.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/pdfco # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/pdforge.mdx
+++ b/turbo/apps/docs/content/docs/integration/pdforge.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/pdforge # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/perplexity.mdx
+++ b/turbo/apps/docs/content/docs/integration/perplexity.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/perplexity # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/plausible.mdx
+++ b/turbo/apps/docs/content/docs/integration/plausible.mdx
@@ -19,7 +19,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/plausible # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/podchaser.mdx
+++ b/turbo/apps/docs/content/docs/integration/podchaser.mdx
@@ -19,7 +19,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/podchaser # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/pushinator.mdx
+++ b/turbo/apps/docs/content/docs/integration/pushinator.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/pushinator # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/qdrant.mdx
+++ b/turbo/apps/docs/content/docs/integration/qdrant.mdx
@@ -19,7 +19,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/qdrant # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/qiita.mdx
+++ b/turbo/apps/docs/content/docs/integration/qiita.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/qiita # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/reportei.mdx
+++ b/turbo/apps/docs/content/docs/integration/reportei.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/reportei # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/resend.mdx
+++ b/turbo/apps/docs/content/docs/integration/resend.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/resend # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/rss-fetch.mdx
+++ b/turbo/apps/docs/content/docs/integration/rss-fetch.mdx
@@ -16,7 +16,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/rss-fetch # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/runway.mdx
+++ b/turbo/apps/docs/content/docs/integration/runway.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/runway # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/scrapeninja.mdx
+++ b/turbo/apps/docs/content/docs/integration/scrapeninja.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/scrapeninja # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/sentry.mdx
+++ b/turbo/apps/docs/content/docs/integration/sentry.mdx
@@ -20,7 +20,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/sentry # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/serpapi.mdx
+++ b/turbo/apps/docs/content/docs/integration/serpapi.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/serpapi # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/shortio.mdx
+++ b/turbo/apps/docs/content/docs/integration/shortio.mdx
@@ -20,7 +20,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/shortio # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/slack-webhook.mdx
+++ b/turbo/apps/docs/content/docs/integration/slack-webhook.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/slack-webhook # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/slack.mdx
+++ b/turbo/apps/docs/content/docs/integration/slack.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/slack # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/streak.mdx
+++ b/turbo/apps/docs/content/docs/integration/streak.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/streak # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/supabase.mdx
+++ b/turbo/apps/docs/content/docs/integration/supabase.mdx
@@ -20,7 +20,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/supabase # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/supadata.mdx
+++ b/turbo/apps/docs/content/docs/integration/supadata.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/supadata # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/tavily.mdx
+++ b/turbo/apps/docs/content/docs/integration/tavily.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/tavily # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/twenty.mdx
+++ b/turbo/apps/docs/content/docs/integration/twenty.mdx
@@ -19,7 +19,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/twenty # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/youtube.mdx
+++ b/turbo/apps/docs/content/docs/integration/youtube.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/youtube # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/zapsign.mdx
+++ b/turbo/apps/docs/content/docs/integration/zapsign.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/zapsign # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/zendesk.mdx
+++ b/turbo/apps/docs/content/docs/integration/zendesk.mdx
@@ -20,7 +20,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/zendesk # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/integration/zeptomail.mdx
+++ b/turbo/apps/docs/content/docs/integration/zeptomail.mdx
@@ -18,7 +18,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/zeptomail # [!code highlight]
 ```

--- a/turbo/apps/docs/content/docs/model-selection/claude.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/claude.mdx
@@ -14,7 +14,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     environment:
       # Required: One of the following authentication methods
       CLAUDE_CODE_OAUTH_TOKEN: "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}" # [!code highlight]
@@ -79,7 +79,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     environment:
       CLAUDE_CODE_OAUTH_TOKEN: "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
 ```
@@ -93,7 +93,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     environment:
       ANTHROPIC_API_KEY: "${{ secrets.ANTHROPIC_API_KEY }}" # [!code highlight]
 ```
@@ -107,7 +107,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     environment:
       CLAUDE_CODE_OAUTH_TOKEN: "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
       ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-5-20251101" # [!code highlight]
@@ -125,7 +125,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     environment:
       CLAUDE_CODE_OAUTH_TOKEN: "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
       ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-sonnet-4-5-20250929" # [!code highlight]
@@ -143,7 +143,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     environment:
       CLAUDE_CODE_OAUTH_TOKEN: "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
       ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-haiku-4-5-20251001" # [!code highlight]

--- a/turbo/apps/docs/content/docs/model-selection/deepseek.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/deepseek.mdx
@@ -16,7 +16,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     environment:
       ANTHROPIC_BASE_URL: "https://api.deepseek.com/anthropic" # [!code highlight]
       ANTHROPIC_AUTH_TOKEN: "${{ secrets.DEEPSEEK_API_KEY }}" # [!code highlight]

--- a/turbo/apps/docs/content/docs/model-selection/index.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/index.mdx
@@ -16,7 +16,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code # [!code highlight]
+    framework: claude-code # [!code highlight]
 ```
 
 Required environment variable:
@@ -34,7 +34,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: codex # [!code highlight]
+    framework: codex # [!code highlight]
 ```
 
 Required environment variable:
@@ -56,7 +56,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     environment:
       ANTHROPIC_BASE_URL: "https://api.example.com/anthropic" # [!code highlight]
       ANTHROPIC_AUTH_TOKEN: "${{ secrets.API_KEY }}" # [!code highlight]

--- a/turbo/apps/docs/content/docs/model-selection/minimax.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/minimax.mdx
@@ -16,7 +16,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     environment:
       ANTHROPIC_BASE_URL: "https://api.minimax.io/anthropic" # [!code highlight]
       ANTHROPIC_AUTH_TOKEN: "${{ secrets.MINIMAX_API_KEY }}" # [!code highlight]

--- a/turbo/apps/docs/content/docs/model-selection/moonshot.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/moonshot.mdx
@@ -16,7 +16,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     environment:
       ANTHROPIC_BASE_URL: "https://api.moonshot.ai/anthropic" # [!code highlight]
       ANTHROPIC_AUTH_TOKEN: "${{ secrets.MOONSHOT_API_KEY }}" # [!code highlight]

--- a/turbo/apps/docs/content/docs/model-selection/openrouter.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/openrouter.mdx
@@ -12,7 +12,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     environment:
       ANTHROPIC_BASE_URL: "https://openrouter.ai/api" # [!code highlight]
       ANTHROPIC_AUTH_TOKEN: "${{ secrets.OPENROUTER_API_KEY }}" # [!code highlight]

--- a/turbo/apps/docs/content/docs/model-selection/zai.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/zai.mdx
@@ -16,7 +16,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     environment:
       ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic" # [!code highlight]
       ANTHROPIC_AUTH_TOKEN: "${{ secrets.ZAI_API_KEY }}" # [!code highlight]

--- a/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
@@ -12,7 +12,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     instructions: AGENTS.md
     environment:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -25,7 +25,7 @@ version: "1.0"
 
 agents:
   my-agent:
-    provider: claude-code
+    framework: claude-code
     instructions: AGENTS.md
     apps:
       - github
@@ -55,7 +55,7 @@ volumes:
 
 | Field          | Type   | Required | Default | Description                                                                                       |
 | -------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------- |
-| `provider`     | string | Yes      | -       | Agent provider: `claude-code` or `codex`. See [Model Selection](/docs/model-selection)            |
+| `framework`    | string | Yes      | -       | Agent framework: `claude-code` or `codex`. See [Model Selection](/docs/model-selection)           |
 | `instructions` | string | No       | -       | Path to instruction file (e.g., `AGENTS.md`). See [Instructions](/docs/core-concept/instructions) |
 | `apps`         | array  | No       | `[]`    | Pre-installed tools. Supported: `github`, `github:dev`, `github:latest`                           |
 | `skills`       | array  | No       | `[]`    | List of skill URLs. See [Skills](/docs/core-concept/skills)                                       |

--- a/turbo/apps/docs/content/docs/tutorial/custom-image.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/custom-image.mdx
@@ -24,7 +24,7 @@ version: "1.0"
 
 agents:
   my-researcher:
-    provider: claude-code
+    framework: claude-code
     apps:
       - github # [!code highlight]
     instructions: AGENTS.md

--- a/turbo/apps/docs/content/docs/tutorial/my-first-agent.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/my-first-agent.mdx
@@ -40,7 +40,7 @@ version: "1.0"
 
 agents:
   my-researcher:
-    provider: claude-code
+    framework: claude-code
     # Build agentic workflow using natural language
     instructions: AGENTS.md
     # Agent skills - see https://github.com/vm0-ai/vm0-skills for available skills

--- a/turbo/apps/docs/content/docs/tutorial/research-capabilities.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/research-capabilities.mdx
@@ -35,7 +35,7 @@ version: "1.0"
 
 agents:
   my-researcher:
-    provider: claude-code
+    framework: claude-code
     instructions: AGENTS.md
     environment:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/turbo/apps/runner/scripts/deploy/Dockerfile
+++ b/turbo/apps/runner/scripts/deploy/Dockerfile
@@ -1,9 +1,9 @@
 # Firecracker VM rootfs image (Universal)
 # Based on Node.js 24 with Python 3.11+, SSH server, and agent CLIs
 #
-# This is a universal image that supports all providers and apps:
-# - Claude Code CLI (@anthropic-ai/claude-code) for provider: claude-code
-# - Codex CLI (@openai/codex) for provider: codex
+# This is a universal image that supports all frameworks and apps:
+# - Claude Code CLI (@anthropic-ai/claude-code) for framework: claude-code
+# - Codex CLI (@openai/codex) for framework: codex
 # - GitHub CLI (gh) for apps: [github]
 #
 # This mirrors the e2b template configurations for consistency.

--- a/turbo/apps/runner/scripts/deploy/build-rootfs.sh
+++ b/turbo/apps/runner/scripts/deploy/build-rootfs.sh
@@ -187,7 +187,7 @@ verify_rootfs() {
         echo "  overlay-init: installed"
     fi
 
-    # Check for Codex CLI (for provider: codex)
+    # Check for Codex CLI (for framework: codex)
     if ! sudo chroot "$MOUNT_POINT" /usr/bin/which codex > /dev/null 2>&1; then
         echo "WARNING: Codex CLI not found in rootfs"
     else


### PR DESCRIPTION
## Summary

- Replace all `provider:` references with `framework:` in documentation YAML examples
- Update test fixtures in setup-github.test.ts  
- Update comments in deployment scripts (Dockerfile, build-rootfs.sh)
- Update reference table in vm0-yaml.mdx to document `framework` field

## Changes

| Category | Files |
|----------|-------|
| Documentation (mdx) | 83 |
| Test fixtures | 1 |
| Deployment scripts | 2 |
| **Total** | **86** |

## Test plan

- [x] All lint checks pass
- [x] All type checks pass
- [x] Relevant tests pass (yaml-validator.test.ts, setup-github.test.ts)
- [x] Verified no remaining `provider:` references except intentional deprecation test

Closes #1463

🤖 Generated with [Claude Code](https://claude.ai/code)