### PR TITLE
feat: add e2e timing metric from api to run-agent.ts start

### DIFF
--- a/turbo/apps/runner/src/lib/executor-env.ts
+++ b/turbo/apps/runner/src/lib/executor-env.ts
@@ -66,6 +66,11 @@ export function buildEnvironmentVariables(
       .join(",");
   }
 
+  // Pass API start time for E2E timing measurement
+  if (context.apiStartTime) {
+    envVars.VM0_API_START_TIME = String(context.apiStartTime);
+  }
+
   // Add user-defined vars
   if (context.vars) {
     for (const [key, value] of Object.entries(context.vars)) {

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -23,6 +23,9 @@ const log = logger("api:runs");
 
 const router = tsr.router(runsMainContract, {
   create: async ({ body }) => {
+    // Capture API start time for E2E timing measurement
+    const apiStartTime = Date.now();
+
     initServices();
 
     const userId = await getUserId();
@@ -375,6 +378,7 @@ const router = tsr.router(runsMainContract, {
         continuedFromSessionId: body.sessionId,
         debugNoMockClaude: body.debugNoMockClaude,
         modelProvider: body.modelProvider,
+        apiStartTime,
       });
 
       // Prepare and dispatch to executor (unified path for E2B and runner)

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
   agentComposeVersions,
 } from "../../../../../../src/db/schema/agent-compose";
 import { scopes } from "../../../../../../src/db/schema/scope";
+import { runnerJobQueue } from "../../../../../../src/db/schema/runner-job-queue";
 import { eq } from "drizzle-orm";
 import { randomUUID } from "crypto";
 import { createTestSandboxToken } from "../../../../../../src/__tests__/api-test-helpers";
@@ -542,4 +543,394 @@ describe("POST /api/webhooks/agent/telemetry", () => {
   // Secrets are now masked client-side in the sandbox before being sent to the server.
   // The server never has access to secret values (only secret names for validation).
   // See: feat: separate secrets from vars in checkpoint/session system
+});
+
+describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
+  const testUserId = `runner-user-${Date.now()}-${process.pid}`;
+  const testScopeId = randomUUID();
+  const testRunId = randomUUID();
+  const testComposeId = randomUUID();
+  const testVersionId =
+    randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
+  let testToken: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    initServices();
+
+    // Generate JWT token for sandbox auth
+    testToken = await createTestSandboxToken(testUserId, testRunId);
+
+    mockClerk({ userId: null });
+
+    const mockHeaders = vi.mocked(headers);
+    mockHeaders.mockResolvedValue({
+      get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+    } as unknown as Headers);
+
+    // Setup Axiom SDK mock
+    const mockAxiomClient = {
+      query: vi.fn().mockResolvedValue({ matches: [] }),
+      ingest: vi.fn(),
+      flush: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(Axiom).mockImplementation(
+      () => mockAxiomClient as unknown as Axiom,
+    );
+
+    // Clean up any existing test data
+    await globalThis.services.db
+      .delete(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, testRunId));
+
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, testRunId));
+
+    await globalThis.services.db
+      .delete(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, testVersionId));
+
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, testComposeId));
+
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, testScopeId));
+
+    // Create test scope
+    await globalThis.services.db.insert(scopes).values({
+      id: testScopeId,
+      slug: `test-${testScopeId.slice(0, 8)}`,
+      type: "personal",
+      ownerId: testUserId,
+    });
+
+    // Create test agent compose
+    await globalThis.services.db.insert(agentComposes).values({
+      id: testComposeId,
+      userId: testUserId,
+      scopeId: testScopeId,
+      name: "test-agent",
+      headVersionId: testVersionId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // Create test agent version
+    await globalThis.services.db.insert(agentComposeVersions).values({
+      id: testVersionId,
+      composeId: testComposeId,
+      content: {
+        agents: {
+          "test-agent": {
+            name: "test-agent",
+            model: "claude-3-5-sonnet-20241022",
+            working_dir: "/workspace",
+          },
+        },
+      },
+      createdBy: testUserId,
+      createdAt: new Date(),
+    });
+
+    // Create test run
+    await globalThis.services.db.insert(agentRuns).values({
+      id: testRunId,
+      userId: testUserId,
+      agentComposeVersionId: testVersionId,
+      status: "running",
+      prompt: "Test prompt",
+      createdAt: new Date(),
+    });
+
+    // Create runner job queue entry (marks this as a runner sandbox)
+    const expiresAt = new Date();
+    expiresAt.setHours(expiresAt.getHours() + 1);
+    await globalThis.services.db.insert(runnerJobQueue).values({
+      runId: testRunId,
+      runnerGroup: "test-group",
+      claimedAt: new Date(),
+      executionContext: {
+        runId: testRunId,
+        prompt: "Test prompt",
+        workingDir: "/workspace",
+        cliAgentType: "claude-code",
+        sandboxToken: "test-token",
+        apiStartTime: Date.now(),
+      },
+      createdAt: new Date(),
+      expiresAt,
+    });
+  });
+
+  afterEach(async () => {
+    clearClerkMock();
+    await globalThis.services.db
+      .delete(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, testRunId));
+
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, testRunId));
+
+    await globalThis.services.db
+      .delete(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, testVersionId));
+
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, testComposeId));
+
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, testScopeId));
+  });
+
+  it("should determine sandbox type as runner and record metrics", async () => {
+    // Spy on ingestToAxiom
+    const ingestToAxiomSpy = vi
+      .spyOn(axiomModule, "ingestToAxiom")
+      .mockResolvedValue(true);
+
+    // Spy on recordSandboxInternalOperation to verify sandbox type
+    const recordMetricsSpy = vi.spyOn(
+      await import("../../../../../../src/lib/metrics"),
+      "recordSandboxInternalOperation",
+    );
+
+    // Simulate telemetry from runner sandbox
+    const sandboxOperations = [
+      {
+        ts: "2025-01-22T10:00:00Z",
+        action_type: "init_total",
+        duration_ms: 1500,
+        success: true,
+      },
+      {
+        ts: "2025-01-22T10:00:02Z",
+        action_type: "cli_execution",
+        duration_ms: 200,
+        success: true,
+      },
+    ];
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/webhooks/agent/telemetry",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testToken}`,
+        },
+        body: JSON.stringify({
+          runId: testRunId,
+          systemLog: "[INFO] Test log from runner\n",
+          sandboxOperations,
+        }),
+      },
+    );
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+
+    // Verify system log was sent to Axiom
+    expect(ingestToAxiomSpy).toHaveBeenCalledWith(
+      "vm0-sandbox-telemetry-system-dev",
+      expect.arrayContaining([
+        expect.objectContaining({
+          runId: testRunId,
+          userId: testUserId,
+          log: "[INFO] Test log from runner\n",
+        }),
+      ]),
+    );
+
+    // Verify sandbox operations were recorded with correct sandbox type
+    expect(recordMetricsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: "init_total",
+        sandboxType: "runner",
+        durationMs: 1500,
+        success: true,
+      }),
+    );
+
+    expect(recordMetricsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: "cli_execution",
+        sandboxType: "runner",
+        durationMs: 200,
+        success: true,
+      }),
+    );
+  });
+
+  it("should determine sandbox type as e2b when not in runner queue", async () => {
+    // Create a separate E2B run (not in runner_job_queue)
+    const e2bRunId = randomUUID();
+    const e2bToken = await createTestSandboxToken(testUserId, e2bRunId);
+
+    const mockHeaders = vi.mocked(headers);
+    mockHeaders.mockResolvedValue({
+      get: vi.fn().mockReturnValue(`Bearer ${e2bToken}`),
+    } as unknown as Headers);
+
+    await globalThis.services.db.insert(agentRuns).values({
+      id: e2bRunId,
+      userId: testUserId,
+      agentComposeVersionId: testVersionId,
+      status: "running",
+      prompt: "E2B test prompt",
+      createdAt: new Date(),
+    });
+
+    // Spy on recordSandboxInternalOperation
+    const recordMetricsSpy = vi.spyOn(
+      await import("../../../../../../src/lib/metrics"),
+      "recordSandboxInternalOperation",
+    );
+
+    const sandboxOperations = [
+      {
+        ts: "2025-01-22T10:00:00Z",
+        action_type: "api_to_agent_start",
+        duration_ms: 500,
+        success: true,
+      },
+    ];
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/webhooks/agent/telemetry",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${e2bToken}`,
+        },
+        body: JSON.stringify({
+          runId: e2bRunId,
+          sandboxOperations,
+        }),
+      },
+    );
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+
+    // Verify sandbox type was determined as e2b
+    expect(recordMetricsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: "api_to_agent_start",
+        sandboxType: "e2b",
+        durationMs: 500,
+        success: true,
+      }),
+    );
+
+    // Cleanup
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, e2bRunId));
+  });
+
+  it("should upload complete telemetry with all data types", async () => {
+    const ingestToAxiomSpy = vi
+      .spyOn(axiomModule, "ingestToAxiom")
+      .mockResolvedValue(true);
+
+    const testMetrics = [
+      {
+        ts: "2025-01-22T10:00:00Z",
+        cpu: 25.5,
+        mem_used: 167190528,
+        mem_total: 1033142272,
+        disk_used: 1556893696,
+        disk_total: 22797680640,
+      },
+    ];
+
+    const testNetworkLogs = [
+      {
+        timestamp: "2025-01-22T10:00:00Z",
+        mode: "sni" as const,
+        action: "ALLOW" as const,
+        host: "api.example.com",
+        port: 443,
+        rule_matched: "allow-all",
+      },
+    ];
+
+    const sandboxOperations = [
+      {
+        ts: "2025-01-22T10:00:00Z",
+        action_type: "storage_download",
+        duration_ms: 1200,
+        success: true,
+      },
+    ];
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/webhooks/agent/telemetry",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testToken}`,
+        },
+        body: JSON.stringify({
+          runId: testRunId,
+          systemLog: "[INFO] Complete telemetry test\n",
+          metrics: testMetrics,
+          networkLogs: testNetworkLogs,
+          sandboxOperations,
+        }),
+      },
+    );
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+
+    // Verify system log ingestion
+    expect(ingestToAxiomSpy).toHaveBeenCalledWith(
+      "vm0-sandbox-telemetry-system-dev",
+      expect.arrayContaining([
+        expect.objectContaining({
+          runId: testRunId,
+          log: "[INFO] Complete telemetry test\n",
+        }),
+      ]),
+    );
+
+    // Verify metrics ingestion
+    expect(ingestToAxiomSpy).toHaveBeenCalledWith(
+      "vm0-sandbox-telemetry-metrics-dev",
+      expect.arrayContaining([
+        expect.objectContaining({
+          runId: testRunId,
+          cpu: 25.5,
+          mem_used: 167190528,
+        }),
+      ]),
+    );
+
+    // Verify network logs ingestion
+    expect(ingestToAxiomSpy).toHaveBeenCalledWith(
+      "vm0-sandbox-telemetry-network-dev",
+      expect.arrayContaining([
+        expect.objectContaining({
+          runId: testRunId,
+          mode: "sni",
+          action: "ALLOW",
+          host: "api.example.com",
+        }),
+      ]),
+    );
+  });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { POST } from "../route";
+import { POST as createCompose } from "../../../../agent/composes/route";
+import { POST as createRun } from "../../../../agent/runs/route";
 import { NextRequest } from "next/server";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
