### PR TITLE
feat: enable observation logs and redirect logged-in users to platform

### DIFF
--- a/turbo/apps/platform/src/views/layout/sidebar.tsx
+++ b/turbo/apps/platform/src/views/layout/sidebar.tsx
@@ -77,10 +77,6 @@ export function Sidebar() {
             return null;
           }
 
-          if (group.label === "Observation" && !featureSwitches?.platformLogs) {
-            return null;
-          }
-
           return (
             <div key={group.label} className="p-2">
               <div className="h-8 flex items-center px-2 opacity-70">

--- a/turbo/apps/platform/src/views/logs-page/__tests__/log-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/logs-page/__tests__/log-detail-page.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { pathname$ } from "../../../signals/route.ts";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { http, HttpResponse } from "msw";
 import { userEvent } from "@testing-library/user-event";
@@ -314,8 +314,9 @@ describe("log detail page", () => {
       expect(screen.getByText("Back Test Agent")).toBeInTheDocument();
     });
 
-    // Click Logs link in breadcrumb
-    await user.click(screen.getByText("Logs"));
+    // Click Logs link in breadcrumb (use within to scope to nav element)
+    const breadcrumbNav = screen.getByRole("navigation");
+    await user.click(within(breadcrumbNav).getByText("Logs"));
 
     // Should navigate to logs list
     await waitFor(() => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -10,5 +10,4 @@ export enum FeatureSwitchKey {
   PlatformSecrets = "platformSecrets",
   PlatformArtifacts = "platformArtifacts",
   PlatformApiKeys = "platformApiKeys",
-  PlatformLogs = "platformLogs",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -43,10 +43,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     enabled: false,
   },
-  [FeatureSwitchKey.PlatformLogs]: {
-    maintainer: "ethan@vm0.ai",
-    enabled: false,
-  },
 };
 
 /**


### PR DESCRIPTION
## Summary

- Remove `PlatformLogs` feature switch to make the Logs feature always visible in the platform sidebar
- Add client-side redirect for logged-in users when visiting the web homepage
- Platform URL is derived from current host (`platform.{domain}` for production, `localhost:3001` for local dev)

## Changes

1. **Feature Switch Removal**
   - Removed `PlatformLogs` enum from `feature-switch-key.ts`
   - Removed `PlatformLogs` configuration from `feature-switch.ts`
   - Removed conditional check for "Observation" group in `sidebar.tsx`

2. **Web Homepage Redirect**
   - Added `useUser()` hook to detect logged-in users in `LandingPage.tsx`
   - Added `getPlatformUrl()` function to construct platform URL from current host
   - Redirect logged-in users to platform automatically

3. **Test Fix**
   - Updated `log-detail-page.test.tsx` to use `within()` for breadcrumb navigation selector (to avoid conflict with sidebar "Logs" link)

## Test plan

- [ ] Verify Logs navigation item is visible in platform sidebar without feature flag
- [ ] Verify logged-in users are redirected from web homepage to platform
- [ ] Verify logged-out users see the landing page normally
- [ ] Verify all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)