### PR TITLE
feat(runner): implement graceful vm shutdown via vsock

### DIFF
--- a/turbo/apps/runner/src/lib/firecracker/__tests__/vsock.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/vsock.test.ts
@@ -815,4 +815,53 @@ describe("VsockClient Integration Tests", () => {
       expect(result.stderr).toContain("Connection closed");
     });
   });
+
+  describe("shutdown", () => {
+    it("should send shutdown request and receive acknowledgment", async () => {
+      const result = await client!.shutdown(5000);
+      expect(result).toBe(true);
+    });
+
+    it("should return false when not connected", async () => {
+      client!.close();
+      const result = await client!.shutdown(1000);
+      expect(result).toBe(false);
+    });
+
+    it("should return false on timeout if agent does not respond", async () => {
+      // Kill the agent so it can't respond
+      if (agent && !agent.killed) {
+        agent.kill("SIGKILL");
+      }
+      // Wait a bit for the kill to take effect
+      await new Promise((r) => setTimeout(r, 100));
+
+      const result = await client!.shutdown(100);
+      expect(result).toBe(false);
+    });
+
+    it("should handle multiple shutdown calls", async () => {
+      // First shutdown should succeed
+      const result1 = await client!.shutdown(5000);
+      expect(result1).toBe(true);
+
+      // Second shutdown should also succeed (agent still running)
+      const result2 = await client!.shutdown(5000);
+      expect(result2).toBe(true);
+    });
+
+    it("should not interfere with concurrent exec", async () => {
+      // Start a slow exec
+      const execPromise = client!.exec("sleep 0.2 && echo done", 5000);
+
+      // Call shutdown while exec is in progress
+      const shutdownResult = await client!.shutdown(5000);
+      expect(shutdownResult).toBe(true);
+
+      // Exec should still complete normally
+      const execResult = await execPromise;
+      expect(execResult.exitCode).toBe(0);
+      expect(execResult.stdout.trim()).toBe("done");
+    });
+  });
 });

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/vsock.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/vsock.test.ts
@@ -832,9 +832,11 @@ describe("VsockClient Integration Tests", () => {
       // Kill the agent so it can't respond
       if (agent && !agent.killed) {
         agent.kill("SIGKILL");
+        // Wait for process to actually exit (more robust than fixed delay)
+        await new Promise<void>((resolve) => {
+          agent!.on("exit", resolve);
+        });
       }
-      // Wait a bit for the kill to take effect
-      await new Promise((r) => setTimeout(r, 100));
 
       const result = await client!.shutdown(100);
       expect(result).toBe(false);

--- a/turbo/apps/runner/src/lib/firecracker/vm.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vm.ts
@@ -313,12 +313,9 @@ export class FirecrackerVM {
   /**
    * Stop the VM
    *
-   * Note: With --no-api mode, we can only force kill the process.
-   * The VM doesn't have an API endpoint for graceful shutdown.
-   *
-   * TODO(#2118): Implement graceful shutdown via vsock command to guest agent.
-   * This would allow the guest to clean up before termination without
-   * adding the startup latency of API mode.
+   * Note: With --no-api mode, we force kill the Firecracker process.
+   * Graceful shutdown (filesystem sync) should be done via vsock
+   * before calling this method.
    */
   async stop(): Promise<void> {
     if (this.state !== "running") {
@@ -328,9 +325,6 @@ export class FirecrackerVM {
 
     this.state = "stopping";
     logger.log(`[VM ${this.config.vmId}] Stopping...`);
-
-    // With --no-api mode, we can only force kill the process
-    // The VM doesn't have an API endpoint for graceful shutdown
     await this.cleanup();
   }
 


### PR DESCRIPTION
## Summary

- Add MSG_SHUTDOWN (0x0A) and MSG_SHUTDOWN_ACK (0x0B) protocol messages
- Guest agent calls `sync()` to flush filesystem buffers before acknowledging
- Host waits for ACK with 2 second timeout, then proceeds with SIGKILL

## Changes

| File | Change |
|------|--------|
| `vsock-agent/src/lib.rs` | Add `handle_shutdown()` that calls `libc::sync()` |
| `vsock.ts` | Add `shutdown()` method with 2s default timeout |
| `executor.ts` | Call `vsockClient.shutdown()` before `vm.kill()` |
| `vm.ts` | Remove TODO comment, update JSDoc |

## Protocol

```
0x0A shutdown      H→G  (empty payload)
0x0B shutdown_ack  G→H  (empty payload)
```

## Test plan

- [x] Unit tests for `shutdown()` method (5 test cases)
  - Normal success
  - Not connected
  - Agent timeout
  - Multiple shutdown calls
  - Concurrent with exec
- [x] All existing tests pass (267 tests)

Closes #2118

🤖 Generated with [Claude Code](https://claude.ai/code)