### PR TITLE
feat(platform): add global window._vm0 method for external integrations

### DIFF
--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  interface Window {
+    _vm0: unknown;
+  }
+}
+
+export {};

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -1,6 +1,10 @@
+interface VM0Global {
+  loggers: DebugLoggers;
+}
+
 declare global {
   interface Window {
-    _vm0: unknown;
+    _vm0: VM0Global | undefined;
   }
 }
 

--- a/turbo/apps/platform/src/signals/__tests__/global-method.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/global-method.test.ts
@@ -9,4 +9,39 @@ describe("global method", () => {
 
     expect(window._vm0).toBeDefined();
   });
+
+  it("should init all loggers in info level", async () => {
+    await setupPage({ context, path: "/" });
+
+    const loggers = window._vm0?.loggers;
+    expect(loggers).toBeDefined();
+    if (loggers) {
+      for (const loggerName of Object.keys(loggers)) {
+        expect(loggers[loggerName].debug).toBeFalsy();
+      }
+    }
+  });
+
+  it("should set logger to debug level when set debug to true", async () => {
+    await setupPage({ context, path: "/" });
+
+    const loggers = window._vm0?.loggers;
+    expect(loggers).toBeDefined();
+
+    loggers.Promise.debug = true;
+    expect(loggers.Promise.debug).toBeTruthy();
+  });
+
+  it("should affected by setupPage debugLoggers", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      debugLoggers: ["Promise"],
+    });
+
+    const loggers = window._vm0?.loggers;
+    expect(loggers).toBeDefined();
+
+    expect(loggers.Promise.debug).toBeTruthy();
+  });
 });

--- a/turbo/apps/platform/src/signals/__tests__/global-method.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/global-method.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { testContext } from "./test-helpers";
+import { setupPage } from "../../__tests__/helper";
+
+const context = testContext();
+describe("global method", () => {
+  it("should has vm0 method after init", async () => {
+    await setupPage({ context, path: "/" });
+
+    expect(window._vm0).toBeDefined();
+  });
+});

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -10,6 +10,7 @@ import { setupHomePage$ } from "./home/home-page.ts";
 import { setupLogsPage$ } from "./logs-page/logs-page.ts";
 import { hasScope$ } from "./scope.ts";
 import { logger } from "./log.ts";
+import { setupGlobalMethod$ } from "./global-method.ts";
 
 const L = logger("bootstrap");
 
@@ -31,6 +32,8 @@ const setupRoutes$ = command(async ({ set }, signal: AbortSignal) => {
 export const bootstrap$ = command(
   async ({ set }, render: () => void, signal: AbortSignal) => {
     set(setRootSignal$, signal);
+
+    set(setupGlobalMethod$, signal);
 
     render();
 

--- a/turbo/apps/platform/src/signals/global-method.ts
+++ b/turbo/apps/platform/src/signals/global-method.ts
@@ -1,11 +1,43 @@
 import { command } from "ccstate";
-import { logger } from "./log";
+import { getLoggers, Level, logger } from "./log";
+import type { DebugLoggers } from "../types/global-method";
 
 const L = logger("GlobalMethod");
 
+function createLoggerControl(name: string) {
+  const loggers = getLoggers();
+  const loggerInstance = loggers[name];
+  if (!loggerInstance) {
+    throw new Error(`Logger "${name}" not found`);
+  }
+
+  return {
+    get debug() {
+      return loggerInstance.shouldLog(Level.Debug);
+    },
+    set debug(value: boolean) {
+      if (value) {
+        loggerInstance.level = Level.Debug;
+      } else if (loggerInstance.level === Level.Debug) {
+        loggerInstance.level = Level.Info;
+      }
+    },
+  };
+}
+
 export const setupGlobalMethod$ = command((_, signal: AbortSignal) => {
   L.debug("Setting up global method vm0");
-  window._vm0 = {};
+
+  window._vm0 = {
+    get loggers() {
+      const loggers = getLoggers();
+      const result: DebugLoggers = {};
+      for (const name of Object.keys(loggers)) {
+        result[name] = createLoggerControl(name);
+      }
+      return result;
+    },
+  };
 
   signal.addEventListener("abort", () => {
     L.debug("Cleaning up global method vm0");

--- a/turbo/apps/platform/src/signals/global-method.ts
+++ b/turbo/apps/platform/src/signals/global-method.ts
@@ -1,0 +1,14 @@
+import { command } from "ccstate";
+import { logger } from "./log";
+
+const L = logger("GlobalMethod");
+
+export const setupGlobalMethod$ = command((_, signal: AbortSignal) => {
+  L.debug("Setting up global method vm0");
+  window._vm0 = {};
+
+  signal.addEventListener("abort", () => {
+    L.debug("Cleaning up global method vm0");
+    delete window._vm0;
+  });
+});

--- a/turbo/apps/platform/src/signals/log.ts
+++ b/turbo/apps/platform/src/signals/log.ts
@@ -200,3 +200,7 @@ export function resetLoggerForTest() {
     }
   }
 }
+
+export function getLoggers(): Partial<Record<string, ConsoleLogger>> {
+  return LOGGERS;
+}

--- a/turbo/apps/platform/src/types/global-method.ts
+++ b/turbo/apps/platform/src/types/global-method.ts
@@ -1,0 +1,6 @@
+export type DebugLoggers = Record<
+  string,
+  {
+    debug: boolean;
+  }
+>;


### PR DESCRIPTION
## Summary
- Adds a global `window._vm0` object that is initialized during platform bootstrap
- Includes TypeScript type declarations for the global Window interface extension
- Provides proper cleanup on signal abort to remove the global method
- Adds test coverage for the global method initialization

## Test plan
- [x] Unit test verifies `window._vm0` is defined after platform initialization
- [x] All lint, type-check, and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)