### PR TITLE
fix(cli): align todo list output with other tool formats

### DIFF
--- a/turbo/apps/cli/src/lib/events/tool-formatters.ts
+++ b/turbo/apps/cli/src/lib/events/tool-formatters.ts
@@ -48,19 +48,19 @@ const toolHeadlineFormatters: Record<
   string,
   (input: Record<string, unknown>) => string
 > = {
-  Read: (input) => `Read(${chalk.dim(String(input.file_path || ""))})`,
-  Edit: (input) => `Edit(${chalk.dim(String(input.file_path || ""))})`,
-  Write: (input) => `Write(${chalk.dim(String(input.file_path || ""))})`,
+  Read: (input) => `Read${chalk.dim(`(${String(input.file_path || "")})`)}`,
+  Edit: (input) => `Edit${chalk.dim(`(${String(input.file_path || "")})`)}`,
+  Write: (input) => `Write${chalk.dim(`(${String(input.file_path || "")})`)}`,
   Bash: (input) =>
-    `Bash(${chalk.dim(truncate(String(input.command || ""), 60))})`,
-  Glob: (input) => `Glob(${chalk.dim(String(input.pattern || ""))})`,
-  Grep: (input) => `Grep(${chalk.dim(String(input.pattern || ""))})`,
+    `Bash${chalk.dim(`(${truncate(String(input.command || ""), 60)})`)}`,
+  Glob: (input) => `Glob${chalk.dim(`(${String(input.pattern || "")})`)}`,
+  Grep: (input) => `Grep${chalk.dim(`(${String(input.pattern || "")})`)}`,
   Task: (input) =>
-    `Task(${chalk.dim(truncate(String(input.description || ""), 60))})`,
+    `Task${chalk.dim(`(${truncate(String(input.description || ""), 60)})`)}`,
   WebFetch: (input) =>
-    `WebFetch(${chalk.dim(truncate(String(input.url || ""), 60))})`,
+    `WebFetch${chalk.dim(`(${truncate(String(input.url || ""), 60)})`)}`,
   WebSearch: (input) =>
-    `WebSearch(${chalk.dim(truncate(String(input.query || ""), 60))})`,
+    `WebSearch${chalk.dim(`(${truncate(String(input.query || ""), 60)})`)}`,
   TodoWrite: () => "TodoWrite",
 };
 
