### PR TITLE
refactor(web): migrate compose tests to use test context pattern

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/__tests__/upsert.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/upsert.test.ts
@@ -1,103 +1,35 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeAll,
-  beforeEach,
-  afterEach,
-  afterAll,
-  vi,
-} from "vitest";
-import { NextRequest } from "next/server";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { POST } from "../route";
 import { GET } from "../[id]/route";
-import { initServices } from "../../../../../src/lib/init-services";
-import { agentComposes } from "../../../../../src/db/schema/agent-compose";
-import { scopes } from "../../../../../src/db/schema/scope";
-import { eq } from "drizzle-orm";
-import { randomUUID } from "crypto";
+import {
+  createTestRequest,
+  createTestCompose,
+} from "../../../../../src/__tests__/api-test-helpers";
+import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { SUPPORTED_FRAMEWORKS } from "@vm0/core";
 
-/**
- * Helper to create a NextRequest for testing.
- * Uses actual NextRequest constructor so ts-rest handler gets nextUrl property.
- */
-function createTestRequest(
-  url: string,
-  options?: {
-    method?: string;
-    body?: string;
-    headers?: Record<string, string>;
-  },
-): NextRequest {
-  return new NextRequest(url, {
-    method: options?.method ?? "GET",
-    headers: options?.headers ?? {},
-    body: options?.body,
-  });
-}
+// Mock external services only
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
 
