### PR TITLE
feat(docs): move codex documentation to experimental section

### DIFF
--- a/turbo/apps/docs/content/docs/core-concept/agent-anatomy.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/agent-anatomy.mdx
@@ -30,13 +30,13 @@ This scenario has many parallels with a VM0 Agent:
 
 `} />
 
-The **Agent Provider** (Claude Code or Codex) is a capable worker, and **Skills** give the agent specialized expertise in specific domains, just like the finance expertise Joseph has. The **Sandbox** is like Joseph's computer with pre-installed software. And **Instruction** is the work plan that tells the agent what to do.
+The **Agent Provider** (Claude Code) is a capable worker, and **Skills** give the agent specialized expertise in specific domains, just like the finance expertise Joseph has. The **Sandbox** is like Joseph's computer with pre-installed software. And **Instruction** is the work plan that tells the agent what to do.
 
 ## Sandbox
 
 The Sandbox provides the runtime environment for your agent. It includes:
 
-- The Agent Provider (Claude Code or Codex)
+- The Agent Provider (Claude Code)
 - System tools and dependencies
 - Base configuration
 
@@ -44,7 +44,7 @@ VM0 prepares your sandbox with the appropriate runtime environment for your prov
 
 ## Skills & Instructions
 
-When you run an agent, VM0 packages your skills and instructions and mounts them into the sandbox at the appropriate location for the agent provider (`~/.claude` for Claude Code, `~/.codex` for Codex).
+When you run an agent, VM0 packages your skills and instructions and mounts them into the sandbox at `~/.claude`.
 
 - **[Instruction](/docs/core-concept/instructions)** - Defines what the agent should do (via `AGENTS.md` or `CLAUDE.md`)
 - **[Skills](/docs/core-concept/skills)** - Reusable packages that add domain-specific capabilities, like [Firecrawl](/docs/agent-skills/firecrawl), [Notion](/docs/agent-skills/notion), or [Create Slides](https://github.com/anthropics/skills/tree/main/skills/pptx)

--- a/turbo/apps/docs/content/docs/core-concept/instructions.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/instructions.mdx
@@ -18,10 +18,7 @@ agents:
     instructions: AGENTS.md # [!code highlight]
 ```
 
-The instructions file becomes part of the agent's system prompt:
-
-- **Claude Code** - Loaded as `~/.claude/CLAUDE.md`
-- **Codex** - Loaded as `~/.codex/AGENTS.md`
+The instructions file is loaded as `~/.claude/CLAUDE.md` in the agent's sandbox and becomes part of the agent's system prompt.
 
 ## Writing Instructions
 

--- a/turbo/apps/docs/content/docs/core-concept/volume.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/volume.mdx
@@ -83,7 +83,7 @@ However, volumes are useful when you need:
 
 - **Private skills** - Skills that can't be hosted publicly
 - **User scripts** - Custom scripts that your agent can execute
-- **Custom config directories** - Mounting directories outside `~/.claude` or `~/.codex`, such as `.vim`, `.ssh`, `.zshrc`, or other dotfiles
+- **Custom config directories** - Mounting directories outside `~/.claude`, such as `.vim`, `.ssh`, `.zshrc`, or other dotfiles
 
 ## Managing Volumes
 

--- a/turbo/apps/docs/content/docs/experimental/codex.mdx
+++ b/turbo/apps/docs/content/docs/experimental/codex.mdx
@@ -1,0 +1,60 @@
+---
+title: Codex Framework
+description: Use OpenAI's Codex as your agent framework
+---
+
+<Callout type="warning">
+  This is an experimental feature. The configuration and behavior may change in future releases.
+</Callout>
+
+Codex is an experimental agent framework that uses OpenAI's models. Unlike Claude Code, Codex requires manual API key configuration and does not support the model provider system.
+
+## Configuration
+
+To use Codex, set the `framework` field to `codex` and provide your OpenAI API key:
+
+```yaml title="vm0.yaml"
+version: "1.0"
+
+agents:
+  my-agent:
+    framework: codex # [!code highlight]
+    instructions: AGENTS.md
+    environment:
+      OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}" # [!code highlight]
+```
+
+## Running Your Agent
+
+Run with your API key passed as a secret:
+
+```bash
+vm0 run my-agent "your prompt" --secrets OPENAI_API_KEY=sk-xxx
+```
+
+## Instructions
+
+Codex loads instructions from a different location than Claude Code:
+
+| Framework | Instructions Path |
+|-----------|------------------|
+| Claude Code | `~/.claude/CLAUDE.md` |
+| Codex | `~/.codex/AGENTS.md` |
+
+When you specify an `instructions` file in your `vm0.yaml`, VM0 automatically mounts it to the correct location based on your framework.
+
+## Limitations
+
+Codex has some limitations compared to Claude Code:
+
+- **No model provider support** - You cannot use `vm0 model-provider setup` with Codex. You must pass the API key manually.
+- **Manual secret passing** - The `OPENAI_API_KEY` must be provided via the `--secrets` flag on every run.
+- **Experimental status** - The feature may have breaking changes in future releases.
+
+## Getting an API Key
+
+To use Codex, you need an OpenAI API key:
+
+1. Go to [OpenAI Platform](https://platform.openai.com/api-keys)
+2. Create a new API key
+3. Use it with the `--secrets` flag when running your agent

--- a/turbo/apps/docs/content/docs/experimental/codex.mdx
+++ b/turbo/apps/docs/content/docs/experimental/codex.mdx
@@ -1,5 +1,5 @@
 ---
-title: Codex Framework
+title: Codex
 description: Use OpenAI's Codex as your agent framework
 ---
 

--- a/turbo/apps/docs/content/docs/experimental/meta.json
+++ b/turbo/apps/docs/content/docs/experimental/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Experimental",
-  "pages": ["firewall"]
+  "pages": ["codex", "firewall"]
 }

