### PR TITLE
feat(cli): update marketplace when setup-claude runs on existing install

### DIFF
--- a/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
@@ -125,13 +125,36 @@ async function addMarketplace(): Promise<void> {
 }
 
 /**
- * Ensure the VM0 skills marketplace is available
- * Adds it if not already installed
+ * Update the VM0 skills marketplace to get latest plugins
+ * Logs warning on failure but does not throw - allows installation to proceed
+ */
+async function updateMarketplace(): Promise<void> {
+  const result = await runClaudeCommand([
+    "plugin",
+    "marketplace",
+    "update",
+    MARKETPLACE_NAME,
+  ]);
+
+  if (!result.success) {
+    console.warn(
+      chalk.yellow(
+        `Warning: Could not update marketplace: ${result.error ?? "unknown error"}`,
+      ),
+    );
+  }
+}
+
+/**
+ * Ensure the VM0 skills marketplace is available and up-to-date
+ * Adds it if not installed, updates it if already present
  */
 async function ensureMarketplace(): Promise<void> {
   const installed = await isMarketplaceInstalled();
   if (!installed) {
     await addMarketplace();
+  } else {
+    await updateMarketplace();
   }
 }
 


### PR DESCRIPTION
## Summary

- When the `vm0-skills` marketplace is already installed, `vm0 setup-claude` now **updates** it to fetch the latest plugin versions instead of skipping it
- If marketplace update fails (network issues, etc.), logs a warning but continues with plugin installation
- Ensures users always get the latest plugins when running `vm0 setup-claude`

## Changes

- Add `updateMarketplace()` function with graceful error handling
- Modify `ensureMarketplace()` to call update when marketplace already exists
- Add CLI command integration tests for marketplace management behavior

## Test plan

- [x] All existing tests pass
- [x] New tests verify:
  - Marketplace update is called when already installed
  - Marketplace add is called when not installed
  - Installation continues even if marketplace update fails

Closes #2113

🤖 Generated with [Claude Code](https://claude.com/claude-code)