### PR TITLE
fix(web): make logo clickable on sign-in and sign-up pages

### DIFF
--- a/turbo/apps/web/app/sign-in/[[...sign-in]]/page.tsx
+++ b/turbo/apps/web/app/sign-in/[[...sign-in]]/page.tsx
@@ -3,6 +3,7 @@
 import { SignIn } from "@clerk/nextjs";
 import { useTheme } from "../../components/ThemeProvider";
 import Image from "next/image";
+import Link from "next/link";
 
 export default function SignInPage() {
   const { theme, toggleTheme } = useTheme();
@@ -324,7 +325,10 @@ export default function SignInPage() {
         </button>
 
         {/* Logo Header */}
-        <div className="absolute left-6 top-6 flex items-center gap-2">
+        <Link
+          href="/"
+          className="absolute left-6 top-6 flex items-center gap-2"
+        >
           <Image
             src={
               theme === "dark"
@@ -346,7 +350,7 @@ export default function SignInPage() {
             className="hidden dark:block"
           />
           <span className="text-2xl text-foreground">Platform</span>
-        </div>
+        </Link>
 
         <SignIn
           appearance={{

--- a/turbo/apps/web/app/sign-up/[[...sign-up]]/page.tsx
+++ b/turbo/apps/web/app/sign-up/[[...sign-up]]/page.tsx
@@ -3,6 +3,7 @@
 import { SignUp } from "@clerk/nextjs";
 import { useTheme } from "../../components/ThemeProvider";
 import Image from "next/image";
+import Link from "next/link";
 
 export default function SignUpPage() {
   const { theme, toggleTheme } = useTheme();
@@ -324,7 +325,10 @@ export default function SignUpPage() {
         </button>
 
         {/* Logo Header */}
-        <div className="absolute left-6 top-6 flex items-center gap-2">
+        <Link
+          href="/"
+          className="absolute left-6 top-6 flex items-center gap-2"
+        >
           <Image
             src={
               theme === "dark"
@@ -346,7 +350,7 @@ export default function SignUpPage() {
             className="hidden dark:block"
           />
           <span className="text-2xl text-foreground">Platform</span>
-        </div>
+        </Link>
 
         <SignUp
           appearance={{


### PR DESCRIPTION
## Summary
- Wraps the logo in the top-left corner of `/sign-in` and `/sign-up` pages with a `Link` component
- Clicking the logo now navigates users back to the homepage (`/`)

## Test plan
- [ ] Navigate to `/sign-up` page
- [ ] Click on the VM0 logo in the top-left corner
- [ ] Verify it navigates to the homepage
- [ ] Navigate to `/sign-in` page
- [ ] Click on the VM0 logo in the top-left corner
- [ ] Verify it navigates to the homepage

Closes #2051

🤖 Generated with [Claude Code](https://claude.com/claude-code)