### PR TITLE
feat(web): add platform navigation button for signed-in users

### DIFF
--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -6,8 +6,11 @@ import { Link } from "../../navigation";
 import { useTranslations } from "next-intl";
 import { useTheme } from "./ThemeProvider";
 import { useUser, useClerk } from "@clerk/nextjs";
+import { IconArrowRight } from "@tabler/icons-react";
 import ThemeToggle from "./ThemeToggle";
 import LanguageSwitcher from "./LanguageSwitcher";
+
+const PLATFORM_URL = "https://platform.vm0.ai";
 
 export default function Navbar() {
   const { theme } = useTheme();
@@ -115,12 +118,23 @@ export default function Navbar() {
               </>
             )}
             {isSignedIn && (
-              <button
-                onClick={handleSignOut}
-                className="btn-try-demo nav-desktop"
-              >
-                Sign out
-              </button>
+              <>
+                <a
+                  href={PLATFORM_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn-get-access nav-desktop"
+                >
+                  <span>Platform</span>
+                  <IconArrowRight size={16} />
+                </a>
+                <button
+                  onClick={handleSignOut}
+                  className="btn-try-demo nav-desktop"
+                >
+                  Sign out
+                </button>
+              </>
             )}
 
             {/* Hamburger Menu Button */}
@@ -197,16 +211,29 @@ export default function Navbar() {
               {t("contact")}
             </a>
             {isSignedIn && (
-              <button
-                onClick={() => {
-                  setMobileMenuOpen(false);
-                  handleSignOut();
-                }}
-                className="mobile-menu-link"
-                style={{ textAlign: "left", width: "100%" }}
-              >
-                Sign out
-              </button>
+              <>
+                <a
+                  href={PLATFORM_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mobile-menu-link"
+                  onClick={() => setMobileMenuOpen(false)}
+                  style={{ display: "flex", alignItems: "center", gap: "8px" }}
+                >
+                  <span>Platform</span>
+                  <IconArrowRight size={16} />
+                </a>
+                <button
+                  onClick={() => {
+                    setMobileMenuOpen(false);
+                    handleSignOut();
+                  }}
+                  className="mobile-menu-link"
+                  style={{ textAlign: "left", width: "100%" }}
+                >
+                  Sign out
+                </button>
+              </>
             )}
           </div>
           <div className="mobile-menu-controls">


### PR DESCRIPTION
## Summary
- Add "Platform" button with arrow icon next to "Sign out" in navbar for signed-in users
- Opens https://platform.vm0.ai in new tab when clicked
- Available in both desktop and mobile navigation menus

## Test plan
- [ ] Sign in to the web app
- [ ] Verify "Platform" button appears next to "Sign out" in desktop navbar
- [ ] Click "Platform" button and verify it opens platform.vm0.ai in new tab
- [ ] Open mobile menu and verify "Platform" link appears before "Sign out"
- [ ] Click mobile "Platform" link and verify it opens platform.vm0.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)