### PR TITLE
fix(web): add ably to server external packages

### DIFF
--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -28,6 +28,7 @@ const nextConfig = {
   experimental: {
     optimizePackageImports: ["next-intl"],
   },
+  serverExternalPackages: ["ably"],
 };
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Summary

Fix "Module not found" errors for keyv adapters when accessing webhook routes that use Ably.

## Problem

The `ably` package's Node.js build uses `got` → `cacheable-request` → `keyv`, which dynamically requires adapters. This conflicts with Next.js App Router bundling:

```
Module not found: Can't resolve ('@keyv/redis' | '@keyv/mongo' | ...)
```

## Solution

Add `ably` to `serverExternalPackages` in `next.config.js`. This tells Next.js to use native Node.js require instead of bundling.

## Reference

- [Next.js serverExternalPackages docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages)
- [Ably npm documentation](https://www.npmjs.com/package/ably)

## Test plan

- [x] Dev server starts without keyv errors
- [x] Webhook routes work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)