### PR TITLE
fix(platform): search only matches visible text in formatted view

### DIFF
--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/formatted-events-view.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/formatted-events-view.tsx
@@ -1,7 +1,7 @@
 import type { AgentEvent } from "../../../../signals/logs-page/types.ts";
 import { EventCard } from "../../components/event-card.tsx";
 import { countMatches } from "../../utils/highlight-text.tsx";
-import { eventMatchesSearch } from "../utils.ts";
+import { eventMatchesSearch, getVisibleEventText } from "../utils.ts";
 
 export function FormattedEventsView({
   events,
@@ -25,8 +25,8 @@ export function FormattedEventsView({
   let totalMatches = 0;
   if (searchTerm.trim()) {
     for (const event of visibleEvents) {
-      const dataStr = JSON.stringify(event.eventData);
-      totalMatches += countMatches(dataStr, searchTerm);
+      const visibleText = getVisibleEventText(event);
+      totalMatches += countMatches(visibleText, searchTerm);
     }
   }
 
@@ -54,9 +54,9 @@ export function FormattedEventsView({
     <div ref={containerRef} className="space-y-3">
       {visibleEvents.map((event) => {
         const eventMatchStart = matchOffset;
-        const eventDataStr = JSON.stringify(event.eventData);
+        const visibleText = getVisibleEventText(event);
         const eventMatches = searchTerm.trim()
-          ? countMatches(eventDataStr, searchTerm)
+          ? countMatches(visibleText, searchTerm)
           : 0;
         matchOffset += eventMatches;
 

--- a/turbo/apps/platform/src/views/logs-page/log-detail/utils.ts
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/utils.ts
@@ -2,6 +2,148 @@ import type { AgentEvent } from "../../../signals/logs-page/types.ts";
 
 const ONE_MINUTE_MS = 60_000;
 
+// Type definitions for extracting visible text
+interface TextContent {
+  type: "text";
+  text: string;
+}
+
+interface ToolUseContent {
+  type: "tool_use";
+  name: string;
+  input: Record<string, unknown>;
+}
+
+interface ToolResultContent {
+  type: "tool_result";
+  content: string;
+}
+
+type MessageContent = TextContent | ToolUseContent | ToolResultContent;
+
+interface EventData {
+  subtype?: string;
+  message?: {
+    content: MessageContent[] | null;
+  };
+  tools?: string[];
+  agents?: string[];
+  slash_commands?: string[];
+  result?: string | null;
+}
+
+/** Extract visible text from tool input based on tool type */
+function extractToolInputText(
+  toolName: string,
+  input: Record<string, unknown>,
+): string[] {
+  const parts: string[] = [];
+  const name = toolName.toLowerCase();
+
+  if (name === "bash" && typeof input.command === "string") {
+    parts.push(input.command);
+  } else if (name === "webfetch" || name === "websearch") {
+    if (typeof input.url === "string") {
+      parts.push(input.url);
+    }
+    if (typeof input.query === "string") {
+      parts.push(input.query);
+    }
+    if (typeof input.prompt === "string") {
+      parts.push(input.prompt);
+    }
+  } else if (["read", "write", "edit", "glob", "grep"].includes(name)) {
+    const filePath = input.file_path ?? input.path ?? input.pattern;
+    if (typeof filePath === "string") {
+      parts.push(filePath);
+    }
+  } else if (name === "todowrite" && Array.isArray(input.todos)) {
+    for (const todo of input.todos) {
+      const item = todo as { content?: string };
+      if (typeof item.content === "string") {
+        parts.push(item.content);
+      } else if (typeof todo === "string") {
+        parts.push(todo);
+      }
+    }
+  }
+
+  return parts;
+}
+
+/** Extract visible text from message content */
+function extractMessageContentText(contents: MessageContent[]): string[] {
+  const parts: string[] = [];
+
+  for (const content of contents) {
+    if (content.type === "text") {
+      const textContent = content as TextContent;
+      if (textContent.text) {
+        parts.push(textContent.text);
+      }
+    } else if (content.type === "tool_use") {
+      const toolContent = content as ToolUseContent;
+      parts.push(toolContent.name);
+      if (toolContent.input) {
+        parts.push(
+          ...extractToolInputText(toolContent.name, toolContent.input),
+        );
+      }
+    } else if (content.type === "tool_result") {
+      const resultContent = content as ToolResultContent;
+      if (resultContent.content) {
+        parts.push(resultContent.content);
+      }
+    }
+  }
+
+  return parts;
+}
+
+/**
+ * Extract visible/searchable text from an event.
+ * Only includes text that is actually displayed to the user in formatted view.
+ */
+export function getVisibleEventText(event: AgentEvent): string {
+  const parts: string[] = [];
+  const eventData = event.eventData as EventData;
+
+  // Event type label
+  parts.push(event.eventType);
+
+  // System events
+  if (event.eventType === "system") {
+    if (eventData.subtype) {
+      parts.push(eventData.subtype);
+      if (eventData.subtype === "init") {
+        parts.push("Initialize");
+      }
+    }
+    if (eventData.tools) {
+      parts.push(...eventData.tools);
+    }
+    if (eventData.agents) {
+      parts.push(...eventData.agents);
+    }
+    if (eventData.slash_commands) {
+      parts.push(...eventData.slash_commands.map((cmd) => `/${cmd}`));
+    }
+  }
+
+  // Result events
+  if (event.eventType === "result" && eventData.result) {
+    parts.push(eventData.result);
+  }
+
+  // Assistant/User events - extract visible content from message
+  const contents = eventData.message?.content;
+  if (Array.isArray(contents)) {
+    parts.push(...extractMessageContentText(contents));
+  }
+
+  return parts.join(" ");
+}
+
 export function formatTime(dateStr: string): string {
   const date = new Date(dateStr);
   const options: Intl.DateTimeFormatOptions = {
@@ -54,11 +196,8 @@ export function eventMatchesSearch(
     return true;
   }
   const lowerSearch = searchTerm.toLowerCase();
-  if (event.eventType.toLowerCase().includes(lowerSearch)) {
-    return true;
-  }
-  const dataStr = JSON.stringify(event.eventData).toLowerCase();
-  return dataStr.includes(lowerSearch);
+  const visibleText = getVisibleEventText(event).toLowerCase();
+  return visibleText.includes(lowerSearch);
 }
 
 export function scrollToMatch(


### PR DESCRIPTION
## Summary
- Add `getVisibleEventText` helper to extract user-visible text from events
- Update `eventMatchesSearch` to use visible text instead of `JSON.stringify`
- Update match counting in formatted-events-view to use visible text

## What's searchable now
- Event type labels (System, Assistant, User, Result)
- Text content from messages
- Tool names
- Visible tool parameters:
  - Bash: command
  - WebFetch/WebSearch: URL, query, prompt
  - File operations: file path
  - TodoWrite: todo content
- Tool results

## What's NOT searchable (as intended)
- Internal JSON structure (IDs, timestamps, metadata)
- Collapsed/hidden content

## Test plan
- [ ] Search for visible text content matches correctly
- [ ] Search for internal JSON data (like "tool_use_id") should NOT match
- [ ] Match count reflects only visible matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)