### PR TITLE
refactor(runner): replace data_dir with base_dir and centralize path management

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1076,7 +1076,7 @@ jobs:
 
           # Create benchmark config with proxy settings (firewall + mitm enabled by default)
           ssh $SSH_OPTS ${METAL_USER}@${RUNNER_HOST} "
-            echo 'data_dir: ${RUNNER_DIR}/benchmark-data' > ${RUNNER_DIR}/benchmark.yaml
+            echo 'base_dir: ${RUNNER_DIR}/benchmark' > ${RUNNER_DIR}/benchmark.yaml
             echo 'firecracker:' >> ${RUNNER_DIR}/benchmark.yaml
             echo '  binary: /usr/local/bin/firecracker' >> ${RUNNER_DIR}/benchmark.yaml
             echo '  kernel: /opt/firecracker/vmlinux' >> ${RUNNER_DIR}/benchmark.yaml

--- a/ansible/playbooks/templates/runner.yaml.j2
+++ b/ansible/playbooks/templates/runner.yaml.j2
@@ -3,7 +3,7 @@
 
 name: vm0-runner-{{ inventory_hostname | regex_replace('[^a-zA-Z0-9]', '-') }}-{{ runner_suffix }}
 group: {{ runner_group }}
-data_dir: {{ runner_base_dir }}/data
+base_dir: {{ runner_base_dir }}
 
 server:
   url: {{ api_url }}

