### PR TITLE
refactor(runner): rename paths to runtimePaths for clarity

### DIFF
--- a/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
+++ b/turbo/apps/runner/src/lib/firecracker/ip-pool.ts
@@ -14,7 +14,7 @@ import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import * as fs from "node:fs";
 import { createLogger } from "../logger.js";
-import { VM0_RUN_DIR, paths } from "../paths.js";
+import { VM0_RUN_DIR, runtimePaths } from "../paths.js";
 
 const execAsync = promisify(exec);
 const logger = createLogger("IP Pool");
@@ -22,7 +22,7 @@ const logger = createLogger("IP Pool");
 /**
  * Configuration constants
  */
-const REGISTRY_FILE_PATH = paths.ipRegistry;
+const REGISTRY_FILE_PATH = runtimePaths.ipRegistry;
 const BRIDGE_NAME = "vm0br0";
 
 /**
@@ -88,7 +88,7 @@ async function ensureRunDir(): Promise<void> {
 async function withLock<T>(fn: () => Promise<T>): Promise<T> {
   await ensureRunDir();
 
-  const lockMarker = paths.ipPoolLock;
+  const lockMarker = runtimePaths.ipPoolLock;
   const startTime = Date.now();
   let lockAcquired = false;
 

--- a/turbo/apps/runner/src/lib/paths.ts
+++ b/turbo/apps/runner/src/lib/paths.ts
@@ -17,7 +17,7 @@ const VM0_TMP_PREFIX = "/tmp/vm0";
  * Runtime state paths (/var/run/vm0/)
  * These are shared across runner instances on the same host
  */
-export const paths = {
+export const runtimePaths = {
   /** Runner PID file for single-instance lock */
   runnerPid: path.join(VM0_RUN_DIR, "runner.pid"),
 

--- a/turbo/apps/runner/src/lib/runner/runner-lock.ts
+++ b/turbo/apps/runner/src/lib/runner/runner-lock.ts
@@ -11,12 +11,12 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 import { createLogger } from "../logger.js";
-import { paths } from "../paths.js";
+import { runtimePaths } from "../paths.js";
 
 const execAsync = promisify(exec);
 const logger = createLogger("RunnerLock");
 
-const DEFAULT_PID_FILE = paths.runnerPid;
+const DEFAULT_PID_FILE = runtimePaths.runnerPid;
 
 // Module state for tracking current lock
 let currentPidFile: string | null = null;


### PR DESCRIPTION
## Summary
- Rename the `paths` export to `runtimePaths` to better distinguish it from `dataPaths` and `tempPaths` exports in the same module

## Test plan
- [x] Type check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)