### PR TITLE
chore(devcontainer): remove /etc/hosts config for dev domains

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -35,15 +35,6 @@ if [ ! -L "$HOME/.claude" ]; then
   echo "✓ Linked ~/.claude to ~/.config/claude"
 fi
 
-# Add local development domains to /etc/hosts
-echo "📝 Adding local domains to /etc/hosts..."
-if ! grep -q "vm7.ai" /etc/hosts; then
-  echo "127.0.0.1 vm7.ai www.vm7.ai docs.vm7.ai platform.vm7.ai storybook.vm7.ai" | sudo tee -a /etc/hosts > /dev/null
-  echo "✓ Added vm7.ai domains to /etc/hosts"
-else
-  echo "✓ vm7.ai domains already in /etc/hosts"
-fi
-
 # Create NSS database in project directory (uses host filesystem, not BTRFS volume)
 # This avoids BTRFS + nodatacow compatibility issues with SQLite
 NSS_DIR="$WORKSPACE_DIR/.mozilla/firefox/mkcert.default"


### PR DESCRIPTION
## Summary
- Remove manual `/etc/hosts` configuration from devcontainer setup
- The vm7.ai domain now has DNS A records pointing to 127.0.0.1, making this configuration unnecessary

## Benefit
- One less setup step for new developers
- No more sudo prompts during container setup
- Automatic resolution for all subdomains via wildcard DNS

## Test plan
- [x] Verify vm7.ai resolves to 127.0.0.1 via `dig vm7.ai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)