### PR TITLE
feat(spec): add slack bot agent trigger specification

### DIFF
--- a/spec/issues/slack-bot-agent-trigger.md
+++ b/spec/issues/slack-bot-agent-trigger.md
@@ -2,20 +2,77 @@
 
 ## Summary
 
-Enable users to trigger VM0 agent runs and continues through @bot mentions in Slack. This feature allows users to create Slack bots on the VM0 platform that bind to an agent compose with pre-configured secrets and variables.
+Enable users to trigger VM0 agent runs and continues through @bot mentions in Slack. Users connect their Slack workspace via OAuth, then create bots that bind to their agents.
 
 ## Motivation
 
-Users want to interact with their VM0 agents directly from Slack without leaving their communication workflow. This is similar to the existing schedule capability but triggered by user mentions instead of cron expressions.
+Users want to interact with their VM0 agents directly from Slack without leaving their communication workflow. The setup should be as simple as possible - no manual Slack App creation required.
 
 ## User Stories
 
-1. As a user, I want to create a Slack bot on VM0 that binds to one of my agents
-2. As a user, I want to @bot in a Slack channel to start a new agent run
-3. As a user, I want to continue a conversation by replying in a Slack thread
-4. As a user, I want to see the agent's result as a reply in the thread
+1. As a user, I want to connect my Slack workspace to VM0 with a simple OAuth flow
+2. As a user, I want to create a Slack bot that binds to one of my agents
+3. As a user, I want to @bot in a Slack channel to start a new agent run
+4. As a user, I want to continue a conversation by replying in a Slack thread
+5. As a user, I want to see the agent's result as a reply in the thread
 
 ## Detailed Design
+
+### Architecture: VM0-Hosted Slack App
+
+VM0 hosts a single Slack App that all users install to their workspaces. This eliminates the need for users to create and configure their own Slack Apps.
+
+**Key characteristics**:
+- Users do OAuth authorization, not Slack App creation
+- VM0 receives events for all connected workspaces (multi-tenant)
+- Events are routed to the correct user's bot based on workspace ID
+
+### User Flow
+
+#### Step 1: Connect Slack Workspace
+
+```bash
+$ vm0 slack connect
+
+Connecting to Slack...
+Opening browser for authorization...
+
+Please authorize VM0 in your Slack workspace.
+
+Waiting for authorization.....
+
+✓ Slack workspace connected: "Acme Corp"
+  Workspace ID: T12345ABC
+```
+
+#### Step 2: Create Bot from Agent
+
+```bash
+$ vm0 slack bot create my-agent
+
+Creating Slack bot for agent "my-agent"...
+
+? Select workspace: Acme Corp (T12345ABC)
+
+Agent requires the following secrets:
+? OPENAI_API_KEY: sk-...
+
+✓ Slack bot created!
+  You can now @VM0 in Acme Corp to trigger "my-agent"
+```
+
+#### Step 3: Use in Slack
+
+```
+User: @VM0 analyze this quarter's sales data
+
+VM0: [thinking...]
+
+VM0: Based on my analysis of Q4 sales data:
+     - Revenue increased 15% QoQ
+     - Top performing region: APAC
+     ...
+```
 
 ### Core Concepts
 
@@ -26,17 +83,16 @@ Users want to interact with their VM0 agents directly from Slack without leaving
 
 #### Permission Model (MVP: Creator-Only)
 
-**Security Constraint**: Only the bot creator can trigger the bot.
+**Security Constraint**: Only the user who connected the workspace can trigger the bot.
 
 Rationale:
-- Allowing anyone in channel to @bot would use creator's secrets without consent
-- Creator's API keys, database passwords, etc. should not be exposed to strangers
-- This differs from Schedule (which is only triggered by cron, not exposed to external users)
+- VM0-hosted app means VM0 controls who triggers
+- Allowing anyone would expose creator's secrets
+- Check Slack user ID against workspace connection owner
 
 Future expansion options:
-- Allowlist: `allowedSlackUserIds: ["U123", "U456"]`
-- Linked users: Require VM0 account binding
-- Per-user secrets: Each user provides their own credentials
+- Allowlist: Configure additional Slack user IDs
+- VM0 account linking: Slack users link their VM0 accounts
 
 #### Secrets Management
 
@@ -47,33 +103,52 @@ Follow the Schedule pattern:
 
 ### Data Model
 
+#### New Table: `slack_workspace_connections`
+
+Stores OAuth tokens for connected Slack workspaces.
+
+```sql
+CREATE TABLE slack_workspace_connections (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id TEXT NOT NULL,                      -- VM0 user (Clerk ID)
+  slack_workspace_id VARCHAR(64) NOT NULL,    -- Slack team_id
+  slack_workspace_name VARCHAR(255),
+  slack_bot_token TEXT NOT NULL,              -- Encrypted xoxb-* token
+  slack_bot_user_id VARCHAR(64),              -- Bot's user ID in Slack
+  slack_installer_user_id VARCHAR(64),        -- Slack user who installed
+  created_at TIMESTAMP DEFAULT NOW() NOT NULL,
+  updated_at TIMESTAMP DEFAULT NOW() NOT NULL,
+
+  UNIQUE(user_id, slack_workspace_id)
+);
+```
+
 #### New Table: `slack_bots`
+
+Links agents to Slack workspaces with runtime configuration.
 
 ```sql
 CREATE TABLE slack_bots (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id TEXT NOT NULL,                    -- Bot creator (Clerk user ID)
+  user_id TEXT NOT NULL,
+  workspace_connection_id UUID NOT NULL REFERENCES slack_workspace_connections(id) ON DELETE CASCADE,
   compose_id UUID NOT NULL REFERENCES agent_composes(id) ON DELETE CASCADE,
-  name VARCHAR(64) NOT NULL,
-
-  -- Slack App credentials (encrypted)
-  slack_bot_token TEXT NOT NULL,            -- xoxb-* token, encrypted
-  slack_signing_secret TEXT NOT NULL,       -- For webhook verification, encrypted
 
   -- Agent runtime configuration
-  encrypted_secrets TEXT,                   -- Same pattern as schedules
+  encrypted_secrets TEXT,
   vars JSONB,
   artifact_name VARCHAR(255),
   volume_versions JSONB,
 
   -- State
-  enabled BOOLEAN DEFAULT false,
+  enabled BOOLEAN DEFAULT true,
 
   -- Timestamps
   created_at TIMESTAMP DEFAULT NOW() NOT NULL,
   updated_at TIMESTAMP DEFAULT NOW() NOT NULL,
 
-  UNIQUE(user_id, name)
+  -- One bot per agent per workspace
+  UNIQUE(workspace_connection_id, compose_id)
 );
 ```
 
@@ -86,81 +161,144 @@ CREATE TABLE slack_thread_sessions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   slack_bot_id UUID NOT NULL REFERENCES slack_bots(id) ON DELETE CASCADE,
   slack_channel_id VARCHAR(64) NOT NULL,
-  slack_thread_ts VARCHAR(64) NOT NULL,     -- Thread timestamp (unique per thread)
+  slack_thread_ts VARCHAR(64) NOT NULL,
   agent_session_id UUID NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
-
   created_at TIMESTAMP DEFAULT NOW() NOT NULL,
 
   UNIQUE(slack_bot_id, slack_channel_id, slack_thread_ts)
 );
 ```
 
+#### New Table: `slack_oauth_sessions`
+
+Temporary storage for OAuth flow (like device_codes for CLI auth).
+
+```sql
+CREATE TABLE slack_oauth_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_token VARCHAR(255) NOT NULL UNIQUE,  -- Random token for CLI polling
+  user_id TEXT NOT NULL,                        -- VM0 user initiating OAuth
+  status VARCHAR(32) DEFAULT 'pending',         -- pending | completed | failed
+  slack_workspace_id VARCHAR(64),               -- Filled after OAuth
+  slack_workspace_name VARCHAR(255),
+  slack_bot_token TEXT,                         -- Encrypted, filled after OAuth
+  error TEXT,
+  expires_at TIMESTAMP NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW() NOT NULL
+);
+```
+
 ### API Endpoints
+
+#### Slack OAuth (CLI Flow)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/cli/slack/connect` | Initiate OAuth, return auth_url + session_token |
+| GET | `/api/cli/slack/connect/status` | Poll for OAuth completion |
+| GET | `/api/slack/oauth/callback` | Slack OAuth redirect handler |
+
+#### Slack Workspace Management
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/agent/slack/workspaces` | List connected workspaces |
+| DELETE | `/api/agent/slack/workspaces/[id]` | Disconnect workspace |
 
 #### Slack Bot Management
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/api/agent/slack-bots` | Create/update Slack bot |
-| GET | `/api/agent/slack-bots` | List user's Slack bots |
-| GET | `/api/agent/slack-bots/[name]` | Get bot by name |
-| DELETE | `/api/agent/slack-bots/[name]` | Delete bot |
-| POST | `/api/agent/slack-bots/[name]/enable` | Enable bot |
-| POST | `/api/agent/slack-bots/[name]/disable` | Disable bot |
+| POST | `/api/agent/slack/bots` | Create bot |
+| GET | `/api/agent/slack/bots` | List bots |
+| DELETE | `/api/agent/slack/bots/[id]` | Delete bot |
 
