### PR TITLE
feat: redirect authenticated users to platform and fix dialog dark mode

### DIFF
--- a/turbo/apps/web/middleware.ts
+++ b/turbo/apps/web/middleware.ts
@@ -1,8 +1,9 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import createIntlMiddleware from "next-intl/middleware";
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { handleCors } from "./middleware.cors";
 import { locales, defaultLocale } from "./i18n";
+import { getPlatformUrl } from "./src/lib/platform-url";
 
 const isPublicRoute = createRouteMatcher([
   "/",
@@ -19,6 +20,9 @@ const isPublicRoute = createRouteMatcher([
   "/robots.txt",
   "/sitemap.xml",
 ]);
+
+// Routes that should redirect authenticated users to platform
+const isLandingRoute = createRouteMatcher(["/", "/:locale"]);
 
 // Create the i18n middleware
 const intlMiddleware = createIntlMiddleware({
@@ -66,6 +70,22 @@ export default clerkMiddleware(async (auth, request: NextRequest) => {
 
     // Return undefined to continue with default Next.js handling
     return undefined;
+  }
+
+  // Redirect authenticated users on landing pages to platform
+  if (isLandingRoute(request)) {
+    try {
+      const { userId } = await auth();
+      if (userId) {
+        const host = request.headers.get("host");
+        if (host) {
+          const platformUrl = getPlatformUrl(host);
+          return NextResponse.redirect(platformUrl);
+        }
+      }
+    } catch {
+      // Auth check failed, continue to show landing page (fail open)
+    }
   }
 
   // Apply i18n middleware for non-API routes

--- a/turbo/apps/web/src/lib/__tests__/platform-url.spec.ts
+++ b/turbo/apps/web/src/lib/__tests__/platform-url.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { getPlatformUrl } from "../platform-url";
+
+describe("getPlatformUrl", () => {
+  test("transforms localhost:3000 to localhost:3001", () => {
+    expect(getPlatformUrl("localhost:3000")).toBe("http://localhost:3001");
+  });
+
+  test("transforms 127.0.0.1:3000 to 127.0.0.1:3001", () => {
+    expect(getPlatformUrl("127.0.0.1:3000")).toBe("http://127.0.0.1:3001");
+  });
+
+  test("transforms localhost without port to localhost:3001", () => {
+    expect(getPlatformUrl("localhost")).toBe("http://localhost:3001");
+  });
+
+  test("transforms vm0.ai to platform.vm0.ai", () => {
+    expect(getPlatformUrl("vm0.ai")).toBe("https://platform.vm0.ai");
+  });
+
+  test("transforms www.vm0.ai to platform.vm0.ai", () => {
+    expect(getPlatformUrl("www.vm0.ai")).toBe("https://platform.vm0.ai");
+  });
+
+  test("transforms vm0.ai:8080 to platform.vm0.ai:8080", () => {
+    expect(getPlatformUrl("vm0.ai:8080")).toBe("https://platform.vm0.ai:8080");
+  });
+
+  test("transforms staging.vm0.ai to platform.staging.vm0.ai", () => {
+    expect(getPlatformUrl("staging.vm0.ai")).toBe(
+      "https://platform.staging.vm0.ai",
+    );
+  });
+
+  test("transforms 127.0.0.1 without port to 127.0.0.1:3001", () => {
+    expect(getPlatformUrl("127.0.0.1")).toBe("http://127.0.0.1:3001");
+  });
+});

--- a/turbo/apps/web/src/lib/platform-url.ts
+++ b/turbo/apps/web/src/lib/platform-url.ts
@@ -1,0 +1,30 @@
+/**
+ * Construct platform URL from current host
+ * - vm0.ai → platform.vm0.ai
+ * - www.vm0.ai → platform.vm0.ai
+ * - localhost:3000 → localhost:3001
+ */
+export function getPlatformUrl(host: string): string {
+  const colonIndex = host.indexOf(":");
+  const hostname = colonIndex === -1 ? host : host.slice(0, colonIndex);
+  const port = colonIndex === -1 ? null : host.slice(colonIndex + 1);
+
+  // Handle localhost - use different port for platform
+  if (hostname === "localhost" || hostname === "127.0.0.1") {
+    return `http://${hostname}:3001`;
+  }
+
+  // For production domains, replace www or prepend platform
+  const parts = hostname.split(".");
+  if (parts[0] === "www") {
+    parts[0] = "platform";
+  } else {
+    parts.unshift("platform");
+  }
+
+  const platformHost = parts.join(".");
+  const protocol = "https";
+  return port
+    ? `${protocol}://${platformHost}:${port}`
+    : `${protocol}://${platformHost}`;
+}

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -18,7 +18,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/80 dark:bg-background/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary
- Add server-side redirect for authenticated users from landing pages to platform
- Add `getPlatformUrl` utility with URL transformation logic (localhost:3000 → localhost:3001, vm0.ai → platform.vm0.ai)
- Fix dialog overlay mask color in dark mode using theme-aware background token

## Test plan
- [x] Unit tests for `getPlatformUrl` function (8 test cases)
- [ ] Verify authenticated user redirect works on landing page
- [ ] Verify dialog overlay appearance in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)