### PR TITLE
fix(cli): remove color from [tool_result] and [result] labels

### DIFF
--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -229,9 +229,8 @@ export class EventRenderer {
   ): void {
     const isError = Boolean(event.data.isError);
     const status = isError ? "Error" : "Completed";
-    const color = isError ? chalk.red : chalk.green;
 
-    console.log(prefix + color("[tool_result]") + suffix + " " + status);
+    console.log(prefix + "[tool_result]" + suffix + " " + status);
 
     // Show full result without truncation
     const result = String(event.data.result || "");
@@ -245,9 +244,8 @@ export class EventRenderer {
   ): void {
     const success = Boolean(event.data.success);
     const status = success ? "✓ completed successfully" : "✗ failed";
-    const color = success ? chalk.green : chalk.red;
 
-    console.log(prefix + color("[result]") + suffix + " " + status);
+    console.log(prefix + "[result]" + suffix + " " + status);
 
     const durationMs = Number(event.data.durationMs || 0);
     const durationSec = (durationMs / 1000).toFixed(1);


### PR DESCRIPTION
## Summary
- Remove green color from `[tool_result]` and `[result]` labels to match other event labels (`[init]`, `[text]`, `[tool_use]`)
- The status text ("Completed", "Error", "✓", "✗") already conveys success/failure, making label color redundant

## Before/After
```
# Before
[init] Starting Claude Code agent
[text] I'll help you...
[tool_use] Write
[tool_result] Completed    ← green
[result] ✓ completed       ← green

# After
[init] Starting Claude Code agent
[text] I'll help you...
[tool_use] Write
[tool_result] Completed    ← plain (consistent)
[result] ✓ completed       ← plain (consistent)
```

## Test plan
- [x] All event-renderer tests pass (35 tests)
- [x] Lint, type-check, and format pass

Fixes #1595

🤖 Generated with [Claude Code](https://claude.com/claude-code)