### PR TITLE
fix(test): make credential service test user id unique

### DIFF
--- a/turbo/apps/web/src/lib/credential/__tests__/credential-service.spec.ts
+++ b/turbo/apps/web/src/lib/credential/__tests__/credential-service.spec.ts
@@ -74,7 +74,7 @@ describe("Credential Service", () => {
   });
 
   describe("Database Operations", () => {
-    const testUserId = "test-credential-service-user";
+    const testUserId = `test-credential-service-user-${Date.now()}`;
     const testSlug = `test-cred-scope-${Date.now()}`;
     let testScopeId: string;
 


### PR DESCRIPTION
## Summary
- Add timestamp to `testUserId` in credential service tests to prevent conflicts when tests run in parallel or are re-run
- This matches the existing pattern already used for `testSlug` in the same test file

## Test plan
- [x] Verified the specific test file passes: `pnpm vitest run apps/web/src/lib/credential/__tests__/credential-service.spec.ts`
- [x] Pre-commit checks (lint, type-check, knip) all pass

---
Generated with [Claude Code](https://claude.com/claude-code)