### PR TITLE
chore: add devcontainer utility scripts and fix hardcoded paths

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,13 +12,13 @@
   "forwardPorts": [8443],
   "runArgs": ["-p", "8443"],
   "remoteEnv": {
-    "CLAUDE_CONFIG_DIR": "/home/vscode/.config/claude",
-    "CRUSH_GLOBAL_CONFIG": "/home/vscode/.config/crush",
-    "HISTFILE": "/home/vscode/.cache/.zsh_history",
+    "CLAUDE_CONFIG_DIR": "${containerEnv:HOME}/.config/claude",
+    "CRUSH_GLOBAL_CONFIG": "${containerEnv:HOME}/.config/crush",
+    "HISTFILE": "${containerEnv:HOME}/.cache/.zsh_history",
     "DATABASE_URL": "postgresql://postgres:postgres@localhost:5432/postgres",
     "NODE_EXTRA_CA_CERTS": "${containerWorkspaceFolder}/.certs/rootCA.pem",
-    "CARGO_HOME": "/home/vscode/.cache/cargo",
-    "PATH": "/home/vscode/.cache/cargo/bin:${containerEnv:PATH}",
+    "CARGO_HOME": "${containerEnv:HOME}/.cache/cargo",
+    "PATH": "${containerEnv:HOME}/.cache/cargo/bin:${containerWorkspaceFolder}/bin:${containerEnv:PATH}",
     "VM0_API_URL": "https://www.vm7.ai:8443"
   },
   "mounts": [

--- a/bin/dcl
+++ b/bin/dcl
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eu
+
+docker ps | grep vsc- | while read -r line; do
+    # Extract vm name from image name (2nd field)
+    image=$(echo "$line" | awk '{print $2}')
+    vm_name=$(echo "$image" | sed -E 's/vsc-([^-]+)-.*/\1/')
+
+    # Extract port number
+    port=$(echo "$line" | ggrep -oP '0\.0\.0\.0:\K[0-9]+(?=->8443)')
+
+    # Extract creation time (between quoted string and "Up")
+    time=$(echo "$line" | gsed -E 's/.*…"[[:space:]]+([^[:space:]].*)[[:space:]]+Up.*/\1/')
+
+    # Construct URL
+    url="https://www.vm7.ai:${port}"
+
+    # Print result
+    printf "%-6s %-30s %s\n" "$vm_name" "$url" "$time"
+done | sort -V

--- a/bin/dcpf
+++ b/bin/dcpf
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ $# -eq 0 ]; then
+    echo "Usage: dcpf <vm_name>"
+    echo "Example: dcpf vm01"
+    exit 1
+fi
+
+vm_name="$1"
+
+# Find the container and extract its port
+port=$(docker ps | grep "vsc-${vm_name}" | ggrep -oP '0\.0\.0\.0:\K[0-9]+(?=->8443)' | head -n1)
+
+if [ -z "$port" ]; then
+    echo "Error: Container for '${vm_name}' not found or no port mapping"
+    echo "Available containers:"
+    docker ps --format "table {{.Names}}\t{{.Ports}}" | grep vsc- || echo "No devcontainers running"
+    exit 1
+fi
+
+echo "Forwarding localhost:8443 -> localhost:${port} (container: ${vm_name})"
+echo "Press Ctrl+C to stop"
+
+# Use socat to forward port 8443 to the container's port
+socat TCP-LISTEN:8443,fork,reuseaddr TCP:localhost:${port}

--- a/bin/dcu
+++ b/bin/dcu
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# Argument provided, use it as workspace name
+workspace="$1"
+FOLDER="$HOME/workspace/$workspace"
+(cd "$FOLDER" && git pull)
+npx @devcontainers/cli up --workspace-folder "$FOLDER" \
+    --dotfiles-repository $VM0_DOTFILES \
+    --remove-existing-container

--- a/bin/dcz
+++ b/bin/dcz
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eu
+
+FOLDER="$HOME/workspace/$1"
+
+# Check if ~/.devcontainer.env file exists and use it
+npx @devcontainers/cli exec --workspace-folder "$FOLDER" zsh

--- a/vm0.code-workspace
+++ b/vm0.code-workspace
@@ -26,6 +26,9 @@
     },
     {
       "path": "scripts"
+    },
+    {
+      "path": "bin"
     }
   ],
   "extensions": {


### PR DESCRIPTION
## Summary

- Add `bin/` folder with devcontainer management scripts for improved developer workflow
- Replace hardcoded `/home/vscode` paths with dynamic `${containerEnv:HOME}` in devcontainer.json
- Add `bin/` to PATH in devcontainer environment for easy script access
- Add `bin/` folder to VS Code workspace for visibility

### Scripts Added

| Script | Purpose |
|--------|---------|
| `dcl` | List running devcontainers with their URLs and creation time |
| `dcpf` | Forward localhost:8443 to a specific devcontainer |
| `dcu` | Start/update a devcontainer for a workspace |
| `dcz` | Execute zsh in a devcontainer |

## Test plan

- [ ] Verify devcontainer builds successfully with the new paths
- [ ] Test that scripts are accessible from PATH inside the container
- [ ] Verify each utility script works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)