### PR TITLE
feat(web): replace waitlist with signup component

### DIFF
--- a/turbo/apps/web/app/sign-up/[[...sign-up]]/page.tsx
+++ b/turbo/apps/web/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Waitlist } from "@clerk/nextjs";
+import { SignUp } from "@clerk/nextjs";
 import { useTheme } from "../../components/ThemeProvider";
 import Image from "next/image";
 
@@ -121,37 +121,118 @@ export default function SignUpPage() {
           color: hsl(var(--muted-foreground)) !important;
         }
 
-        /* Button styles - remove gradients and borders */
+        /* Button styles - remove gradients and borders (exclude social buttons) */
         .cl-formButtonPrimary,
-        .cl-button,
-        button[type="submit"],
+        button[type="submit"]:not(.cl-socialButtonsBlockButton),
         [data-localization-key="formButtonPrimary"],
-        .cl-formButtonPrimary > *,
-        .cl-button > * {
+        .cl-formButtonPrimary > * {
           background-image: none !important;
           background: hsl(var(--primary)) !important;
           border: none !important;
           box-shadow: none !important;
         }
 
-        /* Button hover state */
+        /* Button hover state (exclude social buttons) */
         .cl-formButtonPrimary:hover,
-        .cl-button:hover,
-        button[type="submit"]:hover,
+        button[type="submit"]:not(.cl-socialButtonsBlockButton):hover,
         [data-localization-key="formButtonPrimary"]:hover {
           background-image: none !important;
           background: hsl(var(--primary) / 0.9) !important;
           box-shadow: none !important;
         }
 
-        /* Remove pseudo elements */
+        /* Remove pseudo elements (exclude social buttons) */
         .cl-formButtonPrimary::before,
         .cl-formButtonPrimary::after,
-        .cl-button::before,
-        .cl-button::after,
-        button[type="submit"]::before,
-        button[type="submit"]::after {
+        button[type="submit"]:not(.cl-socialButtonsBlockButton)::before,
+        button[type="submit"]:not(.cl-socialButtonsBlockButton)::after {
           display: none !important;
+          background-image: none !important;
+        }
+
+        /* Social buttons (Google login) - add border and set text color */
+        button[class*="socialButtonsBlockButton"],
+        button[class*="cl-socialButtons"],
+        .cl-socialButtonsBlockButton,
+        div[class*="socialButtons"] button {
+          height: 36px !important;
+          background-color: transparent !important;
+          background-image: none !important;
+          border-width: 1px !important;
+          border-style: solid !important;
+          border-color: var(--color-border) !important;
+          border-radius: 0.5rem !important;
+          color: var(--color-foreground) !important;
+          box-shadow: none !important;
+          display: flex !important;
+          align-items: center !important;
+          justify-content: center !important;
+          gap: 0.5rem !important;
+          transition: background-color 0.2s !important;
+        }
+
+        /* Social buttons hover state */
+        button[class*="socialButtonsBlockButton"]:hover,
+        .cl-socialButtonsBlockButton:hover {
+          background-color: var(--color-muted) !important;
+        }
+
+        /* Force remove all backgrounds from inner elements at all times */
+        button[class*="socialButtonsBlockButton"] *,
+        .cl-socialButtonsBlockButton *,
+        button[class*="socialButtonsBlockButton"] > *,
+        button[class*="socialButtonsBlockButton"] span,
+        button[class*="socialButtonsBlockButton"] div,
+        .cl-socialButtonsBlockButton > *,
+        .cl-socialButtonsBlockButton span,
+        .cl-socialButtonsBlockButton div,
+        [class*="socialButtonsBlockButton"] [class*="internal"],
+        [class*="socialButtonsBlockButton"] [class*="text"],
+        [class*="socialButtonsBlockButton"] [class*="icon"],
+        [class*="socialButtonsBlockButton"] [class*="cl-internal"],
+        button[class*="socialButtonsBlockButton"] [class*="cl-internal"],
+        .cl-internal-2iusy0 {
+          background: none !important;
+          background-color: transparent !important;
+          background-image: none !important;
+          border: none !important;
+        }
+
+        /* Force remove all backgrounds from inner elements on hover */
+        button[class*="socialButtonsBlockButton"]:hover *,
+        .cl-socialButtonsBlockButton:hover *,
+        button[class*="socialButtonsBlockButton"] *:hover,
+        .cl-socialButtonsBlockButton *:hover,
+        button[class*="socialButtonsBlockButton"]:hover > *,
+        button[class*="socialButtonsBlockButton"]:hover span,
+        button[class*="socialButtonsBlockButton"]:hover div,
+        button[class*="socialButtonsBlockButton"] span:hover,
+        button[class*="socialButtonsBlockButton"] div:hover,
+        [class*="socialButtonsBlockButton"]:hover [class*="internal"],
+        [class*="socialButtonsBlockButton"]:hover [class*="text"],
+        [class*="socialButtonsBlockButton"]:hover [class*="icon"],
+        [class*="socialButtonsBlockButton"] [class*="internal"]:hover,
+        [class*="socialButtonsBlockButton"] [class*="text"]:hover,
+        [class*="socialButtonsBlockButton"] [class*="icon"]:hover,
+        [class*="socialButtonsBlockButton"]:hover [class*="cl-internal"],
+        [class*="socialButtonsBlockButton"] [class*="cl-internal"]:hover,
+        button[class*="socialButtonsBlockButton"]:hover [class*="cl-internal"],
+        button[class*="socialButtonsBlockButton"] [class*="cl-internal"]:hover,
+        .cl-internal-2iusy0:hover,
+        button:hover .cl-internal-2iusy0 {
+          background: none !important;
+          background-color: transparent !important;
+          background-image: none !important;
+        }
+
+        /* Social button text color */
+        button[class*="socialButtonsBlockButton"] *,
+        .cl-socialButtonsBlockButton *,
+        .cl-socialButtonsBlockButton span,
+        button[class*="socialButtons"] span {
+          color: var(--color-foreground) !important;
+          background: none !important;
+          background-color: transparent !important;
           background-image: none !important;
         }
 
@@ -267,8 +348,7 @@ export default function SignUpPage() {
           <span className="text-2xl text-foreground">Platform</span>
         </div>
 
-        <Waitlist
-          signInUrl="/sign-in"
+        <SignUp
           appearance={{
             layout: {
               logoImageUrl:
@@ -290,51 +370,10 @@ export default function SignUpPage() {
               headerTitle: "text-foreground font-medium",
               headerSubtitle: "text-muted-foreground",
               socialButtonsBlockButton:
-                "bg-card border border-border text-foreground hover:bg-muted transition-colors",
-              socialButtonsBlockButtonText: "text-foreground font-medium",
-              formButtonPrimary: {
-                backgroundColor: "hsl(var(--primary)) !important",
-                backgroundImage: "none !important",
-                color: "hsl(var(--primary-foreground)) !important",
-                border: "none !important",
-                outline: "none !important",
-                boxShadow: "none !important",
-                fontSize: "0.75rem",
-                fontWeight: "500",
-                height: "2.25rem",
-                borderRadius: "0.375rem",
-                transition: "background-color 0.2s",
-                "&:hover": {
-                  backgroundColor: "hsl(var(--primary) / 0.9) !important",
-                  backgroundImage: "none !important",
-                },
-                "&:focus": {
-                  outline: "none !important",
-                  boxShadow: "none !important",
-                  backgroundImage: "none !important",
-                },
-              },
-              button: {
-                backgroundColor: "hsl(var(--primary)) !important",
-                backgroundImage: "none !important",
-                color: "hsl(var(--primary-foreground)) !important",
-                border: "none !important",
-                outline: "none !important",
-                boxShadow: "none !important",
-                fontSize: "0.75rem",
-                fontWeight: "500",
-                height: "2.25rem",
-                borderRadius: "0.375rem",
-                "&:hover": {
-                  backgroundColor: "hsl(var(--primary) / 0.9) !important",
-                  backgroundImage: "none !important",
-                },
-                "&:focus": {
-                  outline: "none !important",
-                  boxShadow: "none !important",
-                  backgroundImage: "none !important",
-                },
-              },
+                "h-9 bg-transparent border border-border rounded-lg text-foreground flex items-center justify-center gap-2",
+              socialButtonsBlockButtonText: "text-foreground",
+              formButtonPrimary:
+                "bg-primary text-primary-foreground hover:bg-primary/90 transition-colors text-xs font-medium h-9 rounded-md",
               formFieldInput: "text-foreground rounded-lg transition-colors",
               formFieldLabel: "text-foreground",
               footerActionLink: "text-primary hover:text-primary/90",


### PR DESCRIPTION
## Summary
- Replace Clerk `Waitlist` component with `SignUp` component on the sign-up page
- Update CSS styling to properly handle social login buttons (Google) with correct border and hover states
- Simplify button styling configuration by removing redundant inline styles in favor of CSS classes

## Test plan
- [ ] Verify sign-up page loads correctly
- [ ] Test social login button (Google) appearance and hover state
- [ ] Verify primary button styling remains consistent
- [ ] Test in both light and dark themes

---
Generated with [Claude Code](https://claude.ai/code)