### PR TITLE
feat(runner): enforce single runner per device with pid file lock

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check if cleanup needed
         id: check
         env:
-          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS_LY }}
+          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
           SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
         run: |
           if [ -z "$SSH_KEY" ] || [ -z "$METAL_HOSTS" ]; then
@@ -47,7 +47,7 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
-          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS_LY }}
+          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
         run: |
           SSH_KEY_FILE="$HOME/.ssh/metal.pem"
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $SSH_KEY_FILE"

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check if cleanup needed
         id: check
         env:
-          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
+          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS_LY }}
           SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
         run: |
           if [ -z "$SSH_KEY" ] || [ -z "$METAL_HOSTS" ]; then
@@ -47,7 +47,7 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
-          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
+          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS_LY }}
         run: |
           SSH_KEY_FILE="$HOME/.ssh/metal.pem"
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $SSH_KEY_FILE"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -989,22 +989,35 @@ jobs:
           echo "runner-deployed=true" >> $GITHUB_OUTPUT
           echo "Runner started at ${RUNNER_DIR} on ${RUNNER_HOST}"
 
-  # Release runner host lock after cli-e2e-03-runner completes (or fails/times out)
-  # Note: Runner cleanup happens in cleanup.yml when PR is closed (to allow reruns)
+  # Stop runner and release host lock after cli-e2e-03-runner completes (or fails/times out)
+  # Runner must be stopped to prevent stale runners from claiming jobs in subsequent CI runs
   # Skip on push to main - runner deployment is only needed for PRs
   unlock-runner-host:
     runs-on: ubuntu-latest
     needs: [deploy-runner-prepare, cli-e2e-03-runner]
     if: always() && contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') && github.event_name != 'push' && needs.deploy-runner-prepare.outputs.runner-host != ''
     steps:
-      - name: Unlock runner host
+      - name: Stop runner and unlock host
         env:
           RUNNER_HOST: ${{ needs.deploy-runner-prepare.outputs.runner-host }}
+          RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
           METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
           SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
         run: |
           mkdir -p "$HOME/.ssh"
           echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
           chmod 600 "$HOME/.ssh/runner.pem"
-          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i "$HOME/.ssh/runner.pem" ${METAL_USER}@${RUNNER_HOST} "rm -rf /opt/vm0-runner/.lock" || true
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
+
+          # Extract job ref from runner dir (e.g., /opt/vm0-runner/pr-1900 -> pr-1900)
+          JOB_REF=$(basename "$RUNNER_DIR")
+          if [ -n "$JOB_REF" ]; then
+            PM2_NAME="vm0-runner-${JOB_REF}"
+            echo "Stopping runner ${PM2_NAME}..."
+            ssh $SSH_OPTS ${METAL_USER}@${RUNNER_HOST} "pm2 delete ${PM2_NAME} 2>/dev/null || true"
+            echo "Runner stopped"
+          fi
+
+          # Release the host lock
+          ssh $SSH_OPTS ${METAL_USER}@${RUNNER_HOST} "rm -rf /opt/vm0-runner/.lock" || true
           echo "Unlocked runner host: $RUNNER_HOST"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -686,7 +686,7 @@ jobs:
         shell: bash
         env:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
-          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
+          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS_LY }}
           METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
           SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
         run: |

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -686,7 +686,7 @@ jobs:
         shell: bash
         env:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
-          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS_LY }}
+          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
           METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
           SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
         run: |

