### PR TITLE
fix(cli): correct sequence gap detection to expect 1-based events

### DIFF
--- a/turbo/apps/cli/src/lib/realtime/__tests__/stream-events.test.ts
+++ b/turbo/apps/cli/src/lib/realtime/__tests__/stream-events.test.ts
@@ -135,14 +135,14 @@ describe("streamEvents", () => {
       expect(capturedMessageHandler).not.toBeNull();
     });
 
-    // Simulate events message
+    // Simulate events message (sequences are 1-based, matching production behavior)
     const events = [
-      { type: "text", sequenceNumber: 0, text: "Hello" },
-      { type: "text", sequenceNumber: 1, text: "World" },
+      { type: "text", sequenceNumber: 1, text: "Hello" },
+      { type: "text", sequenceNumber: 2, text: "World" },
     ];
     capturedMessageHandler?.({
       name: "events",
-      data: { events, nextSequence: 2 },
+      data: { events, nextSequence: 3 },
     });
 
     expect(options.onEventMock).toHaveBeenCalledTimes(2);
@@ -270,7 +270,7 @@ describe("streamEvents", () => {
       expect(capturedMessageHandler).not.toBeNull();
     });
 
-    // Send events with a gap (skip sequence 0)
+    // Send event with a gap (expecting 1, receiving 5 skips sequences 1-4)
     capturedMessageHandler?.({
       name: "events",
       data: {
@@ -306,8 +306,8 @@ describe("streamEvents", () => {
     capturedMessageHandler?.({
       name: "events",
       data: {
-        events: [{ type: "text", sequenceNumber: 0 }],
-        nextSequence: 1,
+        events: [{ type: "text", sequenceNumber: 1 }],
+        nextSequence: 2,
       },
     });
 

--- a/turbo/apps/cli/src/lib/realtime/stream-events.ts
+++ b/turbo/apps/cli/src/lib/realtime/stream-events.ts
@@ -93,7 +93,8 @@ export async function streamEvents(
     });
 
     let result: StreamResult = { succeeded: true, runId };
-    let nextExpectedSequence = 0;
+    // Sandbox sends 1-based sequence numbers (first event has sequenceNumber: 1)
+    let nextExpectedSequence = 1;
 
     // Handle connection errors
     ablyClient.connection.on("failed", (stateChange: ConnectionStateChange) => {


### PR DESCRIPTION
## Summary

- Fix false positive warning "Event sequence gap detected (expected 0, got 1)" that appeared on every `vm0 run --experimental-realtime` execution
- Update test data to use 1-based sequences matching production behavior

## Root Cause

The sandbox sends events with 1-based sequence numbers (first event has `sequenceNumber: 1`), but the CLI was expecting 0-based sequences (`nextExpectedSequence` initialized to 0). This caused the condition `1 > 0` to always trigger on the first event.

## Changes

1. **stream-events.ts**: Changed `nextExpectedSequence` initialization from `0` to `1`
2. **stream-events.test.ts**: Updated test data to use realistic 1-based sequences

## Test Plan

- [x] All 600 CLI tests pass
- [x] Lint and type checks pass
- [x] Gap detection still works for real gaps (e.g., receiving sequence 5 when expecting 1)

Fixes #1525

🤖 Generated with [Claude Code](https://claude.ai/code)