### PR TITLE
feat(cli): add enable prompt and --enable flag to schedule setup

### DIFF
--- a/turbo/apps/docs/content/docs/tutorial/scheduling.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/scheduling.mdx
@@ -38,7 +38,7 @@ Creating new schedule for agent my-researcher
 ? Prompt to run › research the latest AI news and developments
 ```
 
-After completing the prompts, you'll see a confirmation:
+After completing the prompts, you'll be asked if you want to enable the schedule:
 
 ```
 Deploying schedule for agent my-researcher...
@@ -46,31 +46,37 @@ Deploying schedule for agent my-researcher...
   Timezone: America/Los_Angeles
   Cron: 0 9 * * *
 
-  To activate: vm0 schedule enable my-researcher
-```
-
-## Step 3: Enable the Schedule
-
-Schedules are created in a disabled state by default. To activate your schedule, run:
-
-```bash
-vm0 schedule enable my-researcher
-```
-
-You'll see:
-
-```
+? Enable this schedule? (Y/n) › Yes
 ✓ Enabled schedule for agent my-researcher
 ```
 
 Your agent is now scheduled to run daily at 9:00 AM!
+
+<Callout type="info">
+If you decline to enable the schedule, you can enable it later with `vm0 schedule enable my-researcher`.
+</Callout>
+
+## Quick Setup with --enable Flag
+
+For non-interactive setups (like CI/CD pipelines), you can use the `--enable` flag to create and enable a schedule in one command:
+
+```bash
+vm0 schedule setup my-researcher \
+  --frequency daily \
+  --time 09:00 \
+  --timezone America/Los_Angeles \
+  --prompt "research the latest AI news" \
+  --enable
+```
+
+This creates the schedule and enables it immediately without any prompts.
 
 ## What Just Happened?
 
 You configured VM0's built-in scheduler to run your agent automatically. The scheduler:
 
 1. Stores your schedule configuration on VM0's servers
-2. Waits for you to enable it (schedules start disabled for safety)
+2. Asks if you want to enable it immediately (defaults to yes)
 3. Triggers agent runs at the specified times
 4. Uses your configured secrets and variables
 5. Saves output to the artifact directory

--- a/turbo/apps/docs/content/docs/tutorial/scheduling.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/scheduling.mdx
@@ -56,21 +56,6 @@ Your agent is now scheduled to run daily at 9:00 AM!
 If you decline to enable the schedule, you can enable it later with `vm0 schedule enable my-researcher`.
 </Callout>
 
-## Quick Setup with --enable Flag
-
-For non-interactive setups (like CI/CD pipelines), you can use the `--enable` flag to create and enable a schedule in one command:
-
-```bash
-vm0 schedule setup my-researcher \
-  --frequency daily \
-  --time 09:00 \
-  --timezone America/Los_Angeles \
-  --prompt "research the latest AI news" \
-  --enable
-```
-
-This creates the schedule and enables it immediately without any prompts.
-
 ## What Just Happened?
 
 You configured VM0's built-in scheduler to run your agent automatically. The scheduler:


### PR DESCRIPTION
## Summary

- Add `--enable` (`-e`) flag to auto-enable schedule after creation
- Add interactive prompt "Enable this schedule?" (default: yes) for new schedules  
- Prompt also appears when updating a disabled schedule
- Non-interactive mode without `--enable` maintains backward compatibility
- Graceful error handling if enable fails (shows manual command)
- Update terminology from "To activate" to "To enable" for consistency
- Update scheduling tutorial documentation

## Test plan

- [ ] `vm0 schedule setup my-agent --enable` creates and enables in one command
- [ ] Interactive mode prompts "Enable this schedule?" after creation
- [ ] Prompt defaults to "yes" (pressing Enter enables)
- [ ] Prompt appears when updating a disabled schedule
- [ ] Prompt does NOT appear when updating an already-enabled schedule
- [ ] Non-interactive mode without `--enable` maintains current behavior
- [ ] Enable errors are handled gracefully with helpful message

Closes #1731

🤖 Generated with [Claude Code](https://claude.ai/code)