### PR TITLE
fix: auto-inject model provider credential into environment

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/run-service.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-service.test.ts
@@ -1210,6 +1210,193 @@ describe("run-service", () => {
             .delete(scopes)
             .where(eq(scopes.id, testScopeId));
         });
+
+        test("auto-injects model provider credential into environment when no environment block exists", async () => {
+          const testUserId = `model-provider-auto-inject-${Date.now()}`;
+          const testScopeId = randomUUID();
+          const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
+
+          await globalThis.services.db.insert(scopes).values({
+            id: testScopeId,
+            slug: `mp-auto-inject-${Date.now()}`,
+            type: "personal",
+            ownerId: testUserId,
+          });
+
+          // Create credential for the default model provider
+          const [credential] = await globalThis.services.db
+            .insert(credentials)
+            .values({
+              scopeId: testScopeId,
+              name: "CLAUDE_CODE_OAUTH_TOKEN",
+              encryptedValue: encryptCredentialValue(
+                "test-oauth-token-value",
+                encryptionKey,
+              ),
+            })
+            .returning();
+
+          // Create default model provider
+          await globalThis.services.db.insert(modelProviders).values({
+            scopeId: testScopeId,
+            type: "claude-code-oauth-token",
+            credentialId: credential!.id,
+            isDefault: true,
+          });
+
+          // Create compose WITHOUT any environment block (the bug scenario)
+          const [compose] = await globalThis.services.db
+            .insert(agentComposes)
+            .values({
+              userId: testUserId,
+              scopeId: testScopeId,
+              name: "test-compose-no-env-block",
+            })
+            .returning();
+
+          const versionId = `test-version-no-env-${Date.now()}`;
+          await globalThis.services.db.insert(agentComposeVersions).values({
+            id: versionId,
+            composeId: compose!.id,
+            content: {
+              agents: {
+                "test-agent": {
+                  framework: "claude-code",
+                  working_dir: "/workspace",
+                  // NO environment block at all!
+                },
+              },
+            },
+            createdBy: testUserId,
+          });
+
+          const context = await runService.buildExecutionContext({
+            agentComposeVersionId: versionId,
+            prompt: "test prompt",
+            runId: `run-auto-inject-${Date.now()}`,
+            sandboxToken: "token",
+            userId: testUserId,
+          });
+
+          // BUG FIX: context.environment should contain the model provider credential
+          expect(context.environment).toBeDefined();
+          expect(context.environment!["CLAUDE_CODE_OAUTH_TOKEN"]).toBe(
+            "test-oauth-token-value",
+          );
+
+          // Secrets should also contain the credential (for log masking)
+          expect(context.secrets).toEqual({
+            CLAUDE_CODE_OAUTH_TOKEN: "test-oauth-token-value",
+          });
+
+          // Cleanup
+          await globalThis.services.db
+            .delete(modelProviders)
+            .where(eq(modelProviders.scopeId, testScopeId));
+          await globalThis.services.db
+            .delete(agentComposeVersions)
+            .where(eq(agentComposeVersions.id, versionId));
+          await globalThis.services.db
+            .delete(agentComposes)
+            .where(eq(agentComposes.id, compose!.id));
+          await globalThis.services.db
+            .delete(credentials)
+            .where(eq(credentials.scopeId, testScopeId));
+          await globalThis.services.db
+            .delete(scopes)
+            .where(eq(scopes.id, testScopeId));
+        });
+
+        test("user-defined environment takes precedence over auto-injected credential", async () => {
+          const testUserId = `model-provider-precedence-${Date.now()}`;
+          const testScopeId = randomUUID();
+          const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
+
+          await globalThis.services.db.insert(scopes).values({
+            id: testScopeId,
+            slug: `mp-precedence-${Date.now()}`,
+            type: "personal",
+            ownerId: testUserId,
+          });
+
+          // Create credential for the default model provider
+          const [credential] = await globalThis.services.db
+            .insert(credentials)
+            .values({
+              scopeId: testScopeId,
+              name: "ANTHROPIC_API_KEY",
+              encryptedValue: encryptCredentialValue(
+                "model-provider-key",
+                encryptionKey,
+              ),
+            })
+            .returning();
+
+          await globalThis.services.db.insert(modelProviders).values({
+            scopeId: testScopeId,
+            type: "anthropic-api-key",
+            credentialId: credential!.id,
+            isDefault: true,
+          });
+
+          // Create compose WITH explicit environment value
+          const [compose] = await globalThis.services.db
+            .insert(agentComposes)
+            .values({
+              userId: testUserId,
+              scopeId: testScopeId,
+              name: "test-compose-user-precedence",
+            })
+            .returning();
+
+          const versionId = `test-version-precedence-${Date.now()}`;
+          await globalThis.services.db.insert(agentComposeVersions).values({
+            id: versionId,
+            composeId: compose!.id,
+            content: {
+              agents: {
+                "test-agent": {
+                  framework: "claude-code",
+                  working_dir: "/workspace",
+                  environment: {
+                    ANTHROPIC_API_KEY: "user-defined-key", // User explicitly sets this
+                  },
+                },
+              },
+            },
+            createdBy: testUserId,
+          });
+
+          const context = await runService.buildExecutionContext({
+            agentComposeVersionId: versionId,
+            prompt: "test prompt",
+            runId: `run-precedence-${Date.now()}`,
+            sandboxToken: "token",
+            userId: testUserId,
+          });
+
+          // User-defined value should win (skips model provider injection due to hasExplicitLLMConfig)
+          expect(context.environment!["ANTHROPIC_API_KEY"]).toBe(
+            "user-defined-key",
+          );
+
+          // Cleanup
+          await globalThis.services.db
+            .delete(modelProviders)
+            .where(eq(modelProviders.scopeId, testScopeId));
+          await globalThis.services.db
+            .delete(agentComposeVersions)
+            .where(eq(agentComposeVersions.id, versionId));
+          await globalThis.services.db
+            .delete(agentComposes)
+            .where(eq(agentComposes.id, compose!.id));
+          await globalThis.services.db
+            .delete(credentials)
+            .where(eq(credentials.scopeId, testScopeId));
+          await globalThis.services.db
+            .delete(scopes)
+            .where(eq(scopes.id, testScopeId));
+        });
       });
     });
   });