--- a/turbo/apps/runner/src/lib/proxy/proxy-manager.ts
+++ b/turbo/apps/runner/src/lib/proxy/proxy-manager.ts
@@ -213,6 +213,14 @@ export class ProxyManager {
 
     this.isRunning = true;
     logger.log("mitmproxy started successfully");
+
+    // Register exit handler to ensure proxy is killed when runner exits
+    // This handles cases where pm2 delete doesn't give runner time to cleanup
+    process.on("exit", () => {
+      if (this.process && !this.process.killed) {
+        this.process.kill("SIGKILL");
+      }
+    });
   }
 
   /**

--- a/turbo/apps/runner/src/lib/runner/__tests__/runner-lock.test.ts
+++ b/turbo/apps/runner/src/lib/runner/__tests__/runner-lock.test.ts
@@ -100,6 +100,41 @@ describe("runner-lock", () => {
 
       killSpy.mockRestore();
     });
+
+    it("should exit if process exists but we lack permission (EPERM)", async () => {
+      // PID file exists with process owned by another user
+      const runningPid = 1; // init/systemd - typically can't signal
+      vi.mocked(fs.existsSync).mockImplementation((path) => {
+        if (path === "/var/run/vm0") return true;
+        if (path === "/var/run/vm0/runner.pid") return true;
+        return false;
+      });
+      vi.mocked(fs.readFileSync).mockReturnValue(runningPid.toString());
+
+      // Mock process.kill to throw EPERM (process exists but no permission)
+      const epermError = new Error("EPERM") as Error & { code: string };
+      epermError.code = "EPERM";
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+        throw epermError;
+      });
+      const exitSpy = vi
+        .spyOn(process, "exit")
+        .mockImplementation(() => undefined as never);
+      const errorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      await acquireRunnerLock();
+
+      // EPERM means process exists, so should exit
+      expect(killSpy).toHaveBeenCalledWith(runningPid, 0);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Another runner is already running"),
+      );
+
+      killSpy.mockRestore();
+    });
   });
 
   describe("releaseRunnerLock", () => {

--- a/turbo/apps/runner/src/lib/runner/__tests__/runner-lock.test.ts
+++ b/turbo/apps/runner/src/lib/runner/__tests__/runner-lock.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import { acquireRunnerLock, releaseRunnerLock } from "../runner-lock.js";
+
+const PID_FILE = "/var/run/vm0/runner.pid";
+
+describe("runner-lock", () => {
+  afterEach(() => {
+    // Clean up PID file after each test
+    if (fs.existsSync(PID_FILE)) {
+      fs.unlinkSync(PID_FILE);
+    }
+    vi.restoreAllMocks();
+  });
+
+  describe("acquireRunnerLock", () => {
+    it("should create PID file with current PID", async () => {
+      await acquireRunnerLock();
+
+      expect(fs.existsSync(PID_FILE)).toBe(true);
+      const pid = parseInt(fs.readFileSync(PID_FILE, "utf-8"), 10);
+      expect(pid).toBe(process.pid);
+
+      releaseRunnerLock();
+    });
+
+    it("should clean up stale PID file from non-existent process", async () => {
+      // Write a fake PID that doesn't exist (very high number)
+      fs.writeFileSync(PID_FILE, "999999999");
+
+      await acquireRunnerLock();
+
+      // Should have replaced with current PID
+      const pid = parseInt(fs.readFileSync(PID_FILE, "utf-8"), 10);
+      expect(pid).toBe(process.pid);
+
+      releaseRunnerLock();
+    });
+
+    it("should exit if another runner is running", async () => {
+      // Write current process PID (simulating another runner)
+      // We use a different approach - write PID of a known running process
+      const parentPid = process.ppid;
+      fs.writeFileSync(PID_FILE, parentPid.toString());
+
+      const exitSpy = vi
+        .spyOn(process, "exit")
+        .mockImplementation(() => undefined as never);
+      const errorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      await acquireRunnerLock();
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Another runner is already running"),
+      );
+
+      // Clean up
+      fs.unlinkSync(PID_FILE);
+    });
+  });
+
+  describe("releaseRunnerLock", () => {
+    it("should remove PID file", async () => {
+      await acquireRunnerLock();
+      expect(fs.existsSync(PID_FILE)).toBe(true);
+
+      releaseRunnerLock();
+      expect(fs.existsSync(PID_FILE)).toBe(false);
+    });
+
+    it("should not throw if PID file does not exist", () => {
+      // Should not throw
+      expect(() => releaseRunnerLock()).not.toThrow();
+    });
+  });
+});

--- a/turbo/apps/runner/src/lib/runner/__tests__/runner-lock.test.ts
+++ b/turbo/apps/runner/src/lib/runner/__tests__/runner-lock.test.ts
@@ -1,15 +1,34 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs";
+import { exec } from "node:child_process";
 import { acquireRunnerLock, releaseRunnerLock } from "../runner-lock.js";
 
-const PID_FILE = "/var/run/vm0/runner.pid";
+// Mock modules
+vi.mock("node:fs");
+vi.mock("node:child_process");
 
 describe("runner-lock", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default: directory exists, no PID file
+    vi.mocked(fs.existsSync).mockImplementation((path) => {
+      if (path === "/var/run/vm0") return true;
+      return false;
+    });
+
+    // Mock exec for sudo commands - use type assertion to handle complex overloads
+    vi.mocked(exec).mockImplementation(((_cmd, _options, callback) => {
+      const cb =
+        typeof _options === "function"
+          ? (_options as (error: Error | null) => void)
+          : (callback as ((error: Error | null) => void) | undefined);
+      if (cb) cb(null);
+      return {} as ReturnType<typeof exec>;
+    }) as typeof exec);
+  });
+
   afterEach(() => {
-    // Clean up PID file after each test
-    if (fs.existsSync(PID_FILE)) {
-      fs.unlinkSync(PID_FILE);
-    }
     vi.restoreAllMocks();
   });
 
@@ -17,32 +36,53 @@ describe("runner-lock", () => {
     it("should create PID file with current PID", async () => {
       await acquireRunnerLock();
 
-      expect(fs.existsSync(PID_FILE)).toBe(true);
-      const pid = parseInt(fs.readFileSync(PID_FILE, "utf-8"), 10);
-      expect(pid).toBe(process.pid);
-
-      releaseRunnerLock();
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        "/var/run/vm0/runner.pid",
+        process.pid.toString(),
+      );
     });
 
     it("should clean up stale PID file from non-existent process", async () => {
-      // Write a fake PID that doesn't exist (very high number)
-      fs.writeFileSync(PID_FILE, "999999999");
+      // PID file exists with stale PID
+      vi.mocked(fs.existsSync).mockImplementation((path) => {
+        if (path === "/var/run/vm0") return true;
+        if (path === "/var/run/vm0/runner.pid") return true;
+        return false;
+      });
+      vi.mocked(fs.readFileSync).mockReturnValue("999999999");
+
+      // Mock process.kill to throw (process doesn't exist)
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+        throw new Error("ESRCH");
+      });
 
       await acquireRunnerLock();
 
-      // Should have replaced with current PID
-      const pid = parseInt(fs.readFileSync(PID_FILE, "utf-8"), 10);
-      expect(pid).toBe(process.pid);
+      // Should have tried to check if process exists
+      expect(killSpy).toHaveBeenCalledWith(999999999, 0);
+      // Should have removed stale file
+      expect(fs.unlinkSync).toHaveBeenCalledWith("/var/run/vm0/runner.pid");
+      // Should have written new PID
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        "/var/run/vm0/runner.pid",
+        process.pid.toString(),
+      );
 
-      releaseRunnerLock();
+      killSpy.mockRestore();
     });
 
     it("should exit if another runner is running", async () => {
-      // Write current process PID (simulating another runner)
-      // We use a different approach - write PID of a known running process
-      const parentPid = process.ppid;
-      fs.writeFileSync(PID_FILE, parentPid.toString());
+      // PID file exists with running process
+      const runningPid = 12345;
+      vi.mocked(fs.existsSync).mockImplementation((path) => {
+        if (path === "/var/run/vm0") return true;
+        if (path === "/var/run/vm0/runner.pid") return true;
+        return false;
+      });
+      vi.mocked(fs.readFileSync).mockReturnValue(runningPid.toString());
 
+      // Mock process.kill to succeed (process exists)
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
       const exitSpy = vi
         .spyOn(process, "exit")
         .mockImplementation(() => undefined as never);
@@ -52,28 +92,32 @@ describe("runner-lock", () => {
 
       await acquireRunnerLock();
 
+      expect(killSpy).toHaveBeenCalledWith(runningPid, 0);
       expect(exitSpy).toHaveBeenCalledWith(1);
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining("Another runner is already running"),
       );
 
-      // Clean up
-      fs.unlinkSync(PID_FILE);
+      killSpy.mockRestore();
     });
   });
 
   describe("releaseRunnerLock", () => {
-    it("should remove PID file", async () => {
-      await acquireRunnerLock();
-      expect(fs.existsSync(PID_FILE)).toBe(true);
+    it("should remove PID file", () => {
+      // PID file exists
+      vi.mocked(fs.existsSync).mockReturnValue(true);
 
       releaseRunnerLock();
-      expect(fs.existsSync(PID_FILE)).toBe(false);
+
+      expect(fs.unlinkSync).toHaveBeenCalledWith("/var/run/vm0/runner.pid");
     });
 
     it("should not throw if PID file does not exist", () => {
-      // Should not throw
+      // PID file doesn't exist
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
       expect(() => releaseRunnerLock()).not.toThrow();
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
     });
   });
 });

--- a/turbo/apps/runner/src/lib/runner/__tests__/runner-lock.test.ts
+++ b/turbo/apps/runner/src/lib/runner/__tests__/runner-lock.test.ts
@@ -1,88 +1,54 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs";
-import { exec } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
 import { acquireRunnerLock, releaseRunnerLock } from "../runner-lock.js";
 
-// Mock modules
-vi.mock("node:fs");
-vi.mock("node:child_process");
-
 describe("runner-lock", () => {
+  let testDir: string;
+  let pidFile: string;
+
   beforeEach(() => {
-    vi.clearAllMocks();
-
-    // Default: directory exists, no PID file
-    vi.mocked(fs.existsSync).mockImplementation((path) => {
-      if (path === "/var/run/vm0") return true;
-      return false;
-    });
-
-    // Mock exec for sudo commands - use type assertion to handle complex overloads
-    vi.mocked(exec).mockImplementation(((_cmd, _options, callback) => {
-      const cb =
-        typeof _options === "function"
-          ? (_options as (error: Error | null) => void)
-          : (callback as ((error: Error | null) => void) | undefined);
-      if (cb) cb(null);
-      return {} as ReturnType<typeof exec>;
-    }) as typeof exec);
+    // Create temp directory for each test
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), "runner-lock-test-"));
+    pidFile = path.join(testDir, "runner.pid");
   });
 
   afterEach(() => {
+    // Clean up temp directory
+    fs.rmSync(testDir, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
 
   describe("acquireRunnerLock", () => {
     it("should create PID file with current PID", async () => {
-      await acquireRunnerLock();
+      await acquireRunnerLock({ pidFile, skipSudo: true });
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        "/var/run/vm0/runner.pid",
-        process.pid.toString(),
-      );
+      expect(fs.existsSync(pidFile)).toBe(true);
+      const content = fs.readFileSync(pidFile, "utf-8");
+      expect(content).toBe(process.pid.toString());
+
+      releaseRunnerLock();
     });
 
     it("should clean up stale PID file from non-existent process", async () => {
-      // PID file exists with stale PID
-      vi.mocked(fs.existsSync).mockImplementation((path) => {
-        if (path === "/var/run/vm0") return true;
-        if (path === "/var/run/vm0/runner.pid") return true;
-        return false;
-      });
-      vi.mocked(fs.readFileSync).mockReturnValue("999999999");
+      // Write a fake PID that doesn't exist (very high number)
+      fs.writeFileSync(pidFile, "999999999");
 
-      // Mock process.kill to throw (process doesn't exist)
-      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
-        throw new Error("ESRCH");
-      });
+      await acquireRunnerLock({ pidFile, skipSudo: true });
 
-      await acquireRunnerLock();
+      // Should have replaced with current PID
+      const content = fs.readFileSync(pidFile, "utf-8");
+      expect(content).toBe(process.pid.toString());
 
-      // Should have tried to check if process exists
-      expect(killSpy).toHaveBeenCalledWith(999999999, 0);
-      // Should have removed stale file
-      expect(fs.unlinkSync).toHaveBeenCalledWith("/var/run/vm0/runner.pid");
-      // Should have written new PID
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        "/var/run/vm0/runner.pid",
-        process.pid.toString(),
-      );
-
-      killSpy.mockRestore();
+      releaseRunnerLock();
     });
 
     it("should exit if another runner is running", async () => {
-      // PID file exists with running process
-      const runningPid = 12345;
-      vi.mocked(fs.existsSync).mockImplementation((path) => {
-        if (path === "/var/run/vm0") return true;
-        if (path === "/var/run/vm0/runner.pid") return true;
-        return false;
-      });
-      vi.mocked(fs.readFileSync).mockReturnValue(runningPid.toString());
+      // Write current process's parent PID (known to be running)
+      const parentPid = process.ppid;
+      fs.writeFileSync(pidFile, parentPid.toString());
 
-      // Mock process.kill to succeed (process exists)
-      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
       const exitSpy = vi
         .spyOn(process, "exit")
         .mockImplementation(() => undefined as never);
@@ -90,28 +56,22 @@ describe("runner-lock", () => {
         .spyOn(console, "error")
         .mockImplementation(() => undefined);
 
-      await acquireRunnerLock();
+      await acquireRunnerLock({ pidFile, skipSudo: true });
 
-      expect(killSpy).toHaveBeenCalledWith(runningPid, 0);
       expect(exitSpy).toHaveBeenCalledWith(1);
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining("Another runner is already running"),
       );
 
-      killSpy.mockRestore();
+      // Clean up manually since lock was not acquired
+      fs.unlinkSync(pidFile);
     });
 
     it("should exit if process exists but we lack permission (EPERM)", async () => {
-      // PID file exists with process owned by another user
-      const runningPid = 1; // init/systemd - typically can't signal
-      vi.mocked(fs.existsSync).mockImplementation((path) => {
-        if (path === "/var/run/vm0") return true;
-        if (path === "/var/run/vm0/runner.pid") return true;
-        return false;
-      });
-      vi.mocked(fs.readFileSync).mockReturnValue(runningPid.toString());
+      // Write PID 1 (init/systemd - typically can't signal)
+      fs.writeFileSync(pidFile, "1");
 
-      // Mock process.kill to throw EPERM (process exists but no permission)
+      // Mock process.kill to throw EPERM
       const epermError = new Error("EPERM") as Error & { code: string };
       epermError.code = "EPERM";
       const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
@@ -120,39 +80,31 @@ describe("runner-lock", () => {
       const exitSpy = vi
         .spyOn(process, "exit")
         .mockImplementation(() => undefined as never);
-      const errorSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => undefined);
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
 
-      await acquireRunnerLock();
+      await acquireRunnerLock({ pidFile, skipSudo: true });
 
       // EPERM means process exists, so should exit
-      expect(killSpy).toHaveBeenCalledWith(runningPid, 0);
       expect(exitSpy).toHaveBeenCalledWith(1);
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Another runner is already running"),
-      );
 
       killSpy.mockRestore();
+      fs.unlinkSync(pidFile);
     });
   });
 
   describe("releaseRunnerLock", () => {
-    it("should remove PID file", () => {
-      // PID file exists
-      vi.mocked(fs.existsSync).mockReturnValue(true);
+    it("should remove PID file", async () => {
+      await acquireRunnerLock({ pidFile, skipSudo: true });
+      expect(fs.existsSync(pidFile)).toBe(true);
 
       releaseRunnerLock();
-
-      expect(fs.unlinkSync).toHaveBeenCalledWith("/var/run/vm0/runner.pid");
+      expect(fs.existsSync(pidFile)).toBe(false);
     });
 
     it("should not throw if PID file does not exist", () => {
       // PID file doesn't exist
-      vi.mocked(fs.existsSync).mockReturnValue(false);
-
+      expect(fs.existsSync(pidFile)).toBe(false);
       expect(() => releaseRunnerLock()).not.toThrow();
-      expect(fs.unlinkSync).not.toHaveBeenCalled();
     });
   });
 });

--- a/turbo/apps/runner/src/lib/runner/__tests__/runner-lock.test.ts
+++ b/turbo/apps/runner/src/lib/runner/__tests__/runner-lock.test.ts
@@ -45,6 +45,19 @@ describe("runner-lock", () => {
       releaseRunnerLock();
     });
 
+    it("should clean up invalid PID file with non-numeric content", async () => {
+      // Write invalid content
+      fs.writeFileSync(pidFile, "not-a-number");
+
+      await acquireRunnerLock({ pidFile, skipSudo: true });
+
+      // Should have replaced with current PID
+      const content = fs.readFileSync(pidFile, "utf-8");
+      expect(content).toBe(process.pid.toString());
+
+      releaseRunnerLock();
+    });
+
     it("should exit if another runner is running", async () => {
       // Write current process's parent PID (known to be running)
       const parentPid = process.ppid;

--- a/turbo/apps/runner/src/lib/runner/__tests__/runner-lock.test.ts
+++ b/turbo/apps/runner/src/lib/runner/__tests__/runner-lock.test.ts
@@ -9,6 +9,7 @@ describe("runner-lock", () => {
   let pidFile: string;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     // Create temp directory for each test
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), "runner-lock-test-"));
     pidFile = path.join(testDir, "runner.pid");

--- a/turbo/apps/runner/src/lib/runner/runner-lock.ts
+++ b/turbo/apps/runner/src/lib/runner/runner-lock.ts
@@ -10,7 +10,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
 
+import { createLogger } from "../logger.js";
+
 const execAsync = promisify(exec);
+const logger = createLogger("RunnerLock");
 
 const DEFAULT_RUN_DIR = "/var/run/vm0";
 const DEFAULT_PID_FILE = `${DEFAULT_RUN_DIR}/runner.pid`;
@@ -78,20 +81,20 @@ export async function acquireRunnerLock(
     const pid = parseInt(pidStr, 10);
 
     if (!isNaN(pid) && isProcessRunning(pid)) {
-      console.error(`Error: Another runner is already running (PID ${pid})`);
-      console.error(`If this is incorrect, remove ${pidFile} and try again.`);
+      logger.error(`Error: Another runner is already running (PID ${pid})`);
+      logger.error(`If this is incorrect, remove ${pidFile} and try again.`);
       process.exit(1);
     }
 
     // Stale PID file - clean up
-    console.log(`Cleaning up stale PID file (PID ${pid} not running)`);
+    logger.log(`Cleaning up stale PID file (PID ${pid} not running)`);
     fs.unlinkSync(pidFile);
   }
 
   // Write current PID
   fs.writeFileSync(pidFile, process.pid.toString());
   currentPidFile = pidFile;
-  console.log(`Runner lock acquired (PID ${process.pid})`);
+  logger.log(`Runner lock acquired (PID ${process.pid})`);
 }
 
 /**
@@ -101,7 +104,7 @@ export function releaseRunnerLock(): void {
   const pidFile = currentPidFile ?? DEFAULT_PID_FILE;
   if (fs.existsSync(pidFile)) {
     fs.unlinkSync(pidFile);
-    console.log("Runner lock released");
+    logger.log("Runner lock released");
   }
   currentPidFile = null;
 }

--- a/turbo/apps/runner/src/lib/runner/runner-lock.ts
+++ b/turbo/apps/runner/src/lib/runner/runner-lock.ts
@@ -26,12 +26,22 @@ async function ensureRunDir(): Promise<void> {
 
 /**
  * Check if a process is running
+ *
+ * Uses kill(pid, 0) which checks process existence without sending a signal.
+ * - Returns true if process exists (signal would be deliverable)
+ * - Returns true if EPERM (process exists but we lack permission)
+ * - Returns false if ESRCH (no such process)
  */
 function isProcessRunning(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch (err: unknown) {
+    // EPERM means process exists but we don't have permission to signal it
+    if (err instanceof Error && "code" in err && err.code === "EPERM") {
+      return true;
+    }
+    // ESRCH or other errors mean process doesn't exist
     return false;
   }
 }

