### PR TITLE
refactor(web): migrate storage tests to route-level patterns

### DIFF
--- a/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
@@ -1,125 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "../route";
 import {
-  describe,
-  it,
-  expect,
-  vi,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-} from "vitest";
-import { NextRequest } from "next/server";
-import { eq } from "drizzle-orm";
-import { initServices } from "../../../../../src/lib/init-services";
-import {
-  storages,
-  storageVersions,
-} from "../../../../../src/db/schema/storage";
-import * as s3Client from "../../../../../src/lib/s3/s3-client";
+  createTestRequest,
+  createTestArtifact,
+} from "../../../../../src/__tests__/api-test-helpers";
+import { testContext } from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 
-// Mock Clerk auth (external SaaS)
-vi.mock("@clerk/nextjs/server", () => ({
-  auth: vi.fn(),
-}));
-
-// Mock AWS SDK (external) for S3 operations
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
 vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
 
-// Override default env var with test-specific value
 vi.hoisted(() => {
   vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
 });
 
-// Static imports - mocks are already in place due to hoisting
-import { POST } from "../route";
-import {
-  mockClerk,
-  clearClerkMock,
-} from "../../../../../src/__tests__/clerk-mock";
-
-// Test constants
-const TEST_USER_ID = "test-user-prepare";
-const TEST_PREFIX = "test-prepare-";
+const context = testContext();
 
 describe("POST /api/storages/prepare", () => {
-  beforeAll(async () => {
-    initServices();
-  });
-
   beforeEach(async () => {
-    vi.clearAllMocks();
-
-    // Mock Clerk auth to return test user by default
-    mockClerk({ userId: TEST_USER_ID });
-
-    // Setup S3 mocks
-    vi.spyOn(s3Client, "generatePresignedPutUrl").mockResolvedValue(
-      "https://s3.example.com/presigned-url",
-    );
-    vi.spyOn(s3Client, "downloadManifest").mockResolvedValue({
-      version: "1.0",
-      createdAt: new Date().toISOString(),
-      totalSize: 0,
-      fileCount: 0,
-      files: [],
-    });
-    vi.spyOn(s3Client, "verifyS3FilesExist").mockResolvedValue(true);
-
-    // Clean up test data
-    await globalThis.services.db
-      .update(storages)
-      .set({ headVersionId: null })
-      .where(eq(storages.userId, TEST_USER_ID));
-
-    const testStorages = await globalThis.services.db
-      .select({ id: storages.id })
-      .from(storages)
-      .where(eq(storages.userId, TEST_USER_ID));
-
-    for (const storage of testStorages) {
-      await globalThis.services.db
-        .delete(storageVersions)
-        .where(eq(storageVersions.storageId, storage.id));
-    }
-
-    await globalThis.services.db
-      .delete(storages)
-      .where(eq(storages.userId, TEST_USER_ID));
-  });
-
-  afterEach(() => {
-    clearClerkMock();
-  });
-
-  afterAll(async () => {
-    // Final cleanup
-    await globalThis.services.db
-      .update(storages)
-      .set({ headVersionId: null })
-      .where(eq(storages.userId, TEST_USER_ID));
-
-    const testStorages = await globalThis.services.db
-      .select({ id: storages.id })
-      .from(storages)
-      .where(eq(storages.userId, TEST_USER_ID));
-
-    for (const storage of testStorages) {
-      await globalThis.services.db
-        .delete(storageVersions)
-        .where(eq(storageVersions.storageId, storage.id));
-    }
-
-    await globalThis.services.db
-      .delete(storages)
-      .where(eq(storages.userId, TEST_USER_ID));
+    context.setupMocks();
+    await context.setupUser();
   });
 
   it("should return 401 when not authenticated", async () => {
-    // Mock Clerk to return no user
     mockClerk({ userId: null });
 
-    const request = new NextRequest(
+    const request = createTestRequest(
       "http://localhost:3000/api/storages/prepare",
       {
         method: "POST",
@@ -137,7 +46,7 @@ describe("POST /api/storages/prepare", () => {
   });
 
   it("should return 400 when storageName is missing", async () => {
-    const request = new NextRequest(
+    const request = createTestRequest(
       "http://localhost:3000/api/storages/prepare",
       {
         method: "POST",
@@ -156,7 +65,7 @@ describe("POST /api/storages/prepare", () => {
   });
 
   it("should return 400 when storageType is invalid", async () => {
-    const request = new NextRequest(
+    const request = createTestRequest(
       "http://localhost:3000/api/storages/prepare",
       {
         method: "POST",
@@ -176,9 +85,9 @@ describe("POST /api/storages/prepare", () => {
   });
 
   it("should create new storage when it does not exist", async () => {
-    const storageName = `${TEST_PREFIX}new-storage`;
+    const storageName = `new-storage-${Date.now()}`;
 
-    const request = new NextRequest(
+    const request = createTestRequest(
       "http://localhost:3000/api/storages/prepare",
       {
         method: "POST",
@@ -200,105 +109,42 @@ describe("POST /api/storages/prepare", () => {
     expect(json.uploads).toBeDefined();
     expect(json.uploads.archive).toBeDefined();
     expect(json.uploads.manifest).toBeDefined();
-
-    // Verify storage was created
-    const [storage] = await globalThis.services.db
-      .select()
-      .from(storages)
-      .where(eq(storages.name, storageName));
-    expect(storage).toBeDefined();
-    expect(storage!.userId).toBe(TEST_USER_ID);
   });
 
   it("should return existing=true when version already exists", async () => {
-    const storageName = `${TEST_PREFIX}existing-version`;
-
-    // Create storage first
-    const [storage] = await globalThis.services.db
-      .insert(storages)
-      .values({
-        userId: TEST_USER_ID,
-        name: storageName,
-        type: "volume",
-        s3Prefix: `${TEST_USER_ID}/volume/${storageName}`,
-        size: 100,
-        fileCount: 1,
-      })
-      .returning();
-
-    // Prepare with same files to get the version ID
+    const storageName = `existing-version-${Date.now()}`;
     const files = [{ path: "test.txt", hash: "b".repeat(64), size: 100 }];
-    const request1 = new NextRequest(
+
+    // Create storage and commit version via helper
+    await createTestArtifact(storageName, { files });
+
+    // Prepare again with same files - should return existing: true
+    const request = createTestRequest(
       "http://localhost:3000/api/storages/prepare",
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ storageName, storageType: "volume", files }),
+        body: JSON.stringify({ storageName, storageType: "artifact", files }),
       },
     );
 
-    const response1 = await POST(request1);
-    const json1 = await response1.json();
-    const versionId = json1.versionId;
+    const response = await POST(request);
+    expect(response.status).toBe(200);
 
-    // Create version record
-    await globalThis.services.db.insert(storageVersions).values({
-      id: versionId,
-      storageId: storage!.id,
-      s3Key: `${TEST_USER_ID}/volume/${storageName}/${versionId}`,
-      size: 100,
-      fileCount: 1,
-      createdBy: TEST_USER_ID,
-    });
-
-    // Prepare again with same files
-    const request2 = new NextRequest(
-      "http://localhost:3000/api/storages/prepare",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ storageName, storageType: "volume", files }),
-      },
-    );
-
-    const response2 = await POST(request2);
-    expect(response2.status).toBe(200);
-
-    const json2 = await response2.json();
-    expect(json2.versionId).toBe(versionId);
-    expect(json2.existing).toBe(true);
-    expect(json2.uploads).toBeUndefined();
+    const json = await response.json();
+    expect(json.existing).toBe(true);
+    expect(json.uploads).toBeUndefined();
   });
 
   it("should compute deterministic version ID from files", async () => {
-    const storageName = `${TEST_PREFIX}deterministic`;
-
-    // Create storage
-    await globalThis.services.db.insert(storages).values({
-      userId: TEST_USER_ID,
-      name: storageName,
-      type: "artifact",
-      s3Prefix: `${TEST_USER_ID}/artifact/${storageName}`,
-      size: 0,
-      fileCount: 0,
-    });
-
+    const storageName = `deterministic-${Date.now()}`;
     const files = [
       { path: "a.txt", hash: "c".repeat(64), size: 10 },
       { path: "b.txt", hash: "d".repeat(64), size: 20 },
     ];
 
     // Make two requests with same files
-    const request1 = new NextRequest(
-      "http://localhost:3000/api/storages/prepare",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ storageName, storageType: "artifact", files }),
-      },
-    );
-
-    const request2 = new NextRequest(
+    const request1 = createTestRequest(
       "http://localhost:3000/api/storages/prepare",
       {
         method: "POST",
@@ -308,9 +154,18 @@ describe("POST /api/storages/prepare", () => {
     );
 
     const response1 = await POST(request1);
-    const response2 = await POST(request2);
-
     const json1 = await response1.json();
+
+    const request2 = createTestRequest(
+      "http://localhost:3000/api/storages/prepare",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ storageName, storageType: "artifact", files }),
+      },
+    );
+
+    const response2 = await POST(request2);
     const json2 = await response2.json();
 
     // Version IDs should be identical
@@ -319,69 +174,41 @@ describe("POST /api/storages/prepare", () => {
   });
 
   it("should return upload URLs when version exists but S3 files are missing", async () => {
-    const storageName = `${TEST_PREFIX}s3missing`;
-
-    // Create storage
-    const [storage] = await globalThis.services.db
-      .insert(storages)
-      .values({
-        userId: TEST_USER_ID,
-        name: storageName,
-        type: "volume",
-        s3Prefix: `${TEST_USER_ID}/volume/${storageName}`,
-        size: 100,
-        fileCount: 1,
-      })
-      .returning();
-
-    // Prepare with files to get the version ID
+    const storageName = `s3missing-${Date.now()}`;
     const files = [{ path: "test.txt", hash: "e".repeat(64), size: 100 }];
-    const request1 = new NextRequest(
-      "http://localhost:3000/api/storages/prepare",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ storageName, storageType: "volume", files }),
-      },
-    );
 
-    const response1 = await POST(request1);
-    const json1 = await response1.json();
-    const versionId = json1.versionId;
-
-    // Create version record (simulating DB has record but S3 files deleted)
-    await globalThis.services.db.insert(storageVersions).values({
-      id: versionId,
-      storageId: storage!.id,
-      s3Key: `${TEST_USER_ID}/volume/${storageName}/${versionId}`,
-      size: 100,
-      fileCount: 1,
-      createdBy: TEST_USER_ID,
-    });
+    // Create storage and commit version via helper
+    const { versionId } = await createTestArtifact(storageName, { files });
 
     // Mock S3 files as missing
-    vi.spyOn(s3Client, "verifyS3FilesExist").mockResolvedValueOnce(false);
+    context.mocks.s3.verifyS3FilesExist.mockResolvedValueOnce(false);
 
     // Prepare again with same files - should get upload URLs since S3 missing
-    const request2 = new NextRequest(
+    const request = createTestRequest(
       "http://localhost:3000/api/storages/prepare",
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ storageName, storageType: "volume", files }),
+        body: JSON.stringify({ storageName, storageType: "artifact", files }),
       },
     );
 
-    const response2 = await POST(request2);
-    expect(response2.status).toBe(200);
+    const response = await POST(request);
+    expect(response.status).toBe(200);
 
-    const json2 = await response2.json();
-    expect(json2.versionId).toBe(versionId);
+    const json = await response.json();
+    expect(json.versionId).toBe(versionId);
     // Should NOT return existing: true since S3 files are missing
-    expect(json2.existing).toBe(false);
+    expect(json.existing).toBe(false);
     // Should return upload URLs for re-upload
-    expect(json2.uploads).toBeDefined();
-    expect(json2.uploads.archive.presignedUrl).toBeDefined();
-    expect(json2.uploads.manifest.presignedUrl).toBeDefined();
+    expect(json.uploads).toBeDefined();
+    expect(json.uploads.archive.key).toBeDefined();
+    expect(json.uploads.archive.presignedUrl).toBe(
+      "https://mock-presigned-put-url",
+    );
+    expect(json.uploads.manifest.key).toBeDefined();
+    expect(json.uploads.manifest.presignedUrl).toBe(
+      "https://mock-presigned-put-url",
+    );
   });
 });

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -50,6 +50,14 @@ interface S3Mocks {
       filename?: string,
     ) => Promise<string>
   >;
+  generatePresignedPutUrl: MockInstance<
+    (
+      bucket: string,
+      key: string,
+      contentType?: string,
+      expiresIn?: number,
+    ) => Promise<string>
+  >;
   listS3Objects: MockInstance<
     (bucket: string, prefix: string) => Promise<{ key: string; size: number }[]>
   >;
@@ -165,6 +173,9 @@ export function testContext(): TestContext {
       generatePresignedUrl: vi
         .spyOn(s3Client, "generatePresignedUrl")
         .mockResolvedValue("https://mock-presigned-url"),
+      generatePresignedPutUrl: vi
+        .spyOn(s3Client, "generatePresignedPutUrl")
+        .mockResolvedValue("https://mock-presigned-put-url"),
       listS3Objects: vi.spyOn(s3Client, "listS3Objects").mockResolvedValue([]),
       uploadS3Buffer: vi
         .spyOn(s3Client, "uploadS3Buffer")


### PR DESCRIPTION
## Summary

- Refactor storage API tests (commit, download, prepare) to use the standard route-level testing patterns defined in `.claude/skills/testing/reference/web-testing.md`
- Add `generatePresignedPutUrl` mock to `test-helpers.ts` for storage upload URL testing

### Changes

**Test files refactored:**
- `app/api/storages/commit/__tests__/route.test.ts`
- `app/api/storages/download/__tests__/route.test.ts`
- `app/api/storages/prepare/__tests__/route.test.ts`

**Pattern improvements:**
- Use `testContext()` for test isolation and mock management
- Replace direct database operations with API-based helpers
- Remove manual cleanup code (`beforeEach`/`afterEach`/`afterAll` cleanup)
- Use `createTestArtifact` helper for fixture creation
- Use `createTestRequest` helper for request construction
- Remove imports of internal services and direct DB schema

**Net reduction:** 586 lines of code removed (728 insertions, 1314 deletions)

## Test plan

- [x] All 25 storage tests pass
- [x] Lint passes
- [x] Type check passes
- [x] Knip passes

Related to #1844

🤖 Generated with [Claude Code](https://claude.com/claude-code)