### PR TITLE
fix(cli): resolve schedule by name globally for delete/enable/disable/status

### DIFF
--- a/e2e/tests/02-parallel/t20-vm0-schedule.bats
+++ b/e2e/tests/02-parallel/t20-vm0-schedule.bats
@@ -526,3 +526,81 @@ EOF
     assert_success
     assert_output --partial "(one-time)"
 }
+
+# ============================================================
+# Global resolution tests (commands work from any directory)
+# Issue #1496: Schedule commands should resolve by name globally
+# ============================================================
+
+@test "vm0 schedule status should work from any directory (global resolution)" {
+    cd "$TEST_DIR"
+
+    # Deploy schedule first
+    run $CLI_COMMAND schedule deploy schedule.yaml
+    assert_success
+
+    # Change to a completely different directory (NOT the agent's directory)
+    cd /tmp
+
+    # Status should still work with just the schedule name
+    run $CLI_COMMAND schedule status "$SCHEDULE_NAME"
+    assert_success
+    assert_output --partial "Schedule: $SCHEDULE_NAME"
+    assert_output --partial "enabled"
+}
+
+@test "vm0 schedule disable should work from any directory (global resolution)" {
+    cd "$TEST_DIR"
+
+    # Deploy schedule first
+    run $CLI_COMMAND schedule deploy schedule.yaml
+    assert_success
+
+    # Change to a different directory
+    cd /tmp
+
+    # Disable should still work with just the schedule name
+    run $CLI_COMMAND schedule disable "$SCHEDULE_NAME"
+    assert_success
+    assert_output --partial "Disabled"
+}
+
+@test "vm0 schedule enable should work from any directory (global resolution)" {
+    cd "$TEST_DIR"
+
+    # Deploy and disable schedule first
+    run $CLI_COMMAND schedule deploy schedule.yaml
+    assert_success
+
+    run $CLI_COMMAND schedule disable "$SCHEDULE_NAME"
+    assert_success
+
+    # Change to a different directory
+    cd /tmp
+
+    # Enable should still work with just the schedule name
+    run $CLI_COMMAND schedule enable "$SCHEDULE_NAME"
+    assert_success
+    assert_output --partial "Enabled"
+}
+
+@test "vm0 schedule delete should work from any directory (global resolution)" {
+    cd "$TEST_DIR"
+
+    # Deploy schedule first
+    run $CLI_COMMAND schedule deploy schedule.yaml
+    assert_success
+
+    # Change to a different directory
+    cd /tmp
+
+    # Delete should still work with just the schedule name
+    run $CLI_COMMAND schedule delete "$SCHEDULE_NAME" --force
+    assert_success
+    assert_output --partial "Deleted"
+
+    # Verify it's gone
+    run $CLI_COMMAND schedule list
+    assert_success
+    assert_output --partial "No schedules found"
+}

--- a/turbo/apps/cli/src/commands/schedule/__tests__/init.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/init.test.ts
@@ -11,7 +11,9 @@ import {
   getTomorrowDateLocal,
   getCurrentTimeLocal,
   toISODateTime,
+  resolveScheduleByName,
 } from "../../../lib/domain/schedule-utils";
