### PR TITLE
perf(crates): simplify release profile and pre-allocate decoder buffer

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -5,13 +5,6 @@ members = ["vsock-agent", "vm-init"]
 [profile.release]
 lto = true
 strip = true
-
-[profile.release.package.vsock-agent]
-opt-level = "z"
-codegen-units = 1
-
-[profile.release.package.vm-init]
-opt-level = "z"
 codegen-units = 1
 
 [workspace.lints.rust]

--- a/crates/vsock-agent/src/lib.rs
+++ b/crates/vsock-agent/src/lib.rs
@@ -381,7 +381,11 @@ struct Decoder {
 
 impl Decoder {
     fn new() -> Self {
-        Self { buf: Vec::new() }
+        // Pre-allocate buffer to avoid frequent reallocations
+        // 64KB matches the read buffer size in handle_connection
+        Self {
+            buf: Vec::with_capacity(65536),
+        }
     }
 
     fn decode(&mut self, data: &[u8]) -> Vec<(u8, u32, Vec<u8>)> {


### PR DESCRIPTION
## Summary
- Consolidate per-package release settings into workspace level
- Remove `opt-level="z"` (default `opt-level=3` with `lto` produces smaller binary)
- Pre-allocate 64KB decoder buffer to match read buffer size

## Binary size comparison

| Binary | Before | After | Change |
|--------|--------|-------|--------|
| vm-init | 545 KB | 417 KB | -23% |
| vsock-agent | 506 KB | 385 KB | -24% |

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` passes
- [x] `cargo build --release` produces smaller binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)