### PR TITLE
feat(docs): fix volume version field requirement in vm0.yaml reference

### DIFF
--- a/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
@@ -67,4 +67,4 @@ volumes:
 | Field     | Type   | Required | Default  | Description                                  |
 | --------- | ------ | -------- | -------- | -------------------------------------------- |
 | `name`    | string | Yes      | -        | Volume name (must match `.vm0/storage.yaml`) |
-| `version` | string | No       | `latest` | Version to use                               |
+| `version` | string | Yes      | -        | Version to use (e.g., `latest` or version hash) |


### PR DESCRIPTION
## Summary

- Fix incorrect documentation for volume `version` field in vm0.yaml reference
- The field was documented as optional with default `latest`, but the Zod schema requires it

## Evidence

The schema in `turbo/packages/core/src/contracts/composes.ts` defines:
```typescript
const volumeConfigSchema = z.object({
  name: z.string().min(1, "Volume name is required"),
  version: z.string().min(1, "Volume version is required"),  // REQUIRED
});
```

## Test plan

- [ ] Verify documentation renders correctly on docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)