+import * as api from "../../../lib/api";
 
 describe("schedule init utilities", () => {
   let tempDir: string;
@@ -295,6 +297,140 @@ agents:
 
       const result2 = toISODateTime("2025-01-01 00:00");
       expect(result2).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
+    });
+  });
+
+  describe("resolveScheduleByName", () => {
+    it("should resolve schedule by name from global list", async () => {
+      vi.spyOn(api, "listSchedules").mockResolvedValue({
+        schedules: [
+          {
+            id: "sched-1",
+            name: "my-schedule",
+            composeId: "compose-123",
+            composeName: "my-agent",
+            enabled: true,
+            prompt: "test prompt",
+            scopeSlug: "user/scope",
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+            atTime: null,
+            nextRunAt: "2025-01-15T09:00:00Z",
+            vars: {},
+            secretNames: [],
+            artifactName: null,
+            artifactVersion: null,
+            volumeVersions: {},
+            createdAt: "2025-01-01T00:00:00Z",
+            updatedAt: "2025-01-01T00:00:00Z",
+          },
+        ],
+      });
+
+      const result = await resolveScheduleByName("my-schedule");
+
+      expect(result).toEqual({
+        name: "my-schedule",
+        composeId: "compose-123",
+        composeName: "my-agent",
+      });
+      expect(api.listSchedules).toHaveBeenCalledOnce();
+    });
+
+    it("should find schedule among multiple schedules", async () => {
+      vi.spyOn(api, "listSchedules").mockResolvedValue({
+        schedules: [
+          {
+            id: "sched-1",
+            name: "schedule-1",
+            composeId: "compose-1",
+            composeName: "agent-1",
+            enabled: true,
+            prompt: "prompt 1",
+            scopeSlug: "user/scope",
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+            atTime: null,
+            nextRunAt: null,
+            vars: {},
+            secretNames: [],
+            artifactName: null,
+            artifactVersion: null,
+            volumeVersions: {},
+            createdAt: "2025-01-01T00:00:00Z",
+            updatedAt: "2025-01-01T00:00:00Z",
+          },
+          {
+            id: "sched-2",
+            name: "schedule-2",
+            composeId: "compose-2",
+            composeName: "agent-2",
+            enabled: false,
+            prompt: "prompt 2",
+            scopeSlug: "user/scope",
+            cronExpression: "0 10 * * *",
+            timezone: "UTC",
+            atTime: null,
+            nextRunAt: null,
+            vars: {},
+            secretNames: [],
+            artifactName: null,
+            artifactVersion: null,
+            volumeVersions: {},
+            createdAt: "2025-01-01T00:00:00Z",
+            updatedAt: "2025-01-01T00:00:00Z",
+          },
+        ],
+      });
+
+      const result = await resolveScheduleByName("schedule-2");
+
+      expect(result).toEqual({
+        name: "schedule-2",
+        composeId: "compose-2",
+        composeName: "agent-2",
+      });
+    });
+
+    it("should throw error when schedule not found", async () => {
+      vi.spyOn(api, "listSchedules").mockResolvedValue({
+        schedules: [
+          {
+            id: "sched-1",
+            name: "other-schedule",
+            composeId: "compose-123",
+            composeName: "my-agent",
+            enabled: true,
+            prompt: "test prompt",
+            scopeSlug: "user/scope",
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+            atTime: null,
+            nextRunAt: null,
+            vars: {},
+            secretNames: [],
+            artifactName: null,
+            artifactVersion: null,
+            volumeVersions: {},
+            createdAt: "2025-01-01T00:00:00Z",
+            updatedAt: "2025-01-01T00:00:00Z",
+          },
+        ],
+      });
+
+      await expect(resolveScheduleByName("non-existent")).rejects.toThrow(
+        'Schedule "non-existent" not found',
+      );
+    });
+
+    it("should throw error when no schedules exist", async () => {
+      vi.spyOn(api, "listSchedules").mockResolvedValue({
+        schedules: [],
+      });
+
+      await expect(resolveScheduleByName("my-schedule")).rejects.toThrow(
+        'Schedule "my-schedule" not found',
+      );
     });
   });
 });

--- a/turbo/apps/cli/src/commands/schedule/__tests__/init.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/init.test.ts
@@ -11,9 +11,7 @@ import {
   getTomorrowDateLocal,
   getCurrentTimeLocal,
   toISODateTime,
-  resolveScheduleByName,
 } from "../../../lib/domain/schedule-utils";
-import * as api from "../../../lib/api";
 
 describe("schedule init utilities", () => {
   let tempDir: string;
@@ -300,137 +298,7 @@ agents:
     });
   });
 
