### PR TITLE
fix(web): return null for unknown token formats instead of calling clerk auth

### DIFF
--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,5 +1,5 @@
 // VM0 Runner - Self-hosted runner that polls the VM0 API server and executes agent jobs in isolated Firecracker microVMs
-// Deployment: Added buildkit cache retry mechanism (issue #1328)
+// Deployment: CI baseline test trigger (2026-01-22)
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { doctorCommand } from "./commands/doctor.js";

--- a/turbo/apps/web/src/lib/auth/get-user-id.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-id.ts
@@ -57,10 +57,10 @@ export async function getUserId(): Promise<string | null> {
       return null;
     }
 
-    // Not a CLI or sandbox token - must be Clerk JWT
-    // Verify using Clerk auth (token is automatically verified by Clerk middleware)
-    const { userId } = await auth();
-    return userId;
+    // Unknown token format - reject it
+    // This prevents hanging on invalid tokens passed to Clerk auth()
+    log.debug("Rejected unknown token format");
+    return null;
   }
 
   // Fall back to Clerk session auth

--- a/turbo/apps/web/src/lib/auth/get-user-id.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-id.ts
@@ -57,10 +57,10 @@ export async function getUserId(): Promise<string | null> {
       return null;
     }
 
-    // Unknown token format - reject it
-    // This prevents hanging on invalid tokens passed to Clerk auth()
-    log.debug("Rejected unknown token format");
-    return null;
+    // Not a CLI or sandbox token - must be Clerk JWT
+    // Verify using Clerk auth (token is automatically verified by Clerk middleware)
+    const { userId } = await auth();
+    return userId;
   }
 
   // Fall back to Clerk session auth


### PR DESCRIPTION
## Summary
- Baseline CI test to identify E2E timeout issue
- ~~Auth fix reverted - not the root cause~~

## Root Cause Found

**Vercel Deployment Protection (HTTP 401)** - The sandbox VMs cannot access the Vercel preview API.

Evidence from runner logs:
```
Preflight check failed: HTTP error from server - VM cannot reach VM0 API at
https://vm0-2yghveq15-vm0.vercel.app

HTTP/2 401
content-type: text/html; charset=utf-8
```

The Vercel preview deployment is protected and the `VERCEL_AUTOMATION_BYPASS_SECRET`:
1. May not be configured in Vercel project settings
2. May not be passed to the deployed serverless function
3. May have an incorrect/expired value

## Fix Required

The Vercel project needs `VERCEL_AUTOMATION_BYPASS_SECRET` configured:
1. In Vercel project environment variables (for preview deployments)
2. So the web app can pass it to E2B sandboxes via `VERCEL_PROTECTION_BYPASS` env var

## Test plan
- [ ] Verify `VERCEL_AUTOMATION_BYPASS_SECRET` is set in Vercel project settings
- [ ] CI E2E tests should pass once the bypass secret is properly configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)