### PR TITLE
fix(ci): include run attempt in e2e cache key for workflow reruns

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -372,7 +372,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ~/.vm0
-          key: e2e-auth-${{ github.run_id }}
+          key: e2e-auth-${{ github.run_id }}-${{ github.run_attempt }}
 
   # Run API E2E tests (lightweight, fast)
   api-e2e-test:
@@ -391,7 +391,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.vm0
-          key: e2e-auth-${{ github.run_id }}
+          key: e2e-auth-${{ github.run_id }}-${{ github.run_attempt }}
           fail-on-cache-miss: true
 
       - name: Run API E2E Tests
@@ -440,7 +440,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.vm0
-          key: e2e-auth-${{ github.run_id }}
+          key: e2e-auth-${{ github.run_id }}-${{ github.run_attempt }}
           fail-on-cache-miss: true
 
       - name: Start Cron Simulator
@@ -512,7 +512,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.vm0
-          key: e2e-auth-${{ github.run_id }}
+          key: e2e-auth-${{ github.run_id }}-${{ github.run_attempt }}
           fail-on-cache-miss: true
 
       - name: Start Cron Simulator
@@ -585,7 +585,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.vm0
-          key: e2e-auth-${{ github.run_id }}
+          key: e2e-auth-${{ github.run_id }}-${{ github.run_attempt }}
           fail-on-cache-miss: true
 
       - name: Start Cron Simulator


### PR DESCRIPTION
## Summary

- Adds `github.run_attempt` to E2E authentication cache keys in the CI workflow
- Ensures workflow re-runs get fresh cache instead of potentially stale authentication state from previous attempts
- Affects all E2E test jobs that depend on the authentication cache (api-e2e-test, cli-e2e-serial, cli-e2e-parallel, cli-e2e-runner)

## Test plan

- [ ] Verify CI passes on initial workflow run
- [ ] Manually re-run the workflow and confirm E2E tests pass with fresh cache

---
Generated with [Claude Code](https://claude.ai/code)