### PR TITLE
lint(web): add eslint rule to ban class declarations

### DIFF
--- a/turbo/apps/web/eslint.config.js
+++ b/turbo/apps/web/eslint.config.js
@@ -1,4 +1,23 @@
 import { nextJsConfig } from "@vm0/eslint-config/next-js";
 
 /** @type {import("eslint").Linter.Config} */
-export default nextJsConfig;
+export default [
+  ...nextJsConfig,
+  {
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "ClassDeclaration",
+          message:
+            "Classes are not allowed. Use functions and plain objects instead.",
+        },
+        {
+          selector: "ClassExpression",
+          message:
+            "Classes are not allowed. Use functions and plain objects instead.",
+        },
+      ],
+    },
+  },
+];

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -244,6 +244,7 @@ export function testContext(): TestContext {
         // Replace Date constructor with vi.stubGlobal (auto-restored by vitest)
         vi.stubGlobal(
           "Date",
+          // eslint-disable-next-line no-restricted-syntax -- legacy code
           class extends RealDate {
             constructor(...args: unknown[]) {
               if (args.length === 0) {

--- a/turbo/apps/web/src/lib/errors.ts
+++ b/turbo/apps/web/src/lib/errors.ts
@@ -2,6 +2,7 @@
  * Custom error classes for API
  */
 
+// eslint-disable-next-line no-restricted-syntax -- legacy code
 class ApiError extends Error {
   constructor(
     public statusCode: number,
@@ -13,42 +14,49 @@ class ApiError extends Error {
   }
 }
 
+// eslint-disable-next-line no-restricted-syntax -- legacy code
 export class UnauthorizedError extends ApiError {
   constructor(message = "Unauthorized") {
     super(401, message, "UNAUTHORIZED");
   }
 }
 
+// eslint-disable-next-line no-restricted-syntax -- legacy code
 export class NotFoundError extends ApiError {
   constructor(message = "Resource not found") {
     super(404, message, "NOT_FOUND");
   }
 }
 
+// eslint-disable-next-line no-restricted-syntax -- legacy code
 export class BadRequestError extends ApiError {
   constructor(message = "Bad request") {
     super(400, message, "BAD_REQUEST");
   }
 }
 
+// eslint-disable-next-line no-restricted-syntax -- legacy code
 export class ForbiddenError extends ApiError {
   constructor(message = "Forbidden") {
     super(403, message, "FORBIDDEN");
   }
 }
 
+// eslint-disable-next-line no-restricted-syntax -- legacy code
 export class ConflictError extends ApiError {
   constructor(message = "Conflict") {
     super(409, message, "CONFLICT");
   }
 }
 
+// eslint-disable-next-line no-restricted-syntax -- legacy code
 export class SchedulePastError extends ApiError {
   constructor(message = "Schedule time has already passed") {
     super(400, message, "SCHEDULE_PAST");
   }
 }
 
+// eslint-disable-next-line no-restricted-syntax -- legacy code
 export class ConcurrentRunLimitError extends ApiError {
   constructor(
     message = "You have reached the concurrent agent run limit. Please wait for your current run to complete before starting a new one.",

--- a/turbo/apps/web/src/lib/proxy/proxy-service.ts
+++ b/turbo/apps/web/src/lib/proxy/proxy-service.ts
@@ -45,6 +45,7 @@ interface ProxyResult {
 /**
  * Error thrown when proxy token decryption fails
  */
+// eslint-disable-next-line no-restricted-syntax -- legacy code
 export class ProxyTokenDecryptionError extends Error {
   constructor(
     message: string,

--- a/turbo/apps/web/src/lib/s3/types.ts
+++ b/turbo/apps/web/src/lib/s3/types.ts
@@ -18,6 +18,7 @@ export interface S3Object {
 /**
  * S3 download error
  */
+// eslint-disable-next-line no-restricted-syntax -- legacy code
 export class S3DownloadError extends Error {
   constructor(
     message: string,
@@ -33,6 +34,7 @@ export class S3DownloadError extends Error {
 /**
  * S3 upload error
  */
+// eslint-disable-next-line no-restricted-syntax -- legacy code
 export class S3UploadError extends Error {
   constructor(
     message: string,


### PR DESCRIPTION
## Summary
- Add `no-restricted-syntax` ESLint rule to prohibit `ClassDeclaration` and `ClassExpression` in the web app
- Mark existing 11 classes with `eslint-disable-next-line` comments for incremental migration

## Test plan
- [x] Lint passes: `pnpm turbo run lint --filter=web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)