### PR TITLE
perf(runner): implement native binary vsock protocol for file transfer

### DIFF
--- a/turbo/apps/runner/scripts/deploy/vsock-agent.py
+++ b/turbo/apps/runner/scripts/deploy/vsock-agent.py
@@ -2,30 +2,48 @@
 """
 Vsock Agent for Firecracker VM host-guest communication.
 
-Protocol: 4-byte length prefix (big endian) + JSON message
-Messages: ready, ping/pong, exec/exec_result, error
+Binary Protocol:
+  [4-byte length][1-byte type][4-byte seq][payload]
 
-No socat needed - Python has native vsock support via socket.AF_VSOCK.
+  - length: size of (type + seq + payload), big-endian
+  - type: message type
+  - seq: sequence number for request/response matching, big-endian
+  - payload: type-specific binary data
 
-Guest-initiated connection: Agent connects to Host (CID=2) when ready,
-providing zero-latency notification instead of Host polling.
+Message Types:
+  0x00 ready          G→H  (empty)
+  0x01 ping           H→G  (empty)
+  0x02 pong           G→H  (empty)
+  0x03 exec           H→G  [4-byte timeout_ms][4-byte cmd_len][command]
+  0x04 exec_result    G→H  [4-byte exit_code][4-byte stdout_len][stdout][4-byte stderr_len][stderr]
+  0x05 write_file     H→G  [2-byte path_len][path][1-byte flags][4-byte content_len][content]
+  0x06 write_file_result G→H [1-byte success][2-byte error_len][error]
+  0xFF error          G→H  [2-byte error_len][error]
 
-For testing, supports Unix Domain Socket mode with --unix-socket option,
-where agent connects to the specified socket path (same as production flow).
+For testing, supports Unix Domain Socket mode with --unix-socket option.
 """
 
 import argparse
-import json
+import os
 import socket
 import struct
 import subprocess
 import sys
-import uuid
 from datetime import datetime
 
 VSOCK_PORT = 1000
 HEADER_SIZE = 4
-MAX_MESSAGE_SIZE = 1024 * 1024
+MAX_MESSAGE_SIZE = 16 * 1024 * 1024  # 16MB max
+
+# Message types
+MSG_READY = 0x00
+MSG_PING = 0x01
+MSG_PONG = 0x02
+MSG_EXEC = 0x03
+MSG_EXEC_RESULT = 0x04
+MSG_WRITE_FILE = 0x05
+MSG_WRITE_FILE_RESULT = 0x06
+MSG_ERROR = 0xFF
 
 
 def log(level: str, msg: str) -> None:
@@ -33,40 +51,70 @@ def log(level: str, msg: str) -> None:
     print(f"[{ts}] [vsock-agent] [{level}] {msg}", flush=True)
 
 
-def encode(msg: dict) -> bytes:
-    """Encode message with 4-byte length prefix."""
-    data = json.dumps(msg).encode("utf-8")
-    if len(data) > MAX_MESSAGE_SIZE:
-        raise ValueError(f"Message too large: {len(data)}")
-    header = struct.pack(">I", len(data))
-    return header + data
+def encode(msg_type: int, seq: int, payload: bytes = b"") -> bytes:
+    """Encode message with binary protocol."""
+    body = struct.pack(">BI", msg_type, seq) + payload
+    header = struct.pack(">I", len(body))
+    return header + body
+
+
+def encode_error(seq: int, error: str) -> bytes:
+    """Encode error message."""
+    error_bytes = error.encode("utf-8")[:65535]  # Truncate to fit 2-byte length
+    payload = struct.pack(">H", len(error_bytes)) + error_bytes
+    return encode(MSG_ERROR, seq, payload)
+
+
+def encode_exec_result(seq: int, exit_code: int, stdout: bytes, stderr: bytes) -> bytes:
+    """Encode exec_result message."""
+    payload = struct.pack(">iI", exit_code, len(stdout)) + stdout
+    payload += struct.pack(">I", len(stderr)) + stderr
+    return encode(MSG_EXEC_RESULT, seq, payload)
+
+
+def encode_write_file_result(seq: int, success: bool, error: str = "") -> bytes:
+    """Encode write_file_result message."""
+    error_bytes = error.encode("utf-8")[:65535] if error else b""  # Truncate to fit 2-byte length
+    payload = struct.pack(">BH", 1 if success else 0, len(error_bytes)) + error_bytes
+    return encode(MSG_WRITE_FILE_RESULT, seq, payload)
 
 
 class Decoder:
