### PR TITLE
feat(cli): add ls alias and remove --json from credential list

### DIFF
--- a/e2e/tests/02-parallel/t29-vm0-credential.bats
+++ b/e2e/tests/02-parallel/t29-vm0-credential.bats
@@ -45,16 +45,14 @@ teardown() {
     assert_output --partial "credential(s)"
 }
 
-@test "vm0 experimental-credential list --json outputs valid JSON" {
+@test "vm0 experimental-credential ls works as alias for list" {
     # First create a credential
     $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "secret-value"
 
-    # List in JSON format
-    run $CLI_COMMAND experimental-credential list --json
+    # List using ls alias
+    run $CLI_COMMAND experimental-credential ls
     assert_success
-
-    # Verify JSON is valid and contains our credential
-    echo "$output" | jq -e ".[] | select(.name == \"$TEST_CRED_NAME\")"
+    assert_output --partial "$TEST_CRED_NAME"
 }
 
 @test "vm0 experimental-credential set updates existing credential" {
@@ -81,12 +79,9 @@ teardown() {
     assert_output --partial "Credential \"$TEST_CRED_NAME\" deleted"
 
     # Verify it's gone
-    run $CLI_COMMAND experimental-credential list --json
+    run $CLI_COMMAND experimental-credential list
     assert_success
-    # Should not contain our credential
-    if echo "$output" | jq -e ".[] | select(.name == \"$TEST_CRED_NAME\")" >/dev/null 2>&1; then
-        fail "Credential should have been deleted"
-    fi
+    refute_output --partial "$TEST_CRED_NAME"
 }
 
 # ============================================================================

--- a/turbo/apps/cli/src/__tests__/credential-command.test.ts
+++ b/turbo/apps/cli/src/__tests__/credential-command.test.ts
@@ -65,7 +65,7 @@ describe("Credential Command", () => {
       mockStdoutWrite.mockRestore();
     });
 
-    it("experimental-credential list --help shows options", async () => {
+    it("experimental-credential list --help shows ls alias", async () => {
       const mockStdoutWrite = vi
         .spyOn(process.stdout, "write")
         .mockImplementation(() => true);
@@ -79,7 +79,7 @@ describe("Credential Command", () => {
       const output = mockStdoutWrite.mock.calls.map((call) => call[0]).join("");
 
       expect(output).toContain("List all credentials");
-      expect(output).toContain("--json");
+      expect(output).toContain("ls");
 
       mockStdoutWrite.mockRestore();
     });

--- a/turbo/apps/cli/src/commands/credential/list.ts
+++ b/turbo/apps/cli/src/commands/credential/list.ts
@@ -4,16 +4,11 @@ import { listCredentials } from "../../lib/api";
 
 export const listCommand = new Command()
   .name("list")
+  .alias("ls")
   .description("List all credentials")
-  .option("--json", "Output in JSON format")
-  .action(async (options: { json?: boolean }) => {
+  .action(async () => {
     try {
       const result = await listCredentials();
-
-      if (options.json) {
-        console.log(JSON.stringify(result.credentials, null, 2));
-        return;
-      }
 
       if (result.credentials.length === 0) {
         console.log(chalk.dim("No credentials found."));


### PR DESCRIPTION
## Summary

- Add `ls` as alias for `experimental-credential list` command (consistency with other CLI commands)
- Remove `--json` option from the list command (no longer needed)
- Update unit tests to verify `ls` alias appears in help text
- Update E2E tests to use `ls` alias and remove `--json` usage

## Test plan

- [x] Unit tests pass (`pnpm vitest run apps/cli/src/__tests__/credential-command.test.ts`)
- [x] Lint passes
- [x] Type check passes
- [ ] E2E tests pass (CI will verify)

Closes #1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)