### PR TITLE
feat: reduce vm0 run production timeout from 24 hours to 2 hours

### DIFF
--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -51,7 +51,7 @@
 #   - runner_group: Runner group name (default: vm0/production)
 #   - pm2_process_name: PM2 process name (default: vm0-runner-production)
 #   - enable_drain: Whether to drain before stopping (default: true)
-#   - drain_timeout: Max seconds to wait for drain (default: 86400 = 24h)
+#   - drain_timeout: Max seconds to wait for drain (default: 7200 = 2h)
 #   - extra_env: Additional environment variables as JSON (default: {})
 
 - name: Deploy VM0 Runner
@@ -65,7 +65,7 @@
     runner_group: vm0/production
     pm2_process_name: vm0-runner-production
     enable_drain: true
-    drain_timeout: 86400  # 24 hours
+    drain_timeout: 7200  # 2 hours
     extra_env: {}
     # Rootfs configuration - CI should override for per-PR isolation
     rootfs_path: /opt/firecracker/rootfs.squashfs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,7 @@ The compute layer executes agent workflows in isolated sandbox environments.
 - Third-party managed sandbox service (e2b.dev)
 - Container-based isolation
 - Template system for environment configuration
-- 24-hour timeout (production), 1-hour (development)
+- 2-hour timeout (production), 1-hour (development)
 - Fire-and-forget execution with webhook callbacks
 
 **2. Firecracker (Experimental)**

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -357,9 +357,9 @@ export async function executeJob(
     }
 
     // Poll for completion by checking if exit code file exists
-    // Timeout after 24 hours (same as E2B sandbox timeout)
+    // Timeout after 2 hours (same as E2B sandbox timeout)
     const pollIntervalMs = 2000; // Check every 2 seconds
-    const maxWaitMs = 24 * 60 * 60 * 1000; // 24 hours max
+    const maxWaitMs = 2 * 60 * 60 * 1000; // 2 hours max
     let exitCode = 1;
     let completed = false;
 

--- a/turbo/apps/web/app/[locale]/pricing/page.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/page.tsx
@@ -415,7 +415,7 @@ export default function PricingPage() {
                     feature="Session length"
                     description="Maximum duration for a single agent execution session"
                     free="1 hour"
-                    pro="24 hours"
+                    pro="2 hours"
                   />
 
                   <TableSection title="Storage & Data" />

--- a/turbo/apps/web/src/lib/e2b/e2b-service.ts
+++ b/turbo/apps/web/src/lib/e2b/e2b-service.ts
@@ -379,9 +379,9 @@ class E2BService {
     agentCompose: AgentComposeYaml | undefined,
     userId: string,
   ): Promise<Sandbox> {
-    // Use 24 hour timeout for Vercel production, 1 hour for other environments
+    // Use 2 hour timeout for Vercel production, 1 hour for other environments
     const isVercelProduction = process.env.VERCEL_ENV === "production";
-    const timeoutMs = isVercelProduction ? 86_400_000 : 3_600_000;
+    const timeoutMs = isVercelProduction ? 7_200_000 : 3_600_000;
 
     const sandboxOptions = {
       timeoutMs,

--- a/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
@@ -296,7 +296,7 @@ class E2BExecutor implements Executor {
     userId: string,
   ): Promise<Sandbox> {
     const isVercelProduction = process.env.VERCEL_ENV === "production";
-    const timeoutMs = isVercelProduction ? 86_400_000 : 3_600_000;
+    const timeoutMs = isVercelProduction ? 7_200_000 : 3_600_000;
 
     const agent = getFirstAgent(agentCompose);
     const imageAlias = agent?.image || e2bConfig.defaultTemplate;

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -56,8 +56,8 @@ class RunnerExecutor implements Executor {
     };
 
     // Insert into runner job queue
-    // TTL: 24 hours for job expiration
-    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    // TTL: 2 hours for job expiration
+    const expiresAt = new Date(Date.now() + 2 * 60 * 60 * 1000);
     await globalThis.services.db.insert(runnerJobQueue).values({
       runId: context.runId,
       runnerGroup,


### PR DESCRIPTION
Closes #1510

## Summary
- Reduces production E2B sandbox timeout from 24 hours to 2 hours
- Updates all related timeout configurations across the codebase
- Updates pricing page and documentation to reflect the new limit

## Changes

| File | Change |
|------|--------|
| `e2b-service.ts:384` | `86_400_000` → `7_200_000` (production timeout) |
| `e2b-executor.ts:299` | `86_400_000` → `7_200_000` (production timeout) |
| `runner-executor.ts:60` | `24 * 60 * 60 * 1000` → `2 * 60 * 60 * 1000` (job queue TTL) |
| `executor.ts:362` | `24 * 60 * 60 * 1000` → `2 * 60 * 60 * 1000` (polling timeout) |
| `pricing/page.tsx:418` | `"24 hours"` → `"2 hours"` (Pro tier display) |
| `architecture.md:59` | Documentation update |
| `deploy-runner.yml:54,68` | `86400` → `7200` (drain timeout) |

## Test plan
- [x] Lint passes
- [x] Type check passes (pre-existing failure in @vm0/platform unrelated to this change)
- [x] Knip passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.ai/code)