### PR TITLE
feat(ci): add stable preview deployment url aliases

### DIFF
--- a/.github/DEPLOYMENT_SETUP.md
+++ b/.github/DEPLOYMENT_SETUP.md
@@ -11,15 +11,47 @@ This repository is configured to automatically create preview deployments for pu
    - Creates a new Neon database branch named `preview-pr-{PR_NUMBER}`
    - Runs database migrations on the branch
    - Deploys to Vercel with the branch database URL
+   - Creates stable alias URLs (if `PREVIEW_DOMAIN` is configured)
    - Comments on the PR with deployment links
 3. **PR Updates**: On new commits, the deployment is updated
 4. **PR Closes**: When merged or closed, the Neon branch is automatically deleted
+
+## Stable Preview URLs
+
+When the `PREVIEW_DOMAIN` variable is configured, preview deployments get predictable alias URLs:
+
+| App      | Preview URL Pattern                |
+| -------- | ---------------------------------- |
+| Web      | `web-{sha7}.{PREVIEW_DOMAIN}`      |
+| Platform | `platform-{sha7}.{PREVIEW_DOMAIN}` |
+| Site     | `site-{sha7}.{PREVIEW_DOMAIN}`     |
+| Docs     | `docs-{sha7}.{PREVIEW_DOMAIN}`     |
+
+Where `{sha7}` is the 7-character commit SHA.
+
+### Prerequisites for Stable Preview URLs
+
+1. **DNS Configuration**: Add wildcard CNAME record pointing to Vercel:
+   | Type | Name | Value |
+   |------|------|-------|
+   | CNAME | `*` | `cname.vercel-dns.com` |
+
+2. **Vercel Domain Configuration**:
+   - Go to Vercel Dashboard → Team Settings → Domains
+   - Add `*.{PREVIEW_DOMAIN}` as a wildcard domain
+   - Verify domain ownership
+
+3. **GitHub Repository Variable**:
+   | Name | Value |
+   |------|-------|
+   | `PREVIEW_DOMAIN` | Your preview domain (e.g., `vm6.ai`) |
 
 ## Required GitHub Secrets and Variables
 
 Configure these in your GitHub repository settings (Settings → Secrets and variables → Actions):
 
 ### Secrets (Store as Secrets)
+
 - `VERCEL_TOKEN`: Your Vercel personal access token
   - Generate at: https://vercel.com/account/tokens
 - `NEON_API_KEY`: Your Neon API key (Optional but Recommended)
