### PR TITLE
fix(cli): add default msw handler for /api/scope endpoint

### DIFF
--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -41,4 +41,19 @@ export const apiHandlers = [
   http.get("http://localhost:3000/api/agent/composes/versions", () => {
     return HttpResponse.json({ versionId: "default" }, { status: 200 });
   }),
+
+  // GET /api/scope - getScope
+  http.get("http://localhost:3000/api/scope", () => {
+    return HttpResponse.json(
+      {
+        id: "scope-default",
+        slug: "user-default",
+        type: "personal",
+        displayName: null,
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+      },
+      { status: 200 },
+    );
+  }),
 ];


### PR DESCRIPTION
## Summary
- Add default MSW handler for `/api/scope` endpoint in test mocks
- Fixes flaky runner-validation tests in CI that relied on test-specific handler setup

## Root Cause
The `runner-validation.test.ts` tests use `server.use()` to add handlers for `/api/scope`, but if there's any timing issue in CI, the request could hit before the handler is registered. Adding a default handler ensures robustness.

## Test plan
- [x] Verify tests pass locally
- [ ] Verify tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)