### PR TITLE
refactor(runner): extract VM_PROXY_CA_PATH constant

### DIFF
--- a/turbo/apps/runner/src/lib/executor-env.ts
+++ b/turbo/apps/runner/src/lib/executor-env.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ExecutionContext } from "./api.js";
+import { VM_PROXY_CA_PATH } from "./vm-setup/index.js";
 
 /**
  * Path to environment JSON file in VM
@@ -77,10 +78,9 @@ export function buildEnvironmentVariables(
   // For MITM mode, tell Node.js to trust the proxy CA certificate
   // This is required because mitmproxy intercepts HTTPS traffic and re-signs
   // certificates with its own CA. Without this, Node.js will reject the connection.
-  // Note: Python and curl automatically use the system CA bundle after update-ca-certificates.
+  // Note: Python and curl automatically use the system CA bundle.
   if (context.experimentalFirewall?.experimental_mitm) {
-    envVars.NODE_EXTRA_CA_CERTS =
-      "/usr/local/share/ca-certificates/vm0-proxy-ca.crt";
+    envVars.NODE_EXTRA_CA_CERTS = VM_PROXY_CA_PATH;
   }
 
   return envVars;

--- a/turbo/apps/runner/src/lib/vm-setup/index.ts
+++ b/turbo/apps/runner/src/lib/vm-setup/index.ts
@@ -8,4 +8,5 @@ export {
   downloadStorages,
   restoreSessionHistory,
   installProxyCA,
+  VM_PROXY_CA_PATH,
 } from "./vm-setup.js";


### PR DESCRIPTION
## Summary
- Extract hardcoded `/usr/local/share/ca-certificates/vm0-proxy-ca.crt` path into `VM_PROXY_CA_PATH` constant
- Share between `vm-setup.ts` and `executor-env.ts`

## Test plan
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)