@@ -32,6 +64,7 @@ Configure these in your GitHub repository settings (Settings → Secrets and var
   - Generate by running `cd turbo && pnpm e2b:build`
 
 ### Variables (Store as Repository Variables)
+
 - `VERCEL_TEAM_ID`: Your Vercel team/organization ID
   - Find in Vercel project settings → General → Team ID
 - `VERCEL_PROJECT_ID_WEB`: Your Vercel project ID for web app
@@ -42,6 +75,9 @@ Configure these in your GitHub repository settings (Settings → Secrets and var
   - Find in Neon console → Project Settings → General
 - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`: Your Clerk publishable key (Required)
   - Get from: https://dashboard.clerk.com
+- `PREVIEW_DOMAIN`: Domain for stable preview URLs (Optional)
+  - Example: `vm6.ai`
+  - Requires wildcard DNS and Vercel domain configuration (see "Stable Preview URLs" section)
 
 **Note**: If Neon secrets are not configured, the deployment will still work but without database branching.
 
@@ -63,6 +99,7 @@ Configure these in your GitHub repository settings (Settings → Secrets and var
 ## Database Schema Push
 
 The workflow automatically pushes database schema to preview branches using:
+
 ```bash
 pnpm db:push
 ```
@@ -72,19 +109,24 @@ This uses Drizzle Kit to push your schema defined in `turbo/apps/web/src/db/sche
 ## Environment Variables Details
 
 ### Required Variables
+
 These must be configured for the application to work:
+
 - **CLERK_SECRET_KEY**: Required for user authentication
 - **NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY**: Required for Clerk client-side SDK
 - **DATABASE_URL**: Automatically injected by the workflow from Neon
 
 ### Optional E2B Configuration
+
 For running agent code in sandboxes:
+
 - **E2B_API_KEY**: Your E2B API key for creating sandboxes
 - **E2B_TEMPLATE_NAME**: Custom template with Claude Code CLI pre-installed
   - Build template: `cd turbo && pnpm e2b:build`
   - Without this, the default E2B image is used (Claude Code must be manually installed)
 
 ### Anthropic-Compatible API Configuration
+
 To use Anthropic-compatible model providers (e.g., Anthropic, Minimax, or custom providers), configure environment variables in your Agent Compose YAML using user secrets:
 
 ```yaml
@@ -97,6 +139,7 @@ environment:
 ```
 
 Set up secrets using the VM0 CLI:
+
 ```bash
 vm0 secret set ANTHROPIC_BASE_URL "https://your-api-endpoint.com"
 vm0 secret set ANTHROPIC_API_KEY "your-api-key"

--- a/.github/DEPLOYMENT_SETUP.md
+++ b/.github/DEPLOYMENT_SETUP.md
@@ -20,14 +20,14 @@ This repository is configured to automatically create preview deployments for pu
 
 When the `PREVIEW_DOMAIN` variable is configured, preview deployments get predictable alias URLs:
 
-| App      | Preview URL Pattern                |
-| -------- | ---------------------------------- |
-| Web      | `web-{sha7}.{PREVIEW_DOMAIN}`      |
-| Platform | `platform-{sha7}.{PREVIEW_DOMAIN}` |
-| Site     | `site-{sha7}.{PREVIEW_DOMAIN}`     |
-| Docs     | `docs-{sha7}.{PREVIEW_DOMAIN}`     |
+| App      | Preview URL Pattern                   |
+| -------- | ------------------------------------- |
+| Web      | `{job-ref}-web.{PREVIEW_DOMAIN}`      |
+| Platform | `{job-ref}-platform.{PREVIEW_DOMAIN}` |
+| Site     | `{job-ref}-site.{PREVIEW_DOMAIN}`     |
+| Docs     | `{job-ref}-docs.{PREVIEW_DOMAIN}`     |
 
-Where `{sha7}` is the 7-character commit SHA.
+Where `{job-ref}` is `pr-{number}` for pull requests (e.g., `pr-123-web.vm6.ai`).
 
 ### Prerequisites for Stable Preview URLs
 

--- a/.github/DEPLOYMENT_SETUP.md
+++ b/.github/DEPLOYMENT_SETUP.md
@@ -22,12 +22,12 @@ When the `PREVIEW_DOMAIN` variable is configured, preview deployments get predic
 
 | App      | Preview URL Pattern                   |
 | -------- | ------------------------------------- |
-| Web      | `{job-ref}-web.{PREVIEW_DOMAIN}`      |
+| Web      | `{job-ref}-www.{PREVIEW_DOMAIN}`      |
 | Platform | `{job-ref}-platform.{PREVIEW_DOMAIN}` |
 | Site     | `{job-ref}-site.{PREVIEW_DOMAIN}`     |
 | Docs     | `{job-ref}-docs.{PREVIEW_DOMAIN}`     |
 
-Where `{job-ref}` is `pr-{number}` for pull requests (e.g., `pr-123-web.vm6.ai`).
+Where `{job-ref}` is `pr-{number}` for pull requests (e.g., `pr-123-www.vm6.ai`).
 
 ### Prerequisites for Stable Preview URLs
 

--- a/.github/actions/vercel-alias/action.yml
+++ b/.github/actions/vercel-alias/action.yml
@@ -1,5 +1,5 @@
 name: "Vercel Alias"
-description: "Create a predictable alias URL for a Vercel deployment"
+description: "Create a predictable alias URL for a Vercel deployment and optionally finish GitHub deployment"
 
 inputs:
   vercel-token:
@@ -20,6 +20,14 @@ inputs:
   preview-domain:
     description: "Preview domain (e.g., vm6.ai)"
     required: true
+  deployment-id:
+    description: "GitHub deployment ID (if provided, will finish the deployment with alias URL)"
+    required: false
+    default: ""
+  deployment-env:
+    description: "GitHub deployment environment name (required if deployment-id is provided)"
+    required: false
+    default: ""
 
 outputs:
   url:
@@ -51,3 +59,14 @@ runs:
         FULL_URL="https://${ALIAS_URL}"
         echo "url=${FULL_URL}" >> $GITHUB_OUTPUT
         echo "Alias created: ${FULL_URL}"
+
+    - name: Finish GitHub deployment
+      if: inputs.deployment-id != ''
+      uses: bobheadxi/deployments@v1
+      with:
+        step: finish
+        token: ${{ github.token }}
+        status: success
+        env: ${{ inputs.deployment-env }}
+        env_url: ${{ steps.alias.outputs.url }}
+        deployment_id: ${{ inputs.deployment-id }}

--- a/.github/actions/vercel-alias/action.yml
+++ b/.github/actions/vercel-alias/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: "App identifier (web, platform, site, docs)"
     required: true
   job-ref:
-    description: "Job reference (e.g., pr-123 or staging)"
+    description: "Job reference identifier (e.g., pr-123, staging)"
     required: true
   preview-domain:
     description: "Preview domain (e.g., vm6.ai)"
@@ -41,7 +41,7 @@ runs:
       id: alias
       shell: bash
       run: |
-        # Build alias URL: {job-ref}-{app}.{domain}
+        # Build alias URL: {job-ref}-{app}.{preview-domain}
         ALIAS_URL="${{ inputs.job-ref }}-${{ inputs.app-name }}.${{ inputs.preview-domain }}"
 
         echo "Creating alias: ${ALIAS_URL} -> ${{ inputs.deployment-url }}"

--- a/.github/actions/vercel-alias/action.yml
+++ b/.github/actions/vercel-alias/action.yml
@@ -14,8 +14,8 @@ inputs:
   app-name:
     description: "App identifier (web, platform, site, docs)"
     required: true
-  commit-sha:
-    description: "Full commit SHA (truncated to 7 chars in action)"
+  job-ref:
+    description: "Job reference (e.g., pr-123 or staging)"
     required: true
   preview-domain:
     description: "Preview domain (e.g., vm6.ai)"
@@ -41,12 +41,8 @@ runs:
       id: alias
       shell: bash
       run: |
-        # Truncate commit SHA to 7 characters
-        SHORT_SHA="${{ inputs.commit-sha }}"
-        SHORT_SHA="${SHORT_SHA:0:7}"
-
-        # Build alias URL
-        ALIAS_URL="${{ inputs.app-name }}-${SHORT_SHA}.${{ inputs.preview-domain }}"
+        # Build alias URL: {job-ref}-{app}.{domain}
+        ALIAS_URL="${{ inputs.job-ref }}-${{ inputs.app-name }}.${{ inputs.preview-domain }}"
 
         echo "Creating alias: ${ALIAS_URL} -> ${{ inputs.deployment-url }}"
 

--- a/.github/actions/vercel-alias/action.yml
+++ b/.github/actions/vercel-alias/action.yml
@@ -1,0 +1,53 @@
+name: "Vercel Alias"
+description: "Create a predictable alias URL for a Vercel deployment"
+
+inputs:
+  vercel-token:
+    description: "Vercel authentication token"
+    required: true
+  vercel-org-id:
+    description: "Vercel team/org ID (for --scope)"
+    required: true
+  deployment-url:
+    description: "Vercel deployment URL to alias"
+    required: true
+  app-name:
+    description: "App identifier (web, platform, site, docs)"
+    required: true
+  commit-sha:
+    description: "Full commit SHA (truncated to 7 chars in action)"
+    required: true
+  preview-domain:
+    description: "Preview domain (e.g., vm6.ai)"
+    required: true
+
+outputs:
+  url:
+    description: "The aliased URL"
+    value: ${{ steps.alias.outputs.url }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create Vercel alias
+      id: alias
+      shell: bash
+      run: |
+        # Truncate commit SHA to 7 characters
+        SHORT_SHA="${{ inputs.commit-sha }}"
+        SHORT_SHA="${SHORT_SHA:0:7}"
+
+        # Build alias URL
+        ALIAS_URL="${{ inputs.app-name }}-${SHORT_SHA}.${{ inputs.preview-domain }}"
+
+        echo "Creating alias: ${ALIAS_URL} -> ${{ inputs.deployment-url }}"
+
+        # Set the alias using Vercel CLI
+        vercel alias set "${{ inputs.deployment-url }}" "${ALIAS_URL}" \
+          --token="${{ inputs.vercel-token }}" \
+          --scope="${{ inputs.vercel-org-id }}"
+
+        # Output the full URL
+        FULL_URL="https://${ALIAS_URL}"
+        echo "url=${FULL_URL}" >> $GITHUB_OUTPUT
+        echo "Alias created: ${FULL_URL}"

--- a/.github/actions/vercel-deploy/action.yml
+++ b/.github/actions/vercel-deploy/action.yml
@@ -5,6 +5,12 @@ outputs:
   url:
     description: "The deployment URL"
     value: ${{ steps.deploy.outputs.url }}
+  deployment-id:
+    description: "The GitHub deployment ID (for finishing deployment later)"
+    value: ${{ steps.deployment.outputs.deployment_id }}
+  deployment-env:
+    description: "The GitHub deployment environment name"
+    value: ${{ steps.deployment.outputs.env }}
 
 inputs:
   vercel-token:
@@ -35,6 +41,10 @@ inputs:
   deployment-env:
     description: "Deployment environment name (e.g., web, docs)"
     required: true
+  skip-finish:
+    description: "Skip finishing the deployment (use when you need to set a custom env_url later)"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -105,7 +115,7 @@ runs:
 
     - name: Finish deployment
       uses: bobheadxi/deployments@v1
-      if: always()
+      if: always() && inputs.skip-finish != 'true'
       with:
         step: finish
         token: ${{ github.token }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -429,7 +429,7 @@ jobs:
           vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
           deployment-url: ${{ steps.deploy.outputs.url }}
           app-name: web
-          commit-sha: ${{ github.event.pull_request.head.sha }}
+          job-ref: ${{ needs.prepare.outputs.job-ref }}
           preview-domain: ${{ vars.PREVIEW_DOMAIN }}
           deployment-id: ${{ steps.deploy.outputs.deployment-id }}
           deployment-env: ${{ steps.deploy.outputs.deployment-env }}
@@ -484,7 +484,7 @@ jobs:
           vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
           deployment-url: ${{ steps.deploy.outputs.url }}
           app-name: docs
-          commit-sha: ${{ github.event.pull_request.head.sha }}
+          job-ref: ${{ needs.prepare.outputs.job-ref }}
           preview-domain: ${{ vars.PREVIEW_DOMAIN }}
           deployment-id: ${{ steps.deploy.outputs.deployment-id }}
           deployment-env: ${{ steps.deploy.outputs.deployment-env }}
@@ -530,7 +530,7 @@ jobs:
           vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
           deployment-url: ${{ steps.deploy.outputs.url }}
           app-name: site
-          commit-sha: ${{ github.event.pull_request.head.sha }}
+          job-ref: ${{ needs.prepare.outputs.job-ref }}
           preview-domain: ${{ vars.PREVIEW_DOMAIN }}
           deployment-id: ${{ steps.deploy.outputs.deployment-id }}
           deployment-env: ${{ steps.deploy.outputs.deployment-env }}
@@ -575,7 +575,7 @@ jobs:
           vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
           deployment-url: ${{ steps.deploy.outputs.url }}
           app-name: platform
-          commit-sha: ${{ github.event.pull_request.head.sha }}
+          job-ref: ${{ needs.prepare.outputs.job-ref }}
           preview-domain: ${{ vars.PREVIEW_DOMAIN }}
           deployment-id: ${{ steps.deploy.outputs.deployment-id }}
           deployment-env: ${{ steps.deploy.outputs.deployment-env }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -19,6 +19,7 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260202
     outputs:
       job-ref: ${{ steps.set-job-ref.outputs.job-ref }}
+      web-preview-url: ${{ steps.preview-urls.outputs.web-url }}
       web-changed: ${{ steps.detect.outputs.web-changed }}
       site-changed: ${{ steps.detect.outputs.site-changed }}
       docs-changed: ${{ steps.detect.outputs.docs-changed }}
@@ -86,6 +87,20 @@ jobs:
           else
             echo "job-ref=staging" >> $GITHUB_OUTPUT
             echo "Job ref set to: staging"
+          fi
+
+      - name: Set preview URLs
+        id: preview-urls
+        run: |
+          JOB_REF="${{ steps.set-job-ref.outputs.job-ref }}"
+          PREVIEW_DOMAIN="${{ vars.PREVIEW_DOMAIN }}"
+
+          if [ -n "$PREVIEW_DOMAIN" ] && [ -n "$JOB_REF" ]; then
+            echo "web-url=https://${JOB_REF}-www.${PREVIEW_DOMAIN}" >> $GITHUB_OUTPUT
+            echo "Preview URL set to: https://${JOB_REF}-www.${PREVIEW_DOMAIN}"
+          else
+            echo "web-url=" >> $GITHUB_OUTPUT
+            echo "Preview URL not set (PREVIEW_DOMAIN or job-ref is empty)"
           fi
 
       - name: Generate CLI E2E parallel test matrix
@@ -419,10 +434,10 @@ jobs:
           meta-pr: ${{ needs.prepare.outputs.job-ref }}
           skip-finish: ${{ github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '' }}
 
-      # Step 3: Create stable preview URL alias (only for PRs with PREVIEW_DOMAIN configured)
+      # Step 3: Create stable preview URL alias (when PREVIEW_DOMAIN is configured)
       - name: Create Vercel Alias
         id: alias
-        if: github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != ''
+        if: vars.PREVIEW_DOMAIN != ''
         uses: ./.github/actions/vercel-alias
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
@@ -477,7 +492,7 @@ jobs:
           skip-finish: ${{ github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '' }}
 
       - name: Create Vercel Alias
-        if: github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != ''
+        if: vars.PREVIEW_DOMAIN != ''
         uses: ./.github/actions/vercel-alias
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
@@ -494,7 +509,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260202
-    needs: [prepare, deploy-web]
+    needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and site changed
     if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.site-changed == 'true' }}"
     permissions:
@@ -515,7 +530,7 @@ jobs:
           environment: preview
           deployment-env: site
           environment-variables: |
-            WEB_APP_URL=${{ needs.deploy-web.outputs.preview-url }}
+            WEB_APP_URL=${{ needs.prepare.outputs.web-preview-url }}
             NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
             CLERK_SECRET_KEY=${{ secrets.CLERK_SECRET_KEY }}
           meta-branch: ${{ github.head_ref || github.ref_name }}
@@ -523,7 +538,7 @@ jobs:
           skip-finish: ${{ github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '' }}
 
       - name: Create Vercel Alias
-        if: github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != ''
+        if: vars.PREVIEW_DOMAIN != ''
         uses: ./.github/actions/vercel-alias
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
@@ -540,7 +555,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260202
-    needs: [prepare, deploy-web]
+    needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and platform changed
     if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.platform-changed == 'true' }}"
     permissions:
@@ -562,13 +577,13 @@ jobs:
           deployment-env: platform
           environment-variables: |
             VITE_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
-            VITE_API_URL=${{ needs.deploy-web.outputs.preview-url }}
+            VITE_API_URL=${{ needs.prepare.outputs.web-preview-url }}
           meta-branch: ${{ github.head_ref || github.ref_name }}
           meta-pr: ${{ needs.prepare.outputs.job-ref }}
           skip-finish: ${{ github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '' }}
 
       - name: Create Vercel Alias
-        if: github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != ''
+        if: vars.PREVIEW_DOMAIN != ''
         uses: ./.github/actions/vercel-alias
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -365,7 +365,7 @@ jobs:
         needs.prepare.outputs.platform-changed == 'true'
       )
     outputs:
-      preview-url: ${{ steps.deploy.outputs.url }}
+      preview-url: ${{ steps.alias.outputs.url || steps.deploy.outputs.url }}
     permissions:
       contents: read
       pull-requests: write
@@ -418,11 +418,24 @@ jobs:
           meta-branch: ${{ github.head_ref || github.ref_name }}
           meta-pr: ${{ needs.prepare.outputs.job-ref }}
 
-      # Step 3: Generate test token for E2E tests (runs in parallel with e2e-auth)
+      # Step 3: Create stable preview URL alias (only for PRs with PREVIEW_DOMAIN configured)
+      - name: Create Vercel Alias
+        id: alias
+        if: github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != ''
+        uses: ./.github/actions/vercel-alias
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
+          deployment-url: ${{ steps.deploy.outputs.url }}
+          app-name: web
+          commit-sha: ${{ github.event.pull_request.head.sha }}
+          preview-domain: ${{ vars.PREVIEW_DOMAIN }}
+
+      # Step 4: Generate test token for E2E tests (runs in parallel with e2e-auth)
       - name: Generate E2E test token
         run: e2e/scripts/generate-test-token.sh
         env:
-          VM0_API_URL: ${{ steps.deploy.outputs.url }}
+          VM0_API_URL: ${{ steps.alias.outputs.url || steps.deploy.outputs.url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Save test token to cache
@@ -459,6 +472,17 @@ jobs:
           meta-branch: ${{ github.head_ref || github.ref_name }}
           meta-pr: ${{ needs.prepare.outputs.job-ref }}
 
+      - name: Create Vercel Alias
+        if: github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != ''
+        uses: ./.github/actions/vercel-alias
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
+          deployment-url: ${{ steps.deploy.outputs.url }}
+          app-name: docs
+          commit-sha: ${{ github.event.pull_request.head.sha }}
+          preview-domain: ${{ vars.PREVIEW_DOMAIN }}
+
   # Deploy site application (SEO landing pages)
   deploy-site:
     runs-on: ubuntu-latest
@@ -491,6 +515,17 @@ jobs:
           meta-branch: ${{ github.head_ref || github.ref_name }}
           meta-pr: ${{ needs.prepare.outputs.job-ref }}
 
+      - name: Create Vercel Alias
+        if: github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != ''
+        uses: ./.github/actions/vercel-alias
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
+          deployment-url: ${{ steps.deploy.outputs.url }}
+          app-name: site
+          commit-sha: ${{ github.event.pull_request.head.sha }}
+          preview-domain: ${{ vars.PREVIEW_DOMAIN }}
+
   # Deploy platform (Vite SPA)
   deploy-platform:
     runs-on: ubuntu-latest
@@ -521,6 +556,17 @@ jobs:
             VITE_API_URL=${{ needs.deploy-web.outputs.preview-url }}
           meta-branch: ${{ github.head_ref || github.ref_name }}
           meta-pr: ${{ needs.prepare.outputs.job-ref }}
+
+      - name: Create Vercel Alias
+        if: github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != ''
+        uses: ./.github/actions/vercel-alias
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
+          deployment-url: ${{ steps.deploy.outputs.url }}
+          app-name: platform
+          commit-sha: ${{ github.event.pull_request.head.sha }}
+          preview-domain: ${{ vars.PREVIEW_DOMAIN }}
 
   # Verify device flow authentication works end-to-end (uses Playwright)
   # This job runs in parallel with E2E tests - it does NOT block them
@@ -607,7 +653,19 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260202
-    needs: [prepare, deploy-web, lint-eslint, lint-types, lint-format, lint-knip, test-web, test-cli, test-platform, test-other]
+    needs:
+      [
+        prepare,
+        deploy-web,
+        lint-eslint,
+        lint-types,
+        lint-format,
+        lint-knip,
+        test-web,
+        test-cli,
+        test-platform,
+        test-other,
+      ]
     if: |
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
       needs.prepare.outputs.job-ref != '' && (
@@ -758,7 +816,14 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260202
-    needs: [prepare, cli-e2e-01-serial, deploy-web, deploy-runner-start, deploy-runner-benchmark]
+    needs:
+      [
+        prepare,
+        cli-e2e-01-serial,
+        deploy-web,
+        deploy-runner-start,
+        deploy-runner-benchmark,
+      ]
     if: |
       contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&
       github.event_name != 'push' &&

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -428,7 +428,7 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
           deployment-url: ${{ steps.deploy.outputs.url }}
-          app-name: web
+          app-name: www
           job-ref: ${{ needs.prepare.outputs.job-ref }}
           preview-domain: ${{ vars.PREVIEW_DOMAIN }}
           deployment-id: ${{ steps.deploy.outputs.deployment-id }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -417,6 +417,7 @@ jobs:
             CLAUDE_CODE_VERSION_URL=${{ vars.CLAUDE_CODE_VERSION_URL }}
           meta-branch: ${{ github.head_ref || github.ref_name }}
           meta-pr: ${{ needs.prepare.outputs.job-ref }}
+          skip-finish: ${{ github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '' }}
 
       # Step 3: Create stable preview URL alias (only for PRs with PREVIEW_DOMAIN configured)
       - name: Create Vercel Alias
@@ -430,6 +431,8 @@ jobs:
           app-name: web
           commit-sha: ${{ github.event.pull_request.head.sha }}
           preview-domain: ${{ vars.PREVIEW_DOMAIN }}
+          deployment-id: ${{ steps.deploy.outputs.deployment-id }}
+          deployment-env: ${{ steps.deploy.outputs.deployment-env }}
 
       # Step 4: Generate test token for E2E tests (runs in parallel with e2e-auth)
       - name: Generate E2E test token
@@ -471,6 +474,7 @@ jobs:
           deployment-env: docs
           meta-branch: ${{ github.head_ref || github.ref_name }}
           meta-pr: ${{ needs.prepare.outputs.job-ref }}
+          skip-finish: ${{ github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '' }}
 
       - name: Create Vercel Alias
         if: github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != ''
@@ -482,6 +486,8 @@ jobs:
           app-name: docs
           commit-sha: ${{ github.event.pull_request.head.sha }}
           preview-domain: ${{ vars.PREVIEW_DOMAIN }}
+          deployment-id: ${{ steps.deploy.outputs.deployment-id }}
+          deployment-env: ${{ steps.deploy.outputs.deployment-env }}
 
   # Deploy site application (SEO landing pages)
   deploy-site:
@@ -514,6 +520,7 @@ jobs:
             CLERK_SECRET_KEY=${{ secrets.CLERK_SECRET_KEY }}
           meta-branch: ${{ github.head_ref || github.ref_name }}
           meta-pr: ${{ needs.prepare.outputs.job-ref }}
+          skip-finish: ${{ github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '' }}
 
       - name: Create Vercel Alias
         if: github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != ''
@@ -525,6 +532,8 @@ jobs:
           app-name: site
           commit-sha: ${{ github.event.pull_request.head.sha }}
           preview-domain: ${{ vars.PREVIEW_DOMAIN }}
+          deployment-id: ${{ steps.deploy.outputs.deployment-id }}
+          deployment-env: ${{ steps.deploy.outputs.deployment-env }}
 
   # Deploy platform (Vite SPA)
   deploy-platform:
@@ -556,6 +565,7 @@ jobs:
             VITE_API_URL=${{ needs.deploy-web.outputs.preview-url }}
           meta-branch: ${{ github.head_ref || github.ref_name }}
           meta-pr: ${{ needs.prepare.outputs.job-ref }}
+          skip-finish: ${{ github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '' }}
 
       - name: Create Vercel Alias
         if: github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != ''
@@ -567,6 +577,8 @@ jobs:
           app-name: platform
           commit-sha: ${{ github.event.pull_request.head.sha }}
           preview-domain: ${{ vars.PREVIEW_DOMAIN }}
+          deployment-id: ${{ steps.deploy.outputs.deployment-id }}
+          deployment-env: ${{ steps.deploy.outputs.deployment-env }}
 
   # Verify device flow authentication works end-to-end (uses Playwright)
   # This job runs in parallel with E2E tests - it does NOT block them

--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -1,4 +1,3 @@
-// Next.js configuration
 import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./i18n.ts");

--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -1,3 +1,4 @@
+// Next.js configuration
 import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./i18n.ts");


### PR DESCRIPTION
## Summary

- Add `vercel-alias` GitHub action that creates predictable URL aliases after Vercel deployments
- Update all deploy jobs (web, docs, site, platform) to create stable preview URLs
- Only activate when `PREVIEW_DOMAIN` repository variable is configured
- URL pattern: `{app}-{sha7}.{PREVIEW_DOMAIN}` (e.g., `web-abc1234.vm6.ai`)

## Test plan

- [ ] Verify CI passes without `PREVIEW_DOMAIN` configured (no alias step runs)
- [ ] Configure `PREVIEW_DOMAIN` variable and verify alias URLs are created
- [ ] Test that alias URLs resolve correctly to the deployed preview

Closes #2164

🤖 Generated with [Claude Code](https://claude.com/claude-code)