--- a/turbo/apps/runner/src/lib/runner/runner-lock.ts
+++ b/turbo/apps/runner/src/lib/runner/runner-lock.ts
@@ -87,7 +87,11 @@ export async function acquireRunnerLock(
     }
 
     // Stale PID file - clean up
-    logger.log(`Cleaning up stale PID file (PID ${pid} not running)`);
+    if (isNaN(pid)) {
+      logger.log("Cleaning up invalid PID file");
+    } else {
+      logger.log(`Cleaning up stale PID file (PID ${pid} not running)`);
+    }
     fs.unlinkSync(pidFile);
   }
 

--- a/turbo/apps/runner/src/lib/runner/runner-lock.ts
+++ b/turbo/apps/runner/src/lib/runner/runner-lock.ts
@@ -66,14 +66,8 @@ export async function acquireRunnerLock(): Promise<void> {
  * Release runner lock
  */
 export function releaseRunnerLock(): void {
-  try {
-    if (fs.existsSync(PID_FILE)) {
-      fs.unlinkSync(PID_FILE);
-      console.log("Runner lock released");
-    }
-  } catch (err) {
-    console.warn(
-      `Warning: Failed to release runner lock: ${err instanceof Error ? err.message : err}`,
-    );
+  if (fs.existsSync(PID_FILE)) {
+    fs.unlinkSync(PID_FILE);
+    console.log("Runner lock released");
   }
 }

--- a/turbo/apps/runner/src/lib/runner/runner-lock.ts
+++ b/turbo/apps/runner/src/lib/runner/runner-lock.ts
@@ -1,0 +1,79 @@
+/**
+ * Runner Lock - ensures only one runner per device
+ *
+ * Uses a PID file at /var/run/vm0/runner.pid to prevent multiple
+ * runner instances from running on the same device.
+ */
+
+import { exec } from "node:child_process";
+import fs from "node:fs";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+
+const VM0_RUN_DIR = "/var/run/vm0";
+const PID_FILE = `${VM0_RUN_DIR}/runner.pid`;
+
+/**
+ * Ensure the vm0 run directory exists
+ */
+async function ensureRunDir(): Promise<void> {
+  if (!fs.existsSync(VM0_RUN_DIR)) {
+    await execAsync(`sudo mkdir -p ${VM0_RUN_DIR}`);
+    await execAsync(`sudo chmod 777 ${VM0_RUN_DIR}`);
+  }
+}
+
+/**
+ * Check if a process is running
+ */
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Acquire runner lock - exits if another runner is running
+ */
+export async function acquireRunnerLock(): Promise<void> {
+  await ensureRunDir();
+
+  if (fs.existsSync(PID_FILE)) {
+    const pidStr = fs.readFileSync(PID_FILE, "utf-8").trim();
+    const pid = parseInt(pidStr, 10);
+
+    if (!isNaN(pid) && isProcessRunning(pid)) {
+      console.error(`Error: Another runner is already running (PID ${pid})`);
+      console.error(`If this is incorrect, remove ${PID_FILE} and try again.`);
+      process.exit(1);
+    }
+
+    // Stale PID file - clean up
+    console.log(`Cleaning up stale PID file (PID ${pid} not running)`);
+    fs.unlinkSync(PID_FILE);
+  }
+
+  // Write current PID
+  fs.writeFileSync(PID_FILE, process.pid.toString());
+  console.log(`Runner lock acquired (PID ${process.pid})`);
+}
+
+/**
+ * Release runner lock
+ */
+export function releaseRunnerLock(): void {
+  try {
+    if (fs.existsSync(PID_FILE)) {
+      fs.unlinkSync(PID_FILE);
+      console.log("Runner lock released");
+    }
+  } catch (err) {
+    console.warn(
+      `Warning: Failed to release runner lock: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}

--- a/turbo/apps/runner/src/lib/runner/runner-lock.ts
+++ b/turbo/apps/runner/src/lib/runner/runner-lock.ts
@@ -7,20 +7,35 @@
 
 import { exec } from "node:child_process";
 import fs from "node:fs";
+import path from "node:path";
 import { promisify } from "node:util";
 
 const execAsync = promisify(exec);
 
-const VM0_RUN_DIR = "/var/run/vm0";
-const PID_FILE = `${VM0_RUN_DIR}/runner.pid`;
+const DEFAULT_RUN_DIR = "/var/run/vm0";
+const DEFAULT_PID_FILE = `${DEFAULT_RUN_DIR}/runner.pid`;
+
+// Module state for tracking current lock
+let currentPidFile: string | null = null;
+
+interface RunnerLockOptions {
+  /** Custom PID file path (for testing). Defaults to /var/run/vm0/runner.pid */
+  pidFile?: string;
+  /** Skip sudo for directory creation (for testing). Defaults to false */
+  skipSudo?: boolean;
+}
 
 /**
- * Ensure the vm0 run directory exists
+ * Ensure the directory for PID file exists
  */
-async function ensureRunDir(): Promise<void> {
-  if (!fs.existsSync(VM0_RUN_DIR)) {
-    await execAsync(`sudo mkdir -p ${VM0_RUN_DIR}`);
-    await execAsync(`sudo chmod 777 ${VM0_RUN_DIR}`);
+async function ensureRunDir(dirPath: string, skipSudo: boolean): Promise<void> {
+  if (!fs.existsSync(dirPath)) {
+    if (skipSudo) {
+      fs.mkdirSync(dirPath, { recursive: true });
+    } else {
+      await execAsync(`sudo mkdir -p ${dirPath}`);
+      await execAsync(`sudo chmod 777 ${dirPath}`);
+    }
   }
 }
 
@@ -49,26 +64,33 @@ function isProcessRunning(pid: number): boolean {
 /**
  * Acquire runner lock - exits if another runner is running
  */
-export async function acquireRunnerLock(): Promise<void> {
-  await ensureRunDir();
+export async function acquireRunnerLock(
+  options: RunnerLockOptions = {},
+): Promise<void> {
+  const pidFile = options.pidFile ?? DEFAULT_PID_FILE;
+  const skipSudo = options.skipSudo ?? false;
+  const runDir = path.dirname(pidFile);
 
-  if (fs.existsSync(PID_FILE)) {
-    const pidStr = fs.readFileSync(PID_FILE, "utf-8").trim();
+  await ensureRunDir(runDir, skipSudo);
+
+  if (fs.existsSync(pidFile)) {
+    const pidStr = fs.readFileSync(pidFile, "utf-8").trim();
     const pid = parseInt(pidStr, 10);
 
     if (!isNaN(pid) && isProcessRunning(pid)) {
       console.error(`Error: Another runner is already running (PID ${pid})`);
-      console.error(`If this is incorrect, remove ${PID_FILE} and try again.`);
+      console.error(`If this is incorrect, remove ${pidFile} and try again.`);
       process.exit(1);
     }
 
     // Stale PID file - clean up
     console.log(`Cleaning up stale PID file (PID ${pid} not running)`);
-    fs.unlinkSync(PID_FILE);
+    fs.unlinkSync(pidFile);
   }
 
   // Write current PID
-  fs.writeFileSync(PID_FILE, process.pid.toString());
+  fs.writeFileSync(pidFile, process.pid.toString());
+  currentPidFile = pidFile;
   console.log(`Runner lock acquired (PID ${process.pid})`);
 }
 
@@ -76,8 +98,10 @@ export async function acquireRunnerLock(): Promise<void> {
  * Release runner lock
  */
 export function releaseRunnerLock(): void {
-  if (fs.existsSync(PID_FILE)) {
-    fs.unlinkSync(PID_FILE);
+  const pidFile = currentPidFile ?? DEFAULT_PID_FILE;
+  if (fs.existsSync(pidFile)) {
+    fs.unlinkSync(pidFile);
     console.log("Runner lock released");
   }
+  currentPidFile = null;
 }

--- a/turbo/apps/runner/src/lib/runner/setup.ts
+++ b/turbo/apps/runner/src/lib/runner/setup.ts
@@ -13,6 +13,7 @@ import {
   initVMRegistry,
   getProxyManager,
 } from "../proxy/index.js";
+import { acquireRunnerLock, releaseRunnerLock } from "./runner-lock.js";
 import type { RunnerResources } from "./types.js";
 import { createLogger } from "../logger.js";
 
@@ -29,6 +30,9 @@ export async function setupEnvironment(
   options: SetupOptions,
 ): Promise<RunnerResources> {
   const { config } = options;
+
+  // Acquire runner lock first - ensures only one runner per device
+  await acquireRunnerLock();
 
   // Check network prerequisites
   const networkCheck = checkNetworkPrerequisites();
@@ -110,4 +114,7 @@ export async function cleanupEnvironment(
     logger.log("Stopping network proxy...");
     await getProxyManager().stop();
   }
+
+  // Release runner lock last
+  releaseRunnerLock();
 }


### PR DESCRIPTION
## Summary

Closes #1896

- Add PID file lock mechanism to ensure only one runner per device
- Automatically cleans up stale PID files from crashed runners
- Integrates lock acquire/release into runner lifecycle (setup/cleanup)

## Changes

- New `runner-lock.ts` module with `acquireRunnerLock()` and `releaseRunnerLock()` functions
- Modified `setup.ts` to acquire lock at startup and release on shutdown
- Added comprehensive unit tests for lock functionality

## Test plan

- [x] Unit tests pass for lock acquisition, release, and stale file cleanup
- [ ] Manual test: Start runner, verify PID file created at `/var/run/vm0/runner.pid`
- [ ] Manual test: Start second runner, verify it exits with error
- [ ] Manual test: Kill runner with SIGKILL, restart, verify stale lock cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)