### PR TITLE
fix(runner): replace deprecated z.string().url() with z.url()

### DIFF
--- a/turbo/apps/runner/src/lib/config.ts
+++ b/turbo/apps/runner/src/lib/config.ts
@@ -30,7 +30,7 @@ export const runnerConfigSchema = z.object({
       "Group must be in format 'scope/name' (lowercase, hyphens allowed)",
     ),
   server: z.object({
-    url: z.string().url("Server URL must be a valid URL"),
+    url: z.url({ message: "Server URL must be a valid URL" }),
     token: z.string().min(1, "Server token is required"),
   }),
   sandbox: z
@@ -76,7 +76,7 @@ export const debugConfigSchema = z.object({
   group: z.string().default("debug/local"),
   server: z
     .object({
-      url: z.string().url().default(DEBUG_SERVER_DEFAULTS.url),
+      url: z.url().default(DEBUG_SERVER_DEFAULTS.url),
       token: z.string().default(DEBUG_SERVER_DEFAULTS.token),
     })
     .default(DEBUG_SERVER_DEFAULTS),


### PR DESCRIPTION
## Summary

Replace deprecated `z.string().url()` with `z.url()` in runner config schema.

Zod 4.x deprecated the `.url()` method on `ZodString`. The new approach is to use `z.url()` directly.

## Changes

- `runnerConfigSchema.server.url`: `z.string().url()` → `z.url()`
- `debugConfigSchema.server.url`: `z.string().url()` → `z.url()`

## Test plan

- [x] All runner tests pass (223 tests)
- [x] Type check passes
- [x] No IDE deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)