### PR TITLE
fix(runner): add safety checks to overlay pool

### DIFF
--- a/turbo/apps/runner/src/commands/benchmark.ts
+++ b/turbo/apps/runner/src/commands/benchmark.ts
@@ -7,6 +7,7 @@ import {
   checkNetworkPrerequisites,
   setupBridge,
 } from "../lib/firecracker/network.js";
+import { initOverlayPool } from "../lib/firecracker/overlay-pool.js";
 import { Timer } from "../lib/timing.js";
 import { setGlobalLogger } from "../lib/logger.js";
 
@@ -81,6 +82,13 @@ export const benchmarkCommand = new Command("benchmark")
       // Set up bridge network
       timer.log("Setting up network bridge...");
       await setupBridge();
+
+      // Initialize overlay pool for VM boot
+      timer.log("Initializing overlay pool...");
+      await initOverlayPool({
+        size: 2,
+        replenishThreshold: 1,
+      });
 
       // Create benchmark execution context
       timer.log(`Executing command: ${prompt}`);

--- a/turbo/apps/runner/src/commands/benchmark.ts
+++ b/turbo/apps/runner/src/commands/benchmark.ts
@@ -84,10 +84,12 @@ export const benchmarkCommand = new Command("benchmark")
       await setupBridge();
 
       // Initialize overlay pool for VM boot
