### PR TITLE
perf(web): prioritize clerk session auth over cli token validation

### DIFF
--- a/turbo/apps/web/src/lib/auth/get-user-id.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-id.ts
@@ -17,6 +17,11 @@ const log = logger("auth:user");
  * This ensures sandbox tokens cannot access normal user APIs.
  */
 export async function getUserId(): Promise<string | null> {
+  const { userId } = await auth();
+  if (userId) {
+    return userId;
+  }
+
   const headersList = await headers();
   const authHeader = headersList.get("Authorization");
 
@@ -60,7 +65,5 @@ export async function getUserId(): Promise<string | null> {
     return null;
   }
 
-  // Fall back to Clerk session auth
-  const { userId } = await auth();
   return userId;
 }


### PR DESCRIPTION
## Summary
- Prioritize Clerk session authentication over CLI token validation in `getUserId()`
- Check Clerk session first before attempting header parsing and database queries
- For most web users already authenticated via Clerk, this avoids unnecessary overhead

## Test plan
- [ ] Verify web users authenticated via Clerk session are not affected
- [ ] Verify CLI token authentication still works correctly
- [ ] Verify sandbox token rejection still works

Generated with [Claude Code](https://claude.ai/code)