### PR TITLE
fix(platform): polish responsive design for logs page

### DIFF
--- a/turbo/apps/platform/src/views/layout/navbar.tsx
+++ b/turbo/apps/platform/src/views/layout/navbar.tsx
@@ -65,30 +65,39 @@ export function Navbar({ breadcrumb }: NavbarProps) {
         </div>
 
         {/* Breadcrumb */}
-        <nav className="flex items-center gap-1.5">
+        <nav className="flex items-center gap-1.5 min-w-0">
           {breadcrumb.map((item, index) => {
             const isLast = index === breadcrumb.length - 1;
             return (
               <div
                 key={`${item.label}-${index}`}
-                className="flex items-center gap-1.5"
+                className="flex items-center gap-1.5 min-w-0"
               >
                 {index > 0 && (
-                  <span className="text-muted-foreground/50">/</span>
+                  <span className="text-muted-foreground/50 shrink-0">/</span>
                 )}
                 {item.path ? (
                   <button
                     onClick={() => navigate(item.path!)}
-                    className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+                    className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors whitespace-nowrap"
                   >
                     {item.label}
                   </button>
                 ) : (
-                  <span
-                    className={`text-sm font-medium ${isLast ? "text-foreground" : "text-muted-foreground"}`}
-                  >
-                    {item.label}
-                  </span>
+                  <TooltipProvider delayDuration={300}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span
+                          className={`text-sm font-medium truncate max-w-[200px] sm:max-w-[400px] lg:max-w-[600px] ${isLast ? "text-foreground" : "text-muted-foreground"}`}
+                        >
+                          {item.label}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p className="text-xs">{item.label}</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 )}
               </div>
             );

--- a/turbo/apps/platform/src/views/logs-page/components/grouped-message-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/grouped-message-card.tsx
@@ -195,7 +195,7 @@ function SystemMessageCard({
           {subtype === "init" ? "Initialize" : subtype}
         </span>
         <span className="flex-1" />
-        <span className="text-xs text-muted-foreground shrink-0 ml-4">
+        <span className="text-xs text-muted-foreground shrink-0 ml-4 whitespace-nowrap">
           {formatEventTime(message.createdAt)}
         </span>
       </div>
@@ -229,7 +229,7 @@ function ResultMessageCard({
       >
         <ResultEventContent eventData={eventData} />
       </div>
-      <span className="text-xs text-muted-foreground shrink-0 w-[84px] text-right">
+      <span className="text-xs text-muted-foreground shrink-0 whitespace-nowrap text-right">
         {formatEventTime(message.createdAt)}
       </span>
     </div>
@@ -298,7 +298,7 @@ function TodoCard({
           </span>
         )}
         <span className="flex-1" />
-        <span className="text-xs text-muted-foreground shrink-0 ml-4">
+        <span className="text-xs text-muted-foreground shrink-0 ml-4 whitespace-nowrap">
           {formatEventTime(message.createdAt)}
         </span>
       </summary>
@@ -368,7 +368,7 @@ function AssistantMessageCard({
             matchStartIndex={currentOffset}
           />
         </div>
-        <span className="text-xs text-muted-foreground shrink-0 ml-4">
+        <span className="text-xs text-muted-foreground shrink-0 ml-4 whitespace-nowrap">
           {formatEventTime(message.createdAt)}
         </span>
       </div>,

--- a/turbo/apps/platform/src/views/logs-page/components/tool-summary.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/tool-summary.tsx
@@ -35,7 +35,6 @@ function ToolSummaryHeader({
   keyParam,
   isError,
   hasResult,
-  durationText,
   timestamp,
 }: {
   toolName: string;
@@ -43,7 +42,6 @@ function ToolSummaryHeader({
   keyParam: string;
   isError: boolean;
   hasResult: boolean;
-  durationText: string | null;
   timestamp?: string;
 }) {
   // Determine status dot variant based on result state
@@ -72,13 +70,8 @@ function ToolSummaryHeader({
         </code>
       )}
       {!keyParam && <span className="flex-1" />}
-      {durationText && (
-        <span className="text-xs text-muted-foreground shrink-0">
-          {durationText}
-        </span>
-      )}
       {timestamp && (
-        <span className="text-xs text-muted-foreground shrink-0 ml-4">
+        <span className="text-xs text-muted-foreground shrink-0 ml-4 whitespace-nowrap">
           {timestamp}
         </span>
       )}
@@ -124,13 +117,18 @@ export function ToolSummary({
         keyParam={keyParam}
         isError={isError}
         hasResult={Boolean(result)}
-        durationText={durationText}
         timestamp={timestamp}
       />
 
       <div className="mt-1 flex items-start gap-1.5 ml-[18px] mr-[100px]">
         <span className="text-muted-foreground text-xs shrink-0">└</span>
         <div className="flex-1 min-w-0 space-y-1">
+          {durationText && (
+            <div className="text-xs text-muted-foreground">
+              Duration: {durationText}
+            </div>
+          )}
+
           {input && Object.keys(input).length > 0 && (
             <ToolInputDetails input={input} toolName={toolName} />
           )}

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/artifact-download-button.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/artifact-download-button.tsx
@@ -1,5 +1,5 @@
 import { useSet, useLoadable } from "ccstate-react";
-import { IconFolder } from "@tabler/icons-react";
+import { IconDownload } from "@tabler/icons-react";
 import {
   downloadArtifact$,
   artifactDownloadPromise$,
@@ -35,9 +35,10 @@ export function ArtifactDownloadButton({
         onClick={handleDownload}
         disabled={isLoading}
         className="inline-flex items-center gap-1.5 text-sm text-foreground hover:text-primary disabled:opacity-50 disabled:cursor-not-allowed"
+        title="Download artifact"
       >
-        <IconFolder className="h-4 w-4 text-muted-foreground" />
-        My artifact folders
+        <span className="whitespace-nowrap">Download</span>
+        <IconDownload className="h-4 w-4 text-muted-foreground" />
       </button>
       {errorMessage && (
         <span className="text-xs text-destructive">{errorMessage}</span>

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -2,12 +2,18 @@ import type { ReactNode } from "react";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import { IconClock } from "@tabler/icons-react";
 import { CopyButton } from "@vm0/ui";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vm0/ui/components/ui/tooltip";
 import { logDetailSearchTerm$ } from "../../../../signals/logs-page/log-detail-state.ts";
 import { getOrCreateLogDetail$ } from "../../../../signals/logs-page/logs-signals.ts";
 import { StatusBadge } from "../../status-badge.tsx";
 import { ArtifactDownloadButton } from "./artifact-download-button.tsx";
 import { AgentEventsCard } from "./agent-events-card.tsx";
-import { formatTime, formatDuration } from "../utils.ts";
+import { formatTime, formatTimeShort, formatDuration } from "../utils.ts";
 
 export function LogDetailContent({ logId }: { logId: string }) {
   const getOrCreateLogDetail = useSet(getOrCreateLogDetail$);
@@ -101,9 +107,18 @@ export function LogDetailContent({ logId }: { logId: string }) {
         </InfoItem>
 
         <InfoItem label="Created">
-          <span className="text-foreground">
-            {formatTime(detail.createdAt)}
-          </span>
+          <TooltipProvider delayDuration={100}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="text-foreground whitespace-nowrap text-xs cursor-default">
+                  {formatTimeShort(detail.createdAt)}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="text-xs">{formatTime(detail.createdAt)}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </InfoItem>
 
         <InfoItem label="Run ID">

--- a/turbo/apps/platform/src/views/logs-page/log-detail/utils.ts
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/utils.ts
@@ -194,6 +194,18 @@ export function formatTime(dateStr: string): string {
   return date.toLocaleString("en-US", options);
 }
 
+export function formatTimeShort(dateStr: string): string {
+  const date = new Date(dateStr);
+  const options: Intl.DateTimeFormatOptions = {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  };
+  return date.toLocaleString("en-US", options);
+}
+
 export function formatDuration(
   startedAt: string | null,
   completedAt: string | null,


### PR DESCRIPTION
## Summary
- Add breadcrumb truncation with tooltip for long labels in navbar
- Add `whitespace-nowrap` to time displays in grouped message cards to prevent wrapping
- Move tool duration display to expandable details section for cleaner layout
- Update artifact button with download icon positioned after text
- Add `formatTimeShort` with tooltip for mobile Created field in log detail

This is a follow-up to PR #2094 with additional polish changes.

## Test plan
- [ ] Verify breadcrumb truncation with ellipsis on long labels
- [ ] Verify time displays don't wrap in grouped message cards
- [ ] Verify tool duration appears in details section when expanded
- [ ] Verify artifact download button shows "Download" with icon after text
- [ ] Verify mobile Created field shows short format with full time in tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)