### PR TITLE
feat(platform): add save button validation to onboarding modal

### DIFF
--- a/turbo/apps/platform/src/signals/onboarding.ts
+++ b/turbo/apps/platform/src/signals/onboarding.ts
@@ -34,6 +34,15 @@ export const tokenValue$ = computed((get) => get(internalTokenValue$));
 export const copyStatus$ = computed((get) => get(internalCopyStatus$));
 
 /**
+ * Whether the Save button should be enabled.
+ * Requires a non-empty token value.
+ */
+export const canSaveOnboarding$ = computed((get) => {
+  const tokenValue = get(internalTokenValue$);
+  return tokenValue.trim().length > 0;
+});
+
+/**
  * Set the OAuth token value.
  */
 export const setTokenValue$ = command(({ set }, value: string) => {

--- a/turbo/apps/platform/src/views/home/__tests__/home-page.test.tsx
+++ b/turbo/apps/platform/src/views/home/__tests__/home-page.test.tsx
@@ -49,6 +49,17 @@ describe("home page", () => {
 
     expect(screen.getByText(/First, tell us how your LLM works/)).toBeDefined();
 
+    // Save button should be disabled when token is empty
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    expect(saveButton).toBeDisabled();
+
+    // Type a token value
+    const tokenInput = screen.getByPlaceholderText("sk-ant-oat...");
+    await user.type(tokenInput, "sk-ant-oat-test-token");
+
+    // Save button should now be enabled
+    expect(saveButton).toBeEnabled();
+
     // Click "Add it later" to close the modal
     await user.click(screen.getByText("Add it later"));
 

--- a/turbo/apps/platform/src/views/home/onboarding-modal.tsx
+++ b/turbo/apps/platform/src/views/home/onboarding-modal.tsx
@@ -17,6 +17,7 @@ import {
   saveOnboardingConfig$,
   copyStatus$,
   copyToClipboard$,
+  canSaveOnboarding$,
 } from "../../signals/onboarding.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 
@@ -28,6 +29,7 @@ export function OnboardingModal() {
   const saveConfig = useSet(saveOnboardingConfig$);
   const copyStatus = useGet(copyStatus$);
   const copyToClipboard = useSet(copyToClipboard$);
+  const canSave = useGet(canSaveOnboarding$);
 
   return (
     <Dialog open={isOpen}>
@@ -83,6 +85,7 @@ export function OnboardingModal() {
                 placeholder="sk-ant-oat..."
                 value={tokenValue}
                 onChange={(e) => setTokenValue(e.target.value)}
+                required
               />
             </div>
             <p className="text-xs text-muted-foreground">
@@ -109,7 +112,9 @@ export function OnboardingModal() {
           <Button variant="outline" onClick={() => closeModal()}>
             Add it later
           </Button>
-          <Button onClick={() => saveConfig()}>Save</Button>
+          <Button onClick={() => saveConfig()} disabled={!canSave}>
+            Save
+          </Button>
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- Add `canSaveOnboarding$` computed signal that checks if token value is non-empty
- Disable Save button in onboarding modal when OAuth token input is empty
- Add `required` attribute to the token input field
- Add test coverage verifying the Save button disabled/enabled states

## Test plan
- [x] Verified Save button is disabled when token input is empty
- [x] Verified Save button becomes enabled after entering a token value
- [x] All existing tests pass
- [x] New test validates the button state behavior

---
Generated with [Claude Code](https://claude.ai/code)