### PR TITLE
fix(contracts): use c.noBody() for 204 responses

### DIFF
--- a/turbo/apps/cli/src/commands/model-provider/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/delete.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { deleteCommand } from "../delete";
+
+describe("model-provider delete command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("successful deletion", () => {
+    it("should show success message on successful deletion", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/model-providers/:type", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await deleteCommand.parseAsync(["node", "cli", "anthropic-api-key"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Model provider "anthropic-api-key" deleted'),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("input validation", () => {
+    it("should reject invalid provider type", async () => {
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "invalid-type"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid type "invalid-type"'),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Valid types:"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle not found error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/model-providers/:type", () => {
+          return HttpResponse.json(
+            {
+              error: { message: "Model provider not found", code: "NOT_FOUND" },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "anthropic-api-key"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/model-providers/:type", () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "anthropic-api-key"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/packages/core/src/contracts/credentials.ts
+++ b/turbo/packages/core/src/contracts/credentials.ts
@@ -142,7 +142,7 @@ export const credentialsByNameContract = c.router({
       name: credentialNameSchema,
     }),
     responses: {
-      204: z.undefined(),
+      204: c.noBody(),
       401: apiErrorSchema,
       404: apiErrorSchema,
       500: apiErrorSchema,

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -185,7 +185,7 @@ export const modelProvidersByTypeContract = c.router({
       type: modelProviderTypeSchema,
     }),
     responses: {
-      204: z.undefined(),
+      204: c.noBody(),
       401: apiErrorSchema,
       404: apiErrorSchema,
       500: apiErrorSchema,

--- a/turbo/packages/core/src/contracts/schedules.ts
+++ b/turbo/packages/core/src/contracts/schedules.ts
@@ -214,7 +214,7 @@ export const schedulesByNameContract = c.router({
       composeId: z.string().uuid("Compose ID required"),
     }),
     responses: {
-      204: z.undefined(),
+      204: c.noBody(),
       401: apiErrorSchema,
       404: apiErrorSchema,
     },


### PR DESCRIPTION
## Summary

- Replace `z.undefined()` with `c.noBody()` in ts-rest contracts for 204 No Content responses
- Add comprehensive tests for model-provider delete command

## Problem

CLI delete commands showed "Unexpected end of JSON input" error despite successful deletion. The root cause was using `z.undefined()` instead of `c.noBody()` for 204 responses in ts-rest contracts, which caused:
1. Server to send empty body with `content-type: application/json` header
2. Client to attempt JSON parsing on empty body

## Solution

Use `c.noBody()` (the canonical ts-rest pattern) for 204 responses. This tells ts-rest to:
- Server: Return response with no content-type header
- Client: Skip JSON parsing, return `undefined`

## Changes

| File | Change |
|------|--------|
| `packages/core/src/contracts/model-providers.ts` | `z.undefined()` → `c.noBody()` |
| `packages/core/src/contracts/credentials.ts` | `z.undefined()` → `c.noBody()` |
| `packages/core/src/contracts/schedules.ts` | `z.undefined()` → `c.noBody()` |
| `apps/cli/src/commands/model-provider/__tests__/delete.test.ts` | New test file |

## Test plan

- [x] Unit tests for model-provider delete command (4 test cases)
- [x] Type checking passes
- [x] Lint passes
- [ ] Manual test: `vm0 model-provider delete` shows success message

Closes #1902

🤖 Generated with [Claude Code](https://claude.ai/code)