### PR TITLE
feat(slack): add slash commands and interactive endpoints

### DIFF
--- a/turbo/apps/web/app/api/slack/commands/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/commands/__tests__/route.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createHmac } from "crypto";
+import { POST } from "../route";
+import { testContext } from "../../../../../src/__tests__/test-helpers";
+import { reloadEnv } from "../../../../../src/env";
+import { server } from "../../../../../src/mocks/server";
+
+// Mock only external dependencies (third-party packages)
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
+
+const context = testContext();
+
+// Use the same signing secret as configured in setup.ts
+const testSigningSecret = "test-slack-signing-secret";
+
+/**
+ * Create a valid Slack signature for testing
+ */
+function createSlackSignature(
+  signingSecret: string,
+  timestamp: string,
+  body: string,
+): string {
+  const baseString = `v0:${timestamp}:${body}`;
+  const hmac = createHmac("sha256", signingSecret);
+  return `v0=${hmac.update(baseString).digest("hex")}`;
+}
+
+/**
+ * Create a request with valid Slack signature headers for URL-encoded form data
+ */
+function createSignedSlackRequest(body: string): Request {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const signature = createSlackSignature(testSigningSecret, timestamp, body);
+
+  return new Request("http://localhost/api/slack/commands", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "x-slack-signature": signature,
+      "x-slack-request-timestamp": timestamp,
+    },
+    body,
+  });
+}
+
+/**
+ * Build URL-encoded form body for slash command
+ */
+function buildCommandBody(
+  text: string,
+  workspaceId: string,
+  userId: string,
+): string {
+  const params = new URLSearchParams({
+    token: "test-token",
+    team_id: workspaceId,
+    team_domain: "test-workspace",
+    channel_id: "C123",
+    channel_name: "general",
+    user_id: userId,
+    user_name: "testuser",
+    command: "/vm0",
+    text,
+    response_url: "https://hooks.slack.com/commands/test",
+    trigger_id: "trigger123",
+    api_app_id: "A123",
+  });
+  return params.toString();
+}
+
+describe("POST /api/slack/commands", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  describe("Configuration", () => {
+    it("returns 503 when Slack signing secret is not configured", async () => {
+      vi.stubEnv("SLACK_SIGNING_SECRET", "");
+      reloadEnv();
+
+      const body = buildCommandBody("help", "T123", "U123");
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(data.error).toBe("Slack integration is not configured");
+
+      vi.stubEnv("SLACK_SIGNING_SECRET", testSigningSecret);
+      reloadEnv();
+    });
+  });
+
+  describe("Signature Verification", () => {
+    it("returns 401 when signature headers are missing", async () => {
+      const body = buildCommandBody("help", "T123", "U123");
+      const request = new Request("http://localhost/api/slack/commands", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body,
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("Missing Slack signature headers");
+    });
+
+    it("returns 401 when signature is invalid", async () => {
+      const body = buildCommandBody("help", "T123", "U123");
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+
+      const request = new Request("http://localhost/api/slack/commands", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "x-slack-signature": "v0=invalid-signature",
+          "x-slack-request-timestamp": timestamp,
+        },
+        body,
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("Invalid signature");
+    });
+  });
+
+  describe("Help Command", () => {
+    it("returns help message for empty command", async () => {
+      // Create installation first
+      const { installation } = await context.createSlackInstallation();
+
+      const body = buildCommandBody("", installation.slackWorkspaceId, "U123");
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_type).toBe("ephemeral");
+      expect(data.blocks).toBeDefined();
+    });
+
+    it("returns help message for 'help' command", async () => {
+      const { installation } = await context.createSlackInstallation();
+
+      const body = buildCommandBody(
+        "help",
+        installation.slackWorkspaceId,
+        "U123",
+      );
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_type).toBe("ephemeral");
+      expect(data.blocks).toBeDefined();
+    });
+  });
+
+  describe("Workspace Validation", () => {
+    it("returns error when workspace is not installed", async () => {
+      // Don't create installation - use a random workspace ID
+      const body = buildCommandBody("agent list", "T-nonexistent", "U123");
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_type).toBe("ephemeral");
+      expect(data.text).toContain("not installed");
+    });
+  });
+
+  describe("User Link Validation", () => {
+    it("returns link account message when user is not linked", async () => {
+      const { installation } = await context.createSlackInstallation();
+      // Don't create user link
+
+      const body = buildCommandBody(
+        "agent list",
+        installation.slackWorkspaceId,
+        "U-unlinked",
+      );
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_type).toBe("ephemeral");
+      expect(data.blocks).toBeDefined();
+      // Should contain link URL
+      const blockStr = JSON.stringify(data.blocks);
+      expect(blockStr).toContain("slack/link");
+    });
+  });
+
+  describe("Agent List Command", () => {
+    it("returns empty list when user has no agents", async () => {
+      const { installation, userLink } = await context.createSlackInstallation({
+        withUserLink: true,
+      });
+
+      const body = buildCommandBody(
+        "agent list",
+        installation.slackWorkspaceId,
+        userLink.slackUserId,
+      );
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_type).toBe("ephemeral");
+      expect(data.blocks).toBeDefined();
+    });
+
+    it("returns list of bound agents", async () => {
+      const { installation, userLink } = await context.createSlackInstallation({
+        withUserLink: true,
+      });
+      await context.createSlackBinding(userLink.id, {
+        agentName: "test-agent",
+        description: "A test agent",
+      });
+
+      const body = buildCommandBody(
+        "agent list",
+        installation.slackWorkspaceId,
+        userLink.slackUserId,
+      );
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_type).toBe("ephemeral");
+      const blockStr = JSON.stringify(data.blocks);
+      expect(blockStr).toContain("test-agent");
+    });
+  });
+
+  describe("Agent Remove Command", () => {
+    it("returns error when agent name is not provided", async () => {
+      const { installation, userLink } = await context.createSlackInstallation({
+        withUserLink: true,
+      });
+
+      const body = buildCommandBody(
+        "agent remove",
+        installation.slackWorkspaceId,
+        userLink.slackUserId,
+      );
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_type).toBe("ephemeral");
+      const blockStr = JSON.stringify(data.blocks);
+      expect(blockStr).toContain("specify an agent name");
+    });
+
+    it("returns error when agent does not exist", async () => {
+      const { installation, userLink } = await context.createSlackInstallation({
+        withUserLink: true,
+      });
+
+      const body = buildCommandBody(
+        "agent remove nonexistent",
+        installation.slackWorkspaceId,
+        userLink.slackUserId,
+      );
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_type).toBe("ephemeral");
+      const blockStr = JSON.stringify(data.blocks);
+      expect(blockStr).toContain("not found");
+    });
+
+    it("removes agent successfully", async () => {
+      const { installation, userLink } = await context.createSlackInstallation({
+        withUserLink: true,
+      });
+      await context.createSlackBinding(userLink.id, { agentName: "to-remove" });
+
+      const body = buildCommandBody(
+        "agent remove to-remove",
+        installation.slackWorkspaceId,
+        userLink.slackUserId,
+      );
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_type).toBe("ephemeral");
+      const blockStr = JSON.stringify(data.blocks);
+      expect(blockStr).toContain("has been removed");
+    });
+  });
+
+  describe("Unknown Commands", () => {
+    it("returns error for unknown agent action", async () => {
+      const { installation, userLink } = await context.createSlackInstallation({
+        withUserLink: true,
+      });
+
+      const body = buildCommandBody(
+        "agent unknown",
+        installation.slackWorkspaceId,
+        userLink.slackUserId,
+      );
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_type).toBe("ephemeral");
+      const blockStr = JSON.stringify(data.blocks);
+      expect(blockStr).toContain("Unknown agent command");
+    });
+
+    it("returns help message for unknown top-level command", async () => {
+      const { installation, userLink } = await context.createSlackInstallation({
+        withUserLink: true,
+      });
+
+      const body = buildCommandBody(
+        "unknown",
+        installation.slackWorkspaceId,
+        userLink.slackUserId,
+      );
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_type).toBe("ephemeral");
+      // Returns help message for unknown commands
+      expect(data.blocks).toBeDefined();
+    });
+  });
+});

