### PR TITLE
fix(docker): add rust-src component for rust-analyzer

### DIFF
--- a/.docker/toolchain/Dockerfile
+++ b/.docker/toolchain/Dockerfile
@@ -155,5 +155,8 @@ RUN groupadd -f --gid 1000 vscode \
     && mkdir -p /home/vscode/.local/share /home/vscode/.cache /home/vscode/.config \
     && chown -R vscode:vscode /home/vscode
 
+# Install rust-src for rust-analyzer (IDE support for standard library)
+RUN rustup component add rust-src
+
 # Default command
 CMD ["/usr/bin/zsh"]


### PR DESCRIPTION
## Summary

- Add `rust-src` component to development stage for rust-analyzer IDE support
- Fixes: `ERROR can't load standard library, try installing rust-src`

## Changes

Only affects `development` stage (devcontainer), CI `toolchain` stage unchanged.

## Test plan

- [ ] Rebuild devcontainer and verify rust-analyzer can load standard library

🤖 Generated with [Claude Code](https://claude.com/claude-code)