### PR TITLE
refactor: change event sequence numbers to 0-based indexing

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/run.test.ts
@@ -42,7 +42,7 @@ describe("run command", () => {
   const defaultEventsResponse = {
     events: [
       {
-        sequenceNumber: 1,
+        sequenceNumber: 0,
         eventType: "result",
         eventData: {
           type: "result",
@@ -59,7 +59,7 @@ describe("run command", () => {
       },
     ],
     hasMore: false,
-    nextSequence: 1,
+    nextSequence: 0,
     run: { status: "completed" },
     framework: "claude-code",
   };
@@ -963,34 +963,34 @@ describe("run command", () => {
             const since = url.searchParams.get("since");
             pollCount++;
 
-            if (since === "0") {
-              // First poll
+            if (since === "-1") {
+              // First poll (since=-1 to get event 0)
               return HttpResponse.json({
                 events: [
                   {
-                    sequenceNumber: 1,
+                    sequenceNumber: 0,
                     eventType: "init",
                     eventData: { type: "init", sessionId: "session-123" },
                     createdAt: "2025-01-01T00:00:00Z",
                   },
                 ],
                 hasMore: false,
-                nextSequence: 1,
+                nextSequence: 0,
                 run: { status: "running" },
                 framework: "claude-code",
               });
             }
-            // Second poll (since=1)
+            // Second poll (since=0)
             return HttpResponse.json({
               events: [
                 {
-                  sequenceNumber: 2,
+                  sequenceNumber: 1,
                   eventType: "text",
                   eventData: { type: "text", text: "Processing..." },
                   createdAt: "2025-01-01T00:00:01Z",
                 },
                 {
-                  sequenceNumber: 3,
+                  sequenceNumber: 2,
                   eventType: "result",
                   eventData: {
                     type: "result",
@@ -1007,7 +1007,7 @@ describe("run command", () => {
                 },
               ],
               hasMore: false,
-              nextSequence: 3,
+              nextSequence: 2,
               run: {
                 status: "completed",
                 result: {
@@ -1041,13 +1041,13 @@ describe("run command", () => {
           return HttpResponse.json({
             events: [
               {
-                sequenceNumber: 1,
+                sequenceNumber: 0,
                 eventType: "init",
                 eventData: { type: "init", sessionId: "session-123" },
                 createdAt: "2025-01-01T00:00:00Z",
               },
               {
-                sequenceNumber: 2,
+                sequenceNumber: 1,
                 eventType: "result",
                 eventData: {
                   type: "result",
@@ -1064,7 +1064,7 @@ describe("run command", () => {
               },
             ],
             hasMore: false,
-            nextSequence: 2,
+            nextSequence: 1,
             run: {
               status: "completed",
               result: {
@@ -1108,7 +1108,7 @@ describe("run command", () => {
           return HttpResponse.json({
             events: [
               {
-                sequenceNumber: 1,
+                sequenceNumber: 0,
                 eventType: "result",
                 eventData: {
                   type: "result",
@@ -1125,7 +1125,7 @@ describe("run command", () => {
               },
             ],
             hasMore: false,
-            nextSequence: 1,
+            nextSequence: 0,
             run: {
               status: "completed",
               result: {
@@ -1162,13 +1162,13 @@ describe("run command", () => {
           return HttpResponse.json({
             events: [
               {
-                sequenceNumber: 1,
+                sequenceNumber: 0,
                 eventType: "unknown",
                 eventData: { type: "unknown", data: "something" },
                 createdAt: "2025-01-01T00:00:00Z",
               },
               {
-                sequenceNumber: 2,
+                sequenceNumber: 1,
                 eventType: "result",
                 eventData: {
                   type: "result",
@@ -1185,7 +1185,7 @@ describe("run command", () => {
               },
             ],
             hasMore: false,
-            nextSequence: 2,
+            nextSequence: 1,
             run: {
               status: "completed",
               result: {
@@ -1226,14 +1226,14 @@ describe("run command", () => {
             return HttpResponse.json({
               events: [
                 {
-                  sequenceNumber: 1,
+                  sequenceNumber: 0,
                   eventType: "init",
                   eventData: { type: "init", sessionId: "session-123" },
                   createdAt: "2025-01-01T00:00:00Z",
                 },
               ],
               hasMore: false,
-              nextSequence: 1,
+              nextSequence: 0,
               run: { status: "running" },
               framework: "claude-code",
             });

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -240,7 +240,7 @@ export async function pollEvents(
   runId: string,
   options: PollOptions,
 ): Promise<PollResult> {
-  let nextSequence = 0;
+  let nextSequence = -1;
   let complete = false;
   let result: PollResult = { succeeded: true, runId };
   const pollIntervalMs = 1000;

--- a/turbo/apps/cli/src/lib/api/__tests__/api-client.test.ts
+++ b/turbo/apps/cli/src/lib/api/__tests__/api-client.test.ts
@@ -364,7 +364,7 @@ describe("ApiClient", () => {
       const result = await apiClient.getEvents("run-123");
 
       expect(capturedRequest?.url).toBe(
-        "http://localhost:3000/api/agent/runs/run-123/events?since=0&limit=100",
+        "http://localhost:3000/api/agent/runs/run-123/events?since=-1&limit=100",
       );
       expect(capturedRequest?.method).toBe("GET");
       expect(capturedRequest?.headers.get("authorization")).toBe(
@@ -430,7 +430,7 @@ describe("ApiClient", () => {
       await apiClient.getEvents("run-123", { limit: 50 });
 
       expect(capturedRequest?.url).toBe(
-        "http://localhost:3000/api/agent/runs/run-123/events?since=0&limit=50",
+        "http://localhost:3000/api/agent/runs/run-123/events?since=-1&limit=50",
       );
     });
 
@@ -469,20 +469,20 @@ describe("ApiClient", () => {
       const mockResponse = {
         events: [
           {
-            sequenceNumber: 1,
+            sequenceNumber: 0,
             eventType: "init",
             eventData: { sessionId: "session-123" },
             createdAt: "2025-01-01T00:00:00Z",
           },
           {
-            sequenceNumber: 2,
+            sequenceNumber: 1,
             eventType: "text",
             eventData: { text: "Processing..." },
             createdAt: "2025-01-01T00:00:01Z",
           },
         ],
         hasMore: false,
-        nextSequence: 2,
+        nextSequence: 1,
       };
 
       server.use(
@@ -495,13 +495,13 @@ describe("ApiClient", () => {
 
       expect(result.events).toHaveLength(2);
       expect(result.events[0]).toEqual({
-        sequenceNumber: 1,
+        sequenceNumber: 0,
         eventType: "init",
         eventData: { sessionId: "session-123" },
         createdAt: "2025-01-01T00:00:00Z",
       });
       expect(result.events[1]).toEqual({
-        sequenceNumber: 2,
+        sequenceNumber: 1,
         eventType: "text",
         eventData: { text: "Processing..." },
         createdAt: "2025-01-01T00:00:01Z",

--- a/turbo/apps/cli/src/lib/api/api-client.ts
+++ b/turbo/apps/cli/src/lib/api/api-client.ts
@@ -339,7 +339,7 @@ class ApiClient {
     const result = await client.getEvents({
       params: { id: runId },
       query: {
-        since: options?.since ?? 0,
+        since: options?.since ?? -1,
         limit: options?.limit ?? 100,
       },
     });

--- a/turbo/apps/cli/src/lib/api/domains/runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/runs.ts
@@ -50,7 +50,7 @@ export async function getEvents(
   const result = await client.getEvents({
     params: { id: runId },
     query: {
-      since: options?.since ?? 0,
+      since: options?.since ?? -1,
       limit: options?.limit ?? 100,
     },
   });

--- a/turbo/apps/cli/src/lib/realtime/__tests__/stream-events.test.ts
+++ b/turbo/apps/cli/src/lib/realtime/__tests__/stream-events.test.ts
@@ -135,14 +135,14 @@ describe("streamEvents", () => {
       expect(capturedMessageHandler).not.toBeNull();
     });
 
-    // Simulate events message (sequences are 1-based, matching production behavior)
+    // Simulate events message (sequences are 0-based)
     const events = [
-      { type: "text", sequenceNumber: 1, text: "Hello" },
-      { type: "text", sequenceNumber: 2, text: "World" },
+      { type: "text", sequenceNumber: 0, text: "Hello" },
+      { type: "text", sequenceNumber: 1, text: "World" },
     ];
     capturedMessageHandler?.({
       name: "events",
-      data: { events, nextSequence: 3 },
+      data: { events, nextSequence: 2 },
     });
 
     expect(options.onEventMock).toHaveBeenCalledTimes(2);
@@ -270,7 +270,7 @@ describe("streamEvents", () => {
       expect(capturedMessageHandler).not.toBeNull();
     });
 
-    // Send event with a gap (expecting 1, receiving 5 skips sequences 1-4)
+    // Send event with a gap (expecting 0, receiving 5 skips sequences 0-4)
     capturedMessageHandler?.({
       name: "events",
       data: {
@@ -306,8 +306,8 @@ describe("streamEvents", () => {
     capturedMessageHandler?.({
       name: "events",
       data: {
-        events: [{ type: "text", sequenceNumber: 1 }],
-        nextSequence: 2,
+        events: [{ type: "text", sequenceNumber: 0 }],
+        nextSequence: 1,
       },
     });
 

--- a/turbo/apps/cli/src/lib/realtime/stream-events.ts
+++ b/turbo/apps/cli/src/lib/realtime/stream-events.ts
@@ -93,8 +93,8 @@ export async function streamEvents(
     });
 
     let result: StreamResult = { succeeded: true, runId };
-    // Sandbox sends 1-based sequence numbers (first event has sequenceNumber: 1)
-    let nextExpectedSequence = 1;
+    // Sandbox sends 0-based sequence numbers (first event has sequenceNumber: 0)
+    let nextExpectedSequence = 0;
 
     // Handle connection errors
     ablyClient.connection.on("failed", (stateChange: ConnectionStateChange) => {

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/__tests__/route.test.ts
@@ -334,7 +334,7 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
       queryAxiomSpy.mockResolvedValue([
         createAxiomAgentEvent(
           "2024-01-01T00:00:00Z",
-          1,
+          0,
           "init",
           { type: "init", model: "claude-3" },
           testRunId,
@@ -351,7 +351,7 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.events).toHaveLength(1);
-      expect(data.events[0].sequenceNumber).toBe(1);
+      expect(data.events[0].sequenceNumber).toBe(0);
       expect(data.events[0].eventType).toBe("init");
       expect(data.events[0].eventData).toEqual({
         type: "init",
@@ -372,7 +372,7 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
       queryAxiomSpy.mockResolvedValue([
         createAxiomAgentEvent(
           "2024-01-01T00:00:00Z",
-          1,
+          0,
           "init",
           { type: "init" },
           testRunId,
@@ -380,7 +380,7 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
         ),
         createAxiomAgentEvent(
           "2024-01-01T00:00:01Z",
-          2,
+          1,
           "text",
           { type: "text", content: "Hello" },
           testRunId,
@@ -388,7 +388,7 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
         ),
         createAxiomAgentEvent(
           "2024-01-01T00:00:02Z",
-          3,
+          2,
           "tool_use",
           { type: "tool_use", name: "bash" },
           testRunId,
@@ -396,7 +396,7 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
         ),
         createAxiomAgentEvent(
           "2024-01-01T00:00:03Z",
-          4,
+          3,
           "result",
           { type: "result", success: true },
           testRunId,
@@ -427,6 +427,14 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
       queryAxiomSpy.mockResolvedValue([
         createAxiomAgentEvent(
           "2024-01-01T00:00:00Z",
+          0,
+          "event0",
+          { type: "event0" },
+          testRunId,
+          testUserId,
+        ),
+        createAxiomAgentEvent(
+          "2024-01-01T00:00:01Z",
           1,
           "event1",
           { type: "event1" },
@@ -434,7 +442,7 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
           testUserId,
         ),
         createAxiomAgentEvent(
-          "2024-01-01T00:00:01Z",
+          "2024-01-01T00:00:02Z",
           2,
           "event2",
           { type: "event2" },
@@ -442,18 +450,10 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
           testUserId,
         ),
         createAxiomAgentEvent(
-          "2024-01-01T00:00:02Z",
+          "2024-01-01T00:00:03Z",
           3,
           "event3",
           { type: "event3" },
-          testRunId,
-          testUserId,
-        ),
-        createAxiomAgentEvent(
-          "2024-01-01T00:00:03Z",
-          4,
-          "event4",
-          { type: "event4" },
           testRunId,
           testUserId,
         ), // Extra record
@@ -468,9 +468,9 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.events).toHaveLength(3);
-      expect(data.events[0].sequenceNumber).toBe(1);
-      expect(data.events[1].sequenceNumber).toBe(2);
-      expect(data.events[2].sequenceNumber).toBe(3);
+      expect(data.events[0].sequenceNumber).toBe(0);
+      expect(data.events[1].sequenceNumber).toBe(1);
+      expect(data.events[2].sequenceNumber).toBe(2);
       expect(data.hasMore).toBe(true);
 
       // Verify limit+1 was requested
@@ -483,7 +483,7 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
       queryAxiomSpy.mockResolvedValue([
         createAxiomAgentEvent(
           "2024-01-01T00:00:10Z",
-          2,
+          1,
           "recent_event",
           { type: "recent" },
           testRunId,
@@ -515,7 +515,7 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
       queryAxiomSpy.mockResolvedValue([
         createAxiomAgentEvent(
           "2024-01-15T10:30:00.000Z",
-          1,
+          0,
           "test",
           { type: "test" },
           testRunId,
@@ -552,7 +552,7 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
       queryAxiomSpy.mockResolvedValue([
         createAxiomAgentEvent(
           "2024-01-01T00:00:00Z",
-          1,
+          0,
           "tool_result",
           complexEventData,
           testRunId,

--- a/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
@@ -160,7 +160,7 @@ describe("POST /api/webhooks/agent/events", () => {
             events: [
               {
                 type: "test",
-                sequenceNumber: 1,
+                sequenceNumber: 0,
                 timestamp: Date.now(),
                 data: {},
               },
@@ -199,7 +199,7 @@ describe("POST /api/webhooks/agent/events", () => {
             events: [
               {
                 type: "test",
-                sequenceNumber: 1,
+                sequenceNumber: 0,
                 timestamp: Date.now(),
                 data: {},
               },
@@ -240,7 +240,7 @@ describe("POST /api/webhooks/agent/events", () => {
             events: [
               {
                 type: "test",
-                sequenceNumber: 1,
+                sequenceNumber: 0,
                 timestamp: Date.now(),
                 data: {},
               },
@@ -334,7 +334,7 @@ describe("POST /api/webhooks/agent/events", () => {
             events: [
               {
                 type: "test",
-                sequenceNumber: 1,
+                sequenceNumber: 0,
                 timestamp: Date.now(),
                 data: {},
               },
@@ -381,7 +381,7 @@ describe("POST /api/webhooks/agent/events", () => {
             events: [
               {
                 type: "test",
-                sequenceNumber: 1,
+                sequenceNumber: 0,
                 timestamp: Date.now(),
                 data: {},
               },
@@ -432,13 +432,13 @@ describe("POST /api/webhooks/agent/events", () => {
             events: [
               {
                 type: "tool_use",
-                sequenceNumber: 1,
+                sequenceNumber: 0,
                 timestamp: Date.now(),
                 data: { tool: "bash", command: "ls" },
               },
               {
                 type: "tool_result",
-                sequenceNumber: 2,
+                sequenceNumber: 1,
                 timestamp: Date.now(),
                 data: { exitCode: 0, stdout: "file1.txt\nfile2.txt" },
               },
@@ -454,8 +454,8 @@ describe("POST /api/webhooks/agent/events", () => {
 
       const data = await response.json();
       expect(data.received).toBe(2);
-      expect(data.firstSequence).toBe(1);
-      expect(data.lastSequence).toBe(2);
+      expect(data.firstSequence).toBe(0);
+      expect(data.lastSequence).toBe(1);
 
       // Verify Axiom was called with client-provided sequence numbers
       expect(ingestToAxiomSpy).toHaveBeenCalledWith(
@@ -464,13 +464,13 @@ describe("POST /api/webhooks/agent/events", () => {
           expect.objectContaining({
             runId: testRunId,
             userId: testUserId,
-            sequenceNumber: 1,
+            sequenceNumber: 0,
             eventType: "tool_use",
           }),
           expect.objectContaining({
             runId: testRunId,
             userId: testUserId,
-            sequenceNumber: 2,
+            sequenceNumber: 1,
             eventType: "tool_result",
           }),
         ]),
@@ -502,13 +502,13 @@ describe("POST /api/webhooks/agent/events", () => {
       const testEvents = [
         {
           type: "thinking",
-          sequenceNumber: 1,
+          sequenceNumber: 0,
           timestamp: 1234567890,
           data: { text: "Analyzing the problem..." },
         },
         {
           type: "tool_use",
-          sequenceNumber: 2,
+          sequenceNumber: 1,
           timestamp: 1234567891,
           data: {
             tool: "bash",
@@ -518,7 +518,7 @@ describe("POST /api/webhooks/agent/events", () => {
         },
         {
           type: "tool_result",
-          sequenceNumber: 3,
+          sequenceNumber: 2,
           timestamp: 1234567892,
           data: {
             exitCode: 0,
@@ -588,12 +588,12 @@ describe("POST /api/webhooks/agent/events", () => {
         createdAt: new Date(),
       });
 
-      // Create 15 events with client-provided sequence numbers
+      // Create 15 events with client-provided sequence numbers (0-based)
       const events = Array.from({ length: 15 }, (_, i) => ({
-        type: `event_${i + 1}`,
-        sequenceNumber: i + 1,
+        type: `event_${i}`,
+        sequenceNumber: i,
         timestamp: Date.now() + i,
-        data: { index: i + 1, message: `Event number ${i + 1}` },
+        data: { index: i, message: `Event number ${i}` },
       }));
 
       const request = new NextRequest(
@@ -616,8 +616,8 @@ describe("POST /api/webhooks/agent/events", () => {
 
       const data = await response.json();
       expect(data.received).toBe(15);
-      expect(data.firstSequence).toBe(1);
-      expect(data.lastSequence).toBe(15);
+      expect(data.firstSequence).toBe(0);
+      expect(data.lastSequence).toBe(14);
 
       // Verify Axiom was called with all 15 events
       expect(ingestToAxiomSpy).toHaveBeenCalledWith(
@@ -625,8 +625,8 @@ describe("POST /api/webhooks/agent/events", () => {
         expect.arrayContaining(
           events.map((_, i) =>
             expect.objectContaining({
-              sequenceNumber: i + 1,
-              eventType: `event_${i + 1}`,
+              sequenceNumber: i,
+              eventType: `event_${i}`,
             }),
           ),
         ),

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -181,7 +181,7 @@ export const runEventsContract = c.router({
       id: z.string().min(1, "Run ID is required"),
     }),
     query: z.object({
-      since: z.coerce.number().default(0),
+      since: z.coerce.number().default(-1),
       limit: z.coerce.number().default(100),
     }),
     responses: {

--- a/turbo/packages/core/src/contracts/webhooks.ts
+++ b/turbo/packages/core/src/contracts/webhooks.ts
@@ -19,7 +19,7 @@ const c = initContract();
 const agentEventSchema = z
   .object({
     type: z.string(),
-    sequenceNumber: z.number().int().positive(),
+    sequenceNumber: z.number().int().nonnegative(),
   })
   .passthrough();
 

--- a/turbo/packages/core/src/sandbox/scripts/src/lib/events.ts
+++ b/turbo/packages/core/src/sandbox/scripts/src/lib/events.ts
@@ -31,7 +31,7 @@ interface AgentEvent {
  * Masks secrets before sending.
  *
  * @param event - Event dictionary to send
- * @param sequenceNumber - Sequence number for this event (1-based, maintained by caller)
+ * @param sequenceNumber - Sequence number for this event (0-based, maintained by caller)
  * @returns true on success, false on failure
  */
 export async function sendEvent(

--- a/turbo/packages/core/src/sandbox/scripts/src/run-agent.ts
+++ b/turbo/packages/core/src/sandbox/scripts/src/run-agent.ts
@@ -380,9 +380,9 @@ async function run(): Promise<[number, string]> {
         try {
           const event = JSON.parse(stripped) as Record<string, unknown>;
 
-          // Valid JSONL - send immediately with sequence number
-          eventSequence++;
+          // Valid JSONL - send immediately with sequence number (0-based)
           await sendEvent(event, eventSequence);
+          eventSequence++;
 
           // Extract result from "result" event for stdout
           if (event.type === "result") {


### PR DESCRIPTION
## Summary

- Migrates event sequence numbers from 1-based to 0-based indexing across the codebase
- CLI now polls with `since=-1` to capture the first event at sequence 0
- Stream events expect the first event at sequence number 0
- API contracts updated: default `since` parameter is now -1, and `sequenceNumber` accepts nonnegative values (including 0)
- Sandbox scripts send events before incrementing the sequence counter, so the first event is 0

## Test plan

- [x] All modified tests pass locally (131 tests across 6 test files)
- [x] Pre-commit checks pass (format, lint, type-check, knip)
- [ ] CI pipeline passes

Closes #1530

Generated with [Claude Code](https://claude.ai/code)