### PR TITLE
refactor(web): make schedule service class internal

### DIFF
--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -138,7 +138,7 @@ function buildMissingConfigError(missing: {
  * Schedule Service
  * Handles business logic for schedule management
  */
-export class ScheduleService {
+class ScheduleService {
   /**
    * Calculate next run time from cron expression and timezone
    */


### PR DESCRIPTION
## Summary
- Remove `export` keyword from `ScheduleService` class to make it module-private
- The service functions (like `createSchedule`, `updateSchedule`, etc.) remain exported and serve as the public API
- This improves encapsulation by hiding the class implementation detail

## Test plan
- [x] All existing schedule-related tests pass (149 tests)
- [x] TypeScript type checking passes
- [x] Lint checks pass
- [x] Knip finds no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)