### PR TITLE
fix(platform): improve test stability with act() and suppress console noise

### DIFF
--- a/turbo/apps/platform/src/__tests__/setup-page.test.ts
+++ b/turbo/apps/platform/src/__tests__/setup-page.test.ts
@@ -1,10 +1,16 @@
 import { testContext } from "../signals/__tests__/test-helpers";
 import { setupPage } from "./helper";
-import { expect, it, describe } from "vitest";
+import { expect, it, describe, beforeAll, vi } from "vitest";
 import { Level, logger } from "../signals/log";
 import { localStorageSignals } from "../signals/external/local-storage";
 
 const context = testContext();
+
+beforeAll(() => {
+  // suppress console logs because these cases are not intented to test logging functionality
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "info").mockImplementation(() => {});
+});
 
 describe("setupPage", () => {
   it("should set debug loggers correctly", async () => {

--- a/turbo/apps/platform/src/signals/__tests__/global-method.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/global-method.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { testContext } from "./test-helpers";
 import { setupPage } from "../../__tests__/helper";
 
 const context = testContext();
+beforeAll(() => {
+  // suppress console logs because these cases are not intented to test logging functionality
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "info").mockImplementation(() => {});
+});
+
 describe("global debug loggers", () => {
   it("should has vm0 method after init", async () => {
     await setupPage({ context, path: "/" });

--- a/turbo/apps/platform/src/signals/__tests__/onboarding.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/onboarding.test.ts
@@ -12,6 +12,7 @@ import {
   closeOnboardingModal$,
   startOnboarding$,
 } from "../onboarding.ts";
+import { act } from "@testing-library/react";
 
 const context = testContext();
 
@@ -106,10 +107,15 @@ describe("saveOnboardingConfig$", () => {
 
     await setupPage({ context, path: "/" });
 
-    // Set token value and save
-    context.store.set(startOnboarding$);
-    context.store.set(setTokenValue$, "test-oauth-token");
-    await context.store.set(saveOnboardingConfig$, context.signal);
+    await act(() => {
+      // Set token value and save
+      context.store.set(startOnboarding$);
+      context.store.set(setTokenValue$, "test-oauth-token");
+    });
+
+    await act(async () => {
+      await context.store.set(saveOnboardingConfig$, context.signal);
+    });
 
     expect(scopeCreated).toBeTruthy();
     expect(providerCreated).toBeTruthy();
@@ -128,9 +134,11 @@ describe("saveOnboardingConfig$", () => {
 
     await setupPage({ context, path: "/" });
 
-    // Try to save without setting token
-    context.store.set(startOnboarding$);
-    await context.store.set(saveOnboardingConfig$, context.signal);
+    await act(async () => {
+      // Try to save without setting token
+      context.store.set(startOnboarding$);
+      await context.store.set(saveOnboardingConfig$, context.signal);
+    });
 
     expect(providerCreated).toBeFalsy();
   });
@@ -157,8 +165,10 @@ describe("closeOnboardingModal$", () => {
 
     await setupPage({ context, path: "/" });
 
-    context.store.set(startOnboarding$);
-    await context.store.set(closeOnboardingModal$, context.signal);
+    await act(async () => {
+      context.store.set(startOnboarding$);
+      await context.store.set(closeOnboardingModal$, context.signal);
+    });
 
     expect(scopeCreated).toBeTruthy();
     expect(providerCreated).toBeFalsy();
@@ -178,8 +188,10 @@ describe("closeOnboardingModal$", () => {
     // Default mock has scope
     await setupPage({ context, path: "/" });
 
-    context.store.set(startOnboarding$);
-    await context.store.set(closeOnboardingModal$, context.signal);
+    await act(async () => {
+      context.store.set(startOnboarding$);
+      await context.store.set(closeOnboardingModal$, context.signal);
+    });
 
     expect(scopeCreated).toBeFalsy();
     expect(context.store.get(showOnboardingModal$)).toBeFalsy();


### PR DESCRIPTION
## Summary
- Wrap state updates in `act()` to avoid React warnings in onboarding tests
- Suppress `console.log`/`console.info` in setup-page and global-method tests since they are not testing logging functionality

## Test plan
- [x] All modified tests pass locally
- [x] Lint checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)