### PR TITLE
refactor(web): migrate telemetry route tests to route-level patterns

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/__tests__/route.test.ts
@@ -1,11 +1,4 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeEach,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET } from "../route";
 import {
   createTestRequest,
@@ -18,23 +11,12 @@ import {
 } from "../../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
-import { queryAxiom } from "../../../../../../../../src/lib/axiom";
 
 vi.mock("@clerk/nextjs/server");
 vi.mock("@e2b/code-interpreter");
 vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
 vi.mock("@axiomhq/js");
-vi.mock("../../../../../../../../src/lib/axiom", async (importOriginal) => {
-  const original =
-    await importOriginal<
-      typeof import("../../../../../../../../src/lib/axiom")
-    >();
-  return {
-    ...original,
-    queryAxiom: vi.fn(),
-  };
-});
 
 const context = testContext();
 
@@ -70,14 +52,10 @@ function createAxiomMetricEvent(
 describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
   let user: UserContext;
   let testRunId: string;
-  let queryAxiomMock: MockInstance<typeof queryAxiom>;
 
   beforeEach(async () => {
     context.setupMocks();
     user = await context.setupUser();
-
-    // Setup mock on queryAxiom - returns empty array by default
-    queryAxiomMock = vi.mocked(queryAxiom).mockResolvedValue([]);
 
     // Create test compose and run
     const { composeId } = await createTestCompose(`metrics-${Date.now()}`);
@@ -146,7 +124,7 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
 
   describe("Success - Basic Retrieval", () => {
     it("should return empty metrics when Axiom returns empty", async () => {
-      queryAxiomMock.mockResolvedValue([]);
+      context.mocks.axiom.queryAxiom.mockResolvedValue([]);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/metrics`,
@@ -161,7 +139,7 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
     });
 
     it("should return empty metrics when Axiom is not configured", async () => {
-      queryAxiomMock.mockResolvedValue(null);
+      context.mocks.axiom.queryAxiom.mockResolvedValue(null);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/metrics`,
@@ -176,7 +154,7 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
     });
 
     it("should return metrics from Axiom", async () => {
-      queryAxiomMock.mockResolvedValue([
+      context.mocks.axiom.queryAxiom.mockResolvedValue([
         createAxiomMetricEvent(
           "2024-01-01T00:00:00Z",
           50,
@@ -200,7 +178,7 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
       expect(data.hasMore).toBe(false);
 
       // Verify Axiom was queried with correct APL
-      expect(queryAxiomMock).toHaveBeenCalledWith(
+      expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledWith(
         expect.stringContaining(`where runId == "${testRunId}"`),
       );
     });
@@ -208,7 +186,7 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
 
   describe("Retrieval from Axiom", () => {
     it("should return multiple metrics in order", async () => {
-      queryAxiomMock.mockResolvedValue([
+      context.mocks.axiom.queryAxiom.mockResolvedValue([
         createAxiomMetricEvent(
           "2024-01-01T00:00:00Z",
           10,
@@ -255,7 +233,7 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
   describe("Pagination", () => {
     it("should respect limit parameter and indicate hasMore", async () => {
       // Mock Axiom returning limit+1 records (indicating more data exists)
-      queryAxiomMock.mockResolvedValue([
+      context.mocks.axiom.queryAxiom.mockResolvedValue([
         createAxiomMetricEvent(
           "2024-01-01T00:00:00Z",
           10,
@@ -297,13 +275,13 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
       expect(data.hasMore).toBe(true);
 
       // Verify limit+1 was requested
-      expect(queryAxiomMock).toHaveBeenCalledWith(
+      expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledWith(
         expect.stringContaining("limit 4"),
       );
     });
 
     it("should include since filter in Axiom query", async () => {
-      queryAxiomMock.mockResolvedValue([
+      context.mocks.axiom.queryAxiom.mockResolvedValue([
         createAxiomMetricEvent(
           "2024-01-01T00:00:10Z",
           50,
@@ -325,7 +303,7 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
       expect(data.metrics[0].cpu).toBe(50);
 
       // Verify since filter was included in APL query
-      expect(queryAxiomMock).toHaveBeenCalledWith(
+      expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledWith(
         expect.stringContaining("where _time > datetime"),
       );
     });

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/__tests__/route.test.ts
@@ -3,61 +3,42 @@ import {
   it,
   expect,
   beforeEach,
-  afterEach,
-  afterAll,
   vi,
+  type MockInstance,
 } from "vitest";
 import { GET } from "../route";
-import { NextRequest } from "next/server";
-import { initServices } from "../../../../../../../../src/lib/init-services";
-import { agentRuns } from "../../../../../../../../src/db/schema/agent-run";
 import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../../../../../../../src/db/schema/agent-compose";
-import { scopes } from "../../../../../../../../src/db/schema/scope";
-import { eq } from "drizzle-orm";
+  createTestRequest,
+  createTestCompose,
+  createTestRun,
+} from "../../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
-
-// Mock Axiom module
-vi.mock("../../../../../../../../src/lib/axiom", () => ({
-  queryAxiom: vi.fn(),
-  ingestRequestLog: vi.fn(),
-  ingestSandboxOpLog: vi.fn(),
-  getDatasetName: vi.fn((base: string) => `vm0-${base}-dev`),
-  DATASETS: {
-    SANDBOX_TELEMETRY_METRICS: "sandbox-telemetry-metrics",
-    AGENT_RUN_EVENTS: "agent-run-events",
-    WEB_LOGS: "web-logs",
-    REQUEST_LOG: "request-log",
-    SANDBOX_OP_LOG: "sandbox-op-log",
-  },
-}));
-
 import { queryAxiom } from "../../../../../../../../src/lib/axiom";
-import {
-  mockClerk,
-  clearClerkMock,
-} from "../../../../../../../../src/__tests__/clerk-mock";
 
-const mockQueryAxiom = vi.mocked(queryAxiom);
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
+vi.mock("../../../../../../../../src/lib/axiom", async (importOriginal) => {
+  const original =
+    await importOriginal<
+      typeof import("../../../../../../../../src/lib/axiom")
+    >();
+  return {
+    ...original,
+    queryAxiom: vi.fn(),
+  };
+});
 
-/**
- * Helper to create a NextRequest for testing.
- */
-function createTestRequest(url: string): NextRequest {
-  return new NextRequest(url, { method: "GET" });
-}
+const context = testContext();
 
-/**
- * Create a test Axiom metric event
- */
-function createAxiomMetricEvent(
-  ts: string,
-  cpu: number,
-  runId: string,
-  userId: string,
-): {
+interface AxiomMetricEvent {
   _time: string;
   runId: string;
   userId: string;
@@ -66,7 +47,14 @@ function createAxiomMetricEvent(
   mem_total: number;
   disk_used: number;
   disk_total: number;
-} {
+}
+
+function createAxiomMetricEvent(
+  ts: string,
+  cpu: number,
+  runId: string,
+  userId: string,
+): AxiomMetricEvent {
   return {
     _time: ts,
     runId,
@@ -80,104 +68,22 @@ function createAxiomMetricEvent(
 }
 
 describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
-  const testUserId = `test-user-${Date.now()}-${process.pid}`;
-  const testScopeId = randomUUID();
-  const testRunId = randomUUID();
-  const testComposeId = randomUUID();
-  const testVersionId =
-    randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
+  let user: UserContext;
+  let testRunId: string;
+  let queryAxiomMock: MockInstance<typeof queryAxiom>;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
-    initServices();
+    context.setupMocks();
+    user = await context.setupUser();
 
-    mockClerk({ userId: testUserId });
+    // Setup mock on queryAxiom - returns empty array by default
+    queryAxiomMock = vi.mocked(queryAxiom).mockResolvedValue([]);
 
-    // Setup mockQueryAxiom - returns empty array by default
-    mockQueryAxiom.mockResolvedValue([]);
+    // Create test compose and run
+    const { composeId } = await createTestCompose(`metrics-${Date.now()}`);
 
-    // Clean up any existing test data
-    await globalThis.services.db
-      .delete(agentRuns)
-      .where(eq(agentRuns.id, testRunId));
-
-    await globalThis.services.db
-      .delete(agentComposeVersions)
-      .where(eq(agentComposeVersions.id, testVersionId));
-
-    await globalThis.services.db
-      .delete(agentComposes)
-      .where(eq(agentComposes.id, testComposeId));
-
-    await globalThis.services.db
-      .delete(scopes)
-      .where(eq(scopes.id, testScopeId));
-
-    // Create test scope
-    await globalThis.services.db.insert(scopes).values({
-      id: testScopeId,
-      slug: `test-${testScopeId.slice(0, 8)}`,
-      type: "personal",
-      ownerId: testUserId,
-    });
-
-    // Create test agent compose
-    await globalThis.services.db.insert(agentComposes).values({
-      id: testComposeId,
-      userId: testUserId,
-      scopeId: testScopeId,
-      name: "test-agent",
-      headVersionId: testVersionId,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
-
-    // Create test agent version
-    await globalThis.services.db.insert(agentComposeVersions).values({
-      id: testVersionId,
-      composeId: testComposeId,
-      content: {
-        agents: {
-          "test-agent": {
-            name: "test-agent",
-            model: "claude-3-5-sonnet-20241022",
-            working_dir: "/workspace",
-          },
-        },
-      },
-      createdBy: testUserId,
-      createdAt: new Date(),
-    });
-
-    // Create test agent run
-    await globalThis.services.db.insert(agentRuns).values({
-      id: testRunId,
-      userId: testUserId,
-      agentComposeVersionId: testVersionId,
-      status: "running",
-      prompt: "Test prompt",
-      createdAt: new Date(),
-    });
-  });
-
-  afterEach(async () => {
-    clearClerkMock();
-
-    await globalThis.services.db
-      .delete(agentRuns)
-      .where(eq(agentRuns.id, testRunId));
-
-    await globalThis.services.db
-      .delete(agentComposeVersions)
-      .where(eq(agentComposeVersions.id, testVersionId));
-
-    await globalThis.services.db
-      .delete(agentComposes)
-      .where(eq(agentComposes.id, testComposeId));
-  });
-
-  afterAll(async () => {
-    // Clean up database connections
+    const { runId } = await createTestRun(composeId, "Test prompt");
+    testRunId = runId;
   });
 
   describe("Authentication", () => {
@@ -213,54 +119,18 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
     });
 
     it("should reject request for run owned by different user", async () => {
-      const otherUserId = `other-user-${Date.now()}-${process.pid}`;
-      const otherScopeId = randomUUID();
-      const otherRunId = randomUUID();
-      const otherComposeId = randomUUID();
-      const otherVersionId =
-        randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
+      // Create another user with their own compose and run
+      await context.setupUser({ prefix: "other" });
+      const { composeId: otherComposeId } = await createTestCompose(
+        `other-metrics-${Date.now()}`,
+      );
+      const { runId: otherRunId } = await createTestRun(
+        otherComposeId,
+        "Other user run",
+      );
 
-      await globalThis.services.db.insert(scopes).values({
-        id: otherScopeId,
-        slug: `test-${otherScopeId.slice(0, 8)}`,
-        type: "personal",
-        ownerId: otherUserId,
-      });
-
-      await globalThis.services.db.insert(agentComposes).values({
-        id: otherComposeId,
-        userId: otherUserId,
-        scopeId: otherScopeId,
-        name: "other-agent",
-        headVersionId: otherVersionId,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
-
-      await globalThis.services.db.insert(agentComposeVersions).values({
-        id: otherVersionId,
-        composeId: otherComposeId,
-        content: {
-          agents: {
-            "other-agent": {
-              name: "other-agent",
-              model: "claude-3-5-sonnet-20241022",
-              working_dir: "/workspace",
-            },
-          },
-        },
-        createdBy: otherUserId,
-        createdAt: new Date(),
-      });
-
-      await globalThis.services.db.insert(agentRuns).values({
-        id: otherRunId,
-        userId: otherUserId,
-        agentComposeVersionId: otherVersionId,
-        status: "running",
-        prompt: "Test prompt",
-        createdAt: new Date(),
-      });
+      // Switch back to original user
+      mockClerk({ userId: user.userId });
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${otherRunId}/telemetry/metrics`,
@@ -271,26 +141,12 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
       expect(response.status).toBe(404);
       const data = await response.json();
       expect(data.error.message).toContain("Agent run");
-
-      // Clean up
-      await globalThis.services.db
-        .delete(agentRuns)
-        .where(eq(agentRuns.id, otherRunId));
-      await globalThis.services.db
-        .delete(agentComposeVersions)
-        .where(eq(agentComposeVersions.id, otherVersionId));
-      await globalThis.services.db
-        .delete(agentComposes)
-        .where(eq(agentComposes.id, otherComposeId));
-      await globalThis.services.db
-        .delete(scopes)
-        .where(eq(scopes.id, otherScopeId));
     });
   });
 
   describe("Success - Basic Retrieval", () => {
     it("should return empty metrics when Axiom returns empty", async () => {
-      mockQueryAxiom.mockResolvedValue([]);
+      queryAxiomMock.mockResolvedValue([]);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/metrics`,
@@ -305,7 +161,7 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
     });
 
     it("should return empty metrics when Axiom is not configured", async () => {
-      mockQueryAxiom.mockResolvedValue(null);
+      queryAxiomMock.mockResolvedValue(null);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/metrics`,
@@ -320,12 +176,12 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
     });
 
     it("should return metrics from Axiom", async () => {
-      mockQueryAxiom.mockResolvedValue([
+      queryAxiomMock.mockResolvedValue([
         createAxiomMetricEvent(
           "2024-01-01T00:00:00Z",
           50,
           testRunId,
-          testUserId,
+          user.userId,
         ),
       ]);
 
@@ -344,7 +200,7 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
       expect(data.hasMore).toBe(false);
 
       // Verify Axiom was queried with correct APL
-      expect(mockQueryAxiom).toHaveBeenCalledWith(
+      expect(queryAxiomMock).toHaveBeenCalledWith(
         expect.stringContaining(`where runId == "${testRunId}"`),
       );
     });
@@ -352,30 +208,30 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
 
   describe("Retrieval from Axiom", () => {
     it("should return multiple metrics in order", async () => {
-      mockQueryAxiom.mockResolvedValue([
+      queryAxiomMock.mockResolvedValue([
         createAxiomMetricEvent(
           "2024-01-01T00:00:00Z",
           10,
           testRunId,
-          testUserId,
+          user.userId,
         ),
         createAxiomMetricEvent(
           "2024-01-01T00:00:05Z",
           15,
           testRunId,
-          testUserId,
+          user.userId,
         ),
         createAxiomMetricEvent(
           "2024-01-01T00:00:10Z",
           20,
           testRunId,
-          testUserId,
+          user.userId,
         ),
         createAxiomMetricEvent(
           "2024-01-01T00:00:15Z",
           25,
           testRunId,
-          testUserId,
+          user.userId,
         ),
       ]);
 
@@ -399,30 +255,30 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
   describe("Pagination", () => {
     it("should respect limit parameter and indicate hasMore", async () => {
       // Mock Axiom returning limit+1 records (indicating more data exists)
-      mockQueryAxiom.mockResolvedValue([
+      queryAxiomMock.mockResolvedValue([
         createAxiomMetricEvent(
           "2024-01-01T00:00:00Z",
           10,
           testRunId,
-          testUserId,
+          user.userId,
         ),
         createAxiomMetricEvent(
           "2024-01-01T00:00:05Z",
           20,
           testRunId,
-          testUserId,
+          user.userId,
         ),
         createAxiomMetricEvent(
           "2024-01-01T00:00:10Z",
           30,
           testRunId,
-          testUserId,
+          user.userId,
         ),
         createAxiomMetricEvent(
           "2024-01-01T00:00:15Z",
           40,
           testRunId,
-          testUserId,
+          user.userId,
         ), // Extra record
       ]);
 
@@ -441,18 +297,18 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
       expect(data.hasMore).toBe(true);
 
       // Verify limit+1 was requested
-      expect(mockQueryAxiom).toHaveBeenCalledWith(
+      expect(queryAxiomMock).toHaveBeenCalledWith(
         expect.stringContaining("limit 4"),
       );
     });
 
     it("should include since filter in Axiom query", async () => {
-      mockQueryAxiom.mockResolvedValue([
+      queryAxiomMock.mockResolvedValue([
         createAxiomMetricEvent(
           "2024-01-01T00:00:10Z",
           50,
           testRunId,
-          testUserId,
+          user.userId,
         ),
       ]);
 
@@ -469,7 +325,7 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
       expect(data.metrics[0].cpu).toBe(50);
 
       // Verify since filter was included in APL query
-      expect(mockQueryAxiom).toHaveBeenCalledWith(
+      expect(queryAxiomMock).toHaveBeenCalledWith(
         expect.stringContaining("where _time > datetime"),
       );
     });

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts
@@ -1,11 +1,4 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeEach,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET } from "../route";
 import {
   createTestRequest,
@@ -18,23 +11,12 @@ import {
 } from "../../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
-import { queryAxiom } from "../../../../../../../../src/lib/axiom";
 
 vi.mock("@clerk/nextjs/server");
 vi.mock("@e2b/code-interpreter");
 vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
 vi.mock("@axiomhq/js");
-vi.mock("../../../../../../../../src/lib/axiom", async (importOriginal) => {
-  const original =
-    await importOriginal<
-      typeof import("../../../../../../../../src/lib/axiom")
-    >();
-  return {
-    ...original,
-    queryAxiom: vi.fn(),
-  };
-});
 
 const context = testContext();
 
@@ -74,14 +56,10 @@ function createAxiomNetworkEvent(
 describe("GET /api/agent/runs/:id/telemetry/network", () => {
   let user: UserContext;
   let testRunId: string;
-  let queryAxiomMock: MockInstance<typeof queryAxiom>;
 
   beforeEach(async () => {
     context.setupMocks();
     user = await context.setupUser();
-
-    // Setup mock on queryAxiom - returns empty array by default
-    queryAxiomMock = vi.mocked(queryAxiom).mockResolvedValue([]);
 
     // Create test compose and run
     const { composeId } = await createTestCompose(`network-${Date.now()}`);
@@ -150,7 +128,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
 
   describe("Success - Basic Retrieval", () => {
     it("should return empty network logs when Axiom returns empty", async () => {
-      queryAxiomMock.mockResolvedValue([]);
+      context.mocks.axiom.queryAxiom.mockResolvedValue([]);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/network`,
@@ -165,7 +143,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
     });
 
     it("should return empty network logs when Axiom is not configured", async () => {
-      queryAxiomMock.mockResolvedValue(null);
+      context.mocks.axiom.queryAxiom.mockResolvedValue(null);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/network`,
@@ -180,7 +158,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
     });
 
     it("should return network logs from Axiom", async () => {
-      queryAxiomMock.mockResolvedValue([
+      context.mocks.axiom.queryAxiom.mockResolvedValue([
         createAxiomNetworkEvent(
           "2024-01-01T00:00:00Z",
           "GET",
@@ -207,7 +185,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
       expect(data.hasMore).toBe(false);
 
       // Verify Axiom was queried with correct APL
-      expect(queryAxiomMock).toHaveBeenCalledWith(
+      expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledWith(
         expect.stringContaining(`where runId == "${testRunId}"`),
       );
     });
@@ -215,7 +193,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
 
   describe("Retrieval from Axiom", () => {
     it("should return multiple network logs in order", async () => {
-      queryAxiomMock.mockResolvedValue([
+      context.mocks.axiom.queryAxiom.mockResolvedValue([
         createAxiomNetworkEvent(
           "2024-01-01T00:00:00Z",
           "GET",
@@ -271,7 +249,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
   describe("Pagination", () => {
     it("should respect limit parameter and indicate hasMore", async () => {
       // Mock Axiom returning limit+1 records (indicating more data exists)
-      queryAxiomMock.mockResolvedValue([
+      context.mocks.axiom.queryAxiom.mockResolvedValue([
         createAxiomNetworkEvent(
           "2024-01-01T00:00:00Z",
           "GET",
@@ -321,13 +299,13 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
       expect(data.hasMore).toBe(true);
 
       // Verify limit+1 was requested
-      expect(queryAxiomMock).toHaveBeenCalledWith(
+      expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledWith(
         expect.stringContaining("limit 4"),
       );
     });
 
     it("should include since filter in Axiom query", async () => {
-      queryAxiomMock.mockResolvedValue([
+      context.mocks.axiom.queryAxiom.mockResolvedValue([
         createAxiomNetworkEvent(
           "2024-01-01T00:00:10Z",
           "GET",
@@ -351,7 +329,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
       expect(data.networkLogs[0].url).toBe("https://api.example.com/recent");
 
       // Verify since filter was included in APL query
-      expect(queryAxiomMock).toHaveBeenCalledWith(
+      expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledWith(
         expect.stringContaining("where _time > datetime"),
       );
     });

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts
@@ -3,63 +3,42 @@ import {
   it,
   expect,
   beforeEach,
-  afterEach,
-  afterAll,
   vi,
+  type MockInstance,
 } from "vitest";
 import { GET } from "../route";
-import { NextRequest } from "next/server";
-import { initServices } from "../../../../../../../../src/lib/init-services";
-import { agentRuns } from "../../../../../../../../src/db/schema/agent-run";
 import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../../../../../../../src/db/schema/agent-compose";
-import { scopes } from "../../../../../../../../src/db/schema/scope";
-import { eq } from "drizzle-orm";
+  createTestRequest,
+  createTestCompose,
+  createTestRun,
+} from "../../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
-
-// Mock Axiom module
-vi.mock("../../../../../../../../src/lib/axiom", () => ({
-  queryAxiom: vi.fn(),
-  ingestRequestLog: vi.fn(),
-  ingestSandboxOpLog: vi.fn(),
-  getDatasetName: vi.fn((base: string) => `vm0-${base}-dev`),
-  DATASETS: {
-    SANDBOX_TELEMETRY_NETWORK: "sandbox-telemetry-network",
-    AGENT_RUN_EVENTS: "agent-run-events",
-    WEB_LOGS: "web-logs",
-    REQUEST_LOG: "request-log",
-    SANDBOX_OP_LOG: "sandbox-op-log",
-  },
-}));
-
 import { queryAxiom } from "../../../../../../../../src/lib/axiom";
-import {
-  mockClerk,
-  clearClerkMock,
-} from "../../../../../../../../src/__tests__/clerk-mock";
 
-const mockQueryAxiom = vi.mocked(queryAxiom);
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
+vi.mock("../../../../../../../../src/lib/axiom", async (importOriginal) => {
+  const original =
+    await importOriginal<
+      typeof import("../../../../../../../../src/lib/axiom")
+    >();
+  return {
+    ...original,
+    queryAxiom: vi.fn(),
+  };
+});
 
-/**
- * Helper to create a NextRequest for testing.
- */
-function createTestRequest(url: string): NextRequest {
-  return new NextRequest(url, { method: "GET" });
-}
+const context = testContext();
 
-/**
- * Create a test Axiom network event
- */
-function createAxiomNetworkEvent(
-  timestamp: string,
-  method: string,
-  url: string,
-  status: number,
-  runId: string,
-  userId: string,
-): {
+interface AxiomNetworkEvent {
   _time: string;
   runId: string;
   userId: string;
@@ -69,7 +48,16 @@ function createAxiomNetworkEvent(
   latency_ms: number;
   request_size: number;
   response_size: number;
-} {
+}
+
+function createAxiomNetworkEvent(
+  timestamp: string,
+  method: string,
+  url: string,
+  status: number,
+  runId: string,
+  userId: string,
+): AxiomNetworkEvent {
   return {
     _time: timestamp,
     runId,
@@ -84,104 +72,22 @@ function createAxiomNetworkEvent(
 }
 
 describe("GET /api/agent/runs/:id/telemetry/network", () => {
-  const testUserId = `test-user-${Date.now()}-${process.pid}`;
-  const testScopeId = randomUUID();
-  const testRunId = randomUUID();
-  const testComposeId = randomUUID();
-  const testVersionId =
-    randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
+  let user: UserContext;
+  let testRunId: string;
+  let queryAxiomMock: MockInstance<typeof queryAxiom>;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
-    initServices();
+    context.setupMocks();
+    user = await context.setupUser();
 
-    mockClerk({ userId: testUserId });
+    // Setup mock on queryAxiom - returns empty array by default
+    queryAxiomMock = vi.mocked(queryAxiom).mockResolvedValue([]);
 
-    // Setup mockQueryAxiom - returns empty array by default
-    mockQueryAxiom.mockResolvedValue([]);
+    // Create test compose and run
+    const { composeId } = await createTestCompose(`network-${Date.now()}`);
 
-    // Clean up any existing test data
-    await globalThis.services.db
-      .delete(agentRuns)
-      .where(eq(agentRuns.id, testRunId));
-
-    await globalThis.services.db
-      .delete(agentComposeVersions)
-      .where(eq(agentComposeVersions.id, testVersionId));
-
-    await globalThis.services.db
-      .delete(agentComposes)
-      .where(eq(agentComposes.id, testComposeId));
-
-    await globalThis.services.db
-      .delete(scopes)
-      .where(eq(scopes.id, testScopeId));
-
-    // Create test scope
-    await globalThis.services.db.insert(scopes).values({
-      id: testScopeId,
-      slug: `test-${testScopeId.slice(0, 8)}`,
-      type: "personal",
-      ownerId: testUserId,
-    });
-
-    // Create test agent compose
-    await globalThis.services.db.insert(agentComposes).values({
-      id: testComposeId,
-      userId: testUserId,
-      scopeId: testScopeId,
-      name: "test-agent",
-      headVersionId: testVersionId,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
-
-    // Create test agent version
-    await globalThis.services.db.insert(agentComposeVersions).values({
-      id: testVersionId,
-      composeId: testComposeId,
-      content: {
-        agents: {
-          "test-agent": {
-            name: "test-agent",
-            model: "claude-3-5-sonnet-20241022",
-            working_dir: "/workspace",
-          },
-        },
-      },
-      createdBy: testUserId,
-      createdAt: new Date(),
-    });
-
-    // Create test agent run
-    await globalThis.services.db.insert(agentRuns).values({
-      id: testRunId,
-      userId: testUserId,
-      agentComposeVersionId: testVersionId,
-      status: "running",
-      prompt: "Test prompt",
-      createdAt: new Date(),
-    });
-  });
-
-  afterEach(async () => {
-    clearClerkMock();
-
-    await globalThis.services.db
-      .delete(agentRuns)
-      .where(eq(agentRuns.id, testRunId));
-
-    await globalThis.services.db
-      .delete(agentComposeVersions)
-      .where(eq(agentComposeVersions.id, testVersionId));
-
-    await globalThis.services.db
-      .delete(agentComposes)
-      .where(eq(agentComposes.id, testComposeId));
-  });
-
-  afterAll(async () => {
-    // Clean up database connections
+    const { runId } = await createTestRun(composeId, "Test prompt");
+    testRunId = runId;
   });
 
   describe("Authentication", () => {
@@ -217,54 +123,18 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
     });
 
     it("should reject request for run owned by different user", async () => {
-      const otherUserId = `other-user-${Date.now()}-${process.pid}`;
-      const otherScopeId = randomUUID();
-      const otherRunId = randomUUID();
-      const otherComposeId = randomUUID();
-      const otherVersionId =
-        randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
+      // Create another user with their own compose and run
+      await context.setupUser({ prefix: "other" });
+      const { composeId: otherComposeId } = await createTestCompose(
+        `other-network-${Date.now()}`,
+      );
+      const { runId: otherRunId } = await createTestRun(
+        otherComposeId,
+        "Other user run",
+      );
 
-      await globalThis.services.db.insert(scopes).values({
-        id: otherScopeId,
-        slug: `test-${otherScopeId.slice(0, 8)}`,
-        type: "personal",
-        ownerId: otherUserId,
-      });
-
-      await globalThis.services.db.insert(agentComposes).values({
-        id: otherComposeId,
-        userId: otherUserId,
-        scopeId: otherScopeId,
-        name: "other-agent",
-        headVersionId: otherVersionId,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
-
-      await globalThis.services.db.insert(agentComposeVersions).values({
-        id: otherVersionId,
-        composeId: otherComposeId,
-        content: {
-          agents: {
-            "other-agent": {
-              name: "other-agent",
-              model: "claude-3-5-sonnet-20241022",
-              working_dir: "/workspace",
-            },
-          },
-        },
-        createdBy: otherUserId,
-        createdAt: new Date(),
-      });
-
-      await globalThis.services.db.insert(agentRuns).values({
-        id: otherRunId,
-        userId: otherUserId,
-        agentComposeVersionId: otherVersionId,
-        status: "running",
-        prompt: "Test prompt",
-        createdAt: new Date(),
-      });
+      // Switch back to original user
+      mockClerk({ userId: user.userId });
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${otherRunId}/telemetry/network`,
@@ -275,26 +145,12 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
       expect(response.status).toBe(404);
       const data = await response.json();
       expect(data.error.message).toContain("Agent run");
-
-      // Clean up
-      await globalThis.services.db
-        .delete(agentRuns)
-        .where(eq(agentRuns.id, otherRunId));
-      await globalThis.services.db
-        .delete(agentComposeVersions)
-        .where(eq(agentComposeVersions.id, otherVersionId));
-      await globalThis.services.db
-        .delete(agentComposes)
-        .where(eq(agentComposes.id, otherComposeId));
-      await globalThis.services.db
-        .delete(scopes)
-        .where(eq(scopes.id, otherScopeId));
     });
   });
 
   describe("Success - Basic Retrieval", () => {
     it("should return empty network logs when Axiom returns empty", async () => {
-      mockQueryAxiom.mockResolvedValue([]);
+      queryAxiomMock.mockResolvedValue([]);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/network`,
@@ -309,7 +165,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
     });
 
     it("should return empty network logs when Axiom is not configured", async () => {
-      mockQueryAxiom.mockResolvedValue(null);
+      queryAxiomMock.mockResolvedValue(null);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/network`,
@@ -324,14 +180,14 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
     });
 
     it("should return network logs from Axiom", async () => {
-      mockQueryAxiom.mockResolvedValue([
+      queryAxiomMock.mockResolvedValue([
         createAxiomNetworkEvent(
           "2024-01-01T00:00:00Z",
           "GET",
           "https://api.example.com/data",
           200,
           testRunId,
-          testUserId,
+          user.userId,
         ),
       ]);
 
@@ -351,7 +207,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
       expect(data.hasMore).toBe(false);
 
       // Verify Axiom was queried with correct APL
-      expect(mockQueryAxiom).toHaveBeenCalledWith(
+      expect(queryAxiomMock).toHaveBeenCalledWith(
         expect.stringContaining(`where runId == "${testRunId}"`),
       );
     });
@@ -359,14 +215,14 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
 
   describe("Retrieval from Axiom", () => {
     it("should return multiple network logs in order", async () => {
-      mockQueryAxiom.mockResolvedValue([
+      queryAxiomMock.mockResolvedValue([
         createAxiomNetworkEvent(
           "2024-01-01T00:00:00Z",
           "GET",
           "https://api.example.com/users",
           200,
           testRunId,
-          testUserId,
+          user.userId,
         ),
         createAxiomNetworkEvent(
           "2024-01-01T00:00:05Z",
@@ -374,7 +230,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
           "https://api.example.com/data",
           201,
           testRunId,
-          testUserId,
+          user.userId,
         ),
         createAxiomNetworkEvent(
           "2024-01-01T00:00:10Z",
@@ -382,7 +238,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
           "https://api.example.com/users/1",
           200,
           testRunId,
-          testUserId,
+          user.userId,
         ),
         createAxiomNetworkEvent(
           "2024-01-01T00:00:15Z",
@@ -390,7 +246,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
           "https://api.example.com/users/2",
           404,
           testRunId,
-          testUserId,
+          user.userId,
         ),
       ]);
 
@@ -415,14 +271,14 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
   describe("Pagination", () => {
     it("should respect limit parameter and indicate hasMore", async () => {
       // Mock Axiom returning limit+1 records (indicating more data exists)
-      mockQueryAxiom.mockResolvedValue([
+      queryAxiomMock.mockResolvedValue([
         createAxiomNetworkEvent(
           "2024-01-01T00:00:00Z",
           "GET",
           "https://api.example.com/1",
           200,
           testRunId,
-          testUserId,
+          user.userId,
         ),
         createAxiomNetworkEvent(
           "2024-01-01T00:00:05Z",
@@ -430,7 +286,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
           "https://api.example.com/2",
           200,
           testRunId,
-          testUserId,
+          user.userId,
         ),
         createAxiomNetworkEvent(
           "2024-01-01T00:00:10Z",
@@ -438,7 +294,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
           "https://api.example.com/3",
           200,
           testRunId,
-          testUserId,
+          user.userId,
         ),
         createAxiomNetworkEvent(
           "2024-01-01T00:00:15Z",
@@ -446,7 +302,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
           "https://api.example.com/4",
           200,
           testRunId,
-          testUserId,
+          user.userId,
         ), // Extra record
       ]);
 
@@ -465,20 +321,20 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
       expect(data.hasMore).toBe(true);
 
       // Verify limit+1 was requested
-      expect(mockQueryAxiom).toHaveBeenCalledWith(
+      expect(queryAxiomMock).toHaveBeenCalledWith(
         expect.stringContaining("limit 4"),
       );
     });
 
     it("should include since filter in Axiom query", async () => {
-      mockQueryAxiom.mockResolvedValue([
+      queryAxiomMock.mockResolvedValue([
         createAxiomNetworkEvent(
           "2024-01-01T00:00:10Z",
           "GET",
           "https://api.example.com/recent",
           200,
           testRunId,
-          testUserId,
+          user.userId,
         ),
       ]);
 
@@ -495,7 +351,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
       expect(data.networkLogs[0].url).toBe("https://api.example.com/recent");
 
       // Verify since filter was included in APL query
-      expect(mockQueryAxiom).toHaveBeenCalledWith(
+      expect(queryAxiomMock).toHaveBeenCalledWith(
         expect.stringContaining("where _time > datetime"),
       );
     });

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/__tests__/route.test.ts
@@ -1,11 +1,4 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeEach,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET } from "../route";
 import {
   createTestRequest,
@@ -18,37 +11,22 @@ import {
 } from "../../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
-import { queryAxiom } from "../../../../../../../../src/lib/axiom";
 
 vi.mock("@clerk/nextjs/server");
 vi.mock("@e2b/code-interpreter");
 vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
 vi.mock("@axiomhq/js");
-vi.mock("../../../../../../../../src/lib/axiom", async (importOriginal) => {
-  const original =
-    await importOriginal<
-      typeof import("../../../../../../../../src/lib/axiom")
-    >();
-  return {
-    ...original,
-    queryAxiom: vi.fn(),
-  };
-});
 
 const context = testContext();
 
 describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
   let user: UserContext;
   let testRunId: string;
-  let queryAxiomMock: MockInstance<typeof queryAxiom>;
 
   beforeEach(async () => {
     context.setupMocks();
     user = await context.setupUser();
-
-    // Setup mock on queryAxiom - returns empty array by default
-    queryAxiomMock = vi.mocked(queryAxiom).mockResolvedValue([]);
 
     // Create test compose and run
     const { composeId } = await createTestCompose(`system-log-${Date.now()}`);
@@ -117,7 +95,7 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
 
   describe("Success - Basic Retrieval", () => {
     it("should return empty system log when no telemetry exists", async () => {
-      // Default queryAxiomMock returns empty array
+      // Default context.mocks.axiom.queryAxiom returns empty array
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/system-log`,
       );
@@ -131,7 +109,7 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
     });
 
     it("should return system log from Axiom", async () => {
-      queryAxiomMock.mockResolvedValue([
+      context.mocks.axiom.queryAxiom.mockResolvedValue([
         {
           _time: new Date().toISOString(),
           runId: testRunId,
@@ -154,7 +132,7 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
 
   describe("Aggregation", () => {
     it("should aggregate system logs from multiple records", async () => {
-      queryAxiomMock.mockResolvedValue([
+      context.mocks.axiom.queryAxiom.mockResolvedValue([
         {
           _time: new Date(Date.now() - 2000).toISOString(),
           runId: testRunId,
@@ -187,7 +165,7 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
     });
 
     it("should handle Axiom returning null (not configured)", async () => {
-      queryAxiomMock.mockResolvedValue(null);
+      context.mocks.axiom.queryAxiom.mockResolvedValue(null);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/system-log?limit=10`,
@@ -205,7 +183,7 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
   describe("Pagination", () => {
     it("should respect limit parameter", async () => {
       // Mock Axiom returning 3 records (more than limit of 2)
-      queryAxiomMock.mockResolvedValue([
+      context.mocks.axiom.queryAxiom.mockResolvedValue([
         {
           _time: new Date(Date.now() - 3000).toISOString(),
           runId: testRunId,
@@ -239,7 +217,7 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
 
     it("should pass since parameter to Axiom query", async () => {
       // Mock Axiom returning only recent entry (since filter applied by Axiom)
-      queryAxiomMock.mockResolvedValue([
+      context.mocks.axiom.queryAxiom.mockResolvedValue([
         {
           _time: new Date(Date.now() - 1000).toISOString(),
           runId: testRunId,
@@ -259,7 +237,7 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
       expect(data.systemLog).toBe("[INFO] Recent entry\n");
 
       // Verify queryAxiom was called with a query containing the since filter
-      expect(queryAxiomMock).toHaveBeenCalledWith(
+      expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledWith(
         expect.stringContaining("where _time >"),
       );
     });

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/__tests__/route.test.ts
@@ -3,151 +3,58 @@ import {
   it,
   expect,
   beforeEach,
-  afterEach,
-  afterAll,
   vi,
+  type MockInstance,
 } from "vitest";
 import { GET } from "../route";
-import { NextRequest } from "next/server";
-import { initServices } from "../../../../../../../../src/lib/init-services";
-import { agentRuns } from "../../../../../../../../src/db/schema/agent-run";
 import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../../../../../../../src/db/schema/agent-compose";
-import { scopes } from "../../../../../../../../src/db/schema/scope";
-import { eq } from "drizzle-orm";
+  createTestRequest,
+  createTestCompose,
+  createTestRun,
+} from "../../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
-
-// Mock Axiom module
-vi.mock("../../../../../../../../src/lib/axiom", () => ({
-  queryAxiom: vi.fn(),
-  ingestRequestLog: vi.fn(),
-  ingestSandboxOpLog: vi.fn(),
-  getDatasetName: vi.fn((base: string) => `vm0-${base}-dev`),
-  DATASETS: {
-    SANDBOX_TELEMETRY_SYSTEM: "sandbox-telemetry-system",
-    AGENT_RUN_EVENTS: "agent-run-events",
-    WEB_LOGS: "web-logs",
-    REQUEST_LOG: "request-log",
-    SANDBOX_OP_LOG: "sandbox-op-log",
-  },
-}));
-
 import { queryAxiom } from "../../../../../../../../src/lib/axiom";
-import {
-  mockClerk,
-  clearClerkMock,
-} from "../../../../../../../../src/__tests__/clerk-mock";
 
-const mockQueryAxiom = vi.mocked(queryAxiom);
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
+vi.mock("../../../../../../../../src/lib/axiom", async (importOriginal) => {
+  const original =
+    await importOriginal<
+      typeof import("../../../../../../../../src/lib/axiom")
+    >();
+  return {
+    ...original,
+    queryAxiom: vi.fn(),
+  };
+});
 
-/**
- * Helper to create a NextRequest for testing.
- */
-function createTestRequest(url: string): NextRequest {
-  return new NextRequest(url, { method: "GET" });
-}
+const context = testContext();
 
 describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
-  const testUserId = `test-user-${Date.now()}-${process.pid}`;
-  const testScopeId = randomUUID();
-  const testRunId = randomUUID();
-  const testComposeId = randomUUID();
-  const testVersionId =
-    randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
+  let user: UserContext;
+  let testRunId: string;
+  let queryAxiomMock: MockInstance<typeof queryAxiom>;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
-    initServices();
+    context.setupMocks();
+    user = await context.setupUser();
 
-    mockClerk({ userId: testUserId });
+    // Setup mock on queryAxiom - returns empty array by default
+    queryAxiomMock = vi.mocked(queryAxiom).mockResolvedValue([]);
 
-    // Setup mockQueryAxiom - returns empty array by default
-    mockQueryAxiom.mockResolvedValue([]);
+    // Create test compose and run
+    const { composeId } = await createTestCompose(`system-log-${Date.now()}`);
 
-    // Clean up any existing test data
-    await globalThis.services.db
-      .delete(agentRuns)
-      .where(eq(agentRuns.id, testRunId));
-
-    await globalThis.services.db
-      .delete(agentComposeVersions)
-      .where(eq(agentComposeVersions.id, testVersionId));
-
-    await globalThis.services.db
-      .delete(agentComposes)
-      .where(eq(agentComposes.id, testComposeId));
-
-    await globalThis.services.db
-      .delete(scopes)
-      .where(eq(scopes.id, testScopeId));
-
-    // Create test scope
-    await globalThis.services.db.insert(scopes).values({
-      id: testScopeId,
-      slug: `test-${testScopeId.slice(0, 8)}`,
-      type: "personal",
-      ownerId: testUserId,
-    });
-
-    // Create test agent compose
-    await globalThis.services.db.insert(agentComposes).values({
-      id: testComposeId,
-      userId: testUserId,
-      scopeId: testScopeId,
-      name: "test-agent",
-      headVersionId: testVersionId,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
-
-    // Create test agent version
-    await globalThis.services.db.insert(agentComposeVersions).values({
-      id: testVersionId,
-      composeId: testComposeId,
-      content: {
-        agents: {
-          "test-agent": {
-            name: "test-agent",
-            model: "claude-3-5-sonnet-20241022",
-            working_dir: "/workspace",
-          },
-        },
-      },
-      createdBy: testUserId,
-      createdAt: new Date(),
-    });
-
-    // Create test agent run
-    await globalThis.services.db.insert(agentRuns).values({
-      id: testRunId,
-      userId: testUserId,
-      agentComposeVersionId: testVersionId,
-      status: "running",
-      prompt: "Test prompt",
-      createdAt: new Date(),
-    });
-  });
-
-  afterEach(async () => {
-    clearClerkMock();
-
-    await globalThis.services.db
-      .delete(agentRuns)
-      .where(eq(agentRuns.id, testRunId));
-
-    await globalThis.services.db
-      .delete(agentComposeVersions)
-      .where(eq(agentComposeVersions.id, testVersionId));
-
-    await globalThis.services.db
-      .delete(agentComposes)
-      .where(eq(agentComposes.id, testComposeId));
-  });
-
-  afterAll(async () => {
-    // Clean up database connections
+    const { runId } = await createTestRun(composeId, "Test prompt");
+    testRunId = runId;
   });
 
   describe("Authentication", () => {
@@ -183,54 +90,18 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
     });
 
     it("should reject request for run owned by different user", async () => {
-      const otherUserId = `other-user-${Date.now()}-${process.pid}`;
-      const otherScopeId = randomUUID();
-      const otherRunId = randomUUID();
-      const otherComposeId = randomUUID();
-      const otherVersionId =
-        randomUUID().replace(/-/g, "") + randomUUID().replace(/-/g, "");
+      // Create another user with their own compose and run
+      await context.setupUser({ prefix: "other" });
+      const { composeId: otherComposeId } = await createTestCompose(
+        `other-system-log-${Date.now()}`,
+      );
+      const { runId: otherRunId } = await createTestRun(
+        otherComposeId,
+        "Other user run",
+      );
 
-      await globalThis.services.db.insert(scopes).values({
-        id: otherScopeId,
-        slug: `test-${otherScopeId.slice(0, 8)}`,
-        type: "personal",
-        ownerId: otherUserId,
-      });
-
-      await globalThis.services.db.insert(agentComposes).values({
-        id: otherComposeId,
-        userId: otherUserId,
-        scopeId: otherScopeId,
-        name: "other-agent",
-        headVersionId: otherVersionId,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      });
-
-      await globalThis.services.db.insert(agentComposeVersions).values({
-        id: otherVersionId,
-        composeId: otherComposeId,
-        content: {
-          agents: {
-            "other-agent": {
-              name: "other-agent",
-              model: "claude-3-5-sonnet-20241022",
-              working_dir: "/workspace",
-            },
-          },
-        },
-        createdBy: otherUserId,
-        createdAt: new Date(),
-      });
-
-      await globalThis.services.db.insert(agentRuns).values({
-        id: otherRunId,
-        userId: otherUserId,
-        agentComposeVersionId: otherVersionId,
-        status: "running",
-        prompt: "Test prompt",
-        createdAt: new Date(),
-      });
+      // Switch back to original user
+      mockClerk({ userId: user.userId });
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${otherRunId}/telemetry/system-log`,
@@ -241,26 +112,12 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
       expect(response.status).toBe(404);
       const data = await response.json();
       expect(data.error.message).toContain("Agent run");
-
-      // Clean up
-      await globalThis.services.db
-        .delete(agentRuns)
-        .where(eq(agentRuns.id, otherRunId));
-      await globalThis.services.db
-        .delete(agentComposeVersions)
-        .where(eq(agentComposeVersions.id, otherVersionId));
-      await globalThis.services.db
-        .delete(agentComposes)
-        .where(eq(agentComposes.id, otherComposeId));
-      await globalThis.services.db
-        .delete(scopes)
-        .where(eq(scopes.id, otherScopeId));
     });
   });
 
   describe("Success - Basic Retrieval", () => {
     it("should return empty system log when no telemetry exists", async () => {
-      // Default mockQueryAxiom returns empty array
+      // Default queryAxiomMock returns empty array
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/system-log`,
       );
@@ -274,7 +131,7 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
     });
 
     it("should return system log from Axiom", async () => {
-      mockQueryAxiom.mockResolvedValue([
+      queryAxiomMock.mockResolvedValue([
         {
           _time: new Date().toISOString(),
           runId: testRunId,
@@ -297,7 +154,7 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
 
   describe("Aggregation", () => {
     it("should aggregate system logs from multiple records", async () => {
-      mockQueryAxiom.mockResolvedValue([
+      queryAxiomMock.mockResolvedValue([
         {
           _time: new Date(Date.now() - 2000).toISOString(),
           runId: testRunId,
@@ -330,7 +187,7 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
     });
 
     it("should handle Axiom returning null (not configured)", async () => {
-      mockQueryAxiom.mockResolvedValue(null);
+      queryAxiomMock.mockResolvedValue(null);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/system-log?limit=10`,
@@ -348,7 +205,7 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
   describe("Pagination", () => {
     it("should respect limit parameter", async () => {
       // Mock Axiom returning 3 records (more than limit of 2)
-      mockQueryAxiom.mockResolvedValue([
+      queryAxiomMock.mockResolvedValue([
         {
           _time: new Date(Date.now() - 3000).toISOString(),
           runId: testRunId,
@@ -382,7 +239,7 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
 
     it("should pass since parameter to Axiom query", async () => {
       // Mock Axiom returning only recent entry (since filter applied by Axiom)
-      mockQueryAxiom.mockResolvedValue([
+      queryAxiomMock.mockResolvedValue([
         {
           _time: new Date(Date.now() - 1000).toISOString(),
           runId: testRunId,
@@ -402,7 +259,7 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
       expect(data.systemLog).toBe("[INFO] Recent entry\n");
 
       // Verify queryAxiom was called with a query containing the since filter
-      expect(mockQueryAxiom).toHaveBeenCalledWith(
+      expect(queryAxiomMock).toHaveBeenCalledWith(
         expect.stringContaining("where _time >"),
       );
     });


### PR DESCRIPTION
## Summary
- Migrate metrics, network, and system-log telemetry route tests to follow web testing patterns
- Replace direct DB operations with API helpers (`createTestCompose`, `createTestRun`)
- Use `testContext()` for isolated user contexts with automatic cleanup
- Remove manual cleanup code (`afterEach`, `afterAll`)
- Mock only external services (`@clerk`, `@e2b`, `@aws-sdk`, `@axiomhq`) plus `queryAxiom` function

## Test plan
- [x] All 27 tests pass locally
- [x] Type check passes
- [x] Lint passes with no warnings
- [x] Knip finds no unused code

Part of #1844

🤖 Generated with [Claude Code](https://claude.com/claude-code)