### PR TITLE
refactor(platform): extract clerk components and add external link support

### DIFF
--- a/turbo/apps/platform/src/signals/layout/navigation.ts
+++ b/turbo/apps/platform/src/signals/layout/navigation.ts
@@ -36,10 +36,14 @@ export const NAVIGATION_CONFIG = [
   },
 ] as const satisfies readonly NavGroup[];
 
-// Footer navigation items (non-grouped)
-// Note: "Bill" is handled separately via SubscriptionDetailsButton in sidebar.tsx
 export const FOOTER_NAV_ITEMS = [
-  { id: "docs", label: "Documentation", icon: "HelpCircle", path: "/" },
+  {
+    id: "docs",
+    label: "Documentation",
+    icon: "HelpCircle",
+    url: "https://docs.vm0.ai",
+    newTab: true,
+  },
 ] as const satisfies readonly NavItem[];
 
 // Derived signal: active navigation item based on current pathname
@@ -63,9 +67,12 @@ export const activeNavItem$ = computed((get) => {
     }
   }
 
-  // Check footer navigation
+  // Check footer navigation (only items with internal paths)
   for (const item of FOOTER_NAV_ITEMS) {
-    if (pathname === item.path || pathname.startsWith(item.path + "/")) {
+    if (
+      "path" in item &&
+      (pathname === item.path || pathname.startsWith(item.path + "/"))
+    ) {
       return item.id;
     }
   }

--- a/turbo/apps/platform/src/types/navigation.ts
+++ b/turbo/apps/platform/src/types/navigation.ts
@@ -19,7 +19,9 @@ export interface NavItem {
   id: string;
   label: string;
   icon: NavIconName;
-  path: RoutePath;
+  path?: RoutePath;
+  url?: string;
+  newTab?: boolean;
 }
 
 export interface NavGroup {

--- a/turbo/apps/platform/src/views/clerk/clerk-provider.tsx
+++ b/turbo/apps/platform/src/views/clerk/clerk-provider.tsx
@@ -10,7 +10,7 @@ interface ClerkProviderProps {
   children: ReactNode;
 }
 
-export function ClerkProvider({ children }: ClerkProviderProps) {
+export function VM0ClerkProvider({ children }: ClerkProviderProps) {
   const clerkLoadable = useLoadable(clerk$);
 
   if (clerkLoadable.state !== "hasData") {
@@ -19,47 +19,36 @@ export function ClerkProvider({ children }: ClerkProviderProps) {
 
   const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string;
 
-  // Type assertion needed due to @clerk/shared version mismatch between
-  // @clerk/clerk-js and @clerk/clerk-react packages
   return (
     <BaseClerkProvider
       Clerk={clerkLoadable.data as unknown as BaseClerkProviderProps["Clerk"]}
       publishableKey={publishableKey}
       appearance={{
         variables: {
-          // Primary color matching VM0 design system
-          colorPrimary: "#ED4E01", // primary-800
-          colorText: "#231F1B", // gray-950
-          colorBackground: "#FFFCF9", // gray-0
-          colorInputBackground: "#F9F4EF", // gray-50
-          colorInputText: "#231F1B", // gray-950
-          // Border and radius
+          colorPrimary: "#ED4E01",
+          colorText: "#231F1B",
+          colorBackground: "#FFFCF9",
+          colorInputBackground: "#F9F4EF",
+          colorInputText: "#231F1B",
           borderRadius: "0.5rem",
           colorDanger: "#EF4444",
-          // Font family
           fontFamily:
             "Noto Sans, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif",
         },
         elements: {
-          // Card styling
           card: "shadow-lg",
-          // Drawer header styling
           drawerHeader: {
             backgroundColor: "#F9F4EF",
             borderBottom: "1px solid #E8E2DD",
           },
-          // Form elements
           formButtonPrimary:
             "bg-primary-800 hover:bg-primary-900 text-white font-medium",
           formFieldInput:
             "border-gray-200 focus:border-primary-600 focus:ring-primary-600",
-          // Header
           headerTitle: "text-gray-950",
           headerSubtitle: "text-gray-800",
-          // Footer
           footerAction: "text-gray-800",
           footerActionLink: "text-primary-800 hover:text-primary-900",
-          // Buttons
           socialButtonsBlockButton: "border-gray-200 hover:bg-gray-50",
           socialButtonsBlockButtonText: "text-gray-950 font-medium",
         },

--- a/turbo/apps/platform/src/views/clerk/subscription-detail.tsx
+++ b/turbo/apps/platform/src/views/clerk/subscription-detail.tsx
@@ -1,0 +1,57 @@
+import { SubscriptionDetailsButton } from "@clerk/clerk-react/experimental";
+import { IconReceipt } from "@tabler/icons-react";
+import { VM0ClerkProvider } from "./clerk-provider";
+
+export function VM0SubscriptionDetailsButton() {
+  return (
+    <VM0ClerkProvider>
+      <SubscriptionDetailsButton
+        subscriptionDetailsProps={{
+          appearance: {
+            variables: {
+              colorPrimary: "#ED4E01",
+              colorBackground: "#FFFCF9",
+              borderRadius: "0.5rem",
+              fontFamily:
+                "Noto Sans, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif",
+            },
+            elements: {
+              card: {
+                boxShadow: "none",
+              },
+              subscriptionDetailsCard: {
+                boxShadow: "none",
+                border: "1px solid #E8E2DD",
+              },
+              subscriptionDetailsCardBody: {
+                boxShadow: "none",
+              },
+              drawer: {
+                backgroundColor: "#F9F4EF",
+              },
+              drawerContent: {
+                backgroundColor: "#FFFCF9",
+              },
+              drawerHeader: {
+                backgroundColor: "#F9F4EF !important",
+                borderBottom: "1px solid #E8E2DD !important",
+              },
+              drawerTitle: "text-gray-950",
+              headerBox: "bg-[#F9F4EF]",
+              headerTitle: "text-gray-950",
+              headerSubtitle: "text-gray-800",
+              formButtonPrimary:
+                "bg-primary-800 hover:bg-primary-900 text-white font-medium",
+              footerActionLink: "text-primary-800 hover:text-primary-900",
+            },
+          },
+        }}
+      >
+        <button className="flex w-full items-center gap-2 p-2 h-9 rounded-lg text-sidebar-foreground hover:bg-sidebar-accent transition-colors">
+          <IconReceipt size={16} className="shrink-0" />
+          <span className="text-sm leading-5">Bill</span>
+        </button>
+      </SubscriptionDetailsButton>
+    </VM0ClerkProvider>
+  );
+}

--- a/turbo/apps/platform/src/views/layout/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/layout/__tests__/sidebar.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+import { testContext } from "../../../signals/__tests__/test-helpers";
+import { setupPage } from "../../../__tests__/helper";
+import { screen } from "@testing-library/react";
+
+const context = testContext();
+
+describe("sidebar", () => {
+  it("should open docs in new tab", async () => {
+    await setupPage({
+      context,
+      path: "/",
+    });
+
+    const spyOpen = vi.spyOn(window, "open").mockImplementation(() => null);
+    screen.getByText("Documentation").click();
+    expect(spyOpen).toHaveBeenCalledWith("https://docs.vm0.ai", "_blank");
+  });
+});

--- a/turbo/apps/platform/src/views/layout/nav-link.tsx
+++ b/turbo/apps/platform/src/views/layout/nav-link.tsx
@@ -47,7 +47,15 @@ export function NavLink({ item, isActive }: NavLinkProps) {
   return (
     <button
       onClick={() => {
-        navigate(item.path);
+        if (item.path) {
+          navigate(item.path);
+        } else if (item.url) {
+          if (item.newTab) {
+            window.open(item.url, "_blank");
+          } else {
+            window.location.href = item.url;
+          }
+        }
       }}
       className={`flex w-full items-center gap-2 h-8 p-2 rounded-lg text-sm leading-5 transition-colors ${
         isActive

--- a/turbo/apps/platform/src/views/layout/sidebar.tsx
+++ b/turbo/apps/platform/src/views/layout/sidebar.tsx
@@ -1,6 +1,5 @@
 import { useGet, useLoadable } from "ccstate-react";
-import { IconDotsVertical, IconReceipt } from "@tabler/icons-react";
-import { SubscriptionDetailsButton } from "@clerk/clerk-react/experimental";
+import { IconDotsVertical } from "@tabler/icons-react";
 import {
   NAVIGATION_CONFIG,
   FOOTER_NAV_ITEMS,
@@ -9,20 +8,17 @@ import {
 } from "../../signals/layout/navigation.ts";
 import { clerk$, user$ } from "../../signals/auth.ts";
 import { NavLink } from "./nav-link.tsx";
-import { ClerkProvider } from "./clerk-provider.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
+import { VM0SubscriptionDetailsButton } from "../clerk/subscription-detail.tsx";
 
 export function Sidebar() {
   const activeItem = useGet(activeNavItem$);
 
   return (
     <aside className="hidden md:flex w-[255px] flex-col border-r border-sidebar-border bg-sidebar">
-      {/* Logo header - height: 49px, padding: 8px */}
       <div className="h-[49px] flex flex-col justify-center p-2 border-b border-divider">
         <div className="flex items-center gap-2.5 p-1.5 h-8">
-          {/* VM0 Logo - inline grid layout matching Figma structure */}
           <div className="inline-grid grid-cols-[max-content] grid-rows-[max-content] items-start justify-items-start leading-[0] shrink-0">
-            {/* Logo SVG with proper sizing: 81x24 */}
             <img
               src="/logo_light.svg"
               alt="VM0"
@@ -36,9 +32,7 @@ export function Sidebar() {
         </div>
       </div>
 
-      {/* Main navigation area - gap: 8px between sections */}
       <div className="flex-1 flex flex-col gap-2 overflow-y-auto">
-        {/* Get started section */}
         <div className="p-2">
           <div className="flex flex-col gap-1">
             <NavLink
@@ -46,13 +40,11 @@ export function Sidebar() {
               isActive={activeItem === GET_STARTED_ITEM.id}
             />
           </div>
-          {/* Your agents section label - height: 32px, px: 8px, opacity: 70% */}
           <div className="h-8 flex items-center px-2 opacity-70">
             <span className="text-xs leading-4 text-sidebar-foreground">
               Your agents
             </span>
           </div>
-          {/* Your agents items - gap: 4px */}
           <div className="flex flex-col gap-1">
             {NAVIGATION_CONFIG[0].items.map((item) => (
               <NavLink
@@ -64,16 +56,13 @@ export function Sidebar() {
           </div>
         </div>
 
-        {/* Other navigation groups */}
         {NAVIGATION_CONFIG.slice(1).map((group) => (
           <div key={group.label} className="p-2">
-            {/* Section label - height: 32px, px: 8px, opacity: 70% */}
             <div className="h-8 flex items-center px-2 opacity-70">
               <span className="text-xs leading-4 text-sidebar-foreground">
                 {group.label}
               </span>
             </div>
-            {/* Menu items - gap: 4px */}
             <div className="flex flex-col gap-1">
               {group.items.map((item) => (
                 <NavLink
@@ -87,63 +76,9 @@ export function Sidebar() {
         ))}
       </div>
 
-      {/* Footer navigation - padding: 8px, gap: 4px */}
       <div className="p-2">
         <div className="flex flex-col gap-1">
-          {/* Bill button - opens subscription management modal */}
-          <ClerkProvider>
-            <SubscriptionDetailsButton
-              subscriptionDetailsProps={{
-                appearance: {
-                  variables: {
-                    colorPrimary: "#ED4E01", // primary-800
-                    colorBackground: "#FFFCF9", // gray-0
-                    borderRadius: "0.5rem",
-                    fontFamily:
-                      "Noto Sans, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif",
-                  },
-                  elements: {
-                    // Remove shadows and add borders to subscription plan cards
-                    card: {
-                      boxShadow: "none",
-                    },
-                    subscriptionDetailsCard: {
-                      boxShadow: "none",
-                      border: "1px solid #E8E2DD", // gray-200 (border token)
-                    },
-                    subscriptionDetailsCardBody: {
-                      boxShadow: "none",
-                    },
-                    // Drawer styling
-                    drawer: {
-                      backgroundColor: "#F9F4EF", // sidebar color (gray-50)
-                    },
-                    drawerContent: {
-                      backgroundColor: "#FFFCF9", // background token (gray-0)
-                    },
-                    drawerHeader: {
-                      backgroundColor: "#F9F4EF !important", // sidebar color (gray-50)
-                      borderBottom: "1px solid #E8E2DD !important", // border token (gray-200)
-                    },
-                    drawerTitle: "text-gray-950",
-                    headerBox: "bg-[#F9F4EF]", // sidebar color (gray-50)
-                    headerTitle: "text-gray-950",
-                    headerSubtitle: "text-gray-800",
-                    // Form elements
-                    formButtonPrimary:
-                      "bg-primary-800 hover:bg-primary-900 text-white font-medium",
-                    // Links
-                    footerActionLink: "text-primary-800 hover:text-primary-900",
-                  },
-                },
-              }}
-            >
-              <button className="flex w-full items-center gap-2 p-2 h-9 rounded-lg text-sidebar-foreground hover:bg-sidebar-accent transition-colors">
-                <IconReceipt size={16} className="shrink-0" />
-                <span className="text-sm leading-5">Bill</span>
-              </button>
-            </SubscriptionDetailsButton>
-          </ClerkProvider>
+          <VM0SubscriptionDetailsButton />
           {FOOTER_NAV_ITEMS.map((item) => (
             <NavLink
               key={item.id}
@@ -154,7 +89,6 @@ export function Sidebar() {
         </div>
       </div>
 
-      {/* User profile section - padding: 8px */}
       <UserProfile />
     </aside>
   );


### PR DESCRIPTION
## Summary

- Move Clerk provider and subscription detail components to dedicated `views/clerk/` directory for better organization
- Extend `NavItem` interface to support external URLs with optional `newTab` behavior
- Update Documentation link to open https://docs.vm0.ai in a new tab
- Add test for verifying the documentation link opens in a new tab
- Clean up inline comments in sidebar component

## Test plan

- [ ] Verify sidebar renders correctly with all navigation items
- [ ] Verify clicking "Documentation" opens https://docs.vm0.ai in a new tab
- [ ] Verify "Bill" button opens subscription details modal
- [ ] Run `pnpm vitest run` in apps/platform - all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)