-  describe("resolveScheduleByName", () => {
-    it("should resolve schedule by name from global list", async () => {
-      vi.spyOn(api, "listSchedules").mockResolvedValue({
-        schedules: [
-          {
-            id: "sched-1",
-            name: "my-schedule",
-            composeId: "compose-123",
-            composeName: "my-agent",
-            enabled: true,
-            prompt: "test prompt",
-            scopeSlug: "user/scope",
-            cronExpression: "0 9 * * *",
-            timezone: "UTC",
-            atTime: null,
-            nextRunAt: "2025-01-15T09:00:00Z",
-            vars: {},
-            secretNames: [],
-            artifactName: null,
-            artifactVersion: null,
-            volumeVersions: {},
-            createdAt: "2025-01-01T00:00:00Z",
-            updatedAt: "2025-01-01T00:00:00Z",
-          },
-        ],
-      });
-
-      const result = await resolveScheduleByName("my-schedule");
-
-      expect(result).toEqual({
-        name: "my-schedule",
-        composeId: "compose-123",
-        composeName: "my-agent",
-      });
-      expect(api.listSchedules).toHaveBeenCalledOnce();
-    });
-
-    it("should find schedule among multiple schedules", async () => {
-      vi.spyOn(api, "listSchedules").mockResolvedValue({
-        schedules: [
-          {
-            id: "sched-1",
-            name: "schedule-1",
-            composeId: "compose-1",
-            composeName: "agent-1",
-            enabled: true,
-            prompt: "prompt 1",
-            scopeSlug: "user/scope",
-            cronExpression: "0 9 * * *",
-            timezone: "UTC",
-            atTime: null,
-            nextRunAt: null,
-            vars: {},
-            secretNames: [],
-            artifactName: null,
-            artifactVersion: null,
-            volumeVersions: {},
-            createdAt: "2025-01-01T00:00:00Z",
-            updatedAt: "2025-01-01T00:00:00Z",
-          },
-          {
-            id: "sched-2",
-            name: "schedule-2",
-            composeId: "compose-2",
-            composeName: "agent-2",
-            enabled: false,
-            prompt: "prompt 2",
-            scopeSlug: "user/scope",
-            cronExpression: "0 10 * * *",
-            timezone: "UTC",
-            atTime: null,
-            nextRunAt: null,
-            vars: {},
-            secretNames: [],
-            artifactName: null,
-            artifactVersion: null,
-            volumeVersions: {},
-            createdAt: "2025-01-01T00:00:00Z",
-            updatedAt: "2025-01-01T00:00:00Z",
-          },
-        ],
-      });
-
-      const result = await resolveScheduleByName("schedule-2");
-
-      expect(result).toEqual({
-        name: "schedule-2",
-        composeId: "compose-2",
-        composeName: "agent-2",
-      });
-    });
-
-    it("should throw error when schedule not found", async () => {
-      vi.spyOn(api, "listSchedules").mockResolvedValue({
-        schedules: [
-          {
-            id: "sched-1",
-            name: "other-schedule",
-            composeId: "compose-123",
-            composeName: "my-agent",
-            enabled: true,
-            prompt: "test prompt",
-            scopeSlug: "user/scope",
-            cronExpression: "0 9 * * *",
-            timezone: "UTC",
-            atTime: null,
-            nextRunAt: null,
-            vars: {},
-            secretNames: [],
-            artifactName: null,
-            artifactVersion: null,
-            volumeVersions: {},
-            createdAt: "2025-01-01T00:00:00Z",
-            updatedAt: "2025-01-01T00:00:00Z",
-          },
-        ],
-      });
-
-      await expect(resolveScheduleByName("non-existent")).rejects.toThrow(
-        'Schedule "non-existent" not found',
-      );
-    });
-
-    it("should throw error when no schedules exist", async () => {
-      vi.spyOn(api, "listSchedules").mockResolvedValue({
-        schedules: [],
-      });
-
-      await expect(resolveScheduleByName("my-schedule")).rejects.toThrow(
-        'Schedule "my-schedule" not found',
-      );
-    });
-  });
+  // Note: resolveScheduleByName is tested via E2E tests in
+  // e2e/tests/02-parallel/t20-vm0-schedule.bats (global resolution tests)
+  // since it requires real API calls and mocking internal modules is not acceptable
 });

--- a/turbo/apps/cli/src/commands/schedule/enable.ts
+++ b/turbo/apps/cli/src/commands/schedule/enable.ts
@@ -1,9 +1,9 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { getComposeByName, enableSchedule } from "../../lib/api";
+import { enableSchedule } from "../../lib/api";
 import {
-  loadAgentName,
   loadScheduleName,
+  resolveScheduleByName,
 } from "../../lib/domain/schedule-utils";
 
 export const enableCommand = new Command()
@@ -35,32 +35,11 @@ export const enableCommand = new Command()
         name = scheduleResult.scheduleName;
       }
 
-      // Load vm0.yaml to get agent name
-      const result = loadAgentName();
-      if (result.error) {
-        console.error(chalk.red(`✗ Invalid vm0.yaml: ${result.error}`));
-        process.exit(1);
-      }
-      if (!result.agentName) {
-        console.error(chalk.red("✗ No vm0.yaml found in current directory"));
-        console.error(chalk.dim("  Run this command from the agent directory"));
-        process.exit(1);
-      }
-      const agentName = result.agentName;
-
-      // Get compose ID
-      let composeId: string;
-      try {
-        const compose = await getComposeByName(agentName);
-        composeId = compose.id;
-      } catch {
-        console.error(chalk.red(`✗ Agent not found: ${agentName}`));
-        console.error(chalk.dim("  Make sure the agent is pushed first"));
-        process.exit(1);
-      }
+      // Resolve schedule by name (searches globally across all agents)
+      const resolved = await resolveScheduleByName(name);
 
       // Call API
