### PR TITLE
refactor(cli): replace verification_url with verification_path in device auth

### DIFF
--- a/turbo/apps/cli/src/lib/api/auth.ts
+++ b/turbo/apps/cli/src/lib/api/auth.ts
@@ -28,7 +28,7 @@ function buildHeaders(): Record<string, string> {
 async function requestDeviceCode(apiUrl: string): Promise<{
   device_code: string;
   user_code: string;
-  verification_url: string;
+  verification_path: string;
   expires_in: number;
   interval: number;
 }> {
@@ -45,7 +45,7 @@ async function requestDeviceCode(apiUrl: string): Promise<{
   return response.json() as Promise<{
     device_code: string;
     user_code: string;
-    verification_url: string;
+    verification_path: string;
     expires_in: number;
     interval: number;
   }>;
@@ -92,8 +92,8 @@ export async function authenticate(apiUrl?: string): Promise<void> {
 
   console.log(chalk.green("\nDevice code generated"));
 
-  // Construct verification URL from API URL
-  const verificationUrl = `${targetApiUrl}/cli-auth`;
+  // Construct verification URL from API URL and server-provided path
+  const verificationUrl = `${targetApiUrl}${deviceAuth.verification_path}`;
   console.log(chalk.cyan(`\nTo authenticate, visit: ${verificationUrl}`));
   console.log(`And enter this code: ${chalk.bold(deviceAuth.user_code)}`);
   console.log(

--- a/turbo/apps/web/app/api/cli/auth/device/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/device/route.ts
@@ -37,23 +37,12 @@ const router = tsr.router(cliAuthDeviceContract, {
       updatedAt: new Date(),
     });
 
-    // Priority: NEXT_PUBLIC_APP_URL > VERCEL_URL (for preview deployments)
-    const vercelUrl = process.env.VERCEL_URL;
-    const baseUrl =
-      process.env.NEXT_PUBLIC_APP_URL ||
-      (vercelUrl ? `https://${vercelUrl}` : null);
-    if (!baseUrl) {
-      throw new Error(
-        "NEXT_PUBLIC_APP_URL environment variable is not configured",
-      );
-    }
-
     return {
       status: 200 as const,
       body: {
         device_code: deviceCode,
         user_code: deviceCode,
-        verification_url: `${baseUrl}/cli-auth`,
+        verification_path: "/cli-auth",
         expires_in: 900, // 15 minutes in seconds
         interval: 5, // Poll every 5 seconds
       },

--- a/turbo/packages/core/src/contracts/cli-auth.ts
+++ b/turbo/packages/core/src/contracts/cli-auth.ts
@@ -28,7 +28,7 @@ export const cliAuthDeviceContract = c.router({
       200: z.object({
         device_code: z.string(),
         user_code: z.string(),
-        verification_url: z.string(),
+        verification_path: z.string(),
         expires_in: z.number(),
         interval: z.number(),
       }),


### PR DESCRIPTION
## Summary

- Replace `verification_url` with `verification_path` in CLI device auth flow
- Server returns path `/cli-auth` instead of constructing full URL
- CLI constructs full URL from `apiUrl + verification_path`
- Remove dependency on `NEXT_PUBLIC_APP_URL` / `VERCEL_URL` environment variables

## Changes

| File | Change |
|------|--------|
| `packages/core/src/contracts/cli-auth.ts` | Rename field to `verification_path` |
| `apps/web/app/api/cli/auth/device/route.ts` | Return path, remove env var logic |
| `apps/cli/src/lib/api/auth.ts` | Use server's `verification_path` |

## Test plan

- [x] Build passes for affected packages
- [x] Lint passes
- [x] Type check passes
- [x] Tests pass
- [ ] Manual test: `vm0 auth login` with local dev server

Closes #1740

🤖 Generated with [Claude Code](https://claude.com/claude-code)