### PR TITLE
perf(e2e): simplify model-provider tests to happy path only

### DIFF
--- a/e2e/tests/01-serial/ser-t03-vm0-model-provider.bats
+++ b/e2e/tests/01-serial/ser-t03-vm0-model-provider.bats
@@ -1,25 +1,23 @@
 #!/usr/bin/env bats
 
-# Test VM0 model provider commands
-# Tests the CLI for managing model providers (LLM credentials)
+# Test VM0 model provider commands (happy path)
+# Sets up default provider for parallel tests
 #
 # This test covers PR #1452: Model provider entity + CLI
 # And sets up default provider for parallel tests (PR #1472)
+#
+# Simplified in issue #1522: reduced from 18 tests to 3 happy-path tests
 
 load '../../helpers/setup'
 
-# Generate unique test data for each test run to avoid conflicts
 setup() {
     export TEST_CREDENTIAL_VALUE="test-api-key-$(date +%s%3N)-$RANDOM"
 }
 
 teardown() {
-    # Clean up test model providers created during individual tests
-    # But NOT the stable provider set up in teardown_file
-    # We only clean up anthropic-api-key and openai-api-key here
+    # Clean up test provider (anthropic-api-key only)
     # claude-code-oauth-token is managed by teardown_file for parallel tests
     $CLI_COMMAND model-provider delete "anthropic-api-key" 2>/dev/null || true
-    $CLI_COMMAND model-provider delete "openai-api-key" 2>/dev/null || true
 }
 
 teardown_file() {
@@ -32,111 +30,17 @@ teardown_file() {
 }
 
 # ============================================================================
-# Help Command Tests
+# Happy Path Tests
 # ============================================================================
 
-@test "vm0 model-provider --help shows command description" {
-    run $CLI_COMMAND model-provider --help
-    assert_success
-    assert_output --partial "Manage model providers"
-    assert_output --partial "ls"
-    assert_output --partial "setup"
-    assert_output --partial "delete"
-    assert_output --partial "set-default"
-}
-
-@test "vm0 model-provider ls --help shows options" {
-    run $CLI_COMMAND model-provider ls --help
-    assert_success
-    assert_output --partial "List all model providers"
-}
-
-@test "vm0 model-provider setup --help shows usage" {
-    run $CLI_COMMAND model-provider setup --help
-    assert_success
-    assert_output --partial "Configure a model provider"
-    assert_output --partial "--type"
-    assert_output --partial "--credential"
-}
-
-@test "vm0 model-provider delete --help shows usage" {
-    run $CLI_COMMAND model-provider delete --help
-    assert_success
-    assert_output --partial "Delete a model provider"
-    assert_output --partial "<type>"
-}
-
-@test "vm0 model-provider set-default --help shows usage" {
-    run $CLI_COMMAND model-provider set-default --help
-    assert_success
-    assert_output --partial "Set a model provider as default for its framework"
-    assert_output --partial "<type>"
-}
-
-# ============================================================================
-# Setup Command Tests
-# ============================================================================
-
-@test "vm0 model-provider setup creates anthropic-api-key provider" {
+@test "vm0 model-provider setup creates provider" {
     run $CLI_COMMAND model-provider setup --type "anthropic-api-key" --credential "$TEST_CREDENTIAL_VALUE"
     assert_success
     assert_output --partial "anthropic-api-key"
     assert_output --partial "created"
 }
 
-@test "vm0 model-provider setup creates claude-code-oauth-token provider" {
-    # First delete any existing one
-    $CLI_COMMAND model-provider delete "claude-code-oauth-token" 2>/dev/null || true
-
-    run $CLI_COMMAND model-provider setup --type "claude-code-oauth-token" --credential "$TEST_CREDENTIAL_VALUE"
-    assert_success
-    assert_output --partial "claude-code-oauth-token"
-    assert_output --partial "created"
-}
-
-@test "vm0 model-provider setup creates openai-api-key provider" {
-    run $CLI_COMMAND model-provider setup --type "openai-api-key" --credential "$TEST_CREDENTIAL_VALUE"
-    assert_success
-    assert_output --partial "openai-api-key"
-    assert_output --partial "created"
-}
-
-@test "vm0 model-provider setup updates existing provider" {
-    # Create initial provider
-    $CLI_COMMAND model-provider setup --type "anthropic-api-key" --credential "$TEST_CREDENTIAL_VALUE"
-
-    # Update it
-    local updated_value="updated-key-$(date +%s%3N)"
-    run $CLI_COMMAND model-provider setup --type "anthropic-api-key" --credential "$updated_value"
-    assert_success
-    assert_output --partial "anthropic-api-key"
-    assert_output --partial "updated"
-}
-
-@test "vm0 model-provider setup rejects invalid type" {
-    run $CLI_COMMAND model-provider setup --type "invalid-type" --credential "$TEST_CREDENTIAL_VALUE"
-    assert_failure
-    assert_output --partial "Invalid"
-}
-
-# ============================================================================
-# List Command Tests
-# ============================================================================
-
-@test "vm0 model-provider ls shows empty state" {
-    # Clean up all providers first
-    $CLI_COMMAND model-provider delete "anthropic-api-key" 2>/dev/null || true
-    $CLI_COMMAND model-provider delete "claude-code-oauth-token" 2>/dev/null || true
-    $CLI_COMMAND model-provider delete "openai-api-key" 2>/dev/null || true
-
-    run $CLI_COMMAND model-provider ls
-    assert_success
-    # Should show "No model providers" when empty
-    assert_output --partial "No model providers"
-}
-
 @test "vm0 model-provider ls shows created provider" {
-    # Create a provider first
     $CLI_COMMAND model-provider setup --type "anthropic-api-key" --credential "$TEST_CREDENTIAL_VALUE"
 
     run $CLI_COMMAND model-provider ls
@@ -146,78 +50,10 @@ teardown_file() {
     assert_output --partial "default"
 }
 
-@test "vm0 model-provider ls groups by framework" {
-    # Create providers for different frameworks
-    $CLI_COMMAND model-provider setup --type "anthropic-api-key" --credential "$TEST_CREDENTIAL_VALUE"
-    $CLI_COMMAND model-provider setup --type "openai-api-key" --credential "$TEST_CREDENTIAL_VALUE"
-
-    run $CLI_COMMAND model-provider ls
-    assert_success
-    assert_output --partial "claude-code"
-    assert_output --partial "codex"
-}
-
-# ============================================================================
-# Delete Command Tests
-# ============================================================================
-
 @test "vm0 model-provider delete removes provider" {
-    # Create a provider
     $CLI_COMMAND model-provider setup --type "anthropic-api-key" --credential "$TEST_CREDENTIAL_VALUE"
 
-    # Delete it
     run $CLI_COMMAND model-provider delete "anthropic-api-key"
     assert_success
     assert_output --partial "deleted"
-
-    # Verify it's gone by listing
-    run $CLI_COMMAND model-provider ls
-    assert_success
-    refute_output --partial "anthropic-api-key"
-}
-
-@test "vm0 model-provider delete fails for non-existent provider" {
-    # Make sure it doesn't exist
-    $CLI_COMMAND model-provider delete "anthropic-api-key" 2>/dev/null || true
-
-    run $CLI_COMMAND model-provider delete "anthropic-api-key"
-    assert_failure
-    assert_output --partial "not found"
-}
-
-# ============================================================================
-# Set-Default Command Tests
-# ============================================================================
-
-@test "vm0 model-provider set-default changes default" {
-    # First delete any existing claude-code-oauth-token
-    $CLI_COMMAND model-provider delete "claude-code-oauth-token" 2>/dev/null || true
-
-    # Create two providers for same framework
-    $CLI_COMMAND model-provider setup --type "anthropic-api-key" --credential "$TEST_CREDENTIAL_VALUE"
-    $CLI_COMMAND model-provider setup --type "claude-code-oauth-token" --credential "$TEST_CREDENTIAL_VALUE"
-
-    # Set second as default
-    run $CLI_COMMAND model-provider set-default "claude-code-oauth-token"
-    assert_success
-    assert_output --partial "Default"
-}
-
-@test "vm0 model-provider set-default fails for non-existent provider" {
-    # Make sure it doesn't exist
-    $CLI_COMMAND model-provider delete "anthropic-api-key" 2>/dev/null || true
-
-    run $CLI_COMMAND model-provider set-default "anthropic-api-key"
-    assert_failure
-    assert_output --partial "not found"
-}
-
-@test "vm0 model-provider set-default is idempotent" {
-    # Create a provider (it will be default)
-    $CLI_COMMAND model-provider setup --type "anthropic-api-key" --credential "$TEST_CREDENTIAL_VALUE"
-
-    # Set it as default again (no-op)
-    run $CLI_COMMAND model-provider set-default "anthropic-api-key"
-    assert_success
-    # Should succeed without error
 }

--- a/turbo/apps/cli/src/commands/model-provider/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/setup.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { setupCommand } from "../setup";
+
+describe("model-provider setup command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("input validation", () => {
+    it("should reject invalid provider type", async () => {
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "--type",
+          "invalid-type",
+          "--credential",
+          "test-credential",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid type "invalid-type"'),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Valid types:"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject when only --type is provided without --credential", async () => {
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "--type",
+          "anthropic-api-key",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Both --type and --credential are required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject when only --credential is provided without --type", async () => {
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "--credential",
+          "test-credential",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Both --type and --credential are required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should list valid types when invalid type is provided", async () => {
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "--type",
+          "not-a-real-type",
+          "--credential",
+          "test-credential",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      // Should show anthropic-api-key as a valid type
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("anthropic-api-key"),
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -1,4 +1,4 @@
-// Test change detection
+// CI trigger: issue #1522 - simplify model-provider e2e tests
 import { Command } from "commander";
 import chalk from "chalk";
 import {


### PR DESCRIPTION
## Summary

- Reduce model-provider e2e tests from 18 to 3 tests for ~75% faster execution
- Remove redundant help, error case, and edge case tests (belong in unit tests)
- Simplify teardown to only clean up what tests create

## Changes

| Category | Before | After |
|----------|--------|-------|
| Help tests | 5 | 0 |
| Setup tests | 5 | 1 |
| List tests | 3 | 1 |
| Delete tests | 2 | 1 |
| Set-default tests | 3 | 0 |
| **Total** | **18** | **3** |

## Rationale

- E2E tests are expensive; they should validate happy paths, not every edge case
- Unit tests and integration tests should cover error handling and validation
- Serial tests exist primarily to establish state for parallel tests
- `teardown_file()` already sets up the default provider for parallel tests

## Test plan

- [ ] CI passes with 3 model-provider tests
- [ ] Parallel tests still work (teardown_file unchanged)
- [ ] Execution time reduced from ~57s to ~10-15s

Closes #1522

---
🤖 Generated with [Claude Code](https://claude.ai/code)