### PR TITLE
feat(cli): improve cook command help text

### DIFF
--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -311,7 +311,7 @@ async function autoPullArtifact(
 // Create the cook command with subcommands
 const cookCmd = new Command()
   .name("cook")
-  .description("One-click agent preparation and execution from vm0.yaml");
+  .description("Quick start: prepare, compose and run agent from vm0.yaml");
 
 // Default action for "vm0 cook [prompt]"
 cookCmd


### PR DESCRIPTION
## Summary
- Update cook command description to better reflect its tutorial nature
- New description: "Quick start: prepare, compose and run agent from vm0.yaml"

**Before:**
```
cook [options] [prompt]  One-click agent preparation and execution from vm0.yaml
```

**After:**
```
cook [options] [prompt]  Quick start: prepare, compose and run agent from vm0.yaml
```

## Test plan
- [x] Built CLI and verified help output
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)