### PR TITLE
refactor(platform): improve settings page model provider management

### DIFF
--- a/turbo/apps/platform/src/signals/external/model-providers.ts
+++ b/turbo/apps/platform/src/signals/external/model-providers.ts
@@ -61,3 +61,22 @@ export const createModelProvider$ = command(
     return result;
   },
 );
+
+/**
+ * Delete a model provider by type.
+ */
+export const deleteModelProvider$ = command(
+  async ({ get, set }, type: string) => {
+    const fetchFn = get(fetch$);
+    const response = await fetchFn(`/api/model-providers/${type}`, {
+      method: "DELETE",
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to delete model provider: ${response.status}`);
+    }
+
+    // Trigger reload after successful deletion
+    set(internalReloadModelProviders$, (x) => x + 1);
+  },
+);

--- a/turbo/apps/platform/src/signals/layout/navigation.ts
+++ b/turbo/apps/platform/src/signals/layout/navigation.ts
@@ -38,6 +38,12 @@ export const NAVIGATION_CONFIG = [
 
 export const FOOTER_NAV_ITEMS = [
   {
+    id: "settings",
+    label: "Settings",
+    icon: "Settings",
+    path: "/settings",
+  },
+  {
     id: "docs",
     label: "Documentation",
     icon: "HelpCircle",

--- a/turbo/apps/platform/src/signals/settings-page/model-providers.ts
+++ b/turbo/apps/platform/src/signals/settings-page/model-providers.ts
@@ -1,0 +1,100 @@
+import { command, computed, state } from "ccstate";
+import {
+  createModelProvider$,
+  deleteModelProvider$,
+  modelProviders$,
+} from "../external/model-providers.ts";
+
+const internalTokenValue$ = state("");
+const internalIsEditing$ = state(false);
+
+const internalActionPromise$ = state<Promise<unknown> | null>(null);
+
+export const claudeCodeOauthTokenValue$ = computed((get) =>
+  get(internalTokenValue$),
+);
+
+export const isEditingClaudeCodeOauthToken$ = computed((get) =>
+  get(internalIsEditing$),
+);
+
+export const updateClaudeCodeOauthTokenValue$ = command(
+  ({ set }, value: string) => {
+    set(internalTokenValue$, value);
+  },
+);
+
+export const startEditing$ = command(async ({ set }, signal: AbortSignal) => {
+  set(internalIsEditing$, true);
+  set(internalTokenValue$, "");
+
+  await Promise.resolve();
+  signal.throwIfAborted();
+});
+
+export const claudeCodeOauthTokenPlaceholder$ = computed(async (get) => {
+  const { modelProviders } = await get(modelProviders$);
+  const oauthProvider = modelProviders.find(
+    (p) => p.type === "claude-code-oauth-token",
+  );
+
+  if (oauthProvider) {
+    return "sk-ant-oat********";
+  }
+
+  return "(empty)";
+});
+
+export const saveClaudeCodeOauthToken$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const tokenValue = get(internalTokenValue$);
+    if (!tokenValue) {
+      return;
+    }
+
+    set(internalTokenValue$, "");
+    set(internalIsEditing$, false);
+
+    const promise = set(createModelProvider$, {
+      type: "claude-code-oauth-token",
+      credential: tokenValue,
+    });
+    set(internalActionPromise$, promise);
+    signal.addEventListener("abort", () => {
+      set(internalActionPromise$, null);
+    });
+
+    await promise;
+    signal.throwIfAborted();
+  },
+);
+
+/**
+ * Cancel editing and reset the token input.
+ */
+export const cancelSettingsEdit$ = command(({ set }) => {
+  set(internalTokenValue$, "");
+  set(internalIsEditing$, false);
+});
+
+export const hasClaudeCodeOauthToken$ = computed(async (get) => {
+  const { modelProviders } = await get(modelProviders$);
+  return modelProviders.some((p) => p.type === "claude-code-oauth-token");
+});
+
+export const deleteOAuthToken$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    const promise = set(deleteModelProvider$, "claude-code-oauth-token");
+    set(internalActionPromise$, promise);
+    signal.addEventListener("abort", () => {
+      set(internalActionPromise$, null);
+    });
+
+    await promise;
+    signal.throwIfAborted();
+  },
+);
+
+export const actionPromise$ = computed((get) => {
+  return get(internalActionPromise$);
+});

--- a/turbo/apps/platform/src/signals/settings-page/settings-page.ts
+++ b/turbo/apps/platform/src/signals/settings-page/settings-page.ts
@@ -1,96 +1,11 @@
-import { command, computed, state } from "ccstate";
+import { command } from "ccstate";
 import { createElement } from "react";
-import { updatePage$ } from "../react-router.ts";
-import {
-  createModelProvider$,
-  modelProviders$,
-} from "../external/model-providers.ts";
-
-/**
- * Internal state for token value.
- */
-const internalTokenValue$ = state("");
-
-/**
- * Internal state for editing mode.
- */
-const internalIsEditing$ = state(false);
-
-/**
- * Token value for the settings page input.
- */
-export const settingsTokenValue$ = computed((get) => get(internalTokenValue$));
-
-/**
- * Whether the token input is in editing mode.
- */
-export const settingsIsEditing$ = computed((get) => get(internalIsEditing$));
-
-/**
- * Set the token value.
- */
-export const setSettingsTokenValue$ = command(({ set }, value: string) => {
-  set(internalTokenValue$, value);
-});
-
-/**
- * Set the editing state.
- */
-export const setSettingsIsEditing$ = command(({ set }, value: boolean) => {
-  set(internalIsEditing$, value);
-});
-
-/**
- * Mask for the existing token (e.g., "✳ sk-ant-oa...")
- */
-export const existingTokenMask$ = computed(async (get) => {
-  const { modelProviders } = await get(modelProviders$);
-  const oauthProvider = modelProviders.find(
-    (p) => p.type === "claude-code-oauth-token",
-  );
-
-  if (oauthProvider) {
-    return "\u2733 sk-ant-oa...";
-  }
-  return "";
-});
-
-/**
- * Save the model provider with the current token value.
- */
-export const saveModelProvider$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const tokenValue = get(internalTokenValue$);
-    if (!tokenValue) {
-      return;
-    }
-
-    await set(createModelProvider$, {
-      type: "claude-code-oauth-token",
-      credential: tokenValue,
-    });
-    signal.throwIfAborted();
-
-    // Clear the input after saving
-    set(internalTokenValue$, "");
-    set(internalIsEditing$, false);
-  },
-);
-
-/**
- * Cancel editing and reset the token input.
- */
-export const cancelSettingsEdit$ = command(({ set }) => {
-  set(internalTokenValue$, "");
-  set(internalIsEditing$, false);
-});
+import { updatePage$ } from "../react-router";
+import { SettingsPage } from "../../views/settings-page/settings-page";
 
 /**
  * Setup the settings page.
  */
-export const setupSettingsPage$ = command(async ({ set }) => {
-  const { SettingsPage } = await import(
-    "../../views/settings-page/settings-page.tsx"
-  );
+export const setupSettingsPage$ = command(({ set }) => {
   set(updatePage$, createElement(SettingsPage));
 });

--- a/turbo/apps/platform/src/types/navigation.ts
+++ b/turbo/apps/platform/src/types/navigation.ts
@@ -13,7 +13,8 @@ type NavIconName =
   | "File"
   | "Files"
   | "SquareKey"
-  | "Sparkles";
+  | "Sparkles"
+  | "Settings";
 
 export interface NavItem {
   id: string;

--- a/turbo/apps/platform/src/views/home/onboarding-modal.tsx
+++ b/turbo/apps/platform/src/views/home/onboarding-modal.tsx
@@ -15,12 +15,11 @@ import {
   tokenValue$,
   setTokenValue$,
   saveOnboardingConfig$,
-  copyStatus$,
-  copyToClipboard$,
   canSaveOnboarding$,
 } from "../../signals/onboarding.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import { ClaudeCodeSetupPrompt } from "../settings-page/setup-prompt.tsx";
 
 export function OnboardingModal() {
   const isOpen = useGet(showOnboardingModal$);
@@ -28,8 +27,6 @@ export function OnboardingModal() {
   const tokenValue = useGet(tokenValue$);
   const setTokenValue = useSet(setTokenValue$);
   const saveConfig = useSet(saveOnboardingConfig$);
-  const copyStatus = useGet(copyStatus$);
-  const copyToClipboard = useSet(copyToClipboard$);
   const canSave = useGet(canSaveOnboarding$);
   const pageSignal = useGet(pageSignal$);
 
@@ -90,22 +87,7 @@ export function OnboardingModal() {
                 required
               />
             </div>
-            <p className="text-xs text-muted-foreground">
-              You can find it by enter{" "}
-              <code
-                className="cursor-pointer rounded bg-muted px-1 py-0.5 font-mono hover:bg-muted/80 active:bg-muted/60"
-                onClick={() => {
-                  detach(
-                    copyToClipboard("claude setup-token"),
-                    Reason.DomCallback,
-                  );
-                }}
-                title="Click to copy"
-              >
-                {copyStatus === "copied" ? "copied!" : "claude setup-token"}
-              </code>{" "}
-              in your terminal
-            </p>
+            <ClaudeCodeSetupPrompt />
           </div>
         </div>
 

--- a/turbo/apps/platform/src/views/layout/nav-link.tsx
+++ b/turbo/apps/platform/src/views/layout/nav-link.tsx
@@ -13,6 +13,7 @@ import {
   IconFiles,
   IconSquareKey,
   IconSparkles,
+  IconSettings,
   type Icon,
 } from "@tabler/icons-react";
 import type { NavItem } from "../../types/navigation.ts";
@@ -33,6 +34,7 @@ const ICON_MAP = {
   Files: IconFiles,
   SquareKey: IconSquareKey,
   Sparkles: IconSparkles,
+  Settings: IconSettings,
 } as const satisfies Record<string, Icon>;
 
 interface NavLinkProps {

--- a/turbo/apps/platform/src/views/settings-page/__tests__/settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/settings-page.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { server } from "../../../mocks/server";
+import { http, HttpResponse } from "msw";
+import { setupPage } from "../../../__tests__/helper";
+import { testContext } from "../../../signals/__tests__/test-helpers";
+import { pathname$ } from "../../../signals/route";
+import { screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+
+const context = testContext();
+const user = userEvent.setup();
+
+describe("settings page", () => {
+  it("should be redirect if user has no scope", async () => {
+    server.use(
+      http.get("/api/scope", () => {
+        return new HttpResponse(null, { status: 404 });
+      }),
+    );
+
+    await setupPage({ context, path: "/settings" });
+
+    expect(context.store.get(pathname$)).toBe("/");
+  });
+
+  it("can edit and save user claude oauth token", async () => {
+    const { store } = context;
+
+    await setupPage({ context, path: "/settings" });
+    expect(store.get(pathname$)).toBe("/settings");
+
+    const input = screen.queryByPlaceholderText(/sk-ant.*/i);
+    expect(input).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("button", { name: /save/i }),
+    ).not.toBeInTheDocument();
+
+    await user.click(input!);
+    await user.keyboard("sk-ant-oauth-token-12345");
+
+    const button = screen.getByRole("button", { name: /save/i });
+    await user.click(button);
+
+    expect(button).not.toBeInTheDocument();
+    expect(input).toHaveValue("");
+  });
+
+  it("can cancel input", async () => {
+    const { store } = context;
+
+    await setupPage({ context, path: "/settings" });
+    expect(store.get(pathname$)).toBe("/settings");
+
+    const input = screen.getByPlaceholderText(/sk-ant.*/i);
+    await user.click(input);
+    await user.keyboard("sk-ant-oauth-token-12345");
+
+    expect(input).toHaveValue("sk-ant-oauth-token-12345");
+
+    const button = screen.getByRole("button", { name: /cancel/i });
+    await user.click(button);
+
+    expect(button).not.toBeInTheDocument();
+
+    expect(input).toHaveValue("");
+  });
+
+  it('should be empty if use does not have "claude-code-oauth-token" provider', async () => {
+    server.use(
+      http.get("/api/model-providers", () => {
+        return HttpResponse.json({ modelProviders: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/settings" });
+
+    const input = screen.getByPlaceholderText("(empty)");
+    expect(input).toBeInTheDocument();
+  });
+
+  it('can delete existing "claude-code-oauth-token" provider', async () => {
+    const { store } = context;
+
+    await setupPage({ context, path: "/settings" });
+    expect(store.get(pathname$)).toBe("/settings");
+
+    const input = screen.getByPlaceholderText(/sk-ant.*/i);
+
+    const deleteButton = screen.getByRole("button", {
+      name: /delete claude code oauth token/i,
+    });
+    await user.click(deleteButton);
+
+    expect(input).toHaveProperty("placeholder", "(empty)");
+
+    await user.click(input);
+    await user.keyboard("sk-ant-oauth-token-12345");
+
+    expect(input).toHaveValue("sk-ant-oauth-token-12345");
+    const button = screen.getByRole("button", { name: /save/i });
+    await user.click(button);
+
+    expect(input).toHaveProperty("placeholder", "sk-ant-oat********");
+  });
+});

--- a/turbo/apps/platform/src/views/settings-page/setup-prompt.tsx
+++ b/turbo/apps/platform/src/views/settings-page/setup-prompt.tsx
@@ -1,0 +1,24 @@
+import { useGet, useSet } from "ccstate-react";
+import { detach, Reason } from "../../signals/utils";
+import { copyStatus$, copyToClipboard$ } from "../../signals/onboarding";
+
+export function ClaudeCodeSetupPrompt() {
+  const copyStatus = useGet(copyStatus$);
+  const copyToClipboard = useSet(copyToClipboard$);
+
+  return (
+    <p className="text-xs text-muted-foreground">
+      You can find it by enter{" "}
+      <code
+        className="cursor-pointer rounded bg-muted px-1 py-0.5 font-mono hover:bg-muted/80 active:bg-muted/60"
+        onClick={() => {
+          detach(copyToClipboard("claude setup-token"), Reason.DomCallback);
+        }}
+        title="Click to copy"
+      >
+        {copyStatus === "copied" ? "copied!" : "claude setup-token"}
+      </code>{" "}
+      in your terminal
+    </p>
+  );
+}

--- a/turbo/packages/ui/src/components/ui/card.tsx
+++ b/turbo/packages/ui/src/components/ui/card.tsx
@@ -8,10 +8,7 @@ const Card = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
-      className,
-    )}
+    className={cn("rounded-lg border bg-card text-card-foreground", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## Summary
- Add `deleteModelProvider$` command for removing OAuth tokens from the settings page
- Extract model provider signals to dedicated `model-providers.ts` file for better organization
- Create reusable `ClaudeCodeSetupPrompt` component shared between onboarding modal and settings page
- Add delete button with loading states to settings page for OAuth token management
- Add Settings icon to navigation sidebar for settings page link
- Add comprehensive tests for settings page functionality
- Remove shadow from Card component for cleaner UI

## Test plan
- [x] Run `pnpm format` - code is properly formatted
- [x] Run `pnpm turbo run lint` - no linting errors
- [x] Run `pnpm check-types` - TypeScript types check pass
- [x] Run `pnpm vitest run` - all 2191 tests pass
- [x] Run `pnpm knip` - no unused dependencies or exports
- [ ] Manual testing: verify settings page displays correctly
- [ ] Manual testing: verify OAuth token can be added and deleted
- [ ] Manual testing: verify loading states work properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)