### PR TITLE
chore: reduce test output noise with silent passed-only mode

### DIFF
--- a/turbo/apps/cli/src/commands/schedule/__tests__/gather-configuration.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/gather-configuration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { gatherConfiguration } from "../gather-configuration";
 
 /**
@@ -52,6 +52,14 @@ function createMockDeps(
 }
 
 describe("gatherConfiguration", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe("new schedule scenarios", () => {
     it("should use --secret flag values for new schedule", async () => {
       const deps = createMockDeps({ isInteractive: true });

--- a/turbo/vitest.config.ts
+++ b/turbo/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
   test: {
     globals: true,
     passWithNoTests: true,
+    // Suppress console output from passing tests to reduce noise
+    // Logs from failing tests are still displayed for debugging
+    silent: "passed-only",
 
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary

- Configure Vitest to suppress console output from passing tests using `silent: 'passed-only'`
- Logs from failing tests are still displayed for debugging purposes
- This reduces noise from expected error/warn logs, debug output, and other console messages

## Before

Test output was cluttered with:
- `[ERROR]` logs from tests verifying error handling paths
- `[WARN]` logs from auth, SSRF protection, token expiry tests  
- Debug output from VMRegistry, ProxyManager, IP Pool
- Auth stdout token output

## After

Clean test output showing only test results. Console output is only displayed when tests fail, which is when debugging information is actually needed.

## Test plan

- [x] All 2286 tests pass
- [x] Pre-commit checks pass (lint, type-check, format, knip)
- [x] Verified failing tests still show console output for debugging

Closes #1554

🤖 Generated with [Claude Code](https://claude.com/claude-code)