### PR TITLE
fix(bin): use copy instead of symlinks in dc-sync

### DIFF
--- a/bin/dc-sync
+++ b/bin/dc-sync
@@ -28,8 +28,8 @@ sync_env_files() {
         dest_dir=$(dirname "$dest_file")
 
         if [[ -d "$dest_dir" ]]; then
-            ln -sf "$env_file" "$dest_file"
-            echo "  Linked: $rel_path"
+            cp "$env_file" "$dest_file"
+            echo "  Synced: $rel_path"
         fi
     done < <(find "$SOURCE" -name ".env.local" -type f -print0)
 }
@@ -52,8 +52,8 @@ for dir in "$VM0_WORKSPACES"/vm*/; do
         # Sync .certs directory
         if [[ -d "$SOURCE/.certs" ]]; then
             rm -rf "$dir/.certs"
-            ln -sf "$SOURCE/.certs" "$dir/.certs"
-            echo "  Linked: .certs"
+            cp -a "$SOURCE/.certs" "$dir/.certs"
+            echo "  Synced: .certs"
         fi
     fi
 done

--- a/bin/dc-sync
+++ b/bin/dc-sync
@@ -24,13 +24,10 @@ sync_env_files() {
     while IFS= read -r -d '' env_file; do
         local rel_path="${env_file#"$SOURCE/"}"
         local dest_file="$dest/$rel_path"
-        local dest_dir
-        dest_dir=$(dirname "$dest_file")
+        rm -rf "$dest_file"
+        cp -a "$env_file" "$dest_file"
+        echo "  Synced: $rel_path"
 
-        if [[ -d "$dest_dir" ]]; then
-            cp "$env_file" "$dest_file"
-            echo "  Synced: $rel_path"
-        fi
     done < <(find "$SOURCE" -name ".env.local" -type f -print0)
 }
 


### PR DESCRIPTION
## Summary

- Replace symbolic links with file copies in the dc-sync utility
- Use `cp` for .env.local files and `cp -a` for .certs directory
- Update log messages from "Linked" to "Synced"

## Rationale

Symlinks can cause issues in container and mount scenarios. Using copy ensures consistent behavior across different environments.

## Test plan

- [ ] Run `dc-sync` in a multi-workspace environment
- [ ] Verify .env.local files are properly copied
- [ ] Verify .certs directory is properly copied with permissions preserved

---
Generated with [Claude Code](https://claude.ai/code)