### PR TITLE
perf(test): use unique prefix isolation for slow web tests instead of cleanup

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -117,3 +117,21 @@ export async function deleteTestCliToken(token: string): Promise<void> {
     .delete(cliTokens)
     .where(eq(cliTokens.token, token));
 }
+
+/**
+ * Generate a unique test ID for test isolation.
+ * Each test gets a unique prefix to avoid data collision without cleanup.
+ *
+ * Format: "t" + timestamp (base36) + random (4 hex chars)
+ * Example: "t1abc2def3gh4i5j6k7l"
+ *
+ * This approach eliminates the need for beforeEach/afterEach cleanup
+ * as each test operates on completely isolated data.
+ *
+ * @returns A unique test ID string
+ */
+export function generateTestId(): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(16).substring(2, 6);
+  return `t${timestamp}${random}`;
+}

--- a/turbo/apps/web/vitest.config.ts
+++ b/turbo/apps/web/vitest.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
     // Don't override env vars, let them pass through from system
     // Run tests sequentially to avoid database race conditions
     fileParallelism: false,
+    // Automatically clear mocks before each test (eliminates manual vi.clearAllMocks() calls)
+    clearMocks: true,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- Replace sequential DELETE queries with unique test ID prefixes for test isolation
- Each test now generates a unique prefix (via `generateTestId()`) so tests don't collide without needing cleanup
- Add `clearMocks: true` to vitest.config.ts to automatically clear mocks before each test
- Migrate 4 slowest test files to unique prefix isolation

## Changes

| File | Lines Removed |
|------|---------------|
| storages/commit | ~60 lines of cleanup |
| storages/prepare | ~50 lines of cleanup |
| webhooks/complete | ~40 lines of cleanup |
| agent/runs | ~30 lines of cleanup |

## Test plan

- [x] All 41 tests in migrated files pass
- [x] Full web test suite (782 tests) passes
- [x] Lint passes
- [x] Type check passes
- [x] Knip passes

## Expected Impact

~2.7 seconds saved per full test run (~60-67% improvement per file)

Closes #1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)