@@ -83,6 +83,13 @@ export function formatToolResult(
   const { tool, input } = toolUse;
   const { result: resultText, isError } = result;
   const lines: string[] = [];
+
+  // Special handling for Read - strip line numbers and filter system content
+  if (tool === "Read" && !isError && resultText) {
+    const readLines = formatReadContent(resultText, verbose);
+    lines.push(...readLines);
+    return lines;
+  }
 
   // Special handling for TodoWrite - show the task list
   if (tool === "TodoWrite" && !isError) {
@@ -138,6 +145,56 @@ export function formatToolResult(
   } else {
     // No result content, show done
     lines.push(`└ ✓ ${chalk.dim("Done")}`);
+  }
+
+  return lines;
+}
+
+/**
+ * Format Read tool output - strip line numbers and filter system content
+ * Input format: "     1→content" (line numbers with → separator)
+ * Filters out lines without line numbers (empty lines, system-reminder tags)
+ */
+function formatReadContent(resultText: string, verbose: boolean): string[] {
+  const lines: string[] = [];
+  const rawLines = resultText.split("\n");
+
+  // Parse lines: only keep lines with line number format, strip the number prefix
+  const contentLines: string[] = [];
+  const lineNumberPattern = /^\s*\d+→(.*)$/;
+
+  for (const line of rawLines) {
+    const match = line.match(lineNumberPattern);
+    if (match) {
+      contentLines.push(match[1] ?? "");
+    }
+  }
+
+  const totalLines = contentLines.length;
+
+  if (totalLines === 0) {
+    lines.push(`└ ✓ ${chalk.dim("(empty)")}`);
+    return lines;
+  }
+
+  // Show content preview
+  if (verbose) {
+    for (let i = 0; i < contentLines.length; i++) {
+      const prefix = i === 0 ? "└ " : "  ";
+      lines.push(`${prefix}${chalk.dim(contentLines[i] ?? "")}`);
+    }
+  } else {
+    const previewCount = Math.min(3, totalLines);
+    for (let i = 0; i < previewCount; i++) {
+      const prefix = i === 0 ? "└ " : "  ";
+      lines.push(`${prefix}${chalk.dim(contentLines[i] ?? "")}`);
+    }
+    const remaining = totalLines - previewCount;
+    if (remaining > 0) {
+      lines.push(
+        `  ${chalk.dim(`… +${remaining} ${pluralize(remaining, "line", "lines")} (vm0 logs <runId> to see all)`)}`,
+      );
+    }
   }
 
   return lines;
@@ -203,10 +260,10 @@ function formatEditDiff(
   if (verbose) {
     // Verbose mode: show all lines
     for (const line of oldLines) {
-      lines.push(`  ${chalk.dim(`- ${line}`)}`);
+      lines.push(`  - ${chalk.dim(line)}`);
     }
     for (const line of newLines) {
-      lines.push(`  ${chalk.dim(`+ ${line}`)}`);
+      lines.push(`  + ${chalk.dim(line)}`);
     }
   } else {
     // Compact mode: show first few lines of each
@@ -216,23 +273,23 @@ function formatEditDiff(
 
     // Show removed lines
     for (let i = 0; i < showOld; i++) {
-      lines.push(`  ${chalk.dim(`- ${truncate(oldLines[i] ?? "", 60)}`)}`);
+      lines.push(`  - ${chalk.dim(truncate(oldLines[i] ?? "", 60))}`);
     }
     const remainingOld = oldLines.length - previewLimit;
     if (remainingOld > 0) {
       lines.push(
-        `  ${chalk.dim(`  … +${remainingOld} ${pluralize(remainingOld, "line", "lines")} (vm0 logs <runId> to see all)`)}`,
+        `    ${chalk.dim(`… +${remainingOld} ${pluralize(remainingOld, "line", "lines")} (vm0 logs <runId> to see all)`)}`,
       );
     }
 
     // Show added lines
     for (let i = 0; i < showNew; i++) {
-      lines.push(`  ${chalk.dim(`+ ${truncate(newLines[i] ?? "", 60)}`)}`);
+      lines.push(`  + ${chalk.dim(truncate(newLines[i] ?? "", 60))}`);
     }
     const remainingNew = newLines.length - previewLimit;
     if (remainingNew > 0) {
       lines.push(
-        `  ${chalk.dim(`  … +${remainingNew} ${pluralize(remainingNew, "line", "lines")} (vm0 logs <runId> to see all)`)}`,
+        `    ${chalk.dim(`… +${remainingNew} ${pluralize(remainingNew, "line", "lines")} (vm0 logs <runId> to see all)`)}`,
       );
     }
   }
@@ -259,12 +316,14 @@ function formatTodoList(input: Record<string, unknown>): string[] {
     return lines;
   }
 
-  for (const todo of todos) {
+  for (let i = 0; i < todos.length; i++) {
+    const todo = todos[i]!;
     const content = todo.content || "Unknown task";
     const status = todo.status || "pending";
     const icon = getTodoStatusIcon(status);
     const styledContent = formatTodoContent(content, status);
-    lines.push(`  ${icon} ${styledContent}`);
+    const prefix = i === 0 ? "└ " : "  ";
+    lines.push(`${prefix}${icon} ${styledContent}`);
   }
 
   return lines;

--- a/turbo/apps/cli/src/lib/events/tool-formatters.ts
+++ b/turbo/apps/cli/src/lib/events/tool-formatters.ts
@@ -153,13 +153,13 @@ export function formatToolResult(
 /**
  * Format Read tool output - strip line numbers and filter system content
  * Input format: "     1→content" (line numbers with → separator)
- * Filters out lines without line numbers (empty lines, system-reminder tags)
+ * Falls back to raw content if no line numbers are present
  */
 function formatReadContent(resultText: string, verbose: boolean): string[] {
   const lines: string[] = [];
   const rawLines = resultText.split("\n");
 
-  // Parse lines: only keep lines with line number format, strip the number prefix
+  // Parse lines: try to extract content from line number format, strip the number prefix
   const contentLines: string[] = [];
   const lineNumberPattern = /^\s*\d+→(.*)$/;
 
@@ -170,7 +170,12 @@ function formatReadContent(resultText: string, verbose: boolean): string[] {
     }
   }
 
-  const totalLines = contentLines.length;
+  // If no line numbers found, use raw content (fallback for plain text results)
+  const displayLines =
+    contentLines.length > 0
+      ? contentLines
+      : rawLines.filter((line) => line.trim().length > 0);
+  const totalLines = displayLines.length;
 
   if (totalLines === 0) {
     lines.push(`└ ✓ ${chalk.dim("(empty)")}`);
@@ -179,15 +184,15 @@ function formatReadContent(resultText: string, verbose: boolean): string[] {
 
   // Show content preview
   if (verbose) {
-    for (let i = 0; i < contentLines.length; i++) {
+    for (let i = 0; i < displayLines.length; i++) {
       const prefix = i === 0 ? "└ " : "  ";
-      lines.push(`${prefix}${chalk.dim(contentLines[i] ?? "")}`);
+      lines.push(`${prefix}${chalk.dim(displayLines[i] ?? "")}`);
     }
   } else {
     const previewCount = Math.min(3, totalLines);
     for (let i = 0; i < previewCount; i++) {
       const prefix = i === 0 ? "└ " : "  ";
-      lines.push(`${prefix}${chalk.dim(contentLines[i] ?? "")}`);
+      lines.push(`${prefix}${chalk.dim(displayLines[i] ?? "")}`);
     }
     const remaining = totalLines - previewCount;
     if (remaining > 0) {


### PR DESCRIPTION
## Summary
- Add └ prefix to TodoWrite's first result line for consistency
- Add special formatting for Read tool output:
  - Strip line number prefix (e.g., `     1→`)
  - Filter out lines without line numbers (empty lines, system-reminder tags)

### TodoWrite - Before/After:
```
● TodoWrite
    ✓ Task 1        →    ● TodoWrite
    ✓ Task 2              └ ✓ Task 1
                            ✓ Task 2
```

### Read - Before/After:
```
● Read(/path/file.md)
  └      1→# Title        →    ● Read(/path/file.md)
         2→               →      └ # Title
         3→Content        →        Content
```

🤖 Generated with [Claude Code](https://claude.ai/code)