### PR TITLE
fix(ci): add exponential backoff retry for cache restore in e2e tests

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -582,10 +582,39 @@ jobs:
     needs: [prepare, deploy-web]
     if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.web-changed == 'true' }}"
     timeout-minutes: 5
+    permissions:
+      actions: read  # Required to query cache API
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive # For BATS test framework
+
+      - name: Wait for cache availability with exponential backoff
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          CACHE_KEY: e2e-token-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          DELAYS=(0 2 4 8)
+          for i in "${!DELAYS[@]}"; do
+            if [ "${DELAYS[$i]}" -gt 0 ]; then
+              echo "Cache not found, waiting ${DELAYS[$i]}s before retry $((i))/3..."
+              sleep "${DELAYS[$i]}"
+            fi
+
+            # Check if cache exists using GitHub API
+            CACHE_EXISTS=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/$REPO/actions/caches?key=$CACHE_KEY" \
+              --jq '.actions_caches | length' 2>/dev/null || echo "0")
+
+            if [ "$CACHE_EXISTS" -gt 0 ]; then
+              echo "Cache '$CACHE_KEY' is available"
+              exit 0
+            fi
+            echo "Cache not yet available (attempt $((i+1))/4)"
+          done
+          echo "Cache not available after retries, proceeding anyway..."
 
       - name: Restore test token from cache
         uses: actions/cache/restore@v4
@@ -616,6 +645,8 @@ jobs:
         needs.prepare.outputs.runner-changed == 'true'
       )
     timeout-minutes: 5
+    permissions:
+      actions: read  # Required to query cache API
     steps:
       - uses: actions/checkout@v4
         with:
@@ -636,6 +667,33 @@ jobs:
 
       - name: Setup CLI globally
         run: cd turbo/apps/cli && pnpm link --global
+
+      - name: Wait for cache availability with exponential backoff
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          CACHE_KEY: e2e-token-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          DELAYS=(0 2 4 8)
+          for i in "${!DELAYS[@]}"; do
+            if [ "${DELAYS[$i]}" -gt 0 ]; then
+              echo "Cache not found, waiting ${DELAYS[$i]}s before retry $((i))/3..."
+              sleep "${DELAYS[$i]}"
+            fi
+
+            # Check if cache exists using GitHub API
+            CACHE_EXISTS=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/$REPO/actions/caches?key=$CACHE_KEY" \
+              --jq '.actions_caches | length' 2>/dev/null || echo "0")
+
+            if [ "$CACHE_EXISTS" -gt 0 ]; then
+              echo "Cache '$CACHE_KEY' is available"
+              exit 0
+            fi
+            echo "Cache not yet available (attempt $((i+1))/4)"
+          done
+          echo "Cache not available after retries, proceeding anyway..."
 
       - name: Restore test token from cache
         uses: actions/cache/restore@v4


### PR DESCRIPTION
## Summary

Fix intermittent `api-e2e-test` failures caused by cache race condition.

The cache save in `deploy-web` may not be immediately available when downstream jobs start. This PR adds a retry mechanism with exponential backoff (0, 2, 4, 8 seconds) that checks cache availability via GitHub API before attempting restore.

## Changes

- Add `Wait for cache availability with exponential backoff` step to:
  - `api-e2e-test`: frequently affected due to minimal dependencies
  - `cli-e2e-01-serial`: for consistency (02/03 depend on 01)
- Add `actions: read` permission to query cache API

## How it works

1. Check if cache exists using GitHub API
2. If not found, wait with exponential backoff (2s → 4s → 8s)
3. Retry up to 3 times (total max wait: 14 seconds)
4. Proceed to `actions/cache/restore` once cache is confirmed available

## Test plan

- [ ] CI pipeline passes
- [ ] `api-e2e-test` no longer fails with cache miss errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)