### PR TITLE
fix(web): cleanup stale pending runs and handle null heartbeat fallback

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -353,6 +353,7 @@ const router = tsr.router(runsMainContract, {
         vars: varsToStore,
         secretNames: secretNamesToStore,
         resumedFromCheckpointId: body.checkpointId || null,
+        lastHeartbeatAt: new Date(),
       })
       .returning();
 


### PR DESCRIPTION
## Summary

Fixes the concurrent run limit bug where runs get stuck indefinitely and block users from starting new runs.

**Root cause:** Mismatch between what the concurrent limit counts (`pending` + `running`) and what the cleanup cron handles (only `running` with non-null `lastHeartbeatAt`).

**Changes:**
- Set `lastHeartbeatAt` at run creation to ensure cleanup can always work
- Expand cleanup cron to handle both "pending" and "running" statuses
- Use `createdAt` as fallback when `lastHeartbeatAt` is NULL (legacy runs)
- Add 5-minute timeout for pending runs (vs 2-minute for running)
- Add descriptive timeout error messages based on run status
- Add tests for new cleanup scenarios

## Test plan

- [ ] Verify existing cleanup tests pass
- [ ] Verify new tests for pending run cleanup pass
- [ ] Verify new tests for NULL heartbeat fallback pass
- [ ] Manually test that stuck pending/running runs are cleaned up

Closes #1828

🤖 Generated with [Claude Code](https://claude.com/claude-code)