### PR TITLE
test(cli): stub api url env variable in test setup

### DIFF
--- a/turbo/apps/cli/src/test/setup.ts
+++ b/turbo/apps/cli/src/test/setup.ts
@@ -1,8 +1,14 @@
 import { server } from "../mocks/server";
-import { afterAll, afterEach, beforeAll } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
 
 // Start MSW server before all tests
-beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+beforeEach(() => {
+  vi.stubEnv("VM0_API_URL", undefined);
+});
 
 // Reset handlers after each test
 afterEach(() => server.resetHandlers());


### PR DESCRIPTION
## Summary
- Adds a `beforeEach` hook in CLI test setup to stub the `VM0_API_URL` environment variable to `undefined`
- Ensures tests run with a clean environment state, preventing test pollution from development environment variables

## Test plan
- [x] All existing tests pass (2287 tests)
- [x] Pre-commit checks pass (lint, format, types, knip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)