### PR TITLE
refactor: move landing page auth redirect to middleware

### DIFF
--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -4,60 +4,19 @@ import { useEffect, useRef } from "react";
 import Image from "next/image";
 import Script from "next/script";
 import { useTranslations } from "next-intl";
-import { useUser } from "@clerk/nextjs";
 import Navbar from "./Navbar";
 import Footer from "./Footer";
 import { useTheme } from "./ThemeProvider";
 
-/**
- * Construct platform URL from current host
- * - vm0.ai → platform.vm0.ai
- * - www.vm0.ai → platform.vm0.ai
- * - localhost:3000 → localhost:3001
- */
-function getPlatformUrl(host: string): string {
-  const colonIndex = host.indexOf(":");
-  const hostname = colonIndex === -1 ? host : host.slice(0, colonIndex);
-  const port = colonIndex === -1 ? null : host.slice(colonIndex + 1);
-
-  // Handle localhost - use different port for platform
-  if (hostname === "localhost" || hostname === "127.0.0.1") {
-    return `http://${hostname}:3001`;
-  }
-
-  // For production domains, replace www or prepend platform
-  const parts = hostname.split(".");
-  if (parts[0] === "www") {
-    parts[0] = "platform";
-  } else {
-    parts.unshift("platform");
-  }
-
-  const platformHost = parts.join(".");
-  const protocol = "https";
-  return port
-    ? `${protocol}://${platformHost}:${port}`
-    : `${protocol}://${platformHost}`;
-}
-
 export default function LandingPage() {
   const sandboxRef = useRef<HTMLDivElement>(null);
   const { theme } = useTheme();
-  const { isSignedIn, isLoaded } = useUser();
   const t = useTranslations("hero");
   const tBuild = useTranslations("build");
   const tCliAgents = useTranslations("cliAgents");
   const tFeatures = useTranslations("features");
   const tInfra = useTranslations("infrastructure");
   const tCta = useTranslations("cta");
-
-  // Redirect logged-in users to platform
-  useEffect(() => {
-    if (isLoaded && isSignedIn) {
-      const platformUrl = getPlatformUrl(window.location.host);
-      window.location.href = platformUrl;
-    }
-  }, [isLoaded, isSignedIn]);
 
   useEffect(() => {
     // Defer non-critical animations to improve LCP

--- a/turbo/apps/web/middleware.ts
+++ b/turbo/apps/web/middleware.ts
@@ -1,8 +1,11 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import createIntlMiddleware from "next-intl/middleware";
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { handleCors } from "./middleware.cors";
 import { locales, defaultLocale } from "./i18n";
+import { getPlatformUrl } from "./src/lib/platform-url";
+
+const bypassAuth = process.env.BYPASS_AUTH === "true";
 
 const isPublicRoute = createRouteMatcher([
   "/",
@@ -19,6 +22,9 @@ const isPublicRoute = createRouteMatcher([
   "/robots.txt",
   "/sitemap.xml",
 ]);
+
+// Routes that should redirect authenticated users to platform
+const isLandingRoute = createRouteMatcher(["/", "/:locale"]);
 
 // Create the i18n middleware
 const intlMiddleware = createIntlMiddleware({
@@ -66,6 +72,23 @@ export default clerkMiddleware(async (auth, request: NextRequest) => {
 
     // Return undefined to continue with default Next.js handling
     return undefined;
+  }
+
+  // Redirect authenticated users on landing pages to platform
+  // Skip when BYPASS_AUTH is enabled
+  if (!bypassAuth && isLandingRoute(request)) {
+    try {
+      const { userId } = await auth();
+      if (userId) {
+        const host = request.headers.get("host");
+        if (host) {
+          const platformUrl = getPlatformUrl(host);
+          return NextResponse.redirect(platformUrl);
+        }
+      }
+    } catch {
+      // Auth check failed, continue to show landing page (fail open)
+    }
   }
 
   // Apply i18n middleware for non-API routes

--- a/turbo/apps/web/src/lib/__tests__/platform-url.spec.ts
+++ b/turbo/apps/web/src/lib/__tests__/platform-url.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { getPlatformUrl } from "../platform-url";
+
+describe("getPlatformUrl", () => {
+  test("transforms localhost:3000 to localhost:3001", () => {
+    expect(getPlatformUrl("localhost:3000")).toBe("http://localhost:3001");
+  });
+
+  test("transforms 127.0.0.1:3000 to 127.0.0.1:3001", () => {
+    expect(getPlatformUrl("127.0.0.1:3000")).toBe("http://127.0.0.1:3001");
+  });
+
+  test("transforms localhost without port to localhost:3001", () => {
+    expect(getPlatformUrl("localhost")).toBe("http://localhost:3001");
+  });
+
+  test("transforms vm0.ai to platform.vm0.ai", () => {
+    expect(getPlatformUrl("vm0.ai")).toBe("https://platform.vm0.ai");
+  });
+
+  test("transforms www.vm0.ai to platform.vm0.ai", () => {
+    expect(getPlatformUrl("www.vm0.ai")).toBe("https://platform.vm0.ai");
+  });
+
+  test("transforms vm0.ai:8080 to platform.vm0.ai:8080", () => {
+    expect(getPlatformUrl("vm0.ai:8080")).toBe("https://platform.vm0.ai:8080");
+  });
+
+  test("transforms staging.vm0.ai to platform.staging.vm0.ai", () => {
+    expect(getPlatformUrl("staging.vm0.ai")).toBe(
+      "https://platform.staging.vm0.ai",
+    );
+  });
+
+  test("transforms 127.0.0.1 without port to 127.0.0.1:3001", () => {
+    expect(getPlatformUrl("127.0.0.1")).toBe("http://127.0.0.1:3001");
+  });
+});

--- a/turbo/apps/web/src/lib/platform-url.ts
+++ b/turbo/apps/web/src/lib/platform-url.ts
@@ -1,0 +1,30 @@
+/**
+ * Construct platform URL from current host
+ * - vm0.ai → platform.vm0.ai
+ * - www.vm0.ai → platform.vm0.ai
+ * - localhost:3000 → localhost:3001
+ */
+export function getPlatformUrl(host: string): string {
+  const colonIndex = host.indexOf(":");
+  const hostname = colonIndex === -1 ? host : host.slice(0, colonIndex);
+  const port = colonIndex === -1 ? null : host.slice(colonIndex + 1);
+
+  // Handle localhost - use different port for platform
+  if (hostname === "localhost" || hostname === "127.0.0.1") {
+    return `http://${hostname}:3001`;
+  }
+
+  // For production domains, replace www or prepend platform
+  const parts = hostname.split(".");
+  if (parts[0] === "www") {
+    parts[0] = "platform";
+  } else {
+    parts.unshift("platform");
+  }
+
+  const platformHost = parts.join(".");
+  const protocol = "https";
+  return port
+    ? `${protocol}://${platformHost}:${port}`
+    : `${protocol}://${platformHost}`;
+}


### PR DESCRIPTION
## Summary

- Move authentication check and redirect logic from client-side (`LandingPage.tsx`) to server-side (`middleware.ts`)
- Eliminates the brief flash of landing page for authenticated users
- Better performance by handling redirect at the middleware level before any React rendering

## Changes

- **Add `getPlatformUrl` utility** (`src/lib/platform-url.ts`): Extracted URL construction logic to a shared utility
- **Update middleware** (`middleware.ts`): Add auth redirect logic for landing routes (`/` and `/:locale`)
- **Clean up LandingPage** (`app/components/LandingPage.tsx`): Remove `useUser` hook and redirect `useEffect`
- **Add unit tests** (`src/lib/__tests__/platform-url.spec.ts`): Cover all URL transformation cases

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Logged-in user visits landing | Flash of page, then JS redirect | Immediate server redirect |
| Logged-out user visits landing | Page renders normally | Page renders normally |
| `BYPASS_AUTH=true` | Always redirect if auth present | Never redirect |
| Auth error | Page may break | Page renders (fail open) |

## Test plan

- [x] Unit tests for `getPlatformUrl` function (8 test cases)
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes (no unused code)

Closes #2035

🤖 Generated with [Claude Code](https://claude.ai/claude-code)