### PR TITLE
refactor: require secrets encryption key in all environments

### DIFF
--- a/turbo/apps/web/src/env.ts
+++ b/turbo/apps/web/src/env.ts
@@ -18,7 +18,7 @@ function initEnv() {
       R2_ACCESS_KEY_ID: z.string().min(1),
       R2_SECRET_ACCESS_KEY: z.string().min(1),
       R2_USER_STORAGES_BUCKET_NAME: z.string().min(1),
-      SECRETS_ENCRYPTION_KEY: z.string().length(64).optional(), // 32-byte hex key for AES-256
+      SECRETS_ENCRYPTION_KEY: z.string().length(64), // 32-byte hex key for AES-256
       OFFICIAL_RUNNER_SECRET: z.string().length(64).optional(), // 32-byte hex key for official runner auth
       AXIOM_TOKEN: z.string().min(1).optional(),
       AXIOM_DATASET_SUFFIX: z.enum(["dev", "prod"]).optional(), // Explicit control for Axiom dataset suffix

--- a/turbo/apps/web/src/lib/crypto/__tests__/secrets-encryption.test.ts
+++ b/turbo/apps/web/src/lib/crypto/__tests__/secrets-encryption.test.ts
@@ -47,23 +47,9 @@ describe("secrets-encryption", () => {
       expect(encrypted1).not.toBe(encrypted2);
     });
 
-    it("should store unencrypted in dev mode when key not provided", () => {
-      vi.stubEnv("NODE_ENV", "development");
-
-      const secrets = ["API_KEY"];
-      const result = encryptSecrets(secrets, undefined);
-
-      expect(result).not.toBeNull();
-      const parsed = JSON.parse(result!);
-      expect(parsed.unencrypted).toBe(true);
-      expect(parsed.data).toEqual(secrets);
-    });
-
-    it("should throw in production when key not provided", () => {
-      vi.stubEnv("NODE_ENV", "production");
-
+    it("should throw when key not provided", () => {
       expect(() => encryptSecrets(["SECRET"], undefined)).toThrow(
-        "SECRETS_ENCRYPTION_KEY must be set in production",
+        "SECRETS_ENCRYPTION_KEY is required",
       );
     });
 
@@ -88,21 +74,11 @@ describe("secrets-encryption", () => {
       expect(decrypted).toEqual(secrets);
     });
 
-    it("should handle unencrypted data (dev mode fallback)", () => {
-      const unencrypted = JSON.stringify({
-        unencrypted: true,
-        data: ["SECRET"],
-      });
-      const result = decryptSecrets(unencrypted, undefined);
-
-      expect(result).toEqual(["SECRET"]);
-    });
-
-    it("should throw for encrypted data without key", () => {
+    it("should throw when key not provided", () => {
       const encrypted = encryptSecrets(["SECRET"], TEST_KEY);
 
       expect(() => decryptSecrets(encrypted, undefined)).toThrow(
-        "SECRETS_ENCRYPTION_KEY not configured but encrypted data found",
+        "SECRETS_ENCRYPTION_KEY is required",
       );
     });
 
@@ -154,22 +130,9 @@ describe("secrets-encryption", () => {
       expect(encrypted1).not.toBe(encrypted2);
     });
 
-    it("should store unencrypted in dev mode when key not provided", () => {
-      vi.stubEnv("NODE_ENV", "development");
-
-      const secrets = { API_KEY: "secret123" };
-      const result = encryptSecretsMap(secrets, undefined);
-
-      const parsed = JSON.parse(result!);
-      expect(parsed.unencrypted).toBe(true);
-      expect(parsed.data).toEqual(secrets);
-    });
-
-    it("should throw in production when key not provided", () => {
-      vi.stubEnv("NODE_ENV", "production");
-
+    it("should throw when key not provided", () => {
       expect(() => encryptSecretsMap({ KEY: "value" }, undefined)).toThrow(
-        "SECRETS_ENCRYPTION_KEY must be set in production",
+        "SECRETS_ENCRYPTION_KEY is required",
       );
     });
   });
@@ -192,16 +155,6 @@ describe("secrets-encryption", () => {
       expect(decrypted).toEqual(secrets);
     });
 
-    it("should handle unencrypted data (dev mode fallback)", () => {
-      const unencrypted = JSON.stringify({
-        unencrypted: true,
-        data: { KEY: "value" },
-      });
-      const result = decryptSecretsMap(unencrypted, undefined);
-
-      expect(result).toEqual({ KEY: "value" });
-    });
-
     it("should preserve all key-value pairs through encryption cycle", () => {
       const secrets = {
         key1: "value1",
@@ -216,11 +169,11 @@ describe("secrets-encryption", () => {
       expect(Object.keys(decrypted!)).toHaveLength(4);
     });
 
-    it("should throw for encrypted data without key", () => {
+    it("should throw when key not provided", () => {
       const encrypted = encryptSecretsMap({ KEY: "value" }, TEST_KEY);
 
       expect(() => decryptSecretsMap(encrypted, undefined)).toThrow(
-        "SECRETS_ENCRYPTION_KEY not configured but encrypted data found",
+        "SECRETS_ENCRYPTION_KEY is required",
       );
     });
 

--- a/turbo/apps/web/src/lib/crypto/secrets-encryption.ts
+++ b/turbo/apps/web/src/lib/crypto/secrets-encryption.ts
@@ -1,7 +1,4 @@
 import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
-import { logger } from "../logger";
-
-const log = logger("crypto:secrets");
 
 const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 12; // 96 bits for GCM
@@ -20,14 +17,7 @@ export function encryptSecrets(
   }
 
   if (!encryptionKey) {
-    if (process.env.NODE_ENV === "production") {
-      throw new Error("SECRETS_ENCRYPTION_KEY must be set in production");
-    }
-    // Only allow unencrypted storage in development/test
-    log.debug(
-      "SECRETS_ENCRYPTION_KEY not configured, using unencrypted storage (dev mode)",
-    );
-    return JSON.stringify({ unencrypted: true, data: secrets });
+    throw new Error("SECRETS_ENCRYPTION_KEY is required");
   }
 
   const key = Buffer.from(encryptionKey, "hex");
@@ -69,20 +59,8 @@ export function decryptSecrets(
     return null;
   }
 
-  // Check for unencrypted data (fallback when key not configured)
-  try {
-    const parsed = JSON.parse(encryptedData);
-    if (parsed.unencrypted === true) {
-      return parsed.data as string[];
-    }
-  } catch {
-    // Not JSON, continue with decryption
-  }
-
   if (!encryptionKey) {
-    throw new Error(
-      "SECRETS_ENCRYPTION_KEY not configured but encrypted data found",
-    );
+    throw new Error("SECRETS_ENCRYPTION_KEY is required");
   }
 
   const key = Buffer.from(encryptionKey, "hex");
@@ -127,13 +105,7 @@ export function encryptSecretsMap(
   }
 
   if (!encryptionKey) {
-    if (process.env.NODE_ENV === "production") {
-      throw new Error("SECRETS_ENCRYPTION_KEY must be set in production");
-    }
-    log.debug(
-      "SECRETS_ENCRYPTION_KEY not configured, using unencrypted storage (dev mode)",
-    );
-    return JSON.stringify({ unencrypted: true, data: secrets });
+    throw new Error("SECRETS_ENCRYPTION_KEY is required");
   }
 
   const key = Buffer.from(encryptionKey, "hex");
@@ -175,20 +147,8 @@ export function decryptSecretsMap(
     return null;
   }
 
-  // Check for unencrypted data (fallback when key not configured)
-  try {
-    const parsed = JSON.parse(encryptedData);
-    if (parsed.unencrypted === true) {
-      return parsed.data as Record<string, string>;
-    }
-  } catch {
-    // Not JSON, continue with decryption
-  }
-
   if (!encryptionKey) {
-    throw new Error(
-      "SECRETS_ENCRYPTION_KEY not configured but encrypted data found",
-    );
+    throw new Error("SECRETS_ENCRYPTION_KEY is required");
   }
 
   const key = Buffer.from(encryptionKey, "hex");
@@ -228,13 +188,7 @@ export function encryptCredentialValue(
   encryptionKey: string | undefined,
 ): string {
   if (!encryptionKey) {
-    if (process.env.NODE_ENV === "production") {
-      throw new Error("SECRETS_ENCRYPTION_KEY must be set in production");
-    }
-    log.debug(
-      "SECRETS_ENCRYPTION_KEY not configured, using unencrypted storage (dev mode)",
-    );
-    return JSON.stringify({ unencrypted: true, data: value });
+    throw new Error("SECRETS_ENCRYPTION_KEY is required");
   }
 
   const key = Buffer.from(encryptionKey, "hex");
@@ -268,20 +222,8 @@ export function decryptCredentialValue(
   encryptedData: string,
   encryptionKey: string | undefined,
 ): string {
-  // Check for unencrypted data (fallback when key not configured)
-  try {
-    const parsed = JSON.parse(encryptedData);
-    if (parsed.unencrypted === true) {
-      return parsed.data as string;
-    }
-  } catch {
-    // Not JSON, continue with decryption
-  }
-
   if (!encryptionKey) {
-    throw new Error(
-      "SECRETS_ENCRYPTION_KEY not configured but encrypted data found",
-    );
+    throw new Error("SECRETS_ENCRYPTION_KEY is required");
   }
 
   const key = Buffer.from(encryptionKey, "hex");


### PR DESCRIPTION
## Summary

- Remove fallback unencrypted storage from all 6 encryption functions
- Make `SECRETS_ENCRYPTION_KEY` required in `env.ts` (removes `.optional()`)
- Update tests to remove fallback behavior tests and update error messages

## Changes

| File | Change |
|------|--------|
| `env.ts` | Make `SECRETS_ENCRYPTION_KEY` required |
| `secrets-encryption.ts` | Remove fallback logic from 6 functions (-105 lines) |
| `secrets-encryption.test.ts` | Remove fallback tests, update error messages |

## Affected Functions

- `encryptSecrets()`, `decryptSecrets()` - Runner executor/job claim
- `encryptSecretsMap()`, `decryptSecretsMap()` - Schedule service
- `encryptCredentialValue()`, `decryptCredentialValue()` - Credential/model provider services

## Test plan

- [x] All encryption/decryption tests pass (21 tests)
- [x] Credential service tests pass (19 tests)
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes (no unused exports)

Closes #1640

🤖 Generated with [Claude Code](https://claude.com/claude-code)