### PR TITLE
feat(platform): add infinite scroll pagination for agent events

### DIFF
--- a/turbo/apps/platform/src/signals/logs-page/__tests__/logs-signals.test.ts
+++ b/turbo/apps/platform/src/signals/logs-page/__tests__/logs-signals.test.ts
@@ -425,7 +425,6 @@ describe("logs-signals", () => {
         store.set(initAccumulatedEvents$, {
           events,
           hasMore: true,
-          framework: "claude-code",
         });
 
         expect(store.get(agentEventsAccumulated$)).toStrictEqual(events);
@@ -440,7 +439,6 @@ describe("logs-signals", () => {
         store.set(initAccumulatedEvents$, {
           events: [],
           hasMore: false,
-          framework: "claude-code",
         });
 
         expect(store.get(agentEventsAccumulated$)).toStrictEqual([]);
@@ -467,7 +465,6 @@ describe("logs-signals", () => {
         store.set(initAccumulatedEvents$, {
           events: initialEvents,
           hasMore: true,
-          framework: "claude-code",
         });
 
         // Mock API for load more
@@ -491,7 +488,6 @@ describe("logs-signals", () => {
             return HttpResponse.json({
               events: moreEvents,
               hasMore: false,
-              framework: "claude-code",
             });
           }),
         );
@@ -523,7 +519,6 @@ describe("logs-signals", () => {
             },
           ],
           hasMore: true,
-          framework: "claude-code",
         });
 
         let resolveRequest: (() => void) | null = null;
@@ -537,7 +532,6 @@ describe("logs-signals", () => {
             return HttpResponse.json({
               events: [],
               hasMore: false,
-              framework: "claude-code",
             });
           }),
         );
@@ -573,7 +567,6 @@ describe("logs-signals", () => {
             },
           ],
           hasMore: true,
-          framework: "claude-code",
         });
 
         let capturedRunId: string | null = null;
@@ -593,7 +586,6 @@ describe("logs-signals", () => {
               return HttpResponse.json({
                 events: [],
                 hasMore: false,
-                framework: "claude-code",
               });
             },
           ),
@@ -625,7 +617,6 @@ describe("logs-signals", () => {
             },
           ],
           hasMore: true,
-          framework: "claude-code",
         });
 
         server.use(
@@ -640,7 +631,6 @@ describe("logs-signals", () => {
                 },
               ],
               hasMore: true,
-              framework: "claude-code",
             });
           }),
         );
@@ -667,7 +657,6 @@ describe("logs-signals", () => {
             },
           ],
           hasMore: true,
-          framework: "claude-code",
         });
 
         server.use(
@@ -707,7 +696,6 @@ describe("logs-signals", () => {
             },
           ],
           hasMore: true,
-          framework: "claude-code",
         });
 
         expect(store.get(agentEventsAccumulated$)).toHaveLength(1);

--- a/turbo/apps/platform/src/signals/logs-page/__tests__/logs-signals.test.ts
+++ b/turbo/apps/platform/src/signals/logs-page/__tests__/logs-signals.test.ts
@@ -14,6 +14,11 @@ import {
   rowsPerPageValue$,
   searchQueryValue$,
   currentPageNumber$,
+  initAccumulatedEvents$,
+  loadMoreAgentEvents$,
+  agentEventsAccumulated$,
+  agentEventsHasMore$,
+  agentEventsIsLoadingMore$,
 } from "../logs-signals.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { mockLocation, mockPushState } from "../../location.ts";
