### PR TITLE
feat!: replace implicit .env loading with explicit --env-file flag

### DIFF
--- a/e2e/tests/02-parallel/t13-vm0-cook.bats
+++ b/e2e/tests/02-parallel/t13-vm0-cook.bats
@@ -91,7 +91,7 @@ EOF
     fi
 }
 
-@test "cook command succeeds when variables are set in .env file" {
+@test "cook command succeeds when variables are set via --env-file" {
     # Skip if not authenticated (requires VM0_TOKEN or logged in)
     if $CLI_COMMAND auth status 2>&1 | grep -q "Not authenticated"; then
         skip "Not authenticated - run 'vm0 auth login' first"
@@ -118,8 +118,8 @@ EOF
 E2E_TEST_VAR=test-value-123
 EOF
 
-    echo "# Step 3: Run cook (should succeed)..."
-    run $CLI_COMMAND cook --no-auto-update
+    echo "# Step 3: Run cook with --env-file (should succeed)..."
+    run $CLI_COMMAND cook --no-auto-update --env-file .env
     assert_success
 
     echo "# Step 4: Verify normal cook output..."

--- a/turbo/apps/cli/src/commands/run/__tests__/shared.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/shared.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs/promises";
+import { mkdtempSync, rmSync } from "fs";
+import * as path from "path";
+import * as os from "os";
+import { loadValues } from "../shared";
+
+// Test variable names (using unique prefixes to avoid env collisions)
+const TEST_VAR_1 = "SHARED_TEST_VAR_1";
+const TEST_VAR_2 = "SHARED_TEST_VAR_2";
+const TEST_VAR_3 = "SHARED_TEST_VAR_3";
+
+describe("loadValues", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "test-shared-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    // Clean up any env vars
+    delete process.env[TEST_VAR_1];
+    delete process.env[TEST_VAR_2];
+    delete process.env[TEST_VAR_3];
+  });
+
+  describe("priority order: CLI > file > env", () => {
+    it("CLI values take highest priority over file and env", async () => {
+      // Set up env var
+      vi.stubEnv(TEST_VAR_1, "from-env");
+
+      // Create env file
+      const envFilePath = path.join(tempDir, ".env");
+      await fs.writeFile(envFilePath, `${TEST_VAR_1}=from-file\n`);
+
+      // CLI value should win
+      const cliValues = { [TEST_VAR_1]: "from-cli" };
+      const result = loadValues(cliValues, [TEST_VAR_1], envFilePath);
+
+      expect(result?.[TEST_VAR_1]).toBe("from-cli");
+    });
+
+    it("file values override env vars", async () => {
+      // Set up env var
+      vi.stubEnv(TEST_VAR_1, "from-env");
+
+      // Create env file
+      const envFilePath = path.join(tempDir, ".env");
+      await fs.writeFile(envFilePath, `${TEST_VAR_1}=from-file\n`);
+
+      // File value should override env
+      const result = loadValues({}, [TEST_VAR_1], envFilePath);
+
+      expect(result?.[TEST_VAR_1]).toBe("from-file");
+    });
+
+    it("env vars used as fallback when no file provided", () => {
+      // Set up env var
+      vi.stubEnv(TEST_VAR_1, "from-env");
+
+      // No envFilePath provided
+      const result = loadValues({}, [TEST_VAR_1]);
+
+      expect(result?.[TEST_VAR_1]).toBe("from-env");
+    });
+
+    it("env vars used for keys not in file", async () => {
+      // Set up env vars
+      vi.stubEnv(TEST_VAR_1, "from-env");
+      vi.stubEnv(TEST_VAR_2, "from-env");
+
+      // Create env file with only one variable
+      const envFilePath = path.join(tempDir, ".env");
+      await fs.writeFile(envFilePath, `${TEST_VAR_1}=from-file\n`);
+
+      const result = loadValues({}, [TEST_VAR_1, TEST_VAR_2], envFilePath);
+
+      // VAR_1 from file, VAR_2 from env
+      expect(result?.[TEST_VAR_1]).toBe("from-file");
+      expect(result?.[TEST_VAR_2]).toBe("from-env");
+    });
+  });
+
+  describe("without --env-file", () => {
+    it("only loads from CLI and env when no envFilePath", () => {
+      vi.stubEnv(TEST_VAR_1, "from-env");
+
+      const cliValues = { [TEST_VAR_2]: "from-cli" };
+      const result = loadValues(cliValues, [TEST_VAR_1, TEST_VAR_2]);
+
+      expect(result?.[TEST_VAR_1]).toBe("from-env");
+      expect(result?.[TEST_VAR_2]).toBe("from-cli");
+    });
+
+    it("returns undefined when no values found and no envFilePath", () => {
+      const UNIQUE_VAR = "UNIQUE_VAR_" + Date.now();
+      const result = loadValues({}, [UNIQUE_VAR]);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("with --env-file", () => {
+    it("loads values from specified file", async () => {
+      const envFilePath = path.join(tempDir, "custom.env");
+      await fs.writeFile(envFilePath, `${TEST_VAR_1}=custom-value\n`);
+
+      const result = loadValues({}, [TEST_VAR_1], envFilePath);
+
+      expect(result?.[TEST_VAR_1]).toBe("custom-value");
+    });
+
+    it("throws error when file does not exist", () => {
+      const envFilePath = path.join(tempDir, "nonexistent.env");
+
+      expect(() => loadValues({}, [TEST_VAR_1], envFilePath)).toThrow(
+        `Environment file not found: ${envFilePath}`,
+      );
+    });
+
+    it("handles empty file gracefully", async () => {
+      vi.stubEnv(TEST_VAR_1, "from-env");
+
+      const envFilePath = path.join(tempDir, ".env");
+      await fs.writeFile(envFilePath, "");
+
+      const result = loadValues({}, [TEST_VAR_1], envFilePath);
+
+      // Falls back to env
+      expect(result?.[TEST_VAR_1]).toBe("from-env");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns CLI values even if configNames is empty", () => {
+      const cliValues = { [TEST_VAR_1]: "cli-value" };
+      const result = loadValues(cliValues, []);
+
+      expect(result?.[TEST_VAR_1]).toBe("cli-value");
+    });
+
+    it("returns undefined when cliValues empty and configNames empty", () => {
+      const result = loadValues({}, []);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("only loads keys that are in configNames from file", async () => {
+      const envFilePath = path.join(tempDir, ".env");
+      await fs.writeFile(
+        envFilePath,
+        `${TEST_VAR_1}=value1\n${TEST_VAR_2}=value2\n${TEST_VAR_3}=value3\n`,
+      );
+
+      // Only ask for VAR_1 and VAR_2
+      const result = loadValues({}, [TEST_VAR_1, TEST_VAR_2], envFilePath);
+
+      expect(result?.[TEST_VAR_1]).toBe("value1");
+      expect(result?.[TEST_VAR_2]).toBe("value2");
+      expect(result?.[TEST_VAR_3]).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Replace implicit `.env` loading with explicit `--env-file` flag in CLI commands
- Align with Docker CLI conventions for environment file handling
- Remove auto-generation of `.env` placeholders

## Changes

- Add `--env-file` option to `vm0 run`, `vm0 run continue`, `vm0 run resume`
- Add `--env-file` option to `vm0 cook`, `vm0 cook continue`, `vm0 cook resume`
- Change priority order to match Docker: CLI flags > file > env vars
- Remove `generateEnvPlaceholders` function (no longer needed)
- Update help text to reflect new behavior

## Test plan

- [x] Unit tests for `loadValues` with `--env-file` parameter
- [x] Unit tests for `checkMissingVariables` with optional env file
- [x] E2E test for `--env-file` error handling (nonexistent file)
- [x] All existing tests pass

## Breaking Changes

- The CLI no longer implicitly loads `.env` files from the current directory
- Users must now explicitly specify `--env-file <path>` to load from a file
- Priority order changed: CLI flags > `--env-file` > `process.env` (was CLI > env > file)
- `vm0 cook` no longer auto-generates `.env` placeholders for missing variables

## Migration

Before:
```bash
# Implicitly loads .env from cwd
vm0 run agent "prompt"
```

After:
```bash
# No .env loading unless explicit
vm0 run agent "prompt"

# Explicit .env loading
vm0 run --env-file .env agent "prompt"
```

Closes #1636

🤖 Generated with [Claude Code](https://claude.com/claude-code)