### PR TITLE
chore(skills): remove allowed-tools frontmatter from all skills

### DIFF
--- a/.claude/skills/agent-browser/SKILL.md
+++ b/.claude/skills/agent-browser/SKILL.md
@@ -3,7 +3,6 @@ name: agent-browser
 description: Automates browser interactions for web testing, form filling, screenshots, and data extraction. Use when the user needs to navigate websites, interact with web pages, fill forms, take screenshots, test web applications, or extract information from web pages.
 context: fork
 agent: general-purpose
-allowed-tools: Bash(agent-browser:*), Read, Write
 ---
 
 # Browser Automation with agent-browser

--- a/.claude/skills/cli-e2e-testing/skill.md
+++ b/.claude/skills/cli-e2e-testing/skill.md
@@ -1,7 +1,6 @@
 ---
 name: cli-e2e-testing
 description: CLI E2E testing patterns with BATS - parallelization, state sharing, and timeout management
-allowed-tools: Read, Glob, Grep
 context: fork
 ---
 

--- a/.claude/skills/code-quality/SKILL.md
+++ b/.claude/skills/code-quality/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: code-quality
 description: Deep code review and quality analysis for vm0 project
-allowed-tools: Bash, Read, Grep, Glob, Edit, Write
 context: fork
 ---
 

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: commit
 description: Complete pre-commit workflow - run quality checks (format, lint, type, test) and validate/create conventional commit messages
-allowed-tools: Bash, Read, Glob, Edit
 context: fork
 ---
 

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: dev-server
 description: Development server lifecycle management for the vm0 project
-allowed-tools: Bash, KillShell, TaskOutput
 context: fork
 ---
 

--- a/.claude/skills/issue-action/SKILL.md
+++ b/.claude/skills/issue-action/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: issue-action
 description: Continue working on GitHub issue from conversation context
-allowed-tools: Bash, Read, Write, Edit, Grep, Glob, Task
 ---
 
 # Issue Action Skill

--- a/.claude/skills/issue-compact/SKILL.md
+++ b/.claude/skills/issue-compact/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: issue-compact
 description: Consolidate GitHub issue discussion into clean body for handoff
-allowed-tools: Bash
 ---
 
 # Issue Compact Skill

--- a/.claude/skills/issue-create/SKILL.md
+++ b/.claude/skills/issue-create/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: issue-create
 description: Create GitHub issues from conversation context (general, bug reports, or feature requests)
-allowed-tools: Bash
 ---
 
 # Issue Creation Skill

--- a/.claude/skills/issue-plan/SKILL.md
+++ b/.claude/skills/issue-plan/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: issue-plan
 description: Start working on GitHub issue with deep-dive workflow (research, innovate, plan phases)
-allowed-tools: Bash, Read, Write, Grep, Glob
 ---
 
 # Issue Planning Skill

--- a/.claude/skills/ops-utils/SKILL.md
+++ b/.claude/skills/ops-utils/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ops-utils
 description: Operations and infrastructure utilities for vm0 project
-allowed-tools: Bash
 context: fork
 ---
 

--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pr-check
 description: Monitor PR CI pipeline, auto-fix issues, and loop until all checks pass
-allowed-tools: Bash, Read, Grep, Glob, Edit
 context: fork
 ---
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pr-review
 description: Review a pull request and post findings as a PR comment
-allowed-tools: Bash, Read, Grep, Glob, Edit, Write
 context: fork
 ---
 

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pull-request
 description: PR lifecycle management - create PRs with proper commits, merge with validation, and manage PR comments
-allowed-tools: Bash, Read, Grep
 context: fork
 ---
 

--- a/.claude/skills/query-axiom-logs/SKILL.md
+++ b/.claude/skills/query-axiom-logs/SKILL.md
@@ -3,7 +3,6 @@ name: Query Axiom Logs
 description: Query logs from Axiom for debugging (read-only, no ingestion allowed)
 context: fork
 agent: Explore
-allowed-tools: Bash(axiom:*, source:*), Read
 ---
 
 # Query Axiom Logs

--- a/.claude/skills/skill-alias/SKILL.md
+++ b/.claude/skills/skill-alias/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: skill-alias
 description: Create command aliases for skills with arguments
-allowed-tools: Write, Bash
 context: fork
 ---
 

--- a/.claude/skills/tech-debt/SKILL.md
+++ b/.claude/skills/tech-debt/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: tech-debt
 description: Technical debt management - scan codebase for bad smells and create tracking issues
-allowed-tools: Bash, Read, Grep, Glob, Edit, Write
 context: fork
 ---
 

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: testing
 description: Comprehensive testing patterns and anti-patterns for writing and reviewing tests
-allowed-tools: Read, Glob, Grep
 context: fork
 ---
 


### PR DESCRIPTION
## Summary
- Remove `allowed-tools` frontmatter from all 17 skills that had it
- The field is [not enforced by Claude Code CLI](https://github.com/anthropics/claude-code/issues/18837), making it purely cosmetic
- This allows skills to use all available tools, including TaskCreate/TaskList for progress tracking

## Test plan
- [ ] Verify skills still load correctly after removal
- [ ] Confirm skills can use tools that were previously not in their allowed-tools list

🤖 Generated with [Claude Code](https://claude.com/claude-code)