### PR TITLE
fix(ci): add production environment to release workflow jobs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -126,6 +126,7 @@ jobs:
     permissions:
       contents: read
       deployments: write
+    environment: production
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
@@ -150,6 +151,7 @@ jobs:
     permissions:
       contents: read
       deployments: write
+    environment: production
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
@@ -178,6 +180,7 @@ jobs:
     permissions:
       contents: read
       deployments: write
+    environment: production
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
@@ -270,6 +273,7 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260116
     permissions:
       contents: read
+    environment: production
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+// Core package exports
 export * from "./variable-expander";
 export * from "./contracts";
 export * from "./scope-reference";


### PR DESCRIPTION
## Summary
- Add missing `environment: production` to `deploy-docs-production`, `deploy-site-production`, `deploy-platform-production`, and `deploy-runner-production` jobs
- This ensures these jobs have access to production secrets and variables, matching the pattern used by `deploy-web-production`

## Test plan
- [ ] Verify CI passes
- [ ] On next release, verify deployment jobs can access production environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)