### PR TITLE
refactor(cli): remove redundant auth detail messages in onboard

### DIFF
--- a/turbo/apps/cli/src/commands/onboard/index.ts
+++ b/turbo/apps/cli/src/commands/onboard/index.ts
@@ -58,11 +58,9 @@ async function handleAuthentication(ctx: OnboardContext): Promise<void> {
     process.exit(1);
   }
 
-  ctx.progress.detail("Authentication required...");
-
   await runAuthFlow({
     onInitiating: () => {
-      ctx.progress.detail("Initiating device flow...");
+      // No detail needed - step header is enough
     },
     onDeviceCodeReady: (url, code, expiresIn) => {
       ctx.progress.detail(`Visit: ${url}`);


### PR DESCRIPTION
## Summary

Remove redundant detail messages from authentication step in onboard flow:
- "Authentication required..."
- "Initiating device flow..."

The step header "○ Authentication" provides sufficient context.

## Test plan

- [x] Type check passes
- [ ] Manual test: `vm0 onboard` when not authenticated

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)