### PR TITLE
refactor(scope): remove unused --display-name option

### DIFF
--- a/e2e/tests/01-serial/ser-t02-vm0-scope.bats
+++ b/e2e/tests/01-serial/ser-t02-vm0-scope.bats
@@ -171,11 +171,3 @@ EOF
     assert_output --partial "$NEW_SLUG"
 }
 
-@test "vm0 scope set with --display-name sets custom name" {
-    # Update scope with display name
-    NEW_SLUG="e2e-display-$(date +%s%3N)-$RANDOM"
-    run $CLI_COMMAND scope set "$NEW_SLUG" --display-name "My Test Scope" --force
-    assert_success
-    assert_output --partial "$NEW_SLUG"
-}
-

--- a/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
@@ -61,7 +61,6 @@ describe("scope set command", () => {
               id: "test-id",
               slug: "testslug",
               type: "personal",
-              displayName: null,
               createdAt: "2024-01-01T00:00:00Z",
               updatedAt: "2024-01-01T00:00:00Z",
             },
@@ -79,45 +78,6 @@ describe("scope set command", () => {
         expect.stringContaining("testslug/<agent-name>"),
       );
     });
-
-    it("should create scope with display name", async () => {
-      let capturedBody: unknown;
-      server.use(
-        http.get("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json(
-            { error: { message: "No scope configured", code: "NOT_FOUND" } },
-            { status: 404 },
-          );
-        }),
-        http.post("http://localhost:3000/api/scope", async ({ request }) => {
-          capturedBody = await request.json();
-          return HttpResponse.json(
-            {
-              id: "test-id",
-              slug: "testslug",
-              type: "personal",
-              displayName: "Test Display",
-              createdAt: "2024-01-01T00:00:00Z",
-              updatedAt: "2024-01-01T00:00:00Z",
-            },
-            { status: 201 },
-          );
-        }),
-      );
-
-      await setCommand.parseAsync([
-        "node",
-        "cli",
-        "testslug",
-        "--display-name",
-        "Test Display",
-      ]);
-
-      expect(capturedBody).toEqual({
-        slug: "testslug",
-        displayName: "Test Display",
-      });
-    });
   });
 
   describe("update existing scope", () => {
@@ -128,7 +88,6 @@ describe("scope set command", () => {
             id: "test-id",
             slug: "oldslug",
             type: "personal",
-            displayName: null,
             createdAt: "2024-01-01T00:00:00Z",
             updatedAt: "2024-01-01T00:00:00Z",
           });
@@ -155,7 +114,6 @@ describe("scope set command", () => {
             id: "test-id",
             slug: "oldslug",
             type: "personal",
-            displayName: null,
             createdAt: "2024-01-01T00:00:00Z",
             updatedAt: "2024-01-01T00:00:00Z",
           });
@@ -165,7 +123,6 @@ describe("scope set command", () => {
             id: "test-id",
             slug: "newslug",
             type: "personal",
-            displayName: null,
             createdAt: "2024-01-01T00:00:00Z",
             updatedAt: "2024-01-01T00:00:00Z",
           });

--- a/turbo/apps/cli/src/commands/scope/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/status.test.ts
@@ -79,7 +79,6 @@ describe("scope status command", () => {
             id: "test-id",
             slug: "testuser",
             type: "personal",
-            displayName: "Test User",
             createdAt: "2024-01-01T00:00:00Z",
             updatedAt: "2024-01-01T00:00:00Z",
           });
@@ -96,30 +95,6 @@ describe("scope status command", () => {
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("personal"),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Test User"),
-      );
-    });
-
-    it("should handle scope without display name", async () => {
-      server.use(
-        http.get("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json({
-            id: "test-id",
-            slug: "testuser",
-            type: "personal",
-            displayName: null,
-            createdAt: "2024-01-01T00:00:00Z",
-            updatedAt: "2024-01-01T00:00:00Z",
-          });
-        }),
-      );
-
-      await statusCommand.parseAsync(["node", "cli"]);
-
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("testuser"),
       );
     });
   });

--- a/turbo/apps/cli/src/commands/scope/set.ts
+++ b/turbo/apps/cli/src/commands/scope/set.ts
@@ -7,88 +7,77 @@ export const setCommand = new Command()
   .description("Set your scope slug")
   .argument("<slug>", "The scope slug (e.g., your username)")
   .option("--force", "Force change existing scope (may break references)")
