### PR TITLE
feat(schedule): retry scheduled runs on concurrency limit

### DIFF
--- a/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
@@ -3,14 +3,14 @@ import { GET } from "../route";
 import {
   createTestRequest,
   createTestCompose,
+  createTestRun,
   createTestSchedule,
   enableTestSchedule,
   getTestSchedule,
   getTestScheduleRuns,
-  setScheduleRetryStartedAt,
+  completeTestRun,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
-import { concurrentRunLimit } from "../../../../../src/lib/errors";
 
 vi.mock("@clerk/nextjs/server");
 vi.mock("@e2b/code-interpreter");
@@ -22,10 +22,12 @@ const context = testContext();
 
 describe("GET /api/cron/execute-schedules", () => {
   let testComposeId: string;
+  let testUserId: string;
 
   beforeEach(async () => {
     context.setupMocks();
-    await context.setupUser();
+    const user = await context.setupUser();
+    testUserId = user.userId;
 
     const { composeId } = await createTestCompose(
       `cron-test-agent-${Date.now()}`,
@@ -250,7 +252,7 @@ describe("GET /api/cron/execute-schedules", () => {
 
   describe("Concurrency Retry", () => {
     it("should retry schedule when blocked by concurrency limit", async () => {
-      // 1. Mock time to 8:00 AM UTC
+      // 1. Set time to 8:00 AM
       context.mocks.date.setSystemTime(new Date("2025-01-15T08:00:00Z"));
 
       // 2. Create and enable schedule for 9 AM
@@ -261,211 +263,180 @@ describe("GET /api/cron/execute-schedules", () => {
       });
       await enableTestSchedule(testComposeId, "retry-test");
 
-      // 3. Advance time to 9:01 AM (schedule is due)
+      // 3. Create a pending run to block concurrency (default limit is 1)
+      await createTestRun(testComposeId, "Blocking run");
+
+      // 4. Advance time to 9:01 AM (schedule is due)
       context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
 
-      // 4. Mock checkRunConcurrencyLimit to throw ConcurrentRunLimitError
-      const runService = await import("../../../../../src/lib/run/run-service");
-      const checkSpy = vi
-        .spyOn(runService, "checkRunConcurrencyLimit")
-        .mockRejectedValueOnce(
-          concurrentRunLimit("Concurrent run limit reached"),
-        );
+      // 5. Execute cron - should fail due to concurrency limit
+      const request = createTestRequest(
+        "http://localhost:3000/api/cron/execute-schedules",
+      );
+      const response = await GET(request);
+      expect(response.status).toBe(200);
 
-      try {
-        // 5. Execute cron
-        const request = createTestRequest(
-          "http://localhost:3000/api/cron/execute-schedules",
-        );
-        const response = await GET(request);
-        expect(response.status).toBe(200);
+      // 6. Verify schedule entered retry state
+      const schedule = await getTestSchedule(testComposeId, "retry-test");
+      expect(schedule.retryStartedAt).not.toBeNull();
+      // nextRunAt should be 5 minutes later, not tomorrow 9 AM
+      const nextRunAt = new Date(schedule.nextRunAt!);
+      const expectedRetryAt = new Date("2025-01-15T09:06:00Z");
+      expect(nextRunAt.getTime()).toBe(expectedRetryAt.getTime());
 
-        // 6. Verify schedule was NOT advanced to tomorrow but retries in 5 minutes
-        const schedule = await getTestSchedule(testComposeId, "retry-test");
-        expect(schedule.retryStartedAt).not.toBeNull();
-        // nextRunAt should be ~5 minutes from now, not tomorrow 9 AM
-        const nextRunAt = new Date(schedule.nextRunAt!);
-        const expectedRetryAt = new Date("2025-01-15T09:06:00Z");
-        expect(nextRunAt.getTime()).toBe(expectedRetryAt.getTime());
-
-        // 7. Verify a failed run was created
-        const { runs } = await getTestScheduleRuns(
-          testComposeId,
-          "retry-test",
-          1,
-        );
-        expect(runs.length).toBe(1);
-        expect(runs[0]?.status).toBe("failed");
-        expect(runs[0]?.error).toContain("Concurrent run limit");
-      } finally {
-        checkSpy.mockRestore();
-      }
+      // 7. Verify a failed run was created
+      const { runs } = await getTestScheduleRuns(
+        testComposeId,
+        "retry-test",
+        1,
+      );
+      expect(runs.length).toBe(1);
+      expect(runs[0]?.status).toBe("failed");
+      expect(runs[0]?.error).toContain("concurrent");
     });
 
     it("should preserve retryStartedAt on subsequent retries", async () => {
-      // 1. Mock time to 9:01 AM
-      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+      // 1. Set time to 8:00 AM
+      context.mocks.date.setSystemTime(new Date("2025-01-15T08:00:00Z"));
 
-      // 2. Create schedule and enable it
+      // 2. Create and enable schedule for 9 AM
       await createTestSchedule(testComposeId, "retry-preserve-test", {
         cronExpression: "0 9 * * *",
         prompt: "Daily task",
         timezone: "UTC",
       });
-      const schedule = await enableTestSchedule(
+      await enableTestSchedule(testComposeId, "retry-preserve-test");
+
+      // 3. Create a blocking run
+      await createTestRun(testComposeId, "Blocking run");
+
+      // 4. Advance to 9:01 AM and trigger first retry
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+      await GET(
+        createTestRequest("http://localhost:3000/api/cron/execute-schedules"),
+      );
+
+      // 5. Record the initial retryStartedAt
+      const firstSchedule = await getTestSchedule(
         testComposeId,
         "retry-preserve-test",
       );
+      const initialRetryStartedAt = firstSchedule.retryStartedAt;
+      expect(initialRetryStartedAt).not.toBeNull();
 
-      // 3. Set retryStartedAt to 10 minutes ago (simulating we're already in retry)
-      const retryStart = new Date("2025-01-15T08:51:00Z");
-      await setScheduleRetryStartedAt(schedule.id, retryStart);
+      // 6. Advance to 9:06 AM (5 minutes later - retry time)
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:06:00Z"));
 
-      // 4. Set nextRunAt to now (simulating a retry attempt)
-      const { agentSchedules } = await import(
-        "../../../../../src/db/schema/agent-schedule"
+      // 7. Execute cron again (second retry attempt)
+      await GET(
+        createTestRequest("http://localhost:3000/api/cron/execute-schedules"),
       );
-      const { eq } = await import("drizzle-orm");
-      await globalThis.services.db
-        .update(agentSchedules)
-        .set({ nextRunAt: new Date("2025-01-15T09:01:00Z") })
-        .where(eq(agentSchedules.id, schedule.id));
 
-      // 5. Mock concurrency limit failure again
-      const runService = await import("../../../../../src/lib/run/run-service");
-      const checkSpy = vi
-        .spyOn(runService, "checkRunConcurrencyLimit")
-        .mockRejectedValueOnce(
-          concurrentRunLimit("Concurrent run limit reached"),
-        );
-
-      try {
-        // 6. Execute cron
-        const request = createTestRequest(
-          "http://localhost:3000/api/cron/execute-schedules",
-        );
-        await GET(request);
-
-        // 7. Verify retryStartedAt was preserved (not reset to now)
-        const updatedSchedule = await getTestSchedule(
-          testComposeId,
-          "retry-preserve-test",
-        );
-        expect(new Date(updatedSchedule.retryStartedAt!).getTime()).toBe(
-          retryStart.getTime(),
-        );
-      } finally {
-        checkSpy.mockRestore();
-      }
+      // 8. Verify retryStartedAt was preserved
+      const secondSchedule = await getTestSchedule(
+        testComposeId,
+        "retry-preserve-test",
+      );
+      expect(secondSchedule.retryStartedAt).toBe(initialRetryStartedAt);
     });
 
     it("should advance to next occurrence when retry window expires", async () => {
-      // 1. Mock time to 9:01 AM
-      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+      // 1. Set time to 8:00 AM
+      context.mocks.date.setSystemTime(new Date("2025-01-15T08:00:00Z"));
 
-      // 2. Create and enable schedule
+      // 2. Create and enable schedule for 9 AM
       await createTestSchedule(testComposeId, "retry-expire-test", {
         cronExpression: "0 9 * * *",
         prompt: "Daily task",
         timezone: "UTC",
       });
-      const schedule = await enableTestSchedule(
+      await enableTestSchedule(testComposeId, "retry-expire-test");
+
+      // 3. Create a blocking run
+      await createTestRun(testComposeId, "Blocking run");
+
+      // 4. Advance to 9:01 AM and trigger first retry
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+      await GET(
+        createTestRequest("http://localhost:3000/api/cron/execute-schedules"),
+      );
+
+      // Verify we're in retry state
+      const midSchedule = await getTestSchedule(
         testComposeId,
         "retry-expire-test",
       );
+      expect(midSchedule.retryStartedAt).not.toBeNull();
 
-      // 3. Set retryStartedAt to 35 minutes ago (past the 30-min window)
-      const retryStart = new Date("2025-01-15T08:26:00Z");
-      await setScheduleRetryStartedAt(schedule.id, retryStart);
+      // 5. Advance to 9:36 AM (35 minutes later - past 30-min retry window)
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:36:00Z"));
 
-      // 4. Set nextRunAt to now
-      const { agentSchedules } = await import(
-        "../../../../../src/db/schema/agent-schedule"
+      // 6. Execute cron - retry window should expire
+      await GET(
+        createTestRequest("http://localhost:3000/api/cron/execute-schedules"),
       );
-      const { eq } = await import("drizzle-orm");
-      await globalThis.services.db
-        .update(agentSchedules)
-        .set({ nextRunAt: new Date("2025-01-15T09:01:00Z") })
-        .where(eq(agentSchedules.id, schedule.id));
 
-      // 5. Mock concurrency limit failure
-      const runService = await import("../../../../../src/lib/run/run-service");
-      const checkSpy = vi
-        .spyOn(runService, "checkRunConcurrencyLimit")
-        .mockRejectedValueOnce(
-          concurrentRunLimit("Concurrent run limit reached"),
-        );
-
-      try {
-        // 6. Execute cron
-        const request = createTestRequest(
-          "http://localhost:3000/api/cron/execute-schedules",
-        );
-        await GET(request);
-
-        // 7. Verify schedule advanced to next day (tomorrow 9 AM)
-        const updatedSchedule = await getTestSchedule(
-          testComposeId,
-          "retry-expire-test",
-        );
-        // retryStartedAt should be cleared
-        expect(updatedSchedule.retryStartedAt).toBeNull();
-        // nextRunAt should be tomorrow 9 AM
-        const nextRunAt = new Date(updatedSchedule.nextRunAt!);
-        expect(nextRunAt.toISOString()).toBe("2025-01-16T09:00:00.000Z");
-      } finally {
-        checkSpy.mockRestore();
-      }
+      // 7. Verify schedule advanced to next day (tomorrow 9 AM)
+      const finalSchedule = await getTestSchedule(
+        testComposeId,
+        "retry-expire-test",
+      );
+      expect(finalSchedule.retryStartedAt).toBeNull();
+      const nextRunAt = new Date(finalSchedule.nextRunAt!);
+      expect(nextRunAt.toISOString()).toBe("2025-01-16T09:00:00.000Z");
     });
 
     it("should clear retryStartedAt on successful execution", async () => {
-      // 1. Mock time to 9:01 AM
-      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+      // 1. Set time to 8:00 AM
+      context.mocks.date.setSystemTime(new Date("2025-01-15T08:00:00Z"));
 
-      // 2. Create and enable schedule
+      // 2. Create and enable schedule for 9 AM
       await createTestSchedule(testComposeId, "retry-clear-test", {
         cronExpression: "0 9 * * *",
         prompt: "Daily task",
         timezone: "UTC",
       });
-      const schedule = await enableTestSchedule(
+      await enableTestSchedule(testComposeId, "retry-clear-test");
+
+      // 3. Create a blocking run
+      const { runId: blockingRunId } = await createTestRun(
+        testComposeId,
+        "Blocking run",
+      );
+
+      // 4. Advance to 9:01 AM and trigger first retry
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+      await GET(
+        createTestRequest("http://localhost:3000/api/cron/execute-schedules"),
+      );
+
+      // Verify we're in retry state
+      const midSchedule = await getTestSchedule(
         testComposeId,
         "retry-clear-test",
       );
+      expect(midSchedule.retryStartedAt).not.toBeNull();
 
-      // 3. Set retryStartedAt (simulating previous failed attempt)
-      await setScheduleRetryStartedAt(
-        schedule.id,
-        new Date("2025-01-15T08:51:00Z"),
+      // 5. Complete the blocking run to free up concurrency
+      await completeTestRun(testUserId, blockingRunId);
+
+      // 6. Advance to 9:06 AM (retry time) and execute
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:06:00Z"));
+      await GET(
+        createTestRequest("http://localhost:3000/api/cron/execute-schedules"),
       );
 
-      // 4. Set nextRunAt to now
-      const { agentSchedules } = await import(
-        "../../../../../src/db/schema/agent-schedule"
-      );
-      const { eq } = await import("drizzle-orm");
-      await globalThis.services.db
-        .update(agentSchedules)
-        .set({ nextRunAt: new Date("2025-01-15T09:01:00Z") })
-        .where(eq(agentSchedules.id, schedule.id));
-
-      // 5. Execute cron (no mock = success)
-      const request = createTestRequest(
-        "http://localhost:3000/api/cron/execute-schedules",
-      );
-      await GET(request);
-
-      // 6. Verify retryStartedAt was cleared
-      const updatedSchedule = await getTestSchedule(
+      // 7. Verify retryStartedAt was cleared and execution succeeded
+      const finalSchedule = await getTestSchedule(
         testComposeId,
         "retry-clear-test",
       );
-      expect(updatedSchedule.retryStartedAt).toBeNull();
-      expect(updatedSchedule.lastRunAt).not.toBeNull();
+      expect(finalSchedule.retryStartedAt).toBeNull();
+      expect(finalSchedule.lastRunAt).not.toBeNull();
     });
 
     it("should disable one-time schedule after retry window expires", async () => {
-      // 1. Mock time to 8:00 AM (before the schedule time)
+      // 1. Set time to 8:00 AM
       context.mocks.date.setSystemTime(new Date("2025-01-15T08:00:00Z"));
 
       // 2. Create and enable one-time schedule for 9:00 AM
@@ -474,56 +445,41 @@ describe("GET /api/cron/execute-schedules", () => {
         prompt: "One-time task",
         timezone: "UTC",
       });
-      const schedule = await enableTestSchedule(
+      await enableTestSchedule(testComposeId, "onetime-retry-expire");
+
+      // 3. Create a blocking run
+      await createTestRun(testComposeId, "Blocking run");
+
+      // 4. Advance to 9:01 AM and trigger first retry
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+      await GET(
+        createTestRequest("http://localhost:3000/api/cron/execute-schedules"),
+      );
+
+      // Verify we're in retry state
+      const midSchedule = await getTestSchedule(
         testComposeId,
         "onetime-retry-expire",
       );
+      expect(midSchedule.retryStartedAt).not.toBeNull();
+      expect(midSchedule.enabled).toBe(true);
 
-      // 3. Advance time to 9:01 AM (schedule is due)
-      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+      // 5. Advance to 9:36 AM (35 minutes later - past 30-min retry window)
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:36:00Z"));
 
-      // 4. Set retryStartedAt to 35 minutes ago (past the 30-min window)
-      await setScheduleRetryStartedAt(
-        schedule.id,
-        new Date("2025-01-15T08:26:00Z"),
+      // 6. Execute cron - retry window should expire
+      await GET(
+        createTestRequest("http://localhost:3000/api/cron/execute-schedules"),
       );
 
-      // 5. Set nextRunAt to now (simulating a retry attempt)
-      const { agentSchedules } = await import(
-        "../../../../../src/db/schema/agent-schedule"
+      // 7. Verify one-time schedule was disabled
+      const finalSchedule = await getTestSchedule(
+        testComposeId,
+        "onetime-retry-expire",
       );
-      const { eq } = await import("drizzle-orm");
-      await globalThis.services.db
-        .update(agentSchedules)
-        .set({ nextRunAt: new Date("2025-01-15T09:01:00Z") })
-        .where(eq(agentSchedules.id, schedule.id));
-
-      // 6. Mock concurrency limit failure
-      const runService = await import("../../../../../src/lib/run/run-service");
-      const checkSpy = vi
-        .spyOn(runService, "checkRunConcurrencyLimit")
-        .mockRejectedValueOnce(
-          concurrentRunLimit("Concurrent run limit reached"),
-        );
-
-      try {
-        // 7. Execute cron
-        const request = createTestRequest(
-          "http://localhost:3000/api/cron/execute-schedules",
-        );
-        await GET(request);
-
-        // 8. Verify one-time schedule was disabled
-        const updatedSchedule = await getTestSchedule(
-          testComposeId,
-          "onetime-retry-expire",
-        );
-        expect(updatedSchedule.enabled).toBe(false);
-        expect(updatedSchedule.nextRunAt).toBeNull();
-        expect(updatedSchedule.retryStartedAt).toBeNull();
-      } finally {
-        checkSpy.mockRestore();
-      }
+      expect(finalSchedule.enabled).toBe(false);
+      expect(finalSchedule.nextRunAt).toBeNull();
+      expect(finalSchedule.retryStartedAt).toBeNull();
     });
   });
 });

--- a/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
@@ -10,7 +10,7 @@ import {
   setScheduleRetryStartedAt,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
-import { ConcurrentRunLimitError } from "../../../../../src/lib/errors";
+import { concurrentRunLimit } from "../../../../../src/lib/errors";
 
 vi.mock("@clerk/nextjs/server");
 vi.mock("@e2b/code-interpreter");
@@ -269,7 +269,7 @@ describe("GET /api/cron/execute-schedules", () => {
       const checkSpy = vi
         .spyOn(runService, "checkRunConcurrencyLimit")
         .mockRejectedValueOnce(
-          new ConcurrentRunLimitError("Concurrent run limit reached"),
+          concurrentRunLimit("Concurrent run limit reached"),
         );
 
       try {
@@ -336,7 +336,7 @@ describe("GET /api/cron/execute-schedules", () => {
       const checkSpy = vi
         .spyOn(runService, "checkRunConcurrencyLimit")
         .mockRejectedValueOnce(
-          new ConcurrentRunLimitError("Concurrent run limit reached"),
+          concurrentRunLimit("Concurrent run limit reached"),
         );
 
       try {
@@ -393,7 +393,7 @@ describe("GET /api/cron/execute-schedules", () => {
       const checkSpy = vi
         .spyOn(runService, "checkRunConcurrencyLimit")
         .mockRejectedValueOnce(
-          new ConcurrentRunLimitError("Concurrent run limit reached"),
+          concurrentRunLimit("Concurrent run limit reached"),
         );
 
       try {
@@ -503,7 +503,7 @@ describe("GET /api/cron/execute-schedules", () => {
       const checkSpy = vi
         .spyOn(runService, "checkRunConcurrencyLimit")
         .mockRejectedValueOnce(
-          new ConcurrentRunLimitError("Concurrent run limit reached"),
+          concurrentRunLimit("Concurrent run limit reached"),
         );
 
       try {

--- a/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
@@ -6,8 +6,11 @@ import {
   createTestSchedule,
   enableTestSchedule,
   getTestSchedule,
+  getTestScheduleRuns,
+  setScheduleRetryStartedAt,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
+import { ConcurrentRunLimitError } from "../../../../../src/lib/errors";
 
 vi.mock("@clerk/nextjs/server");
 vi.mock("@e2b/code-interpreter");
@@ -242,6 +245,285 @@ describe("GET /api/cron/execute-schedules", () => {
       expect(afterSchedule.enabled).toBe(false);
       expect(afterSchedule.nextRunAt).toBeNull();
       expect(afterSchedule.lastRunAt).not.toBeNull();
+    });
+  });
+
+  describe("Concurrency Retry", () => {
+    it("should retry schedule when blocked by concurrency limit", async () => {
+      // 1. Mock time to 8:00 AM UTC
+      context.mocks.date.setSystemTime(new Date("2025-01-15T08:00:00Z"));
+
+      // 2. Create and enable schedule for 9 AM
+      await createTestSchedule(testComposeId, "retry-test", {
+        cronExpression: "0 9 * * *",
+        prompt: "Daily task",
+        timezone: "UTC",
+      });
+      await enableTestSchedule(testComposeId, "retry-test");
+
+      // 3. Advance time to 9:01 AM (schedule is due)
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+
+      // 4. Mock checkRunConcurrencyLimit to throw ConcurrentRunLimitError
+      const runService = await import("../../../../../src/lib/run/run-service");
+      const checkSpy = vi
+        .spyOn(runService, "checkRunConcurrencyLimit")
+        .mockRejectedValueOnce(
+          new ConcurrentRunLimitError("Concurrent run limit reached"),
+        );
+
+      try {
+        // 5. Execute cron
+        const request = createTestRequest(
+          "http://localhost:3000/api/cron/execute-schedules",
+        );
+        const response = await GET(request);
+        expect(response.status).toBe(200);
+
+        // 6. Verify schedule was NOT advanced to tomorrow but retries in 5 minutes
+        const schedule = await getTestSchedule(testComposeId, "retry-test");
+        expect(schedule.retryStartedAt).not.toBeNull();
+        // nextRunAt should be ~5 minutes from now, not tomorrow 9 AM
+        const nextRunAt = new Date(schedule.nextRunAt!);
+        const expectedRetryAt = new Date("2025-01-15T09:06:00Z");
+        expect(nextRunAt.getTime()).toBe(expectedRetryAt.getTime());
+
+        // 7. Verify a failed run was created
+        const { runs } = await getTestScheduleRuns(
+          testComposeId,
+          "retry-test",
+          1,
+        );
+        expect(runs.length).toBe(1);
+        expect(runs[0]?.status).toBe("failed");
+        expect(runs[0]?.error).toContain("Concurrent run limit");
+      } finally {
+        checkSpy.mockRestore();
+      }
+    });
+
+    it("should preserve retryStartedAt on subsequent retries", async () => {
+      // 1. Mock time to 9:01 AM
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+
+      // 2. Create schedule and enable it
+      await createTestSchedule(testComposeId, "retry-preserve-test", {
+        cronExpression: "0 9 * * *",
+        prompt: "Daily task",
+        timezone: "UTC",
+      });
+      const schedule = await enableTestSchedule(
+        testComposeId,
+        "retry-preserve-test",
+      );
+
+      // 3. Set retryStartedAt to 10 minutes ago (simulating we're already in retry)
+      const retryStart = new Date("2025-01-15T08:51:00Z");
+      await setScheduleRetryStartedAt(schedule.id, retryStart);
+
+      // 4. Set nextRunAt to now (simulating a retry attempt)
+      const { agentSchedules } = await import(
+        "../../../../../src/db/schema/agent-schedule"
+      );
+      const { eq } = await import("drizzle-orm");
+      await globalThis.services.db
+        .update(agentSchedules)
+        .set({ nextRunAt: new Date("2025-01-15T09:01:00Z") })
+        .where(eq(agentSchedules.id, schedule.id));
+
+      // 5. Mock concurrency limit failure again
+      const runService = await import("../../../../../src/lib/run/run-service");
+      const checkSpy = vi
+        .spyOn(runService, "checkRunConcurrencyLimit")
+        .mockRejectedValueOnce(
+          new ConcurrentRunLimitError("Concurrent run limit reached"),
+        );
+
+      try {
+        // 6. Execute cron
+        const request = createTestRequest(
+          "http://localhost:3000/api/cron/execute-schedules",
+        );
+        await GET(request);
+
+        // 7. Verify retryStartedAt was preserved (not reset to now)
+        const updatedSchedule = await getTestSchedule(
+          testComposeId,
+          "retry-preserve-test",
+        );
+        expect(new Date(updatedSchedule.retryStartedAt!).getTime()).toBe(
+          retryStart.getTime(),
+        );
+      } finally {
+        checkSpy.mockRestore();
+      }
+    });
+
+    it("should advance to next occurrence when retry window expires", async () => {
+      // 1. Mock time to 9:01 AM
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+
+      // 2. Create and enable schedule
+      await createTestSchedule(testComposeId, "retry-expire-test", {
+        cronExpression: "0 9 * * *",
+        prompt: "Daily task",
+        timezone: "UTC",
+      });
+      const schedule = await enableTestSchedule(
+        testComposeId,
+        "retry-expire-test",
+      );
+
+      // 3. Set retryStartedAt to 35 minutes ago (past the 30-min window)
+      const retryStart = new Date("2025-01-15T08:26:00Z");
+      await setScheduleRetryStartedAt(schedule.id, retryStart);
+
+      // 4. Set nextRunAt to now
+      const { agentSchedules } = await import(
+        "../../../../../src/db/schema/agent-schedule"
+      );
+      const { eq } = await import("drizzle-orm");
+      await globalThis.services.db
+        .update(agentSchedules)
+        .set({ nextRunAt: new Date("2025-01-15T09:01:00Z") })
+        .where(eq(agentSchedules.id, schedule.id));
+
+      // 5. Mock concurrency limit failure
+      const runService = await import("../../../../../src/lib/run/run-service");
+      const checkSpy = vi
+        .spyOn(runService, "checkRunConcurrencyLimit")
+        .mockRejectedValueOnce(
+          new ConcurrentRunLimitError("Concurrent run limit reached"),
+        );
+
+      try {
+        // 6. Execute cron
+        const request = createTestRequest(
+          "http://localhost:3000/api/cron/execute-schedules",
+        );
+        await GET(request);
+
+        // 7. Verify schedule advanced to next day (tomorrow 9 AM)
+        const updatedSchedule = await getTestSchedule(
+          testComposeId,
+          "retry-expire-test",
+        );
+        // retryStartedAt should be cleared
+        expect(updatedSchedule.retryStartedAt).toBeNull();
+        // nextRunAt should be tomorrow 9 AM
+        const nextRunAt = new Date(updatedSchedule.nextRunAt!);
+        expect(nextRunAt.toISOString()).toBe("2025-01-16T09:00:00.000Z");
+      } finally {
+        checkSpy.mockRestore();
+      }
+    });
+
+    it("should clear retryStartedAt on successful execution", async () => {
+      // 1. Mock time to 9:01 AM
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+
+      // 2. Create and enable schedule
+      await createTestSchedule(testComposeId, "retry-clear-test", {
+        cronExpression: "0 9 * * *",
+        prompt: "Daily task",
+        timezone: "UTC",
+      });
+      const schedule = await enableTestSchedule(
+        testComposeId,
+        "retry-clear-test",
+      );
+
+      // 3. Set retryStartedAt (simulating previous failed attempt)
+      await setScheduleRetryStartedAt(
+        schedule.id,
+        new Date("2025-01-15T08:51:00Z"),
+      );
+
+      // 4. Set nextRunAt to now
+      const { agentSchedules } = await import(
+        "../../../../../src/db/schema/agent-schedule"
+      );
+      const { eq } = await import("drizzle-orm");
+      await globalThis.services.db
+        .update(agentSchedules)
+        .set({ nextRunAt: new Date("2025-01-15T09:01:00Z") })
+        .where(eq(agentSchedules.id, schedule.id));
+
+      // 5. Execute cron (no mock = success)
+      const request = createTestRequest(
+        "http://localhost:3000/api/cron/execute-schedules",
+      );
+      await GET(request);
+
+      // 6. Verify retryStartedAt was cleared
+      const updatedSchedule = await getTestSchedule(
+        testComposeId,
+        "retry-clear-test",
+      );
+      expect(updatedSchedule.retryStartedAt).toBeNull();
+      expect(updatedSchedule.lastRunAt).not.toBeNull();
+    });
+
+    it("should disable one-time schedule after retry window expires", async () => {
+      // 1. Mock time to 8:00 AM (before the schedule time)
+      context.mocks.date.setSystemTime(new Date("2025-01-15T08:00:00Z"));
+
+      // 2. Create and enable one-time schedule for 9:00 AM
+      await createTestSchedule(testComposeId, "onetime-retry-expire", {
+        atTime: "2025-01-15T09:00:00Z",
+        prompt: "One-time task",
+        timezone: "UTC",
+      });
+      const schedule = await enableTestSchedule(
+        testComposeId,
+        "onetime-retry-expire",
+      );
+
+      // 3. Advance time to 9:01 AM (schedule is due)
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+
+      // 4. Set retryStartedAt to 35 minutes ago (past the 30-min window)
+      await setScheduleRetryStartedAt(
+        schedule.id,
+        new Date("2025-01-15T08:26:00Z"),
+      );
+
+      // 5. Set nextRunAt to now (simulating a retry attempt)
+      const { agentSchedules } = await import(
+        "../../../../../src/db/schema/agent-schedule"
+      );
+      const { eq } = await import("drizzle-orm");
+      await globalThis.services.db
+        .update(agentSchedules)
+        .set({ nextRunAt: new Date("2025-01-15T09:01:00Z") })
+        .where(eq(agentSchedules.id, schedule.id));
+
+      // 6. Mock concurrency limit failure
+      const runService = await import("../../../../../src/lib/run/run-service");
+      const checkSpy = vi
+        .spyOn(runService, "checkRunConcurrencyLimit")
+        .mockRejectedValueOnce(
+          new ConcurrentRunLimitError("Concurrent run limit reached"),
+        );
+
+      try {
+        // 7. Execute cron
+        const request = createTestRequest(
+          "http://localhost:3000/api/cron/execute-schedules",
+        );
+        await GET(request);
+
+        // 8. Verify one-time schedule was disabled
+        const updatedSchedule = await getTestSchedule(
+          testComposeId,
+          "onetime-retry-expire",
+        );
+        expect(updatedSchedule.enabled).toBe(false);
+        expect(updatedSchedule.nextRunAt).toBeNull();
+        expect(updatedSchedule.retryStartedAt).toBeNull();
+      } finally {
+        checkSpy.mockRestore();
+      }
     });
   });
 });

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -797,23 +797,3 @@ export async function createTestVolume(
 }> {
   return createTestStorage(name, { ...options, type: "volume" });
 }
-
-/**
- * Set the retryStartedAt timestamp for a schedule.
- * This is a direct database operation for testing retry scenarios.
- *
- * @param scheduleId - The schedule ID
- * @param retryStartedAt - The retry start time (null to clear)
- */
-export async function setScheduleRetryStartedAt(
-  scheduleId: string,
-  retryStartedAt: Date | null,
-): Promise<void> {
-  const { agentSchedules } = await import("../db/schema/agent-schedule");
-  const { eq } = await import("drizzle-orm");
-
-  await globalThis.services.db
-    .update(agentSchedules)
-    .set({ retryStartedAt })
-    .where(eq(agentSchedules.id, scheduleId));
-}

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -797,3 +797,23 @@ export async function createTestVolume(
 }> {
   return createTestStorage(name, { ...options, type: "volume" });
 }
+
+/**
+ * Set the retryStartedAt timestamp for a schedule.
+ * This is a direct database operation for testing retry scenarios.
+ *
+ * @param scheduleId - The schedule ID
+ * @param retryStartedAt - The retry start time (null to clear)
+ */
+export async function setScheduleRetryStartedAt(
+  scheduleId: string,
+  retryStartedAt: Date | null,
+): Promise<void> {
+  const { agentSchedules } = await import("../db/schema/agent-schedule");
+  const { eq } = await import("drizzle-orm");
+
+  await globalThis.services.db
+    .update(agentSchedules)
+    .set({ retryStartedAt })
+    .where(eq(agentSchedules.id, scheduleId));
+}

--- a/turbo/apps/web/src/db/migrations/0057_add_schedule_retry_started_at.sql
+++ b/turbo/apps/web/src/db/migrations/0057_add_schedule_retry_started_at.sql
@@ -1,0 +1,3 @@
+-- Add retry_started_at to track when concurrency retry cycle began
+-- This enables automatic retry of scheduled runs that fail due to concurrency limits
+ALTER TABLE "agent_schedules" ADD COLUMN "retry_started_at" timestamp;

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -386,6 +386,27 @@
       "when": 1767900000000,
       "tag": "0054_add_model_providers",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1768000000000,
+      "tag": "0055_drop_scope_display_name",
+      "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1768100000000,
+      "tag": "0056_remove_openai_api_key_providers",
+      "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1768200000000,
+      "tag": "0057_add_schedule_retry_started_at",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/agent-schedule.ts
+++ b/turbo/apps/web/src/db/schema/agent-schedule.ts
@@ -52,6 +52,8 @@ export const agentSchedules = pgTable(
     nextRunAt: timestamp("next_run_at"),
     lastRunAt: timestamp("last_run_at"),
     lastRunId: uuid("last_run_id").references(() => agentRuns.id),
+    // Tracks when retry cycle started for concurrency failures (null = not retrying)
+    retryStartedAt: timestamp("retry_started_at"),
 
     // Timestamps
     createdAt: timestamp("created_at").defaultNow().notNull(),

--- a/turbo/apps/web/src/lib/errors.ts
+++ b/turbo/apps/web/src/lib/errors.ts
@@ -47,7 +47,7 @@ interface SchedulePastError extends ApiErrorBase {
   readonly code: "SCHEDULE_PAST";
 }
 
-interface ConcurrentRunLimitError extends ApiErrorBase {
+export interface ConcurrentRunLimitError extends ApiErrorBase {
   readonly name: "ConcurrentRunLimitError";
   readonly statusCode: 429;
   readonly code: "TOO_MANY_REQUESTS";

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -814,17 +814,42 @@ async function handleConcurrencyFailure(
     `Schedule ${schedule.name} retry window expired after ${Math.round(windowElapsed / 60000)} min`,
   );
 
-  if (failedRun) {
+  if (schedule.cronExpression) {
+    // Cron schedule: advance to next occurrence
+    const nextRunAt = calculateNextRun(
+      schedule.cronExpression,
+      schedule.timezone,
+    );
     await globalThis.services.db
       .update(agentSchedules)
       .set({
-        lastRunId: failedRun.id,
+        lastRunId: failedRun?.id ?? schedule.lastRunId,
+        lastRunAt: now,
         retryStartedAt: null,
+        nextRunAt,
       })
       .where(eq(agentSchedules.id, schedule.id));
+    log.debug(
+      `Cron schedule ${schedule.name} retry window expired, next run at ${nextRunAt?.toISOString()}`,
+    );
+  } else {
+    // One-time schedule: disable after retry window expires
+    await globalThis.services.db
+      .update(agentSchedules)
+      .set({
+        enabled: false,
+        lastRunId: failedRun?.id ?? schedule.lastRunId,
+        lastRunAt: now,
+        retryStartedAt: null,
+        nextRunAt: null,
+      })
+      .where(eq(agentSchedules.id, schedule.id));
+    log.debug(
+      `One-time schedule ${schedule.name} retry window expired and disabled`,
+    );
   }
 
-  return false; // Should advance to next occurrence
+  return true; // Already handled, don't re-throw
 }
 
 /**

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -25,6 +25,10 @@ import { generateSandboxToken } from "../auth/sandbox-token";
 
 const log = logger("service:schedule");
 
+// Retry configuration for concurrency failures
+const RETRY_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_RETRY_WINDOW_MS = 30 * 60 * 1000; // 30 minutes
+
 /**
  * Schedule data for API responses
  */
@@ -46,6 +50,7 @@ export interface ScheduleResponse {
   enabled: boolean;
   nextRunAt: string | null;
   lastRunAt: string | null;
+  retryStartedAt: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -188,6 +193,7 @@ function toResponse(
     enabled: schedule.enabled,
     nextRunAt: schedule.nextRunAt?.toISOString() ?? null,
     lastRunAt: schedule.lastRunAt?.toISOString() ?? null,
+    retryStartedAt: schedule.retryStartedAt?.toISOString() ?? null,
     createdAt: schedule.createdAt.toISOString(),
     updatedAt: schedule.updatedAt.toISOString(),
   };
@@ -640,6 +646,7 @@ export async function enableSchedule(
     .set({
       enabled: true,
       nextRunAt,
+      retryStartedAt: null, // Clear any stale retry state
       updatedAt: new Date(Date.now()),
     })
     .where(eq(agentSchedules.id, schedule.id))
@@ -673,6 +680,7 @@ export async function disableSchedule(
     .update(agentSchedules)
     .set({
       enabled: false,
+      retryStartedAt: null, // Clear retry state
       updatedAt: new Date(Date.now()),
     })
     .where(
@@ -750,6 +758,76 @@ export async function executeDueSchedules(): Promise<{
 }
 
 /**
+ * Handle concurrency limit failure with retry logic.
+ * Returns true if retry was scheduled (don't re-throw), false if should advance to next occurrence.
+ */
+async function handleConcurrencyFailure(
+  schedule: typeof agentSchedules.$inferSelect,
+  compose: { userId: string; headVersionId: string },
+  error: ConcurrentRunLimitError,
+): Promise<boolean> {
+  const now = new Date(Date.now());
+
+  // Create failed run record
+  const [failedRun] = await globalThis.services.db
+    .insert(agentRuns)
+    .values({
+      userId: compose.userId,
+      agentComposeVersionId: compose.headVersionId,
+      scheduleId: schedule.id,
+      status: "failed",
+      prompt: schedule.prompt,
+      vars: schedule.vars,
+      error: error.message,
+      completedAt: now,
+      createdAt: now,
+    })
+    .returning();
+
+  // Determine retry window start (use existing or start new window)
+  const retryStartedAt = schedule.retryStartedAt ?? now;
+  const windowElapsed = now.getTime() - retryStartedAt.getTime();
+
+  if (windowElapsed < MAX_RETRY_WINDOW_MS) {
+    // Within retry window: schedule retry in 5 minutes
+    const nextRetryAt = new Date(now.getTime() + RETRY_INTERVAL_MS);
+
+    await globalThis.services.db
+      .update(agentSchedules)
+      .set({
+        lastRunId: failedRun?.id ?? schedule.lastRunId,
+        retryStartedAt,
+        nextRunAt: nextRetryAt,
+      })
+      .where(eq(agentSchedules.id, schedule.id));
+
+    log.debug(
+      `Schedule ${schedule.name} retry scheduled at ${nextRetryAt.toISOString()} ` +
+        `(${Math.round(windowElapsed / 60000)} min into retry window)`,
+    );
+
+    return true; // Retry scheduled, don't re-throw
+  }
+
+  // Retry window expired: clear state and advance to next occurrence
+  log.debug(
+    `Schedule ${schedule.name} retry window expired after ${Math.round(windowElapsed / 60000)} min`,
+  );
+
+  if (failedRun) {
+    await globalThis.services.db
+      .update(agentSchedules)
+      .set({
+        lastRunId: failedRun.id,
+        retryStartedAt: null,
+      })
+      .where(eq(agentSchedules.id, schedule.id));
+  }
+
+  return false; // Should advance to next occurrence
+}
+
+/**
  * Execute a single schedule
  */
 async function executeSchedule(
@@ -788,31 +866,17 @@ async function executeSchedule(
     if (isConcurrentRunLimit(error)) {
       log.debug(`Schedule ${schedule.name} blocked by concurrent run limit`);
 
-      // Create failed run record
-      const [failedRun] = await globalThis.services.db
-        .insert(agentRuns)
-        .values({
-          userId: compose.userId,
-          agentComposeVersionId: compose.headVersionId,
-          scheduleId: schedule.id,
-          status: "failed",
-          prompt: schedule.prompt,
-          vars: schedule.vars,
-          error: error.message,
-          completedAt: new Date(Date.now()),
-          createdAt: new Date(Date.now()),
-        })
-        .returning();
+      const retryScheduled = await handleConcurrencyFailure(
+        schedule,
+        { userId: compose.userId, headVersionId: compose.headVersionId },
+        error,
+      );
 
-      // Update schedule's lastRunId
-      if (failedRun) {
-        await globalThis.services.db
-          .update(agentSchedules)
-          .set({ lastRunId: failedRun.id })
-          .where(eq(agentSchedules.id, schedule.id));
+      if (retryScheduled) {
+        return; // Retry scheduled, don't continue
       }
-
-      throw error; // Re-throw to count as skipped
+      // Retry window expired, re-throw to advance to next occurrence
+      throw error;
     }
     throw error;
   }
@@ -893,19 +957,24 @@ async function executeSchedule(
       );
       await globalThis.services.db
         .update(agentSchedules)
-        .set({ lastRunAt: new Date(Date.now()), nextRunAt })
+        .set({
+          lastRunAt: new Date(Date.now()),
+          nextRunAt,
+          retryStartedAt: null, // Clear retry state on non-concurrency failure
+        })
         .where(eq(agentSchedules.id, schedule.id));
       log.debug(
         `Cron schedule ${schedule.name} failed, next run at ${nextRunAt?.toISOString()}`,
       );
     } else {
-      // One-time schedule: disable after failed execution
+      // One-time schedule: disable after failed execution (non-concurrency errors)
       await globalThis.services.db
         .update(agentSchedules)
         .set({
           enabled: false,
           lastRunAt: new Date(Date.now()),
           nextRunAt: null,
+          retryStartedAt: null, // Clear retry state
         })
         .where(eq(agentSchedules.id, schedule.id));
       log.debug(`One-time schedule ${schedule.name} failed and disabled`);
@@ -926,6 +995,7 @@ async function executeSchedule(
         enabled: false,
         lastRunAt: new Date(Date.now()),
         nextRunAt: null,
+        retryStartedAt: null, // Clear retry state
       })
       .where(eq(agentSchedules.id, schedule.id));
     log.debug(`One-time schedule ${schedule.name} executed and disabled`);
@@ -938,6 +1008,7 @@ async function executeSchedule(
     .set({
       lastRunAt: new Date(Date.now()),
       nextRunAt,
+      retryStartedAt: null, // Clear retry state on success
     })
     .where(eq(agentSchedules.id, schedule.id));
 

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -14,6 +14,7 @@ import {
   badRequest,
   schedulePast,
   isConcurrentRunLimit,
+  type ConcurrentRunLimitError,
 } from "../errors";
 import { logger } from "../logger";
 import {

--- a/turbo/packages/core/src/contracts/__tests__/schedules.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/schedules.test.ts
@@ -351,6 +351,8 @@ describe("schedules contracts", () => {
         volumeVersions: null,
         enabled: true,
         nextRunAt: "2025-01-13T09:00:00Z",
+        lastRunAt: "2025-01-12T09:00:00Z",
+        retryStartedAt: null,
         createdAt: "2025-01-12T10:00:00Z",
         updatedAt: "2025-01-12T10:00:00Z",
       });
@@ -376,6 +378,8 @@ describe("schedules contracts", () => {
         volumeVersions: null,
         enabled: false,
         nextRunAt: null,
+        lastRunAt: null,
+        retryStartedAt: null,
         createdAt: "2025-01-12T10:00:00Z",
         updatedAt: "2025-01-12T10:00:00Z",
       });

--- a/turbo/packages/core/src/contracts/schedules.ts
+++ b/turbo/packages/core/src/contracts/schedules.ts
@@ -94,6 +94,8 @@ const scheduleResponseSchema = z.object({
   volumeVersions: z.record(z.string(), z.string()).nullable(),
   enabled: z.boolean(),
   nextRunAt: z.string().nullable(),
+  lastRunAt: z.string().nullable(),
+  retryStartedAt: z.string().nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });


### PR DESCRIPTION
## Summary

- Implement automatic retry mechanism for scheduled runs that fail due to concurrency limits
- Instead of advancing to the next scheduled occurrence (e.g., tomorrow 9 AM), retry after 5 minutes within a 30-minute window
- Applies to both cron and one-time schedules

## Changes

- **Database**: Add `retry_started_at` column to `agent_schedules` table
- **Service**: Modify concurrency failure handling to schedule retries
- **API**: Add `retryStartedAt` to schedule response schema

## Configuration

- `RETRY_INTERVAL_MS`: 5 minutes between retry attempts
- `MAX_RETRY_WINDOW_MS`: 30 minutes maximum retry window

## How It Works

1. When a scheduled run fails due to `ConcurrentRunLimitError`:
   - Create failed run record (for visibility in run history)
   - If within 30-minute retry window: set `nextRunAt = now + 5 minutes`
   - If window expired: advance to next occurrence (cron) or disable (one-time)

2. Retry state is cleared on:
   - Successful execution
   - Manual enable/disable
   - Non-concurrency failures

## Example Timeline

```
9:00 AM - Schedule A runs, Schedule B fails (retryStartedAt=9:00, nextRunAt=9:05)
9:05 AM - Schedule A still running, Schedule B fails again (nextRunAt=9:10)
9:10 AM - Schedule A completes, Schedule B retries and succeeds (retryStartedAt=null)
```

## Test plan

- [x] TypeScript type checking passes
- [x] Lint passes
- [x] Core package tests pass (including updated schema tests)
- [ ] Run database migration in staging/production

Closes #2001

---
🤖 Generated with [Claude Code](https://claude.ai/code)