### PR TITLE
fix(ci): increase e2e test timeout to 60s for parallel and runner tests

### DIFF
--- a/.claude/skills/cli-e2e-testing/skill.md
+++ b/.claude/skills/cli-e2e-testing/skill.md
@@ -67,7 +67,7 @@ Files run in PARALLEL (up to -j 10)
 
 ### 5. Timeout Management
 
-Each test case has a timeout: **30s for serial tests**, **45s for parallel tests**.
+Each test case has a timeout: **30s for serial**, **60s for parallel/runner tests**.
 
 **Don't stack multiple `vm0 run` in one case - will timeout!**
 
@@ -364,5 +364,5 @@ Before committing E2E tests:
 ## Reference
 
 - BATS documentation: https://bats-core.readthedocs.io/en/stable/writing-tests.html
-- Test timeout: `BATS_TEST_TIMEOUT=30` (serial) / `BATS_TEST_TIMEOUT=45` (parallel)
+- Test timeout: `BATS_TEST_TIMEOUT=30` (serial) / `BATS_TEST_TIMEOUT=60` (parallel/runner)
 - Parallelization: `-j 10 --no-parallelize-within-files`

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -528,7 +528,7 @@ jobs:
       - name: Run Parallel E2E Tests
         run: |
           echo "=== Running Parallel E2E Tests ==="
-          BATS_TEST_TIMEOUT=45 ./e2e/test/libs/bats/bin/bats -T -j 10 --no-parallelize-within-files ./e2e/tests/02-parallel/*.bats
+          BATS_TEST_TIMEOUT=60 ./e2e/test/libs/bats/bin/bats -T -j 10 --no-parallelize-within-files ./e2e/tests/02-parallel/*.bats
           echo "✅ Parallel tests passed"
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
@@ -604,7 +604,7 @@ jobs:
       - name: Run Runner E2E Tests
         run: |
           echo "=== Running Runner E2E Tests (4 parallel) ==="
-          BATS_TEST_TIMEOUT=30 RUNNER_GROUP="vm0/development-${JOB_REF}" ./e2e/test/libs/bats/bin/bats -T -j 4 --no-parallelize-within-files ./e2e/tests/03-experimental-runner/*.bats
+          BATS_TEST_TIMEOUT=60 RUNNER_GROUP="vm0/development-${JOB_REF}" ./e2e/test/libs/bats/bin/bats -T -j 4 --no-parallelize-within-files ./e2e/tests/03-experimental-runner/*.bats
           echo "✅ Runner tests passed"
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}


### PR DESCRIPTION
## Summary

- Increase `BATS_TEST_TIMEOUT` to 60s (1 minute) for parallel and runner E2E tests
- 45s was still too tight for some tests

## Changes

| Test Suite | Before | After |
|------------|--------|-------|
| 01-serial | 30s | 30s (unchanged) |
| 02-parallel | 45s | **60s** |
| 03-experimental-runner | 30s | **60s** |

## Test plan

- [ ] CI passes with increased timeout

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)