### PR TITLE
ci: increase concurrent run limit from 0 to 1

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -159,7 +159,7 @@ jobs:
             CRON_SECRET=${{ secrets.CRON_SECRET }}
             OFFICIAL_RUNNER_SECRET=${{ secrets.OFFICIAL_RUNNER_SECRET }}
             ABLY_API_KEY=${{ secrets.ABLY_API_KEY }}
-            CONCURRENT_RUN_LIMIT=0
+            CONCURRENT_RUN_LIMIT=1
 
       - name: Notify Slack - Success
         if: ${{ success() && steps.slack-start.outputs.ts }}


### PR DESCRIPTION
## Summary
- Increases `CONCURRENT_RUN_LIMIT` from 0 to 1 in the release-please workflow
- This enables concurrent runs to be processed during deployment

## Test plan
- [ ] Verify the release-please workflow runs successfully with the new limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)