### PR TITLE
feat(platform): show onboarding modal when no oauth token exists

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/onboarding.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/onboarding.test.ts
@@ -4,6 +4,14 @@ import { server } from "../../mocks/server.ts";
 import { testContext } from "./test-helpers.ts";
 import { setupPage } from "../../__tests__/helper.ts";
 import { pathname$ } from "../route.ts";
+import {
+  needsOnboarding$,
+  showOnboardingModal$,
+  setTokenValue$,
+  saveOnboardingConfig$,
+  closeOnboardingModal$,
+  startOnboarding$,
+} from "../onboarding.ts";
 
 const context = testContext();
 
@@ -24,5 +32,156 @@ describe("startOnboarding$", () => {
     });
 
     expect(context.store.get(pathname$)).toBe("/");
+  });
+});
+
+describe("needsOnboarding$", () => {
+  it("should return true when no scope exists", async () => {
+    server.use(
+      http.get("/api/scope", () => {
+        return new HttpResponse(null, { status: 404 });
+      }),
+    );
+
+    await setupPage({ context, path: "/" });
+
+    const needsOnboarding = await context.store.get(needsOnboarding$);
+    expect(needsOnboarding).toBeTruthy();
+  });
+
+  it("should return true when no claude-code-oauth-token exists", async () => {
+    server.use(
+      http.get("/api/model-providers", () => {
+        return HttpResponse.json({ modelProviders: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/" });
+
+    const needsOnboarding = await context.store.get(needsOnboarding$);
+    expect(needsOnboarding).toBeTruthy();
+  });
+
+  it("should return false when both scope and oauth token exist", async () => {
+    // Default mocks have both scope and oauth token
+    await setupPage({ context, path: "/" });
+
+    const needsOnboarding = await context.store.get(needsOnboarding$);
+    expect(needsOnboarding).toBeFalsy();
+  });
+});
+
+describe("saveOnboardingConfig$", () => {
+  it("should create scope and model provider when saving", async () => {
+    let scopeCreated = false;
+    let providerCreated = false;
+
+    server.use(
+      http.get("/api/scope", () => {
+        return new HttpResponse(null, { status: 404 });
+      }),
+      http.post("/api/scope", () => {
+        scopeCreated = true;
+        return HttpResponse.json({}, { status: 201 });
+      }),
+      http.put("/api/model-providers", () => {
+        providerCreated = true;
+        return HttpResponse.json(
+          {
+            provider: {
+              id: "new-provider",
+              type: "claude-code-oauth-token",
+              framework: "claude-code",
+              credentialName: "CLAUDE_CODE_OAUTH_TOKEN",
+              isDefault: false,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+            created: true,
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await setupPage({ context, path: "/" });
+
+    // Set token value and save
+    context.store.set(startOnboarding$);
+    context.store.set(setTokenValue$, "test-oauth-token");
+    await context.store.set(saveOnboardingConfig$, context.signal);
+
+    expect(scopeCreated).toBeTruthy();
+    expect(providerCreated).toBeTruthy();
+    expect(context.store.get(showOnboardingModal$)).toBeFalsy();
+  });
+
+  it("should not save when token is empty", async () => {
+    let providerCreated = false;
+
+    server.use(
+      http.put("/api/model-providers", () => {
+        providerCreated = true;
+        return HttpResponse.json({}, { status: 201 });
+      }),
+    );
+
+    await setupPage({ context, path: "/" });
+
+    // Try to save without setting token
+    context.store.set(startOnboarding$);
+    await context.store.set(saveOnboardingConfig$, context.signal);
+
+    expect(providerCreated).toBeFalsy();
+  });
+});
+
+describe("closeOnboardingModal$", () => {
+  it("should create scope when closing without saving", async () => {
+    let scopeCreated = false;
+    let providerCreated = false;
+
+    server.use(
+      http.get("/api/scope", () => {
+        return new HttpResponse(null, { status: 404 });
+      }),
+      http.post("/api/scope", () => {
+        scopeCreated = true;
+        return HttpResponse.json({}, { status: 201 });
+      }),
+      http.put("/api/model-providers", () => {
+        providerCreated = true;
+        return HttpResponse.json({}, { status: 201 });
+      }),
+    );
+
+    await setupPage({ context, path: "/" });
+
+    context.store.set(startOnboarding$);
+    await context.store.set(closeOnboardingModal$, context.signal);
+
+    expect(scopeCreated).toBeTruthy();
+    expect(providerCreated).toBeFalsy();
+    expect(context.store.get(showOnboardingModal$)).toBeFalsy();
+  });
+
+  it("should not create scope if it already exists", async () => {
+    let scopeCreated = false;
+
+    server.use(
+      http.post("/api/scope", () => {
+        scopeCreated = true;
+        return HttpResponse.json({}, { status: 201 });
+      }),
+    );
+
+    // Default mock has scope
+    await setupPage({ context, path: "/" });
+
+    context.store.set(startOnboarding$);
+    await context.store.set(closeOnboardingModal$, context.signal);
+
+    expect(scopeCreated).toBeFalsy();
+    expect(context.store.get(showOnboardingModal$)).toBeFalsy();
   });
 });

--- a/turbo/apps/platform/src/signals/external/__tests__/model-providers.test.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/model-providers.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
 import { testContext } from "../../__tests__/test-helpers";
 import { setupPage } from "../../../__tests__/helper";
-import { modelProviders$ } from "../model-providers";
+import {
+  modelProviders$,
+  hasClaudeCodeOAuthToken$,
+  reloadModelProviders$,
+  createModelProvider$,
+} from "../model-providers";
 
 const context = testContext();
 describe("test model providers", () => {
@@ -15,5 +22,114 @@ describe("test model providers", () => {
       "modelProviders",
       [expect.objectContaining({ id: "dummy-provider" })],
     );
+  });
+
+  describe("hasClaudeCodeOAuthToken$", () => {
+    it("should return true when claude-code-oauth-token provider exists", async () => {
+      await setupPage({ context, path: "/" });
+
+      const hasToken = await context.store.get(hasClaudeCodeOAuthToken$);
+      expect(hasToken).toBeTruthy();
+    });
+
+    it("should return false when no claude-code-oauth-token provider exists", async () => {
+      server.use(
+        http.get("/api/model-providers", () => {
+          return HttpResponse.json({ modelProviders: [] });
+        }),
+      );
+
+      await setupPage({ context, path: "/" });
+
+      const hasToken = await context.store.get(hasClaudeCodeOAuthToken$);
+      expect(hasToken).toBeFalsy();
+    });
+
+    it("should return false when only other provider types exist", async () => {
+      server.use(
+        http.get("/api/model-providers", () => {
+          return HttpResponse.json({
+            modelProviders: [
+              {
+                id: "anthropic-provider",
+                type: "anthropic-api-key",
+                framework: "claude-code",
+                credentialName: "ANTHROPIC_API_KEY",
+                isDefault: false,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+            ],
+          });
+        }),
+      );
+
+      await setupPage({ context, path: "/" });
+
+      const hasToken = await context.store.get(hasClaudeCodeOAuthToken$);
+      expect(hasToken).toBeFalsy();
+    });
+  });
+
+  describe("reloadModelProviders$", () => {
+    it("should trigger reload of model providers", async () => {
+      let callCount = 0;
+      server.use(
+        http.get("/api/model-providers", () => {
+          callCount++;
+          return HttpResponse.json({ modelProviders: [] });
+        }),
+      );
+
+      await setupPage({ context, path: "/" });
+
+      // First fetch
+      await context.store.get(modelProviders$);
+      expect(callCount).toBe(1);
+
+      // Trigger reload
+      context.store.set(reloadModelProviders$);
+      await context.store.get(modelProviders$);
+      expect(callCount).toBe(2);
+    });
+  });
+
+  describe("createModelProvider$", () => {
+    it("should create a new model provider and trigger reload", async () => {
+      let putCalled = false;
+      server.use(
+        http.put("/api/model-providers", async ({ request }) => {
+          putCalled = true;
+          const body = (await request.json()) as {
+            type: string;
+            credential: string;
+          };
+          return HttpResponse.json(
+            {
+              provider: {
+                id: "new-provider",
+                type: body.type,
+                framework: "claude-code",
+                credentialName: "CLAUDE_CODE_OAUTH_TOKEN",
+                isDefault: false,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+              created: true,
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await setupPage({ context, path: "/" });
+
+      await context.store.set(createModelProvider$, {
+        type: "claude-code-oauth-token",
+        credential: "test-token",
+      });
+
+      expect(putCalled).toBeTruthy();
+    });
   });
 });

--- a/turbo/apps/platform/src/signals/home/home-page.ts
+++ b/turbo/apps/platform/src/signals/home/home-page.ts
@@ -2,20 +2,19 @@ import { command } from "ccstate";
 import { createElement } from "react";
 import { HomePage } from "../../views/home/home-page.tsx";
 import { updatePage$ } from "../react-router.ts";
-import { hasScope$ } from "../scope.ts";
-import { startOnboarding$ } from "../onboarding.ts";
+import { needsOnboarding$, startOnboarding$ } from "../onboarding.ts";
 
 export const setupHomePage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(updatePage$, createElement(HomePage));
 
-    // Check if user has scope
-    const scopeExists = await get(hasScope$);
+    // Check if user needs onboarding (no scope or no oauth token)
+    const needsOnboarding = await get(needsOnboarding$);
     signal.throwIfAborted();
 
-    if (!scopeExists) {
-      // Start onboarding flow - shows modal and initializes scope
-      await set(startOnboarding$, signal);
+    if (needsOnboarding) {
+      // Start onboarding flow - shows modal
+      set(startOnboarding$);
     }
   },
 );

--- a/turbo/apps/platform/src/views/home/__tests__/home-page.test.tsx
+++ b/turbo/apps/platform/src/views/home/__tests__/home-page.test.tsx
@@ -65,4 +65,83 @@ describe("home page", () => {
 
     expect(screen.queryByText(/First, tell us how your LLM works/)).toBeNull();
   });
+
+  it("should show onboarding modal when no claude-code-oauth-token exists", async () => {
+    server.use(
+      http.get("/api/model-providers", () => {
+        return HttpResponse.json({ modelProviders: [] });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/",
+    });
+
+    expect(screen.getByText(/First, tell us how your LLM works/)).toBeDefined();
+  });
+
+  it("should not show onboarding modal when both scope and oauth token exist", async () => {
+    // Default mocks have both scope and oauth token
+    await setupPage({
+      context,
+      path: "/",
+    });
+
+    expect(screen.queryByText(/First, tell us how your LLM works/)).toBeNull();
+  });
+
+  it("should create model provider when Save button is clicked", async () => {
+    let providerCreated = false;
+    let createdType: string | null = null;
+
+    server.use(
+      http.get("/api/scope", () => {
+        return new HttpResponse(null, { status: 404 });
+      }),
+      http.post("/api/scope", () => {
+        return HttpResponse.json({}, { status: 201 });
+      }),
+      http.put("/api/model-providers", async ({ request }) => {
+        providerCreated = true;
+        const body = (await request.json()) as {
+          type: string;
+          credential: string;
+        };
+        createdType = body.type;
+        return HttpResponse.json(
+          {
+            provider: {
+              id: "new-provider",
+              type: body.type,
+              framework: "claude-code",
+              credentialName: "CLAUDE_CODE_OAUTH_TOKEN",
+              isDefault: false,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+            created: true,
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/",
+    });
+
+    // Type a token value
+    const tokenInput = screen.getByPlaceholderText("sk-ant-oat...");
+    await user.type(tokenInput, "sk-ant-oat-test-token");
+
+    // Click Save
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    // Wait for async operations
+    expect(providerCreated).toBeTruthy();
+    expect(createdType).toBe("claude-code-oauth-token");
+    expect(screen.queryByText(/First, tell us how your LLM works/)).toBeNull();
+  });
 });

--- a/turbo/apps/platform/src/views/home/onboarding-modal.tsx
+++ b/turbo/apps/platform/src/views/home/onboarding-modal.tsx
@@ -20,6 +20,7 @@ import {
   canSaveOnboarding$,
 } from "../../signals/onboarding.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
 
 export function OnboardingModal() {
   const isOpen = useGet(showOnboardingModal$);
@@ -30,6 +31,7 @@ export function OnboardingModal() {
   const copyStatus = useGet(copyStatus$);
   const copyToClipboard = useSet(copyToClipboard$);
   const canSave = useGet(canSaveOnboarding$);
+  const pageSignal = useGet(pageSignal$);
 
   return (
     <Dialog open={isOpen}>
@@ -43,7 +45,7 @@ export function OnboardingModal() {
         {/* Close button */}
         <DialogClose asChild>
           <button
-            onClick={() => closeModal()}
+            onClick={() => detach(closeModal(pageSignal), Reason.DomCallback)}
             className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
           >
             <IconX className="h-6 w-6 text-foreground" />
@@ -109,10 +111,16 @@ export function OnboardingModal() {
 
         {/* Action Buttons */}
         <div className="flex justify-end gap-2">
-          <Button variant="outline" onClick={() => closeModal()}>
+          <Button
+            variant="outline"
+            onClick={() => detach(closeModal(pageSignal), Reason.DomCallback)}
+          >
             Add it later
           </Button>
-          <Button onClick={() => saveConfig()} disabled={!canSave}>
+          <Button
+            onClick={() => detach(saveConfig(pageSignal), Reason.DomCallback)}
+            disabled={!canSave}
+          >
             Save
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- Extend onboarding flow to check for both scope AND claude-code-oauth-token model provider
- Show onboarding modal when either is missing, allowing users to configure their OAuth token
- Save button creates scope (if needed) and model provider with the entered token
- "Add it later" button creates scope only, deferring token configuration

## Changes
- Add `needsOnboarding$` computed signal that checks for both scope and oauth token
- Add `hasClaudeCodeOAuthToken$`, `reloadModelProviders$`, and `createModelProvider$` to model providers signals
- Update `saveOnboardingConfig$` and `closeOnboardingModal$` commands to handle async operations
- Wire up onboarding modal buttons to use `pageSignal$` for proper abort handling

## Test plan
- [x] Unit tests for `needsOnboarding$` covering all scenarios
- [x] Unit tests for `saveOnboardingConfig$` and `closeOnboardingModal$`
- [x] Unit tests for new model provider signals
- [x] Integration tests for home page onboarding flow
- [x] All 2200 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)