### PR TITLE
feat(runner): add data_dir config for per-instance isolation

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -915,7 +915,8 @@ jobs:
 
           # Create benchmark config with proxy settings (firewall + mitm enabled by default)
           ssh $SSH_OPTS ${METAL_USER}@${RUNNER_HOST} "
-            echo 'firecracker:' > ${RUNNER_DIR}/benchmark.yaml
+            echo 'data_dir: ${RUNNER_DIR}/benchmark-data' > ${RUNNER_DIR}/benchmark.yaml
+            echo 'firecracker:' >> ${RUNNER_DIR}/benchmark.yaml
             echo '  binary: /usr/local/bin/firecracker' >> ${RUNNER_DIR}/benchmark.yaml
             echo '  kernel: /opt/firecracker/vmlinux' >> ${RUNNER_DIR}/benchmark.yaml
             echo '  rootfs: ${RUNNER_DIR}/rootfs.squashfs' >> ${RUNNER_DIR}/benchmark.yaml

--- a/ansible/playbooks/templates/runner.yaml.j2
+++ b/ansible/playbooks/templates/runner.yaml.j2
@@ -3,6 +3,7 @@
 
 name: vm0-runner-{{ inventory_hostname | regex_replace('[^a-zA-Z0-9]', '-') }}
 group: {{ runner_group }}
+data_dir: {{ runner_base_dir }}/data
 
 server:
   url: {{ api_url }}