--- a/turbo/apps/docs/content/docs/model-selection/index.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/index.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: Configure different model providers for your agents
 ---
 
-VM0 supports two agent frameworks: **Claude Code** and **Codex**. You can also use alternative model providers with Claude Code.
+VM0 uses **Claude Code** as the primary agent framework. You can also use alternative model providers with Claude Code.
 
 ## Quick Start with Model Provider
 
@@ -57,7 +57,7 @@ When you run an agent:
 
 ## Framework Selection
 
-VM0 supports two agent frameworks. If you've configured a model provider above, authentication is handled automatically.
+Claude Code is the default and recommended agent framework. If you've configured a model provider above, authentication is handled automatically.
 
 ### Claude Code (Default)
 
@@ -71,30 +71,10 @@ agents:
     framework: claude-code # [!code highlight]
 ```
 
-### Codex
-
-Codex uses OpenAI's models:
-
-```yaml title="vm0.yaml"
-version: "1.0"
-
-agents:
-  my-agent:
-    framework: codex # [!code highlight]
-    environment:
-      OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}" # [!code highlight]
-```
-
-Run with your API key:
-
-```bash
-vm0 run my-agent "your prompt" --secrets OPENAI_API_KEY=sk-xxx
-```
-
-## Alternative Model Providers (Claude Code only)
+## Alternative Model Providers
 
 <Callout type="warning">
-Alternative model providers require manual configuration and are only supported with Claude Code.
+Alternative model providers require manual configuration.
 </Callout>
 
 If you need to use providers other than Anthropic directly (like OpenRouter or DeepSeek), configure them manually in your `vm0.yaml`:

--- a/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
@@ -55,7 +55,7 @@ volumes:
 
 | Field          | Type   | Required | Default | Description                                                                                       |
 | -------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------- |
-| `framework`    | string | Yes      | -       | Agent framework: `claude-code` or `codex`. See [Model Selection](/docs/model-selection)           |
+| `framework`    | string | Yes      | -       | Agent framework: `claude-code` (default) or `codex` ([experimental](/docs/experimental/codex)). See [Model Selection](/docs/model-selection) |
 | `instructions` | string | No       | -       | Path to instruction file (e.g., `AGENTS.md`). See [Instructions](/docs/core-concept/instructions) |
 | `apps`         | array  | No       | `[]`    | Pre-installed tools. Supported: `github`, `github:dev`, `github:latest`                           |
 | `skills`       | array  | No       | `[]`    | List of skill URLs. See [Skills](/docs/core-concept/skills)                                       |


### PR DESCRIPTION
## Summary

- Create `/experimental/codex.mdx` with comprehensive Codex documentation
- Remove Codex references from main documentation
- Update `vm0-yaml.mdx` to link codex to experimental docs
- Add codex to experimental navigation

## Changes

| File | Action |
|------|--------|
| `/experimental/codex.mdx` | **Created** - New comprehensive Codex documentation |
| `/experimental/meta.json` | Updated - Add "codex" to pages |
| `/model-selection/index.mdx` | Updated - Remove Codex content |
| `/core-concept/agent-anatomy.mdx` | Updated - Remove Codex references |
| `/core-concept/instructions.mdx` | Updated - Remove Codex bullet |
| `/core-concept/volume.mdx` | Updated - Remove `~/.codex` |
| `/reference/configuration/vm0-yaml.mdx` | Updated - Add experimental link |

## Test plan

- [x] Documentation builds without errors
- [ ] Verify `/docs/experimental/codex` page renders correctly
- [ ] Verify navigation shows Codex under Experimental section
- [ ] Verify no broken links in documentation

Closes #1975

🤖 Generated with [Claude Code](https://claude.com/claude-code)