--- a/turbo/apps/web/src/lib/run/__tests__/run-service.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-service.test.ts
@@ -29,7 +29,11 @@ vi.mock("../../e2b", () => ({
   },
 }));
 
-// Mock agent-session service (third-party-like service for session management)
+// Mock agent-session service to isolate unit tests from database dependencies.
+// The agent-session service manages CLI agent sessions and conversations, which
+// requires database access. Mocking it allows testing RunService methods that
+// depend on session lookups without requiring actual session records in the database.
+// The relative path "../../agent-session" is resolved by vitest relative to this test file.
 vi.mock("../../agent-session", () => ({
   agentSessionService: {
     getByIdWithConversation: vi.fn(),

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -199,6 +199,8 @@ export async function buildExecutionContext(
 
   // Step 4: Check if credentials are needed and fetch them from the user's scope
   let credentials: Record<string, string> | undefined;
+  // Track which credential is for model provider auto-injection
+  let modelProviderCredentialName: string | undefined;
 
   // Extract variable references from compose to check for credentials
   const compose = agentCompose as {
@@ -293,6 +295,7 @@ export async function buildExecutionContext(
             if (credentialValue) {
               credentials = credentials || {};
               credentials[credentialName] = credentialValue;
+              modelProviderCredentialName = credentialName;
               log.debug(
                 `Injected model provider credential: ${credentialName}`,
               );
@@ -312,7 +315,7 @@ export async function buildExecutionContext(
 
   // Step 5: Expand environment variables from compose config using vars, secrets, and credentials
   // When experimental_firewall.experimental_seal_secrets is enabled, secrets are encrypted
-  const { environment } = expandEnvironmentFromCompose(
+  let { environment } = expandEnvironmentFromCompose(
     agentCompose,
     vars,
     secrets,
@@ -320,6 +323,24 @@ export async function buildExecutionContext(
     params.userId,
     params.runId,
   );
+
+  // Step 5b: Auto-inject model provider credential into environment
+  // This ensures the credential is available even when no environment block exists
+  if (
+    modelProviderCredentialName &&
+    credentials?.[modelProviderCredentialName]
+  ) {
+    // Only inject if not already set (user-defined environment takes precedence)
+    if (!environment?.[modelProviderCredentialName]) {
+      environment = environment || {};
+      // We've already checked credentials[modelProviderCredentialName] is truthy above
+      environment[modelProviderCredentialName] =
+        credentials[modelProviderCredentialName]!;
+      log.debug(
+        `Auto-injected model provider credential to environment: ${modelProviderCredentialName}`,
+      );
+    }
+  }
 
   // Step 6: Merge credentials into secrets for client-side log masking
   // Credentials are server-stored user-level secrets and must be masked like CLI secrets

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -30,6 +30,172 @@ import { getDefaultModelProvider } from "../model-provider/model-provider-servic
 const log = logger("run:build-context");
 
 /**
+ * LLM environment variables that indicate explicit configuration
+ */
+const LLM_ENV_VARS = [
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_BASE_URL",
+  "OPENAI_API_KEY",
+];
+
+/**
+ * Resolve model provider type from explicit value or default
+ */
+async function resolveProviderType(
+  scopeId: string,
+  framework: ModelProviderFramework,
+  explicitModelProvider?: string,
+): Promise<ModelProviderType> {
+  if (explicitModelProvider) {
+    // Validate that the specified model provider type is valid
+    if (!(explicitModelProvider in MODEL_PROVIDER_TYPES)) {
+      throw new BadRequestError(
+        `Unknown model provider type "${explicitModelProvider}". Valid types: ${Object.keys(MODEL_PROVIDER_TYPES).join(", ")}`,
+      );
+    }
+    return explicitModelProvider as ModelProviderType;
+  }
+
+  // Get default provider for framework
+  const defaultProvider = await getDefaultModelProvider(scopeId, framework);
+  if (!defaultProvider?.type) {
+    throw new BadRequestError(
+      "No LLM configuration found. " +
+        "Run 'vm0 model-provider setup' to configure a model provider, " +
+        "or add environment variables to your vm0.yaml.",
+    );
+  }
+  return defaultProvider.type;
+}
+
+/**
+ * Result of model provider credential resolution
+ */
+interface ModelProviderCredentialResult {
+  credentials: Record<string, string> | undefined;
+  credentialName: string | undefined;
+}
+
+/**
+ * Resolve and inject model provider credential if needed
+ * Only injects if no explicit LLM config in compose environment
+ */
+async function resolveModelProviderCredential(
+  userId: string,
+  framework: string,
+  hasExplicitLLMConfig: boolean,
+  existingCredentials: Record<string, string> | undefined,
+  explicitModelProvider?: string,
+): Promise<ModelProviderCredentialResult> {
+  let credentials = existingCredentials;
+
+  // Skip if explicit LLM config exists or framework doesn't use model providers
+  if (
+    hasExplicitLLMConfig ||
+    (framework !== "claude-code" && framework !== "codex")
+  ) {
+    return { credentials, credentialName: undefined };
+  }
+
+  const userScope = await getUserScopeByClerkId(userId);
+  if (!userScope) {
+    return { credentials, credentialName: undefined };
+  }
+
+  // Resolve model provider type (explicit or default)
+  const providerType = await resolveProviderType(
+    userScope.id,
+    framework as ModelProviderFramework,
+    explicitModelProvider,
+  );
+
+  // Validate framework compatibility
+  const providerFramework = getFrameworkForType(providerType);
+  if (providerFramework !== framework) {
+    throw new BadRequestError(
+      `Model provider "${providerType}" is not compatible with framework "${framework}". ` +
+        `This provider is for "${providerFramework}" agents.`,
+    );
+  }
+
+  // Get credential and inject
+  const credentialName = getCredentialNameForType(providerType);
+  const credentialValue = await getCredentialValue(
+    userScope.id,
+    credentialName,
+  );
+
+  if (credentialValue) {
+    credentials = credentials || {};
+    credentials[credentialName] = credentialValue;
+    log.debug(`Injected model provider credential: ${credentialName}`);
+  }
+
+  return { credentials, credentialName };
+}
+
+/**
+ * Fetch credentials referenced in compose environment
+ */
+async function fetchReferencedCredentials(
+  userId: string,
+  environment: Record<string, string> | undefined,
+): Promise<Record<string, string> | undefined> {
+  if (!environment) {
+    return undefined;
+  }
+
+  const refs = extractVariableReferences(environment);
+  const grouped = groupVariablesBySource(refs);
+
+  if (grouped.credentials.length === 0) {
+    return undefined;
+  }
+
+  log.debug(
+    `Credentials referenced in environment: ${grouped.credentials.map((r) => r.name).join(", ")}`,
+  );
+
+  const userScope = await getUserScopeByClerkId(userId);
+  if (!userScope) {
+    return undefined;
+  }
+
+  const credentials = await getCredentialValues(userScope.id);
+  log.debug(
+    `Fetched ${Object.keys(credentials).length} credential(s) from scope ${userScope.slug}`,
+  );
+  return credentials;
+}
+
+/**
+ * Auto-inject model provider credential into environment
+ * Returns the potentially modified environment
+ */
+function autoInjectCredentialToEnvironment(
+  environment: Record<string, string> | undefined,
+  credentialName: string | undefined,
+  credentials: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!credentialName || !credentials?.[credentialName]) {
+    return environment;
+  }
+
+  // Only inject if not already set (user-defined environment takes precedence)
+  if (environment?.[credentialName]) {
+    return environment;
+  }
+
+  const result = environment || {};
+  result[credentialName] = credentials[credentialName]!;
+  log.debug(
+    `Auto-injected model provider credential to environment: ${credentialName}`,
+  );
+  return result;
+}
+
+/**
  * Parameters for building execution context
  */
 export interface BuildContextParams {
@@ -119,7 +285,6 @@ async function loadAgentComposeForNewRun(
  * @param params Unified run parameters
  * @returns Execution context for executors
  */
-// eslint-disable-next-line complexity -- TODO: refactor complex function
 export async function buildExecutionContext(
   params: BuildContextParams,
 ): Promise<ExecutionContext> {
@@ -199,123 +364,43 @@ export async function buildExecutionContext(
 
   // Step 4: Check if credentials are needed and fetch them from the user's scope
   let credentials: Record<string, string> | undefined;
-  // Track which credential is for model provider auto-injection
-  let modelProviderCredentialName: string | undefined;
 
-  // Extract variable references from compose to check for credentials
+  // Extract compose structure
   const compose = agentCompose as {
     agents?: Record<
       string,
       { environment?: Record<string, string>; framework?: string }
     >;
   };
-  if (compose?.agents) {
-    const agents = Object.values(compose.agents);
-    const firstAgent = agents[0];
-    if (firstAgent?.environment) {
-      const refs = extractVariableReferences(firstAgent.environment);
-      const grouped = groupVariablesBySource(refs);
+  const firstAgent = compose?.agents
+    ? Object.values(compose.agents)[0]
+    : undefined;
 
-      // If credentials are referenced, fetch them from the user's scope
-      if (grouped.credentials.length > 0) {
-        log.debug(
-          `Credentials referenced in environment: ${grouped.credentials.map((r) => r.name).join(", ")}`,
-        );
+  // Fetch credentials referenced in environment
+  credentials = await fetchReferencedCredentials(
+    params.userId,
+    firstAgent?.environment,
+  );
 
-        const userScope = await getUserScopeByClerkId(params.userId);
-        if (userScope) {
-          credentials = await getCredentialValues(userScope.id);
-          log.debug(
-            `Fetched ${Object.keys(credentials).length} credential(s) from scope ${userScope.slug}`,
-          );
-        }
-      }
-    }
+  // Step 4b: Model provider credential injection
+  const hasExplicitLLMConfig = LLM_ENV_VARS.some(
+    (v) => firstAgent?.environment?.[v] !== undefined,
+  );
+  const framework = firstAgent?.framework || "claude-code";
 
-    // Step 4b: Model provider credential injection
-    // Only inject if no explicit LLM config in compose environment
-    const LLM_ENV_VARS = [
-      "CLAUDE_CODE_OAUTH_TOKEN",
-      "ANTHROPIC_API_KEY",
-      "ANTHROPIC_BASE_URL",
-      "OPENAI_API_KEY",
-    ];
-
-    const hasExplicitLLMConfig = LLM_ENV_VARS.some(
-      (v) => firstAgent?.environment?.[v] !== undefined,
-    );
-
-    if (!hasExplicitLLMConfig) {
-      const framework = (firstAgent?.framework || "claude-code") as
-        | ModelProviderFramework
-        | "aider";
-
-      // Skip model provider injection for frameworks that don't use it
-      if (framework === "claude-code" || framework === "codex") {
-        const userScope = await getUserScopeByClerkId(params.userId);
-
-        if (userScope) {
-          // Resolve model provider (explicit or default)
-          let providerType: ModelProviderType | undefined;
-
-          if (params.modelProvider) {
-            // Validate that the specified model provider type is valid
-            if (!(params.modelProvider in MODEL_PROVIDER_TYPES)) {
-              throw new BadRequestError(
-                `Unknown model provider type "${params.modelProvider}". Valid types: ${Object.keys(MODEL_PROVIDER_TYPES).join(", ")}`,
-              );
-            }
-            providerType = params.modelProvider as ModelProviderType;
-          } else {
-            // Get default provider for framework
-            const defaultProvider = await getDefaultModelProvider(
-              userScope.id,
-              framework,
-            );
-            providerType = defaultProvider?.type;
-          }
-
-          if (providerType) {
-            // Validate framework compatibility
-            const providerFramework = getFrameworkForType(providerType);
-            if (providerFramework !== framework) {
-              throw new BadRequestError(
-                `Model provider "${providerType}" is not compatible with framework "${framework}". ` +
-                  `This provider is for "${providerFramework}" agents.`,
-              );
-            }
-
-            // Get credential and inject
-            const credentialName = getCredentialNameForType(providerType);
-            const credentialValue = await getCredentialValue(
-              userScope.id,
-              credentialName,
-            );
-
-            if (credentialValue) {
-              credentials = credentials || {};
-              credentials[credentialName] = credentialValue;
-              modelProviderCredentialName = credentialName;
-              log.debug(
-                `Injected model provider credential: ${credentialName}`,
-              );
-            }
-          } else {
-            // No model provider configured - throw helpful error
-            throw new BadRequestError(
-              "No LLM configuration found. " +
-                "Run 'vm0 model-provider setup' to configure a model provider, " +
-                "or add environment variables to your vm0.yaml.",
-            );
-          }
-        }
-      }
-    }
-  }
+  const modelProviderResult = await resolveModelProviderCredential(
+    params.userId,
+    framework,
+    hasExplicitLLMConfig,
+    credentials,
+    params.modelProvider,
+  );
+  credentials = modelProviderResult.credentials;
+  const modelProviderCredentialName = modelProviderResult.credentialName;
 
   // Step 5: Expand environment variables from compose config using vars, secrets, and credentials
   // When experimental_firewall.experimental_seal_secrets is enabled, secrets are encrypted
-  let { environment } = expandEnvironmentFromCompose(
+  const { environment: expandedEnvironment } = expandEnvironmentFromCompose(
     agentCompose,
     vars,
     secrets,
@@ -325,22 +410,11 @@ export async function buildExecutionContext(
   );
 
   // Step 5b: Auto-inject model provider credential into environment
-  // This ensures the credential is available even when no environment block exists
-  if (
-    modelProviderCredentialName &&
-    credentials?.[modelProviderCredentialName]
-  ) {
-    // Only inject if not already set (user-defined environment takes precedence)
-    if (!environment?.[modelProviderCredentialName]) {
-      environment = environment || {};
-      // We've already checked credentials[modelProviderCredentialName] is truthy above
-      environment[modelProviderCredentialName] =
-        credentials[modelProviderCredentialName]!;
-      log.debug(
-        `Auto-injected model provider credential to environment: ${modelProviderCredentialName}`,
-      );
-    }
-  }
+  const environment = autoInjectCredentialToEnvironment(
+    expandedEnvironment,
+    modelProviderCredentialName,
+    credentials,
+  );
 
   // Step 6: Merge credentials into secrets for client-side log masking
   // Credentials are server-stored user-level secrets and must be masked like CLI secrets


### PR DESCRIPTION
## Summary

- Fixes model provider credentials not being auto-injected when vm0.yaml has no environment block
- Adds unit tests to verify the fix and ensure user-defined environment takes precedence

## Test plan

- [x] Added unit test: "auto-injects model provider credential into environment when no environment block exists"
- [x] Added unit test: "user-defined environment takes precedence over auto-injected credential"
- [x] All model provider tests pass (9/9)
- [x] All run-service tests pass (29/29)
- [ ] Manual test with minimal vm0.yaml (no environment block) using `vm0 cook start`

Fixes #1557

🤖 Generated with [Claude Code](https://claude.ai/code)