### PR TITLE
ci: skip runner-related jobs on push to main

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -545,12 +545,14 @@ jobs:
           fi
 
   # Run CLI E2E tests - Phase 3: Runner tests (needs runner deployed)
+  # Skip on push to main - runner tests are only needed for PRs
   cli-e2e-03-runner:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [prepare, cli-e2e-01-serial, deploy-web, deploy-runner-start]
     if: |
+      github.event_name != 'push' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
@@ -619,12 +621,14 @@ jobs:
           fi
 
   # Prepare runner: lock host, build bundle, install deps (runs parallel with deploy-web)
+  # Skip on push to main - runner deployment is only needed for PRs
   deploy-runner-prepare:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [prepare]
     if: |
+      github.event_name != 'push' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
@@ -824,12 +828,14 @@ jobs:
           echo "Runner prepared at ${RUNNER_DIR} on ${RUNNER_HOST}"
 
   # Run benchmark command to test VM boot performance (runs after prepare, before start)
+  # Skip on push to main - runner benchmark is only needed for PRs
   deploy-runner-benchmark:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [prepare, deploy-runner-prepare]
     if: |
+      github.event_name != 'push' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
@@ -869,12 +875,14 @@ jobs:
           echo "=== VM Benchmark Complete ==="
 
   # Start runner after deploy-web provides preview URL
+  # Skip on push to main - runner deployment is only needed for PRs
   deploy-runner-start:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [prepare, deploy-web, deploy-runner-prepare]
     if: |
+      github.event_name != 'push' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
@@ -931,10 +939,11 @@ jobs:
 
   # Release runner host lock after cli-e2e-03-runner completes (or fails/times out)
   # Note: Runner cleanup happens in cleanup.yml when PR is closed (to allow reruns)
+  # Skip on push to main - runner deployment is only needed for PRs
   unlock-runner-host:
     runs-on: ubuntu-latest
     needs: [deploy-runner-prepare, cli-e2e-03-runner]
-    if: always() && needs.deploy-runner-prepare.outputs.runner-host != ''
+    if: always() && github.event_name != 'push' && needs.deploy-runner-prepare.outputs.runner-host != ''
     steps:
       - name: Unlock runner host
         env:


### PR DESCRIPTION
## Summary
- Skip runner-related jobs when triggered by push to main branch
- Affected jobs: `deploy-runner-prepare`, `deploy-runner-start`, `deploy-runner-benchmark`, `cli-e2e-03-runner`, `unlock-runner-host`
- These jobs are only needed for PR testing, not for main branch pushes

## Test plan
- [ ] Verify PR CI runs all jobs including runner-related ones
- [ ] After merge, verify push to main skips runner jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)