### PR TITLE
feat(cli): add claude plugin tip to init next steps

### DIFF
--- a/turbo/apps/cli/src/commands/init/index.ts
+++ b/turbo/apps/cli/src/commands/init/index.ts
@@ -131,7 +131,7 @@ export const initCommand = new Command()
       `  2. Edit ${chalk.cyan("AGENTS.md")} to customize your agent's workflow`,
     );
     console.log(
-      `     Or install Claude plugin: ${chalk.cyan('vm0 setup-claude && claude "/vm0-agent help me build an agent"')}`,
+      `     Or install Claude plugin: ${chalk.cyan('vm0 setup-claude && claude "/vm0-agent let\'s build an agent"')}`,
     );
     console.log(
       `  3. Run your agent: ${chalk.cyan('vm0 cook "let\'s start working"')}`,

--- a/turbo/apps/cli/src/commands/init/index.ts
+++ b/turbo/apps/cli/src/commands/init/index.ts
@@ -125,12 +125,15 @@ export const initCommand = new Command()
     console.log();
     console.log("Next steps:");
     console.log(
-      `  1. Set model provider (one-time): ${chalk.cyan("vm0 model-provider setup")}`,
+      `  1. Set up model provider (one-time): ${chalk.cyan("vm0 model-provider setup")}`,
     );
     console.log(
       `  2. Edit ${chalk.cyan("AGENTS.md")} to customize your agent's workflow`,
     );
     console.log(
-      `  3. Run your agent: ${chalk.cyan(`vm0 cook "let's start working."`)}`,
+      `     Or install Claude plugin: ${chalk.cyan('vm0 setup-claude && claude "/vm0-agent help me build an agent"')}`,
+    );
+    console.log(
+      `  3. Run your agent: ${chalk.cyan('vm0 cook "let\'s start working"')}`,
     );
   });

--- a/turbo/apps/cli/src/commands/onboard/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/onboard/__tests__/index.test.ts
@@ -368,7 +368,7 @@ describe("onboard command", () => {
       expect(logCalls).toContain("cd my-vm0-agent");
       expect(logCalls).toContain("claude");
       expect(logCalls).toContain("/vm0-agent");
-      expect(logCalls).toContain("let's build a workflow");
+      expect(logCalls).toContain("let's build an agent");
     });
 
     it("should show custom agent name in next steps", async () => {

--- a/turbo/apps/cli/src/commands/onboard/index.ts
+++ b/turbo/apps/cli/src/commands/onboard/index.ts
@@ -240,7 +240,7 @@ function printNextSteps(agentName: string): void {
   console.log(chalk.bold("Next step:"));
   console.log();
   console.log(
-    `  ${chalk.cyan(`cd ${agentName} && claude "/${PRIMARY_SKILL_NAME} let's build a workflow"`)}`,
+    `  ${chalk.cyan(`cd ${agentName} && claude "/${PRIMARY_SKILL_NAME} let's build an agent"`)}`,
   );
   console.log();
 }


### PR DESCRIPTION
## Summary

- Add optional Claude plugin workflow as an alternative to manual AGENTS.md editing
- Update `vm0 init` next steps output to show the `vm0 setup-claude` option

**Before:**
```
Next steps:
  1. Set model provider (one-time): vm0 model-provider setup
  2. Edit AGENTS.md to customize your agent's workflow
  3. Run your agent: vm0 cook "let's start working."
```

**After:**
```
Next steps:
  1. Set up model provider (one-time): vm0 model-provider setup
  2. Edit AGENTS.md to customize your agent's workflow
     Or install Claude plugin: vm0 setup-claude && claude "/vm0-agent help me build an agent"
  3. Run your agent: vm0 cook "let's start working"
```

## Test plan

- [x] Unit tests pass
- [ ] Manual test: `vm0 init --name test` shows updated next steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)