### PR TITLE
fix: detect and use existing package manager in install.sh

### DIFF
--- a/turbo/apps/web/public/install.sh
+++ b/turbo/apps/web/public/install.sh
@@ -7,9 +7,34 @@ if ! command -v node &> /dev/null; then
     exit 1
 fi
 
+# Detect which package manager has vm0 installed
+detect_package_manager() {
+    if command -v pnpm &> /dev/null; then
+        pnpm_bin=$(pnpm bin -g 2>/dev/null)
+        if [ -n "$pnpm_bin" ] && [ -x "$pnpm_bin/vm0" ]; then
+            echo "pnpm"
+            return
+        fi
+    fi
+    echo "npm"
+}
+
 # Install
-echo "Installing @vm0/cli..."
-npm install -g @vm0/cli
+pkg_manager=$(detect_package_manager)
+echo "Installing @vm0/cli using $pkg_manager..."
+
+case "$pkg_manager" in
+    pnpm)
+        pnpm add -g @vm0/cli
+        ;;
+    *)
+        npm install -g @vm0/cli
+        # Warn about orphaned pnpm binary
+        if [ -x "${HOME}/.local/share/pnpm/vm0" ]; then
+            echo "Warning: Found old vm0 in ~/.local/share/pnpm/. Consider removing it."
+        fi
+        ;;
+esac
 
 echo "Done! Starting onboard..."
 exec vm0 onboard


### PR DESCRIPTION
## Summary

- Fixes install.sh to detect if vm0 was previously installed via pnpm and use pnpm for updates
- When pnpm-installed vm0 is detected, uses `pnpm add -g` instead of `npm install -g`
- Adds warning when orphaned pnpm binary is detected during npm fallback

## Root Cause

When users have previously installed `@vm0/cli` via pnpm, running `install.sh` would install via npm but then execute the old pnpm version due to PATH ordering (pnpm's bin directory appears before npm's in PATH).

## Solution

Detect which package manager has vm0 installed and use the same one for updates:
1. If vm0 exists in pnpm's global bin → use `pnpm add -g @vm0/cli`
2. Otherwise → default to `npm install -g @vm0/cli`

## Test plan

- [ ] Fresh install (no previous vm0): Uses npm, installs successfully
- [ ] Existing npm installation: Uses npm, updates in place
- [ ] Existing pnpm installation: Uses pnpm, updates in place
- [ ] Orphaned pnpm (pnpm removed): Falls back to npm, shows warning

Fixes #1881

🤖 Generated with [Claude Code](https://claude.com/claude-code)