### PR TITLE
docs: simplify command descriptions and disable typescript-lsp

### DIFF
--- a/.claude/commands/defensive-code-cleanup.md
+++ b/.claude/commands/defensive-code-cleanup.md
@@ -3,15 +3,9 @@ command: defensive-code-cleanup
 description: Clean Defensive Try-Catch Blocks
 ---
 
-Remove defensive try-catch blocks using the code-quality skill with context fork isolation.
-
 ```typescript
 await Skill({
   skill: "code-quality",
   args: "cleanup"
 });
 ```
-
-**Usage**: `/defensive-code-cleanup`
-
-**What it does**: Finds and removes defensive try-catch blocks that violate the "Avoid Defensive Programming" principle, creates PR with changes, and monitors CI pipeline.

--- a/.claude/commands/dev-auth.md
+++ b/.claude/commands/dev-auth.md
@@ -3,17 +3,9 @@ command: dev-auth
 description: Authenticate with local development server and get CLI token
 ---
 
-Authenticate CLI with local development server using the dev-server skill with context fork isolation.
-
 ```typescript
 await Skill({
   skill: "dev-server",
   args: "auth"
 });
 ```
-
-**Usage**: `/dev-auth`
-
-**Prerequisites**: Dev server must be running (use `/dev-start` first)
-
-**What it does**: Uses Playwright to automate Clerk login and authorize CLI device code, saving auth token to `~/.vm0/config.json`.

--- a/.claude/commands/dev-logs.md
+++ b/.claude/commands/dev-logs.md
@@ -3,17 +3,9 @@ command: dev-logs
 description: View development server logs with optional filtering
 ---
 
-View development server logs using the dev-server skill with context fork isolation.
-
 ```typescript
 await Skill({
   skill: "dev-server",
   args: "logs"
 });
 ```
-
-**Usage**:
-- `/dev-logs` - Show all new logs
-- `/dev-logs [pattern]` - Filter logs with regex pattern
-
-**Examples**: `/dev-logs error`, `/dev-logs "compiled|ready"`

--- a/.claude/commands/dev-start.md
+++ b/.claude/commands/dev-start.md
@@ -3,15 +3,9 @@ command: dev-start
 description: Start the development server in background mode
 ---
 
-Start the development server using the dev-server skill with context fork isolation.
-
 ```typescript
 await Skill({
   skill: "dev-server",
   args: "start"
 });
 ```
-
-**Usage**: `/dev-start`
-
-**What it does**: Starts the Turbo development server in background with stream UI mode. Automatically stops any running dev server and generates SSL certificates if needed.

--- a/.claude/commands/dev-stop.md
+++ b/.claude/commands/dev-stop.md
@@ -3,15 +3,9 @@ command: dev-stop
 description: Stop the background development server
 ---
 
-Stop the development server using the dev-server skill with context fork isolation.
-
 ```typescript
 await Skill({
   skill: "dev-server",
   args: "stop"
 });
 ```
-
-**Usage**: `/dev-stop`
-
-**What it does**: Gracefully stops the background development server and verifies the process has terminated.

--- a/.claude/commands/dev-tunnel.md
+++ b/.claude/commands/dev-tunnel.md
@@ -3,15 +3,9 @@ command: dev-tunnel
 description: Start dev server with Cloudflare tunnel and authenticate CLI
 ---
 
-Start dev server with Cloudflare tunnel using the dev-server skill with context fork isolation.
-
 ```typescript
 await Skill({
   skill: "dev-server",
   args: "tunnel"
 });
 ```
-
-**Usage**: `/dev-tunnel`
-
-**What it does**: Installs dependencies, builds project, starts dev server with Cloudflare tunnel for webhook testing, and authenticates CLI. Exposes localhost:3000 via `*.trycloudflare.com` URL.

--- a/.claude/commands/preview-envs-cleanup.md
+++ b/.claude/commands/preview-envs-cleanup.md
@@ -3,15 +3,9 @@ command: preview-envs-cleanup
 description: Clean up old GitHub preview deployment environments
 ---
 
-Clean up preview environments using the ops-utils skill with context fork isolation.
-
 ```typescript
 await Skill({
   skill: "ops-utils",
   args: "cleanup-previews"
 });
 ```
-
-**Usage**: `/preview-envs-cleanup`
-
-**What it does**: Deletes GitHub preview deployment environments older than 3 days, preserving production environments and recent previews.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,6 @@
     "frontend-design@claude-plugins-official": true,
     "code-review@claude-plugins-official": false,
     "security-guidance@claude-plugins-official": false,
-    "typescript-lsp@claude-plugins-official": true
+    "typescript-lsp@claude-plugins-official": false
   }
 }


### PR DESCRIPTION
## Summary
- Remove redundant documentation from command files (defensive-code-cleanup, dev-auth, dev-logs, dev-start, dev-stop, dev-tunnel, preview-envs-cleanup)
- Disable typescript-lsp plugin in Claude settings
- Remove unused eslint-disable directive in platform nav-link component

## Test plan
- [x] Pre-commit checks passed (format, lint, type-check, knip)
- [x] All documentation changes are non-functional
- [x] Platform lint warning resolved

Generated with [Claude Code](https://claude.com/claude-code)