### PR TITLE
fix(devcontainer): add symlink for claude code ide integration

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -26,6 +26,15 @@ echo "✓ Locale configured"
 sudo mkdir -p /home/vscode/.local/bin /home/vscode/.pki
 sudo chown -R vscode:vscode /home/vscode/.config /home/vscode/.cache /home/vscode/.local /home/vscode/.pki
 
+# Create ~/.claude symlink to ~/.config/claude for Claude Code IDE integration
+# The VS Code extension uses ~/.claude/ide/ while CLI respects CLAUDE_CONFIG_DIR
+if [ ! -L "$HOME/.claude" ]; then
+  rm -rf "$HOME/.claude"
+  mkdir -p "$HOME/.config/claude"
+  ln -s "$HOME/.config/claude" "$HOME/.claude"
+  echo "✓ Linked ~/.claude to ~/.config/claude"
+fi
+
 # Add local development domains to /etc/hosts
 echo "📝 Adding local domains to /etc/hosts..."
 if ! grep -q "vm7.ai" /etc/hosts; then


### PR DESCRIPTION
## Summary

Fix Claude Code IDE integration in dev container by creating a symlink from `~/.claude` to `~/.config/claude`.

### Problem

In the dev container, `CLAUDE_CONFIG_DIR` is set to `/home/vscode/.config/claude` (which is mounted as a persistent volume). However, the VS Code extension writes IDE lock files to `~/.claude/ide/`, while the CLI reads from `$CLAUDE_CONFIG_DIR`. This mismatch causes the CLI to fail connecting to the VS Code extension.

### Solution

Create `~/.claude` as a symlink pointing to `~/.config/claude` during dev container setup. This ensures both the extension and CLI use the same directory.

## Test plan

- [x] Verify `~/.claude` is a symlink to `~/.config/claude`
- [x] Run `claude --ide` in VS Code terminal
- [x] Confirm "Connected to Visual Studio Code" message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)