### PR TITLE
refactor(cli): update vm0 init to use model-provider instead of env vars

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/init.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/init.test.ts
@@ -165,7 +165,6 @@ describe("init command", () => {
         "# Build agentic workflow using natural language",
       );
       expect(content).toContain("# Agent skills");
-      expect(content).toContain("CLAUDE_CODE_OAUTH_TOKEN");
     });
 
     it("should display next steps after creation", async () => {
@@ -178,7 +177,7 @@ describe("init command", () => {
         expect.stringContaining("claude setup-token"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("CLAUDE_CODE_OAUTH_TOKEN"),
+        expect.stringContaining("vm0 model-provider setup"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("vm0 cook"),

--- a/turbo/apps/cli/src/commands/__tests__/init.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/init.test.ts
@@ -174,10 +174,10 @@ describe("init command", () => {
 
       expect(mockConsoleLog).toHaveBeenCalledWith("Next steps:");
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("claude setup-token"),
+        expect.stringContaining("vm0 model-provider setup"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("vm0 model-provider setup"),
+        expect.stringContaining("AGENTS.md"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("vm0 cook"),

--- a/turbo/apps/cli/src/commands/init.ts
+++ b/turbo/apps/cli/src/commands/init.ts
@@ -20,9 +20,6 @@ agents:
     # Agent skills - see https://github.com/vm0-ai/vm0-skills for available skills
     # skills:
     #   - https://github.com/vm0-ai/vm0-skills/tree/main/github
-    environment:
-      # Get token using: claude setup-token, then add to .env file
-      CLAUDE_CODE_OAUTH_TOKEN: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 `;
 }
 
@@ -130,8 +127,9 @@ export const initCommand = new Command()
     console.log(
       `  1. Get your Claude Code token: ${chalk.cyan("claude setup-token")}`,
     );
-    console.log(`  2. Set the environment variable (or add to .env file):`);
-    console.log(chalk.dim(`     export CLAUDE_CODE_OAUTH_TOKEN=<your-token>`));
+    console.log(
+      `  2. Configure your model provider: ${chalk.cyan("vm0 model-provider setup")}`,
+    );
     console.log(
       `  3. Run your agent: ${chalk.cyan(`vm0 cook "let's start working."`)}`,
     );

--- a/turbo/apps/cli/src/commands/init.ts
+++ b/turbo/apps/cli/src/commands/init.ts
@@ -125,10 +125,10 @@ export const initCommand = new Command()
     console.log();
     console.log("Next steps:");
     console.log(
-      `  1. Get your Claude Code token: ${chalk.cyan("claude setup-token")}`,
+      `  1. Set model provider (one-time): ${chalk.cyan("vm0 model-provider setup")}`,
     );
     console.log(
-      `  2. Configure your model provider: ${chalk.cyan("vm0 model-provider setup")}`,
+      `  2. Edit ${chalk.cyan("AGENTS.md")} to customize your agent's workflow`,
     );
     console.log(
       `  3. Run your agent: ${chalk.cyan(`vm0 cook "let's start working."`)}`,


### PR DESCRIPTION
## Summary

- Remove environment section from generated vm0.yaml template
- Update "Next steps" to guide users to vm0 model-provider setup instead of manual env var configuration
- Update unit tests to reflect new template and messaging

## Test plan

- [x] Unit tests pass (`pnpm vitest run apps/cli/src/commands/__tests__/init.test.ts`)
- [x] Lint passes
- [x] Type check passes
- [x] Knip passes
- [ ] E2E tests pass (CI)

Closes #1564

🤖 Generated with [Claude Code](https://claude.com/claude-code)