### PR TITLE
fix(cli): vm0 agent status now displays environment variables correctly

### DIFF
--- a/turbo/apps/cli/src/commands/agent/status.ts
+++ b/turbo/apps/cli/src/commands/agent/status.ts
@@ -72,7 +72,7 @@ function formatVolumes(
 }
 
 /**
- * Format secrets and vars with source information
+ * Format secrets, vars, and credentials with source information
  */
 function formatVariableSources(sources: AgentVariableSources): void {
   if (sources.secrets.length > 0) {
@@ -87,6 +87,13 @@ function formatVariableSources(sources: AgentVariableSources): void {
     for (const v of sources.vars) {
       const sourceInfo = chalk.dim(`(${v.source})`);
       console.log(`      - ${v.name.padEnd(20)} ${sourceInfo}`);
+    }
+  }
+  if (sources.credentials.length > 0) {
+    console.log(`    Credentials:`);
+    for (const cred of sources.credentials) {
+      const sourceInfo = chalk.dim(`(${cred.source})`);
+      console.log(`      - ${cred.name.padEnd(20)} ${sourceInfo}`);
     }
   }
 }

--- a/turbo/apps/cli/src/commands/agent/status.ts
+++ b/turbo/apps/cli/src/commands/agent/status.ts
@@ -226,20 +226,21 @@ export const statusCommand = new Command()
 
         const content = compose.content as AgentComposeContent;
 
-        // Derive variable sources if --no-sources flag is not set
-        // Default: sources = true (enabled), --no-sources sets it to false
+        // Derive variable sources
+        // --no-sources: skip network (skill downloads), but still extract variables
+        // Without flag: fetch skills to determine variable sources
         let variableSources: Map<string, AgentVariableSources> | undefined;
-        if (options.sources !== false) {
-          try {
-            variableSources = await deriveComposeVariableSources(content);
-          } catch {
-            // Failed to derive sources, show warning and continue without them
-            console.error(
-              chalk.yellow(
-                "⚠ Warning: Failed to fetch skill sources, showing basic info",
-              ),
-            );
-          }
+        try {
+          variableSources = await deriveComposeVariableSources(content, {
+            skipNetwork: options.sources === false,
+          });
+        } catch {
+          // Failed to derive sources, show warning and continue without them
+          console.error(
+            chalk.yellow(
+              "⚠ Warning: Failed to fetch skill sources, showing basic info",
+            ),
+          );
         }
 
         // Format and display the compose


### PR DESCRIPTION
## Summary

- Fix `vm0 agent status` to correctly display environment variables
- Replace broken local regex with `@vm0/core` extraction function
- Add support for credentials display

## Changes

1. **source-derivation.ts**: Use `@vm0/core`'s `extractVariableReferences` and `groupVariablesBySource` instead of local function with wrong regex
2. **AgentVariableSources interface**: Add `credentials` array
3. **status.ts**: Display credentials section in output
4. **Unit tests**: Update all tests to use correct `${{ secrets.X }}` syntax
5. **CLI E2E tests**: Add 4 new tests for environment variable display

## Root Cause

The local `extractVariableReferences` function used this regex:
```typescript
/\$\{?([A-Z_][A-Z0-9_]*)\}?/g  // Matches ${VAR} or $VAR
```

But actual compose files use:
```yaml
API_KEY: "${{ secrets.MY_API_KEY }}"
```

The correct function from `@vm0/core` was already being used by `compose.ts` and `run/shared.ts`, just not by `source-derivation.ts`.

## Test plan

- [x] Unit tests pass for source-derivation
- [x] Type checking passes
- [x] Lint passes
- [ ] CLI E2E tests for environment variable display

Closes #1658

🤖 Generated with [Claude Code](https://claude.com/claude-code)
