### PR TITLE
fix(schedule): validate required secrets/vars before schedule creation

### DIFF
--- a/turbo/apps/cli/src/lib/utils/prompt-utils.ts
+++ b/turbo/apps/cli/src/lib/utils/prompt-utils.ts
@@ -119,3 +119,32 @@ export async function promptSelect<T>(
 
   return response.value;
 }
+
+/**
+ * Prompt for password/secret input (masked)
+ * @param message - The prompt message
+ * @returns The user's input, or undefined if cancelled or non-interactive
+ */
+export async function promptPassword(
+  message: string,
+): Promise<string | undefined> {
+  // In non-interactive mode, return undefined immediately
+  if (!isInteractive()) {
+    return undefined;
+  }
+
+  const response = await prompts(
+    {
+      type: "password",
+      name: "value",
+      message,
+    },
+    {
+      onCancel: () => {
+        return false;
+      },
+    },
+  );
+
+  return response.value;
+}


### PR DESCRIPTION
## Summary
- Add validation to reject schedule setup when required secrets, vars, or credentials are missing
- Add server-side validation in `schedule-service.deploy()` that checks compose content for required configuration
- Add interactive prompting in CLI for missing configuration values
- Add `extractRequiredConfiguration()` utility to parse compose content for required secrets/vars/credentials
- Add `promptPassword()` for masked secret input

## Test plan
- [x] Added unit tests for `extractRequiredConfiguration()` (6 test cases)
- [x] Added server-side validation tests in `schedule-service.test.ts` (5 test cases)
- [x] Added E2E tests for secrets/vars validation scenarios (4 test cases)
- [ ] Run full CI pipeline to verify

Closes #1650

🤖 Generated with [Claude Code](https://claude.com/claude-code)