### PR TITLE
fix(api): remove unimplemented filters and fix docs gaps

### DIFF
--- a/turbo/apps/docs/content/docs/reference/api/index.mdx
+++ b/turbo/apps/docs/content/docs/reference/api/index.mdx
@@ -103,8 +103,7 @@ The API uses standard HTTP status codes and returns structured error responses.
   "error": {
     "type": "invalid_request_error",
     "code": "resource_not_found",
-    "message": "No such agent: 'my-agent'",
-    "param": "agent_id"
+    "message": "No such agent: 'my-agent'"
   }
 }
 ```
@@ -114,7 +113,6 @@ The API uses standard HTTP status codes and returns structured error responses.
 | `type` | string | Category of the error |
 | `code` | string | Specific error code |
 | `message` | string | Human-readable error description |
-| `param` | string | Parameter that caused the error (when applicable) |
 
 ### Error Types
 
@@ -132,10 +130,7 @@ The API uses standard HTTP status codes and returns structured error responses.
 
 | Code | Description |
 |------|-------------|
-| `missing_api_key` | No Authorization header provided |
-| `invalid_api_key` | Token is malformed or doesn't exist |
-| `expired_api_key` | Token has expired |
-| `revoked_api_key` | Token was revoked |
+| `invalid_api_key` | API key is missing, malformed, expired, or revoked |
 
 #### Request Errors (400)
 
@@ -143,6 +138,7 @@ The API uses standard HTTP status codes and returns structured error responses.
 |------|-------------|
 | `invalid_parameter` | A parameter value is invalid |
 | `missing_parameter` | A required parameter is missing |
+| `invalid_state` | Resource is in an invalid state for the requested operation |
 
 #### Resource Errors (404, 409)
 
@@ -195,7 +191,7 @@ curl "https://api.vm0.ai/v1/agents?limit=10" \
   -H "Authorization: Bearer vm0_live_xxx"
 ```
 
-Use the `next_cursor` from the previous response for subsequent pages:
+Use the `nextCursor` from the previous response for subsequent pages:
 
 ```bash
 curl "https://api.vm0.ai/v1/agents?limit=10&cursor=eyJpZCI6ImFnX2RlZiJ9" \

--- a/turbo/apps/docs/content/docs/reference/api/runs.mdx
+++ b/turbo/apps/docs/content/docs/reference/api/runs.mdx
@@ -32,9 +32,7 @@ Returns a paginated list of runs.
 |-----------|------|---------|-------------|
 | `limit` | integer | 20 | Items per page (1-100) |
 | `cursor` | string | - | Pagination cursor |
-| `agentId` | string | - | Filter by agent ID |
 | `status` | string | - | Filter by status |
-| `since` | string | - | Filter by start time (ISO 8601) |
 
 ### Request
 

--- a/turbo/packages/core/src/contracts/public/runs.ts
+++ b/turbo/packages/core/src/contracts/public/runs.ts
@@ -117,7 +117,7 @@ export const publicRunsListContract = c.router({
       500: publicApiErrorSchema,
     },
     summary: "List runs",
-    description: "List runs with optional filtering by agent, status, and time",
+    description: "List runs with optional filtering by status",
   },
   create: {
     method: "POST",

--- a/turbo/packages/core/src/contracts/public/runs.ts
+++ b/turbo/packages/core/src/contracts/public/runs.ts
@@ -97,9 +97,7 @@ export type CreateRunRequest = z.infer<typeof createRunRequestSchema>;
  * Run list query parameters
  */
 export const runListQuerySchema = listQuerySchema.extend({
-  agentId: z.string().optional(),
   status: publicRunStatusSchema.optional(),
-  since: timestampSchema.optional(),
 });
 
 export type RunListQuery = z.infer<typeof runListQuerySchema>;


### PR DESCRIPTION
## Summary

- Remove unimplemented `agentId` and `since` filters from runs contract
- Update documentation to match actual API behavior

## Changes

1. **Contract**: Remove `agentId` and `since` from `runListQuerySchema` (never implemented)
2. **Docs**: Remove `param` field from error response schema (not implemented)
3. **Docs**: Simplify auth error codes to only `invalid_api_key`
4. **Docs**: Add `invalid_state` error code documentation
5. **Docs**: Fix `next_cursor` to `nextCursor` in pagination example

## Test plan

- [ ] Verify contract changes don't break existing API consumers (no breaking change since filters were never implemented)
- [ ] Review documentation matches actual API behavior

Fixes #1772

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)