### PR TITLE
fix: support dark mode for cli-auth page logo

### DIFF
--- a/turbo/apps/web/app/cli-auth/page.tsx
+++ b/turbo/apps/web/app/cli-auth/page.tsx
@@ -122,6 +122,15 @@ export default function CliAuthPage(): React.JSX.Element {
               width={82}
               height={20}
               priority
+              className="dark:hidden"
+            />
+            <Image
+              src="/assets/vm0-logo.svg"
+              alt="VM0"
+              width={82}
+              height={20}
+              priority
+              className="hidden dark:block"
             />
             <span className="text-2xl text-foreground">Platform</span>
           </div>

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 
+/* Enable Tailwind dark: variant with data-theme attribute */
+@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
+
 /*
  * VM0 Design System
  * Based on Figma: https://www.figma.com/design/eTWIsjktpymTDYEb55OxXx/VM0-Cloud
@@ -230,7 +233,7 @@
     --popover-foreground: var(--gray-950); /* background-950 */
 
     --primary: var(--primary-700); /* primary-700 */
-    --primary-foreground: var(--gray-0); /* background-0 */
+    --primary-foreground: 0 0% 100%; /* white text for contrast on primary */
 
     --secondary: var(--gray-100); /* background-100 */
     --secondary-foreground: var(--gray-950); /* background-950 */


### PR DESCRIPTION
## Summary
- Add dark mode support for the VM0 logo on the CLI auth page by conditionally showing/hiding logos based on theme
- Enable Tailwind dark: variant with data-theme attribute for proper dark mode detection
- Fix primary-foreground color for better contrast on primary backgrounds

## Test plan
- [ ] Verify logo displays correctly in light mode
- [ ] Verify logo displays correctly in dark mode
- [ ] Verify primary button text remains readable in both themes

---
Generated with [Claude Code](https://claude.com/claude-code)