### PR TITLE
refactor(runner): add vmPaths for vm internal paths

### DIFF
--- a/turbo/apps/runner/src/lib/firecracker/vm.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vm.ts
@@ -10,13 +10,13 @@
 
 import { spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
-import path from "node:path";
 import readline from "node:readline";
 import { FirecrackerClient } from "./client.js";
 import { generateNetworkBootArgs, type VMNetworkConfig } from "./network.js";
 import { acquireOverlay } from "./overlay-pool.js";
 import { acquireTap, releaseTap } from "./tap-pool.js";
 import { createLogger } from "../logger.js";
+import { vmPaths } from "../paths.js";
 
 const logger = createLogger("VM");
 
@@ -61,8 +61,8 @@ export class FirecrackerVM {
   constructor(config: VMConfig) {
     this.config = config;
     this.workDir = config.workDir;
-    this.socketPath = path.join(this.workDir, "firecracker.sock");
-    this.vsockPath = path.join(this.workDir, "vsock.sock");
+    this.socketPath = vmPaths.socket(this.workDir);
+    this.vsockPath = vmPaths.vsock(this.workDir);
   }
 
   /**

--- a/turbo/apps/runner/src/lib/paths.ts
+++ b/turbo/apps/runner/src/lib/paths.ts
@@ -54,6 +54,18 @@ export const runnerPaths = {
 };
 
 /**
+ * VM internal paths (within workDir)
+ * These are file names inside each VM's work directory
+ */
+export const vmPaths = {
+  /** Firecracker API socket */
+  socket: (workDir: string) => path.join(workDir, "firecracker.sock"),
+
+  /** Vsock UDS for host-guest communication */
+  vsock: (workDir: string) => path.join(workDir, "vsock.sock"),
+};
+
+/**
  * Temporary file paths (/tmp/vm0-*)
  * These use runId for isolation
  */


### PR DESCRIPTION
## Summary
- Add `vmPaths` to centralize VM work directory file paths (socket, vsock)
- Update `vm.ts` to use `vmPaths` instead of inline `path.join`

This is a follow-up to #2116, continuing the centralized path management pattern.

## Test plan
- [x] Pre-commit checks pass (lint, type-check, knip)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)