### PR TITLE
feat(platform): enhance log viewer with formatted cards and semantic colors

### DIFF
--- a/turbo/apps/platform/src/signals/logs-page/log-detail-state.ts
+++ b/turbo/apps/platform/src/signals/logs-page/log-detail-state.ts
@@ -1,4 +1,5 @@
 import { computed, state } from "ccstate";
+import { getHiddenByDefault } from "../../views/logs-page/constants/event-styles.ts";
 
 // Internal state for current log ID
 const internalCurrentLogId$ = state<string | null>(null);
@@ -6,11 +7,26 @@ const internalCurrentLogId$ = state<string | null>(null);
 // Internal state for search term
 const internalLogDetailSearchTerm$ = state("");
 
+// View mode: 'formatted' shows styled cards, 'raw' shows JSON
+export type ViewMode = "formatted" | "raw";
+const internalViewMode$ = state<ViewMode>("formatted");
+
+// Hidden event types (events that should not be displayed)
+const internalHiddenEventTypes$ = state<Set<string>>(
+  new Set(getHiddenByDefault()),
+);
+
 // Exported computed for read access
 export const currentLogId$ = computed((get) => get(internalCurrentLogId$));
 
 // Exported state-like interface for search term (needs read/write)
 export const logDetailSearchTerm$ = internalLogDetailSearchTerm$;
+
+// Exported view mode state
+export const viewMode$ = internalViewMode$;
+
+// Exported hidden event types state
+export const hiddenEventTypes$ = internalHiddenEventTypes$;
 
 // Export internal state for the page setup command to write to
 export const setCurrentLogId$ = internalCurrentLogId$;

--- a/turbo/apps/platform/src/views/logs-page/__tests__/log-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/logs-page/__tests__/log-detail-page.test.tsx
@@ -250,16 +250,13 @@ describe("log detail page", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Log raw data")).toBeInTheDocument();
+      expect(screen.getByText("Agent Events")).toBeInTheDocument();
     });
 
-    // Verify log content is displayed (formatted as log text)
+    // Verify the events are rendered (in formatted view)
     await waitFor(() => {
       expect(screen.getByText(/Starting task/)).toBeInTheDocument();
     });
