### PR TITLE
feat(eslint): add naming convention rule to base config

### DIFF
--- a/turbo/apps/web/app/api/cli/auth/token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/route.ts
@@ -23,12 +23,12 @@ const router = tsr.router(cliAuthTokenContract, {
   exchange: async ({ body }) => {
     initServices();
 
-    const { device_code } = body;
+    const { device_code: deviceCode } = body;
 
     const [session] = await globalThis.services.db
       .select()
       .from(deviceCodes)
-      .where(eq(deviceCodes.code, device_code))
+      .where(eq(deviceCodes.code, deviceCode))
       .limit(1);
 
     if (!session) {
@@ -68,7 +68,7 @@ const router = tsr.router(cliAuthTokenContract, {
         // Clean up
         await globalThis.services.db
           .delete(deviceCodes)
-          .where(eq(deviceCodes.code, device_code));
+          .where(eq(deviceCodes.code, deviceCode));
 
         return {
           status: 400 as const,
@@ -127,7 +127,7 @@ const router = tsr.router(cliAuthTokenContract, {
         // Clean up device code
         await globalThis.services.db
           .delete(deviceCodes)
-          .where(eq(deviceCodes.code, device_code));
+          .where(eq(deviceCodes.code, deviceCode));
 
         return {
           status: 200 as const,

--- a/turbo/packages/eslint-config/base.js
+++ b/turbo/packages/eslint-config/base.js
@@ -35,6 +35,41 @@ export const config = [
         { ignoreVoid: false },
       ],
       "@typescript-eslint/no-misused-promises": "error",
+      "@typescript-eslint/naming-convention": [
+        "error",
+        // Variables and parameters: camelCase, UPPER_CASE, or PascalCase
+        {
+          selector: ["variable", "parameter"],
+          format: ["camelCase", "UPPER_CASE", "PascalCase"],
+          leadingUnderscore: "allow",
+          trailingUnderscore: "allow",
+          filter: {
+            // Exclude magic variables like __CLI_VERSION__
+            regex: "^__.*__$",
+            match: false,
+          },
+        },
+        // Properties: allow any format (API fields, etc may use snake_case)
+        {
+          selector: "property",
+          format: null,
+        },
+        // Functions: camelCase or PascalCase (React components)
+        {
+          selector: "function",
+          format: ["camelCase", "PascalCase"],
+        },
+        // Type-like: PascalCase
+        {
+          selector: "typeLike",
+          format: ["PascalCase"],
+        },
+        // Enum members: flexible
+        {
+          selector: "enumMember",
+          format: ["camelCase", "UPPER_CASE", "PascalCase"],
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
Add @typescript-eslint/naming-convention rule to enforce TypeScript naming conventions across the monorepo.

## Changes

- Add naming convention rule to base ESLint config with pragmatic approach
- Fix existing violation in web app by renaming device_code to deviceCode
- Configuration allows flexible patterns while maintaining consistency:
  - Variables/parameters: camelCase, UPPER_CASE, or PascalCase
  - Properties: no restrictions (allows API fields with snake_case)
  - Functions: camelCase or PascalCase (React components)
  - Types/interfaces/classes: PascalCase
  - Enum members: flexible formats
  - Excludes magic variables like __CLI_VERSION__

## Test Plan

- [x] Format check passed
- [x] Lint check passed (forced cache bypass to verify)
- [x] Type check passed
- [ ] CI tests will validate in clean environment