### PR TITLE
fix(ci): remove incorrect web deployment dependency from site and platform

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -142,7 +142,7 @@ jobs:
 
   # Deploy site app to production
   deploy-site-production:
-    needs: [release-please, deploy-web-production]
+    needs: release-please
     if: ${{ needs.release-please.outputs.site_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
@@ -170,7 +170,7 @@ jobs:
 
   # Deploy platform (Vite SPA) to production
   deploy-platform-production:
-    needs: [release-please, deploy-web-production]
+    needs: release-please
     if: ${{ needs.release-please.outputs.platform_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
## Summary
- Remove `deploy-web-production` from `needs` array for `deploy-site-production` and `deploy-platform-production` jobs
- These jobs were always skipped because they depended on `deploy-web-production`, which only runs when web has a new release
- Site and platform can now deploy independently whenever they have new releases

## Root Cause
The `deploy-site-production` job had `needs: [release-please, deploy-web-production]`, but `deploy-web-production` only runs when `web_release_created == 'true'`. When web had no release, this job was skipped, causing `deploy-site-production` to also be skipped due to GitHub Actions' dependency behavior.

## Test plan
- [ ] Merge this PR
- [ ] Create a commit that only touches `turbo/apps/site/`
- [ ] Verify the release-please workflow creates a site release and deploys it

🤖 Generated with [Claude Code](https://claude.com/claude-code)