### PR TITLE
refactor(cli): return null instead of throwing for compose not found

### DIFF
--- a/turbo/apps/cli/src/__tests__/info-command.test.ts
+++ b/turbo/apps/cli/src/__tests__/info-command.test.ts
@@ -19,6 +19,8 @@ vi.mock("../lib/api/config", () => ({
   getApiUrl: vi.fn().mockResolvedValue("https://www.vm0.ai"),
 }));
 
+import { program } from "../index";
+
 describe("Info Command", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -32,8 +34,6 @@ describe("Info Command", () => {
   });
 
   it("should display system information header", async () => {
-    const { program } = await import("../index");
-
     await program.parseAsync(["node", "cli", "info"]);
 
     const allCalls = mockConsoleLog.mock.calls.map((call) => call[0] as string);

--- a/turbo/apps/cli/src/commands/agent/inspect.ts
+++ b/turbo/apps/cli/src/commands/agent/inspect.ts
@@ -1,10 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import {
-  getComposeByName,
-  getComposeVersion,
-  type GetComposeResponse,
-} from "../../lib/api";
+import { getComposeByName, getComposeVersion } from "../../lib/api";
 import {
   deriveComposeVariableSources,
   type AgentVariableSources,
@@ -159,16 +155,12 @@ export const inspectCommand = new Command()
         }
 
         // Get compose by name
-        let compose: GetComposeResponse;
-        try {
-          compose = await getComposeByName(name, options.scope);
-        } catch (error) {
-          if (error instanceof Error && error.message.includes("not found")) {
-            console.error(chalk.red(`✗ Agent compose not found: ${name}`));
-            console.error(chalk.dim("  Run: vm0 agent list"));
-            process.exit(1);
-          }
-          throw error;
+        const compose = await getComposeByName(name, options.scope);
+
+        if (!compose) {
+          console.error(chalk.red(`✗ Agent compose not found: ${name}`));
+          console.error(chalk.dim("  Run: vm0 agent list"));
+          process.exit(1);
         }
 
         // Resolve version if not "latest" or full hash

--- a/turbo/apps/cli/src/commands/compose.ts
+++ b/turbo/apps/cli/src/commands/compose.ts
@@ -241,13 +241,9 @@ export const composeCommand = new Command()
 
       // Fetch HEAD version to compare secrets (for smart confirmation)
       let headSecrets = new Set<string>();
-      try {
-        const existingCompose = await getComposeByName(agentName);
-        if (existingCompose.content) {
-          headSecrets = getSecretsFromComposeContent(existingCompose.content);
-        }
-      } catch {
-        // No existing compose - all secrets are new (first-time compose)
+      const existingCompose = await getComposeByName(agentName);
+      if (existingCompose?.content) {
+        headSecrets = getSecretsFromComposeContent(existingCompose.content);
       }
 
       // Determine truly new secrets (not in HEAD version)

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -111,6 +111,16 @@ export const mainRunCommand = new Command()
             console.log(chalk.dim(`  Resolving agent: ${displayRef}`));
           }
           const compose = await getComposeByName(name, scope);
+          if (!compose) {
+            console.error(chalk.red(`✗ Agent not found: ${identifier}`));
+            console.error(
+              chalk.dim(
+                "  Make sure you've composed the agent with: vm0 compose",
+              ),
+            );
+            process.exit(1);
+          }
+
           composeId = compose.id;
           composeContent = compose.content;
           if (verbose) {
@@ -252,6 +262,7 @@ export const mainRunCommand = new Command()
         }
         showNextSteps(result);
       } catch (error) {
+        console.log(error);
         if (error instanceof Error) {
           if (error.message.includes("Not authenticated")) {
             console.error(

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -262,7 +262,6 @@ export const mainRunCommand = new Command()
         }
         showNextSteps(result);
       } catch (error) {
-        console.log(error);
         if (error instanceof Error) {
           if (error.message.includes("Not authenticated")) {
             console.error(

--- a/turbo/apps/cli/src/commands/schedule/deploy.ts
+++ b/turbo/apps/cli/src/commands/schedule/deploy.ts
@@ -121,25 +121,22 @@ export const deployCommand = new Command()
 
       // Resolve agent reference to compose ID
       const agentRef = schedule.run.agent;
-      let composeId: string;
 
-      try {
-        // Parse agent reference: [scope/]name[:version]
-        // For now, just use the name part
-        const namePart = agentRef.includes("/")
-          ? agentRef.split("/").pop()!
-          : agentRef;
-        const agentName = namePart.includes(":")
-          ? namePart.split(":")[0]!
-          : namePart;
+      const namePart = agentRef.includes("/")
+        ? agentRef.split("/").pop()!
+        : agentRef;
+      const agentName = namePart.includes(":")
+        ? namePart.split(":")[0]!
+        : namePart;
 
-        const compose = await getComposeByName(agentName);
-        composeId = compose.id;
-      } catch {
+      const compose = await getComposeByName(agentName);
+      if (!compose) {
         console.error(chalk.red(`✗ Agent not found: ${agentRef}`));
         console.error(chalk.dim("  Make sure the agent is pushed first"));
         process.exit(1);
       }
+
+      const composeId = compose.id;
 
       // Expand environment variables
       const expandedVars = expandEnvVarsInObject(schedule.run.vars);

--- a/turbo/apps/cli/src/lib/api/domains/composes.ts
+++ b/turbo/apps/cli/src/lib/api/domains/composes.ts
@@ -16,7 +16,7 @@ import type {
 export async function getComposeByName(
   name: string,
   scope?: string,
-): Promise<GetComposeResponse> {
+): Promise<GetComposeResponse | null> {
   const config = await getClientConfig();
   const client = initClient(composesMainContract, config);
 
@@ -26,6 +26,10 @@ export async function getComposeByName(
 
   if (result.status === 200) {
     return result.body;
+  }
+
+  if (result.status === 404) {
+    return null;
   }
 
   handleError(result, `Compose not found: ${name}`);

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -1,5 +1,5 @@
 // Core types (only export what's actually used)
-export type { ApiError, GetComposeResponse, RunResult } from "./core/types";
+export type { ApiError, RunResult } from "./core/types";
 
 // HTTP utilities (only export what's actually used)
 export { httpGet } from "./core/http";

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -1,6 +1,14 @@
 import { http, HttpResponse } from "msw";
 
 export const apiHandlers = [
+  // GET /api/agent/composes - getComposeByName
+  http.get("http://localhost:3000/api/agent/composes", () => {
+    return HttpResponse.json(
+      { error: "Not found", message: "Compose not found" },
+      { status: 404 },
+    );
+  }),
+
   // POST /api/agent/composes - createOrUpdateCompose
   http.post("http://localhost:3000/api/agent/composes", () => {
     return HttpResponse.json(

--- a/turbo/apps/cli/src/test/setup.ts
+++ b/turbo/apps/cli/src/test/setup.ts
@@ -2,7 +2,7 @@ import { server } from "../mocks/server";
 import { afterAll, afterEach, beforeAll } from "vitest";
 
 // Start MSW server before all tests
-beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 
 // Reset handlers after each test
 afterEach(() => server.resetHandlers());

--- a/turbo/apps/runner/src/test/setup.ts
+++ b/turbo/apps/runner/src/test/setup.ts
@@ -2,7 +2,7 @@ import { server } from "../mocks/server";
 import { afterAll, afterEach, beforeAll } from "vitest";
 
 // Start MSW server before all tests
-beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 
 // Reset handlers after each test
 afterEach(() => server.resetHandlers());

--- a/turbo/apps/site/src/test/setup.ts
+++ b/turbo/apps/site/src/test/setup.ts
@@ -3,7 +3,7 @@ import { server } from "../mocks/server";
 import { afterAll, afterEach, beforeAll } from "vitest";
 
 // Start MSW server before all tests
-beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 
 // Reset handlers after each test
 afterEach(() => server.resetHandlers());

--- a/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
@@ -164,7 +164,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
     const getResponse = await GET(getRequest);
     const getData = await getResponse.json();
 
-    expect(getResponse.status).toBe(400);
+    expect(getResponse.status).toBe(404);
     expect(getData.error.message).toContain("Agent compose not found");
     expect(getData.error.message).toContain("nonexistent-agent");
   });
@@ -244,7 +244,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
     const getResponse = await GET(getRequest);
     const getData = await getResponse.json();
 
-    expect(getResponse.status).toBe(400);
+    expect(getResponse.status).toBe(404);
     expect(getData.error.message).toContain("Agent compose not found");
 
     // Cleanup

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -79,11 +79,11 @@ const router = tsr.router(composesMainContract, {
 
     if (composes.length === 0 || !composes[0]) {
       return {
-        status: 400 as const,
+        status: 404 as const,
         body: {
           error: {
             message: `Agent compose not found: ${query.name}`,
-            code: "BAD_REQUEST",
+            code: "NOT_FOUND",
           },
         },
       };

--- a/turbo/apps/web/app/api/web/skills/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/web/skills/__tests__/route.test.ts
@@ -25,7 +25,7 @@ const server = setupServer(
   ),
 );
 
-beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 


### PR DESCRIPTION
## Summary
- Change `getComposeByName` to return `null` when a compose is not found (404) instead of throwing an error
- Update all calling code to use explicit null checks instead of try/catch blocks
- Change MSW test setup from `onUnhandledRequest: "bypass"` to `"error"` for stricter testing

This refactoring follows the project's "Avoid Defensive Programming" principle - removing try/catch blocks that were catching and re-throwing, and instead using explicit null checks for cleaner error handling.

## Test plan
- [x] All existing tests pass (2208 tests)
- [x] Lint checks pass
- [x] Type checks pass
- [x] Knip analysis passes (no unused exports)

Generated with [Claude Code](https://claude.com/claude-code)