### PR TITLE
chore(docker): move caddy and cloudflared to dockerfile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,7 @@
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"
-    },
-    "ghcr.io/devcontainers-extra/features/caddy:1": {},
-    "ghcr.io/joedmck/devcontainer-features/cloudflared:1": {}
+    }
   },
   "remoteUser": "vscode",
   "forwardPorts": [8443],

--- a/.docker/toolchain/Dockerfile
+++ b/.docker/toolchain/Dockerfile
@@ -158,5 +158,21 @@ RUN groupadd -f --gid 1000 vscode \
 # Install rust-src for rust-analyzer (IDE support for standard library)
 RUN rustup component add rust-src
 
+# Install Caddy web server (matches devcontainers-extra/features/caddy)
+RUN ARCH=$(dpkg --print-architecture) \
+    && CADDY_VERSION=$(curl -s https://api.github.com/repos/caddyserver/caddy/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') \
+    && curl -fsSL "https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/caddy_${CADDY_VERSION}_linux_${ARCH}.tar.gz" -o /tmp/caddy.tar.gz \
+    && tar -xzf /tmp/caddy.tar.gz -C /usr/local/bin caddy \
+    && chmod +x /usr/local/bin/caddy \
+    && rm /tmp/caddy.tar.gz
+
+# Install Cloudflared tunnel client via apt (matches joedmck/devcontainer-features/cloudflared)
+RUN mkdir -p /usr/share/keyrings \
+    && curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg -o /usr/share/keyrings/cloudflare-main.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/cloudflared.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends cloudflared \
+    && rm -rf /var/lib/apt/lists/*
+
 # Default command
 CMD ["/usr/bin/zsh"]


### PR DESCRIPTION
## Summary
- Remove caddy and cloudflared devcontainer features from devcontainer.json
- Install caddy directly from GitHub releases in Dockerfile
- Install cloudflared via apt from Cloudflare's official repository

This improves build consistency and reduces external feature dependencies.

🤖 Generated with [Claude Code](https://claude.ai/code)