### PR TITLE
refactor(cli): align output formatting with cli-design patterns

### DIFF
--- a/turbo/apps/cli/src/commands/artifact/init.ts
+++ b/turbo/apps/cli/src/commands/artifact/init.ts
@@ -105,7 +105,7 @@ export const initCommand = new Command()
       console.log(chalk.green(`✓ Initialized artifact: ${artifactName}`));
       console.log(
         chalk.dim(
-          `✓ Config saved to ${path.join(cwd, ".vm0", "storage.yaml")}`,
+          `  Config saved to ${path.join(cwd, ".vm0", "storage.yaml")}`,
         ),
       );
     } catch (error) {

--- a/turbo/apps/cli/src/commands/artifact/pull.ts
+++ b/turbo/apps/cli/src/commands/artifact/pull.ts
@@ -6,19 +6,12 @@ import * as os from "os";
 import * as tar from "tar";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
 import { getStorageDownload } from "../../lib/api";
-import { listTarFiles, removeExtraFiles } from "../../lib/utils/file-utils";
+import {
+  formatBytes,
+  listTarFiles,
+  removeExtraFiles,
+} from "../../lib/utils/file-utils";
 import { handleEmptyStorageResponse } from "../../lib/storage/pull-utils";
-
-/**
- * Format bytes to human-readable format
- */
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return "0 B";
-  const k = 1024;
-  const sizes = ["B", "KB", "MB", "GB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
-}
 
 export const pullCommand = new Command()
   .name("pull")

--- a/turbo/apps/cli/src/commands/artifact/push.ts
+++ b/turbo/apps/cli/src/commands/artifact/push.ts
@@ -2,17 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
 import { directUpload } from "../../lib/storage/direct-upload";
-
-/**
- * Format bytes to human-readable format
- */
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return "0 B";
-  const k = 1024;
-  const sizes = ["B", "KB", "MB", "GB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
-}
+import { formatBytes } from "../../lib/utils/file-utils";
 
 export const pushCommand = new Command()
   .name("push")
@@ -57,7 +47,7 @@ export const pushCommand = new Command()
       const shortVersion = result.versionId.slice(0, 8);
 
       if (result.empty) {
-        console.log(chalk.yellow("No files found (empty artifact)"));
+        console.log(chalk.dim("No files found (empty artifact)"));
       } else if (result.deduplicated) {
         console.log(chalk.green("✓ Content unchanged (deduplicated)"));
       } else {

--- a/turbo/apps/cli/src/commands/artifact/status.ts
+++ b/turbo/apps/cli/src/commands/artifact/status.ts
@@ -2,17 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
 import { getStorageDownload } from "../../lib/api";
-
-/**
- * Format bytes to human-readable format
- */
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return "0 B";
-  const k = 1024;
-  const sizes = ["B", "KB", "MB", "GB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
-}
+import { formatBytes } from "../../lib/utils/file-utils";
 
 export const statusCommand = new Command()
   .name("status")

--- a/turbo/apps/cli/src/commands/cook.ts
+++ b/turbo/apps/cli/src/commands/cook.ts
@@ -372,7 +372,7 @@ cookCmd
             console.log();
             console.error(chalk.red("✗ Missing required variables:"));
             for (const varName of missingVars) {
-              console.error(chalk.red(`    ${varName}`));
+              console.error(chalk.red(`  ${varName}`));
             }
             console.error(
               chalk.dim(
@@ -399,9 +399,10 @@ cookCmd
 
           if (!existsSync(volumeDir)) {
             console.error(
-              chalk.red(
-                `✗ Directory not found: ${volumeConfig.name}. Create the directory and add files first.`,
-              ),
+              chalk.red(`✗ Directory not found: ${volumeConfig.name}`),
+            );
+            console.error(
+              chalk.dim("  Create the directory and add files first"),
             );
             process.exit(1);
           }

--- a/turbo/apps/cli/src/commands/credential/delete.ts
+++ b/turbo/apps/cli/src/commands/credential/delete.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { getCredential, deleteCredential } from "../../lib/api";
+import { isInteractive, promptConfirm } from "../../lib/utils/prompt-utils";
 
 export const deleteCommand = new Command()
   .name("delete")
@@ -19,26 +20,20 @@ export const deleteCommand = new Command()
 
       // Confirm deletion unless --yes is passed
       if (!options.yes) {
-        const readline = await import("readline");
-        const rl = readline.createInterface({
-          input: process.stdin,
-          output: process.stdout,
-        });
-
-        const confirmed = await new Promise<boolean>((resolve) => {
-          rl.question(
-            chalk.yellow(
-              `Are you sure you want to delete credential "${name}"? (y/N) `,
-            ),
-            (answer) => {
-              rl.close();
-              resolve(answer.toLowerCase() === "y");
-            },
+        if (!isInteractive()) {
+          console.error(
+            chalk.red("✗ --yes flag is required in non-interactive mode"),
           );
-        });
+          process.exit(1);
+        }
+
+        const confirmed = await promptConfirm(
+          `Are you sure you want to delete credential "${name}"?`,
+          false,
+        );
 
         if (!confirmed) {
-          console.log(chalk.dim("Cancelled."));
+          console.log(chalk.dim("Cancelled"));
           return;
         }
       }

--- a/turbo/apps/cli/src/commands/credential/list.ts
+++ b/turbo/apps/cli/src/commands/credential/list.ts
@@ -11,7 +11,7 @@ export const listCommand = new Command()
       const result = await listCredentials();
 
       if (result.credentials.length === 0) {
-        console.log(chalk.dim("No credentials found."));
+        console.log(chalk.dim("No credentials found"));
         console.log();
         console.log("To add a credential:");
         console.log(chalk.cyan("  vm0 credential set MY_API_KEY <value>"));

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -7,6 +7,7 @@ import {
   NetworkLogEntry,
 } from "../../lib/api/api-client";
 import { parseTime } from "../../lib/utils/time-parser";
+import { formatBytes } from "../../lib/utils/file-utils";
 import { ClaudeEventParser } from "../../lib/events/claude-event-parser";
 import { EventRenderer } from "../../lib/events/event-renderer";
 import { CodexEventRenderer } from "../../lib/events/codex-event-renderer";
@@ -15,17 +16,6 @@ import { CodexEventRenderer } from "../../lib/events/codex-event-renderer";
  * Log type for mutually exclusive options
  */
 type LogType = "agent" | "system" | "metrics" | "network";
-
-/**
- * Format bytes to human-readable string
- */
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return "0 B";
-  const k = 1024;
-  const sizes = ["B", "KB", "MB", "GB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
-}
 
 /**
  * Format a single metric line
@@ -220,7 +210,7 @@ async function showAgentEvents(
   const response = await apiClient.getAgentEvents(runId, options);
 
   if (response.events.length === 0) {
-    console.log(chalk.yellow("No agent events found for this run."));
+    console.log(chalk.yellow("No agent events found for this run"));
     return;
   }
 
@@ -252,7 +242,7 @@ async function showSystemLog(
   const response = await apiClient.getSystemLog(runId, options);
 
   if (!response.systemLog) {
-    console.log(chalk.yellow("No system log found for this run."));
+    console.log(chalk.yellow("No system log found for this run"));
     return;
   }
 
@@ -276,7 +266,7 @@ async function showMetrics(
   const response = await apiClient.getMetrics(runId, options);
 
   if (response.metrics.length === 0) {
-    console.log(chalk.yellow("No metrics found for this run."));
+    console.log(chalk.yellow("No metrics found for this run"));
     return;
   }
 
@@ -312,7 +302,7 @@ async function showNetworkLogs(
   if (response.networkLogs.length === 0) {
     console.log(
       chalk.yellow(
-        "No network logs found for this run. Network logs are only captured when experimental_firewall is enabled on an experimental_runner.",
+        "No network logs found for this run. Network logs are only captured when experimental_firewall is enabled on an experimental_runner",
       ),
     );
     return;

--- a/turbo/apps/cli/src/commands/model-provider/delete.ts
+++ b/turbo/apps/cli/src/commands/model-provider/delete.ts
@@ -10,7 +10,7 @@ export const deleteCommand = new Command()
   .action(async (type: string) => {
     try {
       if (!Object.keys(MODEL_PROVIDER_TYPES).includes(type)) {
-        console.error(chalk.red(`x Invalid type "${type}"`));
+        console.error(chalk.red(`✗ Invalid type "${type}"`));
         console.log();
         console.log("Valid types:");
         for (const [t, config] of Object.entries(MODEL_PROVIDER_TYPES)) {
@@ -20,18 +20,18 @@ export const deleteCommand = new Command()
       }
 
       await deleteModelProvider(type as ModelProviderType);
-      console.log(chalk.green(`Done Model provider "${type}" deleted`));
+      console.log(chalk.green(`✓ Model provider "${type}" deleted`));
     } catch (error) {
       if (error instanceof Error) {
         if (error.message.includes("not found")) {
-          console.error(chalk.red(`x Model provider "${type}" not found`));
+          console.error(chalk.red(`✗ Model provider "${type}" not found`));
         } else if (error.message.includes("Not authenticated")) {
-          console.error(chalk.red("x Not authenticated. Run: vm0 auth login"));
+          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
         } else {
-          console.error(chalk.red(`x ${error.message}`));
+          console.error(chalk.red(`✗ ${error.message}`));
         }
       } else {
-        console.error(chalk.red("x An unexpected error occurred"));
+        console.error(chalk.red("✗ An unexpected error occurred"));
       }
       process.exit(1);
     }

--- a/turbo/apps/cli/src/commands/model-provider/list.ts
+++ b/turbo/apps/cli/src/commands/model-provider/list.ts
@@ -11,7 +11,7 @@ export const listCommand = new Command()
       const result = await listModelProviders();
 
       if (result.modelProviders.length === 0) {
-        console.log(chalk.dim("No model providers configured."));
+        console.log(chalk.dim("No model providers configured"));
         console.log();
         console.log("To add a model provider:");
         console.log(chalk.cyan("  vm0 model-provider setup"));
@@ -56,12 +56,12 @@ export const listCommand = new Command()
     } catch (error) {
       if (error instanceof Error) {
         if (error.message.includes("Not authenticated")) {
-          console.error(chalk.red("x Not authenticated. Run: vm0 auth login"));
+          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
         } else {
-          console.error(chalk.red(`x ${error.message}`));
+          console.error(chalk.red(`✗ ${error.message}`));
         }
       } else {
-        console.error(chalk.red("x An unexpected error occurred"));
+        console.error(chalk.red("✗ An unexpected error occurred"));
       }
       process.exit(1);
     }

--- a/turbo/apps/cli/src/commands/model-provider/set-default.ts
+++ b/turbo/apps/cli/src/commands/model-provider/set-default.ts
@@ -10,7 +10,7 @@ export const setDefaultCommand = new Command()
   .action(async (type: string) => {
     try {
       if (!Object.keys(MODEL_PROVIDER_TYPES).includes(type)) {
-        console.error(chalk.red(`x Invalid type "${type}"`));
+        console.error(chalk.red(`✗ Invalid type "${type}"`));
         console.log();
         console.log("Valid types:");
         for (const [t, config] of Object.entries(MODEL_PROVIDER_TYPES)) {
@@ -22,20 +22,20 @@ export const setDefaultCommand = new Command()
       const provider = await setModelProviderDefault(type as ModelProviderType);
       console.log(
         chalk.green(
-          `Done Default for ${provider.framework} set to "${provider.type}"`,
+          `✓ Default for ${provider.framework} set to "${provider.type}"`,
         ),
       );
     } catch (error) {
       if (error instanceof Error) {
         if (error.message.includes("not found")) {
-          console.error(chalk.red(`x Model provider "${type}" not found`));
+          console.error(chalk.red(`✗ Model provider "${type}" not found`));
         } else if (error.message.includes("Not authenticated")) {
-          console.error(chalk.red("x Not authenticated. Run: vm0 auth login"));
+          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
         } else {
-          console.error(chalk.red(`x ${error.message}`));
+          console.error(chalk.red(`✗ ${error.message}`));
         }
       } else {
-        console.error(chalk.red("x An unexpected error occurred"));
+        console.error(chalk.red("✗ An unexpected error occurred"));
       }
       process.exit(1);
     }

--- a/turbo/apps/cli/src/commands/model-provider/setup.ts
+++ b/turbo/apps/cli/src/commands/model-provider/setup.ts
@@ -39,7 +39,7 @@ export const setupCommand = new Command()
         // Non-interactive mode
         if (options.type && options.credential) {
           if (!Object.keys(MODEL_PROVIDER_TYPES).includes(options.type)) {
-            console.error(chalk.red(`x Invalid type "${options.type}"`));
+            console.error(chalk.red(`✗ Invalid type "${options.type}"`));
             console.log();
             console.log("Valid types:");
             for (const [t, config] of Object.entries(MODEL_PROVIDER_TYPES)) {
@@ -51,13 +51,13 @@ export const setupCommand = new Command()
           credential = options.credential;
         } else if (options.type || options.credential) {
           console.error(
-            chalk.red("x Both --type and --credential are required"),
+            chalk.red("✗ Both --type and --credential are required"),
           );
           process.exit(1);
         } else {
           // Interactive mode
           if (!isInteractive()) {
-            console.error(chalk.red("x Interactive mode requires a TTY"));
+            console.error(chalk.red("✗ Interactive mode requires a TTY"));
             console.log();
             console.log("Use non-interactive mode:");
             console.log(
@@ -103,12 +103,12 @@ export const setupCommand = new Command()
                 : "";
               console.log(
                 chalk.green(
-                  `Done Converted "${checkResult.credentialName}" to model provider${defaultNote}`,
+                  `✓ Converted "${checkResult.credentialName}" to model provider${defaultNote}`,
                 ),
               );
               return;
             } else {
-              console.log(chalk.dim("Aborted."));
+              console.log(chalk.dim("Aborted"));
               process.exit(0);
             }
           }
@@ -146,24 +146,24 @@ export const setupCommand = new Command()
           ? ` (default for ${provider.framework})`
           : "";
         console.log(
-          chalk.green(`Done Model provider "${type}" ${action}${defaultNote}`),
+          chalk.green(`✓ Model provider "${type}" ${action}${defaultNote}`),
         );
       } catch (error) {
         if (error instanceof Error) {
           if (error.message.includes("already exists")) {
-            console.error(chalk.red(`x ${error.message}`));
+            console.error(chalk.red(`✗ ${error.message}`));
             console.log();
             console.log("To convert the existing credential, run:");
             console.log(chalk.cyan("  vm0 model-provider setup --convert"));
           } else if (error.message.includes("Not authenticated")) {
             console.error(
-              chalk.red("x Not authenticated. Run: vm0 auth login"),
+              chalk.red("✗ Not authenticated. Run: vm0 auth login"),
             );
           } else {
-            console.error(chalk.red(`x ${error.message}`));
+            console.error(chalk.red(`✗ ${error.message}`));
           }
         } else {
-          console.error(chalk.red("x An unexpected error occurred"));
+          console.error(chalk.red("✗ An unexpected error occurred"));
         }
         process.exit(1);
       }

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -284,9 +284,7 @@ export const mainRunCommand = new Command()
             );
           } else if (error.message.startsWith("Version not found:")) {
             console.error(chalk.red(`✗ ${error.message}`));
-            console.error(
-              chalk.dim("  Make sure the version hash is correct."),
-            );
+            console.error(chalk.dim("  Make sure the version hash is correct"));
           } else if (error.message.startsWith("Environment file not found:")) {
             console.error(chalk.red(`✗ ${error.message}`));
           } else if (error.message.includes("not found")) {

--- a/turbo/apps/cli/src/commands/schedule/delete.ts
+++ b/turbo/apps/cli/src/commands/schedule/delete.ts
@@ -1,25 +1,8 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import * as readline from "readline";
 import { deleteSchedule } from "../../lib/api";
 import { resolveScheduleByAgent } from "../../lib/domain/schedule-utils";
-
-/**
- * Prompt for confirmation
- */
-async function confirm(message: string): Promise<boolean> {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
-  return new Promise((resolve) => {
-    rl.question(`${message} (y/N) `, (answer) => {
-      rl.close();
-      resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
-    });
-  });
-}
+import { isInteractive, promptConfirm } from "../../lib/utils/prompt-utils";
 
 export const deleteCommand = new Command()
   .name("delete")
@@ -34,8 +17,15 @@ export const deleteCommand = new Command()
 
       // Confirm deletion
       if (!options.force) {
-        const confirmed = await confirm(
+        if (!isInteractive()) {
+          console.error(
+            chalk.red("✗ --force required in non-interactive mode"),
+          );
+          process.exit(1);
+        }
+        const confirmed = await promptConfirm(
           `Delete schedule for agent ${chalk.cyan(agentName)}?`,
+          false,
         );
         if (!confirmed) {
           console.log(chalk.dim("Cancelled"));

--- a/turbo/apps/cli/src/commands/scope/status.ts
+++ b/turbo/apps/cli/src/commands/scope/status.ts
@@ -20,7 +20,7 @@ export const statusCommand = new Command()
         if (error.message.includes("Not authenticated")) {
           console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
         } else if (error.message.includes("No scope configured")) {
-          console.log(chalk.yellow("No scope configured."));
+          console.log(chalk.yellow("No scope configured"));
           console.log();
           console.log("Set your scope with:");
           console.log(chalk.cyan("  vm0 scope set <slug>"));

--- a/turbo/apps/cli/src/commands/usage.ts
+++ b/turbo/apps/cli/src/commands/usage.ts
@@ -113,7 +113,7 @@ export const usageCommand = new Command()
         } catch {
           console.error(
             chalk.red(
-              "Error: Invalid --until format. Use ISO (2026-01-01) or relative (7d, 30d)",
+              "✗ Invalid --until format. Use ISO (2026-01-01) or relative (7d, 30d)",
             ),
           );
           process.exit(1);
@@ -129,7 +129,7 @@ export const usageCommand = new Command()
         } catch {
           console.error(
             chalk.red(
-              "Error: Invalid --since format. Use ISO (2026-01-01) or relative (7d, 30d)",
+              "✗ Invalid --since format. Use ISO (2026-01-01) or relative (7d, 30d)",
             ),
           );
           process.exit(1);
@@ -140,7 +140,7 @@ export const usageCommand = new Command()
 
       // Validate date range
       if (startDate >= endDate) {
-        console.error(chalk.red("Error: --since must be before --until"));
+        console.error(chalk.red("✗ --since must be before --until"));
         process.exit(1);
       }
 
@@ -148,7 +148,7 @@ export const usageCommand = new Command()
       if (rangeMs > MAX_RANGE_MS) {
         console.error(
           chalk.red(
-            "Error: Time range exceeds maximum of 30 days. Use --until to specify an end date.",
+            "✗ Time range exceeds maximum of 30 days. Use --until to specify an end date",
           ),
         );
         process.exit(1);
@@ -199,14 +199,13 @@ export const usageCommand = new Command()
     } catch (error) {
       if (error instanceof Error) {
         if (error.message.includes("Not authenticated")) {
-          console.error(
-            chalk.red("Error: Not authenticated. Run: vm0 auth login"),
-          );
+          console.error(chalk.red("✗ Not authenticated"));
+          console.error(chalk.dim("  Run: vm0 auth login"));
         } else {
-          console.error(chalk.red(`Error: ${error.message}`));
+          console.error(chalk.red(`✗ ${error.message}`));
         }
       } else {
-        console.error(chalk.red("Error: An unexpected error occurred"));
+        console.error(chalk.red("✗ An unexpected error occurred"));
       }
       process.exit(1);
     }

--- a/turbo/apps/cli/src/commands/volume/init.ts
+++ b/turbo/apps/cli/src/commands/volume/init.ts
@@ -87,7 +87,7 @@ export const initCommand = new Command()
       console.log(chalk.green(`✓ Initialized volume: ${volumeName}`));
       console.log(
         chalk.dim(
-          `✓ Config saved to ${path.join(cwd, ".vm0", "storage.yaml")}`,
+          `  Config saved to ${path.join(cwd, ".vm0", "storage.yaml")}`,
         ),
       );
     } catch (error) {

--- a/turbo/apps/cli/src/commands/volume/pull.ts
+++ b/turbo/apps/cli/src/commands/volume/pull.ts
@@ -6,19 +6,12 @@ import * as os from "os";
 import * as tar from "tar";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
 import { getStorageDownload } from "../../lib/api";
-import { listTarFiles, removeExtraFiles } from "../../lib/utils/file-utils";
+import {
+  formatBytes,
+  listTarFiles,
+  removeExtraFiles,
+} from "../../lib/utils/file-utils";
 import { handleEmptyStorageResponse } from "../../lib/storage/pull-utils";
-
-/**
- * Format bytes to human-readable format
- */
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return "0 B";
-  const k = 1024;
-  const sizes = ["B", "KB", "MB", "GB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
-}
 
 export const pullCommand = new Command()
   .name("pull")

--- a/turbo/apps/cli/src/commands/volume/push.ts
+++ b/turbo/apps/cli/src/commands/volume/push.ts
@@ -2,17 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
 import { directUpload } from "../../lib/storage/direct-upload";
-
-/**
- * Format bytes to human-readable format
- */
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return "0 B";
-  const k = 1024;
-  const sizes = ["B", "KB", "MB", "GB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
-}
+import { formatBytes } from "../../lib/utils/file-utils";
 
 export const pushCommand = new Command()
   .name("push")
@@ -47,7 +37,7 @@ export const pushCommand = new Command()
       const shortVersion = result.versionId.slice(0, 8);
 
       if (result.empty) {
-        console.log(chalk.yellow("No files found (empty volume)"));
+        console.log(chalk.dim("No files found (empty volume)"));
       } else if (result.deduplicated) {
         console.log(chalk.green("✓ Content unchanged (deduplicated)"));
       } else {

--- a/turbo/apps/cli/src/commands/volume/status.ts
+++ b/turbo/apps/cli/src/commands/volume/status.ts
@@ -2,17 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
 import { getStorageDownload } from "../../lib/api";
-
-/**
- * Format bytes to human-readable format
- */
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return "0 B";
-  const k = 1024;
-  const sizes = ["B", "KB", "MB", "GB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
-}
+import { formatBytes } from "../../lib/utils/file-utils";
 
 export const statusCommand = new Command()
   .name("status")

--- a/turbo/apps/cli/src/lib/api/auth.ts
+++ b/turbo/apps/cli/src/lib/api/auth.ts
@@ -164,7 +164,7 @@ export async function authenticate(apiUrl?: string): Promise<void> {
 
 export async function logout(): Promise<void> {
   await clearConfig();
-  console.log(chalk.green("Successfully logged out"));
+  console.log(chalk.green("✓ Successfully logged out"));
   console.log("Your credentials have been cleared.");
 }
 
@@ -172,10 +172,10 @@ export async function checkAuthStatus(): Promise<void> {
   const config = await loadConfig();
 
   if (config.token) {
-    console.log(chalk.green("Authenticated"));
+    console.log(chalk.green("✓ Authenticated"));
     console.log("You are logged in to VM0.");
   } else {
-    console.log(chalk.yellow("Not authenticated"));
+    console.log(chalk.red("✗ Not authenticated"));
     console.log("Run 'vm0 auth login' to authenticate.");
   }
 
@@ -189,7 +189,7 @@ export async function setupToken(): Promise<void> {
   const token = await getToken();
 
   if (!token) {
-    console.error(chalk.red("Error: Not authenticated."));
+    console.error(chalk.red("✗ Not authenticated"));
     console.error("");
     console.error("To get a token for CI/CD:");
     console.error("  1. Run 'vm0 auth login' to authenticate");


### PR DESCRIPTION
## Summary

- Replace ASCII `x` with Unicode `✗` for error symbols (21 instances)
- Replace `Done` prefix with `✓` for success messages (4 instances)
- Replace `Error:` prefix with `✗` symbol (8 instances)
- Remove duplicate `formatBytes` implementations, use shared utility (7 files)
- Replace custom readline with `promptConfirm` from prompt-utils (3 files)
- Add `isInteractive()` checks before prompts (3 files)
- Remove trailing periods from messages (~12 instances)
- Fix secondary info formatting (2-space indent, no symbols)

## Files Changed (22)

**model-provider/** - Error/success symbols
- `delete.ts`, `set-default.ts`, `setup.ts`, `list.ts`

**artifact/** - formatBytes deduplication, secondary info
- `pull.ts`, `push.ts`, `status.ts`, `init.ts`

**volume/** - formatBytes deduplication, secondary info
- `pull.ts`, `push.ts`, `status.ts`, `init.ts`

**Other commands** - Various fixes
- `compose.ts` - promptConfirm, isInteractive, period
- `cook.ts` - indentation, period
- `usage.ts` - Error: prefix
- `credential/delete.ts` - promptConfirm, isInteractive, period
- `credential/list.ts` - period
- `schedule/delete.ts` - promptConfirm, isInteractive
- `scope/status.ts` - period
- `run/run.ts` - period
- `logs/index.ts` - formatBytes, periods
- `lib/api/auth.ts` - symbols

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes (0 warnings, 0 errors)
- [x] `pnpm vitest run` passes (731 tests)
- [x] `pnpm knip` passes (no unused code)

Closes #1702

🤖 Generated with [Claude Code](https://claude.com/claude-code)