### PR TITLE
feat(cli): redesign onboard command with interactive flow

### DIFF
--- a/e2e/tests/02-parallel/t31-vm0-onboard.bats
+++ b/e2e/tests/02-parallel/t31-vm0-onboard.bats
@@ -35,7 +35,7 @@ teardown() {
     assert_success
     assert_output --partial "Created my-vm0-agent/"
     assert_output --partial "Installed vm0-agent-builder skill"
-    assert_output --partial "Next steps:"
+    assert_output --partial "Next step:"
     assert_output --partial "cd my-vm0-agent"
 
     # Verify directory and skill were created

--- a/e2e/tests/02-parallel/t31-vm0-onboard.bats
+++ b/e2e/tests/02-parallel/t31-vm0-onboard.bats
@@ -27,35 +27,42 @@ teardown() {
     assert_success
     assert_output --partial "Guided setup for new VM0 users"
     assert_output --partial "--yes"
-    assert_output --partial "--method"
+    assert_output --partial "--name"
 }
 
-@test "vm0 onboard -y --method manual creates demo agent directory" {
-    run $CLI_COMMAND onboard -y --method manual
+@test "vm0 onboard -y creates agent directory with skill" {
+    run $CLI_COMMAND onboard -y
     assert_success
-    assert_output --partial "Created vm0.yaml"
-    assert_output --partial "Created AGENTS.md"
+    assert_output --partial "Created my-vm0-agent/"
+    assert_output --partial "Installed vm0-agent-builder skill"
     assert_output --partial "Next steps:"
-    assert_output --partial "cd vm0-demo-agent"
+    assert_output --partial "cd my-vm0-agent"
 
-    # Verify directory and files were created
-    [ -d "vm0-demo-agent" ]
-    [ -f "vm0-demo-agent/vm0.yaml" ]
-    [ -f "vm0-demo-agent/AGENTS.md" ]
-
-    # Verify basic content
-    run cat vm0-demo-agent/vm0.yaml
-    assert_output --partial "vm0-demo-agent:"
-    assert_output --partial "framework: claude-code"
+    # Verify directory and skill were created
+    [ -d "my-vm0-agent" ]
+    [ -d "my-vm0-agent/.claude/skills/vm0-agent-builder" ]
+    [ -f "my-vm0-agent/.claude/skills/vm0-agent-builder/SKILL.md" ]
 }
 
-@test "vm0 onboard fails if vm0-demo-agent directory exists" {
-    # Create existing directory
-    mkdir vm0-demo-agent
+@test "vm0 onboard -y --name creates custom named agent" {
+    run $CLI_COMMAND onboard -y --name custom-agent
+    assert_success
+    assert_output --partial "Created custom-agent/"
+    assert_output --partial "Installed vm0-agent-builder skill"
+    assert_output --partial "cd custom-agent"
 
-    run $CLI_COMMAND onboard -y --method manual
+    # Verify directory and skill were created with custom name
+    [ -d "custom-agent" ]
+    [ -d "custom-agent/.claude/skills/vm0-agent-builder" ]
+}
+
+@test "vm0 onboard fails if agent directory exists" {
+    # Create existing directory
+    mkdir my-vm0-agent
+
+    run $CLI_COMMAND onboard -y
     assert_failure
-    assert_output --partial "vm0-demo-agent/ already exists"
+    assert_output --partial "my-vm0-agent/ already exists"
 }
 
 # =============================================================================
@@ -94,22 +101,4 @@ teardown() {
     run $CLI_COMMAND setup-claude
     assert_success
     assert_output --partial "Installed vm0-agent-builder skill"
-}
-
-# =============================================================================
-# vm0 onboard --method claude tests
-# =============================================================================
-
-@test "vm0 onboard -y --method claude creates demo agent with skill" {
-    run $CLI_COMMAND onboard -y --method claude
-    assert_success
-
-    # Verify directory structure
-    [ -d "vm0-demo-agent" ]
-    [ -f "vm0-demo-agent/vm0.yaml" ]
-    [ -f "vm0-demo-agent/AGENTS.md" ]
-
-    # Verify skill was installed inside the demo agent
-    [ -d "vm0-demo-agent/.claude/skills/vm0-agent-builder" ]
-    [ -f "vm0-demo-agent/.claude/skills/vm0-agent-builder/SKILL.md" ]
 }

--- a/turbo/apps/cli/src/commands/__tests__/onboard.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/onboard.test.ts
@@ -344,7 +344,7 @@ describe("onboard command", () => {
       await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("Next steps:");
+      expect(logCalls).toContain("Next step:");
       expect(logCalls).toContain("cd my-vm0-agent");
       expect(logCalls).toContain("claude");
       expect(logCalls).toContain("/vm0-agent-builder");

--- a/turbo/apps/cli/src/commands/__tests__/onboard.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/onboard.test.ts
@@ -178,7 +178,7 @@ describe("onboard command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Authentication");
-      expect(logCalls).toContain("Model Provider");
+      expect(logCalls).toContain("Model Provider Setup");
       expect(logCalls).toContain("Create Agent");
     });
   });

--- a/turbo/apps/cli/src/commands/__tests__/onboard.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/onboard.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { onboardCommand } from "../onboard";
-import * as fs from "fs/promises";
+import { onboardCommand } from "../onboard.js";
 import { existsSync, mkdtempSync, rmSync } from "fs";
+import { readFile } from "fs/promises";
 import * as path from "path";
 import * as os from "os";
 import { http, HttpResponse } from "msw";
-import { server } from "../../mocks/server";
+import { server } from "../../mocks/server.js";
 
 // Mock prompts at system boundary (third-party library for user input)
 vi.mock("prompts", () => ({
@@ -33,9 +33,15 @@ describe("onboard command", () => {
     throw new Error("process.exit called");
   }) as never);
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleClear = vi
+    .spyOn(console, "clear")
+    .mockImplementation(() => {});
   const mockConsoleError = vi
     .spyOn(console, "error")
     .mockImplementation(() => {});
+  const mockStdoutWrite = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(() => true);
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -123,11 +129,17 @@ describe("onboard command", () => {
       if (q.name === "type") {
         return { type: "anthropic-api-key" };
       }
-      if (q.name === "credential") {
-        return { credential: "sk-test-key" };
+      if (q.name === "credential" || q.name === "value") {
+        return { [q.name]: "sk-test-key" };
       }
       if (q.name === "convert") {
         return { convert: false };
+      }
+      if (q.name === "value" && q.type === "text") {
+        return { value: "my-vm0-agent" };
+      }
+      if (q.name === "value" && q.type === "confirm") {
+        return { value: true };
       }
       return {};
     });
@@ -138,7 +150,9 @@ describe("onboard command", () => {
     rmSync(tempDir, { recursive: true, force: true });
     mockExit.mockClear();
     mockConsoleLog.mockClear();
+    mockConsoleClear.mockClear();
     mockConsoleError.mockClear();
+    mockStdoutWrite.mockClear();
     vi.unstubAllEnvs();
 
     // Restore TTY state
@@ -149,286 +163,228 @@ describe("onboard command", () => {
     });
   });
 
-  describe("authentication check", () => {
-    it("should show authenticated status when token exists", async () => {
-      await onboardCommand.parseAsync([
-        "node",
-        "cli",
-        "-y",
-        "--method",
-        "manual",
-      ]);
+  describe("welcome screen", () => {
+    it("should display welcome box in interactive mode", async () => {
+      await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Authenticated"),
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Welcome to VM0!");
+    });
+  });
+
+  describe("progress indicator", () => {
+    it("should display progress line with steps", async () => {
+      await onboardCommand.parseAsync(["node", "cli", "-y"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Authentication");
+      expect(logCalls).toContain("Model Provider");
+      expect(logCalls).toContain("Create Agent");
+    });
+  });
+
+  describe("authentication check", () => {
+    it("should proceed when token exists", async () => {
+      await onboardCommand.parseAsync(["node", "cli", "-y"]);
+
+      // Should not show auth required message
+      expect(mockConsoleLog).not.toHaveBeenCalledWith(
+        expect.stringContaining("Authentication required"),
       );
     });
 
-    it("should show auth required message when no token exists", async () => {
-      // Remove token completely (not just empty string)
+    it("should show error in non-interactive mode when no token", async () => {
       vi.unstubAllEnvs();
       vi.stubEnv("VM0_API_URL", "http://localhost:3000");
       delete process.env.VM0_TOKEN;
 
-      // Ensure model providers exist so auth is the only blocking step
-      server.use(
-        http.get("http://localhost:3000/api/model-providers", () => {
-          return HttpResponse.json({
-            modelProviders: [
-              {
-                id: "test-provider-id",
-                type: "anthropic-api-key",
-                framework: "claude-code",
-                credentialName: "ANTHROPIC_API_KEY",
-                isDefault: true,
-                createdAt: "2024-01-01T00:00:00Z",
-                updatedAt: "2024-01-01T00:00:00Z",
-              },
-            ],
-          });
-        }),
-      );
+      // Set non-interactive mode
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: false,
+        writable: true,
+        configurable: true,
+      });
 
-      // Auth flow will run via loginCommand.parseAsync
-      // The full flow involves device code polling which may exit on completion
-      try {
-        await onboardCommand.parseAsync([
-          "node",
-          "cli",
-          "-y",
-          "--method",
-          "manual",
-        ]);
-      } catch {
-        // May throw due to process.exit mock
-      }
+      await expect(async () => {
+        await onboardCommand.parseAsync(["node", "cli", "-y"]);
+      }).rejects.toThrow("process.exit called");
 
-      // Verify auth flow started by checking for auth required message
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Authentication required"),
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
       );
     });
   });
 
   describe("model provider check", () => {
-    it("should show configured status when model providers exist", async () => {
-      await onboardCommand.parseAsync([
-        "node",
-        "cli",
-        "-y",
-        "--method",
-        "manual",
-      ]);
+    it("should proceed when model providers exist", async () => {
+      await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Model provider configured"),
+      // Should not show model provider setup required message
+      expect(mockConsoleLog).not.toHaveBeenCalledWith(
+        expect.stringContaining("Model provider setup required"),
       );
     });
 
-    it("should trigger model provider setup when no providers configured", async () => {
+    it("should show error in non-interactive mode when no providers", async () => {
       server.use(
         http.get("http://localhost:3000/api/model-providers", () => {
           return HttpResponse.json({ modelProviders: [] });
         }),
       );
 
-      await onboardCommand.parseAsync([
-        "node",
-        "cli",
-        "-y",
-        "--method",
-        "manual",
-      ]);
+      // Set non-interactive mode
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: false,
+        writable: true,
+        configurable: true,
+      });
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Model provider setup required"),
-      );
-      // Verify setup completed by checking for success message
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Model provider"),
-      );
-    });
+      await expect(async () => {
+        await onboardCommand.parseAsync(["node", "cli", "-y"]);
+      }).rejects.toThrow("process.exit called");
 
-    it("should attempt setup if model provider check fails", async () => {
-      server.use(
-        http.get("http://localhost:3000/api/model-providers", () => {
-          return HttpResponse.json({ error: "Server error" }, { status: 500 });
-        }),
-      );
-
-      await onboardCommand.parseAsync([
-        "node",
-        "cli",
-        "-y",
-        "--method",
-        "manual",
-      ]);
-
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Setting up model provider"),
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No model provider configured"),
       );
     });
   });
 
-  describe("demo agent creation", () => {
-    it("should create vm0-demo-agent directory with --yes flag", async () => {
+  describe("agent directory creation", () => {
+    it("should create agent directory with default name", async () => {
+      await onboardCommand.parseAsync(["node", "cli", "-y"]);
+
+      expect(existsSync(path.join(tempDir, "my-vm0-agent"))).toBe(true);
+    });
+
+    it("should create agent directory with custom name via --name flag", async () => {
       await onboardCommand.parseAsync([
         "node",
         "cli",
         "-y",
-        "--method",
-        "manual",
+        "--name",
+        "custom-agent",
       ]);
 
-      expect(existsSync(path.join(tempDir, "vm0-demo-agent"))).toBe(true);
+      expect(existsSync(path.join(tempDir, "custom-agent"))).toBe(true);
     });
 
-    it("should create vm0.yaml in the demo agent directory", async () => {
-      await onboardCommand.parseAsync([
-        "node",
-        "cli",
-        "-y",
-        "--method",
-        "manual",
-      ]);
+    it("should exit with error if directory already exists", async () => {
+      const { mkdir } = await import("fs/promises");
+      await mkdir(path.join(tempDir, "my-vm0-agent"));
 
-      const yamlPath = path.join(tempDir, "vm0-demo-agent/vm0.yaml");
-      expect(existsSync(yamlPath)).toBe(true);
+      await expect(async () => {
+        await onboardCommand.parseAsync(["node", "cli", "-y"]);
+      }).rejects.toThrow("process.exit called");
 
-      const content = await fs.readFile(yamlPath, "utf8");
-      expect(content).toContain('version: "1.0"');
-      expect(content).toContain("vm0-demo-agent:");
-      expect(content).toContain("framework: claude-code");
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("my-vm0-agent/ already exists"),
+      );
     });
 
-    it("should create AGENTS.md in the demo agent directory", async () => {
-      await onboardCommand.parseAsync([
-        "node",
-        "cli",
-        "-y",
-        "--method",
-        "manual",
-      ]);
-
-      const mdPath = path.join(tempDir, "vm0-demo-agent/AGENTS.md");
-      expect(existsSync(mdPath)).toBe(true);
-
-      const content = await fs.readFile(mdPath, "utf8");
-      expect(content).toContain("Agent Instructions");
-      expect(content).toContain("HackerNews");
-    });
-
-    it("should exit with error if vm0-demo-agent already exists", async () => {
-      // Create existing directory
-      await fs.mkdir(path.join(tempDir, "vm0-demo-agent"));
-
+    it("should exit with error for invalid agent name", async () => {
       await expect(async () => {
         await onboardCommand.parseAsync([
           "node",
           "cli",
           "-y",
-          "--method",
-          "manual",
+          "--name",
+          "ab", // Too short
         ]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("vm0-demo-agent/ already exists"),
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid agent name"),
       );
-      expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 
-  describe("method selection", () => {
-    it("should support --method claude flag", async () => {
-      await onboardCommand.parseAsync([
-        "node",
-        "cli",
-        "-y",
-        "--method",
-        "claude",
-      ]);
+  describe("skill installation", () => {
+    it("should install vm0-agent-builder skill in agent directory", async () => {
+      await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
-      // setup-claude downloads skill to .claude/skills/vm0-agent-builder
-      expect(
-        existsSync(
-          path.join(tempDir, "vm0-demo-agent/.claude/skills/vm0-agent-builder"),
-        ),
-      ).toBe(true);
+      const skillPath = path.join(
+        tempDir,
+        "my-vm0-agent/.claude/skills/vm0-agent-builder/SKILL.md",
+      );
+      expect(existsSync(skillPath)).toBe(true);
     });
 
-    it("should support --method manual flag", async () => {
-      await onboardCommand.parseAsync([
-        "node",
-        "cli",
-        "-y",
-        "--method",
-        "manual",
-      ]);
+    it("should write correct skill content", async () => {
+      await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
-      expect(mockConsoleLog).toHaveBeenCalledWith("Next steps:");
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("AGENTS.md"),
+      const skillPath = path.join(
+        tempDir,
+        "my-vm0-agent/.claude/skills/vm0-agent-builder/SKILL.md",
       );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("vm0 cook"),
-      );
+      const content = await readFile(skillPath, "utf-8");
+
+      expect(content).toContain("name: vm0-agent-builder");
+      expect(content).toContain("## Workflow");
+    });
+  });
+
+  describe("does NOT create vm0.yaml or AGENTS.md", () => {
+    it("should not create vm0.yaml in agent directory", async () => {
+      await onboardCommand.parseAsync(["node", "cli", "-y"]);
+
+      const yamlPath = path.join(tempDir, "my-vm0-agent/vm0.yaml");
+      expect(existsSync(yamlPath)).toBe(false);
     });
 
-    it("should display correct next steps for manual method", async () => {
+    it("should not create AGENTS.md in agent directory", async () => {
+      await onboardCommand.parseAsync(["node", "cli", "-y"]);
+
+      const mdPath = path.join(tempDir, "my-vm0-agent/AGENTS.md");
+      expect(existsSync(mdPath)).toBe(false);
+    });
+  });
+
+  describe("next steps output", () => {
+    it("should display next steps after completion", async () => {
+      await onboardCommand.parseAsync(["node", "cli", "-y"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Next steps:");
+      expect(logCalls).toContain("cd my-vm0-agent");
+      expect(logCalls).toContain("claude");
+      expect(logCalls).toContain("/vm0-agent-builder");
+    });
+
+    it("should show custom agent name in next steps", async () => {
       await onboardCommand.parseAsync([
         "node",
         "cli",
         "-y",
-        "--method",
-        "manual",
+        "--name",
+        "custom-agent",
       ]);
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("cd vm0-demo-agent"),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Edit"),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("vm0.yaml"),
-      );
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("cd custom-agent");
     });
   });
 
   describe("--yes flag", () => {
-    it("should work with -y short option", async () => {
-      await onboardCommand.parseAsync([
-        "node",
-        "cli",
-        "-y",
-        "--method",
-        "manual",
-      ]);
+    it("should skip prompts with -y short option", async () => {
+      await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
-      expect(existsSync(path.join(tempDir, "vm0-demo-agent"))).toBe(true);
+      expect(existsSync(path.join(tempDir, "my-vm0-agent"))).toBe(true);
+    });
+
+    it("should skip prompts with --yes long option", async () => {
+      await onboardCommand.parseAsync(["node", "cli", "--yes"]);
+
+      expect(existsSync(path.join(tempDir, "my-vm0-agent"))).toBe(true);
     });
   });
 
   describe("output messages", () => {
-    it("should display creation success messages", async () => {
-      await onboardCommand.parseAsync([
-        "node",
-        "cli",
-        "-y",
-        "--method",
-        "manual",
-      ]);
+    it("should display success messages for creation", async () => {
+      await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Created"),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("vm0.yaml"),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("AGENTS.md"),
-      );
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Created my-vm0-agent/");
+      expect(logCalls).toContain("Installed vm0-agent-builder skill");
     });
   });
 });

--- a/turbo/apps/cli/src/commands/onboard.ts
+++ b/turbo/apps/cli/src/commands/onboard.ts
@@ -1,146 +1,265 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import prompts from "prompts";
 import { mkdir } from "fs/promises";
 import { existsSync } from "fs";
-import { getToken } from "../lib/api/config";
-import { listModelProviders } from "../lib/api";
-import { isInteractive } from "../lib/utils/prompt-utils";
-import { loginCommand } from "./auth";
-import { setupCommand as modelProviderSetupCommand } from "./model-provider/setup";
-import { setupClaudeCommand } from "./setup-claude";
-import { initCommand } from "./init";
+import { validateAgentName } from "../lib/domain/yaml-validator.js";
+import {
+  isInteractive,
+  promptText,
+  promptConfirm,
+  promptSelect,
+  promptPassword,
+} from "../lib/utils/prompt-utils.js";
+import { renderOnboardWelcome } from "../lib/ui/welcome-box.js";
+import {
+  createOnboardProgress,
+  type StepStatus,
+} from "../lib/ui/progress-line.js";
+import {
+  isAuthenticated,
+  runAuthFlow,
+  checkModelProviderStatus,
+  getProviderChoices,
+  setupModelProvider,
+  installClaudeSkill,
+} from "../lib/domain/onboard/index.js";
+import type { ModelProviderType } from "@vm0/core";
 
-const DEMO_AGENT_DIR = "vm0-demo-agent";
-const DEMO_AGENT_NAME = "vm0-demo-agent";
+const DEFAULT_AGENT_NAME = "my-vm0-agent";
+
+interface OnboardOptions {
+  yes?: boolean;
+  name?: string;
+}
+
+interface OnboardContext {
+  interactive: boolean;
+  options: OnboardOptions;
+  updateProgress: (index: number, status: StepStatus) => void;
+}
+
+async function handleAuthentication(ctx: OnboardContext): Promise<void> {
+  ctx.updateProgress(0, "in-progress");
+
+  const authenticated = await isAuthenticated();
+  if (authenticated) {
+    ctx.updateProgress(0, "completed");
+    return;
+  }
+
+  if (!ctx.interactive) {
+    console.error(chalk.red("Error: Not authenticated"));
+    console.error("Run 'vm0 auth login' first or set VM0_TOKEN");
+    process.exit(1);
+  }
+
+  console.log(chalk.dim("Authentication required..."));
+  console.log();
+
+  await runAuthFlow({
+    onInitiating: () => {
+      console.log("Initiating authentication...");
+    },
+    onDeviceCodeReady: (url, code, expiresIn) => {
+      console.log(chalk.green("\nDevice code generated"));
+      console.log(chalk.cyan(`\nTo authenticate, visit: ${url}`));
+      console.log(`And enter this code: ${chalk.bold(code)}`);
+      console.log(`\nThe code expires in ${expiresIn} minutes.`);
+      console.log("\nWaiting for authentication...");
+    },
+    onPolling: () => {
+      process.stdout.write(chalk.dim("."));
+    },
+    onSuccess: () => {
+      console.log(chalk.green("\nAuthentication successful!"));
+      console.log("Your credentials have been saved.");
+    },
+    onError: (error) => {
+      console.error(chalk.red(`\n${error.message}`));
+      process.exit(1);
+    },
+  });
+
+  ctx.updateProgress(0, "completed");
+}
+
+async function handleModelProvider(ctx: OnboardContext): Promise<void> {
+  ctx.updateProgress(1, "in-progress");
+
+  const providerStatus = await checkModelProviderStatus();
+  if (providerStatus.hasProvider) {
+    ctx.updateProgress(1, "completed");
+    return;
+  }
+
+  if (!ctx.interactive) {
+    console.error(chalk.red("Error: No model provider configured"));
+    console.error("Run 'vm0 model-provider setup' first");
+    process.exit(1);
+  }
+
+  console.log(chalk.dim("Model provider setup required..."));
+  console.log();
+
+  const choices = getProviderChoices();
+  const providerType = await promptSelect<ModelProviderType>(
+    "Select provider type:",
+    choices.map((c) => ({
+      title: c.label,
+      value: c.type,
+      description: c.helpText,
+    })),
+  );
+
+  if (!providerType) {
+    process.exit(0);
+  }
+
+  const selectedChoice = choices.find((c) => c.type === providerType);
+  if (selectedChoice) {
+    console.log();
+    console.log(chalk.dim(selectedChoice.helpText));
+    console.log();
+  }
+
+  const credential = await promptPassword(
+    `Enter your ${selectedChoice?.credentialLabel ?? "credential"}:`,
+  );
+
+  if (!credential) {
+    console.log(chalk.dim("Cancelled"));
+    process.exit(0);
+  }
+
+  const result = await setupModelProvider(providerType, credential);
+  console.log(
+    chalk.green(
+      `\n✓ Model provider "${providerType}" ${result.created ? "created" : "updated"}${result.isDefault ? ` (default for ${result.framework})` : ""}`,
+    ),
+  );
+
+  ctx.updateProgress(1, "completed");
+}
+
+async function handleAgentCreation(ctx: OnboardContext): Promise<string> {
+  ctx.updateProgress(2, "in-progress");
+
+  let agentName = ctx.options.name ?? DEFAULT_AGENT_NAME;
+
+  if (!ctx.options.yes && !ctx.options.name && ctx.interactive) {
+    const inputName = await promptText(
+      "Enter agent name:",
+      DEFAULT_AGENT_NAME,
+      (value: string) => {
+        if (!validateAgentName(value)) {
+          return "Invalid name: 3-64 chars, alphanumeric + hyphens, start/end with letter/number";
+        }
+        return true;
+      },
+    );
+
+    if (!inputName) {
+      process.exit(0);
+    }
+    agentName = inputName;
+  }
+
+  if (!validateAgentName(agentName)) {
+    console.error(
+      chalk.red(
+        "Invalid agent name: must be 3-64 chars, alphanumeric + hyphens",
+      ),
+    );
+    process.exit(1);
+  }
+
+  if (existsSync(agentName)) {
+    console.error(chalk.red(`\n✗ ${agentName}/ already exists`));
+    console.log();
+    console.log("Remove it first or choose a different name:");
+    console.log(chalk.cyan(`  rm -rf ${agentName}`));
+    process.exit(1);
+  }
+
+  if (!ctx.options.yes && ctx.interactive) {
+    const confirmed = await promptConfirm(`Create ${agentName}/?`, true);
+    if (!confirmed) {
+      console.log(chalk.dim("Cancelled"));
+      process.exit(0);
+    }
+  }
+
+  await mkdir(agentName, { recursive: true });
+  console.log(chalk.green(`✓ Created ${agentName}/`));
+
+  ctx.updateProgress(2, "completed");
+  return agentName;
+}
+
+async function handleSkillInstallation(
+  ctx: OnboardContext,
+  agentName: string,
+): Promise<void> {
+  ctx.updateProgress(3, "in-progress");
+
+  const skillResult = await installClaudeSkill(agentName);
+  console.log(
+    chalk.green(
+      `✓ Installed vm0-agent-builder skill to ${skillResult.skillDir}`,
+    ),
+  );
+
+  ctx.updateProgress(3, "completed");
+}
+
+function printNextSteps(agentName: string): void {
+  console.log();
+  console.log(chalk.bold("Next steps:"));
+  console.log(`  ${chalk.cyan(`cd ${agentName}`)}`);
+  console.log(
+    `  ${chalk.cyan('claude "/vm0-agent-builder I want to build an agent that..."')}`,
+  );
+  console.log();
+}
 
 export const onboardCommand = new Command()
   .name("onboard")
   .description("Guided setup for new VM0 users")
   .option("-y, --yes", "Skip confirmation prompts")
-  .option(
-    "--method <method>",
-    "Agent building method: claude or manual",
-    undefined,
-  )
-  .action(async (options: { yes?: boolean; method?: "claude" | "manual" }) => {
-    // Step 1: Check auth
-    const token = await getToken();
-    if (token) {
-      console.log(chalk.green("Done Authenticated"));
-    } else {
-      console.log(chalk.dim("Authentication required..."));
+  .option("--name <name>", `Agent name (default: ${DEFAULT_AGENT_NAME})`)
+  .action(async (options: OnboardOptions) => {
+    const interactive = isInteractive();
+
+    if (interactive) {
       console.log();
-      await loginCommand.parseAsync([], { from: "user" });
+      renderOnboardWelcome();
+      console.log();
     }
 
-    // Step 2: Check/setup model-provider
-    try {
-      const result = await listModelProviders();
-      if (result.modelProviders.length > 0) {
-        console.log(chalk.green("Done Model provider configured"));
-      } else {
-        console.log(chalk.dim("Model provider setup required..."));
+    const progress = createOnboardProgress();
+
+    const updateProgress = (index: number, status: StepStatus) => {
+      progress.update(index, status);
+      if (interactive) {
+        console.clear();
+        renderOnboardWelcome();
         console.log();
-        await modelProviderSetupCommand.parseAsync([], { from: "user" });
+        progress.render();
+        console.log();
       }
-    } catch {
-      // If we can't check, try to run setup anyway
-      // setupCommand will handle its own errors
-      console.log(chalk.dim("Setting up model provider..."));
+    };
+
+    if (interactive) {
+      progress.render();
       console.log();
-      await modelProviderSetupCommand.parseAsync([], { from: "user" });
     }
 
-    // Step 3: Create demo agent
-    let createAgent = options.yes;
-    if (!createAgent && isInteractive()) {
-      const response = await prompts(
-        {
-          type: "confirm",
-          name: "create",
-          message: `Create ${DEMO_AGENT_DIR}?`,
-          initial: true,
-        },
-        { onCancel: () => process.exit(0) },
-      );
-      createAgent = response.create;
-    }
+    const ctx: OnboardContext = { interactive, options, updateProgress };
 
-    if (!createAgent) {
-      console.log(chalk.dim("Skipped agent creation"));
-      return;
-    }
+    await handleAuthentication(ctx);
+    await handleModelProvider(ctx);
+    const agentName = await handleAgentCreation(ctx);
+    await handleSkillInstallation(ctx, agentName);
 
-    // Check if directory exists
-    if (existsSync(DEMO_AGENT_DIR)) {
-      console.log(chalk.red(`x ${DEMO_AGENT_DIR}/ already exists`));
-      console.log();
-      console.log("Remove it first or use a different directory:");
-      console.log(chalk.cyan(`  rm -rf ${DEMO_AGENT_DIR}`));
-      process.exit(1);
-    }
-
-    // Create directory and run init inside it
-    await mkdir(DEMO_AGENT_DIR, { recursive: true });
-
-    const originalDir = process.cwd();
-    process.chdir(DEMO_AGENT_DIR);
-
-    try {
-      // Use vm0 init to create the project files
-      await initCommand.parseAsync(["--name", DEMO_AGENT_NAME], {
-        from: "user",
-      });
-    } finally {
-      process.chdir(originalDir);
-    }
-
-    console.log();
-
-    // Step 4: Choose method
-    let method = options.method;
-    if (!method && isInteractive()) {
-      const response = await prompts(
-        {
-          type: "select",
-          name: "method",
-          message: "How would you like to build your agent?",
-          choices: [
-            {
-              title: "Use `vm0 setup-claude` to let Claude help (Recommended)",
-              value: "claude",
-            },
-            {
-              title: "I will do it myself (Edit `AGENTS.md` and `vm0.yaml`)",
-              value: "manual",
-            },
-          ],
-        },
-        { onCancel: () => process.exit(0) },
-      );
-      method = response.method as "claude" | "manual";
-    }
-
-    if (method === "claude") {
-      // Change to the demo agent directory and run setup-claude
-      process.chdir(DEMO_AGENT_DIR);
-
-      try {
-        // Run setup-claude action directly, passing agent-dir for the "Next step" message
-        await setupClaudeCommand.parseAsync(["--agent-dir", DEMO_AGENT_DIR], {
-          from: "user",
-        });
-      } finally {
-        process.chdir(originalDir);
-      }
-    } else {
-      console.log("Next steps:");
-      console.log(`  1. ${chalk.cyan(`cd ${DEMO_AGENT_DIR}`)}`);
-      console.log(
-        `  2. Edit ${chalk.cyan("AGENTS.md")} to define your agent's workflow`,
-      );
-      console.log(`  3. Edit ${chalk.cyan("vm0.yaml")} to configure skills`);
-      console.log(`  4. Run ${chalk.cyan('vm0 cook "start working"')} to test`);
-    }
+    printNextSteps(agentName);
   });

--- a/turbo/apps/cli/src/commands/onboard.ts
+++ b/turbo/apps/cli/src/commands/onboard.ts
@@ -214,10 +214,10 @@ async function handleSkillInstallation(
 
 function printNextSteps(agentName: string): void {
   console.log();
-  console.log(chalk.bold("Next steps:"));
-  console.log(`  ${chalk.cyan(`cd ${agentName}`)}`);
+  console.log(chalk.bold("Next step:"));
+  console.log();
   console.log(
-    `  ${chalk.cyan('claude "/vm0-agent-builder I want to build an agent that..."')}`,
+    `  ${chalk.cyan(`cd ${agentName} && claude "/vm0-agent-builder I want to build an agent that..."`)}`,
   );
   console.log();
 }

--- a/turbo/apps/cli/src/lib/domain/onboard/__tests__/auth.test.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/__tests__/auth.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockGetToken = vi.fn();
+const mockSaveConfig = vi.fn();
+const mockGetApiUrl = vi.fn();
+
+vi.mock("../../../api/config.js", () => ({
+  getToken: () => mockGetToken(),
+  saveConfig: (config: unknown) => mockSaveConfig(config),
+  getApiUrl: () => mockGetApiUrl(),
+}));
+
+describe("auth", () => {
+  let isAuthenticated: typeof import("../auth.js").isAuthenticated;
+  let runAuthFlow: typeof import("../auth.js").runAuthFlow;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetApiUrl.mockResolvedValue("https://api.vm0.ai");
+
+    const authModule = await import("../auth.js");
+    isAuthenticated = authModule.isAuthenticated;
+    runAuthFlow = authModule.runAuthFlow;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("isAuthenticated", () => {
+    it("should return true when token exists", async () => {
+      mockGetToken.mockResolvedValue("test-token");
+
+      const result = await isAuthenticated();
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when no token", async () => {
+      mockGetToken.mockResolvedValue(undefined);
+
+      const result = await isAuthenticated();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("runAuthFlow", () => {
+    const mockDeviceCodeResponse = {
+      device_code: "device-code-123",
+      user_code: "USER-CODE",
+      verification_path: "/cli-auth",
+      expires_in: 900,
+      interval: 5,
+    };
+
+    const mockTokenResponse = {
+      access_token: "access-token-123",
+    };
+
+    it("should call callbacks in correct order on success", async () => {
+      const callbacks = {
+        onInitiating: vi.fn(),
+        onDeviceCodeReady: vi.fn(),
+        onPolling: vi.fn(),
+        onSuccess: vi.fn(),
+        onError: vi.fn(),
+      };
+
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockDeviceCodeResponse),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockTokenResponse),
+        } as Response);
+
+      await runAuthFlow(callbacks);
+
+      expect(callbacks.onInitiating).toHaveBeenCalled();
+      expect(callbacks.onDeviceCodeReady).toHaveBeenCalledWith(
+        "https://api.vm0.ai/cli-auth",
+        "USER-CODE",
+        15,
+      );
+      expect(callbacks.onSuccess).toHaveBeenCalled();
+      expect(callbacks.onError).not.toHaveBeenCalled();
+      expect(mockSaveConfig).toHaveBeenCalledWith({
+        token: "access-token-123",
+        apiUrl: "https://api.vm0.ai",
+      });
+    });
+
+    it("should call onError on expired token", async () => {
+      const callbacks = {
+        onError: vi.fn(),
+      };
+
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockDeviceCodeResponse),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ error: "expired_token" }),
+        } as Response);
+
+      await expect(runAuthFlow(callbacks)).rejects.toThrow(
+        "The device code has expired",
+      );
+      expect(callbacks.onError).toHaveBeenCalled();
+    });
+
+    it("should throw on failed device code request", async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        statusText: "Internal Server Error",
+      } as Response);
+
+      await expect(runAuthFlow()).rejects.toThrow(
+        "Failed to request device code",
+      );
+    });
+
+    it("should handle auth errors with description", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockDeviceCodeResponse),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              error: "access_denied",
+              error_description: "User denied access",
+            }),
+        } as Response);
+
+      await expect(runAuthFlow()).rejects.toThrow(
+        "Authentication failed: User denied access",
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/lib/domain/onboard/__tests__/auth.test.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/__tests__/auth.test.ts
@@ -1,35 +1,39 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "fs";
+import { readFile } from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server.js";
+import { isAuthenticated, runAuthFlow } from "../auth.js";
 
-const mockGetToken = vi.fn();
-const mockSaveConfig = vi.fn();
-const mockGetApiUrl = vi.fn();
-
-vi.mock("../../../api/config.js", () => ({
-  getToken: () => mockGetToken(),
-  saveConfig: (config: unknown) => mockSaveConfig(config),
-  getApiUrl: () => mockGetApiUrl(),
-}));
+// Mock os.homedir at system boundary for config file isolation
+vi.mock("os", async (importOriginal) => {
+  const original = await importOriginal<typeof import("os")>();
+  return {
+    ...original,
+    homedir: vi.fn(),
+  };
+});
 
 describe("auth", () => {
-  let isAuthenticated: typeof import("../auth.js").isAuthenticated;
-  let runAuthFlow: typeof import("../auth.js").runAuthFlow;
+  let tempDir: string;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    mockGetApiUrl.mockResolvedValue("https://api.vm0.ai");
-
-    const authModule = await import("../auth.js");
-    isAuthenticated = authModule.isAuthenticated;
-    runAuthFlow = authModule.runAuthFlow;
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "test-auth-"));
+    vi.mocked(os.homedir).mockReturnValue(tempDir);
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
   });
 
   describe("isAuthenticated", () => {
-    it("should return true when token exists", async () => {
-      mockGetToken.mockResolvedValue("test-token");
+    it("should return true when VM0_TOKEN env var exists", async () => {
+      vi.stubEnv("VM0_TOKEN", "test-token");
 
       const result = await isAuthenticated();
 
@@ -37,7 +41,7 @@ describe("auth", () => {
     });
 
     it("should return false when no token", async () => {
-      mockGetToken.mockResolvedValue(undefined);
+      // No VM0_TOKEN env var, no config file
 
       const result = await isAuthenticated();
 
@@ -46,69 +50,70 @@ describe("auth", () => {
   });
 
   describe("runAuthFlow", () => {
-    const mockDeviceCodeResponse = {
-      device_code: "device-code-123",
-      user_code: "USER-CODE",
-      verification_path: "/cli-auth",
-      expires_in: 900,
-      interval: 5,
-    };
+    it("should complete auth flow and save config on success", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/cli/auth/device", () => {
+          return HttpResponse.json({
+            device_code: "device-code-123",
+            user_code: "USER-CODE",
+            verification_path: "/cli-auth",
+            expires_in: 900,
+            interval: 1,
+          });
+        }),
+        http.post("http://localhost:3000/api/cli/auth/token", () => {
+          return HttpResponse.json({
+            access_token: "access-token-123",
+          });
+        }),
+      );
 
-    const mockTokenResponse = {
-      access_token: "access-token-123",
-    };
-
-    it("should call callbacks in correct order on success", async () => {
       const callbacks = {
         onInitiating: vi.fn(),
         onDeviceCodeReady: vi.fn(),
-        onPolling: vi.fn(),
         onSuccess: vi.fn(),
         onError: vi.fn(),
       };
 
-      global.fetch = vi
-        .fn()
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve(mockDeviceCodeResponse),
-        } as Response)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve(mockTokenResponse),
-        } as Response);
-
       await runAuthFlow(callbacks);
 
+      // Verify callbacks were called
       expect(callbacks.onInitiating).toHaveBeenCalled();
       expect(callbacks.onDeviceCodeReady).toHaveBeenCalledWith(
-        "https://api.vm0.ai/cli-auth",
+        "http://localhost:3000/cli-auth",
         "USER-CODE",
         15,
       );
       expect(callbacks.onSuccess).toHaveBeenCalled();
       expect(callbacks.onError).not.toHaveBeenCalled();
-      expect(mockSaveConfig).toHaveBeenCalledWith({
-        token: "access-token-123",
-        apiUrl: "https://api.vm0.ai",
-      });
+
+      // Verify config was saved to filesystem
+      const configPath = path.join(tempDir, ".vm0", "config.json");
+      expect(existsSync(configPath)).toBe(true);
+
+      const configContent = await readFile(configPath, "utf-8");
+      const config = JSON.parse(configContent);
+      expect(config.token).toBe("access-token-123");
+      expect(config.apiUrl).toBe("http://localhost:3000");
     });
 
-    it("should call onError on expired token", async () => {
-      const callbacks = {
-        onError: vi.fn(),
-      };
+    it("should throw on expired token", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/cli/auth/device", () => {
+          return HttpResponse.json({
+            device_code: "device-code-123",
+            user_code: "USER-CODE",
+            verification_path: "/cli-auth",
+            expires_in: 900,
+            interval: 1,
+          });
+        }),
+        http.post("http://localhost:3000/api/cli/auth/token", () => {
+          return HttpResponse.json({ error: "expired_token" });
+        }),
+      );
 
-      global.fetch = vi
-        .fn()
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve(mockDeviceCodeResponse),
-        } as Response)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ error: "expired_token" }),
-        } as Response);
+      const callbacks = { onError: vi.fn() };
 
       await expect(runAuthFlow(callbacks)).rejects.toThrow(
         "The device code has expired",
@@ -117,31 +122,38 @@ describe("auth", () => {
     });
 
     it("should throw on failed device code request", async () => {
-      global.fetch = vi.fn().mockResolvedValueOnce({
-        ok: false,
-        statusText: "Internal Server Error",
-      } as Response);
+      server.use(
+        http.post("http://localhost:3000/api/cli/auth/device", () => {
+          return new HttpResponse(null, {
+            status: 500,
+            statusText: "Internal Server Error",
+          });
+        }),
+      );
 
       await expect(runAuthFlow()).rejects.toThrow(
         "Failed to request device code",
       );
     });
 
-    it("should handle auth errors with description", async () => {
-      global.fetch = vi
-        .fn()
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve(mockDeviceCodeResponse),
-        } as Response)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              error: "access_denied",
-              error_description: "User denied access",
-            }),
-        } as Response);
+    it("should throw with error description on auth failure", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/cli/auth/device", () => {
+          return HttpResponse.json({
+            device_code: "device-code-123",
+            user_code: "USER-CODE",
+            verification_path: "/cli-auth",
+            expires_in: 900,
+            interval: 1,
+          });
+        }),
+        http.post("http://localhost:3000/api/cli/auth/token", () => {
+          return HttpResponse.json({
+            error: "access_denied",
+            error_description: "User denied access",
+          });
+        }),
+      );
 
       await expect(runAuthFlow()).rejects.toThrow(
         "Authentication failed: User denied access",

--- a/turbo/apps/cli/src/lib/domain/onboard/__tests__/claude-setup.test.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/__tests__/claude-setup.test.ts
@@ -49,7 +49,7 @@ describe("claude-setup", () => {
 
       expect(content).toContain("## Workflow");
       expect(content).toContain("Step 1");
-      expect(content).toContain("Write AGENTS.md");
+      expect(content).toContain("Create AGENTS.md");
     });
 
     it("should include available skills", () => {
@@ -63,8 +63,8 @@ describe("claude-setup", () => {
     it("should include example agents", () => {
       const content = getSkillContent();
 
-      expect(content).toContain("## Example Agents");
-      expect(content).toContain("Content Curator Agent");
+      expect(content).toContain("## Examples");
+      expect(content).toContain("HackerNews Curator");
     });
   });
 

--- a/turbo/apps/cli/src/lib/domain/onboard/__tests__/claude-setup.test.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/__tests__/claude-setup.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, rm } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import {
+  SKILL_DIR,
+  SKILL_FILE,
+  getSkillContent,
+  installClaudeSkill,
+} from "../claude-setup.js";
+
+describe("claude-setup", () => {
+  const testDir = "/tmp/test-claude-setup";
+
+  beforeEach(async () => {
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe("constants", () => {
+    it("should have correct SKILL_DIR", () => {
+      expect(SKILL_DIR).toBe(".claude/skills/vm0-agent-builder");
+    });
+
+    it("should have correct SKILL_FILE", () => {
+      expect(SKILL_FILE).toBe("SKILL.md");
+    });
+  });
+
+  describe("getSkillContent", () => {
+    it("should return non-empty content", () => {
+      const content = getSkillContent();
+
+      expect(content.length).toBeGreaterThan(0);
+    });
+
+    it("should include frontmatter", () => {
+      const content = getSkillContent();
+
+      expect(content).toContain("---");
+      expect(content).toContain("name: vm0-agent-builder");
+    });
+
+    it("should include workflow sections", () => {
+      const content = getSkillContent();
+
+      expect(content).toContain("## Workflow");
+      expect(content).toContain("Step 1");
+      expect(content).toContain("Write AGENTS.md");
+    });
+
+    it("should include available skills", () => {
+      const content = getSkillContent();
+
+      expect(content).toContain("## Available Skills");
+      expect(content).toContain("github");
+      expect(content).toContain("slack");
+    });
+
+    it("should include example agents", () => {
+      const content = getSkillContent();
+
+      expect(content).toContain("## Example Agents");
+      expect(content).toContain("Content Curator Agent");
+    });
+  });
+
+  describe("installClaudeSkill", () => {
+    it("should create skill directory", async () => {
+      const result = await installClaudeSkill(testDir);
+
+      expect(existsSync(result.skillDir)).toBe(true);
+    });
+
+    it("should create skill file", async () => {
+      const result = await installClaudeSkill(testDir);
+
+      expect(existsSync(result.skillFile)).toBe(true);
+    });
+
+    it("should return correct paths", async () => {
+      const result = await installClaudeSkill(testDir);
+
+      expect(result.skillDir).toBe(path.join(testDir, SKILL_DIR));
+      expect(result.skillFile).toBe(path.join(testDir, SKILL_DIR, SKILL_FILE));
+    });
+
+    it("should write correct content to file", async () => {
+      await installClaudeSkill(testDir);
+
+      const { readFile } = await import("fs/promises");
+      const content = await readFile(
+        path.join(testDir, SKILL_DIR, SKILL_FILE),
+        "utf-8",
+      );
+
+      expect(content).toBe(getSkillContent());
+    });
+
+    it("should use current directory when no targetDir specified", async () => {
+      const originalCwd = process.cwd();
+      process.chdir(testDir);
+
+      try {
+        const result = await installClaudeSkill();
+
+        expect(result.skillDir).toBe(path.join(testDir, SKILL_DIR));
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+  });
+});

--- a/turbo/apps/cli/src/lib/domain/onboard/__tests__/model-provider.test.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/__tests__/model-provider.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  checkModelProviderStatus,
+  getProviderChoices,
+  checkExistingCredential,
+  setupModelProvider,
+} from "../model-provider.js";
+
+vi.mock("../../../api/domains/model-providers.js", () => ({
+  listModelProviders: vi.fn(),
+  upsertModelProvider: vi.fn(),
+  checkModelProviderCredential: vi.fn(),
+  convertModelProviderCredential: vi.fn(),
+}));
+
+import {
+  listModelProviders,
+  upsertModelProvider,
+  checkModelProviderCredential,
+} from "../../../api/domains/model-providers.js";
+
+describe("model-provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("checkModelProviderStatus", () => {
+    it("should return hasProvider true when providers exist", async () => {
+      vi.mocked(listModelProviders).mockResolvedValue({
+        modelProviders: [
+          {
+            id: "123",
+            type: "anthropic-api-key",
+            framework: "claude-code",
+            credentialName: "ANTHROPIC_API_KEY",
+            isDefault: true,
+            createdAt: "2024-01-01",
+            updatedAt: "2024-01-01",
+          },
+        ],
+      });
+
+      const result = await checkModelProviderStatus();
+
+      expect(result.hasProvider).toBe(true);
+      expect(result.providers.length).toBe(1);
+    });
+
+    it("should return hasProvider false when no providers", async () => {
+      vi.mocked(listModelProviders).mockResolvedValue({
+        modelProviders: [],
+      });
+
+      const result = await checkModelProviderStatus();
+
+      expect(result.hasProvider).toBe(false);
+      expect(result.providers.length).toBe(0);
+    });
+  });
+
+  describe("getProviderChoices", () => {
+    it("should return all provider types", () => {
+      const choices = getProviderChoices();
+
+      expect(choices.length).toBeGreaterThan(0);
+      expect(choices.some((c) => c.type === "anthropic-api-key")).toBe(true);
+      expect(choices.some((c) => c.type === "claude-code-oauth-token")).toBe(
+        true,
+      );
+    });
+
+    it("should include label and helpText for each choice", () => {
+      const choices = getProviderChoices();
+
+      for (const choice of choices) {
+        expect(choice.label).toBeDefined();
+        expect(choice.helpText).toBeDefined();
+        expect(choice.credentialLabel).toBeDefined();
+      }
+    });
+  });
+
+  describe("checkExistingCredential", () => {
+    it("should return exists true when credential exists", async () => {
+      vi.mocked(checkModelProviderCredential).mockResolvedValue({
+        exists: true,
+        credentialName: "ANTHROPIC_API_KEY",
+        currentType: "user",
+      });
+
+      const result = await checkExistingCredential("anthropic-api-key");
+
+      expect(result.exists).toBe(true);
+      expect(result.credentialName).toBe("ANTHROPIC_API_KEY");
+      expect(result.currentType).toBe("user");
+    });
+
+    it("should return exists false when no credential", async () => {
+      vi.mocked(checkModelProviderCredential).mockResolvedValue({
+        exists: false,
+        credentialName: "ANTHROPIC_API_KEY",
+      });
+
+      const result = await checkExistingCredential("anthropic-api-key");
+
+      expect(result.exists).toBe(false);
+    });
+  });
+
+  describe("setupModelProvider", () => {
+    it("should setup provider and return result", async () => {
+      vi.mocked(upsertModelProvider).mockResolvedValue({
+        provider: {
+          id: "123",
+          type: "anthropic-api-key",
+          framework: "claude-code",
+          credentialName: "ANTHROPIC_API_KEY",
+          isDefault: true,
+          createdAt: "2024-01-01",
+          updatedAt: "2024-01-01",
+        },
+        created: true,
+      });
+
+      const result = await setupModelProvider(
+        "anthropic-api-key",
+        "test-credential",
+      );
+
+      expect(result.created).toBe(true);
+      expect(result.isDefault).toBe(true);
+      expect(result.framework).toBe("claude-code");
+      expect(upsertModelProvider).toHaveBeenCalledWith({
+        type: "anthropic-api-key",
+        credential: "test-credential",
+        convert: undefined,
+      });
+    });
+
+    it("should pass convert option when specified", async () => {
+      vi.mocked(upsertModelProvider).mockResolvedValue({
+        provider: {
+          id: "123",
+          type: "anthropic-api-key",
+          framework: "claude-code",
+          credentialName: "ANTHROPIC_API_KEY",
+          isDefault: true,
+          createdAt: "2024-01-01",
+          updatedAt: "2024-01-01",
+        },
+        created: false,
+      });
+
+      await setupModelProvider("anthropic-api-key", "test-credential", {
+        convert: true,
+      });
+
+      expect(upsertModelProvider).toHaveBeenCalledWith({
+        type: "anthropic-api-key",
+        credential: "test-credential",
+        convert: true,
+      });
+    });
+  });
+});

--- a/turbo/apps/cli/src/lib/domain/onboard/__tests__/model-provider.test.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/__tests__/model-provider.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server.js";
 import {
   checkModelProviderStatus,
   getProviderChoices,
@@ -6,50 +8,50 @@ import {
   setupModelProvider,
 } from "../model-provider.js";
 
-vi.mock("../../../api/domains/model-providers.js", () => ({
-  listModelProviders: vi.fn(),
-  upsertModelProvider: vi.fn(),
-  checkModelProviderCredential: vi.fn(),
-  convertModelProviderCredential: vi.fn(),
-}));
-
-import {
-  listModelProviders,
-  upsertModelProvider,
-  checkModelProviderCredential,
-} from "../../../api/domains/model-providers.js";
-
 describe("model-provider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   describe("checkModelProviderStatus", () => {
     it("should return hasProvider true when providers exist", async () => {
-      vi.mocked(listModelProviders).mockResolvedValue({
-        modelProviders: [
-          {
-            id: "123",
-            type: "anthropic-api-key",
-            framework: "claude-code",
-            credentialName: "ANTHROPIC_API_KEY",
-            isDefault: true,
-            createdAt: "2024-01-01",
-            updatedAt: "2024-01-01",
-          },
-        ],
-      });
+      server.use(
+        http.get("http://localhost:3000/api/model-providers", () => {
+          return HttpResponse.json({
+            modelProviders: [
+              {
+                id: "123",
+                type: "anthropic-api-key",
+                framework: "claude-code",
+                credentialName: "ANTHROPIC_API_KEY",
+                isDefault: true,
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
 
       const result = await checkModelProviderStatus();
 
       expect(result.hasProvider).toBe(true);
       expect(result.providers.length).toBe(1);
+      expect(result.providers[0]?.type).toBe("anthropic-api-key");
     });
 
     it("should return hasProvider false when no providers", async () => {
-      vi.mocked(listModelProviders).mockResolvedValue({
-        modelProviders: [],
-      });
+      server.use(
+        http.get("http://localhost:3000/api/model-providers", () => {
+          return HttpResponse.json({ modelProviders: [] });
+        }),
+      );
 
       const result = await checkModelProviderStatus();
 
@@ -82,11 +84,18 @@ describe("model-provider", () => {
 
   describe("checkExistingCredential", () => {
     it("should return exists true when credential exists", async () => {
-      vi.mocked(checkModelProviderCredential).mockResolvedValue({
-        exists: true,
-        credentialName: "ANTHROPIC_API_KEY",
-        currentType: "user",
-      });
+      server.use(
+        http.get(
+          "http://localhost:3000/api/model-providers/check/:type",
+          () => {
+            return HttpResponse.json({
+              exists: true,
+              credentialName: "ANTHROPIC_API_KEY",
+              currentType: "user",
+            });
+          },
+        ),
+      );
 
       const result = await checkExistingCredential("anthropic-api-key");
 
@@ -96,10 +105,17 @@ describe("model-provider", () => {
     });
 
     it("should return exists false when no credential", async () => {
-      vi.mocked(checkModelProviderCredential).mockResolvedValue({
-        exists: false,
-        credentialName: "ANTHROPIC_API_KEY",
-      });
+      server.use(
+        http.get(
+          "http://localhost:3000/api/model-providers/check/:type",
+          () => {
+            return HttpResponse.json({
+              exists: false,
+              credentialName: "ANTHROPIC_API_KEY",
+            });
+          },
+        ),
+      );
 
       const result = await checkExistingCredential("anthropic-api-key");
 
@@ -109,18 +125,22 @@ describe("model-provider", () => {
 
   describe("setupModelProvider", () => {
     it("should setup provider and return result", async () => {
-      vi.mocked(upsertModelProvider).mockResolvedValue({
-        provider: {
-          id: "123",
-          type: "anthropic-api-key",
-          framework: "claude-code",
-          credentialName: "ANTHROPIC_API_KEY",
-          isDefault: true,
-          createdAt: "2024-01-01",
-          updatedAt: "2024-01-01",
-        },
-        created: true,
-      });
+      server.use(
+        http.put("http://localhost:3000/api/model-providers", () => {
+          return HttpResponse.json({
+            provider: {
+              id: "123",
+              type: "anthropic-api-key",
+              framework: "claude-code",
+              credentialName: "ANTHROPIC_API_KEY",
+              isDefault: true,
+              createdAt: "2024-01-01T00:00:00Z",
+              updatedAt: "2024-01-01T00:00:00Z",
+            },
+            created: true,
+          });
+        }),
+      );
 
       const result = await setupModelProvider(
         "anthropic-api-key",
@@ -130,36 +150,33 @@ describe("model-provider", () => {
       expect(result.created).toBe(true);
       expect(result.isDefault).toBe(true);
       expect(result.framework).toBe("claude-code");
-      expect(upsertModelProvider).toHaveBeenCalledWith({
-        type: "anthropic-api-key",
-        credential: "test-credential",
-        convert: undefined,
-      });
     });
 
-    it("should pass convert option when specified", async () => {
-      vi.mocked(upsertModelProvider).mockResolvedValue({
-        provider: {
-          id: "123",
-          type: "anthropic-api-key",
-          framework: "claude-code",
-          credentialName: "ANTHROPIC_API_KEY",
-          isDefault: true,
-          createdAt: "2024-01-01",
-          updatedAt: "2024-01-01",
-        },
-        created: false,
-      });
+    it("should return created false when updating existing provider", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/model-providers", () => {
+          return HttpResponse.json({
+            provider: {
+              id: "123",
+              type: "anthropic-api-key",
+              framework: "claude-code",
+              credentialName: "ANTHROPIC_API_KEY",
+              isDefault: true,
+              createdAt: "2024-01-01T00:00:00Z",
+              updatedAt: "2024-01-01T00:00:00Z",
+            },
+            created: false,
+          });
+        }),
+      );
 
-      await setupModelProvider("anthropic-api-key", "test-credential", {
-        convert: true,
-      });
+      const result = await setupModelProvider(
+        "anthropic-api-key",
+        "test-credential",
+        { convert: true },
+      );
 
-      expect(upsertModelProvider).toHaveBeenCalledWith({
-        type: "anthropic-api-key",
-        credential: "test-credential",
-        convert: true,
-      });
+      expect(result.created).toBe(false);
     });
   });
 });

--- a/turbo/apps/cli/src/lib/domain/onboard/auth.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/auth.ts
@@ -1,0 +1,180 @@
+import { getToken, saveConfig, getApiUrl } from "../../api/config.js";
+
+interface AuthFlowCallbacks {
+  onInitiating?: () => void;
+  onDeviceCodeReady?: (
+    url: string,
+    code: string,
+    expiresInMinutes: number,
+  ) => void;
+  onPolling?: () => void;
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+}
+
+interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_path: string;
+  expires_in: number;
+  interval: number;
+}
+
+interface TokenExchangeResponse {
+  access_token?: string;
+  refresh_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  error?: string;
+  error_description?: string;
+}
+
+function buildHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (bypassSecret) {
+    headers["x-vercel-protection-bypass"] = bypassSecret;
+  }
+
+  return headers;
+}
+
+async function requestDeviceCode(apiUrl: string): Promise<DeviceCodeResponse> {
+  const response = await fetch(`${apiUrl}/api/cli/auth/device`, {
+    method: "POST",
+    headers: buildHeaders(),
+    body: JSON.stringify({}),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to request device code: ${response.statusText}`);
+  }
+
+  return response.json() as Promise<DeviceCodeResponse>;
+}
+
+async function exchangeToken(
+  apiUrl: string,
+  deviceCode: string,
+): Promise<TokenExchangeResponse> {
+  const response = await fetch(`${apiUrl}/api/cli/auth/token`, {
+    method: "POST",
+    headers: buildHeaders(),
+    body: JSON.stringify({ device_code: deviceCode }),
+  });
+
+  return response.json() as Promise<TokenExchangeResponse>;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Check if user is authenticated (has valid token)
+ * @returns true if authenticated, false otherwise
+ */
+export async function isAuthenticated(): Promise<boolean> {
+  const token = await getToken();
+  return !!token;
+}
+
+/**
+ * Handle token exchange result, returning the access token if successful or throwing an error
+ */
+function handleTokenResult(tokenResult: TokenExchangeResponse): string | null {
+  if (tokenResult.access_token) {
+    return tokenResult.access_token;
+  }
+
+  if (tokenResult.error === "authorization_pending") {
+    return null;
+  }
+
+  if (tokenResult.error === "expired_token") {
+    throw new Error("The device code has expired. Please try again.");
+  }
+
+  if (tokenResult.error) {
+    throw new Error(
+      `Authentication failed: ${tokenResult.error_description ?? tokenResult.error}`,
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Poll for token until success or timeout
+ */
+async function pollForToken(
+  apiUrl: string,
+  deviceAuth: DeviceCodeResponse,
+  callbacks?: AuthFlowCallbacks,
+): Promise<string> {
+  const startTime = Date.now();
+  const maxWaitTime = deviceAuth.expires_in * 1000;
+  const pollInterval = (deviceAuth.interval || 5) * 1000;
+
+  let isFirstPoll = true;
+
+  while (Date.now() - startTime < maxWaitTime) {
+    if (!isFirstPoll) {
+      await delay(pollInterval);
+    }
+    isFirstPoll = false;
+
+    const tokenResult = await exchangeToken(apiUrl, deviceAuth.device_code);
+    const accessToken = handleTokenResult(tokenResult);
+
+    if (accessToken) {
+      return accessToken;
+    }
+
+    callbacks?.onPolling?.();
+  }
+
+  throw new Error("Authentication timed out. Please try again.");
+}
+
+/**
+ * Run the device code authentication flow
+ * @param callbacks - Optional callbacks for UI updates
+ * @param apiUrl - Optional API URL override
+ */
+export async function runAuthFlow(
+  callbacks?: AuthFlowCallbacks,
+  apiUrl?: string,
+): Promise<void> {
+  const targetApiUrl = apiUrl ?? (await getApiUrl());
+
+  callbacks?.onInitiating?.();
+
+  const deviceAuth = await requestDeviceCode(targetApiUrl);
+
+  const verificationUrl = `${targetApiUrl}${deviceAuth.verification_path}`;
+  const expiresInMinutes = Math.floor(deviceAuth.expires_in / 60);
+
+  callbacks?.onDeviceCodeReady?.(
+    verificationUrl,
+    deviceAuth.user_code,
+    expiresInMinutes,
+  );
+
+  try {
+    const accessToken = await pollForToken(targetApiUrl, deviceAuth, callbacks);
+
+    await saveConfig({
+      token: accessToken,
+      apiUrl: targetApiUrl,
+    });
+
+    callbacks?.onSuccess?.();
+  } catch (error) {
+    callbacks?.onError?.(error as Error);
+    throw error;
+  }
+}

--- a/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
@@ -10,210 +10,263 @@ export const SKILL_FILE = "SKILL.md";
 export function getSkillContent(): string {
   return `---
 name: vm0-agent-builder
-description: Guide for building VM0 agents with Claude's help. Use this skill when users want to create or improve their agent's AGENTS.md and vm0.yaml configuration.
+description: Build VM0 agents by creating AGENTS.md and vm0.yaml. Use when users describe what agent they want to build.
 ---
 
 # VM0 Agent Builder
 
-Help users create effective AI agents using the VM0 platform. This skill guides the process of designing agent workflows, writing AGENTS.md instructions, and configuring vm0.yaml.
-
-## When to Use
-
-- User wants to create a new VM0 agent from scratch
-- User wants to improve an existing agent's instructions
-- User needs help configuring vm0.yaml with skills
-- User is unsure how to structure their agent's workflow
+Build AI agents that run in VM0's secure sandbox environment. This skill helps you create the two essential files: \`AGENTS.md\` (agent instructions) and \`vm0.yaml\` (configuration).
 
 ## Workflow
 
 ### Step 1: Understand the Goal
 
-Ask the user what they want their agent to accomplish:
-- What is the main task or problem to solve?
-- What inputs will the agent receive?
-- What outputs should the agent produce?
-- Are there any constraints or requirements?
+First, clarify what the user wants their agent to do:
+- What task should the agent accomplish?
+- What inputs does it need? (files, APIs, websites)
+- What outputs should it produce? (reports, files, notifications)
+- Should it run once or on a schedule?
 
-### Step 2: Design the Workflow
+### Step 2: Create AGENTS.md
 
-Break down the task into clear, sequential steps:
-1. Each step should be a single, focused action
-2. Steps should build on each other logically
-3. Include error handling and edge cases
-4. Consider what tools/skills the agent will need
+Write clear, step-by-step instructions. The agent will follow these exactly.
 
-### Step 3: Write AGENTS.md
-
-Create the agent instructions file with:
+**Template:**
 
 \`\`\`markdown
-# Agent Instructions
+# [Agent Name]
 
 You are a [role description].
 
-## Goal
-
-[Clear statement of what the agent should accomplish]
-
 ## Workflow
 
-1. [First step with specific instructions]
-2. [Second step with specific instructions]
-3. [Continue with remaining steps...]
+1. [First action - be specific]
+2. [Second action - include details]
+3. [Continue with clear steps...]
 
 ## Output
 
-[Describe the expected output format and location]
-
-## Constraints
-
-[Any limitations or rules the agent should follow]
+Write results to \`[filename]\` in the current directory.
 \`\`\`
 
-### Step 4: Configure vm0.yaml
+**Writing Tips:**
+- Be specific: "Read the top 10 stories" not "Read some stories"
+- One action per step: Keep steps focused and atomic
+- Specify output: Exact filenames and formats
+- Use active voice: "Create a file" not "A file should be created"
 
-Update the vm0.yaml to include necessary skills:
+### Step 3: Create vm0.yaml
+
+Configure the agent with required skills and environment variables.
 
 \`\`\`yaml
 version: "1.0"
 
 agents:
-  agent-name:
+  [agent-name]:
     framework: claude-code
     instructions: AGENTS.md
     skills:
-      - https://github.com/vm0-ai/vm0-skills/tree/main/skill-name
+      # Add skills the agent needs (optional)
+      - https://github.com/vm0-ai/vm0-skills/tree/main/[skill-name]
     environment:
-      # Add any required environment variables
+      # Add environment variables (optional)
       API_KEY: "\${{ secrets.API_KEY }}"
 \`\`\`
 
-### Step 5: Test the Agent
+### Step 4: Test the Agent
 
-Guide the user to test their agent:
+After creating both files, the user runs:
 
 \`\`\`bash
-# Deploy the agent configuration
-vm0 compose vm0.yaml
-
-# Run the agent with a test prompt
-vm0 cook "start working on the task"
-
-# Check the logs if needed
-vm0 logs <run-id>
+vm0 cook "start working"
 \`\`\`
+
+This command:
+1. Uploads the configuration to VM0
+2. Runs the agent in a secure sandbox
+3. Downloads results to the \`artifact/\` directory
 
 ## Available Skills
 
-Common skills from vm0-skills repository:
+Skills give agents access to external services. Add them to vm0.yaml when needed.
 
-| Skill | Purpose |
-|-------|---------|
-| \`github\` | GitHub API operations (issues, PRs, repos) |
-| \`slack\` | Send messages to Slack channels |
-| \`notion\` | Read/write Notion pages and databases |
-| \`firecrawl\` | Web scraping and content extraction |
-| \`browserbase\` | Browser automation |
-| \`openai\` | OpenAI API for embeddings, completions |
-| \`supabase\` | Database operations with Supabase |
+**Popular Skills:**
 
-Browse all skills: https://github.com/vm0-ai/vm0-skills
+| Skill | Use Case |
+|-------|----------|
+| \`github\` | Read/write issues, PRs, files |
+| \`slack\` | Send messages to channels |
+| \`notion\` | Access Notion pages/databases |
+| \`firecrawl\` | Scrape and extract web content |
+| \`supabase\` | Database operations |
+| \`google-sheets\` | Read/write spreadsheets |
+| \`linear\` | Project management |
+| \`discord\` | Send Discord messages |
+| \`gmail\` | Send emails |
+| \`openai\` | Embeddings, additional AI calls |
 
-## Example Agents
+**All 79 skills:** https://github.com/vm0-ai/vm0-skills
 
-### Content Curator Agent
+**Skill URL format:**
+\`\`\`
+https://github.com/vm0-ai/vm0-skills/tree/main/[skill-name]
+\`\`\`
 
+## Examples
+
+### HackerNews Curator
+
+**AGENTS.md:**
 \`\`\`markdown
-# Agent Instructions
+# HackerNews AI Curator
 
-You are a content curator that monitors HackerNews for AI-related articles.
+You are a content curator that finds AI-related articles on HackerNews.
 
 ## Workflow
 
-1. Go to HackerNews and read the top 30 stories
-2. Filter for AI, ML, and LLM related content
-3. For each relevant article, extract:
+1. Go to https://news.ycombinator.com
+2. Read the top 30 stories
+3. Filter for AI, ML, and LLM related content
+4. For each relevant article, extract:
    - Title and URL
-   - Key points (2-3 sentences)
-   - Why it's interesting
-4. Write a summary to \`daily-digest.md\`
+   - 2-3 sentence summary
+   - Why it matters
+5. Write findings to \`daily-digest.md\`
 
 ## Output
 
 Create \`daily-digest.md\` with today's date as the header.
+Format as a bulleted list with links.
 \`\`\`
 
-### GitHub Issue Tracker Agent
+**vm0.yaml:**
+\`\`\`yaml
+version: "1.0"
 
+agents:
+  hn-curator:
+    framework: claude-code
+    instructions: AGENTS.md
+\`\`\`
+
+### GitHub Issue Reporter
+
+**AGENTS.md:**
 \`\`\`markdown
-# Agent Instructions
+# GitHub Issue Reporter
 
-You are a GitHub issue tracker that summarizes open issues.
+You are a GitHub analyst that creates issue summary reports.
 
 ## Workflow
 
 1. List all open issues in the repository
-2. Group issues by labels (bug, feature, docs)
-3. For each group, summarize:
-   - Number of issues
-   - Oldest issue age
-   - Most discussed issues
-4. Create a report in \`issue-report.md\`
-
-## Skills Required
-
-- github (for API access)
-\`\`\`
-
-### Data Pipeline Agent
-
-\`\`\`markdown
-# Agent Instructions
-
-You are a data pipeline agent that processes CSV files.
-
-## Workflow
-
-1. Read all CSV files from the input volume
-2. For each file:
-   - Validate the schema
-   - Clean missing values
-   - Transform dates to ISO format
-3. Merge all files into \`combined.csv\`
-4. Generate a summary report
-
-## Input
-
-Files are provided via volume mount.
+2. Group by labels: bug, feature, documentation, other
+3. For each group, report:
+   - Total count
+   - Oldest issue (with age in days)
+   - Most commented issue
+4. Write report to \`issue-report.md\`
 
 ## Output
 
-Write results to the artifact directory.
+Create \`issue-report.md\` with sections for each label group.
+Include links to referenced issues.
 \`\`\`
 
-## Best Practices
+**vm0.yaml:**
+\`\`\`yaml
+version: "1.0"
 
-1. **Be Specific**: Vague instructions lead to unpredictable results
-2. **One Task Per Step**: Keep workflow steps focused and atomic
-3. **Define Output Clearly**: Specify exact file names and formats
-4. **Handle Errors**: Include what to do when things go wrong
-5. **Test Incrementally**: Start with simple workflows, add complexity
-6. **Use Skills Wisely**: Only include skills the agent actually needs
+agents:
+  issue-reporter:
+    framework: claude-code
+    instructions: AGENTS.md
+    skills:
+      - https://github.com/vm0-ai/vm0-skills/tree/main/github
+    environment:
+      GITHUB_REPO: "\${{ vars.GITHUB_REPO }}"
+\`\`\`
+
+### Slack Daily Digest
+
+**AGENTS.md:**
+\`\`\`markdown
+# Slack Daily Digest
+
+You are an assistant that posts daily summaries to Slack.
+
+## Workflow
+
+1. Read the contents of \`updates.md\` from the input volume
+2. Summarize the key points (max 5 bullets)
+3. Format as a Slack message with emoji headers
+4. Post to the #daily-updates channel
+
+## Output
+
+Post the summary to Slack. Write a copy to \`sent-message.md\`.
+\`\`\`
+
+**vm0.yaml:**
+\`\`\`yaml
+version: "1.0"
+
+agents:
+  slack-digest:
+    framework: claude-code
+    instructions: AGENTS.md
+    skills:
+      - https://github.com/vm0-ai/vm0-skills/tree/main/slack
+    environment:
+      SLACK_CHANNEL: "\${{ vars.SLACK_CHANNEL }}"
+\`\`\`
+
+## Environment Variables
+
+Use environment variables for sensitive data and configuration:
+
+\`\`\`yaml
+environment:
+  # Secrets (encrypted, for API keys)
+  API_KEY: "\${{ secrets.API_KEY }}"
+
+  # Variables (plain text, for config)
+  REPO_NAME: "\${{ vars.REPO_NAME }}"
+\`\`\`
+
+Set them with:
+\`\`\`bash
+vm0 credential set API_KEY "your-api-key"
+\`\`\`
 
 ## Troubleshooting
 
-### Agent doesn't follow instructions
-- Make instructions more specific and explicit
-- Add examples of expected behavior
+**Agent doesn't follow instructions:**
+- Make steps more specific and explicit
+- Add "Do not..." constraints for unwanted behavior
 - Break complex steps into smaller sub-steps
 
-### Agent uses wrong tools
-- Specify which tools/skills to use for each step
-- Add constraints about what NOT to do
+**Agent can't access a service:**
+- Add the required skill to vm0.yaml
+- Set up credentials with \`vm0 credential set\`
 
-### Output format is wrong
-- Provide exact templates for output files
-- Include example output in the instructions
+**Output is in wrong format:**
+- Provide an exact template in the instructions
+- Include a small example of expected output
+
+## Next Steps After Creating Files
+
+\`\`\`bash
+# Run your agent
+vm0 cook "start working"
+
+# View logs if needed
+vm0 logs [run-id]
+
+# Results are in artifact/ directory
+ls artifact/
+\`\`\`
 `;
 }
 

--- a/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
@@ -66,11 +66,17 @@ agents:
   [agent-name]:
     framework: claude-code
     instructions: AGENTS.md
+    # Pre-install GitHub CLI (optional)
+    apps:
+      - github
+    # Add skills the agent needs (optional)
     skills:
-      # Add skills the agent needs (optional)
       - https://github.com/vm0-ai/vm0-skills/tree/main/[skill-name]
+    # Mount volumes for input files (optional)
+    volumes:
+      - my-volume:/home/user/input
+    # Environment variables (optional)
     environment:
-      # Add environment variables (optional)
       API_KEY: "\${{ secrets.API_KEY }}"
 \`\`\`
 
@@ -233,9 +239,12 @@ environment:
 
   # Variables (plain text, for config)
   REPO_NAME: "\${{ vars.REPO_NAME }}"
+
+  # Credentials (from vm0 credential storage)
+  MY_TOKEN: "\${{ credentials.MY_TOKEN }}"
 \`\`\`
 
-Set them with:
+Set credentials with (names must be UPPERCASE):
 \`\`\`bash
 vm0 credential set API_KEY "your-api-key"
 \`\`\`
@@ -266,6 +275,12 @@ vm0 logs [run-id]
 
 # Results are in artifact/ directory
 ls artifact/
+
+# Continue from where agent left off
+vm0 cook continue "keep going"
+
+# Resume from a checkpoint
+vm0 cook resume "try again"
 \`\`\`
 `;
 }

--- a/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
@@ -1,0 +1,242 @@
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+
+export const SKILL_DIR = ".claude/skills/vm0-agent-builder";
+export const SKILL_FILE = "SKILL.md";
+
+/**
+ * Get the vm0-agent-builder skill content
+ */
+export function getSkillContent(): string {
+  return `---
+name: vm0-agent-builder
+description: Guide for building VM0 agents with Claude's help. Use this skill when users want to create or improve their agent's AGENTS.md and vm0.yaml configuration.
+---
+
+# VM0 Agent Builder
+
+Help users create effective AI agents using the VM0 platform. This skill guides the process of designing agent workflows, writing AGENTS.md instructions, and configuring vm0.yaml.
+
+## When to Use
+
+- User wants to create a new VM0 agent from scratch
+- User wants to improve an existing agent's instructions
+- User needs help configuring vm0.yaml with skills
+- User is unsure how to structure their agent's workflow
+
+## Workflow
+
+### Step 1: Understand the Goal
+
+Ask the user what they want their agent to accomplish:
+- What is the main task or problem to solve?
+- What inputs will the agent receive?
+- What outputs should the agent produce?
+- Are there any constraints or requirements?
+
+### Step 2: Design the Workflow
+
+Break down the task into clear, sequential steps:
+1. Each step should be a single, focused action
+2. Steps should build on each other logically
+3. Include error handling and edge cases
+4. Consider what tools/skills the agent will need
+
+### Step 3: Write AGENTS.md
+
+Create the agent instructions file with:
+
+\`\`\`markdown
+# Agent Instructions
+
+You are a [role description].
+
+## Goal
+
+[Clear statement of what the agent should accomplish]
+
+## Workflow
+
+1. [First step with specific instructions]
+2. [Second step with specific instructions]
+3. [Continue with remaining steps...]
+
+## Output
+
+[Describe the expected output format and location]
+
+## Constraints
+
+[Any limitations or rules the agent should follow]
+\`\`\`
+
+### Step 4: Configure vm0.yaml
+
+Update the vm0.yaml to include necessary skills:
+
+\`\`\`yaml
+version: "1.0"
+
+agents:
+  agent-name:
+    framework: claude-code
+    instructions: AGENTS.md
+    skills:
+      - https://github.com/vm0-ai/vm0-skills/tree/main/skill-name
+    environment:
+      # Add any required environment variables
+      API_KEY: "\${{ secrets.API_KEY }}"
+\`\`\`
+
+### Step 5: Test the Agent
+
+Guide the user to test their agent:
+
+\`\`\`bash
+# Deploy the agent configuration
+vm0 compose vm0.yaml
+
+# Run the agent with a test prompt
+vm0 cook "start working on the task"
+
+# Check the logs if needed
+vm0 logs <run-id>
+\`\`\`
+
+## Available Skills
+
+Common skills from vm0-skills repository:
+
+| Skill | Purpose |
+|-------|---------|
+| \`github\` | GitHub API operations (issues, PRs, repos) |
+| \`slack\` | Send messages to Slack channels |
+| \`notion\` | Read/write Notion pages and databases |
+| \`firecrawl\` | Web scraping and content extraction |
+| \`browserbase\` | Browser automation |
+| \`openai\` | OpenAI API for embeddings, completions |
+| \`supabase\` | Database operations with Supabase |
+
+Browse all skills: https://github.com/vm0-ai/vm0-skills
+
+## Example Agents
+
+### Content Curator Agent
+
+\`\`\`markdown
+# Agent Instructions
+
+You are a content curator that monitors HackerNews for AI-related articles.
+
+## Workflow
+
+1. Go to HackerNews and read the top 30 stories
+2. Filter for AI, ML, and LLM related content
+3. For each relevant article, extract:
+   - Title and URL
+   - Key points (2-3 sentences)
+   - Why it's interesting
+4. Write a summary to \`daily-digest.md\`
+
+## Output
+
+Create \`daily-digest.md\` with today's date as the header.
+\`\`\`
+
+### GitHub Issue Tracker Agent
+
+\`\`\`markdown
+# Agent Instructions
+
+You are a GitHub issue tracker that summarizes open issues.
+
+## Workflow
+
+1. List all open issues in the repository
+2. Group issues by labels (bug, feature, docs)
+3. For each group, summarize:
+   - Number of issues
+   - Oldest issue age
+   - Most discussed issues
+4. Create a report in \`issue-report.md\`
+
+## Skills Required
+
+- github (for API access)
+\`\`\`
+
+### Data Pipeline Agent
+
+\`\`\`markdown
+# Agent Instructions
+
+You are a data pipeline agent that processes CSV files.
+
+## Workflow
+
+1. Read all CSV files from the input volume
+2. For each file:
+   - Validate the schema
+   - Clean missing values
+   - Transform dates to ISO format
+3. Merge all files into \`combined.csv\`
+4. Generate a summary report
+
+## Input
+
+Files are provided via volume mount.
+
+## Output
+
+Write results to the artifact directory.
+\`\`\`
+
+## Best Practices
+
+1. **Be Specific**: Vague instructions lead to unpredictable results
+2. **One Task Per Step**: Keep workflow steps focused and atomic
+3. **Define Output Clearly**: Specify exact file names and formats
+4. **Handle Errors**: Include what to do when things go wrong
+5. **Test Incrementally**: Start with simple workflows, add complexity
+6. **Use Skills Wisely**: Only include skills the agent actually needs
+
+## Troubleshooting
+
+### Agent doesn't follow instructions
+- Make instructions more specific and explicit
+- Add examples of expected behavior
+- Break complex steps into smaller sub-steps
+
+### Agent uses wrong tools
+- Specify which tools/skills to use for each step
+- Add constraints about what NOT to do
+
+### Output format is wrong
+- Provide exact templates for output files
+- Include example output in the instructions
+`;
+}
+
+interface InstallSkillResult {
+  skillDir: string;
+  skillFile: string;
+}
+
+/**
+ * Install the vm0-agent-builder skill in the specified directory
+ * @param targetDir - Base directory to install the skill in (defaults to current directory)
+ */
+export async function installClaudeSkill(
+  targetDir: string = process.cwd(),
+): Promise<InstallSkillResult> {
+  const skillDirPath = path.join(targetDir, SKILL_DIR);
+  const skillFilePath = path.join(skillDirPath, SKILL_FILE);
+
+  await mkdir(skillDirPath, { recursive: true });
+  await writeFile(skillFilePath, getSkillContent());
+
+  return {
+    skillDir: skillDirPath,
+    skillFile: skillFilePath,
+  };
+}

--- a/turbo/apps/cli/src/lib/domain/onboard/index.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/index.ts
@@ -1,0 +1,9 @@
+export { isAuthenticated, runAuthFlow } from "./auth.js";
+
+export {
+  checkModelProviderStatus,
+  getProviderChoices,
+  setupModelProvider,
+} from "./model-provider.js";
+
+export { installClaudeSkill } from "./claude-setup.js";

--- a/turbo/apps/cli/src/lib/domain/onboard/model-provider.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/model-provider.ts
@@ -1,0 +1,97 @@
+import {
+  MODEL_PROVIDER_TYPES,
+  type ModelProviderType,
+  type ModelProviderResponse,
+  type UpsertModelProviderResponse,
+} from "@vm0/core";
+import {
+  listModelProviders,
+  upsertModelProvider,
+  checkModelProviderCredential,
+} from "../../api/domains/model-providers.js";
+
+interface ModelProviderStatus {
+  hasProvider: boolean;
+  providers: ModelProviderResponse[];
+}
+
+interface ProviderChoice {
+  type: ModelProviderType;
+  label: string;
+  helpText: string;
+  credentialLabel: string;
+}
+
+interface SetupResult {
+  provider: ModelProviderResponse;
+  created: boolean;
+  isDefault: boolean;
+  framework: string;
+}
+
+interface ExistingCredentialInfo {
+  exists: boolean;
+  credentialName: string;
+  currentType?: "user" | "model-provider";
+}
+
+/**
+ * Check if user has any model providers configured
+ */
+export async function checkModelProviderStatus(): Promise<ModelProviderStatus> {
+  const response = await listModelProviders();
+  return {
+    hasProvider: response.modelProviders.length > 0,
+    providers: response.modelProviders,
+  };
+}
+
+/**
+ * Get available provider types as choices for selection
+ */
+export function getProviderChoices(): ProviderChoice[] {
+  return (Object.keys(MODEL_PROVIDER_TYPES) as ModelProviderType[]).map(
+    (type) => ({
+      type,
+      label: MODEL_PROVIDER_TYPES[type].label,
+      helpText: MODEL_PROVIDER_TYPES[type].helpText,
+      credentialLabel: MODEL_PROVIDER_TYPES[type].credentialLabel,
+    }),
+  );
+}
+
+/**
+ * Check if a credential already exists for a provider type
+ */
+export async function checkExistingCredential(
+  type: ModelProviderType,
+): Promise<ExistingCredentialInfo> {
+  const response = await checkModelProviderCredential(type);
+  return {
+    exists: response.exists,
+    credentialName: response.credentialName,
+    currentType: response.currentType,
+  };
+}
+
+/**
+ * Setup a model provider with the given credential
+ */
+export async function setupModelProvider(
+  type: ModelProviderType,
+  credential: string,
+  options?: { convert?: boolean },
+): Promise<SetupResult> {
+  const response: UpsertModelProviderResponse = await upsertModelProvider({
+    type,
+    credential,
+    convert: options?.convert,
+  });
+
+  return {
+    provider: response.provider,
+    created: response.created,
+    isDefault: response.provider.isDefault,
+    framework: response.provider.framework,
+  };
+}

--- a/turbo/apps/cli/src/lib/ui/__tests__/progress-line.test.ts
+++ b/turbo/apps/cli/src/lib/ui/__tests__/progress-line.test.ts
@@ -78,9 +78,9 @@ describe("progress-line", () => {
 
       expect(progress.steps.length).toBe(4);
       expect(progress.steps[0]?.label).toBe("Authentication");
-      expect(progress.steps[1]?.label).toBe("Model Provider");
+      expect(progress.steps[1]?.label).toBe("Model Provider Setup");
       expect(progress.steps[2]?.label).toBe("Create Agent");
-      expect(progress.steps[3]?.label).toBe("Setup Complete");
+      expect(progress.steps[3]?.label).toBe("Complete");
     });
 
     it("should initialize all steps as pending", () => {

--- a/turbo/apps/cli/src/lib/ui/__tests__/progress-line.test.ts
+++ b/turbo/apps/cli/src/lib/ui/__tests__/progress-line.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  renderProgressLine,
+  createOnboardProgress,
+  type Step,
+} from "../progress-line.js";
+
+describe("progress-line", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let logOutput: string[];
+
+  beforeEach(() => {
+    logOutput = [];
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation((msg) => {
+      logOutput.push(String(msg));
+    });
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  describe("renderProgressLine", () => {
+    it("should render completed steps with filled circle", () => {
+      const steps: Step[] = [{ label: "Step 1", status: "completed" }];
+      renderProgressLine(steps);
+
+      expect(logOutput[0]).toContain("●");
+      expect(logOutput[0]).toContain("Step 1");
+    });
+
+    it("should render in-progress steps with half circle", () => {
+      const steps: Step[] = [{ label: "Step 1", status: "in-progress" }];
+      renderProgressLine(steps);
+
+      expect(logOutput[0]).toContain("◐");
+      expect(logOutput[0]).toContain("Step 1");
+    });
+
+    it("should render pending steps with empty circle", () => {
+      const steps: Step[] = [{ label: "Step 1", status: "pending" }];
+      renderProgressLine(steps);
+
+      expect(logOutput[0]).toContain("○");
+      expect(logOutput[0]).toContain("Step 1");
+    });
+
+    it("should render failed steps with X", () => {
+      const steps: Step[] = [{ label: "Step 1", status: "failed" }];
+      renderProgressLine(steps);
+
+      expect(logOutput[0]).toContain("✗");
+      expect(logOutput[0]).toContain("Step 1");
+    });
+
+    it("should render connecting lines between steps", () => {
+      const steps: Step[] = [
+        { label: "Step 1", status: "completed" },
+        { label: "Step 2", status: "pending" },
+      ];
+      renderProgressLine(steps);
+
+      expect(logOutput.length).toBe(3);
+      expect(logOutput[1]).toContain("│");
+    });
+
+    it("should not render line after last step", () => {
+      const steps: Step[] = [{ label: "Only Step", status: "completed" }];
+      renderProgressLine(steps);
+
+      expect(logOutput.length).toBe(1);
+    });
+  });
+
+  describe("createOnboardProgress", () => {
+    it("should create progress with 4 steps", () => {
+      const progress = createOnboardProgress();
+
+      expect(progress.steps.length).toBe(4);
+      expect(progress.steps[0]?.label).toBe("Authentication");
+      expect(progress.steps[1]?.label).toBe("Model Provider");
+      expect(progress.steps[2]?.label).toBe("Create Agent");
+      expect(progress.steps[3]?.label).toBe("Setup Complete");
+    });
+
+    it("should initialize all steps as pending", () => {
+      const progress = createOnboardProgress();
+
+      for (const step of progress.steps) {
+        expect(step.status).toBe("pending");
+      }
+    });
+
+    it("should update step status correctly", () => {
+      const progress = createOnboardProgress();
+
+      progress.update(0, "completed");
+      expect(progress.steps[0]?.status).toBe("completed");
+
+      progress.update(1, "in-progress");
+      expect(progress.steps[1]?.status).toBe("in-progress");
+
+      progress.update(2, "failed");
+      expect(progress.steps[2]?.status).toBe("failed");
+    });
+
+    it("should handle out of bounds index gracefully", () => {
+      const progress = createOnboardProgress();
+
+      progress.update(-1, "completed");
+      progress.update(10, "completed");
+
+      for (const step of progress.steps) {
+        expect(step.status).toBe("pending");
+      }
+    });
+
+    it("should render progress line", () => {
+      const progress = createOnboardProgress();
+
+      progress.render();
+
+      expect(logOutput.length).toBeGreaterThan(0);
+      expect(logOutput.some((line) => line.includes("Authentication"))).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/lib/ui/__tests__/welcome-box.test.ts
+++ b/turbo/apps/cli/src/lib/ui/__tests__/welcome-box.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderWelcomeBox, renderOnboardWelcome } from "../welcome-box.js";
+
+describe("welcome-box", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let logOutput: string[];
+
+  beforeEach(() => {
+    logOutput = [];
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation((msg) => {
+      logOutput.push(String(msg));
+    });
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  describe("renderWelcomeBox", () => {
+    it("should render a box with borders", () => {
+      renderWelcomeBox(["Hello"]);
+
+      expect(logOutput.length).toBe(3);
+      expect(logOutput[0]).toContain("┌");
+      expect(logOutput[0]).toContain("┐");
+      expect(logOutput[1]).toContain("│");
+      expect(logOutput[2]).toContain("└");
+      expect(logOutput[2]).toContain("┘");
+    });
+
+    it("should include the text content", () => {
+      renderWelcomeBox(["Test Message"]);
+
+      expect(logOutput[1]).toContain("Test Message");
+    });
+
+    it("should handle multiple lines", () => {
+      renderWelcomeBox(["Line 1", "Line 2", "Line 3"]);
+
+      expect(logOutput.length).toBe(5);
+      expect(logOutput[1]).toContain("Line 1");
+      expect(logOutput[2]).toContain("Line 2");
+      expect(logOutput[3]).toContain("Line 3");
+    });
+
+    it("should render with custom width", () => {
+      renderWelcomeBox(["Hi"], 20);
+
+      const topBorder = logOutput[0];
+      expect(topBorder).toContain("─".repeat(18));
+    });
+  });
+
+  describe("renderOnboardWelcome", () => {
+    it("should render the default welcome message", () => {
+      renderOnboardWelcome();
+
+      const output = logOutput.join("\n");
+      expect(output).toContain("Welcome to VM0!");
+      expect(output).toContain("Let's set up your first agent.");
+    });
+  });
+});

--- a/turbo/apps/cli/src/lib/ui/progress-line.ts
+++ b/turbo/apps/cli/src/lib/ui/progress-line.ts
@@ -1,0 +1,76 @@
+import chalk from "chalk";
+
+export type StepStatus = "pending" | "in-progress" | "completed" | "failed";
+
+export interface Step {
+  label: string;
+  status: StepStatus;
+}
+
+const STATUS_SYMBOLS: Record<StepStatus, string> = {
+  completed: "●",
+  "in-progress": "◐",
+  pending: "○",
+  failed: "✗",
+};
+
+function getStatusColor(status: StepStatus): (text: string) => string {
+  switch (status) {
+    case "completed":
+      return chalk.green;
+    case "in-progress":
+      return chalk.yellow;
+    case "failed":
+      return chalk.red;
+    case "pending":
+    default:
+      return chalk.dim;
+  }
+}
+
+/**
+ * Renders a vertical progress line with steps
+ * @param steps - Array of steps with labels and statuses
+ */
+export function renderProgressLine(steps: Step[]): void {
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    if (!step) continue;
+
+    const symbol = STATUS_SYMBOLS[step.status];
+    const color = getStatusColor(step.status);
+
+    console.log(color(`${symbol} ${step.label}`));
+
+    if (i < steps.length - 1) {
+      console.log(chalk.dim("│"));
+    }
+  }
+}
+
+/**
+ * Creates a progress tracker for the onboard flow
+ */
+export function createOnboardProgress(): {
+  steps: Step[];
+  render: () => void;
+  update: (index: number, status: StepStatus) => void;
+} {
+  const steps: Step[] = [
+    { label: "Authentication", status: "pending" },
+    { label: "Model Provider", status: "pending" },
+    { label: "Create Agent", status: "pending" },
+    { label: "Setup Complete", status: "pending" },
+  ];
+
+  return {
+    steps,
+    render: () => renderProgressLine(steps),
+    update: (index: number, status: StepStatus) => {
+      const step = steps[index];
+      if (step) {
+        step.status = status;
+      }
+    },
+  };
+}

--- a/turbo/apps/cli/src/lib/ui/progress-line.ts
+++ b/turbo/apps/cli/src/lib/ui/progress-line.ts
@@ -58,9 +58,9 @@ export function createOnboardProgress(): {
 } {
   const steps: Step[] = [
     { label: "Authentication", status: "pending" },
-    { label: "Model Provider", status: "pending" },
+    { label: "Model Provider Setup", status: "pending" },
     { label: "Create Agent", status: "pending" },
-    { label: "Setup Complete", status: "pending" },
+    { label: "Complete", status: "pending" },
   ];
 
   return {

--- a/turbo/apps/cli/src/lib/ui/welcome-box.ts
+++ b/turbo/apps/cli/src/lib/ui/welcome-box.ts
@@ -1,0 +1,41 @@
+import chalk from "chalk";
+
+/**
+ * Renders a welcome box with Unicode borders
+ * @param lines - Array of text lines to display inside the box
+ * @param width - Optional fixed width (defaults to auto-fit based on content)
+ */
+export function renderWelcomeBox(lines: string[], width?: number): void {
+  const maxLineLength = Math.max(...lines.map((line) => line.length));
+  const boxWidth = width ?? maxLineLength + 4;
+  const innerWidth = boxWidth - 2;
+
+  const horizontalLine = "─".repeat(innerWidth);
+  const topBorder = `┌${horizontalLine}┐`;
+  const bottomBorder = `└${horizontalLine}┘`;
+
+  console.log(chalk.cyan(topBorder));
+
+  for (const line of lines) {
+    const padding = innerWidth - line.length;
+    const leftPad = Math.floor(padding / 2);
+    const rightPad = padding - leftPad;
+    const centeredLine = " ".repeat(leftPad) + line + " ".repeat(rightPad);
+    console.log(chalk.cyan("│") + centeredLine + chalk.cyan("│"));
+  }
+
+  console.log(chalk.cyan(bottomBorder));
+}
+
+/**
+ * Renders the default VM0 welcome box for onboarding
+ */
+export function renderOnboardWelcome(): void {
+  renderWelcomeBox([
+    "",
+    "Welcome to VM0!",
+    "",
+    "Let's set up your first agent.",
+    "",
+  ]);
+}


### PR DESCRIPTION
## Summary

- Add welcome box and vertical progress line UI components in `lib/ui/`
- Extract auth, model-provider, and claude-setup logic to `lib/domain/onboard/`
- Simplify onboard flow: auth → model provider → create agent directory → install skill
- Remove vm0 init call (no longer generates vm0.yaml or AGENTS.md)
- Add `--name` flag for custom agent directory name (default: `my-vm0-agent`)
- Install vm0-agent-builder skill directly in agent directory

## Test plan

- [x] All 35 tests pass (19 onboard, 11 progress-line, 5 welcome-box)
- [x] All 26 domain library tests pass (auth, model-provider, claude-setup)
- [x] Lint, type-check, and knip all pass
- [ ] Manual test: Run `vm0 onboard` and verify welcome screen displays
- [ ] Manual test: Verify progress line shows correct status updates
- [ ] Manual test: Verify agent directory is created with skill installed

Closes #1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)