### PR TITLE
feat(platform): show raw events view for codex framework

### DIFF
--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
@@ -23,15 +23,18 @@ import {
 
 export function AgentEventsCard({
   logId,
+  framework,
   searchTerm,
   setSearchTerm,
   className,
 }: {
   logId: string;
+  framework: string | null;
   searchTerm: string;
   setSearchTerm: (term: string) => void;
   className?: string;
 }) {
+  const isCodex = framework === "codex";
   const getOrCreateAgentEvents = useSet(getOrCreateAgentEvents$);
   const events$ = getOrCreateAgentEvents(logId);
   const eventsLoadable = useLoadable(events$);
@@ -144,7 +147,7 @@ export function AgentEventsCard({
           </span>
         </div>
         <div className="flex items-center gap-3">
-          {viewMode === "formatted" && events.length > 0 && (
+          {!isCodex && viewMode === "formatted" && events.length > 0 && (
             <EventTypeFilterDropdown
               counts={eventTypeCounts}
               hiddenTypes={hiddenTypes}
@@ -170,13 +173,17 @@ export function AgentEventsCard({
               hasSearchTerm={searchTerm.trim().length > 0}
             />
           </div>
-          <div className="h-5 w-px bg-border" />
-          <ViewModeToggle mode={viewMode} setMode={handleViewModeChange} />
+          {!isCodex && (
+            <>
+              <div className="h-5 w-px bg-border" />
+              <ViewModeToggle mode={viewMode} setMode={handleViewModeChange} />
+            </>
+          )}
         </div>
       </div>
 
       <div id={EVENTS_CONTAINER_ID} className="flex-1 min-h-0 overflow-y-auto">
-        {viewMode === "formatted" ? (
+        {!isCodex && viewMode === "formatted" ? (
           <FormattedEventsView
             events={events}
             searchTerm={searchTerm}

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -107,6 +107,7 @@ export function LogDetailContent({ logId }: { logId: string }) {
 
       <AgentEventsCard
         logId={logId}
+        framework={detail.framework}
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
         className="flex-1 min-h-0"


### PR DESCRIPTION
## Summary
- Pass `framework` prop to `AgentEventsCard` component from `LogDetailContent`
- When framework is "codex", hide the formatted events view, view mode toggle, and event type filter dropdown
- Force raw JSON view for codex framework logs since they don't have structured event types

## Test plan
- [ ] Verify non-codex framework logs still show formatted events view with toggle and filter
- [ ] Verify codex framework logs only show raw JSON view without toggle/filter controls

Generated with [Claude Code](https://claude.ai/code)