### PR TITLE
fix(ci): add vsock-agent build step to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -525,6 +525,14 @@ jobs:
       - name: Build Core Package
         run: cd turbo && pnpm turbo run build --filter=@vm0/core
 
+      # Cross-compile Rust vsock-agent for ARM64 (metal runners are ARM64)
+      - name: Build vsock-agent for ARM64
+        run: |
+          cd crates
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc \
+            cargo build --release --target aarch64-unknown-linux-musl -p vsock-agent
+          ls -la target/aarch64-unknown-linux-musl/release/vsock-agent
+
       - name: Build runner bundle
         run: |
           # Build runner (use subshell to preserve working directory)


### PR DESCRIPTION
## Summary
- Add missing Rust vsock-agent cross-compilation step to `deploy-runner-production` job in release-please.yml
- This matches the same step in turbo.yml

## Problem
Production deploy failed with:
```
cp: cannot stat '/opt/vm0-runner/production/deploy-runner/vsock-agent': No such file or directory
```

See: https://github.com/vm0-ai/vm0/actions/runs/21426741522/job/61697326751

## Test plan
- [ ] Verify next production deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)