### PR TITLE
refactor(web): consolidate setup user into test context method

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -14,7 +14,6 @@ import {
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
-  setupUser,
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
@@ -36,7 +35,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
     context.setupMocks();
 
     // Create unique user for this test
-    user = await setupUser();
+    user = await context.setupUser();
 
     // Create test compose
     const { composeId } = await createTestCompose(`agent-${Date.now()}`);
@@ -540,7 +539,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
     it("should return 404 when session belongs to different user (security)", async () => {
       // Create another user with their own compose and run
-      const otherUser = await setupUser({ prefix: "other" });
+      const otherUser = await context.setupUser({ prefix: "other" });
       const { composeId: otherComposeId } = await createTestCompose(
         `other-agent-${Date.now()}`,
       );

--- a/turbo/apps/web/app/v1/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/v1/runs/__tests__/route.test.ts
@@ -13,7 +13,6 @@ import {
 } from "../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
-  setupUser,
   type UserContext,
 } from "../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../src/__tests__/clerk-mock";
@@ -59,7 +58,7 @@ describe("Public API v1 - Runs Endpoints", () => {
     context.setupMocks();
 
     // Create unique user for this test
-    user = await setupUser();
+    user = await context.setupUser();
 
     // Create test agent with compose
     testAgentName = `agent-${Date.now()}`;
@@ -162,7 +161,7 @@ describe("Public API v1 - Runs Endpoints", () => {
 
     it("should return 404 for run belonging to another user", async () => {
       // Create another user and their run
-      const otherUser = await setupUser({ prefix: "other-user" });
+      const otherUser = await context.setupUser({ prefix: "other-user" });
       const { composeId: otherComposeId } = await createTestCompose(
         `other-agent-${Date.now()}`,
       );

--- a/turbo/apps/web/app/v1/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/v1/runs/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import { randomUUID } from "crypto";
 import {
   createTestRequest,
   createTestCompose,
+  createTestV1Run,
   completeTestRun,
   createTestModelProvider,
 } from "../../../../src/__tests__/api-test-helpers";
@@ -24,28 +25,6 @@ vi.mock("@aws-sdk/s3-request-presigner");
 vi.mock("@axiomhq/js");
 
 const context = testContext();
-
-/**
- * Helper to create a run via v1 API and return the run ID.
- */
-async function createV1Run(
-  agentId: string,
-  prompt: string,
-): Promise<{ id: string; status: string }> {
-  const request = createTestRequest("http://localhost:3000/v1/runs", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ agentId, prompt }),
-  });
-  const response = await createRun(request);
-  const data = await response.json();
-  if (!response.ok) {
-    throw new Error(
-      `Failed to create run: ${data.error?.message || response.status}`,
-    );
-  }
-  return data;
-}
 
 describe("Public API v1 - Runs Endpoints", () => {
   let user: UserContext;
@@ -66,7 +45,7 @@ describe("Public API v1 - Runs Endpoints", () => {
     testAgentId = composeId;
 
     // Create a completed test run for read operations
-    const run = await createV1Run(testAgentId, "Test prompt for runs API");
+    const run = await createTestV1Run(testAgentId, "Test prompt for runs API");
     testRunId = run.id;
 
     // Complete the run so it doesn't block concurrent limit
@@ -168,7 +147,10 @@ describe("Public API v1 - Runs Endpoints", () => {
 
       // Create run as other user
       mockClerk({ userId: otherUser.userId });
-      const otherRun = await createV1Run(otherComposeId, "Other user prompt");
+      const otherRun = await createTestV1Run(
+        otherComposeId,
+        "Other user prompt",
+      );
       await completeTestRun(otherUser.userId, otherRun.id);
 
       // Switch back to original user and try to access other user's run
@@ -188,7 +170,7 @@ describe("Public API v1 - Runs Endpoints", () => {
   describe("POST /v1/runs/:id/cancel - Cancel Run", () => {
     it("should cancel a pending run", async () => {
       // Create a new run (starts as running)
-      const run = await createV1Run(testAgentId, "Run to cancel");
+      const run = await createTestV1Run(testAgentId, "Run to cancel");
 
       const request = createTestRequest(
         `http://localhost:3000/v1/runs/${run.id}/cancel`,
@@ -402,7 +384,7 @@ describe("Public API v1 - Runs Endpoints", () => {
 
       try {
         // First run should succeed (creates running run)
-        const run1 = await createV1Run(testAgentId, "First concurrent run");
+        const run1 = await createTestV1Run(testAgentId, "First concurrent run");
         expect(run1.status).toBe("running");
 
         // Second run should fail with 429
@@ -432,9 +414,9 @@ describe("Public API v1 - Runs Endpoints", () => {
 
       try {
         // Create multiple runs - all should succeed
-        const run1 = await createV1Run(testAgentId, "Run 1 with no limit");
-        const run2 = await createV1Run(testAgentId, "Run 2 with no limit");
-        const run3 = await createV1Run(testAgentId, "Run 3 with no limit");
+        const run1 = await createTestV1Run(testAgentId, "Run 1 with no limit");
+        const run2 = await createTestV1Run(testAgentId, "Run 2 with no limit");
+        const run3 = await createTestV1Run(testAgentId, "Run 3 with no limit");
 
         expect(run1.status).toBe("running");
         expect(run2.status).toBe("running");

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -15,6 +15,7 @@ import { eq } from "drizzle-orm";
 import { POST as createComposeRoute } from "../../app/api/agent/composes/route";
 import { POST as createScopeRoute } from "../../app/api/scope/route";
 import { POST as createRunRoute } from "../../app/api/agent/runs/route";
+import { POST as createV1RunRoute } from "../../app/v1/runs/route";
 import { GET as getRunRoute } from "../../app/v1/runs/[id]/route";
 import { PUT as upsertModelProviderRoute } from "../../app/api/model-providers/route";
 import { POST as checkpointWebhook } from "../../app/api/webhooks/agent/checkpoints/route";
@@ -256,6 +257,32 @@ export async function createTestRun(
   });
   const response = await createRunRoute(request);
   return response.json();
+}
+
+/**
+ * Create a test run via public v1 API route handler.
+ *
+ * @param agentId - The agent/compose ID to run
+ * @param prompt - The prompt for the run
+ * @returns The created run with id and status
+ */
+export async function createTestV1Run(
+  agentId: string,
+  prompt: string,
+): Promise<{ id: string; status: string }> {
+  const request = createTestRequest("http://localhost:3000/v1/runs", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ agentId, prompt }),
+  });
+  const response = await createV1RunRoute(request);
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(
+      `Failed to create v1 run: ${data.error?.message || response.status}`,
+    );
+  }
+  return data;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Moves the standalone `setupUser` function into the `testContext()` object as a method
- Updates test files to use `context.setupUser()` instead of the standalone import
- Improves test helper API consistency by keeping related functionality together

## Test plan
- [x] Verified lint passes
- [x] Verified type checking passes
- [x] Verified tests for modified files pass
- [x] Verified knip finds no unused exports

---
Generated with [Claude Code](https://claude.com/claude-code)