### PR TITLE
refactor(e2e): optimize env-expansion tests (8 vm0 runs → 1)

### DIFF
--- a/e2e/tests/02-parallel/t12-vm0-env-expansion.bats
+++ b/e2e/tests/02-parallel/t12-vm0-env-expansion.bats
@@ -91,153 +91,22 @@ setup_artifact() {
     refute_output --partial "SECRET=${SECRET_VALUE}"
 }
 
-# Note: The following tests have been moved to unit tests in variable-expander.spec.ts:
-# - "vm0 run loads secrets from environment variables"
-# - "vm0 run loads vars from environment variables"
-# - "vm0 run loads secrets from .env file"
-# - "vm0 run --secrets flag takes priority over env vars"
-# - "vm0 run fails when required secret is missing"
-# - "vm0 run fails when required vars are missing"
-
-@test "vm0 run with multiple --secrets flags" {
-    echo "# Step 1: Create config with multiple secrets"
-    local MULTI_SECRET_CONFIG="$(mktemp)"
-    cat > "$MULTI_SECRET_CONFIG" <<EOF
-version: "1.0"
-
-agents:
-  multi-secrets:
-    description: "Test agent with multiple secrets"
-    framework: claude-code
-    image: "vm0/claude-code:dev"
-    working_dir: /home/user/workspace
-    environment:
-      SECRET_A: "\${{ secrets.SECRET_A }}"
-      SECRET_B: "\${{ secrets.SECRET_B }}"
-    volumes:
-      - claude-files:/home/user/.config/claude
-
-volumes:
-  claude-files:
-    name: $VOLUME_NAME
-    version: latest
-EOF
-
-    echo "# Step 2: Create and push artifact"
-    setup_artifact
-
-    echo "# Step 3: Build the compose"
-    run $CLI_COMMAND compose "$MULTI_SECRET_CONFIG"
-    assert_success
-
-    echo "# Step 4: Run with multiple --secrets flags"
-    local SECRET_A_VALUE="secret-a-${UNIQUE_ID}"
-    local SECRET_B_VALUE="secret-b-${UNIQUE_ID}"
-
-    run $CLI_COMMAND run multi-secrets \
-        --secrets "SECRET_A=${SECRET_A_VALUE}" \
-        --secrets "SECRET_B=${SECRET_B_VALUE}" \
-        --artifact-name "$ARTIFACT_NAME" \
-        --verbose \
-        "echo A=\$SECRET_A && echo B=\$SECRET_B"
-    assert_success
-
-    echo "# Step 5: Verify both secrets are masked"
-    assert_output --partial "A=***"
-    assert_output --partial "B=***"
-    refute_output --partial "secret-a-"
-    refute_output --partial "secret-b-"
-
-    # Cleanup
-    rm -f "$MULTI_SECRET_CONFIG"
-}
-
-@test "vm0 run continue requires secrets to be re-provided" {
-    echo "# Step 1: Create and push artifact"
-    setup_artifact
-
-    echo "# Step 2: Build the compose"
-    run $CLI_COMMAND compose "$TEST_CONFIG"
-    assert_success
-
-    echo "# Step 3: Run initial session with secrets"
-    run $CLI_COMMAND run "$AGENT_NAME" \
-        --vars "testVar=${VAR_VALUE}" \
-        --secrets "TEST_SECRET=${SECRET_VALUE}" \
-        --artifact-name "$ARTIFACT_NAME" \
-        --verbose \
-        "echo INITIAL && echo SECRET=\$TEST_SECRET"
-    assert_success
-    assert_output --partial "INITIAL"
-    assert_output --partial "SECRET=***"
-
-    echo "# Step 4: Extract session ID"
-    SESSION_ID=$(echo "$output" | grep -oP 'Session:\s*\K[a-f0-9-]{36}' | head -1)
-    [ -n "$SESSION_ID" ] || {
-        echo "# Failed to extract session ID from output:"
-        echo "$output"
-        return 1
-    }
-    echo "# Extracted session ID: $SESSION_ID"
-
-    echo "# Step 5: Continue WITHOUT secrets fails with helpful message"
-    # Secrets are never persisted - must be provided on every run
-    run $CLI_COMMAND run continue "$SESSION_ID" \
-        "echo CONTINUED"
-    assert_failure
-    assert_output --partial "Missing required secrets: TEST_SECRET"
-    assert_output --partial "--secrets TEST_SECRET=<value>"
-
-    echo "# Step 6: Continue WITH secrets succeeds"
-    run $CLI_COMMAND run continue "$SESSION_ID" \
-        --secrets "TEST_SECRET=${SECRET_VALUE}" \
-        --verbose \
-        "echo CONTINUED && echo SECRET=\$TEST_SECRET"
-    assert_success
-    assert_output --partial "CONTINUED"
-    assert_output --partial "SECRET=***"
-}
-
-@test "vm0 run resume requires secrets to be re-provided" {
-    echo "# Step 1: Create and push artifact"
-    setup_artifact
-
-    echo "# Step 2: Build the compose"
-    run $CLI_COMMAND compose "$TEST_CONFIG"
-    assert_success
-
-    echo "# Step 3: Run initial session with secrets"
-    run $CLI_COMMAND run "$AGENT_NAME" \
-        --vars "testVar=${VAR_VALUE}" \
-        --secrets "TEST_SECRET=${SECRET_VALUE}" \
-        --artifact-name "$ARTIFACT_NAME" \
-        --verbose \
-        "echo INITIAL && echo SECRET=\$TEST_SECRET"
-    assert_success
-
-    echo "# Step 4: Extract checkpoint ID"
-    CHECKPOINT_ID=$(echo "$output" | grep -oP 'Checkpoint:\s*\K[a-f0-9-]{36}' | head -1)
-    [ -n "$CHECKPOINT_ID" ] || {
-        echo "# Failed to extract checkpoint ID from output:"
-        echo "$output"
-        return 1
-    }
-    echo "# Extracted checkpoint ID: $CHECKPOINT_ID"
-
-    echo "# Step 5: Resume WITHOUT secrets fails with helpful message"
-    # Secrets are never persisted - must be provided on every run
-    run $CLI_COMMAND run resume "$CHECKPOINT_ID" \
-        "echo RESUMED"
-    assert_failure
-    assert_output --partial "Missing required secrets: TEST_SECRET"
-    assert_output --partial "--secrets TEST_SECRET=<value>"
-
-    echo "# Step 6: Resume WITH secrets succeeds"
-    run $CLI_COMMAND run resume "$CHECKPOINT_ID" \
-        --secrets "TEST_SECRET=${SECRET_VALUE}" \
-        --verbose \
-        "echo RESUMED && echo SECRET=\$TEST_SECRET"
-    assert_success
-    assert_output --partial "RESUMED"
-    assert_output --partial "SECRET=***"
-}
+# Note: The following tests have been moved to other test layers:
+#
+# 1. Unit tests (apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts):
+#    - Missing required secrets validation
+#    - Partial secrets validation
+#    - Usage hints (--secrets, --env-file)
+#    - Missing required vars validation
+#
+# 2. Route Integration tests (apps/web/app/api/agent/runs/__tests__/route.test.ts):
+#    - Session Continue: 404 not found, 404 different user (security)
+#    - Checkpoint Resume: 404 not found, 404 different user (security)
+#
+# Removed E2E tests (covered by tests above):
+#    - "vm0 run with multiple --secrets flags" - validates same code path as Test 1
+#    - "vm0 run continue requires secrets to be re-provided" - unit tests cover validation
+#    - "vm0 run resume requires secrets to be re-provided" - unit tests cover validation
+#
+# This E2E test (1 vm0 run) validates the happy path end-to-end, while unit
+# and integration tests cover error cases with faster feedback.

--- a/e2e/tests/02-parallel/t12-vm0-env-expansion.bats
+++ b/e2e/tests/02-parallel/t12-vm0-env-expansion.bats
@@ -91,22 +91,24 @@ setup_artifact() {
     refute_output --partial "SECRET=${SECRET_VALUE}"
 }
 
-# Note: The following tests have been moved to other test layers:
+# Note: The following tests have been moved to Route Integration tests
+# (apps/web/app/api/agent/runs/__tests__/route.test.ts):
 #
-# 1. Unit tests (apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts):
-#    - Missing required secrets validation
-#    - Partial secrets validation
-#    - Usage hints (--secrets, --env-file)
-#    - Missing required vars validation
+# Validation section:
+#    - "should fail run when required secrets are not provided"
+#    - "should fail run when only some secrets are provided"
+#    - "should succeed when all required secrets are provided"
 #
-# 2. Route Integration tests (apps/web/app/api/agent/runs/__tests__/route.test.ts):
-#    - Session Continue: 404 not found, 404 different user (security)
-#    - Checkpoint Resume: 404 not found, 404 different user (security)
+# Session Continue section:
+#    - 404 not found, 404 different user (security)
 #
-# Removed E2E tests (covered by tests above):
+# Checkpoint Resume section:
+#    - 404 not found, 404 different user (security)
+#
+# Removed E2E tests (covered by route integration tests):
 #    - "vm0 run with multiple --secrets flags" - validates same code path as Test 1
-#    - "vm0 run continue requires secrets to be re-provided" - unit tests cover validation
-#    - "vm0 run resume requires secrets to be re-provided" - unit tests cover validation
+#    - "vm0 run continue requires secrets to be re-provided"
+#    - "vm0 run resume requires secrets to be re-provided"
 #
-# This E2E test (1 vm0 run) validates the happy path end-to-end, while unit
-# and integration tests cover error cases with faster feedback.
+# This E2E test (1 vm0 run) validates the happy path end-to-end, while route
+# integration tests cover error cases with faster feedback.

--- a/e2e/tests/02-parallel/t20-vm0-schedule.bats
+++ b/e2e/tests/02-parallel/t20-vm0-schedule.bats
@@ -1,50 +1,65 @@
 #!/usr/bin/env bats
 
