### PR TITLE
test(runner): add vsock integration tests and fix connection bugs

### DIFF
--- a/turbo/apps/runner/scripts/deploy/vsock-agent.py
+++ b/turbo/apps/runner/scripts/deploy/vsock-agent.py
@@ -6,9 +6,14 @@ Protocol: 4-byte length prefix (big endian) + JSON message
 Messages: ready, ping/pong, exec/exec_result, error
 
 No socat needed - Python has native vsock support via socket.AF_VSOCK.
+
+For testing, supports Unix Domain Socket mode with --unix-socket option,
+which simulates Firecracker's vsock proxy handshake (CONNECT/OK).
 """
 
+import argparse
 import json
+import os
 import socket
 import struct
 import subprocess
@@ -96,9 +101,42 @@ def handle(msg: dict) -> dict:
         return {"type": "error", "id": msg_id, "payload": {"message": f"Unknown type: {msg_type}"}}
 
 
-def handle_connection(conn: socket.socket) -> None:
+def handle_connection(conn: socket.socket, uds_mode: bool = False) -> None:
     """Handle a single host connection."""
     log("INFO", "Host connected")
+
+    # In UDS mode, simulate Firecracker's vsock proxy handshake
+    if uds_mode:
+        try:
+            # Read "CONNECT port\n" from client
+            handshake_data = b""
+            while b"\n" not in handshake_data:
+                chunk = conn.recv(1024)
+                if not chunk:
+                    log("ERROR", "Connection closed during handshake")
+                    conn.close()
+                    return
+                handshake_data += chunk
+
+            handshake_line = handshake_data.split(b"\n")[0].decode("utf-8")
+            if handshake_line.startswith("CONNECT "):
+                port = handshake_line.split()[1]
+                log("INFO", f"UDS handshake: CONNECT {port}")
+                conn.sendall(f"OK {port}\n".encode("utf-8"))
+            else:
+                log("ERROR", f"Invalid handshake: {handshake_line}")
+                conn.close()
+                return
+        except Exception as e:
+            log("ERROR", f"Handshake error: {e}")
+            conn.close()
+            return
+
+    _handle_messages(conn)
+
+
+def _handle_messages(conn: socket.socket) -> None:
+    """Handle message loop after connection is established."""
     decoder = Decoder()
 
     # Send ready signal
@@ -123,25 +161,51 @@ def handle_connection(conn: socket.socket) -> None:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Vsock agent for Firecracker VM")
+    parser.add_argument(
+        "--unix-socket",
+        type=str,
+        help="Use Unix Domain Socket instead of vsock (for testing)",
+    )
+    args = parser.parse_args()
+
+    uds_mode = args.unix_socket is not None
+
     log("INFO", "Starting vsock agent...")
 
-    # Create vsock socket directly (no socat needed)
-    sock = socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.bind((socket.VMADDR_CID_ANY, VSOCK_PORT))
-    sock.listen(5)
+    if uds_mode:
+        # Unix Domain Socket mode for testing
+        socket_path = args.unix_socket
+        if os.path.exists(socket_path):
+            os.unlink(socket_path)
 
-    log("INFO", f"Listening on vsock port {VSOCK_PORT}")
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(socket_path)
+        sock.listen(5)
+        log("INFO", f"Listening on Unix socket: {socket_path}")
+    else:
+        # Real vsock mode for production
+        sock = socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((socket.VMADDR_CID_ANY, VSOCK_PORT))
+        sock.listen(5)
+        log("INFO", f"Listening on vsock port {VSOCK_PORT}")
 
     try:
         while True:
             conn, addr = sock.accept()
-            log("INFO", f"Accepted connection from CID={addr[0]} port={addr[1]}")
-            handle_connection(conn)
+            if uds_mode:
+                log("INFO", "Accepted Unix socket connection")
+            else:
+                log("INFO", f"Accepted connection from CID={addr[0]} port={addr[1]}")
+            handle_connection(conn, uds_mode)
     except KeyboardInterrupt:
         log("INFO", "Shutting down")
     finally:
         sock.close()
+        if uds_mode and os.path.exists(args.unix_socket):
+            os.unlink(args.unix_socket)
 
 
 if __name__ == "__main__":

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/vsock.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/vsock.test.ts
@@ -1,0 +1,322 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { spawn, type ChildProcess } from "node:child_process";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { VsockClient } from "../vsock.js";
+
+/**
+ * Integration tests for VsockClient and vsock-agent.py
+ *
+ * These tests start a real Python vsock-agent process in UDS mode
+ * and verify the full communication protocol between host and guest.
+ */
+
+const AGENT_SCRIPT = path.resolve(
+  __dirname,
+  "../../../../scripts/deploy/vsock-agent.py",
+);
+
+// Helper to create a unique socket path for each test
+function createSocketPath(): string {
+  return path.join(os.tmpdir(), `vsock-test-${process.pid}-${Date.now()}.sock`);
+}
+
+// Helper to wait for socket file to exist
+async function waitForSocket(
+  socketPath: string,
+  timeoutMs: number = 5000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (fs.existsSync(socketPath)) {
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`Socket ${socketPath} not created within ${timeoutMs}ms`);
+}
+
+// Helper to start the Python agent
+async function startAgent(socketPath: string): Promise<ChildProcess> {
+  const agent = spawn("python3", [AGENT_SCRIPT, "--unix-socket", socketPath], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  // Wait for socket to be created
+  await waitForSocket(socketPath);
+
+  // Give agent a moment to start listening
+  await new Promise((r) => setTimeout(r, 100));
+
+  return agent;
+}
+
+// Helper to stop the agent and cleanup
+async function stopAgent(
+  agent: ChildProcess | null,
+  socketPath: string,
+): Promise<void> {
+  if (agent && !agent.killed) {
+    agent.kill("SIGTERM");
+    // Wait for process to exit
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => {
+        agent.kill("SIGKILL");
+        resolve();
+      }, 1000);
+      agent.on("exit", () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+  }
+
+  // Clean up socket file
+  if (socketPath && fs.existsSync(socketPath)) {
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {
+      // Ignore
+    }
+  }
+}
+
+describe("VsockClient Integration Tests", () => {
+  let socketPath: string;
+  let agent: ChildProcess | null = null;
+  let client: VsockClient | null = null;
+
+  beforeAll(() => {
+    // Verify agent script exists
+    if (!fs.existsSync(AGENT_SCRIPT)) {
+      throw new Error(`Agent script not found: ${AGENT_SCRIPT}`);
+    }
+  });
+
+  beforeEach(async () => {
+    socketPath = createSocketPath();
+    agent = await startAgent(socketPath);
+    client = new VsockClient(socketPath);
+  });
+
+  afterEach(async () => {
+    // Close client first
+    if (client) {
+      client.close();
+      client = null;
+    }
+    // Then stop agent
+    await stopAgent(agent, socketPath);
+    agent = null;
+  });
+
+  afterAll(() => {
+    // Cleanup any leftover sockets
+    const tmpDir = os.tmpdir();
+    try {
+      const files = fs.readdirSync(tmpDir);
+      for (const file of files) {
+        if (file.startsWith("vsock-test-") && file.endsWith(".sock")) {
+          try {
+            fs.unlinkSync(path.join(tmpDir, file));
+          } catch {
+            // Ignore
+          }
+        }
+      }
+    } catch {
+      // Ignore
+    }
+  });
+
+  describe("Connection", () => {
+    it("should connect and verify reachability", async () => {
+      const reachable = await client!.isReachable();
+      expect(reachable).toBe(true);
+    });
+
+    it("should handle connection to non-existent socket", async () => {
+      const badClient = new VsockClient("/non/existent/socket.sock");
+      const reachable = await badClient.isReachable();
+      expect(reachable).toBe(false);
+    });
+
+    it("should wait until reachable", async () => {
+      await client!.waitUntilReachable(5000, 100);
+      // If we get here without error, the test passes
+    });
+  });
+
+  describe("exec", () => {
+    it("should execute simple command", async () => {
+      const result = await client!.exec("echo hello");
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("hello");
+      expect(result.stderr).toBe("");
+    });
+
+    it("should return stderr on error", async () => {
+      const result = await client!.exec("echo error >&2 && exit 1");
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr.trim()).toBe("error");
+    });
+
+    it("should handle command with special characters", async () => {
+      const result = await client!.exec("echo 'hello world' | cat");
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("hello world");
+    });
+
+    it("should handle multiline output", async () => {
+      const result = await client!.exec("printf 'line1\\nline2\\nline3\\n'");
+      expect(result.exitCode).toBe(0);
+      const lines = result.stdout.trim().split("\n");
+      expect(lines).toHaveLength(3);
+      expect(lines[0]).toBe("line1");
+      expect(lines[1]).toBe("line2");
+      expect(lines[2]).toBe("line3");
+    });
+
+    it("should handle environment variables", async () => {
+      const result = await client!.exec(
+        "export TEST_VAR=hello; echo $TEST_VAR",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("hello");
+    });
+  });
+
+  describe("execOrThrow", () => {
+    it("should return stdout on success", async () => {
+      const output = await client!.execOrThrow("echo success");
+      expect(output.trim()).toBe("success");
+    });
+
+    it("should throw on non-zero exit code", async () => {
+      await expect(client!.execOrThrow("exit 1")).rejects.toThrow(
+        /Command failed/,
+      );
+    });
+
+    it("should include stderr in error message", async () => {
+      await expect(
+        client!.execOrThrow("echo 'error message' >&2 && exit 1"),
+      ).rejects.toThrow(/error message/);
+    });
+  });
+
+  describe("File Operations", () => {
+    it("should write and read file", async () => {
+      const testPath = "/tmp/vsock-test-file.txt";
+      const content = "Hello, vsock!";
+
+      await client!.writeFile(testPath, content);
+      const readContent = await client!.readFile(testPath);
+
+      expect(readContent).toBe(content);
+
+      // Cleanup
+      await client!.exec(`rm -f ${testPath}`);
+    });
+
+    it("should write large file in chunks", async () => {
+      const testPath = "/tmp/vsock-test-large.txt";
+      // Create content larger than 65KB chunk size
+      const content = "x".repeat(100000);
+
+      await client!.writeFile(testPath, content);
+      const readContent = await client!.readFile(testPath);
+
+      expect(readContent.length).toBe(content.length);
+      expect(readContent).toBe(content);
+
+      // Cleanup
+      await client!.exec(`rm -f ${testPath}`);
+    });
+
+    it("should write file with special characters", async () => {
+      const testPath = "/tmp/vsock-test-special.txt";
+      const content = 'Line1\nLine2\tTabbed\n"Quoted"';
+
+      await client!.writeFile(testPath, content);
+      const readContent = await client!.readFile(testPath);
+
+      expect(readContent).toBe(content);
+
+      // Cleanup
+      await client!.exec(`rm -f ${testPath}`);
+    });
+
+    it("should throw on reading non-existent file", async () => {
+      await expect(
+        client!.readFile("/non/existent/file.txt"),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("Directory Operations", () => {
+    it("should create directory", async () => {
+      const testDir = "/tmp/vsock-test-dir";
+
+      await client!.mkdir(testDir);
+      const exists = await client!.exists(testDir);
+
+      expect(exists).toBe(true);
+
+      // Cleanup
+      await client!.exec(`rm -rf ${testDir}`);
+    });
+
+    it("should create nested directories", async () => {
+      const testDir = "/tmp/vsock-test-nested/a/b/c";
+
+      await client!.mkdir(testDir);
+      const exists = await client!.exists(testDir);
+
+      expect(exists).toBe(true);
+
+      // Cleanup
+      await client!.exec(`rm -rf /tmp/vsock-test-nested`);
+    });
+
+    it("should check file existence", async () => {
+      const existsResult = await client!.exists("/etc/passwd");
+      expect(existsResult).toBe(true);
+
+      const notExistsResult = await client!.exists("/non/existent/path");
+      expect(notExistsResult).toBe(false);
+    });
+  });
+
+  describe("Connection Lifecycle", () => {
+    it("should handle multiple sequential commands", async () => {
+      for (let i = 0; i < 5; i++) {
+        const result = await client!.exec(`echo ${i}`);
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.trim()).toBe(String(i));
+      }
+    });
+
+    it("should reconnect after close", async () => {
+      // First connection
+      let result = await client!.exec("echo first");
+      expect(result.stdout.trim()).toBe("first");
+
+      // Close connection
+      client!.close();
+
+      // New connection should work (client auto-reconnects)
+      result = await client!.exec("echo second");
+      expect(result.stdout.trim()).toBe("second");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `--unix-socket` option to vsock-agent.py for UDS test mode
- Create integration tests for VsockClient and vsock-agent.py (20 tests)
- Fix packet coalescing bug (ready message discarded when arriving with OK)
- Fix duplicate Promise reject on timeout/error/close events
- Fix Map iteration while deleting pattern

## Test plan

- [x] All 20 vsock integration tests pass
- [x] TypeScript type check passes
- [x] Lint passes

Closes #1568

🤖 Generated with [Claude Code](https://claude.ai/code)