### PR TITLE
fix(ci): disable concurrent run limit in production

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -159,6 +159,7 @@ jobs:
             CRON_SECRET=${{ secrets.CRON_SECRET }}
             OFFICIAL_RUNNER_SECRET=${{ secrets.OFFICIAL_RUNNER_SECRET }}
             ABLY_API_KEY=${{ secrets.ABLY_API_KEY }}
+            CONCURRENT_RUN_LIMIT=0
 
       - name: Notify Slack - Success
         if: ${{ success() && steps.slack-start.outputs.ts }}


### PR DESCRIPTION
## Summary

- Temporarily disable concurrent run limit in production by setting `CONCURRENT_RUN_LIMIT=0`
- Pending runs are not being cleaned up by the cleanup cron job, causing users to be permanently blocked

## Root Cause

The `checkConcurrencyLimit` function checks for both `pending` and `running` status runs, but the cleanup cron job (`cleanup-sandboxes`) only cleans up `running` runs with stale heartbeats. If a run gets stuck in `pending` status (e.g., sandbox fails to start), it will never be cleaned up and permanently blocks the user's concurrent run limit.

## Follow-up

A proper fix should add cleanup logic for stale `pending` runs in the cleanup cron job.

## Test plan

- [ ] Verify production deployment includes the new environment variable
- [ ] Verify users can start new runs without hitting the concurrent limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)