-    """Decode length-prefixed JSON messages from stream."""
+    """Decode binary messages from stream."""
 
     def __init__(self):
         self.buf = b""
 
-    def decode(self, data: bytes) -> list[dict]:
+    def decode(self, data: bytes) -> list[tuple[int, int, bytes]]:
+        """Decode messages, returns list of (type, seq, payload)."""
         self.buf += data
         messages = []
         while len(self.buf) >= HEADER_SIZE:
             length = struct.unpack(">I", self.buf[:HEADER_SIZE])[0]
             if length > MAX_MESSAGE_SIZE:
                 raise ValueError(f"Message too large: {length}")
+            if length < 5:  # minimum: 1 byte type + 4 bytes seq
+                raise ValueError(f"Message too small: {length}")
             total = HEADER_SIZE + length
             if len(self.buf) < total:
                 break
-            payload = self.buf[HEADER_SIZE:total]
-            messages.append(json.loads(payload.decode("utf-8")))
+            body = self.buf[HEADER_SIZE:total]
+            msg_type, seq = struct.unpack(">BI", body[:5])
+            payload = body[5:]
+            messages.append((msg_type, seq, payload))
             self.buf = self.buf[total:]
         return messages
 
 
-def exec_command(command: str, timeout_ms: int = 30000) -> dict:
-    """Execute shell command and return result."""
-    log("INFO", f"Executing: {command[:100]}{'...' if len(command) > 100 else ''}")
+def handle_exec(payload: bytes) -> tuple[int, bytes, bytes]:
+    """Handle exec message, returns (exit_code, stdout, stderr)."""
+    if len(payload) < 8:
+        return (1, b"", b"Invalid exec payload")
+    timeout_ms, cmd_len = struct.unpack(">II", payload[:8])
+    command = payload[8 : 8 + cmd_len].decode("utf-8", errors="replace")
+
+    log("INFO", f"exec: {command[:100]}{'...' if len(command) > 100 else ''}")
+
     try:
         result = subprocess.run(
             command,
@@ -74,53 +122,96 @@ def exec_command(command: str, timeout_ms: int = 30000) -> dict:
             capture_output=True,
             timeout=timeout_ms / 1000,
         )
-        return {
-            "exitCode": result.returncode,
-            "stdout": result.stdout.decode("utf-8", errors="replace"),
-            "stderr": result.stderr.decode("utf-8", errors="replace"),
-        }
+        return (
+            result.returncode,
+            result.stdout,
+            result.stderr,
+        )
     except subprocess.TimeoutExpired:
-        return {"exitCode": 124, "stdout": "", "stderr": "Timeout"}
+        return (124, b"", b"Timeout")
     except Exception as e:
-        return {"exitCode": 1, "stdout": "", "stderr": f"Error: {e}"}
+        return (1, b"", str(e).encode("utf-8"))
 
 
-def handle(msg: dict) -> dict:
-    """Handle incoming message and return response."""
-    msg_type = msg.get("type", "")
-    msg_id = msg.get("id", "")
-    log("INFO", f"Received: type={msg_type} id={msg_id}")
+def handle_write_file(payload: bytes) -> tuple[bool, str]:
+    """Handle write_file message, returns (success, error)."""
+    if len(payload) < 3:
+        return (False, "Invalid write_file payload")
 
