### PR TITLE
feat(platform): add onboarding ui and model providers signal

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-model-providers.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-model-providers.ts
@@ -1,0 +1,119 @@
+/**
+ * Model Providers API Handlers
+ *
+ * Mock handlers for /api/model-providers endpoint.
+ */
+
+import { http, HttpResponse } from "msw";
+import type {
+  ModelProviderListResponse,
+  ModelProviderResponse,
+} from "@vm0/core";
+
+const DUMMY_MODEL_PROVIDER: ModelProviderResponse = {
+  id: "dummy-provider",
+  type: "claude-code-oauth-token",
+  framework: "claude-code",
+  credentialName: "CLAUDE_CODE_OAUTH_TOKEN",
+  isDefault: false,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+// Mock model providers data - empty by default (user has no providers configured)
+let mockModelProviders: ModelProviderResponse[] = [DUMMY_MODEL_PROVIDER];
+
+/**
+ * Reset mock model providers to default state
+ */
+export function resetMockModelProviders(): void {
+  mockModelProviders = [DUMMY_MODEL_PROVIDER];
+}
+
+export const apiModelProvidersHandlers = [
+  // GET /api/model-providers - List all model providers
+  http.get("/api/model-providers", () => {
+    const response: ModelProviderListResponse = {
+      modelProviders: mockModelProviders,
+    };
+    return HttpResponse.json(response);
+  }),
+
+  // PUT /api/model-providers - Create or update model provider
+  http.put("/api/model-providers", async ({ request }) => {
+    const body = (await request.json()) as {
+      type: ModelProviderResponse["type"];
+      credential: string;
+      convert?: boolean;
+    };
+
+    const now = new Date().toISOString();
+    const existing = mockModelProviders.find((p) => p.type === body.type);
+    const created = !existing;
+
+    const provider: ModelProviderResponse = {
+      id: existing?.id ?? crypto.randomUUID(),
+      type: body.type,
+      framework: body.type === "openai-api-key" ? "codex" : "claude-code",
+      credentialName:
+        body.type === "claude-code-oauth-token"
+          ? "CLAUDE_CODE_OAUTH_TOKEN"
+          : body.type === "anthropic-api-key"
+            ? "ANTHROPIC_API_KEY"
+            : "OPENAI_API_KEY",
+      isDefault:
+        mockModelProviders.length === 0 || existing?.isDefault || false,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+
+    // Update mock data
+    if (existing) {
+      mockModelProviders = mockModelProviders.map((p) =>
+        p.type === body.type ? provider : p,
+      );
+    } else {
+      mockModelProviders.push(provider);
+    }
+
+    return HttpResponse.json(
+      { provider, created },
+      { status: created ? 201 : 200 },
+    );
+  }),
+
+  // GET /api/model-providers/check/:type - Check if credential exists
+  http.get("/api/model-providers/check/:type", ({ params }) => {
+    const type = params.type as ModelProviderResponse["type"];
+    const existing = mockModelProviders.find((p) => p.type === type);
+
+    const credentialName =
+      type === "claude-code-oauth-token"
+        ? "CLAUDE_CODE_OAUTH_TOKEN"
+        : type === "anthropic-api-key"
+          ? "ANTHROPIC_API_KEY"
+          : "OPENAI_API_KEY";
+
+    return HttpResponse.json({
+      exists: !!existing,
+      credentialName,
+      ...(existing && { currentType: "model-provider" as const }),
+    });
+  }),
+
+  // DELETE /api/model-providers/:type - Delete model provider
+  http.delete("/api/model-providers/:type", ({ params }) => {
+    const type = params.type as ModelProviderResponse["type"];
+    const existing = mockModelProviders.find((p) => p.type === type);
+
+    if (!existing) {
+      return HttpResponse.json(
+        { error: { message: "Model provider not found", code: "NOT_FOUND" } },
+        { status: 404 },
+      );
+    }
+
+    mockModelProviders = mockModelProviders.filter((p) => p.type !== type);
+    return new HttpResponse(null, { status: 204 });
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -5,12 +5,21 @@
  * Import handlers from individual files and combine them here.
  */
 
+import {
+  apiModelProvidersHandlers,
+  resetMockModelProviders,
+} from "./api-model-providers.ts";
 import { apiScopeHandlers } from "./api-scope.ts";
 import { exampleHandlers } from "./example.ts";
 import { v1RunsHandlers } from "./v1-runs.ts";
 
 export const handlers = [
+  ...apiModelProvidersHandlers,
   ...apiScopeHandlers,
   ...exampleHandlers,
   ...v1RunsHandlers,
 ];
+
+export function resetAllMockHandlers(): void {
+  resetMockModelProviders();
+}

--- a/turbo/apps/platform/src/signals/__tests__/test-helpers.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-helpers.ts
@@ -2,6 +2,7 @@ import { createStore, type Store } from "ccstate";
 import { afterEach } from "vitest";
 import { logger, resetLoggerForTest } from "../log";
 import { resetLocalStorageForTest$ } from "../external/local-storage";
+import { resetAllMockHandlers } from "../../mocks/handlers";
 
 const L = logger("Test");
 
@@ -31,6 +32,7 @@ export function testContext(): TestContext {
         context.signal.addEventListener("abort", () => {
           store?.set(resetLocalStorageForTest$);
           resetLoggerForTest();
+          resetAllMockHandlers();
 
           store = null;
         });

--- a/turbo/apps/platform/src/signals/external/__tests__/model-providers.test.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/model-providers.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { testContext } from "../../__tests__/test-helpers";
+import { setupPage } from "../../../__tests__/helper";
+import { modelProviders$ } from "../model-providers";
+
+const context = testContext();
+describe("test model providers", () => {
+  it("should get correct result from msw", async () => {
+    await setupPage({
+      context,
+      path: "/",
+    });
+
+    await expect(context.store.get(modelProviders$)).resolves.toHaveProperty(
+      "modelProviders",
+      [expect.objectContaining({ id: "dummy-provider" })],
+    );
+  });
+});

--- a/turbo/apps/platform/src/signals/external/model-providers.ts
+++ b/turbo/apps/platform/src/signals/external/model-providers.ts
@@ -1,0 +1,9 @@
+import { computed } from "ccstate";
+import { fetch$ } from "../fetch";
+import type { ModelProviderListResponse } from "@vm0/core";
+
+export const modelProviders$ = computed(async (get) => {
+  const fetchFn = get(fetch$);
+  const resp = fetchFn("/api/model-providers");
+  return (await resp).json() as Promise<ModelProviderListResponse>;
+});

--- a/turbo/apps/platform/src/views/home/__tests__/home-page.test.tsx
+++ b/turbo/apps/platform/src/views/home/__tests__/home-page.test.tsx
@@ -14,7 +14,7 @@ describe("home page", () => {
       path: "/",
     });
 
-    expect(screen.getByText("Welcome, You're in.")).toBeDefined();
+    expect(screen.getByText("Welcome. You're in.")).toBeDefined();
     expect(context.store.get(pathname$)).toBe("/");
   });
 

--- a/turbo/apps/platform/src/views/home/home-page.tsx
+++ b/turbo/apps/platform/src/views/home/home-page.tsx
@@ -1,16 +1,233 @@
+import { Button } from "@vm0/ui/components/ui/button";
+import { Card } from "@vm0/ui/components/ui/card";
+import {
+  IconSparkles,
+  IconBrandGithub,
+  IconBrandDiscord,
+  IconBolt,
+  IconCopy,
+} from "@tabler/icons-react";
 import { AppShell } from "../layout/app-shell.tsx";
 import { OnboardingModal } from "./onboarding-modal.tsx";
+import { useLastResolved } from "ccstate-react";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 
 export function HomePage() {
+  const features = useLastResolved(featureSwitch$);
+
   return (
-    <AppShell
-      breadcrumb={["Get started"]}
-      title="Welcome, You're in."
-      subtitle="A few things you can explore with VM0"
-    >
-      <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50">
-        <OnboardingModal />
+    <>
+      <AppShell
+        breadcrumb={["Get started"]}
+        title="Welcome. You're in."
+        subtitle="A few things you can explore with VM0"
+        gradientBackground
+      >
+        <div className="flex flex-col gap-10 px-8 pb-8">
+          {features?.platformOnboarding && (
+            <>
+              <Step1LLMProvider />
+              <Step2SampleAgents />
+              <Step3InstallSkills />
+              <UsefulReferences />
+            </>
+          )}
+        </div>
+      </AppShell>
+      <OnboardingModal />
+    </>
+  );
+}
+
+function StepHeader({ step, title }: { step: number; title: string }) {
+  return (
+    <div className="flex items-center gap-2 mb-4">
+      <div className="w-1 h-6 bg-primary rounded-full" />
+      <h2 className="text-base font-medium text-foreground">
+        Step {step}: {title}
+      </h2>
+    </div>
+  );
+}
+
+function Step1LLMProvider() {
+  return (
+    <section>
+      <StepHeader step={1} title="Provider your LLM provider" />
+      <Card className="flex items-center justify-between p-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary-100">
+            <IconSparkles className="h-5 w-5 text-primary-800" />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-foreground">
+              Your LLM provider
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Enter LLM provider secrets
+            </p>
+          </div>
+        </div>
+        <Button size="sm">Fill</Button>
+      </Card>
+    </section>
+  );
+}
+
+function AgentCard({
+  name,
+  description,
+  icon,
+  iconBg,
+}: {
+  name: string;
+  description: string;
+  icon: React.ReactNode;
+  iconBg: string;
+}) {
+  return (
+    <Card className="flex items-center justify-between p-4">
+      <div className="flex items-center gap-3 min-w-0">
+        <div
+          className={`flex h-10 w-10 items-center justify-center rounded-lg shrink-0 ${iconBg}`}
+        >
+          {icon}
+        </div>
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-foreground truncate">{name}</p>
+          <p className="text-xs text-muted-foreground truncate">
+            {description}
+          </p>
+        </div>
       </div>
-    </AppShell>
+      <Button size="sm" className="ml-3 shrink-0">
+        Run
+      </Button>
+    </Card>
+  );
+}
+
+function Step2SampleAgents() {
+  return (
+    <section>
+      <StepHeader step={2} title="Run a sample agent" />
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <AgentCard
+          name="Hacker News Research"
+          description="Get the latest insights from Hacker News"
+          icon={<span className="text-lg font-bold text-white">Y</span>}
+          iconBg="bg-orange-500"
+        />
+        <AgentCard
+          name="TikTok Influencer Finder"
+          description="Search, filter, and surface TikTok creators for you"
+          icon={<span className="text-lg font-bold text-white">♪</span>}
+          iconBg="bg-black"
+        />
+        <AgentCard
+          name="TikTok Influencer Finder"
+          description="Search, filter, and surface TikTok creators for you"
+          icon={<span className="text-lg font-bold text-white">♪</span>}
+          iconBg="bg-black"
+        />
+      </div>
+    </section>
+  );
+}
+
+function Step3InstallSkills() {
+  const command = "npm install -g @vm0/cli";
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(command).catch(() => {
+      // Clipboard API not available
+    });
+  };
+
+  return (
+    <section>
+      <StepHeader step={3} title="Install VM0 Skills in Claude Code" />
+      <Card className="flex items-center justify-between p-4 font-mono">
+        <code className="text-sm">
+          <span className="text-primary-800">npm</span>{" "}
+          <span className="text-foreground">install -g</span>{" "}
+          <span className="text-primary-800">@vm0/cli</span>{" "}
+          <span className="text-muted-foreground">
+            {"// Install VM0 skill"}
+          </span>
+        </code>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleCopy}
+          className="shrink-0"
+        >
+          <IconCopy className="h-4 w-4" />
+        </Button>
+      </Card>
+    </section>
+  );
+}
+
+function ReferenceCard({
+  title,
+  description,
+  icon,
+  iconBg,
+  href,
+}: {
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  iconBg: string;
+  href: string;
+}) {
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      <Card className="flex items-center gap-3 p-4 hover:bg-muted/50 transition-colors cursor-pointer">
+        <div
+          className={`flex h-10 w-10 items-center justify-center rounded-lg ${iconBg}`}
+        >
+          {icon}
+        </div>
+        <div>
+          <p className="text-sm font-medium text-foreground">{title}</p>
+          <p className="text-xs text-muted-foreground">{description}</p>
+        </div>
+      </Card>
+    </a>
+  );
+}
+
+function UsefulReferences() {
+  return (
+    <section>
+      <h2 className="text-base font-medium text-foreground mb-4">
+        Useful reference
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <ReferenceCard
+          title="Explore our community"
+          description="Join us on Discord"
+          icon={<IconBrandDiscord className="h-5 w-5 text-white" />}
+          iconBg="bg-indigo-500"
+          href="https://discord.gg/vm0"
+        />
+        <ReferenceCard
+          title="Visit our GitHub"
+          description="Explore our open-source code"
+          icon={<IconBrandGithub className="h-5 w-5 text-white" />}
+          iconBg="bg-gray-900"
+          href="https://github.com/anthropics/claude-code"
+        />
+        <ReferenceCard
+          title="VM0 agent skills"
+          description="71+ of agent skills by VM0"
+          icon={<IconBolt className="h-5 w-5 text-primary-800" />}
+          iconBg="bg-primary-100"
+          href="/skills"
+        />
+      </div>
+    </section>
   );
 }

--- a/turbo/apps/platform/src/views/layout/app-shell.tsx
+++ b/turbo/apps/platform/src/views/layout/app-shell.tsx
@@ -8,6 +8,7 @@ interface AppShellProps {
   title: string;
   subtitle?: string;
   children: ReactNode;
+  gradientBackground?: boolean;
 }
 
 export function AppShell({
@@ -15,13 +16,24 @@ export function AppShell({
   title,
   subtitle,
   children,
+  gradientBackground,
 }: AppShellProps) {
   return (
     <div className="flex h-screen">
       <Sidebar />
       <div className="flex flex-1 flex-col">
         <Navbar breadcrumb={breadcrumb} />
-        <main className="flex-1 overflow-auto">
+        <main
+          className="flex-1 overflow-auto"
+          style={
+            gradientBackground
+              ? {
+                  backgroundImage:
+                    "linear-gradient(91deg, rgba(255, 200, 176, 0.26) 0%, rgba(166, 222, 255, 0.26) 51%, rgba(255, 231, 162, 0.26) 100%), linear-gradient(90deg, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 100%)",
+                }
+              : undefined
+          }
+        >
           <PageHeader title={title} subtitle={subtitle} />
           {children}
         </main>

--- a/turbo/apps/platform/src/views/layout/sidebar.tsx
+++ b/turbo/apps/platform/src/views/layout/sidebar.tsx
@@ -70,6 +70,10 @@ export function Sidebar() {
             return null;
           }
 
+          if (group.label === "Observation" && !featureSwitches?.platformLogs) {
+            return null;
+          }
+
           return (
             <div key={group.label} className="p-2">
               <div className="h-8 flex items-center px-2 opacity-70">
@@ -93,7 +97,7 @@ export function Sidebar() {
 
       <div className="p-2">
         <div className="flex flex-col gap-1">
-          <VM0SubscriptionDetailsButton />
+          {featureSwitches?.pricing && <VM0SubscriptionDetailsButton />}
           {FOOTER_NAV_ITEMS.map((item) => (
             <NavLink
               key={item.id}

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -10,4 +10,6 @@ export enum FeatureSwitchKey {
   PlatformSecrets = "platformSecrets",
   PlatformArtifacts = "platformArtifacts",
   PlatformApiKeys = "platformApiKeys",
+  PlatformOnboarding = "platformOnboarding",
+  PlatformLogs = "platformLogs",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -27,6 +27,10 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     enabled: true,
   },
+  [FeatureSwitchKey.PlatformOnboarding]: {
+    maintainer: "ethan@vm0.ai",
+    enabled: false,
+  },
   [FeatureSwitchKey.PlatformAgents]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
@@ -40,6 +44,10 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
   },
   [FeatureSwitchKey.PlatformApiKeys]: {
+    maintainer: "ethan@vm0.ai",
+    enabled: false,
+  },
+  [FeatureSwitchKey.PlatformLogs]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
   },


### PR DESCRIPTION
## Summary

- Add new home page onboarding UI with step-by-step guidance for LLM provider setup, sample agents, and CLI installation
- Introduce model providers signal with MSW mock handlers for testing
- Add feature switches for `platformOnboarding` and `platformLogs`
- Update sidebar to respect feature flags for Observation section and pricing button
- Add gradient background support to AppShell component

## Test plan
- [x] All platform tests pass
- [x] Type checking passes
- [x] Lint passes
- [x] Knip passes (no unused exports)
- [ ] Verify onboarding UI renders correctly when `platformOnboarding` feature is enabled
- [ ] Verify sidebar hides Observation section when `platformLogs` is disabled
- [ ] Verify pricing button visibility controlled by `pricing` feature flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)