### PR TITLE
fix(ci): use graceful shutdown for runner to prevent resource leaks

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1184,7 +1184,11 @@ jobs:
           JOB_REF=$(basename "$RUNNER_DIR")
           if [ -n "$JOB_REF" ]; then
             PM2_NAME="vm0-runner-${JOB_REF}"
-            echo "Stopping runner ${PM2_NAME}..."
+            echo "Stopping runner ${PM2_NAME} gracefully..."
+            # Use pm2 stop first to send SIGTERM and allow cleanup (TAP/IP release)
+            # --kill-timeout gives the process 10s to cleanup before SIGKILL
+            ssh $SSH_OPTS ${METAL_USER}@${RUNNER_HOST} "pm2 stop ${PM2_NAME} --kill-timeout 10000 2>/dev/null || true"
+            # Remove from pm2 process list
             ssh $SSH_OPTS ${METAL_USER}@${RUNNER_HOST} "pm2 delete ${PM2_NAME} 2>/dev/null || true"
             echo "Runner stopped"
           fi

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -2,6 +2,7 @@
 // Deployment: Added buildkit cache retry mechanism (issue #1328)
 // CI: Refactored E2E tests with setup_file() - parallel tests use 45s timeout (issue #1555)
 // Perf: Replaced Python vsock-agent with Rust for 16x faster VM startup (issue #1668)
+// CI: Use graceful shutdown for runner to prevent orphaned IP registry entries (issue #2060)
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { doctorCommand } from "./commands/doctor.js";


### PR DESCRIPTION
## Summary
- Use `pm2 stop --kill-timeout 10000` before `pm2 delete` to allow graceful shutdown
- Prevents orphaned IP registry entries on metal runners

## Problem
CI was using `pm2 delete` which sends SIGKILL, preventing cleanup code from running. This left orphaned IP allocations in the registry.

## Solution
Send SIGTERM first via `pm2 stop` with 10s timeout for cleanup, then remove from pm2.

🤖 Generated with [Claude Code](https://claude.ai/code)