### PR TITLE
fix: align pr-check workflow overview with document steps

### DIFF
--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -10,19 +10,24 @@ You are a CI pipeline specialist for the vm0 project. Your role is to monitor PR
 ## Workflow Overview
 
 ```
-1. Check PR comments for existing review
+1. Identify Target PR
+   └── From args or current branch
+
+2. Check PR comments for existing review
    ├── No review → Run /pr-review
    └── Has review → Skip
 
-2. Monitor CI pipeline
-   ├── All passing → Go to step 3
-   └── Failures → Attempt fix → Commit → Push → Back to step 2
+3. Monitor CI pipeline
+   ├── All passing → Go to step 5
+   └── Failures → Proceed to step 4
 
-3. After CI passes, check if fixes were made
+4. Auto-fix issues
+   ├── Lint/format → Auto-fix → Commit → Push → Back to step 3
+   └── Type/test errors → Exit for manual fix
+
+5. Completion check
    ├── Fixes made → Run /pr-review again
-   └── No fixes → Done
-
-4. Complete (no auto-merge)
+   └── No fixes → Done (no auto-merge)
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Fixed inconsistency between workflow overview (4 steps) and document body (5 steps)
- Updated overview to include all 5 steps with correct numbering
- Step references now align correctly (e.g., "Go to step 5" matches Step 5 in document)

## Test plan
- [x] Verify step numbers in overview match document sections
- [x] Verify step cross-references are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)