### PR TITLE
chore(runner): move cargo build from pretest to build script

### DIFF
--- a/turbo/apps/runner/package.json
+++ b/turbo/apps/runner/package.json
@@ -16,10 +16,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "cargo build --manifest-path ../../../crates/Cargo.toml -p vsock-agent && tsup",
     "postbuild": "cp package.json dist/ && pnpm json -I -f dist/package.json -e 'this.name=\"@vm0/runner\"; delete this.private; delete this.scripts; delete this.devDependencies; delete this.dependencies[\"@vm0/core\"]; this.bin[\"vm0-runner\"]=\"index.js\"; this.files=[\".\"]'",
     "dev": "tsup --watch",
-    "pretest": "cargo build --manifest-path ../../../crates/Cargo.toml -p vsock-agent",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "oxlint && eslint . --max-warnings 0",

--- a/turbo/package.json
+++ b/turbo/package.json
@@ -7,7 +7,6 @@
     "lint": "turbo run lint --concurrency=2",
     "format": "prettier --write --ignore-unknown .",
     "check-types": "turbo run check-types",
-    "pretest": "cargo build --manifest-path ../crates/Cargo.toml -p vsock-agent",
     "test": "vitest --run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",


### PR DESCRIPTION
## Summary
- Remove `pretest` script from `turbo/package.json` and `turbo/apps/runner/package.json`
- Add cargo build command to runner's `build` script instead

This ensures vsock-agent is built as part of the runner build process rather than as a test prerequisite.

## Test plan
- [ ] Verify `pnpm build` in runner directory builds vsock-agent
- [ ] Verify `pnpm test` still works without pretest

🤖 Generated with [Claude Code](https://claude.com/claude-code)