### PR TITLE
feat(cli): rename experimental-credential to credential

### DIFF
--- a/.github/DEPLOYMENT_SETUP.md
+++ b/.github/DEPLOYMENT_SETUP.md
@@ -85,7 +85,7 @@ For running agent code in sandboxes:
   - Without this, the default E2B image is used (Claude Code must be manually installed)
 
 ### Anthropic-Compatible API Configuration
-To use Anthropic-compatible LLM providers (e.g., Anthropic, Minimax, or custom providers), configure environment variables in your Agent Compose YAML using user secrets:
+To use Anthropic-compatible model providers (e.g., Anthropic, Minimax, or custom providers), configure environment variables in your Agent Compose YAML using user secrets:
 
 ```yaml
 # vm0.config.yaml

--- a/docs/agent-creator.md
+++ b/docs/agent-creator.md
@@ -6,7 +6,7 @@ This skill guides users through creating a complete VM0 agent configuration. The
 
 The wizard follows these phases:
 1. Language preference selection
-2. LLM backend selection
+2. Model provider selection
 3. Workflow description gathering
 4. Skills recommendation and selection
 5. Agent instructions design (AGENTS.md)
@@ -41,12 +41,12 @@ After selection, continue the entire workflow in the user's chosen language.
 
 ---
 
-## Phase 2: LLM Backend Selection
+## Phase 2: Model Provider Selection
 
-Ask the user which LLM backend they want to use:
+Ask the user which model provider they want to use:
 
 ```
-Which LLM backend would you like to use for your agent?
+Which model provider would you like to use for your agent?
 
 1. Claude (OAuth Token) - Recommended for Claude Code users
    Run `claude setup-token` to get your token
@@ -258,7 +258,7 @@ agents:
     skills:
       - "https://github.com/vm0-ai/vm0-skills/tree/main/skill-name"
     environment:
-      # LLM backend variables (from Phase 2 selection)
+      # Model provider variables (from Phase 2 selection)
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       # Skill secrets (API keys, tokens)
       SKILL_API_KEY: ${{ secrets.SKILL_API_KEY }}
@@ -325,7 +325,7 @@ CLOUD_NAME=
 
 For each key in the .env file, provide specific instructions on how to obtain it:
 
-1. **LLM backend keys**: Refer to Phase 2 documentation links
+1. **Model provider keys**: Refer to Phase 2 documentation links
 2. **Skill keys**: Read the skill's README in https://github.com/vm0-ai/vm0-skills/tree/main/[skill-name] - each skill documents how to obtain its required credentials and config values
 
 ### Step 5: Inform user

