### PR TITLE
feat(platform): add interactive json viewer and sticky copy buttons

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -21,7 +21,8 @@
     "ccstate-react": "^5.0.0",
     "path-to-regexp": "^8.3.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-json-view-lite": "^2.5.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.8",

--- a/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
@@ -1,6 +1,7 @@
 import { CopyButton } from "@vm0/ui";
 import { getEventStyle } from "../constants/event-styles.ts";
 import { CollapsibleJson } from "./collapsible-json.tsx";
+import { JsonViewer } from "./json-viewer.tsx";
 import { highlightText } from "../utils/highlight-text.tsx";
 import type { AgentEvent } from "../../../signals/logs-page/types.ts";
 import {
@@ -485,7 +486,7 @@ function ParamValue({ value }: { value: unknown }) {
   }
 
   if (Array.isArray(value) || typeof value === "object") {
-    return <CollapsibleJson data={value} />;
+    return <JsonViewer data={value} maxInitialDepth={1} />;
   }
 
   return <span className="text-xs">{String(value)}</span>;
@@ -625,11 +626,18 @@ function ResultContent({
         <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
           Output ({lines.length} lines)
         </summary>
-        <div className="mt-2 flex gap-2 items-start bg-sidebar rounded-[10px] px-4 py-3 overflow-hidden">
-          <pre className="flex-1 text-xs text-foreground whitespace-pre-wrap max-h-80 overflow-y-auto min-w-0 break-all">
-            {contentElement}
-          </pre>
-          <CopyButton text={text} className="shrink-0 h-4 w-4 p-0" />
+        <div className="mt-2 bg-sidebar rounded-[10px] overflow-hidden">
+          <div className="max-h-80 overflow-y-auto px-4 py-3">
+            <div className="sticky top-0 z-10 flex justify-end -mt-1 mb-1">
+              <CopyButton
+                text={text}
+                className="h-6 w-6 p-1 bg-sidebar/90 hover:bg-sidebar rounded"
+              />
+            </div>
+            <pre className="text-xs text-foreground whitespace-pre-wrap min-w-0 break-all">
+              {contentElement}
+            </pre>
+          </div>
         </div>
       </details>
     );

--- a/turbo/apps/platform/src/views/logs-page/components/json-viewer.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/json-viewer.tsx
@@ -1,0 +1,81 @@
+import { JsonView, darkStyles, defaultStyles } from "react-json-view-lite";
+import "react-json-view-lite/dist/index.css";
+import { CopyButton } from "@vm0/ui";
+
+interface JsonViewerProps {
+  data: unknown;
+  defaultExpanded?: boolean;
+  maxInitialDepth?: number;
+  className?: string;
+  showCopyButton?: boolean;
+}
+
+function getStyles(isDark: boolean) {
+  const baseStyles = isDark ? darkStyles : defaultStyles;
+  return {
+    ...baseStyles,
+    container: "font-mono text-sm",
+    basicChildStyle: "pl-4",
+    label: isDark ? "text-purple-400 mr-1" : "text-purple-600 mr-1",
+    nullValue: "text-gray-500",
+    undefinedValue: "text-gray-500",
+    stringValue: isDark ? "text-green-400" : "text-green-600",
+    booleanValue: isDark ? "text-amber-400" : "text-amber-600",
+    numberValue: isDark ? "text-blue-400" : "text-blue-600",
+    otherValue: "text-foreground",
+    punctuation: "text-muted-foreground",
+    collapseIcon:
+      "inline-block w-4 h-4 mr-1 cursor-pointer text-muted-foreground hover:text-foreground transition-colors",
+    expandIcon:
+      "inline-block w-4 h-4 mr-1 cursor-pointer text-muted-foreground hover:text-foreground transition-colors",
+    collapsedContent:
+      "text-muted-foreground cursor-pointer hover:text-foreground",
+  };
+}
+
+function getExpandFn(
+  maxDepth: number,
+  expandAll: boolean,
+): (level: number, value: unknown, field: string | undefined) => boolean {
+  if (expandAll) {
+    return () => true;
+  }
+  return (level: number) => level < maxDepth;
+}
+
+export function JsonViewer({
+  data,
+  defaultExpanded = false,
+  maxInitialDepth = 2,
+  className,
+  showCopyButton = true,
+}: JsonViewerProps) {
+  // Detect dark mode using CSS media query
+  const isDarkMode =
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+  const styles = getStyles(isDarkMode);
+  const jsonString = JSON.stringify(data, null, 2);
+  const expandFn = getExpandFn(maxInitialDepth, defaultExpanded);
+
+  return (
+    <div className={`relative ${className ?? ""}`}>
+      {showCopyButton && (
+        <div className="absolute top-0 right-0 z-10">
+          <CopyButton
+            text={jsonString}
+            className="h-6 w-6 p-1 opacity-50 hover:opacity-100"
+          />
+        </div>
+      )}
+      <div className="overflow-x-auto rounded bg-muted/30 p-3 pr-8">
+        <JsonView
+          data={data as object}
+          shouldExpandNode={expandFn}
+          style={styles}
+        />
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/raw-json-view.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/raw-json-view.tsx
@@ -35,14 +35,16 @@ export function RawJsonView({
   };
 
   return (
-    <div className="relative h-full">
-      <CopyButton
-        text={jsonString}
-        className="absolute top-2 right-2 h-8 w-8 bg-background/80 hover:bg-background z-10"
-      />
+    <div className="relative h-full bg-muted/30 rounded-lg">
+      <div className="sticky top-0 z-10 flex justify-end p-2 bg-muted/30 rounded-t-lg">
+        <CopyButton
+          text={jsonString}
+          className="h-8 w-8 bg-background/80 hover:bg-background"
+        />
+      </div>
       <pre
         ref={containerRef}
-        className="font-mono text-sm whitespace-pre-wrap h-full p-4 bg-muted/30 rounded-lg"
+        className="font-mono text-sm whitespace-pre-wrap h-full px-4 pb-4"
       >
         {element}
       </pre>

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.1(react@19.2.1)
+      react-json-view-lite:
+        specifier: ^2.5.0
+        version: 2.5.0(react@19.2.1)
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.1.8
@@ -6969,6 +6972,12 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-json-view-lite@2.5.0:
+    resolution: {integrity: sha512-tk7o7QG9oYyELWHL8xiMQ8x4WzjCzbWNyig3uexmkLb54r8jO0yH3WCWx8UZS0c49eSA4QUmG5caiRJ8fAn58g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
@@ -11955,7 +11964,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.18.0)(typescript@5.9.2))(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -15275,6 +15284,10 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
+
+  react-json-view-lite@2.5.0(react@19.2.1):
+    dependencies:
+      react: 19.2.1
 
   react-markdown@10.1.0(@types/react@19.1.12)(react@19.2.1):
     dependencies:


### PR DESCRIPTION
## Summary

- Add `react-json-view-lite` library (~3KB) for interactive JSON tree viewing
- Create `JsonViewer` wrapper component with dark/light theme support
- Replace `CollapsibleJson` with `JsonViewer` for object/array parameter display
- Make copy button sticky in `RawJsonView` (stays at top when scrolling)
- Make copy button sticky in `ResultContent` for long tool outputs

## Test plan

- [x] JSON viewer displays interactive tree for nested data
- [x] Nodes can be expanded/collapsed individually
- [x] Copy button stays visible when scrolling in RawJsonView
- [x] Copy button stays visible when scrolling within long tool output
- [x] All existing tests pass
- [x] Lint and type checks pass

Closes #1982

🤖 Generated with [Claude Code](https://claude.com/claude-code)