### PR TITLE
chore(eslint): add rule to ban next/headers imports

### DIFF
--- a/turbo/packages/eslint-config/next.js
+++ b/turbo/packages/eslint-config/next.js
@@ -79,4 +79,22 @@ export const nextJsConfig = [
       ],
     },
   },
+  {
+    // Prevent importing next/headers - use authHeader parameter instead
+    // See: https://github.com/vm0-ai/vm0/issues/1591
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "next/headers",
+              message:
+                "Use authHeader parameter instead of headers() from next/headers. See issue #1591.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

- Add `no-restricted-imports` ESLint rule to prevent importing from `next/headers`
- This protects the refactoring done in #1591 where we replaced direct `headers()` calls with `authHeader` parameters passed through ts-rest contracts

## Test plan

- [x] ESLint rule triggers on `next/headers` imports with helpful error message
- [x] All existing code passes lint (no false positives)
- [x] Pre-commit hooks pass

Closes #1591

🤖 Generated with [Claude Code](https://claude.com/claude-code)