### PR TITLE
feat(platform): add copy buttons and update event card styling

### DIFF
--- a/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
@@ -1,3 +1,4 @@
+import { CopyButton } from "@vm0/ui";
 import { getEventStyle } from "../constants/event-styles.ts";
 import { CollapsibleJson } from "./collapsible-json.tsx";
 import { highlightText } from "../utils/highlight-text.tsx";
@@ -353,9 +354,17 @@ function ToolInputParams({
   if (lowerName === "bash") {
     const command = input.command as string | undefined;
     return (
-      <code className="block font-mono text-sm bg-input text-foreground px-4 py-3 rounded-[10px] w-full overflow-x-auto whitespace-pre-wrap">
-        {command}
-      </code>
+      <div className="flex gap-2 items-start bg-sidebar rounded-[10px] px-4 py-3 w-full">
+        <code className="flex-1 font-mono text-sm text-foreground overflow-x-auto whitespace-pre-wrap min-w-0">
+          {command}
+        </code>
+        {command && (
+          <CopyButton
+            text={command}
+            className="shrink-0 h-9 w-10 bg-card border border-border rounded-lg"
+          />
+        )}
+      </div>
     );
   }
 
@@ -607,8 +616,6 @@ function ResultContent({
     searchTerm.trim() &&
     text.toLowerCase().includes(searchTerm.toLowerCase());
 
-  const preClass = "bg-input text-foreground";
-
   const contentElement = searchTerm
     ? highlightText(text, {
         searchTerm,
@@ -625,21 +632,29 @@ function ResultContent({
         <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
           Output ({lines.length} lines)
         </summary>
-        <pre
-          className={`mt-2 text-xs whitespace-pre-wrap overflow-x-auto p-3 rounded max-h-80 overflow-y-auto ${preClass}`}
-        >
-          {contentElement}
-        </pre>
+        <div className="mt-2 flex gap-2 items-start bg-sidebar rounded-[10px] px-4 py-3">
+          <pre className="flex-1 text-xs text-foreground whitespace-pre-wrap overflow-x-auto max-h-80 overflow-y-auto min-w-0">
+            {contentElement}
+          </pre>
+          <CopyButton
+            text={text}
+            className="shrink-0 h-9 w-10 bg-card border border-border rounded-lg"
+          />
+        </div>
       </details>
     );
   }
 
   return (
-    <pre
-      className={`text-xs whitespace-pre-wrap overflow-x-auto p-2 rounded ${preClass}`}
-    >
-      {contentElement}
-    </pre>
+    <div className="flex gap-2 items-start bg-sidebar rounded-[10px] px-4 py-3">
+      <pre className="flex-1 text-xs text-foreground whitespace-pre-wrap overflow-x-auto min-w-0">
+        {contentElement}
+      </pre>
+      <CopyButton
+        text={text}
+        className="shrink-0 h-9 w-10 bg-card border border-border rounded-lg"
+      />
+    </div>
   );
 }
 

--- a/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
@@ -359,10 +359,7 @@ function ToolInputParams({
           {command}
         </code>
         {command && (
-          <CopyButton
-            text={command}
-            className="shrink-0 h-9 w-10 bg-card border border-border rounded-lg"
-          />
+          <CopyButton text={command} className="shrink-0 h-4 w-4 p-0" />
         )}
       </div>
     );
@@ -636,10 +633,7 @@ function ResultContent({
           <pre className="flex-1 text-xs text-foreground whitespace-pre-wrap overflow-x-auto max-h-80 overflow-y-auto min-w-0">
             {contentElement}
           </pre>
-          <CopyButton
-            text={text}
-            className="shrink-0 h-9 w-10 bg-card border border-border rounded-lg"
-          />
+          <CopyButton text={text} className="shrink-0 h-4 w-4 p-0" />
         </div>
       </details>
     );
@@ -650,10 +644,7 @@ function ResultContent({
       <pre className="flex-1 text-xs text-foreground whitespace-pre-wrap overflow-x-auto min-w-0">
         {contentElement}
       </pre>
-      <CopyButton
-        text={text}
-        className="shrink-0 h-9 w-10 bg-card border border-border rounded-lg"
-      />
+      <CopyButton text={text} className="shrink-0 h-4 w-4 p-0" />
     </div>
   );
 }
@@ -799,8 +790,8 @@ export function EventCard({
       <div
         className={`rounded-lg border ${style.borderColor} ${style.bgColor} p-4`}
       >
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex-1 space-y-1">
+        <div className="flex gap-4 items-start">
+          <div className="flex-1 min-w-0 space-y-2">
             {/* Badge */}
             <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-lg text-xs font-medium bg-sky-50 border border-sky-600 text-sky-600 dark:bg-sky-950/30 dark:border-sky-500 dark:text-sky-400">
               <Icon className="h-4 w-4" />
@@ -810,18 +801,16 @@ export function EventCard({
             <div className="font-medium text-sm text-foreground">
               {subtype === "init" ? "Initialize" : subtype}
             </div>
+            {subtype === "init" && <SystemInitContent eventData={eventData} />}
+            {subtype !== "init" && eventData.message?.content === null && (
+              <CollapsibleJson data={eventData} label="Event Data" />
+            )}
           </div>
           {/* Timestamp */}
-          <span className="text-sm text-muted-foreground">
+          <span className="shrink-0 text-sm text-muted-foreground">
             {formatEventTime(event.createdAt)}
           </span>
         </div>
-        {subtype === "init" && <SystemInitContent eventData={eventData} />}
-        {subtype !== "init" && eventData.message?.content === null && (
-          <div className="mt-2">
-            <CollapsibleJson data={eventData} label="Event Data" />
-          </div>
-        )}
       </div>
     );
   }
@@ -858,19 +847,19 @@ export function EventCard({
       <div
         className={`rounded-lg border ${style.borderColor} ${style.bgColor} p-4`}
       >
-        <div className="flex items-start justify-between gap-4">
-          <span
-            className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-lg text-xs font-medium ${badgeClass}`}
-          >
-            <Icon className="h-4 w-4" />
-            {isAssistant ? "Assistant" : "User"}
-          </span>
-          <span className="text-sm text-muted-foreground">
+        <div className="flex gap-4 items-start">
+          <div className="flex-1 min-w-0 space-y-2">
+            <span
+              className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-lg text-xs font-medium ${badgeClass}`}
+            >
+              <Icon className="h-4 w-4" />
+              {isAssistant ? "Assistant" : "User"}
+            </span>
+            <CollapsibleJson data={eventData} label="Event Data" />
+          </div>
+          <span className="shrink-0 text-sm text-muted-foreground">
             {formatEventTime(event.createdAt)}
           </span>
-        </div>
-        <div className="mt-2">
-          <CollapsibleJson data={eventData} label="Event Data" />
         </div>
       </div>
     );
@@ -879,85 +868,87 @@ export function EventCard({
   // Render each content block
   return (
     <div
-      className={`rounded-lg border ${style.borderColor} ${style.bgColor} p-4 space-y-2`}
+      className={`rounded-lg border ${style.borderColor} ${style.bgColor} p-4`}
     >
-      <div className="flex items-start justify-between gap-4">
-        <span
-          className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-lg text-xs font-medium ${badgeClass}`}
-        >
-          <Icon className="h-4 w-4" />
-          {isAssistant ? "Assistant" : "User"}
-        </span>
-        <span className="text-sm text-muted-foreground">
-          {formatEventTime(event.createdAt)}
-        </span>
-      </div>
+      <div className="flex gap-4 items-start">
+        <div className="flex-1 min-w-0 space-y-2">
+          <span
+            className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-lg text-xs font-medium ${badgeClass}`}
+          >
+            <Icon className="h-4 w-4" />
+            {isAssistant ? "Assistant" : "User"}
+          </span>
 
-      {contents.map((content) => {
-        const contentKey = `${event.sequenceNumber}-${content.type}-${(content as ToolUseContent).id ?? (content as ToolResultContent).tool_use_id ?? Math.random()}`;
+          {contents.map((content) => {
+            const contentKey = `${event.sequenceNumber}-${content.type}-${(content as ToolUseContent).id ?? (content as ToolResultContent).tool_use_id ?? Math.random()}`;
 
-        if (content.type === "text") {
-          return (
-            <div key={contentKey}>
-              <TextContentView
-                content={content as TextContent}
-                searchTerm={searchTerm}
-                currentMatchIndex={currentMatchIndex}
-                matchStartIndex={localMatchOffset}
-              />
-            </div>
-          );
-        }
+            if (content.type === "text") {
+              return (
+                <div key={contentKey}>
+                  <TextContentView
+                    content={content as TextContent}
+                    searchTerm={searchTerm}
+                    currentMatchIndex={currentMatchIndex}
+                    matchStartIndex={localMatchOffset}
+                  />
+                </div>
+              );
+            }
 
-        if (content.type === "tool_use") {
-          const toolContent = content as ToolUseContent;
-          return (
-            <div key={contentKey}>
-              <ToolUseContentView content={toolContent} />
-            </div>
-          );
-        }
+            if (content.type === "tool_use") {
+              const toolContent = content as ToolUseContent;
+              return (
+                <div key={contentKey}>
+                  <ToolUseContentView content={toolContent} />
+                </div>
+              );
+            }
 
-        if (content.type === "tool_result") {
-          const resultContent = content as ToolResultContent;
-          const isError = resultContent.is_error === true;
-          if (isError) {
+            if (content.type === "tool_result") {
+              const resultContent = content as ToolResultContent;
+              const isError = resultContent.is_error === true;
+              if (isError) {
+                return (
+                  <div key={contentKey}>
+                    <ToolResultContentView
+                      content={resultContent}
+                      toolMeta={eventData.tool_use_result ?? undefined}
+                      searchTerm={searchTerm}
+                      currentMatchIndex={currentMatchIndex}
+                      matchStartIndex={localMatchOffset}
+                    />
+                  </div>
+                );
+              }
+              return (
+                <div key={contentKey}>
+                  <ToolResultContentView
+                    content={resultContent}
+                    toolMeta={eventData.tool_use_result ?? undefined}
+                    searchTerm={searchTerm}
+                    currentMatchIndex={currentMatchIndex}
+                    matchStartIndex={localMatchOffset}
+                  />
+                </div>
+              );
+            }
+
+            // Unknown content type - show as JSON
+            const unknownContent = content as Record<string, unknown>;
             return (
-              <div key={contentKey}>
-                <ToolResultContentView
-                  content={resultContent}
-                  toolMeta={eventData.tool_use_result ?? undefined}
-                  searchTerm={searchTerm}
-                  currentMatchIndex={currentMatchIndex}
-                  matchStartIndex={localMatchOffset}
+              <div key={contentKey} className="mt-2">
+                <CollapsibleJson
+                  data={unknownContent}
+                  label={`Unknown: ${String(unknownContent.type ?? "content")}`}
                 />
               </div>
             );
-          }
-          return (
-            <div key={contentKey}>
-              <ToolResultContentView
-                content={resultContent}
-                toolMeta={eventData.tool_use_result ?? undefined}
-                searchTerm={searchTerm}
-                currentMatchIndex={currentMatchIndex}
-                matchStartIndex={localMatchOffset}
-              />
-            </div>
-          );
-        }
-
-        // Unknown content type - show as JSON
-        const unknownContent = content as Record<string, unknown>;
-        return (
-          <div key={contentKey} className="mt-2">
-            <CollapsibleJson
-              data={unknownContent}
-              label={`Unknown: ${String(unknownContent.type ?? "content")}`}
-            />
-          </div>
-        );
-      })}
+          })}
+        </div>
+        <span className="shrink-0 text-sm text-muted-foreground">
+          {formatEventTime(event.createdAt)}
+        </span>
+      </div>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/logs-page/constants/event-styles.ts
+++ b/turbo/apps/platform/src/views/logs-page/constants/event-styles.ts
@@ -31,7 +31,7 @@ function createEventStyles(): Readonly<Record<string, EventStyle>> {
       icon: IconSettings,
       label: "System",
       borderColor: "border-border",
-      bgColor: "bg-white dark:bg-slate-900",
+      bgColor: "bg-card",
       textColor: "text-sky-600",
       badgeColor:
         "border border-sky-400 text-sky-600 bg-sky-50 dark:border-sky-500 dark:text-sky-400 dark:bg-sky-950/30",
@@ -42,7 +42,7 @@ function createEventStyles(): Readonly<Record<string, EventStyle>> {
       icon: IconUser,
       label: "Assistant",
       borderColor: "border-border",
-      bgColor: "bg-white dark:bg-slate-900",
+      bgColor: "bg-card",
       textColor: "text-amber-600",
       badgeColor:
         "border border-amber-400 text-amber-600 bg-amber-50 dark:border-amber-500 dark:text-amber-400 dark:bg-amber-950/30",
@@ -53,7 +53,7 @@ function createEventStyles(): Readonly<Record<string, EventStyle>> {
       icon: IconUser,
       label: "User",
       borderColor: "border-border",
-      bgColor: "bg-white dark:bg-slate-900",
+      bgColor: "bg-card",
       textColor: "text-pink-500",
       badgeColor:
         "border border-pink-400 text-pink-500 bg-pink-50 dark:border-pink-500 dark:text-pink-400 dark:bg-pink-950/30",
@@ -64,7 +64,7 @@ function createEventStyles(): Readonly<Record<string, EventStyle>> {
       icon: IconSquareCheck,
       label: "Result",
       borderColor: "border-border",
-      bgColor: "bg-white dark:bg-slate-900",
+      bgColor: "bg-card",
       textColor: "text-lime-600",
       badgeColor:
         "border border-lime-600 text-lime-600 bg-lime-50 dark:border-lime-500 dark:text-lime-400 dark:bg-lime-950/30",


### PR DESCRIPTION
## Summary
- Add copy button to bash command display in log events for easy command copying
- Add copy button to result content sections (both collapsed and inline views)
- Use `bg-card` for consistent event card background colors across themes
- Update code block styling to use `bg-sidebar` for better visual consistency

## Test plan
- [ ] Verify copy buttons appear on bash command displays in log events
- [ ] Verify copy buttons appear on result content sections
- [ ] Test copy functionality works correctly
- [ ] Verify event card backgrounds render consistently in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)