### PR TITLE
feat(web): integrate blog into main web app

### DIFF
--- a/turbo/apps/web/app/[locale]/blog/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/page.tsx
@@ -1,0 +1,67 @@
+import { Suspense } from "react";
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { getPosts, getFeatured, getCategories } from "../../lib/blog";
+import { BlogContent } from "../../components/blog";
+import Navbar from "../../components/Navbar";
+import Footer from "../../components/Footer";
+
+export const revalidate = 60;
+
+interface BlogPageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: BlogPageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "blog" });
+
+  return {
+    title: t("title"),
+    description: t("description"),
+    openGraph: {
+      title: `VM0 ${t("title")}`,
+      description: t("description"),
+      url: `https://vm0.ai/${locale}/blog`,
+    },
+  };
+}
+
+export default async function BlogPage({ params }: BlogPageProps) {
+  const { locale } = await params;
+
+  const [posts, featuredPost, categories] = await Promise.all([
+    getPosts(locale),
+    getFeatured(locale),
+    getCategories(locale),
+  ]);
+
+  return (
+    <>
+      <Navbar />
+      <Suspense
+        fallback={
+          <div
+            style={{
+              minHeight: "100vh",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <div style={{ color: "rgba(255, 255, 255, 0.5)" }}>Loading...</div>
+          </div>
+        }
+      >
+        <BlogContent
+          posts={posts}
+          featuredPost={featuredPost}
+          categories={categories}
+        />
+      </Suspense>
+      <Footer />
+    </>
+  );
+}

--- a/turbo/apps/web/app/[locale]/blog/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/page.tsx
@@ -1,7 +1,12 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { getPosts, getFeatured, getCategories } from "../../lib/blog";
+import {
+  getPosts,
+  getFeatured,
+  getCategories,
+  BLOG_BASE_URL,
+} from "../../lib/blog";
 import { BlogContent } from "../../components/blog";
 import Navbar from "../../components/Navbar";
 import Footer from "../../components/Footer";
@@ -24,7 +29,7 @@ export async function generateMetadata({
     openGraph: {
       title: `VM0 ${t("title")}`,
       description: t("description"),
-      url: `https://vm0.ai/${locale}/blog`,
+      url: `${BLOG_BASE_URL}/${locale}/blog`,
     },
   };
 }

--- a/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
@@ -1,0 +1,270 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Image from "next/image";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import { getTranslations } from "next-intl/server";
+import { Link } from "../../../../../navigation";
+import Particles from "../../../../components/Particles";
+import Navbar from "../../../../components/Navbar";
+import Footer from "../../../../components/Footer";
+import { ShareButtons } from "../../../../components/blog";
+import { getPost, getPosts } from "../../../../lib/blog";
+import { locales } from "../../../../../i18n";
+
+export const revalidate = 60;
+
+interface PageProps {
+  params: Promise<{ slug: string; locale: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug, locale } = await params;
+  const post = await getPost(slug, locale);
+
+  if (!post) {
+    return { title: "Post Not Found" };
+  }
+
+  const postUrl = `https://vm0.ai/${locale}/blog/posts/${slug}`;
+  const imageUrl = post.cover.startsWith("http")
+    ? post.cover
+    : `https://vm0.ai${post.cover}`;
+
+  return {
+    title: post.title,
+    description: post.excerpt,
+    openGraph: {
+      title: post.title,
+      description: post.excerpt,
+      type: "article",
+      publishedTime: post.publishedAt,
+      authors: [post.author.name],
+      url: postUrl,
+      images: [
+        {
+          url: imageUrl,
+          width: 1200,
+          height: 630,
+          alt: post.title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: post.title,
+      description: post.excerpt,
+      images: [imageUrl],
+      creator: "@vm0_ai",
+    },
+  };
+}
+
+export async function generateStaticParams() {
+  const params: { slug: string; locale: string }[] = [];
+
+  for (const locale of locales) {
+    const posts = await getPosts(locale);
+    posts.forEach((post) => {
+      params.push({ slug: post.slug, locale });
+    });
+  }
+
+  return params;
+}
+
+export default async function BlogPostPage({ params }: PageProps) {
+  const { slug, locale } = await params;
+  const post = await getPost(slug, locale);
+
+  if (!post) {
+    notFound();
+  }
+
+  const t = await getTranslations("blog");
+
+  const allPosts = await getPosts(locale);
+  const relatedPosts = allPosts
+    .filter((p) => p.category === post.category && p.slug !== post.slug)
+    .slice(0, 3);
+
+  return (
+    <>
+      <Navbar />
+      <Particles />
+
+      {/* Post Header */}
+      <header className="blog-post-header">
+        <div className="container-narrow">
+          <Link href="/blog" className="blog-post-back">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <line x1="19" y1="12" x2="5" y2="12" />
+              <polyline points="12 19 5 12 12 5" />
+            </svg>
+            {t("backToAllPosts")}
+          </Link>
+          <span className="blog-post-category">{post.category}</span>
+          <h1 className="blog-post-title">{post.title}</h1>
+          <div className="blog-post-meta">
+            <div className="blog-post-author">
+              <div className="blog-post-avatar">
+                {post.author.name.charAt(0)}
+              </div>
+              <div className="blog-post-author-info">
+                <span className="blog-post-author-name">
+                  {post.author.name}
+                </span>
+                <span className="blog-post-date">
+                  {new Date(post.publishedAt).toLocaleDateString(locale, {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </span>
+              </div>
+            </div>
+            <span className="blog-post-read-time">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <polyline points="12 6 12 12 16 14" />
+              </svg>
+              {post.readTime}
+            </span>
+          </div>
+        </div>
+      </header>
+
+      {/* Post Content */}
+      <article className="blog-post-content">
+        <div className="container-narrow">
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeHighlight]}
+          >
+            {post.content}
+          </ReactMarkdown>
+        </div>
+      </article>
+
+      {/* Share Section */}
+      <div className="container-narrow">
+        <ShareButtons
+          title={post.title}
+          url={`https://vm0.ai/${locale}/blog/posts/${post.slug}`}
+        />
+      </div>
+
+      {/* Related Posts */}
+      {relatedPosts.length > 0 && (
+        <section className="section-spacing">
+          <div className="container">
+            <h2 className="section-title" style={{ marginBottom: "40px" }}>
+              {t("relatedArticles")}
+            </h2>
+            <div className="blog-grid">
+              {relatedPosts.map((relatedPost) => (
+                <Link
+                  key={relatedPost.slug}
+                  href={`/blog/posts/${relatedPost.slug}`}
+                  style={{ textDecoration: "none" }}
+                >
+                  <article className="blog-card">
+                    <div className="blog-card-cover">
+                      <Image
+                        src={relatedPost.cover}
+                        alt={relatedPost.title}
+                        fill
+                        style={{ objectFit: "cover" }}
+                      />
+                    </div>
+                    <div className="blog-card-body">
+                      <div className="blog-card-meta">
+                        <span className="blog-card-category">
+                          {relatedPost.category}
+                        </span>
+                        <span className="blog-card-date">
+                          {new Date(relatedPost.publishedAt).toLocaleDateString(
+                            locale,
+                            { month: "short", day: "numeric", year: "numeric" },
+                          )}
+                        </span>
+                      </div>
+                      <h3 className="blog-card-title">{relatedPost.title}</h3>
+                      <p className="blog-card-excerpt">{relatedPost.excerpt}</p>
+                      <div className="blog-card-footer">
+                        <div className="blog-card-author">
+                          <div className="blog-card-avatar">
+                            {relatedPost.author.name.charAt(0)}
+                          </div>
+                          <span className="blog-card-author-name">
+                            {relatedPost.author.name}
+                          </span>
+                        </div>
+                        <span className="blog-card-read-more">
+                          {t("readMore")}
+                          <svg
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                          >
+                            <line x1="5" y1="12" x2="19" y2="12" />
+                            <polyline points="12 5 19 12 12 19" />
+                          </svg>
+                        </span>
+                      </div>
+                    </div>
+                  </article>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* CTA Section */}
+      <section className="cta-final">
+        <div className="container">
+          <div className="cta-card">
+            <div className="cta-ellipse"></div>
+            <h2 className="cta-title">{t("stayInLoop")}</h2>
+            <p className="cta-subtitle">{t("stayInLoopDesc")}</p>
+            <div style={{ display: "flex", gap: "16px", flexWrap: "wrap" }}>
+              <a
+                href="https://vm0.ai/sign-up"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn-primary-large"
+              >
+                {t("subscribe")}
+              </a>
+              <a
+                href="https://discord.gg/WMpAmHFfp6"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn-secondary-large"
+              >
+                {t("joinDiscord")}
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <Footer />
+    </>
+  );
+}

--- a/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
@@ -10,7 +10,7 @@ import Particles from "../../../../components/Particles";
 import Navbar from "../../../../components/Navbar";
 import Footer from "../../../../components/Footer";
 import { ShareButtons } from "../../../../components/blog";
-import { getPost, getPosts } from "../../../../lib/blog";
+import { getPost, getPosts, BLOG_BASE_URL } from "../../../../lib/blog";
 import { locales } from "../../../../../i18n";
 
 export const revalidate = 60;
@@ -29,10 +29,10 @@ export async function generateMetadata({
     return { title: "Post Not Found" };
   }
 
-  const postUrl = `https://vm0.ai/${locale}/blog/posts/${slug}`;
+  const postUrl = `${BLOG_BASE_URL}/${locale}/blog/posts/${slug}`;
   const imageUrl = post.cover.startsWith("http")
     ? post.cover
-    : `https://vm0.ai${post.cover}`;
+    : `${BLOG_BASE_URL}${post.cover}`;
 
   return {
     title: post.title,
@@ -163,7 +163,7 @@ export default async function BlogPostPage({ params }: PageProps) {
       <div className="container-narrow">
         <ShareButtons
           title={post.title}
-          url={`https://vm0.ai/${locale}/blog/posts/${post.slug}`}
+          url={`${BLOG_BASE_URL}/${locale}/blog/posts/${post.slug}`}
         />
       </div>
 
@@ -244,7 +244,7 @@ export default async function BlogPostPage({ params }: PageProps) {
             <p className="cta-subtitle">{t("stayInLoopDesc")}</p>
             <div style={{ display: "flex", gap: "16px", flexWrap: "wrap" }}>
               <a
-                href="https://vm0.ai/sign-up"
+                href={`${BLOG_BASE_URL}/sign-up`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="btn-primary-large"

--- a/turbo/apps/web/app/blog.css
+++ b/turbo/apps/web/app/blog.css
@@ -1,0 +1,988 @@
+/* ===== BLOG CSS VARIABLES ===== */
+/* Dark Theme (Default) */
+:root {
+  --primary-light: rgba(237, 78, 1, 0.1);
+  --card-bg: #222222;
+  --border-light: rgba(255, 255, 255, 0.1);
+  --text-secondary: rgba(255, 255, 255, 0.8);
+  --text-primary: #ffffff;
+  --text-muted: #d5d5d5;
+  --accent-color: #ed4e01;
+  --bg-primary: #0a0a0a;
+}
+
+/* Light Theme */
+[data-theme="light"] {
+  --primary-light: rgba(237, 78, 1, 0.1);
+  --card-bg: #ffffff;
+  --border-light: rgba(200, 150, 100, 0.2);
+  --text-secondary: rgba(0, 0, 0, 0.7);
+  --text-primary: #1a1a1a;
+  --text-muted: #4a4a4a;
+  --accent-color: #ed4e01;
+  --bg-primary: #fffbf7;
+}
+
+/* ===== BLOG SPECIFIC STYLES ===== */
+
+/* Blog Grid - 2 cards per row */
+.blog-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 32px;
+}
+
+/* Blog Card - with cover image */
+.blog-card {
+  background: var(--card-bg);
+  border-radius: 16px;
+  overflow: hidden;
+  transition: all 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  z-index: 1;
+  border: 1px solid var(--border-light);
+}
+
+.blog-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+}
+
+[data-theme="light"] .blog-card:hover {
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.1);
+}
+
+/* Blog Card Cover Image */
+.blog-card-cover {
+  width: 100%;
+  height: 200px;
+  position: relative;
+  overflow: hidden;
+}
+
+.blog-card-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
+.blog-card:hover .blog-card-cover img {
+  transform: scale(1.05);
+}
+
+.blog-card-cover::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    rgba(0, 0, 0, 0.1) 100%
+  );
+}
+
+/* Blog Card Body */
+.blog-card-body {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.blog-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.blog-card-category {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent-color);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.blog-card-date {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.blog-card-title {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 12px;
+  line-height: 1.3;
+  transition: color 0.2s ease;
+}
+
+.blog-card:hover .blog-card-title {
+  color: var(--accent-color);
+}
+
+.blog-card-excerpt {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  flex: 1;
+  margin-bottom: 20px;
+}
+
+.blog-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 20px;
+  border-top: 1px solid var(--border-light);
+}
+
+.blog-card-author {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.blog-card-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent-color) 0%, #ff6a1f 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Noto Sans", sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.blog-card-author-name {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.blog-card-read-more {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--accent-color);
+  font-family: "Noto Sans", sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.blog-card-read-more svg {
+  width: 16px;
+  height: 16px;
+  transition: transform 0.2s;
+}
+
+.blog-card:hover .blog-card-read-more svg {
+  transform: translateX(4px);
+}
+
+/* Featured Post - matches feature-card style */
+.featured-post {
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  margin-bottom: 60px;
+  position: relative;
+  z-index: 1;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
+}
+
+.featured-post:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+}
+
+[data-theme="light"] .featured-post:hover {
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.1);
+}
+
+.featured-post-content {
+  background: var(--bg-secondary);
+  padding: 50px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  border-radius: 10px 0 0 10px;
+}
+
+.featured-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--primary-light);
+  color: var(--accent-color);
+  font-family: "Noto Sans", sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: 4px;
+  margin-bottom: 20px;
+  width: fit-content;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.featured-badge svg {
+  width: 14px;
+  height: 14px;
+}
+
+.featured-post-meta {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.featured-post-category {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent-color);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.featured-post-date {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.featured-post-title {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 32px;
+  font-weight: 400;
+  color: var(--text-primary);
+  margin-bottom: 24px;
+  line-height: 1.3;
+  transition: color 0.2s ease;
+}
+
+.featured-post:hover .featured-post-title {
+  color: var(--accent-color);
+}
+
+.featured-post-excerpt {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.featured-post-visual {
+  border-radius: 0 10px 10px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: var(--bg-secondary);
+}
+
+.featured-post-visual img {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+
+@keyframes gridMove {
+  0% {
+    transform: translate(0, 0);
+  }
+  100% {
+    transform: translate(40px, 40px);
+  }
+}
+
+/* Category Filter - matches nav style */
+.category-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 40px;
+}
+
+.category-btn {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--text-secondary);
+  padding: 8px 16px;
+  border-radius: 4px;
+  border: 1px solid var(--border-light);
+  background: transparent;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.category-btn:hover,
+.category-btn.active {
+  color: var(--accent-color);
+  border-color: var(--accent-color);
+  background: var(--primary-light);
+}
+
+/* Blog Post Page */
+.blog-post-header {
+  padding: 160px 0 60px;
+  position: relative;
+  z-index: 1;
+}
+
+.blog-post-back {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: "Noto Sans", sans-serif;
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin-bottom: 32px;
+  transition: color 0.2s;
+  width: fit-content;
+}
+
+.blog-post-back:hover {
+  color: var(--accent-color);
+}
+
+.blog-post-back svg {
+  width: 16px;
+  height: 16px;
+}
+
+.blog-post-category {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--accent-color);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 20px;
+  display: inline-block;
+}
+
+.blog-post-title {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 60px;
+  font-weight: 400;
+  line-height: 1.1;
+  letter-spacing: -0.6px;
+  color: var(--text-primary);
+  margin-bottom: 24px;
+}
+
+.blog-post-meta {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-bottom: 40px;
+}
+
+.blog-post-author {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.blog-post-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent-color) 0%, #ff6a1f 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Noto Sans", sans-serif;
+  font-size: 16px;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.blog-post-author-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.blog-post-author-name {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.blog-post-date {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.blog-post-read-time {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 14px;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.blog-post-read-time svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* Blog Post Content - Article Typography */
+.blog-post-content {
+  padding-bottom: 80px;
+  position: relative;
+  z-index: 1;
+}
+
+.blog-post-content h2 {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 30px;
+  font-weight: 400;
+  line-height: 1.1;
+  letter-spacing: -0.3px;
+  color: var(--text-primary);
+  margin: 48px 0 20px;
+}
+
+.blog-post-content h3 {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 1.1;
+  letter-spacing: -0.22px;
+  color: var(--text-primary);
+  margin: 36px 0 16px;
+}
+
+.blog-post-content p {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.8;
+  color: var(--text-secondary);
+  margin-bottom: 24px;
+}
+
+.blog-post-content a {
+  color: var(--accent-color);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  transition: opacity 0.2s;
+}
+
+.blog-post-content a:hover {
+  opacity: 0.8;
+}
+
+.blog-post-content ul,
+.blog-post-content ol {
+  margin: 24px 0;
+  padding-left: 24px;
+}
+
+.blog-post-content li {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.8;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+
+.blog-post-content code {
+  font-family: "Fira Mono", monospace;
+  font-size: 14px;
+  background: var(--code-input-bg);
+  color: var(--accent-color);
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--code-input-border);
+}
+
+.blog-post-content pre {
+  background: var(--code-input-bg);
+  border: 1px solid var(--code-input-border);
+  border-radius: 6px;
+  padding: 20px 24px;
+  margin: 32px 0;
+  overflow-x: auto;
+}
+
+.blog-post-content pre code {
+  font-family: "Fira Mono", monospace;
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.blog-post-content blockquote {
+  border-left: 4px solid var(--accent-color);
+  padding-left: 24px;
+  margin: 32px 0;
+}
+
+.blog-post-content blockquote p {
+  font-size: 18px;
+  font-style: italic;
+}
+
+.blog-post-content hr {
+  border: none;
+  height: 1px;
+  background: var(--border-light);
+  margin: 48px 0;
+}
+
+.blog-post-content strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+/* Tables (GFM support) */
+.blog-post-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 32px 0;
+  font-size: 14px;
+}
+
+.blog-post-content th,
+.blog-post-content td {
+  padding: 12px 16px;
+  border: 1px solid var(--border-light);
+  text-align: left;
+}
+
+.blog-post-content th {
+  background: var(--bg-secondary);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.blog-post-content td {
+  color: var(--text-secondary);
+}
+
+.blog-post-content tr:hover td {
+  background: var(--card-hover-bg);
+}
+
+/* Images in content */
+.blog-post-content img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  margin: 32px 0;
+}
+
+/* Task lists (GFM support) */
+.blog-post-content input[type="checkbox"] {
+  margin-right: 8px;
+  accent-color: var(--accent-color);
+}
+
+/* Strikethrough */
+.blog-post-content del {
+  color: var(--text-muted);
+}
+
+/* Footnotes */
+.blog-post-content .footnotes {
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid var(--border-light);
+  font-size: 14px;
+}
+
+.blog-post-content .footnotes ol {
+  padding-left: 20px;
+}
+
+.blog-post-content .footnotes li {
+  margin-bottom: 8px;
+}
+
+/* Share Section */
+.blog-post-share {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 40px 0;
+  border-top: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--border-light);
+  margin-top: 60px;
+}
+
+.share-label {
+  font-family: "Noto Sans", sans-serif;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.share-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-light);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  transition: all 0.2s;
+  cursor: pointer;
+}
+
+.share-btn:hover {
+  background: var(--accent-color);
+  border-color: var(--accent-color);
+  color: white;
+}
+
+.share-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+/* Container narrow for blog content */
+.container-narrow {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 30px;
+  box-sizing: border-box;
+  width: 100%;
+}
+
+/* ===== RESPONSIVE ===== */
+@media (max-width: 1024px) {
+  .featured-post {
+    grid-template-columns: 1fr;
+    height: auto;
+  }
+
+  .featured-post-content {
+    padding: 40px;
+    border-radius: 10px 10px 0 0;
+  }
+
+  .featured-post-visual {
+    border-radius: 0 0 10px 10px;
+  }
+
+  .featured-post-title {
+    font-size: 28px;
+  }
+}
+
+@media (max-width: 900px) {
+  .blog-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .featured-post-content {
+    padding: 30px;
+  }
+
+  .featured-post-title {
+    font-size: 24px;
+  }
+
+  .featured-post-excerpt {
+    font-size: 14px;
+  }
+
+  .blog-post-header {
+    padding: 120px 0 40px;
+  }
+
+  .blog-post-title {
+    font-size: 36px;
+  }
+
+  .blog-post-meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .blog-post-content h2 {
+    font-size: 24px;
+  }
+
+  .blog-post-content h3 {
+    font-size: 20px;
+  }
+
+  .container-narrow {
+    padding: 0 24px;
+  }
+}
+
+@media (max-width: 480px) {
+  .featured-post-content {
+    padding: 24px;
+  }
+
+  .featured-post-title {
+    font-size: 20px;
+  }
+
+  .blog-card-body {
+    padding: 16px;
+  }
+
+  .blog-card-title {
+    font-size: 18px;
+  }
+
+  .blog-post-title {
+    font-size: 28px;
+  }
+
+  .container-narrow {
+    padding: 0 16px;
+  }
+}
+
+/* ===== CODE BLOCK STYLES ===== */
+.blog-post-content pre {
+  background: #0d1117 !important;
+  border-radius: 12px;
+  padding: 20px;
+  margin: 24px 0;
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.blog-post-content pre code {
+  background: transparent !important;
+  padding: 0;
+  font-family: "Fira Code", "Fira Mono", monospace;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.blog-post-content code {
+  background: rgba(255, 140, 77, 0.15);
+  color: var(--accent);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: "Fira Code", "Fira Mono", monospace;
+  font-size: 0.9em;
+}
+
+.blog-post-content pre code {
+  color: #e6edf3;
+}
+
+/* Dark mode syntax highlighting (GitHub Dark) */
+.hljs-comment,
+.hljs-quote {
+  color: #8b949e;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-addition {
+  color: #ff7b72;
+}
+
+.hljs-number,
+.hljs-string,
+.hljs-meta .hljs-meta-string,
+.hljs-literal,
+.hljs-doctag,
+.hljs-regexp {
+  color: #a5d6ff;
+}
+
+.hljs-title,
+.hljs-section,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class {
+  color: #d2a8ff;
+}
+
+.hljs-attribute,
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-class .hljs-title,
+.hljs-type {
+  color: #7ee787;
+}
+
+.hljs-symbol,
+.hljs-bullet,
+.hljs-subst,
+.hljs-meta,
+.hljs-meta .hljs-keyword,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-link {
+  color: #ffa657;
+}
+
+.hljs-built_in,
+.hljs-deletion {
+  color: #ffa198;
+}
+
+.hljs-formula {
+  background: #161b22;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
+/* Light mode code styles */
+[data-theme="light"] .blog-post-content pre {
+  background: #f6f8fa !important;
+  border: 1px solid #d0d7de;
+}
+
+[data-theme="light"] .blog-post-content code {
+  background: rgba(175, 184, 193, 0.2);
+  color: #cf222e;
+}
+
+[data-theme="light"] .blog-post-content pre code {
+  color: #24292f;
+}
+
+/* Light mode syntax highlighting (GitHub Light) */
+[data-theme="light"] .hljs-comment,
+[data-theme="light"] .hljs-quote {
+  color: #6e7781;
+}
+
+[data-theme="light"] .hljs-keyword,
+[data-theme="light"] .hljs-selector-tag,
+[data-theme="light"] .hljs-addition {
+  color: #cf222e;
+}
+
+[data-theme="light"] .hljs-number,
+[data-theme="light"] .hljs-string,
+[data-theme="light"] .hljs-meta .hljs-meta-string,
+[data-theme="light"] .hljs-literal,
+[data-theme="light"] .hljs-doctag,
+[data-theme="light"] .hljs-regexp {
+  color: #0a3069;
+}
+
+[data-theme="light"] .hljs-title,
+[data-theme="light"] .hljs-section,
+[data-theme="light"] .hljs-name,
+[data-theme="light"] .hljs-selector-id,
+[data-theme="light"] .hljs-selector-class {
+  color: #8250df;
+}
+
+[data-theme="light"] .hljs-attribute,
+[data-theme="light"] .hljs-attr,
+[data-theme="light"] .hljs-variable,
+[data-theme="light"] .hljs-template-variable,
+[data-theme="light"] .hljs-class .hljs-title,
+[data-theme="light"] .hljs-type {
+  color: #116329;
+}
+
+[data-theme="light"] .hljs-symbol,
+[data-theme="light"] .hljs-bullet,
+[data-theme="light"] .hljs-subst,
+[data-theme="light"] .hljs-meta,
+[data-theme="light"] .hljs-meta .hljs-keyword,
+[data-theme="light"] .hljs-selector-attr,
+[data-theme="light"] .hljs-selector-pseudo,
+[data-theme="light"] .hljs-link {
+  color: #953800;
+}
+
+[data-theme="light"] .hljs-built_in,
+[data-theme="light"] .hljs-deletion {
+  color: #82071e;
+}
+
+[data-theme="light"] .hljs-formula {
+  background: #f6f8fa;
+}
+
+/* Blockquote styles */
+.blog-post-content blockquote {
+  border-left: 4px solid var(--accent);
+  margin: 24px 0;
+  padding: 16px 24px;
+  background: rgba(255, 140, 77, 0.05);
+  border-radius: 0 12px 12px 0;
+  font-style: italic;
+}
+
+.blog-post-content blockquote p {
+  margin: 0;
+}
+
+/* Table styles */
+.blog-post-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 24px 0;
+}
+
+.blog-post-content th,
+.blog-post-content td {
+  border: 1px solid var(--border-light);
+  padding: 12px 16px;
+  text-align: left;
+}
+
+.blog-post-content th {
+  background: rgba(255, 140, 77, 0.1);
+  font-weight: 600;
+}
+
+.blog-post-content tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+[data-theme="light"] .blog-post-content tr:nth-child(even) {
+  background: rgba(0, 0, 0, 0.02);
+}

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -77,14 +77,9 @@ export default function Navbar() {
             >
               {t("docs")}
             </a>
-            <a
-              href="https://blog.vm0.ai"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="nav-link"
-            >
+            <Link href="/blog" className="nav-link">
               {t("blog")}
-            </a>
+            </Link>
             <Link href="/skills" className="nav-link">
               {t("skills")}
             </Link>
@@ -162,15 +157,13 @@ export default function Navbar() {
             >
               {t("docs")}
             </a>
-            <a
-              href="https://blog.vm0.ai"
-              target="_blank"
-              rel="noopener noreferrer"
+            <Link
+              href="/blog"
               className="mobile-menu-link"
               onClick={() => setMobileMenuOpen(false)}
             >
               {t("blog")}
-            </a>
+            </Link>
             <Link
               href="/skills"
               className="mobile-menu-link"

--- a/turbo/apps/web/app/components/Particles.tsx
+++ b/turbo/apps/web/app/components/Particles.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+export default function Particles() {
+  const particles = [];
+  for (let i = 0; i < 12; i++) {
+    const size = i % 3 === 0 ? "large" : i % 3 === 1 ? "medium" : "small";
+    particles.push(<div key={i} className={`particle particle-${size}`}></div>);
+  }
+
+  return (
+    <>
+      {/* Grid Background - only hero area with fade */}
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          height: "100vh",
+          zIndex: 0,
+          pointerEvents: "none",
+          backgroundImage:
+            "linear-gradient(rgba(255, 140, 77, 0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(255, 140, 77, 0.1) 1px, transparent 1px)",
+          backgroundSize: "40px 40px",
+          opacity: 0.3,
+          maskImage:
+            "linear-gradient(to bottom, black 0%, black 50%, transparent 100%)",
+          WebkitMaskImage:
+            "linear-gradient(to bottom, black 0%, black 50%, transparent 100%)",
+        }}
+      />
+      {/* Particles */}
+      <div
+        className="particles"
+        style={{
+          position: "fixed",
+          inset: 0,
+          zIndex: 0,
+          pointerEvents: "none",
+        }}
+      >
+        {particles}
+      </div>
+    </>
+  );
+}

--- a/turbo/apps/web/app/components/blog/BlogContent.tsx
+++ b/turbo/apps/web/app/components/blog/BlogContent.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import Image from "next/image";
+import { useSearchParams, useParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Link } from "../../../navigation";
+import Particles from "../Particles";
+import type { BlogPost } from "../../lib/blog/types";
+
+interface BlogContentProps {
+  posts: BlogPost[];
+  featuredPost: BlogPost | null;
+  categories: string[];
+}
+
+export default function BlogContent({
+  posts,
+  featuredPost,
+  categories,
+}: BlogContentProps) {
+  const searchParams = useSearchParams();
+  const params = useParams();
+  const locale = (params.locale as string) || "en";
+  const categoryFilter = searchParams.get("category");
+  const t = useTranslations("blog");
+
+  const filteredPosts = categoryFilter
+    ? posts.filter(
+        (post) => post.category.toLowerCase() === categoryFilter.toLowerCase(),
+      )
+    : posts;
+
+  const regularPosts = filteredPosts.filter((post) => !post.featured);
+
+  return (
+    <>
+      <Particles />
+
+      {/* Hero Section */}
+      <section className="hero-section" style={{ paddingBottom: "40px" }}>
+        <div className="container">
+          <div>
+            <h1 className="hero-title">{t("title")}</h1>
+            <p className="hero-description">{t("description")}</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Featured Post */}
+      {featuredPost && !categoryFilter && (
+        <section className="section-spacing" style={{ paddingTop: 0 }}>
+          <div className="container">
+            <Link
+              href={`/blog/posts/${featuredPost.slug}`}
+              style={{ textDecoration: "none" }}
+            >
+              <article className="featured-post">
+                <div className="featured-post-content">
+                  <div className="featured-post-meta">
+                    <span className="featured-post-category">
+                      {featuredPost.category}
+                    </span>
+                    <span className="featured-post-date">
+                      {new Date(featuredPost.publishedAt).toLocaleDateString(
+                        locale,
+                        {
+                          year: "numeric",
+                          month: "long",
+                          day: "numeric",
+                        },
+                      )}
+                    </span>
+                  </div>
+                  <h2 className="featured-post-title">{featuredPost.title}</h2>
+                  <p className="featured-post-excerpt">
+                    {featuredPost.excerpt}
+                  </p>
+                </div>
+                <div className="featured-post-visual">
+                  <Image
+                    src={featuredPost.cover}
+                    alt={featuredPost.title}
+                    width={800}
+                    height={500}
+                    style={{ width: "100%", height: "auto" }}
+                  />
+                </div>
+              </article>
+            </Link>
+          </div>
+        </section>
+      )}
+
+      {/* Category Filter */}
+      <section style={{ paddingBottom: "20px" }}>
+        <div className="container">
+          <div className="category-filter">
+            <Link
+              href="/blog"
+              className={`category-btn ${!categoryFilter ? "active" : ""}`}
+            >
+              {t("allPosts")}
+            </Link>
+            {categories.map((category) => (
+              <Link
+                key={category}
+                href={`/blog?category=${category.toLowerCase()}`}
+                className={`category-btn ${
+                  categoryFilter?.toLowerCase() === category.toLowerCase()
+                    ? "active"
+                    : ""
+                }`}
+              >
+                {category}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Blog Grid */}
+      <section className="section-spacing" style={{ paddingTop: 0 }}>
+        <div className="container">
+          {categoryFilter && (
+            <h2
+              className="section-title"
+              style={{ marginBottom: "40px", textTransform: "capitalize" }}
+            >
+              {categoryFilter}
+            </h2>
+          )}
+          <div className="blog-grid">
+            {regularPosts.map((post) => (
+              <Link
+                key={post.slug}
+                href={`/blog/posts/${post.slug}`}
+                style={{ textDecoration: "none" }}
+              >
+                <article className="blog-card">
+                  <div className="blog-card-cover">
+                    <Image
+                      src={post.cover}
+                      alt={post.title}
+                      fill
+                      style={{ objectFit: "cover" }}
+                    />
+                  </div>
+                  <div className="blog-card-body">
+                    <div className="blog-card-meta">
+                      <span className="blog-card-category">
+                        {post.category}
+                      </span>
+                      <span className="blog-card-date">
+                        {new Date(post.publishedAt).toLocaleDateString(locale, {
+                          month: "short",
+                          day: "numeric",
+                          year: "numeric",
+                        })}
+                      </span>
+                    </div>
+                    <h3 className="blog-card-title">{post.title}</h3>
+                    <p className="blog-card-excerpt">{post.excerpt}</p>
+                    <div className="blog-card-footer">
+                      <div className="blog-card-author">
+                        <div className="blog-card-avatar">
+                          {post.author.name.charAt(0)}
+                        </div>
+                        <span className="blog-card-author-name">
+                          {post.author.name}
+                        </span>
+                      </div>
+                      <span className="blog-card-read-more">
+                        {t("readMore")}
+                        <svg
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                        >
+                          <line x1="5" y1="12" x2="19" y2="12" />
+                          <polyline points="12 5 19 12 12 19" />
+                        </svg>
+                      </span>
+                    </div>
+                  </div>
+                </article>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <section className="cta-final">
+        <div className="container">
+          <div className="cta-card">
+            <div className="cta-ellipse"></div>
+            <h2 className="cta-title">{t("stayInLoop")}</h2>
+            <p className="cta-subtitle">{t("stayInLoopDesc")}</p>
+            <div style={{ display: "flex", gap: "16px", flexWrap: "wrap" }}>
+              <a
+                href="https://vm0.ai/sign-up"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn-primary-large"
+              >
+                {t("subscribe")}
+              </a>
+              <a
+                href="https://discord.gg/WMpAmHFfp6"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn-secondary-large"
+              >
+                {t("joinDiscord")}
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/turbo/apps/web/app/components/blog/BlogContent.tsx
+++ b/turbo/apps/web/app/components/blog/BlogContent.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 import { Link } from "../../../navigation";
 import Particles from "../Particles";
 import type { BlogPost } from "../../lib/blog/types";
+import { BLOG_BASE_URL } from "../../lib/blog/config";
 
 interface BlogContentProps {
   posts: BlogPost[];
@@ -199,7 +200,7 @@ export default function BlogContent({
             <p className="cta-subtitle">{t("stayInLoopDesc")}</p>
             <div style={{ display: "flex", gap: "16px", flexWrap: "wrap" }}>
               <a
-                href="https://vm0.ai/sign-up"
+                href={`${BLOG_BASE_URL}/sign-up`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="btn-primary-large"

--- a/turbo/apps/web/app/components/blog/ShareButtons.tsx
+++ b/turbo/apps/web/app/components/blog/ShareButtons.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+interface ShareButtonsProps {
+  title: string;
+  url: string;
+}
+
+export default function ShareButtons({ title, url }: ShareButtonsProps) {
+  const t = useTranslations("blog");
+  const encodedTitle = encodeURIComponent(title);
+  const encodedUrl = encodeURIComponent(url);
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(url).catch(() => {
+      // Silently fail if clipboard is unavailable
+    });
+  };
+
+  return (
+    <div className="blog-post-share">
+      <span className="share-label">{t("shareArticle")}</span>
+      <a
+        href={`https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedUrl}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="share-btn"
+        aria-label="Share on Twitter"
+      >
+        <svg viewBox="0 0 24 24" fill="currentColor">
+          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+      </a>
+      <a
+        href={`https://www.linkedin.com/shareArticle?mini=true&url=${encodedUrl}&title=${encodedTitle}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="share-btn"
+        aria-label="Share on LinkedIn"
+      >
+        <svg viewBox="0 0 24 24" fill="currentColor">
+          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+        </svg>
+      </a>
+      <button
+        onClick={copyToClipboard}
+        className="share-btn"
+        aria-label="Copy link"
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/turbo/apps/web/app/components/blog/ShareButtons.tsx
+++ b/turbo/apps/web/app/components/blog/ShareButtons.tsx
@@ -13,8 +13,9 @@ export default function ShareButtons({ title, url }: ShareButtonsProps) {
   const encodedUrl = encodeURIComponent(url);
 
   const copyToClipboard = () => {
-    navigator.clipboard.writeText(url).catch(() => {
-      // Silently fail if clipboard is unavailable
+    navigator.clipboard.writeText(url).catch((error: unknown) => {
+      // Log error when clipboard API is unavailable (e.g., insecure context)
+      console.warn("Failed to copy to clipboard:", error);
     });
   };
 

--- a/turbo/apps/web/app/components/blog/index.ts
+++ b/turbo/apps/web/app/components/blog/index.ts
@@ -1,0 +1,2 @@
+export { default as BlogContent } from "./BlogContent";
+export { default as ShareButtons } from "./ShareButtons";

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -6,6 +6,7 @@ import { getClerkPublishableKey } from "../src/lib/clerk-config";
 import { ThemeProvider } from "./components/ThemeProvider";
 import "./globals.css";
 import "./landing.css";
+import "./blog.css";
 
 const bypassAuth = process.env.BYPASS_AUTH === "true";
 

--- a/turbo/apps/web/app/lib/blog/__tests__/config.test.ts
+++ b/turbo/apps/web/app/lib/blog/__tests__/config.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("blog/config", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("BLOG_BASE_URL", () => {
+    it("returns the configured base URL", async () => {
+      vi.stubEnv("NEXT_PUBLIC_BASE_URL", "https://vm0.ai");
+
+      const { BLOG_BASE_URL } = await import("../config");
+
+      expect(BLOG_BASE_URL).toBe("https://vm0.ai");
+    });
+
+    it("throws when NEXT_PUBLIC_BASE_URL is not configured", async () => {
+      // Don't stub the env var - leave it undefined
+
+      await expect(import("../config")).rejects.toThrow(
+        "NEXT_PUBLIC_BASE_URL environment variable is not configured",
+      );
+    });
+  });
+});

--- a/turbo/apps/web/app/lib/blog/__tests__/data-source.test.ts
+++ b/turbo/apps/web/app/lib/blog/__tests__/data-source.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { BlogPost } from "../types";
+
+// Mock the strapi module
+vi.mock("../strapi", () => ({
+  getPostsFromStrapi: vi.fn(),
+  getPostBySlugFromStrapi: vi.fn(),
+  getFeaturedPostFromStrapi: vi.fn(),
+  getAllCategoriesFromStrapi: vi.fn(),
+}));
+
+describe("blog/data-source", () => {
+  const mockPost: BlogPost = {
+    slug: "test-post",
+    title: "Test Post",
+    excerpt: "Test excerpt",
+    content: "Test content",
+    category: "Technology",
+    author: { name: "Test Author" },
+    publishedAt: "2024-01-01T00:00:00.000Z",
+    readTime: "5 min read",
+    cover: "/covers/test.jpg",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("getPosts", () => {
+    it("delegates to strapi when data source is strapi", async () => {
+      const { getPostsFromStrapi } = await import("../strapi");
+      vi.mocked(getPostsFromStrapi).mockResolvedValue([mockPost]);
+
+      const { getPosts } = await import("../data-source");
+      const posts = await getPosts("en");
+
+      expect(getPostsFromStrapi).toHaveBeenCalledWith("en");
+      expect(posts).toEqual([mockPost]);
+    });
+
+    it("uses default locale when not provided", async () => {
+      const { getPostsFromStrapi } = await import("../strapi");
+      vi.mocked(getPostsFromStrapi).mockResolvedValue([]);
+
+      const { getPosts } = await import("../data-source");
+      await getPosts();
+
+      expect(getPostsFromStrapi).toHaveBeenCalledWith("en");
+    });
+  });
+
+  describe("getPost", () => {
+    it("delegates to strapi when data source is strapi", async () => {
+      const { getPostBySlugFromStrapi } = await import("../strapi");
+      vi.mocked(getPostBySlugFromStrapi).mockResolvedValue(mockPost);
+
+      const { getPost } = await import("../data-source");
+      const post = await getPost("test-post", "en");
+
+      expect(getPostBySlugFromStrapi).toHaveBeenCalledWith("test-post", "en");
+      expect(post).toEqual(mockPost);
+    });
+
+    it("returns null when post not found", async () => {
+      const { getPostBySlugFromStrapi } = await import("../strapi");
+      vi.mocked(getPostBySlugFromStrapi).mockResolvedValue(null);
+
+      const { getPost } = await import("../data-source");
+      const post = await getPost("non-existent", "en");
+
+      expect(post).toBeNull();
+    });
+  });
+
+  describe("getFeatured", () => {
+    it("delegates to strapi when data source is strapi", async () => {
+      const { getFeaturedPostFromStrapi } = await import("../strapi");
+      const featuredPost = { ...mockPost, featured: true };
+      vi.mocked(getFeaturedPostFromStrapi).mockResolvedValue(featuredPost);
+
+      const { getFeatured } = await import("../data-source");
+      const post = await getFeatured("en");
+
+      expect(getFeaturedPostFromStrapi).toHaveBeenCalledWith("en");
+      expect(post).toEqual(featuredPost);
+    });
+
+    it("returns null when no featured post exists", async () => {
+      const { getFeaturedPostFromStrapi } = await import("../strapi");
+      vi.mocked(getFeaturedPostFromStrapi).mockResolvedValue(null);
+
+      const { getFeatured } = await import("../data-source");
+      const post = await getFeatured("en");
+
+      expect(post).toBeNull();
+    });
+  });
+
+  describe("getCategories", () => {
+    it("delegates to strapi when data source is strapi", async () => {
+      const { getAllCategoriesFromStrapi } = await import("../strapi");
+      const categories = ["Technology", "Business", "Lifestyle"];
+      vi.mocked(getAllCategoriesFromStrapi).mockResolvedValue(categories);
+
+      const { getCategories } = await import("../data-source");
+      const result = await getCategories("en");
+
+      expect(getAllCategoriesFromStrapi).toHaveBeenCalledWith("en");
+      expect(result).toEqual(categories);
+    });
+
+    it("returns empty array when no categories exist", async () => {
+      const { getAllCategoriesFromStrapi } = await import("../strapi");
+      vi.mocked(getAllCategoriesFromStrapi).mockResolvedValue([]);
+
+      const { getCategories } = await import("../data-source");
+      const result = await getCategories("en");
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/turbo/apps/web/app/lib/blog/__tests__/data-source.test.ts
+++ b/turbo/apps/web/app/lib/blog/__tests__/data-source.test.ts
@@ -1,74 +1,149 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { BlogPost } from "../types";
+import { describe, it, expect, beforeAll, afterEach, afterAll } from "vitest";
+import { setupServer } from "msw/node";
+import { http, HttpResponse } from "msw";
 
-// Mock the strapi module
-vi.mock("../strapi", () => ({
-  getPostsFromStrapi: vi.fn(),
-  getPostBySlugFromStrapi: vi.fn(),
-  getFeaturedPostFromStrapi: vi.fn(),
-  getAllCategoriesFromStrapi: vi.fn(),
-}));
+const STRAPI_URL = "https://test-strapi.example.com";
+
+// Mock article data
+const mockArticle = {
+  id: 1,
+  documentId: "doc-1",
+  title: "Test Post",
+  description: "Test excerpt",
+  slug: "test-post",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+  publishedAt: "2024-01-01T00:00:00.000Z",
+  cover: { url: "/covers/test.jpg" },
+  author: { name: "Test Author" },
+  category: { name: "Technology", slug: "technology" },
+  blocks: [{ __component: "shared.rich-text", id: 1, body: "Test content" }],
+};
+
+const mockCategories = [
+  { id: 1, name: "Technology", slug: "technology" },
+  { id: 2, name: "Business", slug: "business" },
+  { id: 3, name: "Lifestyle", slug: "lifestyle" },
+];
+
+// Set up MSW server to intercept Strapi API requests
+const server = setupServer(
+  // Mock GET /api/articles
+  http.get(`${STRAPI_URL}/api/articles`, ({ request }) => {
+    const url = new URL(request.url);
+    const slug = url.searchParams.get("filters[slug][$eq]");
+    const limit = url.searchParams.get("pagination[limit]");
+
+    // If filtering by slug
+    if (slug) {
+      if (slug === "test-post") {
+        return HttpResponse.json({ data: [mockArticle], meta: {} });
+      }
+      return HttpResponse.json({ data: [], meta: {} });
+    }
+
+    // If requesting featured (limit=1)
+    if (limit === "1") {
+      return HttpResponse.json({ data: [mockArticle], meta: {} });
+    }
+
+    // Default: return all articles
+    return HttpResponse.json({ data: [mockArticle], meta: {} });
+  }),
+
+  // Mock GET /api/categories
+  http.get(`${STRAPI_URL}/api/categories`, () => {
+    return HttpResponse.json({ data: mockCategories, meta: {} });
+  }),
+);
+
+// Store original env values
+const originalStrapiUrl = process.env.NEXT_PUBLIC_STRAPI_URL;
+const originalDataSource = process.env.NEXT_PUBLIC_DATA_SOURCE;
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_STRAPI_URL = STRAPI_URL;
+  process.env.NEXT_PUBLIC_DATA_SOURCE = "strapi";
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+  // Restore original env values
+  if (originalStrapiUrl !== undefined) {
+    process.env.NEXT_PUBLIC_STRAPI_URL = originalStrapiUrl;
+  } else {
+    delete process.env.NEXT_PUBLIC_STRAPI_URL;
+  }
+  if (originalDataSource !== undefined) {
+    process.env.NEXT_PUBLIC_DATA_SOURCE = originalDataSource;
+  } else {
+    delete process.env.NEXT_PUBLIC_DATA_SOURCE;
+  }
+});
 
 describe("blog/data-source", () => {
-  const mockPost: BlogPost = {
-    slug: "test-post",
-    title: "Test Post",
-    excerpt: "Test excerpt",
-    content: "Test content",
-    category: "Technology",
-    author: { name: "Test Author" },
-    publishedAt: "2024-01-01T00:00:00.000Z",
-    readTime: "5 min read",
-    cover: "/covers/test.jpg",
-  };
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
   describe("getPosts", () => {
-    it("delegates to strapi when data source is strapi", async () => {
-      const { getPostsFromStrapi } = await import("../strapi");
-      vi.mocked(getPostsFromStrapi).mockResolvedValue([mockPost]);
-
+    it("fetches posts from strapi and returns transformed data", async () => {
       const { getPosts } = await import("../data-source");
       const posts = await getPosts("en");
 
-      expect(getPostsFromStrapi).toHaveBeenCalledWith("en");
-      expect(posts).toEqual([mockPost]);
+      expect(posts).toHaveLength(1);
+      expect(posts[0]).toMatchObject({
+        slug: "test-post",
+        title: "Test Post",
+        excerpt: "Test excerpt",
+        category: "Technology",
+        author: { name: "Test Author" },
+      });
     });
 
     it("uses default locale when not provided", async () => {
-      const { getPostsFromStrapi } = await import("../strapi");
-      vi.mocked(getPostsFromStrapi).mockResolvedValue([]);
+      let capturedLocale: string | null = null;
+
+      server.use(
+        http.get(`${STRAPI_URL}/api/articles`, ({ request }) => {
+          const url = new URL(request.url);
+          capturedLocale = url.searchParams.get("locale");
+          return HttpResponse.json({ data: [], meta: {} });
+        }),
+      );
 
       const { getPosts } = await import("../data-source");
       await getPosts();
 
-      expect(getPostsFromStrapi).toHaveBeenCalledWith("en");
+      expect(capturedLocale).toBe("en");
+    });
+
+    it("returns empty array when no posts exist", async () => {
+      server.use(
+        http.get(`${STRAPI_URL}/api/articles`, () => {
+          return HttpResponse.json({ data: [], meta: {} });
+        }),
+      );
+
+      const { getPosts } = await import("../data-source");
+      const posts = await getPosts("en");
+
+      expect(posts).toEqual([]);
     });
   });
 
   describe("getPost", () => {
-    it("delegates to strapi when data source is strapi", async () => {
-      const { getPostBySlugFromStrapi } = await import("../strapi");
-      vi.mocked(getPostBySlugFromStrapi).mockResolvedValue(mockPost);
-
+    it("fetches single post by slug from strapi", async () => {
       const { getPost } = await import("../data-source");
       const post = await getPost("test-post", "en");
 
-      expect(getPostBySlugFromStrapi).toHaveBeenCalledWith("test-post", "en");
-      expect(post).toEqual(mockPost);
+      expect(post).not.toBeNull();
+      expect(post?.slug).toBe("test-post");
+      expect(post?.title).toBe("Test Post");
     });
 
     it("returns null when post not found", async () => {
-      const { getPostBySlugFromStrapi } = await import("../strapi");
-      vi.mocked(getPostBySlugFromStrapi).mockResolvedValue(null);
-
       const { getPost } = await import("../data-source");
       const post = await getPost("non-existent", "en");
 
@@ -77,21 +152,20 @@ describe("blog/data-source", () => {
   });
 
   describe("getFeatured", () => {
-    it("delegates to strapi when data source is strapi", async () => {
-      const { getFeaturedPostFromStrapi } = await import("../strapi");
-      const featuredPost = { ...mockPost, featured: true };
-      vi.mocked(getFeaturedPostFromStrapi).mockResolvedValue(featuredPost);
-
+    it("fetches featured post from strapi and marks it as featured", async () => {
       const { getFeatured } = await import("../data-source");
       const post = await getFeatured("en");
 
-      expect(getFeaturedPostFromStrapi).toHaveBeenCalledWith("en");
-      expect(post).toEqual(featuredPost);
+      expect(post).not.toBeNull();
+      expect(post?.featured).toBe(true);
     });
 
     it("returns null when no featured post exists", async () => {
-      const { getFeaturedPostFromStrapi } = await import("../strapi");
-      vi.mocked(getFeaturedPostFromStrapi).mockResolvedValue(null);
+      server.use(
+        http.get(`${STRAPI_URL}/api/articles`, () => {
+          return HttpResponse.json({ data: [], meta: {} });
+        }),
+      );
 
       const { getFeatured } = await import("../data-source");
       const post = await getFeatured("en");
@@ -101,26 +175,24 @@ describe("blog/data-source", () => {
   });
 
   describe("getCategories", () => {
-    it("delegates to strapi when data source is strapi", async () => {
-      const { getAllCategoriesFromStrapi } = await import("../strapi");
-      const categories = ["Technology", "Business", "Lifestyle"];
-      vi.mocked(getAllCategoriesFromStrapi).mockResolvedValue(categories);
-
+    it("fetches categories from strapi", async () => {
       const { getCategories } = await import("../data-source");
-      const result = await getCategories("en");
+      const categories = await getCategories("en");
 
-      expect(getAllCategoriesFromStrapi).toHaveBeenCalledWith("en");
-      expect(result).toEqual(categories);
+      expect(categories).toEqual(["Technology", "Business", "Lifestyle"]);
     });
 
     it("returns empty array when no categories exist", async () => {
-      const { getAllCategoriesFromStrapi } = await import("../strapi");
-      vi.mocked(getAllCategoriesFromStrapi).mockResolvedValue([]);
+      server.use(
+        http.get(`${STRAPI_URL}/api/categories`, () => {
+          return HttpResponse.json({ data: [], meta: {} });
+        }),
+      );
 
       const { getCategories } = await import("../data-source");
-      const result = await getCategories("en");
+      const categories = await getCategories("en");
 
-      expect(result).toEqual([]);
+      expect(categories).toEqual([]);
     });
   });
 });

--- a/turbo/apps/web/app/lib/blog/__tests__/strapi.test.ts
+++ b/turbo/apps/web/app/lib/blog/__tests__/strapi.test.ts
@@ -1,57 +1,105 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterEach, afterAll } from "vitest";
+import { setupServer } from "msw/node";
+import { http, HttpResponse } from "msw";
 
-// Mock fetch globally
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
+const STRAPI_URL = "https://test-strapi.example.com";
+
+// Mock articles for testing
+const mockArticles = [
+  {
+    id: 1,
+    documentId: "doc-1",
+    title: "Test Post",
+    description: "Test description",
+    slug: "test-post",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-02T00:00:00.000Z",
+    publishedAt: "2024-01-01T12:00:00.000Z",
+    cover: { url: "https://cdn.example.com/image.jpg" },
+    author: { name: "John Doe" },
+    category: { name: "Technology", slug: "technology" },
+    blocks: [
+      {
+        __component: "shared.rich-text",
+        id: 1,
+        body: "This is the content of the post with many words to test read time calculation.",
+      },
+    ],
+  },
+];
+
+// Set up MSW server to intercept Strapi API requests
+const server = setupServer(
+  // Mock GET /api/articles
+  http.get(`${STRAPI_URL}/api/articles`, ({ request }) => {
+    const url = new URL(request.url);
+    const slug = url.searchParams.get("filters[slug][$eq]");
+    const limit = url.searchParams.get("pagination[limit]");
+
+    // If filtering by slug
+    if (slug) {
+      const article = mockArticles.find((a) => a.slug === slug);
+      return HttpResponse.json({
+        data: article ? [article] : [],
+        meta: {},
+      });
+    }
+
+    // If requesting featured (limit=1)
+    if (limit === "1") {
+      return HttpResponse.json({
+        data: mockArticles.slice(0, 1),
+        meta: {},
+      });
+    }
+
+    // Default: return all articles
+    return HttpResponse.json({
+      data: mockArticles,
+      meta: {},
+    });
+  }),
+
+  // Mock GET /api/categories
+  http.get(`${STRAPI_URL}/api/categories`, () => {
+    return HttpResponse.json({
+      data: [
+        { id: 1, name: "Technology", slug: "technology" },
+        { id: 2, name: "Business", slug: "business" },
+        { id: 3, name: "Lifestyle", slug: "lifestyle" },
+      ],
+      meta: {},
+    });
+  }),
+);
+
+// Store original env value
+const originalEnv = process.env.NEXT_PUBLIC_STRAPI_URL;
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_STRAPI_URL = STRAPI_URL;
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+  // Restore original env
+  if (originalEnv !== undefined) {
+    process.env.NEXT_PUBLIC_STRAPI_URL = originalEnv;
+  } else {
+    delete process.env.NEXT_PUBLIC_STRAPI_URL;
+  }
+});
 
 describe("blog/strapi", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.resetModules();
-    vi.stubEnv("NEXT_PUBLIC_STRAPI_URL", "https://test-strapi.example.com");
-  });
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
   describe("getPostsFromStrapi", () => {
     it("fetches posts and transforms them correctly", async () => {
-      const mockArticles = [
-        {
-          id: 1,
-          documentId: "doc-1",
-          title: "Test Post",
-          description: "Test description",
-          slug: "test-post",
-          createdAt: "2024-01-01T00:00:00.000Z",
-          updatedAt: "2024-01-02T00:00:00.000Z",
-          publishedAt: "2024-01-01T12:00:00.000Z",
-          cover: { url: "https://cdn.example.com/image.jpg" },
-          author: { name: "John Doe" },
-          category: { name: "Technology", slug: "technology" },
-          blocks: [
-            {
-              __component: "shared.rich-text",
-              id: 1,
-              body: "This is the content of the post with many words to test read time calculation.",
-            },
-          ],
-        },
-      ];
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: mockArticles, meta: {} }),
-      });
-
       const { getPostsFromStrapi } = await import("../strapi");
       const posts = await getPostsFromStrapi("en");
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        "https://test-strapi.example.com/api/articles?locale=en&populate=*&sort=publishedAt:desc",
-        { next: { revalidate: 60 } },
-      );
 
       expect(posts).toHaveLength(1);
       expect(posts[0]).toMatchObject({
@@ -67,11 +115,14 @@ describe("blog/strapi", () => {
     });
 
     it("throws error when fetch fails", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: "Internal Server Error",
-      });
+      server.use(
+        http.get(`${STRAPI_URL}/api/articles`, () => {
+          return new HttpResponse(null, {
+            status: 500,
+            statusText: "Internal Server Error",
+          });
+        }),
+      );
 
       const { getPostsFromStrapi } = await import("../strapi");
 
@@ -81,38 +132,42 @@ describe("blog/strapi", () => {
     });
 
     it("uses default locale when not provided", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: [], meta: {} }),
-      });
+      let capturedLocale: string | null = null;
+
+      server.use(
+        http.get(`${STRAPI_URL}/api/articles`, ({ request }) => {
+          const url = new URL(request.url);
+          capturedLocale = url.searchParams.get("locale");
+          return HttpResponse.json({ data: [], meta: {} });
+        }),
+      );
 
       const { getPostsFromStrapi } = await import("../strapi");
       await getPostsFromStrapi();
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("locale=en"),
-        expect.anything(),
-      );
+      expect(capturedLocale).toBe("en");
     });
 
     it("handles articles without optional fields", async () => {
-      const mockArticles = [
-        {
-          id: 1,
-          documentId: "doc-1",
-          title: "Minimal Post",
-          description: "",
-          slug: "minimal-post",
-          createdAt: "2024-01-01T00:00:00.000Z",
-          updatedAt: "2024-01-01T00:00:00.000Z",
-          publishedAt: "",
-        },
-      ];
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: mockArticles, meta: {} }),
-      });
+      server.use(
+        http.get(`${STRAPI_URL}/api/articles`, () => {
+          return HttpResponse.json({
+            data: [
+              {
+                id: 1,
+                documentId: "doc-1",
+                title: "Minimal Post",
+                description: "",
+                slug: "minimal-post",
+                createdAt: "2024-01-01T00:00:00.000Z",
+                updatedAt: "2024-01-01T00:00:00.000Z",
+                publishedAt: "",
+              },
+            ],
+            meta: {},
+          });
+        }),
+      );
 
       const { getPostsFromStrapi } = await import("../strapi");
       const posts = await getPostsFromStrapi("en");
@@ -128,40 +183,14 @@ describe("blog/strapi", () => {
 
   describe("getPostBySlugFromStrapi", () => {
     it("fetches single post by slug", async () => {
-      const mockArticle = {
-        id: 1,
-        documentId: "doc-1",
-        title: "Single Post",
-        description: "Single post description",
-        slug: "single-post",
-        createdAt: "2024-01-01T00:00:00.000Z",
-        updatedAt: "2024-01-01T00:00:00.000Z",
-        publishedAt: "2024-01-01T00:00:00.000Z",
-      };
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: [mockArticle], meta: {} }),
-      });
-
       const { getPostBySlugFromStrapi } = await import("../strapi");
-      const post = await getPostBySlugFromStrapi("single-post", "en");
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        "https://test-strapi.example.com/api/articles?locale=en&filters[slug][$eq]=single-post&populate=*",
-        { next: { revalidate: 60 } },
-      );
+      const post = await getPostBySlugFromStrapi("test-post", "en");
 
       expect(post).not.toBeNull();
-      expect(post?.slug).toBe("single-post");
+      expect(post?.slug).toBe("test-post");
     });
 
     it("returns null when post not found", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: [], meta: {} }),
-      });
-
       const { getPostBySlugFromStrapi } = await import("../strapi");
       const post = await getPostBySlugFromStrapi("non-existent", "en");
 
@@ -169,11 +198,14 @@ describe("blog/strapi", () => {
     });
 
     it("throws error when fetch fails", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-        statusText: "Not Found",
-      });
+      server.use(
+        http.get(`${STRAPI_URL}/api/articles`, () => {
+          return new HttpResponse(null, {
+            status: 404,
+            statusText: "Not Found",
+          });
+        }),
+      );
 
       const { getPostBySlugFromStrapi } = await import("../strapi");
 
@@ -185,39 +217,19 @@ describe("blog/strapi", () => {
 
   describe("getFeaturedPostFromStrapi", () => {
     it("fetches featured post and marks it as featured", async () => {
-      const mockArticle = {
-        id: 1,
-        documentId: "doc-1",
-        title: "Featured Post",
-        description: "Featured description",
-        slug: "featured-post",
-        createdAt: "2024-01-01T00:00:00.000Z",
-        updatedAt: "2024-01-01T00:00:00.000Z",
-        publishedAt: "2024-01-01T00:00:00.000Z",
-      };
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: [mockArticle], meta: {} }),
-      });
-
       const { getFeaturedPostFromStrapi } = await import("../strapi");
       const post = await getFeaturedPostFromStrapi("en");
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("pagination[limit]=1"),
-        expect.anything(),
-      );
 
       expect(post).not.toBeNull();
       expect(post?.featured).toBe(true);
     });
 
     it("returns null when no posts exist", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: [], meta: {} }),
-      });
+      server.use(
+        http.get(`${STRAPI_URL}/api/articles`, () => {
+          return HttpResponse.json({ data: [], meta: {} });
+        }),
+      );
 
       const { getFeaturedPostFromStrapi } = await import("../strapi");
       const post = await getFeaturedPostFromStrapi("en");
@@ -226,11 +238,14 @@ describe("blog/strapi", () => {
     });
 
     it("throws error when fetch fails", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 503,
-        statusText: "Service Unavailable",
-      });
+      server.use(
+        http.get(`${STRAPI_URL}/api/articles`, () => {
+          return new HttpResponse(null, {
+            status: 503,
+            statusText: "Service Unavailable",
+          });
+        }),
+      );
 
       const { getFeaturedPostFromStrapi } = await import("../strapi");
 
@@ -242,33 +257,18 @@ describe("blog/strapi", () => {
 
   describe("getAllCategoriesFromStrapi", () => {
     it("fetches and returns category names", async () => {
-      const mockCategories = [
-        { id: 1, name: "Technology", slug: "technology" },
-        { id: 2, name: "Business", slug: "business" },
-        { id: 3, name: "Lifestyle", slug: "lifestyle" },
-      ];
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: mockCategories, meta: {} }),
-      });
-
       const { getAllCategoriesFromStrapi } = await import("../strapi");
       const categories = await getAllCategoriesFromStrapi("en");
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        "https://test-strapi.example.com/api/categories?locale=en",
-        { next: { revalidate: 60 } },
-      );
 
       expect(categories).toEqual(["Technology", "Business", "Lifestyle"]);
     });
 
     it("returns empty array when no categories exist", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: [], meta: {} }),
-      });
+      server.use(
+        http.get(`${STRAPI_URL}/api/categories`, () => {
+          return HttpResponse.json({ data: [], meta: {} });
+        }),
+      );
 
       const { getAllCategoriesFromStrapi } = await import("../strapi");
       const categories = await getAllCategoriesFromStrapi("en");
@@ -277,11 +277,14 @@ describe("blog/strapi", () => {
     });
 
     it("throws error when fetch fails", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: "Internal Server Error",
-      });
+      server.use(
+        http.get(`${STRAPI_URL}/api/categories`, () => {
+          return new HttpResponse(null, {
+            status: 500,
+            statusText: "Internal Server Error",
+          });
+        }),
+      );
 
       const { getAllCategoriesFromStrapi } = await import("../strapi");
 
@@ -293,55 +296,61 @@ describe("blog/strapi", () => {
 
   describe("article transformation", () => {
     it("handles relative cover URLs by prepending STRAPI_URL", async () => {
-      const mockArticle = {
-        id: 1,
-        documentId: "doc-1",
-        title: "Test",
-        description: "Test",
-        slug: "test",
-        createdAt: "2024-01-01T00:00:00.000Z",
-        updatedAt: "2024-01-01T00:00:00.000Z",
-        publishedAt: "2024-01-01T00:00:00.000Z",
-        cover: { url: "/uploads/image.jpg" },
-      };
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: [mockArticle], meta: {} }),
-      });
+      server.use(
+        http.get(`${STRAPI_URL}/api/articles`, () => {
+          return HttpResponse.json({
+            data: [
+              {
+                id: 1,
+                documentId: "doc-1",
+                title: "Test",
+                description: "Test",
+                slug: "test",
+                createdAt: "2024-01-01T00:00:00.000Z",
+                updatedAt: "2024-01-01T00:00:00.000Z",
+                publishedAt: "2024-01-01T00:00:00.000Z",
+                cover: { url: "/uploads/image.jpg" },
+              },
+            ],
+            meta: {},
+          });
+        }),
+      );
 
       const { getPostsFromStrapi } = await import("../strapi");
       const posts = await getPostsFromStrapi("en");
 
-      expect(posts[0]?.cover).toBe(
-        "https://test-strapi.example.com/uploads/image.jpg",
-      );
+      expect(posts[0]?.cover).toBe(`${STRAPI_URL}/uploads/image.jpg`);
     });
 
     it("transforms shared.quote blocks correctly", async () => {
-      const mockArticle = {
-        id: 1,
-        documentId: "doc-1",
-        title: "Test",
-        description: "Test",
-        slug: "test",
-        createdAt: "2024-01-01T00:00:00.000Z",
-        updatedAt: "2024-01-01T00:00:00.000Z",
-        publishedAt: "2024-01-01T00:00:00.000Z",
-        blocks: [
-          {
-            __component: "shared.quote",
-            id: 1,
-            title: "Famous Person",
-            body: "This is a quote",
-          },
-        ],
-      };
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: [mockArticle], meta: {} }),
-      });
+      server.use(
+        http.get(`${STRAPI_URL}/api/articles`, () => {
+          return HttpResponse.json({
+            data: [
+              {
+                id: 1,
+                documentId: "doc-1",
+                title: "Test",
+                description: "Test",
+                slug: "test",
+                createdAt: "2024-01-01T00:00:00.000Z",
+                updatedAt: "2024-01-01T00:00:00.000Z",
+                publishedAt: "2024-01-01T00:00:00.000Z",
+                blocks: [
+                  {
+                    __component: "shared.quote",
+                    id: 1,
+                    title: "Famous Person",
+                    body: "This is a quote",
+                  },
+                ],
+              },
+            ],
+            meta: {},
+          });
+        }),
+      );
 
       const { getPostsFromStrapi } = await import("../strapi");
       const posts = await getPostsFromStrapi("en");
@@ -353,22 +362,29 @@ describe("blog/strapi", () => {
     it("calculates read time based on word count", async () => {
       // 400 words should be 2 min read (200 words per minute)
       const longContent = Array(400).fill("word").join(" ");
-      const mockArticle = {
-        id: 1,
-        documentId: "doc-1",
-        title: "Test",
-        description: "Test",
-        slug: "test",
-        createdAt: "2024-01-01T00:00:00.000Z",
-        updatedAt: "2024-01-01T00:00:00.000Z",
-        publishedAt: "2024-01-01T00:00:00.000Z",
-        blocks: [{ __component: "shared.rich-text", id: 1, body: longContent }],
-      };
 
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: [mockArticle], meta: {} }),
-      });
+      server.use(
+        http.get(`${STRAPI_URL}/api/articles`, () => {
+          return HttpResponse.json({
+            data: [
+              {
+                id: 1,
+                documentId: "doc-1",
+                title: "Test",
+                description: "Test",
+                slug: "test",
+                createdAt: "2024-01-01T00:00:00.000Z",
+                updatedAt: "2024-01-01T00:00:00.000Z",
+                publishedAt: "2024-01-01T00:00:00.000Z",
+                blocks: [
+                  { __component: "shared.rich-text", id: 1, body: longContent },
+                ],
+              },
+            ],
+            meta: {},
+          });
+        }),
+      );
 
       const { getPostsFromStrapi } = await import("../strapi");
       const posts = await getPostsFromStrapi("en");
@@ -377,37 +393,31 @@ describe("blog/strapi", () => {
     });
 
     it("uses description as content when no blocks exist", async () => {
-      const mockArticle = {
-        id: 1,
-        documentId: "doc-1",
-        title: "Test",
-        description: "This is the description used as content",
-        slug: "test",
-        createdAt: "2024-01-01T00:00:00.000Z",
-        updatedAt: "2024-01-01T00:00:00.000Z",
-        publishedAt: "2024-01-01T00:00:00.000Z",
-        blocks: [],
-      };
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: [mockArticle], meta: {} }),
-      });
+      server.use(
+        http.get(`${STRAPI_URL}/api/articles`, () => {
+          return HttpResponse.json({
+            data: [
+              {
+                id: 1,
+                documentId: "doc-1",
+                title: "Test",
+                description: "This is the description used as content",
+                slug: "test",
+                createdAt: "2024-01-01T00:00:00.000Z",
+                updatedAt: "2024-01-01T00:00:00.000Z",
+                publishedAt: "2024-01-01T00:00:00.000Z",
+                blocks: [],
+              },
+            ],
+            meta: {},
+          });
+        }),
+      );
 
       const { getPostsFromStrapi } = await import("../strapi");
       const posts = await getPostsFromStrapi("en");
 
       expect(posts[0]?.content).toBe("This is the description used as content");
-    });
-  });
-
-  describe("environment configuration", () => {
-    it("throws when NEXT_PUBLIC_STRAPI_URL is not configured", async () => {
-      vi.unstubAllEnvs();
-
-      await expect(import("../strapi")).rejects.toThrow(
-        "NEXT_PUBLIC_STRAPI_URL environment variable is not configured",
-      );
     });
   });
 });

--- a/turbo/apps/web/app/lib/blog/__tests__/strapi.test.ts
+++ b/turbo/apps/web/app/lib/blog/__tests__/strapi.test.ts
@@ -1,0 +1,413 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe("blog/strapi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    vi.stubEnv("NEXT_PUBLIC_STRAPI_URL", "https://test-strapi.example.com");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("getPostsFromStrapi", () => {
+    it("fetches posts and transforms them correctly", async () => {
+      const mockArticles = [
+        {
+          id: 1,
+          documentId: "doc-1",
+          title: "Test Post",
+          description: "Test description",
+          slug: "test-post",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-02T00:00:00.000Z",
+          publishedAt: "2024-01-01T12:00:00.000Z",
+          cover: { url: "https://cdn.example.com/image.jpg" },
+          author: { name: "John Doe" },
+          category: { name: "Technology", slug: "technology" },
+          blocks: [
+            {
+              __component: "shared.rich-text",
+              id: 1,
+              body: "This is the content of the post with many words to test read time calculation.",
+            },
+          ],
+        },
+      ];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: mockArticles, meta: {} }),
+      });
+
+      const { getPostsFromStrapi } = await import("../strapi");
+      const posts = await getPostsFromStrapi("en");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://test-strapi.example.com/api/articles?locale=en&populate=*&sort=publishedAt:desc",
+        { next: { revalidate: 60 } },
+      );
+
+      expect(posts).toHaveLength(1);
+      expect(posts[0]).toMatchObject({
+        slug: "test-post",
+        title: "Test Post",
+        excerpt: "Test description",
+        category: "Technology",
+        author: { name: "John Doe" },
+        cover: "https://cdn.example.com/image.jpg",
+        featured: false,
+      });
+      expect(posts[0]?.readTime).toMatch(/\d+ min read/);
+    });
+
+    it("throws error when fetch fails", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      });
+
+      const { getPostsFromStrapi } = await import("../strapi");
+
+      await expect(getPostsFromStrapi("en")).rejects.toThrow(
+        "Failed to fetch posts: 500 Internal Server Error",
+      );
+    });
+
+    it("uses default locale when not provided", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [], meta: {} }),
+      });
+
+      const { getPostsFromStrapi } = await import("../strapi");
+      await getPostsFromStrapi();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("locale=en"),
+        expect.anything(),
+      );
+    });
+
+    it("handles articles without optional fields", async () => {
+      const mockArticles = [
+        {
+          id: 1,
+          documentId: "doc-1",
+          title: "Minimal Post",
+          description: "",
+          slug: "minimal-post",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+          publishedAt: "",
+        },
+      ];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: mockArticles, meta: {} }),
+      });
+
+      const { getPostsFromStrapi } = await import("../strapi");
+      const posts = await getPostsFromStrapi("en");
+
+      expect(posts[0]).toMatchObject({
+        slug: "minimal-post",
+        category: "General",
+        author: { name: "VM0 Team" },
+        cover: "/covers/default.png",
+      });
+    });
+  });
+
+  describe("getPostBySlugFromStrapi", () => {
+    it("fetches single post by slug", async () => {
+      const mockArticle = {
+        id: 1,
+        documentId: "doc-1",
+        title: "Single Post",
+        description: "Single post description",
+        slug: "single-post",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+        publishedAt: "2024-01-01T00:00:00.000Z",
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [mockArticle], meta: {} }),
+      });
+
+      const { getPostBySlugFromStrapi } = await import("../strapi");
+      const post = await getPostBySlugFromStrapi("single-post", "en");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://test-strapi.example.com/api/articles?locale=en&filters[slug][$eq]=single-post&populate=*",
+        { next: { revalidate: 60 } },
+      );
+
+      expect(post).not.toBeNull();
+      expect(post?.slug).toBe("single-post");
+    });
+
+    it("returns null when post not found", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [], meta: {} }),
+      });
+
+      const { getPostBySlugFromStrapi } = await import("../strapi");
+      const post = await getPostBySlugFromStrapi("non-existent", "en");
+
+      expect(post).toBeNull();
+    });
+
+    it("throws error when fetch fails", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+      });
+
+      const { getPostBySlugFromStrapi } = await import("../strapi");
+
+      await expect(getPostBySlugFromStrapi("test", "en")).rejects.toThrow(
+        "Failed to fetch post by slug: 404 Not Found",
+      );
+    });
+  });
+
+  describe("getFeaturedPostFromStrapi", () => {
+    it("fetches featured post and marks it as featured", async () => {
+      const mockArticle = {
+        id: 1,
+        documentId: "doc-1",
+        title: "Featured Post",
+        description: "Featured description",
+        slug: "featured-post",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+        publishedAt: "2024-01-01T00:00:00.000Z",
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [mockArticle], meta: {} }),
+      });
+
+      const { getFeaturedPostFromStrapi } = await import("../strapi");
+      const post = await getFeaturedPostFromStrapi("en");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("pagination[limit]=1"),
+        expect.anything(),
+      );
+
+      expect(post).not.toBeNull();
+      expect(post?.featured).toBe(true);
+    });
+
+    it("returns null when no posts exist", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [], meta: {} }),
+      });
+
+      const { getFeaturedPostFromStrapi } = await import("../strapi");
+      const post = await getFeaturedPostFromStrapi("en");
+
+      expect(post).toBeNull();
+    });
+
+    it("throws error when fetch fails", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        statusText: "Service Unavailable",
+      });
+
+      const { getFeaturedPostFromStrapi } = await import("../strapi");
+
+      await expect(getFeaturedPostFromStrapi("en")).rejects.toThrow(
+        "Failed to fetch featured post: 503 Service Unavailable",
+      );
+    });
+  });
+
+  describe("getAllCategoriesFromStrapi", () => {
+    it("fetches and returns category names", async () => {
+      const mockCategories = [
+        { id: 1, name: "Technology", slug: "technology" },
+        { id: 2, name: "Business", slug: "business" },
+        { id: 3, name: "Lifestyle", slug: "lifestyle" },
+      ];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: mockCategories, meta: {} }),
+      });
+
+      const { getAllCategoriesFromStrapi } = await import("../strapi");
+      const categories = await getAllCategoriesFromStrapi("en");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://test-strapi.example.com/api/categories?locale=en",
+        { next: { revalidate: 60 } },
+      );
+
+      expect(categories).toEqual(["Technology", "Business", "Lifestyle"]);
+    });
+
+    it("returns empty array when no categories exist", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [], meta: {} }),
+      });
+
+      const { getAllCategoriesFromStrapi } = await import("../strapi");
+      const categories = await getAllCategoriesFromStrapi("en");
+
+      expect(categories).toEqual([]);
+    });
+
+    it("throws error when fetch fails", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      });
+
+      const { getAllCategoriesFromStrapi } = await import("../strapi");
+
+      await expect(getAllCategoriesFromStrapi("en")).rejects.toThrow(
+        "Failed to fetch categories: 500 Internal Server Error",
+      );
+    });
+  });
+
+  describe("article transformation", () => {
+    it("handles relative cover URLs by prepending STRAPI_URL", async () => {
+      const mockArticle = {
+        id: 1,
+        documentId: "doc-1",
+        title: "Test",
+        description: "Test",
+        slug: "test",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+        publishedAt: "2024-01-01T00:00:00.000Z",
+        cover: { url: "/uploads/image.jpg" },
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [mockArticle], meta: {} }),
+      });
+
+      const { getPostsFromStrapi } = await import("../strapi");
+      const posts = await getPostsFromStrapi("en");
+
+      expect(posts[0]?.cover).toBe(
+        "https://test-strapi.example.com/uploads/image.jpg",
+      );
+    });
+
+    it("transforms shared.quote blocks correctly", async () => {
+      const mockArticle = {
+        id: 1,
+        documentId: "doc-1",
+        title: "Test",
+        description: "Test",
+        slug: "test",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+        publishedAt: "2024-01-01T00:00:00.000Z",
+        blocks: [
+          {
+            __component: "shared.quote",
+            id: 1,
+            title: "Famous Person",
+            body: "This is a quote",
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [mockArticle], meta: {} }),
+      });
+
+      const { getPostsFromStrapi } = await import("../strapi");
+      const posts = await getPostsFromStrapi("en");
+
+      expect(posts[0]?.content).toContain("> **Famous Person**");
+      expect(posts[0]?.content).toContain("> This is a quote");
+    });
+
+    it("calculates read time based on word count", async () => {
+      // 400 words should be 2 min read (200 words per minute)
+      const longContent = Array(400).fill("word").join(" ");
+      const mockArticle = {
+        id: 1,
+        documentId: "doc-1",
+        title: "Test",
+        description: "Test",
+        slug: "test",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+        publishedAt: "2024-01-01T00:00:00.000Z",
+        blocks: [{ __component: "shared.rich-text", id: 1, body: longContent }],
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [mockArticle], meta: {} }),
+      });
+
+      const { getPostsFromStrapi } = await import("../strapi");
+      const posts = await getPostsFromStrapi("en");
+
+      expect(posts[0]?.readTime).toBe("2 min read");
+    });
+
+    it("uses description as content when no blocks exist", async () => {
+      const mockArticle = {
+        id: 1,
+        documentId: "doc-1",
+        title: "Test",
+        description: "This is the description used as content",
+        slug: "test",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+        publishedAt: "2024-01-01T00:00:00.000Z",
+        blocks: [],
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [mockArticle], meta: {} }),
+      });
+
+      const { getPostsFromStrapi } = await import("../strapi");
+      const posts = await getPostsFromStrapi("en");
+
+      expect(posts[0]?.content).toBe("This is the description used as content");
+    });
+  });
+
+  describe("environment configuration", () => {
+    it("throws when NEXT_PUBLIC_STRAPI_URL is not configured", async () => {
+      vi.unstubAllEnvs();
+
+      await expect(import("../strapi")).rejects.toThrow(
+        "NEXT_PUBLIC_STRAPI_URL environment variable is not configured",
+      );
+    });
+  });
+});