-    if msg_type == "ping":
-        return {"type": "pong", "id": msg_id, "payload": {}}
-    elif msg_type == "exec":
-        payload = msg.get("payload", {})
-        command = payload.get("command", "")
-        timeout_ms = payload.get("timeoutMs", 30000)
-        result = exec_command(command, timeout_ms)
-        return {"type": "exec_result", "id": msg_id, "payload": result}
+    path_len = struct.unpack(">H", payload[:2])[0]
+    if len(payload) < 2 + path_len + 1 + 4:
+        return (False, "Invalid write_file payload: too short")
+
+    path = payload[2 : 2 + path_len].decode("utf-8", errors="replace")
+    flags = payload[2 + path_len]
+    content_len = struct.unpack(">I", payload[3 + path_len : 7 + path_len])[0]
+
+    if len(payload) < 7 + path_len + content_len:
+        return (False, "Invalid write_file payload: content truncated")
+
+    content = payload[7 + path_len : 7 + path_len + content_len]
+
+    sudo = bool(flags & 0x01)
+    log("INFO", f"write_file: path={path} size={len(content)} sudo={sudo}")
+
+    try:
+        if sudo:
+            # Use sudo tee to write directly
+            result = subprocess.run(
+                ["sudo", "tee", path],
+                input=content,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                return (False, f"sudo tee failed: {result.stderr.decode()}")
+        else:
+            # Ensure parent directory exists
+            dir_path = os.path.dirname(path)
+            if dir_path:
+                os.makedirs(dir_path, exist_ok=True)
+            with open(path, "wb") as f:
+                f.write(content)
+        return (True, "")
+    except Exception as e:
+        log("ERROR", f"write_file failed: {e}")
+        return (False, str(e))
+
+
+def handle_message(msg_type: int, seq: int, payload: bytes) -> bytes | None:
+    """Handle incoming message and return response bytes."""
+    log("INFO", f"Received: type=0x{msg_type:02X} seq={seq}")
+
+    if msg_type == MSG_PING:
+        return encode(MSG_PONG, seq)
+    elif msg_type == MSG_EXEC:
+        exit_code, stdout, stderr = handle_exec(payload)
+        return encode_exec_result(seq, exit_code, stdout, stderr)
+    elif msg_type == MSG_WRITE_FILE:
+        success, error = handle_write_file(payload)
+        return encode_write_file_result(seq, success, error)
     else:
-        return {"type": "error", "id": msg_id, "payload": {"message": f"Unknown type: {msg_type}"}}
+        return encode_error(seq, f"Unknown message type: 0x{msg_type:02X}")
 
 
 def _handle_messages(conn: socket.socket) -> None:
     """Handle message loop after connection is established."""
     decoder = Decoder()
 
-    # Send ready signal
-    ready = {"type": "ready", "id": str(uuid.uuid4()), "payload": {}}
-    conn.sendall(encode(ready))
+    # Send ready signal (seq=0 for ready)
+    conn.sendall(encode(MSG_READY, 0))
     log("INFO", "Sent ready signal")
 
     try:
         while True:
-            data = conn.recv(4096)
+            data = conn.recv(65536)
             if not data:
                 break
-            for msg in decoder.decode(data):
-                resp = handle(msg)
+            for msg_type, seq, payload in decoder.decode(data):
+                resp = handle_message(msg_type, seq, payload)
                 if resp:
-                    conn.sendall(encode(resp))
+                    conn.sendall(resp)
     except Exception as e:
         log("ERROR", f"Connection error: {e}")
     finally:
@@ -131,12 +222,10 @@ def _handle_messages(conn: socket.socket) -> None:
 def connect(unix_socket: str | None = None) -> None:
     """Connect to host and handle messages."""
     if unix_socket:
-        # Unix Domain Socket mode (for testing)
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         addr = unix_socket
         log("INFO", f"Connecting to Unix socket: {unix_socket}...")
     else:
-        # Vsock mode (production) - CID 2 is always the host
         sock = socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM)
         addr = (2, VSOCK_PORT)
         log("INFO", "Connecting to host (CID=2)...")

--- a/turbo/apps/runner/src/lib/firecracker/vsock.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vsock.ts
@@ -9,70 +9,197 @@
  * - Firecracker forwards connection to Host's listener
  * - No polling needed - instant notification when guest is ready
  *