@@ -392,6 +397,329 @@ describe("logs-signals", () => {
       store.set(initLogs$, signal);
 
       expect(store.get(hasPrevPage$)).toBeFalsy();
+    });
+  });
+
+  describe("agent events pagination", () => {
+    describe("initAccumulatedEvents$", () => {
+      it("should initialize accumulated events with provided data", () => {
+        const { store, signal } = context;
+
+        store.set(initLogs$, signal);
+
+        const events = [
+          {
+            sequenceNumber: 1,
+            eventType: "test-event",
+            eventData: { foo: "bar" },
+            createdAt: "2024-01-01T00:00:00.000Z",
+          },
+          {
+            sequenceNumber: 2,
+            eventType: "test-event-2",
+            eventData: { baz: "qux" },
+            createdAt: "2024-01-01T00:00:01.000Z",
+          },
+        ];
+
+        store.set(initAccumulatedEvents$, {
+          events,
+          hasMore: true,
+          framework: "claude-code",
+        });
+
+        expect(store.get(agentEventsAccumulated$)).toStrictEqual(events);
+        expect(store.get(agentEventsHasMore$)).toBeTruthy();
+      });
+
+      it("should set hasMore to false when no more events", () => {
+        const { store, signal } = context;
+
+        store.set(initLogs$, signal);
+
+        store.set(initAccumulatedEvents$, {
+          events: [],
+          hasMore: false,
+          framework: "claude-code",
+        });
+
+        expect(store.get(agentEventsAccumulated$)).toStrictEqual([]);
+        expect(store.get(agentEventsHasMore$)).toBeFalsy();
+      });
+    });
+
+    describe("loadMoreAgentEvents$", () => {
+      it("should append new events to accumulated state", async () => {
+        const { store, signal } = context;
+
+        // Initialize with some events
+        store.set(initLogs$, signal);
+
+        const initialEvents = [
+          {
+            sequenceNumber: 1,
+            eventType: "initial",
+            eventData: {},
+            createdAt: "2024-01-01T00:00:00.000Z",
+          },
+        ];
+
+        store.set(initAccumulatedEvents$, {
+          events: initialEvents,
+          hasMore: true,
+          framework: "claude-code",
+        });
+
+        // Mock API for load more
+        const moreEvents = [
+          {
+            sequenceNumber: 2,
+            eventType: "more",
+            eventData: {},
+            createdAt: "2024-01-01T00:00:01.000Z",
+          },
+          {
+            sequenceNumber: 3,
+            eventType: "more-2",
+            eventData: {},
+            createdAt: "2024-01-01T00:00:02.000Z",
+          },
+        ];
+
+        server.use(
+          http.get("*/api/agent/runs/:runId/telemetry/agent", () => {
+            return HttpResponse.json({
+              events: moreEvents,
+              hasMore: false,
+              framework: "claude-code",
+            });
+          }),
+        );
+
+        await store.set(loadMoreAgentEvents$, {
+          runId: "test-run-id",
+          since: "2024-01-01T00:00:00.000Z",
+        });
+
+        const accumulated = store.get(agentEventsAccumulated$);
+        expect(accumulated).toHaveLength(3);
+        expect(accumulated[0]).toStrictEqual(initialEvents[0]);
+        expect(accumulated[1]).toStrictEqual(moreEvents[0]);
+        expect(accumulated[2]).toStrictEqual(moreEvents[1]);
+        expect(store.get(agentEventsHasMore$)).toBeFalsy();
+      });
+
+      it("should set loading state during fetch", async () => {
+        const { store, signal } = context;
+
+        store.set(initLogs$, signal);
+        store.set(initAccumulatedEvents$, {
+          events: [
+            {
+              sequenceNumber: 1,
+              eventType: "initial",
+              eventData: {},
+              createdAt: "2024-01-01T00:00:00.000Z",
+            },
+          ],
+          hasMore: true,
+          framework: "claude-code",
+        });
+
+        let resolveRequest: (() => void) | null = null;
+        const requestPromise = new Promise<void>((resolve) => {
+          resolveRequest = resolve;
+        });
+
+        server.use(
+          http.get("*/api/agent/runs/:runId/telemetry/agent", async () => {
+            await requestPromise;
+            return HttpResponse.json({
+              events: [],
+              hasMore: false,
+              framework: "claude-code",
+            });
+          }),
+        );
+
+        // Start loading (don't await)
+        const loadPromise = store.set(loadMoreAgentEvents$, {
+          runId: "test-run-id",
+          since: "2024-01-01T00:00:00.000Z",
+        });
+
+        // Check loading state is true during fetch
+        expect(store.get(agentEventsIsLoadingMore$)).toBeTruthy();
+
+        // Resolve the request
+        resolveRequest!();
+        await loadPromise;
+
+        // Loading state should be false after completion
+        expect(store.get(agentEventsIsLoadingMore$)).toBeFalsy();
+      });
+
+      it("should pass correct parameters to API", async () => {
+        const { store, signal } = context;
+
+        store.set(initLogs$, signal);
+        store.set(initAccumulatedEvents$, {
+          events: [
+            {
+              sequenceNumber: 1,
+              eventType: "initial",
+              eventData: {},
+              createdAt: "2024-01-01T00:00:00.000Z",
+            },
+          ],
+          hasMore: true,
+          framework: "claude-code",
+        });
+
+        let capturedRunId: string | null = null;
+        let capturedSince: string | null = null;
+        let capturedLimit: string | null = null;
+        let capturedOrder: string | null = null;
+
+        server.use(
+          http.get(
+            "*/api/agent/runs/:runId/telemetry/agent",
+            ({ request, params }) => {
+              capturedRunId = params.runId as string;
+              const url = new URL(request.url);
+              capturedSince = url.searchParams.get("since");
+              capturedLimit = url.searchParams.get("limit");
+              capturedOrder = url.searchParams.get("order");
+              return HttpResponse.json({
+                events: [],
+                hasMore: false,
+                framework: "claude-code",
+              });
+            },
+          ),
+        );
+
+        const sinceDate = "2024-01-15T12:30:00.000Z";
+        await store.set(loadMoreAgentEvents$, {
+          runId: "my-test-run-123",
+          since: sinceDate,
+        });
+
+        expect(capturedRunId).toBe("my-test-run-123");
+        expect(capturedSince).toBe(String(new Date(sinceDate).getTime()));
+        expect(capturedLimit).toBe("30");
+        expect(capturedOrder).toBe("asc");
+      });
+
+      it("should update hasMore based on API response", async () => {
+        const { store, signal } = context;
+
+        store.set(initLogs$, signal);
+        store.set(initAccumulatedEvents$, {
+          events: [
+            {
+              sequenceNumber: 1,
+              eventType: "initial",
+              eventData: {},
+              createdAt: "2024-01-01T00:00:00.000Z",
+            },
+          ],
+          hasMore: true,
+          framework: "claude-code",
+        });
+
+        server.use(
+          http.get("*/api/agent/runs/:runId/telemetry/agent", () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 2,
+                  eventType: "more",
+                  eventData: {},
+                  createdAt: "2024-01-01T00:00:01.000Z",
+                },
+              ],
+              hasMore: true,
+              framework: "claude-code",
+            });
+          }),
+        );
+
+        await store.set(loadMoreAgentEvents$, {
+          runId: "test-run-id",
+          since: "2024-01-01T00:00:00.000Z",
+        });
+
+        expect(store.get(agentEventsHasMore$)).toBeTruthy();
+      });
+
+      it("should reset loading state on error", async () => {
+        const { store, signal } = context;
+
+        store.set(initLogs$, signal);
+        store.set(initAccumulatedEvents$, {
+          events: [
+            {
+              sequenceNumber: 1,
+              eventType: "initial",
+              eventData: {},
+              createdAt: "2024-01-01T00:00:00.000Z",
+            },
+          ],
+          hasMore: true,
+          framework: "claude-code",
+        });
+
+        server.use(
+          http.get("*/api/agent/runs/:runId/telemetry/agent", () => {
+            return HttpResponse.json(
+              { error: "Internal Server Error" },
+              { status: 500 },
+            );
+          }),
+        );
+
+        await expect(
+          store.set(loadMoreAgentEvents$, {
+            runId: "test-run-id",
+            since: "2024-01-01T00:00:00.000Z",
+          }),
+        ).rejects.toThrow("Failed to fetch more agent events");
+
+        // Loading state should be reset even on error
+        expect(store.get(agentEventsIsLoadingMore$)).toBeFalsy();
+      });
+    });
+
+    describe("initLogs$ resets accumulated events", () => {
+      it("should reset accumulated events state on init", () => {
+        const { store, signal } = context;
+
+        // First set some accumulated events
+        store.set(initLogs$, signal);
+        store.set(initAccumulatedEvents$, {
+          events: [
+            {
+              sequenceNumber: 1,
+              eventType: "test",
+              eventData: {},
+              createdAt: "2024-01-01T00:00:00.000Z",
+            },
+          ],
+          hasMore: true,
+          framework: "claude-code",
+        });
+
+        expect(store.get(agentEventsAccumulated$)).toHaveLength(1);
+        expect(store.get(agentEventsHasMore$)).toBeTruthy();
+
+        // Re-init logs should reset accumulated events
+        store.set(initLogs$, signal);
+
+        expect(store.get(agentEventsAccumulated$)).toStrictEqual([]);
+        expect(store.get(agentEventsHasMore$)).toBeFalsy();
+        expect(store.get(agentEventsIsLoadingMore$)).toBeFalsy();
+      });
     });
   });
 });