-// Mock Clerk auth (external SaaS)
-vi.mock("@clerk/nextjs/server", () => ({
-  auth: vi.fn(),
-}));
-
-import {
-  mockClerk,
-  clearClerkMock,
-} from "../../../../../src/__tests__/clerk-mock";
+const context = testContext();
 
 describe("Agent Compose Upsert Behavior", () => {
-  const testUserId = "test-user-123";
-  const testScopeId = randomUUID();
-
-  beforeAll(async () => {
-    initServices();
-
-    // Clean up any existing test data
-    await globalThis.services.db
-      .delete(agentComposes)
-      .where(eq(agentComposes.userId, testUserId));
-
-    await globalThis.services.db
-      .delete(scopes)
-      .where(eq(scopes.id, testScopeId));
-
-    // Create test scope for the user (required for compose creation)
-    await globalThis.services.db.insert(scopes).values({
-      id: testScopeId,
-      slug: `test-${testScopeId.slice(0, 8)}`,
-      type: "personal",
-      ownerId: testUserId,
-    });
-  });
-
-  beforeEach(() => {
-    // Mock Clerk auth to return test user by default
-    mockClerk({ userId: testUserId });
-  });
-
-  afterEach(() => {
-    clearClerkMock();
-  });
-
-  afterAll(async () => {
-    // Cleanup: Delete test composes
-    await globalThis.services.db
-      .delete(agentComposes)
-      .where(eq(agentComposes.userId, testUserId));
-
-    await globalThis.services.db
-      .delete(scopes)
-      .where(eq(scopes.id, testScopeId));
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
   });
 
   describe("POST /api/agent/composes", () => {
     it("should create new compose when name does not exist", async () => {
+      const agentName = `test-agent-create-${Date.now()}`;
       const config = {
         version: "1.0",
         agents: {
-          "test-agent-create": {
+          [agentName]: {
             framework: "claude-code",
           },
         },
@@ -117,17 +49,18 @@ describe("Agent Compose Upsert Behavior", () => {
 
       expect(response.status).toBe(201);
       expect(data.action).toBe("created");
-      expect(data.name).toBe("test-agent-create");
+      expect(data.name).toBe(agentName);
       expect(data.composeId).toBeDefined();
       expect(data.versionId).toBeDefined();
       expect(data.updatedAt).toBeDefined();
     });
 
     it("should resolve image and working_dir server-side", async () => {
+      const agentName = `test-server-resolve-${Date.now()}`;
       const config = {
         version: "1.0",
         agents: {
-          "test-server-resolve": {
+          [agentName]: {
             framework: "claude-code",
           },
         },
@@ -157,21 +90,17 @@ describe("Agent Compose Upsert Behavior", () => {
       const composeData = await getResponse.json();
 
       // Verify server resolved image and working_dir
-      const agent = composeData.content.agents["test-server-resolve"];
+      const agent = composeData.content.agents[agentName];
       expect(agent.image).toMatch(/^vm0\/claude-code:/);
       expect(agent.working_dir).toBe("/home/user/workspace");
-
-      // Cleanup
-      await globalThis.services.db
-        .delete(agentComposes)
-        .where(eq(agentComposes.id, data.composeId));
     });
 
     it("should resolve github app-specific image", async () => {
+      const agentName = `test-github-app-${Date.now()}`;
       const config = {
         version: "1.0",
         agents: {
-          "test-github-app": {
+          [agentName]: {
             framework: "claude-code",
             apps: ["github"],
           },
@@ -202,20 +131,16 @@ describe("Agent Compose Upsert Behavior", () => {
       const composeData = await getResponse.json();
 
       // Verify server resolved github-specific image
-      const agent = composeData.content.agents["test-github-app"];
+      const agent = composeData.content.agents[agentName];
       expect(agent.image).toMatch(/^vm0\/claude-code-github:/);
-
-      // Cleanup
-      await globalThis.services.db
-        .delete(agentComposes)
-        .where(eq(agentComposes.id, data.composeId));
     });
 
     it("should ignore deprecated image and working_dir fields from input", async () => {
+      const agentName = `test-ignore-deprecated-${Date.now()}`;
       const config = {
         version: "1.0",
         agents: {
-          "test-ignore-deprecated": {
+          [agentName]: {
             framework: "claude-code",
             // These deprecated fields should be ignored
             image: "custom/image:v1",
@@ -248,23 +173,19 @@ describe("Agent Compose Upsert Behavior", () => {
       const composeData = await getResponse.json();
 
       // Verify server resolved values, not user-provided deprecated values
-      const agent = composeData.content.agents["test-ignore-deprecated"];
+      const agent = composeData.content.agents[agentName];
       expect(agent.image).toMatch(/^vm0\/claude-code:/);
       expect(agent.image).not.toBe("custom/image:v1");
       expect(agent.working_dir).toBe("/home/user/workspace");
       expect(agent.working_dir).not.toBe("/custom/path");
-
-      // Cleanup
-      await globalThis.services.db
-        .delete(agentComposes)
-        .where(eq(agentComposes.id, data.composeId));
     });
 
     it("should update existing compose when name matches", async () => {
+      const agentName = `test-agent-update-${Date.now()}`;
       const config = {
         version: "1.0",
         agents: {
-          "test-agent-update": {
+          [agentName]: {
             description: "Initial description",
             framework: "claude-code",
           },
@@ -291,8 +212,8 @@ describe("Agent Compose Upsert Behavior", () => {
       const updatedConfig = {
         ...config,
         agents: {
-          "test-agent-update": {
-            ...config.agents["test-agent-update"],
+          [agentName]: {
+            ...config.agents[agentName],
             description: "Updated description",
           },
         },
@@ -314,7 +235,7 @@ describe("Agent Compose Upsert Behavior", () => {
       expect(data2.action).toBe("created"); // New version created (different content hash)
       expect(data2.composeId).toBe(composeId); // Same compose ID
       expect(data2.versionId).not.toBe(data1.versionId); // Different version (different content)
-      expect(data2.name).toBe("test-agent-update");
+      expect(data2.name).toBe(agentName);
       expect(data2.updatedAt).toBeDefined();
 
       // Verify the compose was actually updated
@@ -326,44 +247,23 @@ describe("Agent Compose Upsert Behavior", () => {
       const getResponse = await GET(getRequest);
       const composeData = await getResponse.json();
 
-      expect(composeData.content.agents["test-agent-update"].description).toBe(
+      expect(composeData.content.agents[agentName].description).toBe(
         "Updated description",
       );
     });
 
     it("should maintain unique constraint on (userId, name)", async () => {
-      // Create scopes for user-1 and user-2
-      const scope1Id = randomUUID();
-      const scope2Id = randomUUID();
-
-      // Create scope for user-1
-      await globalThis.services.db.insert(scopes).values({
-        id: scope1Id,
-        slug: `test-${scope1Id.slice(0, 8)}`,
-        type: "personal",
-        ownerId: "user-1",
-      });
-
-      // Create scope for user-2
-      await globalThis.services.db.insert(scopes).values({
-        id: scope2Id,
-        slug: `test-${scope2Id.slice(0, 8)}`,
-        type: "personal",
-        ownerId: "user-2",
-      });
-
+      const agentName = `test-unique-constraint-${Date.now()}`;
       const config = {
         version: "1.0",
         agents: {
-          "test-unique-constraint": {
+          [agentName]: {
             framework: "claude-code",
           },
         },
       };
 
-      // Create compose for user 1
-      mockClerk({ userId: "user-1" });
-
+      // Create compose for user 1 (current user from context)
       const request1 = createTestRequest(
         "http://localhost:3000/api/agent/composes",
         {
@@ -377,9 +277,11 @@ describe("Agent Compose Upsert Behavior", () => {
       const data1 = await response1.json();
       expect(response1.status).toBe(201);
 
-      // Create compose with same name for user 2 (should succeed)
-      mockClerk({ userId: "user-2" });
+      // Create a second user
+      const user2 = await context.setupUser({ prefix: "user-2" });
+      void user2; // Mark as used - setupUser also mocks Clerk for this user
 
+      // Create compose with same name for user 2 (should succeed)
       const request2 = createTestRequest(
         "http://localhost:3000/api/agent/composes",
         {
@@ -395,20 +297,6 @@ describe("Agent Compose Upsert Behavior", () => {
 
       // Should be different compose IDs
       expect(data1.composeId).not.toBe(data2.composeId);
-
-      // Cleanup
-      await globalThis.services.db
-        .delete(agentComposes)
-        .where(eq(agentComposes.userId, "user-1"));
-      await globalThis.services.db
-        .delete(agentComposes)
-        .where(eq(agentComposes.userId, "user-2"));
-      await globalThis.services.db
-        .delete(scopes)
-        .where(eq(scopes.id, scope1Id));
-      await globalThis.services.db
-        .delete(scopes)
-        .where(eq(scopes.id, scope2Id));
     });
   });
 
@@ -472,10 +360,11 @@ describe("Agent Compose Upsert Behavior", () => {
     });
 
     it("should accept valid name with hyphens", async () => {
+      const agentName = `my-test-agent-123-${Date.now()}`;
       const config = {
         version: "1.0",
         agents: {
-          "my-test-agent-123": {
+          [agentName]: {
             framework: "claude-code",
           },
         },
@@ -493,21 +382,16 @@ describe("Agent Compose Upsert Behavior", () => {
       const response = await POST(request);
 
       expect(response.status).toBe(201);
-
-      // Cleanup
-      const data = await response.json();
-      await globalThis.services.db
-        .delete(agentComposes)
-        .where(eq(agentComposes.id, data.composeId));
     });
   });
 
   describe("framework validation", () => {
     it("should reject unsupported framework", async () => {
+      const agentName = `test-unsupported-framework-${Date.now()}`;
       const config = {
         version: "1.0",
         agents: {
-          "test-unsupported-framework": {
+          [agentName]: {
             framework: "unsupported-framework",
           },
         },
@@ -531,10 +415,11 @@ describe("Agent Compose Upsert Behavior", () => {
     });
 
     it("should accept claude-code framework", async () => {
+      const agentName = `test-claude-code-${Date.now()}`;
       const config = {
         version: "1.0",
         agents: {
-          "test-claude-code": {
+          [agentName]: {
             framework: "claude-code",
           },
         },
@@ -551,19 +436,14 @@ describe("Agent Compose Upsert Behavior", () => {
 
       const response = await POST(request);
       expect(response.status).toBe(201);
-
-      // Cleanup
-      const data = await response.json();
-      await globalThis.services.db
-        .delete(agentComposes)
-        .where(eq(agentComposes.id, data.composeId));
     });
 
     it("should accept codex framework", async () => {
+      const agentName = `test-codex-framework-${Date.now()}`;
       const config = {
         version: "1.0",
         agents: {
-          "test-codex-framework": {
+          [agentName]: {
             framework: "codex",
           },
         },
@@ -591,44 +471,20 @@ describe("Agent Compose Upsert Behavior", () => {
       const getResponse = await GET(getRequest);
       const composeData = await getResponse.json();
 
-      const agent = composeData.content.agents["test-codex-framework"];
+      const agent = composeData.content.agents[agentName];
       expect(agent.image).toMatch(/^vm0\/codex:/);
-
-      // Cleanup
-      await globalThis.services.db
-        .delete(agentComposes)
-        .where(eq(agentComposes.id, data.composeId));
     });
   });
 
   describe("GET /api/agent/composes/:id", () => {
     it("should return compose with name field", async () => {
-      const config = {
-        version: "1.0",
-        agents: {
-          "test-get-compose": {
-            description: "Test",
-            framework: "claude-code",
-          },
-        },
-      };
-
-      // Create compose
-      const createRequest = createTestRequest(
-        "http://localhost:3000/api/agent/composes",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ content: config }),
-        },
-      );
-
-      const createResponse = await POST(createRequest);
-      const createData = await createResponse.json();
+      // Use the helper to create a compose
+      const agentName = `test-get-compose-${Date.now()}`;
+      const { composeId } = await createTestCompose(agentName);
 
       // Get compose
       const getRequest = createTestRequest(
-        `http://localhost:3000/api/agent/composes/${createData.composeId}`,
+        `http://localhost:3000/api/agent/composes/${composeId}`,
         { method: "GET" },
       );
 
@@ -637,13 +493,8 @@ describe("Agent Compose Upsert Behavior", () => {
       expect(getResponse.status).toBe(200);
       const getData = await getResponse.json();
 
-      expect(getData.name).toBe("test-get-compose");
-      expect(getData.content.agents["test-get-compose"]).toBeDefined();
-
-      // Cleanup
-      await globalThis.services.db
-        .delete(agentComposes)
-        .where(eq(agentComposes.id, createData.composeId));
+      expect(getData.name).toBe(agentName);
+      expect(getData.content.agents[agentName]).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Migrates `get-by-name.test.ts` and `upsert.test.ts` compose API tests to use the `testContext()` pattern
- Eliminates manual database cleanup by leveraging the test context's automatic transaction rollback
- Uses `createTestCompose()` helper for consistent test data setup
- Reduces test boilerplate by ~60% (294 lines removed)

## Test plan
- [x] All 19 tests pass locally (`pnpm vitest run apps/web/app/api/agent/composes/__tests__`)
- [x] Lint, type-check, and knip pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)