### PR TITLE
chore(devcontainer): simplify ssl certificate setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,14 +11,14 @@
   },
   "remoteUser": "vscode",
   "forwardPorts": [8443],
-  "runArgs": [
-    "-p", "8443"
-  ],
+  "runArgs": ["-p", "8443"],
   "remoteEnv": {
     "CLAUDE_CONFIG_DIR": "/home/vscode/.config/claude",
     "CRUSH_GLOBAL_CONFIG": "/home/vscode/.config/crush",
     "HISTFILE": "/home/vscode/.cache/.zsh_history",
-    "DATABASE_URL": "postgresql://postgres:postgres@localhost:5432/postgres"
+    "DATABASE_URL": "postgresql://postgres:postgres@localhost:5432/postgres",
+    "NODE_EXTRA_CA_CERTS": "${containerWorkspaceFolder}/.certs/rootCA.pem",
+    "VM0_API_URL": "https://www.vm7.ai:8443"
   },
   "mounts": [
     "source=config,target=/home/vscode/.config",


### PR DESCRIPTION
## Summary

- Remove Firefox NSS database setup from devcontainer setup script (unused complexity)
- Add `NODE_EXTRA_CA_CERTS` environment variable to properly configure Node.js SSL CA
- Add `VM0_API_URL` environment variable for local development API endpoint
- Minor formatting cleanup in devcontainer.json

## Test plan

- [ ] Verify devcontainer builds successfully
- [ ] Confirm SSL certificates work with Node.js applications
- [ ] Test local API connectivity via the configured URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)