### PR TITLE
feat(cli): show helpful hints when concurrent run limit exceeded

### DIFF
--- a/turbo/apps/cli/src/commands/run/continue.ts
+++ b/turbo/apps/cli/src/commands/run/continue.ts
@@ -10,6 +10,7 @@ import {
   pollEvents,
   streamRealtimeEvents,
   showNextSteps,
+  handleGenericRunError,
 } from "./shared";
 
 export const continueCommand = new Command()
@@ -159,8 +160,7 @@ export const continueCommand = new Command()
               chalk.red(`✗ Agent session not found: ${agentSessionId}`),
             );
           } else {
-            console.error(chalk.red("✗ Continue failed"));
-            console.error(chalk.dim(`  ${error.message}`));
+            handleGenericRunError(error, "Continue");
           }
         } else {
           console.error(chalk.red("✗ An unexpected error occurred"));

--- a/turbo/apps/cli/src/commands/run/resume.ts
+++ b/turbo/apps/cli/src/commands/run/resume.ts
@@ -10,6 +10,7 @@ import {
   pollEvents,
   streamRealtimeEvents,
   showNextSteps,
+  handleGenericRunError,
 } from "./shared";
 
 export const resumeCommand = new Command()
@@ -156,8 +157,7 @@ export const resumeCommand = new Command()
           } else if (error.message.includes("not found")) {
             console.error(chalk.red(`✗ Checkpoint not found: ${checkpointId}`));
           } else {
-            console.error(chalk.red("✗ Resume failed"));
-            console.error(chalk.dim(`  ${error.message}`));
+            handleGenericRunError(error, "Resume");
           }
         } else {
           console.error(chalk.red("✗ An unexpected error occurred"));

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -18,6 +18,7 @@ import {
   pollEvents,
   streamRealtimeEvents,
   showNextSteps,
+  handleGenericRunError,
 } from "./shared";
 
 export const mainRunCommand = new Command()
@@ -209,8 +210,7 @@ export const mainRunCommand = new Command()
               ),
             );
           } else {
-            console.error(chalk.red("✗ Run failed"));
-            console.error(chalk.dim(`  ${error.message}`));
+            handleGenericRunError(error, "Run");
           }
         } else {
           console.error(chalk.red("✗ An unexpected error occurred"));


### PR DESCRIPTION
## Summary
- Add `handleGenericRunError` helper function to centralize error handling across run commands
- When users hit the concurrent agent run limit error, display helpful hints about `vm0 run list` and `vm0 run kill` commands
- Apply the improved error handling to `run`, `resume`, and `continue` commands
- Add comprehensive tests for the new error handling behavior

## Test plan
- [x] Run `pnpm vitest run apps/cli/src/commands/run/__tests__/shared.test.ts` - all tests pass
- [x] Run `pnpm vitest run apps/cli/src/commands/__tests__/run.test.ts` - all tests pass
- [x] Pre-commit checks pass (lint, type-check, format, knip)


Generated with [Claude Code](https://claude.com/claude-code)