### PR TITLE
feat(web): redirect get started button to platform for signed-in users

### DIFF
--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -7,8 +7,7 @@ import { IconChevronDown, IconFile } from "@tabler/icons-react";
 import { useUser } from "@clerk/nextjs";
 import Navbar from "./Navbar";
 import Footer from "./Footer";
-
-const PLATFORM_URL = "https://platform.vm0.ai";
+import { getPlatformUrl } from "../../src/lib/url";
 
 const TYPED_TEXT = "Help me build an agent for tech news aggregation";
 const RUN_TYPED_TEXT = {
@@ -413,7 +412,7 @@ export default function LandingPage() {
                 <div className="w-full max-w-[566px]">
                   {isSignedIn ? (
                     <a
-                      href={PLATFORM_URL}
+                      href={getPlatformUrl()}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white w-full px-[24px] py-[12px] rounded-[10px] flex items-center justify-center transition-colors"
@@ -3980,7 +3979,7 @@ export default function LandingPage() {
                 <div className="flex flex-col sm:flex-row gap-[12px] sm:gap-[20px]">
                   {isSignedIn ? (
                     <a
-                      href={PLATFORM_URL}
+                      href={getPlatformUrl()}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white px-[24px] py-[12px] rounded-[10px] font-medium text-[18px] leading-[28px] w-full sm:w-[160px] transition-colors flex items-center justify-center"

--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -4,8 +4,11 @@ import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { IconChevronDown, IconFile } from "@tabler/icons-react";
+import { useUser } from "@clerk/nextjs";
 import Navbar from "./Navbar";
 import Footer from "./Footer";
+
+const PLATFORM_URL = "https://platform.vm0.ai";
 
 const TYPED_TEXT = "Help me build an agent for tech news aggregation";
 const RUN_TYPED_TEXT = {
@@ -17,6 +20,7 @@ const RUN_TYPED_TEXT = {
 
 // eslint-disable-next-line complexity
 export default function LandingPage() {
+  const { isSignedIn } = useUser();
   const [activeTab, setActiveTab] = useState<"agents" | "yaml">("agents");
   const [selectedAgent, setSelectedAgent] = useState<
     "hackernews" | "tiktok" | "blog" | "daily-report"
@@ -407,14 +411,27 @@ export default function LandingPage() {
 
                 {/* CTA Button */}
                 <div className="w-full max-w-[566px]">
-                  <Link
-                    href="/sign-up"
-                    className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white w-full px-[24px] py-[12px] rounded-[10px] flex items-center justify-center transition-colors"
-                  >
-                    <span className="font-medium leading-[28px] text-[18px] tracking-normal !text-white">
-                      Get started
-                    </span>
-                  </Link>
+                  {isSignedIn ? (
+                    <a
+                      href={PLATFORM_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white w-full px-[24px] py-[12px] rounded-[10px] flex items-center justify-center transition-colors"
+                    >
+                      <span className="font-medium leading-[28px] text-[18px] tracking-normal !text-white">
+                        Get started
+                      </span>
+                    </a>
+                  ) : (
+                    <Link
+                      href="/sign-up"
+                      className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white w-full px-[24px] py-[12px] rounded-[10px] flex items-center justify-center transition-colors"
+                    >
+                      <span className="font-medium leading-[28px] text-[18px] tracking-normal !text-white">
+                        Get started
+                      </span>
+                    </Link>
+                  )}
                 </div>
               </div>
             </div>
@@ -3961,13 +3978,25 @@ export default function LandingPage() {
                 </div>
 
                 <div className="flex flex-col sm:flex-row gap-[12px] sm:gap-[20px]">
-                  <Link
-                    href="/sign-up"
-                    className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white px-[24px] py-[12px] rounded-[10px] font-medium text-[18px] leading-[28px] w-full sm:w-[160px] transition-colors flex items-center justify-center"
-                    style={{ fontFamily: "var(--font-noto-sans)" }}
-                  >
-                    Get started
-                  </Link>
+                  {isSignedIn ? (
+                    <a
+                      href={PLATFORM_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white px-[24px] py-[12px] rounded-[10px] font-medium text-[18px] leading-[28px] w-full sm:w-[160px] transition-colors flex items-center justify-center"
+                      style={{ fontFamily: "var(--font-noto-sans)" }}
+                    >
+                      Get started
+                    </a>
+                  ) : (
+                    <Link
+                      href="/sign-up"
+                      className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white px-[24px] py-[12px] rounded-[10px] font-medium text-[18px] leading-[28px] w-full sm:w-[160px] transition-colors flex items-center justify-center"
+                      style={{ fontFamily: "var(--font-noto-sans)" }}
+                    >
+                      Get started
+                    </Link>
+                  )}
                   <a
                     href="https://github.com/vm0-ai/vm0"
                     target="_blank"

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -9,8 +9,7 @@ import { useUser, useClerk } from "@clerk/nextjs";
 import { IconArrowRight } from "@tabler/icons-react";
 import ThemeToggle from "./ThemeToggle";
 import LanguageSwitcher from "./LanguageSwitcher";
-
-const PLATFORM_URL = "https://platform.vm0.ai";
+import { getPlatformUrl } from "../../src/lib/url";
 
 export default function Navbar() {
   const { theme } = useTheme();
@@ -126,7 +125,7 @@ export default function Navbar() {
                   Sign out
                 </button>
                 <a
-                  href={PLATFORM_URL}
+                  href={getPlatformUrl()}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="btn-get-access nav-desktop group"
@@ -226,7 +225,7 @@ export default function Navbar() {
                   Sign out
                 </button>
                 <a
-                  href={PLATFORM_URL}
+                  href={getPlatformUrl()}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="mobile-menu-link group"

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -6,8 +6,11 @@ import { Link } from "../../navigation";
 import { useTranslations } from "next-intl";
 import { useTheme } from "./ThemeProvider";
 import { useUser, useClerk } from "@clerk/nextjs";
+import { IconArrowRight } from "@tabler/icons-react";
 import ThemeToggle from "./ThemeToggle";
 import LanguageSwitcher from "./LanguageSwitcher";
+
+const PLATFORM_URL = "https://platform.vm0.ai";
 
 export default function Navbar() {
   const { theme } = useTheme();
@@ -115,12 +118,26 @@ export default function Navbar() {
               </>
             )}
             {isSignedIn && (
-              <button
-                onClick={handleSignOut}
-                className="btn-try-demo nav-desktop"
-              >
-                Sign out
-              </button>
+              <>
+                <button
+                  onClick={handleSignOut}
+                  className="btn-try-demo nav-desktop"
+                >
+                  Sign out
+                </button>
+                <a
+                  href={PLATFORM_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn-get-access nav-desktop group"
+                >
+                  <span>Platform</span>
+                  <IconArrowRight
+                    size={16}
+                    className="transition-transform group-hover:translate-x-0.5"
+                  />
+                </a>
+              </>
             )}
 
             {/* Hamburger Menu Button */}
@@ -197,16 +214,32 @@ export default function Navbar() {
               {t("contact")}
             </a>
             {isSignedIn && (
-              <button
-                onClick={() => {
-                  setMobileMenuOpen(false);
-                  handleSignOut();
-                }}
-                className="mobile-menu-link"
-                style={{ textAlign: "left", width: "100%" }}
-              >
-                Sign out
-              </button>
+              <>
+                <button
+                  onClick={() => {
+                    setMobileMenuOpen(false);
+                    handleSignOut();
+                  }}
+                  className="mobile-menu-link"
+                  style={{ textAlign: "left", width: "100%" }}
+                >
+                  Sign out
+                </button>
+                <a
+                  href={PLATFORM_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mobile-menu-link group"
+                  onClick={() => setMobileMenuOpen(false)}
+                  style={{ display: "flex", alignItems: "center", gap: "8px" }}
+                >
+                  <span>Platform</span>
+                  <IconArrowRight
+                    size={16}
+                    className="transition-transform group-hover:translate-x-0.5"
+                  />
+                </a>
+              </>
             )}
           </div>
           <div className="mobile-menu-controls">

--- a/turbo/apps/web/src/lib/__tests__/url.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/url.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { getPlatformUrl } from "../url";
+
+describe("url", () => {
+  describe("getPlatformUrl", () => {
+    const originalWindow = global.window;
+
+    afterEach(() => {
+      // Restore original window
+      if (originalWindow) {
+        global.window = originalWindow;
+      } else {
+        // @ts-expect-error - deliberately setting window to undefined for SSR test
+        delete global.window;
+      }
+      vi.restoreAllMocks();
+    });
+
+    it("replaces www with platform in hostname", () => {
+      // Mock window.location
+      Object.defineProperty(global, "window", {
+        value: {
+          location: {
+            origin: "https://www.vm0.ai",
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      expect(getPlatformUrl()).toBe("https://platform.vm0.ai");
+    });
+
+    it("preserves port when replacing www with platform", () => {
+      Object.defineProperty(global, "window", {
+        value: {
+          location: {
+            origin: "https://www.vm7.ai:8443",
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      expect(getPlatformUrl()).toBe("https://platform.vm7.ai:8443");
+    });
+
+    it("preserves http protocol", () => {
+      Object.defineProperty(global, "window", {
+        value: {
+          location: {
+            origin: "http://www.localhost:3000",
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      expect(getPlatformUrl()).toBe("http://platform.localhost:3000");
+    });
+
+    it("returns fallback URL when window is undefined (SSR)", () => {
+      // @ts-expect-error - deliberately setting window to undefined for SSR test
+      delete global.window;
+
+      expect(getPlatformUrl()).toBe("https://platform.vm0.ai");
+    });
+
+    it("handles hostname without www prefix", () => {
+      Object.defineProperty(global, "window", {
+        value: {
+          location: {
+            origin: "https://vm0.ai",
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      // When there's no www, the hostname remains unchanged
+      expect(getPlatformUrl()).toBe("https://vm0.ai");
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/__tests__/url.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/url.test.ts
@@ -3,16 +3,8 @@ import { getPlatformUrl } from "../url";
 
 describe("url", () => {
   describe("getPlatformUrl", () => {
-    const originalWindow = global.window;
-
     afterEach(() => {
-      // Restore original window
-      if (originalWindow) {
-        global.window = originalWindow;
-      } else {
-        // @ts-expect-error - deliberately setting window to undefined for SSR test
-        delete global.window;
-      }
+      vi.unstubAllGlobals();
       vi.restoreAllMocks();
     });
 
@@ -60,8 +52,7 @@ describe("url", () => {
     });
 
     it("returns fallback URL when window is undefined (SSR)", () => {
-      // @ts-expect-error - deliberately setting window to undefined for SSR test
-      delete global.window;
+      vi.stubGlobal("window", undefined);
 
       expect(getPlatformUrl()).toBe("https://platform.vm0.ai");
     });

--- a/turbo/apps/web/src/lib/url.ts
+++ b/turbo/apps/web/src/lib/url.ts
@@ -1,0 +1,31 @@
+/**
+ * URL utilities for deriving related service URLs
+ */
+
+/**
+ * Resolves the Platform URL from the current browser origin.
+ * Replaces "www" with "platform" in the hostname.
+ *
+ * This is the inverse of resolveApiBase() in apps/platform/src/signals/fetch.ts,
+ * which replaces "platform" with "www" to get the API URL.
+ *
+ * @example
+ * // In browser at https://www.vm0.ai
+ * getPlatformUrl() // returns "https://platform.vm0.ai"
+ *
+ * // In browser at https://www.vm7.ai:8443
+ * getPlatformUrl() // returns "https://platform.vm7.ai:8443"
+ *
+ * @returns The platform URL derived from the current origin
+ */
+export function getPlatformUrl(): string {
+  if (typeof window === "undefined") {
+    // Fallback for server-side rendering
+    return "https://platform.vm0.ai";
+  }
+
+  const currentOrigin = window.location.origin;
+  const url = new URL(currentOrigin);
+  url.hostname = url.hostname.replace("www", "platform");
+  return url.origin;
+}


### PR DESCRIPTION
## Summary
- When user is signed in, "Get started" buttons open platform URL in a new tab
- Add "Platform" button with arrow icon to the right of "Sign out" in navbar
- Arrow icon has hover animation (moves right)
- Add `getPlatformUrl()` utility that derives platform URL from current origin (replaces www with platform)
- Available in both desktop and mobile navigation menus

## Test plan
- [ ] Visit landing page while signed out - verify "Get started" buttons go to /sign-up
- [ ] Sign in and revisit landing page - verify "Get started" buttons open platform URL
- [ ] Verify "Platform" button appears to the right of "Sign out" in navbar
- [ ] Hover over "Platform" button and verify arrow icon moves right
- [ ] Click "Platform" button and verify it opens platform URL in new tab
- [ ] Test on different environments (www.vm0.ai → platform.vm0.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)