### PR TITLE
test(web): add test for clerk auth priority over sandbox token

### DIFF
--- a/turbo/apps/web/src/lib/auth/get-user-id.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-id.ts
@@ -9,19 +9,26 @@ import { logger } from "../logger";
 const log = logger("auth:user");
 
 /**
- * Get the current user ID from CLI token or Clerk session
+ * Get the current user ID from Clerk session or CLI token
  * Returns null if not authenticated
+ *
+ * Priority:
+ * 1. Clerk session auth (for web users)
+ * 2. CLI token auth (for CLI/API users)
  *
  * IMPORTANT: This function rejects sandbox JWT tokens.
  * Sandbox tokens can only be used on webhook endpoints via getSandboxAuth().
  * This ensures sandbox tokens cannot access normal user APIs.
  */
 export async function getUserId(): Promise<string | null> {
+  // Check Clerk session first - most web users are authenticated via Clerk
+  // This avoids unnecessary header parsing and database queries
   const { userId } = await auth();
   if (userId) {
     return userId;
   }
 
+  // Fall back to Authorization header for CLI tokens
   const headersList = await headers();
   const authHeader = headersList.get("Authorization");
 
@@ -57,13 +64,8 @@ export async function getUserId(): Promise<string | null> {
 
         return tokenRecord.userId;
       }
-
-      return null;
     }
-
-    // Unknown token format
-    return null;
   }
 
-  return userId;
+  return null;
 }


### PR DESCRIPTION
## Summary
- Add test case verifying that Clerk session auth takes priority even when a sandbox token is present in the Authorization header
- Improve documentation in `get-user-id.ts` to clarify the auth priority order (Clerk first, CLI token second)
- Clean up redundant return statements in the auth flow

## Test plan
- [x] All 781 tests pass locally
- [x] New test validates Clerk auth priority when sandbox token is present
- [x] Pre-commit hooks pass (lint, types, format, knip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)