### PR TITLE
fix(cli): improve missing secrets/vars error messages to mention --env-file option

### DIFF
--- a/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
+++ b/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
@@ -170,6 +170,17 @@ describe("expandEnvironmentFromCompose", () => {
         },
       };
 
+      expect(() =>
+        expandEnvironmentFromCompose(
+          compose,
+          undefined,
+          undefined,
+          undefined,
+          userId,
+          runId,
+        ),
+      ).toThrow(BadRequestError);
+
       try {
         expandEnvironmentFromCompose(
           compose,
@@ -289,6 +300,17 @@ describe("expandEnvironmentFromCompose", () => {
           },
         },
       };
+
+      expect(() =>
+        expandEnvironmentFromCompose(
+          compose,
+          undefined,
+          undefined,
+          undefined,
+          userId,
+          runId,
+        ),
+      ).toThrow(BadRequestError);
 
       try {
         expandEnvironmentFromCompose(

--- a/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
+++ b/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
@@ -156,6 +156,33 @@ describe("expandEnvironmentFromCompose", () => {
         expect((error as BadRequestError).message).toContain("API_KEY=<value>");
       }
     });
+
+    it("should include --env-file hint in error message", () => {
+      const compose = {
+        version: "1.0",
+        agents: {
+          "test-agent": {
+            framework: "claude-code",
+            environment: {
+              API_KEY: "${{ secrets.API_KEY }}",
+            },
+          },
+        },
+      };
+
+      try {
+        expandEnvironmentFromCompose(
+          compose,
+          undefined,
+          undefined,
+          undefined,
+          userId,
+          runId,
+        );
+      } catch (error) {
+        expect((error as BadRequestError).message).toContain("--env-file");
+      }
+    });
   });
 
   describe("missing required vars", () => {
@@ -247,6 +274,37 @@ describe("expandEnvironmentFromCompose", () => {
         );
         expect((error as BadRequestError).message).toContain("REGION");
         expect((error as BadRequestError).message).not.toContain("CLOUD_NAME");
+      }
+    });
+
+    it("should include --vars and --env-file hints in error message", () => {
+      const compose = {
+        version: "1.0",
+        agents: {
+          "test-agent": {
+            framework: "claude-code",
+            environment: {
+              CLOUD_NAME: "${{ vars.CLOUD_NAME }}",
+            },
+          },
+        },
+      };
+
+      try {
+        expandEnvironmentFromCompose(
+          compose,
+          undefined,
+          undefined,
+          undefined,
+          userId,
+          runId,
+        );
+      } catch (error) {
+        expect((error as BadRequestError).message).toContain("--vars");
+        expect((error as BadRequestError).message).toContain(
+          "CLOUD_NAME=<value>",
+        );
+        expect((error as BadRequestError).message).toContain("--env-file");
       }
     });
   });

--- a/turbo/apps/web/src/lib/run/environment/expand-environment.ts
+++ b/turbo/apps/web/src/lib/run/environment/expand-environment.ts
@@ -88,7 +88,7 @@ export function expandEnvironmentFromCompose(
     );
     if (missingSecrets.length > 0) {
       throw new BadRequestError(
-        `Missing required secrets: ${missingSecrets.join(", ")}. Use '--secrets ${missingSecrets[0]}=<value>' to provide them.`,
+        `Missing required secrets: ${missingSecrets.join(", ")}. Use '--secrets ${missingSecrets[0]}=<value>' or '--env-file <path>' to provide them.`,
       );
     }
 
@@ -190,7 +190,7 @@ export function expandEnvironmentFromCompose(
     .map((v) => v.name);
   if (missingVarNames.length > 0) {
     throw new BadRequestError(
-      `Missing required variables for environment: ${missingVarNames.join(", ")}`,
+      `Missing required variables: ${missingVarNames.join(", ")}. Use '--vars ${missingVarNames[0]}=<value>' or '--env-file <path>' to provide them.`,
     );
   }
 


### PR DESCRIPTION
## Summary

- Add `--env-file <path>` hint to missing secrets error message
- Add `--vars` and `--env-file` hints to missing variables error message  
- Add unit tests for the new `--env-file` hints

**Before:**
```
Missing required secrets: FIRECRAWL_API_KEY. Use '--secrets FIRECRAWL_API_KEY=<value>' to provide them.
```

**After:**
```
Missing required secrets: FIRECRAWL_API_KEY. Use '--secrets FIRECRAWL_API_KEY=<value>' or '--env-file <path>' to provide them.
```

**Before (vars):**
```
Missing required variables for environment: MY_VAR
```

**After (vars):**
```
Missing required variables: MY_VAR. Use '--vars MY_VAR=<value>' or '--env-file <path>' to provide them.
```

Closes #1649

## Test plan

- [x] Unit tests added for `--env-file` hint in secrets error
- [x] Unit tests added for `--vars` and `--env-file` hints in variables error
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)