### PR TITLE
fix(cli): remove unnecessary confirmation prompt in onboard command

### DIFF
--- a/turbo/apps/cli/src/commands/onboard.ts
+++ b/turbo/apps/cli/src/commands/onboard.ts
@@ -6,7 +6,6 @@ import { validateAgentName } from "../lib/domain/yaml-validator.js";
 import {
   isInteractive,
   promptText,
-  promptConfirm,
   promptSelect,
   promptPassword,
 } from "../lib/utils/prompt-utils.js";
@@ -179,14 +178,6 @@ async function handleAgentCreation(ctx: OnboardContext): Promise<string> {
     console.log("Remove it first or choose a different name:");
     console.log(chalk.cyan(`  rm -rf ${agentName}`));
     process.exit(1);
-  }
-
-  if (!ctx.options.yes && ctx.interactive) {
-    const confirmed = await promptConfirm(`Create ${agentName}/?`, true);
-    if (!confirmed) {
-      console.log(chalk.dim("Cancelled"));
-      process.exit(0);
-    }
   }
 
   await mkdir(agentName, { recursive: true });


### PR DESCRIPTION
## Summary
- Remove the unused `promptConfirm` import from onboard command
- Remove the redundant confirmation prompt before creating agent directory (the user has already specified the agent name, no additional confirmation needed)

## Test plan
- [x] All CLI unit tests pass (791 tests)
- [x] Type checking passes
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)