### PR TITLE
fix(cli): preserve color output in nested vm0 run from cook

### DIFF
--- a/turbo/apps/cli/src/commands/cook/utils.ts
+++ b/turbo/apps/cli/src/commands/cook/utils.ts
@@ -70,8 +70,14 @@ export function execVm0RunWithCapture(
   options: { cwd?: string } = {},
 ): Promise<string> {
   return new Promise((resolve, reject) => {
+    // Force color output when parent is a TTY, since piped stdio disables TTY detection
+    const env = process.stdout.isTTY
+      ? { ...process.env, FORCE_COLOR: "1" }
+      : process.env;
+
     const proc = spawn("vm0", args, {
       cwd: options.cwd,
+      env,
       stdio: ["inherit", "pipe", "pipe"],
       shell: process.platform === "win32",
     });


### PR DESCRIPTION
## Summary

- Fix color output loss when `vm0 run` is spawned from `vm0 cook`
- Pass `FORCE_COLOR=1` environment variable when parent is a TTY

## Problem

When `vm0 cook` spawns `vm0 run`, it uses piped stdio (`["inherit", "pipe", "pipe"]`) to capture output for parsing run IDs and artifact versions. This caused chalk to disable colors since stdout was no longer a TTY.

## Solution

Pass `FORCE_COLOR=1` environment variable to the child process when the parent's stdout is a TTY. This tells chalk to emit ANSI color codes regardless of TTY detection.

The parsing code already handles ANSI escape codes, so this change is backward-compatible.

## Test plan

- [ ] Run `vm0 cook "your prompt"` and verify colored output from nested `vm0 run`
- [ ] Run `vm0 cook "your prompt" | cat` and verify no colors (respects non-TTY parent)

🤖 Generated with [Claude Code](https://claude.ai/code)