--- a/turbo/apps/runner/src/__tests__/benchmark.test.ts
+++ b/turbo/apps/runner/src/__tests__/benchmark.test.ts
@@ -4,6 +4,7 @@ import { debugConfigSchema } from "../lib/config.js";
 describe("debugConfigSchema", () => {
   it("should parse minimal config with only firecracker paths", () => {
     const config = {
+      data_dir: "/tmp/vm0-data",
       firecracker: {
         binary: "/usr/bin/firecracker",
         kernel: "/opt/vmlinux",
@@ -26,6 +27,7 @@ describe("debugConfigSchema", () => {
 
   it("should allow custom sandbox settings", () => {
     const config = {
+      data_dir: "/tmp/vm0-data",
       firecracker: {
         binary: "/usr/bin/firecracker",
         kernel: "/opt/vmlinux",
@@ -49,6 +51,7 @@ describe("debugConfigSchema", () => {
 
   it("should allow custom server settings", () => {
     const config = {
+      data_dir: "/tmp/vm0-data",
       firecracker: {
         binary: "/usr/bin/firecracker",
         kernel: "/opt/vmlinux",

--- a/turbo/apps/runner/src/__tests__/config.test.ts
+++ b/turbo/apps/runner/src/__tests__/config.test.ts
@@ -13,6 +13,7 @@ describe("RunnerConfig Schema", () => {
     const config = {
       name: "test-runner",
       group: "test/e2e",
+      data_dir: "/opt/runner/data",
       server: {
         url: "https://example.com",
         token: "test-token",
@@ -46,6 +47,7 @@ describe("RunnerConfig Schema", () => {
     const config = {
       name: "test",
       group: "scope/name",
+      data_dir: "/opt/runner/data",
       server: {
         url: "https://example.com",
         token: "test-token",
@@ -235,6 +237,7 @@ describe("loadConfig", () => {
     const yamlContent = `
 name: test-runner
 group: e2e/test
+data_dir: /opt/runner/data
 server:
   url: https://example.com
   token: test-token

--- a/turbo/apps/runner/src/commands/benchmark.ts
+++ b/turbo/apps/runner/src/commands/benchmark.ts
@@ -10,7 +10,7 @@ import {
 import { initOverlayPool } from "../lib/firecracker/overlay-pool.js";
 import { Timer } from "../lib/timing.js";
 import { setGlobalLogger } from "../lib/logger.js";
-import { paths } from "../lib/paths.js";
+import { dataPaths } from "../lib/paths.js";
 
 interface BenchmarkOptions {
   config: string;
@@ -85,12 +85,11 @@ export const benchmarkCommand = new Command("benchmark")
       await setupBridge();
 
       // Initialize overlay pool for VM boot
-      // Use separate directory to avoid conflicts with running runner
       timer.log("Initializing overlay pool...");
       await initOverlayPool({
         size: 2,
         replenishThreshold: 1,
-        poolDir: paths.overlayPoolBenchmark,
+        poolDir: dataPaths.overlayPool(config.data_dir),
       });
 
       // Create benchmark execution context

--- a/turbo/apps/runner/src/lib/config.ts
+++ b/turbo/apps/runner/src/lib/config.ts
@@ -30,6 +30,7 @@ export const runnerConfigSchema = z.object({
       /^[a-z0-9-]+\/[a-z0-9-]+$/,
       "Group must be in format 'scope/name' (lowercase, hyphens allowed)",
     ),
+  data_dir: z.string().min(1, "Data directory is required"),
   server: z.object({
     url: z.url({ message: "Server URL must be a valid URL" }),
     token: z.string().min(1, "Server token is required"),
@@ -75,6 +76,7 @@ const DEBUG_SERVER_DEFAULTS = {
 export const debugConfigSchema = z.object({
   name: z.string().default("debug-runner"),
   group: z.string().default("debug/local"),
+  data_dir: z.string().min(1, "Data directory is required"),
   server: z
     .object({
       url: z.url().default(DEBUG_SERVER_DEFAULTS.url),

--- a/turbo/apps/runner/src/lib/firecracker/overlay-pool.ts
+++ b/turbo/apps/runner/src/lib/firecracker/overlay-pool.ts
@@ -18,7 +18,6 @@ import fs from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
 import { createLogger } from "../logger.js";
-import { paths } from "../paths.js";
 
 const execAsync = promisify(exec);
 const logger = createLogger("OverlayPool");
@@ -26,7 +25,6 @@ const logger = createLogger("OverlayPool");
 /**
  * Configuration constants
  */
-const DEFAULT_POOL_DIR = paths.overlayPool;
 const OVERLAY_SIZE = 2 * 1024 * 1024 * 1024; // 2GB sparse file
 
 /**
@@ -37,8 +35,8 @@ interface OverlayPoolConfig {
   size: number;
   /** Start replenishing when pool drops below this count */
   replenishThreshold: number;
-  /** Custom pool directory (optional, for testing) */
-  poolDir?: string;
+  /** Pool directory for overlay files */
+  poolDir: string;
   /** Custom file creator function (optional, for testing) */
   createFile?: (filePath: string) => Promise<void>;
 }
@@ -69,7 +67,7 @@ export class OverlayPool {
     this.config = {
       size: config.size,
       replenishThreshold: config.replenishThreshold,
-      poolDir: config.poolDir ?? DEFAULT_POOL_DIR,
+      poolDir: config.poolDir,
       createFile: config.createFile ?? defaultCreateFile,
     };
   }

--- a/turbo/apps/runner/src/lib/paths.ts
+++ b/turbo/apps/runner/src/lib/paths.ts
@@ -26,13 +26,16 @@ export const paths = {
 
   /** IP allocation registry */
   ipRegistry: path.join(VM0_RUN_DIR, "ip-registry.json"),
-
-  /** Overlay pool directory */
-  overlayPool: path.join(VM0_RUN_DIR, "overlay-pool"),
-
-  /** Overlay pool directory for benchmark (isolated) */
-  overlayPoolBenchmark: path.join(VM0_RUN_DIR, "overlay-pool-benchmark"),
 } as const;
+
+/**
+ * Per-runner data paths (config.data_dir)
+ * Each runner instance has its own data directory
+ */
+export const dataPaths = {
+  /** Overlay pool directory for pre-warmed VM overlays */
+  overlayPool: (dataDir: string) => path.join(dataDir, "overlay-pool"),
+};
 
 /**
  * Temporary file paths (/tmp/vm0-*)

--- a/turbo/apps/runner/src/lib/runner/setup.ts
+++ b/turbo/apps/runner/src/lib/runner/setup.ts
@@ -1,4 +1,5 @@
 import type { RunnerConfig } from "../config.js";
+import { dataPaths } from "../paths.js";
 import {
   checkNetworkPrerequisites,
   setupBridge,
@@ -73,6 +74,7 @@ export async function setupEnvironment(
   await initOverlayPool({
     size: config.sandbox.max_concurrent + 2,
     replenishThreshold: config.sandbox.max_concurrent,
+    poolDir: dataPaths.overlayPool(config.data_dir),
   });
 
   // Initialize proxy for network security mode


### PR DESCRIPTION
## Summary
- Add `data_dir` config field to isolate overlay pool per runner instance
- Each runner/benchmark uses its own data directory
- Fixes overlay pool conflict when benchmark cleans runner's active files

## Changes
- **config.ts**: Add required `data_dir` field to schemas
- **paths.ts**: Add `dataPaths.overlayPool()` helper function  
- **overlay-pool.ts**: Make `poolDir` required parameter
- **setup.ts / benchmark.ts**: Use `dataPaths.overlayPool(config.data_dir)`
- **Ansible template**: Set `data_dir` to `{{ runner_base_dir }}/data`
- **CI benchmark**: Set `data_dir` to `${RUNNER_DIR}/benchmark-data`

## Test plan
- [x] Type check passes
- [x] Overlay pool tests pass
- [ ] CI benchmark runs successfully

Closes #2016

🤖 Generated with [Claude Code](https://claude.ai/code)