- * Protocol: length-prefixed JSON
- * - 4-byte length prefix (big endian) + JSON message
- * - Message types: ready, ping, pong, exec, exec_result, error
+ * Binary Protocol:
+ *   [4-byte length][1-byte type][4-byte seq][payload]
+ *
+ *   - length: size of (type + seq + payload), big-endian
+ *   - type: message type
+ *   - seq: sequence number for request/response matching, big-endian
+ *   - payload: type-specific binary data
+ *
+ * Message Types:
+ *   0x00 ready          G→H  (empty)
+ *   0x01 ping           H→G  (empty)
+ *   0x02 pong           G→H  (empty)
+ *   0x03 exec           H→G  [4-byte timeout_ms][4-byte cmd_len][command]
+ *   0x04 exec_result    G→H  [4-byte exit_code][4-byte stdout_len][stdout][4-byte stderr_len][stderr]
+ *   0x05 write_file     H→G  [2-byte path_len][path][1-byte flags][4-byte content_len][content]
+ *   0x06 write_file_result G→H [1-byte success][2-byte error_len][error]
+ *   0xFF error          G→H  [2-byte error_len][error]
  */
 
 import * as net from "node:net";
 import * as fs from "node:fs";
-import * as crypto from "node:crypto";
 import type { ExecResult, GuestClient } from "./guest.js";
 
 const VSOCK_PORT = 1000;
 const HEADER_SIZE = 4;
-const MAX_MESSAGE_SIZE = 1024 * 1024;
+const MAX_MESSAGE_SIZE = 16 * 1024 * 1024; // 16MB max
 const DEFAULT_EXEC_TIMEOUT_MS = 300000; // 5 minutes
 
-// Message types matching the guest agent
-type MessageType = "ready" | "ping" | "pong" | "exec" | "exec_result" | "error";
+// Message types (see protocol docs in header)
+const MSG_READY = 0x00;
+const MSG_PING = 0x01;
+const MSG_PONG = 0x02;
+const MSG_EXEC = 0x03;
+const MSG_WRITE_FILE = 0x05;
+const MSG_ERROR = 0xff;
 