-  .option("--display-name <name>", "Display name for the scope")
-  .action(
-    async (
-      slug: string,
-      options: { force?: boolean; displayName?: string },
-    ) => {
+  .action(async (slug: string, options: { force?: boolean }) => {
+    try {
+      // First check if user already has a scope
+      let existingScope;
       try {
-        // First check if user already has a scope
-        let existingScope;
-        try {
-          existingScope = await getScope();
-        } catch (error) {
-          // Only swallow "No scope configured" errors - that's the expected case for new users
-          // All other errors (network, auth, etc.) should propagate to the outer handler
-          if (
-            !(error instanceof Error) ||
-            !error.message.includes("No scope configured")
-          ) {
-            throw error;
-          }
-        }
-
-        let scope;
-        if (existingScope) {
-          // User already has a scope - update it
-          if (!options.force) {
-            console.error(
-              chalk.yellow(`You already have a scope: ${existingScope.slug}`),
-            );
-            console.error();
-            console.error("To change your scope, use --force:");
-            console.error(chalk.cyan(`  vm0 scope set ${slug} --force`));
-            console.error();
-            console.error(
-              chalk.yellow(
-                "Warning: Changing your scope may break existing agent references.",
-              ),
-            );
-            process.exit(1);
-          }
-
-          scope = await updateScope({ slug, force: true });
-          console.log(chalk.green(`✓ Scope updated to ${scope.slug}`));
-        } else {
-          // Create new scope
-          scope = await createScope({
-            slug,
-            displayName: options.displayName,
-          });
-          console.log(chalk.green(`✓ Scope created: ${scope.slug}`));
-        }
-
-        console.log();
-        console.log("Your agents will now be namespaced as:");
-        console.log(chalk.cyan(`  ${scope.slug}/<agent-name>`));
+        existingScope = await getScope();
       } catch (error) {
-        if (error instanceof Error) {
-          if (error.message.includes("Not authenticated")) {
-            console.error(
-              chalk.red("✗ Not authenticated. Run: vm0 auth login"),
-            );
-          } else if (error.message.includes("already exists")) {
-            console.error(
-              chalk.red(
-                `✗ Scope "${slug}" is already taken. Please choose a different slug.`,
-              ),
-            );
-          } else if (error.message.includes("reserved")) {
-            console.error(chalk.red(`✗ ${error.message}`));
-          } else if (error.message.includes("vm0")) {
-            console.error(
-              chalk.red(
-                "✗ Scope slugs cannot start with 'vm0' (reserved for system use)",
-              ),
-            );
-          } else {
-            console.error(chalk.red(`✗ ${error.message}`));
-          }
-        } else {
-          console.error(chalk.red("✗ An unexpected error occurred"));
+        // Only swallow "No scope configured" errors - that's the expected case for new users
+        // All other errors (network, auth, etc.) should propagate to the outer handler
+        if (
+          !(error instanceof Error) ||
+          !error.message.includes("No scope configured")
+        ) {
+          throw error;
         }
-        process.exit(1);
       }
-    },
-  );
+
+      let scope;
+      if (existingScope) {
+        // User already has a scope - update it
+        if (!options.force) {
+          console.error(
+            chalk.yellow(`You already have a scope: ${existingScope.slug}`),
+          );
+          console.error();
+          console.error("To change your scope, use --force:");
+          console.error(chalk.cyan(`  vm0 scope set ${slug} --force`));
+          console.error();
+          console.error(
+            chalk.yellow(
+              "Warning: Changing your scope may break existing agent references.",
+            ),
+          );
+          process.exit(1);
+        }
+
+        scope = await updateScope({ slug, force: true });
+        console.log(chalk.green(`✓ Scope updated to ${scope.slug}`));
+      } else {
+        // Create new scope
+        scope = await createScope({ slug });
+        console.log(chalk.green(`✓ Scope created: ${scope.slug}`));
+      }
+
+      console.log();
+      console.log("Your agents will now be namespaced as:");
+      console.log(chalk.cyan(`  ${scope.slug}/<agent-name>`));
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes("Not authenticated")) {
+          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
+        } else if (error.message.includes("already exists")) {
+          console.error(
+            chalk.red(
+              `✗ Scope "${slug}" is already taken. Please choose a different slug.`,
+            ),
+          );
+        } else if (error.message.includes("reserved")) {
+          console.error(chalk.red(`✗ ${error.message}`));
+        } else if (error.message.includes("vm0")) {
+          console.error(
+            chalk.red(
+              "✗ Scope slugs cannot start with 'vm0' (reserved for system use)",
+            ),
+          );
+        } else {
+          console.error(chalk.red(`✗ ${error.message}`));
+        }
+      } else {
+        console.error(chalk.red("✗ An unexpected error occurred"));
+      }
+      process.exit(1);
+    }
+  });

