### PR TITLE
fix(cli): show helpful hints when concurrent run limit is reached

### DIFF
--- a/turbo/apps/cli/src/commands/run/__tests__/shared.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/shared.test.ts
@@ -188,19 +188,17 @@ describe("handleGenericRunError", () => {
 
     handleGenericRunError(error, "Run");
 
-    // Check that the error message is shown
+    // Check that the error message and hints are shown together
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("Run failed"),
     );
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("concurrent agent run limit"),
     );
-
-    // Check that the hints are shown
-    expect(consoleLogSpy).toHaveBeenCalledWith(
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("vm0 run list"),
     );
-    expect(consoleLogSpy).toHaveBeenCalledWith(
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("vm0 run kill"),
     );
   });

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -340,12 +340,11 @@ export function handleGenericRunError(
     error.code === "concurrent_run_limit_exceeded"
   ) {
     console.error(chalk.red(`✗ ${commandLabel} failed`));
-    console.error(chalk.dim(`  ${error.message}`));
-    console.log();
-    console.log("  To view active runs:");
-    console.log(chalk.cyan("    vm0 run list"));
-    console.log("  To cancel a run:");
-    console.log(chalk.cyan("    vm0 run kill <run-id>"));
+    console.error(
+      chalk.dim(
+        `  ${error.message} Use 'vm0 run list' to view runs, 'vm0 run kill <id>' to cancel.`,
+      ),
+    );
   } else {
     console.error(chalk.red(`✗ ${commandLabel} failed`));
     console.error(chalk.dim(`  ${error.message}`));

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -3,11 +3,7 @@ import {
   tsr,
   TsRestResponse,
 } from "../../../../src/lib/ts-rest-handler";
-import {
-  runsMainContract,
-  createErrorResponse,
-  type RunStatus,
-} from "@vm0/core";
+import { runsMainContract, type RunStatus } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
   agentComposes,
@@ -139,7 +135,15 @@ const router = tsr.router(runsMainContract, {
       await checkRunConcurrencyLimit(userId);
     } catch (error) {
       if (isConcurrentRunLimit(error)) {
-        return createErrorResponse("TOO_MANY_REQUESTS", error.message);
+        return {
+          status: 429 as const,
+          body: {
+            error: {
+              message: error.message,
+              code: "concurrent_run_limit_exceeded",
+            },
+          },
+        };
       }
       throw error;
     }


### PR DESCRIPTION
## Summary

- Fix error code mismatch: API endpoint returned `TOO_MANY_REQUESTS`, but CLI expected `concurrent_run_limit_exceeded`
- Add inline hints for `vm0 run list` and `vm0 run kill` when users hit the concurrent run limit
- Condense hints to a single line for better UX

**Before:**
```
✗ Run failed
  You have reached the concurrent agent run limit. Please wait for your current run to complete before starting a new one.
```

**After:**
```
✗ Run failed
  You have reached the concurrent agent run limit. Please wait for your current run to complete before starting a new one. Use 'vm0 run list' to view runs, 'vm0 run kill <id>' to cancel.
```

## Test plan

- [x] Unit tests updated and passing
- [x] Lint and type checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)