### PR TITLE
refactor(runner): remove redundant api url env variable

### DIFF
--- a/turbo/apps/runner/src/lib/proxy/__tests__/proxy-manager.test.ts
+++ b/turbo/apps/runner/src/lib/proxy/__tests__/proxy-manager.test.ts
@@ -63,6 +63,7 @@ describe("ProxyManager", () => {
       const minimalDir = path.join(tempDir, "minimal", "proxy");
       const minimalManager = new ProxyManager({
         caDir: minimalDir,
+        apiUrl: "https://test.api.com",
       });
 
       const config = minimalManager.getConfig();

--- a/turbo/apps/runner/src/lib/proxy/proxy-manager.ts
+++ b/turbo/apps/runner/src/lib/proxy/proxy-manager.ts
@@ -21,6 +21,8 @@ const logger = createLogger("ProxyManager");
 interface RequiredProxyConfig {
   /** Path to the mitmproxy CA directory (per-runner isolation) */
   caDir: string;
+  /** VM0 API URL for the addon (from runner config server.url) */
+  apiUrl: string;
 }
 
 /**
@@ -31,8 +33,6 @@ interface OptionalProxyConfig {
   port: number;
   /** Path to the VM registry file */
   registryPath: string;
-  /** VM0 API URL for the addon */
-  apiUrl: string;
 }
 
 /**
@@ -54,7 +54,6 @@ type ProxyConfigInput = RequiredProxyConfig & Partial<OptionalProxyConfig>;
 const DEFAULT_PROXY_OPTIONS: OptionalProxyConfig = {
   port: 8080,
   registryPath: DEFAULT_REGISTRY_PATH,
-  apiUrl: process.env.VM0_API_URL || "https://www.vm0.ai",
 };
 
 /**


### PR DESCRIPTION
## Summary
- Make `apiUrl` a required parameter for ProxyManager (was optional with env fallback)
- Remove unused `VM0_API_URL` environment variable fallback from proxy-manager.ts
- The value is always provided from `config.server.url` via setup.ts

## Context
The `VM0_API_URL` environment variable was never used in practice because `setup.ts` always passes `apiUrl: config.server.url` to `initProxyManager()`. This removes the dead code path.

## Test plan
- [x] Type check passes
- [x] proxy-manager tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)