### PR TITLE
chore(toolchain): add rust toolchain with arm64 cross-compilation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,7 +39,8 @@
         "dbaeumer.vscode-eslint",
         "vitest.explorer",
         "mtxr.sqltools-driver-pg",
-        "foxundermoon.shell-format"
+        "foxundermoon.shell-format",
+        "rust-lang.rust-analyzer"
       ],
       "settings": {
         "sqltools.connections": [

--- a/.docker/toolchain/Dockerfile
+++ b/.docker/toolchain/Dockerfile
@@ -35,6 +35,20 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install ansible
 
+# Install Rust toolchain with ARM64 cross-compilation support
+# Used for building vsock-agent for Firecracker VMs (ARM64 metal runners)
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+RUN apt-get update && apt-get install -y \
+    musl-tools \
+    gcc-aarch64-linux-gnu \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable \
+    && rustup target add aarch64-unknown-linux-musl \
+    && rustup component add rustfmt clippy \
+    && rustc --version && cargo --version
+
 # Install Playwright system dependencies for Chromium
 # This is needed for e2e tests in CI
 RUN npx playwright install-deps chromium


### PR DESCRIPTION
## Summary
- Add Rust toolchain to `.docker/toolchain/Dockerfile` with ARM64 cross-compilation support
- Include `aarch64-unknown-linux-musl` target for static linking
- Add `rustfmt` and `clippy` for code formatting and linting in CI
- Add `rust-lang.rust-analyzer` extension to devcontainer

## Context
This PR adds the Rust toolchain to the Docker image so we don't need to install it in GitHub Actions each time. The toolchain includes cross-compilation support for building vsock-agent binaries that run on ARM64 Firecracker VMs.

## Test plan
- [ ] Build the new toolchain image
- [ ] Verify `rustc`, `cargo`, `rustfmt`, `clippy` are available
- [ ] Verify `aarch64-unknown-linux-musl` target works

🤖 Generated with [Claude Code](https://claude.com/claude-code)