### PR TITLE
refactor(auth): make secrets encryption key required

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -228,6 +228,9 @@ describe("POST /api/agent/runs - Fire-and-Forget Execution", () => {
     });
 
     it("should return 'failed' status if sandbox preparation fails", async () => {
+      // Silence expected error logs in this test
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
       // Make E2B SDK throw an error
       vi.mocked(Sandbox.create).mockRejectedValue(
         new Error("Sandbox creation failed"),
@@ -261,6 +264,9 @@ describe("POST /api/agent/runs - Fire-and-Forget Execution", () => {
       expect(failedRun!.status).toBe("failed");
       expect(failedRun!.error).toContain("Sandbox creation failed");
       expect(failedRun!.completedAt).toBeDefined();
+
+      // Verify error was logged (validates error handling path)
+      expect(errorSpy).toHaveBeenCalled();
     });
 
     it("should return quickly even with complex context building", async () => {

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -22,3 +22,6 @@ process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
   "pk_test_mock_instance.clerk.accounts.dev$";
 process.env.CLERK_SECRET_KEY = "sk_test_mock_secret_key_for_testing";
 process.env.AXIOM_DATASET_SUFFIX = "dev";
+// 64 hex chars = 32 bytes encryption key for sandbox token signing
+process.env.SECRETS_ENCRYPTION_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";

--- a/turbo/apps/web/src/lib/auth/sandbox-token.ts
+++ b/turbo/apps/web/src/lib/auth/sandbox-token.ts
@@ -1,4 +1,4 @@
-import { createHmac, hkdfSync, randomBytes } from "crypto";
+import { createHmac, hkdfSync } from "crypto";
 import { env } from "../../env";
 import { logger } from "../logger";
 
@@ -45,14 +45,7 @@ function base64UrlDecode(data: string): Buffer {
 function deriveJwtKey(): Buffer {
   const keyHex = env().SECRETS_ENCRYPTION_KEY;
   if (!keyHex) {
-    // Development fallback - NOT FOR PRODUCTION
-    if (env().NODE_ENV === "production") {
-      throw new Error("SECRETS_ENCRYPTION_KEY must be set in production");
-    }
-    log.warn(
-      "SECRETS_ENCRYPTION_KEY not configured, using random key (dev mode only)",
-    );
-    return randomBytes(32);
+    throw new Error("SECRETS_ENCRYPTION_KEY must be configured");
   }
 
   const masterKey = Buffer.from(keyHex, "hex");


### PR DESCRIPTION
## Summary
- Remove development fallback for missing `SECRETS_ENCRYPTION_KEY` and require it in all environments
- Add test encryption key to test setup for proper test environment configuration  
- Add error spy in test to silence expected console.error output during failure test cases

## Test plan
- [x] All 2189 tests pass
- [x] Type checking passes
- [x] Linting passes
- [x] Knip finds no unused code

---
Generated with [Claude Code](https://claude.com/claude-code)