-      await enableSchedule({ name, composeId });
+      await enableSchedule({ name, composeId: resolved.composeId });
 
       console.log(chalk.green(`✓ Enabled schedule ${chalk.cyan(name)}`));
     } catch (error) {
@@ -68,6 +47,9 @@ export const enableCommand = new Command()
       if (error instanceof Error) {
         if (error.message.includes("Not authenticated")) {
           console.error(chalk.dim("  Run: vm0 auth login"));
+        } else if (error.message.toLowerCase().includes("not found")) {
+          console.error(chalk.dim(`  Schedule "${nameArg}" not found`));
+          console.error(chalk.dim("  Run: vm0 schedule list"));
         } else {
           console.error(chalk.dim(`  ${error.message}`));
         }

--- a/turbo/apps/cli/src/commands/schedule/status.ts
+++ b/turbo/apps/cli/src/commands/schedule/status.ts
@@ -1,15 +1,11 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import { getScheduleByName, listScheduleRuns } from "../../lib/api";
 import {
-  getComposeByName,
-  getScheduleByName,
-  listScheduleRuns,
-} from "../../lib/api";
-import {
-  loadAgentName,
   loadScheduleName,
   formatDateTime,
   detectTimezone,
+  resolveScheduleByName,
 } from "../../lib/domain/schedule-utils";
 import type { ScheduleResponse, RunSummary } from "@vm0/core";
 
@@ -92,29 +88,9 @@ export const statusCommand = new Command()
         name = scheduleResult.scheduleName;
       }
 
-      // Load vm0.yaml to get agent name
-      const result = loadAgentName();
-      if (result.error) {
-        console.error(chalk.red(`✗ Invalid vm0.yaml: ${result.error}`));
-        process.exit(1);
-      }
-      if (!result.agentName) {
-        console.error(chalk.red("✗ No vm0.yaml found in current directory"));
-        console.error(chalk.dim("  Run this command from the agent directory"));
-        process.exit(1);
-      }
-      const agentName = result.agentName;
-
-      // Get compose ID
-      let composeId: string;
-      try {
-        const compose = await getComposeByName(agentName);
-        composeId = compose.id;
-      } catch {
-        console.error(chalk.red(`✗ Agent not found: ${agentName}`));
-        console.error(chalk.dim("  Make sure the agent is pushed first"));
-        process.exit(1);
-      }
+      // Resolve schedule by name (searches globally across all agents)
+      const resolved = await resolveScheduleByName(name);
+      const composeId = resolved.composeId;
 
       // Get schedule details
       const schedule = await getScheduleByName({ name, composeId });
@@ -238,6 +214,7 @@ export const statusCommand = new Command()
           console.error(
             chalk.dim(`  Schedule "${nameArg ?? "unknown"}" not found`),
           );
+          console.error(chalk.dim("  Run: vm0 schedule list"));
         } else {
           console.error(chalk.dim(`  ${error.message}`));
         }

--- a/turbo/apps/cli/src/lib/domain/schedule-utils.ts
+++ b/turbo/apps/cli/src/lib/domain/schedule-utils.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "fs";
 import { parse as parseYaml } from "yaml";
+import { listSchedules } from "../api";
 
 const CONFIG_FILE = "vm0.yaml";
 const SCHEDULE_FILE = "schedule.yaml";
@@ -347,4 +348,36 @@ export function toISODateTime(dateTimeStr: string): string {
   const isoStr = dateTimeStr.replace(" ", "T") + ":00";
   const date = new Date(isoStr);
   return date.toISOString();
+}
+
+/**
+ * Result of resolving a schedule by name
+ */
+interface ResolveScheduleResult {
+  name: string;
+  composeId: string;
+  composeName: string;
+}
+
+/**
+ * Resolve a schedule by name using the list API.
+ * Searches across all user's schedules globally.
+ * @throws Error if schedule not found
+ */
+export async function resolveScheduleByName(
+  name: string,
+): Promise<ResolveScheduleResult> {
+  const { schedules } = await listSchedules();
+
+  const schedule = schedules.find((s) => s.name === name);
+
+  if (!schedule) {
+    throw new Error(`Schedule "${name}" not found`);
+  }
+
+  return {
+    name: schedule.name,
+    composeId: schedule.composeId,
+    composeName: schedule.composeName,
+  };
 }


### PR DESCRIPTION
## Summary

- Fix schedule commands to work from any directory by resolving schedule name globally
- Add `resolveScheduleByName()` helper that uses list API to find schedule's composeId
- Update delete, enable, disable, and status commands to use the new resolver

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] Type check passes
- [x] All 600 CLI tests pass
- [ ] Manual verification: `vm0 schedule delete <name>` works from any directory

Closes #1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)