### PR TITLE
chore(cli): update onboard banner messaging

### DIFF
--- a/turbo/apps/cli/src/commands/onboard/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/onboard/__tests__/index.test.ts
@@ -189,7 +189,9 @@ describe("onboard command", () => {
       await onboardCommand.parseAsync(["node", "cli", "-y"]);
 
       const logCalls = vi.mocked(console.log).mock.calls.flat().join("\n");
-      expect(logCalls).toContain("Welcome to VM0!");
+      expect(logCalls).toContain(
+        "Build agentic workflows using natural language.",
+      );
     });
   });
 

--- a/turbo/apps/cli/src/lib/ui/welcome-box.ts
+++ b/turbo/apps/cli/src/lib/ui/welcome-box.ts
@@ -40,9 +40,10 @@ function renderVm0Banner(): void {
  */
 export function renderOnboardWelcome(): void {
   renderVm0Banner();
-  console.log(`  ${chalk.bold("Welcome to VM0!")}`);
+  console.log(`  Build agentic workflows using natural language.`);
+  console.log(`  ${chalk.dim("Currently in beta, enjoy it free.")}`);
   console.log(
-    `  ${chalk.dim("Build agentic workflows using natural language.")}`,
+    `  ${chalk.dim("Star us on GitHub: https://github.com/vm0-ai/vm0")}`,
   );
   console.log();
 }


### PR DESCRIPTION
## Summary
- Remove "Welcome to VM0!" greeting
- Keep tagline "Build agentic workflows using natural language." as first line
- Add beta status: "Currently in beta, enjoy it free."
- Add GitHub star CTA: "Star us on GitHub: https://github.com/vm0-ai/vm0"

## Preview
```
██╗   ██╗███╗   ███╗ ██████╗ 
██║   ██║████╗ ████║██╔═████╗
██║   ██║██╔████╔██║██║██╔██║
╚██╗ ██╔╝██║╚██╔╝██║████╔╝██║
 ╚████╔╝ ██║ ╚═╝ ██║╚██████╔╝
  ╚═══╝  ╚═╝     ╚═╝ ╚═════╝ 

  Build agentic workflows using natural language.
  Currently in beta, enjoy it free.
  Star us on GitHub: https://github.com/vm0-ai/vm0
```

## Test plan
- [ ] Run `vm0 onboard` and verify the banner displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)