### PR TITLE
fix(platform): correct step 1 description on homepage

### DIFF
--- a/turbo/apps/platform/src/views/home/home-page.tsx
+++ b/turbo/apps/platform/src/views/home/home-page.tsx
@@ -48,7 +48,7 @@ function Step1InstallSkill() {
     <section>
       <StepHeader
         step={1}
-        title="Install the VM0 builder skill and build with natural language"
+        title="Install the VM0 CLI and build AI agents with natural language"
       />
       <Card className="flex items-center justify-between p-4 font-mono">
         <code className="text-sm overflow-x-auto text-muted-foreground">


### PR DESCRIPTION
## Summary
- Change "Install the VM0 builder skill" to "Install the VM0 CLI" to accurately describe what the `npm install -g @vm0/cli` command does
- The original description was misleading as it mentioned "builder skill" instead of CLI

## Test plan
- [ ] Verify the homepage displays the updated Step 1 title

🤖 Generated with [Claude Code](https://claude.com/claude-code)