### PR TITLE
feat(cli): add platform url output to logs command

### DIFF
--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -6,11 +6,39 @@ import {
   RunEvent,
   NetworkLogEntry,
 } from "../../lib/api/api-client";
+import { getApiUrl } from "../../lib/api/config";
 import { parseTime } from "../../lib/utils/time-parser";
 import { formatBytes } from "../../lib/utils/file-utils";
 import { ClaudeEventParser } from "../../lib/events/claude-event-parser";
 import { EventRenderer } from "../../lib/events/event-renderer";
 import { CodexEventRenderer } from "../../lib/events/codex-event-renderer";
+
+/**
+ * Build platform URL for logs viewer
+ * Transforms API URL to platform URL and appends logs path
+ */
+function buildPlatformLogsUrl(apiUrl: string, runId: string): string {
+  const url = new URL(apiUrl);
+  const hostname = url.hostname;
+
+  // Handle localhost
+  if (hostname === "localhost" || hostname === "127.0.0.1") {
+    return `http://${hostname}:3001/logs/${runId}`;
+  }
+
+  // Transform: www.vm0.ai → platform.vm0.ai
+  //            vm0.ai → platform.vm0.ai
+  const parts = hostname.split(".");
+  if (parts[0] === "www") {
+    parts[0] = "platform";
+  } else {
+    parts.unshift("platform");
+  }
+
+  const platformHost = parts.join(".");
+  const port = url.port ? `:${url.port}` : "";
+  return `https://${platformHost}${port}/logs/${runId}`;
+}
 
 /**
  * Log type for mutually exclusive options
@@ -195,9 +223,20 @@ export const logsCommand = new Command()
         );
         const order: "asc" | "desc" = isHead ? "asc" : "desc";
 
+        // Build platform URL (fail fast if invalid)
+        const apiUrl = await getApiUrl();
+        let platformUrl: string;
+        try {
+          platformUrl = buildPlatformLogsUrl(apiUrl, runId);
+        } catch {
+          console.error(chalk.red("Failed to build platform URL"));
+          console.error(chalk.dim(`  API URL: ${apiUrl}`));
+          process.exit(1);
+        }
+
         switch (logType) {
           case "agent":
-            await showAgentEvents(runId, { since, limit, order });
+            await showAgentEvents(runId, { since, limit, order }, platformUrl);
             break;
           case "system":
             await showSystemLog(runId, { since, limit, order });
@@ -226,6 +265,7 @@ async function showAgentEvents(
     limit: number;
     order: "asc" | "desc";
   },
+  platformUrl: string,
 ): Promise<void> {
   const response = await apiClient.getAgentEvents(runId, options);
 
@@ -253,6 +293,7 @@ async function showAgentEvents(
       ),
     );
   }
+  console.log(chalk.dim(`View on platform: ${platformUrl}`));
 }
 
 /**

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -223,16 +223,9 @@ export const logsCommand = new Command()
         );
         const order: "asc" | "desc" = isHead ? "asc" : "desc";
 
-        // Build platform URL (fail fast if invalid)
+        // Build platform URL for agent logs
         const apiUrl = await getApiUrl();
-        let platformUrl: string;
-        try {
-          platformUrl = buildPlatformLogsUrl(apiUrl, runId);
-        } catch {
-          console.error(chalk.red("Failed to build platform URL"));
-          console.error(chalk.dim(`  API URL: ${apiUrl}`));
-          process.exit(1);
-        }
+        const platformUrl = buildPlatformLogsUrl(apiUrl, runId);
 
         switch (logType) {
           case "agent":


### PR DESCRIPTION
## Summary

- Add platform URL output to `vm0 logs` command for easy access to web-based log viewer
- URL appears after agent logs in footer, matching existing CLI hint style
- Only shown for agent logs (not system/metrics/network since platform doesn't support them)

## Changes

- Add `buildPlatformLogsUrl()` function to transform API URL to platform URL
- Transform `www.vm0.ai` → `platform.vm0.ai`
- Handle localhost by using port 3001
- Preserve port for local dev (e.g., `vm7.ai:8443` → `platform.vm7.ai:8443`)

## Output Example

```
[logs output...]

Showing 5 events. Use --tail to see more.
View on platform: https://platform.vm0.ai/logs/run-123
```

## Test plan

- [x] Unit tests added for platform URL display
- [x] Tests verify URL appears for agent logs only
- [x] Tests verify URL transformation for various domains
- [ ] Manual test: `vm0 logs <runId>` shows platform URL
- [ ] Manual test: `vm0 logs <runId> --system` does NOT show platform URL

Closes #2055

🤖 Generated with [Claude Code](https://claude.ai/code)