### PR TITLE
fix(ci): correct misleading comment in benchmark job

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -876,7 +876,7 @@ jobs:
           echo "proxy-port=${PROXY_PORT}" >> $GITHUB_OUTPUT
           echo "Runner prepared at ${RUNNER_DIR} on ${RUNNER_HOST}"
 
-  # Run benchmark command to test VM boot performance (runs after prepare, before start)
+  # Run benchmark command to test VM boot performance (runs after start)
   # Skip on push to main - runner benchmark is only needed for PRs
   deploy-runner-benchmark:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Fix misleading comment that said benchmark runs "before start" when it actually runs after start (depends on `deploy-runner-start`)

## Test plan

- [x] Comment-only change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)