### PR TITLE
refactor(platform): extract bootstrap modules and add local storage signals

### DIFF
--- a/turbo/apps/platform/src/__tests__/helper.ts
+++ b/turbo/apps/platform/src/__tests__/helper.ts
@@ -9,8 +9,8 @@ import {
   setPathname,
   setSearch,
 } from "../signals/location";
-import { Level, logger } from "../signals/log";
 import { vi } from "vitest";
+import { localStorageSignals } from "../signals/external/local-storage";
 
 export async function setupPage(options: {
   context: TestContext;
@@ -22,8 +22,11 @@ export async function setupPage(options: {
   createPushStateMock(options.context.signal);
   pushState({}, "", options.path);
 
-  for (const loggerName of options.debugLoggers ?? []) {
-    logger(loggerName).level = Level.Debug;
+  if (options.debugLoggers) {
+    options.context.store.set(
+      localStorageSignals("debugLoggers").set$,
+      JSON.stringify(options.debugLoggers ?? []),
+    );
   }
 
   mockUser(

--- a/turbo/apps/platform/src/__tests__/setup-page.test.ts
+++ b/turbo/apps/platform/src/__tests__/setup-page.test.ts
@@ -1,0 +1,31 @@
+import { testContext } from "../signals/__tests__/test-helpers";
+import { setupPage } from "./helper";
+import { expect, it, describe } from "vitest";
+import { Level, logger } from "../signals/log";
+import { localStorageSignals } from "../signals/external/local-storage";
+
+const context = testContext();
+
+describe("setupPage", () => {
+  it("should set debug loggers correctly", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      debugLoggers: ["Foo"],
+    });
+
+    expect(logger("Foo").level).toBe(Level.Debug);
+  });
+
+  it("should load debug loggers correctly", async () => {
+    const { set$ } = localStorageSignals("debugLoggers");
+    context.store.set(set$, JSON.stringify(["Foo"]));
+
+    await setupPage({
+      context,
+      path: "/",
+    });
+
+    expect(logger("Foo").level).toBe(Level.Debug);
+  });
+});

--- a/turbo/apps/platform/src/signals/__tests__/test-helpers.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-helpers.ts
@@ -1,6 +1,7 @@
 import { createStore, type Store } from "ccstate";
 import { afterEach } from "vitest";
-import { logger } from "../log";
+import { logger, resetLoggerForTest } from "../log";
+import { resetLocalStorageForTest$ } from "../external/local-storage";
 
 const L = logger("Test");
 
@@ -28,6 +29,9 @@ export function testContext(): TestContext {
         L.debug("create store");
         store = createStore();
         context.signal.addEventListener("abort", () => {
+          store?.set(resetLocalStorageForTest$);
+          resetLoggerForTest();
+
           store = null;
         });
       }

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -10,9 +10,10 @@ import { setupHomePage$ } from "./home/home-page.ts";
 import { setupLogsPage$ } from "./logs-page/logs-page.ts";
 import { hasScope$ } from "./scope.ts";
 import { logger } from "./log.ts";
-import { setupGlobalMethod$ } from "./global-method.ts";
+import { setupGlobalMethod$ } from "./bootstrap/global-method.ts";
+import { setupLoggers$ } from "./bootstrap/loggers.ts";
 
-const L = logger("bootstrap");
+const L = logger("Bootstrap");
 
 const ROUTE_CONFIG = [
   {
@@ -33,6 +34,7 @@ export const bootstrap$ = command(
   async ({ set }, render: () => void, signal: AbortSignal) => {
     set(setRootSignal$, signal);
 
+    set(setupLoggers$);
     set(setupGlobalMethod$, signal);
 
     render();

--- a/turbo/apps/platform/src/signals/bootstrap/global-method.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/global-method.ts
@@ -1,6 +1,6 @@
 import { command } from "ccstate";
-import { getLoggers, Level, logger } from "./log";
-import type { DebugLoggers } from "../types/global-method";
+import { getLoggers, Level, logger } from "../log";
+import type { DebugLoggers } from "../../types/global-method";
 
 const L = logger("GlobalMethod");
 

--- a/turbo/apps/platform/src/signals/bootstrap/loggers.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/loggers.ts
@@ -1,0 +1,30 @@
+import { command } from "ccstate";
+import { localStorageSignals } from "../external/local-storage";
+import { Level, logger } from "../log";
+import { throwIfAbort } from "../utils";
+
+const { get$ } = localStorageSignals("debugLoggers");
+
+const L = logger("Logger");
+
+export const setupLoggers$ = command(({ get }) => {
+  const debugLoggers = get(get$);
+  if (debugLoggers) {
+    let loggerNames: string[] = [];
+    try {
+      loggerNames = JSON.parse(debugLoggers);
+    } catch (error) {
+      throwIfAbort(error);
+      // silence JSON parse errors because this data only for debugging
+    }
+    if (loggerNames.length > 0) {
+      L.infoGroup("Enable DEBUG for loggers:");
+      for (const name of loggerNames) {
+        L.info(name);
+        const l = logger(name);
+        l.level = Level.Debug;
+      }
+      L.infoGroupEnd();
+    }
+  }
+});

--- a/turbo/apps/platform/src/signals/external/__tests__/local-storage.test.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/local-storage.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { testContext } from "../../__tests__/test-helpers";
+import { setupPage } from "../../../__tests__/helper";
+import { localStorageSignals } from "../local-storage";
+
+const context = testContext();
+
+describe("local storage signal", () => {
+  it("can read and write to local storage", async () => {
+    await setupPage({ context, path: "/" });
+
+    const { get$, set$, clear$ } = localStorageSignals("foo");
+    expect(context.store.get(get$)).toBeNull();
+
+    context.store.set(set$, "bar");
+    expect(context.store.get(get$)).toBe("bar");
+
+    context.store.set(clear$);
+    expect(context.store.get(get$)).toBeNull();
+  });
+
+  it("should clear after last test", async () => {
+    await setupPage({ context, path: "/" });
+
+    const { get$ } = localStorageSignals("foo");
+    expect(context.store.get(get$)).toBeNull();
+  });
+});

--- a/turbo/apps/platform/src/signals/external/local-storage.ts
+++ b/turbo/apps/platform/src/signals/external/local-storage.ts
@@ -1,0 +1,47 @@
+import { command, computed, state } from "ccstate";
+
+const registeredLocalStorageKeys$ = state<Set<string> | null>(null);
+
+export const resetLocalStorageForTest$ = command(({ set, get }) => {
+  const keys = get(registeredLocalStorageKeys$);
+  if (!keys) {
+    return;
+  }
+
+  for (const key of keys) {
+    localStorage.removeItem(key);
+  }
+
+  set(registeredLocalStorageKeys$, null);
+});
+
+export function localStorageSignals(key: string) {
+  const reload$ = state(0);
+
+  const get$ = computed((get) => {
+    get(reload$);
+
+    return localStorage.getItem(key);
+  });
+
+  const set$ = command(({ set }, value: string) => {
+    set(registeredLocalStorageKeys$, (x) => {
+      if (x?.has(key)) {
+        return x;
+      }
+
+      x = new Set(x ?? []);
+      x.add(key);
+      return x;
+    });
+    localStorage.setItem(key, value);
+    set(reload$, (prev) => prev + 1);
+  });
+
+  const clear$ = command(({ set }) => {
+    localStorage.removeItem(key);
+    set(reload$, (prev) => prev + 1);
+  });
+
+  return Object.freeze({ get$, set$, clear$ });
+}


### PR DESCRIPTION
## Summary
- Move `global-method.ts` from `signals/` to `signals/bootstrap/` directory for better organization
- Add `setupLoggers$` bootstrap module that initializes debug loggers from localStorage
- Create `localStorageSignals` utility providing reactive localStorage access with ccstate signals
- Add proper cleanup of localStorage in test helpers to prevent state leakage between tests
- Add tests for localStorage signals and setupPage debug logger functionality

## Test plan
- [x] All existing tests pass (2197 tests)
- [x] New tests added for localStorage signals
- [x] New tests added for setupPage debugLoggers functionality
- [x] Lint, type-check, and knip checks pass

:robot: Generated with [Claude Code](https://claude.com/claude-code)