### PR TITLE
fix(ci): increase parallel e2e test timeout to 45s

### DIFF
--- a/.claude/skills/cli-e2e-testing/skill.md
+++ b/.claude/skills/cli-e2e-testing/skill.md
@@ -67,7 +67,7 @@ Files run in PARALLEL (up to -j 10)
 
 ### 5. Timeout Management
 
-Each test case has a **30-second timeout** (`BATS_TEST_TIMEOUT=30`).
+Each test case has a timeout: **30s for serial tests**, **45s for parallel tests**.
 
 **Don't stack multiple `vm0 run` in one case - will timeout!**
 
@@ -364,5 +364,5 @@ Before committing E2E tests:
 ## Reference
 
 - BATS documentation: https://bats-core.readthedocs.io/en/stable/writing-tests.html
-- Test timeout: `BATS_TEST_TIMEOUT=30` (30 seconds per case)
+- Test timeout: `BATS_TEST_TIMEOUT=30` (serial) / `BATS_TEST_TIMEOUT=45` (parallel)
 - Parallelization: `-j 10 --no-parallelize-within-files`

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -528,7 +528,7 @@ jobs:
       - name: Run Parallel E2E Tests
         run: |
           echo "=== Running Parallel E2E Tests ==="
-          BATS_TEST_TIMEOUT=30 ./e2e/test/libs/bats/bin/bats -T -j 10 --no-parallelize-within-files ./e2e/tests/02-parallel/*.bats
+          BATS_TEST_TIMEOUT=45 ./e2e/test/libs/bats/bin/bats -T -j 10 --no-parallelize-within-files ./e2e/tests/02-parallel/*.bats
           echo "✅ Parallel tests passed"
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,6 +1,7 @@
 // VM0 Runner - Self-hosted runner that polls the VM0 API server and executes agent jobs in isolated Firecracker microVMs
 // Deployment: Added buildkit cache retry mechanism (issue #1328)
 // CI: Refactored E2E tests with setup_file() and reduced timeout to 30s (issue #1555)
+// CI baseline check: verifying flaky test behavior (2026-01-23)
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { doctorCommand } from "./commands/doctor.js";

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,7 +1,6 @@
 // VM0 Runner - Self-hosted runner that polls the VM0 API server and executes agent jobs in isolated Firecracker microVMs
 // Deployment: Added buildkit cache retry mechanism (issue #1328)
-// CI: Refactored E2E tests with setup_file() and reduced timeout to 30s (issue #1555)
-// CI baseline check: verifying flaky test behavior (2026-01-23)
+// CI: Refactored E2E tests with setup_file() - parallel tests use 45s timeout (issue #1555)
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { doctorCommand } from "./commands/doctor.js";


### PR DESCRIPTION
## Summary

- Increase `BATS_TEST_TIMEOUT` from 30s to 45s for parallel E2E tests
- Tests were timing out with operations taking ~28-30s

## Context

Main branch CI run [#21280167727](https://github.com/vm0-ai/vm0/actions/runs/21280167727) and baseline PR run both failed with timeout errors in `cli-e2e-02-parallel`. Tests like `vm0 run continue requires secrets to be re-provided` were taking 28-30s, hitting the 30s timeout limit.

## Changes

- `.github/workflows/turbo.yml`: `BATS_TEST_TIMEOUT=30` → `BATS_TEST_TIMEOUT=45` for parallel tests
- Updated skill documentation to reflect different timeouts (30s serial, 45s parallel)

## Test plan

- [ ] CI passes with increased timeout
- [ ] No test takes longer than 45s

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)