--- a/turbo/apps/runner/src/__tests__/benchmark.test.ts
+++ b/turbo/apps/runner/src/__tests__/benchmark.test.ts
@@ -4,7 +4,7 @@ import { debugConfigSchema } from "../lib/config.js";
 describe("debugConfigSchema", () => {
   it("should parse minimal config with only firecracker paths", () => {
     const config = {
-      data_dir: "/tmp/vm0-data",
+      base_dir: "/tmp/vm0",
       firecracker: {
         binary: "/usr/bin/firecracker",
         kernel: "/opt/vmlinux",
@@ -27,7 +27,7 @@ describe("debugConfigSchema", () => {
 
   it("should allow custom sandbox settings", () => {
     const config = {
-      data_dir: "/tmp/vm0-data",
+      base_dir: "/tmp/vm0",
       firecracker: {
         binary: "/usr/bin/firecracker",
         kernel: "/opt/vmlinux",
@@ -51,7 +51,7 @@ describe("debugConfigSchema", () => {
 
   it("should allow custom server settings", () => {
     const config = {
-      data_dir: "/tmp/vm0-data",
+      base_dir: "/tmp/vm0",
       firecracker: {
         binary: "/usr/bin/firecracker",
         kernel: "/opt/vmlinux",

--- a/turbo/apps/runner/src/__tests__/config.test.ts
+++ b/turbo/apps/runner/src/__tests__/config.test.ts
@@ -13,7 +13,7 @@ describe("RunnerConfig Schema", () => {
     const config = {
       name: "test-runner",
       group: "test/e2e",
-      data_dir: "/opt/runner/data",
+      base_dir: "/opt/runner",
       server: {
         url: "https://example.com",
         token: "test-token",
@@ -47,7 +47,7 @@ describe("RunnerConfig Schema", () => {
     const config = {
       name: "test",
       group: "scope/name",
-      data_dir: "/opt/runner/data",
+      base_dir: "/opt/runner",
       server: {
         url: "https://example.com",
         token: "test-token",
@@ -237,7 +237,7 @@ describe("loadConfig", () => {
     const yamlContent = `
 name: test-runner
 group: e2e/test
-data_dir: /opt/runner/data
+base_dir: /opt/runner
 server:
   url: https://example.com
   token: test-token

--- a/turbo/apps/runner/src/commands/benchmark.ts
+++ b/turbo/apps/runner/src/commands/benchmark.ts
@@ -14,7 +14,7 @@ import {
 import { initTapPool, cleanupTapPool } from "../lib/firecracker/tap-pool.js";
 import { Timer } from "../lib/timing.js";
 import { setGlobalLogger } from "../lib/logger.js";
-import { dataPaths } from "../lib/paths.js";
+import { runnerPaths } from "../lib/paths.js";
 
 interface BenchmarkOptions {
   config: string;
@@ -96,7 +96,7 @@ export const benchmarkCommand = new Command("benchmark")
       await initOverlayPool({
         size: 2,
         replenishThreshold: 1,
-        poolDir: dataPaths.overlayPool(config.data_dir),
+        poolDir: runnerPaths.overlayPool(config.base_dir),
       });
       await initTapPool({ name: config.name, size: 2, replenishThreshold: 1 });
       poolsInitialized = true;

--- a/turbo/apps/runner/src/commands/kill.ts
+++ b/turbo/apps/runner/src/commands/kill.ts
@@ -9,9 +9,9 @@
 
 import { Command } from "commander";
 import { existsSync, readFileSync, writeFileSync, rmSync } from "fs";
-import { dirname, join } from "path";
 import * as readline from "readline";
 import { loadConfig } from "../lib/config.js";
+import { runnerPaths } from "../lib/paths.js";
 import { findProcessByVmId, killProcess } from "../lib/firecracker/process.js";
 import { getIPForVm } from "../lib/firecracker/ip-registry.js";
 
@@ -41,10 +41,8 @@ export const killCommand = new Command("kill")
       options: { config: string; force?: boolean },
     ): Promise<void> => {
       try {
-        loadConfig(options.config); // Validate config exists
-        const configDir = dirname(options.config);
-        const statusFilePath = join(configDir, "status.json");
-        const workspacesDir = join(configDir, "workspaces");
+        const config = loadConfig(options.config);
+        const statusFilePath = runnerPaths.statusFile(config.base_dir);
 
         // Resolve run ID
         const { vmId, runId } = resolveRunId(runIdArg, statusFilePath);
@@ -54,7 +52,7 @@ export const killCommand = new Command("kill")
         // Find resources
         const proc = findProcessByVmId(vmId);
         const guestIp = getIPForVm(vmId);
-        const workspaceDir = join(workspacesDir, `vm0-${vmId}`);
+        const workspaceDir = runnerPaths.vmWorkDir(config.base_dir, vmId);
 
         // Show what will be cleaned up
         console.log("");

--- a/turbo/apps/runner/src/commands/start.ts
+++ b/turbo/apps/runner/src/commands/start.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
-import { dirname, join } from "path";
 import { loadConfig, validateFirecrackerPaths } from "../lib/config.js";
+import { runnerPaths } from "../lib/paths.js";
 import { Runner } from "../lib/runner/index.js";
 
 export const startCommand = new Command("start")
@@ -12,7 +12,7 @@ export const startCommand = new Command("start")
       validateFirecrackerPaths(config.firecracker);
       console.log("Config valid");
 
-      const statusFilePath = join(dirname(options.config), "status.json");
+      const statusFilePath = runnerPaths.statusFile(config.base_dir);
       const runner = new Runner(config, statusFilePath);
       await runner.start();
     } catch (error) {

--- a/turbo/apps/runner/src/lib/config.ts
+++ b/turbo/apps/runner/src/lib/config.ts
@@ -30,7 +30,7 @@ export const runnerConfigSchema = z.object({
       /^[a-z0-9-]+\/[a-z0-9-]+$/,
       "Group must be in format 'scope/name' (lowercase, hyphens allowed)",
     ),
-  data_dir: z.string().min(1, "Data directory is required"),
+  base_dir: z.string().min(1, "Base directory is required"),
   server: z.object({
     url: z.url({ message: "Server URL must be a valid URL" }),
     token: z.string().min(1, "Server token is required"),
@@ -76,7 +76,7 @@ const DEBUG_SERVER_DEFAULTS = {
 export const debugConfigSchema = z.object({
   name: z.string().default("debug-runner"),
   group: z.string().default("debug/local"),
-  data_dir: z.string().min(1, "Data directory is required"),
+  base_dir: z.string().min(1, "Base directory is required"),
   server: z
     .object({
       url: z.url().default(DEBUG_SERVER_DEFAULTS.url),

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -11,12 +11,12 @@
  * - Supporting checkpoint/resume functionality
  */
 
-import path from "path";
 import { FirecrackerVM, type VMConfig } from "./firecracker/vm.js";
 import type { GuestClient } from "./firecracker/guest.js";
 import { VsockClient } from "./firecracker/vsock.js";
 import type { ExecutionContext } from "./api.js";
 import type { RunnerConfig } from "./config.js";
+import { runnerPaths } from "./paths.js";
 import { ENV_LOADER_PATH } from "./scripts/index.js";
 import { getVMRegistry } from "./proxy/index.js";
 import {
@@ -80,9 +80,8 @@ export async function executeJob(
 
   try {
     // Create VM configuration
-    // Use workspaces directory under runner's working directory for easy cleanup
-    // When runner is stopped, the entire PR directory can be deleted
-    const workspacesDir = path.join(process.cwd(), "workspaces");
+    // Use workspaces directory under runner's base_dir for easy cleanup
+    // When runner is stopped, the entire base directory can be deleted
     const vmConfig: VMConfig = {
       vmId,
       vcpus: config.sandbox.vcpu,
@@ -90,7 +89,7 @@ export async function executeJob(
       kernelPath: config.firecracker.kernel,
       rootfsPath: config.firecracker.rootfs,
       firecrackerBinary: config.firecracker.binary,
-      workDir: path.join(workspacesDir, `vm0-${vmId}`),
+      workDir: runnerPaths.vmWorkDir(config.base_dir, vmId),
     };
 
     // Create and start VM

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/ip-registry.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/ip-registry.test.ts
@@ -19,7 +19,7 @@ describe("IPRegistry", () => {
   const mockCheckTapExists = vi.fn(async (tap: string) =>
     mockTapDevices.has(tap),
   );
-  const mockEnsureRunDir = vi.fn(async () => {});
+  const mockEnsureRegistryDir = vi.fn(async () => {});
 
   beforeEach(() => {
     // Create a unique temp directory for each test
@@ -31,9 +31,8 @@ describe("IPRegistry", () => {
 
     // Create registry with test config
     registry = new IPRegistry({
-      runDir: testDir,
       registryPath: path.join(testDir, "ip-registry.json"),
-      ensureRunDir: mockEnsureRunDir,
+      ensureRegistryDir: mockEnsureRegistryDir,
       scanTapDevices: mockScanTapDevices,
       checkTapExists: mockCheckTapExists,
     });
@@ -417,16 +416,16 @@ describe("IPRegistry", () => {
   describe("global instance", () => {
     it("should return same instance from initIPRegistry when called twice", () => {
       const instance1 = initIPRegistry({
-        runDir: testDir,
-        ensureRunDir: mockEnsureRunDir,
+        registryPath: path.join(testDir, "ip-registry.json"),
+        ensureRegistryDir: mockEnsureRegistryDir,
         scanTapDevices: mockScanTapDevices,
         checkTapExists: mockCheckTapExists,
       });
 
       // Second call should return new instance (replaces previous)
       const instance2 = initIPRegistry({
-        runDir: testDir,
-        ensureRunDir: mockEnsureRunDir,
+        registryPath: path.join(testDir, "ip-registry.json"),
+        ensureRegistryDir: mockEnsureRegistryDir,
         scanTapDevices: mockScanTapDevices,
         checkTapExists: mockCheckTapExists,
       });
@@ -437,8 +436,8 @@ describe("IPRegistry", () => {
 
     it("should create new instance after reset", () => {
       const config: IPRegistryConfig = {
-        runDir: testDir,
-        ensureRunDir: mockEnsureRunDir,
+        registryPath: path.join(testDir, "ip-registry.json"),
+        ensureRegistryDir: mockEnsureRegistryDir,
         scanTapDevices: mockScanTapDevices,
         checkTapExists: mockCheckTapExists,
       };

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/tap-pool.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/tap-pool.test.ts
@@ -31,7 +31,7 @@ describe("TapPool", () => {
   const mockCheckTapExists = vi.fn(async (tap: string) =>
     mockTapDevices.has(tap),
   );
-  const mockEnsureRunDir = vi.fn(async () => {});
+  const mockEnsureRegistryDir = vi.fn(async () => {});
 
   /** Helper to read IP registry and get allocation count */
   function getIPAllocationCount(): number {
@@ -61,9 +61,8 @@ describe("TapPool", () => {
     // Create temp directory and initialize global IPRegistry
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), "tap-pool-test-"));
     initIPRegistry({
-      runDir: testDir,
       registryPath: path.join(testDir, "ip-registry.json"),
-      ensureRunDir: mockEnsureRunDir,
+      ensureRegistryDir: mockEnsureRegistryDir,
       scanTapDevices: mockScanTapDevices,
       checkTapExists: mockCheckTapExists,
     });

--- a/turbo/apps/runner/src/lib/firecracker/ip-registry.ts
+++ b/turbo/apps/runner/src/lib/firecracker/ip-registry.ts
@@ -10,9 +10,8 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import * as fs from "node:fs";
-import path from "node:path";
 import { createLogger } from "../logger.js";
-import { VM0_RUN_DIR } from "../paths.js";
+import { VM0_RUN_DIR, runtimePaths } from "../paths.js";
 import { withFileLock } from "../utils/file-lock.js";
 
 const execAsync = promisify(exec);
@@ -127,8 +126,7 @@ export class IPRegistry {
     const runDir = config.runDir ?? VM0_RUN_DIR;
     this.config = {
       runDir,
-      registryPath:
-        config.registryPath ?? path.join(runDir, "ip-registry.json"),
+      registryPath: config.registryPath ?? runtimePaths.ipRegistry,
       ensureRunDir: config.ensureRunDir ?? (() => defaultEnsureRunDir(runDir)),
       scanTapDevices: config.scanTapDevices ?? defaultScanTapDevices,
       checkTapExists: config.checkTapExists ?? defaultCheckTapExists,

--- a/turbo/apps/runner/src/lib/firecracker/ip-registry.ts
+++ b/turbo/apps/runner/src/lib/firecracker/ip-registry.ts
@@ -10,8 +10,9 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import * as fs from "node:fs";
+import path from "node:path";
 import { createLogger } from "../logger.js";
-import { VM0_RUN_DIR, runtimePaths } from "../paths.js";
+import { runtimePaths } from "../paths.js";
 import { withFileLock } from "../utils/file-lock.js";
 
 const execAsync = promisify(exec);
@@ -45,12 +46,10 @@ interface IPRegistryData {
  * IP Registry configuration
  */
 export interface IPRegistryConfig {
-  /** Runtime directory (default: /var/run/vm0) */
-  runDir?: string;
-  /** Registry file path (default: runDir/ip-registry.json) */
+  /** Registry file path (default: /var/run/vm0/ip-registry.json) */
   registryPath?: string;
-  /** Function to ensure run directory exists */
-  ensureRunDir?: () => Promise<void>;
+  /** Function to ensure registry directory exists */
+  ensureRegistryDir?: () => Promise<void>;
   /** Function to scan all TAP devices on system */
   scanTapDevices?: () => Promise<Set<string>>;
   /** Function to check if a TAP device exists */
@@ -59,10 +58,11 @@ export interface IPRegistryConfig {
 
 // ============ Default Functions ============
 
-async function defaultEnsureRunDir(runDir: string): Promise<void> {
-  if (!fs.existsSync(runDir)) {
-    await execAsync(`sudo mkdir -p ${runDir}`);
-    await execAsync(`sudo chmod 777 ${runDir}`);
+async function defaultEnsureRegistryDir(registryPath: string): Promise<void> {
+  const dir = path.dirname(registryPath);
+  if (!fs.existsSync(dir)) {
+    await execAsync(`sudo mkdir -p ${dir}`);
+    await execAsync(`sudo chmod 777 ${dir}`);
   }
 }
 
@@ -123,11 +123,12 @@ export class IPRegistry {
   private readonly config: Required<IPRegistryConfig>;
 
   constructor(config: IPRegistryConfig = {}) {
-    const runDir = config.runDir ?? VM0_RUN_DIR;
+    const registryPath = config.registryPath ?? runtimePaths.ipRegistry;
     this.config = {
-      runDir,
-      registryPath: config.registryPath ?? runtimePaths.ipRegistry,
-      ensureRunDir: config.ensureRunDir ?? (() => defaultEnsureRunDir(runDir)),
+      registryPath,
+      ensureRegistryDir:
+        config.ensureRegistryDir ??
+        (() => defaultEnsureRegistryDir(registryPath)),
       scanTapDevices: config.scanTapDevices ?? defaultScanTapDevices,
       checkTapExists: config.checkTapExists ?? defaultCheckTapExists,
     };
@@ -139,7 +140,7 @@ export class IPRegistry {
    * Execute a function while holding an exclusive lock on the IP pool
    */
   private async withIPLock<T>(fn: () => Promise<T>): Promise<T> {
-    await this.config.ensureRunDir();
+    await this.config.ensureRegistryDir();
 
     // Ensure registry file exists (proper-lockfile requires file to exist)
     // Check first to avoid unnecessary syscall on every lock operation

--- a/turbo/apps/runner/src/lib/firecracker/vm.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vm.ts
@@ -17,7 +17,6 @@ import { generateNetworkBootArgs, type VMNetworkConfig } from "./network.js";
 import { acquireOverlay } from "./overlay-pool.js";
 import { acquireTap, releaseTap } from "./tap-pool.js";
 import { createLogger } from "../logger.js";
-import { tempPaths } from "../paths.js";
 
 const logger = createLogger("VM");
 
@@ -31,7 +30,7 @@ export interface VMConfig {
   kernelPath: string;
   rootfsPath: string;
   firecrackerBinary: string;
-  workDir?: string; // Working directory for VM files (default: /tmp/vm0-vm-{vmId})
+  workDir: string; // Working directory for VM files
 }
 
 /**
@@ -61,7 +60,7 @@ export class FirecrackerVM {
 
   constructor(config: VMConfig) {
     this.config = config;
-    this.workDir = config.workDir || tempPaths.vmWorkDir(config.vmId);
+    this.workDir = config.workDir;
     this.socketPath = path.join(this.workDir, "firecracker.sock");
     this.vsockPath = path.join(this.workDir, "vsock.sock");
   }

--- a/turbo/apps/runner/src/lib/paths.ts
+++ b/turbo/apps/runner/src/lib/paths.ts
@@ -10,7 +10,7 @@ import path from "node:path";
 /**
  * Base directories
  */
-export const VM0_RUN_DIR = "/var/run/vm0";
+const VM0_RUN_DIR = "/var/run/vm0";
 const VM0_TMP_PREFIX = "/tmp/vm0";
 
 /**

--- a/turbo/apps/runner/src/lib/paths.ts
+++ b/turbo/apps/runner/src/lib/paths.ts
@@ -55,7 +55,7 @@ export const runnerPaths = {
 
 /**
  * Temporary file paths (/tmp/vm0-*)
- * These use runId or vmId for isolation
+ * These use runId for isolation
  */
 export const tempPaths = {
   /** Default proxy CA directory */
@@ -63,9 +63,6 @@ export const tempPaths = {
 
   /** VM registry for proxy */
   vmRegistry: `${VM0_TMP_PREFIX}-vm-registry.json`,
-
-  /** VM work directory (fallback when not using workspaces) */
-  vmWorkDir: (vmId: string) => `${VM0_TMP_PREFIX}-vm-${vmId}`,
 
   /** Network log file for a run */
   networkLog: (runId: string) => `${VM0_TMP_PREFIX}-network-${runId}.jsonl`,

--- a/turbo/apps/runner/src/lib/paths.ts
+++ b/turbo/apps/runner/src/lib/paths.ts
@@ -25,13 +25,32 @@ export const runtimePaths = {
   ipRegistry: path.join(VM0_RUN_DIR, "ip-registry.json"),
 } as const;
 
+/** Prefix for VM workspace directories */
+const VM_WORKSPACE_PREFIX = "vm0-";
+
 /**
- * Per-runner data paths (config.data_dir)
- * Each runner instance has its own data directory
+ * Per-runner paths derived from config.base_dir
+ * Each runner instance has its own base directory
  */
-export const dataPaths = {
+export const runnerPaths = {
   /** Overlay pool directory for pre-warmed VM overlays */
-  overlayPool: (dataDir: string) => path.join(dataDir, "overlay-pool"),
+  overlayPool: (baseDir: string) => path.join(baseDir, "overlay-pool"),
+
+  /** Workspaces directory for VM work directories */
+  workspacesDir: (baseDir: string) => path.join(baseDir, "workspaces"),
+
+  /** VM work directory */
+  vmWorkDir: (baseDir: string, vmId: string) =>
+    path.join(baseDir, "workspaces", `${VM_WORKSPACE_PREFIX}${vmId}`),
+
+  /** Runner status file */
+  statusFile: (baseDir: string) => path.join(baseDir, "status.json"),
+
+  /** Check if a directory name is a VM workspace */
+  isVmWorkspace: (dirname: string) => dirname.startsWith(VM_WORKSPACE_PREFIX),
+
+  /** Extract vmId from workspace directory name */
+  extractVmId: (dirname: string) => dirname.replace(VM_WORKSPACE_PREFIX, ""),
 };
 
 /**

--- a/turbo/apps/runner/src/lib/runner/setup.ts
+++ b/turbo/apps/runner/src/lib/runner/setup.ts
@@ -1,5 +1,5 @@
 import type { RunnerConfig } from "../config.js";
-import { dataPaths } from "../paths.js";
+import { runnerPaths } from "../paths.js";
 import {
   checkNetworkPrerequisites,
   setupBridge,
@@ -69,7 +69,7 @@ export async function setupEnvironment(
   await initOverlayPool({
     size: config.sandbox.max_concurrent + 2,
     replenishThreshold: config.sandbox.max_concurrent,
-    poolDir: dataPaths.overlayPool(config.data_dir),
+    poolDir: runnerPaths.overlayPool(config.base_dir),
   });
 
   // Initialize TAP pool for faster VM boot


### PR DESCRIPTION
## Summary

- Rename `data_dir` to `base_dir` in runner config schema
- Add `runnerPaths` object to centralize all base_dir-derived paths
- Add `VM_WORKSPACE_PREFIX` constant and helper functions (`isVmWorkspace`, `extractVmId`)
- Replace `process.cwd()` and `dirname(config_path)` with `runnerPaths.*`
- Update Ansible template and CI benchmark config

## Directory Structure

```
{base_dir}/
├── overlay-pool/
├── workspaces/
│   └── vm0-{vmId}/
└── status.json
```

## Test plan

- [ ] Type check passes
- [ ] Lint passes
- [ ] Unit tests pass
- [ ] CI benchmark job passes

Closes #2109

🤖 Generated with [Claude Code](https://claude.ai/code)