### PR TITLE
ci: use ly runner host for metal runner

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check if cleanup needed
         id: check
         env:
-          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
+          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS_LY }}
           SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
         run: |
           if [ -z "$SSH_KEY" ] || [ -z "$METAL_HOSTS" ]; then
@@ -47,7 +47,7 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
-          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
+          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS_LY }}
         run: |
           SSH_KEY_FILE="$HOME/.ssh/metal.pem"
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $SSH_KEY_FILE"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -648,7 +648,7 @@ jobs:
         shell: bash
         env:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
-          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
+          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS_LY }}
           METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
           SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
         run: |

--- a/turbo/apps/runner/src/lib/firecracker/vm.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vm.ts
@@ -60,6 +60,7 @@ export class FirecrackerVM {
 
   constructor(config: VMConfig) {
     this.config = config;
+
     this.workDir = config.workDir || `/tmp/vm0-vm-${config.vmId}`;
     this.socketPath = path.join(this.workDir, "firecracker.sock");
     this.vmOverlayPath = path.join(this.workDir, "overlay.ext4");


### PR DESCRIPTION
## Summary
- Switch metal runner host from `CI_AWS_METAL_RUNNER_HOSTS` to `CI_AWS_METAL_RUNNER_HOSTS_LY` secret
- This change applies to both `turbo.yml` and `cleanup.yml` workflows

## Test plan
- [ ] CI pipeline runs successfully with the new runner host

🤖 Generated with [Claude Code](https://claude.com/claude-code)