### PR TITLE
docs(cli): update scope command terminology from images to agents

### DIFF
--- a/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
@@ -76,7 +76,7 @@ describe("scope set command", () => {
         expect.stringContaining("Scope created: testslug"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("testslug/<image-name>"),
+        expect.stringContaining("testslug/<agent-name>"),
       );
     });
 

--- a/turbo/apps/cli/src/commands/scope/index.ts
+++ b/turbo/apps/cli/src/commands/scope/index.ts
@@ -4,6 +4,6 @@ import { setCommand } from "./set";
 
 export const scopeCommand = new Command()
   .name("scope")
-  .description("Manage your scope (namespace for images)")
+  .description("Manage your scope (namespace for agents)")
   .addCommand(statusCommand)
   .addCommand(setCommand);

--- a/turbo/apps/cli/src/commands/scope/set.ts
+++ b/turbo/apps/cli/src/commands/scope/set.ts
@@ -42,7 +42,7 @@ export const setCommand = new Command()
             console.error();
             console.error(
               chalk.yellow(
-                "Warning: Changing your scope may break existing image references.",
+                "Warning: Changing your scope may break existing agent references.",
               ),
             );
             process.exit(1);
@@ -60,8 +60,8 @@ export const setCommand = new Command()
         }
 
         console.log();
-        console.log("Your images will now be namespaced as:");
-        console.log(chalk.cyan(`  ${scope.slug}/<image-name>`));
+        console.log("Your agents will now be namespaced as:");
+        console.log(chalk.cyan(`  ${scope.slug}/<agent-name>`));
       } catch (error) {
         if (error instanceof Error) {
           if (error.message.includes("Not authenticated")) {


### PR DESCRIPTION
## Summary
- Update CLI scope command user-facing messages to use "agents" instead of "images"
- Align terminology with current product naming conventions
- Update corresponding test assertions

## Test plan
- [x] All existing tests pass after updating test assertions
- [x] Pre-commit checks (lint, format, type-check, knip) pass

---
Generated with [Claude Code](https://claude.com/claude-code)