### PR TITLE
docs: reference /testing conventions in planning skills

### DIFF
--- a/.claude/commands/deep-plan.md
+++ b/.claude/commands/deep-plan.md
@@ -73,10 +73,8 @@ Apply these thinking approaches during planning:
    - Acceptance criteria
 
 3. **Define test requirements:**
-   - **Unit tests**: Test individual functions, components, or modules in isolation
-   - **E2E tests**: Test user-facing workflows and critical paths through the system
-   - Specify which type of test is needed for each task
-   - Include test file locations and key test scenarios
+   - Include test strategy following `/testing` conventions
+   - Specify test file locations and key test scenarios
 
 4. **Identify risks and blockers:**
    - Technical challenges

--- a/.claude/skills/issue-plan/SKILL.md
+++ b/.claude/skills/issue-plan/SKILL.md
@@ -34,6 +34,7 @@ If no issue ID is provided in args, ask the user: "Which issue would you like to
 - Follow software engineering best practices: create independent feature branches (git checkout -b feature/issue-{id}-xxx)
 - Commit messages must follow Conventional Commits specification (feat / fix / docs / refactor / test / chore)
 - Follow the small iteration principle: implement small, focused changes with corresponding test cases
+- **Include test strategy in the plan following `/testing` conventions**
 - After each change, run relevant tests to verify functionality before proceeding
 - When fixing bugs: reproduce via tests first, then fix, then verify tests pass
 - In regression testing: fix failed tests one at a time, verify each individually


### PR DESCRIPTION
## Summary

- Update `/deep-plan` to reference `/testing` conventions instead of defining test types inline
- Add `/testing` reference to `/issue-plan` Important Notes section

This ensures planning skills align with the project's established testing conventions.

## Test plan

- [x] Verify changes are documentation only
- [x] No code changes requiring tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)