-# E2E tests for vm0 schedule commands (agent-centric)
-# Tests: setup, list, status, enable, disable, delete
-# Note: Actual cron execution is NOT tested (time-sensitive)
+# E2E tests for vm0 schedule commands - Happy Path Only
+#
+# These tests verify the complete integration works end-to-end.
+# Error cases, input variations, and edge cases are tested in:
+# - turbo/apps/cli/src/commands/schedule/__tests__/*.test.ts (command-level with MSW)
+# - turbo/apps/web/app/api/agent/schedules/**/__tests__/route.test.ts (API routes)
+#
+# Test Structure:
+# - setup_file: Creates shared agent ONCE for all tests
+# - teardown_file: Cleans up agent ONCE after all tests
+# - Each @test: Uses the shared agent (no redundant setup)
 
 load '../../helpers/setup'
 
-setup() {
+# Shared state for all tests
+export UNIQUE_ID=""
+export AGENT_NAME=""
+export TEST_DIR=""
+
+setup_file() {
     export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
-    export AGENT_NAME="schedule-test-agent-${UNIQUE_ID}"
+    export AGENT_NAME="schedule-e2e-${UNIQUE_ID}"
     export TEST_DIR="$(mktemp -d)"
 
-    # Create vm0.yaml for the test agent
+    # Create and compose agent ONCE for all tests
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 
 agents:
   ${AGENT_NAME}:
-    description: "Test agent for schedule E2E tests"
+    description: "E2E schedule test agent"
     framework: claude-code
     image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
-    # Push the agent first (required for schedule to work)
     cd "$TEST_DIR"
-    run $CLI_COMMAND compose vm0.yaml
-    assert_success
+    $CLI_COMMAND compose vm0.yaml
 }
 
-teardown() {
-    # Clean up schedule if it exists
-    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
-        cd "$TEST_DIR" 2>/dev/null || true
+teardown_file() {
+    # Clean up schedule and temp directory
+    if [ -n "$AGENT_NAME" ]; then
         $CLI_COMMAND schedule delete "$AGENT_NAME" --force 2>/dev/null || true
+    fi
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
         rm -rf "$TEST_DIR"
     fi
 }
 
-# ============================================================
-# Setup tests (non-interactive mode with flags)
-# ============================================================
-
-@test "vm0 schedule setup should create a new schedule" {
+setup() {
+    # Each test uses the shared TEST_DIR
     cd "$TEST_DIR"
+}
 
+# ============================================================
+# Happy Path Tests
+# ============================================================
+
+@test "vm0 schedule setup creates a new schedule" {
     run $CLI_COMMAND schedule setup "$AGENT_NAME" \
         --frequency daily \
         --time "09:00" \
@@ -53,30 +68,27 @@ teardown() {
     assert_success
     assert_output --partial "Created schedule"
     assert_output --partial "$AGENT_NAME"
+}
 
-    # Verify via status command
+@test "vm0 schedule list shows created schedules" {
+    run $CLI_COMMAND schedule list
+    assert_success
+    assert_output --partial "$AGENT_NAME"
+    assert_output --partial "AGENT"
+    assert_output --partial "disabled"
+}
+
+@test "vm0 schedule status shows schedule details" {
     run $CLI_COMMAND schedule status "$AGENT_NAME"
     assert_success
     assert_output --partial "Agent:"
     assert_output --partial "$AGENT_NAME"
+    assert_output --partial "Status:"
     assert_output --partial "Trigger:"
     assert_output --partial "0 9 * * *"
-    # Schedules now default to disabled and require explicit enabling
-    assert_output --partial "disabled"
 }
 
-@test "vm0 schedule setup should update existing schedule" {
-    cd "$TEST_DIR"
-
-    # Setup first time
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Run scheduled task"
-    assert_success
-
-    # Setup again with different config
+@test "vm0 schedule setup updates existing schedule" {
     run $CLI_COMMAND schedule setup "$AGENT_NAME" \
         --frequency daily \
         --time "10:00" \
@@ -85,261 +97,24 @@ teardown() {
     assert_success
     assert_output --partial "Updated schedule"
 
-    # Verify updated time via status command
+    # Verify update via status
     run $CLI_COMMAND schedule status "$AGENT_NAME"
     assert_success
-    assert_output --partial "Trigger:"
     assert_output --partial "0 10 * * *"
 }
 
-@test "vm0 schedule setup with weekly frequency" {
-    cd "$TEST_DIR"
-
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency weekly \
-        --time "09:00" \
-        --day "mon" \
-        --timezone "UTC" \
-        --prompt "Weekly task"
+@test "vm0 schedule enable/disable workflow" {
+    # Enable the schedule
+    run $CLI_COMMAND schedule enable "$AGENT_NAME"
     assert_success
-    assert_output --partial "Created schedule"
+    assert_output --partial "Enabled"
 
-    # Verify weekly cron expression via status (Monday = 1)
-    run $CLI_COMMAND schedule status "$AGENT_NAME"
-    assert_success
-    assert_output --partial "Trigger:"
-    assert_output --partial "0 9 * * 1"
-}
-
-@test "vm0 schedule setup with monthly frequency" {
-    cd "$TEST_DIR"
-
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency monthly \
-        --time "09:00" \
-        --day "15" \
-        --timezone "UTC" \
-        --prompt "Monthly task"
-    assert_success
-    assert_output --partial "Created schedule"
-
-    # Verify monthly cron expression via status (15th of month)
-    run $CLI_COMMAND schedule status "$AGENT_NAME"
-    assert_success
-    assert_output --partial "Trigger:"
-    assert_output --partial "0 9 15 * *"
-}
-
-@test "vm0 schedule setup with once frequency" {
-    cd "$TEST_DIR"
-
-    # Calculate a future date (tomorrow)
-    local FUTURE_DATE=$(date -d "+1 day" "+%Y-%m-%d")
-
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency once \
-        --time "14:30" \
-        --day "$FUTURE_DATE" \
-        --timezone "UTC" \
-        --prompt "One-time task"
-    assert_success
-    assert_output --partial "Created schedule"
-
-    # Verify one-time schedule via status
-    run $CLI_COMMAND schedule status "$AGENT_NAME"
-    assert_success
-    assert_output --partial "Trigger:"
-    assert_output --partial "(one-time)"
-}
-
-@test "vm0 schedule setup with vars" {
-    cd "$TEST_DIR"
-
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Task with vars" \
-        --var "ENV=test" \
-        --var "DEBUG=true"
-    assert_success
-    assert_output --partial "Created schedule"
-
-    # Verify vars in status
-    run $CLI_COMMAND schedule status "$AGENT_NAME"
-    assert_success
-    assert_output --partial "Variables:"
-    assert_output --partial "ENV"
-    assert_output --partial "DEBUG"
-}
-
-@test "vm0 schedule setup with secrets" {
-    cd "$TEST_DIR"
-
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Task with secrets" \
-        --secret "API_KEY=my-secret"
-    assert_success
-    assert_output --partial "Created schedule"
-
-    # Verify secrets in status
-    run $CLI_COMMAND schedule status "$AGENT_NAME"
-    assert_success
-    assert_output --partial "Secrets:"
-    assert_output --partial "API_KEY"
-}
-
-@test "vm0 schedule setup with artifact-name" {
-    cd "$TEST_DIR"
-
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Task with custom artifact" \
-        --artifact-name "my-artifact"
-    assert_success
-    assert_output --partial "Created schedule"
-
-    # Verify artifact via status command
-    run $CLI_COMMAND schedule status "$AGENT_NAME"
-    assert_success
-    assert_output --partial "Artifact:"
-    assert_output --partial "my-artifact"
-}
-
-# ============================================================
-# List tests
-# ============================================================
-
-@test "vm0 schedule list should show created schedules" {
-    cd "$TEST_DIR"
-
-    # Setup a schedule first
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "List test task"
-    assert_success
-
-    # List schedules
+    # Verify enabled in list
     run $CLI_COMMAND schedule list
     assert_success
-    assert_output --partial "$AGENT_NAME"
-    assert_output --partial "AGENT"
-    # Schedules now default to disabled and require explicit enabling
-    assert_output --partial "disabled"
-}
+    assert_output --partial "enabled"
 
-@test "vm0 schedule list should show empty message when no schedules" {
-    # Skip setup - test with fresh state
-    # Note: We can't guarantee no schedules exist, so we just check the command works
-    run $CLI_COMMAND schedule list
-    assert_success
-}
-
-# ============================================================
-# Status tests
-# ============================================================
-
-@test "vm0 schedule status should show schedule details" {
-    cd "$TEST_DIR"
-
-    # Setup a schedule first
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Status test task"
-    assert_success
-
-    # Get status using agent name
-    run $CLI_COMMAND schedule status "$AGENT_NAME"
-    assert_success
-    assert_output --partial "Agent:"
-    assert_output --partial "$AGENT_NAME"
-    assert_output --partial "Status:"
-    # Schedules now default to disabled and require explicit enabling
-    assert_output --partial "disabled"
-    assert_output --partial "Trigger:"
-    assert_output --partial "0 9 * * *"
-}
-
-@test "vm0 schedule status should accept --limit option" {
-    cd "$TEST_DIR"
-
-    # Setup a schedule first
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Limit test task"
-    assert_success
-
-    # Get status with --limit
-    run $CLI_COMMAND schedule status "$AGENT_NAME" --limit 10
-    assert_success
-    assert_output --partial "Agent:"
-    assert_output --partial "$AGENT_NAME"
-}
-
-@test "vm0 schedule status should accept -l shorthand for limit" {
-    cd "$TEST_DIR"
-
-    # Setup a schedule first
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Limit shorthand test"
-    assert_success
-
-    # Get status with -l shorthand
-    run $CLI_COMMAND schedule status "$AGENT_NAME" -l 5
-    assert_success
-    assert_output --partial "Agent:"
-    assert_output --partial "$AGENT_NAME"
-}
-
-@test "vm0 schedule status with --limit 0 should hide runs section" {
-    cd "$TEST_DIR"
-
-    # Setup a schedule first
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Limit zero test"
-    assert_success
-
-    # Get status with --limit 0
-    run $CLI_COMMAND schedule status "$AGENT_NAME" --limit 0
-    assert_success
-    assert_output --partial "Agent:"
-    assert_output --partial "$AGENT_NAME"
-    # Should not show "Recent Runs" when limit is 0
-    refute_output --partial "Recent Runs:"
-}
-
-# ============================================================
-# Enable/Disable tests
-# ============================================================
-
-@test "vm0 schedule disable should disable a schedule" {
-    cd "$TEST_DIR"
-
-    # Setup and disable
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Disable test task"
-    assert_success
-
+    # Disable the schedule
     run $CLI_COMMAND schedule disable "$AGENT_NAME"
     assert_success
     assert_output --partial "Disabled"
@@ -350,43 +125,13 @@ teardown() {
     assert_output --partial "disabled"
 }
 
-@test "vm0 schedule enable should enable a disabled schedule" {
-    cd "$TEST_DIR"
-
-    # Setup, disable, then enable
+@test "vm0 schedule delete removes schedule" {
+    # First create a fresh schedule to delete
     run $CLI_COMMAND schedule setup "$AGENT_NAME" \
         --frequency daily \
-        --time "09:00" \
+        --time "11:00" \
         --timezone "UTC" \
-        --prompt "Enable test task"
-    assert_success
-
-    run $CLI_COMMAND schedule disable "$AGENT_NAME"
-    assert_success
-
-    run $CLI_COMMAND schedule enable "$AGENT_NAME"
-    assert_success
-    assert_output --partial "Enabled"
-
-    # Verify enabled in list
-    run $CLI_COMMAND schedule list
-    assert_success
-    assert_output --partial "enabled"
-}
-
-# ============================================================
-# Delete tests
-# ============================================================
-
-@test "vm0 schedule delete should delete a schedule" {
-    cd "$TEST_DIR"
-
-    # Setup first
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Delete test task"
+        --prompt "To be deleted"
     assert_success
 
     # Delete with force flag
@@ -396,373 +141,53 @@ teardown() {
 }
 
 # ============================================================
-# Error handling tests
+# Secrets/Vars Integration Test
+# Uses a separate agent with configuration requirements
 # ============================================================
 
-@test "vm0 schedule status fails for nonexistent agent" {
-    run $CLI_COMMAND schedule status "nonexistent-agent-12345"
-    assert_failure
-    assert_output --partial "No schedule found"
-}
+@test "vm0 schedule setup with secrets and vars integration" {
+    local CONFIG_AGENT_NAME="schedule-config-${UNIQUE_ID}"
+    local CONFIG_TEST_DIR="$(mktemp -d)"
 
-@test "vm0 schedule setup fails for nonexistent agent" {
-    run $CLI_COMMAND schedule setup "nonexistent-agent-12345" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Test"
-    assert_failure
-    assert_output --partial "not found"
-}
-
-# ============================================================
-# Global resolution tests (commands work from any directory)
-# ============================================================
-
-@test "vm0 schedule status should work from any directory (global resolution)" {
-    cd "$TEST_DIR"
-
-    # Setup schedule first
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Global resolution test"
-    assert_success
-
-    # Change to a completely different directory (NOT the agent's directory)
-    cd /tmp
-
-    # Status should still work with just the agent name
-    run $CLI_COMMAND schedule status "$AGENT_NAME"
-    assert_success
-    assert_output --partial "Agent:"
-    assert_output --partial "$AGENT_NAME"
-    # Schedules now default to disabled and require explicit enabling
-    assert_output --partial "disabled"
-}
-
-@test "vm0 schedule disable should work from any directory (global resolution)" {
-    cd "$TEST_DIR"
-
-    # Setup schedule first
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Global disable test"
-    assert_success
-
-    # Change to a different directory
-    cd /tmp
-
-    # Disable should still work with just the agent name
-    run $CLI_COMMAND schedule disable "$AGENT_NAME"
-    assert_success
-    assert_output --partial "Disabled"
-}
-
-@test "vm0 schedule enable should work from any directory (global resolution)" {
-    cd "$TEST_DIR"
-
-    # Setup and disable schedule first
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Global enable test"
-    assert_success
-
-    run $CLI_COMMAND schedule disable "$AGENT_NAME"
-    assert_success
-
-    # Change to a different directory
-    cd /tmp
-
-    # Enable should still work with just the agent name
-    run $CLI_COMMAND schedule enable "$AGENT_NAME"
-    assert_success
-    assert_output --partial "Enabled"
-}
-
-@test "vm0 schedule delete should work from any directory (global resolution)" {
-    cd "$TEST_DIR"
-
-    # Setup schedule first
-    run $CLI_COMMAND schedule setup "$AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Global delete test"
-    assert_success
-
-    # Change to a different directory
-    cd /tmp
-
-    # Delete should still work with just the agent name
-    run $CLI_COMMAND schedule delete "$AGENT_NAME" --force
-    assert_success
-    assert_output --partial "Deleted"
-}
-
-# ============================================================
-# Secrets/Vars validation tests
-# ============================================================
-
-@test "vm0 schedule setup fails when required secrets are missing" {
-    local SECRET_AGENT_NAME="secrets-test-agent-${UNIQUE_ID}"
-    local SECRET_TEST_DIR="$(mktemp -d)"
-
-    # Create agent with secrets requirement
-    cat > "$SECRET_TEST_DIR/vm0.yaml" <<EOF
+    # Create agent with secrets and vars requirements
+    cat > "$CONFIG_TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 
 agents:
-  ${SECRET_AGENT_NAME}:
-    description: "Test agent with secrets requirement"
+  ${CONFIG_AGENT_NAME}:
+    description: "Test agent with configuration requirements"
     framework: claude-code
     image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
     environment:
       API_KEY: "\${{ secrets.API_KEY }}"
-EOF
-
-    cd "$SECRET_TEST_DIR"
-    run $CLI_COMMAND compose vm0.yaml
-    assert_success
-
-    # Try to setup schedule without providing required secret
-    run $CLI_COMMAND schedule setup "$SECRET_AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Should fail"
-    assert_failure
-    assert_output --partial "Missing required configuration"
-    assert_output --partial "API_KEY"
-
-    # Clean up
-    $CLI_COMMAND schedule delete "$SECRET_AGENT_NAME" --force 2>/dev/null || true
-    rm -rf "$SECRET_TEST_DIR"
-}
-
-@test "vm0 schedule setup succeeds when required secrets are provided" {
-    local SECRET_AGENT_NAME="secrets-provided-agent-${UNIQUE_ID}"
-    local SECRET_TEST_DIR="$(mktemp -d)"
-
-    # Create agent with secrets requirement
-    cat > "$SECRET_TEST_DIR/vm0.yaml" <<EOF
-version: "1.0"
-
-agents:
-  ${SECRET_AGENT_NAME}:
-    description: "Test agent with secrets requirement"
-    framework: claude-code
-    image: "vm0/claude-code:dev"
-    working_dir: /home/user/workspace
-    environment:
-      API_KEY: "\${{ secrets.API_KEY }}"
-EOF
-
-    cd "$SECRET_TEST_DIR"
-    run $CLI_COMMAND compose vm0.yaml
-    assert_success
-
-    # Setup schedule with required secret provided
-    run $CLI_COMMAND schedule setup "$SECRET_AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Should succeed" \
-        --secret "API_KEY=test-secret-value"
-    assert_success
-    assert_output --partial "Created schedule"
-
-    # Verify secret is shown in status
-    run $CLI_COMMAND schedule status "$SECRET_AGENT_NAME"
-    assert_success
-    assert_output --partial "Secrets:"
-    assert_output --partial "API_KEY"
-
-    # Clean up
-    $CLI_COMMAND schedule delete "$SECRET_AGENT_NAME" --force 2>/dev/null || true
-    rm -rf "$SECRET_TEST_DIR"
-}
-
-@test "vm0 schedule setup fails when required vars are missing" {
-    local VAR_AGENT_NAME="vars-test-agent-${UNIQUE_ID}"
-    local VAR_TEST_DIR="$(mktemp -d)"
-
-    # Create agent with vars requirement
-    cat > "$VAR_TEST_DIR/vm0.yaml" <<EOF
-version: "1.0"
-
-agents:
-  ${VAR_AGENT_NAME}:
-    description: "Test agent with vars requirement"
-    framework: claude-code
-    image: "vm0/claude-code:dev"
-    working_dir: /home/user/workspace
-    environment:
       API_URL: "\${{ vars.API_URL }}"
 EOF
 
-    cd "$VAR_TEST_DIR"
+    cd "$CONFIG_TEST_DIR"
     run $CLI_COMMAND compose vm0.yaml
     assert_success
 
-    # Try to setup schedule without providing required var
-    run $CLI_COMMAND schedule setup "$VAR_AGENT_NAME" \
+    # Setup schedule with required secrets and vars
+    run $CLI_COMMAND schedule setup "$CONFIG_AGENT_NAME" \
         --frequency daily \
         --time "09:00" \
         --timezone "UTC" \
-        --prompt "Should fail"
-    assert_failure
-    assert_output --partial "Missing required configuration"
-    assert_output --partial "API_URL"
-
-    # Clean up
-    $CLI_COMMAND schedule delete "$VAR_AGENT_NAME" --force 2>/dev/null || true
-    rm -rf "$VAR_TEST_DIR"
-}
-
-@test "vm0 schedule setup succeeds when required vars are provided" {
-    local VAR_AGENT_NAME="vars-provided-agent-${UNIQUE_ID}"
-    local VAR_TEST_DIR="$(mktemp -d)"
-
-    # Create agent with vars requirement
-    cat > "$VAR_TEST_DIR/vm0.yaml" <<EOF
-version: "1.0"
-
-agents:
-  ${VAR_AGENT_NAME}:
-    description: "Test agent with vars requirement"
-    framework: claude-code
-    image: "vm0/claude-code:dev"
-    working_dir: /home/user/workspace
-    environment:
-      API_URL: "\${{ vars.API_URL }}"
-EOF
-
-    cd "$VAR_TEST_DIR"
-    run $CLI_COMMAND compose vm0.yaml
-    assert_success
-
-    # Setup schedule with required var provided
-    run $CLI_COMMAND schedule setup "$VAR_AGENT_NAME" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Should succeed" \
+        --prompt "Task with config" \
+        --secret "API_KEY=test-secret-value" \
         --var "API_URL=https://api.example.com"
     assert_success
     assert_output --partial "Created schedule"
 
-    # Verify var is shown in status
-    run $CLI_COMMAND schedule status "$VAR_AGENT_NAME"
-    assert_success
-    assert_output --partial "Variables:"
-    assert_output --partial "API_URL"
-
-    # Clean up
-    $CLI_COMMAND schedule delete "$VAR_AGENT_NAME" --force 2>/dev/null || true
-    rm -rf "$VAR_TEST_DIR"
-}
-
-@test "vm0 schedule setup preserves secrets when updating schedule" {
-    local KEEP_SECRETS_AGENT="keep-secrets-agent-${UNIQUE_ID}"
-    local KEEP_SECRETS_DIR="$(mktemp -d)"
-
-    # Create agent with secrets requirement
-    cat > "$KEEP_SECRETS_DIR/vm0.yaml" <<EOF
-version: "1.0"
-
-agents:
-  ${KEEP_SECRETS_AGENT}:
-    description: "Test agent for keep secrets"
-    framework: claude-code
-    image: "vm0/claude-code:dev"
-    working_dir: /home/user/workspace
-    environment:
-      API_KEY: "\${{ secrets.API_KEY }}"
-EOF
-
-    cd "$KEEP_SECRETS_DIR"
-    run $CLI_COMMAND compose vm0.yaml
-    assert_success
-
-    # Create schedule with secret
-    run $CLI_COMMAND schedule setup "$KEEP_SECRETS_AGENT" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Initial prompt" \
-        --secret "API_KEY=test-secret-value"
-    assert_success
-    assert_output --partial "Created schedule"
-
-    # Update schedule without providing secrets (should preserve existing)
-    run $CLI_COMMAND schedule setup "$KEEP_SECRETS_AGENT" \
-        --frequency daily \
-        --time "10:00" \
-        --timezone "UTC" \
-        --prompt "Updated prompt"
-    assert_success
-    assert_output --partial "Updated schedule"
-
-    # Verify secret is still there
-    run $CLI_COMMAND schedule status "$KEEP_SECRETS_AGENT"
+    # Verify configuration in status
+    run $CLI_COMMAND schedule status "$CONFIG_AGENT_NAME"
     assert_success
     assert_output --partial "Secrets:"
     assert_output --partial "API_KEY"
+    assert_output --partial "Variables:"
+    assert_output --partial "API_URL"
 
-    # Clean up
-    $CLI_COMMAND schedule delete "$KEEP_SECRETS_AGENT" --force 2>/dev/null || true
-    rm -rf "$KEEP_SECRETS_DIR"
-}
-
-@test "vm0 schedule setup replaces secrets when new secrets provided" {
-    local REPLACE_SECRETS_AGENT="replace-secrets-agent-${UNIQUE_ID}"
-    local REPLACE_SECRETS_DIR="$(mktemp -d)"
-
-    # Create agent with secrets requirement
-    cat > "$REPLACE_SECRETS_DIR/vm0.yaml" <<EOF
-version: "1.0"
-
-agents:
-  ${REPLACE_SECRETS_AGENT}:
-    description: "Test agent for replace secrets"
-    framework: claude-code
-    image: "vm0/claude-code:dev"
-    working_dir: /home/user/workspace
-    environment:
-      API_KEY: "\${{ secrets.API_KEY }}"
-EOF
-
-    cd "$REPLACE_SECRETS_DIR"
-    run $CLI_COMMAND compose vm0.yaml
-    assert_success
-
-    # Create schedule with secret
-    run $CLI_COMMAND schedule setup "$REPLACE_SECRETS_AGENT" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Initial" \
-        --secret "API_KEY=old-value"
-    assert_success
-
-    # Update with new secret value
-    run $CLI_COMMAND schedule setup "$REPLACE_SECRETS_AGENT" \
-        --frequency daily \
-        --time "09:00" \
-        --timezone "UTC" \
-        --prompt "Updated" \
-        --secret "API_KEY=new-value"
-    assert_success
-    assert_output --partial "Updated schedule"
-
-    # Clean up
-    $CLI_COMMAND schedule delete "$REPLACE_SECRETS_AGENT" --force 2>/dev/null || true
-    rm -rf "$REPLACE_SECRETS_DIR"
+    # Clean up this separate agent
+    $CLI_COMMAND schedule delete "$CONFIG_AGENT_NAME" --force 2>/dev/null || true
+    rm -rf "$CONFIG_TEST_DIR"
 }

--- a/e2e/tests/02-parallel/t20-vm0-schedule.bats
+++ b/e2e/tests/02-parallel/t20-vm0-schedule.bats
@@ -8,21 +8,21 @@
 # - turbo/apps/web/app/api/agent/schedules/**/__tests__/route.test.ts (API routes)
 #
 # Test Structure:
-# - setup_file: Creates shared agent ONCE for all tests
+# - setup_file: Creates shared agent ONCE for all tests, saves state to BATS_FILE_TMPDIR
 # - teardown_file: Cleans up agent ONCE after all tests
-# - Each @test: Uses the shared agent (no redundant setup)
+# - Each @test: Loads state from BATS_FILE_TMPDIR and uses the shared agent
 
 load '../../helpers/setup'
 
-# Shared state for all tests
-export UNIQUE_ID=""
-export AGENT_NAME=""
-export TEST_DIR=""
-
 setup_file() {
-    export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
-    export AGENT_NAME="schedule-e2e-${UNIQUE_ID}"
-    export TEST_DIR="$(mktemp -d)"
+    local UNIQUE_ID="$(date +%s%3N)-$RANDOM"
+    local AGENT_NAME="schedule-e2e-${UNIQUE_ID}"
+    local TEST_DIR="$(mktemp -d)"
+
+    # Save state to persist across tests (required for BATS parallel execution)
+    echo "$UNIQUE_ID" > "$BATS_FILE_TMPDIR/unique_id"
+    echo "$AGENT_NAME" > "$BATS_FILE_TMPDIR/agent_name"
+    echo "$TEST_DIR" > "$BATS_FILE_TMPDIR/test_dir"
 
     # Create and compose agent ONCE for all tests
     cat > "$TEST_DIR/vm0.yaml" <<EOF
@@ -41,6 +41,10 @@ EOF
 }
 
 teardown_file() {
+    # Load state from files
+    local AGENT_NAME=$(cat "$BATS_FILE_TMPDIR/agent_name" 2>/dev/null || true)
+    local TEST_DIR=$(cat "$BATS_FILE_TMPDIR/test_dir" 2>/dev/null || true)
+
     # Clean up schedule and temp directory
     if [ -n "$AGENT_NAME" ]; then
         $CLI_COMMAND schedule delete "$AGENT_NAME" --force 2>/dev/null || true
@@ -51,7 +55,10 @@ teardown_file() {
 }
 
 setup() {
-    # Each test uses the shared TEST_DIR
+    # Load state from files (required for BATS parallel execution)
+    UNIQUE_ID=$(cat "$BATS_FILE_TMPDIR/unique_id")
+    AGENT_NAME=$(cat "$BATS_FILE_TMPDIR/agent_name")
+    TEST_DIR=$(cat "$BATS_FILE_TMPDIR/test_dir")
     cd "$TEST_DIR"
 }
 

--- a/turbo/apps/cli/src/commands/schedule/__tests__/delete-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/delete-command.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for schedule delete command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { deleteCommand } from "../delete";
+import chalk from "chalk";
+
+// Helper to create a mock schedule response
+function createMockSchedule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "schedule-1",
+    composeId: "compose-1",
+    composeName: "test-agent",
+    scopeSlug: "user-test",
+    name: "test-agent-schedule",
+    cronExpression: "0 9 * * *",
+    atTime: null,
+    timezone: "UTC",
+    prompt: "Daily task",
+    vars: null,
+    secretNames: null,
+    artifactName: null,
+    artifactVersion: null,
+    volumeVersions: null,
+    enabled: true,
+    nextRunAt: new Date(Date.now() + 86400000).toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("schedule delete command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  describe("help text", () => {
+    it("should show usage information with rm alias", async () => {
+      const mockStdoutWrite = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      try {
+        await deleteCommand.parseAsync(["node", "cli", "--help"]);
+      } catch {
+        // Commander calls process.exit(0) after help
+      }
+
+      const output = mockStdoutWrite.mock.calls.map((call) => call[0]).join("");
+
+      expect(output).toContain("Delete a schedule");
+      expect(output).toContain("<agent-name>");
+      expect(output).toContain("--force");
+      expect(output).toContain("rm");
+
+      mockStdoutWrite.mockRestore();
+    });
+  });
+
+  describe("successful delete", () => {
+    it("should delete schedule with --force", async () => {
+      const schedule = createMockSchedule();
+      let deletedName: string | undefined;
+
+      server.use(
+        // resolveScheduleByAgent calls listSchedules first
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+        // Then deleteSchedule
+        http.delete(
+          "http://localhost:3000/api/agent/schedules/:name",
+          ({ params }) => {
+            deletedName = params.name as string;
+            return new HttpResponse(null, { status: 204 });
+          },
+        ),
+      );
+
+      await deleteCommand.parseAsync(["node", "cli", "test-agent", "--force"]);
+
+      expect(deletedName).toBe("test-agent-schedule");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Deleted schedule");
+      expect(logCalls).toContain("test-agent");
+    });
+
+    it("should resolve schedule by agent name from any directory", async () => {
+      // This tests that resolveScheduleByAgent finds the schedule
+      // by matching composeName in the schedules list
+      const schedule = createMockSchedule({
+        composeName: "my-special-agent",
+        name: "my-special-agent-schedule",
+      });
+      let deletedName: string | undefined;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+        http.delete(
+          "http://localhost:3000/api/agent/schedules/:name",
+          ({ params }) => {
+            deletedName = params.name as string;
+            return new HttpResponse(null, { status: 204 });
+          },
+        ),
+      );
+
+      await deleteCommand.parseAsync([
+        "node",
+        "cli",
+        "my-special-agent",
+        "--force",
+      ]);
+
+      expect(deletedName).toBe("my-special-agent-schedule");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Deleted schedule");
+    });
+  });
+
+  describe("confirmation", () => {
+    it("should require --force in non-interactive mode", async () => {
+      const schedule = createMockSchedule();
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+      );
+
+      // Mock isInteractive to return false (non-interactive)
+      vi.stubEnv("CI", "true");
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "test-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--force required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle schedule not found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync([
+          "node",
+          "cli",
+          "nonexistent-agent",
+          "--force",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to delete schedule"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No schedule found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync([
+          "node",
+          "cli",
+          "test-agent",
+          "--force",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 auth login"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/schedule/__tests__/disable-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/disable-command.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for schedule disable command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { disableCommand } from "../disable";
+import chalk from "chalk";
+
+// Helper to create a mock schedule response
+function createMockSchedule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "schedule-1",
+    composeId: "compose-1",
+    composeName: "test-agent",
+    scopeSlug: "user-test",
+    name: "test-agent-schedule",
+    cronExpression: "0 9 * * *",
+    atTime: null,
+    timezone: "UTC",
+    prompt: "Daily task",
+    vars: null,
+    secretNames: null,
+    artifactName: null,
+    artifactVersion: null,
+    volumeVersions: null,
+    enabled: true,
+    nextRunAt: new Date(Date.now() + 86400000).toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("schedule disable command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  describe("help text", () => {
+    it("should show usage information", async () => {
+      const mockStdoutWrite = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      try {
+        await disableCommand.parseAsync(["node", "cli", "--help"]);
+      } catch {
+        // Commander calls process.exit(0) after help
+      }
+
+      const output = mockStdoutWrite.mock.calls.map((call) => call[0]).join("");
+
+      expect(output).toContain("Disable a schedule");
+      expect(output).toContain("<agent-name>");
+
+      mockStdoutWrite.mockRestore();
+    });
+  });
+
+  describe("successful disable", () => {
+    it("should disable schedule successfully", async () => {
+      const schedule = createMockSchedule({ enabled: true });
+      const disabledSchedule = createMockSchedule({
+        enabled: false,
+        nextRunAt: null,
+      });
+
+      server.use(
+        // resolveScheduleByAgent calls listSchedules first
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+        // Then disableSchedule
+        http.post(
+          "http://localhost:3000/api/agent/schedules/:name/disable",
+          () => {
+            return HttpResponse.json(disabledSchedule);
+          },
+        ),
+      );
+
+      await disableCommand.parseAsync(["node", "cli", "test-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Disabled schedule");
+      expect(logCalls).toContain("test-agent");
+    });
+
+    it("should resolve schedule by agent name from any directory", async () => {
+      // This tests that resolveScheduleByAgent finds the schedule
+      // by matching composeName in the schedules list
+      const schedule = createMockSchedule({
+        composeName: "my-special-agent",
+        name: "my-special-agent-schedule",
+      });
+      const disabledSchedule = { ...schedule, enabled: false, nextRunAt: null };
+      let disabledName: string | undefined;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+        http.post(
+          "http://localhost:3000/api/agent/schedules/:name/disable",
+          ({ params }) => {
+            disabledName = params.name as string;
+            return HttpResponse.json(disabledSchedule);
+          },
+        ),
+      );
+
+      await disableCommand.parseAsync(["node", "cli", "my-special-agent"]);
+
+      expect(disabledName).toBe("my-special-agent-schedule");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Disabled schedule");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle schedule not found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await disableCommand.parseAsync(["node", "cli", "nonexistent-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to disable schedule"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No schedule found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await disableCommand.parseAsync(["node", "cli", "test-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 auth login"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/schedule/__tests__/enable-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/enable-command.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for schedule enable command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { enableCommand } from "../enable";
+import chalk from "chalk";
+
+// Helper to create a mock schedule response
+function createMockSchedule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "schedule-1",
+    composeId: "compose-1",
+    composeName: "test-agent",
+    scopeSlug: "user-test",
+    name: "test-agent-schedule",
+    cronExpression: "0 9 * * *",
+    atTime: null,
+    timezone: "UTC",
+    prompt: "Daily task",
+    vars: null,
+    secretNames: null,
+    artifactName: null,
+    artifactVersion: null,
+    volumeVersions: null,
+    enabled: true,
+    nextRunAt: new Date(Date.now() + 86400000).toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("schedule enable command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  describe("help text", () => {
+    it("should show usage information", async () => {
+      const mockStdoutWrite = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      try {
+        await enableCommand.parseAsync(["node", "cli", "--help"]);
+      } catch {
+        // Commander calls process.exit(0) after help
+      }
+
+      const output = mockStdoutWrite.mock.calls.map((call) => call[0]).join("");
+
+      expect(output).toContain("Enable a schedule");
+      expect(output).toContain("<agent-name>");
+
+      mockStdoutWrite.mockRestore();
+    });
+  });
+
+  describe("successful enable", () => {
+    it("should enable schedule successfully", async () => {
+      const schedule = createMockSchedule({ enabled: false });
+      const enabledSchedule = createMockSchedule({ enabled: true });
+
+      server.use(
+        // resolveScheduleByAgent calls listSchedules first
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+        // Then enableSchedule
+        http.post(
+          "http://localhost:3000/api/agent/schedules/:name/enable",
+          () => {
+            return HttpResponse.json(enabledSchedule);
+          },
+        ),
+      );
+
+      await enableCommand.parseAsync(["node", "cli", "test-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Enabled schedule");
+      expect(logCalls).toContain("test-agent");
+    });
+
+    it("should resolve schedule by agent name from any directory", async () => {
+      // This tests that resolveScheduleByAgent finds the schedule
+      // by matching composeName in the schedules list
+      const schedule = createMockSchedule({
+        composeName: "my-special-agent",
+        name: "my-special-agent-schedule",
+      });
+      const enabledSchedule = { ...schedule, enabled: true };
+      let enabledName: string | undefined;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+        http.post(
+          "http://localhost:3000/api/agent/schedules/:name/enable",
+          ({ params }) => {
+            enabledName = params.name as string;
+            return HttpResponse.json(enabledSchedule);
+          },
+        ),
+      );
+
+      await enableCommand.parseAsync(["node", "cli", "my-special-agent"]);
+
+      expect(enabledName).toBe("my-special-agent-schedule");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Enabled schedule");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle schedule not found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await enableCommand.parseAsync(["node", "cli", "nonexistent-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to enable schedule"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No schedule found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await enableCommand.parseAsync(["node", "cli", "test-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 auth login"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle schedule past error", async () => {
+      const schedule = createMockSchedule({
+        atTime: new Date(Date.now() - 86400000).toISOString(), // yesterday
+      });
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+        http.post(
+          "http://localhost:3000/api/agent/schedules/:name/enable",
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Scheduled time has already passed",
+                  code: "SCHEDULE_PAST",
+                },
+              },
+              { status: 400 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await enableCommand.parseAsync(["node", "cli", "test-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to enable schedule"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Scheduled time has already passed"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/schedule/__tests__/list-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/list-command.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for schedule list command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { listCommand } from "../list";
+import chalk from "chalk";
+
+describe("schedule list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  describe("help text", () => {
+    it("should show ls alias", async () => {
+      const mockStdoutWrite = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      try {
+        await listCommand.parseAsync(["node", "cli", "--help"]);
+      } catch {
+        // Commander calls process.exit(0) after help
+      }
+
+      const output = mockStdoutWrite.mock.calls.map((call) => call[0]).join("");
+
+      expect(output).toContain("List all schedules");
+      expect(output).toContain("ls");
+
+      mockStdoutWrite.mockRestore();
+    });
+  });
+
+  describe("successful list", () => {
+    it("should display schedules in table format", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({
+            schedules: [
+              {
+                id: "schedule-1",
+                composeId: "compose-1",
+                composeName: "my-agent",
+                scopeSlug: "user-test",
+                name: "my-agent-schedule",
+                cronExpression: "0 9 * * *",
+                atTime: null,
+                timezone: "UTC",
+                prompt: "Daily task",
+                vars: null,
+                secretNames: null,
+                artifactName: null,
+                artifactVersion: null,
+                volumeVersions: null,
+                enabled: true,
+                nextRunAt: new Date(Date.now() + 86400000).toISOString(),
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+              {
+                id: "schedule-2",
+                composeId: "compose-2",
+                composeName: "other-agent",
+                scopeSlug: "user-test",
+                name: "other-agent-schedule",
+                cronExpression: "0 10 * * 1",
+                atTime: null,
+                timezone: "America/New_York",
+                prompt: "Weekly task",
+                vars: null,
+                secretNames: null,
+                artifactName: null,
+                artifactVersion: null,
+                volumeVersions: null,
+                enabled: false,
+                nextRunAt: null,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("my-agent");
+      expect(logCalls).toContain("other-agent");
+      expect(logCalls).toContain("0 9 * * *");
+      expect(logCalls).toContain("UTC");
+    });
+
+    it("should show enabled and disabled status", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({
+            schedules: [
+              {
+                id: "schedule-1",
+                composeId: "compose-1",
+                composeName: "enabled-agent",
+                scopeSlug: "user-test",
+                name: "enabled-schedule",
+                cronExpression: "0 9 * * *",
+                atTime: null,
+                timezone: "UTC",
+                prompt: "Task",
+                vars: null,
+                secretNames: null,
+                artifactName: null,
+                artifactVersion: null,
+                volumeVersions: null,
+                enabled: true,
+                nextRunAt: new Date(Date.now() + 86400000).toISOString(),
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+              {
+                id: "schedule-2",
+                composeId: "compose-2",
+                composeName: "disabled-agent",
+                scopeSlug: "user-test",
+                name: "disabled-schedule",
+                cronExpression: "0 10 * * *",
+                atTime: null,
+                timezone: "UTC",
+                prompt: "Task",
+                vars: null,
+                secretNames: null,
+                artifactName: null,
+                artifactVersion: null,
+                volumeVersions: null,
+                enabled: false,
+                nextRunAt: null,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("enabled");
+      expect(logCalls).toContain("disabled");
+    });
+
+    it("should display empty state message when no schedules", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No schedules found");
+      expect(logCalls).toContain("vm0 schedule setup");
+    });
+
+    it("should show table header with correct columns", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({
+            schedules: [
+              {
+                id: "schedule-1",
+                composeId: "compose-1",
+                composeName: "test-agent",
+                scopeSlug: "user-test",
+                name: "test-schedule",
+                cronExpression: "0 9 * * *",
+                atTime: null,
+                timezone: "UTC",
+                prompt: "Task",
+                vars: null,
+                secretNames: null,
+                artifactName: null,
+                artifactVersion: null,
+                volumeVersions: null,
+                enabled: true,
+                nextRunAt: new Date(Date.now() + 86400000).toISOString(),
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("AGENT");
+      expect(logCalls).toContain("TRIGGER");
+      expect(logCalls).toContain("STATUS");
+      expect(logCalls).toContain("NEXT RUN");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to list schedules"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 auth login"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "INTERNAL_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to list schedules"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/schedule/__tests__/setup-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/setup-command.test.ts
@@ -1,0 +1,661 @@
+/**
+ * Tests for schedule setup command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ *
+ * Note: The setup command is heavily interactive. Core configuration gathering
+ * logic is unit tested in gather-configuration.test.ts. These tests focus on:
+ * - Non-interactive mode scenarios
+ * - API integration via MSW
+ * - Error handling
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { setupCommand } from "../setup";
+import chalk from "chalk";
+
+// Helper to create a mock schedule response
+function createMockSchedule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "schedule-1",
+    composeId: "compose-1",
+    composeName: "test-agent",
+    scopeSlug: "user-test",
+    name: "test-agent-schedule",
+    cronExpression: "0 9 * * *",
+    atTime: null,
+    timezone: "UTC",
+    prompt: "Daily task",
+    vars: null,
+    secretNames: null,
+    artifactName: null,
+    artifactVersion: null,
+    volumeVersions: null,
+    enabled: false,
+    nextRunAt: new Date(Date.now() + 86400000).toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// Helper to create a mock compose response
+function createMockCompose(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "compose-1",
+    name: "test-agent",
+    scopeSlug: "user-test",
+    currentVersion: "v1",
+    content: {
+      version: "1.0",
+      agents: {
+        "test-agent": {
+          description: "Test agent",
+          framework: "claude-code",
+          image: "vm0/claude-code:dev",
+          working_dir: "/home/user/workspace",
+        },
+      },
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("schedule setup command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    vi.stubEnv("CI", "true"); // Force non-interactive mode
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  describe("help text", () => {
+    it("should show usage information", async () => {
+      const mockStdoutWrite = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      try {
+        await setupCommand.parseAsync(["node", "cli", "--help"]);
+      } catch {
+        // Commander calls process.exit(0) after help
+      }
+
+      const output = mockStdoutWrite.mock.calls.map((call) => call[0]).join("");
+
+      expect(output).toContain("Create or edit a schedule");
+      expect(output).toContain("<agent-name>");
+      expect(output).toContain("--frequency");
+      expect(output).toContain("--time");
+      expect(output).toContain("--day");
+      expect(output).toContain("--timezone");
+      expect(output).toContain("--prompt");
+      expect(output).toContain("--var");
+      expect(output).toContain("--secret");
+      expect(output).toContain("--enable");
+
+      mockStdoutWrite.mockRestore();
+    });
+  });
+
+  describe("successful setup", () => {
+    it("should create daily schedule in non-interactive mode", async () => {
+      const compose = createMockCompose();
+      const schedule = createMockSchedule({
+        cronExpression: "0 14 * * *",
+        timezone: "America/New_York",
+      });
+      let deployPayload: Record<string, unknown> | undefined;
+
+      server.use(
+        // getComposeByName
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("name") === "test-agent") {
+            return HttpResponse.json(compose);
+          }
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
+        // listSchedules (to check for existing)
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+        // deploySchedule
+        http.post(
+          "http://localhost:3000/api/agent/schedules",
+          async ({ request }) => {
+            deployPayload = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(
+              { created: true, schedule },
+              { status: 201 },
+            );
+          },
+        ),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "test-agent",
+        "--frequency",
+        "daily",
+        "--time",
+        "14:00",
+        "--timezone",
+        "America/New_York",
+        "--prompt",
+        "Run daily task",
+      ]);
+
+      expect(deployPayload).toBeDefined();
+      expect(deployPayload!.cronExpression).toBe("0 14 * * *");
+      expect(deployPayload!.timezone).toBe("America/New_York");
+      expect(deployPayload!.prompt).toBe("Run daily task");
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Created schedule");
+      expect(logCalls).toContain("test-agent");
+    });
+
+    it("should create weekly schedule with day option", async () => {
+      const compose = createMockCompose();
+      const schedule = createMockSchedule({ cronExpression: "0 9 * * 1" });
+      let deployPayload: Record<string, unknown> | undefined;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(compose);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+        http.post(
+          "http://localhost:3000/api/agent/schedules",
+          async ({ request }) => {
+            deployPayload = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(
+              { created: true, schedule },
+              { status: 201 },
+            );
+          },
+        ),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "test-agent",
+        "--frequency",
+        "weekly",
+        "--day",
+        "mon",
+        "--time",
+        "09:00",
+        "--prompt",
+        "Weekly report",
+      ]);
+
+      expect(deployPayload).toBeDefined();
+      expect(deployPayload!.cronExpression).toBe("0 9 * * 1");
+    });
+
+    it("should create monthly schedule with day option", async () => {
+      const compose = createMockCompose();
+      const schedule = createMockSchedule({ cronExpression: "0 12 15 * *" });
+      let deployPayload: Record<string, unknown> | undefined;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(compose);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+        http.post(
+          "http://localhost:3000/api/agent/schedules",
+          async ({ request }) => {
+            deployPayload = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(
+              { created: true, schedule },
+              { status: 201 },
+            );
+          },
+        ),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "test-agent",
+        "--frequency",
+        "monthly",
+        "--day",
+        "15",
+        "--time",
+        "12:00",
+        "--prompt",
+        "Monthly review",
+      ]);
+
+      expect(deployPayload).toBeDefined();
+      expect(deployPayload!.cronExpression).toBe("0 12 15 * *");
+    });
+
+    it("should update existing schedule", async () => {
+      const compose = createMockCompose();
+      const existingSchedule = createMockSchedule();
+      const updatedSchedule = createMockSchedule({
+        cronExpression: "0 10 * * *",
+        prompt: "Updated task",
+      });
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(compose);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [existingSchedule] });
+        }),
+        http.post("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(
+            { created: false, schedule: updatedSchedule },
+            { status: 200 },
+          );
+        }),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "test-agent",
+        "--frequency",
+        "daily",
+        "--time",
+        "10:00",
+        "--prompt",
+        "Updated task",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Editing existing schedule");
+      expect(logCalls).toContain("Updated schedule");
+    });
+
+    it("should pass vars and secrets to API", async () => {
+      const compose = createMockCompose();
+      const schedule = createMockSchedule();
+      let deployPayload: Record<string, unknown> | undefined;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(compose);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+        http.post(
+          "http://localhost:3000/api/agent/schedules",
+          async ({ request }) => {
+            deployPayload = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(
+              { created: true, schedule },
+              { status: 201 },
+            );
+          },
+        ),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "test-agent",
+        "--frequency",
+        "daily",
+        "--time",
+        "09:00",
+        "--prompt",
+        "Task with config",
+        "--var",
+        "ENV=production",
+        "--var",
+        "DEBUG=false",
+        "--secret",
+        "API_KEY=secret-value",
+      ]);
+
+      expect(deployPayload).toBeDefined();
+      expect(deployPayload!.vars).toEqual({
+        ENV: "production",
+        DEBUG: "false",
+      });
+      expect(deployPayload!.secrets).toEqual({ API_KEY: "secret-value" });
+    });
+
+    it("should enable schedule with --enable flag", async () => {
+      const compose = createMockCompose();
+      const schedule = createMockSchedule({ enabled: false });
+      const enabledSchedule = createMockSchedule({ enabled: true });
+      let enableCalled = false;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(compose);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+        http.post("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(
+            { created: true, schedule },
+            { status: 201 },
+          );
+        }),
+        http.post(
+          "http://localhost:3000/api/agent/schedules/:name/enable",
+          () => {
+            enableCalled = true;
+            return HttpResponse.json(enabledSchedule);
+          },
+        ),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "test-agent",
+        "--frequency",
+        "daily",
+        "--time",
+        "09:00",
+        "--prompt",
+        "Daily task",
+        "--enable",
+      ]);
+
+      expect(enableCalled).toBe(true);
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Enabled schedule");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle agent not found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "nonexistent-agent",
+          "--frequency",
+          "daily",
+          "--time",
+          "09:00",
+          "--prompt",
+          "Task",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Agent not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "test-agent",
+          "--frequency",
+          "daily",
+          "--time",
+          "09:00",
+          "--prompt",
+          "Task",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 auth login"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should require --frequency in non-interactive mode", async () => {
+      const compose = createMockCompose();
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(compose);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "test-agent",
+          "--time",
+          "09:00",
+          "--prompt",
+          "Task",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--frequency is required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should require --day for weekly in non-interactive mode", async () => {
+      const compose = createMockCompose();
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(compose);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "test-agent",
+          "--frequency",
+          "weekly",
+          "--time",
+          "09:00",
+          "--prompt",
+          "Task",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--day is required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should require --time in non-interactive mode", async () => {
+      const compose = createMockCompose();
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(compose);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "test-agent",
+          "--frequency",
+          "daily",
+          "--prompt",
+          "Task",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--time is required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should require --prompt in non-interactive mode", async () => {
+      const compose = createMockCompose();
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(compose);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "test-agent",
+          "--frequency",
+          "daily",
+          "--time",
+          "09:00",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--prompt is required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should validate time format", async () => {
+      const compose = createMockCompose();
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(compose);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "test-agent",
+          "--frequency",
+          "daily",
+          "--time",
+          "invalid",
+          "--prompt",
+          "Task",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid time"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should validate day format for weekly", async () => {
+      const compose = createMockCompose();
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(compose);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "test-agent",
+          "--frequency",
+          "weekly",
+          "--day",
+          "invalid",
+          "--time",
+          "09:00",
+          "--prompt",
+          "Task",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid day"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/schedule/__tests__/status-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/status-command.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Tests for schedule status command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { statusCommand } from "../status";
+import chalk from "chalk";
+
+// Helper to create a mock schedule response
+function createMockSchedule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "schedule-1",
+    composeId: "compose-1",
+    composeName: "test-agent",
+    scopeSlug: "user-test",
+    name: "test-agent-schedule",
+    cronExpression: "0 9 * * *",
+    atTime: null,
+    timezone: "UTC",
+    prompt: "Daily task",
+    vars: null,
+    secretNames: null,
+    artifactName: null,
+    artifactVersion: null,
+    volumeVersions: null,
+    enabled: true,
+    nextRunAt: new Date(Date.now() + 86400000).toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("schedule status command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  describe("help text", () => {
+    it("should show usage information", async () => {
+      const mockStdoutWrite = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      try {
+        await statusCommand.parseAsync(["node", "cli", "--help"]);
+      } catch {
+        // Commander calls process.exit(0) after help
+      }
+
+      const output = mockStdoutWrite.mock.calls.map((call) => call[0]).join("");
+
+      expect(output).toContain("Show detailed status");
+      expect(output).toContain("<agent-name>");
+      expect(output).toContain("--limit");
+
+      mockStdoutWrite.mockRestore();
+    });
+  });
+
+  describe("successful status", () => {
+    it("should display schedule details", async () => {
+      const schedule = createMockSchedule();
+
+      server.use(
+        // resolveScheduleByAgent calls listSchedules first
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+        // Then getScheduleByName
+        http.get(
+          "http://localhost:3000/api/agent/schedules/:name",
+          ({ params }) => {
+            if (params.name === "test-agent-schedule") {
+              return HttpResponse.json(schedule);
+            }
+            return HttpResponse.json(
+              { error: { message: "Not found", code: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          },
+        ),
+        // Then listScheduleRuns
+        http.get("http://localhost:3000/api/agent/schedules/:name/runs", () => {
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "test-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("test-agent");
+      expect(logCalls).toContain("Status:");
+      expect(logCalls).toContain("enabled");
+      expect(logCalls).toContain("Agent:");
+      expect(logCalls).toContain("Prompt:");
+      expect(logCalls).toContain("Trigger:");
+      expect(logCalls).toContain("0 9 * * *");
+    });
+
+    it("should show vars and secrets names when present", async () => {
+      const schedule = createMockSchedule({
+        vars: { ENV: "production", DEBUG: "false" },
+        secretNames: ["API_KEY", "DB_PASSWORD"],
+      });
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+        http.get("http://localhost:3000/api/agent/schedules/:name", () => {
+          return HttpResponse.json(schedule);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules/:name/runs", () => {
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "test-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Variables:");
+      expect(logCalls).toContain("ENV");
+      expect(logCalls).toContain("DEBUG");
+      expect(logCalls).toContain("Secrets:");
+      expect(logCalls).toContain("API_KEY");
+      expect(logCalls).toContain("DB_PASSWORD");
+    });
+
+    it("should show artifact when present", async () => {
+      const schedule = createMockSchedule({
+        artifactName: "my-artifact",
+        artifactVersion: "v1.0",
+      });
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+        http.get("http://localhost:3000/api/agent/schedules/:name", () => {
+          return HttpResponse.json(schedule);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules/:name/runs", () => {
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "test-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Artifact:");
+      expect(logCalls).toContain("my-artifact:v1.0");
+    });
+
+    it("should show recent runs when available", async () => {
+      const schedule = createMockSchedule();
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+        http.get("http://localhost:3000/api/agent/schedules/:name", () => {
+          return HttpResponse.json(schedule);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules/:name/runs", () => {
+          return HttpResponse.json({
+            runs: [
+              {
+                id: "run-1",
+                status: "completed",
+                createdAt: new Date().toISOString(),
+                completedAt: new Date().toISOString(),
+                error: null,
+              },
+              {
+                id: "run-2",
+                status: "failed",
+                createdAt: new Date().toISOString(),
+                completedAt: new Date().toISOString(),
+                error: "Something went wrong",
+              },
+            ],
+          });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "test-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Recent Runs:");
+      expect(logCalls).toContain("run-1");
+      expect(logCalls).toContain("completed");
+      expect(logCalls).toContain("run-2");
+      expect(logCalls).toContain("failed");
+    });
+  });
+
+  describe("--limit option", () => {
+    it("should respect --limit option", async () => {
+      const schedule = createMockSchedule();
+      let requestedLimit: number | undefined;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+        http.get("http://localhost:3000/api/agent/schedules/:name", () => {
+          return HttpResponse.json(schedule);
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/schedules/:name/runs",
+          ({ request }) => {
+            const url = new URL(request.url);
+            requestedLimit = parseInt(url.searchParams.get("limit") || "5", 10);
+            return HttpResponse.json({ runs: [] });
+          },
+        ),
+      );
+
+      await statusCommand.parseAsync([
+        "node",
+        "cli",
+        "test-agent",
+        "--limit",
+        "10",
+      ]);
+
+      expect(requestedLimit).toBe(10);
+    });
+
+    it("should respect -l shorthand", async () => {
+      const schedule = createMockSchedule();
+      let requestedLimit: number | undefined;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+        http.get("http://localhost:3000/api/agent/schedules/:name", () => {
+          return HttpResponse.json(schedule);
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/schedules/:name/runs",
+          ({ request }) => {
+            const url = new URL(request.url);
+            requestedLimit = parseInt(url.searchParams.get("limit") || "5", 10);
+            return HttpResponse.json({ runs: [] });
+          },
+        ),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "test-agent", "-l", "3"]);
+
+      expect(requestedLimit).toBe(3);
+    });
+
+    it("should hide runs section when --limit 0", async () => {
+      const schedule = createMockSchedule();
+      let runsRequested = false;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+        http.get("http://localhost:3000/api/agent/schedules/:name", () => {
+          return HttpResponse.json(schedule);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules/:name/runs", () => {
+          runsRequested = true;
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await statusCommand.parseAsync([
+        "node",
+        "cli",
+        "test-agent",
+        "--limit",
+        "0",
+      ]);
+
+      expect(runsRequested).toBe(false);
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).not.toContain("Recent Runs:");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle schedule not found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli", "nonexistent-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to get schedule status"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No schedule found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli", "test-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vm0 auth login"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("global resolution", () => {
+    it("should resolve schedule by agent name from any directory", async () => {
+      // This tests that resolveScheduleByAgent finds the schedule
+      // by matching composeName in the schedules list
+      const schedule = createMockSchedule({
+        composeName: "my-special-agent",
+        name: "my-special-agent-schedule",
+      });
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [schedule] });
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/schedules/:name",
+          ({ params }) => {
+            if (params.name === "my-special-agent-schedule") {
+              return HttpResponse.json(schedule);
+            }
+            return HttpResponse.json(
+              { error: { message: "Not found", code: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules/:name/runs", () => {
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "my-special-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("my-special-agent");
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/schedule/status.ts
+++ b/turbo/apps/cli/src/commands/schedule/status.ts
@@ -189,8 +189,9 @@ export const statusCommand = new Command()
       printRunConfiguration(schedule);
       printTimeSchedule(schedule);
 
+      const parsed = parseInt(options.limit, 10);
       const limit = Math.min(
-        Math.max(0, parseInt(options.limit, 10) || 5),
+        Math.max(0, Number.isNaN(parsed) ? 5 : parsed),
         100,
       );
       await printRecentRuns(name, composeId, limit);

--- a/turbo/apps/cli/src/mocks/handlers/index.ts
+++ b/turbo/apps/cli/src/mocks/handlers/index.ts
@@ -1,4 +1,9 @@
 import { apiHandlers } from "./api-handlers";
 import { npmRegistryHandlers } from "./npm-registry-handlers";
+import { scheduleHandlers } from "./schedule-handlers";
 
-export const handlers = [...apiHandlers, ...npmRegistryHandlers];
+export const handlers = [
+  ...apiHandlers,
+  ...npmRegistryHandlers,
+  ...scheduleHandlers,
+];

--- a/turbo/apps/cli/src/mocks/handlers/schedule-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/schedule-handlers.ts
@@ -1,0 +1,118 @@
+import { http, HttpResponse } from "msw";
+
+/**
+ * Default MSW handlers for schedule API endpoints.
+ *
+ * These provide default responses for testing. Individual tests can override
+ * these handlers using server.use() to test specific scenarios.
+ */
+export const scheduleHandlers = [
+  // GET /api/agent/schedules - listSchedules
+  http.get("http://localhost:3000/api/agent/schedules", () => {
+    return HttpResponse.json({ schedules: [] }, { status: 200 });
+  }),
+
+  // POST /api/agent/schedules - deploySchedule
+  http.post("http://localhost:3000/api/agent/schedules", () => {
+    return HttpResponse.json(
+      {
+        created: true,
+        schedule: {
+          id: "schedule-default-id",
+          composeId: "compose-default-id",
+          composeName: "test-agent",
+          scopeSlug: "user-default",
+          name: "test-schedule",
+          cronExpression: "0 9 * * *",
+          atTime: null,
+          timezone: "UTC",
+          prompt: "Test prompt",
+          vars: null,
+          secretNames: null,
+          artifactName: null,
+          artifactVersion: null,
+          volumeVersions: null,
+          enabled: false,
+          nextRunAt: new Date(Date.now() + 86400000).toISOString(),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      },
+      { status: 201 },
+    );
+  }),
+
+  // GET /api/agent/schedules/:name - getScheduleByName
+  http.get("http://localhost:3000/api/agent/schedules/:name", () => {
+    return HttpResponse.json(
+      {
+        error: { message: "Schedule not found", code: "NOT_FOUND" },
+      },
+      { status: 404 },
+    );
+  }),
+
+  // DELETE /api/agent/schedules/:name - deleteSchedule
+  http.delete("http://localhost:3000/api/agent/schedules/:name", () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  // POST /api/agent/schedules/:name/enable - enableSchedule
+  http.post("http://localhost:3000/api/agent/schedules/:name/enable", () => {
+    return HttpResponse.json(
+      {
+        id: "schedule-default-id",
+        composeId: "compose-default-id",
+        composeName: "test-agent",
+        scopeSlug: "user-default",
+        name: "test-schedule",
+        cronExpression: "0 9 * * *",
+        atTime: null,
+        timezone: "UTC",
+        prompt: "Test prompt",
+        vars: null,
+        secretNames: null,
+        artifactName: null,
+        artifactVersion: null,
+        volumeVersions: null,
+        enabled: true,
+        nextRunAt: new Date(Date.now() + 86400000).toISOString(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }),
+
+  // POST /api/agent/schedules/:name/disable - disableSchedule
+  http.post("http://localhost:3000/api/agent/schedules/:name/disable", () => {
+    return HttpResponse.json(
+      {
+        id: "schedule-default-id",
+        composeId: "compose-default-id",
+        composeName: "test-agent",
+        scopeSlug: "user-default",
+        name: "test-schedule",
+        cronExpression: "0 9 * * *",
+        atTime: null,
+        timezone: "UTC",
+        prompt: "Test prompt",
+        vars: null,
+        secretNames: null,
+        artifactName: null,
+        artifactVersion: null,
+        volumeVersions: null,
+        enabled: false,
+        nextRunAt: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }),
+
+  // GET /api/agent/schedules/:name/runs - listScheduleRuns
+  http.get("http://localhost:3000/api/agent/schedules/:name/runs", () => {
+    return HttpResponse.json({ runs: [] }, { status: 200 });
+  }),
+];

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -150,10 +150,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       );
 
       // Try to create run WITHOUT providing required secrets
-      const data = await createTestRun(
-        secretComposeId,
-        "Test without secrets",
-      );
+      const data = await createTestRun(secretComposeId, "Test without secrets");
 
       // Route creates run first, then fails during preparation
       expect(data.status).toBe("failed");

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -134,6 +134,10 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(response.status).toBe(400);
       expect(data.error.message).toContain("both checkpointId and sessionId");
     });
+
+    // Note: Secrets validation (missing secrets, partial secrets, success cases) is tested
+    // via unit tests in expand-environment.test.ts which directly validates the
+    // expandEnvironmentFromCompose function with comprehensive test cases.
   });
 
   describe("Authorization", () => {
@@ -571,5 +575,73 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(response.status).toBe(404);
       expect(data.error.message).toMatch(/session/i);
     });
+
+    // Note: "Missing required secrets" validation for session continue is tested via
+    // unit tests in expand-environment.test.ts which validates the error is thrown
+    // with correct message when secrets are not provided.
+  });
+
+  describe("Checkpoint Resume", () => {
+    it("should return 404 when checkpoint not found", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            checkpointId: randomUUID(),
+            prompt: "Resume checkpoint",
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.message).toMatch(/checkpoint/i);
+    });
+
+    it("should return 404 when checkpoint belongs to different user (security)", async () => {
+      // Create another user with their own compose and run
+      const otherUser = await context.setupUser({ prefix: "other-cp" });
+      const { composeId: otherComposeId } = await createTestCompose(
+        `other-cp-agent-${Date.now()}`,
+      );
+
+      // Create and complete run for other user (creates checkpoint)
+      const otherRun = await createTestRun(otherComposeId, "Other user run");
+      const { checkpointId } = await completeTestRun(
+        otherUser.userId,
+        otherRun.runId,
+      );
+
+      // Switch back to original user
+      mockClerk({ userId: user.userId });
+
+      // Try to resume other user's checkpoint
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            checkpointId,
+            prompt: "Resume other checkpoint",
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Returns 404 for security (don't leak checkpoint existence)
+      expect(response.status).toBe(404);
+      expect(data.error.message).toMatch(/checkpoint/i);
+    });
+
+    // Note: "Missing required secrets" validation for checkpoint resume is tested via
+    // unit tests in expand-environment.test.ts which validates the error is thrown
+    // with correct message when secrets are not provided.
   });
 });

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -135,9 +135,93 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(data.error.message).toContain("both checkpointId and sessionId");
     });
 
-    // Note: Secrets validation (missing secrets, partial secrets, success cases) is tested
-    // via unit tests in expand-environment.test.ts which directly validates the
-    // expandEnvironmentFromCompose function with comprehensive test cases.
+    it("should fail run when required secrets are not provided", async () => {
+      // Create compose that requires secrets
+      const { composeId: secretComposeId } = await createTestCompose(
+        `secret-required-${Date.now()}`,
+        {
+          overrides: {
+            environment: {
+              ANTHROPIC_API_KEY: "test-key",
+              MY_SECRET: "${{ secrets.MY_SECRET }}",
+            },
+          },
+        },
+      );
+
+      // Try to create run WITHOUT providing required secrets
+      const data = await createTestRun(
+        secretComposeId,
+        "Test without secrets",
+      );
+
+      // Route creates run first, then fails during preparation
+      expect(data.status).toBe("failed");
+
+      // Verify error via API
+      const run = await getTestRun(data.runId);
+
+      expect(run.error).toMatch(/Missing required secrets/i);
+      expect(run.error).toContain("MY_SECRET");
+      expect(run.error).toContain("--secrets");
+    });
+
+    it("should fail run when only some secrets are provided", async () => {
+      // Create compose that requires multiple secrets
+      const { composeId: multiSecretComposeId } = await createTestCompose(
+        `multi-secret-${Date.now()}`,
+        {
+          overrides: {
+            environment: {
+              ANTHROPIC_API_KEY: "test-key",
+              SECRET_A: "${{ secrets.SECRET_A }}",
+              SECRET_B: "${{ secrets.SECRET_B }}",
+            },
+          },
+        },
+      );
+
+      // Try to create run with only one secret
+      const data = await createTestRun(
+        multiSecretComposeId,
+        "Test with partial secrets",
+        { secrets: { SECRET_A: "value-a" } }, // Missing SECRET_B
+      );
+
+      // Route creates run first, then fails during preparation
+      expect(data.status).toBe("failed");
+
+      // Verify error via API
+      const run = await getTestRun(data.runId);
+
+      expect(run.error).toMatch(/Missing required secrets/i);
+      expect(run.error).toContain("SECRET_B");
+      // SECRET_A should NOT be in the error (it was provided)
+      expect(run.error).not.toContain("SECRET_A");
+    });
+
+    it("should succeed when all required secrets are provided", async () => {
+      // Create compose that requires secrets
+      const { composeId: secretComposeId } = await createTestCompose(
+        `secret-success-${Date.now()}`,
+        {
+          overrides: {
+            environment: {
+              ANTHROPIC_API_KEY: "test-key",
+              MY_SECRET: "${{ secrets.MY_SECRET }}",
+            },
+          },
+        },
+      );
+
+      // Create run WITH required secrets
+      const data = await createTestRun(secretComposeId, "Test with secrets", {
+        secrets: { MY_SECRET: "secret-value" },
+      });
+
+      // Should succeed (running, not failed)
+      expect(data.status).toBe("running");
+    });
   });
 
   describe("Authorization", () => {

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -78,7 +78,9 @@ export function createDefaultComposeConfig(
   // Support both old signature (overrides only) and new signature (options object)
   const opts: ComposeConfigOptions =
     options &&
-    ("skipDefaultApiKey" in options || "noEnvironmentBlock" in options)
+    ("skipDefaultApiKey" in options ||
+      "noEnvironmentBlock" in options ||
+      "overrides" in options)
       ? options
       : { overrides: options as Partial<AgentComposeYaml["agents"][string]> };
 


### PR DESCRIPTION
## Summary

- Remove 3 redundant E2E tests from `t12-vm0-env-expansion.bats` (7 `vm0 run` calls eliminated)
- Add new Checkpoint Resume integration tests to `route.test.ts` (404 not found, 404 different user)
- Update test coverage documentation in E2E file comments

## Removed E2E Tests (covered by unit/integration tests)

| Removed Test | vm0 runs | Coverage |
|--------------|----------|----------|
| "vm0 run with multiple --secrets flags" | 1 | Same code path as Test 1 |
| "vm0 run continue requires secrets to be re-provided" | 3 | Unit tests + route tests |
| "vm0 run resume requires secrets to be re-provided" | 3 | Unit tests + route tests |

## Test Coverage Pyramid

- **Unit tests** (`expand-environment.test.ts`): Secrets validation logic and error messages
- **Route tests** (`route.test.ts`): Session/checkpoint access control (404 cases)
- **E2E test** (1 `vm0 run`): Happy path end-to-end validation

## Test plan

- [x] Route integration tests pass (27 tests)
- [ ] E2E tests pass (verified in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)