### PR TITLE
refactor(skills): remove context fork from issue-related skills

### DIFF
--- a/.claude/skills/issue-action/SKILL.md
+++ b/.claude/skills/issue-action/SKILL.md
@@ -2,7 +2,6 @@
 name: issue-action
 description: Continue working on GitHub issue from conversation context
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, Task
-context: fork
 ---
 
 # Issue Action Skill

--- a/.claude/skills/issue-compact/SKILL.md
+++ b/.claude/skills/issue-compact/SKILL.md
@@ -2,7 +2,6 @@
 name: issue-compact
 description: Consolidate GitHub issue discussion into clean body for handoff
 allowed-tools: Bash
-context: fork
 ---
 
 # Issue Compact Skill

--- a/.claude/skills/issue-create/SKILL.md
+++ b/.claude/skills/issue-create/SKILL.md
@@ -2,7 +2,6 @@
 name: issue-create
 description: Create GitHub issues from conversation context (general, bug reports, or feature requests)
 allowed-tools: Bash
-context: fork
 ---
 
 # Issue Creation Skill

--- a/.claude/skills/issue-plan/SKILL.md
+++ b/.claude/skills/issue-plan/SKILL.md
@@ -2,7 +2,6 @@
 name: issue-plan
 description: Start working on GitHub issue with deep-dive workflow (research, innovate, plan phases)
 allowed-tools: Bash, Read, Write, Grep, Glob
-context: fork
 ---
 
 # Issue Planning Skill


### PR DESCRIPTION
## Summary
- Remove `context: fork` frontmatter from issue-action, issue-plan, issue-create, and issue-compact skills

## Test plan
- [ ] Verify issue skills still work without context fork setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)