-interface Message<T = unknown> {
-  type: MessageType;
-  id: string;
-  payload: T;
+// Write file flags
+const FLAG_SUDO = 0x01;
+
+interface DecodedMessage {
+  type: number;
+  seq: number;
+  payload: Buffer;
 }
 
-interface ExecPayload {
-  command: string;
-  timeoutMs: number;
+interface PendingRequest {
+  resolve: (msg: DecodedMessage) => void;
+  reject: (err: Error) => void;
+  timeout: NodeJS.Timeout;
 }
 
-interface ExecResultPayload {
-  exitCode: number;
-  stdout: string;
-  stderr: string;
-}
+/**
+ * Encode a message with binary protocol
+ */
+function encode(
+  type: number,
+  seq: number,
+  payload: Buffer = Buffer.alloc(0),
+): Buffer {
+  const body = Buffer.alloc(5 + payload.length);
+  body.writeUInt8(type, 0);
+  body.writeUInt32BE(seq, 1);
+  payload.copy(body, 5);
 
-interface ErrorPayload {
-  message: string;
-}
-
-// Encode message with length prefix
-function encode<T>(msg: Message<T>): Buffer {
-  const json = Buffer.from(JSON.stringify(msg), "utf-8");
   const header = Buffer.alloc(HEADER_SIZE);
-  header.writeUInt32BE(json.length, 0);
-  return Buffer.concat([header, json]);
+  header.writeUInt32BE(body.length, 0);
+
+  return Buffer.concat([header, body]);
 }
 
-// Message decoder with buffering
+/**
+ * Encode exec message payload
+ */
+function encodeExecPayload(command: string, timeoutMs: number): Buffer {
+  const cmdBuf = Buffer.from(command, "utf-8");
+  const payload = Buffer.alloc(8 + cmdBuf.length);
+  payload.writeUInt32BE(timeoutMs, 0);
+  payload.writeUInt32BE(cmdBuf.length, 4);
+  cmdBuf.copy(payload, 8);
+  return payload;
+}
+
+/**
+ * Encode write_file message payload
+ */
+function encodeWriteFilePayload(
+  path: string,
+  content: Buffer,
+  sudo: boolean,
+): Buffer {
+  const pathBuf = Buffer.from(path, "utf-8");
+  if (pathBuf.length > 65535) {
+    throw new Error(`Path too long: ${pathBuf.length} bytes (max 65535)`);
+  }
+  const payload = Buffer.alloc(2 + pathBuf.length + 1 + 4 + content.length);
+  let offset = 0;
+
+  payload.writeUInt16BE(pathBuf.length, offset);
+  offset += 2;
+
+  pathBuf.copy(payload, offset);
+  offset += pathBuf.length;
+
+  payload.writeUInt8(sudo ? FLAG_SUDO : 0, offset);
+  offset += 1;
+
+  payload.writeUInt32BE(content.length, offset);
+  offset += 4;
+
+  content.copy(payload, offset);
+
+  return payload;
+}
+
+/**
+ * Decode exec_result payload
+ */
+function decodeExecResult(payload: Buffer): ExecResult {
+  if (payload.length < 8) {
+    return { exitCode: 1, stdout: "", stderr: "Invalid exec_result payload" };
+  }
+
+  const exitCode = payload.readInt32BE(0);
+  const stdoutLen = payload.readUInt32BE(4);
+  const stdout = payload.subarray(8, 8 + stdoutLen).toString("utf-8");
+  const stderrLenOffset = 8 + stdoutLen;
+  const stderrLen = payload.readUInt32BE(stderrLenOffset);
+  const stderr = payload
+    .subarray(stderrLenOffset + 4, stderrLenOffset + 4 + stderrLen)
+    .toString("utf-8");
+
+  return { exitCode, stdout, stderr };
+}
+
+/**
+ * Decode write_file_result payload
+ */
+function decodeWriteFileResult(payload: Buffer): {
+  success: boolean;
+  error: string;
+} {
+  if (payload.length < 3) {
+    return { success: false, error: "Invalid write_file_result payload" };
+  }
+
+  const success = payload.readUInt8(0) === 1;
+  const errorLen = payload.readUInt16BE(1);
+  const error = payload.subarray(3, 3 + errorLen).toString("utf-8");
+
+  return { success, error };
+}
+
+/**
+ * Decode error payload
+ */
+function decodeError(payload: Buffer): string {
+  if (payload.length < 2) {
+    return "Invalid error payload";
+  }
+  const errorLen = payload.readUInt16BE(0);
+  return payload.subarray(2, 2 + errorLen).toString("utf-8");
+}
+
+/**
+ * Message decoder with buffering
+ */
 class Decoder {
   private buf = Buffer.alloc(0);
 
-  decode(data: Buffer): Message[] {
+  decode(data: Buffer): DecodedMessage[] {
     this.buf = Buffer.concat([this.buf, data]);
-    const messages: Message[] = [];
+    const messages: DecodedMessage[] = [];
 
     while (this.buf.length >= HEADER_SIZE) {
-      const len = this.buf.readUInt32BE(0);
-      if (len > MAX_MESSAGE_SIZE) throw new Error(`Message too large: ${len}`);
+      const length = this.buf.readUInt32BE(0);
+      if (length > MAX_MESSAGE_SIZE) {
+        throw new Error(`Message too large: ${length}`);
+      }
+      if (length < 5) {
+        throw new Error(`Message too small: ${length}`);
+      }
 
-      const total = HEADER_SIZE + len;
+      const total = HEADER_SIZE + length;
       if (this.buf.length < total) break;
 
-      const json = this.buf.subarray(HEADER_SIZE, total);
-      messages.push(JSON.parse(json.toString("utf-8")));
+      const body = this.buf.subarray(HEADER_SIZE, total);
+      const type = body.readUInt8(0);
+      const seq = body.readUInt32BE(1);
+      const payload = body.subarray(5);
+
+      messages.push({ type, seq, payload });
       this.buf = this.buf.subarray(total);
     }
     return messages;
@@ -89,27 +216,31 @@ export class VsockClient implements GuestClient {
   private vsockPath: string;
   private socket: net.Socket | null = null;
   private connected = false;
-  private pendingRequests = new Map<
-    string,
-    {
-      resolve: (msg: Message) => void;
-      reject: (err: Error) => void;
-      timeout: NodeJS.Timeout;
-    }
-  >();
+  private nextSeq = 1;
+  private pendingRequests = new Map<number, PendingRequest>();
 
   constructor(vsockPath: string) {
     this.vsockPath = vsockPath;
   }
 
   /**
+   * Get next sequence number
+   */
+  private getNextSeq(): number {
+    const seq = this.nextSeq;
+    this.nextSeq = (this.nextSeq + 1) & 0xffffffff;
+    if (this.nextSeq === 0) this.nextSeq = 1; // Skip 0
+    return seq;
+  }
+
+  /**
    * Handle incoming message and route to pending request
    */
-  private handleMessage(msg: Message): void {
-    const pending = this.pendingRequests.get(msg.id);
+  private handleMessage(msg: DecodedMessage): void {
+    const pending = this.pendingRequests.get(msg.seq);
     if (pending) {
       clearTimeout(pending.timeout);
-      this.pendingRequests.delete(msg.id);
+      this.pendingRequests.delete(msg.seq);
       pending.resolve(msg);
     }
   }
@@ -117,31 +248,26 @@ export class VsockClient implements GuestClient {
   /**
    * Send a request and wait for response
    */
-  private async request<T, R>(
-    type: MessageType,
-    payload: T,
+  private async request(
+    type: number,
+    payload: Buffer,
     timeoutMs: number,
-  ): Promise<Message<R>> {
+  ): Promise<DecodedMessage> {
     if (!this.connected || !this.socket) {
       throw new Error("Not connected - call waitForGuestConnection() first");
     }
 
-    const id = crypto.randomUUID();
-    const msg: Message<T> = { type, id, payload };
+    const seq = this.getNextSeq();
 
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
-        this.pendingRequests.delete(id);
-        reject(new Error(`Request timeout: ${type}`));
+        this.pendingRequests.delete(seq);
+        reject(new Error(`Request timeout: type=0x${type.toString(16)}`));
       }, timeoutMs);
 
-      this.pendingRequests.set(id, {
-        resolve: resolve as (msg: Message) => void,
-        reject,
-        timeout,
-      });
+      this.pendingRequests.set(seq, { resolve, reject, timeout });
 
-      this.socket!.write(encode(msg));
+      this.socket!.write(encode(type, seq, payload));
     });
   }
 
@@ -152,26 +278,22 @@ export class VsockClient implements GuestClient {
     const actualTimeout = timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS;
 
     try {
-      const response = await this.request<ExecPayload, ExecResultPayload>(
-        "exec",
-        { command, timeoutMs: actualTimeout },
+      const payload = encodeExecPayload(command, actualTimeout);
+      const response = await this.request(
+        MSG_EXEC,
+        payload,
         actualTimeout + 5000, // Add buffer for network latency
       );
 
-      if (response.type === "error") {
-        const errorPayload = response.payload as unknown as ErrorPayload;
+      if (response.type === MSG_ERROR) {
         return {
           exitCode: 1,
           stdout: "",
-          stderr: errorPayload.message,
+          stderr: decodeError(response.payload),
         };
       }
 
-      return {
-        exitCode: response.payload.exitCode,
-        stdout: response.payload.stdout,
-        stderr: response.payload.stderr,
-      };
+      return decodeExecResult(response.payload);
     } catch (e) {
       return {
         exitCode: 1,
@@ -197,46 +319,46 @@ export class VsockClient implements GuestClient {
   /**
    * Write content to a file on the remote VM
    */
-  async writeFile(remotePath: string, content: string): Promise<void> {
-    // Use exec with base64 encoding to handle binary content
-    const encoded = Buffer.from(content).toString("base64");
-    const maxChunkSize = 65000;
-
-    if (encoded.length <= maxChunkSize) {
-      await this.execOrThrow(`echo '${encoded}' | base64 -d > '${remotePath}'`);
-    } else {
-      await this.execOrThrow(`rm -f '${remotePath}'`);
-      for (let i = 0; i < encoded.length; i += maxChunkSize) {
-        const chunk = encoded.slice(i, i + maxChunkSize);
-        const operator = i === 0 ? ">" : ">>";
-        await this.execOrThrow(
-          `echo '${chunk}' | base64 -d ${operator} '${remotePath}'`,
-        );
-      }
+  private async writeFileInternal(
+    remotePath: string,
+    content: string,
+    sudo: boolean,
+  ): Promise<void> {
+    const contentBuf = Buffer.from(content, "utf-8");
+    if (contentBuf.length > MAX_MESSAGE_SIZE - 1024) {
+      throw new Error(
+        `Content too large: ${contentBuf.length} bytes (max ${MAX_MESSAGE_SIZE - 1024})`,
+      );
     }
+    const payload = encodeWriteFilePayload(remotePath, contentBuf, sudo);
+    const response = await this.request(
+      MSG_WRITE_FILE,
+      payload,
+      DEFAULT_EXEC_TIMEOUT_MS,
+    );
+
+    if (response.type === MSG_ERROR) {
+      throw new Error(`Write file failed: ${decodeError(response.payload)}`);
+    }
+
+    const result = decodeWriteFileResult(response.payload);
+    if (!result.success) {
+      throw new Error(`Write file failed: ${result.error}`);
+    }
+  }
+
+  /**
+   * Write content to a file on the remote VM
+   */
+  async writeFile(remotePath: string, content: string): Promise<void> {
+    return this.writeFileInternal(remotePath, content, false);
   }
 
   /**
    * Write content to a file on the remote VM using sudo
    */
   async writeFileWithSudo(remotePath: string, content: string): Promise<void> {
-    const encoded = Buffer.from(content).toString("base64");
-    const maxChunkSize = 65000;
-
-    if (encoded.length <= maxChunkSize) {
-      await this.execOrThrow(
-        `echo '${encoded}' | base64 -d | sudo tee '${remotePath}' > /dev/null`,
-      );
-    } else {
-      await this.execOrThrow(`sudo rm -f '${remotePath}'`);
-      for (let i = 0; i < encoded.length; i += maxChunkSize) {
-        const chunk = encoded.slice(i, i + maxChunkSize);
-        const teeFlag = i === 0 ? "" : "-a";
-        await this.execOrThrow(
-          `echo '${chunk}' | base64 -d | sudo tee ${teeFlag} '${remotePath}' > /dev/null`,
-        );
-      }
-    }
+    return this.writeFileInternal(remotePath, content, true);
   }
 
   /**
@@ -330,19 +452,19 @@ export class VsockClient implements GuestClient {
           Connected,
         }
         let state = State.WaitingForReady;
-        let pingId: string | null = null;
+        let pingSeq = 0;
 
         socket.on("data", (data: Buffer) => {
           try {
             for (const msg of decoder.decode(data)) {
-              if (state === State.WaitingForReady && msg.type === "ready") {
+              if (state === State.WaitingForReady && msg.type === MSG_READY) {
                 state = State.WaitingForPong;
-                pingId = crypto.randomUUID();
-                socket.write(encode({ type: "ping", id: pingId, payload: {} }));
+                pingSeq = this.getNextSeq();
+                socket.write(encode(MSG_PING, pingSeq));
               } else if (
                 state === State.WaitingForPong &&
-                msg.type === "pong" &&
-                msg.id === pingId
+                msg.type === MSG_PONG &&
+                msg.seq === pingSeq
               ) {
                 if (settled) {
                   // Timeout already fired, discard this connection


### PR DESCRIPTION
## Summary

- Replace JSON-based vsock protocol with binary format for improved performance
- Add native `write_file` message (0x05) eliminating base64+exec overhead
- Binary protocol: `[4-byte length][1-byte type][4-byte seq][payload]`
- Add proper length prefixes for all variable-length fields
- Add size validation to prevent overflow and truncation (16MB max)

Closes #1651

## Test plan

- [x] TypeScript type check passes
- [x] ESLint passes
- [x] All 167 runner tests pass (including 18 vsock tests)
- [ ] Integration test with real VM after rootfs rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)