### PR TITLE
fix(devcontainer): grant vscode user write access to cargo directories

### DIFF
--- a/.docker/toolchain/Dockerfile
+++ b/.docker/toolchain/Dockerfile
@@ -153,7 +153,8 @@ RUN groupadd -f --gid 1000 vscode \
     && echo "vscode ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/vscode \
     && chmod 0440 /etc/sudoers.d/vscode \
     && mkdir -p /home/vscode/.local/share /home/vscode/.cache /home/vscode/.config \
-    && chown -R vscode:vscode /home/vscode
+    && chown -R vscode:vscode /home/vscode \
+    && chown -R vscode:vscode /usr/local/cargo /usr/local/rustup
 
 # Default command
 CMD ["/usr/bin/zsh"]


### PR DESCRIPTION
## Summary
- Fix permission denied error when running cargo commands in dev container
- Grant vscode user ownership of `/usr/local/cargo` and `/usr/local/rustup` directories

## Test plan
- [ ] Rebuild dev container
- [ ] Run `pnpm test` in turbo directory to verify cargo builds work

🤖 Generated with [Claude Code](https://claude.com/claude-code)