### PR TITLE
chore(bin): make workspace path configurable via environment variable

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,13 +12,13 @@
   "forwardPorts": [8443],
   "runArgs": ["-p", "8443"],
   "remoteEnv": {
-    "CLAUDE_CONFIG_DIR": "${containerEnv:HOME}/.config/claude",
-    "CRUSH_GLOBAL_CONFIG": "${containerEnv:HOME}/.config/crush",
-    "HISTFILE": "${containerEnv:HOME}/.cache/.zsh_history",
+    "CLAUDE_CONFIG_DIR": "/home/vscode/.config/claude",
+    "CRUSH_GLOBAL_CONFIG": "/home/vscode/.config/crush",
+    "HISTFILE": "/home/vscode/.cache/.zsh_history",
     "DATABASE_URL": "postgresql://postgres:postgres@localhost:5432/postgres",
     "NODE_EXTRA_CA_CERTS": "${containerWorkspaceFolder}/.certs/rootCA.pem",
-    "CARGO_HOME": "${containerEnv:HOME}/.cache/cargo",
-    "PATH": "${containerEnv:HOME}/.cache/cargo/bin:${containerWorkspaceFolder}/bin:${containerEnv:PATH}",
+    "CARGO_HOME": "/home/vscode/.cache/cargo",
+    "PATH": "/home/vscode/.cache/cargo/bin:${containerWorkspaceFolder}/bin:${containerEnv:PATH}",
     "VM0_API_URL": "https://www.vm7.ai:8443"
   },
   "mounts": [

--- a/bin/dcu
+++ b/bin/dcu
@@ -4,7 +4,8 @@ set -eu
 
 # Argument provided, use it as workspace name
 workspace="$1"
-FOLDER="$HOME/workspace/$workspace"
+VM0_WORKSPACES="${VM0_WORKSPACES:-$HOME/workspaces}"
+FOLDER="$VM0_WORKSPACES/$workspace"
 (cd "$FOLDER" && git pull)
 npx @devcontainers/cli up --workspace-folder "$FOLDER" \
     --dotfiles-repository $VM0_DOTFILES \

--- a/bin/dcz
+++ b/bin/dcz
@@ -2,7 +2,8 @@
 
 set -eu
 
-FOLDER="$HOME/workspace/$1"
+VM0_WORKSPACES="${VM0_WORKSPACES:-$HOME/workspaces}"
+FOLDER="$VM0_WORKSPACES/$1"
 
 # Check if ~/.devcontainer.env file exists and use it
 npx @devcontainers/cli exec --workspace-folder "$FOLDER" zsh


### PR DESCRIPTION
## Summary
- Add `VM0_WORKSPACES` environment variable support to `bin/dcu` and `bin/dcz`
- Defaults to `$HOME/workspaces` if not set
- Fix devcontainer environment variables to use hardcoded `/home/vscode` path instead of `${containerEnv:HOME}` which wasn't resolving correctly

## Test plan
- [ ] Verify `dcu` and `dcz` work with default path
- [ ] Verify custom `VM0_WORKSPACES` path is respected
- [ ] Verify devcontainer environment variables are set correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)