--- a/e2e/tests/01-serial/ser-t03-vm0-model-provider.bats
+++ b/e2e/tests/01-serial/ser-t03-vm0-model-provider.bats
@@ -22,7 +22,7 @@ teardown() {
 
 teardown_file() {
     # Set a stable model provider at the end for subsequent parallel tests to use
-    # This ensures all tests in 02-parallel have a default LLM configuration
+    # This ensures all tests in 02-parallel have a default model provider configuration
     # Using claude-code-oauth-token as the default for claude-code framework
     $CLI_COMMAND model-provider setup \
         --type "claude-code-oauth-token" \

--- a/e2e/tests/02-parallel/t29-vm0-credential.bats
+++ b/e2e/tests/02-parallel/t29-vm0-credential.bats
@@ -13,11 +13,11 @@ setup() {
 
 teardown() {
     # Clean up test credential if it exists
-    $CLI_COMMAND experimental-credential delete -y "$TEST_CRED_NAME" 2>/dev/null || true
+    $CLI_COMMAND credential delete -y "$TEST_CRED_NAME" 2>/dev/null || true
 }
 
-@test "vm0 experimental-credential --help shows command description" {
-    run $CLI_COMMAND experimental-credential --help
+@test "vm0 credential --help shows command description" {
+    run $CLI_COMMAND credential --help
     assert_success
     assert_output --partial "Manage stored credentials"
     assert_output --partial "list"
@@ -25,61 +25,61 @@ teardown() {
     assert_output --partial "delete"
 }
 
-@test "vm0 experimental-credential set creates a credential" {
-    run $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "test-secret-value"
+@test "vm0 credential set creates a credential" {
+    run $CLI_COMMAND credential set "$TEST_CRED_NAME" "test-secret-value"
     assert_success
     assert_output --partial "Credential \"$TEST_CRED_NAME\" saved"
     assert_output --partial "Use in vm0.yaml"
     assert_output --partial "\${{ credentials.$TEST_CRED_NAME }}"
 }
 
-@test "vm0 experimental-credential list shows created credential" {
+@test "vm0 credential list shows created credential" {
     # First create a credential
-    $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "secret-value" --description "E2E test"
+    $CLI_COMMAND credential set "$TEST_CRED_NAME" "secret-value" --description "E2E test"
 
     # Then list credentials
-    run $CLI_COMMAND experimental-credential list
+    run $CLI_COMMAND credential list
     assert_success
     assert_output --partial "$TEST_CRED_NAME"
     assert_output --partial "E2E test"
     assert_output --partial "credential(s)"
 }
 
-@test "vm0 experimental-credential ls works as alias for list" {
+@test "vm0 credential ls works as alias for list" {
     # First create a credential
-    $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "secret-value"
+    $CLI_COMMAND credential set "$TEST_CRED_NAME" "secret-value"
 
     # List using ls alias
-    run $CLI_COMMAND experimental-credential ls
+    run $CLI_COMMAND credential ls
     assert_success
     assert_output --partial "$TEST_CRED_NAME"
 }
 
-@test "vm0 experimental-credential set updates existing credential" {
+@test "vm0 credential set updates existing credential" {
     # Create initial credential
-    $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "initial-value"
+    $CLI_COMMAND credential set "$TEST_CRED_NAME" "initial-value"
 
     # Update it
-    run $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "updated-value" --description "Updated"
+    run $CLI_COMMAND credential set "$TEST_CRED_NAME" "updated-value" --description "Updated"
     assert_success
     assert_output --partial "Credential \"$TEST_CRED_NAME\" saved"
 
     # Verify description was updated
-    run $CLI_COMMAND experimental-credential list
+    run $CLI_COMMAND credential list
     assert_output --partial "Updated"
 }
 
-@test "vm0 experimental-credential delete removes credential" {
+@test "vm0 credential delete removes credential" {
     # Create a credential
-    $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "to-be-deleted"
+    $CLI_COMMAND credential set "$TEST_CRED_NAME" "to-be-deleted"
 
     # Delete it (use -y to skip confirmation)
-    run $CLI_COMMAND experimental-credential delete -y "$TEST_CRED_NAME"
+    run $CLI_COMMAND credential delete -y "$TEST_CRED_NAME"
     assert_success
     assert_output --partial "Credential \"$TEST_CRED_NAME\" deleted"
 
     # Verify it's gone
-    run $CLI_COMMAND experimental-credential list
+    run $CLI_COMMAND credential list
     assert_success
     refute_output --partial "$TEST_CRED_NAME"
 }
@@ -107,7 +107,7 @@ teardown() {
 
     # Step 1: Create a credential in the platform
     echo "# Creating credential: $TEST_CRED_NAME"
-    run $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "$cred_value"
+    run $CLI_COMMAND credential set "$TEST_CRED_NAME" "$cred_value"
     assert_success
 
     # Step 2: Create config that uses the credential (without runner)
@@ -180,7 +180,7 @@ EOF
 
     # Step 1: Create a credential in the platform
     echo "# Creating credential: $TEST_CRED_NAME"
-    run $CLI_COMMAND experimental-credential set "$TEST_CRED_NAME" "$cred_value"
+    run $CLI_COMMAND credential set "$TEST_CRED_NAME" "$cred_value"
     assert_success
 
     # Step 2: Create config that uses both a credential and a secret

--- a/turbo/apps/cli/src/__tests__/credential-command.test.ts
+++ b/turbo/apps/cli/src/__tests__/credential-command.test.ts
@@ -43,7 +43,7 @@ describe("Credential Command", () => {
   });
 
   describe("help text", () => {
-    it("experimental-credential --help shows command description", async () => {
+    it("credential --help shows command description", async () => {
       // Commander outputs help to stdout via process.stdout.write
       const mockStdoutWrite = vi
         .spyOn(process.stdout, "write")
@@ -65,7 +65,7 @@ describe("Credential Command", () => {
       mockStdoutWrite.mockRestore();
     });
 
-    it("experimental-credential list --help shows ls alias", async () => {
+    it("credential list --help shows ls alias", async () => {
       const mockStdoutWrite = vi
         .spyOn(process.stdout, "write")
         .mockImplementation(() => true);
@@ -84,7 +84,7 @@ describe("Credential Command", () => {
       mockStdoutWrite.mockRestore();
     });
 
-    it("experimental-credential set --help shows usage", async () => {
+    it("credential set --help shows usage", async () => {
       const mockStdoutWrite = vi
         .spyOn(process.stdout, "write")
         .mockImplementation(() => true);
@@ -105,7 +105,7 @@ describe("Credential Command", () => {
       mockStdoutWrite.mockRestore();
     });
 
-    it("experimental-credential delete --help shows usage", async () => {
+    it("credential delete --help shows usage", async () => {
       const mockStdoutWrite = vi
         .spyOn(process.stdout, "write")
         .mockImplementation(() => true);

--- a/turbo/apps/cli/src/commands/credential/index.ts
+++ b/turbo/apps/cli/src/commands/credential/index.ts
@@ -4,8 +4,8 @@ import { setCommand } from "./set";
 import { deleteCommand } from "./delete";
 
 export const credentialCommand = new Command()
-  .name("experimental-credential")
-  .description("[Experimental] Manage stored credentials for agent runs")
+  .name("credential")
+  .description("Manage stored credentials for agent runs")
   .addCommand(listCommand)
   .addCommand(setCommand)
   .addCommand(deleteCommand);

--- a/turbo/apps/cli/src/commands/credential/list.ts
+++ b/turbo/apps/cli/src/commands/credential/list.ts
@@ -14,9 +14,7 @@ export const listCommand = new Command()
         console.log(chalk.dim("No credentials found."));
         console.log();
         console.log("To add a credential:");
-        console.log(
-          chalk.cyan("  vm0 experimental-credential set MY_API_KEY <value>"),
-        );
+        console.log(chalk.cyan("  vm0 credential set MY_API_KEY <value>"));
         return;
       }
 

--- a/turbo/apps/cli/src/commands/run/continue.ts
+++ b/turbo/apps/cli/src/commands/run/continue.ts
@@ -45,7 +45,7 @@ export const continueCommand = new Command()
   )
   .option(
     "--model-provider <type>",
-    "Override model provider for LLM credentials (e.g., anthropic-api-key)",
+    "Override model provider (e.g., anthropic-api-key)",
   )
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .action(

--- a/turbo/apps/cli/src/commands/run/resume.ts
+++ b/turbo/apps/cli/src/commands/run/resume.ts
@@ -43,7 +43,7 @@ export const resumeCommand = new Command()
   )
   .option(
     "--model-provider <type>",
-    "Override model provider for LLM credentials (e.g., anthropic-api-key)",
+    "Override model provider (e.g., anthropic-api-key)",
   )
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .action(

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -63,7 +63,7 @@ export const mainRunCommand = new Command()
   )
   .option(
     "--model-provider <type>",
-    "Override model provider for LLM credentials (e.g., anthropic-api-key)",
+    "Override model provider (e.g., anthropic-api-key)",
   )
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .action(

--- a/turbo/apps/cli/src/lib/api/domains/runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/runs.ts
@@ -21,7 +21,7 @@ export async function createRun(body: {
   vars?: Record<string, string>;
   secrets?: Record<string, string>;
   volumeVersions?: Record<string, string>;
-  // Model provider for automatic LLM credential injection
+  // Model provider for automatic credential injection
   modelProvider?: string;
   // Debug flag (internal use only)
   debugNoMockClaude?: boolean;

--- a/turbo/apps/docs/content/docs/core-concept/environment-variable.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/environment-variable.mdx
@@ -147,9 +147,9 @@ Organize your configuration logically:
 
 ```yaml title="vm0.yaml"
 environment:
-  # LLM Provider Configuration
-  ANTHROPIC_BASE_URL: "${{ vars.LLM_BASE_URL }}"
-  ANTHROPIC_AUTH_TOKEN: "${{ secrets.LLM_API_KEY }}"
+  # Model Provider Configuration
+  ANTHROPIC_BASE_URL: "${{ vars.MODEL_PROVIDER_BASE_URL }}"
+  ANTHROPIC_AUTH_TOKEN: "${{ secrets.MODEL_PROVIDER_API_KEY }}"
 
   # Database Configuration
   DATABASE_URL: "${{ secrets.DATABASE_URL }}"

--- a/turbo/apps/docs/content/docs/experimental/firewall.mdx
+++ b/turbo/apps/docs/content/docs/experimental/firewall.mdx
@@ -99,7 +99,7 @@ Rules are evaluated **top to bottom** with **first-match-wins** semantics:
 3. If no rule matches, traffic is **denied by default** (zero-trust)
 
 <Callout type="info">
-  The platform automatically allows essential domains (`*.vm0.ai`, `*.cloudflarestorage.com`, and your LLM provider) before your rules are evaluated.
+  The platform automatically allows essential domains (`*.vm0.ai`, `*.cloudflarestorage.com`, and your model provider) before your rules are evaluated.
 </Callout>
 
 ## Auto-Injected Rules

--- a/turbo/apps/docs/content/docs/index.mdx
+++ b/turbo/apps/docs/content/docs/index.mdx
@@ -109,7 +109,7 @@ Welcome to VM0 documentation. Get started with building AI agents.
   <Card
     title="Overview"
     href="/docs/model-selection"
-    description="Configure different LLM providers for your agents"
+    description="Configure different model providers for your agents"
   />
   <Card
     title="Claude"

--- a/turbo/apps/docs/content/docs/integration/minimax.mdx
+++ b/turbo/apps/docs/content/docs/integration/minimax.mdx
@@ -1,6 +1,6 @@
 ---
 title: MiniMax
-description: Chinese LLM for chat, TTS, and video generation
+description: Chinese model provider for chat, TTS, and video generation
 ---
 
 [MiniMax](https://platform.minimax.io/) provides AI models for chat completion, text-to-speech, and video generation optimized for Chinese language.

--- a/turbo/apps/docs/content/docs/model-selection/index.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Overview
-description: Configure different LLM providers for your agents
+description: Configure different model providers for your agents
 ---
 
-VM0 supports two agent providers: **Claude Code** and **Codex**. You can also use alternative LLM providers with Claude Code.
+VM0 supports two agent providers: **Claude Code** and **Codex**. You can also use alternative model providers with Claude Code.
 
 ## Provider Selection
 
@@ -43,13 +43,13 @@ Required environment variable:
 | ---------------- | ------------------- |
 | `OPENAI_API_KEY` | API key from OpenAI |
 
-## Alternative LLM Providers (Claude Code only)
+## Alternative Model Providers (Claude Code only)
 
 <Callout type="warning">
-  Alternative LLM providers are only supported with Claude Code, not Codex.
+  Alternative model providers are only supported with Claude Code, not Codex.
 </Callout>
 
-You can use various LLM providers that implement the Anthropic API by setting environment variables:
+You can use various model providers that implement the Anthropic API by setting environment variables:
 
 ```yaml title="vm0.yaml"
 version: "1.0"

--- a/turbo/apps/docs/content/docs/quick-start.mdx
+++ b/turbo/apps/docs/content/docs/quick-start.mdx
@@ -49,7 +49,7 @@ claude setup-token
 echo "CLAUDE_CODE_OAUTH_TOKEN=<your-token>" > .env
 ```
 
-You can also use other LLM providers instead of Claude, like Moonshot (Kimi), MiniMax, DeepSeek, Z.AI (GLM), or OpenRouter. See [Model Selection](/docs/model-selection) for configuration options.
+You can also use other model providers instead of Claude, like Moonshot (Kimi), MiniMax, DeepSeek, Z.AI (GLM), or OpenRouter. See [Model Selection](/docs/model-selection) for configuration options.
 
 ## Run Your Agent
 

--- a/turbo/apps/docs/content/docs/tutorial/my-first-agent.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/my-first-agent.mdx
@@ -87,7 +87,7 @@ Replace `<your-token>` with the actual token you received from the authenticatio
 </Callout>
 
 <Callout type="tip">
-You can also use other LLM providers instead of Claude, such as Moonshot (Kimi), MiniMax, DeepSeek, Z.AI (GLM), or OpenRouter. See [Model Selection](/docs/model-selection) for configuration options.
+You can also use other model providers instead of Claude, such as Moonshot (Kimi), MiniMax, DeepSeek, Z.AI (GLM), or OpenRouter. See [Model Selection](/docs/model-selection) for configuration options.
 </Callout>
 
 ## Step 4: Run Your First Agent

--- a/turbo/apps/platform/src/views/home/home-page.tsx
+++ b/turbo/apps/platform/src/views/home/home-page.tsx
@@ -26,7 +26,7 @@ export function HomePage() {
         <div className="flex flex-col gap-10 px-8 pb-8">
           {features?.platformOnboarding && (
             <>
-              <Step1LLMProvider />
+              <Step1ModelProvider />
               <Step2SampleAgents />
               <Step3InstallSkills />
               <UsefulReferences />
@@ -50,10 +50,10 @@ function StepHeader({ step, title }: { step: number; title: string }) {
   );
 }
 
-function Step1LLMProvider() {
+function Step1ModelProvider() {
   return (
     <section>
-      <StepHeader step={1} title="Provider your LLM provider" />
+      <StepHeader step={1} title="Configure your model provider" />
       <Card className="flex items-center justify-between p-4">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary-100">
@@ -61,10 +61,10 @@ function Step1LLMProvider() {
           </div>
           <div>
             <p className="text-sm font-medium text-foreground">
-              Your LLM provider
+              Your model provider
             </p>
             <p className="text-xs text-muted-foreground">
-              Enter LLM provider secrets
+              Enter model provider secrets
             </p>
           </div>
         </div>

--- a/turbo/apps/web/app/[locale]/pricing/page.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/page.tsx
@@ -478,8 +478,8 @@ export default function PricingPage() {
                     pro={true}
                   />
                   <TableRow2
-                    feature="Bring your own LLM"
-                    description="Use your own language model API keys and configurations"
+                    feature="Bring your own model"
+                    description="Use your own model provider API keys and configurations"
                     free={true}
                     pro={true}
                   />

--- a/turbo/apps/web/src/db/schema/model-provider.ts
+++ b/turbo/apps/web/src/db/schema/model-provider.ts
@@ -12,7 +12,7 @@ import { credentials } from "./credential";
 
 /**
  * Model Providers table
- * Stores metadata for LLM backend configurations
+ * Stores metadata for model provider configurations
  * Actual credentials stored in credentials table via FK
  */
 export const modelProviders = pgTable(

--- a/turbo/apps/web/src/lib/run/__tests__/run-service.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-service.test.ts
@@ -720,7 +720,7 @@ describe("run-service", () => {
             ownerId: testUserId,
           });
 
-          // Create a compose with explicit LLM config
+          // Create a compose with explicit model provider config
           const [compose] = await globalThis.services.db
             .insert(agentComposes)
             .values({
@@ -740,7 +740,7 @@ describe("run-service", () => {
                   framework: "claude-code",
                   working_dir: "/workspace",
                   environment: {
-                    // Explicit LLM config - model provider should be skipped
+                    // Explicit model provider config - injection should be skipped
                     ANTHROPIC_API_KEY: "explicit-api-key-value",
                   },
                 },
@@ -900,17 +900,17 @@ describe("run-service", () => {
             isDefault: false,
           });
 
-          // Create compose WITHOUT explicit LLM config
+          // Create compose WITHOUT explicit model provider config
           const [compose] = await globalThis.services.db
             .insert(agentComposes)
             .values({
               userId: testUserId,
               scopeId: testScopeId,
-              name: "test-compose-no-llm-config",
+              name: "test-compose-no-mp-config",
             })
             .returning();
 
-          const versionId = `test-version-no-llm-${Date.now()}`;
+          const versionId = `test-version-no-mp-config-${Date.now()}`;
           await globalThis.services.db.insert(agentComposeVersions).values({
             id: versionId,
             composeId: compose!.id,
@@ -977,7 +977,7 @@ describe("run-service", () => {
             isDefault: true, // This is the default!
           });
 
-          // Create compose WITHOUT explicit LLM config
+          // Create compose WITHOUT explicit model provider config
           const [compose] = await globalThis.services.db
             .insert(agentComposes)
             .values({
@@ -1018,7 +1018,7 @@ describe("run-service", () => {
           });
         });
 
-        test("throws BadRequestError when no LLM config and no model provider", async () => {
+        test("throws BadRequestError when no model provider configured", async () => {
           const testUserId = `model-provider-none-${Date.now()}`;
           const testScopeId = randomUUID();
           createdScopeIds.add(testScopeId);
@@ -1030,7 +1030,7 @@ describe("run-service", () => {
             ownerId: testUserId,
           });
 
-          // Create compose WITHOUT explicit LLM config and NO model provider
+          // Create compose WITHOUT explicit model provider config and NO model provider
           const [compose] = await globalThis.services.db
             .insert(agentComposes)
             .values({
@@ -1075,7 +1075,7 @@ describe("run-service", () => {
               sandboxToken: "token",
               userId: testUserId,
             }),
-          ).rejects.toThrow(/No LLM configuration found/);
+          ).rejects.toThrow(/No model provider configured/);
         });
 
         test("throws BadRequestError when model provider type is invalid", async () => {
@@ -1372,7 +1372,7 @@ describe("run-service", () => {
             userId: testUserId,
           });
 
-          // User-defined value should win (skips model provider injection due to hasExplicitLLMConfig)
+          // User-defined value should win (skips model provider injection due to hasExplicitModelProviderConfig)
           expect(context.environment!["ANTHROPIC_API_KEY"]).toBe(
             "user-defined-key",
           );

--- a/turbo/apps/web/src/lib/run/environment/expand-environment.ts
+++ b/turbo/apps/web/src/lib/run/environment/expand-environment.ts
@@ -125,7 +125,7 @@ export function expandEnvironmentFromCompose(
     );
     if (missingCredentials.length > 0) {
       throw new BadRequestError(
-        `Missing required credentials: ${missingCredentials.join(", ")}. Use 'vm0 experimental-credential set ${missingCredentials[0]} <value>' to add them.`,
+        `Missing required credentials: ${missingCredentials.join(", ")}. Use 'vm0 credential set ${missingCredentials[0]} <value>' to add them.`,
       );
     }
 

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -36,7 +36,7 @@ const unifiedRunRequestSchema = z.object({
   // Debug flag to force real Claude in mock environments (internal use only)
   debugNoMockClaude: z.boolean().optional(),
 
-  // Model provider for automatic LLM credential injection
+  // Model provider for automatic credential injection
   modelProvider: z.string().optional(),
 
   // Required


### PR DESCRIPTION
## Summary

- Rename CLI command from `experimental-credential` to `credential`
- Update command description from `[Experimental] Manage stored credentials...` to `Manage stored credentials for agent runs`
- Update help text examples and error messages
- Update all related unit and E2E tests

## Changes

| File | Changes |
|------|---------|
| `/turbo/apps/cli/src/commands/credential/index.ts` | Command name and description |
| `/turbo/apps/cli/src/commands/credential/list.ts` | Help text example |
| `/turbo/apps/web/src/lib/run/environment/expand-environment.ts` | Error message |
| `/turbo/apps/cli/src/__tests__/credential-command.test.ts` | Test descriptions |
| `/e2e/tests/02-parallel/t29-vm0-credential.bats` | E2E test commands |

## Test plan

- [x] Unit tests pass (`pnpm vitest run credential-command`)
- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [ ] E2E tests verify credential CRUD operations
- [ ] CI pipeline passes

Closes #1581

🤖 Generated with [Claude Code](https://claude.com/claude-code)