### PR TITLE
feat(api): add platform logs API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 ### Node ###
 # Logs
 logs
+# Exception for platform logs API folder
+!**/app/api/platform/logs/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/turbo/apps/web/app/api/platform/logs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/platform/logs/[id]/__tests__/route.test.ts
@@ -1,0 +1,450 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../../../src/db/schema/agent-compose";
+import { scopes } from "../../../../../../src/db/schema/scope";
+import { eq } from "drizzle-orm";
+import { randomUUID } from "crypto";
+import { createHash } from "crypto";
+
+/**
+ * Helper to create a NextRequest for testing.
+ */
+function createTestRequest(url: string): NextRequest {
+  return new NextRequest(url, {
+    method: "GET",
+  });
+}
+
+/**
+ * Helper to generate a content hash for compose versions.
+ */
+function generateContentHash(content: object): string {
+  return createHash("sha256").update(JSON.stringify(content)).digest("hex");
+}
+
+// Mock the auth module
+let mockUserId: string | null = "test-user-platform-log-detail";
+vi.mock("../../../../../../src/lib/auth/get-user-id", () => ({
+  getUserId: async () => mockUserId,
+}));
+
+describe("GET /api/platform/logs/[id]", () => {
+  const testUserId = "test-user-platform-log-detail";
+  const testScopeId = randomUUID();
+  const testScopeSlug = `test-log-detail-${testScopeId.slice(0, 8)}`;
+
+  // Test data IDs
+  let composeId: string;
+  let versionId: string;
+  let runId: string;
+
+  beforeAll(async () => {
+    initServices();
+
+    // Clean up any existing test data
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.userId, testUserId));
+
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.userId, testUserId));
+
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, testScopeId));
+
+    // Create test scope for the user
+    await globalThis.services.db.insert(scopes).values({
+      id: testScopeId,
+      slug: testScopeSlug,
+      type: "personal",
+      ownerId: testUserId,
+    });
+
+    // Create a compose and version
+    composeId = randomUUID();
+    const content = {
+      version: "1.0",
+      agents: {
+        "test-detail-agent": {
+          description: "Test agent for detail",
+          provider: "claude-code",
+          working_dir: "/home/user/workspace",
+        },
+      },
+    };
+    versionId = generateContentHash(content);
+
+    await globalThis.services.db.insert(agentComposes).values({
+      id: composeId,
+      name: "test-detail-agent",
+      userId: testUserId,
+      scopeId: testScopeId,
+      headVersionId: versionId,
+    });
+
+    await globalThis.services.db.insert(agentComposeVersions).values({
+      id: versionId,
+      composeId: composeId,
+      content: content,
+      createdBy: testUserId,
+    });
+
+    // Create a test run
+    runId = randomUUID();
+    const now = new Date();
+    await globalThis.services.db.insert(agentRuns).values({
+      id: runId,
+      userId: testUserId,
+      agentComposeVersionId: versionId,
+      prompt: "Test prompt for detail",
+      status: "completed",
+      createdAt: now,
+      startedAt: new Date(now.getTime() + 1000),
+      completedAt: new Date(now.getTime() + 5000),
+      result: {
+        agentSessionId: "test-session-123",
+        artifactName: "test-artifact",
+        artifactVersion: "1.0.0",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    // Cleanup in reverse order of creation
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, runId));
+
+    await globalThis.services.db
+      .delete(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, versionId));
+
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, composeId));
+
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, testScopeId));
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockUserId = null;
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/platform/logs/${runId}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.message).toBe("Not authenticated");
+
+    mockUserId = testUserId;
+  });
+
+  it("should return 400 for invalid UUID format", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/platform/logs/invalid-uuid",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("should return 404 for non-existent run", async () => {
+    const nonExistentId = randomUUID();
+    const request = createTestRequest(
+      `http://localhost:3000/api/platform/logs/${nonExistentId}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return 404 when accessing another user's run", async () => {
+    // Create another user's run
+    const otherUserId = "other-user-log-detail";
+    const otherScopeId = randomUUID();
+
+    await globalThis.services.db.insert(scopes).values({
+      id: otherScopeId,
+      slug: `test-other-detail-${otherScopeId.slice(0, 8)}`,
+      type: "personal",
+      ownerId: otherUserId,
+    });
+
+    const otherComposeId = randomUUID();
+    const otherContent = {
+      version: "1.0",
+      agents: {
+        "other-detail-agent": {
+          description: "Other user agent",
+          provider: "claude-code",
+          working_dir: "/home/user/workspace",
+        },
+      },
+    };
+    const otherVersionId = generateContentHash(otherContent);
+
+    await globalThis.services.db.insert(agentComposes).values({
+      id: otherComposeId,
+      name: "other-detail-agent",
+      userId: otherUserId,
+      scopeId: otherScopeId,
+      headVersionId: otherVersionId,
+    });
+
+    await globalThis.services.db.insert(agentComposeVersions).values({
+      id: otherVersionId,
+      composeId: otherComposeId,
+      content: otherContent,
+      createdBy: otherUserId,
+    });
+
+    const otherRunId = randomUUID();
+    await globalThis.services.db.insert(agentRuns).values({
+      id: otherRunId,
+      userId: otherUserId,
+      agentComposeVersionId: otherVersionId,
+      prompt: "Other user prompt",
+      status: "completed",
+    });
+
+    // Try to access as test user
+    const request = createTestRequest(
+      `http://localhost:3000/api/platform/logs/${otherRunId}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+
+    // Cleanup
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, otherRunId));
+    await globalThis.services.db
+      .delete(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, otherVersionId));
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, otherComposeId));
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, otherScopeId));
+  });
+
+  it("should return full run details for authenticated owner", async () => {
+    const request = createTestRequest(
+      `http://localhost:3000/api/platform/logs/${runId}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.id).toBe(runId);
+    expect(data.sessionId).toBe("test-session-123");
+    expect(data.agentName).toBe("test-detail-agent");
+    expect(data.provider).toBe("claude-code");
+    expect(data.status).toBe("completed");
+    expect(data.prompt).toBe("Test prompt for detail");
+    expect(data.error).toBeNull();
+    expect(data.createdAt).toBeDefined();
+    expect(data.startedAt).toBeDefined();
+    expect(data.completedAt).toBeDefined();
+    expect(data.artifact).toEqual({
+      name: "test-artifact",
+      version: "1.0.0",
+    });
+  });
+
+  it("should handle run with single agent.provider format", async () => {
+    // Create compose with single agent format
+    const singleComposeId = randomUUID();
+    const singleContent = {
+      version: "1.0",
+      agent: {
+        description: "Single agent format",
+        provider: "openai",
+        working_dir: "/home/user/workspace",
+      },
+    };
+    const singleVersionId = generateContentHash(singleContent);
+
+    await globalThis.services.db.insert(agentComposes).values({
+      id: singleComposeId,
+      name: "single-agent",
+      userId: testUserId,
+      scopeId: testScopeId,
+      headVersionId: singleVersionId,
+    });
+
+    await globalThis.services.db.insert(agentComposeVersions).values({
+      id: singleVersionId,
+      composeId: singleComposeId,
+      content: singleContent,
+      createdBy: testUserId,
+    });
+
+    const singleRunId = randomUUID();
+    await globalThis.services.db.insert(agentRuns).values({
+      id: singleRunId,
+      userId: testUserId,
+      agentComposeVersionId: singleVersionId,
+      prompt: "Single agent prompt",
+      status: "completed",
+    });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/platform/logs/${singleRunId}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.provider).toBe("openai");
+
+    // Cleanup
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, singleRunId));
+    await globalThis.services.db
+      .delete(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, singleVersionId));
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, singleComposeId));
+  });
+
+  it("should use default provider when not specified in compose", async () => {
+    // Create compose without provider
+    const noProviderComposeId = randomUUID();
+    const noProviderContent = {
+      version: "1.0",
+      agents: {
+        "no-provider-agent": {
+          description: "Agent without provider",
+          working_dir: "/home/user/workspace",
+        },
+      },
+    };
+    const noProviderVersionId = generateContentHash(noProviderContent);
+
+    await globalThis.services.db.insert(agentComposes).values({
+      id: noProviderComposeId,
+      name: "no-provider-agent",
+      userId: testUserId,
+      scopeId: testScopeId,
+      headVersionId: noProviderVersionId,
+    });
+
+    await globalThis.services.db.insert(agentComposeVersions).values({
+      id: noProviderVersionId,
+      composeId: noProviderComposeId,
+      content: noProviderContent,
+      createdBy: testUserId,
+    });
+
+    const noProviderRunId = randomUUID();
+    await globalThis.services.db.insert(agentRuns).values({
+      id: noProviderRunId,
+      userId: testUserId,
+      agentComposeVersionId: noProviderVersionId,
+      prompt: "No provider prompt",
+      status: "completed",
+    });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/platform/logs/${noProviderRunId}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.provider).toBe("claude-code"); // default
+
+    // Cleanup
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, noProviderRunId));
+    await globalThis.services.db
+      .delete(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, noProviderVersionId));
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, noProviderComposeId));
+  });
+
+  it("should handle run without result data", async () => {
+    // Create run without result
+    const noResultRunId = randomUUID();
+    await globalThis.services.db.insert(agentRuns).values({
+      id: noResultRunId,
+      userId: testUserId,
+      agentComposeVersionId: versionId,
+      prompt: "No result prompt",
+      status: "pending",
+      result: null,
+    });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/platform/logs/${noResultRunId}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.sessionId).toBeNull();
+    expect(data.artifact).toEqual({
+      name: null,
+      version: null,
+    });
+
+    // Cleanup
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, noResultRunId));
+  });
+
+  it("should handle failed run with error message", async () => {
+    // Create failed run
+    const failedRunId = randomUUID();
+    await globalThis.services.db.insert(agentRuns).values({
+      id: failedRunId,
+      userId: testUserId,
+      agentComposeVersionId: versionId,
+      prompt: "Failed run prompt",
+      status: "failed",
+      error: "Something went wrong",
+    });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/platform/logs/${failedRunId}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.status).toBe("failed");
+    expect(data.error).toBe("Something went wrong");
+
+    // Cleanup
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, failedRunId));
+  });
+});

--- a/turbo/apps/web/app/api/platform/logs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/platform/logs/[id]/__tests__/route.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  vi,
+} from "vitest";
 import { NextRequest } from "next/server";
 import { GET } from "../route";
 import { initServices } from "../../../../../../src/lib/init-services";
@@ -28,11 +36,15 @@ function generateContentHash(content: object): string {
   return createHash("sha256").update(JSON.stringify(content)).digest("hex");
 }
 
-// Mock the auth module
-let mockUserId: string | null = "test-user-platform-log-detail";
-vi.mock("../../../../../../src/lib/auth/get-user-id", () => ({
-  getUserId: async () => mockUserId,
+// Mock Clerk auth (external SaaS)
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
 }));
+
+import {
+  mockClerk,
+  clearClerkMock,
+} from "../../../../../../src/__tests__/clerk-mock";
 
 describe("GET /api/platform/logs/[id]", () => {
   const testUserId = "test-user-platform-log-detail";
@@ -117,7 +129,15 @@ describe("GET /api/platform/logs/[id]", () => {
     });
   });
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock Clerk auth to return test user by default
+    mockClerk({ userId: testUserId });
+  });
+
   afterAll(async () => {
+    clearClerkMock();
+
     // Cleanup in reverse order of creation
     await globalThis.services.db
       .delete(agentRuns)
@@ -137,7 +157,7 @@ describe("GET /api/platform/logs/[id]", () => {
   });
 
   it("should return 401 when not authenticated", async () => {
-    mockUserId = null;
+    mockClerk({ userId: null });
 
     const request = createTestRequest(
       `http://localhost:3000/api/platform/logs/${runId}`,
@@ -147,8 +167,6 @@ describe("GET /api/platform/logs/[id]", () => {
 
     expect(response.status).toBe(401);
     expect(data.error.message).toBe("Not authenticated");
-
-    mockUserId = testUserId;
   });
 
   it("should return 400 for invalid UUID format", async () => {

--- a/turbo/apps/web/app/api/platform/logs/[id]/route.ts
+++ b/turbo/apps/web/app/api/platform/logs/[id]/route.ts
@@ -41,7 +41,14 @@ interface ComposeContent {
 const DEFAULT_PROVIDER = "claude-code";
 
 /**
- * Extract provider from compose content
+ * Extract provider from compose content.
+ *
+ * Note: This function uses a fallback to DEFAULT_PROVIDER intentionally.
+ * This is acceptable here because:
+ * 1. This is a read-only logs endpoint - failing would prevent users from viewing their history
+ * 2. The provider field is for display purposes only, not for critical business logic
+ * 3. Historical runs may have compose content without an explicit provider field
+ * 4. The default "claude-code" is a reasonable assumption for this platform
  */
 function extractProvider(content: ComposeContent | null): string {
   if (!content) {

--- a/turbo/apps/web/app/api/platform/logs/[id]/route.ts
+++ b/turbo/apps/web/app/api/platform/logs/[id]/route.ts
@@ -1,0 +1,187 @@
+/**
+ * Platform API - Log Detail Endpoint
+ *
+ * GET /api/platform/logs/:id - Get agent run log details
+ */
+import {
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../../../../../src/lib/ts-rest-handler";
+import { platformLogsByIdContract } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { agentRuns } from "../../../../../src/db/schema/agent-run";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../../src/db/schema/agent-compose";
+import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import { eq } from "drizzle-orm";
+
+interface RunResult {
+  checkpointId?: string;
+  agentSessionId?: string;
+  artifactName?: string;
+  artifactVersion?: string;
+  volumes?: Record<string, string>;
+}
+
+interface ComposeContent {
+  agent?: {
+    provider?: string;
+  };
+  agents?: Record<
+    string,
+    {
+      provider?: string;
+    }
+  >;
+}
+
+const DEFAULT_PROVIDER = "claude-code";
+
+/**
+ * Extract provider from compose content
+ */
+function extractProvider(content: ComposeContent | null): string {
+  if (!content) {
+    return DEFAULT_PROVIDER;
+  }
+
+  if (content.agent?.provider) {
+    return content.agent.provider;
+  }
+
+  if (content.agents) {
+    const firstAgentKey = Object.keys(content.agents)[0];
+    if (firstAgentKey) {
+      return content.agents[firstAgentKey]?.provider ?? DEFAULT_PROVIDER;
+    }
+  }
+
+  return DEFAULT_PROVIDER;
+}
+
+/**
+ * Create unauthorized response
+ */
+function unauthorizedResponse() {
+  return {
+    status: 401 as const,
+    body: {
+      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    },
+  };
+}
+
+/**
+ * Create not found response
+ */
+function notFoundResponse() {
+  return {
+    status: 404 as const,
+    body: {
+      error: { message: "Log not found", code: "NOT_FOUND" },
+    },
+  };
+}
+
+const router = tsr.router(platformLogsByIdContract, {
+  getById: async ({ params }) => {
+    initServices();
+
+    const userId = await getUserId();
+    if (!userId) {
+      return unauthorizedResponse();
+    }
+
+    // Query run with compose info
+    const [result] = await globalThis.services.db
+      .select({
+        run: agentRuns,
+        compose: agentComposes,
+        composeVersion: agentComposeVersions,
+      })
+      .from(agentRuns)
+      .leftJoin(
+        agentComposeVersions,
+        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+      )
+      .leftJoin(
+        agentComposes,
+        eq(agentComposeVersions.composeId, agentComposes.id),
+      )
+      .where(eq(agentRuns.id, params.id))
+      .limit(1);
+
+    if (!result || result.run.userId !== userId) {
+      return notFoundResponse();
+    }
+
+    const { run, compose, composeVersion } = result;
+
+    // Extract data from result
+    const runResult = run.result as RunResult | null;
+    const sessionId = runResult?.agentSessionId ?? null;
+    const composeContent = composeVersion?.content as ComposeContent | null;
+
+    return {
+      status: 200 as const,
+      body: {
+        id: run.id,
+        sessionId,
+        agentName: compose?.name ?? "unknown",
+        provider: extractProvider(composeContent),
+        status: run.status as
+          | "pending"
+          | "running"
+          | "completed"
+          | "failed"
+          | "timeout"
+          | "cancelled",
+        prompt: run.prompt,
+        error: run.error ?? null,
+        createdAt: run.createdAt.toISOString(),
+        startedAt: run.startedAt?.toISOString() ?? null,
+        completedAt: run.completedAt?.toISOString() ?? null,
+        artifact: {
+          name: runResult?.artifactName ?? null,
+          version: runResult?.artifactVersion ?? null,
+        },
+      },
+    };
+  },
+});
+
+/**
+ * Custom error handler to convert validation errors to API error format
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (err && typeof err === "object" && "pathParamsError" in err) {
+    const validationError = err as {
+      pathParamsError: {
+        issues: Array<{ path: string[]; message: string }>;
+      } | null;
+    };
+
+    if (validationError.pathParamsError) {
+      const issue = validationError.pathParamsError.issues[0];
+      if (issue) {
+        const path = issue.path.join(".");
+        const message = path ? `${path}: ${issue.message}` : issue.message;
+        return TsRestResponse.fromJson(
+          { error: { message, code: "BAD_REQUEST" } },
+          { status: 400 },
+        );
+      }
+    }
+  }
+
+  return undefined;
+}
+
+const handler = createHandler(platformLogsByIdContract, router, {
+  errorHandler,
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/platform/logs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/platform/logs/__tests__/route.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  vi,
+} from "vitest";
 import { NextRequest } from "next/server";
 import { GET } from "../route";
 import { initServices } from "../../../../../src/lib/init-services";
@@ -28,11 +36,15 @@ function generateContentHash(content: object): string {
   return createHash("sha256").update(JSON.stringify(content)).digest("hex");
 }
 
-// Mock the auth module
-let mockUserId: string | null = "test-user-platform-logs";
-vi.mock("../../../../../src/lib/auth/get-user-id", () => ({
-  getUserId: async () => mockUserId,
+// Mock Clerk auth (external SaaS)
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
 }));
+
+import {
+  mockClerk,
+  clearClerkMock,
+} from "../../../../../src/__tests__/clerk-mock";
 
 describe("GET /api/platform/logs", () => {
   const testUserId = "test-user-platform-logs";
@@ -69,7 +81,15 @@ describe("GET /api/platform/logs", () => {
     });
   });
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock Clerk auth to return test user by default
+    mockClerk({ userId: testUserId });
+  });
+
   afterAll(async () => {
+    clearClerkMock();
+
     // Cleanup in reverse order of creation
     for (const runId of runIds) {
       await globalThis.services.db
@@ -95,7 +115,7 @@ describe("GET /api/platform/logs", () => {
   });
 
   it("should return 401 when not authenticated", async () => {
-    mockUserId = null;
+    mockClerk({ userId: null });
 
     const request = createTestRequest(
       "http://localhost:3000/api/platform/logs",
@@ -105,8 +125,6 @@ describe("GET /api/platform/logs", () => {
 
     expect(response.status).toBe(401);
     expect(data.error.message).toBe("Not authenticated");
-
-    mockUserId = testUserId;
   });
 
   it("should return empty list when user has no runs", async () => {

--- a/turbo/apps/web/app/api/platform/logs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/platform/logs/__tests__/route.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { initServices } from "../../../../../src/lib/init-services";
+import { agentRuns } from "../../../../../src/db/schema/agent-run";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../../src/db/schema/agent-compose";
+import { scopes } from "../../../../../src/db/schema/scope";
+import { eq } from "drizzle-orm";
+import { randomUUID } from "crypto";
+import { createHash } from "crypto";
+
+/**
+ * Helper to create a NextRequest for testing.
+ */
+function createTestRequest(url: string): NextRequest {
+  return new NextRequest(url, {
+    method: "GET",
+  });
+}
+
+/**
+ * Helper to generate a content hash for compose versions.
+ */
+function generateContentHash(content: object): string {
+  return createHash("sha256").update(JSON.stringify(content)).digest("hex");
+}
+
+// Mock the auth module
+let mockUserId: string | null = "test-user-platform-logs";
+vi.mock("../../../../../src/lib/auth/get-user-id", () => ({
+  getUserId: async () => mockUserId,
+}));
+
+describe("GET /api/platform/logs", () => {
+  const testUserId = "test-user-platform-logs";
+  const testScopeId = randomUUID();
+  const testScopeSlug = `test-logs-${testScopeId.slice(0, 8)}`;
+
+  // Test data IDs
+  const composeIds: string[] = [];
+  const versionIds: string[] = [];
+  const runIds: string[] = [];
+
+  beforeAll(async () => {
+    initServices();
+
+    // Clean up any existing test data
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.userId, testUserId));
+
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.userId, testUserId));
+
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, testScopeId));
+
+    // Create test scope for the user
+    await globalThis.services.db.insert(scopes).values({
+      id: testScopeId,
+      slug: testScopeSlug,
+      type: "personal",
+      ownerId: testUserId,
+    });
+  });
+
+  afterAll(async () => {
+    // Cleanup in reverse order of creation
+    for (const runId of runIds) {
+      await globalThis.services.db
+        .delete(agentRuns)
+        .where(eq(agentRuns.id, runId));
+    }
+
+    for (const versionId of versionIds) {
+      await globalThis.services.db
+        .delete(agentComposeVersions)
+        .where(eq(agentComposeVersions.id, versionId));
+    }
+
+    for (const composeId of composeIds) {
+      await globalThis.services.db
+        .delete(agentComposes)
+        .where(eq(agentComposes.id, composeId));
+    }
+
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, testScopeId));
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockUserId = null;
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/platform/logs",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.message).toBe("Not authenticated");
+
+    mockUserId = testUserId;
+  });
+
+  it("should return empty list when user has no runs", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/platform/logs",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.data).toEqual([]);
+    expect(data.pagination.has_more).toBe(false);
+    expect(data.pagination.next_cursor).toBeNull();
+  });
+
+  it("should return list of run IDs ordered by createdAt DESC", async () => {
+    // Create a compose and version first
+    const composeId = randomUUID();
+    const content = {
+      version: "1.0",
+      agents: {
+        "test-agent": {
+          description: "Test agent",
+          provider: "claude-code",
+          working_dir: "/home/user/workspace",
+        },
+      },
+    };
+    const versionId = generateContentHash(content);
+
+    await globalThis.services.db.insert(agentComposes).values({
+      id: composeId,
+      name: "test-agent",
+      userId: testUserId,
+      scopeId: testScopeId,
+      headVersionId: versionId,
+    });
+    composeIds.push(composeId);
+
+    await globalThis.services.db.insert(agentComposeVersions).values({
+      id: versionId,
+      composeId: composeId,
+      content: content,
+      createdBy: testUserId,
+    });
+    versionIds.push(versionId);
+
+    // Create multiple runs with different timestamps
+    const now = new Date();
+    const runData = [
+      { id: randomUUID(), createdAt: new Date(now.getTime() - 3000) },
+      { id: randomUUID(), createdAt: new Date(now.getTime() - 2000) },
+      { id: randomUUID(), createdAt: new Date(now.getTime() - 1000) },
+    ];
+
+    for (const run of runData) {
+      await globalThis.services.db.insert(agentRuns).values({
+        id: run.id,
+        userId: testUserId,
+        agentComposeVersionId: versionId,
+        prompt: "Test prompt",
+        status: "completed",
+        createdAt: run.createdAt,
+      });
+      runIds.push(run.id);
+    }
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/platform/logs",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.data).toHaveLength(3);
+
+    // Check ordering (newest first)
+    expect(data.data[0].id).toBe(runData[2]!.id);
+    expect(data.data[1].id).toBe(runData[1]!.id);
+    expect(data.data[2].id).toBe(runData[0]!.id);
+  });
+
+  it("should paginate correctly with limit and cursor", async () => {
+    // Request with limit=2
+    const request1 = createTestRequest(
+      "http://localhost:3000/api/platform/logs?limit=2",
+    );
+    const response1 = await GET(request1);
+    const data1 = await response1.json();
+
+    expect(response1.status).toBe(200);
+    expect(data1.data).toHaveLength(2);
+    expect(data1.pagination.has_more).toBe(true);
+    expect(data1.pagination.next_cursor).not.toBeNull();
+
+    // Request second page using cursor
+    const request2 = createTestRequest(
+      `http://localhost:3000/api/platform/logs?limit=2&cursor=${encodeURIComponent(data1.pagination.next_cursor)}`,
+    );
+    const response2 = await GET(request2);
+    const data2 = await response2.json();
+
+    expect(response2.status).toBe(200);
+    expect(data2.data).toHaveLength(1);
+    expect(data2.pagination.has_more).toBe(false);
+    expect(data2.pagination.next_cursor).toBeNull();
+
+    // Ensure no duplicate IDs between pages
+    const allIds = [
+      ...data1.data.map((r: { id: string }) => r.id),
+      ...data2.data.map((r: { id: string }) => r.id),
+    ];
+    const uniqueIds = new Set(allIds);
+    expect(uniqueIds.size).toBe(allIds.length);
+  });
+
+  it("should filter by agent name with fuzzy search", async () => {
+    // Create another compose with different name
+    const composeId2 = randomUUID();
+    const content2 = {
+      version: "1.0",
+      agents: {
+        "different-agent": {
+          description: "Different agent",
+          provider: "claude-code",
+          working_dir: "/home/user/workspace",
+        },
+      },
+    };
+    const versionId2 = generateContentHash(content2);
+
+    await globalThis.services.db.insert(agentComposes).values({
+      id: composeId2,
+      name: "different-agent",
+      userId: testUserId,
+      scopeId: testScopeId,
+      headVersionId: versionId2,
+    });
+    composeIds.push(composeId2);
+
+    await globalThis.services.db.insert(agentComposeVersions).values({
+      id: versionId2,
+      composeId: composeId2,
+      content: content2,
+      createdBy: testUserId,
+    });
+    versionIds.push(versionId2);
+
+    // Create a run for the different agent
+    const runId = randomUUID();
+    await globalThis.services.db.insert(agentRuns).values({
+      id: runId,
+      userId: testUserId,
+      agentComposeVersionId: versionId2,
+      prompt: "Test prompt for different agent",
+      status: "completed",
+    });
+    runIds.push(runId);
+
+    // Search for "different"
+    const request = createTestRequest(
+      "http://localhost:3000/api/platform/logs?search=different",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.data).toHaveLength(1);
+    expect(data.data[0].id).toBe(runId);
+  });
+
+  it("should return empty list when search has no matches", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/platform/logs?search=nonexistent-agent-xyz",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.data).toEqual([]);
+    expect(data.pagination.has_more).toBe(false);
+  });
+
+  it("should be case-insensitive for search", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/platform/logs?search=DIFFERENT",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.data.length).toBeGreaterThan(0);
+  });
+
+  it("should not return runs from other users", async () => {
+    // Create run for another user
+    const otherUserId = "other-user-platform-logs";
+    const otherScopeId = randomUUID();
+
+    await globalThis.services.db.insert(scopes).values({
+      id: otherScopeId,
+      slug: `test-other-${otherScopeId.slice(0, 8)}`,
+      type: "personal",
+      ownerId: otherUserId,
+    });
+
+    const otherComposeId = randomUUID();
+    const otherContent = {
+      version: "1.0",
+      agents: {
+        "other-user-agent": {
+          description: "Other user agent",
+          provider: "claude-code",
+          working_dir: "/home/user/workspace",
+        },
+      },
+    };
+    const otherVersionId = generateContentHash(otherContent);
+
+    await globalThis.services.db.insert(agentComposes).values({
+      id: otherComposeId,
+      name: "other-user-agent",
+      userId: otherUserId,
+      scopeId: otherScopeId,
+      headVersionId: otherVersionId,
+    });
+
+    await globalThis.services.db.insert(agentComposeVersions).values({
+      id: otherVersionId,
+      composeId: otherComposeId,
+      content: otherContent,
+      createdBy: otherUserId,
+    });
+
+    const otherRunId = randomUUID();
+    await globalThis.services.db.insert(agentRuns).values({
+      id: otherRunId,
+      userId: otherUserId,
+      agentComposeVersionId: otherVersionId,
+      prompt: "Other user prompt",
+      status: "completed",
+    });
+
+    // List as test user - should not see other user's run
+    const request = createTestRequest(
+      "http://localhost:3000/api/platform/logs",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    const otherRunInResults = data.data.some(
+      (r: { id: string }) => r.id === otherRunId,
+    );
+    expect(otherRunInResults).toBe(false);
+
+    // Cleanup other user's data
+    await globalThis.services.db
+      .delete(agentRuns)
+      .where(eq(agentRuns.id, otherRunId));
+    await globalThis.services.db
+      .delete(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, otherVersionId));
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, otherComposeId));
+    await globalThis.services.db
+      .delete(scopes)
+      .where(eq(scopes.id, otherScopeId));
+  });
+
+  it("should return 400 for invalid limit", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/platform/logs?limit=0",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("should return 400 for limit exceeding maximum", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/platform/logs?limit=101",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.code).toBe("BAD_REQUEST");
+  });
+});