+      // Use separate directory to avoid conflicts with running runner
       timer.log("Initializing overlay pool...");
       await initOverlayPool({
         size: 2,
         replenishThreshold: 1,
+        poolDir: "/var/run/vm0/overlay-pool-benchmark",
       });
 
       // Create benchmark execution context

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/overlay-pool.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/overlay-pool.test.ts
@@ -1,0 +1,198 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OverlayPool } from "../overlay-pool.js";
+
+/**
+ * Simple file creator for testing (no mkfs.ext4)
+ */
+async function testCreateFile(filePath: string): Promise<void> {
+  fs.writeFileSync(filePath, "test-overlay");
+}
+
+describe("OverlayPool", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "overlay-pool-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe("init", () => {
+    it("creates pool directory and pre-warms files", async () => {
+      const poolDir = path.join(tempDir, "pool");
+      const pool = new OverlayPool({
+        poolDir,
+        size: 3,
+        replenishThreshold: 1,
+        createFile: testCreateFile,
+      });
+
+      await pool.init();
+
+      expect(fs.existsSync(poolDir)).toBe(true);
+      const files = fs.readdirSync(poolDir);
+      expect(files.length).toBe(3);
+      expect(files.every((f) => f.startsWith("overlay-"))).toBe(true);
+      expect(files.every((f) => f.endsWith(".ext4"))).toBe(true);
+
+      pool.cleanup();
+    });
+
+    it("cleans up stale files from previous runs", async () => {
+      const poolDir = path.join(tempDir, "pool");
+      fs.mkdirSync(poolDir, { recursive: true });
+
+      // Create stale files
+      fs.writeFileSync(path.join(poolDir, "overlay-stale-1.ext4"), "stale");
+      fs.writeFileSync(path.join(poolDir, "overlay-stale-2.ext4"), "stale");
+      fs.writeFileSync(path.join(poolDir, "other-file.txt"), "keep");
+
+      const pool = new OverlayPool({
+        poolDir,
+        size: 2,
+        replenishThreshold: 1,
+        createFile: testCreateFile,
+      });
+      await pool.init();
+
+      const files = fs.readdirSync(poolDir);
+      // Should have 2 new files + 1 non-overlay file
+      expect(files.filter((f) => f.startsWith("overlay-")).length).toBe(2);
+      expect(files.includes("other-file.txt")).toBe(true);
+      // Stale files should be gone
+      expect(files.includes("overlay-stale-1.ext4")).toBe(false);
+      expect(files.includes("overlay-stale-2.ext4")).toBe(false);
+
+      pool.cleanup();
+    });
+  });
+
+  describe("acquire", () => {
+    it("returns file from pool", async () => {
+      const poolDir = path.join(tempDir, "pool");
+      const pool = new OverlayPool({
+        poolDir,
+        size: 2,
+        replenishThreshold: 1,
+        createFile: testCreateFile,
+      });
+      await pool.init();
+
+      const file1 = await pool.acquire();
+      expect(file1.startsWith(poolDir)).toBe(true);
+      expect(fs.existsSync(file1)).toBe(true);
+
+      const file2 = await pool.acquire();
+      expect(file2).not.toBe(file1);
+      expect(fs.existsSync(file2)).toBe(true);
+
+      pool.cleanup();
+    });
+
+    it("creates on-demand when pool exhausted", async () => {
+      const poolDir = path.join(tempDir, "pool");
+      const pool = new OverlayPool({
+        poolDir,
+        size: 1,
+        replenishThreshold: 0,
+        createFile: testCreateFile,
+      });
+      await pool.init();
+
+      // Acquire the only pre-warmed file
+      const file1 = await pool.acquire();
+      expect(fs.existsSync(file1)).toBe(true);
+
+      // Pool is exhausted, should create on-demand
+      const file2 = await pool.acquire();
+      expect(file2).not.toBe(file1);
+      expect(fs.existsSync(file2)).toBe(true);
+
+      pool.cleanup();
+    });
+
+    it("triggers background replenishment when below threshold", async () => {
+      const poolDir = path.join(tempDir, "pool");
+      const createFileSpy = vi.fn(testCreateFile);
+      const pool = new OverlayPool({
+        poolDir,
+        size: 3,
+        replenishThreshold: 2,
+        createFile: createFileSpy,
+      });
+      await pool.init();
+
+      // Initial creation: 3 files
+      expect(createFileSpy).toHaveBeenCalledTimes(3);
+
+      // Acquire one, drops to 2 (at threshold, no replenish yet)
+      await pool.acquire();
+
+      // Acquire another, drops to 1 (below threshold, triggers replenish)
+      await pool.acquire();
+
+      // Wait for background replenishment
+      await vi.waitFor(() => {
+        expect(createFileSpy.mock.calls.length).toBeGreaterThan(3);
+      });
+
+      pool.cleanup();
+    });
+  });
+
+  describe("cleanup", () => {
+    it("deletes all files in pool", async () => {
+      const poolDir = path.join(tempDir, "pool");
+      const pool = new OverlayPool({
+        poolDir,
+        size: 3,
+        replenishThreshold: 1,
+        createFile: testCreateFile,
+      });
+      await pool.init();
+
+      expect(fs.readdirSync(poolDir).length).toBe(3);
+
+      pool.cleanup();
+
+      const remaining = fs.readdirSync(poolDir);
+      expect(remaining.filter((f) => f.startsWith("overlay-")).length).toBe(0);
+    });
+
+    it("handles missing files gracefully", async () => {
+      const poolDir = path.join(tempDir, "pool");
+      const pool = new OverlayPool({
+        poolDir,
+        size: 2,
+        replenishThreshold: 1,
+        createFile: testCreateFile,
+      });
+      await pool.init();
+
+      // Delete one file externally (simulating VM cleanup)
+      const files = fs.readdirSync(poolDir);
+      fs.unlinkSync(path.join(poolDir, files[0]!));
+
+      // Cleanup should not throw
+      expect(() => pool.cleanup()).not.toThrow();
+    });
+
+    it("does nothing if not initialized", () => {
+      const poolDir = path.join(tempDir, "pool");
+      const pool = new OverlayPool({
+        poolDir,
+        size: 2,
+        replenishThreshold: 1,
+        createFile: testCreateFile,
+      });
+
+      // Should not throw
+      expect(() => pool.cleanup()).not.toThrow();
+    });
+  });
+});

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/overlay-pool.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/overlay-pool.test.ts
@@ -73,6 +73,20 @@ describe("OverlayPool", () => {
   });
 
   describe("acquire", () => {
+    it("throws if pool not initialized", async () => {
+      const poolDir = path.join(tempDir, "pool");
+      const pool = new OverlayPool({
+        poolDir,
+        size: 2,
+        replenishThreshold: 1,
+        createFile: testCreateFile,
+      });
+
+      await expect(pool.acquire()).rejects.toThrow(
+        "Overlay pool not initialized",
+      );
+    });
+
     it("returns file from pool", async () => {
       const poolDir = path.join(tempDir, "pool");
       const pool = new OverlayPool({

--- a/turbo/apps/runner/src/lib/firecracker/overlay-pool.ts
+++ b/turbo/apps/runner/src/lib/firecracker/overlay-pool.ts
@@ -26,7 +26,7 @@ const logger = createLogger("OverlayPool");
  * Configuration constants
  */
 const VM0_RUN_DIR = "/var/run/vm0";
-const POOL_DIR = path.join(VM0_RUN_DIR, "overlay-pool");
+const DEFAULT_POOL_DIR = path.join(VM0_RUN_DIR, "overlay-pool");
 const OVERLAY_SIZE = 2 * 1024 * 1024 * 1024; // 2GB sparse file
 
 /**
@@ -37,42 +37,17 @@ interface OverlayPoolConfig {
   size: number;
   /** Start replenishing when pool drops below this count */
   replenishThreshold: number;
+  /** Custom pool directory (optional, for testing) */
+  poolDir?: string;
+  /** Custom file creator function (optional, for testing) */
+  createFile?: (filePath: string) => Promise<void>;
 }
 
 /**
- * Pool state
+ * Default overlay file creator
+ * Creates a sparse ext4 file
  */
-interface PoolState {
-  initialized: boolean;
-  config: OverlayPoolConfig | null;
-  queue: string[];
-  replenishing: boolean;
-}
-
-const poolState: PoolState = {
-  initialized: false,
-  config: null,
-  queue: [],
-  replenishing: false,
-};
-
-/**
- * Ensure the pool directory exists
- */
-async function ensurePoolDir(): Promise<void> {
-  if (!fs.existsSync(VM0_RUN_DIR)) {
-    await execAsync(`sudo mkdir -p ${VM0_RUN_DIR}`);
-    await execAsync(`sudo chmod 777 ${VM0_RUN_DIR}`);
-  }
-  if (!fs.existsSync(POOL_DIR)) {
-    fs.mkdirSync(POOL_DIR, { recursive: true });
-  }
-}
-
-/**
- * Create a single overlay file
- */
-async function createOverlayFile(filePath: string): Promise<void> {
+async function defaultCreateFile(filePath: string): Promise<void> {
   const fd = fs.openSync(filePath, "w");
   fs.ftruncateSync(fd, OVERLAY_SIZE);
   fs.closeSync(fd);
@@ -80,161 +55,233 @@ async function createOverlayFile(filePath: string): Promise<void> {
 }
 
 /**
- * Generate unique file name using UUID
+ * Overlay Pool class
+ *
+ * Manages a pool of pre-created overlay files for fast VM boot.
  */
-function generateFileName(): string {
-  return `overlay-${randomUUID()}.ext4`;
-}
+export class OverlayPool {
+  private initialized = false;
+  private queue: string[] = [];
+  private replenishing = false;
+  private readonly config: Required<OverlayPoolConfig>;
 
-/**
- * Scan pool directory for overlay files
- */
-function scanPoolDir(): string[] {
-  if (!fs.existsSync(POOL_DIR)) {
-    return [];
-  }
-  return fs
-    .readdirSync(POOL_DIR)
-    .filter((f) => f.startsWith("overlay-") && f.endsWith(".ext4"))
-    .map((f) => path.join(POOL_DIR, f));
-}
-
-/**
- * Replenish the pool in background
- */
-async function replenishPool(): Promise<void> {
-  if (poolState.replenishing || !poolState.initialized || !poolState.config) {
-    return;
+  constructor(config: OverlayPoolConfig) {
+    this.config = {
+      size: config.size,
+      replenishThreshold: config.replenishThreshold,
+      poolDir: config.poolDir ?? DEFAULT_POOL_DIR,
+      createFile: config.createFile ?? defaultCreateFile,
+    };
   }
 
-  const needed = poolState.config.size - poolState.queue.length;
-  if (needed <= 0) {
-    return;
+  /**
+   * Generate unique file name using UUID
+   */
+  private generateFileName(): string {
+    return `overlay-${randomUUID()}.ext4`;
   }
 
-  poolState.replenishing = true;
-  logger.log(`Replenishing pool: creating ${needed} overlay(s)...`);
-
-  try {
-    const promises = [];
-    for (let i = 0; i < needed; i++) {
-      const filePath = path.join(POOL_DIR, generateFileName());
-      promises.push(
-        createOverlayFile(filePath).then(() => {
-          poolState.queue.push(filePath);
-        }),
-      );
+  /**
+   * Ensure the pool directory exists
+   */
+  private async ensurePoolDir(): Promise<void> {
+    const parentDir = path.dirname(this.config.poolDir);
+    if (!fs.existsSync(parentDir)) {
+      await execAsync(`sudo mkdir -p ${parentDir}`);
+      await execAsync(`sudo chmod 777 ${parentDir}`);
     }
-    await Promise.all(promises);
-    logger.log(`Pool replenished: ${poolState.queue.length} available`);
-  } catch (err) {
-    logger.error(
-      `Replenish failed: ${err instanceof Error ? err.message : "Unknown"}`,
+    if (!fs.existsSync(this.config.poolDir)) {
+      fs.mkdirSync(this.config.poolDir, { recursive: true });
+    }
+  }
+
+  /**
+   * Scan pool directory for overlay files
+   */
+  private scanPoolDir(): string[] {
+    if (!fs.existsSync(this.config.poolDir)) {
+      return [];
+    }
+    return fs
+      .readdirSync(this.config.poolDir)
+      .filter((f) => f.startsWith("overlay-") && f.endsWith(".ext4"))
+      .map((f) => path.join(this.config.poolDir, f));
+  }
+
+  /**
+   * Replenish the pool in background
+   */
+  private async replenish(): Promise<void> {
+    if (this.replenishing || !this.initialized) {
+      return;
+    }
+
+    const needed = this.config.size - this.queue.length;
+    if (needed <= 0) {
+      return;
+    }
+
+    this.replenishing = true;
+    logger.log(`Replenishing pool: creating ${needed} overlay(s)...`);
+
+    try {
+      const promises = [];
+      for (let i = 0; i < needed; i++) {
+        const filePath = path.join(
+          this.config.poolDir,
+          this.generateFileName(),
+        );
+        promises.push(
+          this.config.createFile(filePath).then(() => {
+            this.queue.push(filePath);
+          }),
+        );
+      }
+      await Promise.all(promises);
+      logger.log(`Pool replenished: ${this.queue.length} available`);
+    } catch (err) {
+      logger.error(
+        `Replenish failed: ${err instanceof Error ? err.message : "Unknown"}`,
+      );
+    } finally {
+      this.replenishing = false;
+    }
+  }
+
+  /**
+   * Initialize the overlay pool
+   */
+  async init(): Promise<void> {
+    this.queue = [];
+
+    logger.log(
+      `Initializing overlay pool (size=${this.config.size}, threshold=${this.config.replenishThreshold})...`,
     );
-  } finally {
-    poolState.replenishing = false;
+
+    await this.ensurePoolDir();
+
+    // Clean up stale files from previous runs
+    const existing = this.scanPoolDir();
+    if (existing.length > 0) {
+      logger.log(`Cleaning up ${existing.length} stale overlay(s)`);
+      for (const file of existing) {
+        fs.unlinkSync(file);
+      }
+    }
+
+    this.initialized = true;
+    await this.replenish();
+    logger.log("Overlay pool initialized");
+  }
+
+  /**
+   * Acquire an overlay file from the pool
+   *
+   * Returns the file path. Caller owns the file and must delete it when done.
+   * Falls back to on-demand creation if pool is exhausted.
+   */
+  async acquire(): Promise<string> {
+    const filePath = this.queue.shift();
+
+    if (filePath) {
+      logger.log(`Acquired overlay from pool (${this.queue.length} remaining)`);
+
+      // Trigger background replenishment if below threshold
+      if (this.queue.length < this.config.replenishThreshold) {
+        this.replenish().catch((err) => {
+          logger.error(
+            `Background replenish failed: ${err instanceof Error ? err.message : "Unknown"}`,
+          );
+        });
+      }
+
+      return filePath;
+    }
+
+    // Pool exhausted - create on demand
+    logger.log("Pool exhausted, creating overlay on-demand");
+    const newPath = path.join(this.config.poolDir, this.generateFileName());
+    await this.config.createFile(newPath);
+    return newPath;
+  }
+
+  /**
+   * Clean up the overlay pool
+   */
+  cleanup(): void {
+    if (!this.initialized) {
+      return;
+    }
+
+    logger.log("Cleaning up overlay pool...");
+
+    // Delete files in queue
+    for (const file of this.queue) {
+      try {
+        fs.unlinkSync(file);
+      } catch (err) {
+        logger.log(
+          `Failed to delete ${file}: ${err instanceof Error ? err.message : "Unknown"}`,
+        );
+      }
+    }
+    this.queue = [];
+
+    // Also clean any orphaned files
+    for (const file of this.scanPoolDir()) {
+      try {
+        fs.unlinkSync(file);
+      } catch (err) {
+        logger.log(
+          `Failed to delete ${file}: ${err instanceof Error ? err.message : "Unknown"}`,
+        );
+      }
+    }
+
+    this.initialized = false;
+    this.replenishing = false;
+    logger.log("Overlay pool cleaned up");
   }
 }
 
 /**
- * Initialize the overlay pool
+ * Global instance management (for backward compatibility)
+ */
+let overlayPoolInstance: OverlayPool | null = null;
+
+/**
+ * Initialize the global overlay pool
  */
 export async function initOverlayPool(
   config: OverlayPoolConfig,
 ): Promise<void> {
-  poolState.config = config;
-  poolState.queue = [];
-
-  logger.log(
-    `Initializing overlay pool (size=${config.size}, threshold=${config.replenishThreshold})...`,
-  );
-
-  await ensurePoolDir();
-
-  // Clean up stale files from previous runs
-  const existing = scanPoolDir();
-  if (existing.length > 0) {
-    logger.log(`Cleaning up ${existing.length} stale overlay(s)`);
-    for (const file of existing) {
-      fs.unlinkSync(file);
-    }
-  }
-
-  poolState.initialized = true;
-  await replenishPool();
-  logger.log("Overlay pool initialized");
+  overlayPoolInstance = new OverlayPool(config);
+  await overlayPoolInstance.init();
 }
 
 /**
- * Acquire an overlay file from the pool
- *
- * Returns the file path. Caller owns the file and must delete it when done.
- * Falls back to on-demand creation if pool is exhausted.
+ * Get the global overlay pool instance
+ */
+function getOverlayPool(): OverlayPool {
+  if (!overlayPoolInstance) {
+    throw new Error("Overlay pool not initialized");
+  }
+  return overlayPoolInstance;
+}
+
+/**
+ * Acquire an overlay file from the global pool
  */
 export async function acquireOverlay(): Promise<string> {
-  const filePath = poolState.queue.shift();
-
-  if (filePath) {
-    logger.log(
-      `Acquired overlay from pool (${poolState.queue.length} remaining)`,
-    );
-
-    // Trigger background replenishment if below threshold
-    if (
-      poolState.config &&
-      poolState.queue.length < poolState.config.replenishThreshold
-    ) {
-      replenishPool().catch((err) => {
-        logger.error(
-          `Background replenish failed: ${err instanceof Error ? err.message : "Unknown"}`,
-        );
-      });
-    }
-
-    return filePath;
-  }
-
-  // Pool exhausted - create on demand
-  logger.log("Pool exhausted, creating overlay on-demand");
-  const newPath = path.join(POOL_DIR, generateFileName());
-  await createOverlayFile(newPath);
-  return newPath;
+  return getOverlayPool().acquire();
 }
 
 /**
- * Clean up the overlay pool
+ * Clean up the global overlay pool
  */
 export function cleanupOverlayPool(): void {
-  if (!poolState.initialized) {
-    return;
+  if (overlayPoolInstance) {
+    overlayPoolInstance.cleanup();
+    overlayPoolInstance = null;
   }
-
-  logger.log("Cleaning up overlay pool...");
-
-  // Delete files in queue
-  for (const file of poolState.queue) {
-    try {
-      fs.unlinkSync(file);
-    } catch (err) {
-      logger.log(
-        `Failed to delete ${file}: ${err instanceof Error ? err.message : "Unknown"}`,
-      );
-    }
-  }
-  poolState.queue = [];
-
-  // Also clean any orphaned files
-  for (const file of scanPoolDir()) {
-    try {
-      fs.unlinkSync(file);
-    } catch (err) {
-      logger.log(
-        `Failed to delete ${file}: ${err instanceof Error ? err.message : "Unknown"}`,
-      );
-    }
-  }
-
-  poolState.initialized = false;
-  poolState.replenishing = false;
-  logger.log("Overlay pool cleaned up");
 }

--- a/turbo/apps/runner/src/lib/firecracker/overlay-pool.ts
+++ b/turbo/apps/runner/src/lib/firecracker/overlay-pool.ts
@@ -7,7 +7,7 @@
  *
  * Design:
  * - Pool maintains a queue of pre-created overlay file paths
- * - acquireOverlay() returns a path from the pool (VM owns the file)
+ * - acquire() returns a path from the pool (VM owns the file)
  * - VM deletes the file when done
  * - Pool replenishes in background when below threshold
  */
@@ -181,6 +181,10 @@ export class OverlayPool {
    * Falls back to on-demand creation if pool is exhausted.
    */
   async acquire(): Promise<string> {
+    if (!this.initialized) {
+      throw new Error("Overlay pool not initialized");
+    }
+
     const filePath = this.queue.shift();
 
     if (filePath) {
@@ -245,43 +249,43 @@ export class OverlayPool {
 }
 
 /**
- * Global instance management (for backward compatibility)
+ * Global overlay pool instance
  */
-let overlayPoolInstance: OverlayPool | null = null;
+let overlayPool: OverlayPool | null = null;
 
 /**
  * Initialize the global overlay pool
  */
 export async function initOverlayPool(
   config: OverlayPoolConfig,
-): Promise<void> {
-  overlayPoolInstance = new OverlayPool(config);
-  await overlayPoolInstance.init();
-}
-
-/**
- * Get the global overlay pool instance
- */
-function getOverlayPool(): OverlayPool {
-  if (!overlayPoolInstance) {
-    throw new Error("Overlay pool not initialized");
+): Promise<OverlayPool> {
+  if (overlayPool) {
+    overlayPool.cleanup();
   }
-  return overlayPoolInstance;
+  overlayPool = new OverlayPool(config);
+  await overlayPool.init();
+  return overlayPool;
 }
 
 /**
  * Acquire an overlay file from the global pool
+ * @throws Error if pool was not initialized with initOverlayPool
  */
-export async function acquireOverlay(): Promise<string> {
-  return getOverlayPool().acquire();
+export function acquireOverlay(): Promise<string> {
+  if (!overlayPool) {
+    throw new Error(
+      "Overlay pool not initialized. Call initOverlayPool() first.",
+    );
+  }
+  return overlayPool.acquire();
 }
 
 /**
  * Clean up the global overlay pool
  */
 export function cleanupOverlayPool(): void {
-  if (overlayPoolInstance) {
-    overlayPoolInstance.cleanup();
-    overlayPoolInstance = null;
+  if (overlayPool) {
+    overlayPool.cleanup();
+    overlayPool = null;
   }
 }

--- a/turbo/apps/runner/src/lib/firecracker/vm.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vm.ts
@@ -59,7 +59,7 @@ export class FirecrackerVM {
   private state: VMState = "created";
   private workDir: string;
   private socketPath: string;
-  private vmOverlayPath: string | null = null; // Set by acquireOverlay() during start
+  private vmOverlayPath: string | null = null; // Set during start()
   private vsockPath: string; // Vsock UDS path for host-guest communication
 
   constructor(config: VMConfig) {

--- a/turbo/apps/runner/src/lib/runner/setup.ts
+++ b/turbo/apps/runner/src/lib/runner/setup.ts
@@ -72,7 +72,7 @@ export async function setupEnvironment(
   logger.log("Initializing overlay pool...");
   await initOverlayPool({
     size: config.sandbox.max_concurrent + 2,
-    replenishThreshold: config.sandbox.max_concurrent, // Start replenishing early to handle bursts
+    replenishThreshold: config.sandbox.max_concurrent,
   });
 
   // Initialize proxy for network security mode


### PR DESCRIPTION
## Summary
- Add initialization check in `acquire()` to fail fast if pool not initialized
- `initOverlayPool()` now cleans up existing instance to prevent file leaks on repeated calls
- Simplify exported API: `initOverlayPool`, `acquireOverlay`, `cleanupOverlayPool`

## Test plan
- [x] Unit tests pass (9 tests)
- [x] Added test for uninitialized acquire behavior

🤖 Generated with [Claude Code](https://claude.ai/code)