### PR TITLE
fix(cli): fix schedule setup secrets not sent for new schedules

### DIFF
--- a/turbo/apps/cli/src/commands/schedule/__tests__/gather-configuration.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/gather-configuration.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { gatherConfiguration } from "../gather-configuration";
+import * as promptUtils from "../../../lib/utils/prompt-utils";
+
+// Mock prompt utilities
+vi.mock("../../../lib/utils/prompt-utils", () => ({
+  isInteractive: vi.fn(),
+  promptConfirm: vi.fn(),
+  promptPassword: vi.fn(),
+  promptText: vi.fn(),
+}));
+
+describe("gatherConfiguration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("new schedule scenarios", () => {
+    it("should use --secret flag values for new schedule", async () => {
+      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
+
+      const result = await gatherConfiguration({
+        required: { secrets: ["API_KEY"], vars: [], credentials: [] },
+        optionSecrets: ["API_KEY=my-secret-value"],
+        optionVars: [],
+        existingSchedule: undefined,
+      });
+
+      expect(result.secrets).toEqual({ API_KEY: "my-secret-value" });
+      expect(result.preserveExistingSecrets).toBe(false);
+      // Should not prompt when --secret flag is provided
+      expect(promptUtils.promptPassword).not.toHaveBeenCalled();
+    });
+
+    it("should prompt for secrets interactively for new schedule (THE BUG FIX)", async () => {
+      // This is the bug scenario: new schedule, no --secret flag, required secrets
+      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
+      vi.mocked(promptUtils.promptPassword).mockResolvedValue("entered-value");
+
+      const result = await gatherConfiguration({
+        required: { secrets: ["FIRECRAWL_API_KEY"], vars: [], credentials: [] },
+        optionSecrets: [],
+        optionVars: [],
+        existingSchedule: undefined, // New schedule - no existing secrets
+      });
+
+      // The fix: secrets should be gathered and sent, not discarded
+      expect(result.secrets).toEqual({ FIRECRAWL_API_KEY: "entered-value" });
+      expect(result.preserveExistingSecrets).toBe(false);
+      expect(promptUtils.promptPassword).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not prompt in non-interactive mode for new schedule", async () => {
+      vi.mocked(promptUtils.isInteractive).mockReturnValue(false);
+
+      const result = await gatherConfiguration({
+        required: { secrets: ["API_KEY"], vars: [], credentials: [] },
+        optionSecrets: [],
+        optionVars: [],
+        existingSchedule: undefined,
+      });
+
+      // Non-interactive: return what we have, server will validate
+      expect(result.secrets).toEqual({});
+      expect(result.preserveExistingSecrets).toBe(false);
+      expect(promptUtils.promptPassword).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("update schedule scenarios", () => {
+    it("should preserve existing secrets when user chooses to keep them", async () => {
+      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
+      vi.mocked(promptUtils.promptConfirm).mockResolvedValue(true);
+
+      const result = await gatherConfiguration({
+        required: { secrets: ["API_KEY"], vars: [], credentials: [] },
+        optionSecrets: [],
+        optionVars: [],
+        existingSchedule: {
+          secretNames: ["API_KEY"],
+          vars: null,
+        },
+      });
+
+      expect(result.secrets).toEqual({});
+      expect(result.preserveExistingSecrets).toBe(true);
+      expect(promptUtils.promptConfirm).toHaveBeenCalledWith(
+        "Keep existing secrets? (API_KEY)",
+        true,
+      );
+      // Should not prompt for password when keeping existing
+      expect(promptUtils.promptPassword).not.toHaveBeenCalled();
+    });
+
+    it("should prompt for new secrets when user chooses to replace", async () => {
+      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
+      vi.mocked(promptUtils.promptConfirm).mockResolvedValue(false);
+      vi.mocked(promptUtils.promptPassword).mockResolvedValue("new-value");
+
+      const result = await gatherConfiguration({
+        required: { secrets: ["API_KEY"], vars: [], credentials: [] },
+        optionSecrets: [],
+        optionVars: [],
+        existingSchedule: {
+          secretNames: ["API_KEY"],
+          vars: null,
+        },
+      });
+
+      expect(result.secrets).toEqual({ API_KEY: "new-value" });
+      expect(result.preserveExistingSecrets).toBe(false);
+      expect(promptUtils.promptPassword).toHaveBeenCalledTimes(1);
+    });
+
+    it("should use --secret flag to override existing secrets", async () => {
+      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
+
+      const result = await gatherConfiguration({
+        required: { secrets: ["API_KEY"], vars: [], credentials: [] },
+        optionSecrets: ["API_KEY=new-from-flag"],
+        optionVars: [],
+        existingSchedule: {
+          secretNames: ["API_KEY"],
+          vars: null,
+        },
+      });
+
+      expect(result.secrets).toEqual({ API_KEY: "new-from-flag" });
+      expect(result.preserveExistingSecrets).toBe(false);
+      // Should not prompt when --secret flag is provided
+      expect(promptUtils.promptConfirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("vars handling", () => {
+    it("should keep existing vars when user chooses to", async () => {
+      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
+      vi.mocked(promptUtils.promptConfirm).mockResolvedValue(true);
+
+      const result = await gatherConfiguration({
+        required: { secrets: [], vars: ["ENV"], credentials: [] },
+        optionSecrets: [],
+        optionVars: [],
+        existingSchedule: {
+          secretNames: null,
+          vars: { ENV: "production" },
+        },
+      });
+
+      expect(result.vars).toEqual({ ENV: "production" });
+    });
+
+    it("should prompt for missing vars for new schedule", async () => {
+      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
+      vi.mocked(promptUtils.promptText).mockResolvedValue(
+        "https://api.example.com",
+      );
+
+      const result = await gatherConfiguration({
+        required: { secrets: [], vars: ["API_URL"], credentials: [] },
+        optionSecrets: [],
+        optionVars: [],
+        existingSchedule: undefined,
+      });
+
+      expect(result.vars).toEqual({ API_URL: "https://api.example.com" });
+      expect(promptUtils.promptText).toHaveBeenCalledTimes(1);
+    });
+
+    it("should use --var flag values", async () => {
+      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
+
+      const result = await gatherConfiguration({
+        required: { secrets: [], vars: ["ENV"], credentials: [] },
+        optionSecrets: [],
+        optionVars: ["ENV=staging"],
+        existingSchedule: undefined,
+      });
+
+      expect(result.vars).toEqual({ ENV: "staging" });
+      expect(promptUtils.promptText).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty required configuration", async () => {
+      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
+
+      const result = await gatherConfiguration({
+        required: { secrets: [], vars: [], credentials: [] },
+        optionSecrets: [],
+        optionVars: [],
+        existingSchedule: undefined,
+      });
+
+      expect(result.secrets).toEqual({});
+      expect(result.vars).toEqual({});
+      expect(result.preserveExistingSecrets).toBe(false);
+    });
+
+    it("should handle multiple secrets and vars", async () => {
+      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
+      vi.mocked(promptUtils.promptPassword)
+        .mockResolvedValueOnce("secret1-value")
+        .mockResolvedValueOnce("secret2-value");
+      vi.mocked(promptUtils.promptText).mockResolvedValue("var-value");
+
+      const result = await gatherConfiguration({
+        required: {
+          secrets: ["SECRET1", "SECRET2"],
+          vars: ["VAR1"],
+          credentials: [],
+        },
+        optionSecrets: [],
+        optionVars: [],
+        existingSchedule: undefined,
+      });
+
+      expect(result.secrets).toEqual({
+        SECRET1: "secret1-value",
+        SECRET2: "secret2-value",
+      });
+      expect(result.vars).toEqual({ VAR1: "var-value" });
+    });
+
+    it("should skip prompting for secrets that are already provided", async () => {
+      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
+      vi.mocked(promptUtils.promptPassword).mockResolvedValue("prompted-value");
+
+      const result = await gatherConfiguration({
+        required: {
+          secrets: ["PROVIDED_SECRET", "MISSING_SECRET"],
+          vars: [],
+          credentials: [],
+        },
+        optionSecrets: ["PROVIDED_SECRET=from-flag"],
+        optionVars: [],
+        existingSchedule: undefined,
+      });
+
+      expect(result.secrets).toEqual({
+        PROVIDED_SECRET: "from-flag",
+        MISSING_SECRET: "prompted-value",
+      });
+      // Should only prompt for the missing secret
+      expect(promptUtils.promptPassword).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/schedule/__tests__/gather-configuration.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/gather-configuration.test.ts
@@ -1,197 +1,276 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { gatherConfiguration } from "../gather-configuration";
-import * as promptUtils from "../../../lib/utils/prompt-utils";
 
-// Mock prompt utilities
-vi.mock("../../../lib/utils/prompt-utils", () => ({
-  isInteractive: vi.fn(),
-  promptConfirm: vi.fn(),
-  promptPassword: vi.fn(),
-  promptText: vi.fn(),
-}));
+/**
+ * Create mock prompt dependencies for testing.
+ * Uses dependency injection instead of vi.mock() to avoid AP-4 violation
+ * (mocking internal code).
+ */
+function createMockDeps(
+  overrides: {
+    isInteractive?: boolean;
+    promptConfirm?: boolean | boolean[];
+    promptPassword?: string | string[];
+    promptText?: string | string[];
+  } = {},
+) {
+  let confirmIndex = 0;
+  let passwordIndex = 0;
+  let textIndex = 0;
+
+  const confirmValues = Array.isArray(overrides.promptConfirm)
+    ? overrides.promptConfirm
+    : [overrides.promptConfirm ?? false];
+  const passwordValues = Array.isArray(overrides.promptPassword)
+    ? overrides.promptPassword
+    : [overrides.promptPassword ?? ""];
+  const textValues = Array.isArray(overrides.promptText)
+    ? overrides.promptText
+    : [overrides.promptText ?? ""];
+
+  return {
+    isInteractive: vi.fn(() => overrides.isInteractive ?? true),
+    promptConfirm: vi.fn(async () => {
+      const value =
+        confirmValues[confirmIndex] ?? confirmValues[confirmValues.length - 1];
+      confirmIndex++;
+      return value ?? false;
+    }),
+    promptPassword: vi.fn(async () => {
+      const value =
+        passwordValues[passwordIndex] ??
+        passwordValues[passwordValues.length - 1];
+      passwordIndex++;
+      return value ?? "";
+    }),
+    promptText: vi.fn(async () => {
+      const value = textValues[textIndex] ?? textValues[textValues.length - 1];
+      textIndex++;
+      return value ?? "";
+    }),
+  };
+}
 
 describe("gatherConfiguration", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   describe("new schedule scenarios", () => {
     it("should use --secret flag values for new schedule", async () => {
-      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
+      const deps = createMockDeps({ isInteractive: true });
 
-      const result = await gatherConfiguration({
-        required: { secrets: ["API_KEY"], vars: [], credentials: [] },
-        optionSecrets: ["API_KEY=my-secret-value"],
-        optionVars: [],
-        existingSchedule: undefined,
-      });
+      const result = await gatherConfiguration(
+        {
+          required: { secrets: ["API_KEY"], vars: [], credentials: [] },
+          optionSecrets: ["API_KEY=my-secret-value"],
+          optionVars: [],
+          existingSchedule: undefined,
+        },
+        deps,
+      );
 
       expect(result.secrets).toEqual({ API_KEY: "my-secret-value" });
       expect(result.preserveExistingSecrets).toBe(false);
       // Should not prompt when --secret flag is provided
-      expect(promptUtils.promptPassword).not.toHaveBeenCalled();
+      expect(deps.promptPassword).not.toHaveBeenCalled();
     });
 
     it("should prompt for secrets interactively for new schedule (THE BUG FIX)", async () => {
       // This is the bug scenario: new schedule, no --secret flag, required secrets
-      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
-      vi.mocked(promptUtils.promptPassword).mockResolvedValue("entered-value");
-
-      const result = await gatherConfiguration({
-        required: { secrets: ["FIRECRAWL_API_KEY"], vars: [], credentials: [] },
-        optionSecrets: [],
-        optionVars: [],
-        existingSchedule: undefined, // New schedule - no existing secrets
+      const deps = createMockDeps({
+        isInteractive: true,
+        promptPassword: "entered-value",
       });
+
+      const result = await gatherConfiguration(
+        {
+          required: {
+            secrets: ["FIRECRAWL_API_KEY"],
+            vars: [],
+            credentials: [],
+          },
+          optionSecrets: [],
+          optionVars: [],
+          existingSchedule: undefined, // New schedule - no existing secrets
+        },
+        deps,
+      );
 
       // The fix: secrets should be gathered and sent, not discarded
       expect(result.secrets).toEqual({ FIRECRAWL_API_KEY: "entered-value" });
       expect(result.preserveExistingSecrets).toBe(false);
-      expect(promptUtils.promptPassword).toHaveBeenCalledTimes(1);
+      expect(deps.promptPassword).toHaveBeenCalledTimes(1);
     });
 
     it("should not prompt in non-interactive mode for new schedule", async () => {
-      vi.mocked(promptUtils.isInteractive).mockReturnValue(false);
+      const deps = createMockDeps({ isInteractive: false });
 
-      const result = await gatherConfiguration({
-        required: { secrets: ["API_KEY"], vars: [], credentials: [] },
-        optionSecrets: [],
-        optionVars: [],
-        existingSchedule: undefined,
-      });
+      const result = await gatherConfiguration(
+        {
+          required: { secrets: ["API_KEY"], vars: [], credentials: [] },
+          optionSecrets: [],
+          optionVars: [],
+          existingSchedule: undefined,
+        },
+        deps,
+      );
 
       // Non-interactive: return what we have, server will validate
       expect(result.secrets).toEqual({});
       expect(result.preserveExistingSecrets).toBe(false);
-      expect(promptUtils.promptPassword).not.toHaveBeenCalled();
+      expect(deps.promptPassword).not.toHaveBeenCalled();
     });
   });
 
   describe("update schedule scenarios", () => {
     it("should preserve existing secrets when user chooses to keep them", async () => {
-      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
-      vi.mocked(promptUtils.promptConfirm).mockResolvedValue(true);
-
-      const result = await gatherConfiguration({
-        required: { secrets: ["API_KEY"], vars: [], credentials: [] },
-        optionSecrets: [],
-        optionVars: [],
-        existingSchedule: {
-          secretNames: ["API_KEY"],
-          vars: null,
-        },
+      const deps = createMockDeps({
+        isInteractive: true,
+        promptConfirm: true,
       });
+
+      const result = await gatherConfiguration(
+        {
+          required: { secrets: ["API_KEY"], vars: [], credentials: [] },
+          optionSecrets: [],
+          optionVars: [],
+          existingSchedule: {
+            secretNames: ["API_KEY"],
+            vars: null,
+          },
+        },
+        deps,
+      );
 
       expect(result.secrets).toEqual({});
       expect(result.preserveExistingSecrets).toBe(true);
-      expect(promptUtils.promptConfirm).toHaveBeenCalledWith(
+      expect(deps.promptConfirm).toHaveBeenCalledWith(
         "Keep existing secrets? (API_KEY)",
         true,
       );
       // Should not prompt for password when keeping existing
-      expect(promptUtils.promptPassword).not.toHaveBeenCalled();
+      expect(deps.promptPassword).not.toHaveBeenCalled();
     });
 
     it("should prompt for new secrets when user chooses to replace", async () => {
-      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
-      vi.mocked(promptUtils.promptConfirm).mockResolvedValue(false);
-      vi.mocked(promptUtils.promptPassword).mockResolvedValue("new-value");
-
-      const result = await gatherConfiguration({
-        required: { secrets: ["API_KEY"], vars: [], credentials: [] },
-        optionSecrets: [],
-        optionVars: [],
-        existingSchedule: {
-          secretNames: ["API_KEY"],
-          vars: null,
-        },
+      const deps = createMockDeps({
+        isInteractive: true,
+        promptConfirm: false,
+        promptPassword: "new-value",
       });
+
+      const result = await gatherConfiguration(
+        {
+          required: { secrets: ["API_KEY"], vars: [], credentials: [] },
+          optionSecrets: [],
+          optionVars: [],
+          existingSchedule: {
+            secretNames: ["API_KEY"],
+            vars: null,
+          },
+        },
+        deps,
+      );
 
       expect(result.secrets).toEqual({ API_KEY: "new-value" });
       expect(result.preserveExistingSecrets).toBe(false);
-      expect(promptUtils.promptPassword).toHaveBeenCalledTimes(1);
+      expect(deps.promptPassword).toHaveBeenCalledTimes(1);
     });
 
     it("should use --secret flag to override existing secrets", async () => {
-      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
+      const deps = createMockDeps({ isInteractive: true });
 
-      const result = await gatherConfiguration({
-        required: { secrets: ["API_KEY"], vars: [], credentials: [] },
-        optionSecrets: ["API_KEY=new-from-flag"],
-        optionVars: [],
-        existingSchedule: {
-          secretNames: ["API_KEY"],
-          vars: null,
+      const result = await gatherConfiguration(
+        {
+          required: { secrets: ["API_KEY"], vars: [], credentials: [] },
+          optionSecrets: ["API_KEY=new-from-flag"],
+          optionVars: [],
+          existingSchedule: {
+            secretNames: ["API_KEY"],
+            vars: null,
+          },
         },
-      });
+        deps,
+      );
 
       expect(result.secrets).toEqual({ API_KEY: "new-from-flag" });
       expect(result.preserveExistingSecrets).toBe(false);
       // Should not prompt when --secret flag is provided
-      expect(promptUtils.promptConfirm).not.toHaveBeenCalled();
+      expect(deps.promptConfirm).not.toHaveBeenCalled();
     });
   });
 
   describe("vars handling", () => {
     it("should keep existing vars when user chooses to", async () => {
-      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
-      vi.mocked(promptUtils.promptConfirm).mockResolvedValue(true);
-
-      const result = await gatherConfiguration({
-        required: { secrets: [], vars: ["ENV"], credentials: [] },
-        optionSecrets: [],
-        optionVars: [],
-        existingSchedule: {
-          secretNames: null,
-          vars: { ENV: "production" },
-        },
+      const deps = createMockDeps({
+        isInteractive: true,
+        promptConfirm: true,
       });
+
+      const result = await gatherConfiguration(
+        {
+          required: { secrets: [], vars: ["ENV"], credentials: [] },
+          optionSecrets: [],
+          optionVars: [],
+          existingSchedule: {
+            secretNames: null,
+            vars: { ENV: "production" },
+          },
+        },
+        deps,
+      );
 
       expect(result.vars).toEqual({ ENV: "production" });
     });
 
     it("should prompt for missing vars for new schedule", async () => {
-      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
-      vi.mocked(promptUtils.promptText).mockResolvedValue(
-        "https://api.example.com",
-      );
-
-      const result = await gatherConfiguration({
-        required: { secrets: [], vars: ["API_URL"], credentials: [] },
-        optionSecrets: [],
-        optionVars: [],
-        existingSchedule: undefined,
+      const deps = createMockDeps({
+        isInteractive: true,
+        promptText: "https://api.example.com",
       });
 
+      const result = await gatherConfiguration(
+        {
+          required: { secrets: [], vars: ["API_URL"], credentials: [] },
+          optionSecrets: [],
+          optionVars: [],
+          existingSchedule: undefined,
+        },
+        deps,
+      );
+
       expect(result.vars).toEqual({ API_URL: "https://api.example.com" });
-      expect(promptUtils.promptText).toHaveBeenCalledTimes(1);
+      expect(deps.promptText).toHaveBeenCalledTimes(1);
     });
 
     it("should use --var flag values", async () => {
-      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
+      const deps = createMockDeps({ isInteractive: true });
 
-      const result = await gatherConfiguration({
-        required: { secrets: [], vars: ["ENV"], credentials: [] },
-        optionSecrets: [],
-        optionVars: ["ENV=staging"],
-        existingSchedule: undefined,
-      });
+      const result = await gatherConfiguration(
+        {
+          required: { secrets: [], vars: ["ENV"], credentials: [] },
+          optionSecrets: [],
+          optionVars: ["ENV=staging"],
+          existingSchedule: undefined,
+        },
+        deps,
+      );
 
       expect(result.vars).toEqual({ ENV: "staging" });
-      expect(promptUtils.promptText).not.toHaveBeenCalled();
+      expect(deps.promptText).not.toHaveBeenCalled();
     });
   });
 
   describe("edge cases", () => {
     it("should handle empty required configuration", async () => {
-      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
+      const deps = createMockDeps({ isInteractive: true });
 
-      const result = await gatherConfiguration({
-        required: { secrets: [], vars: [], credentials: [] },
-        optionSecrets: [],
-        optionVars: [],
-        existingSchedule: undefined,
-      });
+      const result = await gatherConfiguration(
+        {
+          required: { secrets: [], vars: [], credentials: [] },
+          optionSecrets: [],
+          optionVars: [],
+          existingSchedule: undefined,
+        },
+        deps,
+      );
 
       expect(result.secrets).toEqual({});
       expect(result.vars).toEqual({});
@@ -199,22 +278,25 @@ describe("gatherConfiguration", () => {
     });
 
     it("should handle multiple secrets and vars", async () => {
-      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
-      vi.mocked(promptUtils.promptPassword)
-        .mockResolvedValueOnce("secret1-value")
-        .mockResolvedValueOnce("secret2-value");
-      vi.mocked(promptUtils.promptText).mockResolvedValue("var-value");
-
-      const result = await gatherConfiguration({
-        required: {
-          secrets: ["SECRET1", "SECRET2"],
-          vars: ["VAR1"],
-          credentials: [],
-        },
-        optionSecrets: [],
-        optionVars: [],
-        existingSchedule: undefined,
+      const deps = createMockDeps({
+        isInteractive: true,
+        promptPassword: ["secret1-value", "secret2-value"],
+        promptText: "var-value",
       });
+
+      const result = await gatherConfiguration(
+        {
+          required: {
+            secrets: ["SECRET1", "SECRET2"],
+            vars: ["VAR1"],
+            credentials: [],
+          },
+          optionSecrets: [],
+          optionVars: [],
+          existingSchedule: undefined,
+        },
+        deps,
+      );
 
       expect(result.secrets).toEqual({
         SECRET1: "secret1-value",
@@ -224,26 +306,31 @@ describe("gatherConfiguration", () => {
     });
 
     it("should skip prompting for secrets that are already provided", async () => {
-      vi.mocked(promptUtils.isInteractive).mockReturnValue(true);
-      vi.mocked(promptUtils.promptPassword).mockResolvedValue("prompted-value");
-
-      const result = await gatherConfiguration({
-        required: {
-          secrets: ["PROVIDED_SECRET", "MISSING_SECRET"],
-          vars: [],
-          credentials: [],
-        },
-        optionSecrets: ["PROVIDED_SECRET=from-flag"],
-        optionVars: [],
-        existingSchedule: undefined,
+      const deps = createMockDeps({
+        isInteractive: true,
+        promptPassword: "prompted-value",
       });
+
+      const result = await gatherConfiguration(
+        {
+          required: {
+            secrets: ["PROVIDED_SECRET", "MISSING_SECRET"],
+            vars: [],
+            credentials: [],
+          },
+          optionSecrets: ["PROVIDED_SECRET=from-flag"],
+          optionVars: [],
+          existingSchedule: undefined,
+        },
+        deps,
+      );
 
       expect(result.secrets).toEqual({
         PROVIDED_SECRET: "from-flag",
         MISSING_SECRET: "prompted-value",
       });
       // Should only prompt for the missing secret
-      expect(promptUtils.promptPassword).toHaveBeenCalledTimes(1);
+      expect(deps.promptPassword).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/turbo/apps/cli/src/commands/schedule/gather-configuration.ts
+++ b/turbo/apps/cli/src/commands/schedule/gather-configuration.ts
@@ -1,0 +1,239 @@
+import chalk from "chalk";
+import {
+  isInteractive,
+  promptText,
+  promptConfirm,
+  promptPassword,
+} from "../../lib/utils/prompt-utils";
+import type { RequiredConfiguration } from "../../lib/domain/schedule-utils";
+
+/**
+ * Result of gathering configuration for schedule setup
+ */
+interface GatherConfigurationResult {
+  /** Secrets to send to the server (may be empty) */
+  secrets: Record<string, string>;
+  /** Vars to send to the server (may be empty) */
+  vars: Record<string, string>;
+  /** If true, send undefined to server to preserve existing secrets */
+  preserveExistingSecrets: boolean;
+}
+
+/**
+ * Existing schedule information relevant to configuration gathering
+ */
+interface ExistingScheduleConfig {
+  vars?: Record<string, string> | null;
+  secretNames?: string[] | null;
+}
+
+/**
+ * Parameters for gatherConfiguration function
+ */
+interface GatherConfigurationParams {
+  required: RequiredConfiguration;
+  optionSecrets: string[];
+  optionVars: string[];
+  existingSchedule: ExistingScheduleConfig | undefined;
+}
+
+/**
+ * Parse key=value pairs into object
+ */
+function parseKeyValuePairs(pairs: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const pair of pairs) {
+    const eqIndex = pair.indexOf("=");
+    if (eqIndex > 0) {
+      const key = pair.slice(0, eqIndex);
+      const value = pair.slice(eqIndex + 1);
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Handle secrets from options or existing schedule.
+ * Returns the initial secrets and whether to preserve existing.
+ */
+async function handleSecrets(
+  optionSecrets: string[],
+  existingSecretNames: string[],
+): Promise<{
+  secrets: Record<string, string>;
+  preserveExistingSecrets: boolean;
+}> {
+  // Case 1: Explicit --secret flags provided
+  if (optionSecrets.length > 0) {
+    return {
+      secrets: parseKeyValuePairs(optionSecrets),
+      preserveExistingSecrets: false,
+    };
+  }
+
+  // Case 2: Updating schedule with existing secrets - ask user
+  if (existingSecretNames.length > 0 && isInteractive()) {
+    const keepSecrets = await promptConfirm(
+      `Keep existing secrets? (${existingSecretNames.join(", ")})`,
+      true,
+    );
+
+    if (keepSecrets) {
+      return { secrets: {}, preserveExistingSecrets: true };
+    }
+
+    console.log(chalk.dim("  Note: You'll need to provide new secret values"));
+    return { secrets: {}, preserveExistingSecrets: false };
+  }
+
+  // Case 3: New schedule (no existing secrets)
+  return { secrets: {}, preserveExistingSecrets: false };
+}
+
+/**
+ * Handle vars from options or existing schedule.
+ */
+async function handleVars(
+  optionVars: string[],
+  existingVars: Record<string, string> | null,
+): Promise<Record<string, string>> {
+  // Explicit --var flags provided
+  if (optionVars.length > 0) {
+    return parseKeyValuePairs(optionVars);
+  }
+
+  // Updating schedule with existing vars - ask user
+  if (existingVars && isInteractive()) {
+    const keepVars = await promptConfirm(
+      `Keep existing variables? (${Object.keys(existingVars).join(", ")})`,
+      true,
+    );
+
+    if (keepVars) {
+      return { ...existingVars };
+    }
+  }
+
+  return {};
+}
+
+/**
+ * Display missing configuration requirements
+ */
+function displayMissingRequirements(
+  missingSecrets: string[],
+  missingVars: string[],
+): void {
+  console.log(chalk.yellow("\nAgent requires the following configuration:"));
+
+  if (missingSecrets.length > 0) {
+    console.log(chalk.dim("  Secrets:"));
+    for (const name of missingSecrets) {
+      console.log(chalk.dim(`    ${name}`));
+    }
+  }
+
+  if (missingVars.length > 0) {
+    console.log(chalk.dim("  Vars:"));
+    for (const name of missingVars) {
+      console.log(chalk.dim(`    ${name}`));
+    }
+  }
+
+  console.log("");
+}
+
+/**
+ * Prompt for missing secrets interactively
+ */
+async function promptForMissingSecrets(
+  missingSecrets: string[],
+  secrets: Record<string, string>,
+): Promise<void> {
+  for (const name of missingSecrets) {
+    const value = await promptPassword(
+      `Enter value for secret ${chalk.cyan(name)}`,
+    );
+    if (value) {
+      secrets[name] = value;
+    }
+  }
+}
+
+/**
+ * Prompt for missing vars interactively
+ */
+async function promptForMissingVars(
+  missingVars: string[],
+  vars: Record<string, string>,
+): Promise<void> {
+  for (const name of missingVars) {
+    const value = await promptText(
+      `Enter value for var ${chalk.cyan(name)}`,
+      "",
+    );
+    if (value) {
+      vars[name] = value;
+    }
+  }
+}
+
+/**
+ * Gather all configuration (secrets and vars) for schedule setup.
+ *
+ * This function handles:
+ * 1. --secret and --var flags (non-interactive)
+ * 2. Prompting to keep existing secrets/vars (update scenario)
+ * 3. Prompting for missing required secrets/vars (interactive)
+ *
+ * The key insight is that `preserveExistingSecrets` should ONLY be true when:
+ * - There ARE existing secrets on the server, AND
+ * - The user explicitly chose to keep them
+ *
+ * For new schedules (no existing secrets), even if no --secret flag is provided,
+ * we should gather secrets interactively and send them to the server.
+ */
+export async function gatherConfiguration(
+  params: GatherConfigurationParams,
+): Promise<GatherConfigurationResult> {
+  const { required, optionSecrets, optionVars, existingSchedule } = params;
+
+  const existingSecretNames = existingSchedule?.secretNames ?? [];
+  const existingVars = existingSchedule?.vars ?? null;
+
+  // Handle secrets and vars from options or existing schedule
+  const { secrets, preserveExistingSecrets } = await handleSecrets(
+    optionSecrets,
+    existingSecretNames,
+  );
+  const vars = await handleVars(optionVars, existingVars);
+
+  // Determine which secrets/vars are missing
+  const effectiveExistingSecrets = preserveExistingSecrets
+    ? existingSecretNames
+    : [];
+  const missingSecrets = required.secrets.filter(
+    (name) =>
+      !Object.keys(secrets).includes(name) &&
+      !effectiveExistingSecrets.includes(name),
+  );
+  const missingVars = required.vars.filter(
+    (name) => !Object.keys(vars).includes(name),
+  );
+
+  // If nothing is missing or non-interactive, return early
+  if (missingSecrets.length === 0 && missingVars.length === 0) {
+    return { secrets, vars, preserveExistingSecrets };
+  }
+  if (!isInteractive()) {
+    return { secrets, vars, preserveExistingSecrets };
+  }
+
+  // Interactive mode: show requirements and prompt for missing values
+  displayMissingRequirements(missingSecrets, missingVars);
+  await promptForMissingSecrets(missingSecrets, secrets);
+  await promptForMissingVars(missingVars, vars);
+
+  return { secrets, vars, preserveExistingSecrets };
+}

--- a/turbo/apps/cli/src/commands/schedule/gather-configuration.ts
+++ b/turbo/apps/cli/src/commands/schedule/gather-configuration.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
 import {
-  isInteractive,
-  promptText,
-  promptConfirm,
-  promptPassword,
+  isInteractive as defaultIsInteractive,
+  promptText as defaultPromptText,
+  promptConfirm as defaultPromptConfirm,
+  promptPassword as defaultPromptPassword,
 } from "../../lib/utils/prompt-utils";
 import type { RequiredConfiguration } from "../../lib/domain/schedule-utils";
 
@@ -38,6 +38,33 @@ interface GatherConfigurationParams {
 }
 
 /**
+ * Prompt dependencies for dependency injection (enables testing without mocking internal code)
+ */
+interface PromptDeps {
+  isInteractive: () => boolean;
+  promptConfirm: (
+    message: string,
+    defaultValue?: boolean,
+  ) => Promise<boolean | undefined>;
+  promptPassword: (message: string) => Promise<string | undefined>;
+  promptText: (
+    message: string,
+    defaultValue?: string,
+    validate?: (value: string) => boolean | string,
+  ) => Promise<string | undefined>;
+}
+
+/**
+ * Default prompt dependencies using real prompt-utils
+ */
+const defaultPromptDeps: PromptDeps = {
+  isInteractive: defaultIsInteractive,
+  promptConfirm: defaultPromptConfirm,
+  promptPassword: defaultPromptPassword,
+  promptText: defaultPromptText,
+};
+
+/**
  * Parse key=value pairs into object
  */
 function parseKeyValuePairs(pairs: string[]): Record<string, string> {
@@ -60,6 +87,7 @@ function parseKeyValuePairs(pairs: string[]): Record<string, string> {
 async function handleSecrets(
   optionSecrets: string[],
   existingSecretNames: string[],
+  deps: PromptDeps,
 ): Promise<{
   secrets: Record<string, string>;
   preserveExistingSecrets: boolean;
@@ -73,8 +101,8 @@ async function handleSecrets(
   }
 
   // Case 2: Updating schedule with existing secrets - ask user
-  if (existingSecretNames.length > 0 && isInteractive()) {
-    const keepSecrets = await promptConfirm(
+  if (existingSecretNames.length > 0 && deps.isInteractive()) {
+    const keepSecrets = await deps.promptConfirm(
       `Keep existing secrets? (${existingSecretNames.join(", ")})`,
       true,
     );
@@ -97,6 +125,7 @@ async function handleSecrets(
 async function handleVars(
   optionVars: string[],
   existingVars: Record<string, string> | null,
+  deps: PromptDeps,
 ): Promise<Record<string, string>> {
   // Explicit --var flags provided
   if (optionVars.length > 0) {
@@ -104,8 +133,8 @@ async function handleVars(
   }
 
   // Updating schedule with existing vars - ask user
-  if (existingVars && isInteractive()) {
-    const keepVars = await promptConfirm(
+  if (existingVars && deps.isInteractive()) {
+    const keepVars = await deps.promptConfirm(
       `Keep existing variables? (${Object.keys(existingVars).join(", ")})`,
       true,
     );
@@ -150,9 +179,10 @@ function displayMissingRequirements(
 async function promptForMissingSecrets(
   missingSecrets: string[],
   secrets: Record<string, string>,
+  deps: PromptDeps,
 ): Promise<void> {
   for (const name of missingSecrets) {
-    const value = await promptPassword(
+    const value = await deps.promptPassword(
       `Enter value for secret ${chalk.cyan(name)}`,
     );
     if (value) {
@@ -167,9 +197,10 @@ async function promptForMissingSecrets(
 async function promptForMissingVars(
   missingVars: string[],
   vars: Record<string, string>,
+  deps: PromptDeps,
 ): Promise<void> {
   for (const name of missingVars) {
-    const value = await promptText(
+    const value = await deps.promptText(
       `Enter value for var ${chalk.cyan(name)}`,
       "",
     );
@@ -193,9 +224,13 @@ async function promptForMissingVars(
  *
  * For new schedules (no existing secrets), even if no --secret flag is provided,
  * we should gather secrets interactively and send them to the server.
+ *
+ * @param params - Configuration parameters
+ * @param deps - Prompt dependencies (optional, for testing)
  */
 export async function gatherConfiguration(
   params: GatherConfigurationParams,
+  deps: PromptDeps = defaultPromptDeps,
 ): Promise<GatherConfigurationResult> {
   const { required, optionSecrets, optionVars, existingSchedule } = params;
 
@@ -206,8 +241,9 @@ export async function gatherConfiguration(
   const { secrets, preserveExistingSecrets } = await handleSecrets(
     optionSecrets,
     existingSecretNames,
+    deps,
   );
-  const vars = await handleVars(optionVars, existingVars);
+  const vars = await handleVars(optionVars, existingVars, deps);
 
   // Determine which secrets/vars are missing
   const effectiveExistingSecrets = preserveExistingSecrets
@@ -226,14 +262,14 @@ export async function gatherConfiguration(
   if (missingSecrets.length === 0 && missingVars.length === 0) {
     return { secrets, vars, preserveExistingSecrets };
   }
-  if (!isInteractive()) {
+  if (!deps.isInteractive()) {
     return { secrets, vars, preserveExistingSecrets };
   }
 
   // Interactive mode: show requirements and prompt for missing values
   displayMissingRequirements(missingSecrets, missingVars);
-  await promptForMissingSecrets(missingSecrets, secrets);
-  await promptForMissingVars(missingVars, vars);
+  await promptForMissingSecrets(missingSecrets, secrets, deps);
+  await promptForMissingVars(missingVars, vars, deps);
 
   return { secrets, vars, preserveExistingSecrets };
 }


### PR DESCRIPTION
## Summary

- Fixes bug where secrets entered interactively during `vm0 schedule setup` for **new schedules** were discarded
- Refactors secret/var gathering logic into a clear, testable `gatherConfiguration()` function
- Adds 12 unit tests covering all scenarios

## Root Cause

The `gatherSecrets()` function returned `undefined` for two semantically different cases:
1. User chose "Keep existing secrets? Yes" (update scenario)
2. No existing secrets exist (new schedule scenario)

The code then set `keepExistingSecrets = true` for both cases, causing secrets gathered via interactive prompts to be discarded for new schedules.

## Changes

- **New file**: `gather-configuration.ts` - unified configuration gathering with clear semantics
- **Modified**: `setup.ts` - uses the new function, removes old `gatherSecrets()` and `gatherMissingConfiguration()`
- **New tests**: 12 unit tests in `gather-configuration.test.ts`

## Test plan

- [x] Unit tests pass (12 new tests)
- [x] All CLI tests pass (743 tests)
- [x] Lint and type checks pass
- [ ] E2E tests in CI

Fixes #1711

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)