--- a/turbo/apps/web/app/lib/blog/config.ts
+++ b/turbo/apps/web/app/lib/blog/config.ts
@@ -1,1 +1,11 @@
-export const BLOG_BASE_URL = "https://vm0.ai";
+function getBlogBaseUrl(): string {
+  const url = process.env.NEXT_PUBLIC_BASE_URL;
+  if (!url) {
+    throw new Error(
+      "NEXT_PUBLIC_BASE_URL environment variable is not configured",
+    );
+  }
+  return url;
+}
+
+export const BLOG_BASE_URL = getBlogBaseUrl();

--- a/turbo/apps/web/app/lib/blog/config.ts
+++ b/turbo/apps/web/app/lib/blog/config.ts
@@ -1,0 +1,1 @@
+export const BLOG_BASE_URL = "https://vm0.ai";

--- a/turbo/apps/web/app/lib/blog/data-source.ts
+++ b/turbo/apps/web/app/lib/blog/data-source.ts
@@ -1,0 +1,42 @@
+import { BlogPost } from "./types";
+import {
+  getPostsFromStrapi,
+  getPostBySlugFromStrapi,
+  getFeaturedPostFromStrapi,
+  getAllCategoriesFromStrapi,
+} from "./strapi";
+
+const DATA_SOURCE = process.env.NEXT_PUBLIC_DATA_SOURCE || "strapi";
+
+export async function getPosts(locale: string = "en"): Promise<BlogPost[]> {
+  if (DATA_SOURCE === "strapi") {
+    return getPostsFromStrapi(locale);
+  }
+  return [];
+}
+
+export async function getPost(
+  slug: string,
+  locale: string = "en",
+): Promise<BlogPost | null> {
+  if (DATA_SOURCE === "strapi") {
+    return getPostBySlugFromStrapi(slug, locale);
+  }
+  return null;
+}
+
+export async function getFeatured(
+  locale: string = "en",
+): Promise<BlogPost | null> {
+  if (DATA_SOURCE === "strapi") {
+    return getFeaturedPostFromStrapi(locale);
+  }
+  return null;
+}
+
+export async function getCategories(locale: string = "en"): Promise<string[]> {
+  if (DATA_SOURCE === "strapi") {
+    return getAllCategoriesFromStrapi(locale);
+  }
+  return [];
+}

