### PR TITLE
feat: add status page link to landing page footer

### DIFF
--- a/turbo/apps/web/app/components/Footer.tsx
+++ b/turbo/apps/web/app/components/Footer.tsx
@@ -35,6 +35,15 @@ export default function Footer() {
           <div className="footer-left">
             <p className="footer-copyright">{t("copyright")}</p>
             <div className="footer-legal-links">
+              <a
+                href="https://status.vm0.ai"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="footer-legal-link"
+              >
+                {t("status")}
+              </a>
+              <span className="footer-legal-separator">•</span>
               <Link href="/terms-of-use" className="footer-legal-link">
                 {t("termsOfUse")}
               </Link>

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -95,6 +95,7 @@
     "tagline": "Die moderne Laufzeitumgebung für agentenbasierte Entwicklung",
     "copyright": "© 2026 VM0.ai Alle Rechte vorbehalten.",
     "language": "Sprache",
+    "status": "Status",
     "termsOfUse": "Nutzungsbedingungen",
     "privacyPolicy": "Datenschutzrichtlinie"
   },

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -95,6 +95,7 @@
     "tagline": "Build agents and automate workflows with natural language",
     "copyright": "© 2026 VM0.ai All rights reserved.",
     "language": "Language",
+    "status": "Status",
     "termsOfUse": "Terms of Use",
     "privacyPolicy": "Privacy Policy"
   },

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -95,6 +95,7 @@
     "tagline": "El tiempo de ejecución moderno para desarrollo nativo de agentes",
     "copyright": "© 2026 VM0.ai Todos los derechos reservados.",
     "language": "Idioma",
+    "status": "Estado",
     "termsOfUse": "Términos de Uso",
     "privacyPolicy": "Política de Privacidad"
   },

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -95,6 +95,7 @@
     "tagline": "エージェントネイティブ開発のための最新ランタイム",
     "copyright": "© 2026 VM0.ai 無断転載禁止",
     "language": "言語",
+    "status": "ステータス",
     "termsOfUse": "利用規約",
     "privacyPolicy": "プライバシーポリシー"
   },


### PR DESCRIPTION
## Summary

- Add "Status" link to landing page footer before Terms of Use
- Link points to `https://status.vm0.ai` and opens in new tab
- Add i18n translations for all 4 locales (en, de, es, ja)
- Use existing `footer-legal-link` styling for consistency

## SEO Considerations

- External link with `target="_blank"` and `rel="noopener noreferrer"`
- No `nofollow` (same brand subdomain, link equity should flow)
- Descriptive anchor text for accessibility

## Test plan

- [ ] Status link appears before Terms of Use in footer
- [ ] Clicking link opens status.vm0.ai in new tab
- [ ] Translations display correctly in all locales
- [ ] Link styling matches existing legal links
- [ ] Hover effect applies accent color

Closes #2139

🤖 Generated with [Claude Code](https://claude.com/claude-code)