-#### Slack Webhook
+#### Slack Webhook (from Slack)
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/api/webhooks/slack/events` | Receive Slack events (app_mention) |
+| POST | `/api/webhooks/slack/events` | Receive Slack events |
+
+### CLI Commands
+
+```bash
+# Connect Slack workspace (opens browser for OAuth)
+vm0 slack connect
+
+# List connected workspaces
+vm0 slack workspaces
+
+# Disconnect workspace
+vm0 slack disconnect <workspace-name>
+
+# Create bot from agent
+vm0 slack bot create <agent-name> [--workspace <name>] [--secrets KEY=value]
+
+# List bots
+vm0 slack bot list
+
+# Delete bot
+vm0 slack bot delete <agent-name> [--workspace <name>]
+```
+
+### OAuth Flow Detail
+
+```
+CLI                          VM0 Server                    Slack
+ │                               │                           │
+ │ POST /api/cli/slack/connect   │                           │
+ │ ─────────────────────────────►│                           │
+ │                               │                           │
+ │ { session_token, auth_url }   │                           │
+ │ ◄─────────────────────────────│                           │
+ │                               │                           │
+ │ [Open browser to auth_url]    │                           │
+ │ ═══════════════════════════════════════════════════════► │
+ │                               │                           │
+ │                               │    User clicks "Allow"    │
+ │                               │ ◄═══════════════════════ │
+ │                               │                           │
+ │                               │ GET /callback?code=xxx    │
+ │                               │ ◄═════════════════════════│
+ │                               │                           │
+ │                               │ POST oauth.v2.access      │
+ │                               │ ═════════════════════════►│
+ │                               │                           │
+ │                               │ { bot_token, team_id }    │
+ │                               │ ◄═════════════════════════│
+ │                               │                           │
+ │                               │ [Store in oauth_sessions] │
+ │                               │                           │
+ │ GET /api/cli/slack/connect/status                         │
+ │ ─────────────────────────────►│                           │
+ │                               │                           │
+ │ { status: "completed", workspace_name }                   │
+ │ ◄─────────────────────────────│                           │
+```
 
 ### Webhook Processing Flow
 
 ```
 1. POST /api/webhooks/slack/events
+   {
+     "team_id": "T12345",
+     "event": { "type": "app_mention", "user": "U67890", ... }
+   }
    ↓
-2. Verify Slack signature (signing secret)
+2. Respond HTTP 200 immediately (Slack 3-second requirement)
    ↓
-3. Respond HTTP 200 immediately (Slack 3-second requirement)
+3. Async processing:
+   a. Find workspace_connection by team_id
+   b. Find slack_bot by workspace_connection_id
+   c. Verify trigger permission:
+      - event.user == workspace_connection.slack_installer_user_id?
+   d. Check thread_ts for new vs continue
    ↓
-4. Async processing:
-   a. Parse event (app_mention)
-   b. Find slack_bot by bot_user_id
-   c. Verify trigger permission (creator only for MVP)
-   d. Check thread_ts:
-      - No thread_ts or thread_ts == ts → New session
-      - Has thread_ts and thread_ts != ts → Continue existing session
+4. Create/continue run with bot's secrets
    ↓
-5. Create/continue run:
-   a. Decrypt bot's secrets
-   b. Build execution context
-   c. Dispatch run
+5. Wait for completion
    ↓
-6. Wait for completion (poll or subscribe to Ably)
-   ↓
-7. Post result to Slack thread via chat.postMessage
-```
-
-### CLI Commands
-
-```bash
-# Deploy a Slack bot
-vm0 slack deploy <agent-name> \
-  --name "my-slack-bot" \
-  --bot-token "xoxb-..." \
-  --signing-secret "..." \
-  --secrets KEY=value \
-  --vars KEY=value
-
-# List Slack bots
-vm0 slack list
-
-# Enable/disable
-vm0 slack enable <name>
-vm0 slack disable <name>
-
-# Delete
-vm0 slack delete <name>
+6. Post result to Slack thread via chat.postMessage
 ```
 
 ## Technical Constraints
@@ -168,33 +306,40 @@ vm0 slack delete <name>
 ### Slack API Requirements
 
 1. **3-second response**: Must acknowledge webhook within 3 seconds
-2. **Signing secret verification**: Validate `X-Slack-Signature` header
-3. **Bot token scopes needed**: `app_mentions:read`, `chat:write`, `channels:history`
+2. **OAuth scopes needed**: `app_mentions:read`, `chat:write`
+3. **Event subscription**: `app_mention` event
 
-### VM0 Architecture Constraints
+### VM0 Slack App Setup (One-time)
 
-1. **Session secrets**: Sessions don't store secret values (security design)
-   - Solution: Store encrypted secrets in `slack_bots` table (like schedules)
+VM0 needs to register a Slack App at api.slack.com:
 
-2. **User ownership**: All runs require `userId`
-   - Solution: Use bot creator's userId for all runs
+| Setting | Value |
+|---------|-------|
+| App Name | VM0 Agent |
+| OAuth Redirect URL | `https://api.vm0.ai/api/slack/oauth/callback` |
+| Bot Token Scopes | `app_mentions:read`, `chat:write` |
+| Event Request URL | `https://api.vm0.ai/api/webhooks/slack/events` |
+| Subscribe to events | `app_mention` |
 
-3. **No agent sharing**: Cannot run another user's agent
-   - Not a blocker for MVP (creator-only model)
+### Multi-tenant Considerations
+
+- Single Slack App serves all VM0 users
+- Events routed by `team_id` to correct user's bot
+- All bots appear as "@VM0 Agent" in Slack (single app identity)
 
 ## Security Considerations
 
