### PR TITLE
ci: add 60-second per-test timeout for cli e2e tests

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -456,7 +456,7 @@ jobs:
       - name: Run Serial E2E Tests
         run: |
           echo "=== Running Serial E2E Tests ==="
-          ./e2e/test/libs/bats/bin/bats -T ./e2e/tests/01-serial/*.bats
+          BATS_TEST_TIMEOUT=60 ./e2e/test/libs/bats/bin/bats -T ./e2e/tests/01-serial/*.bats
           echo "✅ Serial tests passed"
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
@@ -528,7 +528,7 @@ jobs:
       - name: Run Parallel E2E Tests
         run: |
           echo "=== Running Parallel E2E Tests ==="
-          ./e2e/test/libs/bats/bin/bats -T -j 10 --no-parallelize-within-files ./e2e/tests/02-parallel/*.bats
+          BATS_TEST_TIMEOUT=60 ./e2e/test/libs/bats/bin/bats -T -j 10 --no-parallelize-within-files ./e2e/tests/02-parallel/*.bats
           echo "✅ Parallel tests passed"
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
@@ -604,7 +604,7 @@ jobs:
       - name: Run Runner E2E Tests
         run: |
           echo "=== Running Runner E2E Tests (4 parallel) ==="
-          RUNNER_GROUP="vm0/development-${JOB_REF}" ./e2e/test/libs/bats/bin/bats -T -j 4 --no-parallelize-within-files ./e2e/tests/03-experimental-runner/*.bats
+          BATS_TEST_TIMEOUT=60 RUNNER_GROUP="vm0/development-${JOB_REF}" ./e2e/test/libs/bats/bin/bats -T -j 4 --no-parallelize-within-files ./e2e/tests/03-experimental-runner/*.bats
           echo "✅ Runner tests passed"
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,6 +1,6 @@
 // VM0 Runner - Self-hosted runner that polls the VM0 API server and executes agent jobs in isolated Firecracker microVMs
 // Deployment: Added buildkit cache retry mechanism (issue #1328)
-// Test: Verify needs-runner-pipeline label control (issue #1544) - with label
+// CI: Added 60-second per-test timeout for E2E tests (issue #1549)
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { doctorCommand } from "./commands/doctor.js";


### PR DESCRIPTION
## Summary

- Add `BATS_TEST_TIMEOUT=60` to all three CLI E2E test phases (serial, parallel, runner)
- Prevents individual slow/stuck tests from causing overall CI workflow cancellation
- When a test exceeds the timeout, it fails with a clear message showing which test timed out

## Background

When CI E2E tests hang, the entire GitHub Actions workflow times out and gets **cancelled**, providing no visibility into which specific test failed.

BATS supports per-test timeouts via `BATS_TEST_TIMEOUT`. When exceeded, the test fails with:
```
not ok 1 test name in XXXms # timeout after 60s
#   `command' failed due to timeout
```

## Analysis

Based on CI run data (#21274437011):
- **138 parallel tests** analyzed
- **Slowest test**: 33 seconds
- **96% of tests** complete under 30 seconds
- 60-second timeout provides ~82% buffer above the slowest test

## Test plan

- [ ] Verify existing E2E tests continue to pass (no false failures from timeout)
- [ ] CI workflow completes successfully

Closes #1549

🤖 Generated with [Claude Code](https://claude.com/claude-code)