### PR TITLE
refactor(cli): migrate credential command tests to colocated structure

### DIFF
--- a/turbo/apps/cli/src/commands/credential/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/credential/__tests__/delete.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for credential delete command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { deleteCommand } from "../delete";
+import chalk from "chalk";
+
+describe("credential delete command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  describe("help text", () => {
+    it("should show usage information", async () => {
+      const mockStdoutWrite = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      try {
+        await deleteCommand.parseAsync(["node", "cli", "--help"]);
+      } catch {
+        // Commander calls process.exit(0) after help
+      }
+
+      const output = mockStdoutWrite.mock.calls.map((call) => call[0]).join("");
+
+      expect(output).toContain("Delete a credential");
+      expect(output).toContain("<name>");
+
+      mockStdoutWrite.mockRestore();
+    });
+  });
+
+  describe("successful delete", () => {
+    it("should delete credential with confirmation flag", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/credentials/:name", () => {
+          return HttpResponse.json({
+            name: "MY_API_KEY",
+            description: "API key for testing",
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+        }),
+        http.delete("http://localhost:3000/api/credentials/:name", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await deleteCommand.parseAsync(["node", "cli", "MY_API_KEY", "-y"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("MY_API_KEY");
+      expect(logCalls).toContain("deleted");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should fail when deleting non-existent credential", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/credentials/:name",
+          ({ params }) => {
+            const { name } = params;
+            return HttpResponse.json(
+              {
+                error: {
+                  message: `Credential "${name}" not found`,
+                  code: "NOT_FOUND",
+                },
+              },
+              { status: 404 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync([
+          "node",
+          "cli",
+          "NONEXISTENT_CRED",
+          "-y",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/credentials/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "MY_API_KEY", "-y"]);
+      }).rejects.toThrow("process.exit called");
+
+      // The delete command catches the error and displays "not found" message
+      // because it wraps the get call in a try/catch
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/credential/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/credential/__tests__/index.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for credential parent command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { credentialCommand } from "../index";
+import chalk from "chalk";
+
+describe("credential command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("help text", () => {
+    it("should show command description and subcommands", async () => {
+      // Commander outputs help to stdout via process.stdout.write
+      const mockStdoutWrite = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      try {
+        await credentialCommand.parseAsync(["node", "cli", "--help"]);
+      } catch {
+        // Commander calls process.exit(0) after help
+      }
+
+      const output = mockStdoutWrite.mock.calls.map((call) => call[0]).join("");
+
+      expect(output).toContain("Manage stored credentials");
+      expect(output).toContain("list");
+      expect(output).toContain("set");
+      expect(output).toContain("delete");
+
+      mockStdoutWrite.mockRestore();
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/credential/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/credential/__tests__/list.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for credential list command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { listCommand } from "../list";
+import chalk from "chalk";
+
+describe("credential list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  describe("help text", () => {
+    it("should show ls alias", async () => {
+      const mockStdoutWrite = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      try {
+        await listCommand.parseAsync(["node", "cli", "--help"]);
+      } catch {
+        // Commander calls process.exit(0) after help
+      }
+
+      const output = mockStdoutWrite.mock.calls.map((call) => call[0]).join("");
+
+      expect(output).toContain("List all credentials");
+      expect(output).toContain("ls");
+
+      mockStdoutWrite.mockRestore();
+    });
+  });
+
+  describe("successful list", () => {
+    it("should display credentials in table format", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/credentials", () => {
+          return HttpResponse.json({
+            credentials: [
+              {
+                name: "MY_API_KEY",
+                description: "API key for testing",
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+              {
+                name: "GITHUB_TOKEN",
+                description: "GitHub access token",
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("MY_API_KEY");
+      expect(logCalls).toContain("GITHUB_TOKEN");
+    });
+
+    it("should display empty state message when no credentials", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/credentials", () => {
+          return HttpResponse.json({ credentials: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No credentials found");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/credentials", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 auth login"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Split credential command tests into colocated test files per subcommand
- Added new test cases for list success and delete success scenarios
- All tests follow CLI testing patterns: parseAsync entry point, MSW for external API mocking

## Changes

- `commands/credential/__tests__/set.test.ts` - validation and auth error tests
- `commands/credential/__tests__/list.test.ts` - list success, empty state, and auth error tests  
- `commands/credential/__tests__/delete.test.ts` - delete success, non-existent, and auth error tests
- `commands/credential/__tests__/index.test.ts` - parent command help test
- Deleted `src/__tests__/credential-command.test.ts`

## Test plan

- [x] All credential command tests pass (15 tests)
- [x] Full CLI test suite passes (883 tests)
- [x] Lint, type check, and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)