### PR TITLE
refactor(cli): rename vm0 agent inspect to vm0 agent status

### DIFF
--- a/e2e/tests/02-parallel/t26-vm0-agent-list-status.bats
+++ b/e2e/tests/02-parallel/t26-vm0-agent-list-status.bats
@@ -2,7 +2,7 @@
 
 load '../../helpers/setup'
 
-# vm0 agent list and inspect command tests
+# vm0 agent list and status command tests
 #
 # Note: Help/alias tests (command description, name, alias) have been moved to unit tests:
 # turbo/apps/cli/src/__tests__/agent-commands.test.ts
@@ -78,17 +78,17 @@ EOF
 }
 
 # ============================================
-# Inspect Command Tests
+# Status Command Tests
 # ============================================
 
-@test "vm0 agent inspect shows agent details" {
+@test "vm0 agent status shows agent details" {
     echo "# Step 1: Create vm0.yaml config file"
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 
 agents:
   $AGENT_NAME:
-    description: "Test agent for inspect command"
+    description: "Test agent for status command"
     framework: claude-code
     image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
@@ -98,8 +98,8 @@ EOF
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
-    echo "# Step 3: Run vm0 agent inspect"
-    run $CLI_COMMAND agent inspect "$AGENT_NAME"
+    echo "# Step 3: Run vm0 agent status"
+    run $CLI_COMMAND agent status "$AGENT_NAME"
     assert_success
     assert_output --partial "Name:"
     assert_output --partial "Version:"
@@ -107,7 +107,7 @@ EOF
     assert_output --partial "Framework:"
 }
 
-@test "vm0 agent inspect with version specifier" {
+@test "vm0 agent status with version specifier" {
     echo "# Step 1: Create vm0.yaml config file"
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
@@ -126,13 +126,13 @@ EOF
     VERSION=$(echo "$output" | grep -oP 'Version:\s+\K[0-9a-f]+')
     echo "# Captured version: $VERSION"
 
-    echo "# Step 3: Run vm0 agent inspect with version specifier"
-    run $CLI_COMMAND agent inspect "$AGENT_NAME:$VERSION"
+    echo "# Step 3: Run vm0 agent status with version specifier"
+    run $CLI_COMMAND agent status "$AGENT_NAME:$VERSION"
     assert_success
     assert_output --partial "$VERSION"
 }
 
-@test "vm0 agent inspect with :latest tag" {
+@test "vm0 agent status with :latest tag" {
     echo "# Step 1: Create vm0.yaml config file"
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
@@ -149,14 +149,14 @@ EOF
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
-    echo "# Step 3: Run vm0 agent inspect with :latest"
-    run $CLI_COMMAND agent inspect "$AGENT_NAME:latest"
+    echo "# Step 3: Run vm0 agent status with :latest"
+    run $CLI_COMMAND agent status "$AGENT_NAME:latest"
     assert_success
     assert_output --partial "Name:"
     assert_output --partial "Version:"
 }
 
-@test "vm0 agent inspect with --no-sources flag" {
+@test "vm0 agent status with --no-sources flag" {
     echo "# Step 1: Create vm0.yaml config file"
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
@@ -173,8 +173,8 @@ EOF
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
-    echo "# Step 3: Run vm0 agent inspect with --no-sources flag"
-    run $CLI_COMMAND agent inspect "$AGENT_NAME" --no-sources
+    echo "# Step 3: Run vm0 agent status with --no-sources flag"
+    run $CLI_COMMAND agent status "$AGENT_NAME" --no-sources
     assert_success
     assert_output --partial "Name:"
 }
@@ -183,13 +183,13 @@ EOF
 # Error Handling Tests
 # ============================================
 
-@test "vm0 agent inspect fails for nonexistent agent" {
-    run $CLI_COMMAND agent inspect "nonexistent-agent-12345"
+@test "vm0 agent status fails for nonexistent agent" {
+    run $CLI_COMMAND agent status "nonexistent-agent-12345"
     assert_failure
     assert_output --partial "not found"
 }
 
-@test "vm0 agent inspect fails for nonexistent version" {
+@test "vm0 agent status fails for nonexistent version" {
     echo "# Step 1: Create vm0.yaml config file"
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
@@ -206,8 +206,8 @@ EOF
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
-    echo "# Step 3: Run vm0 agent inspect with nonexistent version"
-    run $CLI_COMMAND agent inspect "$AGENT_NAME:deadbeef"
+    echo "# Step 3: Run vm0 agent status with nonexistent version"
+    run $CLI_COMMAND agent status "$AGENT_NAME:deadbeef"
     assert_failure
     assert_output --partial "Version not found"
 }

--- a/turbo/apps/cli/src/__tests__/agent-commands.test.ts
+++ b/turbo/apps/cli/src/__tests__/agent-commands.test.ts
@@ -1,8 +1,8 @@
 /**
- * Unit tests for agent list and inspect commands
+ * Unit tests for agent list and status commands
  *
  * These tests validate command metadata (name, description, aliases).
- * This replaces E2E tests for help/alias tests from t26-vm0-agent-list-inspect.bats.
+ * This replaces E2E tests for help/alias tests from t26-vm0-agent-list-status.bats.
  *
  * Note: API interaction tests (error handling for nonexistent agents/versions)
  * remain in E2E tests because ts-rest client intercepting requires complex setup.
@@ -16,7 +16,7 @@
 
 import { describe, it, expect } from "vitest";
 import { listCommand } from "../commands/agent/list";
-import { inspectCommand } from "../commands/agent/inspect";
+import { statusCommand } from "../commands/agent/status";
 
 describe("agent list command", () => {
   describe("command metadata", () => {
@@ -42,26 +42,26 @@ describe("agent list command", () => {
   });
 });
 
-describe("agent inspect command", () => {
+describe("agent status command", () => {
   describe("command metadata", () => {
     it("should have correct command description", () => {
-      expect(inspectCommand.description()).toBe("Inspect an agent compose");
+      expect(statusCommand.description()).toBe("Show status of agent compose");
     });
 
     it("should have correct command name", () => {
-      expect(inspectCommand.name()).toBe("inspect");
+      expect(statusCommand.name()).toBe("status");
     });
 
     it("should accept name[:version] argument format", () => {
       // The command is configured to accept a single required argument
-      const args = inspectCommand.registeredArguments;
+      const args = statusCommand.registeredArguments;
       expect(args.length).toBe(1);
       expect(args[0]?.name()).toBe("name[:version]");
       expect(args[0]?.required).toBe(true);
     });
 
     it("should have --scope option", () => {
-      const scopeOption = inspectCommand.options.find(
+      const scopeOption = statusCommand.options.find(
         (opt) => opt.long === "--scope",
       );
       expect(scopeOption).toBeDefined();
@@ -69,7 +69,7 @@ describe("agent inspect command", () => {
     });
 
     it("should have --no-sources option", () => {
-      const noSourcesOption = inspectCommand.options.find(
+      const noSourcesOption = statusCommand.options.find(
         (opt) => opt.long === "--no-sources",
       );
       expect(noSourcesOption).toBeDefined();

--- a/turbo/apps/cli/src/commands/agent/index.ts
+++ b/turbo/apps/cli/src/commands/agent/index.ts
@@ -1,9 +1,9 @@
 import { Command } from "commander";
 import { listCommand } from "./list";
-import { inspectCommand } from "./inspect";
+import { statusCommand } from "./status";
 
 export const agentCommand = new Command()
   .name("agent")
   .description("Manage agent composes")
   .addCommand(listCommand)
-  .addCommand(inspectCommand);
+  .addCommand(statusCommand);

--- a/turbo/apps/cli/src/commands/agent/status.ts
+++ b/turbo/apps/cli/src/commands/agent/status.ts
@@ -126,9 +126,9 @@ function formatComposeOutput(
   }
 }
 
-export const inspectCommand = new Command()
-  .name("inspect")
-  .description("Inspect an agent compose")
+export const statusCommand = new Command()
+  .name("status")
+  .description("Show status of agent compose")
   .argument(
     "<name[:version]>",
     "Agent name with optional version (e.g., my-agent:latest or my-agent:a1b2c3d4)",
@@ -224,7 +224,7 @@ export const inspectCommand = new Command()
           variableSources,
         );
       } catch (error) {
-        console.error(chalk.red("✗ Failed to inspect agent compose"));
+        console.error(chalk.red("✗ Failed to get agent compose status"));
         if (error instanceof Error) {
           if (error.message.includes("Not authenticated")) {
             console.error(chalk.dim("  Run: vm0 auth login"));

--- a/turbo/apps/docs/content/docs/reference/cli/index.mdx
+++ b/turbo/apps/docs/content/docs/reference/cli/index.mdx
@@ -29,7 +29,7 @@ description: Complete reference for all VM0 CLI commands
 | `vm0 run resume <checkpoint-id> <prompt>` | Resume from checkpoint | Same as `run` |
 | `vm0 cook [prompt]` | Prepare and execute agent from `vm0.yaml` | `-y, --yes` |
 | `vm0 agent list` | List all agent composes | `--json` |
-| `vm0 agent inspect <name[:version]>` | Inspect agent configuration | `--json` |
+| `vm0 agent status <name[:version]>` | Show agent compose status | `--json` |
 
 ### `vm0 run` Examples
 


### PR DESCRIPTION
## Summary

- Rename `vm0 agent inspect` command to `vm0 agent status` to align with naming conventions used by other CLI commands (`volume status`, `artifact status`, `schedule status`, `scope status`)
- Update command description to "Show status of agent compose"
- Update error message accordingly
- Update all unit tests and E2E tests
- Update CLI documentation

## Test plan

- [x] Unit tests pass (`pnpm vitest run apps/cli`)
- [x] Type check passes (`pnpm check-types --filter=@vm0/cli`)
- [x] Lint passes (`pnpm turbo run lint --filter=@vm0/cli`)
- [ ] E2E tests pass (CI will verify)
- [x] No references to "agent inspect" remain in source code

Closes #1626

🤖 Generated with [Claude Code](https://claude.com/claude-code)