### PR TITLE
fix(runner): ensure proper cleanup and metrics collection

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1188,11 +1188,12 @@ jobs:
             # Use pm2 stop first to send SIGTERM and allow cleanup (TAP/IP release)
             # --kill-timeout gives the process 10s to cleanup before SIGKILL
             ssh $SSH_OPTS ${METAL_USER}@${RUNNER_HOST} "pm2 stop ${PM2_NAME} --kill-timeout 10000 2>/dev/null || true"
-            # Wait for process to fully exit (pm2 stop is async) (pm2 stop is async)
+            # Wait for process to fully exit (pm2 stop is async)
+            # pm2 pid returns 0 when process is stopped, empty when deleted
             echo "Waiting for runner to exit..."
             for i in $(seq 1 15); do
               pid=$(ssh $SSH_OPTS ${METAL_USER}@${RUNNER_HOST} "pm2 pid ${PM2_NAME} 2>/dev/null" || true)
-              if [ -z "$pid" ]; then
+              if [ -z "$pid" ] || [ "$pid" = "0" ]; then
                 echo "Runner exited"
                 break
               fi

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1188,9 +1188,20 @@ jobs:
             # Use pm2 stop first to send SIGTERM and allow cleanup (TAP/IP release)
             # --kill-timeout gives the process 10s to cleanup before SIGKILL
             ssh $SSH_OPTS ${METAL_USER}@${RUNNER_HOST} "pm2 stop ${PM2_NAME} --kill-timeout 10000 2>/dev/null || true"
+            # Wait for process to fully exit (pm2 stop is async) (pm2 stop is async)
+            echo "Waiting for runner to exit..."
+            for i in $(seq 1 15); do
+              pid=$(ssh $SSH_OPTS ${METAL_USER}@${RUNNER_HOST} "pm2 pid ${PM2_NAME} 2>/dev/null" || true)
+              if [ -z "$pid" ]; then
+                echo "Runner exited"
+                break
+              fi
+              echo "  Still running (pid: $pid), waiting..."
+              sleep 1
+            done
             # Remove from pm2 process list
             ssh $SSH_OPTS ${METAL_USER}@${RUNNER_HOST} "pm2 delete ${PM2_NAME} 2>/dev/null || true"
-            echo "Runner stopped"
+            echo "Runner stopped and removed from pm2"
           fi
 
           # Release the host lock

--- a/turbo/apps/runner/src/commands/benchmark.ts
+++ b/turbo/apps/runner/src/commands/benchmark.ts
@@ -124,7 +124,7 @@ export const benchmarkCommand = new Command("benchmark")
       );
     } finally {
       if (poolsInitialized) {
-        cleanupTapPool();
+        await cleanupTapPool();
         cleanupOverlayPool();
       }
     }

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -3,6 +3,7 @@
 // CI: Refactored E2E tests with setup_file() - parallel tests use 45s timeout (issue #1555)
 // Perf: Replaced Python vsock-agent with Rust for 16x faster VM startup (issue #1668)
 // CI: Use graceful shutdown for runner to prevent orphaned IP registry entries (issue #2060)
+// CI: Wait for runner process to exit before pm2 delete to avoid orphaned resources (PR #2088)
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { doctorCommand } from "./commands/doctor.js";

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/tap-pool.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/tap-pool.test.ts
@@ -70,10 +70,10 @@ describe("TapPool", () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     // Cleanup all pools to terminate any pending async operations (e.g., replenish)
     for (const pool of activePools) {
-      pool.cleanup();
+      await pool.cleanup();
     }
     vi.restoreAllMocks();
     resetIPRegistry();
@@ -361,7 +361,7 @@ describe("TapPool", () => {
       await pool.init();
       const config = await pool.acquire("vm1");
 
-      pool.cleanup();
+      await pool.cleanup();
       deleteTapCalls = [];
 
       await pool.release(config.tapDevice, config.guestIp, "vm1");
@@ -635,7 +635,7 @@ describe("TapPool", () => {
       );
 
       // Cleanup while replenish is blocked on createTap
-      pool.cleanup();
+      await pool.cleanup();
 
       // Unblock the createTap - replenish should detect shutdown
       for (const resolve of resolvers) {
@@ -643,7 +643,7 @@ describe("TapPool", () => {
       }
 
       // Wait for ALL delete operations to complete:
-      // 1. cleanup() fire-and-forget deletes pool pair (index 1)
+      // 1. cleanup() deletes pool pair (index 1)
       // 2. replenish cleanup deletes in-flight pair (index 2)
       await vi.waitFor(
         () => {

--- a/turbo/apps/runner/src/lib/runner/setup.ts
+++ b/turbo/apps/runner/src/lib/runner/setup.ts
@@ -159,7 +159,7 @@ export async function cleanupEnvironment(
 
   // Cleanup TAP pool
   try {
-    cleanupTapPool();
+    await cleanupTapPool();
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
     errors.push(error);


### PR DESCRIPTION
## Summary
Fix multiple CI reliability issues:
1. CI workflow calling `pm2 delete` before runner fully exited
2. Runner `cleanup()` using fire-and-forget for `releaseIP()` calls
3. Metrics not collected for short-running agents

## Problem 1: CI Runner Stop (pm2)
- `pm2 stop` is async - sends SIGTERM and returns immediately
- `pm2 delete` was called right after, potentially before process finished cleanup
- `pm2 pid` returns `0` for stopped processes (not empty string)

## Solution 1
- Add wait loop after `pm2 stop` to ensure process fully exits (up to 15 seconds)
- Check for both empty string and "0" from `pm2 pid`
- Only call `pm2 delete` after process has exited

## Problem 2: Runner Cleanup (fire-and-forget)
- `TapPool.cleanup()` was using fire-and-forget for `releaseIP()` calls
- `process.exit(0)` was called immediately after, interrupting async operations
- This left orphaned entries in `/var/run/vm0/ip-registry.json`

## Solution 2
- Changed `cleanup()` to async, await all `releaseIP()`/`deleteTap()` operations
- Updated `cleanupTapPool()` and callers to properly await

## Problem 3: Missing Metrics for Short-Running Agents
- `startMetricsCollector()` used `setTimeout(..., 0)` to start collection
- If agent finished very quickly, first metrics might not be collected
- Caused `t07-runner-telemetry.bats` test to fail with "No metrics found"

## Solution 3
- Collect first metrics synchronously in `startMetricsCollector()`
- Ensures at least one data point exists even for very short-running agents

## Test plan
- [ ] Run CI pipeline with `needs-runner-pipeline` label
- [ ] Verify no orphaned entries in ip-registry.json after CI completes
- [ ] Verify t07-runner-telemetry test passes (metrics available)

🤖 Generated with [Claude Code](https://claude.ai/code)