### PR TITLE
fix(web): wrap async assertion in vi.waitfor for home page test

### DIFF
--- a/turbo/apps/platform/src/views/home/__tests__/home-page.test.tsx
+++ b/turbo/apps/platform/src/views/home/__tests__/home-page.test.tsx
@@ -67,7 +67,9 @@ describe("home page", () => {
     // Click "Add it later" to close the modal
     await user.click(screen.getByText("Add it later"));
 
-    expect(saveButton).not.toBeInTheDocument();
+    await vi.waitFor(() => {
+      expect(saveButton).not.toBeInTheDocument();
+    });
   });
 
   it("should show onboarding modal when no claude-code-oauth-token exists", async () => {


### PR DESCRIPTION
## Summary
- Wrapped `expect(saveButton).not.toBeInTheDocument()` assertion in `vi.waitFor()` to properly handle async DOM updates after modal dismissal
- This ensures the test waits for the DOM to update before asserting the button is removed

## Test plan
- [x] Run `pnpm vitest run apps/platform/src/views/home/__tests__/home-page.test.tsx` - all 6 tests pass
- [x] Pre-commit checks pass (lint, type-check, format, knip)

---
Generated with [Claude Code](https://claude.ai/code)