### PR TITLE
fix: use merge base for pr comparison in ci workflow

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -40,8 +40,8 @@ jobs:
 
           # Determine base ref based on event type
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF="${{ github.event.pull_request.base.sha }}"
-            echo "PR mode: comparing against base branch $BASE_REF"
+            BASE_REF=$(git merge-base ${{ github.event.pull_request.base.sha }} HEAD)
+            echo "PR mode: comparing against merge base $BASE_REF"
           elif [ "${{ github.event_name }}" = "merge_group" ]; then
             BASE_REF="${{ github.event.merge_group.base_sha }}"
             echo "Merge queue mode: comparing against base $BASE_REF"


### PR DESCRIPTION
## Summary

This PR improves the CI workflow's base reference detection for pull requests by using `git merge-base` instead of directly using the base SHA. This ensures more accurate change detection by comparing against the common ancestor commit.

### Changes

1. **CI Workflow Enhancement**: Modified `.github/workflows/turbo.yml` to use `git merge-base` for determining the base reference in PR mode
   - Before: Compared against `github.event.pull_request.base.sha` directly
   - After: Uses `git merge-base` to find the common ancestor between base and HEAD
   - This provides more reliable detection of actual changes in the PR

2. **Code Cleanup**: Removed unused eslint-disable directive in `turbo/apps/platform/src/views/layout/nav-link.tsx`

### Benefits

- More accurate detection of changed files in PRs
- Prevents false positives when base branch has diverged
- Aligns with git best practices for diff comparison

### Test Plan

- [x] All pre-commit checks passed (format, lint, type-check, knip, tests)
- [x] Verified commit message follows conventional commit format
- [ ] CI checks will validate the workflow change

🤖 Generated with [Claude Code](https://claude.com/claude-code)