### PR TITLE
refactor(web): migrate v1 api and webhook tests to route-level patterns

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -535,3 +535,23 @@ export async function createTestArtifact(
 }> {
   return createTestStorage(name, { ...options, type: "artifact" });
 }
+
+/**
+ * Create a test volume via API route handlers.
+ * Convenience wrapper around createTestStorage with type="volume".
+ *
+ * @param name - Volume name
+ * @param options - Optional configuration
+ * @returns The created volume with versionId
+ */
+export async function createTestVolume(
+  name: string,
+  options?: Omit<CreateTestStorageOptions, "type">,
+): Promise<{
+  versionId: string;
+  name: string;
+  size: number;
+  fileCount: number;
+}> {
+  return createTestStorage(name, { ...options, type: "volume" });
+}

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -73,6 +73,8 @@ interface AxiomMocks {
   flush: Mock;
   /** Spy for queryAxiom function - use mockResolvedValue to set return value */
   queryAxiom: MockInstance<typeof axiomClient.queryAxiom>;
+  /** Spy for ingestToAxiom function - use mockResolvedValue to set return value */
+  ingestToAxiom: MockInstance<typeof axiomClient.ingestToAxiom>;
 }
 
 /**
@@ -185,6 +187,11 @@ export function testContext(): TestContext {
       queryAxiom: vi
         .spyOn(axiomClient, "queryAxiom")
         .mockResolvedValue([]) as MockInstance<typeof axiomClient.queryAxiom>,
+      ingestToAxiom: vi
+        .spyOn(axiomClient, "ingestToAxiom")
+        .mockResolvedValue(true) as MockInstance<
+        typeof axiomClient.ingestToAxiom
+      >,
     };
     // Use try/catch since Axiom may not be mocked in all test files
     try {


### PR DESCRIPTION
## Summary
- Refactored 4 test files to follow route-level testing patterns as part of issue #1844
- Replaced direct DB operations with API test helpers (`createTestCompose`, `createTestArtifact`, `createTestVolume`)
- Used `testContext()` for isolated user setup per test
- Removed `beforeAll`/`afterAll` manual cleanup
- Removed imports from `db/schema`
- Added `createTestVolume` helper for volume test creation

**Files refactored:**
- `app/api/webhooks/agent/telemetry/__tests__/route.test.ts`
- `app/v1/agents/__tests__/route.test.ts`
- `app/v1/artifacts/__tests__/route.test.ts`
- `app/v1/volumes/__tests__/route.test.ts`

## Test plan
- [x] All 38 tests pass when run together
- [x] Lint checks pass
- [x] Type checks pass
- [x] Format checks pass

Note: CI knip check may fail due to a pre-existing issue introduced in #1859 (unrelated CLI unused exports). This PR only touches web app test files.

Closes part of #1844

🤖 Generated with [Claude Code](https://claude.com/claude-code)