### PR TITLE
fix(platform): improve responsive layout for logs page and sidebar

### DIFF
--- a/turbo/apps/platform/src/signals/sidebar.ts
+++ b/turbo/apps/platform/src/signals/sidebar.ts
@@ -1,19 +1,31 @@
 import { command, computed, state } from "ccstate";
 
 /**
- * Internal state for sidebar collapsed/expanded.
+ * Internal state for sidebar collapsed/expanded (desktop).
  */
 const internalSidebarCollapsed$ = state(false);
 
 /**
- * Current sidebar collapsed state.
+ * Internal state for mobile sidebar open/closed.
+ */
+const internalMobileSidebarOpen$ = state(false);
+
+/**
+ * Current sidebar collapsed state (desktop).
  */
 export const sidebarCollapsed$ = computed((get) =>
   get(internalSidebarCollapsed$),
 );
 
 /**
- * Toggle sidebar between collapsed and expanded.
+ * Current mobile sidebar open state.
+ */
+export const mobileSidebarOpen$ = computed((get) =>
+  get(internalMobileSidebarOpen$),
+);
+
+/**
+ * Toggle sidebar between collapsed and expanded (desktop).
  */
 export const toggleSidebar$ = command(({ get, set }) => {
   const current = get(internalSidebarCollapsed$);
@@ -22,6 +34,21 @@ export const toggleSidebar$ = command(({ get, set }) => {
 
   // Persist to localStorage
   localStorage.setItem("sidebar-collapsed", String(newValue));
+});
+
+/**
+ * Toggle mobile sidebar open/closed.
+ */
+export const toggleMobileSidebar$ = command(({ get, set }) => {
+  const current = get(internalMobileSidebarOpen$);
+  set(internalMobileSidebarOpen$, !current);
+});
+
+/**
+ * Close mobile sidebar.
+ */
+export const closeMobileSidebar$ = command(({ set }) => {
+  set(internalMobileSidebarOpen$, false);
 });
 
 /**

--- a/turbo/apps/platform/src/views/components/pagination.tsx
+++ b/turbo/apps/platform/src/views/components/pagination.tsx
@@ -50,10 +50,10 @@ export function Pagination({
   };
 
   return (
-    <div className="flex items-center justify-end gap-8">
+    <div className="flex flex-wrap items-center justify-end gap-4 sm:gap-8">
       {/* Rows per page selector */}
       <div className="flex items-center gap-2">
-        <span className="pr-2 text-sm font-medium text-foreground">
+        <span className="pr-2 text-sm font-medium text-foreground whitespace-nowrap">
           Rows per page
         </span>
         <Select
@@ -74,7 +74,7 @@ export function Pagination({
       </div>
 
       {/* Page indicator */}
-      <span className="pr-2 text-sm font-medium text-foreground">
+      <span className="pr-2 text-sm font-medium text-foreground whitespace-nowrap">
         Page {currentPage}
         {totalPages !== undefined ? ` of ${totalPages}` : ""}
       </span>

--- a/turbo/apps/platform/src/views/layout/app-shell.tsx
+++ b/turbo/apps/platform/src/views/layout/app-shell.tsx
@@ -35,7 +35,7 @@ export function AppShell({
   return (
     <div className="flex h-screen">
       <Sidebar />
-      <div className="flex flex-1 flex-col">
+      <div className="flex flex-1 flex-col min-w-0">
         <Navbar breadcrumb={normalizedBreadcrumb} />
         <main
           className={`flex-1 overflow-auto ${gradientBackground ? "bg-background" : ""}`}

--- a/turbo/apps/platform/src/views/layout/nav-link.tsx
+++ b/turbo/apps/platform/src/views/layout/nav-link.tsx
@@ -1,4 +1,4 @@
-import { useGet, useSet } from "ccstate-react";
+import { useSet } from "ccstate-react";
 import {
   IconRobot,
   IconCircleDotFilled,
@@ -24,7 +24,6 @@ import {
 } from "@vm0/ui/components/ui/tooltip";
 import type { NavItem } from "../../types/navigation.ts";
 import { navigateInReact$ } from "../../signals/route.ts";
-import { sidebarCollapsed$ } from "../../signals/sidebar.ts";
 
 // eslint-disable-next-line ccstate/no-package-variable -- static readonly icon mapping
 const ICON_MAP = {
@@ -47,11 +46,11 @@ const ICON_MAP = {
 interface NavLinkProps {
   item: NavItem;
   isActive: boolean;
+  collapsed: boolean;
 }
 
-export function NavLink({ item, isActive }: NavLinkProps) {
+export function NavLink({ item, isActive, collapsed }: NavLinkProps) {
   const navigate = useSet(navigateInReact$);
-  const collapsed = useGet(sidebarCollapsed$);
   const IconComponent = ICON_MAP[item.icon];
 
   const handleClick = () => {

--- a/turbo/apps/platform/src/views/layout/navbar.tsx
+++ b/turbo/apps/platform/src/views/layout/navbar.tsx
@@ -8,7 +8,7 @@ import {
 } from "@vm0/ui/components/ui/tooltip";
 import { ThemeToggle } from "../components/theme-toggle.tsx";
 import { navigateInReact$ } from "../../signals/route.ts";
-import { toggleSidebar$ } from "../../signals/sidebar.ts";
+import { toggleSidebar$, toggleMobileSidebar$ } from "../../signals/sidebar.ts";
 import type { RoutePath } from "../../types/route.ts";
 
 export interface BreadcrumbItem {
@@ -23,6 +23,16 @@ interface NavbarProps {
 export function Navbar({ breadcrumb }: NavbarProps) {
   const navigate = useSet(navigateInReact$);
   const toggleSidebar = useSet(toggleSidebar$);
+  const toggleMobileSidebar = useSet(toggleMobileSidebar$);
+
+  const handleToggle = () => {
+    // Check if we're on mobile (< md breakpoint)
+    if (window.innerWidth < 768) {
+      toggleMobileSidebar();
+    } else {
+      toggleSidebar();
+    }
+  };
 
   return (
     <header className="h-[49px] flex items-center border-b border-divider bg-background">
@@ -36,7 +46,7 @@ export function Navbar({ breadcrumb }: NavbarProps) {
                 <button
                   className="icon-button"
                   aria-label="Toggle sidebar"
-                  onClick={toggleSidebar}
+                  onClick={handleToggle}
                 >
                   <IconLayoutSidebar
                     size={16}

--- a/turbo/apps/platform/src/views/layout/page-header.tsx
+++ b/turbo/apps/platform/src/views/layout/page-header.tsx
@@ -5,9 +5,15 @@ interface PageHeaderProps {
 
 export function PageHeader({ title, subtitle }: PageHeaderProps) {
   return (
-    <div className="px-8 pt-8 pb-[30px]">
-      <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
-      {subtitle && <p className="mt-1 text-muted-foreground">{subtitle}</p>}
+    <div className="px-4 sm:px-8 pt-6 sm:pt-8 pb-4 sm:pb-[30px]">
+      <h1 className="text-xl sm:text-2xl font-semibold tracking-tight">
+        {title}
+      </h1>
+      {subtitle && (
+        <p className="mt-1 text-sm sm:text-base text-muted-foreground">
+          {subtitle}
+        </p>
+      )}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/logs-page/__tests__/log-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/logs-page/__tests__/log-detail-page.test.tsx
@@ -94,13 +94,15 @@ describe("log detail page", () => {
     });
 
     // Wait for detail to load - all info is now inline in the info card
+    // Note: Both desktop and mobile info cards are rendered (CSS controls visibility)
+    // so we use getAllByText to handle multiple matches
     await waitFor(() => {
-      expect(screen.getByText("My Test Agent")).toBeInTheDocument();
+      expect(screen.getAllByText("My Test Agent").length).toBeGreaterThan(0);
     });
-    expect(screen.getByText("Done")).toBeInTheDocument(); // Status badge
-    expect(screen.getByText("openai")).toBeInTheDocument(); // Framework
-    expect(screen.getByText("Run:")).toBeInTheDocument(); // Run label
-    expect(screen.getByText("Session:")).toBeInTheDocument(); // Session label
+    expect(screen.getAllByText("Done").length).toBeGreaterThan(0); // Status badge
+    expect(screen.getAllByText("openai").length).toBeGreaterThan(0); // Framework
+    expect(screen.getByText("Run:")).toBeInTheDocument(); // Run label (desktop only)
+    expect(screen.getByText("Session:")).toBeInTheDocument(); // Session label (desktop only)
   });
 
   it("should display duration correctly", async () => {
@@ -130,8 +132,9 @@ describe("log detail page", () => {
       path: "/logs/run-duration-test",
     });
 
+    // Both desktop and mobile info cards show duration
     await waitFor(() => {
-      expect(screen.getByText("1m 30s")).toBeInTheDocument();
+      expect(screen.getAllByText("1m 30s").length).toBeGreaterThan(0);
     });
   });
 
@@ -162,8 +165,9 @@ describe("log detail page", () => {
       path: "/logs/run-no-session",
     });
 
+    // Both desktop and mobile info cards show agent name
     await waitFor(() => {
-      expect(screen.getByText("No Session Agent")).toBeInTheDocument();
+      expect(screen.getAllByText("No Session Agent").length).toBeGreaterThan(0);
     });
 
     // Session label should not be shown when sessionId is null
@@ -197,8 +201,9 @@ describe("log detail page", () => {
       path: "/logs/run-failed",
     });
 
+    // Both desktop and mobile info cards show status badge
     await waitFor(() => {
-      expect(screen.getByText("Failed")).toBeInTheDocument();
+      expect(screen.getAllByText("Failed").length).toBeGreaterThan(0);
     });
     expect(
       screen.getByText("Connection timeout after 30 seconds"),
@@ -309,9 +314,9 @@ describe("log detail page", () => {
       path: "/logs/run-back-test",
     });
 
-    // Wait for page to load - check for agent name
+    // Wait for page to load - both desktop and mobile info cards show agent name
     await waitFor(() => {
-      expect(screen.getByText("Back Test Agent")).toBeInTheDocument();
+      expect(screen.getAllByText("Back Test Agent").length).toBeGreaterThan(0);
     });
 
     // Click Logs link in breadcrumb (use within to scope to nav element)

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
@@ -129,19 +129,19 @@ export function AgentEventsCard({
 
   return (
     <div className={`flex flex-col gap-4 ${className ?? ""}`}>
-      <div className="flex items-center justify-between shrink-0">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 shrink-0">
         <div className="flex items-center gap-3">
-          <span className="text-base font-medium text-foreground">
+          <span className="text-base font-medium text-foreground whitespace-nowrap">
             Agent events
           </span>
-          <span className="text-sm text-muted-foreground">
+          <span className="text-sm text-muted-foreground whitespace-nowrap">
             {searchTerm.trim()
               ? `(${matchingCount}/${events.length} matched)`
               : `${events.length} total`}
           </span>
         </div>
-        <div className="flex items-center gap-3">
-          <div className="relative flex h-9 items-center rounded-md border border-border bg-card">
+        <div className="flex items-center gap-2 sm:gap-3">
+          <div className="relative flex h-9 flex-1 sm:flex-none items-center rounded-md border border-border bg-card">
             <div className="pl-2">
               <IconSearch className="h-4 w-4 text-muted-foreground" />
             </div>
@@ -150,7 +150,7 @@ export function AgentEventsCard({
               value={searchTerm}
               onChange={(e) => handleSearchChange(e.target.value)}
               onKeyDown={handleKeyDown}
-              className="h-full w-44 border-0 text-sm focus-visible:ring-0 focus-visible:ring-offset-0 pl-2 pr-20"
+              className="h-full w-full sm:w-44 border-0 text-sm focus-visible:ring-0 focus-visible:ring-offset-0 pl-2 pr-20"
             />
             <SearchNavigation
               currentIndex={currentMatchIdx}
@@ -162,7 +162,7 @@ export function AgentEventsCard({
           </div>
           {!isCodex && (
             <>
-              <div className="h-5 w-px bg-border" />
+              <div className="h-5 w-px bg-border hidden sm:block" />
               <ViewModeToggle mode={viewMode} setMode={handleViewModeChange} />
             </>
           )}

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import { IconClock } from "@tabler/icons-react";
 import { CopyButton } from "@vm0/ui";
@@ -38,37 +39,29 @@ export function LogDetailContent({ logId }: { logId: string }) {
 
   return (
     <div className="flex flex-col gap-4 h-full min-h-0">
-      {/* Info Card */}
-      <div className="shrink-0 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm px-4 py-3 bg-muted/30 rounded-lg border border-border">
+      {/* Info Card - Desktop: single row, Mobile: 2-column grid */}
+      {/* Desktop version */}
+      <div className="shrink-0 hidden lg:flex flex-wrap items-center gap-x-4 gap-y-2 text-sm px-4 py-3 bg-muted/30 rounded-lg border border-border">
         <StatusBadge status={detail.status} />
-
         <span className="font-medium text-foreground">{detail.agentName}</span>
-
         {detail.framework && (
           <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
             {detail.framework}
           </span>
         )}
-
         <Separator />
-
         <span className="flex items-center gap-1 text-muted-foreground">
           <IconClock className="h-3.5 w-3.5" />
           {formatDuration(detail.startedAt, detail.completedAt)}
         </span>
-
         <span className="text-muted-foreground">
           {formatTime(detail.createdAt)}
         </span>
-
         <Separator />
-
         <CopyableId label="Run" value={detail.id} />
-
         {detail.sessionId && (
           <CopyableId label="Session" value={detail.sessionId} />
         )}
-
         {detail.artifact.name && detail.artifact.version && (
           <>
             <Separator />
@@ -77,6 +70,59 @@ export function LogDetailContent({ logId }: { logId: string }) {
               version={detail.artifact.version}
             />
           </>
+        )}
+      </div>
+
+      {/* Mobile version */}
+      <div className="shrink-0 lg:hidden grid grid-cols-3 gap-x-4 gap-y-3 text-sm px-4 py-3 bg-muted/30 rounded-lg border border-border">
+        <InfoItem label="Status">
+          <StatusBadge status={detail.status} />
+        </InfoItem>
+
+        <InfoItem label="Agent">
+          <span className="font-medium text-foreground">
+            {detail.agentName}
+          </span>
+        </InfoItem>
+
+        {detail.framework && (
+          <InfoItem label="Framework">
+            <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+              {detail.framework}
+            </span>
+          </InfoItem>
+        )}
+
+        <InfoItem label="Duration">
+          <span className="flex items-center gap-1 text-foreground">
+            <IconClock className="h-3.5 w-3.5 text-muted-foreground" />
+            {formatDuration(detail.startedAt, detail.completedAt)}
+          </span>
+        </InfoItem>
+
+        <InfoItem label="Created">
+          <span className="text-foreground">
+            {formatTime(detail.createdAt)}
+          </span>
+        </InfoItem>
+
+        <InfoItem label="Run ID">
+          <CopyableId value={detail.id} />
+        </InfoItem>
+
+        {detail.sessionId && (
+          <InfoItem label="Session ID">
+            <CopyableId value={detail.sessionId} />
+          </InfoItem>
+        )}
+
+        {detail.artifact.name && detail.artifact.version && (
+          <InfoItem label="Artifact">
+            <ArtifactDownloadButton
+              name={detail.artifact.name}
+              version={detail.artifact.version}
+            />
+          </InfoItem>
         )}
       </div>
 
@@ -103,10 +149,19 @@ function Separator() {
   return <span className="text-border">|</span>;
 }
 
-function CopyableId({ label, value }: { label: string; value: string }) {
+function InfoItem({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <div className="flex items-center">{children}</div>
+    </div>
+  );
+}
+
+function CopyableId({ label, value }: { label?: string; value: string }) {
   return (
     <span className="inline-flex items-center gap-1 text-muted-foreground">
-      <span>{label}:</span>
+      {label && <span>{label}:</span>}
       <span className="font-mono text-xs">{value.slice(0, 8)}</span>
       <CopyButton text={value} className="h-4 w-4 p-0" />
     </span>

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/view-mode-toggle.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/view-mode-toggle.tsx
@@ -11,7 +11,7 @@ export function ViewModeToggle({
     <div className="flex items-center">
       <button
         onClick={() => setMode("formatted")}
-        className={`h-9 px-4 text-sm font-medium transition-colors rounded-l-lg ${
+        className={`h-9 px-3 sm:px-4 text-sm font-medium whitespace-nowrap transition-colors rounded-l-lg ${
           mode === "formatted"
             ? "border border-sidebar-primary bg-accent text-sidebar-primary"
             : "border border-border border-r-0 bg-card text-foreground hover:bg-muted"
@@ -21,7 +21,7 @@ export function ViewModeToggle({
       </button>
       <button
         onClick={() => setMode("raw")}
-        className={`h-9 px-4 text-sm font-medium transition-colors rounded-r-lg ${
+        className={`h-9 px-3 sm:px-4 text-sm font-medium whitespace-nowrap transition-colors rounded-r-lg ${
           mode === "raw"
             ? "border border-sidebar-primary bg-accent text-sidebar-primary"
             : "border border-border border-l-0 bg-card text-foreground hover:bg-muted"

--- a/turbo/apps/platform/src/views/logs-page/log-detail/log-detail.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/log-detail.tsx
@@ -13,7 +13,7 @@ export function LogDetailPage() {
 
   return (
     <AppShell breadcrumb={breadcrumb}>
-      <div className="p-8 h-full flex flex-col">
+      <div className="p-4 sm:p-8 h-full flex flex-col">
         {logId ? (
           <LogDetailContent logId={logId} />
         ) : (

--- a/turbo/apps/platform/src/views/logs-page/logs-page.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-page.tsx
@@ -10,7 +10,7 @@ export function LogsPage() {
       title="Logs"
       subtitle="View all agent runs and execution history."
     >
-      <div className="flex flex-col gap-6 px-6 mb-8">
+      <div className="flex flex-col gap-6 px-4 sm:px-6 mb-8">
         {/* Search */}
         <LogsSearch />
 

--- a/turbo/apps/platform/src/views/logs-page/logs-search.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-search.tsx
@@ -34,7 +34,7 @@ export function LogsSearch() {
   };
 
   return (
-    <div className="relative w-64">
+    <div className="relative w-full sm:w-64">
       <IconSearch className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
       <Input
         type="text"

--- a/turbo/apps/platform/src/views/logs-page/logs-table.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-table.tsx
@@ -36,8 +36,8 @@ function LogsTableHeader() {
 
 function LoadingTable() {
   return (
-    <div className="overflow-hidden rounded-md border border-border bg-card">
-      <Table>
+    <div className="overflow-x-auto rounded-md border border-border bg-card">
+      <Table className="min-w-[800px]">
         <LogsTableHeader />
         <TableBody>
           <TableRow>
@@ -64,8 +64,8 @@ export function LogsTable() {
         ? currentPage.error.message
         : "Failed to load logs";
     return (
-      <div className="overflow-hidden rounded-md border border-border bg-card">
-        <Table>
+      <div className="overflow-x-auto rounded-md border border-border bg-card">
+        <Table className="min-w-[800px]">
           <LogsTableHeader />
           <TableBody>
             <TableRow>
@@ -103,8 +103,8 @@ function LogsTableData({ pageComputed }: LogsTableDataProps) {
         ? dataLoadable.error.message
         : "Failed to load logs";
     return (
-      <div className="overflow-hidden rounded-md border border-border bg-card">
-        <Table>
+      <div className="overflow-x-auto rounded-md border border-border bg-card">
+        <Table className="min-w-[800px]">
           <LogsTableHeader />
           <TableBody>
             <TableRow>
@@ -123,8 +123,8 @@ function LogsTableData({ pageComputed }: LogsTableDataProps) {
   }
 
   return (
-    <div className="overflow-hidden rounded-md border border-border bg-card">
-      <Table>
+    <div className="overflow-x-auto rounded-md border border-border bg-card">
+      <Table className="min-w-[800px]">
         <LogsTableHeader />
         <TableBody>
           {dataLoadable.data.data.map((entry) => (


### PR DESCRIPTION
## Summary

- Add mobile sidebar drawer that opens as overlay on small screens
- Fix sidebar toggle not working on mobile by adding separate mobile state
- Make logs table horizontally scrollable on small screens
- Add responsive padding and font sizes to page header
- Make pagination wrap properly on mobile with flex-wrap
- Redesign log detail info card with 3-column grid on mobile, single row on desktop
- Fix "Raw JSON" text wrapping by adding whitespace-nowrap
- Make agent events card header stack vertically on mobile

## Test plan

- [ ] Test sidebar toggle on mobile viewport (< 768px) - should open as drawer overlay
- [ ] Test sidebar toggle on desktop viewport (>= 768px) - should collapse/expand
- [ ] Test logs list page on mobile - table should scroll horizontally
- [ ] Test log detail page on mobile - info card should display as 3-column grid
- [ ] Test log detail page on desktop - info card should display as single row
- [ ] Test pagination on mobile - should wrap properly

🤖 Generated with [Claude Code](https://claude.ai/code)