--- a/turbo/apps/web/app/lib/blog/data-source.ts
+++ b/turbo/apps/web/app/lib/blog/data-source.ts
@@ -8,35 +8,35 @@ import {
 
 const DATA_SOURCE = process.env.NEXT_PUBLIC_DATA_SOURCE || "strapi";
 
-export async function getPosts(locale: string = "en"): Promise<BlogPost[]> {
-  if (DATA_SOURCE === "strapi") {
-    return getPostsFromStrapi(locale);
+function assertStrapiDataSource(dataSource: string): void {
+  if (dataSource !== "strapi") {
+    throw new Error(
+      `Unsupported data source: ${dataSource}. Only "strapi" is supported.`,
+    );
   }
-  return [];
+}
+
+export async function getPosts(locale: string = "en"): Promise<BlogPost[]> {
+  assertStrapiDataSource(DATA_SOURCE);
+  return getPostsFromStrapi(locale);
 }
 
 export async function getPost(
   slug: string,
   locale: string = "en",
 ): Promise<BlogPost | null> {
-  if (DATA_SOURCE === "strapi") {
-    return getPostBySlugFromStrapi(slug, locale);
-  }
-  return null;
+  assertStrapiDataSource(DATA_SOURCE);
+  return getPostBySlugFromStrapi(slug, locale);
 }
 
 export async function getFeatured(
   locale: string = "en",
 ): Promise<BlogPost | null> {
-  if (DATA_SOURCE === "strapi") {
-    return getFeaturedPostFromStrapi(locale);
-  }
-  return null;
+  assertStrapiDataSource(DATA_SOURCE);
+  return getFeaturedPostFromStrapi(locale);
 }
 
 export async function getCategories(locale: string = "en"): Promise<string[]> {
-  if (DATA_SOURCE === "strapi") {
-    return getAllCategoriesFromStrapi(locale);
-  }
-  return [];
+  assertStrapiDataSource(DATA_SOURCE);
+  return getAllCategoriesFromStrapi(locale);
 }

--- a/turbo/apps/web/app/lib/blog/index.ts
+++ b/turbo/apps/web/app/lib/blog/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./data-source";

--- a/turbo/apps/web/app/lib/blog/index.ts
+++ b/turbo/apps/web/app/lib/blog/index.ts
@@ -1,2 +1,3 @@
 export * from "./types";
 export * from "./data-source";
+export * from "./config";

--- a/turbo/apps/web/app/lib/blog/strapi.ts
+++ b/turbo/apps/web/app/lib/blog/strapi.ts
@@ -1,0 +1,201 @@
+import { BlogPost } from "./types";
+
+const STRAPI_URL =
+  process.env.NEXT_PUBLIC_STRAPI_URL || "http://localhost:1337";
+
+interface StrapiResponse<T> {
+  data: T;
+  meta: {
+    pagination?: {
+      page: number;
+      pageSize: number;
+      pageCount: number;
+      total: number;
+    };
+  };
+}
+
+interface StrapiBlock {
+  __component: string;
+  id: number;
+  body?: string;
+  title?: string;
+}
+
+interface StrapiArticle {
+  id: number;
+  documentId: string;
+  title: string;
+  description: string;
+  slug: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+  cover?: {
+    url: string;
+    alternativeText?: string;
+  };
+  author?: {
+    name: string;
+    email?: string;
+    avatar?: {
+      url: string;
+    };
+  };
+  category?: {
+    name: string;
+    slug: string;
+  };
+  blocks?: StrapiBlock[];
+}
+
+function transformArticle(article: StrapiArticle): BlogPost {
+  let coverUrl = "/covers/default.png";
+  if (article.cover?.url) {
+    const url = article.cover.url;
+    coverUrl = url.startsWith("http") ? url : `${STRAPI_URL}${url}`;
+  }
+
+  let content = "";
+  if (article.blocks && article.blocks.length > 0) {
+    content = article.blocks
+      .map((block) => {
+        if (block.__component === "shared.rich-text" && block.body) {
+          return block.body;
+        }
+        if (block.__component === "shared.quote" && block.body) {
+          return `> **${block.title || ""}**\n> ${block.body}`;
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n\n");
+  }
+
+  if (!content) {
+    content = article.description || "";
+  }
+
+  const wordCount = content.split(/\s+/).length || 0;
+  const readTime = Math.max(1, Math.ceil(wordCount / 200));
+
+  return {
+    slug: article.slug,
+    title: article.title,
+    excerpt: article.description || "",
+    content: content,
+    category: article.category?.name || "General",
+    author: {
+      name: article.author?.name || "VM0 Team",
+    },
+    publishedAt: article.publishedAt || article.createdAt,
+    readTime: `${readTime} min read`,
+    featured: false,
+    cover: coverUrl,
+  };
+}
+
+export async function getPostsFromStrapi(
+  locale: string = "en",
+): Promise<BlogPost[]> {
+  const url = `${STRAPI_URL}/api/articles?locale=${locale}&populate=*&sort=publishedAt:desc`;
+
+  try {
+    const res = await fetch(url, {
+      next: { revalidate: 60 },
+    });
+
+    if (!res.ok) {
+      return [];
+    }
+
+    const data: StrapiResponse<StrapiArticle[]> = await res.json();
+    return data.data.map(transformArticle);
+  } catch {
+    // Return empty array when Strapi is unavailable (e.g., during CI build)
+    return [];
+  }
+}
+
+export async function getPostBySlugFromStrapi(
+  slug: string,
+  locale: string = "en",
+): Promise<BlogPost | null> {
+  const url = `${STRAPI_URL}/api/articles?locale=${locale}&filters[slug][$eq]=${slug}&populate=*`;
+
+  try {
+    const res = await fetch(url, {
+      next: { revalidate: 60 },
+    });
+
+    if (!res.ok) {
+      return null;
+    }
+
+    const data: StrapiResponse<StrapiArticle[]> = await res.json();
+
+    if (data.data.length === 0) {
+      return null;
+    }
+
+    return transformArticle(data.data[0]!);
+  } catch {
+    // Return null when Strapi is unavailable (e.g., during CI build)
+    return null;
+  }
+}
+
+export async function getFeaturedPostFromStrapi(
+  locale: string = "en",
+): Promise<BlogPost | null> {
+  const url = `${STRAPI_URL}/api/articles?locale=${locale}&populate=*&sort=publishedAt:desc&pagination[limit]=1`;
+
+  try {
+    const res = await fetch(url, {
+      next: { revalidate: 60 },
+    });
+
+    if (!res.ok) {
+      return null;
+    }
+
+    const data: StrapiResponse<StrapiArticle[]> = await res.json();
+
+    if (data.data.length === 0) {
+      return null;
+    }
+
+    const post = transformArticle(data.data[0]!);
+    post.featured = true;
+    return post;
+  } catch {
+    // Return null when Strapi is unavailable (e.g., during CI build)
+    return null;
+  }
+}
+
+export async function getAllCategoriesFromStrapi(
+  locale: string = "en",
+): Promise<string[]> {
+  try {
+    const res = await fetch(`${STRAPI_URL}/api/categories?locale=${locale}`, {
+      next: { revalidate: 60 },
+    });
+
+    if (!res.ok) {
+      return [];
+    }
+
+    interface StrapiCategory {
+      id: number;
+      name: string;
+      slug: string;
+    }
+
+    const data: StrapiResponse<StrapiCategory[]> = await res.json();
+    return data.data.map((cat) => cat.name);
+  } catch {
+    // Return empty array when Strapi is unavailable (e.g., during CI build)
+    return [];
+  }
+}

--- a/turbo/apps/web/app/lib/blog/strapi.ts
+++ b/turbo/apps/web/app/lib/blog/strapi.ts
@@ -100,21 +100,16 @@ export async function getPostsFromStrapi(
 ): Promise<BlogPost[]> {
   const url = `${STRAPI_URL}/api/articles?locale=${locale}&populate=*&sort=publishedAt:desc`;
 
-  try {
-    const res = await fetch(url, {
-      next: { revalidate: 60 },
-    });
+  const res = await fetch(url, {
+    next: { revalidate: 60 },
+  });
 
-    if (!res.ok) {
-      return [];
-    }
-
-    const data: StrapiResponse<StrapiArticle[]> = await res.json();
-    return data.data.map(transformArticle);
-  } catch {
-    // Return empty array when Strapi is unavailable (e.g., during CI build)
-    return [];
+  if (!res.ok) {
+    throw new Error(`Failed to fetch posts: ${res.status} ${res.statusText}`);
   }
+
+  const data: StrapiResponse<StrapiArticle[]> = await res.json();
+  return data.data.map(transformArticle);
 }
 
 export async function getPostBySlugFromStrapi(
@@ -123,26 +118,23 @@ export async function getPostBySlugFromStrapi(
 ): Promise<BlogPost | null> {
   const url = `${STRAPI_URL}/api/articles?locale=${locale}&filters[slug][$eq]=${slug}&populate=*`;
 
-  try {
-    const res = await fetch(url, {
-      next: { revalidate: 60 },
-    });
+  const res = await fetch(url, {
+    next: { revalidate: 60 },
+  });
 
-    if (!res.ok) {
-      return null;
-    }
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch post by slug: ${res.status} ${res.statusText}`,
+    );
+  }
 
-    const data: StrapiResponse<StrapiArticle[]> = await res.json();
+  const data: StrapiResponse<StrapiArticle[]> = await res.json();
 
-    if (data.data.length === 0) {
-      return null;
-    }
-
-    return transformArticle(data.data[0]!);
-  } catch {
-    // Return null when Strapi is unavailable (e.g., during CI build)
+  if (data.data.length === 0) {
     return null;
   }
+
+  return transformArticle(data.data[0]!);
 }
 
 export async function getFeaturedPostFromStrapi(
@@ -150,52 +142,46 @@ export async function getFeaturedPostFromStrapi(
 ): Promise<BlogPost | null> {
   const url = `${STRAPI_URL}/api/articles?locale=${locale}&populate=*&sort=publishedAt:desc&pagination[limit]=1`;
 
-  try {
-    const res = await fetch(url, {
-      next: { revalidate: 60 },
-    });
+  const res = await fetch(url, {
+    next: { revalidate: 60 },
+  });
 
-    if (!res.ok) {
-      return null;
-    }
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch featured post: ${res.status} ${res.statusText}`,
+    );
+  }
 
-    const data: StrapiResponse<StrapiArticle[]> = await res.json();
+  const data: StrapiResponse<StrapiArticle[]> = await res.json();
 
-    if (data.data.length === 0) {
-      return null;
-    }
-
-    const post = transformArticle(data.data[0]!);
-    post.featured = true;
-    return post;
-  } catch {
-    // Return null when Strapi is unavailable (e.g., during CI build)
+  if (data.data.length === 0) {
     return null;
   }
+
+  const post = transformArticle(data.data[0]!);
+  post.featured = true;
+  return post;
 }
 
 export async function getAllCategoriesFromStrapi(
   locale: string = "en",
 ): Promise<string[]> {
-  try {
-    const res = await fetch(`${STRAPI_URL}/api/categories?locale=${locale}`, {
-      next: { revalidate: 60 },
-    });
+  const res = await fetch(`${STRAPI_URL}/api/categories?locale=${locale}`, {
+    next: { revalidate: 60 },
+  });
 
-    if (!res.ok) {
-      return [];
-    }
-
-    interface StrapiCategory {
-      id: number;
-      name: string;
-      slug: string;
-    }
-
-    const data: StrapiResponse<StrapiCategory[]> = await res.json();
-    return data.data.map((cat) => cat.name);
-  } catch {
-    // Return empty array when Strapi is unavailable (e.g., during CI build)
-    return [];
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch categories: ${res.status} ${res.statusText}`,
+    );
   }
+
+  interface StrapiCategory {
+    id: number;
+    name: string;
+    slug: string;
+  }
+
+  const data: StrapiResponse<StrapiCategory[]> = await res.json();
+  return data.data.map((cat) => cat.name);
 }

--- a/turbo/apps/web/app/lib/blog/strapi.ts
+++ b/turbo/apps/web/app/lib/blog/strapi.ts
@@ -1,7 +1,16 @@
 import { BlogPost } from "./types";
 
-const STRAPI_URL =
-  process.env.NEXT_PUBLIC_STRAPI_URL || "http://localhost:1337";
+function getStrapiUrl(): string {
+  const url = process.env.NEXT_PUBLIC_STRAPI_URL;
+  if (!url) {
+    throw new Error(
+      "NEXT_PUBLIC_STRAPI_URL environment variable is not configured",
+    );
+  }
+  return url;
+}
+
+const STRAPI_URL = getStrapiUrl();
 
 interface StrapiResponse<T> {
   data: T;

--- a/turbo/apps/web/app/lib/blog/types.ts
+++ b/turbo/apps/web/app/lib/blog/types.ts
@@ -1,0 +1,15 @@
+export interface BlogPost {
+  slug: string;
+  title: string;
+  excerpt: string;
+  content: string;
+  category: string;
+  author: {
+    name: string;
+    avatar?: string;
+  };
+  publishedAt: string;
+  readTime: string;
+  featured?: boolean;
+  cover: string;
+}

--- a/turbo/apps/web/app/sitemap.ts
+++ b/turbo/apps/web/app/sitemap.ts
@@ -1,8 +1,7 @@
-import { MetadataRoute } from "next";
+import type { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = "https://vm0.ai";
-  const blogUrl = "https://blog.vm0.ai";
   const docsUrl = "https://docs.vm0.ai";
   const locales = ["en", "de", "es", "ja"];
 
@@ -16,6 +15,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
       path: "/skills",
       priority: 0.9,
       changeFrequency: "weekly" as const,
+    },
+    {
+      path: "/blog",
+      priority: 0.8,
+      changeFrequency: "weekly" as const,
+    },
+    {
+      path: "/glossary",
+      priority: 0.7,
+      changeFrequency: "monthly" as const,
     },
     {
       path: "/sign-up",
@@ -50,16 +59,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
         changeFrequency: route.changeFrequency,
         priority: route.priority,
       });
-    });
-  });
-
-  // Add blog URLs with locales
-  locales.forEach((locale) => {
-    urls.push({
-      url: `${blogUrl}/${locale}`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.8,
     });
   });
 

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -272,5 +272,18 @@
         "definition": "Ein Befehlszeilenwerkzeug für Agentenentwicklung und -bereitstellung. Codex bietet Entwicklern Dienstprogramme zum Erstellen, Testen und Verwalten von Agenten über das Terminal. Es bietet Funktionen wie Code-Generierung, Scaffolding und Integration mit KI-Modellen, um den Agenten-Entwicklungsworkflow zu optimieren."
       }
     }
+  },
+  "blog": {
+    "title": "Blog",
+    "description": "Einblicke, Tutorials und Updates zur agentenzentrierten Entwicklung und der Zukunft der KI-Infrastruktur.",
+    "allPosts": "Alle Beiträge",
+    "readMore": "Mehr lesen",
+    "backToAllPosts": "Zurück zu allen Beiträgen",
+    "relatedArticles": "Verwandte Artikel",
+    "stayInLoop": "Bleiben Sie auf dem Laufenden",
+    "stayInLoopDesc": "// Erhalten Sie die neuesten Einblicke zur agentenzentrierten Entwicklung.",
+    "subscribe": "Abonnieren",
+    "joinDiscord": "Discord beitreten",
+    "shareArticle": "Artikel teilen"
   }
 }

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -272,5 +272,18 @@
         "definition": "A command-line tool for agent development and deployment. Codex provides developers with utilities for building, testing, and managing agents through the terminal. It offers features like code generation, scaffolding, and integration with AI models to streamline the agent development workflow."
       }
     }
+  },
+  "blog": {
+    "title": "Blog",
+    "description": "Insights, tutorials, and updates on agent-native development and the future of AI infrastructure.",
+    "allPosts": "All Posts",
+    "readMore": "Read more",
+    "backToAllPosts": "Back to all posts",
+    "relatedArticles": "Related Articles",
+    "stayInLoop": "Stay in the loop",
+    "stayInLoopDesc": "// Get the latest insights on agent-native development.",
+    "subscribe": "Subscribe",
+    "joinDiscord": "Join Discord",
+    "shareArticle": "Share this article"
   }
 }

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -272,5 +272,18 @@
         "definition": "Una herramienta de línea de comandos para el desarrollo y despliegue de agentes. Codex proporciona a los desarrolladores utilidades para construir, probar y gestionar agentes a través del terminal. Ofrece características como generación de código, scaffolding e integración con modelos de IA para optimizar el flujo de trabajo de desarrollo de agentes."
       }
     }
+  },
+  "blog": {
+    "title": "Blog",
+    "description": "Perspectivas, tutoriales y actualizaciones sobre desarrollo nativo de agentes y el futuro de la infraestructura de IA.",
+    "allPosts": "Todas las publicaciones",
+    "readMore": "Leer más",
+    "backToAllPosts": "Volver a todas las publicaciones",
+    "relatedArticles": "Artículos relacionados",
+    "stayInLoop": "Mantente al día",
+    "stayInLoopDesc": "// Obtén las últimas perspectivas sobre desarrollo nativo de agentes.",
+    "subscribe": "Suscribirse",
+    "joinDiscord": "Únete a Discord",
+    "shareArticle": "Compartir este artículo"
   }
 }

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -271,5 +271,18 @@
         "definition": "Agent開発および展開のためのコマンドラインツール。Codexは開発者にターミナルを通じてAgent構築、テスト、管理用のユーティリティを提供します。コード生成、Scaffolding、AIモデルとの統合などの機能を提供し、agent開発ワークフローを簡素化します。"
       }
     }
+  },
+  "blog": {
+    "title": "ブログ",
+    "description": "エージェントネイティブ開発とAIインフラの未来に関する洞察、チュートリアル、最新情報。",
+    "allPosts": "すべての記事",
+    "readMore": "続きを読む",
+    "backToAllPosts": "すべての記事に戻る",
+    "relatedArticles": "関連記事",
+    "stayInLoop": "最新情報をキャッチ",
+    "stayInLoopDesc": "// エージェントネイティブ開発の最新インサイトを入手。",
+    "subscribe": "購読する",
+    "joinDiscord": "Discordに参加",
+    "shareArticle": "この記事を共有"
   }
 }

--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -16,6 +16,16 @@ const nextConfig = {
     formats: ["image/avif", "image/webp"],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**.strapiapp.com",
+      },
+      {
+        protocol: "https",
+        hostname: "**.media.strapiapp.com",
+      },
+    ],
   },
   compiler: {
     removeConsole:

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -43,6 +43,9 @@
     "postgres": "^3.4.7",
     "react": "^19.1.2",
     "react-dom": "^19.1.2",
+    "react-markdown": "^10.1.0",
+    "rehype-highlight": "^7.0.2",
+    "remark-gfm": "^4.0.1",
     "server-only": "^0.0.1",
     "zod": "^4.1.12"
   },

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -60,7 +60,7 @@
       "entry": ["src/main.ts", "**/*.{test,spec}.ts?(x)"],
       "project": ["**/*.{ts,tsx}"],
       "ignore": ["custom-eslint/**"],
-      "ignoreDependencies": ["tailwindcss", "typescript-eslint"]
+      "ignoreDependencies": ["tailwindcss", "typescript-eslint", "@clerk/clerk-react"]
     },
     "apps/runner": {
       "entry": [

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -60,7 +60,11 @@
       "entry": ["src/main.ts", "**/*.{test,spec}.ts?(x)"],
       "project": ["**/*.{ts,tsx}"],
       "ignore": ["custom-eslint/**"],
-      "ignoreDependencies": ["tailwindcss", "typescript-eslint", "@clerk/clerk-react"]
+      "ignoreDependencies": [
+        "tailwindcss",
+        "typescript-eslint",
+        "@clerk/clerk-react"
+      ]
     },
     "apps/runner": {
       "entry": [

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -493,6 +493,15 @@ importers:
       react-dom:
         specifier: ^19.1.2
         version: 19.2.1(react@19.2.1)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.1.12)(react@19.2.1)
+      rehype-highlight:
+        specifier: ^7.0.2
+        version: 7.0.2
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       server-only:
         specifier: ^0.0.1
         version: 0.0.1


### PR DESCRIPTION
## Summary
- Replace external blog subdomain link with internal blog pages integrated directly into the main web app
- Add blog listing page at `/blog` and individual post detail pages at `/blog/posts/[slug]`
- Implement Strapi CMS integration for blog content management
- Add i18n support for blog translations (en, de, es, ja)
- Update sitemap to include new blog and glossary routes
- Add knip configuration hint for @clerk/clerk-react dependency

## Test plan
- [ ] Verify blog listing page loads at `/blog`
- [ ] Verify individual blog posts load at `/blog/posts/[slug]`
- [ ] Verify navbar links to internal blog instead of external subdomain
- [ ] Verify mobile menu blog link works correctly
- [ ] Verify translations work for all supported locales
- [ ] Verify sitemap includes new blog routes

Generated with [Claude Code](https://claude.ai/claude-code)