### PR TITLE
fix(cli): show correct next steps when skipping claude plugin in onboard

### DIFF
--- a/.claude/skills/testing/reference/cli-testing.md
+++ b/.claude/skills/testing/reference/cli-testing.md
@@ -285,59 +285,45 @@ it("should create files with --name flag", async () => {
 
 Use `prompts.inject()` - the library's native testing feature - to simulate user responses. This is NOT mocking; it's using the official testing API provided by the `prompts` library.
 
-**Setup**: Enable TTY and inject responses before running the command.
+**Prerequisites**:
+1. Enable TTY mode (usually done in test file's `beforeEach`)
+2. Inject ALL prompt responses in the order they will be asked
+
+**Example**: Testing that onboard shows `vm0 init` when user skips plugin installation.
 
 ```typescript
-import prompts from "prompts";
+it("should show vm0 init when plugin installation is skipped", async () => {
+  const prompts = await import("prompts");
+  // Inject responses in order:
+  // 1. "my-vm0-agent" for agent name prompt
+  // 2. false for "Install VM0 Claude Plugin?" confirmation
+  prompts.default.inject(["my-vm0-agent", false]);
 
-describe("interactive mode", () => {
-  beforeEach(() => {
-    // Enable interactive mode by setting TTY
-    Object.defineProperty(process.stdout, "isTTY", {
-      value: true,
-      writable: true,
-      configurable: true,
-    });
-  });
+  await onboardCommand.parseAsync(["node", "cli"]);
 
-  it("should prompt for name and create files", async () => {
-    // Inject user responses in order they will be prompted
-    prompts.inject(["my-agent"]);
+  const logCalls = vi.mocked(console.log).mock.calls.flat().join("\n");
+  expect(logCalls).toContain("cd my-vm0-agent && vm0 init");
+  expect(logCalls).not.toContain("/vm0-agent");
+});
+```
 
-    await initCommand.parseAsync(["node", "cli"]);
+**TTY Setup** (if not already in beforeEach):
 
-    expect(existsSync(path.join(tempDir, "vm0.yaml"))).toBe(true);
-  });
-
-  it("should skip plugin when user declines", async () => {
-    // Inject: false for "Install plugin?" confirmation
-    prompts.inject([false]);
-
-    await onboardCommand.parseAsync(["node", "cli"]);
-
-    const logCalls = vi.mocked(console.log).mock.calls.flat().join("\n");
-    expect(logCalls).toContain("vm0 init");
-    expect(logCalls).not.toContain("/vm0-agent");
-  });
-
-  it("should handle user cancellation", async () => {
-    // Inject Error to simulate Ctrl+C
-    prompts.inject([new Error("User cancelled")]);
-
-    await initCommand.parseAsync(["node", "cli"]);
-
-    expect(mockConsoleLog).toHaveBeenCalledWith(
-      expect.stringContaining("Cancelled"),
-    );
+```typescript
+beforeEach(() => {
+  Object.defineProperty(process.stdout, "isTTY", {
+    value: true,
+    writable: true,
+    configurable: true,
   });
 });
 ```
 
 **Key Points**:
-- `prompts.inject([...])` - Inject responses in prompt order
-- `prompts.inject([new Error()])` - Simulate user cancellation (Ctrl+C)
-- Responses are consumed in order; inject multiple values for multiple prompts
-- Set `process.stdout.isTTY = true` to enable interactive mode
+- Use dynamic import: `const prompts = await import("prompts")`
+- Call inject on default export: `prompts.default.inject([...])`
+- Inject ALL responses in prompt order - missing values will cause prompts to hang or return undefined
+- `prompts.default.inject([new Error()])` - Simulate user cancellation (Ctrl+C)
 
 ---
 

--- a/.claude/skills/testing/reference/cli-testing.md
+++ b/.claude/skills/testing/reference/cli-testing.md
@@ -254,13 +254,16 @@ expect(mockExit).toHaveBeenCalledWith(1);
 
 ## Interactive Prompts
 
-Only test non-interactive mode. Do not mock prompt libraries.
+Test both interactive and non-interactive modes. Use `prompts.inject()` for interactive mode testing.
 
-**Rationale**: When `isInteractive()` returns `false` (default in test environment), prompts return `undefined` automatically. Tests should verify non-interactive behavior.
+### Non-Interactive Mode
+
+When `isInteractive()` returns `false` (non-TTY environment), prompts return `undefined` automatically. Test that commands handle this gracefully.
 
 ```typescript
-// Test that command works in non-interactive mode
+// Test that command requires flags in non-interactive mode
 it("should require --name flag in non-interactive mode", async () => {
+  // Non-TTY by default in test environment
   await expect(async () => {
     await initCommand.parseAsync(["node", "cli"]);
   }).rejects.toThrow("process.exit called");
@@ -277,6 +280,64 @@ it("should create files with --name flag", async () => {
   expect(existsSync(path.join(tempDir, "vm0.yaml"))).toBe(true);
 });
 ```
+
+### Interactive Mode
+
+Use `prompts.inject()` - the library's native testing feature - to simulate user responses. This is NOT mocking; it's using the official testing API provided by the `prompts` library.
+
+**Setup**: Enable TTY and inject responses before running the command.
+
+```typescript
+import prompts from "prompts";
+
+describe("interactive mode", () => {
+  beforeEach(() => {
+    // Enable interactive mode by setting TTY
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("should prompt for name and create files", async () => {
+    // Inject user responses in order they will be prompted
+    prompts.inject(["my-agent"]);
+
+    await initCommand.parseAsync(["node", "cli"]);
+
+    expect(existsSync(path.join(tempDir, "vm0.yaml"))).toBe(true);
+  });
+
+  it("should skip plugin when user declines", async () => {
+    // Inject: false for "Install plugin?" confirmation
+    prompts.inject([false]);
+
+    await onboardCommand.parseAsync(["node", "cli"]);
+
+    const logCalls = vi.mocked(console.log).mock.calls.flat().join("\n");
+    expect(logCalls).toContain("vm0 init");
+    expect(logCalls).not.toContain("/vm0-agent");
+  });
+
+  it("should handle user cancellation", async () => {
+    // Inject Error to simulate Ctrl+C
+    prompts.inject([new Error("User cancelled")]);
+
+    await initCommand.parseAsync(["node", "cli"]);
+
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect.stringContaining("Cancelled"),
+    );
+  });
+});
+```
+
+**Key Points**:
+- `prompts.inject([...])` - Inject responses in prompt order
+- `prompts.inject([new Error()])` - Simulate user cancellation (Ctrl+C)
+- Responses are consumed in order; inject multiple values for multiple prompts
+- Set `process.stdout.isTTY = true` to enable interactive mode
 
 ---
 

--- a/.claude/skills/testing/reference/cli-testing.md
+++ b/.claude/skills/testing/reference/cli-testing.md
@@ -286,18 +286,20 @@ it("should create files with --name flag", async () => {
 Use `prompts.inject()` - the library's native testing feature - to simulate user responses. This is NOT mocking; it's using the official testing API provided by the `prompts` library.
 
 **Prerequisites**:
-1. Enable TTY mode (usually done in test file's `beforeEach`)
-2. Inject ALL prompt responses in the order they will be asked
+1. Import prompts at top of file: `import prompts from "prompts"`
+2. Enable TTY mode (usually done in test file's `beforeEach`)
+3. Inject ALL prompt responses in the order they will be asked
 
 **Example**: Testing that onboard shows `vm0 init` when user skips plugin installation.
 
 ```typescript
+import prompts from "prompts";
+
 it("should show vm0 init when plugin installation is skipped", async () => {
-  const prompts = await import("prompts");
   // Inject responses in order:
   // 1. "my-vm0-agent" for agent name prompt
   // 2. false for "Install VM0 Claude Plugin?" confirmation
-  prompts.default.inject(["my-vm0-agent", false]);
+  prompts.inject(["my-vm0-agent", false]);
 
   await onboardCommand.parseAsync(["node", "cli"]);
 
@@ -320,10 +322,9 @@ beforeEach(() => {
 ```
 
 **Key Points**:
-- Use dynamic import: `const prompts = await import("prompts")`
-- Call inject on default export: `prompts.default.inject([...])`
+- Use static import: `import prompts from "prompts"`
 - Inject ALL responses in prompt order - missing values will cause prompts to hang or return undefined
-- `prompts.default.inject([new Error()])` - Simulate user cancellation (Ctrl+C)
+- `prompts.inject([new Error()])` - Simulate user cancellation (Ctrl+C)
 
 ---
 

--- a/turbo/apps/cli/src/commands/onboard/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/onboard/__tests__/index.test.ts
@@ -33,6 +33,7 @@ vi.mock("child_process", () => ({
 }));
 
 import { spawn } from "child_process";
+import prompts from "prompts";
 import { onboardCommand } from "../index";
 
 // Helper to create a mock child process
@@ -385,11 +386,10 @@ describe("onboard command", () => {
     });
 
     it("should show vm0 init when plugin installation is skipped", async () => {
-      const prompts = await import("prompts");
       // Inject responses in order:
       // 1. "my-vm0-agent" for agent name prompt
       // 2. false for "Install VM0 Claude Plugin?" confirmation
-      prompts.default.inject(["my-vm0-agent", false]);
+      prompts.inject(["my-vm0-agent", false]);
 
       await onboardCommand.parseAsync(["node", "cli"]);
 

--- a/turbo/apps/cli/src/commands/onboard/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/onboard/__tests__/index.test.ts
@@ -383,6 +383,21 @@ describe("onboard command", () => {
       const logCalls = vi.mocked(console.log).mock.calls.flat().join("\n");
       expect(logCalls).toContain("cd custom-agent");
     });
+
+    it("should show vm0 init when plugin installation is skipped", async () => {
+      const prompts = await import("prompts");
+      // Inject responses in order:
+      // 1. "my-vm0-agent" for agent name prompt
+      // 2. false for "Install VM0 Claude Plugin?" confirmation
+      prompts.default.inject(["my-vm0-agent", false]);
+
+      await onboardCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = vi.mocked(console.log).mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Next step:");
+      expect(logCalls).toContain("cd my-vm0-agent && vm0 init");
+      expect(logCalls).not.toContain("/vm0-agent");
+    });
   });
 
   describe("--yes flag", () => {


### PR DESCRIPTION
## Summary

- When user skips Claude plugin installation in `vm0 onboard`, show the correct next steps
- Previously: always showed `cd <name> && claude "/vm0-agent let's build an agent"` even when plugin wasn't installed
- Now: shows `cd <name> && vm0 init` when plugin is skipped

**With plugin installed:**
```
Next step:
  cd my-vm0-agent && claude "/vm0-agent let's build an agent"
```

**Without plugin:**
```
Next step:
  cd my-vm0-agent && vm0 init
```

## Test plan

- [x] Unit tests pass
- [ ] Manual test: run `vm0 onboard`, skip plugin installation, verify correct next steps shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)