### PR TITLE
feat(platform): persist logs pagination state in url

### DIFF
--- a/turbo/apps/platform/src/views/components/pagination.tsx
+++ b/turbo/apps/platform/src/views/components/pagination.tsx
@@ -1,0 +1,109 @@
+import {
+  IconChevronLeft,
+  IconChevronRight,
+  IconChevronsLeft,
+  IconChevronsRight,
+} from "@tabler/icons-react";
+import { Button } from "@vm0/ui";
+
+const ROWS_PER_PAGE_OPTIONS = [10, 20, 50, 100] as const;
+
+interface PaginationProps {
+  currentPage: number;
+  rowsPerPage: number;
+  hasNext: boolean;
+  hasPrev: boolean;
+  isLoading?: boolean;
+  onNextPage: () => void;
+  onPrevPage: () => void;
+  onForwardTwoPages: () => void;
+  onBackTwoPages: () => void;
+  onRowsPerPageChange: (limit: number) => void;
+}
+
+export function Pagination({
+  currentPage,
+  rowsPerPage,
+  hasNext,
+  hasPrev,
+  isLoading = false,
+  onNextPage,
+  onPrevPage,
+  onForwardTwoPages,
+  onBackTwoPages,
+  onRowsPerPageChange,
+}: PaginationProps) {
+  const canGoBackTwo = currentPage > 1;
+
+  const handleRowsPerPageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const limit = Number.parseInt(e.target.value, 10);
+    onRowsPerPageChange(limit);
+  };
+
+  return (
+    <div className="flex items-center justify-end gap-6 py-4">
+      {/* Rows per page selector */}
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-muted-foreground">Rows per page</span>
+        <select
+          value={rowsPerPage}
+          onChange={handleRowsPerPageChange}
+          className="h-8 rounded-md border border-input bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          {ROWS_PER_PAGE_OPTIONS.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Page indicator */}
+      <span className="text-sm text-muted-foreground">Page {currentPage}</span>
+
+      {/* Navigation buttons */}
+      <div className="flex items-center gap-1">
+        {/* Back two pages */}
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8"
+          onClick={onBackTwoPages}
+          disabled={!canGoBackTwo}
+        >
+          <IconChevronsLeft className="h-4 w-4" />
+        </Button>
+        {/* Previous page */}
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8"
+          onClick={onPrevPage}
+          disabled={!hasPrev}
+        >
+          <IconChevronLeft className="h-4 w-4" />
+        </Button>
+        {/* Next page */}
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8"
+          onClick={onNextPage}
+          disabled={!hasNext || isLoading}
+        >
+          <IconChevronRight className="h-4 w-4" />
+        </Button>
+        {/* Forward two pages */}
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8"
+          onClick={onForwardTwoPages}
+          disabled={!hasNext || isLoading}
+        >
+          <IconChevronsRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/logs-page/logs-pagination.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-pagination.tsx
@@ -1,12 +1,5 @@
 import type { Computed } from "ccstate";
 import { useSet, useLoadable, useGet } from "ccstate-react";
-import {
-  IconChevronLeft,
-  IconChevronRight,
-  IconChevronsLeft,
-  IconChevronsRight,
-} from "@tabler/icons-react";
-import { Button } from "@vm0/ui";
 import type { LogsListResponse } from "../../signals/logs-page/types.ts";
 import {
   currentPageLogs$,
@@ -21,9 +14,9 @@ import {
 } from "../../signals/logs-page/logs-signals.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import { Pagination } from "../components/pagination.tsx";
 
 export function LogsPagination() {
-  const rowsPerPageOptions = [10, 20, 50, 100] as const;
   const currentPageLoadable = useLoadable(currentPageLogs$);
   const hasPrev = useGet(hasPrevPage$);
   const currentPage = useGet(currentPageNumber$);
@@ -51,8 +44,7 @@ export function LogsPagination() {
     detach(goBackTwo(pageSignal), Reason.DomCallback);
   };
 
-  const handleRowsPerPageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const limit = Number.parseInt(e.target.value, 10);
+  const handleRowsPerPageChange = (limit: number) => {
     detach(setRowsPerPageFn({ limit, signal: pageSignal }), Reason.DomCallback);
   };
 
@@ -60,113 +52,61 @@ export function LogsPagination() {
   const pageComputed =
     currentPageLoadable.state === "hasData" ? currentPageLoadable.data : null;
 
-  // Can go back two pages if current page > 1
-  const canGoBackTwo = currentPage > 1;
+  if (!pageComputed) {
+    return (
+      <Pagination
+        currentPage={currentPage}
+        rowsPerPage={rowsPerPage}
+        hasNext={false}
+        hasPrev={hasPrev}
+        isLoading
+        onNextPage={handleNextPage}
+        onPrevPage={handlePrevPage}
+        onForwardTwoPages={handleForwardTwoPages}
+        onBackTwoPages={handleBackTwoPages}
+        onRowsPerPageChange={handleRowsPerPageChange}
+      />
+    );
+  }
 
   return (
-    <div className="flex items-center justify-end gap-6 py-4">
-      {/* Rows per page selector */}
-      <div className="flex items-center gap-2">
-        <span className="text-sm text-muted-foreground">Rows per page</span>
-        <select
-          value={rowsPerPage}
-          onChange={handleRowsPerPageChange}
-          className="h-8 rounded-md border border-input bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-        >
-          {rowsPerPageOptions.map((option) => (
-            <option key={option} value={option}>
-              {option}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {/* Page indicator */}
-      <span className="text-sm text-muted-foreground">Page {currentPage}</span>
-
-      {/* Navigation buttons */}
-      <div className="flex items-center gap-1">
-        {/* Back two pages */}
-        <Button
-          variant="outline"
-          size="icon"
-          className="h-8 w-8"
-          onClick={handleBackTwoPages}
-          disabled={!canGoBackTwo}
-        >
-          <IconChevronsLeft className="h-4 w-4" />
-        </Button>
-        {/* Previous page */}
-        <Button
-          variant="outline"
-          size="icon"
-          className="h-8 w-8"
-          onClick={handlePrevPage}
-          disabled={!hasPrev}
-        >
-          <IconChevronLeft className="h-4 w-4" />
-        </Button>
-        {/* Next page */}
-        {pageComputed ? (
-          <NextPageButton
-            pageComputed={pageComputed}
-            onClick={handleNextPage}
-          />
-        ) : (
-          <Button variant="outline" size="icon" className="h-8 w-8" disabled>
-            <IconChevronRight className="h-4 w-4" />
-          </Button>
-        )}
-        {/* Forward two pages */}
-        {pageComputed ? (
-          <ForwardTwoPagesButton
-            pageComputed={pageComputed}
-            onClick={handleForwardTwoPages}
-          />
-        ) : (
-          <Button variant="outline" size="icon" className="h-8 w-8" disabled>
-            <IconChevronsRight className="h-4 w-4" />
-          </Button>
-        )}
-      </div>
-    </div>
+    <LogsPaginationWithData
+      pageComputed={pageComputed}
+      currentPage={currentPage}
+      rowsPerPage={rowsPerPage}
+      hasPrev={hasPrev}
+      onNextPage={handleNextPage}
+      onPrevPage={handlePrevPage}
+      onForwardTwoPages={handleForwardTwoPages}
+      onBackTwoPages={handleBackTwoPages}
+      onRowsPerPageChange={handleRowsPerPageChange}
+    />
   );
 }
 
-interface NextPageButtonProps {
+interface LogsPaginationWithDataProps {
   pageComputed: Computed<Promise<LogsListResponse>>;
-  onClick: () => void;
+  currentPage: number;
+  rowsPerPage: number;
+  hasPrev: boolean;
+  onNextPage: () => void;
+  onPrevPage: () => void;
+  onForwardTwoPages: () => void;
+  onBackTwoPages: () => void;
+  onRowsPerPageChange: (limit: number) => void;
 }
 
-function NextPageButton({ pageComputed, onClick }: NextPageButtonProps) {
-  const dataLoadable = useLoadable(pageComputed);
-
-  const hasNext =
-    dataLoadable.state === "hasData" && dataLoadable.data.pagination.hasMore;
-  const isLoading = dataLoadable.state === "loading";
-
-  return (
-    <Button
-      variant="outline"
-      size="icon"
-      className="h-8 w-8"
-      onClick={onClick}
-      disabled={!hasNext || isLoading}
-    >
-      <IconChevronRight className="h-4 w-4" />
-    </Button>
-  );
-}
-
-interface ForwardTwoPagesButtonProps {
-  pageComputed: Computed<Promise<LogsListResponse>>;
-  onClick: () => void;
-}
-
-function ForwardTwoPagesButton({
+function LogsPaginationWithData({
   pageComputed,
-  onClick,
-}: ForwardTwoPagesButtonProps) {
+  currentPage,
+  rowsPerPage,
+  hasPrev,
+  onNextPage,
+  onPrevPage,
+  onForwardTwoPages,
+  onBackTwoPages,
+  onRowsPerPageChange,
+}: LogsPaginationWithDataProps) {
   const dataLoadable = useLoadable(pageComputed);
 
   const hasNext =
@@ -174,14 +114,17 @@ function ForwardTwoPagesButton({
   const isLoading = dataLoadable.state === "loading";
 
   return (
-    <Button
-      variant="outline"
-      size="icon"
-      className="h-8 w-8"
-      onClick={onClick}
-      disabled={!hasNext || isLoading}
-    >
-      <IconChevronsRight className="h-4 w-4" />
-    </Button>
+    <Pagination
+      currentPage={currentPage}
+      rowsPerPage={rowsPerPage}
+      hasNext={hasNext}
+      hasPrev={hasPrev}
+      isLoading={isLoading}
+      onNextPage={onNextPage}
+      onPrevPage={onPrevPage}
+      onForwardTwoPages={onForwardTwoPages}
+      onBackTwoPages={onBackTwoPages}
+      onRowsPerPageChange={onRowsPerPageChange}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- Add URL synchronization for logs pagination so that page state (cursor, limit, search) persists across page reloads and is shareable via URL
- Extract reusable Pagination component from logs-specific code
- Update tests to properly mock location for cleaner URL state

## Test plan
- [ ] Verify that navigating pages updates the URL with cursor parameter
- [ ] Verify that changing rows per page updates the URL with limit parameter
- [ ] Verify that searching updates the URL with search parameter
- [ ] Verify that page state is restored when loading a URL with pagination params
- [ ] Verify that sharing a URL with pagination params loads the correct page

🤖 Generated with [Claude Code](https://claude.com/claude-code)