### PR TITLE
feat(platform): update log detail page ui to match figma design

### DIFF
--- a/turbo/apps/platform/src/views/logs-page/__tests__/log-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/logs-page/__tests__/log-detail-page.test.tsx
@@ -272,7 +272,7 @@ describe("log detail page", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Agent Events")).toBeInTheDocument();
+      expect(screen.getByText("Agent events")).toBeInTheDocument();
     });
 
     // Verify the events are rendered (in formatted view)

--- a/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
@@ -788,10 +788,11 @@ function EventHeader({
 
   return (
     <div className="flex items-center gap-2 text-sm">
-      <Icon className={`h-4 w-4 ${style.textColor}`} />
+      {/* Badge with icon inside */}
       <span
-        className={`px-2 py-0.5 rounded-full text-xs font-medium ${style.badgeColor}`}
+        className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium ${style.badgeColor}`}
       >
+        <Icon className="h-3.5 w-3.5" />
         {label}
       </span>
       {sublabel && (
@@ -819,7 +820,7 @@ export function EventCard({
     const subtype = eventData.subtype;
     return (
       <div
-        className={`rounded-lg border-l-4 ${style.borderColor} ${style.bgColor} p-3`}
+        className={`rounded-lg border ${style.borderColor} ${style.bgColor} p-4`}
       >
         <EventHeader
           event={event}
@@ -843,9 +844,9 @@ export function EventCard({
     const resultStyle = isError ? getEventStyle("tool_result_error") : style;
     return (
       <div
-        className={`rounded-lg border-l-4 ${resultStyle.borderColor} ${resultStyle.bgColor} p-3`}
+        className={`rounded-lg border ${resultStyle.borderColor} ${resultStyle.bgColor} p-4`}
       >
-        <EventHeader event={event} label={isError ? "Failed" : "Completed"} />
+        <EventHeader event={event} label={isError ? "Failed" : "Result"} />
         <ResultEventContent eventData={eventData} />
       </div>
     );
@@ -859,7 +860,7 @@ export function EventCard({
     // Fallback: show raw data
     return (
       <div
-        className={`rounded-lg border-l-4 ${style.borderColor} ${style.bgColor} p-3`}
+        className={`rounded-lg border ${style.borderColor} ${style.bgColor} p-4`}
       >
         <EventHeader event={event} label={event.eventType} />
         <div className="mt-2">
@@ -872,7 +873,7 @@ export function EventCard({
   // Render each content block
   return (
     <div
-      className={`rounded-lg border-l-4 ${style.borderColor} ${style.bgColor} p-3 space-y-3`}
+      className={`rounded-lg border ${style.borderColor} ${style.bgColor} p-4 space-y-3`}
     >
       <EventHeader
         event={event}

--- a/turbo/apps/platform/src/views/logs-page/constants/event-styles.ts
+++ b/turbo/apps/platform/src/views/logs-page/constants/event-styles.ts
@@ -1,16 +1,15 @@
 import {
-  IconRocket,
+  IconSettings,
   IconMessage,
   IconTool,
   IconCheck,
-  IconBrain,
   IconUser,
-  IconFlag,
   IconAlertCircle,
+  IconSquareCheck,
 } from "@tabler/icons-react";
 
 interface EventStyle {
-  icon: typeof IconRocket;
+  icon: typeof IconSettings;
   label: string;
   borderColor: string;
   bgColor: string;
@@ -19,57 +18,56 @@ interface EventStyle {
 }
 
 /**
- * Event styles using semantic colors for clear visual hierarchy.
- * - Blue for system/init events (informational)
- * - Gray for assistant events (neutral)
- * - Cyan for user events (user interaction)
- * - Green for result events (success/completion)
- * - Red for errors only
+ * Event styles matching Figma design.
+ * - Orange border badge for system/assistant events
+ * - Red border badge for user events
+ * - Green border badge for result events
+ * Cards have white background with light border (no left color stripe)
  */
 function createEventStyles(): Readonly<Record<string, EventStyle>> {
   return {
-    // System event - blue (informational)
+    // System event - gear icon, blue border badge (matching Figma)
     system: {
-      icon: IconRocket,
+      icon: IconSettings,
       label: "System",
-      borderColor: "border-l-blue-500",
-      bgColor: "bg-blue-50 dark:bg-blue-950/30",
-      textColor: "text-blue-700 dark:text-blue-400",
+      borderColor: "border-border",
+      bgColor: "bg-white dark:bg-slate-900",
+      textColor: "text-sky-600",
       badgeColor:
-        "bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-400",
+        "border border-sky-400 text-sky-600 bg-sky-50 dark:border-sky-500 dark:text-sky-400 dark:bg-sky-950/30",
     },
 
-    // Assistant event - neutral gray
+    // Assistant event - user icon, orange/amber border badge (matching Figma)
     assistant: {
-      icon: IconBrain,
+      icon: IconUser,
       label: "Assistant",
-      borderColor: "border-l-slate-400 dark:border-l-slate-500",
-      bgColor: "bg-slate-50 dark:bg-slate-900/30",
-      textColor: "text-slate-700 dark:text-slate-300",
+      borderColor: "border-border",
+      bgColor: "bg-white dark:bg-slate-900",
+      textColor: "text-amber-600",
       badgeColor:
-        "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
+        "border border-amber-400 text-amber-600 bg-amber-50 dark:border-amber-500 dark:text-amber-400 dark:bg-amber-950/30",
     },
 
-    // User event - cyan/teal (user interaction)
+    // User event - user icon, pink/magenta border badge (matching Figma)
     user: {
       icon: IconUser,
       label: "User",
-      borderColor: "border-l-cyan-500",
-      bgColor: "bg-cyan-50 dark:bg-cyan-950/30",
-      textColor: "text-cyan-700 dark:text-cyan-400",
+      borderColor: "border-border",
+      bgColor: "bg-white dark:bg-slate-900",
+      textColor: "text-pink-500",
       badgeColor:
-        "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/50 dark:text-cyan-400",
+        "border border-pink-400 text-pink-500 bg-pink-50 dark:border-pink-500 dark:text-pink-400 dark:bg-pink-950/30",
     },
 
-    // Result event - green (success/completion)
+    // Result event - check icon, lime border badge (matching Figma)
     result: {
-      icon: IconFlag,
+      icon: IconSquareCheck,
       label: "Result",
-      borderColor: "border-l-emerald-500",
-      bgColor: "bg-emerald-50 dark:bg-emerald-950/30",
-      textColor: "text-emerald-700 dark:text-emerald-400",
+      borderColor: "border-border",
+      bgColor: "bg-white dark:bg-slate-900",
+      textColor: "text-lime-600",
       badgeColor:
-        "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-400",
+        "border border-lime-600 text-lime-600 bg-lime-50 dark:border-lime-500 dark:text-lime-400 dark:bg-lime-950/30",
     },
 
     // Content types - subtle styling within cards
@@ -112,7 +110,7 @@ function createEventStyles(): Readonly<Record<string, EventStyle>> {
 
     // Legacy types for backwards compatibility
     init: {
-      icon: IconRocket,
+      icon: IconSettings,
       label: "Init",
       borderColor: "border-l-blue-500",
       bgColor: "bg-blue-50 dark:bg-blue-950/30",
@@ -121,7 +119,7 @@ function createEventStyles(): Readonly<Record<string, EventStyle>> {
         "bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-400",
     },
     thinking: {
-      icon: IconBrain,
+      icon: IconUser,
       label: "Thinking",
       borderColor: "border-l-violet-400 dark:border-l-violet-500",
       bgColor: "bg-violet-50/50 dark:bg-violet-950/20",

--- a/turbo/apps/platform/src/views/logs-page/utils/highlight-text.tsx
+++ b/turbo/apps/platform/src/views/logs-page/utils/highlight-text.tsx
@@ -56,8 +56,8 @@ export function highlightText(
           data-match-index={globalIndex}
           className={
             isCurrent
-              ? "bg-orange-300 text-orange-900 rounded px-0.5"
-              : "bg-yellow-200 text-yellow-900 rounded px-0.5"
+              ? "bg-orange-200 text-orange-900 rounded px-0.5"
+              : "bg-orange-100 text-orange-800 rounded px-0.5"
           }
         >
           {part}


### PR DESCRIPTION
## Summary

- Update event card styling with new badge colors and icons matching Figma design
  - System: sky/blue with gear icon
  - Assistant: amber/orange with user icon
  - User: pink with user icon
  - Result: lime/green with check icon
- Update ViewModeToggle to capsule tab design using design system tokens
- Update toolbar layout (removed card wrapper, added vertical separators)
- Update highlight colors for search matches to use orange tones
- Use design system variables consistently (bg-card, bg-accent, border-sidebar-primary)

## Test plan

- [ ] Verify event cards display correct colors and icons for each event type
- [ ] Verify Formatted/Raw JSON toggle uses capsule tab style
- [ ] Verify search highlighting uses orange color scheme
- [ ] Verify All types dropdown and Search logs input have correct backgrounds
- [ ] Verify dark mode styling works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)