-1. **Trigger permission**: Only bot creator can @bot (MVP)
-2. **Secret storage**: AES-256-GCM encryption at rest
-3. **Webhook verification**: Validate Slack signing secret
-4. **Token storage**: Bot tokens encrypted like other credentials
+1. **Trigger permission**: Only workspace connection owner can @bot (MVP)
+2. **Secret storage**: AES-256-GCM encryption for bot tokens and agent secrets
+3. **OAuth state**: Use session_token as state parameter to prevent CSRF
+4. **Token refresh**: Handle token expiration (Slack tokens generally don't expire)
 
 ## Out of Scope (Future)
 
 1. Allowlist-based trigger permissions
 2. VM0 account linking for Slack users
 3. Per-user secrets
-4. Multi-workspace support for single bot
+4. Custom bot names per workspace
 5. Streaming responses to Slack
 
 ## Dependencies
@@ -202,10 +347,12 @@ vm0 slack delete <name>
 - Existing: `schedule-service.ts` pattern for encrypted secrets
 - Existing: `agent-session-service.ts` for session management
 - Existing: `run-service.ts` for run orchestration
-- New: Slack SDK or raw API calls for posting messages
+- Existing: CLI auth device code pattern for OAuth polling
+- New: Slack Web API client for posting messages
 
 ## References
 
+- [Slack OAuth 2.0](https://api.slack.com/authentication/oauth-v2)
+- [Slack Events API](https://api.slack.com/apis/events-api)
 - Research document: `/tmp/deep-dive/slack-vm0-agent-bot/research.md`
-- Schedule service: `/turbo/apps/web/src/lib/schedule/schedule-service.ts`
-- Session service: `/turbo/apps/web/src/lib/agent-session/agent-session-service.ts`
+- Innovate document: `/tmp/deep-dive/slack-vm0-agent-bot/innovate/create-slack-bot-flow.md`

--- a/spec/issues/slack-bot-agent-trigger.md
+++ b/spec/issues/slack-bot-agent-trigger.md
@@ -1,0 +1,211 @@
+# Slack Bot for VM0 Agent Run & Continue
+
+## Summary
+
+Enable users to trigger VM0 agent runs and continues through @bot mentions in Slack. This feature allows users to create Slack bots on the VM0 platform that bind to an agent compose with pre-configured secrets and variables.
+
+## Motivation
+
+Users want to interact with their VM0 agents directly from Slack without leaving their communication workflow. This is similar to the existing schedule capability but triggered by user mentions instead of cron expressions.
+
+## User Stories
+
+1. As a user, I want to create a Slack bot on VM0 that binds to one of my agents
+2. As a user, I want to @bot in a Slack channel to start a new agent run
+3. As a user, I want to continue a conversation by replying in a Slack thread
+4. As a user, I want to see the agent's result as a reply in the thread
+
+## Detailed Design
+
+### Core Concepts
+
+#### Thread-to-Session Mapping
+- Main message @bot → Creates new VM0 session
+- Thread reply @bot → Continues existing session
+- Use Slack's `thread_ts` to distinguish between new runs and continues
+
+#### Permission Model (MVP: Creator-Only)
+
+**Security Constraint**: Only the bot creator can trigger the bot.
+
+Rationale:
+- Allowing anyone in channel to @bot would use creator's secrets without consent
+- Creator's API keys, database passwords, etc. should not be exposed to strangers
+- This differs from Schedule (which is only triggered by cron, not exposed to external users)
+
+Future expansion options:
+- Allowlist: `allowedSlackUserIds: ["U123", "U456"]`
+- Linked users: Require VM0 account binding
+- Per-user secrets: Each user provides their own credentials
+
+#### Secrets Management
+
+Follow the Schedule pattern:
+- Store encrypted secrets at bot configuration time
+- Decrypt at runtime for each run
+- Use `SECRETS_ENCRYPTION_KEY` with AES-256-GCM
+
+### Data Model
+
+#### New Table: `slack_bots`
+
+```sql
+CREATE TABLE slack_bots (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id TEXT NOT NULL,                    -- Bot creator (Clerk user ID)
+  compose_id UUID NOT NULL REFERENCES agent_composes(id) ON DELETE CASCADE,
+  name VARCHAR(64) NOT NULL,
+
+  -- Slack App credentials (encrypted)
+  slack_bot_token TEXT NOT NULL,            -- xoxb-* token, encrypted
+  slack_signing_secret TEXT NOT NULL,       -- For webhook verification, encrypted
+
+  -- Agent runtime configuration
+  encrypted_secrets TEXT,                   -- Same pattern as schedules
+  vars JSONB,
+  artifact_name VARCHAR(255),
+  volume_versions JSONB,
+
+  -- State
+  enabled BOOLEAN DEFAULT false,
+
+  -- Timestamps
+  created_at TIMESTAMP DEFAULT NOW() NOT NULL,
+  updated_at TIMESTAMP DEFAULT NOW() NOT NULL,
+
+  UNIQUE(user_id, name)
+);
+```
+
+#### New Table: `slack_thread_sessions`
+
+Maps Slack threads to VM0 sessions for continue operations.
+
+```sql
+CREATE TABLE slack_thread_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slack_bot_id UUID NOT NULL REFERENCES slack_bots(id) ON DELETE CASCADE,
+  slack_channel_id VARCHAR(64) NOT NULL,
+  slack_thread_ts VARCHAR(64) NOT NULL,     -- Thread timestamp (unique per thread)
+  agent_session_id UUID NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
+
+  created_at TIMESTAMP DEFAULT NOW() NOT NULL,
+
+  UNIQUE(slack_bot_id, slack_channel_id, slack_thread_ts)
+);
+```
+
+### API Endpoints
+
+#### Slack Bot Management
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/agent/slack-bots` | Create/update Slack bot |
+| GET | `/api/agent/slack-bots` | List user's Slack bots |
+| GET | `/api/agent/slack-bots/[name]` | Get bot by name |
+| DELETE | `/api/agent/slack-bots/[name]` | Delete bot |
+| POST | `/api/agent/slack-bots/[name]/enable` | Enable bot |
+| POST | `/api/agent/slack-bots/[name]/disable` | Disable bot |
+
+#### Slack Webhook
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/webhooks/slack/events` | Receive Slack events (app_mention) |
+
+### Webhook Processing Flow
+
+```
+1. POST /api/webhooks/slack/events
+   ↓
+2. Verify Slack signature (signing secret)
+   ↓
+3. Respond HTTP 200 immediately (Slack 3-second requirement)
+   ↓
+4. Async processing:
+   a. Parse event (app_mention)
+   b. Find slack_bot by bot_user_id
+   c. Verify trigger permission (creator only for MVP)
+   d. Check thread_ts:
+      - No thread_ts or thread_ts == ts → New session
+      - Has thread_ts and thread_ts != ts → Continue existing session
+   ↓
+5. Create/continue run:
+   a. Decrypt bot's secrets
+   b. Build execution context
+   c. Dispatch run
+   ↓
+6. Wait for completion (poll or subscribe to Ably)
+   ↓
+7. Post result to Slack thread via chat.postMessage
+```
+
+### CLI Commands
+
+```bash
+# Deploy a Slack bot
+vm0 slack deploy <agent-name> \
+  --name "my-slack-bot" \
+  --bot-token "xoxb-..." \
+  --signing-secret "..." \
+  --secrets KEY=value \
+  --vars KEY=value
+
+# List Slack bots
+vm0 slack list
+
+# Enable/disable
+vm0 slack enable <name>
+vm0 slack disable <name>
+
+# Delete
+vm0 slack delete <name>
+```
+
+## Technical Constraints
+
+### Slack API Requirements
+
+1. **3-second response**: Must acknowledge webhook within 3 seconds
+2. **Signing secret verification**: Validate `X-Slack-Signature` header
+3. **Bot token scopes needed**: `app_mentions:read`, `chat:write`, `channels:history`
+
+### VM0 Architecture Constraints
+
+1. **Session secrets**: Sessions don't store secret values (security design)
+   - Solution: Store encrypted secrets in `slack_bots` table (like schedules)
+
+2. **User ownership**: All runs require `userId`
+   - Solution: Use bot creator's userId for all runs
+
+3. **No agent sharing**: Cannot run another user's agent
+   - Not a blocker for MVP (creator-only model)
+
+## Security Considerations
+
+1. **Trigger permission**: Only bot creator can @bot (MVP)
+2. **Secret storage**: AES-256-GCM encryption at rest
+3. **Webhook verification**: Validate Slack signing secret
+4. **Token storage**: Bot tokens encrypted like other credentials
+
+## Out of Scope (Future)
+
+1. Allowlist-based trigger permissions
+2. VM0 account linking for Slack users
+3. Per-user secrets
+4. Multi-workspace support for single bot
+5. Streaming responses to Slack
+
+## Dependencies
+
+- Existing: `schedule-service.ts` pattern for encrypted secrets
+- Existing: `agent-session-service.ts` for session management
+- Existing: `run-service.ts` for run orchestration
+- New: Slack SDK or raw API calls for posting messages
+
+## References
+
+- Research document: `/tmp/deep-dive/slack-vm0-agent-bot/research.md`
+- Schedule service: `/turbo/apps/web/src/lib/schedule/schedule-service.ts`
+- Session service: `/turbo/apps/web/src/lib/agent-session/agent-session-service.ts`

--- a/spec/issues/slack-bot-agent-trigger.md
+++ b/spec/issues/slack-bot-agent-trigger.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Enable users to trigger VM0 agent runs and continues through @bot mentions in Slack. Users connect their Slack workspace via OAuth, then create bots that bind to their agents.
+Enable users to trigger VM0 agent runs and continues through @bot mentions in Slack. Users connect their Slack workspace via OAuth, then bind multiple agents to the workspace. An LLM Router automatically selects the appropriate agent based on the user's message.
 
 ## Motivation
 
@@ -11,10 +11,12 @@ Users want to interact with their VM0 agents directly from Slack without leaving
 ## User Stories
 
 1. As a user, I want to connect my Slack workspace to VM0 with a simple OAuth flow
-2. As a user, I want to create a Slack bot that binds to one of my agents
-3. As a user, I want to @bot in a Slack channel to start a new agent run
-4. As a user, I want to continue a conversation by replying in a Slack thread
-5. As a user, I want to see the agent's result as a reply in the thread
+2. As a user, I want to bind multiple agents to my Slack workspace
+3. As a user, I want to @VM0 in Slack and have the system auto-select the right agent
+4. As a user, I want to explicitly specify an agent with `@VM0 <agent-name> <prompt>`
+5. As a user, I want to continue a conversation by replying in a Slack thread
+6. As a user, I want to see the agent's result as a reply in the thread
+7. As a user, I want to use `/vm0 list` to see my bound agents
 
 ## Detailed Design
 
@@ -45,28 +47,43 @@ Waiting for authorization.....
   Workspace ID: T12345ABC
 ```
 
-#### Step 2: Create Bot from Agent
+#### Step 2: Bind Agents to Workspace
 
 ```bash
-$ vm0 slack bot create my-agent
+$ vm0 slack agent add my-coder
 
-Creating Slack bot for agent "my-agent"...
+Adding agent "my-coder" to Slack workspace...
 
 ? Select workspace: Acme Corp (T12345ABC)
+? Description (for auto-routing): Writes and reviews code, fixes bugs
 
 Agent requires the following secrets:
 ? OPENAI_API_KEY: sk-...
 
-✓ Slack bot created!
-  You can now @VM0 in Acme Corp to trigger "my-agent"
+✓ Agent "my-coder" bound to Acme Corp
+```
+
+```bash
+$ vm0 slack agent add my-analyst
+
+Adding agent "my-analyst" to Slack workspace...
+
+? Select workspace: Acme Corp (T12345ABC)
+? Description (for auto-routing): Analyzes data, creates reports and charts
+
+Agent requires the following secrets:
+? OPENAI_API_KEY: sk-...
+
+✓ Agent "my-analyst" bound to Acme Corp
 ```
 
 #### Step 3: Use in Slack
 
+**Auto-routing (LLM selects agent):**
 ```
 User: @VM0 analyze this quarter's sales data
 
-VM0: [thinking...]
+VM0: [Using my-analyst...]
 
 VM0: Based on my analysis of Q4 sales data:
      - Revenue increased 15% QoQ
@@ -74,12 +91,72 @@ VM0: Based on my analysis of Q4 sales data:
      ...
 ```
 
+**Explicit agent selection:**
+```
+User: @VM0 my-coder fix the bug in auth.ts
+
+VM0: [Using my-coder...]
+
+VM0: I've identified and fixed the authentication bug...
+```
+
+**Continue in thread (same agent):**
+```
+User (in thread): @VM0 also check the login page
+
+VM0: [Continuing with my-coder...]
+
+VM0: I've reviewed the login page as well...
+```
+
+**List bound agents:**
+```
+User: /vm0 list
+
+VM0: Your agents in this workspace:
+     • my-coder - Writes and reviews code, fixes bugs
+     • my-analyst - Analyzes data, creates reports and charts
+```
+
 ### Core Concepts
 
+#### Multi-Agent Routing
+
+Each workspace can have multiple agents bound. When a user @mentions VM0, the system routes to the appropriate agent:
+
+```
+@VM0 <message>
+    │
+    ├─► 1. Existing thread session? → Use same agent (continue)
+    │
+    ├─► 2. Message starts with agent name? (@VM0 my-coder ...) → Use specified agent
+    │
+    ├─► 3. LLM Router selection
+    │       ├─► Match found → Use selected agent
+    │       └─► No match → Prompt user
+    │
+    └─► 4. Prompt: "I have multiple agents available: [list]. Please specify: @VM0 <agent-name> <prompt>"
+```
+
+**LLM Router**: Uses agent descriptions to match user intent. Lightweight LLM call that returns the best-matching agent name or "none".
+
+**Routing Input**:
+```json
+{
+  "user_message": "fix the bug in auth.ts",
+  "agents": [
+    { "name": "my-coder", "description": "Writes and reviews code, fixes bugs" },
+    { "name": "my-analyst", "description": "Analyzes data, creates reports" }
+  ]
+}
+```
+
+**Routing Output**: `"my-coder"` or `"none"`
+
 #### Thread-to-Session Mapping
-- Main message @bot → Creates new VM0 session
-- Thread reply @bot → Continues existing session
-- Use Slack's `thread_ts` to distinguish between new runs and continues
+- Main message @VM0 → Creates new VM0 session with routed agent
+- Thread reply @VM0 → Continues existing session (uses same agent)
+- Use Slack's `thread_ts` to track which agent owns the thread
 
 #### Permission Model (MVP: Creator-Only)
 
@@ -133,6 +210,9 @@ CREATE TABLE slack_bots (
   user_id TEXT NOT NULL,
   workspace_connection_id UUID NOT NULL REFERENCES slack_workspace_connections(id) ON DELETE CASCADE,
   compose_id UUID NOT NULL REFERENCES agent_composes(id) ON DELETE CASCADE,
+
+  -- For LLM Router
+  description TEXT,                           -- User-provided description for auto-routing
 
   -- Agent runtime configuration
   encrypted_secrets TEXT,
@@ -205,19 +285,21 @@ CREATE TABLE slack_oauth_sessions (
 | GET | `/api/agent/slack/workspaces` | List connected workspaces |
 | DELETE | `/api/agent/slack/workspaces/[id]` | Disconnect workspace |
 
-#### Slack Bot Management
+#### Slack Agent Binding
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/api/agent/slack/bots` | Create bot |
-| GET | `/api/agent/slack/bots` | List bots |
-| DELETE | `/api/agent/slack/bots/[id]` | Delete bot |
+| POST | `/api/agent/slack/bots` | Bind agent to workspace |
+| GET | `/api/agent/slack/bots` | List bound agents |
+| PATCH | `/api/agent/slack/bots/[id]` | Update agent binding |
+| DELETE | `/api/agent/slack/bots/[id]` | Remove agent from workspace |
 
-#### Slack Webhook (from Slack)
+#### Slack Webhooks (from Slack)
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/api/webhooks/slack/events` | Receive Slack events |
+| POST | `/api/webhooks/slack/events` | Receive Slack events (app_mention) |
+| POST | `/api/webhooks/slack/commands` | Receive slash commands (/vm0) |
 
 ### CLI Commands
 
@@ -231,14 +313,17 @@ vm0 slack workspaces
 # Disconnect workspace
 vm0 slack disconnect <workspace-name>
 
-# Create bot from agent
-vm0 slack bot create <agent-name> [--workspace <name>] [--secrets KEY=value]
+# Bind agent to workspace
+vm0 slack agent add <agent-name> [--workspace <name>] [--description <desc>] [--secrets KEY=value]
 
-# List bots
-vm0 slack bot list
+# List bound agents
+vm0 slack agent list [--workspace <name>]
 
-# Delete bot
-vm0 slack bot delete <agent-name> [--workspace <name>]
+# Update agent binding (secrets, description)
+vm0 slack agent update <agent-name> [--workspace <name>] [--description <desc>] [--secrets KEY=value]
+
+# Remove agent from workspace
+vm0 slack agent remove <agent-name> [--workspace <name>]
 ```
 
 ### OAuth Flow Detail
@@ -282,17 +367,21 @@ CLI                          VM0 Server                    Slack
 1. POST /api/webhooks/slack/events
    {
      "team_id": "T12345",
-     "event": { "type": "app_mention", "user": "U67890", ... }
+     "event": { "type": "app_mention", "user": "U67890", "text": "@VM0 ...", "thread_ts": ... }
    }
    ↓
 2. Respond HTTP 200 immediately (Slack 3-second requirement)
    ↓
 3. Async processing:
    a. Find workspace_connection by team_id
-   b. Find slack_bot by workspace_connection_id
-   c. Verify trigger permission:
+   b. Verify trigger permission:
       - event.user == workspace_connection.slack_installer_user_id?
-   d. Check thread_ts for new vs continue
+   c. Route to agent:
+      ┌─ Has thread_ts with existing session? → Use session's agent (continue)
+      ├─ Message starts with agent name? → Use specified agent
+      ├─ LLM Router matches? → Use matched agent
+      └─ No match → Reply with agent list, abort
+   d. Find slack_bot for selected agent
    ↓
 4. Create/continue run with bot's secrets
    ↓
@@ -301,13 +390,28 @@ CLI                          VM0 Server                    Slack
 6. Post result to Slack thread via chat.postMessage
 ```
 
+### Slash Command Processing
+
+```
+/vm0 list
+   ↓
+1. Find workspace_connection by team_id
+   ↓
+2. Verify user permission
+   ↓
+3. List all slack_bots for this workspace
+   ↓
+4. Reply with agent list (ephemeral message)
+```
+
 ## Technical Constraints
 
 ### Slack API Requirements
 
 1. **3-second response**: Must acknowledge webhook within 3 seconds
-2. **OAuth scopes needed**: `app_mentions:read`, `chat:write`
+2. **OAuth scopes needed**: `app_mentions:read`, `chat:write`, `commands`
 3. **Event subscription**: `app_mention` event
+4. **Slash command**: `/vm0` with subcommands (`list`)
 
 ### VM0 Slack App Setup (One-time)
 
@@ -315,17 +419,19 @@ VM0 needs to register a Slack App at api.slack.com:
 
 | Setting | Value |
 |---------|-------|
-| App Name | VM0 Agent |
+| App Name | VM0 |
 | OAuth Redirect URL | `https://api.vm0.ai/api/slack/oauth/callback` |
-| Bot Token Scopes | `app_mentions:read`, `chat:write` |
+| Bot Token Scopes | `app_mentions:read`, `chat:write`, `commands` |
 | Event Request URL | `https://api.vm0.ai/api/webhooks/slack/events` |
 | Subscribe to events | `app_mention` |
+| Slash Commands | `/vm0` → `https://api.vm0.ai/api/webhooks/slack/commands` |
 
 ### Multi-tenant Considerations
 
 - Single Slack App serves all VM0 users
-- Events routed by `team_id` to correct user's bot
-- All bots appear as "@VM0 Agent" in Slack (single app identity)
+- Events routed by `team_id` to correct user's workspace
+- LLM Router selects appropriate agent within user's bound agents
+- All responses appear as "@VM0" in Slack (single app identity)
 
 ## Security Considerations
 
@@ -339,8 +445,8 @@ VM0 needs to register a Slack App at api.slack.com:
 1. Allowlist-based trigger permissions
 2. VM0 account linking for Slack users
 3. Per-user secrets
-4. Custom bot names per workspace
-5. Streaming responses to Slack
+4. Streaming responses to Slack
+5. Multiple slash command subcommands (only `/vm0 list` for MVP)
 
 ## Dependencies
 
@@ -349,6 +455,7 @@ VM0 needs to register a Slack App at api.slack.com:
 - Existing: `run-service.ts` for run orchestration
 - Existing: CLI auth device code pattern for OAuth polling
 - New: Slack Web API client for posting messages
+- New: LLM Router service for agent selection (lightweight model call)
 
 ## References
 

--- a/spec/issues/slack-bot-agent-trigger.md
+++ b/spec/issues/slack-bot-agent-trigger.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Enable users to trigger VM0 agent runs and continues through @bot mentions in Slack. Users connect their Slack workspace via OAuth, then bind multiple agents to the workspace. An LLM Router automatically selects the appropriate agent based on the user's message.
+Enable users to trigger VM0 agent runs and continues through @bot mentions in Slack. Each Slack user links their VM0 account and binds their own agents to the workspace. When a user @VM0, they trigger their own agents (not someone else's). An LLM Router automatically selects the appropriate agent based on the user's message.
 
 ## Motivation
 
@@ -10,9 +10,9 @@ Users want to interact with their VM0 agents directly from Slack without leaving
 
 ## User Stories
 
-1. As a user, I want to connect my Slack workspace to VM0 with a simple OAuth flow
-2. As a user, I want to bind multiple agents to my Slack workspace
-3. As a user, I want to @VM0 in Slack and have the system auto-select the right agent
+1. As a user, I want to link my Slack account to my VM0 account
+2. As a user, I want to bind my agents to my Slack workspace
+3. As a user, I want to @VM0 in Slack and have the system auto-select the right agent from MY enabled agents
 4. As a user, I want to explicitly specify an agent with `@VM0 <agent-name> <prompt>`
 5. As a user, I want to continue a conversation by replying in a Slack thread
 6. As a user, I want to see the agent's result as a reply in the thread
@@ -22,32 +22,46 @@ Users want to interact with their VM0 agents directly from Slack without leaving
 
 ### Architecture: VM0-Hosted Slack App
 
-VM0 hosts a single Slack App that all users install to their workspaces. This eliminates the need for users to create and configure their own Slack Apps.
+VM0 hosts a single Slack App that serves all workspaces. Each Slack user links their VM0 account and binds their own agents.
 
 **Key characteristics**:
-- Users do OAuth authorization, not Slack App creation
-- VM0 receives events for all connected workspaces (multi-tenant)
-- Events are routed to the correct user's bot based on workspace ID
+- Single @VM0 bot identity across all workspaces
+- Each Slack user links to their VM0 account
+- Each user binds their own agents with their own secrets
+- When User A @VM0, only User A's agents are available
+- No cross-user secret exposure
 
 ### User Flow
 
-#### Step 1: Connect Slack Workspace
+#### Step 1: Link Slack Account to VM0
 
 ```bash
-$ vm0 slack connect
+$ vm0 slack link
 
-Connecting to Slack...
-Opening browser for authorization...
+Linking Slack account to VM0...
+Opening browser for Slack authorization...
 
-Please authorize VM0 in your Slack workspace.
+Please sign in to Slack and authorize VM0.
 
 Waiting for authorization.....
 
-✓ Slack workspace connected: "Acme Corp"
-  Workspace ID: T12345ABC
+✓ Slack account linked!
+  Workspace: Acme Corp (T12345ABC)
+  Slack User: @alice (U12345)
 ```
 
-#### Step 2: Bind Agents to Workspace
+Or in Slack (first-time @VM0):
+```
+Alice: @VM0 hello
+
+VM0: Hi Alice! Please link your VM0 account first: https://vm0.ai/slack/link?token=xxx
+
+[Alice clicks link, completes OAuth]
+
+VM0: ✓ Account linked! You can now bind agents with `vm0 slack agent add <agent-name>`
+```
+
+#### Step 2: Bind Your Agents to Workspace
 
 ```bash
 $ vm0 slack agent add my-coder
@@ -158,18 +172,29 @@ Each workspace can have multiple agents bound. When a user @mentions VM0, the sy
 - Thread reply @VM0 → Continues existing session (uses same agent)
 - Use Slack's `thread_ts` to track which agent owns the thread
 
-#### Permission Model (MVP: Creator-Only)
+#### Permission Model: User Triggers Own Agents
 
-**Security Constraint**: Only the user who connected the workspace can trigger the bot.
+**Security Principle**: When a user @VM0, they trigger their OWN agents enabled on VM0.
 
-Rationale:
-- VM0-hosted app means VM0 controls who triggers
-- Allowing anyone would expose creator's secrets
-- Check Slack user ID against workspace connection owner
+```
+Slack Workspace "Acme Corp"
+├── Alice (linked to VM0 account alice@acme.com)
+│   └── Enabled agents: my-coder, my-analyst (with Alice's secrets)
+│
+├── Bob (linked to VM0 account bob@acme.com)
+│   └── Enabled agents: research-bot (with Bob's secrets)
+│
+└── Carol (NOT linked to VM0)
+    └── @VM0 → "Please link your VM0 account first"
+```
 
-Future expansion options:
-- Allowlist: Configure additional Slack user IDs
-- VM0 account linking: Slack users link their VM0 accounts
+**Security Properties**:
+- ✅ No one can use another user's secrets
+- ✅ No one can trigger another user's agents
+- ✅ Clear ownership and billing attribution
+- ✅ Per-user audit trail
+
+**Requirement**: Slack users must link their VM0 accounts before using @VM0.
 
 #### Secrets Management
 
@@ -180,39 +205,52 @@ Follow the Schedule pattern:
 
 ### Data Model
 
-#### New Table: `slack_workspace_connections`
+#### New Table: `slack_workspaces`
 
-Stores OAuth tokens for connected Slack workspaces.
+Stores workspace-level OAuth tokens (one per workspace).
 
 ```sql
-CREATE TABLE slack_workspace_connections (
+CREATE TABLE slack_workspaces (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id TEXT NOT NULL,                      -- VM0 user (Clerk ID)
-  slack_workspace_id VARCHAR(64) NOT NULL,    -- Slack team_id
+  slack_workspace_id VARCHAR(64) NOT NULL UNIQUE,  -- Slack team_id
   slack_workspace_name VARCHAR(255),
-  slack_bot_token TEXT NOT NULL,              -- Encrypted xoxb-* token
-  slack_bot_user_id VARCHAR(64),              -- Bot's user ID in Slack
-  slack_installer_user_id VARCHAR(64),        -- Slack user who installed
+  slack_bot_token TEXT NOT NULL,                    -- Encrypted xoxb-* token
+  slack_bot_user_id VARCHAR(64),                    -- Bot's user ID in Slack
+  installed_by_vm0_user_id TEXT NOT NULL,           -- Who first installed
   created_at TIMESTAMP DEFAULT NOW() NOT NULL,
-  updated_at TIMESTAMP DEFAULT NOW() NOT NULL,
-
-  UNIQUE(user_id, slack_workspace_id)
+  updated_at TIMESTAMP DEFAULT NOW() NOT NULL
 );
 ```
 
-#### New Table: `slack_bots`
+#### New Table: `slack_user_links`
 
-Links agents to Slack workspaces with runtime configuration.
+Maps Slack users to VM0 accounts.
 
 ```sql
-CREATE TABLE slack_bots (
+CREATE TABLE slack_user_links (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id TEXT NOT NULL,
-  workspace_connection_id UUID NOT NULL REFERENCES slack_workspace_connections(id) ON DELETE CASCADE,
+  slack_workspace_id VARCHAR(64) NOT NULL,
+  slack_user_id VARCHAR(64) NOT NULL,
+  vm0_user_id TEXT NOT NULL,                        -- Clerk user ID
+  linked_at TIMESTAMP DEFAULT NOW() NOT NULL,
+
+  UNIQUE(slack_workspace_id, slack_user_id)
+);
+```
+
+#### New Table: `slack_agent_bindings`
+
+Each user's agent bindings to a workspace.
+
+```sql
+CREATE TABLE slack_agent_bindings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slack_workspace_id VARCHAR(64) NOT NULL,
+  vm0_user_id TEXT NOT NULL,                         -- Owner
   compose_id UUID NOT NULL REFERENCES agent_composes(id) ON DELETE CASCADE,
 
   -- For LLM Router
-  description TEXT,                           -- User-provided description for auto-routing
+  description TEXT,                                  -- User-provided description for auto-routing
 
   -- Agent runtime configuration
   encrypted_secrets TEXT,
@@ -227,8 +265,8 @@ CREATE TABLE slack_bots (
   created_at TIMESTAMP DEFAULT NOW() NOT NULL,
   updated_at TIMESTAMP DEFAULT NOW() NOT NULL,
 
-  -- One bot per agent per workspace
-  UNIQUE(workspace_connection_id, compose_id)
+  -- One binding per (workspace, user, agent)
+  UNIQUE(slack_workspace_id, vm0_user_id, compose_id)
 );
 ```
 
@@ -239,30 +277,30 @@ Maps Slack threads to VM0 sessions for continue operations.
 ```sql
 CREATE TABLE slack_thread_sessions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  slack_bot_id UUID NOT NULL REFERENCES slack_bots(id) ON DELETE CASCADE,
+  slack_workspace_id VARCHAR(64) NOT NULL,
   slack_channel_id VARCHAR(64) NOT NULL,
   slack_thread_ts VARCHAR(64) NOT NULL,
+  slack_user_id VARCHAR(64) NOT NULL,                -- Slack user who started thread
+  agent_binding_id UUID NOT NULL REFERENCES slack_agent_bindings(id) ON DELETE CASCADE,
   agent_session_id UUID NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
   created_at TIMESTAMP DEFAULT NOW() NOT NULL,
 
-  UNIQUE(slack_bot_id, slack_channel_id, slack_thread_ts)
+  UNIQUE(slack_workspace_id, slack_channel_id, slack_thread_ts)
 );
 ```
 
-#### New Table: `slack_oauth_sessions`
+#### New Table: `slack_link_sessions`
 
-Temporary storage for OAuth flow (like device_codes for CLI auth).
+Temporary storage for account linking flow.
 
 ```sql
-CREATE TABLE slack_oauth_sessions (
+CREATE TABLE slack_link_sessions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  session_token VARCHAR(255) NOT NULL UNIQUE,  -- Random token for CLI polling
-  user_id TEXT NOT NULL,                        -- VM0 user initiating OAuth
-  status VARCHAR(32) DEFAULT 'pending',         -- pending | completed | failed
-  slack_workspace_id VARCHAR(64),               -- Filled after OAuth
-  slack_workspace_name VARCHAR(255),
-  slack_bot_token TEXT,                         -- Encrypted, filled after OAuth
-  error TEXT,
+  link_token VARCHAR(255) NOT NULL UNIQUE,      -- Token in link URL
+  slack_workspace_id VARCHAR(64) NOT NULL,
+  slack_user_id VARCHAR(64) NOT NULL,
+  vm0_user_id TEXT,                              -- Filled after VM0 OAuth
+  status VARCHAR(32) DEFAULT 'pending',          -- pending | completed | expired
   expires_at TIMESTAMP NOT NULL,
   created_at TIMESTAMP DEFAULT NOW() NOT NULL
 );
@@ -270,29 +308,29 @@ CREATE TABLE slack_oauth_sessions (
 
 ### API Endpoints
 
-#### Slack OAuth (CLI Flow)
+#### Account Linking (CLI Flow)
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/api/cli/slack/connect` | Initiate OAuth, return auth_url + session_token |
-| GET | `/api/cli/slack/connect/status` | Poll for OAuth completion |
-| GET | `/api/slack/oauth/callback` | Slack OAuth redirect handler |
+| POST | `/api/cli/slack/link` | Initiate linking, return auth_url + link_token |
+| GET | `/api/cli/slack/link/status` | Poll for linking completion |
+| GET | `/api/slack/link/callback` | VM0 OAuth callback for linking |
 
-#### Slack Workspace Management
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/agent/slack/workspaces` | List connected workspaces |
-| DELETE | `/api/agent/slack/workspaces/[id]` | Disconnect workspace |
-
-#### Slack Agent Binding
+#### Account Linking (Slack-initiated)
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/api/agent/slack/bots` | Bind agent to workspace |
-| GET | `/api/agent/slack/bots` | List bound agents |
-| PATCH | `/api/agent/slack/bots/[id]` | Update agent binding |
-| DELETE | `/api/agent/slack/bots/[id]` | Remove agent from workspace |
+| GET | `/api/slack/link` | Landing page for link URL from Slack |
+| POST | `/api/slack/link/complete` | Complete linking after VM0 OAuth |
+
+#### Agent Binding
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/agent/slack/bindings` | Bind agent to workspace |
+| GET | `/api/agent/slack/bindings` | List my bound agents |
+| PATCH | `/api/agent/slack/bindings/[id]` | Update agent binding |
+| DELETE | `/api/agent/slack/bindings/[id]` | Remove agent from workspace |
 
 #### Slack Webhooks (from Slack)
 
@@ -304,19 +342,19 @@ CREATE TABLE slack_oauth_sessions (
 ### CLI Commands
 
 ```bash
-# Connect Slack workspace (opens browser for OAuth)
-vm0 slack connect
+# Link Slack account to VM0 (opens browser for Slack OAuth)
+vm0 slack link
 
-# List connected workspaces
-vm0 slack workspaces
+# Check link status
+vm0 slack status
 
-# Disconnect workspace
-vm0 slack disconnect <workspace-name>
+# Unlink Slack account
+vm0 slack unlink [--workspace <name>]
 
 # Bind agent to workspace
 vm0 slack agent add <agent-name> [--workspace <name>] [--description <desc>] [--secrets KEY=value]
 
-# List bound agents
+# List my bound agents
 vm0 slack agent list [--workspace <name>]
 
 # Update agent binding (secrets, description)
@@ -326,39 +364,60 @@ vm0 slack agent update <agent-name> [--workspace <name>] [--description <desc>] 
 vm0 slack agent remove <agent-name> [--workspace <name>]
 ```
 
-### OAuth Flow Detail
+### Account Linking Flow (CLI-initiated)
 
 ```
 CLI                          VM0 Server                    Slack
  │                               │                           │
- │ POST /api/cli/slack/connect   │                           │
+ │ POST /api/cli/slack/link      │                           │
  │ ─────────────────────────────►│                           │
  │                               │                           │
- │ { session_token, auth_url }   │                           │
+ │ { link_token, auth_url }      │                           │
  │ ◄─────────────────────────────│                           │
  │                               │                           │
  │ [Open browser to auth_url]    │                           │
  │ ═══════════════════════════════════════════════════════► │
  │                               │                           │
- │                               │    User clicks "Allow"    │
+ │                               │  User signs in to Slack   │
  │                               │ ◄═══════════════════════ │
  │                               │                           │
- │                               │ GET /callback?code=xxx    │
+ │                               │ GET /callback (identity)  │
  │                               │ ◄═════════════════════════│
  │                               │                           │
- │                               │ POST oauth.v2.access      │
- │                               │ ═════════════════════════►│
+ │                               │ [Create user link:        │
+ │                               │  slack_user ↔ vm0_user]   │
  │                               │                           │
- │                               │ { bot_token, team_id }    │
- │                               │ ◄═════════════════════════│
- │                               │                           │
- │                               │ [Store in oauth_sessions] │
- │                               │                           │
- │ GET /api/cli/slack/connect/status                         │
+ │ GET /api/cli/slack/link/status                            │
  │ ─────────────────────────────►│                           │
  │                               │                           │
- │ { status: "completed", workspace_name }                   │
+ │ { status: "completed", workspace: "Acme Corp" }           │
  │ ◄─────────────────────────────│                           │
+```
+
+### Account Linking Flow (Slack-initiated)
+
+```
+Slack                        VM0 Server                    Browser
+ │                               │                           │
+ │ User @VM0 (not linked)        │                           │
+ │ ─────────────────────────────►│                           │
+ │                               │                           │
+ │ Reply: "Link account: [url]"  │                           │
+ │ ◄─────────────────────────────│                           │
+ │                               │                           │
+ │                               │ User clicks link          │
+ │                               │ ◄═════════════════════════│
+ │                               │                           │
+ │                               │ GET /api/slack/link?token=│
+ │                               │ [Show VM0 login page]     │
+ │                               │ ═════════════════════════►│
+ │                               │                           │
+ │                               │ [User logs in to VM0]     │
+ │                               │ ◄═════════════════════════│
+ │                               │                           │
+ │                               │ [Create user link]        │
+ │                               │ [Show success page]       │
+ │                               │ ═════════════════════════►│
 ```
 
 ### Webhook Processing Flow
@@ -373,17 +432,17 @@ CLI                          VM0 Server                    Slack
 2. Respond HTTP 200 immediately (Slack 3-second requirement)
    ↓
 3. Async processing:
-   a. Find workspace_connection by team_id
-   b. Verify trigger permission:
-      - event.user == workspace_connection.slack_installer_user_id?
-   c. Route to agent:
+   a. Find slack_user_link by (team_id, event.user)
+      ├─ Not found → Reply "Please link your VM0 account: [link]", abort
+      └─ Found → Get vm0_user_id
+   b. Route to agent (using THIS USER's agents only):
       ┌─ Has thread_ts with existing session? → Use session's agent (continue)
       ├─ Message starts with agent name? → Use specified agent
-      ├─ LLM Router matches? → Use matched agent
-      └─ No match → Reply with agent list, abort
-   d. Find slack_bot for selected agent
+      ├─ LLM Router on user's agents → Use matched agent
+      └─ No match → Reply with user's agent list, abort
+   c. Find slack_agent_binding for selected agent
    ↓
-4. Create/continue run with bot's secrets
+4. Create/continue run with user's binding secrets
    ↓
 5. Wait for completion
    ↓
@@ -395,13 +454,13 @@ CLI                          VM0 Server                    Slack
 ```
 /vm0 list
    ↓
-1. Find workspace_connection by team_id
+1. Find slack_user_link by (team_id, user_id)
+   ├─ Not found → "Please link your VM0 account first"
+   └─ Found → Get vm0_user_id
    ↓
-2. Verify user permission
+2. List slack_agent_bindings for (workspace, vm0_user_id)
    ↓
-3. List all slack_bots for this workspace
-   ↓
-4. Reply with agent list (ephemeral message)
+3. Reply with THIS USER's agent list (ephemeral message)
 ```
 
 ## Technical Constraints
@@ -428,25 +487,25 @@ VM0 needs to register a Slack App at api.slack.com:
 
 ### Multi-tenant Considerations
 
-- Single Slack App serves all VM0 users
-- Events routed by `team_id` to correct user's workspace
-- LLM Router selects appropriate agent within user's bound agents
+- Single Slack App serves all workspaces
+- Events routed by `(team_id, slack_user_id)` to correct VM0 user
+- Each user's agents are isolated - LLM Router only sees that user's agents
 - All responses appear as "@VM0" in Slack (single app identity)
 
 ## Security Considerations
 
-1. **Trigger permission**: Only workspace connection owner can @bot (MVP)
-2. **Secret storage**: AES-256-GCM encryption for bot tokens and agent secrets
-3. **OAuth state**: Use session_token as state parameter to prevent CSRF
-4. **Token refresh**: Handle token expiration (Slack tokens generally don't expire)
+1. **User isolation**: Each user triggers their own agents with their own secrets
+2. **No cross-user access**: Users cannot see or trigger other users' agents
+3. **Account linking required**: Unlinked Slack users cannot use @VM0
+4. **Secret storage**: AES-256-GCM encryption for bot tokens and agent secrets
+5. **OAuth state**: Use link_token as state parameter to prevent CSRF
 
 ## Out of Scope (Future)
 
-1. Allowlist-based trigger permissions
-2. VM0 account linking for Slack users
-3. Per-user secrets
-4. Streaming responses to Slack
-5. Multiple slash command subcommands (only `/vm0 list` for MVP)
+1. Team/shared agents (all users see same agents)
+2. Streaming responses to Slack
+3. Multiple slash command subcommands (only `/vm0 list` for MVP)
+4. Cross-workspace agent sharing
 
 ## Dependencies
 

--- a/spec/issues/slack-bot-agent-trigger.md
+++ b/spec/issues/slack-bot-agent-trigger.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Enable users to trigger VM0 agent runs and continues through @bot mentions in Slack. Each Slack user links their VM0 account and binds their own agents to the workspace. When a user @VM0, they trigger their own agents (not someone else's). An LLM Router automatically selects the appropriate agent based on the user's message.
+Enable users to trigger VM0 agent runs and continues through @bot mentions in Slack. Each Slack user links their VM0 account and creates bindings (agent + secrets) in the workspace. When a user @VM0, they use their own bindings with their own secrets. An LLM Router automatically selects the appropriate agent based on the user's message.
 
 ## Motivation
 
@@ -146,25 +146,35 @@ Each user can bind multiple agents to a workspace. When @VM0 is triggered, the s
 - Thread reply @VM0 → Continues existing session (uses same agent)
 - Use Slack's `thread_ts` to track which agent owns the thread
 
-#### Permission Model: User Triggers Own Agents
+#### Permission Model: Binding Ownership
 
-**Security Principle**: When a user @VM0, they trigger their OWN agents enabled on VM0.
+**Key Distinction**:
+- **Agent** = Definition only, does not hold secrets. May be public in the future (like GitHub repos).
+- **Binding** = User's instance of an agent with their secrets. Similar to Schedule. Belongs to a scope.
+
+When a user binds an agent to Slack (their own or a public agent), they create a **binding entity** that:
+- Stores their secrets (encrypted)
+- Belongs to their scope
+- Is only accessible by them
 
 ```
 Slack Workspace "Acme Corp"
-├── Alice (linked to VM0 account alice@acme.com)
-│   └── Enabled agents: my-coder, my-analyst (with Alice's secrets)
+├── Alice (linked to VM0 account)
+│   └── Bindings:
+│       • my-coder (Alice's agent + Alice's secrets)
+│       • public/data-analyst (public agent + Alice's secrets)
 │
-├── Bob (linked to VM0 account bob@acme.com)
-│   └── Enabled agents: research-bot (with Bob's secrets)
+├── Bob (linked to VM0 account)
+│   └── Bindings:
+│       • research-bot (Bob's agent + Bob's secrets)
 │
 └── Carol (NOT linked to VM0)
     └── @VM0 → "Please link your VM0 account first"
 ```
 
 **Security Properties**:
-- No one can use another user's secrets
-- No one can trigger another user's agents
+- No one can use another user's secrets (secrets belong to binding, not agent)
+- No one can use another user's bindings
 - Clear ownership and billing attribution
 - Per-user audit trail
 
@@ -178,16 +188,18 @@ Follow the Schedule pattern:
 
 ## Security Considerations
 
-1. **User isolation**: Each user triggers their own agents with their own secrets
-2. **No cross-user access**: Users cannot see or trigger other users' agents
+1. **Binding isolation**: Secrets belong to bindings (not agents). Each user's bindings are isolated.
+2. **No cross-user secret access**: Users cannot access another user's bindings or secrets
 3. **Account linking required**: Unlinked Slack users cannot use @VM0
+4. **Public agents supported**: Users can bind public agents but use their own secrets
 
 ## Out of Scope (Future)
 
-1. Team/shared agents (all users see same agents)
-2. Streaming responses to Slack
-3. Multiple slash command subcommands (only `/vm0 list` for MVP)
-4. Cross-workspace agent sharing
+1. Public agents (users can share agent definitions)
+2. Team/shared bindings (all users see same bindings)
+3. Streaming responses to Slack
+4. Multiple slash command subcommands (only `/vm0 list` for MVP)
+5. Cross-workspace binding sharing
 
 ## References
 

--- a/spec/issues/slack-bot-agent-trigger.md
+++ b/spec/issues/slack-bot-agent-trigger.md
@@ -77,20 +77,6 @@ Agent requires the following secrets:
 ✓ Agent "my-coder" bound to Acme Corp
 ```
 
-```bash
-$ vm0 slack agent add my-analyst
-
-Adding agent "my-analyst" to Slack workspace...
-
-? Select workspace: Acme Corp (T12345ABC)
-? Description (for auto-routing): Analyzes data, creates reports and charts
-
-Agent requires the following secrets:
-? OPENAI_API_KEY: sk-...
-
-✓ Agent "my-analyst" bound to Acme Corp
-```
-
 #### Step 3: Use in Slack
 
 **Auto-routing (LLM selects agent):**
@@ -136,7 +122,7 @@ VM0: Your agents in this workspace:
 
 #### Multi-Agent Routing
 
-Each workspace can have multiple agents bound. When a user @mentions VM0, the system routes to the appropriate agent:
+Each user can bind multiple agents to a workspace. When @VM0 is triggered, the system routes to the appropriate agent:
 
 ```
 @VM0 <message>
@@ -152,22 +138,10 @@ Each workspace can have multiple agents bound. When a user @mentions VM0, the sy
     └─► 4. Prompt: "I have multiple agents available: [list]. Please specify: @VM0 <agent-name> <prompt>"
 ```
 
-**LLM Router**: Uses agent descriptions to match user intent. Lightweight LLM call that returns the best-matching agent name or "none".
-
-**Routing Input**:
-```json
-{
-  "user_message": "fix the bug in auth.ts",
-  "agents": [
-    { "name": "my-coder", "description": "Writes and reviews code, fixes bugs" },
-    { "name": "my-analyst", "description": "Analyzes data, creates reports" }
-  ]
-}
-```
-
-**Routing Output**: `"my-coder"` or `"none"`
+**LLM Router**: Uses agent descriptions to match user intent. Returns the best-matching agent name or "none".
 
 #### Thread-to-Session Mapping
+
 - Main message @VM0 → Creates new VM0 session with routed agent
 - Thread reply @VM0 → Continues existing session (uses same agent)
 - Use Slack's `thread_ts` to track which agent owns the thread
@@ -189,316 +163,24 @@ Slack Workspace "Acme Corp"
 ```
 
 **Security Properties**:
-- ✅ No one can use another user's secrets
-- ✅ No one can trigger another user's agents
-- ✅ Clear ownership and billing attribution
-- ✅ Per-user audit trail
+- No one can use another user's secrets
+- No one can trigger another user's agents
+- Clear ownership and billing attribution
+- Per-user audit trail
 
 **Requirement**: Slack users must link their VM0 accounts before using @VM0.
 
 #### Secrets Management
 
 Follow the Schedule pattern:
-- Store encrypted secrets at bot configuration time
+- Store encrypted secrets at agent binding time
 - Decrypt at runtime for each run
-- Use `SECRETS_ENCRYPTION_KEY` with AES-256-GCM
-
-### Data Model
-
-#### New Table: `slack_workspaces`
-
-Stores workspace-level OAuth tokens (one per workspace).
-
-```sql
-CREATE TABLE slack_workspaces (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  slack_workspace_id VARCHAR(64) NOT NULL UNIQUE,  -- Slack team_id
-  slack_workspace_name VARCHAR(255),
-  slack_bot_token TEXT NOT NULL,                    -- Encrypted xoxb-* token
-  slack_bot_user_id VARCHAR(64),                    -- Bot's user ID in Slack
-  installed_by_vm0_user_id TEXT NOT NULL,           -- Who first installed
-  created_at TIMESTAMP DEFAULT NOW() NOT NULL,
-  updated_at TIMESTAMP DEFAULT NOW() NOT NULL
-);
-```
-
-#### New Table: `slack_user_links`
-
-Maps Slack users to VM0 accounts.
-
-```sql
-CREATE TABLE slack_user_links (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  slack_workspace_id VARCHAR(64) NOT NULL,
-  slack_user_id VARCHAR(64) NOT NULL,
-  vm0_user_id TEXT NOT NULL,                        -- Clerk user ID
-  linked_at TIMESTAMP DEFAULT NOW() NOT NULL,
-
-  UNIQUE(slack_workspace_id, slack_user_id)
-);
-```
-
-#### New Table: `slack_agent_bindings`
-
-Each user's agent bindings to a workspace.
-
-```sql
-CREATE TABLE slack_agent_bindings (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  slack_workspace_id VARCHAR(64) NOT NULL,
-  vm0_user_id TEXT NOT NULL,                         -- Owner
-  compose_id UUID NOT NULL REFERENCES agent_composes(id) ON DELETE CASCADE,
-
-  -- For LLM Router
-  description TEXT,                                  -- User-provided description for auto-routing
-
-  -- Agent runtime configuration
-  encrypted_secrets TEXT,
-  vars JSONB,
-  artifact_name VARCHAR(255),
-  volume_versions JSONB,
-
-  -- State
-  enabled BOOLEAN DEFAULT true,
-
-  -- Timestamps
-  created_at TIMESTAMP DEFAULT NOW() NOT NULL,
-  updated_at TIMESTAMP DEFAULT NOW() NOT NULL,
-
-  -- One binding per (workspace, user, agent)
-  UNIQUE(slack_workspace_id, vm0_user_id, compose_id)
-);
-```
-
-#### New Table: `slack_thread_sessions`
-
-Maps Slack threads to VM0 sessions for continue operations.
-
-```sql
-CREATE TABLE slack_thread_sessions (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  slack_workspace_id VARCHAR(64) NOT NULL,
-  slack_channel_id VARCHAR(64) NOT NULL,
-  slack_thread_ts VARCHAR(64) NOT NULL,
-  slack_user_id VARCHAR(64) NOT NULL,                -- Slack user who started thread
-  agent_binding_id UUID NOT NULL REFERENCES slack_agent_bindings(id) ON DELETE CASCADE,
-  agent_session_id UUID NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
-  created_at TIMESTAMP DEFAULT NOW() NOT NULL,
-
-  UNIQUE(slack_workspace_id, slack_channel_id, slack_thread_ts)
-);
-```
-
-#### New Table: `slack_link_sessions`
-
-Temporary storage for account linking flow.
-
-```sql
-CREATE TABLE slack_link_sessions (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  link_token VARCHAR(255) NOT NULL UNIQUE,      -- Token in link URL
-  slack_workspace_id VARCHAR(64) NOT NULL,
-  slack_user_id VARCHAR(64) NOT NULL,
-  vm0_user_id TEXT,                              -- Filled after VM0 OAuth
-  status VARCHAR(32) DEFAULT 'pending',          -- pending | completed | expired
-  expires_at TIMESTAMP NOT NULL,
-  created_at TIMESTAMP DEFAULT NOW() NOT NULL
-);
-```
-
-### API Endpoints
-
-#### Account Linking (CLI Flow)
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| POST | `/api/cli/slack/link` | Initiate linking, return auth_url + link_token |
-| GET | `/api/cli/slack/link/status` | Poll for linking completion |
-| GET | `/api/slack/link/callback` | VM0 OAuth callback for linking |
-
-#### Account Linking (Slack-initiated)
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/slack/link` | Landing page for link URL from Slack |
-| POST | `/api/slack/link/complete` | Complete linking after VM0 OAuth |
-
-#### Agent Binding
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| POST | `/api/agent/slack/bindings` | Bind agent to workspace |
-| GET | `/api/agent/slack/bindings` | List my bound agents |
-| PATCH | `/api/agent/slack/bindings/[id]` | Update agent binding |
-| DELETE | `/api/agent/slack/bindings/[id]` | Remove agent from workspace |
-
-#### Slack Webhooks (from Slack)
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| POST | `/api/webhooks/slack/events` | Receive Slack events (app_mention) |
-| POST | `/api/webhooks/slack/commands` | Receive slash commands (/vm0) |
-
-### CLI Commands
-
-```bash
-# Link Slack account to VM0 (opens browser for Slack OAuth)
-vm0 slack link
-
-# Check link status
-vm0 slack status
-
-# Unlink Slack account
-vm0 slack unlink [--workspace <name>]
-
-# Bind agent to workspace
-vm0 slack agent add <agent-name> [--workspace <name>] [--description <desc>] [--secrets KEY=value]
-
-# List my bound agents
-vm0 slack agent list [--workspace <name>]
-
-# Update agent binding (secrets, description)
-vm0 slack agent update <agent-name> [--workspace <name>] [--description <desc>] [--secrets KEY=value]
-
-# Remove agent from workspace
-vm0 slack agent remove <agent-name> [--workspace <name>]
-```
-
-### Account Linking Flow (CLI-initiated)
-
-```
-CLI                          VM0 Server                    Slack
- │                               │                           │
- │ POST /api/cli/slack/link      │                           │
- │ ─────────────────────────────►│                           │
- │                               │                           │
- │ { link_token, auth_url }      │                           │
- │ ◄─────────────────────────────│                           │
- │                               │                           │
- │ [Open browser to auth_url]    │                           │
- │ ═══════════════════════════════════════════════════════► │
- │                               │                           │
- │                               │  User signs in to Slack   │
- │                               │ ◄═══════════════════════ │
- │                               │                           │
- │                               │ GET /callback (identity)  │
- │                               │ ◄═════════════════════════│
- │                               │                           │
- │                               │ [Create user link:        │
- │                               │  slack_user ↔ vm0_user]   │
- │                               │                           │
- │ GET /api/cli/slack/link/status                            │
- │ ─────────────────────────────►│                           │
- │                               │                           │
- │ { status: "completed", workspace: "Acme Corp" }           │
- │ ◄─────────────────────────────│                           │
-```
-
-### Account Linking Flow (Slack-initiated)
-
-```
-Slack                        VM0 Server                    Browser
- │                               │                           │
- │ User @VM0 (not linked)        │                           │
- │ ─────────────────────────────►│                           │
- │                               │                           │
- │ Reply: "Link account: [url]"  │                           │
- │ ◄─────────────────────────────│                           │
- │                               │                           │
- │                               │ User clicks link          │
- │                               │ ◄═════════════════════════│
- │                               │                           │
- │                               │ GET /api/slack/link?token=│
- │                               │ [Show VM0 login page]     │
- │                               │ ═════════════════════════►│
- │                               │                           │
- │                               │ [User logs in to VM0]     │
- │                               │ ◄═════════════════════════│
- │                               │                           │
- │                               │ [Create user link]        │
- │                               │ [Show success page]       │
- │                               │ ═════════════════════════►│
-```
-
-### Webhook Processing Flow
-
-```
-1. POST /api/webhooks/slack/events
-   {
-     "team_id": "T12345",
-     "event": { "type": "app_mention", "user": "U67890", "text": "@VM0 ...", "thread_ts": ... }
-   }
-   ↓
-2. Respond HTTP 200 immediately (Slack 3-second requirement)
-   ↓
-3. Async processing:
-   a. Find slack_user_link by (team_id, event.user)
-      ├─ Not found → Reply "Please link your VM0 account: [link]", abort
-      └─ Found → Get vm0_user_id
-   b. Route to agent (using THIS USER's agents only):
-      ┌─ Has thread_ts with existing session? → Use session's agent (continue)
-      ├─ Message starts with agent name? → Use specified agent
-      ├─ LLM Router on user's agents → Use matched agent
-      └─ No match → Reply with user's agent list, abort
-   c. Find slack_agent_binding for selected agent
-   ↓
-4. Create/continue run with user's binding secrets
-   ↓
-5. Wait for completion
-   ↓
-6. Post result to Slack thread via chat.postMessage
-```
-
-### Slash Command Processing
-
-```
-/vm0 list
-   ↓
-1. Find slack_user_link by (team_id, user_id)
-   ├─ Not found → "Please link your VM0 account first"
-   └─ Found → Get vm0_user_id
-   ↓
-2. List slack_agent_bindings for (workspace, vm0_user_id)
-   ↓
-3. Reply with THIS USER's agent list (ephemeral message)
-```
-
-## Technical Constraints
-
-### Slack API Requirements
-
-1. **3-second response**: Must acknowledge webhook within 3 seconds
-2. **OAuth scopes needed**: `app_mentions:read`, `chat:write`, `commands`
-3. **Event subscription**: `app_mention` event
-4. **Slash command**: `/vm0` with subcommands (`list`)
-
-### VM0 Slack App Setup (One-time)
-
-VM0 needs to register a Slack App at api.slack.com:
-
-| Setting | Value |
-|---------|-------|
-| App Name | VM0 |
-| OAuth Redirect URL | `https://api.vm0.ai/api/slack/oauth/callback` |
-| Bot Token Scopes | `app_mentions:read`, `chat:write`, `commands` |
-| Event Request URL | `https://api.vm0.ai/api/webhooks/slack/events` |
-| Subscribe to events | `app_mention` |
-| Slash Commands | `/vm0` → `https://api.vm0.ai/api/webhooks/slack/commands` |
-
-### Multi-tenant Considerations
-
-- Single Slack App serves all workspaces
-- Events routed by `(team_id, slack_user_id)` to correct VM0 user
-- Each user's agents are isolated - LLM Router only sees that user's agents
-- All responses appear as "@VM0" in Slack (single app identity)
 
 ## Security Considerations
 
 1. **User isolation**: Each user triggers their own agents with their own secrets
 2. **No cross-user access**: Users cannot see or trigger other users' agents
 3. **Account linking required**: Unlinked Slack users cannot use @VM0
-4. **Secret storage**: AES-256-GCM encryption for bot tokens and agent secrets
-5. **OAuth state**: Use link_token as state parameter to prevent CSRF
 
 ## Out of Scope (Future)
 
@@ -507,18 +189,8 @@ VM0 needs to register a Slack App at api.slack.com:
 3. Multiple slash command subcommands (only `/vm0 list` for MVP)
 4. Cross-workspace agent sharing
 
-## Dependencies
-
-- Existing: `schedule-service.ts` pattern for encrypted secrets
-- Existing: `agent-session-service.ts` for session management
-- Existing: `run-service.ts` for run orchestration
-- Existing: CLI auth device code pattern for OAuth polling
-- New: Slack Web API client for posting messages
-- New: LLM Router service for agent selection (lightweight model call)
-
 ## References
 
 - [Slack OAuth 2.0](https://api.slack.com/authentication/oauth-v2)
 - [Slack Events API](https://api.slack.com/apis/events-api)
 - Research document: `/tmp/deep-dive/slack-vm0-agent-bot/research.md`
-- Innovate document: `/tmp/deep-dive/slack-vm0-agent-bot/innovate/create-slack-bot-flow.md`


### PR DESCRIPTION
Add detailed specification for Slack bot integration that allows users
to trigger VM0 agent runs and continues through @bot mentions.

Key design decisions:
- Creator-only trigger permission for security
- Thread-to-session mapping for continue operations
- Encrypted secrets storage following schedule pattern
- Async webhook processing for Slack 3-second requirement

https://claude.ai/code/session_0126tMJobFjnxYvSDfjBUJFf