--- a/turbo/apps/web/app/api/slack/commands/route.ts
+++ b/turbo/apps/web/app/api/slack/commands/route.ts
@@ -1,0 +1,344 @@
+import { NextResponse } from "next/server";
+import { eq, and } from "drizzle-orm";
+import { initServices } from "../../../../src/lib/init-services";
+import { env } from "../../../../src/env";
+import {
+  verifySlackSignature,
+  getSlackSignatureHeaders,
+} from "../../../../src/lib/slack/verify";
+import { slackInstallations } from "../../../../src/db/schema/slack-installation";
+import { slackUserLinks } from "../../../../src/db/schema/slack-user-link";
+import { slackBindings } from "../../../../src/db/schema/slack-binding";
+import { agentComposes } from "../../../../src/db/schema/agent-compose";
+import { decryptCredentialValue } from "../../../../src/lib/crypto/secrets-encryption";
+import { createSlackClient } from "../../../../src/lib/slack";
+import {
+  buildAgentAddModal,
+  buildAgentListMessage,
+  buildHelpMessage,
+  buildErrorMessage,
+  buildSuccessMessage,
+  buildLinkAccountMessage,
+} from "../../../../src/lib/slack/blocks";
+
+/**
+ * Slack Slash Commands Endpoint
+ *
+ * POST /api/slack/commands
+ *
+ * Handles /vm0 slash commands:
+ * - /vm0 agent add - Open add agent modal
+ * - /vm0 agent list - List bound agents
+ * - /vm0 agent remove <name> - Remove agent binding
+ * - /vm0 help - Show help message
+ */
+
+interface SlackCommandPayload {
+  token: string;
+  team_id: string;
+  team_domain: string;
+  channel_id: string;
+  channel_name: string;
+  user_id: string;
+  user_name: string;
+  command: string;
+  text: string;
+  response_url: string;
+  trigger_id: string;
+  api_app_id: string;
+}
+
+/**
+ * Parse URL-encoded form data into SlackCommandPayload
+ */
+function parseCommandPayload(body: string): SlackCommandPayload {
+  const params = new URLSearchParams(body);
+  return {
+    token: params.get("token") ?? "",
+    team_id: params.get("team_id") ?? "",
+    team_domain: params.get("team_domain") ?? "",
+    channel_id: params.get("channel_id") ?? "",
+    channel_name: params.get("channel_name") ?? "",
+    user_id: params.get("user_id") ?? "",
+    user_name: params.get("user_name") ?? "",
+    command: params.get("command") ?? "",
+    text: params.get("text") ?? "",
+    response_url: params.get("response_url") ?? "",
+    trigger_id: params.get("trigger_id") ?? "",
+    api_app_id: params.get("api_app_id") ?? "",
+  };
+}
+
+/**
+ * Verify the Slack request signature
+ */
+function verifyRequest(
+  request: Request,
+  body: string,
+  signingSecret: string,
+): NextResponse | null {
+  const headers = getSlackSignatureHeaders(request.headers);
+  if (!headers) {
+    return NextResponse.json(
+      { error: "Missing Slack signature headers" },
+      { status: 401 },
+    );
+  }
+
+  const isValid = verifySlackSignature(
+    signingSecret,
+    headers.signature,
+    headers.timestamp,
+    body,
+  );
+
+  if (!isValid) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  return null;
+}
+
+/**
+ * Handle agent subcommands
+ */
+async function handleAgentCommand(
+  action: string,
+  args: string[],
+  client: ReturnType<typeof createSlackClient>,
+  payload: SlackCommandPayload,
+  userLinkId: string,
+  vm0UserId: string,
+): Promise<NextResponse> {
+  switch (action) {
+    case "add":
+      return handleAgentAdd(client, payload, vm0UserId);
+
+    case "list":
+      return handleAgentList(userLinkId);
+
+    case "remove": {
+      const agentName = args[2];
+      if (!agentName) {
+        return NextResponse.json({
+          response_type: "ephemeral",
+          blocks: buildErrorMessage(
+            "Please specify an agent name: `/vm0 agent remove <name>`",
+          ),
+        });
+      }
+      return handleAgentRemove(userLinkId, agentName);
+    }
+
+    default:
+      return NextResponse.json({
+        response_type: "ephemeral",
+        blocks: buildErrorMessage(
+          `Unknown agent command: \`${action}\`\n\nAvailable commands:\n• \`/vm0 agent add\`\n• \`/vm0 agent list\`\n• \`/vm0 agent remove <name>\``,
+        ),
+      });
+  }
+}
+
+export async function POST(request: Request) {
+  const { SLACK_SIGNING_SECRET, SECRETS_ENCRYPTION_KEY } = env();
+
+  if (!SLACK_SIGNING_SECRET) {
+    return NextResponse.json(
+      { error: "Slack integration is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const body = await request.text();
+
+  const verifyError = verifyRequest(request, body, SLACK_SIGNING_SECRET);
+  if (verifyError) {
+    return verifyError;
+  }
+
+  const payload = parseCommandPayload(body);
+
+  initServices();
+
+  // Get workspace installation
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackInstallations)
+    .where(eq(slackInstallations.slackWorkspaceId, payload.team_id))
+    .limit(1);
+
+  if (!installation) {
+    return NextResponse.json({
+      response_type: "ephemeral",
+      text: "VM0 is not installed in this workspace.",
+    });
+  }
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+
+  // Check if user is linked
+  const [userLink] = await globalThis.services.db
+    .select()
+    .from(slackUserLinks)
+    .where(
+      and(
+        eq(slackUserLinks.slackUserId, payload.user_id),
+        eq(slackUserLinks.slackWorkspaceId, payload.team_id),
+      ),
+    )
+    .limit(1);
+
+  // Parse command text
+  const args = payload.text.trim().split(/\s+/);
+  const subCommand = args[0]?.toLowerCase() ?? "";
+  const action = args[1]?.toLowerCase() ?? "";
+
+  // Handle help command (doesn't require linking)
+  if (subCommand === "help" || subCommand === "") {
+    return NextResponse.json({
+      response_type: "ephemeral",
+      blocks: buildHelpMessage(),
+    });
+  }
+
+  // Check if user needs to link account
+  if (!userLink) {
+    const { SLACK_REDIRECT_BASE_URL } = env();
+    const baseUrl = SLACK_REDIRECT_BASE_URL ?? "https://www.vm0.ai";
+    const linkUrl = `${baseUrl}/slack/link?w=${payload.team_id}&u=${payload.user_id}`;
+
+    return NextResponse.json({
+      response_type: "ephemeral",
+      blocks: buildLinkAccountMessage(linkUrl),
+    });
+  }
+
+  // Handle agent commands
+  if (subCommand === "agent") {
+    return handleAgentCommand(
+      action,
+      args,
+      client,
+      payload,
+      userLink.id,
+      userLink.vm0UserId,
+    );
+  }
+
+  // Unknown command
+  return NextResponse.json({
+    response_type: "ephemeral",
+    blocks: buildHelpMessage(),
+  });
+}
+
+/**
+ * Handle /vm0 agent add - Open modal to add agent
+ */
+async function handleAgentAdd(
+  client: ReturnType<typeof createSlackClient>,
+  payload: SlackCommandPayload,
+  vm0UserId: string,
+): Promise<NextResponse> {
+  // Fetch user's available agents
+  const composes = await globalThis.services.db
+    .select({
+      id: agentComposes.id,
+      name: agentComposes.name,
+    })
+    .from(agentComposes)
+    .where(eq(agentComposes.userId, vm0UserId));
+
+  if (composes.length === 0) {
+    return NextResponse.json({
+      response_type: "ephemeral",
+      blocks: buildErrorMessage(
+        "You don't have any agents in VM0 yet.\n\nCreate one first with the VM0 CLI: `vm0 build`",
+      ),
+    });
+  }
+
+  // Open modal
+  const modal = buildAgentAddModal(
+    composes.map((c) => ({ id: c.id, name: c.name })),
+  );
+
+  try {
+    await client.views.open({
+      trigger_id: payload.trigger_id,
+      view: modal,
+    });
+
+    // Return empty response (Slack expects this when opening modal)
+    return NextResponse.json({});
+  } catch (error) {
+    console.error("Error opening modal:", error);
+    return NextResponse.json({
+      response_type: "ephemeral",
+      blocks: buildErrorMessage("Failed to open the add agent dialog."),
+    });
+  }
+}
+
+/**
+ * Handle /vm0 agent list - List bound agents
+ */
+async function handleAgentList(userLinkId: string): Promise<NextResponse> {
+  const bindings = await globalThis.services.db
+    .select({
+      agentName: slackBindings.agentName,
+      description: slackBindings.description,
+      enabled: slackBindings.enabled,
+    })
+    .from(slackBindings)
+    .where(eq(slackBindings.slackUserLinkId, userLinkId));
+
+  return NextResponse.json({
+    response_type: "ephemeral",
+    blocks: buildAgentListMessage(bindings),
+  });
+}
+
+/**
+ * Handle /vm0 agent remove - Remove agent binding
+ */
+async function handleAgentRemove(
+  userLinkId: string,
+  agentName: string,
+): Promise<NextResponse> {
+  // Find binding
+  const [binding] = await globalThis.services.db
+    .select()
+    .from(slackBindings)
+    .where(
+      and(
+        eq(slackBindings.slackUserLinkId, userLinkId),
+        eq(slackBindings.agentName, agentName.toLowerCase()),
+      ),
+    )
+    .limit(1);
+
+  if (!binding) {
+    return NextResponse.json({
+      response_type: "ephemeral",
+      blocks: buildErrorMessage(
+        `Agent "${agentName}" not found.\n\nUse \`/vm0 agent list\` to see your agents.`,
+      ),
+    });
+  }
+
+  // Delete binding
+  await globalThis.services.db
+    .delete(slackBindings)
+    .where(eq(slackBindings.id, binding.id));
+
+  return NextResponse.json({
+    response_type: "ephemeral",
+    blocks: buildSuccessMessage(`Agent "${agentName}" has been removed.`),
+  });
+}

--- a/turbo/apps/web/app/api/slack/commands/route.ts
+++ b/turbo/apps/web/app/api/slack/commands/route.ts
@@ -268,21 +268,13 @@ async function handleAgentAdd(
     composes.map((c) => ({ id: c.id, name: c.name })),
   );
 
-  try {
-    await client.views.open({
-      trigger_id: payload.trigger_id,
-      view: modal,
-    });
+  await client.views.open({
+    trigger_id: payload.trigger_id,
+    view: modal,
+  });
 
-    // Return empty response (Slack expects this when opening modal)
-    return NextResponse.json({});
-  } catch (error) {
-    console.error("Error opening modal:", error);
-    return NextResponse.json({
-      response_type: "ephemeral",
-      blocks: buildErrorMessage("Failed to open the add agent dialog."),
-    });
-  }
+  // Return empty response (Slack expects this when opening modal)
+  return NextResponse.json({});
 }
 
 /**

--- a/turbo/apps/web/app/api/slack/interactive/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/interactive/__tests__/route.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createHmac } from "crypto";
+import { POST } from "../route";
+import { testContext } from "../../../../../src/__tests__/test-helpers";
+import { reloadEnv } from "../../../../../src/env";
+import { server } from "../../../../../src/mocks/server";
+
+// Mock only external dependencies (third-party packages)
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
+
+const context = testContext();
+
+// Use the same signing secret as configured in setup.ts
+const testSigningSecret = "test-slack-signing-secret";
+
+/**
+ * Create a valid Slack signature for testing
+ */
+function createSlackSignature(
+  signingSecret: string,
+  timestamp: string,
+  body: string,
+): string {
+  const baseString = `v0:${timestamp}:${body}`;
+  const hmac = createHmac("sha256", signingSecret);
+  return `v0=${hmac.update(baseString).digest("hex")}`;
+}
+
+/**
+ * Create a request with valid Slack signature headers for interactive payload
+ */
+function createSignedSlackRequest(body: string): Request {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const signature = createSlackSignature(testSigningSecret, timestamp, body);
+
+  return new Request("http://localhost/api/slack/interactive", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "x-slack-signature": signature,
+      "x-slack-request-timestamp": timestamp,
+    },
+    body,
+  });
+}
+
+/**
+ * Build URL-encoded form body for interactive payload
+ */
+function buildInteractiveBody(payload: Record<string, unknown>): string {
+  const params = new URLSearchParams({
+    payload: JSON.stringify(payload),
+  });
+  return params.toString();
+}
+
+describe("POST /api/slack/interactive", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  describe("Configuration", () => {
+    it("returns 503 when Slack signing secret is not configured", async () => {
+      vi.stubEnv("SLACK_SIGNING_SECRET", "");
+      reloadEnv();
+
+      const body = buildInteractiveBody({ type: "block_actions" });
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(data.error).toBe("Slack integration is not configured");
+
+      vi.stubEnv("SLACK_SIGNING_SECRET", testSigningSecret);
+      reloadEnv();
+    });
+  });
+
+  describe("Signature Verification", () => {
+    it("returns 401 when signature headers are missing", async () => {
+      const body = buildInteractiveBody({ type: "block_actions" });
+      const request = new Request("http://localhost/api/slack/interactive", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body,
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("Missing Slack signature headers");
+    });
+
+    it("returns 401 when signature is invalid", async () => {
+      const body = buildInteractiveBody({ type: "block_actions" });
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+
+      const request = new Request("http://localhost/api/slack/interactive", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "x-slack-signature": "v0=invalid-signature",
+          "x-slack-request-timestamp": timestamp,
+        },
+        body,
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("Invalid signature");
+    });
+  });
+
+  describe("Payload Parsing", () => {
+    it("returns 400 when payload is missing", async () => {
+      const body = "other=value";
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("Missing payload");
+    });
+
+    it("returns 400 when payload is invalid JSON", async () => {
+      const params = new URLSearchParams({ payload: "not-json" });
+      const body = params.toString();
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("Invalid payload");
+    });
+  });
+
+  describe("Block Actions", () => {
+    it("returns 200 for block_actions type", async () => {
+      const body = buildInteractiveBody({
+        type: "block_actions",
+        user: { id: "U123", username: "testuser", team_id: "T123" },
+        team: { id: "T123", domain: "test" },
+        actions: [],
+      });
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("View Submission - Agent Add Modal", () => {
+    it("returns error when form values are missing", async () => {
+      const body = buildInteractiveBody({
+        type: "view_submission",
+        user: { id: "U123", username: "testuser", team_id: "T123" },
+        team: { id: "T123", domain: "test" },
+        view: {
+          id: "V123",
+          callback_id: "agent_add_modal",
+          state: {},
+        },
+      });
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_action).toBe("errors");
+      expect(data.errors.agent_select).toBe("Missing form values");
+    });
+
+    it("returns error when agent is not selected", async () => {
+      const body = buildInteractiveBody({
+        type: "view_submission",
+        user: { id: "U123", username: "testuser", team_id: "T123" },
+        team: { id: "T123", domain: "test" },
+        view: {
+          id: "V123",
+          callback_id: "agent_add_modal",
+          state: {
+            values: {
+              agent_select: { agent: {} },
+              agent_name: { name: { value: "my-agent" } },
+            },
+          },
+        },
+      });
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_action).toBe("errors");
+      expect(data.errors.agent_select).toBe("Please select an agent");
+    });
+
+    it("returns error when agent name is empty", async () => {
+      const body = buildInteractiveBody({
+        type: "view_submission",
+        user: { id: "U123", username: "testuser", team_id: "T123" },
+        team: { id: "T123", domain: "test" },
+        view: {
+          id: "V123",
+          callback_id: "agent_add_modal",
+          state: {
+            values: {
+              agent_select: {
+                agent: { selected_option: { value: "compose123" } },
+              },
+              agent_name: { name: { value: "" } },
+            },
+          },
+        },
+      });
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_action).toBe("errors");
+      expect(data.errors.agent_name).toBe("Please enter a name");
+    });
+
+    it("returns error when agent name has invalid format", async () => {
+      const body = buildInteractiveBody({
+        type: "view_submission",
+        user: { id: "U123", username: "testuser", team_id: "T123" },
+        team: { id: "T123", domain: "test" },
+        view: {
+          id: "V123",
+          callback_id: "agent_add_modal",
+          state: {
+            values: {
+              agent_select: {
+                agent: { selected_option: { value: "compose123" } },
+              },
+              agent_name: { name: { value: "Invalid Name!" } },
+            },
+          },
+        },
+      });
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_action).toBe("errors");
+      expect(data.errors.agent_name).toContain("lowercase letters");
+    });
+
+    it("returns error when user is not linked", async () => {
+      const body = buildInteractiveBody({
+        type: "view_submission",
+        user: { id: "U-unlinked", username: "testuser", team_id: "T-test" },
+        team: { id: "T-test", domain: "test" },
+        view: {
+          id: "V123",
+          callback_id: "agent_add_modal",
+          state: {
+            values: {
+              agent_select: {
+                agent: { selected_option: { value: "compose123" } },
+              },
+              agent_name: { name: { value: "valid-name" } },
+            },
+          },
+        },
+      });
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_action).toBe("errors");
+      expect(data.errors.agent_select).toContain("not linked");
+    });
+
+    it("returns error when agent name already exists", async () => {
+      const { installation, userLink } = await context.createSlackInstallation({
+        withUserLink: true,
+      });
+      await context.createSlackBinding(userLink.id, {
+        agentName: "existing-agent",
+      });
+
+      const body = buildInteractiveBody({
+        type: "view_submission",
+        user: {
+          id: userLink.slackUserId,
+          username: "testuser",
+          team_id: installation.slackWorkspaceId,
+        },
+        team: { id: installation.slackWorkspaceId, domain: "test" },
+        view: {
+          id: "V123",
+          callback_id: "agent_add_modal",
+          state: {
+            values: {
+              agent_select: {
+                agent: { selected_option: { value: "compose123" } },
+              },
+              agent_name: { name: { value: "existing-agent" } },
+            },
+          },
+        },
+      });
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.response_action).toBe("errors");
+      expect(data.errors.agent_name).toContain("already exists");
+    });
+
+    it("creates binding successfully", async () => {
+      const { installation, userLink } = await context.createSlackInstallation({
+        withUserLink: true,
+      });
+      // Create a compose to bind to (we'll use its compose ID)
+      const { composeId } = await context.createSlackBinding(userLink.id, {
+        agentName: "temp-agent",
+      });
+
+      const body = buildInteractiveBody({
+        type: "view_submission",
+        user: {
+          id: userLink.slackUserId,
+          username: "testuser",
+          team_id: installation.slackWorkspaceId,
+        },
+        team: { id: installation.slackWorkspaceId, domain: "test" },
+        view: {
+          id: "V123",
+          callback_id: "agent_add_modal",
+          state: {
+            values: {
+              agent_select: {
+                agent: { selected_option: { value: composeId } },
+              },
+              agent_name: { name: { value: "new-agent" } },
+              description: { description: { value: "A new agent" } },
+            },
+          },
+        },
+      });
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+
+      // Success returns empty 200 to close the modal
+      expect(response.status).toBe(200);
+      const text = await response.text();
+      expect(text).toBe("");
+    });
+  });
+
+  describe("Unknown Callback", () => {
+    it("returns 200 for unknown callback_id", async () => {
+      const body = buildInteractiveBody({
+        type: "view_submission",
+        user: { id: "U123", username: "testuser", team_id: "T123" },
+        team: { id: "T123", domain: "test" },
+        view: {
+          id: "V123",
+          callback_id: "unknown_modal",
+          state: { values: {} },
+        },
+      });
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -1,0 +1,339 @@
+import { NextResponse } from "next/server";
+import { eq, and } from "drizzle-orm";
+import { initServices } from "../../../../src/lib/init-services";
+import { env } from "../../../../src/env";
+import {
+  verifySlackSignature,
+  getSlackSignatureHeaders,
+} from "../../../../src/lib/slack/verify";
+import { slackInstallations } from "../../../../src/db/schema/slack-installation";
+import { slackUserLinks } from "../../../../src/db/schema/slack-user-link";
+import { slackBindings } from "../../../../src/db/schema/slack-binding";
+import {
+  decryptCredentialValue,
+  encryptCredentialValue,
+} from "../../../../src/lib/crypto/secrets-encryption";
+import { createSlackClient, postMessage } from "../../../../src/lib/slack";
+
+/**
+ * Slack Interactive Components Endpoint
+ *
+ * POST /api/slack/interactive
+ *
+ * Handles interactive component callbacks:
+ * - view_submission - Modal form submissions
+ * - block_actions - Button clicks, select changes
+ */
+
+interface SlackInteractivePayload {
+  type: "view_submission" | "block_actions" | "shortcut";
+  user: {
+    id: string;
+    username: string;
+    team_id: string;
+  };
+  team: {
+    id: string;
+    domain: string;
+  };
+  trigger_id?: string;
+  view?: {
+    id: string;
+    callback_id: string;
+    state: {
+      values: Record<
+        string,
+        Record<
+          string,
+          {
+            type: string;
+            value?: string;
+            selected_option?: { value: string };
+          }
+        >
+      >;
+    };
+    private_metadata?: string;
+  };
+  actions?: Array<{
+    action_id: string;
+    block_id: string;
+    value?: string;
+    selected_option?: { value: string };
+  }>;
+  response_url?: string;
+  channel?: {
+    id: string;
+    name: string;
+  };
+}
+
+export async function POST(request: Request) {
+  const { SLACK_SIGNING_SECRET, SECRETS_ENCRYPTION_KEY } = env();
+
+  if (!SLACK_SIGNING_SECRET) {
+    return NextResponse.json(
+      { error: "Slack integration is not configured" },
+      { status: 503 },
+    );
+  }
+
+  // Get raw body for signature verification
+  const body = await request.text();
+
+  // Verify Slack signature
+  const headers = getSlackSignatureHeaders(request.headers);
+  if (!headers) {
+    return NextResponse.json(
+      { error: "Missing Slack signature headers" },
+      { status: 401 },
+    );
+  }
+
+  const isValid = verifySlackSignature(
+    SLACK_SIGNING_SECRET,
+    headers.signature,
+    headers.timestamp,
+    body,
+  );
+
+  if (!isValid) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  // Parse URL-encoded form data (payload is in 'payload' field)
+  const params = new URLSearchParams(body);
+  const payloadStr = params.get("payload");
+
+  if (!payloadStr) {
+    return NextResponse.json({ error: "Missing payload" }, { status: 400 });
+  }
+
+  let payload: SlackInteractivePayload;
+  try {
+    payload = JSON.parse(payloadStr) as SlackInteractivePayload;
+  } catch {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  initServices();
+
+  // Handle different interaction types
+  switch (payload.type) {
+    case "view_submission":
+      return handleViewSubmission(payload, SECRETS_ENCRYPTION_KEY);
+
+    case "block_actions":
+      // Block actions typically don't need a response
+      return new Response("", { status: 200 });
+
+    default:
+      return new Response("", { status: 200 });
+  }
+}
+
+/**
+ * Handle modal submission
+ */
+async function handleViewSubmission(
+  payload: SlackInteractivePayload,
+  encryptionKey: string,
+): Promise<Response> {
+  const callbackId = payload.view?.callback_id;
+
+  if (callbackId === "agent_add_modal") {
+    return handleAgentAddSubmission(payload, encryptionKey);
+  }
+
+  // Unknown callback - just acknowledge
+  return new Response("", { status: 200 });
+}
+
+interface AgentAddFormValues {
+  composeId: string | undefined;
+  agentName: string | undefined;
+  description: string | null;
+  secretsText: string | null;
+}
+
+type ModalStateValues = NonNullable<
+  SlackInteractivePayload["view"]
+>["state"]["values"];
+
+/**
+ * Extract form values from the modal submission
+ */
+function extractFormValues(values: ModalStateValues): AgentAddFormValues {
+  return {
+    composeId: values.agent_select?.agent?.selected_option?.value,
+    agentName: values.agent_name?.name?.value?.trim().toLowerCase(),
+    description: values.description?.description?.value?.trim() || null,
+    secretsText: values.secrets?.secrets?.value?.trim() || null,
+  };
+}
+
+/**
+ * Validate the agent add form values
+ */
+function validateAgentAddForm(formValues: AgentAddFormValues): Response | null {
+  if (!formValues.composeId) {
+    return NextResponse.json({
+      response_action: "errors",
+      errors: { agent_select: "Please select an agent" },
+    });
+  }
+
+  if (!formValues.agentName) {
+    return NextResponse.json({
+      response_action: "errors",
+      errors: { agent_name: "Please enter a name" },
+    });
+  }
+
+  if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/.test(formValues.agentName)) {
+    return NextResponse.json({
+      response_action: "errors",
+      errors: {
+        agent_name:
+          "Name must be lowercase letters, numbers, and hyphens. Must start and end with letter or number.",
+      },
+    });
+  }
+
+  return null;
+}
+
+/**
+ * Send confirmation DM to user after agent is added
+ */
+async function sendConfirmationDM(
+  workspaceId: string,
+  userId: string,
+  agentName: string,
+  encryptionKey: string,
+): Promise<void> {
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackInstallations)
+    .where(eq(slackInstallations.slackWorkspaceId, workspaceId))
+    .limit(1);
+
+  if (!installation) {
+    return;
+  }
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    encryptionKey,
+  );
+  const client = createSlackClient(botToken);
+
+  const dmResult = await client.conversations.open({ users: userId });
+
+  if (dmResult.ok && dmResult.channel?.id) {
+    await postMessage(
+      client,
+      dmResult.channel.id,
+      `Agent "${agentName}" has been added successfully!\n\nYou can now use it by mentioning me: \`@VM0 use ${agentName} <message>\``,
+    );
+  }
+}
+
+/**
+ * Handle agent add modal submission
+ */
+async function handleAgentAddSubmission(
+  payload: SlackInteractivePayload,
+  encryptionKey: string,
+): Promise<Response> {
+  const values = payload.view?.state?.values;
+
+  if (!values) {
+    return NextResponse.json({
+      response_action: "errors",
+      errors: { agent_select: "Missing form values" },
+    });
+  }
+
+  const formValues = extractFormValues(values);
+
+  const validationError = validateAgentAddForm(formValues);
+  if (validationError) {
+    return validationError;
+  }
+
+  // Get user link
+  const [userLink] = await globalThis.services.db
+    .select()
+    .from(slackUserLinks)
+    .where(
+      and(
+        eq(slackUserLinks.slackUserId, payload.user.id),
+        eq(slackUserLinks.slackWorkspaceId, payload.team.id),
+      ),
+    )
+    .limit(1);
+
+  if (!userLink) {
+    return NextResponse.json({
+      response_action: "errors",
+      errors: {
+        agent_select:
+          "Your account is not linked. Please link your account first.",
+      },
+    });
+  }
+
+  // Check if agent name already exists for this user
+  const [existingBinding] = await globalThis.services.db
+    .select()
+    .from(slackBindings)
+    .where(
+      and(
+        eq(slackBindings.slackUserLinkId, userLink.id),
+        eq(slackBindings.agentName, formValues.agentName!),
+      ),
+    )
+    .limit(1);
+
+  if (existingBinding) {
+    return NextResponse.json({
+      response_action: "errors",
+      errors: {
+        agent_name: `An agent named "${formValues.agentName}" already exists. Use a different name or remove the existing one first.`,
+      },
+    });
+  }
+
+  // Encrypt secrets if provided
+  let encryptedSecrets: string | null = null;
+  if (formValues.secretsText) {
+    encryptedSecrets = encryptCredentialValue(
+      formValues.secretsText,
+      encryptionKey,
+    );
+  }
+
+  // Create binding
+  await globalThis.services.db.insert(slackBindings).values({
+    slackUserLinkId: userLink.id,
+    composeId: formValues.composeId!,
+    agentName: formValues.agentName!,
+    description: formValues.description,
+    encryptedSecrets,
+    enabled: true,
+  });
+
+  // Send confirmation message via DM (fire-and-forget)
+  sendConfirmationDM(
+    payload.team.id,
+    payload.user.id,
+    formValues.agentName!,
+    encryptionKey,
+  ).catch((error) => {
+    console.error("Error sending confirmation DM:", error);
+  });
+
+  // Close modal
+  return new Response("", { status: 200 });
+}

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -156,6 +156,14 @@ interface AgentAddFormValues {
   secretsText: string | null;
 }
 
+/** Validated form values with required fields guaranteed */
+interface ValidatedAgentAddForm {
+  composeId: string;
+  agentName: string;
+  description: string | null;
+  secretsText: string | null;
+}
+
 type ModalStateValues = NonNullable<
   SlackInteractivePayload["view"]
 >["state"]["values"];
@@ -173,9 +181,12 @@ function extractFormValues(values: ModalStateValues): AgentAddFormValues {
 }
 
 /**
- * Validate the agent add form values
+ * Validate the agent add form values.
+ * Returns validated form with narrowed types on success, or error Response on failure.
  */
-function validateAgentAddForm(formValues: AgentAddFormValues): Response | null {
+function validateAgentAddForm(
+  formValues: AgentAddFormValues,
+): ValidatedAgentAddForm | Response {
   if (!formValues.composeId) {
     return NextResponse.json({
       response_action: "errors",
@@ -200,7 +211,13 @@ function validateAgentAddForm(formValues: AgentAddFormValues): Response | null {
     });
   }
 
-  return null;
+  // Return validated form with narrowed types
+  return {
+    composeId: formValues.composeId,
+    agentName: formValues.agentName,
+    description: formValues.description,
+    secretsText: formValues.secretsText,
+  };
 }
 
 /**
@@ -255,12 +272,15 @@ async function handleAgentAddSubmission(
     });
   }
 
-  const formValues = extractFormValues(values);
+  const rawFormValues = extractFormValues(values);
 
-  const validationError = validateAgentAddForm(formValues);
-  if (validationError) {
-    return validationError;
+  const validationResult = validateAgentAddForm(rawFormValues);
+  // If validation returns a Response, it's an error
+  if (validationResult instanceof Response) {
+    return validationResult;
   }
+  // Otherwise, we have validated form values with narrowed types
+  const formValues = validationResult;
 
   // Get user link
   const [userLink] = await globalThis.services.db
@@ -291,7 +311,7 @@ async function handleAgentAddSubmission(
     .where(
       and(
         eq(slackBindings.slackUserLinkId, userLink.id),
-        eq(slackBindings.agentName, formValues.agentName!),
+        eq(slackBindings.agentName, formValues.agentName),
       ),
     )
     .limit(1);
@@ -317,18 +337,19 @@ async function handleAgentAddSubmission(
   // Create binding
   await globalThis.services.db.insert(slackBindings).values({
     slackUserLinkId: userLink.id,
-    composeId: formValues.composeId!,
-    agentName: formValues.agentName!,
+    composeId: formValues.composeId,
+    agentName: formValues.agentName,
     description: formValues.description,
     encryptedSecrets,
     enabled: true,
   });
 
-  // Send confirmation message via DM (fire-and-forget)
+  // Fire-and-forget: DM confirmation is non-critical, failure should not
+  // affect the binding creation. Log errors for debugging but don't propagate.
   sendConfirmationDM(
     payload.team.id,
     payload.user.id,
-    formValues.agentName!,
+    formValues.agentName,
     encryptionKey,
   ).catch((error) => {
     console.error("Error sending confirmation DM:", error);


### PR DESCRIPTION
## Summary
- Add `/api/slack/commands` endpoint for handling `/vm0` slash commands
- Add `/api/slack/interactive` endpoint for handling modal submissions
- Add test helpers for Slack installations and bindings

### Slash Commands (`/vm0`)
- `/vm0 help` - Show help message
- `/vm0 agent add` - Open modal to add agent binding
- `/vm0 agent list` - List bound agents
- `/vm0 agent remove <name>` - Remove agent binding

### Modal Interactions
- Process agent add modal form
- Validate agent name format (lowercase alphanumeric with hyphens)
- Create slack binding with encrypted secrets
- Send confirmation DM on success

## Test plan
- [x] Configuration tests (503 when not configured)
- [x] Signature verification tests (401 for invalid/missing signatures)
- [x] Help command tests
- [x] Workspace validation tests
- [x] User link validation tests
- [x] Agent list command tests
- [x] Agent remove command tests
- [x] Unknown command handling tests
- [x] Modal submission validation tests
- [x] Modal submission success tests

Part of #2086
Closes #2106

🤖 Generated with [Claude Code](https://claude.com/claude-code)