### PR TITLE
refactor(web): remove unused mocks from expand-environment test

### DIFF
--- a/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
+++ b/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
@@ -11,27 +11,9 @@
  * - "vm0 run fails when experimental_vars shorthand vars are missing"
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { expandEnvironmentFromCompose } from "../expand-environment";
 import { BadRequestError } from "../../../errors";
-
-// Mock the proxy token service
-vi.mock("../../../proxy/token-service", () => ({
-  createProxyToken: vi.fn(
-    (_runId: string, _userId: string, name: string, value: string) =>
-      `vm0_enc_${name}_${value.slice(0, 4)}`,
-  ),
-}));
-
-// Mock the logger
-vi.mock("../../../logger", () => ({
-  logger: () => ({
-    debug: vi.fn(),
-    warn: vi.fn(),
-    info: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
 
 describe("expandEnvironmentFromCompose", () => {
   const userId = "user-123";


### PR DESCRIPTION
## Summary
- Removed unused `vi.mock` calls for `proxy/token-service` and `logger` from the expand-environment test file
- The test file still passes all 13 tests without these mocks
- Reduces test setup complexity and improves maintainability

## Test plan
- [x] All 13 tests in `expand-environment.test.ts` pass
- [x] Pre-commit checks pass (lint, type-check, format, knip)

🤖 Generated with [Claude Code](https://claude.ai/code)