### PR TITLE
refactor(cli): remove auto-configure hints from compose output

### DIFF
--- a/e2e/tests/02-parallel/t17-vm0-simplified-compose.bats
+++ b/e2e/tests/02-parallel/t17-vm0-simplified-compose.bats
@@ -34,9 +34,7 @@ EOF
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
-    echo "# Verifying image and working_dir were auto-configured..."
-    assert_output --partial "Auto-configured image"
-    assert_output --partial "Auto-configured working_dir"
+    echo "# Verifying compose succeeded..."
     assert_output --partial "Compose created"
 }
 
@@ -56,10 +54,8 @@ EOF
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
-    echo "# Verifying deprecation warning and working_dir auto-configured..."
+    echo "# Verifying deprecation warning..."
     assert_output --partial "deprecated"
-    refute_output --partial "Auto-configured image"
-    assert_output --partial "Auto-configured working_dir"
     assert_output --partial "Compose"
 }
 
@@ -80,8 +76,8 @@ EOF
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
-    echo "# Verifying no auto-configuration..."
-    refute_output --partial "Auto-configured"
+    echo "# Verifying compose succeeded..."
+    assert_output --partial "Compose"
 }
 
 @test "vm0 compose with apps selects github image variant" {
@@ -101,9 +97,7 @@ EOF
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
-    echo "# Verifying github image variant was auto-configured..."
-    assert_output --partial "Auto-configured image"
-    assert_output --partial "claude-code-github"
+    echo "# Verifying compose succeeded..."
     assert_output --partial "Compose"
 }
 

--- a/turbo/apps/cli/src/commands/compose.ts
+++ b/turbo/apps/cli/src/commands/compose.ts
@@ -162,18 +162,10 @@ export const composeCommand = new Command()
             );
             if (defaultImage) {
               agent.image = defaultImage;
-              console.log(
-                chalk.dim(`  Auto-configured image: ${defaultImage}`),
-              );
             }
           }
           if (!agent.working_dir) {
             agent.working_dir = defaults.workingDir;
-            console.log(
-              chalk.dim(
-                `  Auto-configured working_dir: ${defaults.workingDir}`,
-              ),
-            );
           }
         }
       }

--- a/turbo/apps/docs/content/docs/tutorial/custom-image.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/custom-image.mdx
@@ -81,8 +81,6 @@ vm0 compose vm0.yaml
 You'll see output showing the GitHub skill being added:
 
 ```
-  Auto-configured image: vm0/claude-code-github:latest
-  Auto-configured working_dir: /home/user/workspace
 Uploading instructions: AGENTS.md
 ✓ Instructions uploaded: 1191fd33
 Uploading 3 skill(s)...

--- a/turbo/apps/docs/content/docs/tutorial/my-first-agent.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/my-first-agent.mdx
@@ -113,8 +113,6 @@ Processing artifact:
 
 Composing agent:
 > vm0 compose vm0.yaml
-  Auto-configured image: vm0/claude-code:latest
-  Auto-configured working_dir: /home/user/workspace
 Uploading instructions: AGENTS.md
 ✓ Instructions (unchanged): b2d77a3d
 Uploading compose...

--- a/turbo/apps/docs/content/docs/tutorial/research-capabilities.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/research-capabilities.mdx
@@ -85,8 +85,6 @@ vm0 compose vm0.yaml
 You'll see output showing the skills being downloaded and uploaded:
 
 ```
-  Auto-configured image: vm0/claude-code:latest
-  Auto-configured working_dir: /home/user/workspace
 Uploading instructions: AGENTS.md
 ✓ Instructions uploaded: 15f0ffee
 Uploading 2 skill(s)...

--- a/turbo/apps/docs/content/docs/tutorial/writing-instructions.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/writing-instructions.mdx
@@ -70,8 +70,6 @@ vm0 compose vm0.yaml
 You should see output like:
 
 ```
-Auto-configured image: vm0/claude-code:latest
-Auto-configured working_dir: /home/user/workspace
 Uploading instructions: AGENTS.md
 ✓ Instructions (changed): a3f89b2c
 Uploading compose...


### PR DESCRIPTION
## Summary

- Remove auto-configure hints (`Auto-configured image:` and `Auto-configured working_dir:`) from `vm0 compose` output
- Since `image` and `working_dir` are internal implementation details not exposed to users, these hints add noise without providing actionable information

## Changes

- `turbo/apps/cli/src/commands/compose.ts` - Remove 2 `console.log` statements
- `e2e/tests/02-parallel/t17-vm0-simplified-compose.bats` - Update test assertions
- 4 documentation files - Remove hint lines from example outputs

## Test plan

- [x] Lint passes
- [x] Type check passes
- [ ] E2E tests pass (CI will verify)

Closes #1516

🤖 Generated with [Claude Code](https://claude.ai/code)