### PR TITLE
refactor(cli): remove --scope flag from agent list and status commands

### DIFF
--- a/turbo/apps/cli/src/__tests__/agent-commands.test.ts
+++ b/turbo/apps/cli/src/__tests__/agent-commands.test.ts
@@ -31,14 +31,6 @@ describe("agent list command", () => {
     it("should have 'ls' as an alias", () => {
       expect(listCommand.alias()).toBe("ls");
     });
-
-    it("should have --scope option", () => {
-      const scopeOption = listCommand.options.find(
-        (opt) => opt.long === "--scope",
-      );
-      expect(scopeOption).toBeDefined();
-      expect(scopeOption?.description).toContain("Scope");
-    });
   });
 });
 
@@ -58,14 +50,6 @@ describe("agent status command", () => {
       expect(args.length).toBe(1);
       expect(args[0]?.name()).toBe("name[:version]");
       expect(args[0]?.required).toBe(true);
-    });
-
-    it("should have --scope option", () => {
-      const scopeOption = statusCommand.options.find(
-        (opt) => opt.long === "--scope",
-      );
-      expect(scopeOption).toBeDefined();
-      expect(scopeOption?.description).toContain("Scope");
     });
 
     it("should have --no-sources option", () => {

--- a/turbo/apps/cli/src/commands/agent/list.ts
+++ b/turbo/apps/cli/src/commands/agent/list.ts
@@ -20,15 +20,9 @@ export const listCommand = new Command()
   .name("list")
   .alias("ls")
   .description("List all agent composes")
-  .option("-s, --scope <scope>", "Scope to list composes from")
-  .action(async (options: { scope?: string }) => {
+  .action(async () => {
     try {
-      // Build URL with optional scope parameter
-      const url = options.scope
-        ? `/api/agent/composes/list?scope=${encodeURIComponent(options.scope)}`
-        : "/api/agent/composes/list";
-
-      const response = await httpGet(url);
+      const response = await httpGet("/api/agent/composes/list");
 
       if (!response.ok) {
         const error = (await response.json()) as ApiError;


### PR DESCRIPTION
## Summary

- Remove `--scope`/`-s` flag from `vm0 agent list` command
- Remove `--scope`/`-s` flag from `vm0 agent status` command
- Update unit tests to remove `--scope` option tests

## Rationale

The `--scope` flag has limited practical value:
- Personal scopes are private (users can only access their own)
- Organization scopes are not yet implemented
- The flag adds unnecessary complexity

## Changes

| File | Change |
|------|--------|
| `turbo/apps/cli/src/commands/agent/list.ts` | Remove --scope option and simplify URL building |
| `turbo/apps/cli/src/commands/agent/status.ts` | Remove --scope option and update getComposeByName call |
| `turbo/apps/cli/src/__tests__/agent-commands.test.ts` | Remove --scope option tests |

## Notes

- API layer scope support is preserved for future organization feature
- `vm0 run` command is unaffected (uses `scope/name` argument format, not `--scope` flag)
- `vm0 scope` commands are unaffected (manage user's own scope)

## Test plan

- [x] Unit tests pass (`pnpm vitest run apps/cli`)
- [x] Lint passes (`pnpm turbo run lint --filter=@vm0/cli`)
- [x] Type checking passes (`tsc --noEmit`)
- [x] Pre-commit hooks pass

Closes #1664

🤖 Generated with [Claude Code](https://claude.com/claude-code)