### PR TITLE
docs: update home page cli setup and sample agent instructions

### DIFF
--- a/turbo/apps/platform/src/views/home/home-page.tsx
+++ b/turbo/apps/platform/src/views/home/home-page.tsx
@@ -42,7 +42,7 @@ function StepHeader({ step, title }: { step: number; title: string }) {
 }
 
 function Step1InstallSkill() {
-  const command = "npx @vm0/cli setup-claude";
+  const command = "npm install -g @vm0/cli && vm0 onboard";
 
   return (
     <section>
@@ -52,7 +52,7 @@ function Step1InstallSkill() {
       />
       <Card className="flex items-center justify-between p-4 font-mono">
         <code className="text-sm overflow-x-auto text-muted-foreground">
-          <span>npx</span> <span>@vm0/cli</span> <span>setup-claude</span>
+          <span>npm install -g @vm0/cli && vm0 onboard</span>
         </code>
         <CopyButton text={`${command}`} />
       </Card>
@@ -118,8 +118,9 @@ function Step2SampleAgents() {
           iconBg=""
           commands={[
             "git clone https://github.com/vm0-ai/vm0-cookbooks",
-            "cd vm0-cookbooks/201-hackernews",
-            "vm0 cook start",
+            "cd vm0-cookbooks/examples/201-hackernews",
+            "vm0 setup-claude",
+            'claude "introduce this agent to me."',
           ]}
         />
         <SampleAgentCard
@@ -135,8 +136,9 @@ function Step2SampleAgents() {
           iconBg=""
           commands={[
             "git clone https://github.com/vm0-ai/vm0-cookbooks",
-            "cd vm0-cookbooks/206-tiktok-influencer",
-            "vm0 cook start",
+            "cd vm0-cookbooks/examples/206-tiktok-influencer",
+            "vm0 setup-claude",
+            'claude "introduce this agent to me."',
           ]}
         />
       </div>

--- a/turbo/apps/platform/src/views/home/home-page.tsx
+++ b/turbo/apps/platform/src/views/home/home-page.tsx
@@ -120,7 +120,7 @@ function Step2SampleAgents() {
             "git clone https://github.com/vm0-ai/vm0-cookbooks",
             "cd vm0-cookbooks/examples/201-hackernews",
             "vm0 setup-claude",
-            'claude "introduce this agent to me."',
+            'claude "Show me the agent and run it."',
           ]}
         />
         <SampleAgentCard
@@ -138,7 +138,7 @@ function Step2SampleAgents() {
             "git clone https://github.com/vm0-ai/vm0-cookbooks",
             "cd vm0-cookbooks/examples/206-tiktok-influencer",
             "vm0 setup-claude",
-            'claude "introduce this agent to me."',
+            'claude "Show me the agent and run it."',
           ]}
         />
       </div>


### PR DESCRIPTION
## Summary
- Update install command from `npx @vm0/cli setup-claude` to `npm install -g @vm0/cli && vm0 onboard`
- Update sample agent paths to include `examples` subdirectory (e.g., `vm0-cookbooks/examples/201-hackernews`)
- Replace `vm0 cook start` workflow with `vm0 setup-claude` followed by `claude "introduce this agent to me."`

## Test plan
- [ ] Verify the home page renders correctly with the updated commands
- [ ] Test copy button functionality for the new install command
- [ ] Verify the sample agent cards display the correct commands

---
Generated with [Claude Code](https://claude.ai/code)