### PR TITLE
fix(cli): update description to accurately reflect VM0's purpose

### DIFF
--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -29,7 +29,7 @@ declare const __CLI_VERSION__: string;
 
 program
   .name("vm0")
-  .description("VM0 CLI - A modern build tool")
+  .description("VM0 CLI - Build and run agents with natural language")
   .version(__CLI_VERSION__);
 
 program


### PR DESCRIPTION
## Summary
- Update CLI description from "A modern build tool" to "VM0 CLI - Build and run agents with natural language"
- The previous description was misleading as VM0 is an AI agent infrastructure platform, not a build tool

## Test plan
- [x] Verify `vm0 --help` shows the new description

🤖 Generated with [Claude Code](https://claude.com/claude-code)