### PR TITLE
fix(core): add missing node types for sandbox scripts

### DIFF
--- a/turbo/packages/core/package.json
+++ b/turbo/packages/core/package.json
@@ -18,6 +18,7 @@
     "check-types": "tsc --noEmit"
   },
   "devDependencies": {
+    "@types/node": "^24.3.0",
     "@vm0/eslint-config": "workspace:*",
     "@vm0/typescript-config": "workspace:*",
     "esbuild": "^0.24.0",

--- a/turbo/packages/core/tsconfig.json
+++ b/turbo/packages/core/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@vm0/typescript-config/base.json",
   "compilerOptions": {
     "lib": ["ES2022"],
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "node"]
   },
   "include": ["src/**/*", "scripts/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -579,6 +579,9 @@ importers:
         specifier: ^4.1.12
         version: 4.1.12
     devDependencies:
+      '@types/node':
+        specifier: ^24.3.0
+        version: 24.3.0
       '@vm0/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -12133,7 +12136,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.18.0)(typescript@5.9.2))(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:


### PR DESCRIPTION
## Summary
- Add `@types/node` as devDependency to `packages/core`
- Add `"node"` to the types array in `packages/core/tsconfig.json`

This fixes TypeScript errors where sandbox scripts (which use Node.js APIs like `fs`, `child_process`, `process`, etc.) were failing type checks because only `vitest/globals` types were included in the tsconfig.

This was the root cause of the type-check failures in the dependabot PRs #2072-2076.

## Test plan
- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)