### PR TITLE
feat(docs): add vm0 run list and kill commands to cli reference

### DIFF
--- a/turbo/apps/docs/content/docs/reference/cli/index.mdx
+++ b/turbo/apps/docs/content/docs/reference/cli/index.mdx
@@ -9,7 +9,7 @@ description: Complete reference for all VM0 CLI commands
 | ------- | ----------- | ------- |
 | `vm0 info` | Display environment information | - |
 | `vm0 init` | Initialize a new VM0 project with `vm0.yaml` | `-f, --force`, `-n, --name <name>` |
-| `vm0 onboard` | Guided setup for new VM0 users | `-y, --yes`, `--method <claude\|manual>` |
+| `vm0 onboard` | Guided setup for new VM0 users | `-y, --yes`, `--name <name>` |
 | `vm0 setup-claude` | Install vm0-cli skill for Claude | - |
 
 ## Authentication
@@ -85,6 +85,8 @@ Scopes are namespaces for organizing agents.
 | `vm0 run <agent-name> <prompt>` | Run an agent | See options table below |
 | `vm0 run continue <session-id> <prompt>` | Continue from session (uses latest artifact) | `--env-file`, `--vars`, `--secrets`, `--volume-version`, `--model-provider` |
 | `vm0 run resume <checkpoint-id> <prompt>` | Resume from checkpoint (uses snapshot data) | `--env-file`, `--vars`, `--secrets`, `--volume-version`, `--model-provider` |
+| `vm0 run list` | List active runs (pending and running) | Alias: `ls` |
+| `vm0 run kill <run-id>` | Kill (cancel) a pending or running run | - |
 | `vm0 cook [prompt]` | Prepare and execute agent from `vm0.yaml` | `--env-file <path>`, `-y, --yes` |
 | `vm0 cook logs` | View logs from the last cook run | Same as `vm0 logs` options |
 | `vm0 cook continue <prompt>` | Continue from last session | `--env-file <path>` |


### PR DESCRIPTION
## Summary

- Add `vm0 run list` command to CLI reference documentation (lists active runs)
- Add `vm0 run kill` command to CLI reference documentation (cancels a run)
- Fix `vm0 onboard` options: replace non-existent `--method` with actual `--name <name>`

## Test plan

- [x] Documentation builds successfully
- [x] Table formatting is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)