### PR TITLE
chore(bin): add dc-sync utility for multi-workspace env syncing

### DIFF
--- a/bin/dc-sync
+++ b/bin/dc-sync
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+VM0_WORKSPACES="${VM0_WORKSPACES:-$HOME/workspaces}"
+SOURCE="$VM0_WORKSPACES/vm0"
+
+if [[ ! -d "$SOURCE" ]]; then
+    echo "Error: Source directory $SOURCE does not exist"
+    exit 1
+fi
+
+# Check if a directory is a vm0-ai/vm0 project
+is_vm0_project() {
+    local dir="$1"
+    [[ -d "$dir/.git" ]] && git -C "$dir" remote -v 2>/dev/null | grep -qE "vm0-ai/vm0(\.git|[[:space:]])"
+}
+
+# Find all .env.local files in source and symlink them to destination
+sync_env_files() {
+    local dest="$1"
+
+    while IFS= read -r -d '' env_file; do
+        local rel_path="${env_file#"$SOURCE/"}"
+        local dest_file="$dest/$rel_path"
+        local dest_dir
+        dest_dir=$(dirname "$dest_file")
+
+        if [[ -d "$dest_dir" ]]; then
+            ln -sf "$env_file" "$dest_file"
+            echo "  Linked: $rel_path"
+        fi
+    done < <(find "$SOURCE" -name ".env.local" -type f -print0)
+}
+
+# Iterate through all vm* directories in VM0_WORKSPACES
+for dir in "$VM0_WORKSPACES"/vm*/; do
+    [[ ! -d "$dir" ]] && continue
+
+    # Skip the source directory itself
+    [[ "$(realpath "$dir")" == "$(realpath "$SOURCE")" ]] && continue
+
+    dir_name=$(basename "$dir")
+
+    if is_vm0_project "$dir"; then
+        echo "Syncing to $dir_name..."
+
+        # Sync .env.local files
+        sync_env_files "$dir"
+
+        # Sync .certs directory
+        if [[ -d "$SOURCE/.certs" ]]; then
+            rm -rf "$dir/.certs"
+            ln -sf "$SOURCE/.certs" "$dir/.certs"
+            echo "  Linked: .certs"
+        fi
+    fi
+done

--- a/bin/dcu
+++ b/bin/dcu
@@ -2,10 +2,9 @@
 
 set -eu
 
-# Argument provided, use it as workspace name
-workspace="$1"
 VM0_WORKSPACES="${VM0_WORKSPACES:-$HOME/workspaces}"
-FOLDER="$VM0_WORKSPACES/$workspace"
+FOLDER="$VM0_WORKSPACES/$1"
+
 (cd "$FOLDER" && git pull)
 npx @devcontainers/cli up --workspace-folder "$FOLDER" \
     --dotfiles-repository $VM0_DOTFILES \

--- a/bin/dcz
+++ b/bin/dcz
@@ -5,5 +5,4 @@ set -eu
 VM0_WORKSPACES="${VM0_WORKSPACES:-$HOME/workspaces}"
 FOLDER="$VM0_WORKSPACES/$1"
 
-# Check if ~/.devcontainer.env file exists and use it
 npx @devcontainers/cli exec --workspace-folder "$FOLDER" zsh


### PR DESCRIPTION
## Summary

- Adds `bin/dc-sync` utility script to sync `.env.local` files and `.certs` directory from a source vm0 workspace to other vm0 workspaces in the `VM0_WORKSPACES` directory
- Simplifies `bin/dcu` by removing redundant intermediate variable
- Cleans up `bin/dcz` by removing unnecessary comment

## Test plan

- [ ] Run `dc-sync` manually to verify it correctly syncs `.env.local` files
- [ ] Verify symlinks are created properly for both `.env.local` and `.certs`
- [ ] Test `dcu` and `dcz` commands still work as expected

:robot: Generated with [Claude Code](https://claude.com/claude-code)