### PR TITLE
refactor(web): migrate test env vars from dotenv to vi.stubenv

### DIFF
--- a/turbo/apps/web/__tests__/middleware.cors.test.ts
+++ b/turbo/apps/web/__tests__/middleware.cors.test.ts
@@ -4,12 +4,15 @@ import { handleCors } from "../middleware.cors";
 import { reloadEnv } from "../src/env";
 
 function getHandleCors(vercelEnv?: string) {
-  vi.unstubAllEnvs();
-
+  // Reset VERCEL_ENV and NODE_ENV to simulate different environments
+  // Note: vi.stubEnv overwrites previous stubs, so we can just set new values
   if (vercelEnv === "development") {
     vi.stubEnv("NODE_ENV", vercelEnv);
+    vi.stubEnv("VERCEL_ENV", ""); // Clear VERCEL_ENV
   } else if (vercelEnv) {
     vi.stubEnv("VERCEL_ENV", vercelEnv);
+  } else {
+    vi.stubEnv("VERCEL_ENV", ""); // Clear VERCEL_ENV for undefined case
   }
 
   reloadEnv();

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
@@ -60,7 +60,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     mockSandboxConnect.mockResolvedValue(mockSandbox as unknown as Sandbox);
 
     // Set CRON_SECRET for tests
-    process.env.CRON_SECRET = cronSecret;
+    vi.stubEnv("CRON_SECRET", cronSecret);
     // Reset mock auth header
     mockAuthHeader = null;
 

--- a/turbo/apps/web/app/api/storages/commit/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/commit/__tests__/route.test.ts
@@ -23,8 +23,10 @@ vi.mock("@clerk/nextjs/server", () => ({
 vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
 
-// Set required environment variables
-process.env.R2_USER_STORAGES_BUCKET_NAME = "test-storages-bucket";
+// Override default env var with test-specific value
+vi.hoisted(() => {
+  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
+});
 
 // Static imports - mocks are already in place due to hoisting
 import { POST } from "../route";

--- a/turbo/apps/web/app/api/storages/download/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/download/__tests__/route.test.ts
@@ -31,8 +31,10 @@ vi.mock("@clerk/nextjs/server", () => ({
 vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
 
-// Set required environment variables
-process.env.R2_USER_STORAGES_BUCKET_NAME = "test-storages-bucket";
+// Override default env var with test-specific value
+vi.hoisted(() => {
+  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
+});
 
 // Static imports - mocks are already in place due to hoisting
 import { GET } from "../route";

--- a/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
@@ -22,8 +22,10 @@ vi.mock("@clerk/nextjs/server", () => ({
 vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
 
-// Set required environment variables
-process.env.R2_USER_STORAGES_BUCKET_NAME = "test-storages-bucket";
+// Override default env var with test-specific value
+vi.hoisted(() => {
+  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
+});
 
 // Static imports - mocks are already in place due to hoisting
 import { POST } from "../route";

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -34,7 +34,6 @@
     "ably": "^2.17.0",
     "archiver": "^7.0.1",
     "croner": "^9.1.0",
-    "dotenv": "^17.2.1",
     "drizzle-orm": "^0.44.5",
     "next": "^15.5.7",
     "next-intl": "^4.6.1",

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -1,9 +1,37 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
-import { config } from "dotenv";
 
-// Load environment variables from .env file
-config({ path: "./.env" });
+// Stub environment variables before any imports
+// Using vi.hoisted() ensures stubs run before module imports
+//
+// All env vars are explicitly stubbed here for deterministic test behavior.
+// Tests run in GitHub Actions and dev containers with consistent database config.
+vi.hoisted(() => {
+  // Database connection (same in CI and devcontainer)
+  vi.stubEnv(
+    "DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/postgres",
+  );
+  // Required env vars from env.ts schema
+  vi.stubEnv(
+    "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+    "pk_test_mock_instance.clerk.accounts.dev$",
+  );
+  vi.stubEnv("CLERK_SECRET_KEY", "sk_test_mock_secret_key_for_testing");
+  vi.stubEnv("E2B_API_KEY", "e2b_test_api_key");
+  vi.stubEnv("E2B_TEMPLATE_NAME", "test-template");
+  vi.stubEnv("R2_ACCOUNT_ID", "test-account-id");
+  vi.stubEnv("R2_ACCESS_KEY_ID", "test-access-key");
+  vi.stubEnv("R2_SECRET_ACCESS_KEY", "test-secret-key");
+  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-bucket");
+  // Optional env vars
+  vi.stubEnv("AXIOM_DATASET_SUFFIX", "dev");
+  // 64 hex chars = 32 bytes encryption key for sandbox token signing
+  vi.stubEnv(
+    "SECRETS_ENCRYPTION_KEY",
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  );
+});
 
 // Mock server-only package (no-op in tests)
 // This package throws when imported outside of a server component
@@ -16,12 +44,3 @@ vi.mock("@clerk/nextjs/server", () => ({
   clerkMiddleware: vi.fn(),
   createRouteMatcher: vi.fn(),
 }));
-
-// Set test environment variables
-process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
-  "pk_test_mock_instance.clerk.accounts.dev$";
-process.env.CLERK_SECRET_KEY = "sk_test_mock_secret_key_for_testing";
-process.env.AXIOM_DATASET_SUFFIX = "dev";
-// 64 hex chars = 32 bytes encryption key for sandbox token signing
-process.env.SECRETS_ENCRYPTION_KEY =
-  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -5,13 +5,10 @@ import { vi } from "vitest";
 // Using vi.hoisted() ensures stubs run before module imports
 //
 // All env vars are explicitly stubbed here for deterministic test behavior.
-// Tests run in GitHub Actions and dev containers with consistent database config.
+// Note: DATABASE_URL is NOT stubbed because it differs between environments:
+// - Local dev: postgresql://postgres:postgres@localhost:5432/postgres
+// - CI (GitHub Actions): postgresql://postgres@postgres:5432/postgres (service container)
 vi.hoisted(() => {
-  // Database connection (same in CI and devcontainer)
-  vi.stubEnv(
-    "DATABASE_URL",
-    "postgresql://postgres:postgres@localhost:5432/postgres",
-  );
   // Required env vars from env.ts schema
   vi.stubEnv(
     "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",

--- a/turbo/apps/web/src/lib/__tests__/artifact-storage.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/artifact-storage.test.ts
@@ -30,8 +30,10 @@ import * as s3Client from "../s3/s3-client";
 vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
 
-// Set required environment variables
-process.env.R2_USER_STORAGES_BUCKET_NAME = "test-storages-bucket";
+// Override default env var with test-specific value
+vi.hoisted(() => {
+  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
+});
 
 // Test constants
 const TEST_USER_ID = "test-user-artifact-storage";

--- a/turbo/apps/web/src/lib/__tests__/logger.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/logger.test.ts
@@ -41,7 +41,10 @@ describe("logger", () => {
   });
 
   afterEach(() => {
-    vi.unstubAllEnvs();
+    // Only restore individual env vars that were stubbed in this file
+    // Don't use vi.unstubAllEnvs() as it clears stubs from setup.ts
+    vi.stubEnv("DEBUG", "");
+    vi.stubEnv("NODE_ENV", "test");
   });
 
   describe("console output", () => {
@@ -211,7 +214,8 @@ describe("logger", () => {
 
   describe("Axiom not configured", () => {
     it("should not send to Axiom when AXIOM_TOKEN is not set", () => {
-      vi.unstubAllEnvs();
+      // Clear AXIOM_TOKEN to simulate unconfigured state
+      vi.stubEnv("AXIOM_TOKEN", "");
       clearLoggerCache();
 
       const log = logger("test");
@@ -285,7 +289,8 @@ describe("logger", () => {
     });
 
     it("should not throw when Axiom is not configured", async () => {
-      vi.unstubAllEnvs();
+      // Clear AXIOM_TOKEN to simulate unconfigured state
+      vi.stubEnv("AXIOM_TOKEN", "");
       clearLoggerCache();
 
       // Should not throw

--- a/turbo/apps/web/src/lib/__tests__/logger.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/logger.test.ts
@@ -211,7 +211,7 @@ describe("logger", () => {
 
   describe("Axiom not configured", () => {
     it("should not send to Axiom when AXIOM_TOKEN is not set", () => {
-      delete process.env.AXIOM_TOKEN;
+      vi.unstubAllEnvs();
       clearLoggerCache();
 
       const log = logger("test");
@@ -250,7 +250,7 @@ describe("logger", () => {
 
   describe("formatMessage helper", () => {
     it("should handle empty args", () => {
-      process.env.AXIOM_TOKEN = "test-token";
+      vi.stubEnv("AXIOM_TOKEN", "test-token");
       clearLoggerCache();
 
       const log = logger("test");
@@ -260,7 +260,7 @@ describe("logger", () => {
     });
 
     it("should convert non-string first arg to string", () => {
-      process.env.AXIOM_TOKEN = "test-token";
+      vi.stubEnv("AXIOM_TOKEN", "test-token");
       clearLoggerCache();
 
       const log = logger("test");
@@ -272,7 +272,7 @@ describe("logger", () => {
 
   describe("flushLogs", () => {
     it("should call flush on Axiom logger when configured", async () => {
-      process.env.AXIOM_TOKEN = "test-token";
+      vi.stubEnv("AXIOM_TOKEN", "test-token");
       clearLoggerCache();
 
       // Trigger logger initialization
@@ -285,7 +285,7 @@ describe("logger", () => {
     });
 
     it("should not throw when Axiom is not configured", async () => {
-      delete process.env.AXIOM_TOKEN;
+      vi.unstubAllEnvs();
       clearLoggerCache();
 
       // Should not throw

--- a/turbo/apps/web/src/lib/auth/__tests__/runner-auth.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/runner-auth.test.ts
@@ -17,6 +17,14 @@ const TEST_OFFICIAL_SECRET =
 const TEST_CLI_TOKEN = "vm0_live_test_token_12345";
 const TEST_USER_ID = "test-user-runner-auth";
 
+// Set required environment variables before initServices
+vi.hoisted(() => {
+  vi.stubEnv(
+    "OFFICIAL_RUNNER_SECRET",
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  );
+});
+
 // Mock the headers
 const mockHeaders = vi.fn();
 vi.mock("next/headers", () => ({
@@ -27,9 +35,6 @@ vi.mock("next/headers", () => ({
 vi.mock("../sandbox-token", () => ({
   isSandboxToken: (token: string) => token.split(".").length === 3,
 }));
-
-// Set required environment variables before initServices
-process.env.OFFICIAL_RUNNER_SECRET = TEST_OFFICIAL_SECRET;
 
 // Import module after setting up mocks
 let getRunnerAuth: typeof import("../runner-auth").getRunnerAuth;

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -5,9 +5,7 @@ import {
   isSandboxToken,
 } from "../sandbox-token";
 
-// Set required environment variables before any imports
-process.env.SECRETS_ENCRYPTION_KEY =
-  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+// SECRETS_ENCRYPTION_KEY is set in setup.ts
 
 describe("sandbox-token", () => {
   describe("generateSandboxToken", () => {

--- a/turbo/apps/web/src/lib/blob/__tests__/blob-service.test.ts
+++ b/turbo/apps/web/src/lib/blob/__tests__/blob-service.test.ts
@@ -16,8 +16,10 @@ import type { FileEntry } from "../../storage/content-hash";
 // Mock AWS SDK (third-party external dependency)
 vi.mock("@aws-sdk/client-s3");
 
-// Set required environment variables before initServices
-process.env.R2_USER_STORAGES_BUCKET_NAME = "test-blobs-bucket";
+// Override default env var with test-specific value
+vi.hoisted(() => {
+  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-blobs-bucket");
+});
 
 // Prefix for test data to enable cleanup
 const TEST_HASH_PREFIX = "test_";

--- a/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
+++ b/turbo/apps/web/src/lib/e2b/__tests__/e2b-service.test.ts
@@ -36,11 +36,11 @@ vi.mock("@e2b/code-interpreter");
 vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
 
-// Set required environment variables for e2b config
-process.env.E2B_TEMPLATE_NAME = "mock-template";
-
-// Set required environment variables before initServices
-process.env.R2_USER_STORAGES_BUCKET_NAME = "test-storages-bucket";
+// Override default env vars with test-specific values
+vi.hoisted(() => {
+  vi.stubEnv("E2B_TEMPLATE_NAME", "mock-template");
+  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
+});
 
 // Import e2bService after mocks are set up
 let e2bService: typeof import("../e2b-service").e2bService;

--- a/turbo/apps/web/src/lib/realtime/__tests__/client.test.ts
+++ b/turbo/apps/web/src/lib/realtime/__tests__/client.test.ts
@@ -38,8 +38,6 @@ vi.mock("ably", () => {
 });
 
 describe("realtime/client", () => {
-  const originalEnv = process.env.ABLY_API_KEY;
-
   beforeEach(() => {
     vi.clearAllMocks();
     // Reset module cache to get fresh singleton state
@@ -56,17 +54,12 @@ describe("realtime/client", () => {
   });
 
   afterEach(() => {
-    // Restore original env
-    if (originalEnv) {
-      process.env.ABLY_API_KEY = originalEnv;
-    } else {
-      delete process.env.ABLY_API_KEY;
-    }
+    vi.unstubAllEnvs();
   });
 
   describe("publishEvents", () => {
     it("should return false when ABLY_API_KEY is not configured", async () => {
-      delete process.env.ABLY_API_KEY;
+      // ABLY_API_KEY is not set by default
       const { publishEvents } = await import("../client");
 
       const result = await publishEvents("run-123", [{ type: "test" }], 1);
@@ -75,7 +68,7 @@ describe("realtime/client", () => {
     });
 
     it("should publish events to the correct channel when configured", async () => {
-      process.env.ABLY_API_KEY = "test-api-key";
+      vi.stubEnv("ABLY_API_KEY", "test-api-key");
       const { publishEvents } = await import("../client");
 
       const events = [{ type: "test", data: "value" }];
@@ -94,7 +87,7 @@ describe("realtime/client", () => {
     });
 
     it("should return false and not throw when publish fails", async () => {
-      process.env.ABLY_API_KEY = "test-api-key";
+      vi.stubEnv("ABLY_API_KEY", "test-api-key");
 
       // Make publish fail by re-mocking
       vi.mocked(Ably.Rest).mockImplementationOnce(() => {
@@ -116,7 +109,7 @@ describe("realtime/client", () => {
 
   describe("publishStatus", () => {
     it("should return false when ABLY_API_KEY is not configured", async () => {
-      delete process.env.ABLY_API_KEY;
+      // ABLY_API_KEY is not set by default
       const { publishStatus } = await import("../client");
 
       const result = await publishStatus("run-123", "completed", {
@@ -127,7 +120,7 @@ describe("realtime/client", () => {
     });
 
     it("should publish status to the correct channel when configured", async () => {
-      process.env.ABLY_API_KEY = "test-api-key";
+      vi.stubEnv("ABLY_API_KEY", "test-api-key");
       const { publishStatus } = await import("../client");
 
       const result = await publishStatus(
@@ -144,7 +137,7 @@ describe("realtime/client", () => {
 
   describe("generateRunToken", () => {
     it("should return null when ABLY_API_KEY is not configured", async () => {
-      delete process.env.ABLY_API_KEY;
+      // ABLY_API_KEY is not set by default
       const { generateRunToken } = await import("../client");
 
       const result = await generateRunToken("run-123");
@@ -153,7 +146,7 @@ describe("realtime/client", () => {
     });
 
     it("should generate token with correct capability when configured", async () => {
-      process.env.ABLY_API_KEY = "test-api-key";
+      vi.stubEnv("ABLY_API_KEY", "test-api-key");
       const { generateRunToken } = await import("../client");
 
       const result = await generateRunToken("run-789");
@@ -175,7 +168,7 @@ describe("realtime/client", () => {
     });
 
     it("should return null when token generation fails", async () => {
-      process.env.ABLY_API_KEY = "test-api-key";
+      vi.stubEnv("ABLY_API_KEY", "test-api-key");
 
       // Make token generation fail
       vi.mocked(Ably.Rest).mockImplementationOnce(() => {

--- a/turbo/apps/web/src/lib/s3/__tests__/s3-client.test.ts
+++ b/turbo/apps/web/src/lib/s3/__tests__/s3-client.test.ts
@@ -2,11 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { parseS3Uri, uploadStorageVersionArchive } from "../s3-client";
 import type { FileEntry } from "../../storage/content-hash";
 
-// Set required environment variables before any imports
-process.env.R2_ACCOUNT_ID = "test-account-id";
-process.env.R2_ACCESS_KEY_ID = "test-key";
-process.env.R2_SECRET_ACCESS_KEY = "test-secret";
-process.env.R2_USER_STORAGES_BUCKET_NAME = "test-bucket";
+// R2 env vars are set in setup.ts
 
 // Mock AWS SDK
 vi.mock("@aws-sdk/client-s3", () => ({

--- a/turbo/apps/web/src/lib/session-history/__tests__/session-history-service.test.ts
+++ b/turbo/apps/web/src/lib/session-history/__tests__/session-history-service.test.ts
@@ -16,8 +16,10 @@ import * as s3Client from "../../s3/s3-client";
 // Mock AWS SDK (third-party external dependency)
 vi.mock("@aws-sdk/client-s3");
 
-// Set required environment variables
-process.env.R2_USER_STORAGES_BUCKET_NAME = "test-storages-bucket";
+// Override default env var with test-specific value
+vi.hoisted(() => {
+  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
+});
 
 describe("SessionHistoryService", () => {
   let service: SessionHistoryService;

--- a/turbo/apps/web/src/lib/storage/__tests__/storage-service.test.ts
+++ b/turbo/apps/web/src/lib/storage/__tests__/storage-service.test.ts
@@ -17,8 +17,10 @@ import { storages, storageVersions } from "../../../db/schema/storage";
 vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
 
-// Set required environment variables before initServices
-process.env.R2_USER_STORAGES_BUCKET_NAME = "test-storages-bucket";
+// Override default env var with test-specific value
+vi.hoisted(() => {
+  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
+});
 
 // Test user ID for isolation
 const TEST_USER_ID = "test-user-storage-service";

--- a/turbo/apps/web/vitest.config.ts
+++ b/turbo/apps/web/vitest.config.ts
@@ -1,13 +1,5 @@
 import { defineConfig } from "vitest/config";
 import { resolve } from "path";
-import { config } from "dotenv";
-import { existsSync } from "fs";
-
-// Load .env.local for tests if it exists (local development)
-const envLocalPath = resolve(__dirname, ".env.local");
-if (existsSync(envLocalPath)) {
-  config({ path: envLocalPath });
-}
 
 export default defineConfig({
   test: {

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -454,9 +454,6 @@ importers:
       croner:
         specifier: ^9.1.0
         version: 9.1.0
-      dotenv:
-        specifier: ^17.2.1
-        version: 17.2.1
       drizzle-orm:
         specifier: ^0.44.5
         version: 0.44.5(@neondatabase/serverless@1.0.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(pg@8.16.3)(postgres@3.4.7)
@@ -11766,7 +11763,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.18.0)(typescript@5.9.2))(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:


### PR DESCRIPTION
## Summary
- Remove dotenv dependency from web package test setup
- Use Vitest's native `vi.stubEnv` with `vi.hoisted()` for deterministic test env vars
- Centralize all required env var stubs in `setup.ts`
- Update 14+ test files to use `vi.stubEnv` instead of `process.env` assignments

Closes #1603

## Test plan
- [x] All 782 web tests pass locally
- [x] Lint, type check, and knip pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)