### PR TITLE
test(e2e): increase axiom metrics retry tolerance

### DIFF
--- a/e2e/tests/03-experimental-runner/t07-runner-telemetry.bats
+++ b/e2e/tests/03-experimental-runner/t07-runner-telemetry.bats
@@ -141,12 +141,16 @@ teardown() {
     echo "# System log OK"
 
     # Step 7: Verify --metrics option (with retry for eventual consistency)
-    # Axiom is eventually consistent - metrics may not be immediately queryable
+    # Axiom is eventually consistent - metrics may take 10-20s to be queryable
     echo "# Step 7: Testing --metrics option..."
 
+    # Initial delay to allow Axiom to index the data
+    echo "# Waiting 5s for Axiom to index metrics..."
+    sleep 5
+
     local attempt=1
-    local max_attempts=5
-    local delay=2
+    local max_attempts=8
+    local delay=3
 
     while [[ $attempt -le $max_attempts ]]; do
         run $CLI_COMMAND logs "$RUN_ID" --metrics --tail 100


### PR DESCRIPTION
## Summary

Increase retry tolerance for Axiom metrics test to reduce flakiness.

## Problem

The `t07-runner-telemetry.bats` test was failing intermittently because Axiom's eventual consistency means metrics may take 10-20s to be queryable after upload.

Previous config:
- 5 attempts × 2s delay = 8s max wait

## Solution

- Add 5s initial delay for Axiom indexing
- Increase max attempts: 5 → 8
- Increase delay between attempts: 2s → 3s
- Total max wait: 5s + 7×3s = **26s** (was 8s)

## Test plan

- [ ] CI passes without flaky metrics test failure

🤖 Generated with [Claude Code](https://claude.ai/code)