### PR TITLE
feat(cli): replace embedded vm0-agent-builder with dynamic vm0-cli skill

### DIFF
--- a/e2e/tests/02-parallel/t31-vm0-onboard.bats
+++ b/e2e/tests/02-parallel/t31-vm0-onboard.bats
@@ -30,18 +30,22 @@ teardown() {
     assert_output --partial "--name"
 }
 
-@test "vm0 onboard -y creates agent directory with skill" {
+@test "vm0 onboard -y creates agent directory with skills" {
     run $CLI_COMMAND onboard -y
     assert_success
     assert_output --partial "Created my-vm0-agent/"
     assert_output --partial "Installed vm0-cli skill"
+    assert_output --partial "Installed vm0-agent skill"
     assert_output --partial "Next step:"
     assert_output --partial "cd my-vm0-agent"
+    assert_output --partial "/vm0-agent"
 
-    # Verify directory and skill were created
+    # Verify directory and skills were created
     [ -d "my-vm0-agent" ]
     [ -d "my-vm0-agent/.claude/skills/vm0-cli" ]
     [ -f "my-vm0-agent/.claude/skills/vm0-cli/SKILL.md" ]
+    [ -d "my-vm0-agent/.claude/skills/vm0-agent" ]
+    [ -f "my-vm0-agent/.claude/skills/vm0-agent/SKILL.md" ]
 }
 
 @test "vm0 onboard -y --name creates custom named agent" {
@@ -49,11 +53,13 @@ teardown() {
     assert_success
     assert_output --partial "Created custom-agent/"
     assert_output --partial "Installed vm0-cli skill"
+    assert_output --partial "Installed vm0-agent skill"
     assert_output --partial "cd custom-agent"
 
-    # Verify directory and skill were created with custom name
+    # Verify directory and skills were created with custom name
     [ -d "custom-agent" ]
     [ -d "custom-agent/.claude/skills/vm0-cli" ]
+    [ -d "custom-agent/.claude/skills/vm0-agent" ]
 }
 
 @test "vm0 onboard fails if agent directory exists" {
@@ -72,19 +78,22 @@ teardown() {
 @test "vm0 setup-claude --help shows command description" {
     run $CLI_COMMAND setup-claude --help
     assert_success
-    assert_output --partial "Add/update Claude skill for VM0 CLI usage"
+    assert_output --partial "Add/update Claude skills for VM0 usage"
 }
 
-@test "vm0 setup-claude installs skill from GitHub" {
+@test "vm0 setup-claude installs skills from GitHub" {
     run $CLI_COMMAND setup-claude
     assert_success
     assert_output --partial "Installed vm0-cli skill"
+    assert_output --partial "Installed vm0-agent skill"
     assert_output --partial "Next step:"
-    assert_output --partial "/vm0-cli"
+    assert_output --partial "/vm0-agent"
 
-    # Verify skill directory was created
+    # Verify skill directories were created
     [ -d ".claude/skills/vm0-cli" ]
     [ -f ".claude/skills/vm0-cli/SKILL.md" ]
+    [ -d ".claude/skills/vm0-agent" ]
+    [ -f ".claude/skills/vm0-agent/SKILL.md" ]
 
     # Verify skill content
     run cat .claude/skills/vm0-cli/SKILL.md
@@ -101,4 +110,5 @@ teardown() {
     run $CLI_COMMAND setup-claude
     assert_success
     assert_output --partial "Installed vm0-cli skill"
+    assert_output --partial "Installed vm0-agent skill"
 }

--- a/e2e/tests/02-parallel/t31-vm0-onboard.bats
+++ b/e2e/tests/02-parallel/t31-vm0-onboard.bats
@@ -34,26 +34,26 @@ teardown() {
     run $CLI_COMMAND onboard -y
     assert_success
     assert_output --partial "Created my-vm0-agent/"
-    assert_output --partial "Installed vm0-agent-builder skill"
+    assert_output --partial "Installed vm0-cli skill"
     assert_output --partial "Next step:"
     assert_output --partial "cd my-vm0-agent"
 
     # Verify directory and skill were created
     [ -d "my-vm0-agent" ]
-    [ -d "my-vm0-agent/.claude/skills/vm0-agent-builder" ]
-    [ -f "my-vm0-agent/.claude/skills/vm0-agent-builder/SKILL.md" ]
+    [ -d "my-vm0-agent/.claude/skills/vm0-cli" ]
+    [ -f "my-vm0-agent/.claude/skills/vm0-cli/SKILL.md" ]
 }
 
 @test "vm0 onboard -y --name creates custom named agent" {
     run $CLI_COMMAND onboard -y --name custom-agent
     assert_success
     assert_output --partial "Created custom-agent/"
-    assert_output --partial "Installed vm0-agent-builder skill"
+    assert_output --partial "Installed vm0-cli skill"
     assert_output --partial "cd custom-agent"
 
     # Verify directory and skill were created with custom name
     [ -d "custom-agent" ]
-    [ -d "custom-agent/.claude/skills/vm0-agent-builder" ]
+    [ -d "custom-agent/.claude/skills/vm0-cli" ]
 }
 
 @test "vm0 onboard fails if agent directory exists" {
@@ -72,24 +72,24 @@ teardown() {
 @test "vm0 setup-claude --help shows command description" {
     run $CLI_COMMAND setup-claude --help
     assert_success
-    assert_output --partial "Add/update Claude skill for agent building"
+    assert_output --partial "Add/update Claude skill for VM0 CLI usage"
 }
 
-@test "vm0 setup-claude installs skill from embedded content" {
+@test "vm0 setup-claude installs skill from GitHub" {
     run $CLI_COMMAND setup-claude
     assert_success
-    assert_output --partial "Installed vm0-agent-builder skill"
+    assert_output --partial "Installed vm0-cli skill"
     assert_output --partial "Next step:"
-    assert_output --partial "/vm0-agent-builder"
+    assert_output --partial "/vm0-cli"
 
     # Verify skill directory was created
-    [ -d ".claude/skills/vm0-agent-builder" ]
-    [ -f ".claude/skills/vm0-agent-builder/SKILL.md" ]
+    [ -d ".claude/skills/vm0-cli" ]
+    [ -f ".claude/skills/vm0-cli/SKILL.md" ]
 
     # Verify skill content
-    run cat .claude/skills/vm0-agent-builder/SKILL.md
-    assert_output --partial "name: vm0-agent-builder"
-    assert_output --partial "# VM0 Agent Builder"
+    run cat .claude/skills/vm0-cli/SKILL.md
+    assert_output --partial "name: vm0-cli"
+    assert_output --partial "# VM0 CLI"
 }
 
 @test "vm0 setup-claude is idempotent (can run multiple times)" {
@@ -100,5 +100,5 @@ teardown() {
     # Run second time - should succeed and overwrite
     run $CLI_COMMAND setup-claude
     assert_success
-    assert_output --partial "Installed vm0-agent-builder skill"
+    assert_output --partial "Installed vm0-cli skill"
 }

--- a/turbo/apps/cli/src/commands/__tests__/onboard.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/onboard.test.ts
@@ -24,7 +24,7 @@ vi.mock("os", async (importOriginal) => {
 import prompts from "prompts";
 import { onboardCommand } from "../onboard.js";
 
-const MOCK_SKILL_CONTENT = `---
+const MOCK_CLI_SKILL_CONTENT = `---
 name: vm0-cli
 description: VM0 CLI for building and running AI agents in secure sandboxes.
 vm0_secrets:
@@ -38,6 +38,16 @@ Build and run AI agents in secure sandboxed environments.
 ## When to Use
 
 Use this skill when you need to install and set up the VM0 CLI.
+`;
+
+const MOCK_AGENT_SKILL_CONTENT = `---
+name: vm0-agent
+description: VM0 Agent skill for building workflows.
+---
+
+# VM0 Agent
+
+Build AI agent workflows.
 `;
 
 describe("onboard command", () => {
@@ -70,10 +80,18 @@ describe("onboard command", () => {
     vi.spyOn(global, "fetch").mockImplementation(async (input, init) => {
       const url = typeof input === "string" ? input : input.toString();
       if (url.includes("raw.githubusercontent.com")) {
-        return {
-          ok: true,
-          text: () => Promise.resolve(MOCK_SKILL_CONTENT),
-        } as Response;
+        if (url.includes("vm0-cli")) {
+          return {
+            ok: true,
+            text: () => Promise.resolve(MOCK_CLI_SKILL_CONTENT),
+          } as Response;
+        }
+        if (url.includes("vm0-agent")) {
+          return {
+            ok: true,
+            text: () => Promise.resolve(MOCK_AGENT_SKILL_CONTENT),
+          } as Response;
+        }
       }
       return originalFetch(input, init);
     });
@@ -329,27 +347,38 @@ describe("onboard command", () => {
   });
 
   describe("skill installation", () => {
-    it("should install vm0-cli skill in agent directory", async () => {
+    it("should install both skills in agent directory", async () => {
       await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
-      const skillPath = path.join(
+      const cliSkillPath = path.join(
         tempDir,
         "my-vm0-agent/.claude/skills/vm0-cli/SKILL.md",
       );
-      expect(existsSync(skillPath)).toBe(true);
+      const agentSkillPath = path.join(
+        tempDir,
+        "my-vm0-agent/.claude/skills/vm0-agent/SKILL.md",
+      );
+      expect(existsSync(cliSkillPath)).toBe(true);
+      expect(existsSync(agentSkillPath)).toBe(true);
     });
 
-    it("should write correct skill content", async () => {
+    it("should write correct skill content for both skills", async () => {
       await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
-      const skillPath = path.join(
+      const cliSkillPath = path.join(
         tempDir,
         "my-vm0-agent/.claude/skills/vm0-cli/SKILL.md",
       );
-      const content = await readFile(skillPath, "utf-8");
+      const agentSkillPath = path.join(
+        tempDir,
+        "my-vm0-agent/.claude/skills/vm0-agent/SKILL.md",
+      );
 
-      expect(content).toContain("name: vm0-cli");
-      expect(content).toContain("## When to Use");
+      const cliContent = await readFile(cliSkillPath, "utf-8");
+      expect(cliContent).toContain("name: vm0-cli");
+
+      const agentContent = await readFile(agentSkillPath, "utf-8");
+      expect(agentContent).toContain("name: vm0-agent");
     });
   });
 
@@ -377,7 +406,8 @@ describe("onboard command", () => {
       expect(logCalls).toContain("Next step:");
       expect(logCalls).toContain("cd my-vm0-agent");
       expect(logCalls).toContain("claude");
-      expect(logCalls).toContain("/vm0-cli");
+      expect(logCalls).toContain("/vm0-agent");
+      expect(logCalls).toContain("let's build a workflow");
     });
 
     it("should show custom agent name in next steps", async () => {
@@ -415,6 +445,7 @@ describe("onboard command", () => {
       const logCalls = vi.mocked(console.log).mock.calls.flat().join("\n");
       expect(logCalls).toContain("Created my-vm0-agent/");
       expect(logCalls).toContain("Installed vm0-cli skill");
+      expect(logCalls).toContain("Installed vm0-agent skill");
     });
   });
 });

--- a/turbo/apps/cli/src/commands/__tests__/onboard.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/onboard.test.ts
@@ -21,13 +21,10 @@ vi.mock("os", async (importOriginal) => {
   };
 });
 
-// Mock fetchSkillContent to avoid real network calls
-vi.mock("../../lib/domain/onboard/index.js", async (importOriginal) => {
-  const original =
-    await importOriginal<typeof import("../../lib/domain/onboard/index.js")>();
-  return {
-    ...original,
-    fetchSkillContent: vi.fn().mockResolvedValue(`---
+import prompts from "prompts";
+import { onboardCommand } from "../onboard.js";
+
+const MOCK_SKILL_CONTENT = `---
 name: vm0-cli
 description: VM0 CLI for building and running AI agents in secure sandboxes.
 vm0_secrets:
@@ -41,37 +38,45 @@ Build and run AI agents in secure sandboxed environments.
 ## When to Use
 
 Use this skill when you need to install and set up the VM0 CLI.
-`),
-  };
-});
-
-import prompts from "prompts";
-import { onboardCommand } from "../onboard.js";
+`;
 
 describe("onboard command", () => {
   let tempDir: string;
   let originalCwd: string;
   let originalIsTTY: boolean | undefined;
-
-  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
-    throw new Error("process.exit called");
-  }) as never);
-  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
-  const mockConsoleClear = vi
-    .spyOn(console, "clear")
-    .mockImplementation(() => {});
-  const mockConsoleError = vi
-    .spyOn(console, "error")
-    .mockImplementation(() => {});
-  const mockStdoutWrite = vi
-    .spyOn(process.stdout, "write")
-    .mockImplementation(() => true);
+  const originalExit = process.exit;
+  let mockExit: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     vi.clearAllMocks();
+
+    // Mock process.exit to throw (simulates process termination)
+    mockExit = vi.fn().mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    process.exit = mockExit as unknown as typeof process.exit;
+
+    // Mock console
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "clear").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     tempDir = mkdtempSync(path.join(os.tmpdir(), "test-onboard-"));
     originalCwd = process.cwd();
     process.chdir(tempDir);
+
+    // Mock fetch for GitHub skill content only, let MSW handle API calls
+    const originalFetch = global.fetch;
+    vi.spyOn(global, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("raw.githubusercontent.com")) {
+        return {
+          ok: true,
+          text: () => Promise.resolve(MOCK_SKILL_CONTENT),
+        } as Response;
+      }
+      return originalFetch(input, init);
+    });
 
     // Mock homedir to return temp directory for config isolation
     vi.mocked(os.homedir).mockReturnValue(tempDir);
@@ -172,12 +177,9 @@ describe("onboard command", () => {
   afterEach(() => {
     process.chdir(originalCwd);
     rmSync(tempDir, { recursive: true, force: true });
-    mockExit.mockClear();
-    mockConsoleLog.mockClear();
-    mockConsoleClear.mockClear();
-    mockConsoleError.mockClear();
-    mockStdoutWrite.mockClear();
+    process.exit = originalExit;
     vi.unstubAllEnvs();
+    vi.restoreAllMocks();
 
     // Restore TTY state
     Object.defineProperty(process.stdout, "isTTY", {
@@ -191,7 +193,7 @@ describe("onboard command", () => {
     it("should display welcome box in interactive mode", async () => {
       await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      const logCalls = vi.mocked(console.log).mock.calls.flat().join("\n");
       expect(logCalls).toContain("Welcome to VM0!");
     });
   });
@@ -200,7 +202,7 @@ describe("onboard command", () => {
     it("should display progress line with steps", async () => {
       await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      const logCalls = vi.mocked(console.log).mock.calls.flat().join("\n");
       expect(logCalls).toContain("Authentication");
       expect(logCalls).toContain("Model Provider Setup");
       expect(logCalls).toContain("Create Agent");
@@ -212,7 +214,7 @@ describe("onboard command", () => {
       await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
       // Should not show auth required message
-      expect(mockConsoleLog).not.toHaveBeenCalledWith(
+      expect(console.log).not.toHaveBeenCalledWith(
         expect.stringContaining("Authentication required"),
       );
     });
@@ -229,11 +231,12 @@ describe("onboard command", () => {
         configurable: true,
       });
 
-      await expect(async () => {
-        await onboardCommand.parseAsync(["node", "cli", "-y"]);
-      }).rejects.toThrow("process.exit called");
+      await expect(
+        onboardCommand.parseAsync(["node", "cli", "-y"]),
+      ).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining("Not authenticated"),
       );
     });
@@ -244,7 +247,7 @@ describe("onboard command", () => {
       await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
       // Should not show model provider setup required message
-      expect(mockConsoleLog).not.toHaveBeenCalledWith(
+      expect(console.log).not.toHaveBeenCalledWith(
         expect.stringContaining("Model provider setup required"),
       );
     });
@@ -263,11 +266,12 @@ describe("onboard command", () => {
         configurable: true,
       });
 
-      await expect(async () => {
-        await onboardCommand.parseAsync(["node", "cli", "-y"]);
-      }).rejects.toThrow("process.exit called");
+      await expect(
+        onboardCommand.parseAsync(["node", "cli", "-y"]),
+      ).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining("No model provider configured"),
       );
     });
@@ -296,27 +300,29 @@ describe("onboard command", () => {
       const { mkdir } = await import("fs/promises");
       await mkdir(path.join(tempDir, "my-vm0-agent"));
 
-      await expect(async () => {
-        await onboardCommand.parseAsync(["node", "cli", "-y"]);
-      }).rejects.toThrow("process.exit called");
+      await expect(
+        onboardCommand.parseAsync(["node", "cli", "-y"]),
+      ).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining("my-vm0-agent/ already exists"),
       );
     });
 
     it("should exit with error for invalid agent name", async () => {
-      await expect(async () => {
-        await onboardCommand.parseAsync([
+      await expect(
+        onboardCommand.parseAsync([
           "node",
           "cli",
           "-y",
           "--name",
           "ab", // Too short
-        ]);
-      }).rejects.toThrow("process.exit called");
+        ]),
+      ).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining("Invalid agent name"),
       );
     });
@@ -367,7 +373,7 @@ describe("onboard command", () => {
     it("should display next steps after completion", async () => {
       await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      const logCalls = vi.mocked(console.log).mock.calls.flat().join("\n");
       expect(logCalls).toContain("Next step:");
       expect(logCalls).toContain("cd my-vm0-agent");
       expect(logCalls).toContain("claude");
@@ -383,7 +389,7 @@ describe("onboard command", () => {
         "custom-agent",
       ]);
 
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      const logCalls = vi.mocked(console.log).mock.calls.flat().join("\n");
       expect(logCalls).toContain("cd custom-agent");
     });
   });
@@ -406,7 +412,7 @@ describe("onboard command", () => {
     it("should display success messages for creation", async () => {
       await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      const logCalls = vi.mocked(console.log).mock.calls.flat().join("\n");
       expect(logCalls).toContain("Created my-vm0-agent/");
       expect(logCalls).toContain("Installed vm0-cli skill");
     });

--- a/turbo/apps/cli/src/commands/__tests__/onboard.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/onboard.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { onboardCommand } from "../onboard.js";
 import { existsSync, mkdtempSync, rmSync } from "fs";
 import { readFile } from "fs/promises";
 import * as path from "path";
@@ -22,7 +21,32 @@ vi.mock("os", async (importOriginal) => {
   };
 });
 
+// Mock fetchSkillContent to avoid real network calls
+vi.mock("../../lib/domain/onboard/index.js", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("../../lib/domain/onboard/index.js")>();
+  return {
+    ...original,
+    fetchSkillContent: vi.fn().mockResolvedValue(`---
+name: vm0-cli
+description: VM0 CLI for building and running AI agents in secure sandboxes.
+vm0_secrets:
+  - VM0_TOKEN
+---
+
+# VM0 CLI
+
+Build and run AI agents in secure sandboxed environments.
+
+## When to Use
+
+Use this skill when you need to install and set up the VM0 CLI.
+`),
+  };
+});
+
 import prompts from "prompts";
+import { onboardCommand } from "../onboard.js";
 
 describe("onboard command", () => {
   let tempDir: string;
@@ -299,12 +323,12 @@ describe("onboard command", () => {
   });
 
   describe("skill installation", () => {
-    it("should install vm0-agent-builder skill in agent directory", async () => {
+    it("should install vm0-cli skill in agent directory", async () => {
       await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
       const skillPath = path.join(
         tempDir,
-        "my-vm0-agent/.claude/skills/vm0-agent-builder/SKILL.md",
+        "my-vm0-agent/.claude/skills/vm0-cli/SKILL.md",
       );
       expect(existsSync(skillPath)).toBe(true);
     });
@@ -314,12 +338,12 @@ describe("onboard command", () => {
 
       const skillPath = path.join(
         tempDir,
-        "my-vm0-agent/.claude/skills/vm0-agent-builder/SKILL.md",
+        "my-vm0-agent/.claude/skills/vm0-cli/SKILL.md",
       );
       const content = await readFile(skillPath, "utf-8");
 
-      expect(content).toContain("name: vm0-agent-builder");
-      expect(content).toContain("## Workflow");
+      expect(content).toContain("name: vm0-cli");
+      expect(content).toContain("## When to Use");
     });
   });
 
@@ -347,7 +371,7 @@ describe("onboard command", () => {
       expect(logCalls).toContain("Next step:");
       expect(logCalls).toContain("cd my-vm0-agent");
       expect(logCalls).toContain("claude");
-      expect(logCalls).toContain("/vm0-agent-builder");
+      expect(logCalls).toContain("/vm0-cli");
     });
 
     it("should show custom agent name in next steps", async () => {
@@ -384,7 +408,7 @@ describe("onboard command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Created my-vm0-agent/");
-      expect(logCalls).toContain("Installed vm0-agent-builder skill");
+      expect(logCalls).toContain("Installed vm0-cli skill");
     });
   });
 });

--- a/turbo/apps/cli/src/commands/__tests__/setup-claude.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/setup-claude.test.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 import * as os from "os";
 import { setupClaudeCommand } from "../setup-claude";
 
-const MOCK_SKILL_CONTENT = `---
+const MOCK_CLI_SKILL_CONTENT = `---
 name: vm0-cli
 description: VM0 CLI for building and running AI agents in secure sandboxes.
 vm0_secrets:
@@ -19,6 +19,16 @@ Build and run AI agents in secure sandboxed environments.
 ## When to Use
 
 Use this skill when you need to install and set up the VM0 CLI.
+`;
+
+const MOCK_AGENT_SKILL_CONTENT = `---
+name: vm0-agent
+description: VM0 Agent skill for building workflows.
+---
+
+# VM0 Agent
+
+Build AI agent workflows.
 `;
 
 describe("setup-claude command", () => {
@@ -43,11 +53,27 @@ describe("setup-claude command", () => {
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
 
-    // Mock fetch at system boundary
-    vi.spyOn(global, "fetch").mockResolvedValue({
-      ok: true,
-      text: () => Promise.resolve(MOCK_SKILL_CONTENT),
-    } as Response);
+    // Mock fetch at system boundary - handle both skill URLs
+    vi.spyOn(global, "fetch").mockImplementation(async (url) => {
+      const urlStr = url.toString();
+      if (urlStr.includes("vm0-cli")) {
+        return {
+          ok: true,
+          text: () => Promise.resolve(MOCK_CLI_SKILL_CONTENT),
+        } as Response;
+      }
+      if (urlStr.includes("vm0-agent")) {
+        return {
+          ok: true,
+          text: () => Promise.resolve(MOCK_AGENT_SKILL_CONTENT),
+        } as Response;
+      }
+      return {
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+      } as Response;
+    });
   });
 
   afterEach(() => {
@@ -58,24 +84,37 @@ describe("setup-claude command", () => {
   });
 
   describe("skill installation", () => {
-    it("should create .claude/skills/vm0-cli directory", async () => {
+    it("should create skill directories for both skills", async () => {
       await setupClaudeCommand.parseAsync(["node", "cli"]);
 
       expect(existsSync(path.join(tempDir, ".claude/skills/vm0-cli"))).toBe(
         true,
       );
+      expect(existsSync(path.join(tempDir, ".claude/skills/vm0-agent"))).toBe(
+        true,
+      );
     });
 
-    it("should create SKILL.md with fetched content", async () => {
+    it("should create SKILL.md with fetched content for both skills", async () => {
       await setupClaudeCommand.parseAsync(["node", "cli"]);
 
-      const skillPath = path.join(tempDir, ".claude/skills/vm0-cli/SKILL.md");
-      expect(existsSync(skillPath)).toBe(true);
+      const cliSkillPath = path.join(
+        tempDir,
+        ".claude/skills/vm0-cli/SKILL.md",
+      );
+      const agentSkillPath = path.join(
+        tempDir,
+        ".claude/skills/vm0-agent/SKILL.md",
+      );
 
-      const content = await fs.readFile(skillPath, "utf8");
-      expect(content).toContain("name: vm0-cli");
-      expect(content).toContain("# VM0 CLI");
-      expect(content).toContain("## When to Use");
+      expect(existsSync(cliSkillPath)).toBe(true);
+      expect(existsSync(agentSkillPath)).toBe(true);
+
+      const cliContent = await fs.readFile(cliSkillPath, "utf8");
+      expect(cliContent).toContain("name: vm0-cli");
+
+      const agentContent = await fs.readFile(agentSkillPath, "utf8");
+      expect(agentContent).toContain("name: vm0-agent");
     });
 
     it("should overwrite existing files (idempotent)", async () => {
@@ -104,17 +143,23 @@ describe("setup-claude command", () => {
       expect(console.log).toHaveBeenCalledWith(
         expect.stringContaining("Installed vm0-cli skill"),
       );
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining("Installed vm0-agent skill"),
+      );
       expect(console.log).toHaveBeenCalledWith("Next step:");
       expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining("/vm0-cli"),
+        expect.stringContaining("/vm0-agent"),
       );
     });
 
-    it("should fetch skill content from GitHub", async () => {
+    it("should fetch skill content from GitHub for both skills", async () => {
       await setupClaudeCommand.parseAsync(["node", "cli"]);
 
       expect(global.fetch).toHaveBeenCalledWith(
         "https://raw.githubusercontent.com/vm0-ai/vm0-skills/main/vm0-cli/SKILL.md",
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://raw.githubusercontent.com/vm0-ai/vm0-skills/main/vm0-agent/SKILL.md",
       );
     });
   });

--- a/turbo/apps/cli/src/commands/__tests__/setup-claude.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/setup-claude.test.ts
@@ -1,15 +1,47 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { setupClaudeCommand } from "../setup-claude";
 import * as fs from "fs/promises";
 import { existsSync, mkdtempSync, rmSync } from "fs";
 import * as path from "path";
 import * as os from "os";
+
+// Mock fetchSkillContent before importing the command
+vi.mock("../../lib/domain/onboard/index.js", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("../../lib/domain/onboard/index.js")>();
+  return {
+    ...original,
+    fetchSkillContent: vi.fn().mockResolvedValue(`---
+name: vm0-cli
+description: VM0 CLI for building and running AI agents in secure sandboxes.
+vm0_secrets:
+  - VM0_TOKEN
+---
+
+# VM0 CLI
+
+Build and run AI agents in secure sandboxed environments.
+
+## When to Use
+
+Use this skill when you need to install and set up the VM0 CLI.
+`),
+  };
+});
+
+import { setupClaudeCommand } from "../setup-claude";
+import { fetchSkillContent } from "../../lib/domain/onboard/index.js";
 
 describe("setup-claude command", () => {
   let tempDir: string;
   let originalCwd: string;
 
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -22,50 +54,48 @@ describe("setup-claude command", () => {
     process.chdir(originalCwd);
     rmSync(tempDir, { recursive: true, force: true });
     mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    mockExit.mockClear();
   });
 
   describe("skill installation", () => {
-    it("should create .claude/skills/vm0-agent-builder directory", async () => {
+    it("should create .claude/skills/vm0-cli directory", async () => {
       await setupClaudeCommand.parseAsync(["node", "cli"]);
 
-      expect(
-        existsSync(path.join(tempDir, ".claude/skills/vm0-agent-builder")),
-      ).toBe(true);
+      expect(existsSync(path.join(tempDir, ".claude/skills/vm0-cli"))).toBe(
+        true,
+      );
     });
 
-    it("should create SKILL.md with embedded content", async () => {
+    it("should create SKILL.md with fetched content", async () => {
       await setupClaudeCommand.parseAsync(["node", "cli"]);
 
-      const skillPath = path.join(
-        tempDir,
-        ".claude/skills/vm0-agent-builder/SKILL.md",
-      );
+      const skillPath = path.join(tempDir, ".claude/skills/vm0-cli/SKILL.md");
       expect(existsSync(skillPath)).toBe(true);
 
       const content = await fs.readFile(skillPath, "utf8");
-      expect(content).toContain("name: vm0-agent-builder");
-      expect(content).toContain("# VM0 Agent Builder");
+      expect(content).toContain("name: vm0-cli");
+      expect(content).toContain("# VM0 CLI");
       expect(content).toContain("## When to Use");
-      expect(content).toContain("## Workflow");
     });
 
     it("should overwrite existing files (idempotent)", async () => {
       // Create existing skill directory with old content
-      await fs.mkdir(path.join(tempDir, ".claude/skills/vm0-agent-builder"), {
+      await fs.mkdir(path.join(tempDir, ".claude/skills/vm0-cli"), {
         recursive: true,
       });
       await fs.writeFile(
-        path.join(tempDir, ".claude/skills/vm0-agent-builder/SKILL.md"),
+        path.join(tempDir, ".claude/skills/vm0-cli/SKILL.md"),
         "old content",
       );
 
       await setupClaudeCommand.parseAsync(["node", "cli"]);
 
       const content = await fs.readFile(
-        path.join(tempDir, ".claude/skills/vm0-agent-builder/SKILL.md"),
+        path.join(tempDir, ".claude/skills/vm0-cli/SKILL.md"),
         "utf8",
       );
-      expect(content).toContain("# VM0 Agent Builder");
+      expect(content).toContain("# VM0 CLI");
       expect(content).not.toContain("old content");
     });
 
@@ -73,11 +103,36 @@ describe("setup-claude command", () => {
       await setupClaudeCommand.parseAsync(["node", "cli"]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Installed vm0-agent-builder skill"),
+        expect.stringContaining("Installed vm0-cli skill"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith("Next step:");
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("/vm0-agent-builder"),
+        expect.stringContaining("/vm0-cli"),
+      );
+    });
+
+    it("should fetch skill content from GitHub", async () => {
+      await setupClaudeCommand.parseAsync(["node", "cli"]);
+
+      expect(fetchSkillContent).toHaveBeenCalled();
+    });
+  });
+
+  describe("error handling", () => {
+    it("should exit with error when fetch fails", async () => {
+      vi.mocked(fetchSkillContent).mockRejectedValueOnce(
+        new Error("Network error"),
+      );
+
+      await expect(
+        setupClaudeCommand.parseAsync(["node", "cli"]),
+      ).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to fetch skill from GitHub"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Network error"),
       );
     });
   });

--- a/turbo/apps/cli/src/commands/__tests__/setup-claude.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/setup-claude.test.ts
@@ -3,14 +3,9 @@ import * as fs from "fs/promises";
 import { existsSync, mkdtempSync, rmSync } from "fs";
 import * as path from "path";
 import * as os from "os";
+import { setupClaudeCommand } from "../setup-claude";
 
-// Mock fetchSkillContent before importing the command
-vi.mock("../../lib/domain/onboard/index.js", async (importOriginal) => {
-  const original =
-    await importOriginal<typeof import("../../lib/domain/onboard/index.js")>();
-  return {
-    ...original,
-    fetchSkillContent: vi.fn().mockResolvedValue(`---
+const MOCK_SKILL_CONTENT = `---
 name: vm0-cli
 description: VM0 CLI for building and running AI agents in secure sandboxes.
 vm0_secrets:
@@ -24,38 +19,42 @@ Build and run AI agents in secure sandboxed environments.
 ## When to Use
 
 Use this skill when you need to install and set up the VM0 CLI.
-`),
-  };
-});
-
-import { setupClaudeCommand } from "../setup-claude";
-import { fetchSkillContent } from "../../lib/domain/onboard/index.js";
+`;
 
 describe("setup-claude command", () => {
   let tempDir: string;
   let originalCwd: string;
-
-  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
-  const mockConsoleError = vi
-    .spyOn(console, "error")
-    .mockImplementation(() => {});
-  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
-    throw new Error("process.exit called");
-  }) as never);
+  const originalExit = process.exit;
+  let mockExit: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     tempDir = mkdtempSync(path.join(os.tmpdir(), "test-setup-claude-"));
     originalCwd = process.cwd();
     process.chdir(tempDir);
+
+    // Mock process.exit to throw (simulates process termination)
+    mockExit = vi.fn().mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    process.exit = mockExit as unknown as typeof process.exit;
+
+    // Mock console
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Mock fetch at system boundary
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(MOCK_SKILL_CONTENT),
+    } as Response);
   });
 
   afterEach(() => {
     process.chdir(originalCwd);
     rmSync(tempDir, { recursive: true, force: true });
-    mockConsoleLog.mockClear();
-    mockConsoleError.mockClear();
-    mockExit.mockClear();
+    process.exit = originalExit;
+    vi.restoreAllMocks();
   });
 
   describe("skill installation", () => {
@@ -102,11 +101,11 @@ describe("setup-claude command", () => {
     it("should display success message and next steps", async () => {
       await setupClaudeCommand.parseAsync(["node", "cli"]);
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(console.log).toHaveBeenCalledWith(
         expect.stringContaining("Installed vm0-cli skill"),
       );
-      expect(mockConsoleLog).toHaveBeenCalledWith("Next step:");
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(console.log).toHaveBeenCalledWith("Next step:");
+      expect(console.log).toHaveBeenCalledWith(
         expect.stringContaining("/vm0-cli"),
       );
     });
@@ -114,13 +113,15 @@ describe("setup-claude command", () => {
     it("should fetch skill content from GitHub", async () => {
       await setupClaudeCommand.parseAsync(["node", "cli"]);
 
-      expect(fetchSkillContent).toHaveBeenCalled();
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://raw.githubusercontent.com/vm0-ai/vm0-skills/main/vm0-cli/SKILL.md",
+      );
     });
   });
 
   describe("error handling", () => {
     it("should exit with error when fetch fails", async () => {
-      vi.mocked(fetchSkillContent).mockRejectedValueOnce(
+      vi.spyOn(global, "fetch").mockRejectedValueOnce(
         new Error("Network error"),
       );
 
@@ -128,10 +129,11 @@ describe("setup-claude command", () => {
         setupClaudeCommand.parseAsync(["node", "cli"]),
       ).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining("Failed to fetch skill from GitHub"),
       );
-      expect(mockConsoleError).toHaveBeenCalledWith(
+      expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining("Network error"),
       );
     });

--- a/turbo/apps/cli/src/commands/onboard.ts
+++ b/turbo/apps/cli/src/commands/onboard.ts
@@ -21,6 +21,8 @@ import {
   getProviderChoices,
   setupModelProvider,
   installClaudeSkill,
+  SKILL_NAME,
+  SKILL_URL,
 } from "../lib/domain/onboard/index.js";
 import type { ModelProviderType } from "@vm0/core";
 
@@ -193,12 +195,19 @@ async function handleSkillInstallation(
 ): Promise<void> {
   ctx.updateProgress(3, "in-progress");
 
-  const skillResult = await installClaudeSkill(agentName);
-  console.log(
-    chalk.green(
-      `✓ Installed vm0-agent-builder skill to ${skillResult.skillDir}`,
-    ),
-  );
+  try {
+    const skillResult = await installClaudeSkill(agentName);
+    console.log(
+      chalk.green(`✓ Installed ${SKILL_NAME} skill to ${skillResult.skillDir}`),
+    );
+  } catch (error) {
+    console.error(chalk.red(`Failed to fetch skill from GitHub: ${SKILL_URL}`));
+    if (error instanceof Error) {
+      console.error(chalk.red(error.message));
+    }
+    console.error(chalk.dim("Please check your network connection."));
+    process.exit(1);
+  }
 
   ctx.updateProgress(3, "completed");
 }
@@ -208,7 +217,7 @@ function printNextSteps(agentName: string): void {
   console.log(chalk.bold("Next step:"));
   console.log();
   console.log(
-    `  ${chalk.cyan(`cd ${agentName} && claude "/vm0-agent-builder I want to build an agent that..."`)}`,
+    `  ${chalk.cyan(`cd ${agentName} && claude "/${SKILL_NAME} I want to build an agent that..."`)}`,
   );
   console.log();
 }

--- a/turbo/apps/cli/src/commands/onboard.ts
+++ b/turbo/apps/cli/src/commands/onboard.ts
@@ -20,9 +20,10 @@ import {
   checkModelProviderStatus,
   getProviderChoices,
   setupModelProvider,
-  installClaudeSkill,
+  installAllClaudeSkills,
   handleFetchError,
-  SKILL_NAME,
+  SKILLS,
+  PRIMARY_SKILL_NAME,
 } from "../lib/domain/onboard/index.js";
 import type { ModelProviderType } from "@vm0/core";
 
@@ -196,10 +197,15 @@ async function handleSkillInstallation(
   ctx.updateProgress(3, "in-progress");
 
   try {
-    const skillResult = await installClaudeSkill(agentName);
-    console.log(
-      chalk.green(`✓ Installed ${SKILL_NAME} skill to ${skillResult.skillDir}`),
-    );
+    const result = await installAllClaudeSkills(agentName);
+    result.skills.forEach((skillResult, i) => {
+      const skillName = SKILLS[i]?.name ?? "unknown";
+      console.log(
+        chalk.green(
+          `✓ Installed ${skillName} skill to ${skillResult.skillDir}`,
+        ),
+      );
+    });
   } catch (error) {
     handleFetchError(error);
   }
@@ -212,7 +218,7 @@ function printNextSteps(agentName: string): void {
   console.log(chalk.bold("Next step:"));
   console.log();
   console.log(
-    `  ${chalk.cyan(`cd ${agentName} && claude "/${SKILL_NAME} I want to build an agent that..."`)}`,
+    `  ${chalk.cyan(`cd ${agentName} && claude "/${PRIMARY_SKILL_NAME} let's build a workflow"`)}`,
   );
   console.log();
 }

--- a/turbo/apps/cli/src/commands/onboard.ts
+++ b/turbo/apps/cli/src/commands/onboard.ts
@@ -21,8 +21,8 @@ import {
   getProviderChoices,
   setupModelProvider,
   installClaudeSkill,
+  handleFetchError,
   SKILL_NAME,
-  SKILL_URL,
 } from "../lib/domain/onboard/index.js";
 import type { ModelProviderType } from "@vm0/core";
 
@@ -201,12 +201,7 @@ async function handleSkillInstallation(
       chalk.green(`✓ Installed ${SKILL_NAME} skill to ${skillResult.skillDir}`),
     );
   } catch (error) {
-    console.error(chalk.red(`Failed to fetch skill from GitHub: ${SKILL_URL}`));
-    if (error instanceof Error) {
-      console.error(chalk.red(error.message));
-    }
-    console.error(chalk.dim("Please check your network connection."));
-    process.exit(1);
+    handleFetchError(error);
   }
 
   ctx.updateProgress(3, "completed");

--- a/turbo/apps/cli/src/commands/setup-claude.ts
+++ b/turbo/apps/cli/src/commands/setup-claude.ts
@@ -2,243 +2,52 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
-
-const SKILL_DIR = ".claude/skills/vm0-agent-builder";
-
-// Embedded skill content - no external dependency on GitHub
-const SKILL_CONTENT = `---
-name: vm0-agent-builder
-description: Guide for building VM0 agents with Claude's help. Use this skill when users want to create or improve their agent's AGENTS.md and vm0.yaml configuration.
----
-
-# VM0 Agent Builder
-
-Help users create effective AI agents using the VM0 platform. This skill guides the process of designing agent workflows, writing AGENTS.md instructions, and configuring vm0.yaml.
-
-## When to Use
-
-- User wants to create a new VM0 agent from scratch
-- User wants to improve an existing agent's instructions
-- User needs help configuring vm0.yaml with skills
-- User is unsure how to structure their agent's workflow
-
-## Workflow
-
-### Step 1: Understand the Goal
-
-Ask the user what they want their agent to accomplish:
-- What is the main task or problem to solve?
-- What inputs will the agent receive?
-- What outputs should the agent produce?
-- Are there any constraints or requirements?
-
-### Step 2: Design the Workflow
-
-Break down the task into clear, sequential steps:
-1. Each step should be a single, focused action
-2. Steps should build on each other logically
-3. Include error handling and edge cases
-4. Consider what tools/skills the agent will need
-
-### Step 3: Write AGENTS.md
-
-Create the agent instructions file with:
-
-\`\`\`markdown
-# Agent Instructions
-
-You are a [role description].
-
-## Goal
-
-[Clear statement of what the agent should accomplish]
-
-## Workflow
-
-1. [First step with specific instructions]
-2. [Second step with specific instructions]
-3. [Continue with remaining steps...]
-
-## Output
-
-[Describe the expected output format and location]
-
-## Constraints
-
-[Any limitations or rules the agent should follow]
-\`\`\`
-
-### Step 4: Configure vm0.yaml
-
-Update the vm0.yaml to include necessary skills:
-
-\`\`\`yaml
-version: "1.0"
-
-agents:
-  agent-name:
-    framework: claude-code
-    instructions: AGENTS.md
-    skills:
-      - https://github.com/vm0-ai/vm0-skills/tree/main/skill-name
-    environment:
-      # Add any required environment variables
-      API_KEY: "\${{ secrets.API_KEY }}"
-\`\`\`
-
-### Step 5: Test the Agent
-
-Guide the user to test their agent:
-
-\`\`\`bash
-# Deploy the agent configuration
-vm0 compose vm0.yaml
-
-# Run the agent with a test prompt
-vm0 cook "start working on the task"
-
-# Check the logs if needed
-vm0 logs <run-id>
-\`\`\`
-
-## Available Skills
-
-Common skills from vm0-skills repository:
-
-| Skill | Purpose |
-|-------|---------|
-| \`github\` | GitHub API operations (issues, PRs, repos) |
-| \`slack\` | Send messages to Slack channels |
-| \`notion\` | Read/write Notion pages and databases |
-| \`firecrawl\` | Web scraping and content extraction |
-| \`browserbase\` | Browser automation |
-| \`openai\` | OpenAI API for embeddings, completions |
-| \`supabase\` | Database operations with Supabase |
-
-Browse all skills: https://github.com/vm0-ai/vm0-skills
-
-## Example Agents
-
-### Content Curator Agent
-
-\`\`\`markdown
-# Agent Instructions
-
-You are a content curator that monitors HackerNews for AI-related articles.
-
-## Workflow
-
-1. Go to HackerNews and read the top 30 stories
-2. Filter for AI, ML, and LLM related content
-3. For each relevant article, extract:
-   - Title and URL
-   - Key points (2-3 sentences)
-   - Why it's interesting
-4. Write a summary to \`daily-digest.md\`
-
-## Output
-
-Create \`daily-digest.md\` with today's date as the header.
-\`\`\`
-
-### GitHub Issue Tracker Agent
-
-\`\`\`markdown
-# Agent Instructions
-
-You are a GitHub issue tracker that summarizes open issues.
-
-## Workflow
-
-1. List all open issues in the repository
-2. Group issues by labels (bug, feature, docs)
-3. For each group, summarize:
-   - Number of issues
-   - Oldest issue age
-   - Most discussed issues
-4. Create a report in \`issue-report.md\`
-
-## Skills Required
-
-- github (for API access)
-\`\`\`
-
-### Data Pipeline Agent
-
-\`\`\`markdown
-# Agent Instructions
-
-You are a data pipeline agent that processes CSV files.
-
-## Workflow
-
-1. Read all CSV files from the input volume
-2. For each file:
-   - Validate the schema
-   - Clean missing values
-   - Transform dates to ISO format
-3. Merge all files into \`combined.csv\`
-4. Generate a summary report
-
-## Input
-
-Files are provided via volume mount.
-
-## Output
-
-Write results to the artifact directory.
-\`\`\`
-
-## Best Practices
-
-1. **Be Specific**: Vague instructions lead to unpredictable results
-2. **One Task Per Step**: Keep workflow steps focused and atomic
-3. **Define Output Clearly**: Specify exact file names and formats
-4. **Handle Errors**: Include what to do when things go wrong
-5. **Test Incrementally**: Start with simple workflows, add complexity
-6. **Use Skills Wisely**: Only include skills the agent actually needs
-
-## Troubleshooting
-
-### Agent doesn't follow instructions
-- Make instructions more specific and explicit
-- Add examples of expected behavior
-- Break complex steps into smaller sub-steps
-
-### Agent uses wrong tools
-- Specify which tools/skills to use for each step
-- Add constraints about what NOT to do
-
-### Output format is wrong
-- Provide exact templates for output files
-- Include example output in the instructions
-`;
+import {
+  fetchSkillContent,
+  SKILL_DIR,
+  SKILL_NAME,
+  SKILL_URL,
+} from "../lib/domain/onboard/index.js";
 
 export const setupClaudeCommand = new Command()
   .name("setup-claude")
-  .description("Add/update Claude skill for agent building")
+  .description("Add/update Claude skill for VM0 CLI usage")
   .option(
     "--agent-dir <dir>",
     "Agent directory (shown in next step instructions)",
   )
   .action(async (options: { agentDir?: string }) => {
-    console.log(chalk.dim("Installing vm0-agent-builder skill..."));
+    console.log(chalk.dim(`Installing ${SKILL_NAME} skill...`));
+
+    let content: string;
+    try {
+      content = await fetchSkillContent();
+    } catch (error) {
+      console.error(
+        chalk.red(`Failed to fetch skill from GitHub: ${SKILL_URL}`),
+      );
+      if (error instanceof Error) {
+        console.error(chalk.red(error.message));
+      }
+      console.error(chalk.dim("Please check your network connection."));
+      process.exit(1);
+    }
 
     // Create directory
     await mkdir(SKILL_DIR, { recursive: true });
 
     // Write skill file
-    await writeFile(path.join(SKILL_DIR, "SKILL.md"), SKILL_CONTENT);
+    await writeFile(path.join(SKILL_DIR, "SKILL.md"), content);
 
     console.log(
-      chalk.green(`Done Installed vm0-agent-builder skill to ${SKILL_DIR}`),
+      chalk.green(`Done! Installed ${SKILL_NAME} skill to ${SKILL_DIR}`),
     );
     console.log();
     console.log("Next step:");
     const cdPrefix = options.agentDir ? `cd ${options.agentDir} && ` : "";
     console.log(
       chalk.cyan(
-        `  ${cdPrefix}claude "/vm0-agent-builder I want to build an agent that..."`,
+        `  ${cdPrefix}claude "/${SKILL_NAME} I want to build an agent that..."`,
       ),
     );
   });

--- a/turbo/apps/cli/src/commands/setup-claude.ts
+++ b/turbo/apps/cli/src/commands/setup-claude.ts
@@ -1,46 +1,42 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { mkdir, writeFile } from "fs/promises";
-import path from "path";
 import {
-  fetchSkillContent,
+  installAllClaudeSkills,
   handleFetchError,
-  SKILL_DIR,
-  SKILL_NAME,
+  SKILLS,
+  PRIMARY_SKILL_NAME,
 } from "../lib/domain/onboard/index.js";
 
 export const setupClaudeCommand = new Command()
   .name("setup-claude")
-  .description("Add/update Claude skill for VM0 CLI usage")
+  .description("Add/update Claude skills for VM0 usage")
   .option(
     "--agent-dir <dir>",
     "Agent directory (shown in next step instructions)",
   )
   .action(async (options: { agentDir?: string }) => {
-    console.log(chalk.dim(`Installing ${SKILL_NAME} skill...`));
+    console.log(chalk.dim("Installing Claude skills..."));
 
-    let content: string;
     try {
-      content = await fetchSkillContent();
+      const result = await installAllClaudeSkills();
+      result.skills.forEach((skillResult, i) => {
+        const skillName = SKILLS[i]?.name ?? "unknown";
+        console.log(
+          chalk.green(
+            `✓ Installed ${skillName} skill to ${skillResult.skillDir}`,
+          ),
+        );
+      });
     } catch (error) {
       handleFetchError(error);
     }
 
-    // Create directory
-    await mkdir(SKILL_DIR, { recursive: true });
-
-    // Write skill file
-    await writeFile(path.join(SKILL_DIR, "SKILL.md"), content);
-
-    console.log(
-      chalk.green(`Done! Installed ${SKILL_NAME} skill to ${SKILL_DIR}`),
-    );
     console.log();
     console.log("Next step:");
     const cdPrefix = options.agentDir ? `cd ${options.agentDir} && ` : "";
     console.log(
       chalk.cyan(
-        `  ${cdPrefix}claude "/${SKILL_NAME} I want to build an agent that..."`,
+        `  ${cdPrefix}claude "/${PRIMARY_SKILL_NAME} let's build a workflow"`,
       ),
     );
   });

--- a/turbo/apps/cli/src/commands/setup-claude.ts
+++ b/turbo/apps/cli/src/commands/setup-claude.ts
@@ -4,9 +4,9 @@ import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 import {
   fetchSkillContent,
+  handleFetchError,
   SKILL_DIR,
   SKILL_NAME,
-  SKILL_URL,
 } from "../lib/domain/onboard/index.js";
 
 export const setupClaudeCommand = new Command()
@@ -23,14 +23,7 @@ export const setupClaudeCommand = new Command()
     try {
       content = await fetchSkillContent();
     } catch (error) {
-      console.error(
-        chalk.red(`Failed to fetch skill from GitHub: ${SKILL_URL}`),
-      );
-      if (error instanceof Error) {
-        console.error(chalk.red(error.message));
-      }
-      console.error(chalk.dim("Please check your network connection."));
-      process.exit(1);
+      handleFetchError(error);
     }
 
     // Create directory

--- a/turbo/apps/cli/src/lib/domain/onboard/__tests__/claude-setup.test.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/__tests__/claude-setup.test.ts
@@ -1,78 +1,112 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdir, rm } from "fs/promises";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdir, rm, readFile } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import {
   SKILL_DIR,
   SKILL_FILE,
-  getSkillContent,
+  SKILL_NAME,
+  SKILL_URL,
+  fetchSkillContent,
   installClaudeSkill,
 } from "../claude-setup.js";
+
+const MOCK_SKILL_CONTENT = `---
+name: vm0-cli
+description: VM0 CLI for building and running AI agents in secure sandboxes.
+vm0_secrets:
+  - VM0_TOKEN
+---
+
+# VM0 CLI
+
+Build and run AI agents in secure sandboxed environments.
+
+## When to Use
+
+Use this skill when you need to:
+- Install and set up the VM0 CLI
+- Run agents with prompts and inputs
+`;
 
 describe("claude-setup", () => {
   const testDir = "/tmp/test-claude-setup";
 
   beforeEach(async () => {
+    vi.clearAllMocks();
     await mkdir(testDir, { recursive: true });
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await rm(testDir, { recursive: true, force: true });
   });
 
   describe("constants", () => {
     it("should have correct SKILL_DIR", () => {
-      expect(SKILL_DIR).toBe(".claude/skills/vm0-agent-builder");
+      expect(SKILL_DIR).toBe(".claude/skills/vm0-cli");
     });
 
     it("should have correct SKILL_FILE", () => {
       expect(SKILL_FILE).toBe("SKILL.md");
     });
+
+    it("should have correct SKILL_NAME", () => {
+      expect(SKILL_NAME).toBe("vm0-cli");
+    });
+
+    it("should have correct SKILL_URL", () => {
+      expect(SKILL_URL).toBe(
+        "https://raw.githubusercontent.com/vm0-ai/vm0-skills/main/vm0-cli/SKILL.md",
+      );
+    });
   });
 
-  describe("getSkillContent", () => {
-    it("should return non-empty content", () => {
-      const content = getSkillContent();
+  describe("fetchSkillContent", () => {
+    it("should fetch content from GitHub", async () => {
+      const mockFetch = vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(MOCK_SKILL_CONTENT),
+      } as Response);
 
-      expect(content.length).toBeGreaterThan(0);
+      const content = await fetchSkillContent();
+
+      expect(content).toBe(MOCK_SKILL_CONTENT);
+      expect(mockFetch).toHaveBeenCalledWith(SKILL_URL);
     });
 
-    it("should include frontmatter", () => {
-      const content = getSkillContent();
+    it("should throw error on fetch failure", async () => {
+      vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+      } as Response);
 
-      expect(content).toContain("---");
-      expect(content).toContain("name: vm0-agent-builder");
+      await expect(fetchSkillContent()).rejects.toThrow(
+        `Failed to fetch skill from ${SKILL_URL}: 404 Not Found`,
+      );
     });
 
-    it("should include workflow sections", () => {
-      const content = getSkillContent();
+    it("should throw error on network failure", async () => {
+      vi.spyOn(global, "fetch").mockRejectedValue(new Error("Network error"));
 
-      expect(content).toContain("## Workflow");
-      expect(content).toContain("Step 1");
-      expect(content).toContain("Create AGENTS.md");
-    });
-
-    it("should include available skills", () => {
-      const content = getSkillContent();
-
-      expect(content).toContain("## Available Skills");
-      expect(content).toContain("github");
-      expect(content).toContain("slack");
-    });
-
-    it("should include example agents", () => {
-      const content = getSkillContent();
-
-      expect(content).toContain("## Examples");
-      expect(content).toContain("HackerNews Curator");
+      await expect(fetchSkillContent()).rejects.toThrow("Network error");
     });
   });
 
   describe("installClaudeSkill", () => {
+    beforeEach(() => {
+      vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(MOCK_SKILL_CONTENT),
+      } as Response);
+    });
+
     it("should create skill directory", async () => {
       const result = await installClaudeSkill(testDir);
 
       expect(existsSync(result.skillDir)).toBe(true);
+      expect(result.skillDir).toBe(path.join(testDir, SKILL_DIR));
     });
 
     it("should create skill file", async () => {
@@ -88,16 +122,15 @@ describe("claude-setup", () => {
       expect(result.skillFile).toBe(path.join(testDir, SKILL_DIR, SKILL_FILE));
     });
 
-    it("should write correct content to file", async () => {
+    it("should write fetched content to file", async () => {
       await installClaudeSkill(testDir);
 
-      const { readFile } = await import("fs/promises");
       const content = await readFile(
         path.join(testDir, SKILL_DIR, SKILL_FILE),
         "utf-8",
       );
 
-      expect(content).toBe(getSkillContent());
+      expect(content).toBe(MOCK_SKILL_CONTENT);
     });
 
     it("should use current directory when no targetDir specified", async () => {
@@ -111,6 +144,18 @@ describe("claude-setup", () => {
       } finally {
         process.chdir(originalCwd);
       }
+    });
+
+    it("should propagate fetch errors", async () => {
+      vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      } as Response);
+
+      await expect(installClaudeSkill(testDir)).rejects.toThrow(
+        "Failed to fetch skill",
+      );
     });
   });
 });

--- a/turbo/apps/cli/src/lib/domain/onboard/__tests__/claude-setup.test.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/__tests__/claude-setup.test.ts
@@ -9,6 +9,7 @@ import {
   SKILL_URL,
   fetchSkillContent,
   installClaudeSkill,
+  handleFetchError,
 } from "../claude-setup.js";
 
 const MOCK_SKILL_CONTENT = `---
@@ -91,6 +92,55 @@ describe("claude-setup", () => {
       vi.spyOn(global, "fetch").mockRejectedValue(new Error("Network error"));
 
       await expect(fetchSkillContent()).rejects.toThrow("Network error");
+    });
+  });
+
+  describe("handleFetchError", () => {
+    const originalExit = process.exit;
+    let mockExit: ReturnType<typeof vi.fn>;
+    let mockConsoleError: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      mockExit = vi.fn();
+      process.exit = mockExit as unknown as typeof process.exit;
+      mockConsoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      process.exit = originalExit;
+    });
+
+    it("should log error message with URL", () => {
+      handleFetchError(new Error("test"));
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(SKILL_URL),
+      );
+    });
+
+    it("should log error message when error is Error instance", () => {
+      handleFetchError(new Error("Network failed"));
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Network failed"),
+      );
+    });
+
+    it("should log network connection hint", () => {
+      handleFetchError(new Error("test"));
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("network connection"),
+      );
+    });
+
+    it("should exit with code 1", () => {
+      handleFetchError(new Error("test"));
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle non-Error objects", () => {
+      handleFetchError("string error");
+      expect(mockExit).toHaveBeenCalledWith(1);
     });
   });
 

--- a/turbo/apps/cli/src/lib/domain/onboard/__tests__/claude-setup.test.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/__tests__/claude-setup.test.ts
@@ -6,9 +6,11 @@ import {
   SKILL_DIR,
   SKILL_FILE,
   SKILL_NAME,
-  SKILL_URL,
+  SKILLS,
+  PRIMARY_SKILL_NAME,
   fetchSkillContent,
   installClaudeSkill,
+  installAllClaudeSkills,
   handleFetchError,
 } from "../claude-setup.js";
 
@@ -30,6 +32,16 @@ Use this skill when you need to:
 - Run agents with prompts and inputs
 `;
 
+const MOCK_AGENT_SKILL_CONTENT = `---
+name: vm0-agent
+description: VM0 Agent skill for building workflows.
+---
+
+# VM0 Agent
+
+Build AI agent workflows.
+`;
+
 describe("claude-setup", () => {
   const testDir = "/tmp/test-claude-setup";
 
@@ -44,7 +56,7 @@ describe("claude-setup", () => {
   });
 
   describe("constants", () => {
-    it("should have correct SKILL_DIR", () => {
+    it("should have correct SKILL_DIR (legacy)", () => {
       expect(SKILL_DIR).toBe(".claude/skills/vm0-cli");
     });
 
@@ -52,19 +64,31 @@ describe("claude-setup", () => {
       expect(SKILL_FILE).toBe("SKILL.md");
     });
 
-    it("should have correct SKILL_NAME", () => {
+    it("should have correct SKILL_NAME (legacy)", () => {
       expect(SKILL_NAME).toBe("vm0-cli");
     });
 
-    it("should have correct SKILL_URL", () => {
-      expect(SKILL_URL).toBe(
+    it("should have correct PRIMARY_SKILL_NAME", () => {
+      expect(PRIMARY_SKILL_NAME).toBe("vm0-agent");
+    });
+
+    it("should have correct SKILLS array", () => {
+      expect(SKILLS).toHaveLength(2);
+      expect(SKILLS[0].name).toBe("vm0-cli");
+      expect(SKILLS[0].dir).toBe(".claude/skills/vm0-cli");
+      expect(SKILLS[0].url).toBe(
         "https://raw.githubusercontent.com/vm0-ai/vm0-skills/main/vm0-cli/SKILL.md",
+      );
+      expect(SKILLS[1].name).toBe("vm0-agent");
+      expect(SKILLS[1].dir).toBe(".claude/skills/vm0-agent");
+      expect(SKILLS[1].url).toBe(
+        "https://raw.githubusercontent.com/vm0-ai/vm0-skills/main/vm0-agent/SKILL.md",
       );
     });
   });
 
   describe("fetchSkillContent", () => {
-    it("should fetch content from GitHub", async () => {
+    it("should fetch content from GitHub using default URL", async () => {
       const mockFetch = vi.spyOn(global, "fetch").mockResolvedValue({
         ok: true,
         text: () => Promise.resolve(MOCK_SKILL_CONTENT),
@@ -73,7 +97,20 @@ describe("claude-setup", () => {
       const content = await fetchSkillContent();
 
       expect(content).toBe(MOCK_SKILL_CONTENT);
-      expect(mockFetch).toHaveBeenCalledWith(SKILL_URL);
+      expect(mockFetch).toHaveBeenCalledWith(SKILLS[0].url);
+    });
+
+    it("should fetch content from custom URL", async () => {
+      const customUrl = "https://example.com/skill.md";
+      const mockFetch = vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(MOCK_SKILL_CONTENT),
+      } as Response);
+
+      const content = await fetchSkillContent(customUrl);
+
+      expect(content).toBe(MOCK_SKILL_CONTENT);
+      expect(mockFetch).toHaveBeenCalledWith(customUrl);
     });
 
     it("should throw error on fetch failure", async () => {
@@ -84,7 +121,7 @@ describe("claude-setup", () => {
       } as Response);
 
       await expect(fetchSkillContent()).rejects.toThrow(
-        `Failed to fetch skill from ${SKILL_URL}: 404 Not Found`,
+        `Failed to fetch skill from ${SKILLS[0].url}: 404 Not Found`,
       );
     });
 
@@ -112,10 +149,18 @@ describe("claude-setup", () => {
       process.exit = originalExit;
     });
 
-    it("should log error message with URL", () => {
+    it("should log error message with default GitHub text", () => {
       handleFetchError(new Error("test"));
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(SKILL_URL),
+        expect.stringContaining("GitHub"),
+      );
+    });
+
+    it("should log error message with custom URL", () => {
+      const customUrl = "https://example.com/skill.md";
+      handleFetchError(new Error("test"), customUrl);
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(customUrl),
       );
     });
 
@@ -204,6 +249,78 @@ describe("claude-setup", () => {
       } as Response);
 
       await expect(installClaudeSkill(testDir)).rejects.toThrow(
+        "Failed to fetch skill",
+      );
+    });
+  });
+
+  describe("installAllClaudeSkills", () => {
+    beforeEach(() => {
+      vi.spyOn(global, "fetch").mockImplementation(async (url) => {
+        const urlStr = url.toString();
+        if (urlStr.includes("vm0-cli")) {
+          return {
+            ok: true,
+            text: () => Promise.resolve(MOCK_SKILL_CONTENT),
+          } as Response;
+        }
+        if (urlStr.includes("vm0-agent")) {
+          return {
+            ok: true,
+            text: () => Promise.resolve(MOCK_AGENT_SKILL_CONTENT),
+          } as Response;
+        }
+        return {
+          ok: false,
+          status: 404,
+          statusText: "Not Found",
+        } as Response;
+      });
+    });
+
+    it("should install all skills", async () => {
+      const result = await installAllClaudeSkills(testDir);
+
+      expect(result.skills).toHaveLength(2);
+      expect(existsSync(result.skills[0]!.skillDir)).toBe(true);
+      expect(existsSync(result.skills[1]!.skillDir)).toBe(true);
+    });
+
+    it("should create correct directories for each skill", async () => {
+      const result = await installAllClaudeSkills(testDir);
+
+      expect(result.skills[0]!.skillDir).toBe(
+        path.join(testDir, ".claude/skills/vm0-cli"),
+      );
+      expect(result.skills[1]!.skillDir).toBe(
+        path.join(testDir, ".claude/skills/vm0-agent"),
+      );
+    });
+
+    it("should write correct content to each skill file", async () => {
+      await installAllClaudeSkills(testDir);
+
+      const cliContent = await readFile(
+        path.join(testDir, ".claude/skills/vm0-cli/SKILL.md"),
+        "utf-8",
+      );
+      const agentContent = await readFile(
+        path.join(testDir, ".claude/skills/vm0-agent/SKILL.md"),
+        "utf-8",
+      );
+
+      expect(cliContent).toContain("vm0-cli");
+      expect(agentContent).toContain("vm0-agent");
+    });
+
+    it("should propagate fetch errors", async () => {
+      vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      } as Response);
+
+      await expect(installAllClaudeSkills(testDir)).rejects.toThrow(
         "Failed to fetch skill",
       );
     });

--- a/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
@@ -1,288 +1,26 @@
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 
-export const SKILL_DIR = ".claude/skills/vm0-agent-builder";
+export const SKILL_DIR = ".claude/skills/vm0-cli";
 export const SKILL_FILE = "SKILL.md";
+export const SKILL_NAME = "vm0-cli";
+export const SKILL_URL =
+  "https://raw.githubusercontent.com/vm0-ai/vm0-skills/main/vm0-cli/SKILL.md";
 
 /**
- * Get the vm0-agent-builder skill content
+ * Fetch the vm0-cli skill content from GitHub
+ * @throws Error if fetch fails
  */
-export function getSkillContent(): string {
-  return `---
-name: vm0-agent-builder
-description: Build VM0 agents by creating AGENTS.md and vm0.yaml. Use when users describe what agent they want to build.
----
-
-# VM0 Agent Builder
-
-Build AI agents that run in VM0's secure sandbox environment. This skill helps you create the two essential files: \`AGENTS.md\` (agent instructions) and \`vm0.yaml\` (configuration).
-
-## Workflow
-
-### Step 1: Understand the Goal
-
-First, clarify what the user wants their agent to do:
-- What task should the agent accomplish?
-- What inputs does it need? (files, APIs, websites)
-- What outputs should it produce? (reports, files, notifications)
-- Should it run once or on a schedule?
-
-### Step 2: Create AGENTS.md
-
-Write clear, step-by-step instructions. The agent will follow these exactly.
-
-**Template:**
-
-\`\`\`markdown
-# [Agent Name]
-
-You are a [role description].
-
-## Workflow
-
-1. [First action - be specific]
-2. [Second action - include details]
-3. [Continue with clear steps...]
-
-## Output
-
-Write results to \`[filename]\` in the current directory.
-\`\`\`
-
-**Writing Tips:**
-- Be specific: "Read the top 10 stories" not "Read some stories"
-- One action per step: Keep steps focused and atomic
-- Specify output: Exact filenames and formats
-- Use active voice: "Create a file" not "A file should be created"
-
-### Step 3: Create vm0.yaml
-
-Configure the agent with required skills and environment variables.
-
-\`\`\`yaml
-version: "1.0"
-
-agents:
-  [agent-name]:
-    framework: claude-code
-    instructions: AGENTS.md
-    # Pre-install GitHub CLI (optional)
-    apps:
-      - github
-    # Add skills the agent needs (optional)
-    skills:
-      - https://github.com/vm0-ai/vm0-skills/tree/main/[skill-name]
-    # Mount volumes for input files (optional)
-    volumes:
-      - my-volume:/home/user/input
-    # Environment variables (optional)
-    environment:
-      API_KEY: "\${{ secrets.API_KEY }}"
-\`\`\`
-
-### Step 4: Test the Agent
-
-After creating both files, the user runs:
-
-\`\`\`bash
-vm0 cook "start working"
-\`\`\`
-
-This command:
-1. Uploads the configuration to VM0
-2. Runs the agent in a secure sandbox
-3. Downloads results to the \`artifact/\` directory
-
-## Available Skills
-
-Skills give agents access to external services. Add them to vm0.yaml when needed.
-
-**Popular Skills:**
-
-| Skill | Use Case |
-|-------|----------|
-| \`github\` | Read/write issues, PRs, files |
-| \`slack\` | Send messages to channels |
-| \`notion\` | Access Notion pages/databases |
-| \`firecrawl\` | Scrape and extract web content |
-| \`supabase\` | Database operations |
-| \`google-sheets\` | Read/write spreadsheets |
-| \`linear\` | Project management |
-| \`discord\` | Send Discord messages |
-| \`gmail\` | Send emails |
-| \`openai\` | Embeddings, additional AI calls |
-
-**All 79 skills:** https://github.com/vm0-ai/vm0-skills
-
-**Skill URL format:**
-\`\`\`
-https://github.com/vm0-ai/vm0-skills/tree/main/[skill-name]
-\`\`\`
-
-## Examples
-
-### HackerNews Curator
-
-**AGENTS.md:**
-\`\`\`markdown
-# HackerNews AI Curator
-
-You are a content curator that finds AI-related articles on HackerNews.
-
-## Workflow
-
-1. Go to https://news.ycombinator.com
-2. Read the top 30 stories
-3. Filter for AI, ML, and LLM related content
-4. For each relevant article, extract:
-   - Title and URL
-   - 2-3 sentence summary
-   - Why it matters
-5. Write findings to \`daily-digest.md\`
-
-## Output
-
-Create \`daily-digest.md\` with today's date as the header.
-Format as a bulleted list with links.
-\`\`\`
-
-**vm0.yaml:**
-\`\`\`yaml
-version: "1.0"
-
-agents:
-  hn-curator:
-    framework: claude-code
-    instructions: AGENTS.md
-\`\`\`
-
-### GitHub Issue Reporter
-
-**AGENTS.md:**
-\`\`\`markdown
-# GitHub Issue Reporter
-
-You are a GitHub analyst that creates issue summary reports.
-
-## Workflow
-
-1. List all open issues in the repository
-2. Group by labels: bug, feature, documentation, other
-3. For each group, report:
-   - Total count
-   - Oldest issue (with age in days)
-   - Most commented issue
-4. Write report to \`issue-report.md\`
-
-## Output
-
-Create \`issue-report.md\` with sections for each label group.
-Include links to referenced issues.
-\`\`\`
-
-**vm0.yaml:**
-\`\`\`yaml
-version: "1.0"
-
-agents:
-  issue-reporter:
-    framework: claude-code
-    instructions: AGENTS.md
-    skills:
-      - https://github.com/vm0-ai/vm0-skills/tree/main/github
-    environment:
-      GITHUB_REPO: "\${{ vars.GITHUB_REPO }}"
-\`\`\`
-
-### Slack Daily Digest
-
-**AGENTS.md:**
-\`\`\`markdown
-# Slack Daily Digest
-
-You are an assistant that posts daily summaries to Slack.
-
-## Workflow
-
-1. Read the contents of \`updates.md\` from the input volume
-2. Summarize the key points (max 5 bullets)
-3. Format as a Slack message with emoji headers
-4. Post to the #daily-updates channel
-
-## Output
-
-Post the summary to Slack. Write a copy to \`sent-message.md\`.
-\`\`\`
-
-**vm0.yaml:**
-\`\`\`yaml
-version: "1.0"
-
-agents:
-  slack-digest:
-    framework: claude-code
-    instructions: AGENTS.md
-    skills:
-      - https://github.com/vm0-ai/vm0-skills/tree/main/slack
-    environment:
-      SLACK_CHANNEL: "\${{ vars.SLACK_CHANNEL }}"
-\`\`\`
-
-## Environment Variables
-
-Use environment variables for sensitive data and configuration:
-
-\`\`\`yaml
-environment:
-  # Secrets (encrypted, for API keys)
-  API_KEY: "\${{ secrets.API_KEY }}"
-
-  # Variables (plain text, for config)
-  REPO_NAME: "\${{ vars.REPO_NAME }}"
-
-  # Credentials (from vm0 credential storage)
-  MY_TOKEN: "\${{ credentials.MY_TOKEN }}"
-\`\`\`
-
-Set credentials with (names must be UPPERCASE):
-\`\`\`bash
-vm0 credential set API_KEY "your-api-key"
-\`\`\`
-
-## Troubleshooting
-
-**Agent doesn't follow instructions:**
-- Make steps more specific and explicit
-- Add "Do not..." constraints for unwanted behavior
-- Break complex steps into smaller sub-steps
-
-**Agent can't access a service:**
-- Add the required skill to vm0.yaml
-- Set up credentials with \`vm0 credential set\`
-
-**Output is in wrong format:**
-- Provide an exact template in the instructions
-- Include a small example of expected output
-
-## Next Steps After Creating Files
-
-\`\`\`bash
-# Run your agent
-vm0 cook "start working"
-
-# View logs if needed
-vm0 logs [run-id]
-
-# Results are in artifact/ directory
-ls artifact/
-
-# Continue from where agent left off
-vm0 cook continue "keep going"
-
-# Resume from a checkpoint
-vm0 cook resume "try again"
-\`\`\`
-`;
+export async function fetchSkillContent(): Promise<string> {
+  const response = await fetch(SKILL_URL);
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch skill from ${SKILL_URL}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return response.text();
 }
 
 interface InstallSkillResult {
@@ -291,8 +29,9 @@ interface InstallSkillResult {
 }
 
 /**
- * Install the vm0-agent-builder skill in the specified directory
+ * Install the vm0-cli skill in the specified directory
  * @param targetDir - Base directory to install the skill in (defaults to current directory)
+ * @throws Error if fetch fails or file operations fail
  */
 export async function installClaudeSkill(
   targetDir: string = process.cwd(),
@@ -300,8 +39,10 @@ export async function installClaudeSkill(
   const skillDirPath = path.join(targetDir, SKILL_DIR);
   const skillFilePath = path.join(skillDirPath, SKILL_FILE);
 
+  const content = await fetchSkillContent();
+
   await mkdir(skillDirPath, { recursive: true });
-  await writeFile(skillFilePath, getSkillContent());
+  await writeFile(skillFilePath, content);
 
   return {
     skillDir: skillDirPath,

--- a/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
@@ -1,11 +1,24 @@
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
+import chalk from "chalk";
 
 export const SKILL_DIR = ".claude/skills/vm0-cli";
 export const SKILL_FILE = "SKILL.md";
 export const SKILL_NAME = "vm0-cli";
 export const SKILL_URL =
   "https://raw.githubusercontent.com/vm0-ai/vm0-skills/main/vm0-cli/SKILL.md";
+
+/**
+ * Handle fetch error with user-friendly message and exit
+ */
+export function handleFetchError(error: unknown): never {
+  console.error(chalk.red(`Failed to fetch skill from GitHub: ${SKILL_URL}`));
+  if (error instanceof Error) {
+    console.error(chalk.red(error.message));
+  }
+  console.error(chalk.dim("Please check your network connection."));
+  process.exit(1);
+}
 
 /**
  * Fetch the vm0-cli skill content from GitHub

--- a/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
@@ -2,17 +2,48 @@ import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 import chalk from "chalk";
 
-export const SKILL_DIR = ".claude/skills/vm0-cli";
+// Skill definitions
+interface SkillDefinition {
+  name: string;
+  dir: string;
+  url: string;
+}
+
+// Define skills as a tuple to ensure type safety
+const VM0_CLI_SKILL: SkillDefinition = {
+  name: "vm0-cli",
+  dir: ".claude/skills/vm0-cli",
+  url: "https://raw.githubusercontent.com/vm0-ai/vm0-skills/main/vm0-cli/SKILL.md",
+};
+
+const VM0_AGENT_SKILL: SkillDefinition = {
+  name: "vm0-agent",
+  dir: ".claude/skills/vm0-agent",
+  url: "https://raw.githubusercontent.com/vm0-ai/vm0-skills/main/vm0-agent/SKILL.md",
+};
+
+export const SKILLS: readonly [SkillDefinition, SkillDefinition] = [
+  VM0_CLI_SKILL,
+  VM0_AGENT_SKILL,
+];
+
+// Primary skill for user prompt (vm0-agent)
+export const PRIMARY_SKILL_NAME = "vm0-agent";
+
+// Legacy exports for backward compatibility
+export const SKILL_DIR = VM0_CLI_SKILL.dir;
 export const SKILL_FILE = "SKILL.md";
-export const SKILL_NAME = "vm0-cli";
-export const SKILL_URL =
-  "https://raw.githubusercontent.com/vm0-ai/vm0-skills/main/vm0-cli/SKILL.md";
+export const SKILL_NAME = VM0_CLI_SKILL.name;
+
+// Default URL for legacy fetchSkillContent
+const DEFAULT_SKILL_URL = VM0_CLI_SKILL.url;
 
 /**
  * Handle fetch error with user-friendly message and exit
  */
-export function handleFetchError(error: unknown): never {
-  console.error(chalk.red(`Failed to fetch skill from GitHub: ${SKILL_URL}`));
+export function handleFetchError(error: unknown, url?: string): never {
+  const displayUrl = url ?? "GitHub";
+  console.error(chalk.red(`Failed to fetch skill from ${displayUrl}`));
   if (error instanceof Error) {
     console.error(chalk.red(error.message));
   }
@@ -21,15 +52,16 @@ export function handleFetchError(error: unknown): never {
 }
 
 /**
- * Fetch the vm0-cli skill content from GitHub
+ * Fetch skill content from a URL
  * @throws Error if fetch fails
  */
-export async function fetchSkillContent(): Promise<string> {
-  const response = await fetch(SKILL_URL);
+export async function fetchSkillContent(url?: string): Promise<string> {
+  const fetchUrl = url ?? DEFAULT_SKILL_URL;
+  const response = await fetch(fetchUrl);
 
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch skill from ${SKILL_URL}: ${response.status} ${response.statusText}`,
+      `Failed to fetch skill from ${fetchUrl}: ${response.status} ${response.statusText}`,
     );
   }
 
@@ -41,18 +73,21 @@ interface InstallSkillResult {
   skillFile: string;
 }
 
+interface InstallAllSkillsResult {
+  skills: InstallSkillResult[];
+}
+
 /**
- * Install the vm0-cli skill in the specified directory
- * @param targetDir - Base directory to install the skill in (defaults to current directory)
- * @throws Error if fetch fails or file operations fail
+ * Install a single skill in the specified directory
  */
-export async function installClaudeSkill(
-  targetDir: string = process.cwd(),
+async function installSingleSkill(
+  skill: SkillDefinition,
+  targetDir: string,
 ): Promise<InstallSkillResult> {
-  const skillDirPath = path.join(targetDir, SKILL_DIR);
+  const skillDirPath = path.join(targetDir, skill.dir);
   const skillFilePath = path.join(skillDirPath, SKILL_FILE);
 
-  const content = await fetchSkillContent();
+  const content = await fetchSkillContent(skill.url);
 
   await mkdir(skillDirPath, { recursive: true });
   await writeFile(skillFilePath, content);
@@ -61,4 +96,33 @@ export async function installClaudeSkill(
     skillDir: skillDirPath,
     skillFile: skillFilePath,
   };
+}
+
+/**
+ * Install the vm0-cli skill in the specified directory (legacy function)
+ * @param targetDir - Base directory to install the skill in (defaults to current directory)
+ * @throws Error if fetch fails or file operations fail
+ */
+export async function installClaudeSkill(
+  targetDir: string = process.cwd(),
+): Promise<InstallSkillResult> {
+  return installSingleSkill(VM0_CLI_SKILL, targetDir);
+}
+
+/**
+ * Install all Claude skills in the specified directory
+ * @param targetDir - Base directory to install skills in (defaults to current directory)
+ * @throws Error if fetch fails or file operations fail
+ */
+export async function installAllClaudeSkills(
+  targetDir: string = process.cwd(),
+): Promise<InstallAllSkillsResult> {
+  const results: InstallSkillResult[] = [];
+
+  for (const skill of SKILLS) {
+    const result = await installSingleSkill(skill, targetDir);
+    results.push(result);
+  }
+
+  return { skills: results };
 }

--- a/turbo/apps/cli/src/lib/domain/onboard/index.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/index.ts
@@ -6,4 +6,10 @@ export {
   setupModelProvider,
 } from "./model-provider.js";
 
-export { installClaudeSkill } from "./claude-setup.js";
+export {
+  installClaudeSkill,
+  fetchSkillContent,
+  SKILL_DIR,
+  SKILL_NAME,
+  SKILL_URL,
+} from "./claude-setup.js";

--- a/turbo/apps/cli/src/lib/domain/onboard/index.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/index.ts
@@ -9,7 +9,7 @@ export {
 export {
   installClaudeSkill,
   fetchSkillContent,
+  handleFetchError,
   SKILL_DIR,
   SKILL_NAME,
-  SKILL_URL,
 } from "./claude-setup.js";

--- a/turbo/apps/cli/src/lib/domain/onboard/index.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/index.ts
@@ -7,9 +7,8 @@ export {
 } from "./model-provider.js";
 
 export {
-  installClaudeSkill,
-  fetchSkillContent,
+  installAllClaudeSkills,
   handleFetchError,
-  SKILL_DIR,
-  SKILL_NAME,
+  SKILLS,
+  PRIMARY_SKILL_NAME,
 } from "./claude-setup.js";

--- a/turbo/apps/docs/content/docs/reference/cli/index.mdx
+++ b/turbo/apps/docs/content/docs/reference/cli/index.mdx
@@ -10,7 +10,7 @@ description: Complete reference for all VM0 CLI commands
 | `vm0 info` | Display environment information | - |
 | `vm0 init` | Initialize a new VM0 project with `vm0.yaml` | `-f, --force`, `-n, --name <name>` |
 | `vm0 onboard` | Guided setup for new VM0 users | `-y, --yes`, `--method <claude\|manual>` |
-| `vm0 setup-claude` | Install vm0-agent-builder skill for Claude | - |
+| `vm0 setup-claude` | Install vm0-cli skill for Claude | - |
 
 ## Authentication
 


### PR DESCRIPTION
## Summary

- Replace hardcoded vm0-agent-builder skill with dynamically fetched vm0-cli skill from GitHub
- Skill content is now fetched at install time from https://raw.githubusercontent.com/vm0-ai/vm0-skills/main/vm0-cli/SKILL.md
- Skill directory changed from .claude/skills/vm0-agent-builder to .claude/skills/vm0-cli
- Added proper error handling for network failures with clear error messages
- Consolidated duplicate embedded content (was in 2 files with slightly different versions)

## Test plan

- [x] All unit tests updated and passing (794 tests)
- [x] TypeScript compilation passes
- [x] Linting passes
- [x] Knip finds no unused exports
- [ ] E2E tests (will run in CI)
- [ ] Manual verification of vm0 onboard and vm0 setup-claude

Closes #1827