### PR TITLE
fix(style): update card and popover backgrounds to gray-100

### DIFF
--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -47,6 +47,7 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.18",
     "@testing-library/jest-dom": "^6.7.0",
     "@testing-library/react": "^16.1.0",
     "@types/archiver": "^7.0.0",
@@ -62,6 +63,7 @@
     "eslint": "^9.34.0",
     "msw": "^2.7.0",
     "oxlint": "^1.14.0",
+    "postcss": "^8.5.6",
     "tsx": "^4.20.5",
     "typescript": "5.9.2",
     "vitest": "^3.2.4"

--- a/turbo/apps/web/postcss.config.js
+++ b/turbo/apps/web/postcss.config.js
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -223,10 +223,10 @@
     --background: var(--gray-0); /* background-0 */
     --foreground: var(--gray-950); /* background-950 */
 
-    --card: 0 0% 100%; /* white */
+    --card: var(--gray-100); /* background-100 - dark background */
     --card-foreground: var(--gray-950); /* background-950 */
 
-    --popover: 0 0% 100%; /* white */
+    --popover: var(--gray-100); /* background-100 - dark background */
     --popover-foreground: var(--gray-950); /* background-950 */
 
     --primary: var(--primary-700); /* primary-700 */

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -485,6 +485,9 @@ importers:
         specifier: ^4.1.12
         version: 4.1.12
     devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.1.18
+        version: 4.1.18
       '@testing-library/jest-dom':
         specifier: ^6.7.0
         version: 6.8.0
@@ -530,6 +533,9 @@ importers:
       oxlint:
         specifier: ^1.14.0
         version: 1.38.0
+      postcss:
+        specifier: ^8.5.6
+        version: 8.5.6
       tsx:
         specifier: ^4.20.5
         version: 4.20.5
@@ -3588,6 +3594,9 @@ packages:
 
   '@tailwindcss/postcss@4.1.12':
     resolution: {integrity: sha512-5PpLYhCAwf9SJEeIsSmCDLgyVfdBhdBpzX1OJ87anT9IVR0Z9pjM0FNixCAUAHGnMBGB8K99SwAheXrT0Kh6QQ==}
+
+  '@tailwindcss/postcss@4.1.18':
+    resolution: {integrity: sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==}
 
   '@tailwindcss/vite@4.1.18':
     resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
@@ -11140,6 +11149,14 @@ snapshots:
       '@tailwindcss/oxide': 4.1.12
       postcss: 8.5.6
       tailwindcss: 4.1.12
+
+  '@tailwindcss/postcss@4.1.18':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.1.18
+      '@tailwindcss/oxide': 4.1.18
+      postcss: 8.5.6
+      tailwindcss: 4.1.18
 
   '@tailwindcss/vite@4.1.18(vite@6.4.1(@types/node@22.18.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:


### PR DESCRIPTION
Updated card and popover backgrounds from pure white to gray-100 for better visual consistency in the UI design system.

## Changes
- Updated `--card` and `--popover` CSS variables from `0 0% 100%` (white) to `var(--gray-100)`
- Added Tailwind CSS v4 PostCSS plugin configuration
- Added required dependencies: `@tailwindcss/postcss` and `postcss`

## Test Plan
- Visual inspection of UI components using card and popover backgrounds
- Verify that cards and popovers now have a subtle gray background instead of pure white