### PR TITLE
fix(cli): include cd instruction in onboard next step message

### DIFF
--- a/turbo/apps/cli/src/commands/onboard.ts
+++ b/turbo/apps/cli/src/commands/onboard.ts
@@ -127,8 +127,10 @@ export const onboardCommand = new Command()
       process.chdir(DEMO_AGENT_DIR);
 
       try {
-        // Run setup-claude action directly
-        await setupClaudeCommand.parseAsync([], { from: "user" });
+        // Run setup-claude action directly, passing agent-dir for the "Next step" message
+        await setupClaudeCommand.parseAsync(["--agent-dir", DEMO_AGENT_DIR], {
+          from: "user",
+        });
       } finally {
         process.chdir(originalDir);
       }

--- a/turbo/apps/cli/src/commands/setup-claude.ts
+++ b/turbo/apps/cli/src/commands/setup-claude.ts
@@ -217,7 +217,11 @@ Write results to the artifact directory.
 export const setupClaudeCommand = new Command()
   .name("setup-claude")
   .description("Add/update Claude skill for agent building")
-  .action(async () => {
+  .option(
+    "--agent-dir <dir>",
+    "Agent directory (shown in next step instructions)",
+  )
+  .action(async (options: { agentDir?: string }) => {
     console.log(chalk.dim("Installing vm0-agent-builder skill..."));
 
     // Create directory
@@ -231,9 +235,10 @@ export const setupClaudeCommand = new Command()
     );
     console.log();
     console.log("Next step:");
+    const cdPrefix = options.agentDir ? `cd ${options.agentDir} && ` : "";
     console.log(
       chalk.cyan(
-        '  claude /vm0-agent-builder "I want to build an agent that..."',
+        `  ${cdPrefix}claude "/vm0-agent-builder I want to build an agent that..."`,
       ),
     );
   });


### PR DESCRIPTION
## Summary
- Fixed the "Next step" message in `vm0 onboard` flow to include `cd vm0-demo-agent` instruction
- Added `--agent-dir` option to `setup-claude` command for context-aware messaging
- After onboarding completes, users are back in the parent directory but need to know to `cd` into the agent directory first

## Test plan
- [ ] Run `vm0 onboard -y --method claude` and verify the "Next step" message shows `cd vm0-demo-agent && claude "/vm0-agent-builder..."`
- [ ] Run `vm0 setup-claude` standalone and verify the message shows just `claude "/vm0-agent-builder..."` (without cd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)