### PR TITLE
fix(web): add todo for pending run cleanup bug

### DIFF
--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -246,6 +246,10 @@ export class RunService {
    * @param userId User ID to check
    * @param limit Maximum allowed concurrent runs (default: 1, or CONCURRENT_RUN_LIMIT env var, 0 = no limit)
    * @throws ConcurrentRunLimitError if limit exceeded
+   *
+   * TODO: cleanup-sandboxes cron job only cleans up "running" runs, not "pending" runs.
+   * If a run gets stuck in "pending" status, it will block the user's concurrent limit forever.
+   * Need to add cleanup logic for stale pending runs.
    */
   async checkConcurrencyLimit(userId: string, limit?: number): Promise<void> {
     // Use provided limit, or env var, or default to 1


### PR DESCRIPTION
## Summary

- Add TODO comment documenting a bug where pending runs are not cleaned up

## Root Cause

The `checkConcurrencyLimit` function checks for both `pending` and `running` status runs, but the cleanup cron job (`cleanup-sandboxes`) only cleans up `running` runs with stale heartbeats. If a run gets stuck in `pending` status (e.g., sandbox fails to start), it will never be cleaned up and permanently blocks the user's concurrent run limit.

## Follow-up

A proper fix should add cleanup logic for stale `pending` runs in the cleanup cron job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)