### PR TITLE
fix(run): recognize alternative llm auth methods in env detection

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/run-service.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-service.test.ts
@@ -790,6 +790,70 @@ describe("run-service", () => {
             .where(eq(scopes.id, testScopeId));
         });
 
+        test("skips injection when compose has alternative auth method (CLAUDE_CODE_USE_FOUNDRY)", async () => {
+          const testUserId = `model-provider-skip-foundry-${Date.now()}`;
+          const testScopeId = randomUUID();
+
+          await globalThis.services.db.insert(scopes).values({
+            id: testScopeId,
+            slug: `mp-skip-foundry-${Date.now()}`,
+            type: "personal",
+            ownerId: testUserId,
+          });
+
+          // Create a compose with Azure Foundry config (alternative auth)
+          const [compose] = await globalThis.services.db
+            .insert(agentComposes)
+            .values({
+              userId: testUserId,
+              scopeId: testScopeId,
+              name: "test-compose-foundry",
+            })
+            .returning();
+
+          const versionId = `test-version-foundry-${Date.now()}`;
+          await globalThis.services.db.insert(agentComposeVersions).values({
+            id: versionId,
+            composeId: compose!.id,
+            content: {
+              agents: {
+                "test-agent": {
+                  framework: "claude-code",
+                  working_dir: "/workspace",
+                  environment: {
+                    // Alternative auth - should be detected as explicit LLM config
+                    CLAUDE_CODE_USE_FOUNDRY: "1",
+                  },
+                },
+              },
+            },
+            createdBy: testUserId,
+          });
+
+          // Build context - should NOT throw even without model provider configured
+          const context = await runService.buildExecutionContext({
+            agentComposeVersionId: versionId,
+            prompt: "test prompt",
+            runId: `run-foundry-${Date.now()}`,
+            sandboxToken: "token",
+            userId: testUserId,
+          });
+
+          // No credentials injected from model provider (compose has alternative auth)
+          expect(context.secrets).toBeUndefined();
+
+          // Cleanup
+          await globalThis.services.db
+            .delete(agentComposeVersions)
+            .where(eq(agentComposeVersions.id, versionId));
+          await globalThis.services.db
+            .delete(agentComposes)
+            .where(eq(agentComposes.id, compose!.id));
+          await globalThis.services.db
+            .delete(scopes)
+            .where(eq(scopes.id, testScopeId));
+        });
+
         test("uses specified model provider when --model-provider is passed", async () => {
           const testUserId = `model-provider-explicit-${Date.now()}`;
           const testScopeId = randomUUID();

--- a/turbo/apps/web/src/lib/run/__tests__/run-service.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-service.test.ts
@@ -4,6 +4,7 @@ import {
   expect,
   vi,
   beforeEach,
+  afterEach,
   beforeAll,
   afterAll,
 } from "vitest";
@@ -666,9 +667,51 @@ describe("run-service", () => {
       });
 
       describe("model provider credential injection", () => {
+        // Track created scope IDs for cleanup (AP-4: use afterEach for robustness)
+        const createdScopeIds = new Set<string>();
+
+        afterEach(async () => {
+          // Clean up all resources for tracked scopes in correct order
+          for (const scopeId of createdScopeIds) {
+            // 1. Delete model providers (references credentials)
+            await globalThis.services.db
+              .delete(modelProviders)
+              .where(eq(modelProviders.scopeId, scopeId));
+
+            // 2. Find and delete compose versions for this scope
+            const scopeComposes = await globalThis.services.db
+              .select({ id: agentComposes.id })
+              .from(agentComposes)
+              .where(eq(agentComposes.scopeId, scopeId));
+
+            for (const compose of scopeComposes) {
+              await globalThis.services.db
+                .delete(agentComposeVersions)
+                .where(eq(agentComposeVersions.composeId, compose.id));
+            }
+
+            // 3. Delete composes
+            await globalThis.services.db
+              .delete(agentComposes)
+              .where(eq(agentComposes.scopeId, scopeId));
+
+            // 4. Delete credentials
+            await globalThis.services.db
+              .delete(credentials)
+              .where(eq(credentials.scopeId, scopeId));
+
+            // 5. Delete scope
+            await globalThis.services.db
+              .delete(scopes)
+              .where(eq(scopes.id, scopeId));
+          }
+          createdScopeIds.clear();
+        });
+
         test("skips injection when compose has explicit ANTHROPIC_API_KEY", async () => {
           const testUserId = `model-provider-skip-anthro-${Date.now()}`;
           const testScopeId = randomUUID();
+          createdScopeIds.add(testScopeId);
 
           await globalThis.services.db.insert(scopes).values({
             id: testScopeId,
@@ -717,22 +760,12 @@ describe("run-service", () => {
 
           // No credentials injected from model provider (compose has explicit config)
           expect(context.secrets).toBeUndefined();
-
-          // Cleanup
-          await globalThis.services.db
-            .delete(agentComposeVersions)
-            .where(eq(agentComposeVersions.id, versionId));
-          await globalThis.services.db
-            .delete(agentComposes)
-            .where(eq(agentComposes.id, compose!.id));
-          await globalThis.services.db
-            .delete(scopes)
-            .where(eq(scopes.id, testScopeId));
         });
 
         test("skips injection when compose has explicit OPENAI_API_KEY", async () => {
           const testUserId = `model-provider-skip-openai-${Date.now()}`;
           const testScopeId = randomUUID();
+          createdScopeIds.add(testScopeId);
 
           await globalThis.services.db.insert(scopes).values({
             id: testScopeId,
@@ -777,22 +810,12 @@ describe("run-service", () => {
           });
 
           expect(context.secrets).toBeUndefined();
-
-          // Cleanup
-          await globalThis.services.db
-            .delete(agentComposeVersions)
-            .where(eq(agentComposeVersions.id, versionId));
-          await globalThis.services.db
-            .delete(agentComposes)
-            .where(eq(agentComposes.id, compose!.id));
-          await globalThis.services.db
-            .delete(scopes)
-            .where(eq(scopes.id, testScopeId));
         });
 
         test("skips injection when compose has alternative auth method (CLAUDE_CODE_USE_FOUNDRY)", async () => {
           const testUserId = `model-provider-skip-foundry-${Date.now()}`;
           const testScopeId = randomUUID();
+          createdScopeIds.add(testScopeId);
 
           await globalThis.services.db.insert(scopes).values({
             id: testScopeId,
@@ -841,22 +864,12 @@ describe("run-service", () => {
 
           // No credentials injected from model provider (compose has alternative auth)
           expect(context.secrets).toBeUndefined();
-
-          // Cleanup
-          await globalThis.services.db
-            .delete(agentComposeVersions)
-            .where(eq(agentComposeVersions.id, versionId));
-          await globalThis.services.db
-            .delete(agentComposes)
-            .where(eq(agentComposes.id, compose!.id));
-          await globalThis.services.db
-            .delete(scopes)
-            .where(eq(scopes.id, testScopeId));
         });
 
         test("uses specified model provider when --model-provider is passed", async () => {
           const testUserId = `model-provider-explicit-${Date.now()}`;
           const testScopeId = randomUUID();
+          createdScopeIds.add(testScopeId);
           const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
 
           await globalThis.services.db.insert(scopes).values({
@@ -928,28 +941,12 @@ describe("run-service", () => {
           expect(context.secrets).toEqual({
             ANTHROPIC_API_KEY: "test-anthropic-api-key-value",
           });
-
-          // Cleanup
-          await globalThis.services.db
-            .delete(modelProviders)
-            .where(eq(modelProviders.scopeId, testScopeId));
-          await globalThis.services.db
-            .delete(agentComposeVersions)
-            .where(eq(agentComposeVersions.id, versionId));
-          await globalThis.services.db
-            .delete(agentComposes)
-            .where(eq(agentComposes.id, compose!.id));
-          await globalThis.services.db
-            .delete(credentials)
-            .where(eq(credentials.scopeId, testScopeId));
-          await globalThis.services.db
-            .delete(scopes)
-            .where(eq(scopes.id, testScopeId));
         });
 
         test("uses default model provider when no explicit config", async () => {
           const testUserId = `model-provider-default-${Date.now()}`;
           const testScopeId = randomUUID();
+          createdScopeIds.add(testScopeId);
           const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
 
           await globalThis.services.db.insert(scopes).values({
@@ -1019,28 +1016,12 @@ describe("run-service", () => {
           expect(context.secrets).toEqual({
             ANTHROPIC_API_KEY: "default-provider-key-value",
           });
-
-          // Cleanup
-          await globalThis.services.db
-            .delete(modelProviders)
-            .where(eq(modelProviders.scopeId, testScopeId));
-          await globalThis.services.db
-            .delete(agentComposeVersions)
-            .where(eq(agentComposeVersions.id, versionId));
-          await globalThis.services.db
-            .delete(agentComposes)
-            .where(eq(agentComposes.id, compose!.id));
-          await globalThis.services.db
-            .delete(credentials)
-            .where(eq(credentials.scopeId, testScopeId));
-          await globalThis.services.db
-            .delete(scopes)
-            .where(eq(scopes.id, testScopeId));
         });
 
         test("throws BadRequestError when no LLM config and no model provider", async () => {
           const testUserId = `model-provider-none-${Date.now()}`;
           const testScopeId = randomUUID();
+          createdScopeIds.add(testScopeId);
 
           await globalThis.services.db.insert(scopes).values({
             id: testScopeId,
@@ -1095,22 +1076,12 @@ describe("run-service", () => {
               userId: testUserId,
             }),
           ).rejects.toThrow(/No LLM configuration found/);
-
-          // Cleanup
-          await globalThis.services.db
-            .delete(agentComposeVersions)
-            .where(eq(agentComposeVersions.id, versionId));
-          await globalThis.services.db
-            .delete(agentComposes)
-            .where(eq(agentComposes.id, compose!.id));
-          await globalThis.services.db
-            .delete(scopes)
-            .where(eq(scopes.id, testScopeId));
         });
 
         test("throws BadRequestError when model provider type is invalid", async () => {
           const testUserId = `model-provider-invalid-${Date.now()}`;
           const testScopeId = randomUUID();
+          createdScopeIds.add(testScopeId);
 
           await globalThis.services.db.insert(scopes).values({
             id: testScopeId,
@@ -1166,22 +1137,12 @@ describe("run-service", () => {
               modelProvider: "non-existent-provider",
             }),
           ).rejects.toThrow(/Unknown model provider type/);
-
-          // Cleanup
-          await globalThis.services.db
-            .delete(agentComposeVersions)
-            .where(eq(agentComposeVersions.id, versionId));
-          await globalThis.services.db
-            .delete(agentComposes)
-            .where(eq(agentComposes.id, compose!.id));
-          await globalThis.services.db
-            .delete(scopes)
-            .where(eq(scopes.id, testScopeId));
         });
 
         test("throws BadRequestError when model provider incompatible with framework", async () => {
           const testUserId = `model-provider-mismatch-${Date.now()}`;
           const testScopeId = randomUUID();
+          createdScopeIds.add(testScopeId);
           const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
 
           await globalThis.services.db.insert(scopes).values({
@@ -1260,28 +1221,12 @@ describe("run-service", () => {
               modelProvider: "openai-api-key",
             }),
           ).rejects.toThrow(/not compatible with framework/);
-
-          // Cleanup
-          await globalThis.services.db
-            .delete(modelProviders)
-            .where(eq(modelProviders.scopeId, testScopeId));
-          await globalThis.services.db
-            .delete(agentComposeVersions)
-            .where(eq(agentComposeVersions.id, versionId));
-          await globalThis.services.db
-            .delete(agentComposes)
-            .where(eq(agentComposes.id, compose!.id));
-          await globalThis.services.db
-            .delete(credentials)
-            .where(eq(credentials.scopeId, testScopeId));
-          await globalThis.services.db
-            .delete(scopes)
-            .where(eq(scopes.id, testScopeId));
         });
 
         test("auto-injects model provider credential into environment when no environment block exists", async () => {
           const testUserId = `model-provider-auto-inject-${Date.now()}`;
           const testScopeId = randomUUID();
+          createdScopeIds.add(testScopeId);
           const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
 
           await globalThis.services.db.insert(scopes).values({
@@ -1356,28 +1301,12 @@ describe("run-service", () => {
           expect(context.secrets).toEqual({
             CLAUDE_CODE_OAUTH_TOKEN: "test-oauth-token-value",
           });
-
-          // Cleanup
-          await globalThis.services.db
-            .delete(modelProviders)
-            .where(eq(modelProviders.scopeId, testScopeId));
-          await globalThis.services.db
-            .delete(agentComposeVersions)
-            .where(eq(agentComposeVersions.id, versionId));
-          await globalThis.services.db
-            .delete(agentComposes)
-            .where(eq(agentComposes.id, compose!.id));
-          await globalThis.services.db
-            .delete(credentials)
-            .where(eq(credentials.scopeId, testScopeId));
-          await globalThis.services.db
-            .delete(scopes)
-            .where(eq(scopes.id, testScopeId));
         });
 
         test("user-defined environment takes precedence over auto-injected credential", async () => {
           const testUserId = `model-provider-precedence-${Date.now()}`;
           const testScopeId = randomUUID();
+          createdScopeIds.add(testScopeId);
           const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
 
           await globalThis.services.db.insert(scopes).values({
@@ -1447,23 +1376,6 @@ describe("run-service", () => {
           expect(context.environment!["ANTHROPIC_API_KEY"]).toBe(
             "user-defined-key",
           );
-
-          // Cleanup
-          await globalThis.services.db
-            .delete(modelProviders)
-            .where(eq(modelProviders.scopeId, testScopeId));
-          await globalThis.services.db
-            .delete(agentComposeVersions)
-            .where(eq(agentComposeVersions.id, versionId));
-          await globalThis.services.db
-            .delete(agentComposes)
-            .where(eq(agentComposes.id, compose!.id));
-          await globalThis.services.db
-            .delete(credentials)
-            .where(eq(credentials.scopeId, testScopeId));
-          await globalThis.services.db
-            .delete(scopes)
-            .where(eq(scopes.id, testScopeId));
         });
       });
     });

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -30,13 +30,20 @@ import { getDefaultModelProvider } from "../model-provider/model-provider-servic
 const log = logger("run:build-context");
 
 /**
- * LLM environment variables that indicate explicit configuration
+ * LLM environment variables that indicate explicit configuration.
+ * Includes both model-provider supported vars and alternative auth methods.
  */
 const LLM_ENV_VARS = [
+  // Model-provider supported
   "CLAUDE_CODE_OAUTH_TOKEN",
   "ANTHROPIC_API_KEY",
   "ANTHROPIC_BASE_URL",
   "OPENAI_API_KEY",
+  // Alternative auth methods (not model-provider supported yet)
+  "ANTHROPIC_AUTH_TOKEN",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "CLAUDE_CODE_USE_FOUNDRY",
+  "CLAUDE_CODE_USE_VERTEX",
 ];
 
 /**


### PR DESCRIPTION
## Summary

- Expand `LLM_ENV_VARS` to recognize alternative authentication methods that Claude Code supports but aren't yet offered as model-provider options
- Add unit test for Azure Foundry alternative auth detection
- Refactor model provider tests to use afterEach cleanup for robustness

## Changes

**Feature: Alternative auth detection**
Added 4 new environment variables to `LLM_ENV_VARS` detection:
- `ANTHROPIC_AUTH_TOKEN`
- `CLAUDE_CODE_USE_BEDROCK`
- `CLAUDE_CODE_USE_FOUNDRY`
- `CLAUDE_CODE_USE_VERTEX`

**Test refactor: afterEach cleanup pattern**
Moved inline test cleanup to afterEach hook in the model provider credential injection test suite:
- Track created scope IDs in a Set
- Clean up all related resources in afterEach
- Ensures cleanup runs even if tests fail

## Test plan

- [x] New unit test: "skips injection when compose has alternative auth method (CLAUDE_CODE_USE_FOUNDRY)"
- [x] All existing tests pass (30/30)
- [x] Lint passes
- [x] Type check passes

Closes #1577

🤖 Generated with [Claude Code](https://claude.com/claude-code)