### PR TITLE
feat(platform): display TodoWrite todos as checklist in log detail

### DIFF
--- a/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
@@ -436,8 +436,13 @@ function ToolInputParams({
                   ? "text-blue-600 dark:text-blue-400"
                   : "text-muted-foreground";
             return (
-              <div key={`${status}-${content}`} className="flex items-start gap-2">
-                <StatusIcon className={`h-4 w-4 shrink-0 mt-0.5 ${statusColor}`} />
+              <div
+                key={`${status}-${content}`}
+                className="flex items-start gap-2"
+              >
+                <StatusIcon
+                  className={`h-4 w-4 shrink-0 mt-0.5 ${statusColor}`}
+                />
                 <span
                   className={
                     status === "completed"

--- a/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
@@ -10,6 +10,10 @@ import {
   IconCurrencyDollar,
   IconAlertCircle,
   IconArrowRight,
+  IconCircleCheck,
+  IconLoader2,
+  IconCircle,
+  IconListCheck,
 } from "@tabler/icons-react";
 
 interface EventCardProps {
@@ -287,6 +291,9 @@ function getToolIcon(toolName: string) {
   if (name === "websearch") {
     return IconSearch;
   }
+  if (name === "todowrite") {
+    return IconListCheck;
+  }
   if (
     name.includes("read") ||
     name.includes("write") ||
@@ -400,6 +407,52 @@ function ToolInputParams({
         </code>
       </div>
     );
+  }
+
+  // TodoWrite - show as a checklist
+  if (lowerName === "todowrite") {
+    const todos = input.todos;
+    if (Array.isArray(todos)) {
+      return (
+        <div className="space-y-1.5 text-sm">
+          {todos.map((todo) => {
+            const item = todo as {
+              content?: string;
+              status?: string;
+              activeForm?: string;
+            };
+            const content = item.content ?? String(todo);
+            const status = item.status ?? "pending";
+            const StatusIcon =
+              status === "completed"
+                ? IconCircleCheck
+                : status === "in_progress"
+                  ? IconLoader2
+                  : IconCircle;
+            const statusColor =
+              status === "completed"
+                ? "text-emerald-600 dark:text-emerald-400"
+                : status === "in_progress"
+                  ? "text-blue-600 dark:text-blue-400"
+                  : "text-muted-foreground";
+            return (
+              <div key={`${status}-${content}`} className="flex items-start gap-2">
+                <StatusIcon className={`h-4 w-4 shrink-0 mt-0.5 ${statusColor}`} />
+                <span
+                  className={
+                    status === "completed"
+                      ? "text-muted-foreground line-through"
+                      : "text-foreground"
+                  }
+                >
+                  {content}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
   }
 
   // Generic: show all parameters as key-value pairs


### PR DESCRIPTION
## Summary
- Replace JSON display with styled checklist for TodoWrite tool events in log detail page
- Completed items show green checkmark (✓) with strikethrough text
- In-progress items show blue spinner icon
- Pending items show empty circle

## Test plan
- [ ] Navigate to a log detail page with TodoWrite events
- [ ] Verify todos display as a checklist instead of raw JSON
- [ ] Verify status icons and styling are correct for each state

🤖 Generated with [Claude Code](https://claude.com/claude-code)