### PR TITLE
refactor(web): migrate proxy route tests to msw pattern

### DIFF
--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
-import { vi } from "vitest";
+import { afterAll, afterEach, beforeAll, vi } from "vitest";
+import { server } from "../mocks/server";
 
 // Stub environment variables before any imports
 // Using vi.hoisted() ensures stubs run before module imports
@@ -41,3 +42,19 @@ vi.mock("@clerk/nextjs/server", () => ({
   clerkMiddleware: vi.fn(),
   createRouteMatcher: vi.fn(),
 }));
+
+// MSW server lifecycle
+// Note: Using "bypass" because some test files have their own MSW server setup
+// (e.g., strapi.test.ts). The "error" strategy would conflict with those.
+// Tests that want strict unhandled request checking should use their own server.
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: "bypass" });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});

--- a/turbo/apps/web/src/mocks/server.ts
+++ b/turbo/apps/web/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from "msw/node";
+
+// Empty handlers - tests will use server.use() for inline handlers
+export const server = setupServer();


### PR DESCRIPTION
## Summary

- Replace direct fetch mocking (`vi.stubGlobal("fetch")`) with MSW (Mock Service Worker) for proxy route tests
- Add MSW server infrastructure to apps/web
- Address AP-2 anti-pattern (direct fetch mocking) from issue #1923

## Changes

- **`apps/web/src/mocks/server.ts`** (new): MSW server instance for web app tests
- **`apps/web/src/__tests__/setup.ts`**: Add MSW lifecycle hooks (beforeAll/afterEach/afterAll)
- **`apps/web/app/api/webhooks/agent/proxy/__tests__/route.test.ts`**: Migrate from `vi.stubGlobal("fetch")` to inline MSW handlers with request capture pattern

## Test plan

- [x] All 24 proxy route tests pass
- [x] All 827 web tests pass (no regressions)
- [x] Lint passes
- [x] Type check passes

## Notes

The global MSW server uses `onUnhandledRequest: "bypass"` because some existing test files (e.g., `strapi.test.ts`) have their own MSW server instances that would conflict with `"error"` mode.

Closes #1923

🤖 Generated with [Claude Code](https://claude.com/claude-code)