--- a/turbo/apps/platform/src/signals/logs-page/logs-signals.ts
+++ b/turbo/apps/platform/src/signals/logs-page/logs-signals.ts
@@ -87,7 +87,6 @@ const agentEventsCache$ = state<
 const internalAgentEventsAccumulated$ = state<AgentEvent[]>([]);
 const internalAgentEventsHasMore$ = state<boolean>(false);
 const internalAgentEventsIsLoadingMore$ = state<boolean>(false);
-const internalAgentEventsFramework$ = state<string>("");
 
 // Exported computed for accumulated events
 export const agentEventsAccumulated$ = computed((get) =>
@@ -104,13 +103,9 @@ export const agentEventsIsLoadingMore$ = computed((get) =>
  * Command to initialize accumulated events from initial load.
  */
 export const initAccumulatedEvents$ = command(
-  (
-    { set },
-    params: { events: AgentEvent[]; hasMore: boolean; framework: string },
-  ) => {
+  ({ set }, params: { events: AgentEvent[]; hasMore: boolean }) => {
     set(internalAgentEventsAccumulated$, params.events);
     set(internalAgentEventsHasMore$, params.hasMore);
-    set(internalAgentEventsFramework$, params.framework);
   },
 );
 
@@ -285,7 +280,6 @@ export const initLogs$ = command(({ get, set }, signal: AbortSignal) => {
   set(internalAgentEventsAccumulated$, []);
   set(internalAgentEventsHasMore$, false);
   set(internalAgentEventsIsLoadingMore$, false);
-  set(internalAgentEventsFramework$, "");
 
   // Read initial values from URL searchParams
   const params = get(searchParams$);

--- a/turbo/apps/platform/src/signals/logs-page/logs-signals.ts
+++ b/turbo/apps/platform/src/signals/logs-page/logs-signals.ts
@@ -101,9 +101,15 @@ export const agentEventsIsLoadingMore$ = computed((get) =>
 
 /**
  * Command to initialize accumulated events from initial load.
+ * This command is idempotent - it only sets state if not already initialized.
  */
 export const initAccumulatedEvents$ = command(
-  ({ set }, params: { events: AgentEvent[]; hasMore: boolean }) => {
+  ({ get, set }, params: { events: AgentEvent[]; hasMore: boolean }) => {
+    // Skip if already initialized to prevent race conditions during render
+    const current = get(internalAgentEventsAccumulated$);
+    if (current.length > 0) {
+      return;
+    }
     set(internalAgentEventsAccumulated$, params.events);
     set(internalAgentEventsHasMore$, params.hasMore);
   },

--- a/turbo/apps/platform/src/signals/logs-page/logs-signals.ts
+++ b/turbo/apps/platform/src/signals/logs-page/logs-signals.ts
@@ -4,6 +4,7 @@ import type {
   LogDetail,
   AgentEventsResponse,
   ArtifactDownloadResponse,
+  AgentEvent,
 } from "./types.ts";
 import { fetch$ } from "../fetch.ts";
 import { searchParams$, updateSearchParams$ } from "../route.ts";
@@ -73,10 +74,45 @@ const logDetailCache$ = state<Map<string, Computed<Promise<LogDetail>>>>(
   new Map(),
 );
 
+// Agent events pagination constants
+const AGENT_EVENTS_INITIAL_LIMIT = 30;
+const AGENT_EVENTS_LOAD_MORE_LIMIT = 30;
+
 // State for agent events cache (id -> computed events)
 const agentEventsCache$ = state<
   Map<string, Computed<Promise<AgentEventsResponse>>>
 >(new Map());
+
+// Accumulated events state for infinite scroll
+const internalAgentEventsAccumulated$ = state<AgentEvent[]>([]);
+const internalAgentEventsHasMore$ = state<boolean>(false);
+const internalAgentEventsIsLoadingMore$ = state<boolean>(false);
+const internalAgentEventsFramework$ = state<string>("");
+
+// Exported computed for accumulated events
+export const agentEventsAccumulated$ = computed((get) =>
+  get(internalAgentEventsAccumulated$),
+);
+export const agentEventsHasMore$ = computed((get) =>
+  get(internalAgentEventsHasMore$),
+);
+export const agentEventsIsLoadingMore$ = computed((get) =>
+  get(internalAgentEventsIsLoadingMore$),
+);
+
+/**
+ * Command to initialize accumulated events from initial load.
+ */
+export const initAccumulatedEvents$ = command(
+  (
+    { set },
+    params: { events: AgentEvent[]; hasMore: boolean; framework: string },
+  ) => {
+    set(internalAgentEventsAccumulated$, params.events);
+    set(internalAgentEventsHasMore$, params.hasMore);
+    set(internalAgentEventsFramework$, params.framework);
+  },
+);
 
 /**
  * Create a computed for fetching log detail by ID.
@@ -115,7 +151,7 @@ export const getOrCreateLogDetail$ = command(
 );
 
 /**
- * Create a computed for fetching agent events by run ID.
+ * Create a computed for fetching initial agent events by run ID.
  */
 function createAgentEventsComputed(
   runId: string,
@@ -123,7 +159,7 @@ function createAgentEventsComputed(
   return computed(async (get) => {
     const fetchFn = get(fetch$);
     const params = new URLSearchParams({
-      limit: "100",
+      limit: String(AGENT_EVENTS_INITIAL_LIMIT),
       order: "asc",
     });
     const response = await fetchFn(
@@ -155,6 +191,47 @@ export const getOrCreateAgentEvents$ = command(
       return newCache;
     });
     return events$;
+  },
+);
+
+/**
+ * Command to load more agent events for a run.
+ * Updates accumulated state with the additional events.
+ */
+export const loadMoreAgentEvents$ = command(
+  async (
+    { get, set },
+    params: { runId: string; since: string },
+  ): Promise<void> => {
+    const { runId, since } = params;
+
+    // Set loading state
+    set(internalAgentEventsIsLoadingMore$, true);
+
+    try {
+      const fetchFn = get(fetch$);
+      const sinceMs = new Date(since).getTime();
+      const urlParams = new URLSearchParams({
+        limit: String(AGENT_EVENTS_LOAD_MORE_LIMIT),
+        order: "asc",
+        since: String(sinceMs),
+      });
+      const response = await fetchFn(
+        `/api/agent/runs/${runId}/telemetry/agent?${urlParams.toString()}`,
+      );
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch more agent events: ${response.statusText}`,
+        );
+      }
+      const data = (await response.json()) as AgentEventsResponse;
+
+      // Append new events to accumulated state
+      set(internalAgentEventsAccumulated$, (prev) => [...prev, ...data.events]);
+      set(internalAgentEventsHasMore$, data.hasMore);
+    } finally {
+      set(internalAgentEventsIsLoadingMore$, false);
+    }
   },
 );
 
@@ -203,6 +280,12 @@ export const initLogs$ = command(({ get, set }, signal: AbortSignal) => {
   // Clear caches
   set(logDetailCache$, new Map());
   set(agentEventsCache$, new Map());
+
+  // Reset accumulated events state
+  set(internalAgentEventsAccumulated$, []);
+  set(internalAgentEventsHasMore$, false);
+  set(internalAgentEventsIsLoadingMore$, false);
+  set(internalAgentEventsFramework$, "");
 
   // Read initial values from URL searchParams
   const params = get(searchParams$);

--- a/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
@@ -1,6 +1,5 @@
 import {
   IconClock,
-  IconCurrencyDollar,
   IconArrowRight,
   IconTool,
   IconRobot,
@@ -99,13 +98,6 @@ export function formatDuration(ms: number): string {
   return `${minutes}m ${remainingSeconds.toFixed(0)}s`;
 }
 
-function formatCost(usd: number): string {
-  if (usd < 0.01) {
-    return `$${usd.toFixed(4)}`;
-  }
-  return `$${usd.toFixed(2)}`;
-}
-
 // ============ SYSTEM EVENT (Init) ============
 
 function CategoryPopover({
@@ -190,7 +182,6 @@ export function SystemInitContent({ eventData }: { eventData: EventData }) {
 
 // Exported for use in GroupedMessageCard
 export function ResultEventContent({ eventData }: { eventData: EventData }) {
-  const totalCost = eventData.total_cost_usd;
   const durationMs = eventData.duration_ms;
   const numTurns = eventData.num_turns;
   const modelUsage = eventData.modelUsage;
@@ -206,12 +197,6 @@ export function ResultEventContent({ eventData }: { eventData: EventData }) {
             <span className="text-foreground">
               {formatDuration(durationMs)}
             </span>
-          </div>
-        )}
-        {totalCost !== null && totalCost !== undefined && (
-          <div className="flex items-center gap-1.5">
-            <IconCurrencyDollar className="h-4 w-4 text-muted-foreground" />
-            <span className="text-foreground">{formatCost(totalCost)}</span>
           </div>
         )}
         {numTurns !== null && numTurns !== undefined && (
@@ -230,10 +215,7 @@ export function ResultEventContent({ eventData }: { eventData: EventData }) {
           </summary>
           <div className="mt-1 space-y-0.5 pl-2">
             {Object.entries(modelUsage)
-              .filter(
-                ([, usage]) =>
-                  usage.inputTokens || usage.outputTokens || usage.costUSD,
-              )
+              .filter(([, usage]) => usage.inputTokens || usage.outputTokens)
               .map(([model, usage]) => (
                 <div key={model} className="text-muted-foreground">
                   {model}{" "}
@@ -246,12 +228,6 @@ export function ResultEventContent({ eventData }: { eventData: EventData }) {
                     {usage.outputTokens
                       ? `out: ${usage.outputTokens.toLocaleString()}`
                       : ""}
-                    {usage.costUSD ? (
-                      <span className="text-emerald-600">
-                        {" "}
-                        {formatCost(usage.costUSD)}
-                      </span>
-                    ) : null}
                     )
                   </span>
                 </div>

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
@@ -1,5 +1,5 @@
 import { useGet, useSet, useLoadable } from "ccstate-react";
-import { IconSearch } from "@tabler/icons-react";
+import { IconSearch, IconLoader2 } from "@tabler/icons-react";
 import { Input } from "@vm0/ui";
 import {
   viewMode$,
@@ -7,7 +7,14 @@ import {
   totalMatchCount$,
   type ViewMode,
 } from "../../../../signals/logs-page/log-detail-state.ts";
-import { getOrCreateAgentEvents$ } from "../../../../signals/logs-page/logs-signals.ts";
+import {
+  getOrCreateAgentEvents$,
+  loadMoreAgentEvents$,
+  agentEventsAccumulated$,
+  agentEventsHasMore$,
+  agentEventsIsLoadingMore$,
+  initAccumulatedEvents$,
+} from "../../../../signals/logs-page/logs-signals.ts";
 import { SearchNavigation } from "../../components/search-navigation.tsx";
 import { ViewModeToggle } from "./view-mode-toggle.tsx";
 import { RawJsonView } from "./raw-json-view.tsx";
@@ -33,8 +40,15 @@ export function AgentEventsCard({
 }) {
   const isCodex = framework === "codex";
   const getOrCreateAgentEvents = useSet(getOrCreateAgentEvents$);
+  const loadMoreAgentEvents = useSet(loadMoreAgentEvents$);
+  const initAccumulatedEvents = useSet(initAccumulatedEvents$);
   const events$ = getOrCreateAgentEvents(logId);
   const eventsLoadable = useLoadable(events$);
+
+  // Get accumulated events state
+  const accumulatedEvents = useGet(agentEventsAccumulated$);
+  const hasMore = useGet(agentEventsHasMore$);
+  const isLoadingMore = useGet(agentEventsIsLoadingMore$);
 
   const viewMode = useGet(viewMode$);
   const setViewMode = useSet(viewMode$);
@@ -43,6 +57,19 @@ export function AgentEventsCard({
   const setCurrentMatchIdx = useSet(currentMatchIndex$);
   const totalMatches = useGet(totalMatchCount$);
   const setTotalMatches = useSet(totalMatchCount$);
+
+  // Initialize accumulated events when initial data loads
+  if (
+    eventsLoadable.state === "hasData" &&
+    accumulatedEvents.length === 0 &&
+    eventsLoadable.data.events.length > 0
+  ) {
+    initAccumulatedEvents({
+      events: eventsLoadable.data.events,
+      hasMore: eventsLoadable.data.hasMore,
+      framework: eventsLoadable.data.framework,
+    });
+  }
 
   const scrollToMatchByIndex = (matchIndex: number) => {
     const container = document.getElementById(EVENTS_CONTAINER_ID);
@@ -91,6 +118,43 @@ export function AgentEventsCard({
     setCurrentMatchIdx(0);
   };
 
+  const handleLoadMore = () => {
+    if (accumulatedEvents.length > 0 && !isLoadingMore) {
+      const lastEvent = accumulatedEvents[accumulatedEvents.length - 1];
+      loadMoreAgentEvents({
+        runId: logId,
+        since: lastEvent.createdAt,
+      }).catch(() => {
+        // Error handled in command
+      });
+    }
+  };
+
+  // Ref callback for infinite scroll sentinel
+  const sentinelRef = (node: HTMLDivElement | null) => {
+    if (!node) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          handleLoadMore();
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(node);
+
+    // Cleanup on unmount - store observer on node for cleanup
+    (
+      node as HTMLDivElement & { _observer?: IntersectionObserver }
+    )._observer?.disconnect();
+    (node as HTMLDivElement & { _observer?: IntersectionObserver })._observer =
+      observer;
+  };
+
   if (eventsLoadable.state === "loading") {
     return (
       <div className="space-y-4">
@@ -99,8 +163,8 @@ export function AgentEventsCard({
             Agent events
           </span>
         </div>
-        <div className="p-8 text-center text-muted-foreground">
-          Loading events...
+        <div className="flex items-center justify-center p-8">
+          <IconLoader2 className="h-5 w-5 animate-spin text-muted-foreground" />
         </div>
       </div>
     );
@@ -121,11 +185,21 @@ export function AgentEventsCard({
     );
   }
 
-  const { events } = eventsLoadable.data;
+  // Use accumulated events for rendering (or initial if not yet accumulated)
+  const events =
+    accumulatedEvents.length > 0
+      ? accumulatedEvents
+      : eventsLoadable.data.events;
+  const showHasMore =
+    accumulatedEvents.length > 0 ? hasMore : eventsLoadable.data.hasMore;
 
   const matchingCount = searchTerm.trim()
     ? events.filter((e) => eventMatchesSearch(e, searchTerm)).length
     : events.length;
+
+  const totalCountDisplay = showHasMore
+    ? `${events.length}+`
+    : `${events.length}`;
 
   return (
     <div className={`flex flex-col gap-4 ${className ?? ""}`}>
@@ -137,7 +211,7 @@ export function AgentEventsCard({
           <span className="text-sm text-muted-foreground whitespace-nowrap">
             {searchTerm.trim()
               ? `(${matchingCount}/${events.length} matched)`
-              : `${events.length} total`}
+              : `${totalCountDisplay} total`}
           </span>
         </div>
         <div className="flex items-center gap-2 sm:gap-3">
@@ -188,6 +262,14 @@ export function AgentEventsCard({
             currentMatchIndex={currentMatchIdx}
             setTotalMatches={setTotalMatches}
           />
+        )}
+        {showHasMore && (
+          <div
+            ref={sentinelRef}
+            className="flex items-center justify-center py-4"
+          >
+            <IconLoader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
         )}
       </div>
     </div>

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
@@ -26,11 +26,6 @@ import {
 } from "../utils.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 
-// Type for DOM node with observer attached
-type NodeWithObserver = HTMLDivElement & {
-  _observer?: IntersectionObserver;
-};
-
 export function AgentEventsCard({
   logId,
   framework,
@@ -124,9 +119,9 @@ export function AgentEventsCard({
     setCurrentMatchIdx(0);
   };
 
-  // Ref callback for infinite scroll sentinel
+  // Ref callback for infinite scroll sentinel with cleanup (React 19 feature)
   // Uses key={events.length} to ensure fresh closure values after each load
-  const sentinelRef = (node: HTMLDivElement | null) => {
+  const sentinelRef = (node: HTMLDivElement | null): (() => void) | void => {
     if (!node) {
       return;
     }
@@ -152,7 +147,11 @@ export function AgentEventsCard({
     );
 
     observer.observe(node);
-    (node as NodeWithObserver)._observer = observer;
+
+    // Return cleanup function - called when element is unmounted (React 19)
+    return () => {
+      observer.disconnect();
+    };
   };
 
   if (eventsLoadable.state === "loading") {

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
@@ -24,6 +24,12 @@ import {
   scrollToMatch,
   EVENTS_CONTAINER_ID,
 } from "../utils.ts";
+import { detach, Reason } from "../../../../signals/utils.ts";
+
+// Type for DOM node with observer attached
+type NodeWithObserver = HTMLDivElement & {
+  _observer?: IntersectionObserver;
+};
 
 export function AgentEventsCard({
   logId,
@@ -59,6 +65,7 @@ export function AgentEventsCard({
   const setTotalMatches = useSet(totalMatchCount$);
 
   // Initialize accumulated events when initial data loads
+  // This is safe to call during render as initAccumulatedEvents$ is idempotent
   if (
     eventsLoadable.state === "hasData" &&
     accumulatedEvents.length === 0 &&
@@ -67,7 +74,6 @@ export function AgentEventsCard({
     initAccumulatedEvents({
       events: eventsLoadable.data.events,
       hasMore: eventsLoadable.data.hasMore,
-      framework: eventsLoadable.data.framework,
     });
   }
 
@@ -118,41 +124,35 @@ export function AgentEventsCard({
     setCurrentMatchIdx(0);
   };
 
-  const handleLoadMore = () => {
-    if (accumulatedEvents.length > 0 && !isLoadingMore) {
-      const lastEvent = accumulatedEvents[accumulatedEvents.length - 1];
-      loadMoreAgentEvents({
-        runId: logId,
-        since: lastEvent.createdAt,
-      }).catch(() => {
-        // Error handled in command
-      });
-    }
-  };
-
   // Ref callback for infinite scroll sentinel
+  // Uses key={events.length} to ensure fresh closure values after each load
   const sentinelRef = (node: HTMLDivElement | null) => {
     if (!node) {
       return;
     }
 
+    // Create observer with current closure values
+    // The key-based remount ensures we always have fresh values
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting) {
-          handleLoadMore();
+        if (entries[0].isIntersecting && !isLoadingMore) {
+          if (accumulatedEvents.length > 0) {
+            const lastEvent = accumulatedEvents[accumulatedEvents.length - 1];
+            detach(
+              loadMoreAgentEvents({
+                runId: logId,
+                since: lastEvent.createdAt,
+              }),
+              Reason.DomCallback,
+            );
+          }
         }
       },
       { threshold: 0.1 },
     );
 
     observer.observe(node);
-
-    // Cleanup on unmount - store observer on node for cleanup
-    (
-      node as HTMLDivElement & { _observer?: IntersectionObserver }
-    )._observer?.disconnect();
-    (node as HTMLDivElement & { _observer?: IntersectionObserver })._observer =
-      observer;
+    (node as NodeWithObserver)._observer = observer;
   };
 
   if (eventsLoadable.state === "loading") {
@@ -265,6 +265,7 @@ export function AgentEventsCard({
         )}
         {showHasMore && (
           <div
+            key={`sentinel-${events.length}`}
             ref={sentinelRef}
             className="flex items-center justify-center py-4"
           >


### PR DESCRIPTION
## Summary

- Implement lazy loading for agent events in log detail view, reducing initial load from 100 to 30 events
- Add IntersectionObserver-based infinite scroll that loads additional events when user scrolls to the bottom
- Introduce accumulated events state management for seamless pagination
- Remove cost display from event cards (total cost and per-model breakdown)
- Replace text "Loading events..." with spinner for cleaner loading states

## Test plan

- [ ] Verify agent events load correctly with initial 30 events
- [ ] Scroll to bottom and confirm additional events load automatically
- [ ] Check that "X+ total" count updates as more events are loaded
- [ ] Confirm loading spinner appears during load more operation
- [ ] Verify search functionality works across accumulated events

🤖 Generated with [Claude Code](https://claude.com/claude-code)