@@ -11,7 +13,11 @@ import { scopes } from "../../../../../../src/db/schema/scope";
 import { runnerJobQueue } from "../../../../../../src/db/schema/runner-job-queue";
 import { eq } from "drizzle-orm";
 import { randomUUID } from "crypto";
-import { createTestSandboxToken } from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  createTestSandboxToken,
+  createTestRequest,
+  createDefaultComposeConfig,
+} from "../../../../../../src/__tests__/api-test-helpers";
 
 // Mock Next.js headers() function
 vi.mock("next/headers", () => ({
@@ -26,7 +32,11 @@ vi.mock("@clerk/nextjs/server", () => ({
 // Mock Axiom SDK (external)
 vi.mock("@axiomhq/js");
 
+// Mock E2B SDK (external)
+vi.mock("@e2b/code-interpreter");
+
 import { headers } from "next/headers";
+import { Sandbox } from "@e2b/code-interpreter";
 import {
   mockClerk,
   clearClerkMock,
@@ -548,25 +558,42 @@ describe("POST /api/webhooks/agent/telemetry", () => {
 describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
   const testUserId = `runner-user-${Date.now()}-${process.pid}`;
   const testScopeId = randomUUID();
-  const testRunId = randomUUID();
-  const testComposeId = randomUUID();
-  const testVersionId =
-    randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
+  const testAgentName = `test-runner-telemetry-${Date.now()}`;
+  let testComposeId: string;
+  let testRunId: string;
   let testToken: string;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     initServices();
 
-    // Generate JWT token for sandbox auth
-    testToken = await createTestSandboxToken(testUserId, testRunId);
-
-    mockClerk({ userId: null });
+    // Mock Clerk auth
+    mockClerk({ userId: testUserId });
 
     const mockHeaders = vi.mocked(headers);
     mockHeaders.mockResolvedValue({
-      get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+      get: vi.fn().mockReturnValue(null),
     } as unknown as Headers);
+
+    // Setup E2B SDK mock
+    const mockSandbox = {
+      sandboxId: `test-sandbox-${Date.now()}`,
+      getHostname: () => "test-sandbox.e2b.dev",
+      files: {
+        write: vi.fn().mockResolvedValue(undefined),
+      },
+      commands: {
+        run: vi.fn().mockResolvedValue({
+          stdout: "Mock output",
+          stderr: "",
+          exitCode: 0,
+        }),
+      },
+      kill: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(Sandbox.create).mockResolvedValue(
+      mockSandbox as unknown as Sandbox,
+    );
 
     // Setup Axiom SDK mock
     const mockAxiomClient = {
@@ -578,28 +605,20 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
       () => mockAxiomClient as unknown as Axiom,
     );
 
-    // Clean up any existing test data
-    await globalThis.services.db
-      .delete(runnerJobQueue)
-      .where(eq(runnerJobQueue.runId, testRunId));
-
+    // Clean up test data from previous runs
     await globalThis.services.db
       .delete(agentRuns)
-      .where(eq(agentRuns.id, testRunId));
-
-    await globalThis.services.db
-      .delete(agentComposeVersions)
-      .where(eq(agentComposeVersions.id, testVersionId));
+      .where(eq(agentRuns.userId, testUserId));
 
     await globalThis.services.db
       .delete(agentComposes)
-      .where(eq(agentComposes.id, testComposeId));
+      .where(eq(agentComposes.userId, testUserId));
 
     await globalThis.services.db
       .delete(scopes)
       .where(eq(scopes.id, testScopeId));
 
-    // Create test scope
+    // Create test scope (required for compose creation)
     await globalThis.services.db.insert(scopes).values({
       id: testScopeId,
       slug: `test-${testScopeId.slice(0, 8)}`,
@@ -607,45 +626,45 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
       ownerId: testUserId,
     });
 
-    // Create test agent compose
-    await globalThis.services.db.insert(agentComposes).values({
-      id: testComposeId,
-      userId: testUserId,
-      scopeId: testScopeId,
-      name: "test-agent",
-      headVersionId: testVersionId,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
-
-    // Create test agent version
-    await globalThis.services.db.insert(agentComposeVersions).values({
-      id: testVersionId,
-      composeId: testComposeId,
-      content: {
-        agents: {
-          "test-agent": {
-            name: "test-agent",
-            model: "claude-3-5-sonnet-20241022",
-            working_dir: "/workspace",
-          },
-        },
+    // Create test compose via API
+    const config = createDefaultComposeConfig(testAgentName);
+    const composeRequest = createTestRequest(
+      "http://localhost:3000/api/agent/composes",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: config }),
       },
-      createdBy: testUserId,
-      createdAt: new Date(),
+    );
+
+    const composeResponse = await createCompose(composeRequest);
+    const composeData = await composeResponse.json();
+    testComposeId = composeData.composeId;
+
+    // Create test run via API (will create E2B sandbox)
+    const runRequest = new NextRequest("http://localhost:3000/api/agent/runs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        agentComposeId: testComposeId,
+        prompt: "Test prompt for telemetry",
+      }),
     });
 
-    // Create test run
-    await globalThis.services.db.insert(agentRuns).values({
-      id: testRunId,
-      userId: testUserId,
-      agentComposeVersionId: testVersionId,
-      status: "running",
-      prompt: "Test prompt",
-      createdAt: new Date(),
-    });
+    const runResponse = await createRun(runRequest);
+    const runData = await runResponse.json();
+    testRunId = runData.runId;
 
-    // Create runner job queue entry (marks this as a runner sandbox)
+    // Generate sandbox token for this run
+    testToken = await createTestSandboxToken(testUserId, testRunId);
+
+    // Mock headers to use sandbox token for webhook requests
+    mockHeaders.mockResolvedValue({
+      get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
+    } as unknown as Headers);
+
+    // Add runner job queue entry to mark this as a runner sandbox
+    // (This is the only direct DB operation, as there's no API to create runner jobs)
     const expiresAt = new Date();
     expiresAt.setHours(expiresAt.getHours() + 1);
     await globalThis.services.db.insert(runnerJobQueue).values({
@@ -654,10 +673,10 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
       claimedAt: new Date(),
       executionContext: {
         runId: testRunId,
-        prompt: "Test prompt",
+        prompt: "Test prompt for telemetry",
         workingDir: "/workspace",
         cliAgentType: "claude-code",
-        sandboxToken: "test-token",
+        sandboxToken: testToken,
         apiStartTime: Date.now(),
       },
       createdAt: new Date(),
@@ -667,21 +686,14 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
 
   afterEach(async () => {
     clearClerkMock();
-    await globalThis.services.db
-      .delete(runnerJobQueue)
-      .where(eq(runnerJobQueue.runId, testRunId));
-
+    // Clean up test data (cascade deletes will handle related records)
     await globalThis.services.db
       .delete(agentRuns)
-      .where(eq(agentRuns.id, testRunId));
-
-    await globalThis.services.db
-      .delete(agentComposeVersions)
-      .where(eq(agentComposeVersions.id, testVersionId));
+      .where(eq(agentRuns.userId, testUserId));
 
     await globalThis.services.db
       .delete(agentComposes)
-      .where(eq(agentComposes.id, testComposeId));
+      .where(eq(agentComposes.userId, testUserId));
 
     await globalThis.services.db
       .delete(scopes)
@@ -771,23 +783,35 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
   });
 
   it("should determine sandbox type as e2b when not in runner queue", async () => {
-    // Create a separate E2B run (not in runner_job_queue)
-    const e2bRunId = randomUUID();
+    // Temporarily reset headers mock to allow Clerk auth for run creation
+    const mockHeaders = vi.mocked(headers);
+    mockHeaders.mockResolvedValue({
+      get: vi.fn().mockReturnValue(null),
+    } as unknown as Headers);
+
+    // Create a separate E2B run via API (will not be in runner_job_queue)
+    const e2bRunRequest = new NextRequest(
+      "http://localhost:3000/api/agent/runs",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentComposeId: testComposeId,
+          prompt: "E2B test prompt",
+        }),
+      },
+    );
+
+    const e2bRunResponse = await createRun(e2bRunRequest);
+    const e2bRunData = await e2bRunResponse.json();
+    const e2bRunId = e2bRunData.runId;
+
     const e2bToken = await createTestSandboxToken(testUserId, e2bRunId);
 
-    const mockHeaders = vi.mocked(headers);
+    // Restore headers mock to use e2b sandbox token for webhook requests
     mockHeaders.mockResolvedValue({
       get: vi.fn().mockReturnValue(`Bearer ${e2bToken}`),
     } as unknown as Headers);
-
-    await globalThis.services.db.insert(agentRuns).values({
-      id: e2bRunId,
-      userId: testUserId,
-      agentComposeVersionId: testVersionId,
-      status: "running",
-      prompt: "E2B test prompt",
-      createdAt: new Date(),
-    });
 
     // Spy on recordSandboxInternalOperation
     const recordMetricsSpy = vi.spyOn(

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
@@ -10,6 +10,7 @@ import {
   agentComposeVersions,
 } from "../../../../../../src/db/schema/agent-compose";
 import { scopes } from "../../../../../../src/db/schema/scope";
+import { runnerJobQueue } from "../../../../../../src/db/schema/runner-job-queue";
 import { eq } from "drizzle-orm";
 import { randomUUID } from "crypto";
 import {
@@ -838,6 +839,68 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
     await globalThis.services.db
       .delete(agentRuns)
       .where(eq(agentRuns.id, e2bRunId));
+  });
+
+  it("should verify runner run is in job queue and system log uploads correctly", async () => {
+    // Step 1: Verify run is in runner_job_queue (created by API)
+    const [runnerJob] = await globalThis.services.db
+      .select()
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, testRunId))
+      .limit(1);
+
+    expect(runnerJob).toBeDefined();
+    expect(runnerJob!.runId).toBe(testRunId);
+    expect(runnerJob!.runnerGroup).toBe("vm0/test-runner-group");
+
+    // Step 2: Send telemetry with system log
+    const ingestToAxiomSpy = vi
+      .spyOn(axiomModule, "ingestToAxiom")
+      .mockResolvedValue(true);
+
+    // Simulate realistic system log from run-agent.ts
+    const systemLog = `[2025-01-22T10:00:00.123Z] [INFO] [sandbox:init] Starting sandbox initialization
+[2025-01-22T10:00:00.234Z] [INFO] [sandbox:init] E2E time from API to agent start: 1234ms
+[2025-01-22T10:00:00.345Z] [INFO] [sandbox:init] Working directory: /home/user/workspace
+[2025-01-22T10:00:01.456Z] [INFO] [sandbox:cli] Starting Claude Code agent
+[2025-01-22T10:00:02.567Z] [INFO] [sandbox:telemetry] Telemetry upload started (interval: 30s)
+`;
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/webhooks/agent/telemetry",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testToken}`,
+        },
+        body: JSON.stringify({
+          runId: testRunId,
+          systemLog,
+        }),
+      },
+    );
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+
+    // Step 3: Verify system log was ingested to Axiom
+    expect(ingestToAxiomSpy).toHaveBeenCalledWith(
+      "vm0-sandbox-telemetry-system-dev",
+      expect.arrayContaining([
+        expect.objectContaining({
+          runId: testRunId,
+          userId: testUserId,
+          log: systemLog,
+        }),
+      ]),
+    );
+
+    // Step 4: Verify log contains expected patterns (matches E2E test expectations)
+    expect(systemLog).toContain("[INFO]");
+    expect(systemLog).toContain("[sandbox:");
+    expect(systemLog).toContain("E2E time from API to agent start");
   });
 
   it("should upload complete telemetry with all data types", async () => {

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
@@ -10,7 +10,6 @@ import {
   agentComposeVersions,
 } from "../../../../../../src/db/schema/agent-compose";
 import { scopes } from "../../../../../../src/db/schema/scope";
-import { runnerJobQueue } from "../../../../../../src/db/schema/runner-job-queue";
 import { eq } from "drizzle-orm";
 import { randomUUID } from "crypto";
 import {
@@ -557,8 +556,8 @@ describe("POST /api/webhooks/agent/telemetry", () => {
 
 describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
   const testUserId = `runner-user-${Date.now()}-${process.pid}`;
-  const testScopeId = randomUUID();
   const testAgentName = `test-runner-telemetry-${Date.now()}`;
+  let testScopeId: string;
   let testComposeId: string;
   let testRunId: string;
   let testToken: string;
@@ -566,6 +565,9 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     initServices();
+
+    // Generate unique test scope ID for this test
+    testScopeId = randomUUID();
 
     // Mock Clerk auth
     mockClerk({ userId: testUserId });
@@ -605,19 +607,6 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
       () => mockAxiomClient as unknown as Axiom,
     );
 
-    // Clean up test data from previous runs
-    await globalThis.services.db
-      .delete(agentRuns)
-      .where(eq(agentRuns.userId, testUserId));
-
-    await globalThis.services.db
-      .delete(agentComposes)
-      .where(eq(agentComposes.userId, testUserId));
-
-    await globalThis.services.db
-      .delete(scopes)
-      .where(eq(scopes.id, testScopeId));
-
     // Create test scope (required for compose creation)
     await globalThis.services.db.insert(scopes).values({
       id: testScopeId,
@@ -626,8 +615,12 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
       ownerId: testUserId,
     });
 
-    // Create test compose via API
-    const config = createDefaultComposeConfig(testAgentName);
+    // Create test compose with experimental_runner
+    const config = createDefaultComposeConfig(testAgentName, {
+      experimental_runner: {
+        group: "vm0/test-runner-group",
+      },
+    });
     const composeRequest = createTestRequest(
       "http://localhost:3000/api/agent/composes",
       {
@@ -641,7 +634,7 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
     const composeData = await composeResponse.json();
     testComposeId = composeData.composeId;
 
-    // Create test run via API (will create E2B sandbox)
+    // Create test run via API (will create runner job in queue)
     const runRequest = new NextRequest("http://localhost:3000/api/agent/runs", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -662,42 +655,10 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
     mockHeaders.mockResolvedValue({
       get: vi.fn().mockReturnValue(`Bearer ${testToken}`),
     } as unknown as Headers);
-
-    // Add runner job queue entry to mark this as a runner sandbox
-    // (This is the only direct DB operation, as there's no API to create runner jobs)
-    const expiresAt = new Date();
-    expiresAt.setHours(expiresAt.getHours() + 1);
-    await globalThis.services.db.insert(runnerJobQueue).values({
-      runId: testRunId,
-      runnerGroup: "test-group",
-      claimedAt: new Date(),
-      executionContext: {
-        runId: testRunId,
-        prompt: "Test prompt for telemetry",
-        workingDir: "/workspace",
-        cliAgentType: "claude-code",
-        sandboxToken: testToken,
-        apiStartTime: Date.now(),
-      },
-      createdAt: new Date(),
-      expiresAt,
-    });
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     clearClerkMock();
-    // Clean up test data (cascade deletes will handle related records)
-    await globalThis.services.db
-      .delete(agentRuns)
-      .where(eq(agentRuns.userId, testUserId));
-
-    await globalThis.services.db
-      .delete(agentComposes)
-      .where(eq(agentComposes.userId, testUserId));
-
-    await globalThis.services.db
-      .delete(scopes)
-      .where(eq(scopes.id, testScopeId));
   });
 
   it("should determine sandbox type as runner and record metrics", async () => {
@@ -789,6 +750,22 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
       get: vi.fn().mockReturnValue(null),
     } as unknown as Headers);
 
+    // Create a separate E2B compose without experimental_runner
+    const e2bAgentName = `test-e2b-telemetry-${Date.now()}`;
+    const e2bConfig = createDefaultComposeConfig(e2bAgentName);
+    const e2bComposeRequest = createTestRequest(
+      "http://localhost:3000/api/agent/composes",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: e2bConfig }),
+      },
+    );
+
+    const e2bComposeResponse = await createCompose(e2bComposeRequest);
+    const e2bComposeData = await e2bComposeResponse.json();
+    const e2bComposeId = e2bComposeData.composeId;
+
     // Create a separate E2B run via API (will not be in runner_job_queue)
     const e2bRunRequest = new NextRequest(
       "http://localhost:3000/api/agent/runs",
@@ -796,7 +773,7 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          agentComposeId: testComposeId,
+          agentComposeId: e2bComposeId,
           prompt: "E2B test prompt",
         }),
       },

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
@@ -50,6 +50,13 @@ const mockHeaders = vi.mocked(headers);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let ingestToAxiomSpy: any;
 
+// Mock Axiom client - will be set up in beforeEach
+let mockAxiomClient: {
+  query: ReturnType<typeof vi.fn>;
+  ingest: ReturnType<typeof vi.fn>;
+  flush: ReturnType<typeof vi.fn>;
+};
+
 describe("POST /api/webhooks/agent/telemetry", () => {
   const testUserId = `test-user-${Date.now()}-${process.pid}`;
   const testScopeId = randomUUID();
@@ -72,8 +79,11 @@ describe("POST /api/webhooks/agent/telemetry", () => {
       get: vi.fn().mockReturnValue(null),
     } as unknown as Headers);
 
+    // Set AXIOM_TOKEN for tests so getAxiomClient() returns the mocked client
+    process.env.AXIOM_TOKEN = "test-axiom-token";
+
     // Setup Axiom SDK mock
-    const mockAxiomClient = {
+    mockAxiomClient = {
       query: vi.fn().mockResolvedValue({ matches: [] }),
       ingest: vi.fn(),
       flush: vi.fn().mockResolvedValue(undefined),
@@ -598,8 +608,11 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
       mockSandbox as unknown as Sandbox,
     );
 
+    // Set AXIOM_TOKEN for tests so getAxiomClient() returns the mocked client
+    process.env.AXIOM_TOKEN = "test-axiom-token";
+
     // Setup Axiom SDK mock
-    const mockAxiomClient = {
+    mockAxiomClient = {
       query: vi.fn().mockResolvedValue({ matches: [] }),
       ingest: vi.fn(),
       flush: vi.fn().mockResolvedValue(undefined),
@@ -668,11 +681,8 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
       .spyOn(axiomModule, "ingestToAxiom")
       .mockResolvedValue(true);
 
-    // Spy on recordSandboxInternalOperation to verify sandbox type
-    const recordMetricsSpy = vi.spyOn(
-      await import("../../../../../../src/lib/metrics"),
-      "recordSandboxInternalOperation",
-    );
+    // Spy on ingestSandboxOpLog to verify what gets sent to Axiom
+    const ingestSandboxOpLogSpy = vi.spyOn(axiomModule, "ingestSandboxOpLog");
 
     // Simulate telemetry from runner sandbox
     const sandboxOperations = [
@@ -724,22 +734,22 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
       ]),
     );
 
-    // Verify sandbox operations were recorded with correct sandbox type
-    expect(recordMetricsSpy).toHaveBeenCalledWith(
+    // Verify sandbox operations were ingested to Axiom with correct sandbox type
+    expect(ingestSandboxOpLogSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        actionType: "init_total",
-        sandboxType: "runner",
-        durationMs: 1500,
-        success: true,
+        source: "sandbox",
+        op_type: "init_total",
+        sandbox_type: "runner",
+        duration_ms: 1500,
       }),
     );
 
-    expect(recordMetricsSpy).toHaveBeenCalledWith(
+    expect(ingestSandboxOpLogSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        actionType: "cli_execution",
-        sandboxType: "runner",
-        durationMs: 200,
-        success: true,
+        source: "sandbox",
+        op_type: "cli_execution",
+        sandbox_type: "runner",
+        duration_ms: 200,
       }),
     );
   });
@@ -791,11 +801,8 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
       get: vi.fn().mockReturnValue(`Bearer ${e2bToken}`),
     } as unknown as Headers);
 
-    // Spy on recordSandboxInternalOperation
-    const recordMetricsSpy = vi.spyOn(
-      await import("../../../../../../src/lib/metrics"),
-      "recordSandboxInternalOperation",
-    );
+    // Spy on ingestSandboxOpLog to verify what gets sent to Axiom
+    const ingestSandboxOpLogSpy = vi.spyOn(axiomModule, "ingestSandboxOpLog");
 
     const sandboxOperations = [
       {
@@ -825,13 +832,13 @@ describe("POST /api/webhooks/agent/telemetry - Runner Integration", () => {
 
     expect(response.status).toBe(200);
 
-    // Verify sandbox type was determined as e2b
-    expect(recordMetricsSpy).toHaveBeenCalledWith(
+    // Verify sandbox operations were ingested to Axiom with correct sandbox type
+    expect(ingestSandboxOpLogSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        actionType: "api_to_agent_start",
-        sandboxType: "e2b",
-        durationMs: 500,
-        success: true,
+        source: "sandbox",
+        op_type: "api_to_agent_start",
+        sandbox_type: "e2b",
+        duration_ms: 500,
       }),
     );
 

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
@@ -139,6 +139,7 @@ const router = tsr.router(webhookTelemetryContract, {
     }
 
     // Record sandbox internal operations as OpenTelemetry metrics (to sandbox-metric-{env} dataset)
+    // Sandbox operations include: init_total, storage_download, cli_execution, checkpoint, cleanup
     if (body.sandboxOperations && body.sandboxOperations.length > 0) {
       // Determine sandbox type by checking if run exists in runner_job_queue
       const [runnerJob] = await globalThis.services.db

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
@@ -6,6 +6,7 @@ import {
 import { webhookTelemetryContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
+import { runnerJobQueue } from "../../../../../src/db/schema/runner-job-queue";
 import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../src/lib/auth/get-sandbox-auth";
 import { logger } from "../../../../../src/lib/logger";
@@ -138,12 +139,20 @@ const router = tsr.router(webhookTelemetryContract, {
     }
 
     // Record sandbox internal operations as OpenTelemetry metrics (to sandbox-metric-{env} dataset)
-    // Note: Currently only runner sandbox sends internal operations. E2B support can be added later.
     if (body.sandboxOperations && body.sandboxOperations.length > 0) {
+      // Determine sandbox type by checking if run exists in runner_job_queue
+      const [runnerJob] = await globalThis.services.db
+        .select({ runId: runnerJobQueue.runId })
+        .from(runnerJobQueue)
+        .where(eq(runnerJobQueue.runId, body.runId))
+        .limit(1);
+
+      const sandboxType = runnerJob ? "runner" : "e2b";
+
       for (const op of body.sandboxOperations) {
         recordSandboxInternalOperation({
           actionType: op.action_type,
-          sandboxType: "runner",
+          sandboxType,
           durationMs: op.duration_ms,
           success: op.success,
         });

--- a/turbo/apps/web/app/v1/runs/route.ts
+++ b/turbo/apps/web/app/v1/runs/route.ts
@@ -126,6 +126,9 @@ const router = tsr.router(publicRunsListContract, {
   },
 
   create: async ({ body }) => {
+    // Capture API start time for E2E timing measurement
+    const apiStartTime = Date.now();
+
     initServices();
 
     const auth = await authenticatePublicApi();
@@ -339,6 +342,7 @@ const router = tsr.router(publicRunsListContract, {
       agentName: agentCompose?.name,
       resumedFromCheckpointId: body.checkpoint_id,
       continuedFromSessionId: body.session_id,
+      apiStartTime,
     });
 
     const result = await runService.prepareAndDispatch(context);

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -57,6 +57,8 @@ export interface BuildContextParams {
   debugNoMockClaude?: boolean;
   // Model provider for automatic LLM credential injection
   modelProvider?: string;
+  // API start time for E2E timing measurement (milliseconds since epoch)
+  apiStartTime?: number;
 }
 
 /**
@@ -348,5 +350,7 @@ export async function buildExecutionContext(
     continuedFromSessionId: params.continuedFromSessionId,
     // Debug flag
     debugNoMockClaude: params.debugNoMockClaude,
+    // API start time for E2E timing
+    apiStartTime: params.apiStartTime,
   };
 }

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -246,6 +246,9 @@ export async function prepareForExecution(
 
     // Debug flag
     debugNoMockClaude: context.debugNoMockClaude || false,
+
+    // API start time for E2E timing
+    apiStartTime: context.apiStartTime || null,
   };
 
   log.debug(`PreparedContext built for run ${context.runId}`);

--- a/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
@@ -284,6 +284,11 @@ class E2BExecutor implements Executor {
       sandboxEnvVars.VM0_SECRET_VALUES = encodedValues.join(",");
     }
 
+    // Pass API start time for E2E timing measurement
+    if (context.apiStartTime) {
+      sandboxEnvVars.VM0_API_START_TIME = String(context.apiStartTime);
+    }
+
     return sandboxEnvVars;
   }
 

--- a/turbo/apps/web/src/lib/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/run/executors/types.ts
@@ -52,6 +52,9 @@ export interface PreparedContext {
 
   // Debug flag to force real Claude in mock environments (internal use only)
   debugNoMockClaude: boolean;
+
+  // API start time for E2E timing measurement (milliseconds since epoch)
+  apiStartTime: number | null;
 }
 
 /**

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -82,4 +82,7 @@ export interface ExecutionContext {
 
   // Debug flag to force real Claude in mock environments (internal use only)
   debugNoMockClaude?: boolean;
+
+  // API start time for E2E timing measurement (milliseconds since epoch)
+  apiStartTime?: number;
 }

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -127,6 +127,8 @@ export const storedExecutionContextSchema = z.object({
   experimentalFirewall: experimentalFirewallSchema.optional(),
   // Debug flag to force real Claude in mock environments (internal use only)
   debugNoMockClaude: z.boolean().optional(),
+  // API start time for E2E timing measurement (milliseconds since epoch)
+  apiStartTime: z.number().optional(),
 });
 
 /**
@@ -151,6 +153,8 @@ export const executionContextSchema = z.object({
   experimentalFirewall: experimentalFirewallSchema.optional(),
   // Debug flag to force real Claude in mock environments (internal use only)
   debugNoMockClaude: z.boolean().optional(),
+  // API start time for E2E timing measurement (milliseconds since epoch)
+  apiStartTime: z.number().optional(),
 });
 
 /**

--- a/turbo/packages/core/src/sandbox/scripts/src/lib/common.ts
+++ b/turbo/packages/core/src/sandbox/scripts/src/lib/common.ts
@@ -11,6 +11,7 @@ export const API_TOKEN = process.env.VM0_API_TOKEN ?? "";
 export const PROMPT = process.env.VM0_PROMPT ?? "";
 export const VERCEL_BYPASS = process.env.VERCEL_PROTECTION_BYPASS ?? "";
 export const RESUME_SESSION_ID = process.env.VM0_RESUME_SESSION_ID ?? "";
+export const API_START_TIME = process.env.VM0_API_START_TIME ?? "";
 
 // CLI agent type - determines which CLI to invoke (claude-code or codex)
 export const CLI_AGENT_TYPE = process.env.CLI_AGENT_TYPE ?? "claude-code";

--- a/turbo/packages/core/src/sandbox/scripts/src/run-agent.ts
+++ b/turbo/packages/core/src/sandbox/scripts/src/run-agent.ts
@@ -28,6 +28,7 @@ import {
   AGENT_LOG_FILE,
   CLI_AGENT_TYPE,
   OPENAI_MODEL,
+  API_START_TIME,
   validateConfig,
   recordSandboxOp,
 } from "./lib/common.js";
@@ -158,6 +159,16 @@ async function run(): Promise<[number, string]> {
   // Lifecycle: Initialization
   logInfo("▷ Initialization");
   const initStartTime = Date.now();
+
+  // Record E2E time from API to agent start if available
+  if (API_START_TIME) {
+    const apiStartTimeMs = parseInt(API_START_TIME, 10);
+    if (!isNaN(apiStartTimeMs)) {
+      const e2eTimeMs = Date.now() - apiStartTimeMs;
+      recordSandboxOp("api_to_agent_start", e2eTimeMs, true);
+      logInfo(`E2E time from API to agent start: ${e2eTimeMs}ms`);
+    }
+  }
 
   logInfo(`Working directory: ${WORKING_DIR}`);
 


### PR DESCRIPTION
## Summary

Implements timestamp propagation to capture end-to-end time from API request receipt to run-agent.ts process start. This enables accurate performance comparison between E2B and Runner execution paths.

Resolves #1485

## Changes

- **Add `apiStartTime` field** to ExecutionContext, PreparedContext, and runner contracts
- **Capture timestamp** at `/v1/runs` POST handler entry point
- **Propagate timestamp** through execution context building pipeline
- **Pass timestamp** to both E2B and Runner executors via `VM0_API_START_TIME` environment variable
- **Calculate and report E2E time** in run-agent.ts using `recordSandboxOp()`
- **New metric** `api_to_agent_start` now available in Axiom `sandbox-op-log` dataset

## Technical Details

### Approach
Uses timestamp propagation via environment variable (Approach 1 from design document):
- Single clock source (API server) for highest accuracy
- Works identically for both E2B and Runner paths
- Leverages existing telemetry infrastructure
- No database schema changes required

### Backward Compatibility
All changes are backward compatible:
- `apiStartTime` field is optional in all interfaces
- run-agent.ts gracefully handles missing or invalid timestamps
- No breaking changes to existing functionality

## Test Plan

- [x] TypeScript type checking passes
- [x] Linting passes
- [x] Knip finds no unused exports
- [ ] Manual testing: Create run and verify metric appears in Axiom
- [ ] E2E test coverage (Task 7 from plan - can be done in follow-up PR)

## Impact

This metric enables:
- Comparing E2B vs Runner dispatch performance
- Identifying startup bottlenecks in the pipeline
- Measuring true end-to-end latency from user perspective
- Tracking performance regressions

Generated with Claude Code