### PR TITLE
refactor(runner): add 'stopping' state for accurate status reporting

### DIFF
--- a/turbo/apps/runner/src/lib/runner/runner.ts
+++ b/turbo/apps/runner/src/lib/runner/runner.ts
@@ -72,6 +72,8 @@ export class Runner {
         // If no active jobs, shutdown immediately
         if (this.state.activeRuns.size === 0) {
           logger.log("[Maintenance] No active jobs, exiting immediately");
+          this.state.mode = "stopping";
+          this.updateStatus();
           this.resolveShutdown?.();
         }
       },
@@ -234,6 +236,8 @@ export class Runner {
             this.state.activeRuns.size === 0
           ) {
             logger.log("[Maintenance] All jobs completed, exiting");
+            this.state.mode = "stopping";
+            this.updateStatus();
             this.resolveShutdown?.();
             return;
           }

--- a/turbo/apps/runner/src/lib/runner/signals.ts
+++ b/turbo/apps/runner/src/lib/runner/signals.ts
@@ -17,18 +17,19 @@ export function setupSignalHandlers(
   handlers: SignalHandlers,
 ): void {
   // Handle graceful shutdown (SIGINT, SIGTERM)
+  // Set to "stopping" first, "stopped" is set after cleanup completes
   process.on("SIGINT", () => {
     logger.log("\nShutting down...");
-    handlers.onShutdown();
-    state.mode = "stopped";
+    state.mode = "stopping";
     handlers.updateStatus();
+    handlers.onShutdown();
   });
 
   process.on("SIGTERM", () => {
     logger.log("\nShutting down...");
-    handlers.onShutdown();
-    state.mode = "stopped";
+    state.mode = "stopping";
     handlers.updateStatus();
+    handlers.onShutdown();
   });
 
   // Handle SIGUSR1 for maintenance/drain mode

--- a/turbo/apps/runner/src/lib/runner/types.ts
+++ b/turbo/apps/runner/src/lib/runner/types.ts
@@ -1,7 +1,13 @@
 /**
  * Runner mode for lifecycle management
+ *
+ * State transitions:
+ * - running -> stopping (SIGTERM/SIGINT received)
+ * - running -> draining (SIGUSR1 received)
+ * - draining -> stopping (all jobs completed)
+ * - stopping -> stopped (cleanup completed)
  */
-export type RunnerMode = "running" | "draining" | "stopped";
+export type RunnerMode = "running" | "draining" | "stopping" | "stopped";
 
 /**
  * Internal runner state shared across modules


### PR DESCRIPTION
## Summary

- Add `stopping` state to `RunnerMode` type
- Set state to `stopping` when shutdown initiated (SIGTERM/SIGINT)
- Set state to `stopping` when drain mode completes
- Set state to `stopped` only after cleanup completes

## State Diagram

```
running --[SIGTERM]--> stopping --[cleanup done]--> stopped
running --[SIGUSR1]--> draining --[jobs done]--> stopping --> stopped
```

## Test plan

- [x] Type check passes
- [x] Lint passes
- [ ] Manual verification: status.json shows `stopping` during shutdown

Closes #1956

🤖 Generated with [Claude Code](https://claude.ai/code)