### PR TITLE
refactor(runner): use proper-lockfile for robust file locking

### DIFF
--- a/turbo/apps/runner/package.json
+++ b/turbo/apps/runner/package.json
@@ -29,11 +29,13 @@
     "@vm0/core": "workspace:*",
     "ably": "^2.17.0",
     "commander": "^14.0.0",
+    "proper-lockfile": "^4.1.2",
     "yaml": "^2.3.4",
     "zod": "^4.1.12"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
+    "@types/proper-lockfile": "^4.1.4",
     "@vm0/eslint-config": "workspace:*",
     "@vm0/typescript-config": "workspace:*",
     "eslint": "^9.34.0",

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/ip-registry.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/ip-registry.test.ts
@@ -32,7 +32,6 @@ describe("IPRegistry", () => {
     // Create registry with test config
     registry = new IPRegistry({
       runDir: testDir,
-      lockPath: path.join(testDir, "ip-pool.lock"),
       registryPath: path.join(testDir, "ip-registry.json"),
       ensureRunDir: mockEnsureRunDir,
       scanTapDevices: mockScanTapDevices,
@@ -376,8 +375,10 @@ describe("IPRegistry", () => {
     it("should acquire and release lock", async () => {
       await registry.allocateIP("tap000");
 
-      // Lock file should not exist after operation completes
-      expect(fs.existsSync(path.join(testDir, "ip-pool.lock"))).toBe(false);
+      // proper-lockfile creates .lock directory, should not exist after operation completes
+      expect(fs.existsSync(path.join(testDir, "ip-registry.json.lock"))).toBe(
+        false,
+      );
     });
 
     it("should handle concurrent operations", async () => {

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/tap-pool.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/tap-pool.test.ts
@@ -62,7 +62,6 @@ describe("TapPool", () => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), "tap-pool-test-"));
     initIPRegistry({
       runDir: testDir,
-      lockPath: path.join(testDir, "ip-pool.lock"),
       registryPath: path.join(testDir, "ip-registry.json"),
       ensureRunDir: mockEnsureRunDir,
       scanTapDevices: mockScanTapDevices,

--- a/turbo/apps/runner/src/lib/paths.ts
+++ b/turbo/apps/runner/src/lib/paths.ts
@@ -21,9 +21,6 @@ export const runtimePaths = {
   /** Runner PID file for single-instance lock */
   runnerPid: path.join(VM0_RUN_DIR, "runner.pid"),
 
-  /** IP pool lock file */
-  ipPoolLock: path.join(VM0_RUN_DIR, "ip-pool.lock.active"),
-
   /** IP allocation registry */
   ipRegistry: path.join(VM0_RUN_DIR, "ip-registry.json"),
 } as const;

--- a/turbo/apps/runner/src/lib/utils/__tests__/file-lock.test.ts
+++ b/turbo/apps/runner/src/lib/utils/__tests__/file-lock.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { withFileLock } from "../file-lock.js";
+
+describe("withFileLock", () => {
+  let testDir: string;
+  let testFile: string;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), "file-lock-test-"));
+    testFile = path.join(testDir, "test.txt");
+    fs.writeFileSync(testFile, "test content");
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it("should execute function and return result", async () => {
+    const result = await withFileLock(testFile, async () => {
+      return "success";
+    });
+
+    expect(result).toBe("success");
+  });
+
+  it("should release lock after function completes", async () => {
+    await withFileLock(testFile, async () => {
+      // Lock is held here
+    });
+
+    // Lock should be released - should be able to acquire again
+    const result = await withFileLock(testFile, async () => "second");
+    expect(result).toBe("second");
+  });
+
+  it("should release lock even if function throws", async () => {
+    await expect(
+      withFileLock(testFile, async () => {
+        throw new Error("test error");
+      }),
+    ).rejects.toThrow("test error");
+
+    // Lock should be released - should be able to acquire again
+    const result = await withFileLock(testFile, async () => "recovered");
+    expect(result).toBe("recovered");
+  });
+
+  it("should handle concurrent access", async () => {
+    let counter = 0;
+    const operations = Array.from({ length: 5 }, () =>
+      withFileLock(testFile, async () => {
+        const current = counter;
+        await new Promise((r) => setTimeout(r, 10));
+        counter = current + 1;
+        return counter;
+      }),
+    );
+
+    await Promise.all(operations);
+
+    // With proper locking, counter should reach 5
+    expect(counter).toBe(5);
+  });
+});

--- a/turbo/apps/runner/src/lib/utils/file-lock.ts
+++ b/turbo/apps/runner/src/lib/utils/file-lock.ts
@@ -1,0 +1,37 @@
+/**
+ * File locking utility using proper-lockfile
+ *
+ * Provides a simple wrapper around proper-lockfile with sensible defaults
+ * for cross-process file locking.
+ */
+import lockfile from "proper-lockfile";
+
+const DEFAULT_OPTIONS: lockfile.LockOptions = {
+  stale: 30000, // Consider lock stale after 30 seconds
+  retries: {
+    retries: 5,
+    minTimeout: 100,
+    maxTimeout: 1000,
+  },
+};
+
+/**
+ * Execute a function while holding an exclusive lock on a file
+ *
+ * @param path - Path to the file to lock
+ * @param fn - Function to execute while holding the lock
+ * @param options - Optional lock options to override defaults
+ * @returns The result of the function
+ */
+export async function withFileLock<T>(
+  path: string,
+  fn: () => Promise<T>,
+  options?: Partial<lockfile.LockOptions>,
+): Promise<T> {
+  const release = await lockfile.lock(path, { ...DEFAULT_OPTIONS, ...options });
+  try {
+    return await fn();
+  } finally {
+    await release();
+  }
+}

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
       commander:
         specifier: ^14.0.0
         version: 14.0.0
+      proper-lockfile:
+        specifier: ^4.1.2
+        version: 4.1.2
       yaml:
         specifier: ^2.3.4
         version: 2.8.1
@@ -306,6 +309,9 @@ importers:
       '@types/node':
         specifier: ^24.3.0
         version: 24.3.0
+      '@types/proper-lockfile':
+        specifier: ^4.1.4
+        version: 4.1.4
       '@vm0/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
@@ -3924,6 +3930,9 @@ packages:
   '@types/prompts@2.4.9':
     resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
 
+  '@types/proper-lockfile@4.1.4':
+    resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
+
   '@types/react-dom@19.1.9':
     resolution: {integrity: sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==}
     peerDependencies:
@@ -3937,6 +3946,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/retry@0.12.5':
+    resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
@@ -7022,6 +7034,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   property-information@6.5.0:
     resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
 
@@ -7276,6 +7291,10 @@ packages:
   responselike@2.0.1:
     resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
   rettime@0.7.0:
     resolution: {integrity: sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw==}
 
@@ -7387,6 +7406,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -11783,6 +11805,10 @@ snapshots:
       '@types/node': 24.3.0
       kleur: 3.0.3
 
+  '@types/proper-lockfile@4.1.4':
+    dependencies:
+      '@types/retry': 0.12.5
+
   '@types/react-dom@19.1.9(@types/react@19.1.12)':
     dependencies:
       '@types/react': 19.1.12
@@ -11798,6 +11824,8 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 24.3.0
+
+  '@types/retry@0.12.5': {}
 
   '@types/statuses@2.0.6': {}
 
@@ -12133,7 +12161,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.18.0)(typescript@5.9.2))(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -15542,6 +15570,12 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   property-information@6.5.0: {}
 
   property-information@7.1.0: {}
@@ -15909,6 +15943,8 @@ snapshots:
     dependencies:
       lowercase-keys: 2.0.0
 
+  retry@0.12.0: {}
+
   rettime@0.7.0: {}
 
   reusify@1.1.0: {}
@@ -16091,6 +16127,8 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 


### PR DESCRIPTION
## Summary

- Replace custom `wx` flag-based locking in ip-registry.ts with `proper-lockfile`
- Add `withFileLock` utility for cross-process file locking with sensible defaults
- Remove unused `ipPoolLock` path and `lockPath` config option

## Changes

| File | Change |
|------|--------|
| `package.json` | Add `proper-lockfile` and `@types/proper-lockfile` |
| `src/lib/utils/file-lock.ts` | New `withFileLock` utility (~35 lines) |
| `src/lib/firecracker/ip-registry.ts` | Replace `withIPLock` implementation |
| `src/lib/paths.ts` | Remove unused `ipPoolLock` |
| Tests | Update config and add new utility tests |

## Benefits

- Uses atomic `mkdir` operation (reliable on NFS)
- Built-in mtime-based staleness detection (30s threshold)
- Built-in retry with exponential backoff (5 retries, 100ms-1s)
- Cross-platform (Linux + macOS)

## Test plan

- [x] `withFileLock` utility tests pass (4/4)
- [x] `ip-registry` tests pass (21/21)
- [x] Type check passes
- [x] Lint passes

Closes #2091

🤖 Generated with [Claude Code](https://claude.ai/code)