### PR TITLE
refactor(cli): migrate command tests to colocated structure

### DIFF
--- a/turbo/apps/cli/src/commands/auth/__tests__/login.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/login.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for auth login command
+ *
+ * Covers:
+ * - Initial authentication message
+ * - Device code request errors
+ * - API URL configuration
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { loginCommand } from "../login";
+import { mkdtempSync } from "fs";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import chalk from "chalk";
+
+// Mock os.homedir to use temp directory
+const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "test-auth-login-home-"));
+vi.mock("os", async (importOriginal) => {
+  const original = await importOriginal<typeof import("os")>();
+  return {
+    ...original,
+    homedir: () => TEST_HOME,
+  };
+});
+
+describe("auth login", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+  const mockStdoutWrite = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(() => true);
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+
+    // Ensure clean config state
+    const configDir = path.join(TEST_HOME, ".vm0");
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    mockStdoutWrite.mockClear();
+    vi.unstubAllEnvs();
+
+    // Clean up config
+    const configDir = path.join(TEST_HOME, ".vm0");
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  describe("authentication flow", () => {
+    it("should show initiating message", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/cli/auth/device", () => {
+          return HttpResponse.json({
+            device_code: "test-device-code",
+            user_code: "TEST-CODE",
+            verification_path: "/auth/device",
+            expires_in: 300,
+            interval: 5,
+          });
+        }),
+        http.post("http://localhost:3000/api/cli/auth/token", () => {
+          // Return success immediately to avoid polling
+          return HttpResponse.json({
+            access_token: "test-access-token",
+            token_type: "bearer",
+          });
+        }),
+      );
+
+      await loginCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Initiating authentication"),
+      );
+    });
+
+    it("should show device code and verification URL", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/cli/auth/device", () => {
+          return HttpResponse.json({
+            device_code: "test-device-code",
+            user_code: "ABCD-1234",
+            verification_path: "/auth/device",
+            expires_in: 300,
+            interval: 5,
+          });
+        }),
+        http.post("http://localhost:3000/api/cli/auth/token", () => {
+          // Return success immediately to avoid polling
+          return HttpResponse.json({
+            access_token: "test-access-token",
+            token_type: "bearer",
+          });
+        }),
+      );
+
+      await loginCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Device code generated"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("http://localhost:3000/auth/device"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("ABCD-1234"),
+      );
+    });
+
+    it("should save token on successful authentication", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/cli/auth/device", () => {
+          return HttpResponse.json({
+            device_code: "test-device-code",
+            user_code: "TEST-CODE",
+            verification_path: "/auth/device",
+            expires_in: 300,
+            interval: 5,
+          });
+        }),
+        http.post("http://localhost:3000/api/cli/auth/token", () => {
+          return HttpResponse.json({
+            access_token: "saved-access-token",
+            token_type: "bearer",
+          });
+        }),
+      );
+
+      await loginCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Authentication successful"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("credentials have been saved"),
+      );
+
+      // Verify config was saved
+      const configPath = path.join(TEST_HOME, ".vm0", "config.json");
+      const configContent = await fs.readFile(configPath, "utf8");
+      const config = JSON.parse(configContent);
+      expect(config.token).toBe("saved-access-token");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should fail if device code request fails", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/cli/auth/device", () => {
+          return HttpResponse.json({ error: "server_error" }, { status: 500 });
+        }),
+      );
+
+      await expect(async () => {
+        await loginCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow();
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Initiating authentication"),
+      );
+    });
+
+    it("should handle expired token error", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/cli/auth/device", () => {
+          return HttpResponse.json({
+            device_code: "test-device-code",
+            user_code: "TEST-CODE",
+            verification_path: "/auth/device",
+            expires_in: 300,
+            interval: 5,
+          });
+        }),
+        http.post("http://localhost:3000/api/cli/auth/token", () => {
+          return HttpResponse.json({
+            error: "expired_token",
+            error_description: "The device code has expired",
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await loginCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("expired"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/cli/auth/device", () => {
+          return HttpResponse.json({
+            device_code: "test-device-code",
+            user_code: "TEST-CODE",
+            verification_path: "/auth/device",
+            expires_in: 300,
+            interval: 5,
+          });
+        }),
+        http.post("http://localhost:3000/api/cli/auth/token", () => {
+          return HttpResponse.json({
+            error: "access_denied",
+            error_description: "User denied access",
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await loginCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Authentication failed"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/auth/__tests__/logout.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/logout.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for auth logout command
+ *
+ * Covers:
+ * - Successful logout (clears config)
+ * - Logout when already logged out
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { logoutCommand } from "../logout";
+import { mkdtempSync } from "fs";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import chalk from "chalk";
+
+// Mock os.homedir to use temp directory
+const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "test-auth-logout-home-"));
+vi.mock("os", async (importOriginal) => {
+  const original = await importOriginal<typeof import("os")>();
+  return {
+    ...original,
+    homedir: () => TEST_HOME,
+  };
+});
+
+describe("auth logout", () => {
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+
+    // Ensure clean config state
+    const configDir = path.join(TEST_HOME, ".vm0");
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    mockConsoleLog.mockClear();
+    vi.unstubAllEnvs();
+
+    // Clean up config
+    const configDir = path.join(TEST_HOME, ".vm0");
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  describe("successful logout", () => {
+    it("should clear config and show success message", async () => {
+      // Create config with token
+      const configDir = path.join(TEST_HOME, ".vm0");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "config.json"),
+        JSON.stringify({ token: "test-token-123" }),
+      );
+
+      await logoutCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Successfully logged out"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("credentials have been cleared"),
+      );
+    });
+
+    it("should work even when not logged in", async () => {
+      // No config exists
+      await logoutCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Successfully logged out"),
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/auth/__tests__/setup-token.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/setup-token.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for auth setup-token command
+ *
+ * Covers:
+ * - Token output when authenticated (via config)
+ * - Token output when authenticated (via env var)
+ * - Error when not authenticated
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { setupTokenCommand } from "../setup-token";
+import { mkdtempSync } from "fs";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import chalk from "chalk";
+
+// Mock os.homedir to use temp directory
+const TEST_HOME = mkdtempSync(
+  path.join(os.tmpdir(), "test-auth-setup-token-home-"),
+);
+vi.mock("os", async (importOriginal) => {
+  const original = await importOriginal<typeof import("os")>();
+  return {
+    ...original,
+    homedir: () => TEST_HOME,
+  };
+});
+
+describe("auth setup-token", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+
+    // Ensure clean config state
+    const configDir = path.join(TEST_HOME, ".vm0");
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+
+    // Clean up config
+    const configDir = path.join(TEST_HOME, ".vm0");
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  describe("authenticated via config", () => {
+    it("should output token from config file", async () => {
+      // Create config with token
+      const configDir = path.join(TEST_HOME, ".vm0");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "config.json"),
+        JSON.stringify({ token: "vm0_live_test123" }),
+      );
+
+      await setupTokenCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("token exported successfully"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith("vm0_live_test123");
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("export VM0_TOKEN"),
+      );
+    });
+  });
+
+  describe("authenticated via environment", () => {
+    it("should output token from VM0_TOKEN env var", async () => {
+      vi.stubEnv("VM0_TOKEN", "vm0_live_envtoken456");
+
+      await setupTokenCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("token exported successfully"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith("vm0_live_envtoken456");
+    });
+  });
+
+  describe("not authenticated", () => {
+    it("should exit with error and show instructions", async () => {
+      await expect(async () => {
+        await setupTokenCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 auth login"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("CI/CD"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/auth/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/status.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for auth status command
+ *
+ * Covers:
+ * - Authenticated state (with token in config)
+ * - Not authenticated state
+ * - Token from environment variable
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { statusCommand } from "../status";
+import { mkdtempSync } from "fs";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import chalk from "chalk";
+
+// Mock os.homedir to use temp directory
+const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "test-auth-status-home-"));
+vi.mock("os", async (importOriginal) => {
+  const original = await importOriginal<typeof import("os")>();
+  return {
+    ...original,
+    homedir: () => TEST_HOME,
+  };
+});
+
+describe("auth status", () => {
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+
+    // Ensure clean config state
+    const configDir = path.join(TEST_HOME, ".vm0");
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    mockConsoleLog.mockClear();
+    vi.unstubAllEnvs();
+
+    // Clean up config
+    const configDir = path.join(TEST_HOME, ".vm0");
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  describe("authenticated state", () => {
+    it("should show authenticated when token exists in config", async () => {
+      // Create config with token
+      const configDir = path.join(TEST_HOME, ".vm0");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "config.json"),
+        JSON.stringify({ token: "test-token-123" }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Authenticated"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("logged in"),
+      );
+    });
+  });
+
+  describe("not authenticated state", () => {
+    it("should show not authenticated when no token exists", async () => {
+      await statusCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 auth login"),
+      );
+    });
+  });
+
+  describe("environment variable token", () => {
+    it("should indicate when using VM0_TOKEN env var", async () => {
+      vi.stubEnv("VM0_TOKEN", "env-token-456");
+
+      await statusCommand.parseAsync(["node", "cli"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("VM0_TOKEN"),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Migrate all CLI command tests to a colocated structure where tests live in
`commands/<command>/__tests__/` directories instead of scattered `__tests__/` folders.

## Changes
**Auth tests** (14 tests):
- login: Device code flow, token saving, error handling
- logout: Successful logout scenarios
- status: Authenticated state display
- setup-token: Token export functionality

**Remaining command tests** (131 tests):
- compose: 19 tests - file validation, YAML parsing, API interaction
- cook: 25 tests - environment variables, run ID parsing, config detection
- init: 19 tests - file existence check, agent name validation, file creation
- onboard: 19 tests - welcome screen, progress indicator, auth/provider checks
- run: 28 tests - compose ID validation, template variables, event polling
- setup-claude: 7 tests - plugin installation, error handling
- usage: 14 tests - date options, API interaction, output formatting

## Test strategy
- Tests use `command.parseAsync()` to run commands
- MSW for HTTP API mocking
- `vi.stubEnv()` for environment variables
- Real temp directories with `mkdtempSync()` for filesystem state
- `os.homedir()` mock for config file isolation in auth tests

## Test plan
- [x] All 896 CLI tests pass locally
- [x] Lint passes
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)