### PR TITLE
fix(schedule): reject enabling past one-time schedules and default to disabled

### DIFF
--- a/e2e/tests/02-parallel/t20-vm0-schedule.bats
+++ b/e2e/tests/02-parallel/t20-vm0-schedule.bats
@@ -61,7 +61,8 @@ teardown() {
     assert_output --partial "$AGENT_NAME"
     assert_output --partial "Trigger:"
     assert_output --partial "0 9 * * *"
-    assert_output --partial "enabled"
+    # Schedules now default to disabled and require explicit enabling
+    assert_output --partial "disabled"
 }
 
 @test "vm0 schedule setup should update existing schedule" {
@@ -230,7 +231,8 @@ teardown() {
     assert_success
     assert_output --partial "$AGENT_NAME"
     assert_output --partial "AGENT"
-    assert_output --partial "enabled"
+    # Schedules now default to disabled and require explicit enabling
+    assert_output --partial "disabled"
 }
 
 @test "vm0 schedule list should show empty message when no schedules" {
@@ -261,7 +263,8 @@ teardown() {
     assert_output --partial "Agent:"
     assert_output --partial "$AGENT_NAME"
     assert_output --partial "Status:"
-    assert_output --partial "enabled"
+    # Schedules now default to disabled and require explicit enabling
+    assert_output --partial "disabled"
     assert_output --partial "Trigger:"
     assert_output --partial "0 9 * * *"
 }
@@ -435,7 +438,8 @@ teardown() {
     assert_success
     assert_output --partial "Agent:"
     assert_output --partial "$AGENT_NAME"
-    assert_output --partial "enabled"
+    # Schedules now default to disabled and require explicit enabling
+    assert_output --partial "disabled"
 }
 
 @test "vm0 schedule disable should work from any directory (global resolution)" {

--- a/turbo/apps/cli/src/commands/schedule/enable.ts
+++ b/turbo/apps/cli/src/commands/schedule/enable.ts
@@ -34,6 +34,12 @@ export const enableCommand = new Command()
             chalk.dim(`  No schedule found for agent "${agentName}"`),
           );
           console.error(chalk.dim("  Run: vm0 schedule list"));
+        } else if (
+          error.message.includes("already passed") ||
+          error.message.includes("SCHEDULE_PAST")
+        ) {
+          console.error(chalk.dim("  Scheduled time has already passed"));
+          console.error(chalk.dim(`  Run: vm0 schedule setup ${agentName}`));
         } else {
           console.error(chalk.dim(`  ${error.message}`));
         }

--- a/turbo/apps/cli/src/commands/schedule/enable.ts
+++ b/turbo/apps/cli/src/commands/schedule/enable.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { enableSchedule } from "../../lib/api";
+import { enableSchedule, ApiRequestError } from "../../lib/api";
 import { resolveScheduleByAgent } from "../../lib/domain/schedule-utils";
 
 export const enableCommand = new Command()
@@ -23,23 +23,28 @@ export const enableCommand = new Command()
       );
     } catch (error) {
       console.error(chalk.red("✗ Failed to enable schedule"));
-      if (error instanceof Error) {
-        if (error.message.includes("Not authenticated")) {
-          console.error(chalk.dim("  Run: vm0 auth login"));
-        } else if (
-          error.message.toLowerCase().includes("not found") ||
-          error.message.includes("No schedule found")
-        ) {
+      if (error instanceof ApiRequestError) {
+        if (error.code === "SCHEDULE_PAST") {
+          console.error(chalk.dim("  Scheduled time has already passed"));
+          console.error(chalk.dim(`  Run: vm0 schedule setup ${agentName}`));
+        } else if (error.code === "NOT_FOUND") {
           console.error(
             chalk.dim(`  No schedule found for agent "${agentName}"`),
           );
           console.error(chalk.dim("  Run: vm0 schedule list"));
-        } else if (
-          error.message.includes("already passed") ||
-          error.message.includes("SCHEDULE_PAST")
-        ) {
-          console.error(chalk.dim("  Scheduled time has already passed"));
-          console.error(chalk.dim(`  Run: vm0 schedule setup ${agentName}`));
+        } else if (error.code === "UNAUTHORIZED") {
+          console.error(chalk.dim("  Run: vm0 auth login"));
+        } else {
+          console.error(chalk.dim(`  ${error.message}`));
+        }
+      } else if (error instanceof Error) {
+        if (error.message.includes("Not authenticated")) {
+          console.error(chalk.dim("  Run: vm0 auth login"));
+        } else if (error.message.includes("No schedule found")) {
+          console.error(
+            chalk.dim(`  No schedule found for agent "${agentName}"`),
+          );
+          console.error(chalk.dim("  Run: vm0 schedule list"));
         } else {
           console.error(chalk.dim(`  ${error.message}`));
         }

--- a/turbo/apps/cli/src/commands/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/schedule/setup.ts
@@ -762,7 +762,7 @@ function displayDeployResult(
   if (deployResult.created) {
     console.log();
     console.log(
-      chalk.yellow(`  Run 'vm0 schedule enable ${agentName}' to activate`),
+      `  To activate: ${chalk.cyan(`vm0 schedule enable ${agentName}`)}`,
     );
   }
 }

--- a/turbo/apps/cli/src/commands/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/schedule/setup.ts
@@ -758,6 +758,13 @@ function displayDeployResult(
     );
     console.log(chalk.dim(`  At: ${atTimeFormatted}`));
   }
+
+  if (deployResult.created) {
+    console.log();
+    console.log(
+      chalk.yellow(`  Run 'vm0 schedule enable ${agentName}' to activate`),
+    );
+  }
 }
 
 export const setupCommand = new Command()

--- a/turbo/apps/cli/src/lib/api/core/client-factory.ts
+++ b/turbo/apps/cli/src/lib/api/core/client-factory.ts
@@ -2,6 +2,19 @@ import { getApiUrl, getToken } from "../config";
 import type { ApiErrorResponse } from "@vm0/core";
 
 /**
+ * Custom API request error with code
+ */
+export class ApiRequestError extends Error {
+  constructor(
+    message: string,
+    public code: string,
+  ) {
+    super(message);
+    this.name = "ApiRequestError";
+  }
+}
+
+/**
  * Get authentication headers for API requests
  */
 export async function getHeaders(): Promise<Record<string, string>> {
@@ -58,5 +71,6 @@ export function handleError(
 ): never {
   const errorBody = result.body as ApiErrorResponse;
   const message = errorBody.error?.message || defaultMessage;
-  throw new Error(message);
+  const code = errorBody.error?.code || "UNKNOWN";
+  throw new ApiRequestError(message, code);
 }

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -1,6 +1,9 @@
 // Core types (only export what's actually used)
 export type { ApiError, RunResult } from "./core/types";
 
+// Custom error class
+export { ApiRequestError } from "./core/client-factory";
+
 // HTTP utilities (only export what's actually used)
 export { httpGet } from "./core/http";
 

--- a/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
@@ -3,7 +3,10 @@ import { initServices } from "../../../../../../src/lib/init-services";
 import { getUserId } from "../../../../../../src/lib/auth/get-user-id";
 import { scheduleService } from "../../../../../../src/lib/schedule";
 import { logger } from "../../../../../../src/lib/logger";
-import { NotFoundError } from "../../../../../../src/lib/errors";
+import {
+  NotFoundError,
+  SchedulePastError,
+} from "../../../../../../src/lib/errors";
 
 const log = logger("api:schedules:enable");
 
@@ -53,6 +56,12 @@ export async function POST(
       return NextResponse.json(
         { error: { message: error.message, code: "NOT_FOUND" } },
         { status: 404 },
+      );
+    }
+    if (error instanceof SchedulePastError) {
+      return NextResponse.json(
+        { error: { message: error.message, code: "SCHEDULE_PAST" } },
+        { status: 400 },
       );
     }
     throw error;

--- a/turbo/apps/web/src/lib/errors.ts
+++ b/turbo/apps/web/src/lib/errors.ts
@@ -42,3 +42,9 @@ export class ConflictError extends ApiError {
     super(409, message, "CONFLICT");
   }
 }
+
+export class SchedulePastError extends ApiError {
+  constructor(message = "Schedule time has already passed") {
+    super(400, message, "SCHEDULE_PAST");
+  }
+}


### PR DESCRIPTION
## Summary

- Fix bug where enabling a past one-time schedule silently sets `nextRunAt` to null
- Change new schedules to default to `enabled: false` (require explicit enable)

## Changes

- Add `SchedulePastError` class for past schedule detection
- Throw error in `enable()` when one-time schedule's `atTime` has passed
- Update CLI enable command to show helpful error message for past schedules
- Update CLI setup command to show "run enable to activate" hint
- Update API route to handle `SchedulePastError` with `SCHEDULE_PAST` code
- Add tests for new enable behavior
- Update existing tests to explicitly enable schedules for execution tests

## Test plan

- [x] `enable()` throws error for past one-time schedules
- [x] `enable()` succeeds for future one-time schedules
- [x] `enable()` succeeds for cron schedules
- [x] New schedules default to `enabled: false`
- [x] All existing schedule tests pass

Closes #1689

🤖 Generated with [Claude Code](https://claude.com/claude-code)