### PR TITLE
chore: add cargo home env to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,8 @@
     "HISTFILE": "/home/vscode/.cache/.zsh_history",
     "DATABASE_URL": "postgresql://postgres:postgres@localhost:5432/postgres",
     "NODE_EXTRA_CA_CERTS": "${containerWorkspaceFolder}/.certs/rootCA.pem",
+    "CARGO_HOME": "/home/vscode/.cache/cargo",
+    "PATH": "/home/vscode/.cache/cargo/bin:${containerEnv:PATH}",
     "VM0_API_URL": "https://www.vm7.ai:8443"
   },
   "mounts": [


### PR DESCRIPTION
## Summary
- Add `CARGO_HOME` environment variable pointing to `/home/vscode/.cache/cargo`
- Update `PATH` to include Cargo's bin directory for installed tools

This ensures Rust/Cargo installations persist across container rebuilds by storing them in the cache volume.

## Test plan
- [ ] Rebuild devcontainer and verify `CARGO_HOME` is set correctly
- [ ] Install a Rust tool with `cargo install` and verify it persists after container restart

---
Generated with [Claude Code](https://claude.ai/code)