### PR TITLE
fix: add missing NEXT_PUBLIC_BASE_URL env var for blog

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -145,6 +145,7 @@ jobs:
           deployment-env: web
           environment-variables: |
             DATABASE_URL=${{ steps.get-db-url.outputs.database-url }}
+            NEXT_PUBLIC_BASE_URL=https://www.vm0.ai
             NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
             CLERK_SECRET_KEY=${{ secrets.CLERK_SECRET_KEY }}
             E2B_API_KEY=${{ secrets.E2B_API_KEY }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -244,6 +244,7 @@ jobs:
           deployment-env: web
           environment-variables: |
             DATABASE_URL=${{ steps.branch.outputs.database-url }}
+            NEXT_PUBLIC_BASE_URL=https://www.vm0.ai
             NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
             CLERK_SECRET_KEY=${{ secrets.CLERK_SECRET_KEY }}
             E2B_API_KEY=${{ secrets.E2B_API_KEY }}

--- a/turbo/apps/web/app/lib/blog/config.ts
+++ b/turbo/apps/web/app/lib/blog/config.ts
@@ -1,3 +1,4 @@
+// Returns the base URL for blog content
 function getBlogBaseUrl(): string {
   const url = process.env.NEXT_PUBLIC_BASE_URL;
   if (!url) {


### PR DESCRIPTION
## Summary
- Adds `NEXT_PUBLIC_BASE_URL=https://www.vm0.ai` environment variable to both workflow files
- Updates `release-please.yml` for production deployments
- Updates `turbo.yml` for preview deployments

## Test plan
- [ ] Verify CI workflows run successfully
- [ ] Verify deployments have access to the new environment variable

Generated with [Claude Code](https://claude.ai/code)