--- a/turbo/apps/web/app/api/platform/logs/route.ts
+++ b/turbo/apps/web/app/api/platform/logs/route.ts
@@ -1,0 +1,162 @@
+/**
+ * Platform API - Logs List Endpoint
+ *
+ * GET /api/platform/logs - List agent run logs with pagination and search
+ */
+import {
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../../../../src/lib/ts-rest-handler";
+import { platformLogsListContract } from "@vm0/core";
+import { initServices } from "../../../../src/lib/init-services";
+import { agentRuns } from "../../../../src/db/schema/agent-run";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../src/db/schema/agent-compose";
+import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { eq, and, desc, lt, or, ilike } from "drizzle-orm";
+
+const router = tsr.router(platformLogsListContract, {
+  list: async ({ query }) => {
+    initServices();
+
+    const userId = await getUserId();
+    if (!userId) {
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        },
+      };
+    }
+
+    const limit = query.limit ?? 20;
+
+    // Build base conditions - filter by user
+    const conditions = [eq(agentRuns.userId, userId)];
+
+    // Handle cursor-based pagination
+    // Cursor format: "createdAt|id" (ISO timestamp|uuid)
+    if (query.cursor) {
+      const separatorIndex = query.cursor.lastIndexOf("|");
+      if (separatorIndex > 0) {
+        const cursorTime = query.cursor.slice(0, separatorIndex);
+        const cursorId = query.cursor.slice(separatorIndex + 1);
+        const cursorDate = new Date(cursorTime);
+        // Get records older than cursor, or same time but smaller id
+        conditions.push(
+          or(
+            lt(agentRuns.createdAt, cursorDate),
+            and(
+              eq(agentRuns.createdAt, cursorDate),
+              lt(agentRuns.id, cursorId),
+            ),
+          )!,
+        );
+      }
+    }
+
+    // Build the query with joins
+    let queryBuilder = globalThis.services.db
+      .select({
+        id: agentRuns.id,
+        createdAt: agentRuns.createdAt,
+        composeName: agentComposes.name,
+      })
+      .from(agentRuns)
+      .leftJoin(
+        agentComposeVersions,
+        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+      )
+      .leftJoin(
+        agentComposes,
+        eq(agentComposeVersions.composeId, agentComposes.id),
+      )
+      .where(and(...conditions))
+      .orderBy(desc(agentRuns.createdAt), desc(agentRuns.id))
+      .limit(limit + 1);
+
+    // Apply search filter if provided (fuzzy match on agent name)
+    if (query.search) {
+      queryBuilder = globalThis.services.db
+        .select({
+          id: agentRuns.id,
+          createdAt: agentRuns.createdAt,
+          composeName: agentComposes.name,
+        })
+        .from(agentRuns)
+        .leftJoin(
+          agentComposeVersions,
+          eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+        )
+        .leftJoin(
+          agentComposes,
+          eq(agentComposeVersions.composeId, agentComposes.id),
+        )
+        .where(
+          and(...conditions, ilike(agentComposes.name, `%${query.search}%`)),
+        )
+        .orderBy(desc(agentRuns.createdAt), desc(agentRuns.id))
+        .limit(limit + 1);
+    }
+
+    const runs = await queryBuilder;
+
+    // Determine pagination info
+    const hasMore = runs.length > limit;
+    const data = hasMore ? runs.slice(0, limit) : runs;
+
+    // Build next cursor from last item
+    let nextCursor: string | null = null;
+    if (hasMore && data.length > 0) {
+      const lastItem = data[data.length - 1]!;
+      nextCursor = `${lastItem.createdAt.toISOString()}|${lastItem.id}`;
+    }
+
+    return {
+      status: 200 as const,
+      body: {
+        data: data.map((run) => ({
+          id: run.id,
+        })),
+        pagination: {
+          has_more: hasMore,
+          next_cursor: nextCursor,
+        },
+      },
+    };
+  },
+});
+
+/**
+ * Custom error handler to convert Zod validation errors to API error format
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (err && typeof err === "object" && "queryError" in err) {
+    const validationError = err as {
+      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
+    };
+
+    if (validationError.queryError) {
+      const issue = validationError.queryError.issues[0];
+      if (issue) {
+        const path = issue.path.join(".");
+        const message = path ? `${path}: ${issue.message}` : issue.message;
+        return TsRestResponse.fromJson(
+          { error: { message, code: "BAD_REQUEST" } },
+          { status: 400 },
+        );
+      }
+    }
+  }
+
+  return undefined;
+}
+
+const handler = createHandler(platformLogsListContract, router, {
+  errorHandler,
+});
+
+export { handler as GET };

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -286,5 +286,25 @@ export {
   type AblyTokenRequest,
 } from "./realtime";
 
+export {
+  platformLogsListContract,
+  platformLogsByIdContract,
+  platformLogStatusSchema,
+  platformLogEntrySchema,
+  paginationSchema,
+  platformLogsListResponseSchema,
+  artifactSchema,
+  platformLogDetailSchema,
+  type PlatformLogsListContract,
+  type PlatformLogsByIdContract,
+  // Inferred types
+  type PlatformLogStatus,
+  type PlatformLogEntry,
+  type Pagination,
+  type PlatformLogsListResponse,
+  type Artifact,
+  type PlatformLogDetail,
+} from "./platform";
+
 // Public API v1 contracts (developer-friendly external API)
 export * from "./public";

--- a/turbo/packages/core/src/contracts/platform.ts
+++ b/turbo/packages/core/src/contracts/platform.ts
@@ -1,0 +1,127 @@
+import { z } from "zod";
+import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import {
+  createPaginatedResponseSchema,
+  listQuerySchema,
+} from "./public/common";
+
+const c = initContract();
+
+/**
+ * Run status enum for platform logs
+ */
+const platformLogStatusSchema = z.enum([
+  "pending",
+  "running",
+  "completed",
+  "failed",
+  "timeout",
+  "cancelled",
+]);
+
+/**
+ * Log entry in list response - only includes id for efficiency
+ */
+const platformLogEntrySchema = z.object({
+  id: z.string().uuid(),
+});
+
+/**
+ * Logs list response schema using standard pagination
+ */
+const platformLogsListResponseSchema = createPaginatedResponseSchema(
+  platformLogEntrySchema,
+);
+
+/**
+ * Artifact information schema
+ */
+const artifactSchema = z.object({
+  name: z.string().nullable(),
+  version: z.string().nullable(),
+});
+
+/**
+ * Log detail response schema
+ */
+const platformLogDetailSchema = z.object({
+  id: z.string().uuid(),
+  sessionId: z.string().nullable(),
+  agentName: z.string(),
+  provider: z.string(),
+  status: platformLogStatusSchema,
+  prompt: z.string(),
+  error: z.string().nullable(),
+  createdAt: z.string(),
+  startedAt: z.string().nullable(),
+  completedAt: z.string().nullable(),
+  artifact: artifactSchema,
+});
+
+/**
+ * Platform logs list contract
+ * GET /api/platform/logs
+ */
+export const platformLogsListContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/platform/logs",
+    query: listQuerySchema.extend({
+      search: z.string().optional(),
+    }),
+    responses: {
+      200: platformLogsListResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "List agent run logs with pagination",
+  },
+});
+
+/**
+ * Platform logs by ID contract
+ * GET /api/platform/logs/:id
+ */
+export const platformLogsByIdContract = c.router({
+  getById: {
+    method: "GET",
+    path: "/api/platform/logs/:id",
+    pathParams: z.object({
+      id: z.string().uuid("Invalid log ID"),
+    }),
+    responses: {
+      200: platformLogDetailSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get agent run log details by ID",
+  },
+});
+
+// Contract type exports
+export type PlatformLogsListContract = typeof platformLogsListContract;
+export type PlatformLogsByIdContract = typeof platformLogsByIdContract;
+
+// Schema exports for reuse
+export {
+  platformLogStatusSchema,
+  platformLogEntrySchema,
+  platformLogsListResponseSchema,
+  artifactSchema,
+  platformLogDetailSchema,
+};
+
+// Re-export pagination schema from common
+export { paginationSchema } from "./public/common";
+
+// Inferred type exports
+export type PlatformLogStatus = z.infer<typeof platformLogStatusSchema>;
+export type PlatformLogEntry = z.infer<typeof platformLogEntrySchema>;
+export type PlatformLogsListResponse = z.infer<
+  typeof platformLogsListResponseSchema
+>;
+export type Artifact = z.infer<typeof artifactSchema>;
+export type PlatformLogDetail = z.infer<typeof platformLogDetailSchema>;
+
+// Re-export Pagination type from common
+export type { Pagination } from "./public/common";


### PR DESCRIPTION
## Summary
- Add `GET /api/platform/logs` list endpoint with cursor-based pagination and fuzzy search
- Add `GET /api/platform/logs/[id]` detail endpoint with full run information
- Add ts-rest contracts in `@vm0/core` using `createPaginatedResponseSchema` for type-safe API definitions

## Changes
- **New files:**
  - `turbo/packages/core/src/contracts/platform.ts` - Contract definitions
  - `turbo/apps/web/app/api/platform/logs/route.ts` - List endpoint
  - `turbo/apps/web/app/api/platform/logs/[id]/route.ts` - Detail endpoint
  - Unit tests for both endpoints (19 tests total)

- **Modified files:**
  - `turbo/packages/core/src/contracts/index.ts` - Export platform contracts
  - `.gitignore` - Exception for platform logs API folder

## Test plan
- [x] All 19 unit tests pass
- [x] Type checking passes
- [x] Linting passes
- [x] Full test suite passes (1742 tests)

Closes #1710

🤖 Generated with [Claude Code](https://claude.com/claude-code)