### PR TITLE
feat(platform): add logs page ui with table display

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -11,13 +11,13 @@ import {
 } from "./api-model-providers.ts";
 import { apiScopeHandlers } from "./api-scope.ts";
 import { exampleHandlers } from "./example.ts";
-import { v1RunsHandlers } from "./v1-runs.ts";
+import { platformLogsHandlers } from "./v1-runs.ts";
 
 export const handlers = [
   ...apiModelProvidersHandlers,
   ...apiScopeHandlers,
   ...exampleHandlers,
-  ...v1RunsHandlers,
+  ...platformLogsHandlers,
 ];
 
 export function resetAllMockHandlers(): void {

--- a/turbo/apps/platform/src/mocks/handlers/v1-runs.ts
+++ b/turbo/apps/platform/src/mocks/handlers/v1-runs.ts
@@ -1,53 +1,68 @@
 /**
- * v1 API Runs Handlers
+ * Platform Logs API Handlers
  *
- * Mock handlers for /v1/runs endpoint
+ * Mock handlers for /api/platform/logs endpoints
  */
 
 import { http, HttpResponse } from "msw";
-import type { LogResponse, Run } from "../../signals/logs-page/types.ts";
+import type {
+  LogsListResponse,
+  LogDetail,
+} from "../../signals/logs-page/types.ts";
 
-// Mock data
-const mockRuns: Run[] = [
+// Mock data for log details
+const mockLogDetails: LogDetail[] = [
   {
     id: "run_1",
-    agent_id: "agent_1",
-    agent_name: "Test Agent",
+    sessionId: "session_1",
+    agentName: "Test Agent",
+    provider: "claude-code",
     status: "completed",
     prompt: "Test prompt",
-    created_at: "2024-01-01T00:00:00Z",
-    started_at: "2024-01-01T00:00:01Z",
-    completed_at: "2024-01-01T00:00:10Z",
+    error: null,
+    createdAt: "2024-01-01T00:00:00Z",
+    startedAt: "2024-01-01T00:00:01Z",
+    completedAt: "2024-01-01T00:00:10Z",
+    artifact: {
+      name: "test-artifact",
+      version: "1.0.0",
+    },
   },
   {
     id: "run_2",
-    agent_id: "agent_2",
-    agent_name: "Another Agent",
+    sessionId: "session_2",
+    agentName: "Another Agent",
+    provider: "claude-code",
     status: "completed",
     prompt: "Another prompt",
-    created_at: "2024-01-02T00:00:00Z",
-    started_at: "2024-01-02T00:00:01Z",
-    completed_at: "2024-01-02T00:00:10Z",
+    error: null,
+    createdAt: "2024-01-02T00:00:00Z",
+    startedAt: "2024-01-02T00:00:01Z",
+    completedAt: "2024-01-02T00:00:10Z",
+    artifact: {
+      name: null,
+      version: null,
+    },
   },
 ];
 
-export const v1RunsHandlers = [
-  // GET /v1/runs - List runs
-  http.get("/v1/runs", ({ request }) => {
+export const platformLogsHandlers = [
+  // GET /api/platform/logs - List logs (returns only IDs)
+  http.get("*/api/platform/logs", ({ request }) => {
     const url = new URL(request.url);
     const cursor = url.searchParams.get("cursor");
     const limit = Number.parseInt(url.searchParams.get("limit") || "20", 10);
 
     // Simple pagination logic
     const cursorIndex = cursor
-      ? mockRuns.findIndex((r) => r.id === cursor) + 1
+      ? mockLogDetails.findIndex((r) => r.id === cursor) + 1
       : 0;
-    const data = mockRuns.slice(cursorIndex, cursorIndex + limit);
-    const hasMore = cursorIndex + limit < mockRuns.length;
+    const data = mockLogDetails.slice(cursorIndex, cursorIndex + limit);
+    const hasMore = cursorIndex + limit < mockLogDetails.length;
     const nextCursor = hasMore ? data[data.length - 1]?.id || null : null;
 
-    const response: LogResponse = {
-      data,
+    const response: LogsListResponse = {
+      data: data.map((log) => ({ id: log.id })),
       pagination: {
         has_more: hasMore,
         next_cursor: nextCursor,
@@ -55,5 +70,20 @@ export const v1RunsHandlers = [
     };
 
     return HttpResponse.json(response);
+  }),
+
+  // GET /api/platform/logs/:id - Get log detail
+  http.get("*/api/platform/logs/:id", ({ params }) => {
+    const { id } = params;
+    const logDetail = mockLogDetails.find((log) => log.id === id);
+
+    if (!logDetail) {
+      return HttpResponse.json(
+        { error: { message: "Log not found", code: "NOT_FOUND" } },
+        { status: 404 },
+      );
+    }
+
+    return HttpResponse.json(logDetail);
   }),
 ];

--- a/turbo/apps/platform/src/signals/logs-page/__tests__/logs-signals.test.ts
+++ b/turbo/apps/platform/src/signals/logs-page/__tests__/logs-signals.test.ts
@@ -94,7 +94,7 @@ describe("logs-signals", () => {
 
       // Mock API to return specific cursor
       server.use(
-        http.get("/v1/runs", ({ request }) => {
+        http.get("*/api/platform/logs", ({ request }) => {
           const url = new URL(request.url);
           const cursor = url.searchParams.get("cursor");
 
@@ -149,7 +149,7 @@ describe("logs-signals", () => {
 
       // Mock API response with cursor
       server.use(
-        http.get("/v1/runs", () =>
+        http.get("*/api/platform/logs", () =>
           HttpResponse.json({
             data: [],
             pagination: { has_more: true, next_cursor: "cursor456" },
@@ -171,7 +171,7 @@ describe("logs-signals", () => {
 
       // Mock API response without cursor
       server.use(
-        http.get("/v1/runs", () =>
+        http.get("*/api/platform/logs", () =>
           HttpResponse.json({
             data: [],
             pagination: { has_more: false, next_cursor: null },

--- a/turbo/apps/platform/src/signals/logs-page/logs-signals.ts
+++ b/turbo/apps/platform/src/signals/logs-page/logs-signals.ts
@@ -1,12 +1,53 @@
 import { state, computed, command, type Computed } from "ccstate";
-import type { LogResponse } from "./types.ts";
+import type { LogsListResponse, LogDetail } from "./types.ts";
 import { fetch$ } from "../fetch.ts";
 
-// Internal state: Array of computed promises, each representing a batch of data
-const internalLogs$ = state<Computed<Promise<LogResponse>>[]>([]);
+// Internal state: Array of computed promises, each representing a batch of log IDs
+const internalLogs$ = state<Computed<Promise<LogsListResponse>>[]>([]);
 
 // Exported computed: Read-only access to logs
 export const logs$ = computed((get) => get(internalLogs$));
+
+// State for log detail cache (id -> computed detail)
+const logDetailCache$ = state<Map<string, Computed<Promise<LogDetail>>>>(
+  new Map(),
+);
+
+/**
+ * Create a computed for fetching log detail by ID.
+ */
+function createLogDetailComputed(logId: string): Computed<Promise<LogDetail>> {
+  return computed(async (get) => {
+    const fetchFn = get(fetch$);
+    const response = await fetchFn(`/api/platform/logs/${logId}`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch log detail: ${response.statusText}`);
+    }
+    return (await response.json()) as LogDetail;
+  });
+}
+
+/**
+ * Command to get or create a log detail computed.
+ * Returns the cached computed if it exists, otherwise creates and caches a new one.
+ */
+export const getOrCreateLogDetail$ = command(
+  ({ get, set }, logId: string): Computed<Promise<LogDetail>> => {
+    const cache = get(logDetailCache$);
+    const cached = cache.get(logId);
+    if (cached) {
+      return cached;
+    }
+
+    const detail$ = createLogDetailComputed(logId);
+    set(logDetailCache$, (prev) => {
+      const newCache = new Map(prev);
+      newCache.set(logId, detail$);
+      return newCache;
+    });
+    return detail$;
+  },
+);
 
 // Computed: Get next_cursor from last log response
 export const currentCursor$ = computed(async (get) => {
@@ -46,20 +87,21 @@ export const hasMore$ = computed(async (get) => {
 export const initLogs$ = command(({ set }, signal: AbortSignal) => {
   signal.throwIfAborted();
 
-  // Clear internal logs
+  // Clear internal logs and detail cache
   set(internalLogs$, []);
+  set(logDetailCache$, new Map());
 
   // Load first batch (no cursor for first batch)
   const firstBatch$ = computed(async (get) => {
     const fetchFn = get(fetch$);
     const params = new URLSearchParams({ limit: "20" });
 
-    const response = await fetchFn(`/v1/runs?${params.toString()}`);
+    const response = await fetchFn(`/api/platform/logs?${params.toString()}`);
     if (!response.ok) {
-      throw new Error(`Failed to fetch runs: ${response.statusText}`);
+      throw new Error(`Failed to fetch logs: ${response.statusText}`);
     }
 
-    return (await response.json()) as LogResponse;
+    return (await response.json()) as LogsListResponse;
   });
 
   set(internalLogs$, [firstBatch$]);
@@ -80,12 +122,12 @@ export const loadMore$ = command(async ({ get, set }, signal: AbortSignal) => {
       params.set("cursor", cursor);
     }
 
-    const response = await fetchFn(`/v1/runs?${params.toString()}`);
+    const response = await fetchFn(`/api/platform/logs?${params.toString()}`);
     if (!response.ok) {
-      throw new Error(`Failed to fetch runs: ${response.statusText}`);
+      throw new Error(`Failed to fetch logs: ${response.statusText}`);
     }
 
-    return (await response.json()) as LogResponse;
+    return (await response.json()) as LogsListResponse;
   });
 
   set(internalLogs$, (prev) => [...prev, nextBatch$]);

--- a/turbo/apps/platform/src/signals/logs-page/types.ts
+++ b/turbo/apps/platform/src/signals/logs-page/types.ts
@@ -1,25 +1,42 @@
-// API response types (matching v1 API contract)
-export interface LogResponse {
-  data: Run[];
+// API response types (matching platform API contracts)
+
+// List response - only contains IDs for efficiency
+interface LogEntry {
+  id: string;
+}
+
+export interface LogsListResponse {
+  data: LogEntry[];
   pagination: {
     has_more: boolean;
     next_cursor: string | null;
   };
 }
 
-export interface Run {
+// Detail response - full log information
+export type LogStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "timeout"
+  | "cancelled";
+
+interface Artifact {
+  name: string | null;
+  version: string | null;
+}
+
+export interface LogDetail {
   id: string;
-  agent_id: string;
-  agent_name: string;
-  status:
-    | "pending"
-    | "running"
-    | "completed"
-    | "failed"
-    | "timeout"
-    | "cancelled";
+  sessionId: string | null;
+  agentName: string;
+  provider: string;
+  status: LogStatus;
   prompt: string;
-  created_at: string; // ISO timestamp
-  started_at: string | null;
-  completed_at: string | null;
+  error: string | null;
+  createdAt: string; // ISO timestamp
+  startedAt: string | null;
+  completedAt: string | null;
+  artifact: Artifact;
 }

--- a/turbo/apps/platform/src/views/logs-page/__tests__/logs-page.test.tsx
+++ b/turbo/apps/platform/src/views/logs-page/__tests__/logs-page.test.tsx
@@ -1,10 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/helper.ts";
 import { pathname$ } from "../../../signals/route.ts";
-import { screen } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
+import { server } from "../../../mocks/server.ts";
+import { http, HttpResponse } from "msw";
+import { userEvent } from "@testing-library/user-event";
 
 const context = testContext();
+const user = userEvent.setup();
 
 describe("logs page", () => {
   it("should render the logs page", async () => {
@@ -17,5 +21,290 @@ describe("logs page", () => {
       screen.getByText("View all agent runs and execution history."),
     ).toBeDefined();
     expect(context.store.get(pathname$)).toBe("/logs");
+  });
+
+  it("should render table headers correctly", async () => {
+    await setupPage({
+      context,
+      path: "/logs",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Run ID")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Session ID")).toBeInTheDocument();
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+    expect(screen.getByText("Model")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Generate time")).toBeInTheDocument();
+  });
+
+  it("should display log entries from API", async () => {
+    await setupPage({
+      context,
+      path: "/logs",
+    });
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.getByText("Test Agent")).toBeInTheDocument();
+    });
+
+    // Verify mock data is displayed
+    expect(screen.getByText("session_1")).toBeInTheDocument();
+    // Multiple rows can have claude-code
+    const providerCells = screen.getAllByText("claude-code");
+    expect(providerCells.length).toBeGreaterThan(0);
+
+    // Verify status badge is rendered
+    const completedBadges = screen.getAllByText("completed");
+    expect(completedBadges.length).toBeGreaterThan(0);
+  });
+
+  it("should show empty table when no logs exist", async () => {
+    server.use(
+      http.get("*/api/platform/logs", () => {
+        return HttpResponse.json({
+          data: [],
+          pagination: { has_more: false, next_cursor: null },
+        });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/logs",
+    });
+
+    // Wait for table to render
+    await waitFor(() => {
+      expect(screen.getByRole("table")).toBeInTheDocument();
+    });
+
+    // Table should have headers but no data rows
+    const table = screen.getByRole("table");
+    const tbody = within(table).getAllByRole("rowgroup")[1]; // tbody is second rowgroup
+    expect(tbody).toBeDefined();
+    // tbody should be empty (no rows)
+    expect(within(tbody!).queryAllByRole("row")).toHaveLength(0);
+  });
+
+  it("should show Load More button when has more data", async () => {
+    server.use(
+      http.get("*/api/platform/logs", ({ request }) => {
+        const url = new URL(request.url);
+        const cursor = url.searchParams.get("cursor");
+
+        if (!cursor) {
+          return HttpResponse.json({
+            data: [{ id: "run_1" }],
+            pagination: { has_more: true, next_cursor: "run_1" },
+          });
+        }
+        return HttpResponse.json({
+          data: [{ id: "run_2" }],
+          pagination: { has_more: false, next_cursor: null },
+        });
+      }),
+      http.get("*/api/platform/logs/:id", ({ params }) => {
+        const { id } = params;
+        return HttpResponse.json({
+          id,
+          sessionId: `session_${id}`,
+          agentName: `Agent ${id}`,
+          provider: "claude-code",
+          status: "completed",
+          prompt: "Test",
+          error: null,
+          createdAt: "2024-01-01T00:00:00Z",
+          startedAt: "2024-01-01T00:00:01Z",
+          completedAt: "2024-01-01T00:00:10Z",
+          artifact: { name: null, version: null },
+        });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/logs",
+    });
+
+    // Wait for Load More button to appear
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Load More" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should load more data when Load More button is clicked", async () => {
+    let loadMoreCalled = false;
+
+    server.use(
+      http.get("*/api/platform/logs", ({ request }) => {
+        const url = new URL(request.url);
+        const cursor = url.searchParams.get("cursor");
+
+        if (!cursor) {
+          return HttpResponse.json({
+            data: [{ id: "run_first" }],
+            pagination: { has_more: true, next_cursor: "run_first" },
+          });
+        }
+        loadMoreCalled = true;
+        return HttpResponse.json({
+          data: [{ id: "run_second" }],
+          pagination: { has_more: false, next_cursor: null },
+        });
+      }),
+      http.get("*/api/platform/logs/:id", ({ params }) => {
+        const { id } = params;
+        return HttpResponse.json({
+          id,
+          sessionId: `session_${id}`,
+          agentName: `Agent ${id}`,
+          provider: "claude-code",
+          status: "completed",
+          prompt: "Test",
+          error: null,
+          createdAt: "2024-01-01T00:00:00Z",
+          startedAt: null,
+          completedAt: null,
+          artifact: { name: null, version: null },
+        });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/logs",
+    });
+
+    // Wait for first batch
+    await waitFor(() => {
+      expect(screen.getByText("Agent run_first")).toBeInTheDocument();
+    });
+
+    // Click Load More
+    const loadMoreButton = screen.getByRole("button", { name: "Load More" });
+    await user.click(loadMoreButton);
+
+    // Verify second batch is loaded
+    await vi.waitFor(() => {
+      expect(loadMoreCalled).toBeTruthy();
+    });
+  });
+
+  it("should display different status badges with correct styles", async () => {
+    server.use(
+      http.get("*/api/platform/logs", () => {
+        return HttpResponse.json({
+          data: [
+            { id: "run_pending" },
+            { id: "run_running" },
+            { id: "run_failed" },
+          ],
+          pagination: { has_more: false, next_cursor: null },
+        });
+      }),
+      http.get("*/api/platform/logs/:id", ({ params }) => {
+        const { id } = params;
+        const statusMap: Record<string, string> = {
+          run_pending: "pending",
+          run_running: "running",
+          run_failed: "failed",
+        };
+        return HttpResponse.json({
+          id,
+          sessionId: null,
+          agentName: `Agent ${id}`,
+          provider: "claude-code",
+          status: statusMap[id as string] ?? "completed",
+          prompt: "Test",
+          error: id === "run_failed" ? "Something went wrong" : null,
+          createdAt: "2024-01-01T00:00:00Z",
+          startedAt: null,
+          completedAt: null,
+          artifact: { name: null, version: null },
+        });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/logs",
+    });
+
+    // Wait for data to load and verify status badges
+    await waitFor(() => {
+      expect(screen.getByText("pending")).toBeInTheDocument();
+    });
+    expect(screen.getByText("running")).toBeInTheDocument();
+    expect(screen.getByText("failed")).toBeInTheDocument();
+  });
+
+  it("should display dash when sessionId is null", async () => {
+    server.use(
+      http.get("*/api/platform/logs", () => {
+        return HttpResponse.json({
+          data: [{ id: "run_no_session" }],
+          pagination: { has_more: false, next_cursor: null },
+        });
+      }),
+      http.get("*/api/platform/logs/:id", () => {
+        return HttpResponse.json({
+          id: "run_no_session",
+          sessionId: null,
+          agentName: "Test Agent",
+          provider: "claude-code",
+          status: "pending",
+          prompt: "Test",
+          error: null,
+          createdAt: "2024-01-01T00:00:00Z",
+          startedAt: null,
+          completedAt: null,
+          artifact: { name: null, version: null },
+        });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/logs",
+    });
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.getByText("Test Agent")).toBeInTheDocument();
+    });
+
+    // Find the table row and check for dash in session column
+    const table = screen.getByRole("table");
+    const rows = within(table).getAllByRole("row");
+    // First row is header, second is data row
+    const dataRow = rows[1];
+    expect(dataRow).toBeDefined();
+    expect(within(dataRow!).getByText("-")).toBeInTheDocument();
+  });
+
+  it("should handle API error gracefully", async () => {
+    server.use(
+      http.get("*/api/platform/logs", () => {
+        return HttpResponse.json(
+          { error: { message: "Internal server error", code: "SERVER_ERROR" } },
+          { status: 500 },
+        );
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/logs",
+    });
+
+    // Should show error message when API fails
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to fetch logs/)).toBeInTheDocument();
+    });
   });
 });

--- a/turbo/apps/platform/src/views/logs-page/logs-table-row.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-table-row.tsx
@@ -1,17 +1,75 @@
-import type { Run } from "../../signals/logs-page/types.ts";
+import { useSet, useLoadable } from "ccstate-react";
+import { getOrCreateLogDetail$ } from "../../signals/logs-page/logs-signals.ts";
+import type { LogStatus } from "../../signals/logs-page/types.ts";
 import { TableRow, TableCell } from "@vm0/ui";
 
 interface LogsTableRowProps {
-  run: Run;
+  logId: string;
 }
 
-export function LogsTableRow({ run }: LogsTableRowProps) {
-  // TODO: Add navigation to run detail page once it's implemented
+function StatusBadge({ status }: { status: LogStatus }) {
+  const statusStyles: Record<LogStatus, string> = {
+    pending: "bg-yellow-100 text-yellow-800",
+    running: "bg-blue-100 text-blue-800",
+    completed: "bg-green-100 text-green-800",
+    failed: "bg-red-100 text-red-800",
+    timeout: "bg-orange-100 text-orange-800",
+    cancelled: "bg-gray-100 text-gray-800",
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${statusStyles[status]}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+export function LogsTableRow({ logId }: LogsTableRowProps) {
+  // Get or create the log detail computed (command is idempotent due to caching)
+  const getOrCreateLogDetail = useSet(getOrCreateLogDetail$);
+  const detail$ = getOrCreateLogDetail(logId);
+  const loadable = useLoadable(detail$);
+
+  if (loadable.state === "loading") {
+    return (
+      <TableRow>
+        <td colSpan={6} className="p-4 text-center text-muted-foreground">
+          Loading...
+        </td>
+      </TableRow>
+    );
+  }
+
+  if (loadable.state === "hasError") {
+    const errorMessage =
+      loadable.error instanceof Error
+        ? loadable.error.message
+        : "Failed to load details";
+    return (
+      <TableRow>
+        <td colSpan={6} className="p-4 text-center text-destructive">
+          Error: {errorMessage}
+        </td>
+      </TableRow>
+    );
+  }
+
+  const detail = loadable.data;
+
   return (
     <TableRow>
-      <TableCell>{run.id}</TableCell>
-      <TableCell>{run.agent_name}</TableCell>
-      <TableCell>{new Date(run.created_at).toLocaleString()}</TableCell>
+      <TableCell className="font-mono text-sm">{detail.id}</TableCell>
+      <TableCell className="font-mono text-sm">
+        {detail.sessionId ?? "-"}
+      </TableCell>
+      <TableCell>{detail.agentName}</TableCell>
+      <TableCell>{detail.provider}</TableCell>
+      <TableCell>
+        <StatusBadge status={detail.status} />
+      </TableCell>
+      <TableCell>{new Date(detail.createdAt).toLocaleString()}</TableCell>
     </TableRow>
   );
 }

--- a/turbo/apps/platform/src/views/logs-page/logs-table.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-table.tsx
@@ -3,11 +3,11 @@ import type { Computed } from "ccstate";
 import { logs$ } from "../../signals/logs-page/logs-signals.ts";
 import { LogsTableRow } from "./logs-table-row.tsx";
 import { LogsEmptyState } from "./logs-empty-state.tsx";
-import type { LogResponse } from "../../signals/logs-page/types.ts";
+import type { LogsListResponse } from "../../signals/logs-page/types.ts";
 import { Table, TableHeader, TableBody, TableHead, TableRow } from "@vm0/ui";
 
 interface LogBatchProps {
-  logComputed: Computed<Promise<LogResponse>>;
+  logComputed: Computed<Promise<LogsListResponse>>;
   index: number;
 }
 
@@ -17,7 +17,7 @@ function LogBatch({ logComputed, index }: LogBatchProps) {
   if (loadable.state === "loading") {
     return (
       <TableRow key={`loading-${index}`}>
-        <td colSpan={3} className="p-4 text-center">
+        <td colSpan={6} className="p-4 text-center">
           Loading...
         </td>
       </TableRow>
@@ -28,10 +28,10 @@ function LogBatch({ logComputed, index }: LogBatchProps) {
     const errorMessage =
       loadable.error instanceof Error
         ? loadable.error.message
-        : "Failed to load runs";
+        : "Failed to load logs";
     return (
       <TableRow key={`error-${index}`}>
-        <td colSpan={3} className="p-4 text-center text-destructive">
+        <td colSpan={6} className="p-4 text-center text-destructive">
           Error: {errorMessage}
         </td>
       </TableRow>
@@ -40,8 +40,8 @@ function LogBatch({ logComputed, index }: LogBatchProps) {
 
   return (
     <>
-      {loadable.data.data.map((run) => (
-        <LogsTableRow key={run.id} run={run} />
+      {loadable.data.data.map((entry) => (
+        <LogsTableRow key={entry.id} logId={entry.id} />
       ))}
     </>
   );
@@ -59,7 +59,10 @@ export function LogsTable() {
       <TableHeader>
         <TableRow>
           <TableHead>Run ID</TableHead>
+          <TableHead>Session ID</TableHead>
           <TableHead>Agent</TableHead>
+          <TableHead>Model</TableHead>
+          <TableHead>Status</TableHead>
           <TableHead>Generate time</TableHead>
         </TableRow>
       </TableHeader>


### PR DESCRIPTION
## Summary
- Add LogsTable and LogsTableRow components displaying: Run ID, Session ID, Agent, Model, Status, Generate time
- Add StatusBadge component with colored status indicators
- Implement logs signals for data fetching with cursor-based pagination
- Add mock handlers for platform logs API
- Add 9 comprehensive integration tests for logs page

Closes #1710

## Test plan
- [x] All existing tests pass
- [x] New integration tests cover table rendering, data display, pagination, status badges, error handling
- [ ] Manual testing with real API data

🤖 Generated with [Claude Code](https://claude.com/claude-code)