### PR TITLE
chore: bump claude-code version to 2.1.27

### DIFF
--- a/turbo/scripts/e2b/vm0-claude-code-github/template.ts
+++ b/turbo/scripts/e2b/vm0-claude-code-github/template.ts
@@ -12,7 +12,7 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "ripgrep", "jq", "file"])
-  .npmInstall("@anthropic-ai/claude-code@2.1.12", { g: true })
+  .npmInstall("@anthropic-ai/claude-code@2.1.27", { g: true })
   // Install GitHub CLI
   // https://github.com/cli/cli/blob/trunk/docs/install_linux.md
   .runCmd(

--- a/turbo/scripts/e2b/vm0-claude-code/template.ts
+++ b/turbo/scripts/e2b/vm0-claude-code/template.ts
@@ -11,4 +11,4 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "ripgrep", "jq", "file"])
-  .npmInstall("@anthropic-ai/claude-code@2.1.12", { g: true });
+  .npmInstall("@anthropic-ai/claude-code@2.1.27", { g: true });


### PR DESCRIPTION
## Summary
- Update `@anthropic-ai/claude-code` package from version 2.1.12 to 2.1.27 in E2B templates
- Affects both `vm0-claude-code` and `vm0-claude-code-github` templates

## Test plan
- [ ] Verify E2B templates build correctly with new version
- [ ] Test Claude Code functionality in sandbox environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)