### PR TITLE
fix(ci): use awk for posix-compatible proxy port calculation

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -837,7 +837,7 @@ jobs:
         run: |
           RUNNER_DIR="/opt/vm0-runner/${JOB_REF}"
           # Use numeric hash of job-ref for proxy port to ensure consistency
-          PROXY_PORT=$((8080 + 10#$(echo -n "${JOB_REF}" | md5sum | cut -c1-8 | sed 's/[a-f]//g' | cut -c1-3)))
+          PROXY_PORT=$(echo -n "${JOB_REF}" | md5sum | cut -c1-8 | sed 's/[a-f]//g' | cut -c1-3 | awk '{print 8080 + int($1)}')
 
           mkdir -p "$HOME/.ssh"
           echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
@@ -948,7 +948,7 @@ jobs:
           VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
         run: |
-          PROXY_PORT=$((8080 + 10#$(echo -n "${JOB_REF}" | md5sum | cut -c1-8 | sed 's/[a-f]//g' | cut -c1-3)))
+          PROXY_PORT=$(echo -n "${JOB_REF}" | md5sum | cut -c1-8 | sed 's/[a-f]//g' | cut -c1-3 | awk '{print 8080 + int($1)}')
 
           mkdir -p "$HOME/.ssh"
           echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"


### PR DESCRIPTION
## Summary

- Fix PROXY_PORT calculation to work with POSIX sh (not just bash)
- Use `awk` which treats numbers as decimal regardless of leading zeros

## Problem

The previous fix (#1701) used `10#` prefix which is bash-specific:
```bash
PROXY_PORT=$((8080 + 10#086))  # Works in bash, fails in sh
```

Error in CI:
```
arithmetic expression: expecting EOF: "8080 + 10#086"
```

## Solution

Use `awk` which is POSIX-compatible and handles leading zeros correctly:
```bash
# Before (bash-specific)
PROXY_PORT=$((8080 + 10#$(... | cut -c1-3)))

# After (POSIX-compatible)
PROXY_PORT=$(... | cut -c1-3 | awk '{print 8080 + int($1)}')
```

## Test

```bash
$ echo "086" | awk '{print 8080 + int($1)}'
8166
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)