### PR TITLE
refactor(cli): remove cost display from event renderer

### DIFF
--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -301,9 +301,6 @@ export class EventRenderer {
     const durationSec = (durationMs / 1000).toFixed(1);
     console.log(`  Duration: ${chalk.dim(durationSec + "s")}`);
 
-    const cost = Number(event.data.cost || 0);
-    console.log(`  Cost: ${chalk.dim("$" + cost.toFixed(4))}`);
-
     const numTurns = Number(event.data.numTurns || 0);
     console.log(`  Turns: ${chalk.dim(String(numTurns))}`);
 


### PR DESCRIPTION
## Summary
- Removes the cost display line from the CLI event renderer output
- Simplifies the event completion summary to show only duration and turns

## Test plan
- [x] CLI tests pass (614 tests)
- [x] Pre-commit checks pass (check-types, lint, format, knip)

---
Generated with [Claude Code](https://claude.com/claude-code)