### PR TITLE
ci: add needs-runner-pipeline label to control runner jobs

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -552,6 +552,7 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [prepare, cli-e2e-01-serial, deploy-web, deploy-runner-start]
     if: |
+      contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&
       github.event_name != 'push' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
@@ -628,6 +629,7 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [prepare]
     if: |
+      contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&
       github.event_name != 'push' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
@@ -835,6 +837,7 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [prepare, deploy-runner-prepare]
     if: |
+      contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&
       github.event_name != 'push' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
@@ -882,6 +885,7 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     needs: [prepare, deploy-web, deploy-runner-prepare]
     if: |
+      contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&
       github.event_name != 'push' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
@@ -943,7 +947,7 @@ jobs:
   unlock-runner-host:
     runs-on: ubuntu-latest
     needs: [deploy-runner-prepare, cli-e2e-03-runner]
-    if: always() && github.event_name != 'push' && needs.deploy-runner-prepare.outputs.runner-host != ''
+    if: always() && contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') && github.event_name != 'push' && needs.deploy-runner-prepare.outputs.runner-host != ''
     steps:
       - name: Unlock runner host
         env:

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,5 +1,6 @@
 // VM0 Runner - Self-hosted runner that polls the VM0 API server and executes agent jobs in isolated Firecracker microVMs
 // Deployment: Added buildkit cache retry mechanism (issue #1328)
+// Test: Verify needs-runner-pipeline label control (issue #1544)
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { doctorCommand } from "./commands/doctor.js";

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,6 +1,6 @@
 // VM0 Runner - Self-hosted runner that polls the VM0 API server and executes agent jobs in isolated Firecracker microVMs
 // Deployment: Added buildkit cache retry mechanism (issue #1328)
-// Test: Verify needs-runner-pipeline label control (issue #1544)
+// Test: Verify needs-runner-pipeline label control (issue #1544) - with label
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { doctorCommand } from "./commands/doctor.js";


### PR DESCRIPTION
## Summary

- Add `needs-runner-pipeline` label check to 5 runner-related jobs so they only run when the PR has the label
- Jobs affected: `deploy-runner-prepare`, `deploy-runner-benchmark`, `deploy-runner-start`, `cli-e2e-03-runner`, `unlock-runner-host`
- PRs without the label will skip runner jobs, speeding up CI feedback

## Behavior

| Scenario | Runner Jobs |
|----------|-------------|
| PR without label | ❌ Skipped |
| PR with `needs-runner-pipeline` label | ✅ Run |
| Push to main | ❌ Skipped (unchanged) |

## Test plan

- [ ] Create PR without label → verify runner jobs are skipped
- [ ] Add `needs-runner-pipeline` label to PR → verify runner jobs run on re-trigger
- [ ] Verify lint/test/deploy jobs still work normally

Closes #1544

🤖 Generated with [Claude Code](https://claude.com/claude-code)