### PR TITLE
feat(skills): auto-assign issues to creator in issue-create skill

### DIFF
--- a/.claude/skills/issue-create/SKILL.md
+++ b/.claude/skills/issue-create/SKILL.md
@@ -128,7 +128,8 @@ Create the issue:
 gh issue create \
   --title "[type]: [clear, descriptive description]" \
   --body "[Synthesized content]" \
-  --label "[appropriate-labels]"
+  --label "[appropriate-labels]" \
+  --assignee @me
 ```
 
 ### Step 5: Return Result
@@ -218,7 +219,8 @@ Create the issue directly with:
 gh issue create \
   --title "bug: [concise description]" \
   --body "[Organized content]" \
-  --label "bug"
+  --label "bug" \
+  --assignee @me
 ```
 
 **Title format:** Use Conventional Commit style with `bug:` prefix followed by lowercase description (no period at end).
@@ -300,7 +302,8 @@ Create the issue directly with:
 gh issue create \
   --title "feat: [clear, concise description]" \
   --body "[Organized content]" \
-  --label "enhancement"
+  --label "enhancement" \
+  --assignee @me
 ```
 
 **Title format:** Use Conventional Commit style with `feat:` prefix followed by lowercase description (no period at end).


### PR DESCRIPTION
## Summary
- Add `--assignee @me` flag to all `gh issue create` commands in the issue-create skill
- Issues created via `/issue-create`, `/issue-create bug`, and `/issue-create feature` will now be automatically assigned to the creator

## Test plan
- [ ] Run `/issue-create` and verify the created issue is assigned to the current user
- [ ] Run `/issue-create bug` and verify the created issue is assigned to the current user
- [ ] Run `/issue-create feature` and verify the created issue is assigned to the current user

🤖 Generated with [Claude Code](https://claude.ai/code)