### PR TITLE
fix(ci): force decimal interpretation for PROXY_PORT calculation

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -837,7 +837,7 @@ jobs:
         run: |
           RUNNER_DIR="/opt/vm0-runner/${JOB_REF}"
           # Use numeric hash of job-ref for proxy port to ensure consistency
-          PROXY_PORT=$((8080 + $(echo -n "${JOB_REF}" | md5sum | cut -c1-8 | sed 's/[a-f]//g' | cut -c1-3)))
+          PROXY_PORT=$((8080 + 10#$(echo -n "${JOB_REF}" | md5sum | cut -c1-8 | sed 's/[a-f]//g' | cut -c1-3)))
 
           mkdir -p "$HOME/.ssh"
           echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
@@ -948,7 +948,7 @@ jobs:
           VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
         run: |
-          PROXY_PORT=$((8080 + $(echo -n "${JOB_REF}" | md5sum | cut -c1-8 | sed 's/[a-f]//g' | cut -c1-3)))
+          PROXY_PORT=$((8080 + 10#$(echo -n "${JOB_REF}" | md5sum | cut -c1-8 | sed 's/[a-f]//g' | cut -c1-3)))
 
           mkdir -p "$HOME/.ssh"
           echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"


### PR DESCRIPTION
## Summary

- Fix bash arithmetic error when PROXY_PORT hash has leading zeros
- Use `10#` prefix to force decimal interpretation

## Problem

The md5sum hash extraction could produce numbers with leading zeros (e.g., `086`), which bash interprets as octal. Since 8 and 9 are not valid octal digits, this caused errors:

```
arithmetic expression: expecting EOF: "8080 + 086"
```

## Solution

```bash
# Before
PROXY_PORT=$((8080 + $(echo -n "${JOB_REF}" | md5sum | ... )))

# After  
PROXY_PORT=$((8080 + 10#$(echo -n "${JOB_REF}" | md5sum | ... )))
```

The `10#` prefix forces bash to interpret the number as base-10 (decimal).

## Test plan

- [x] Verified fix locally with `echo $((8080 + 10#086))` → `8166`

🤖 Generated with [Claude Code](https://claude.com/claude-code)