### PR TITLE
fix(api): use camelcase for sse lasteventid query parameter

### DIFF
--- a/turbo/apps/web/app/v1/runs/[id]/events/route.ts
+++ b/turbo/apps/web/app/v1/runs/[id]/events/route.ts
@@ -117,9 +117,9 @@ export async function GET(
     );
   }
 
-  // Get last_event_id from query for reconnection support
+  // Get lastEventId from query for reconnection support
   const url = new URL(request.url);
-  const lastEventId = url.searchParams.get("last_event_id");
+  const lastEventId = url.searchParams.get("lastEventId");
   let lastSequence = lastEventId ? parseInt(lastEventId, 10) : 0;
 
   // Create SSE stream


### PR DESCRIPTION
## Summary

- Fix query parameter casing from `last_event_id` to `lastEventId`
- Update associated comment to reflect correct parameter name

## Problem

The SSE events endpoint (`GET /v1/runs/:id/events`) used snake_case (`last_event_id`) for its query parameter, while the project convention, contract definition, and documentation all use camelCase (`lastEventId`).

## Solution

Simple two-line change in `turbo/apps/web/app/v1/runs/[id]/events/route.ts`:
- Line 120: Update comment from `last_event_id` to `lastEventId`
- Line 122: Change `url.searchParams.get("last_event_id")` to `url.searchParams.get("lastEventId")`

## Test Plan

- [x] Verify lint passes
- [x] Verify type check passes
- [ ] CI tests (existing tests pass; SSE endpoint has no dedicated tests)
- [ ] Manual verification: SSE endpoint accepts `?lastEventId=xxx`

## Breaking Change

This is technically a breaking change for any clients using `?last_event_id=xxx`, but:
1. The documented API always showed `lastEventId` (camelCase)
2. The contract definition uses `lastEventId`
3. SSE reconnection is an advanced feature rarely implemented by clients

Fixes #1764

---
Generated with Claude Code