### PR TITLE
refactor(runner): unify logging with global logger module

### DIFF
--- a/turbo/apps/runner/src/commands/benchmark.ts
+++ b/turbo/apps/runner/src/commands/benchmark.ts
@@ -8,6 +8,7 @@ import {
   setupBridge,
 } from "../lib/firecracker/network.js";
 import { Timer } from "../lib/timing.js";
+import { setGlobalLogger } from "../lib/logger.js";
 
 interface BenchmarkOptions {
   config: string;
@@ -56,6 +57,9 @@ export const benchmarkCommand = new Command("benchmark")
   .action(async (prompt: string, options: BenchmarkOptions): Promise<void> => {
     const timer = new Timer();
 
+    // Set global logger to use Timer.log for all modules
+    setGlobalLogger(timer.log.bind(timer));
+
     try {
       // Load config
       timer.log("Loading configuration...");
@@ -85,7 +89,6 @@ export const benchmarkCommand = new Command("benchmark")
       // Execute job in benchmark mode (runs bash command directly, skips run-agent.py)
       const result = await executeJob(context, config, {
         benchmarkMode: true,
-        logger: timer.log.bind(timer),
       });
 
       // Output results

--- a/turbo/apps/runner/src/lib/executor-types.ts
+++ b/turbo/apps/runner/src/lib/executor-types.ts
@@ -24,13 +24,6 @@ export interface ExecutionOptions {
    * Used by the benchmark command
    */
   benchmarkMode?: boolean;
-
-  /**
-   * Custom logger function for execution output.
-   * If provided, executor will use this instead of console.log.
-   * Useful for adding timestamps or custom prefixes.
-   */
-  logger?: (message: string) => void;
 }
 
 /**

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/network-cleanup.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/network-cleanup.test.ts
@@ -67,7 +67,7 @@ describe("Network Cleanup Functions", () => {
       await flushBridgeArpCache();
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "Bridge does not exist, skipping ARP flush",
+        "[Network] Bridge does not exist, skipping ARP flush",
       );
       consoleSpy.mockRestore();
     });
@@ -87,7 +87,9 @@ describe("Network Cleanup Functions", () => {
 
       await flushBridgeArpCache();
 
-      expect(consoleSpy).toHaveBeenCalledWith("No ARP entries on bridge");
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[Network] No ARP entries on bridge",
+      );
       consoleSpy.mockRestore();
     });
 
@@ -121,7 +123,7 @@ describe("Network Cleanup Functions", () => {
       expect(deletedIps).toContain("172.16.0.2");
       expect(deletedIps).toContain("172.16.0.3");
       expect(consoleSpy).toHaveBeenCalledWith(
-        "Cleared 2 ARP entries from bridge",
+        "[Network] Cleared 2 ARP entries from bridge",
       );
       consoleSpy.mockRestore();
     });
@@ -144,7 +146,7 @@ describe("Network Cleanup Functions", () => {
       await expect(flushBridgeArpCache()).resolves.toBeUndefined();
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Warning: Could not flush ARP cache"),
+        expect.stringContaining("[Network] Warning: Could not flush ARP cache"),
       );
       consoleSpy.mockRestore();
     });
@@ -163,7 +165,9 @@ describe("Network Cleanup Functions", () => {
 
       await cleanupOrphanedProxyRules("test-runner");
 
-      expect(consoleSpy).toHaveBeenCalledWith("No orphaned proxy rules found");
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[Network] No orphaned proxy rules found",
+      );
       consoleSpy.mockRestore();
     });
 
@@ -196,7 +200,7 @@ describe("Network Cleanup Functions", () => {
       expect(deletedRules.some((r) => r.includes("172.16.0.4"))).toBe(false);
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "Found 2 orphaned rule(s) to clean up",
+        "[Network] Found 2 orphaned rule(s) to clean up",
       );
       consoleSpy.mockRestore();
     });
@@ -214,7 +218,9 @@ describe("Network Cleanup Functions", () => {
       ).resolves.toBeUndefined();
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Warning: Could not clean up orphaned rules"),
+        expect.stringContaining(
+          "[Network] Warning: Could not clean up orphaned rules",
+        ),
       );
       consoleSpy.mockRestore();
     });
@@ -246,7 +252,7 @@ describe("Network Cleanup Functions", () => {
       // Should attempt to delete both rules even if first fails
       expect(deleteCallCount).toBe(2);
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to delete rule"),
+        expect.stringContaining("[Network] Failed to delete rule"),
       );
       consoleSpy.mockRestore();
     });

--- a/turbo/apps/runner/src/lib/logger.ts
+++ b/turbo/apps/runner/src/lib/logger.ts
@@ -1,0 +1,52 @@
+/**
+ * Global Logger Module
+ *
+ * Provides unified logging across all runner modules.
+ * Default: console.log / console.error
+ * Benchmark mode: Timer.log (both log and error go to Timer.log)
+ */
+
+type LogFn = (message: string) => void;
+
+let _log: LogFn | null = null;
+let _error: LogFn | null = null;
+
+// Getters that lazily resolve to console.log/error if not set
+// This allows tests to mock console before the logger is used
+function getLog(): LogFn {
+  return _log ?? console.log.bind(console);
+}
+
+function getError(): LogFn {
+  return _error ?? console.error.bind(console);
+}
+
+/**
+ * Set the global logger functions
+ * Call this at application entry point (benchmark.ts)
+ * @param log - Function for normal log output
+ * @param error - Function for error output (defaults to log if not provided)
+ */
+export function setGlobalLogger(log: LogFn, error?: LogFn): void {
+  _log = log;
+  _error = error ?? log;
+}
+
+/**
+ * Logger interface with log and error methods
+ */
+interface Logger {
+  log: LogFn;
+  error: LogFn;
+}
+
+/**
+ * Create a logger with a module prefix
+ * @param prefix Module name (e.g., 'VMSetup', 'Executor')
+ */
+export function createLogger(prefix: string): Logger {
+  return {
+    log: (message: string) => getLog()(`[${prefix}] ${message}`),
+    error: (message: string) => getError()(`[${prefix}] ${message}`),
+  };
+}

--- a/turbo/apps/runner/src/lib/network-logs/network-logs.ts
+++ b/turbo/apps/runner/src/lib/network-logs/network-logs.ts
@@ -7,6 +7,9 @@
 
 import fs from "fs";
 import type { NetworkLogEntry } from "./types.js";
+import { createLogger } from "../logger.js";
+
+const logger = createLogger("NetworkLogs");
 
 /**
  * Get the network log file path for a run
@@ -30,8 +33,8 @@ function readNetworkLogs(runId: string): NetworkLogEntry[] {
     const lines = content.split("\n").filter((line) => line.trim());
     return lines.map((line) => JSON.parse(line) as NetworkLogEntry);
   } catch (err) {
-    console.error(
-      `[Executor] Failed to read network logs: ${err instanceof Error ? err.message : "Unknown error"}`,
+    logger.error(
+      `Failed to read network logs: ${err instanceof Error ? err.message : "Unknown error"}`,
     );
     return [];
   }
@@ -48,8 +51,8 @@ function cleanupNetworkLogs(runId: string): void {
       fs.unlinkSync(logPath);
     }
   } catch (err) {
-    console.error(
-      `[Executor] Failed to cleanup network logs: ${err instanceof Error ? err.message : "Unknown error"}`,
+    logger.error(
+      `Failed to cleanup network logs: ${err instanceof Error ? err.message : "Unknown error"}`,
     );
   }
 }
@@ -65,12 +68,12 @@ export async function uploadNetworkLogs(
   const networkLogs = readNetworkLogs(runId);
 
   if (networkLogs.length === 0) {
-    console.log(`[Executor] No network logs to upload for ${runId}`);
+    logger.log(`No network logs to upload for ${runId}`);
     return;
   }
 
-  console.log(
-    `[Executor] Uploading ${networkLogs.length} network log entries for ${runId}`,
+  logger.log(
+    `Uploading ${networkLogs.length} network log entries for ${runId}`,
   );
 
   const headers: Record<string, string> = {
@@ -95,11 +98,11 @@ export async function uploadNetworkLogs(
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error(`[Executor] Failed to upload network logs: ${errorText}`);
+    logger.error(`Failed to upload network logs: ${errorText}`);
     return;
   }
 
-  console.log(`[Executor] Network logs uploaded successfully for ${runId}`);
+  logger.log(`Network logs uploaded successfully for ${runId}`);
 
   // Cleanup log file after successful upload
   cleanupNetworkLogs(runId);

--- a/turbo/apps/runner/src/lib/proxy/vm-registry.ts
+++ b/turbo/apps/runner/src/lib/proxy/vm-registry.ts
@@ -8,6 +8,9 @@
  * The registry is stored as a JSON file that the mitmproxy addon can read.
  */
 import fs from "fs";
+import { createLogger } from "../logger.js";
+
+const logger = createLogger("VMRegistry");
 
 /**
  * Firewall rule for VM network egress control
@@ -120,8 +123,8 @@ export class VMRegistry {
       ? ` with ${options.firewallRules.length} firewall rules`
       : "";
     const mitmInfo = options?.mitmEnabled ? ", MITM enabled" : "";
-    console.log(
-      `[VMRegistry] Registered VM ${vmIp} for run ${runId}${firewallInfo}${mitmInfo}`,
+    logger.log(
+      `Registered VM ${vmIp} for run ${runId}${firewallInfo}${mitmInfo}`,
     );
   }
 
@@ -133,9 +136,7 @@ export class VMRegistry {
       const registration = this.data.vms[vmIp];
       delete this.data.vms[vmIp];
       this.save();
-      console.log(
-        `[VMRegistry] Unregistered VM ${vmIp} (run ${registration.runId})`,
-      );
+      logger.log(`Unregistered VM ${vmIp} (run ${registration.runId})`);
     }
   }
 
@@ -159,7 +160,7 @@ export class VMRegistry {
   clear(): void {
     this.data.vms = {};
     this.save();
-    console.log("[VMRegistry] Cleared all registrations");
+    logger.log("Cleared all registrations");
   }
 
   /**

--- a/turbo/apps/runner/src/lib/runner/setup.ts
+++ b/turbo/apps/runner/src/lib/runner/setup.ts
@@ -14,6 +14,9 @@ import {
   getProxyManager,
 } from "../proxy/index.js";
 import type { RunnerResources } from "./types.js";
+import { createLogger } from "../logger.js";
+
+const logger = createLogger("Runner");
 
 interface SetupOptions {
   config: RunnerConfig;
@@ -30,35 +33,35 @@ export async function setupEnvironment(
   // Check network prerequisites
   const networkCheck = checkNetworkPrerequisites();
   if (!networkCheck.ok) {
-    console.error("Network prerequisites not met:");
+    logger.error("Network prerequisites not met:");
     for (const error of networkCheck.errors) {
-      console.error(`  - ${error}`);
+      logger.error(`  - ${error}`);
     }
     process.exit(1);
   }
 
   // Set up bridge network
-  console.log("Setting up network bridge...");
+  logger.log("Setting up network bridge...");
   await setupBridge();
 
   // Flush bridge ARP cache to clear stale entries from previous runs
   // This prevents routing issues when IPs are reused with different MACs
-  console.log("Flushing bridge ARP cache...");
+  logger.log("Flushing bridge ARP cache...");
   await flushBridgeArpCache();
 
   // Clean up orphaned proxy rules from previous runs
   // This handles rules left behind after crashes or SIGKILL
-  console.log("Cleaning up orphaned proxy rules...");
+  logger.log("Cleaning up orphaned proxy rules...");
   await cleanupOrphanedProxyRules(config.name);
 
   // Clean up orphaned IP allocations from previous runs
   // This reconciles the IP registry with actual TAP devices
-  console.log("Cleaning up orphaned IP allocations...");
+  logger.log("Cleaning up orphaned IP allocations...");
   await cleanupOrphanedAllocations();
 
   // Initialize proxy for network security mode
   // The proxy is always started but only used when experimentalFirewall is enabled
-  console.log("Initializing network proxy...");
+  logger.log("Initializing network proxy...");
   initVMRegistry();
   const proxyManager = initProxyManager({
     apiUrl: config.server.url,
@@ -71,18 +74,18 @@ export async function setupEnvironment(
   try {
     await proxyManager.start();
     proxyEnabled = true;
-    console.log("Network proxy initialized successfully");
+    logger.log("Network proxy initialized successfully");
 
     // Set up CIDR-based proxy rules for all VMs
     // This redirects all VM traffic (172.16.0.0/24) to the proxy at startup
     // The proxy handles unregistered VMs by passing traffic through
-    console.log("Setting up CIDR proxy rules...");
+    logger.log("Setting up CIDR proxy rules...");
     await setupCIDRProxyRules(config.proxy.port);
   } catch (err) {
-    console.warn(
+    logger.log(
       `Network proxy not available: ${err instanceof Error ? err.message : "Unknown error"}`,
     );
-    console.warn(
+    logger.log(
       "Jobs with experimentalFirewall enabled will run without network interception",
     );
   }
@@ -98,13 +101,13 @@ export async function cleanupEnvironment(
 ): Promise<void> {
   // Cleanup CIDR proxy rules first
   if (resources.proxyEnabled) {
-    console.log("Cleaning up CIDR proxy rules...");
+    logger.log("Cleaning up CIDR proxy rules...");
     await cleanupCIDRProxyRules(resources.proxyPort);
   }
 
   // Cleanup proxy
   if (resources.proxyEnabled) {
-    console.log("Stopping network proxy...");
+    logger.log("Stopping network proxy...");
     await getProxyManager().stop();
   }
 }

--- a/turbo/apps/runner/src/lib/runner/signals.ts
+++ b/turbo/apps/runner/src/lib/runner/signals.ts
@@ -1,4 +1,7 @@
 import type { RunnerState } from "./types.js";
+import { createLogger } from "../logger.js";
+
+const logger = createLogger("Runner");
 
 interface SignalHandlers {
   onShutdown: () => void;
@@ -15,14 +18,14 @@ export function setupSignalHandlers(
 ): void {
   // Handle graceful shutdown (SIGINT, SIGTERM)
   process.on("SIGINT", () => {
-    console.log("\nShutting down...");
+    logger.log("\nShutting down...");
     handlers.onShutdown();
     state.mode = "stopped";
     handlers.updateStatus();
   });
 
   process.on("SIGTERM", () => {
-    console.log("\nShutting down...");
+    logger.log("\nShutting down...");
     handlers.onShutdown();
     state.mode = "stopped";
     handlers.updateStatus();
@@ -32,8 +35,8 @@ export function setupSignalHandlers(
   // When received, stop polling for new jobs but continue executing active jobs
   process.on("SIGUSR1", () => {
     if (state.mode === "running") {
-      console.log("\n[Maintenance] Entering drain mode...");
-      console.log(
+      logger.log("\n[Maintenance] Entering drain mode...");
+      logger.log(
         `[Maintenance] Active jobs: ${state.activeRuns.size} (will wait for completion)`,
       );
       state.mode = "draining";

--- a/turbo/apps/runner/src/lib/runner/status.ts
+++ b/turbo/apps/runner/src/lib/runner/status.ts
@@ -1,5 +1,8 @@
 import { writeFileSync } from "fs";
 import type { RunnerMode, RunnerState, RunnerStatus } from "./types.js";
+import { createLogger } from "../logger.js";
+
+const logger = createLogger("Runner");
 
 /**
  * Write runner status to a JSON file for external monitoring.
@@ -23,7 +26,7 @@ function writeStatusFile(
     writeFileSync(statusFilePath, JSON.stringify(status, null, 2));
   } catch (err) {
     // Non-fatal: log and continue
-    console.error(
+    logger.error(
       `Failed to write status file: ${err instanceof Error ? err.message : "Unknown error"}`,
     );
   }


### PR DESCRIPTION
## Summary

- Add `lib/logger.ts` with `setGlobalLogger` and `createLogger`
- Benchmark mode: `setGlobalLogger(timer.log)` for timing output
- Runner mode: default `console.log`
- Migrate all modules to use `createLogger` with prefixes:
  - Executor, VMSetup, VMRegistry, ProxyManager, Runner, Network
- Remove `options.logger` from `ExecutorOptions` (use global logger)
- Remove `logger` parameter from `createTapDevice`

## Before/After

**Before:**
```typescript
// executor.ts
const log = options.logger ?? console.log;
log(`[Executor] Starting job...`);

// vm-setup.ts (called by executor)
console.log(`[Executor] Installing CA...`);  // Wrong prefix, doesn't use executor's logger
```

**After:**
```typescript
// benchmark.ts
setGlobalLogger(timer.log.bind(timer));  // All modules use this

// executor.ts
const log = createLogger("Executor");
log(`Starting job...`);  // Output: [Executor] Starting job...

// vm-setup.ts
const log = createLogger("VMSetup");
log(`Installing CA...`);  // Output: [VMSetup] Installing CA...
```

## Test plan

- [ ] Benchmark mode logs use Timer.log (with timestamps)
- [ ] Runner mode logs use console.log
- [ ] Each module has correct prefix
- [ ] Type check passes
- [ ] Lint passes

Closes #1904

🤖 Generated with [Claude Code](https://claude.com/claude-code)