### PR TITLE
chore(crates): move lint config to cargo workspace lints

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -28,11 +28,9 @@ jobs:
       - name: Run clippy
         run: |
           cd crates
-          cargo clippy --all-targets --all-features -- -D warnings
+          cargo clippy --all-targets --all-features
 
       - name: Build
-        env:
-          RUSTFLAGS: "-D warnings"
         run: |
           cd crates
           cargo build --all-targets

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -9,3 +9,9 @@ strip = true
 [profile.release.package.vsock-agent]
 opt-level = "z"
 codegen-units = 1
+
+[workspace.lints.rust]
+warnings = "deny"
+
+[workspace.lints.clippy]
+all = "deny"

--- a/crates/lefthook.yml
+++ b/crates/lefthook.yml
@@ -8,9 +8,9 @@ pre-commit:
       stage_fixed: true
     cargo-clippy:
       root: crates/
-      run: cargo clippy --all-targets --all-features -- -D warnings
+      run: cargo clippy --all-targets --all-features
       glob: "crates/**/*.{rs,toml}"
     cargo-check:
       root: crates/
-      run: RUSTFLAGS="-D warnings" cargo check --all-targets
+      run: cargo check --all-targets
       glob: "crates/**/*.{rs,toml}"

--- a/crates/vsock-agent/Cargo.toml
+++ b/crates/vsock-agent/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2024"
 
 [dependencies]
 libc = "0.2"
+
+[lints]
+workspace = true


### PR DESCRIPTION
## Summary
- Move lint configuration from RUSTFLAGS to Cargo.toml workspace lints
- Avoid compilation cache invalidation caused by RUSTFLAGS changes
- Remove `-D warnings` flags from lefthook and CI workflow

## Test plan
- [x] `cargo check --all-targets` passes
- [x] `cargo clippy --all-targets --all-features` passes
- [x] CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)