### PR TITLE
refactor(runner): remove dns configuration function

### DIFF
--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -38,7 +38,6 @@ import {
   downloadStorages,
   restoreSessionHistory,
   installProxyCA,
-  configureDNS,
 } from "./vm-setup/index.js";
 
 /**
@@ -259,10 +258,6 @@ export async function executeJob(
         await installProxyCA(guest, caCertPath);
       }
     }
-
-    // Configure DNS - systemd may have overwritten resolv.conf at boot
-    log(`[Executor] Configuring DNS...`);
-    await configureDNS(guest);
 
     // Upload all Python scripts
     log(`[Executor] Uploading scripts...`);

--- a/turbo/apps/runner/src/lib/vm-setup/index.ts
+++ b/turbo/apps/runner/src/lib/vm-setup/index.ts
@@ -9,5 +9,4 @@ export {
   downloadStorages,
   restoreSessionHistory,
   installProxyCA,
-  configureDNS,
 } from "./vm-setup.js";

--- a/turbo/apps/runner/src/lib/vm-setup/vm-setup.ts
+++ b/turbo/apps/runner/src/lib/vm-setup/vm-setup.ts
@@ -140,22 +140,3 @@ export async function installProxyCA(
   await guest.execOrThrow("sudo update-ca-certificates");
   console.log(`[Executor] Proxy CA certificate installed successfully`);
 }
-
-/**
- * Verify DNS configuration in the VM
- * DNS is pre-configured in the rootfs image during build (build-rootfs.sh).
- * This function verifies the configuration is correct.
- */
-export async function configureDNS(guest: GuestClient): Promise<void> {
-  const expectedDns = `nameserver 8.8.8.8
-nameserver 8.8.4.4
-nameserver 1.1.1.1`;
-
-  const actualDns = (await guest.execOrThrow("cat /etc/resolv.conf")).trim();
-
-  if (actualDns !== expectedDns) {
-    console.warn(
-      `[Executor] DNS config mismatch. Expected:\n${expectedDns}\nActual:\n${actualDns}`,
-    );
-  }
-}

--- a/turbo/apps/runner/src/lib/vm-setup/vm-setup.ts
+++ b/turbo/apps/runner/src/lib/vm-setup/vm-setup.ts
@@ -142,19 +142,20 @@ export async function installProxyCA(
 }
 
 /**
- * Configure DNS in the VM
- * Systemd-resolved may overwrite /etc/resolv.conf at boot,
- * so we need to ensure DNS servers are configured after the VM is ready.
- * Requires sudo since we're connected as 'user', not root.
+ * Verify DNS configuration in the VM
+ * DNS is pre-configured in the rootfs image during build (build-rootfs.sh).
+ * This function verifies the configuration is correct.
  */
 export async function configureDNS(guest: GuestClient): Promise<void> {
-  // Remove any symlink and write static DNS configuration
-  // Use sudo since /etc/resolv.conf requires root access
-  const dnsConfig = `nameserver 8.8.8.8
+  const expectedDns = `nameserver 8.8.8.8
 nameserver 8.8.4.4
 nameserver 1.1.1.1`;
 
-  await guest.execOrThrow(
-    `sudo sh -c 'rm -f /etc/resolv.conf && echo "${dnsConfig}" > /etc/resolv.conf'`,
-  );
+  const actualDns = (await guest.execOrThrow("cat /etc/resolv.conf")).trim();
+
+  if (actualDns !== expectedDns) {
+    console.warn(
+      `[Executor] DNS config mismatch. Expected:\n${expectedDns}\nActual:\n${actualDns}`,
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- Remove `configureDNS` function from vm-setup
- DNS is pre-configured in the rootfs image during build (`build-rootfs.sh`)
- Runtime configuration/verification is unnecessary overhead

## Context

After PR #1642, DNS configuration is handled during rootfs build. The `configureDNS` function was redundant - if DNS is misconfigured, network operations will fail with clear errors anyway.

## Test plan

- [ ] Run VM and verify DNS resolution works
- [ ] Verify no DNS-related logs in executor output

Closes #1648

🤖 Generated with [Claude Code](https://claude.ai/code)