### PR TITLE
refactor(runner): centralize path management with paths.ts module

### DIFF
--- a/turbo/apps/runner/src/commands/benchmark.ts
+++ b/turbo/apps/runner/src/commands/benchmark.ts
@@ -10,6 +10,7 @@ import {
 import { initOverlayPool } from "../lib/firecracker/overlay-pool.js";
 import { Timer } from "../lib/timing.js";
 import { setGlobalLogger } from "../lib/logger.js";
+import { paths } from "../lib/paths.js";
 
 interface BenchmarkOptions {
   config: string;
@@ -89,7 +90,7 @@ export const benchmarkCommand = new Command("benchmark")
       await initOverlayPool({
         size: 2,
         replenishThreshold: 1,
-        poolDir: "/var/run/vm0/overlay-pool-benchmark",
+        poolDir: paths.overlayPoolBenchmark,
       });
 
       // Create benchmark execution context

--- a/turbo/apps/runner/src/lib/config.ts
+++ b/turbo/apps/runner/src/lib/config.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import fs from "fs";
 import yaml from "yaml";
+import { tempPaths } from "./paths.js";
 
 /**
  * Default values for sandbox configuration
@@ -104,9 +105,9 @@ export const debugConfigSchema = z.object({
   proxy: z
     .object({
       port: z.number().int().min(1024).max(65535).default(PROXY_DEFAULTS.port),
-      ca_dir: z.string().default("/tmp/vm0-proxy"),
+      ca_dir: z.string().default(tempPaths.proxyDir),
     })
-    .default({ ...PROXY_DEFAULTS, ca_dir: "/tmp/vm0-proxy" }),
+    .default({ ...PROXY_DEFAULTS, ca_dir: tempPaths.proxyDir }),
 });
 
 type DebugConfig = z.infer<typeof debugConfigSchema>;

--- a/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
+++ b/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
@@ -13,8 +13,8 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import * as fs from "node:fs";
-import * as path from "node:path";
 import { createLogger } from "../logger.js";
+import { VM0_RUN_DIR, paths } from "../paths.js";
 
 const execAsync = promisify(exec);
 const logger = createLogger("IP Pool");
@@ -22,8 +22,7 @@ const logger = createLogger("IP Pool");
 /**
  * Configuration constants
  */
-const VM0_RUN_DIR = "/var/run/vm0";
-const REGISTRY_FILE_PATH = path.join(VM0_RUN_DIR, "ip-registry.json");
+const REGISTRY_FILE_PATH = paths.ipRegistry;
 const BRIDGE_NAME = "vm0br0";
 
 /**
@@ -89,7 +88,7 @@ async function ensureRunDir(): Promise<void> {
 async function withLock<T>(fn: () => Promise<T>): Promise<T> {
   await ensureRunDir();
 
-  const lockMarker = path.join(VM0_RUN_DIR, "ip-pool.lock.active");
+  const lockMarker = paths.ipPoolLock;
   const startTime = Date.now();
   let lockAcquired = false;
 

--- a/turbo/apps/runner/src/lib/firecracker/overlay-pool.ts
+++ b/turbo/apps/runner/src/lib/firecracker/overlay-pool.ts
@@ -18,6 +18,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
 import { createLogger } from "../logger.js";
+import { paths } from "../paths.js";
 
 const execAsync = promisify(exec);
 const logger = createLogger("OverlayPool");
@@ -25,8 +26,7 @@ const logger = createLogger("OverlayPool");
 /**
  * Configuration constants
  */
-const VM0_RUN_DIR = "/var/run/vm0";
-const DEFAULT_POOL_DIR = path.join(VM0_RUN_DIR, "overlay-pool");
+const DEFAULT_POOL_DIR = paths.overlayPool;
 const OVERLAY_SIZE = 2 * 1024 * 1024 * 1024; // 2GB sparse file
 
 /**

--- a/turbo/apps/runner/src/lib/firecracker/vm.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vm.ts
@@ -21,6 +21,7 @@ import {
 } from "./network.js";
 import { acquireOverlay } from "./overlay-pool.js";
 import { createLogger } from "../logger.js";
+import { tempPaths } from "../paths.js";
 
 const logger = createLogger("VM");
 
@@ -64,7 +65,7 @@ export class FirecrackerVM {
 
   constructor(config: VMConfig) {
     this.config = config;
-    this.workDir = config.workDir || `/tmp/vm0-vm-${config.vmId}`;
+    this.workDir = config.workDir || tempPaths.vmWorkDir(config.vmId);
     this.socketPath = path.join(this.workDir, "firecracker.sock");
     this.vsockPath = path.join(this.workDir, "vsock.sock");
   }

--- a/turbo/apps/runner/src/lib/network-logs/network-logs.ts
+++ b/turbo/apps/runner/src/lib/network-logs/network-logs.ts
@@ -8,6 +8,7 @@
 import fs from "fs";
 import type { NetworkLogEntry } from "./types.js";
 import { createLogger } from "../logger.js";
+import { tempPaths } from "../paths.js";
 
 const logger = createLogger("NetworkLogs");
 
@@ -15,7 +16,7 @@ const logger = createLogger("NetworkLogs");
  * Get the network log file path for a run
  */
 function getNetworkLogPath(runId: string): string {
-  return `/tmp/vm0-network-${runId}.jsonl`;
+  return tempPaths.networkLog(runId);
 }
 
 /**

--- a/turbo/apps/runner/src/lib/paths.ts
+++ b/turbo/apps/runner/src/lib/paths.ts
@@ -1,0 +1,53 @@
+/**
+ * Centralized path management for runner
+ *
+ * All file system paths used by the runner should be defined here
+ * to make it easy to change directory structure in the future.
+ */
+
+import path from "node:path";
+
+/**
+ * Base directories
+ */
+export const VM0_RUN_DIR = "/var/run/vm0";
+const VM0_TMP_PREFIX = "/tmp/vm0";
+
+/**
+ * Runtime state paths (/var/run/vm0/)
+ * These are shared across runner instances on the same host
+ */
+export const paths = {
+  /** Runner PID file for single-instance lock */
+  runnerPid: path.join(VM0_RUN_DIR, "runner.pid"),
+
+  /** IP pool lock file */
+  ipPoolLock: path.join(VM0_RUN_DIR, "ip-pool.lock.active"),
+
+  /** IP allocation registry */
+  ipRegistry: path.join(VM0_RUN_DIR, "ip-registry.json"),
+
+  /** Overlay pool directory */
+  overlayPool: path.join(VM0_RUN_DIR, "overlay-pool"),
+
+  /** Overlay pool directory for benchmark (isolated) */
+  overlayPoolBenchmark: path.join(VM0_RUN_DIR, "overlay-pool-benchmark"),
+} as const;
+
+/**
+ * Temporary file paths (/tmp/vm0-*)
+ * These use runId or vmId for isolation
+ */
+export const tempPaths = {
+  /** Default proxy CA directory */
+  proxyDir: `${VM0_TMP_PREFIX}-proxy`,
+
+  /** VM registry for proxy */
+  vmRegistry: `${VM0_TMP_PREFIX}-vm-registry.json`,
+
+  /** VM work directory (fallback when not using workspaces) */
+  vmWorkDir: (vmId: string) => `${VM0_TMP_PREFIX}-vm-${vmId}`,
+
+  /** Network log file for a run */
+  networkLog: (runId: string) => `${VM0_TMP_PREFIX}-network-${runId}.jsonl`,
+} as const;

--- a/turbo/apps/runner/src/lib/proxy/vm-registry.ts
+++ b/turbo/apps/runner/src/lib/proxy/vm-registry.ts
@@ -9,6 +9,7 @@
  */
 import fs from "fs";
 import { createLogger } from "../logger.js";
+import { tempPaths } from "../paths.js";
 
 const logger = createLogger("VMRegistry");
 
@@ -55,7 +56,7 @@ interface RegistryData {
  * Default path for the registry file
  * This path is read by the mitmproxy addon
  */
-export const DEFAULT_REGISTRY_PATH = "/tmp/vm0-vm-registry.json";
+export const DEFAULT_REGISTRY_PATH = tempPaths.vmRegistry;
 
 /**
  * VM Registry class for managing VM IP → RunId mappings

--- a/turbo/apps/runner/src/lib/runner/runner-lock.ts
+++ b/turbo/apps/runner/src/lib/runner/runner-lock.ts
@@ -1,8 +1,8 @@
 /**
  * Runner Lock - ensures only one runner per device
  *
- * Uses a PID file at /var/run/vm0/runner.pid to prevent multiple
- * runner instances from running on the same device.
+ * Uses a PID file to prevent multiple runner instances
+ * from running on the same device.
  */
 
 import { exec } from "node:child_process";
@@ -11,12 +11,12 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 import { createLogger } from "../logger.js";
+import { paths } from "../paths.js";
 
 const execAsync = promisify(exec);
 const logger = createLogger("RunnerLock");
 
-const DEFAULT_RUN_DIR = "/var/run/vm0";
-const DEFAULT_PID_FILE = `${DEFAULT_RUN_DIR}/runner.pid`;
+const DEFAULT_PID_FILE = paths.runnerPid;
 
 // Module state for tracking current lock
 let currentPidFile: string | null = null;


### PR DESCRIPTION
## Summary

- Create `lib/paths.ts` with centralized path constants (`VM0_RUN_DIR`, `paths`, `tempPaths`)
- Update 9 files to use the centralized path module instead of hardcoded strings
- Eliminates scattered hardcoded paths across the codebase

### Files updated:
- `ip-pool.ts` - uses `paths.ipRegistry` and `paths.ipPoolLock`
- `overlay-pool.ts` - uses `paths.overlayPool`
- `runner-lock.ts` - uses `paths.runnerPid`
- `vm.ts` - uses `tempPaths.vmWorkDir`
- `network-logs.ts` - uses `tempPaths.networkLog`
- `vm-registry.ts` - uses `tempPaths.vmRegistry`
- `config.ts` - uses `tempPaths.proxyDir`
- `benchmark.ts` - uses `paths.overlayPoolBenchmark`

### Note
Guest VM internal paths (`/tmp/vm0-env.json`, `/tmp/vm0-main-*.log`) are intentionally NOT changed as they exist inside the VM filesystem, not on the host.

Python paths in `mitm-addon-script.ts` are kept in sync with TypeScript paths but remain as string literals since they're embedded Python code.

## Test plan
- [x] All runner tests pass (223 tests)
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)