### PR TITLE
feat(web): add install.sh for curl-based cli installation

### DIFF
--- a/turbo/apps/web/public/install.sh
+++ b/turbo/apps/web/public/install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Check Node.js
+if ! command -v node &> /dev/null; then
+    echo "Error: Node.js is required. Install from https://nodejs.org"
+    exit 1
+fi
+
+# Install
+echo "Installing @vm0/cli..."
+npm install -g @vm0/cli
+
+echo "Done! Starting onboard..."
+exec vm0 onboard


### PR DESCRIPTION
## Summary
- Add `install.sh` to web public directory for one-line CLI installation
- Users can now install vm0 CLI via: `curl -fsSL https://vm0.ai/install.sh | bash`
- Script checks for Node.js, installs `@vm0/cli` globally, and runs `vm0 onboard`

## Test plan
- [ ] Verify script is accessible at https://vm0.ai/install.sh after deployment
- [ ] Test `curl -fsSL https://vm0.ai/install.sh | bash` on a clean machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)