-
-    // Verify tool_use event is displayed in log format
-    expect(screen.getByText(/\[tool_use\]/)).toBeInTheDocument();
   });
 
   it("should navigate to logs list via breadcrumb", async () => {

--- a/turbo/apps/platform/src/views/logs-page/__tests__/log-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/logs-page/__tests__/log-detail-page.test.tsx
@@ -16,8 +16,13 @@ function createDefaultAgentEventsResponse() {
     events: [
       {
         sequenceNumber: 1,
-        eventType: "text",
-        eventData: { content: "Hello" },
+        eventType: "assistant",
+        eventData: {
+          message: {
+            content: [{ type: "text", text: "Hello" }],
+            role: "assistant",
+          },
+        },
         createdAt: "2024-01-01T00:00:02Z",
       },
     ],
@@ -227,14 +232,31 @@ describe("log detail page", () => {
           events: [
             {
               sequenceNumber: 1,
-              eventType: "text",
-              eventData: { content: "Starting task" },
+              eventType: "assistant",
+              eventData: {
+                message: {
+                  content: [{ type: "text", text: "Starting task" }],
+                  role: "assistant",
+                },
+              },
               createdAt: "2024-01-01T00:00:02Z",
             },
             {
               sequenceNumber: 2,
-              eventType: "tool_use",
-              eventData: { tool: "read_file", path: "/test.txt" },
+              eventType: "assistant",
+              eventData: {
+                message: {
+                  content: [
+                    {
+                      type: "tool_use",
+                      id: "tool-1",
+                      name: "Read",
+                      input: { file_path: "/test.txt" },
+                    },
+                  ],
+                  role: "assistant",
+                },
+              },
               createdAt: "2024-01-01T00:00:03Z",
             },
           ],

--- a/turbo/apps/platform/src/views/logs-page/components/collapsible-json.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/collapsible-json.tsx
@@ -1,0 +1,137 @@
+import { CopyButton } from "@vm0/ui";
+import { IconChevronRight } from "@tabler/icons-react";
+
+interface CollapsibleJsonProps {
+  data: unknown;
+  label?: string;
+  defaultOpen?: boolean;
+  maxPreviewLength?: number;
+}
+
+function generatePreview(data: unknown, maxLength: number): string {
+  if (data === null || data === undefined) {
+    return String(data);
+  }
+
+  if (typeof data === "string") {
+    if (data.length > maxLength) {
+      return `"${data.slice(0, maxLength)}..."`;
+    }
+    return `"${data}"`;
+  }
+
+  if (typeof data !== "object") {
+    return String(data);
+  }
+
+  const json = JSON.stringify(data);
+  if (json.length <= maxLength) {
+    return json;
+  }
+
+  // For objects/arrays, show a truncated preview
+  if (Array.isArray(data)) {
+    return `[${data.length} items]`;
+  }
+
+  const keys = Object.keys(data);
+  if (keys.length === 0) {
+    return "{}";
+  }
+
+  // Show first key as preview
+  const firstKey = keys[0];
+  const firstValue = (data as Record<string, unknown>)[firstKey];
+  const valuePreview =
+    typeof firstValue === "string"
+      ? `"${firstValue.slice(0, 20)}${firstValue.length > 20 ? "..." : ""}"`
+      : typeof firstValue === "object"
+        ? Array.isArray(firstValue)
+          ? `[${firstValue.length}]`
+          : "{...}"
+        : String(firstValue);
+
+  return `{ ${firstKey}: ${valuePreview}${keys.length > 1 ? ", ..." : ""} }`;
+}
+
+function JsonSyntaxHighlight({ json }: { json: string }) {
+  // Simple syntax highlighting using regex
+  const highlighted = json
+    .replace(
+      /"([^"]+)":/g,
+      '<span class="text-purple-600 dark:text-purple-400">"$1"</span>:',
+    )
+    .replace(
+      /: "([^"]*)"/g,
+      ': <span class="text-green-600 dark:text-green-400">"$1"</span>',
+    )
+    .replace(
+      /: (\d+\.?\d*)/g,
+      ': <span class="text-blue-600 dark:text-blue-400">$1</span>',
+    )
+    .replace(
+      /: (true|false)/g,
+      ': <span class="text-amber-600 dark:text-amber-400">$1</span>',
+    )
+    .replace(
+      /: (null)/g,
+      ': <span class="text-gray-500 dark:text-gray-500">$1</span>',
+    );
+
+  return (
+    <code
+      className="text-sm"
+      dangerouslySetInnerHTML={{ __html: highlighted }}
+    />
+  );
+}
+
+export function CollapsibleJson({
+  data,
+  label,
+  defaultOpen = false,
+  maxPreviewLength = 60,
+}: CollapsibleJsonProps) {
+  const jsonString = JSON.stringify(data, null, 2);
+  const preview = generatePreview(data, maxPreviewLength);
+  const isSimple = jsonString.length < 100 && !jsonString.includes("\n");
+
+  // For simple values, just show inline without collapse
+  if (isSimple) {
+    return (
+      <div className="flex items-center gap-2 font-mono text-sm">
+        {label && (
+          <span className="text-muted-foreground shrink-0">{label}:</span>
+        )}
+        <JsonSyntaxHighlight json={jsonString} />
+        <CopyButton text={jsonString} className="h-4 w-4 shrink-0 opacity-50" />
+      </div>
+    );
+  }
+
+  return (
+    <details className="group" open={defaultOpen}>
+      <summary className="flex cursor-pointer list-none items-center gap-2 font-mono text-sm hover:bg-muted/50 rounded px-1 -mx-1">
+        <IconChevronRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
+        {label && (
+          <span className="text-muted-foreground shrink-0">{label}:</span>
+        )}
+        <span className="text-muted-foreground truncate group-open:hidden">
+          {preview}
+        </span>
+        <span className="text-muted-foreground hidden group-open:inline">
+          {Array.isArray(data) ? `[${(data as unknown[]).length} items]` : "{"}
+        </span>
+        <CopyButton
+          text={jsonString}
+          className="h-4 w-4 shrink-0 opacity-50 ml-auto"
+        />
+      </summary>
+      <div className="mt-2 overflow-x-auto rounded bg-muted/30 p-3 font-mono text-sm">
+        <pre className="whitespace-pre-wrap break-all">
+          <JsonSyntaxHighlight json={jsonString} />
+        </pre>
+      </div>
+    </details>
+  );
+}

--- a/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
@@ -1,0 +1,271 @@
+import { getEventStyle } from "../constants/event-styles.ts";
+import { CollapsibleJson } from "./collapsible-json.tsx";
+import type { AgentEvent } from "../../../signals/logs-page/types.ts";
+
+interface EventCardProps {
+  event: AgentEvent;
+  searchTerm?: string;
+}
+
+function formatEventTime(isoString: string): string {
+  const date = new Date(isoString);
+  const now = new Date();
+  const isToday = date.toDateString() === now.toDateString();
+
+  if (isToday) {
+    return date.toLocaleTimeString("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    });
+  }
+
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+function highlightText(
+  text: string,
+  searchTerm: string,
+): React.ReactNode | string {
+  if (!searchTerm.trim()) {
+    return text;
+  }
+
+  const escapedTerm = searchTerm.replace(
+    /[.*+?^${}()|[\]\\]/g,
+    String.raw`\$&`,
+  );
+  const parts = text.split(new RegExp(`(${escapedTerm})`, "gi"));
+
+  return parts.map((part) =>
+    part.toLowerCase() === searchTerm.toLowerCase() ? (
+      <mark
+        key={`${part}-${Math.random()}`}
+        className="bg-yellow-200 text-yellow-900 rounded px-0.5"
+      >
+        {part}
+      </mark>
+    ) : (
+      part
+    ),
+  );
+}
+
+function EventHeader({
+  event,
+  style,
+}: {
+  event: AgentEvent;
+  style: ReturnType<typeof getEventStyle>;
+}) {
+  const Icon = style.icon;
+  const eventData = event.eventData as Record<string, unknown>;
+
+  // Get tool name for tool_use events
+  const toolName =
+    event.eventType === "tool_use"
+      ? String(eventData.name ?? eventData.tool ?? "")
+      : "";
+
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <Icon className={`h-4 w-4 ${style.textColor}`} />
+      <span
+        className={`px-2 py-0.5 rounded-full text-xs font-medium ${style.badgeColor}`}
+      >
+        {style.label}
+      </span>
+      {toolName && (
+        <span className="font-medium text-foreground">{toolName}</span>
+      )}
+      <span className="text-muted-foreground ml-auto">
+        {formatEventTime(event.createdAt)}
+      </span>
+    </div>
+  );
+}
+
+function TextEventContent({
+  event,
+  searchTerm,
+}: {
+  event: AgentEvent;
+  searchTerm?: string;
+}) {
+  const eventData = event.eventData as Record<string, unknown>;
+  const content = String(eventData.content ?? "");
+
+  return (
+    <div className="mt-2 text-sm text-foreground whitespace-pre-wrap">
+      {searchTerm ? highlightText(content, searchTerm) : content}
+    </div>
+  );
+}
+
+function ToolUseEventContent({ event }: { event: AgentEvent }) {
+  const eventData = event.eventData as Record<string, unknown>;
+
+  return (
+    <div className="mt-2">
+      {eventData.input !== undefined && (
+        <CollapsibleJson data={eventData.input} label="Input" />
+      )}
+    </div>
+  );
+}
+
+function ToolResultEventContent({
+  event,
+  searchTerm,
+}: {
+  event: AgentEvent;
+  searchTerm?: string;
+}) {
+  const eventData = event.eventData as Record<string, unknown>;
+  const content = eventData.content;
+
+  if (typeof content === "string") {
+    // Text content - show with optional highlighting
+    const lines = content.split("\n");
+    const isLong = lines.length > 10 || content.length > 500;
+
+    if (isLong) {
+      return (
+        <details className="mt-2 group">
+          <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
+            Output ({lines.length} lines)
+          </summary>
+          <pre className="mt-2 text-sm whitespace-pre-wrap overflow-x-auto bg-muted/30 p-3 rounded max-h-96 overflow-y-auto">
+            {searchTerm ? highlightText(content, searchTerm) : content}
+          </pre>
+        </details>
+      );
+    }
+
+    return (
+      <pre className="mt-2 text-sm whitespace-pre-wrap overflow-x-auto">
+        {searchTerm ? highlightText(content, searchTerm) : content}
+      </pre>
+    );
+  }
+
+  // JSON content
+  return (
+    <div className="mt-2">
+      <CollapsibleJson data={content} label="Output" />
+    </div>
+  );
+}
+
+function ThinkingEventContent({
+  event,
+  searchTerm,
+}: {
+  event: AgentEvent;
+  searchTerm?: string;
+}) {
+  const eventData = event.eventData as Record<string, unknown>;
+  const content = String(eventData.content ?? "");
+
+  return (
+    <details className="mt-2 group">
+      <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground italic">
+        Thinking...
+      </summary>
+      <div className="mt-2 text-sm text-muted-foreground italic whitespace-pre-wrap">
+        {searchTerm ? highlightText(content, searchTerm) : content}
+      </div>
+    </details>
+  );
+}
+
+function InitEventContent({ event }: { event: AgentEvent }) {
+  const eventData = event.eventData as Record<string, unknown>;
+
+  return (
+    <div className="mt-2 space-y-1 text-sm">
+      {eventData.session !== null && eventData.session !== undefined && (
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground">Session:</span>
+          <code className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">
+            {String(eventData.session)}
+          </code>
+        </div>
+      )}
+      {eventData.model !== null && eventData.model !== undefined && (
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground">Model:</span>
+          <span className="font-medium">{String(eventData.model)}</span>
+        </div>
+      )}
+      {Array.isArray(eventData.tools) && eventData.tools.length > 0 && (
+        <details className="group">
+          <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+            Tools ({eventData.tools.length})
+          </summary>
+          <div className="mt-1 flex flex-wrap gap-1">
+            {(eventData.tools as unknown[]).map((tool) => (
+              <span
+                key={String(tool)}
+                className="text-xs bg-muted px-1.5 py-0.5 rounded"
+              >
+                {String(tool)}
+              </span>
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}
+
+function GenericEventContent({ event }: { event: AgentEvent }) {
+  return (
+    <div className="mt-2">
+      <CollapsibleJson data={event.eventData} />
+    </div>
+  );
+}
+
+export function EventCard({ event, searchTerm }: EventCardProps) {
+  const style = getEventStyle(event.eventType);
+
+  const renderContent = () => {
+    switch (event.eventType) {
+      case "text": {
+        return <TextEventContent event={event} searchTerm={searchTerm} />;
+      }
+      case "tool_use": {
+        return <ToolUseEventContent event={event} />;
+      }
+      case "tool_result": {
+        return <ToolResultEventContent event={event} searchTerm={searchTerm} />;
+      }
+      case "thinking": {
+        return <ThinkingEventContent event={event} searchTerm={searchTerm} />;
+      }
+      case "init": {
+        return <InitEventContent event={event} />;
+      }
+      default: {
+        return <GenericEventContent event={event} />;
+      }
+    }
+  };
+
+  return (
+    <div
+      className={`rounded-lg border-l-4 ${style.borderColor} ${style.bgColor} p-3`}
+    >
+      <EventHeader event={event} style={style} />
+      {renderContent()}
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
@@ -203,7 +203,7 @@ function SystemInitContent({ eventData }: { eventData: EventData }) {
             {tools.map((tool) => (
               <span
                 key={tool}
-                className="text-xs bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300 px-2 py-0.5 rounded-full"
+                className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full"
               >
                 {tool}
               </span>
@@ -222,7 +222,7 @@ function SystemInitContent({ eventData }: { eventData: EventData }) {
             {agents.map((agent) => (
               <span
                 key={agent}
-                className="text-xs bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300 px-2 py-0.5 rounded-full"
+                className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full"
               >
                 {agent}
               </span>
@@ -241,7 +241,7 @@ function SystemInitContent({ eventData }: { eventData: EventData }) {
             {slashCommands.map((cmd) => (
               <span
                 key={cmd}
-                className="text-xs bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 px-2 py-0.5 rounded-full font-mono"
+                className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-mono"
               >
                 /{cmd}
               </span>
@@ -308,12 +308,8 @@ function ToolUseContentView({ content }: { content: ToolUseContent }) {
     <div className="space-y-2">
       {/* Tool header */}
       <div className="flex items-center gap-2">
-        {ToolIcon && (
-          <ToolIcon className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-        )}
-        <span className="font-medium text-amber-700 dark:text-amber-300">
-          {toolName}
-        </span>
+        {ToolIcon && <ToolIcon className="h-4 w-4 text-muted-foreground" />}
+        <span className="font-medium text-foreground">{toolName}</span>
       </div>
 
       {/* Tool parameters */}
@@ -378,7 +374,7 @@ function ToolInputParams({
     return (
       <div className="flex items-start gap-2 text-sm">
         <IconTerminal className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
-        <code className="font-mono text-xs bg-gray-900 text-gray-100 dark:bg-gray-950 px-2 py-1 rounded block w-full overflow-x-auto whitespace-pre-wrap">
+        <code className="font-mono text-xs bg-foreground/90 text-background px-2 py-1 rounded block w-full overflow-x-auto whitespace-pre-wrap">
           {command}
         </code>
       </div>
@@ -434,8 +430,8 @@ function ParamValue({ value }: { value: unknown }) {
       <span
         className={
           value
-            ? "text-green-600 dark:text-green-400 text-xs"
-            : "text-red-600 dark:text-red-400 text-xs"
+            ? "text-emerald-600 dark:text-emerald-400 text-xs font-medium"
+            : "text-muted-foreground text-xs"
         }
       >
         {value ? "true" : "false"}
@@ -445,7 +441,9 @@ function ParamValue({ value }: { value: unknown }) {
 
   if (typeof value === "number") {
     return (
-      <span className="text-blue-600 dark:text-blue-400 text-xs">{value}</span>
+      <span className="text-violet-600 dark:text-violet-400 text-xs font-medium">
+        {value}
+      </span>
     );
   }
 
@@ -462,11 +460,7 @@ function ParamValue({ value }: { value: unknown }) {
         </details>
       );
     }
-    return (
-      <span className="text-green-700 dark:text-green-400 text-xs">
-        &quot;{value}&quot;
-      </span>
-    );
+    return <span className="text-foreground text-xs">&quot;{value}&quot;</span>;
   }
 
   if (Array.isArray(value) || typeof value === "object") {
@@ -493,12 +487,12 @@ function ToolResultContentView({
   // Error display
   if (isError) {
     return (
-      <div className="p-3 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 rounded text-sm">
-        <div className="flex items-center gap-2 text-red-700 dark:text-red-300 font-medium mb-2">
+      <div className="p-3 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900/50 rounded text-sm">
+        <div className="flex items-center gap-2 text-red-700 dark:text-red-400 font-medium mb-2">
           <IconAlertCircle className="h-4 w-4" />
           Error
         </div>
-        <pre className="whitespace-pre-wrap overflow-x-auto text-xs text-red-600 dark:text-red-400">
+        <pre className="whitespace-pre-wrap overflow-x-auto text-xs text-red-700 dark:text-red-400">
           {searchTerm ? highlightText(resultText, searchTerm) : resultText}
         </pre>
       </div>
@@ -578,7 +572,7 @@ function ResultContent({
     /^\s{2,}/m.test(text);
 
   const preClass = looksLikeCode
-    ? "bg-gray-900 text-gray-100 dark:bg-gray-950"
+    ? "bg-foreground/90 text-background"
     : "bg-muted/30 text-foreground";
 
   if (isLong) {
@@ -670,7 +664,7 @@ function ResultEventContent({ eventData }: { eventData: EventData }) {
                         <span>Out: {usage.outputTokens.toLocaleString()}</span>
                       )}
                     {usage.costUSD !== null && usage.costUSD !== undefined && (
-                      <span className="text-green-600 dark:text-green-400">
+                      <span className="text-emerald-600 dark:text-emerald-400 font-medium">
                         {formatCost(usage.costUSD)}
                       </span>
                     )}
@@ -685,7 +679,7 @@ function ResultEventContent({ eventData }: { eventData: EventData }) {
       {/* Result text */}
       {result && (
         <div
-          className={`p-3 rounded text-sm ${isError ? "bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-300" : "bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-300"}`}
+          className={`p-3 rounded text-sm ${isError ? "bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-400" : "bg-emerald-50 dark:bg-emerald-950/30 text-emerald-700 dark:text-emerald-400"}`}
         >
           <div className="font-medium mb-1">
             {isError ? "Error" : "Success"}

--- a/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
@@ -1,11 +1,92 @@
 import { getEventStyle } from "../constants/event-styles.ts";
 import { CollapsibleJson } from "./collapsible-json.tsx";
 import type { AgentEvent } from "../../../signals/logs-page/types.ts";
-import { IconFile, IconCode, IconTerminal } from "@tabler/icons-react";
+import {
+  IconFile,
+  IconTerminal,
+  IconWorld,
+  IconSearch,
+  IconClock,
+  IconCurrencyDollar,
+  IconAlertCircle,
+  IconArrowRight,
+} from "@tabler/icons-react";
 
 interface EventCardProps {
   event: AgentEvent;
   searchTerm?: string;
+}
+
+// Type definitions for message content
+interface TextContent {
+  type: "text";
+  text: string;
+}
+
+interface ToolUseContent {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+interface ToolResultContent {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string;
+  is_error?: boolean;
+}
+
+type MessageContent = TextContent | ToolUseContent | ToolResultContent;
+
+interface MessageData {
+  content: MessageContent[] | null;
+  id: string | null;
+  model: string | null;
+  role: string | null;
+  stop_reason: string | null;
+  usage?: {
+    input_tokens: number | null;
+    output_tokens: number | null;
+    cache_read_input_tokens: number | null;
+  };
+}
+
+interface ToolResultMeta {
+  bytes?: number | null;
+  code?: number | null;
+  codeText?: string | null;
+  durationMs?: number | null;
+  url?: string | null;
+  filePath?: string | null;
+  query?: string | null;
+  result?: string | null;
+}
+
+interface EventData {
+  type?: string;
+  subtype?: string;
+  message?: MessageData;
+  tool_use_result?: ToolResultMeta;
+  model?: string;
+  session_id?: string;
+  tools?: string[];
+  agents?: string[];
+  slash_commands?: string[];
+  total_cost_usd?: number | null;
+  duration_ms?: number | null;
+  duration_api_ms?: number | null;
+  num_turns?: number | null;
+  modelUsage?: Record<
+    string,
+    {
+      costUSD?: number | null;
+      inputTokens?: number | null;
+      outputTokens?: number | null;
+    }
+  >;
+  is_error?: boolean;
+  result?: string | null;
 }
 
 function formatEventTime(isoString: string): string {
@@ -59,61 +140,293 @@ function highlightText(
   );
 }
 
-function EventHeader({
-  event,
-  style,
-}: {
-  event: AgentEvent;
-  style: ReturnType<typeof getEventStyle>;
-}) {
-  const Icon = style.icon;
-  const eventData = event.eventData as Record<string, unknown>;
+function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  const seconds = ms / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(1)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}m ${remainingSeconds.toFixed(0)}s`;
+}
 
-  // Get tool name for tool_use events
-  const toolName =
-    event.eventType === "tool_use"
-      ? String(eventData.name ?? eventData.tool ?? "")
-      : "";
+function formatCost(usd: number): string {
+  if (usd < 0.01) {
+    return `$${usd.toFixed(4)}`;
+  }
+  return `$${usd.toFixed(2)}`;
+}
+
+// ============ SYSTEM EVENT (Init) ============
+
+function SystemInitContent({ eventData }: { eventData: EventData }) {
+  const tools = eventData.tools ?? [];
+  const agents = eventData.agents ?? [];
+  const slashCommands = eventData.slash_commands ?? [];
 
   return (
-    <div className="flex items-center gap-2 text-sm">
-      <Icon className={`h-4 w-4 ${style.textColor}`} />
-      <span
-        className={`px-2 py-0.5 rounded-full text-xs font-medium ${style.badgeColor}`}
-      >
-        {style.label}
-      </span>
-      {toolName && (
-        <span className="font-medium text-foreground">{toolName}</span>
+    <div className="mt-3 space-y-3">
+      {/* Model & Session */}
+      <div className="grid grid-cols-2 gap-4 text-sm">
+        {eventData.model && (
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground text-xs uppercase tracking-wide">
+              Model
+            </span>
+            <span className="font-medium text-foreground">
+              {eventData.model}
+            </span>
+          </div>
+        )}
+        {eventData.session_id && (
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground text-xs uppercase tracking-wide">
+              Session
+            </span>
+            <code className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded truncate max-w-[200px]">
+              {eventData.session_id}
+            </code>
+          </div>
+        )}
+      </div>
+
+      {/* Tools */}
+      {tools.length > 0 && (
+        <details className="group">
+          <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground uppercase tracking-wide">
+            {tools.length} Tools Available
+          </summary>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {tools.map((tool) => (
+              <span
+                key={tool}
+                className="text-xs bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300 px-2 py-0.5 rounded-full"
+              >
+                {tool}
+              </span>
+            ))}
+          </div>
+        </details>
       )}
-      <span className="text-muted-foreground ml-auto">
-        {formatEventTime(event.createdAt)}
-      </span>
+
+      {/* Agents */}
+      {agents.length > 0 && (
+        <details className="group">
+          <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground uppercase tracking-wide">
+            {agents.length} Agents
+          </summary>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {agents.map((agent) => (
+              <span
+                key={agent}
+                className="text-xs bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300 px-2 py-0.5 rounded-full"
+              >
+                {agent}
+              </span>
+            ))}
+          </div>
+        </details>
+      )}
+
+      {/* Slash Commands */}
+      {slashCommands.length > 0 && (
+        <details className="group">
+          <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground uppercase tracking-wide">
+            {slashCommands.length} Slash Commands
+          </summary>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {slashCommands.map((cmd) => (
+              <span
+                key={cmd}
+                className="text-xs bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 px-2 py-0.5 rounded-full font-mono"
+              >
+                /{cmd}
+              </span>
+            ))}
+          </div>
+        </details>
+      )}
     </div>
   );
 }
 
-function TextEventContent({
-  event,
+// ============ TEXT CONTENT ============
+
+function TextContentView({
+  content,
   searchTerm,
 }: {
-  event: AgentEvent;
+  content: TextContent;
   searchTerm?: string;
 }) {
-  const eventData = event.eventData as Record<string, unknown>;
-  const content = String(eventData.content ?? "");
+  const text = content.text;
+  if (!text) {
+    return null;
+  }
 
   return (
-    <div className="mt-2 text-sm text-foreground whitespace-pre-wrap">
-      {searchTerm ? highlightText(content, searchTerm) : content}
+    <div className="text-sm text-foreground whitespace-pre-wrap">
+      {searchTerm ? highlightText(text, searchTerm) : text}
     </div>
   );
 }
 
-/** Render a single parameter value in a user-friendly way */
-function ParameterValue({ value }: { value: unknown }) {
+// ============ TOOL USE CONTENT ============
+
+function getToolIcon(toolName: string) {
+  const name = toolName.toLowerCase();
+  if (name === "bash") {
+    return IconTerminal;
+  }
+  if (name === "webfetch") {
+    return IconWorld;
+  }
+  if (name === "websearch") {
+    return IconSearch;
+  }
+  if (
+    name.includes("read") ||
+    name.includes("write") ||
+    name.includes("edit") ||
+    name.includes("glob") ||
+    name.includes("grep")
+  ) {
+    return IconFile;
+  }
+  return null;
+}
+
+function ToolUseContentView({ content }: { content: ToolUseContent }) {
+  const toolName = content.name;
+  const input = content.input;
+  const ToolIcon = getToolIcon(toolName);
+
+  return (
+    <div className="space-y-2">
+      {/* Tool header */}
+      <div className="flex items-center gap-2">
+        {ToolIcon && (
+          <ToolIcon className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+        )}
+        <span className="font-medium text-amber-700 dark:text-amber-300">
+          {toolName}
+        </span>
+      </div>
+
+      {/* Tool parameters */}
+      <ToolInputParams input={input} toolName={toolName} />
+    </div>
+  );
+}
+
+function ToolInputParams({
+  input,
+  toolName,
+}: {
+  input: Record<string, unknown>;
+  toolName: string;
+}) {
+  if (!input || Object.keys(input).length === 0) {
+    return null;
+  }
+
+  // Special rendering for common tools
+  const lowerName = toolName.toLowerCase();
+
+  // WebFetch / WebSearch - show URL and prompt prominently
+  if (lowerName === "webfetch" || lowerName === "websearch") {
+    const url = input.url as string | undefined;
+    const prompt = input.prompt as string | undefined;
+    const query = input.query as string | undefined;
+
+    return (
+      <div className="space-y-2 text-sm">
+        {url && (
+          <div className="flex items-center gap-2">
+            <IconWorld className="h-4 w-4 text-muted-foreground shrink-0" />
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono text-xs text-blue-600 dark:text-blue-400 hover:underline break-all"
+            >
+              {url}
+            </a>
+          </div>
+        )}
+        {query && (
+          <div className="flex items-start gap-2">
+            <IconSearch className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
+            <span className="text-foreground">{query}</span>
+          </div>
+        )}
+        {prompt && (
+          <div className="text-muted-foreground text-xs mt-1 pl-6">
+            {prompt}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Bash - show command
+  if (lowerName === "bash") {
+    const command = input.command as string | undefined;
+    return (
+      <div className="flex items-start gap-2 text-sm">
+        <IconTerminal className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
+        <code className="font-mono text-xs bg-gray-900 text-gray-100 dark:bg-gray-950 px-2 py-1 rounded block w-full overflow-x-auto whitespace-pre-wrap">
+          {command}
+        </code>
+      </div>
+    );
+  }
+
+  // File operations - show file path
+  if (
+    lowerName === "read" ||
+    lowerName === "write" ||
+    lowerName === "edit" ||
+    lowerName === "glob" ||
+    lowerName === "grep"
+  ) {
+    const filePath = (input.file_path ?? input.path ?? input.pattern) as
+      | string
+      | undefined;
+    return (
+      <div className="flex items-center gap-2 text-sm">
+        <IconFile className="h-4 w-4 text-muted-foreground shrink-0" />
+        <code className="font-mono text-xs bg-muted px-2 py-1 rounded">
+          {filePath}
+        </code>
+      </div>
+    );
+  }
+
+  // Generic: show all parameters as key-value pairs
+  const entries = Object.entries(input);
+  return (
+    <div className="space-y-1.5 text-sm">
+      {entries.map(([key, val]) => (
+        <div key={key} className="flex items-start gap-2">
+          <span className="text-muted-foreground shrink-0 min-w-[80px] text-xs">
+            {key}:
+          </span>
+          <div className="min-w-0 flex-1">
+            <ParamValue value={val} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ParamValue({ value }: { value: unknown }) {
   if (value === null || value === undefined) {
-    return <span className="text-muted-foreground italic">null</span>;
+    return <span className="text-muted-foreground italic text-xs">null</span>;
   }
 
   if (typeof value === "boolean") {
@@ -121,8 +434,8 @@ function ParameterValue({ value }: { value: unknown }) {
       <span
         className={
           value
-            ? "text-green-600 dark:text-green-400"
-            : "text-red-600 dark:text-red-400"
+            ? "text-green-600 dark:text-green-400 text-xs"
+            : "text-red-600 dark:text-red-400 text-xs"
         }
       >
         {value ? "true" : "false"}
@@ -131,223 +444,153 @@ function ParameterValue({ value }: { value: unknown }) {
   }
 
   if (typeof value === "number") {
-    return <span className="text-blue-600 dark:text-blue-400">{value}</span>;
+    return (
+      <span className="text-blue-600 dark:text-blue-400 text-xs">{value}</span>
+    );
   }
 
   if (typeof value === "string") {
-    // Check if it looks like a file path
-    if (value.startsWith("/") || value.includes("/")) {
-      return (
-        <span className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded inline-flex items-center gap-1">
-          <IconFile className="h-3 w-3 text-muted-foreground" />
-          {value}
-        </span>
-      );
-    }
-
-    // Check if it's a multi-line string (likely code or content)
-    if (value.includes("\n")) {
-      const lines = value.split("\n");
-      if (lines.length > 5) {
-        return (
-          <details className="group">
-            <summary className="cursor-pointer text-muted-foreground hover:text-foreground text-xs">
-              {lines.length} lines
-            </summary>
-            <pre className="mt-1 text-xs bg-muted/50 p-2 rounded overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap">
-              {value}
-            </pre>
-          </details>
-        );
-      }
-      return (
-        <pre className="text-xs bg-muted/50 p-2 rounded overflow-x-auto whitespace-pre-wrap">
-          {value}
-        </pre>
-      );
-    }
-
-    // Regular string
     if (value.length > 100) {
       return (
         <details className="group inline">
-          <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+          <summary className="cursor-pointer text-muted-foreground hover:text-foreground text-xs">
             &quot;{value.slice(0, 50)}...&quot;
           </summary>
-          <div className="mt-1 text-xs bg-muted/50 p-2 rounded">{value}</div>
+          <div className="mt-1 text-xs bg-muted/50 p-2 rounded whitespace-pre-wrap">
+            {value}
+          </div>
         </details>
       );
     }
-
     return (
-      <span className="text-green-700 dark:text-green-400">
+      <span className="text-green-700 dark:text-green-400 text-xs">
         &quot;{value}&quot;
       </span>
     );
   }
 
-  if (Array.isArray(value)) {
-    if (value.length === 0) {
-      return <span className="text-muted-foreground">[]</span>;
-    }
+  if (Array.isArray(value) || typeof value === "object") {
     return <CollapsibleJson data={value} />;
   }
 
-  if (typeof value === "object") {
-    return <CollapsibleJson data={value} />;
-  }
-
-  return <span>{String(value)}</span>;
+  return <span className="text-xs">{String(value)}</span>;
 }
 
-/** Render tool input parameters as labeled key-value pairs */
-function ToolParameters({ input }: { input: unknown }) {
-  if (input === null || input === undefined) {
-    return null;
-  }
+// ============ TOOL RESULT CONTENT ============
 
-  // If input is not an object, show it directly
-  if (typeof input !== "object" || Array.isArray(input)) {
+function ToolResultContentView({
+  content,
+  toolMeta,
+  searchTerm,
+}: {
+  content: ToolResultContent;
+  toolMeta?: ToolResultMeta;
+  searchTerm?: string;
+}) {
+  const isError = content.is_error === true;
+  const resultText = content.content;
+
+  // Error display
+  if (isError) {
     return (
-      <div className="mt-2">
-        <CollapsibleJson data={input} label="Input" />
-      </div>
-    );
-  }
-
-  const params = input as Record<string, unknown>;
-  const entries = Object.entries(params);
-
-  if (entries.length === 0) {
-    return null;
-  }
-
-  // Special case: if there's only a file_path or path, show it prominently
-  if (entries.length === 1 && (params.file_path || params.path)) {
-    const path = String(params.file_path ?? params.path);
-    return (
-      <div className="mt-2 flex items-center gap-2 text-sm">
-        <IconFile className="h-4 w-4 text-muted-foreground shrink-0" />
-        <code className="font-mono text-xs bg-muted px-2 py-1 rounded">
-          {path}
-        </code>
-      </div>
-    );
-  }
-
-  // Special case: if there's a command, show it like a terminal
-  if (params.command) {
-    return (
-      <div className="mt-2 space-y-2">
-        <div className="flex items-start gap-2 text-sm">
-          <IconTerminal className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
-          <code className="font-mono text-xs bg-muted px-2 py-1 rounded block w-full overflow-x-auto">
-            {String(params.command)}
-          </code>
+      <div className="p-3 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 rounded text-sm">
+        <div className="flex items-center gap-2 text-red-700 dark:text-red-300 font-medium mb-2">
+          <IconAlertCircle className="h-4 w-4" />
+          Error
         </div>
-        {entries.length > 1 && (
-          <details className="text-xs">
-            <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
-              Other parameters ({entries.length - 1})
-            </summary>
-            <div className="mt-1 space-y-1 pl-6">
-              {entries
-                .filter(([key]) => key !== "command")
-                .map(([key, val]) => (
-                  <div key={key} className="flex items-start gap-2">
-                    <span className="text-muted-foreground shrink-0">
-                      {key}:
-                    </span>
-                    <ParameterValue value={val} />
-                  </div>
-                ))}
-            </div>
-          </details>
-        )}
+        <pre className="whitespace-pre-wrap overflow-x-auto text-xs text-red-600 dark:text-red-400">
+          {searchTerm ? highlightText(resultText, searchTerm) : resultText}
+        </pre>
       </div>
     );
   }
 
-  // General case: show all parameters
+  // Tool metadata (bytes, duration, etc.)
+  const metaItems: { label: string; value: string }[] = [];
+  if (toolMeta?.url) {
+    metaItems.push({ label: "URL", value: toolMeta.url });
+  }
+  if (toolMeta?.code !== null && toolMeta?.code !== undefined) {
+    metaItems.push({
+      label: "Status",
+      value: `${toolMeta.code} ${toolMeta.codeText ?? ""}`,
+    });
+  }
+  if (toolMeta?.durationMs !== null && toolMeta?.durationMs !== undefined) {
+    metaItems.push({
+      label: "Duration",
+      value: formatDuration(toolMeta.durationMs),
+    });
+  }
+  if (toolMeta?.bytes !== null && toolMeta?.bytes !== undefined) {
+    metaItems.push({
+      label: "Size",
+      value: `${(toolMeta.bytes / 1024).toFixed(1)} KB`,
+    });
+  }
+
   return (
-    <div className="mt-2 space-y-1.5 text-sm">
-      {entries.map(([key, val]) => (
-        <div key={key} className="flex items-start gap-2">
-          <span className="text-muted-foreground shrink-0 min-w-[80px]">
-            {key}:
-          </span>
-          <div className="min-w-0 flex-1">
-            <ParameterValue value={val} />
-          </div>
+    <div className="space-y-2">
+      {/* Metadata badges */}
+      {metaItems.length > 0 && (
+        <div className="flex flex-wrap gap-2 text-xs">
+          {metaItems.map((item) => (
+            <span
+              key={item.label}
+              className="bg-muted px-2 py-0.5 rounded text-muted-foreground"
+            >
+              {item.label}:{" "}
+              <span className="text-foreground">{item.value}</span>
+            </span>
+          ))}
         </div>
-      ))}
+      )}
+
+      {/* Result content */}
+      <ResultContent text={resultText} searchTerm={searchTerm} />
     </div>
   );
 }
 
-function ToolUseEventContent({ event }: { event: AgentEvent }) {
-  const eventData = event.eventData as Record<string, unknown>;
+function ResultContent({
+  text,
+  searchTerm,
+}: {
+  text: string;
+  searchTerm?: string;
+}) {
+  if (!text || text.trim() === "") {
+    return (
+      <div className="text-sm text-muted-foreground italic">(empty output)</div>
+    );
+  }
 
-  return <ToolParameters input={eventData.input} />;
-}
+  const lines = text.split("\n");
+  const isLong = lines.length > 10 || text.length > 500;
 
-/** Check if text looks like code */
-function looksLikeCode(text: string): boolean {
-  return (
+  // Check if it looks like code
+  const looksLikeCode =
     text.includes("function ") ||
     text.includes("const ") ||
     text.includes("import ") ||
     text.includes("class ") ||
-    /^\s{2,}/m.test(text)
-  );
-}
+    text.includes("```") ||
+    /^\s{2,}/m.test(text);
 
-/** Render error content for tool results */
-function ToolResultError({
-  content,
-  searchTerm,
-}: {
-  content: unknown;
-  searchTerm?: string;
-}) {
-  const errorText =
-    typeof content === "string" ? content : JSON.stringify(content, null, 2);
-  return (
-    <div className="mt-2 p-2 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 rounded text-sm text-red-700 dark:text-red-300">
-      <div className="font-medium mb-1">Error</div>
-      <pre className="whitespace-pre-wrap overflow-x-auto text-xs">
-        {searchTerm ? highlightText(errorText, searchTerm) : errorText}
-      </pre>
-    </div>
-  );
-}
-
-/** Render string content for tool results */
-function ToolResultString({
-  content,
-  searchTerm,
-}: {
-  content: string;
-  searchTerm?: string;
-}) {
-  const lines = content.split("\n");
-  const isLong = lines.length > 8 || content.length > 400;
-  const isCode = looksLikeCode(content);
-  const codeStyle = isCode
+  const preClass = looksLikeCode
     ? "bg-gray-900 text-gray-100 dark:bg-gray-950"
-    : "bg-muted/30";
+    : "bg-muted/30 text-foreground";
 
   if (isLong) {
     return (
-      <details className="mt-2 group" open={lines.length <= 15}>
-        <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground flex items-center gap-2">
-          <IconCode className="h-3 w-3" />
-          <span>Output ({lines.length} lines)</span>
+      <details className="group" open={lines.length <= 15}>
+        <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
+          Output ({lines.length} lines)
         </summary>
         <pre
-          className={`mt-2 text-xs whitespace-pre-wrap overflow-x-auto p-3 rounded max-h-80 overflow-y-auto ${codeStyle}`}
+          className={`mt-2 text-xs whitespace-pre-wrap overflow-x-auto p-3 rounded max-h-80 overflow-y-auto ${preClass}`}
         >
-          {searchTerm ? highlightText(content, searchTerm) : content}
+          {searchTerm ? highlightText(text, searchTerm) : text}
         </pre>
       </details>
     );
@@ -355,200 +598,264 @@ function ToolResultString({
 
   return (
     <pre
-      className={`mt-2 text-xs whitespace-pre-wrap overflow-x-auto p-2 rounded ${codeStyle}`}
+      className={`text-xs whitespace-pre-wrap overflow-x-auto p-2 rounded ${preClass}`}
     >
-      {searchTerm ? highlightText(content, searchTerm) : content}
+      {searchTerm ? highlightText(text, searchTerm) : text}
     </pre>
   );
 }
 
-/** Render array content blocks for tool results */
-function ToolResultArray({
-  content,
-  searchTerm,
-}: {
-  content: unknown[];
-  searchTerm?: string;
-}) {
+// ============ RESULT EVENT (Final stats) ============
+
+function ResultEventContent({ eventData }: { eventData: EventData }) {
+  const isError = eventData.is_error === true;
+  const totalCost = eventData.total_cost_usd;
+  const durationMs = eventData.duration_ms;
+  const numTurns = eventData.num_turns;
+  const modelUsage = eventData.modelUsage;
+  const result = eventData.result;
+
   return (
-    <div className="mt-2 space-y-2">
-      {content.map((item) => {
-        if (typeof item === "object" && item !== null) {
-          const obj = item as Record<string, unknown>;
-          if (obj.type === "text" && typeof obj.text === "string") {
-            const textKey = `text-${String(obj.text).slice(0, 50)}`;
-            return (
-              <div key={textKey} className="text-sm whitespace-pre-wrap">
-                {searchTerm ? highlightText(obj.text, searchTerm) : obj.text}
-              </div>
-            );
-          }
-        }
-        const itemKey = `item-${JSON.stringify(item).slice(0, 50)}`;
-        return (
-          <div key={itemKey}>
-            <CollapsibleJson data={item} />
+    <div className="mt-3 space-y-3">
+      {/* Summary stats */}
+      <div className="flex flex-wrap gap-4 text-sm">
+        {durationMs !== null && durationMs !== undefined && (
+          <div className="flex items-center gap-1.5">
+            <IconClock className="h-4 w-4 text-muted-foreground" />
+            <span className="text-foreground">
+              {formatDuration(durationMs)}
+            </span>
           </div>
-        );
-      })}
-    </div>
-  );
-}
-
-function ToolResultEventContent({
-  event,
-  searchTerm,
-}: {
-  event: AgentEvent;
-  searchTerm?: string;
-}) {
-  const eventData = event.eventData as Record<string, unknown>;
-  const content = eventData.content;
-  const isError = eventData.is_error === true || eventData.isError === true;
-
-  if (isError) {
-    return <ToolResultError content={content} searchTerm={searchTerm} />;
-  }
-
-  if (typeof content === "string") {
-    if (content.trim() === "") {
-      return (
-        <div className="mt-2 text-sm text-muted-foreground italic">
-          (empty output)
-        </div>
-      );
-    }
-    return <ToolResultString content={content} searchTerm={searchTerm} />;
-  }
-
-  if (Array.isArray(content)) {
-    return <ToolResultArray content={content} searchTerm={searchTerm} />;
-  }
-
-  if (content !== null && content !== undefined) {
-    return (
-      <div className="mt-2">
-        <CollapsibleJson data={content} label="Output" />
+        )}
+        {totalCost !== null && totalCost !== undefined && (
+          <div className="flex items-center gap-1.5">
+            <IconCurrencyDollar className="h-4 w-4 text-muted-foreground" />
+            <span className="text-foreground">{formatCost(totalCost)}</span>
+          </div>
+        )}
+        {numTurns !== null && numTurns !== undefined && (
+          <div className="flex items-center gap-1.5">
+            <IconArrowRight className="h-4 w-4 text-muted-foreground" />
+            <span className="text-foreground">{numTurns} turns</span>
+          </div>
+        )}
       </div>
-    );
-  }
 
-  return (
-    <div className="mt-2 text-sm text-muted-foreground italic">(no output)</div>
-  );
-}
-
-function ThinkingEventContent({
-  event,
-  searchTerm,
-}: {
-  event: AgentEvent;
-  searchTerm?: string;
-}) {
-  const eventData = event.eventData as Record<string, unknown>;
-  const content = String(eventData.content ?? "");
-
-  return (
-    <details className="mt-2 group">
-      <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground italic">
-        Thinking...
-      </summary>
-      <div className="mt-2 text-sm text-muted-foreground italic whitespace-pre-wrap">
-        {searchTerm ? highlightText(content, searchTerm) : content}
-      </div>
-    </details>
-  );
-}
-
-function InitEventContent({ event }: { event: AgentEvent }) {
-  const eventData = event.eventData as Record<string, unknown>;
-  const tools = Array.isArray(eventData.tools) ? eventData.tools : [];
-
-  return (
-    <div className="mt-3 grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
-      {eventData.model !== null && eventData.model !== undefined && (
-        <div className="flex items-center gap-2">
-          <span className="text-muted-foreground text-xs uppercase tracking-wide">
-            Model
-          </span>
-          <span className="font-medium text-foreground">
-            {String(eventData.model)}
-          </span>
-        </div>
-      )}
-      {eventData.session !== null && eventData.session !== undefined && (
-        <div className="flex items-center gap-2">
-          <span className="text-muted-foreground text-xs uppercase tracking-wide">
-            Session
-          </span>
-          <code className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded truncate max-w-[200px]">
-            {String(eventData.session)}
-          </code>
-        </div>
-      )}
-      {tools.length > 0 && (
-        <div className="col-span-2 mt-1">
-          <details className="group">
-            <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground uppercase tracking-wide">
-              {tools.length} Tools Available
-            </summary>
-            <div className="mt-2 flex flex-wrap gap-1.5">
-              {(tools as unknown[]).map((tool) => (
-                <span
-                  key={String(tool)}
-                  className="text-xs bg-muted/70 text-muted-foreground px-2 py-0.5 rounded-full"
+      {/* Model usage breakdown */}
+      {modelUsage && Object.keys(modelUsage).length > 0 && (
+        <details className="group">
+          <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground uppercase tracking-wide">
+            Model Usage
+          </summary>
+          <div className="mt-2 space-y-2">
+            {Object.entries(modelUsage).map(([model, usage]) => {
+              if (!usage.inputTokens && !usage.outputTokens) {
+                return null;
+              }
+              return (
+                <div
+                  key={model}
+                  className="flex items-center justify-between text-xs bg-muted/50 p-2 rounded"
                 >
-                  {String(tool)}
-                </span>
-              ))}
-            </div>
-          </details>
+                  <span className="font-mono text-muted-foreground">
+                    {model}
+                  </span>
+                  <div className="flex gap-3">
+                    {usage.inputTokens !== null &&
+                      usage.inputTokens !== undefined && (
+                        <span>In: {usage.inputTokens.toLocaleString()}</span>
+                      )}
+                    {usage.outputTokens !== null &&
+                      usage.outputTokens !== undefined && (
+                        <span>Out: {usage.outputTokens.toLocaleString()}</span>
+                      )}
+                    {usage.costUSD !== null && usage.costUSD !== undefined && (
+                      <span className="text-green-600 dark:text-green-400">
+                        {formatCost(usage.costUSD)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </details>
+      )}
+
+      {/* Result text */}
+      {result && (
+        <div
+          className={`p-3 rounded text-sm ${isError ? "bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-300" : "bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-300"}`}
+        >
+          <div className="font-medium mb-1">
+            {isError ? "Error" : "Success"}
+          </div>
+          <div className="whitespace-pre-wrap">{result}</div>
         </div>
       )}
     </div>
   );
 }
 
-function GenericEventContent({ event }: { event: AgentEvent }) {
+// ============ MAIN EVENT CARD ============
+
+function EventHeader({
+  event,
+  label,
+  sublabel,
+}: {
+  event: AgentEvent;
+  label: string;
+  sublabel?: string;
+}) {
+  const style = getEventStyle(event.eventType);
+  const Icon = style.icon;
+
   return (
-    <div className="mt-2">
-      <CollapsibleJson data={event.eventData} />
+    <div className="flex items-center gap-2 text-sm">
+      <Icon className={`h-4 w-4 ${style.textColor}`} />
+      <span
+        className={`px-2 py-0.5 rounded-full text-xs font-medium ${style.badgeColor}`}
+      >
+        {label}
+      </span>
+      {sublabel && (
+        <span className="font-medium text-foreground">{sublabel}</span>
+      )}
+      <span className="text-muted-foreground ml-auto">
+        {formatEventTime(event.createdAt)}
+      </span>
     </div>
   );
 }
 
 export function EventCard({ event, searchTerm }: EventCardProps) {
+  const eventData = event.eventData as EventData;
   const style = getEventStyle(event.eventType);
 
-  const renderContent = () => {
-    switch (event.eventType) {
-      case "text": {
-        return <TextEventContent event={event} searchTerm={searchTerm} />;
-      }
-      case "tool_use": {
-        return <ToolUseEventContent event={event} />;
-      }
-      case "tool_result": {
-        return <ToolResultEventContent event={event} searchTerm={searchTerm} />;
-      }
-      case "thinking": {
-        return <ThinkingEventContent event={event} searchTerm={searchTerm} />;
-      }
-      case "init": {
-        return <InitEventContent event={event} />;
-      }
-      default: {
-        return <GenericEventContent event={event} />;
-      }
-    }
-  };
+  // System event (init)
+  if (event.eventType === "system") {
+    const subtype = eventData.subtype;
+    return (
+      <div
+        className={`rounded-lg border-l-4 ${style.borderColor} ${style.bgColor} p-3`}
+      >
+        <EventHeader
+          event={event}
+          label="System"
+          sublabel={subtype === "init" ? "Initialize" : subtype}
+        />
+        {subtype === "init" && <SystemInitContent eventData={eventData} />}
+        {subtype !== "init" && eventData.message?.content === null && (
+          <div className="mt-2">
+            <CollapsibleJson data={eventData} label="Event Data" />
+          </div>
+        )}
+      </div>
+    );
+  }
 
+  // Result event (final stats)
+  if (event.eventType === "result") {
+    const subtype = eventData.subtype;
+    const isError = eventData.is_error === true || subtype === "error";
+    const resultStyle = isError ? getEventStyle("tool_result_error") : style;
+    return (
+      <div
+        className={`rounded-lg border-l-4 ${resultStyle.borderColor} ${resultStyle.bgColor} p-3`}
+      >
+        <EventHeader event={event} label={isError ? "Failed" : "Completed"} />
+        <ResultEventContent eventData={eventData} />
+      </div>
+    );
+  }
+
+  // Assistant or User event - render message.content array
+  const message = eventData.message;
+  const contents = message?.content;
+
+  if (!contents || !Array.isArray(contents) || contents.length === 0) {
+    // Fallback: show raw data
+    return (
+      <div
+        className={`rounded-lg border-l-4 ${style.borderColor} ${style.bgColor} p-3`}
+      >
+        <EventHeader event={event} label={event.eventType} />
+        <div className="mt-2">
+          <CollapsibleJson data={eventData} label="Event Data" />
+        </div>
+      </div>
+    );
+  }
+
+  // Render each content block
   return (
     <div
-      className={`rounded-lg border-l-4 ${style.borderColor} ${style.bgColor} p-3`}
+      className={`rounded-lg border-l-4 ${style.borderColor} ${style.bgColor} p-3 space-y-3`}
     >
-      <EventHeader event={event} style={style} />
-      {renderContent()}
+      <EventHeader
+        event={event}
+        label={event.eventType === "assistant" ? "Assistant" : "User"}
+      />
+
+      {contents.map((content) => {
+        const contentKey = `${event.sequenceNumber}-${content.type}-${(content as ToolUseContent).id ?? (content as ToolResultContent).tool_use_id ?? Math.random()}`;
+
+        if (content.type === "text") {
+          return (
+            <div key={contentKey}>
+              <TextContentView
+                content={content as TextContent}
+                searchTerm={searchTerm}
+              />
+            </div>
+          );
+        }
+
+        if (content.type === "tool_use") {
+          const toolContent = content as ToolUseContent;
+          const toolStyle = getEventStyle("tool_use");
+          return (
+            <div
+              key={contentKey}
+              className={`rounded border-l-2 ${toolStyle.borderColor} ${toolStyle.bgColor} p-2`}
+            >
+              <ToolUseContentView content={toolContent} />
+            </div>
+          );
+        }
+
+        if (content.type === "tool_result") {
+          const resultContent = content as ToolResultContent;
+          const isError = resultContent.is_error === true;
+          const resultStyle = getEventStyle(
+            isError ? "tool_result_error" : "tool_result",
+          );
+          return (
+            <div
+              key={contentKey}
+              className={`rounded border-l-2 ${resultStyle.borderColor} ${resultStyle.bgColor} p-2`}
+            >
+              <ToolResultContentView
+                content={resultContent}
+                toolMeta={eventData.tool_use_result ?? undefined}
+                searchTerm={searchTerm}
+              />
+            </div>
+          );
+        }
+
+        // Unknown content type - show as JSON
+        const unknownContent = content as Record<string, unknown>;
+        return (
+          <div key={contentKey} className="mt-2">
+            <CollapsibleJson
+              data={unknownContent}
+              label={`Unknown: ${String(unknownContent.type ?? "content")}`}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
@@ -1,6 +1,7 @@
 import { getEventStyle } from "../constants/event-styles.ts";
 import { CollapsibleJson } from "./collapsible-json.tsx";
 import type { AgentEvent } from "../../../signals/logs-page/types.ts";
+import { IconFile, IconCode, IconTerminal } from "@tabler/icons-react";
 
 interface EventCardProps {
   event: AgentEvent;
@@ -109,14 +110,287 @@ function TextEventContent({
   );
 }
 
+/** Render a single parameter value in a user-friendly way */
+function ParameterValue({ value }: { value: unknown }) {
+  if (value === null || value === undefined) {
+    return <span className="text-muted-foreground italic">null</span>;
+  }
+
+  if (typeof value === "boolean") {
+    return (
+      <span
+        className={
+          value
+            ? "text-green-600 dark:text-green-400"
+            : "text-red-600 dark:text-red-400"
+        }
+      >
+        {value ? "true" : "false"}
+      </span>
+    );
+  }
+
+  if (typeof value === "number") {
+    return <span className="text-blue-600 dark:text-blue-400">{value}</span>;
+  }
+
+  if (typeof value === "string") {
+    // Check if it looks like a file path
+    if (value.startsWith("/") || value.includes("/")) {
+      return (
+        <span className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded inline-flex items-center gap-1">
+          <IconFile className="h-3 w-3 text-muted-foreground" />
+          {value}
+        </span>
+      );
+    }
+
+    // Check if it's a multi-line string (likely code or content)
+    if (value.includes("\n")) {
+      const lines = value.split("\n");
+      if (lines.length > 5) {
+        return (
+          <details className="group">
+            <summary className="cursor-pointer text-muted-foreground hover:text-foreground text-xs">
+              {lines.length} lines
+            </summary>
+            <pre className="mt-1 text-xs bg-muted/50 p-2 rounded overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap">
+              {value}
+            </pre>
+          </details>
+        );
+      }
+      return (
+        <pre className="text-xs bg-muted/50 p-2 rounded overflow-x-auto whitespace-pre-wrap">
+          {value}
+        </pre>
+      );
+    }
+
+    // Regular string
+    if (value.length > 100) {
+      return (
+        <details className="group inline">
+          <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+            &quot;{value.slice(0, 50)}...&quot;
+          </summary>
+          <div className="mt-1 text-xs bg-muted/50 p-2 rounded">{value}</div>
+        </details>
+      );
+    }
+
+    return (
+      <span className="text-green-700 dark:text-green-400">
+        &quot;{value}&quot;
+      </span>
+    );
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return <span className="text-muted-foreground">[]</span>;
+    }
+    return <CollapsibleJson data={value} />;
+  }
+
+  if (typeof value === "object") {
+    return <CollapsibleJson data={value} />;
+  }
+
+  return <span>{String(value)}</span>;
+}
+
+/** Render tool input parameters as labeled key-value pairs */
+function ToolParameters({ input }: { input: unknown }) {
+  if (input === null || input === undefined) {
+    return null;
+  }
+
+  // If input is not an object, show it directly
+  if (typeof input !== "object" || Array.isArray(input)) {
+    return (
+      <div className="mt-2">
+        <CollapsibleJson data={input} label="Input" />
+      </div>
+    );
+  }
+
+  const params = input as Record<string, unknown>;
+  const entries = Object.entries(params);
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  // Special case: if there's only a file_path or path, show it prominently
+  if (entries.length === 1 && (params.file_path || params.path)) {
+    const path = String(params.file_path ?? params.path);
+    return (
+      <div className="mt-2 flex items-center gap-2 text-sm">
+        <IconFile className="h-4 w-4 text-muted-foreground shrink-0" />
+        <code className="font-mono text-xs bg-muted px-2 py-1 rounded">
+          {path}
+        </code>
+      </div>
+    );
+  }
+
+  // Special case: if there's a command, show it like a terminal
+  if (params.command) {
+    return (
+      <div className="mt-2 space-y-2">
+        <div className="flex items-start gap-2 text-sm">
+          <IconTerminal className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
+          <code className="font-mono text-xs bg-muted px-2 py-1 rounded block w-full overflow-x-auto">
+            {String(params.command)}
+          </code>
+        </div>
+        {entries.length > 1 && (
+          <details className="text-xs">
+            <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+              Other parameters ({entries.length - 1})
+            </summary>
+            <div className="mt-1 space-y-1 pl-6">
+              {entries
+                .filter(([key]) => key !== "command")
+                .map(([key, val]) => (
+                  <div key={key} className="flex items-start gap-2">
+                    <span className="text-muted-foreground shrink-0">
+                      {key}:
+                    </span>
+                    <ParameterValue value={val} />
+                  </div>
+                ))}
+            </div>
+          </details>
+        )}
+      </div>
+    );
+  }
+
+  // General case: show all parameters
+  return (
+    <div className="mt-2 space-y-1.5 text-sm">
+      {entries.map(([key, val]) => (
+        <div key={key} className="flex items-start gap-2">
+          <span className="text-muted-foreground shrink-0 min-w-[80px]">
+            {key}:
+          </span>
+          <div className="min-w-0 flex-1">
+            <ParameterValue value={val} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function ToolUseEventContent({ event }: { event: AgentEvent }) {
   const eventData = event.eventData as Record<string, unknown>;
 
+  return <ToolParameters input={eventData.input} />;
+}
+
+/** Check if text looks like code */
+function looksLikeCode(text: string): boolean {
   return (
-    <div className="mt-2">
-      {eventData.input !== undefined && (
-        <CollapsibleJson data={eventData.input} label="Input" />
-      )}
+    text.includes("function ") ||
+    text.includes("const ") ||
+    text.includes("import ") ||
+    text.includes("class ") ||
+    /^\s{2,}/m.test(text)
+  );
+}
+
+/** Render error content for tool results */
+function ToolResultError({
+  content,
+  searchTerm,
+}: {
+  content: unknown;
+  searchTerm?: string;
+}) {
+  const errorText =
+    typeof content === "string" ? content : JSON.stringify(content, null, 2);
+  return (
+    <div className="mt-2 p-2 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 rounded text-sm text-red-700 dark:text-red-300">
+      <div className="font-medium mb-1">Error</div>
+      <pre className="whitespace-pre-wrap overflow-x-auto text-xs">
+        {searchTerm ? highlightText(errorText, searchTerm) : errorText}
+      </pre>
+    </div>
+  );
+}
+
+/** Render string content for tool results */
+function ToolResultString({
+  content,
+  searchTerm,
+}: {
+  content: string;
+  searchTerm?: string;
+}) {
+  const lines = content.split("\n");
+  const isLong = lines.length > 8 || content.length > 400;
+  const isCode = looksLikeCode(content);
+  const codeStyle = isCode
+    ? "bg-gray-900 text-gray-100 dark:bg-gray-950"
+    : "bg-muted/30";
+
+  if (isLong) {
+    return (
+      <details className="mt-2 group" open={lines.length <= 15}>
+        <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground flex items-center gap-2">
+          <IconCode className="h-3 w-3" />
+          <span>Output ({lines.length} lines)</span>
+        </summary>
+        <pre
+          className={`mt-2 text-xs whitespace-pre-wrap overflow-x-auto p-3 rounded max-h-80 overflow-y-auto ${codeStyle}`}
+        >
+          {searchTerm ? highlightText(content, searchTerm) : content}
+        </pre>
+      </details>
+    );
+  }
+
+  return (
+    <pre
+      className={`mt-2 text-xs whitespace-pre-wrap overflow-x-auto p-2 rounded ${codeStyle}`}
+    >
+      {searchTerm ? highlightText(content, searchTerm) : content}
+    </pre>
+  );
+}
+
+/** Render array content blocks for tool results */
+function ToolResultArray({
+  content,
+  searchTerm,
+}: {
+  content: unknown[];
+  searchTerm?: string;
+}) {
+  return (
+    <div className="mt-2 space-y-2">
+      {content.map((item) => {
+        if (typeof item === "object" && item !== null) {
+          const obj = item as Record<string, unknown>;
+          if (obj.type === "text" && typeof obj.text === "string") {
+            const textKey = `text-${String(obj.text).slice(0, 50)}`;
+            return (
+              <div key={textKey} className="text-sm whitespace-pre-wrap">
+                {searchTerm ? highlightText(obj.text, searchTerm) : obj.text}
+              </div>
+            );
+          }
+        }
+        const itemKey = `item-${JSON.stringify(item).slice(0, 50)}`;
+        return (
+          <div key={itemKey}>
+            <CollapsibleJson data={item} />
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -130,37 +404,37 @@ function ToolResultEventContent({
 }) {
   const eventData = event.eventData as Record<string, unknown>;
   const content = eventData.content;
+  const isError = eventData.is_error === true || eventData.isError === true;
+
+  if (isError) {
+    return <ToolResultError content={content} searchTerm={searchTerm} />;
+  }
 
   if (typeof content === "string") {
-    // Text content - show with optional highlighting
-    const lines = content.split("\n");
-    const isLong = lines.length > 10 || content.length > 500;
-
-    if (isLong) {
+    if (content.trim() === "") {
       return (
-        <details className="mt-2 group">
-          <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
-            Output ({lines.length} lines)
-          </summary>
-          <pre className="mt-2 text-sm whitespace-pre-wrap overflow-x-auto bg-muted/30 p-3 rounded max-h-96 overflow-y-auto">
-            {searchTerm ? highlightText(content, searchTerm) : content}
-          </pre>
-        </details>
+        <div className="mt-2 text-sm text-muted-foreground italic">
+          (empty output)
+        </div>
       );
     }
+    return <ToolResultString content={content} searchTerm={searchTerm} />;
+  }
 
+  if (Array.isArray(content)) {
+    return <ToolResultArray content={content} searchTerm={searchTerm} />;
+  }
+
+  if (content !== null && content !== undefined) {
     return (
-      <pre className="mt-2 text-sm whitespace-pre-wrap overflow-x-auto">
-        {searchTerm ? highlightText(content, searchTerm) : content}
-      </pre>
+      <div className="mt-2">
+        <CollapsibleJson data={content} label="Output" />
+      </div>
     );
   }
 
-  // JSON content
   return (
-    <div className="mt-2">
-      <CollapsibleJson data={content} label="Output" />
-    </div>
+    <div className="mt-2 text-sm text-muted-foreground italic">(no output)</div>
   );
 }
 
@@ -188,39 +462,48 @@ function ThinkingEventContent({
 
 function InitEventContent({ event }: { event: AgentEvent }) {
   const eventData = event.eventData as Record<string, unknown>;
+  const tools = Array.isArray(eventData.tools) ? eventData.tools : [];
 
   return (
-    <div className="mt-2 space-y-1 text-sm">
+    <div className="mt-3 grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+      {eventData.model !== null && eventData.model !== undefined && (
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground text-xs uppercase tracking-wide">
+            Model
+          </span>
+          <span className="font-medium text-foreground">
+            {String(eventData.model)}
+          </span>
+        </div>
+      )}
       {eventData.session !== null && eventData.session !== undefined && (
         <div className="flex items-center gap-2">
-          <span className="text-muted-foreground">Session:</span>
-          <code className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">
+          <span className="text-muted-foreground text-xs uppercase tracking-wide">
+            Session
+          </span>
+          <code className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded truncate max-w-[200px]">
             {String(eventData.session)}
           </code>
         </div>
       )}
-      {eventData.model !== null && eventData.model !== undefined && (
-        <div className="flex items-center gap-2">
-          <span className="text-muted-foreground">Model:</span>
-          <span className="font-medium">{String(eventData.model)}</span>
+      {tools.length > 0 && (
+        <div className="col-span-2 mt-1">
+          <details className="group">
+            <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground uppercase tracking-wide">
+              {tools.length} Tools Available
+            </summary>
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {(tools as unknown[]).map((tool) => (
+                <span
+                  key={String(tool)}
+                  className="text-xs bg-muted/70 text-muted-foreground px-2 py-0.5 rounded-full"
+                >
+                  {String(tool)}
+                </span>
+              ))}
+            </div>
+          </details>
         </div>
-      )}
-      {Array.isArray(eventData.tools) && eventData.tools.length > 0 && (
-        <details className="group">
-          <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
-            Tools ({eventData.tools.length})
-          </summary>
-          <div className="mt-1 flex flex-wrap gap-1">
-            {(eventData.tools as unknown[]).map((tool) => (
-              <span
-                key={String(tool)}
-                className="text-xs bg-muted px-1.5 py-0.5 rounded"
-              >
-                {String(tool)}
-              </span>
-            ))}
-          </div>
-        </details>
       )}
     </div>
   );

--- a/turbo/apps/platform/src/views/logs-page/constants/event-styles.ts
+++ b/turbo/apps/platform/src/views/logs-page/constants/event-styles.ts
@@ -18,81 +18,96 @@ interface EventStyle {
   badgeColor: string;
 }
 
+/**
+ * Event styles using semantic colors for clear visual hierarchy.
+ * - Blue for system/init events (informational)
+ * - Gray for assistant events (neutral)
+ * - Cyan for user events (user interaction)
+ * - Green for result events (success/completion)
+ * - Red for errors only
+ */
 function createEventStyles(): Readonly<Record<string, EventStyle>> {
   return {
-    // Main event types (from eventType field)
+    // System event - blue (informational)
     system: {
       icon: IconRocket,
       label: "System",
       borderColor: "border-l-blue-500",
       bgColor: "bg-blue-50 dark:bg-blue-950/30",
-      textColor: "text-blue-700 dark:text-blue-300",
+      textColor: "text-blue-700 dark:text-blue-400",
       badgeColor:
-        "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+        "bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-400",
     },
+
+    // Assistant event - neutral gray
     assistant: {
       icon: IconBrain,
       label: "Assistant",
-      borderColor: "border-l-purple-500",
-      bgColor: "bg-purple-50 dark:bg-purple-950/30",
-      textColor: "text-purple-700 dark:text-purple-300",
+      borderColor: "border-l-slate-400 dark:border-l-slate-500",
+      bgColor: "bg-slate-50 dark:bg-slate-900/30",
+      textColor: "text-slate-700 dark:text-slate-300",
       badgeColor:
-        "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
+        "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
     },
+
+    // User event - cyan/teal (user interaction)
     user: {
       icon: IconUser,
       label: "User",
-      borderColor: "border-l-green-500",
-      bgColor: "bg-green-50 dark:bg-green-950/30",
-      textColor: "text-green-700 dark:text-green-300",
+      borderColor: "border-l-cyan-500",
+      bgColor: "bg-cyan-50 dark:bg-cyan-950/30",
+      textColor: "text-cyan-700 dark:text-cyan-400",
       badgeColor:
-        "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
+        "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/50 dark:text-cyan-400",
     },
+
+    // Result event - green (success/completion)
     result: {
       icon: IconFlag,
       label: "Result",
       borderColor: "border-l-emerald-500",
       bgColor: "bg-emerald-50 dark:bg-emerald-950/30",
-      textColor: "text-emerald-700 dark:text-emerald-300",
+      textColor: "text-emerald-700 dark:text-emerald-400",
       badgeColor:
-        "bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300",
+        "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-400",
     },
 
-    // Content types (from message.content[].type)
+    // Content types - subtle styling within cards
     text: {
       icon: IconMessage,
       label: "Text",
-      borderColor: "border-l-gray-400",
-      bgColor: "bg-gray-50 dark:bg-gray-900/30",
-      textColor: "text-gray-700 dark:text-gray-300",
+      borderColor: "border-l-transparent",
+      bgColor: "bg-transparent",
+      textColor: "text-foreground",
       badgeColor:
-        "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+        "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400",
     },
     tool_use: {
       icon: IconTool,
       label: "Tool",
-      borderColor: "border-l-amber-500",
-      bgColor: "bg-amber-50 dark:bg-amber-950/30",
-      textColor: "text-amber-700 dark:text-amber-300",
+      borderColor: "border-l-amber-400 dark:border-l-amber-500",
+      bgColor: "bg-amber-50/50 dark:bg-amber-950/20",
+      textColor: "text-foreground",
       badgeColor:
-        "bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300",
+        "bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-400",
     },
     tool_result: {
       icon: IconCheck,
       label: "Result",
-      borderColor: "border-l-green-500",
-      bgColor: "bg-green-50 dark:bg-green-950/30",
-      textColor: "text-green-700 dark:text-green-300",
+      borderColor: "border-l-emerald-400 dark:border-l-emerald-500",
+      bgColor: "bg-emerald-50/50 dark:bg-emerald-950/20",
+      textColor: "text-emerald-700 dark:text-emerald-400",
       badgeColor:
-        "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
+        "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-400",
     },
     tool_result_error: {
       icon: IconAlertCircle,
       label: "Error",
       borderColor: "border-l-red-500",
       bgColor: "bg-red-50 dark:bg-red-950/30",
-      textColor: "text-red-700 dark:text-red-300",
-      badgeColor: "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+      textColor: "text-red-700 dark:text-red-400",
+      badgeColor:
+        "bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-400",
     },
 
     // Legacy types for backwards compatibility
@@ -101,27 +116,27 @@ function createEventStyles(): Readonly<Record<string, EventStyle>> {
       label: "Init",
       borderColor: "border-l-blue-500",
       bgColor: "bg-blue-50 dark:bg-blue-950/30",
-      textColor: "text-blue-700 dark:text-blue-300",
+      textColor: "text-blue-700 dark:text-blue-400",
       badgeColor:
-        "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+        "bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-400",
     },
     thinking: {
       icon: IconBrain,
       label: "Thinking",
-      borderColor: "border-l-purple-500",
-      bgColor: "bg-purple-50 dark:bg-purple-950/30",
-      textColor: "text-purple-700 dark:text-purple-300",
+      borderColor: "border-l-violet-400 dark:border-l-violet-500",
+      bgColor: "bg-violet-50/50 dark:bg-violet-950/20",
+      textColor: "text-violet-700 dark:text-violet-400",
       badgeColor:
-        "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
+        "bg-violet-100 text-violet-700 dark:bg-violet-900/50 dark:text-violet-400",
     },
     default: {
       icon: IconMessage,
       label: "Event",
-      borderColor: "border-l-gray-300",
-      bgColor: "bg-gray-50 dark:bg-gray-900/30",
-      textColor: "text-gray-600 dark:text-gray-400",
+      borderColor: "border-l-slate-300 dark:border-l-slate-600",
+      bgColor: "bg-slate-50 dark:bg-slate-900/30",
+      textColor: "text-slate-600 dark:text-slate-400",
       badgeColor:
-        "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
+        "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400",
     },
   };
 }

--- a/turbo/apps/platform/src/views/logs-page/constants/event-styles.ts
+++ b/turbo/apps/platform/src/views/logs-page/constants/event-styles.ts
@@ -3,8 +3,10 @@ import {
   IconMessage,
   IconTool,
   IconCheck,
-  IconBulb,
-  IconList,
+  IconBrain,
+  IconUser,
+  IconFlag,
+  IconAlertCircle,
 } from "@tabler/icons-react";
 
 interface EventStyle {
@@ -18,15 +20,45 @@ interface EventStyle {
 
 function createEventStyles(): Readonly<Record<string, EventStyle>> {
   return {
-    init: {
+    // Main event types (from eventType field)
+    system: {
       icon: IconRocket,
-      label: "Init",
+      label: "System",
       borderColor: "border-l-blue-500",
       bgColor: "bg-blue-50 dark:bg-blue-950/30",
       textColor: "text-blue-700 dark:text-blue-300",
       badgeColor:
         "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
     },
+    assistant: {
+      icon: IconBrain,
+      label: "Assistant",
+      borderColor: "border-l-purple-500",
+      bgColor: "bg-purple-50 dark:bg-purple-950/30",
+      textColor: "text-purple-700 dark:text-purple-300",
+      badgeColor:
+        "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
+    },
+    user: {
+      icon: IconUser,
+      label: "User",
+      borderColor: "border-l-green-500",
+      bgColor: "bg-green-50 dark:bg-green-950/30",
+      textColor: "text-green-700 dark:text-green-300",
+      badgeColor:
+        "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
+    },
+    result: {
+      icon: IconFlag,
+      label: "Result",
+      borderColor: "border-l-emerald-500",
+      bgColor: "bg-emerald-50 dark:bg-emerald-950/30",
+      textColor: "text-emerald-700 dark:text-emerald-300",
+      badgeColor:
+        "bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300",
+    },
+
+    // Content types (from message.content[].type)
     text: {
       icon: IconMessage,
       label: "Text",
@@ -54,8 +86,27 @@ function createEventStyles(): Readonly<Record<string, EventStyle>> {
       badgeColor:
         "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
     },
+    tool_result_error: {
+      icon: IconAlertCircle,
+      label: "Error",
+      borderColor: "border-l-red-500",
+      bgColor: "bg-red-50 dark:bg-red-950/30",
+      textColor: "text-red-700 dark:text-red-300",
+      badgeColor: "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+    },
+
+    // Legacy types for backwards compatibility
+    init: {
+      icon: IconRocket,
+      label: "Init",
+      borderColor: "border-l-blue-500",
+      bgColor: "bg-blue-50 dark:bg-blue-950/30",
+      textColor: "text-blue-700 dark:text-blue-300",
+      badgeColor:
+        "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+    },
     thinking: {
-      icon: IconBulb,
+      icon: IconBrain,
       label: "Thinking",
       borderColor: "border-l-purple-500",
       bgColor: "bg-purple-50 dark:bg-purple-950/30",
@@ -64,7 +115,7 @@ function createEventStyles(): Readonly<Record<string, EventStyle>> {
         "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
     },
     default: {
-      icon: IconList,
+      icon: IconMessage,
       label: "Event",
       borderColor: "border-l-gray-300",
       bgColor: "bg-gray-50 dark:bg-gray-900/30",
@@ -87,9 +138,8 @@ export function getHiddenByDefault(): ReadonlySet<string> {
 
 /** All known event types for filtering */
 export const KNOWN_EVENT_TYPES = [
-  "init",
-  "text",
-  "tool_use",
-  "tool_result",
-  "thinking",
+  "system",
+  "assistant",
+  "user",
+  "result",
 ] as const;

--- a/turbo/apps/platform/src/views/logs-page/constants/event-styles.ts
+++ b/turbo/apps/platform/src/views/logs-page/constants/event-styles.ts
@@ -1,0 +1,95 @@
+import {
+  IconRocket,
+  IconMessage,
+  IconTool,
+  IconCheck,
+  IconBulb,
+  IconList,
+} from "@tabler/icons-react";
+
+interface EventStyle {
+  icon: typeof IconRocket;
+  label: string;
+  borderColor: string;
+  bgColor: string;
+  textColor: string;
+  badgeColor: string;
+}
+
+function createEventStyles(): Readonly<Record<string, EventStyle>> {
+  return {
+    init: {
+      icon: IconRocket,
+      label: "Init",
+      borderColor: "border-l-blue-500",
+      bgColor: "bg-blue-50 dark:bg-blue-950/30",
+      textColor: "text-blue-700 dark:text-blue-300",
+      badgeColor:
+        "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+    },
+    text: {
+      icon: IconMessage,
+      label: "Text",
+      borderColor: "border-l-gray-400",
+      bgColor: "bg-gray-50 dark:bg-gray-900/30",
+      textColor: "text-gray-700 dark:text-gray-300",
+      badgeColor:
+        "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+    },
+    tool_use: {
+      icon: IconTool,
+      label: "Tool",
+      borderColor: "border-l-amber-500",
+      bgColor: "bg-amber-50 dark:bg-amber-950/30",
+      textColor: "text-amber-700 dark:text-amber-300",
+      badgeColor:
+        "bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300",
+    },
+    tool_result: {
+      icon: IconCheck,
+      label: "Result",
+      borderColor: "border-l-green-500",
+      bgColor: "bg-green-50 dark:bg-green-950/30",
+      textColor: "text-green-700 dark:text-green-300",
+      badgeColor:
+        "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
+    },
+    thinking: {
+      icon: IconBulb,
+      label: "Thinking",
+      borderColor: "border-l-purple-500",
+      bgColor: "bg-purple-50 dark:bg-purple-950/30",
+      textColor: "text-purple-700 dark:text-purple-300",
+      badgeColor:
+        "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
+    },
+    default: {
+      icon: IconList,
+      label: "Event",
+      borderColor: "border-l-gray-300",
+      bgColor: "bg-gray-50 dark:bg-gray-900/30",
+      textColor: "text-gray-600 dark:text-gray-400",
+      badgeColor:
+        "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
+    },
+  };
+}
+
+export function getEventStyle(eventType: string): EventStyle {
+  const styles = createEventStyles();
+  return styles[eventType] ?? styles.default;
+}
+
+/** Event types that are hidden by default */
+export function getHiddenByDefault(): ReadonlySet<string> {
+  return new Set(["thinking"]);
+}
+
+/** All known event types for filtering */
+export const KNOWN_EVENT_TYPES = [
+  "init",
+  "text",
+  "tool_use",
+  "tool_result",
+  "thinking",
+] as const;

--- a/turbo/apps/platform/src/views/logs-page/log-detail-page.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail-page.tsx
@@ -258,6 +258,21 @@ function RawJsonView({ events }: { events: AgentEvent[] }) {
   );
 }
 
+/** Check if event contains the search term */
+function eventMatchesSearch(event: AgentEvent, searchTerm: string): boolean {
+  if (!searchTerm.trim()) {
+    return true;
+  }
+  const lowerSearch = searchTerm.toLowerCase();
+  // Search in eventType
+  if (event.eventType.toLowerCase().includes(lowerSearch)) {
+    return true;
+  }
+  // Search in eventData (serialized to JSON)
+  const dataStr = JSON.stringify(event.eventData).toLowerCase();
+  return dataStr.includes(lowerSearch);
+}
+
 /** Formatted event cards view */
 function FormattedEventsView({
   events,
@@ -269,7 +284,9 @@ function FormattedEventsView({
   hiddenTypes: Set<string>;
 }) {
   const visibleEvents = events.filter(
-    (event) => !hiddenTypes.has(event.eventType),
+    (event) =>
+      !hiddenTypes.has(event.eventType) &&
+      eventMatchesSearch(event, searchTerm),
   );
 
   if (visibleEvents.length === 0) {
@@ -277,7 +294,9 @@ function FormattedEventsView({
       <div className="p-8 text-center text-muted-foreground">
         {events.length === 0
           ? "No events available"
-          : "All events are filtered out"}
+          : searchTerm.trim()
+            ? `No events matching "${searchTerm}"`
+            : "All events are filtered out"}
       </div>
     );
   }
@@ -372,6 +391,11 @@ function AgentEventsCard({
   const { events } = eventsLoadable.data;
   const eventTypeCounts = getEventTypeCounts(events);
 
+  // Count matching events for search
+  const matchingCount = searchTerm.trim()
+    ? events.filter((e) => eventMatchesSearch(e, searchTerm)).length
+    : events.length;
+
   return (
     <Card className="overflow-hidden">
       <div className="flex flex-col gap-3 rounded-t-lg border-b border-border bg-muted px-4 py-3">
@@ -382,7 +406,9 @@ function AgentEventsCard({
               Agent Events
             </span>
             <span className="text-xs text-muted-foreground">
-              ({events.length} total)
+              {searchTerm.trim()
+                ? `(${matchingCount}/${events.length} matched)`
+                : `(${events.length} total)`}
             </span>
           </div>
           <div className="flex items-center gap-3">

--- a/turbo/apps/platform/src/views/logs-page/log-detail-page.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail-page.tsx
@@ -4,12 +4,17 @@ import {
   IconFolder,
   IconList,
   IconRobot,
+  IconCode,
+  IconLayoutList,
 } from "@tabler/icons-react";
 import { AppShell } from "../layout/app-shell.tsx";
 import { Card, CardContent, CopyButton, Input } from "@vm0/ui";
 import {
   currentLogId$,
   logDetailSearchTerm$,
+  viewMode$,
+  hiddenEventTypes$,
+  type ViewMode,
 } from "../../signals/logs-page/log-detail-state.ts";
 import {
   getOrCreateLogDetail$,
@@ -20,6 +25,8 @@ import {
 import { detach, Reason } from "../../signals/utils.ts";
 import type { AgentEvent } from "../../signals/logs-page/types.ts";
 import { StatusBadge } from "./status-badge.tsx";
+import { EventCard } from "./components/event-card.tsx";
+import { getEventStyle, KNOWN_EVENT_TYPES } from "./constants/event-styles.ts";
 
 function InfoRow({
   label,
@@ -83,31 +90,6 @@ function formatDuration(startedAt: string | null, completedAt: string | null) {
   return `${minutes}m ${seconds}s`;
 }
 
-function escapeRegExp(str: string) {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-}
-
-function highlightText(text: string, term: string) {
-  if (!term.trim()) {
-    return text;
-  }
-
-  const parts = text.split(new RegExp(`(${escapeRegExp(term)})`, "gi"));
-
-  return parts.map((part, idx) =>
-    part.toLowerCase() === term.toLowerCase() ? (
-      <mark
-        key={`highlight-${part}-${idx}`}
-        className="bg-yellow-200 text-yellow-900"
-      >
-        {part}
-      </mark>
-    ) : (
-      part
-    ),
-  );
-}
-
 function ArtifactDownloadButton({
   name,
   version,
@@ -148,71 +130,169 @@ function ArtifactDownloadButton({
   );
 }
 
-/**
- * Format events as log text similar to CLI output
- */
-function formatEventsAsLogText(events: AgentEvent[]): string {
-  const lines: string[] = [];
-
+/** Compute event type counts from events array */
+function getEventTypeCounts(events: AgentEvent[]): Map<string, number> {
+  const counts = new Map<string, number>();
   for (const event of events) {
-    const timestamp = new Date(event.createdAt).toISOString();
-    const eventData = event.eventData as Record<string, unknown>;
+    const type = event.eventType;
+    counts.set(type, (counts.get(type) ?? 0) + 1);
+  }
+  return counts;
+}
 
-    if (event.eventType === "text") {
-      const content = String(eventData.content ?? "");
-      lines.push(`  [${timestamp}] [text] ${content}`);
-    } else if (event.eventType === "tool_use") {
-      const toolName = String(eventData.name ?? eventData.tool ?? "unknown");
-      lines.push(`  [${timestamp}] [tool_use] ${toolName}`);
-      // Format tool input if present
-      if (eventData.input) {
-        const inputStr = JSON.stringify(eventData.input, null, 2);
-        const indentedInput = inputStr
-          .split("\n")
-          .map((line) => `      ${line}`)
-          .join("\n");
-        lines.push(indentedInput);
-      }
-    } else if (event.eventType === "tool_result") {
-      lines.push(`  [${timestamp}] [tool_result]`);
-      if (eventData.content) {
-        const content = String(eventData.content);
-        const indentedContent = content
-          .split("\n")
-          .map((line) => `      ${line}`)
-          .join("\n");
-        lines.push(indentedContent);
-      }
-    } else if (event.eventType === "thinking") {
-      const content = String(eventData.content ?? "");
-      lines.push(`  [${timestamp}] [thinking] ${content}`);
-    } else if (event.eventType === "init") {
-      lines.push(`  [${timestamp}] [init] Starting Claude Code agent`);
-      if (eventData.session) {
-        lines.push(`\n      Session: ${eventData.session}`);
-      }
-      if (eventData.model) {
-        lines.push(`      Model: ${eventData.model}`);
-      }
-      if (eventData.tools && Array.isArray(eventData.tools)) {
-        const toolsList = (eventData.tools as string[]).join(", ");
-        lines.push(`      Tools: ${toolsList}`);
-      }
+/** View mode toggle button */
+function ViewModeToggle({
+  mode,
+  setMode,
+}: {
+  mode: ViewMode;
+  setMode: (mode: ViewMode) => void;
+}) {
+  return (
+    <div className="flex items-center rounded-md border border-border bg-background">
+      <button
+        onClick={() => setMode("formatted")}
+        className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-l-md transition-colors ${
+          mode === "formatted"
+            ? "bg-primary text-primary-foreground"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        <IconLayoutList className="h-4 w-4" />
+        Formatted
+      </button>
+      <button
+        onClick={() => setMode("raw")}
+        className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-r-md transition-colors ${
+          mode === "raw"
+            ? "bg-primary text-primary-foreground"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        <IconCode className="h-4 w-4" />
+        Raw JSON
+      </button>
+    </div>
+  );
+}
+
+/** Event type filter buttons */
+function EventTypeFilters({
+  counts,
+  hiddenTypes,
+  setHiddenTypes,
+}: {
+  counts: Map<string, number>;
+  hiddenTypes: Set<string>;
+  setHiddenTypes: (types: Set<string>) => void;
+}) {
+  const toggleType = (type: string) => {
+    const newHidden = new Set(hiddenTypes);
+    if (newHidden.has(type)) {
+      newHidden.delete(type);
     } else {
-      // Generic format for other event types
-      lines.push(`  [${timestamp}] [${event.eventType}]`);
-      const dataStr = JSON.stringify(eventData, null, 2);
-      const indentedData = dataStr
-        .split("\n")
-        .map((line) => `      ${line}`)
-        .join("\n");
-      lines.push(indentedData);
+      newHidden.add(type);
     }
+    setHiddenTypes(newHidden);
+  };
 
-    lines.push(""); // Empty line between events
+  // Get all types that exist in events
+  const existingTypes = KNOWN_EVENT_TYPES.filter(
+    (type) => (counts.get(type) ?? 0) > 0,
+  );
+
+  // Also include any unknown types
+  const unknownTypes = Array.from(counts.keys()).filter(
+    (type) =>
+      !KNOWN_EVENT_TYPES.includes(type as (typeof KNOWN_EVENT_TYPES)[number]),
+  );
+
+  const allTypes = [...existingTypes, ...unknownTypes];
+
+  if (allTypes.length === 0) {
+    return null;
   }
 
-  return lines.join("\n");
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {allTypes.map((type) => {
+        const style = getEventStyle(type);
+        const Icon = style.icon;
+        const count = counts.get(type) ?? 0;
+        const isHidden = hiddenTypes.has(type);
+
+        return (
+          <button
+            key={type}
+            onClick={() => toggleType(type)}
+            className={`flex items-center gap-1.5 px-2 py-1 text-xs rounded-full border transition-colors ${
+              isHidden
+                ? "border-border text-muted-foreground opacity-50"
+                : `${style.badgeColor} border-transparent`
+            }`}
+          >
+            <Icon className="h-3 w-3" />
+            <span>{style.label}</span>
+            <span className="opacity-70">({count})</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Raw JSON view with syntax highlighting */
+function RawJsonView({ events }: { events: AgentEvent[] }) {
+  const jsonString = JSON.stringify(events, null, 2);
+
+  return (
+    <div className="relative">
+      <CopyButton
+        text={jsonString}
+        className="absolute top-2 right-2 h-8 w-8 bg-background/80 hover:bg-background"
+      />
+      <pre className="font-mono text-sm whitespace-pre-wrap overflow-auto max-h-[600px] p-4 bg-muted/30 rounded-lg">
+        {jsonString}
+      </pre>
+    </div>
+  );
+}
+
+/** Formatted event cards view */
+function FormattedEventsView({
+  events,
+  searchTerm,
+  hiddenTypes,
+}: {
+  events: AgentEvent[];
+  searchTerm: string;
+  hiddenTypes: Set<string>;
+}) {
+  const visibleEvents = events.filter(
+    (event) => !hiddenTypes.has(event.eventType),
+  );
+
+  if (visibleEvents.length === 0) {
+    return (
+      <div className="p-8 text-center text-muted-foreground">
+        {events.length === 0
+          ? "No events available"
+          : "All events are filtered out"}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 max-h-[600px] overflow-y-auto pr-1">
+      {visibleEvents.map((event) => (
+        <EventCard
+          key={`${event.sequenceNumber}-${event.createdAt}`}
+          event={event}
+          searchTerm={searchTerm}
+        />
+      ))}
+    </div>
+  );
 }
 
 function AgentEventsCard({
@@ -228,17 +308,45 @@ function AgentEventsCard({
   const events$ = getOrCreateAgentEvents(logId);
   const eventsLoadable = useLoadable(events$);
 
+  const viewMode = useGet(viewMode$);
+  const setViewMode = useSet(viewMode$);
+  const hiddenTypes = useGet(hiddenEventTypes$);
+  const setHiddenTypes = useSet(hiddenEventTypes$);
+
+  // Common header for loading/error states
+  const renderHeader = (showControls = false) => (
+    <div className="flex flex-col gap-3 rounded-t-lg border-b border-border bg-muted px-4 py-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <IconList className="h-5 w-5 text-muted-foreground" />
+          <span className="text-sm font-medium text-card-foreground">
+            Agent Events
+          </span>
+        </div>
+        {showControls && (
+          <div className="flex items-center gap-3">
+            <ViewModeToggle mode={viewMode} setMode={setViewMode} />
+            <div className="flex h-9 items-center rounded-md border border-border bg-background">
+              <Input
+                placeholder="Search logs"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="h-full w-48 border-0 text-sm focus-visible:ring-0"
+              />
+              <div className="flex h-9 w-9 items-center justify-center border-l border-border">
+                <IconSearch className="h-5 w-5 text-muted-foreground" />
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
   if (eventsLoadable.state === "loading") {
     return (
       <Card className="overflow-hidden">
-        <div className="flex items-center justify-between rounded-t-lg border-b border-border bg-muted px-4 py-2">
-          <div className="flex items-center gap-2">
-            <IconList className="h-5 w-5 text-muted-foreground" />
-            <span className="text-sm font-medium text-card-foreground">
-              Log raw data
-            </span>
-          </div>
-        </div>
+        {renderHeader()}
         <CardContent className="p-4">
           <div className="p-8 text-center text-muted-foreground">
             Loading events...
@@ -251,14 +359,7 @@ function AgentEventsCard({
   if (eventsLoadable.state === "hasError") {
     return (
       <Card className="overflow-hidden">
-        <div className="flex items-center justify-between rounded-t-lg border-b border-border bg-muted px-4 py-2">
-          <div className="flex items-center gap-2">
-            <IconList className="h-5 w-5 text-muted-foreground" />
-            <span className="text-sm font-medium text-card-foreground">
-              Log raw data
-            </span>
-          </div>
-        </div>
+        {renderHeader()}
         <CardContent className="p-4">
           <div className="p-8 text-center text-muted-foreground">
             Failed to load events
@@ -269,40 +370,53 @@ function AgentEventsCard({
   }
 
   const { events } = eventsLoadable.data;
-
-  // Format events as log text
-  const logText = formatEventsAsLogText(events);
+  const eventTypeCounts = getEventTypeCounts(events);
 
   return (
     <Card className="overflow-hidden">
-      <div className="flex items-center justify-between rounded-t-lg border-b border-border bg-muted px-4 py-2">
-        <div className="flex items-center gap-2">
-          <IconList className="h-5 w-5 text-muted-foreground" />
-          <span className="text-sm font-medium text-card-foreground">
-            Log raw data
-          </span>
-        </div>
-        <div className="flex h-9 items-center rounded-md border border-border bg-background">
-          <Input
-            placeholder="Search logs"
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            className="h-full w-48 border-0 text-sm focus-visible:ring-0"
-          />
-          <div className="flex h-9 w-9 items-center justify-center border-l border-border">
-            <IconSearch className="h-5 w-5 text-muted-foreground" />
+      <div className="flex flex-col gap-3 rounded-t-lg border-b border-border bg-muted px-4 py-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <IconList className="h-5 w-5 text-muted-foreground" />
+            <span className="text-sm font-medium text-card-foreground">
+              Agent Events
+            </span>
+            <span className="text-xs text-muted-foreground">
+              ({events.length} total)
+            </span>
+          </div>
+          <div className="flex items-center gap-3">
+            <ViewModeToggle mode={viewMode} setMode={setViewMode} />
+            <div className="flex h-9 items-center rounded-md border border-border bg-background">
+              <Input
+                placeholder="Search logs"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="h-full w-48 border-0 text-sm focus-visible:ring-0"
+              />
+              <div className="flex h-9 w-9 items-center justify-center border-l border-border">
+                <IconSearch className="h-5 w-5 text-muted-foreground" />
+              </div>
+            </div>
           </div>
         </div>
+        {viewMode === "formatted" && events.length > 0 && (
+          <EventTypeFilters
+            counts={eventTypeCounts}
+            hiddenTypes={hiddenTypes}
+            setHiddenTypes={setHiddenTypes}
+          />
+        )}
       </div>
       <CardContent className="p-4">
-        {events.length === 0 ? (
-          <div className="p-8 text-center text-muted-foreground">
-            No events available
-          </div>
+        {viewMode === "formatted" ? (
+          <FormattedEventsView
+            events={events}
+            searchTerm={searchTerm}
+            hiddenTypes={hiddenTypes}
+          />
         ) : (
-          <pre className="font-mono text-sm whitespace-pre-wrap overflow-auto max-h-[600px] leading-relaxed">
-            {searchTerm ? highlightText(logText, searchTerm) : logText}
-          </pre>
+          <RawJsonView events={events} />
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary

Implements an enhanced log viewer for Claude Code logs with:

- **Card-based event timeline** - Each event rendered as a distinct card with type-specific styling
- **Semantic color scheme** - Blue for system, gray for assistant, cyan for user, green for results, red for errors only
- **Collapsible JSON sections** - JSON payloads collapsed by default with copy-to-clipboard
- **View mode toggle** - Switch between Formatted and Raw JSON views
- **Event type filtering** - Filter toggles for each event type with counts
- **Tool-specific rendering** - Special displays for WebFetch, Bash, file operations
- **Dark mode support** - All colors have proper dark mode variants

## Test plan

- [ ] Verify each event type displays with correct colors (system=blue, assistant=gray, user=cyan, result=green)
- [ ] Test collapsible JSON sections expand/collapse correctly
- [ ] Verify copy-to-clipboard works for JSON content
- [ ] Test toggle between Formatted and Raw views
- [ ] Test event type filters show/hide events correctly
- [ ] Verify search highlighting works in both views
- [ ] Test in both light and dark modes
- [ ] Run existing tests: `pnpm vitest run --filter=log-detail`

Closes #1784

🤖 Generated with [Claude Code](https://claude.com/claude-code)