--- a/turbo/apps/cli/src/commands/scope/status.ts
+++ b/turbo/apps/cli/src/commands/scope/status.ts
@@ -12,9 +12,6 @@ export const statusCommand = new Command()
       console.log(chalk.bold("Scope Information:"));
       console.log(`  Slug: ${chalk.green(scope.slug)}`);
       console.log(`  Type: ${scope.type}`);
-      if (scope.displayName) {
-        console.log(`  Display Name: ${scope.displayName}`);
-      }
       console.log(
         `  Created: ${new Date(scope.createdAt).toLocaleDateString()}`,
       );

--- a/turbo/apps/cli/src/lib/api/domains/scopes.ts
+++ b/turbo/apps/cli/src/lib/api/domains/scopes.ts
@@ -24,7 +24,6 @@ export async function getScope(): Promise<ScopeResponse> {
  */
 export async function createScope(body: {
   slug: string;
-  displayName?: string;
 }): Promise<ScopeResponse> {
   const config = await getClientConfig();
   const client = initClient(scopeContract, config);

--- a/turbo/apps/platform/src/mocks/handlers/api-scope.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-scope.ts
@@ -13,7 +13,6 @@ const mockScope: Scope = {
   id: "scope_1",
   slug: "user-12345678",
   type: "personal",
-  displayName: null,
   createdAt: "2024-01-01T00:00:00Z",
   updatedAt: "2024-01-01T00:00:00Z",
 };

--- a/turbo/apps/platform/src/signals/scope.ts
+++ b/turbo/apps/platform/src/signals/scope.ts
@@ -18,7 +18,6 @@ export interface Scope {
   id: string;
   slug: string;
   type: "personal" | "organization" | "system";
-  displayName: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/turbo/apps/web/app/api/scope/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/route.test.ts
@@ -96,7 +96,7 @@ describe("/api/scope", () => {
       const request = new NextRequest("http://localhost:3000/api/scope", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ slug, displayName: "Test Scope" }),
+        body: JSON.stringify({ slug }),
       });
 
       const response = await POST(request);
@@ -104,7 +104,6 @@ describe("/api/scope", () => {
 
       expect(response.status).toBe(201);
       expect(data.slug).toBe(slug);
-      expect(data.displayName).toBe("Test Scope");
       expect(data.type).toBe("personal");
       expect(data.id).toBeDefined();
     });

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -46,7 +46,6 @@ const router = tsr.router(scopeContract, {
         id: scope.id,
         slug: scope.slug,
         type: scope.type,
-        displayName: scope.displayName,
         createdAt: scope.createdAt.toISOString(),
         updatedAt: scope.updatedAt.toISOString(),
       },
@@ -64,12 +63,12 @@ const router = tsr.router(scopeContract, {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
 
-    const { slug, displayName } = body;
+    const { slug } = body;
 
     log.debug("creating user scope", { userId, slug });
 
     try {
-      const scope = await createUserScope(userId, slug, displayName);
+      const scope = await createUserScope(userId, slug);
 
       return {
         status: 201 as const,
@@ -77,7 +76,6 @@ const router = tsr.router(scopeContract, {
           id: scope.id,
           slug: scope.slug,
           type: scope.type,
-          displayName: scope.displayName,
           createdAt: scope.createdAt.toISOString(),
           updatedAt: scope.updatedAt.toISOString(),
         },
@@ -137,7 +135,6 @@ const router = tsr.router(scopeContract, {
           id: scope.id,
           slug: scope.slug,
           type: scope.type,
-          displayName: scope.displayName,
           createdAt: scope.createdAt.toISOString(),
           updatedAt: scope.updatedAt.toISOString(),
         },

--- a/turbo/apps/web/src/db/migrations/0055_drop_scope_display_name.sql
+++ b/turbo/apps/web/src/db/migrations/0055_drop_scope_display_name.sql
@@ -1,0 +1,2 @@
+-- Drop unused display_name column from scopes table
+ALTER TABLE "scopes" DROP COLUMN IF EXISTS "display_name";

--- a/turbo/apps/web/src/db/schema/scope.ts
+++ b/turbo/apps/web/src/db/schema/scope.ts
@@ -33,7 +33,6 @@ export const scopes = pgTable(
     slug: varchar("slug", { length: 64 }).notNull().unique(),
     type: scopeTypeEnum("type").notNull().default("personal"),
     ownerId: text("owner_id"), // Clerk user ID, null for system scopes
-    displayName: varchar("display_name", { length: 128 }),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },

--- a/turbo/apps/web/src/lib/scope/__tests__/scope-service.spec.ts
+++ b/turbo/apps/web/src/lib/scope/__tests__/scope-service.spec.ts
@@ -88,18 +88,12 @@ describe("Scope Service", () => {
 
     describe("createScope", () => {
       it("should create a scope successfully", async () => {
-        const scope = await createScope(
-          testSlug,
-          "personal",
-          testUserId,
-          "Test Scope",
-        );
+        const scope = await createScope(testSlug, "personal", testUserId);
 
         expect(scope).toBeDefined();
         expect(scope.slug).toBe(testSlug);
         expect(scope.type).toBe("personal");
         expect(scope.ownerId).toBe(testUserId);
-        expect(scope.displayName).toBe("Test Scope");
         expect(scope.id).toBeDefined();
       });
 
@@ -171,13 +165,12 @@ describe("Scope Service", () => {
         const userId = `test-create-user-${Date.now()}`;
         const slug = `user-create-${Date.now()}`;
 
-        const scope = await createUserScope(userId, slug, "My Personal Scope");
+        const scope = await createUserScope(userId, slug);
 
         expect(scope).toBeDefined();
         expect(scope.slug).toBe(slug);
         expect(scope.type).toBe("personal");
         expect(scope.ownerId).toBe(userId);
-        expect(scope.displayName).toBe("My Personal Scope");
       });
 
       it("should reject if user already has a scope", async () => {

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -86,7 +86,6 @@ export async function createScope(
   slug: string,
   type: ScopeType,
   ownerId?: string,
-  displayName?: string,
 ) {
   validateScopeSlug(slug);
 
@@ -104,7 +103,6 @@ export async function createScope(
       slug,
       type,
       ownerId,
-      displayName,
     })
     .returning();
 
@@ -117,11 +115,7 @@ export async function createScope(
  * Create a personal scope for a user and link it to their user record
  * This is the main entry point for setting up a user's scope
  */
-export async function createUserScope(
-  clerkUserId: string,
-  slug: string,
-  displayName?: string,
-) {
+export async function createUserScope(clerkUserId: string, slug: string) {
   // First check if user already has a scope via ownerId
   const existingScope = await globalThis.services.db
     .select()
@@ -136,7 +130,7 @@ export async function createUserScope(
   }
 
   // Create the scope
-  const scope = await createScope(slug, "personal", clerkUserId, displayName);
+  const scope = await createScope(slug, "personal", clerkUserId);
 
   log.debug("user scope created", { clerkUserId, scopeId: scope.id, slug });
 

--- a/turbo/packages/core/src/contracts/scopes.ts
+++ b/turbo/packages/core/src/contracts/scopes.ts
@@ -37,7 +37,6 @@ export const scopeResponseSchema = z.object({
   id: z.string().uuid(),
   slug: z.string(),
   type: scopeTypeSchema,
-  displayName: z.string().nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
@@ -49,7 +48,6 @@ export type ScopeResponse = z.infer<typeof scopeResponseSchema>;
  */
 export const createScopeRequestSchema = z.object({
   slug: scopeSlugSchema,
-  displayName: z.string().max(128).optional(),
 });
 
 export type CreateScopeRequest = z.infer<typeof createScopeRequestSchema>;


### PR DESCRIPTION
## Summary

- Remove the dead `--display-name` option from the scope command
- Analysis confirmed this feature was never used in the Web UI, agent references, or runner validation
- Only stored in the database and displayed in CLI status output
- Following YAGNI principle to remove unused code aggressively

## Changes

**Database:**
- Create migration 0055 to drop `display_name` column from scopes table

**Core Contracts:**
- Remove `displayName` from `scopeResponseSchema`
- Remove `displayName` from `createScopeRequestSchema`

**Service Layer:**
- Remove `displayName` parameter from `createScope()` function
- Remove `displayName` parameter from `createUserScope()` function

**API Layer:**
- Remove `displayName` from GET/POST/PUT response bodies
- Remove `displayName` from POST body destructuring

**CLI:**
- Remove `--display-name` option from `vm0 scope set` command
- Remove displayName display from `vm0 scope status` command
- Update CLI API client

**Platform:**
- Remove `displayName` from Scope interface
- Update mock handlers

**Tests:**
- Update unit tests for scope service, API routes, and CLI commands
- Remove E2E test for `--display-name` flag

## Test plan

- [x] Unit tests pass for scope service
- [x] Unit tests pass for API routes
- [x] Unit tests pass for CLI commands
- [x] Linting passes
- [x] Knip passes (no unused code)
- [ ] E2E tests pass in CI

Closes #1686

🤖 Generated with [Claude Code](https://claude.com/claude-code)