### PR TITLE
feat(cli): improve model-provider setup ux with configuration status

### DIFF
--- a/turbo/apps/cli/src/lib/api/domains/model-providers.ts
+++ b/turbo/apps/cli/src/lib/api/domains/model-providers.ts
@@ -5,6 +5,7 @@ import {
   modelProvidersByTypeContract,
   modelProvidersConvertContract,
   modelProvidersSetDefaultContract,
+  modelProvidersUpdateModelContract,
   type ModelProviderType,
   type ModelProviderListResponse,
   type ModelProviderResponse,
@@ -128,4 +129,26 @@ export async function setModelProviderDefault(
   }
 
   handleError(result, "Failed to set default model provider");
+}
+
+/**
+ * Update model selection for an existing provider (keeps credential unchanged)
+ */
+export async function updateModelProviderModel(
+  type: ModelProviderType,
+  selectedModel?: string,
+): Promise<ModelProviderResponse> {
+  const config = await getClientConfig();
+  const client = initClient(modelProvidersUpdateModelContract, config);
+
+  const result = await client.updateModel({
+    params: { type },
+    body: { selectedModel },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to update model provider");
 }

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -59,6 +59,7 @@ export {
   deleteModelProvider,
   convertModelProviderCredential,
   setModelProviderDefault,
+  updateModelProviderModel,
 } from "./domains/model-providers";
 
 // Domain modules - Usage

--- a/turbo/apps/web/app/api/model-providers/[type]/model/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/model/__tests__/route.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { PATCH } from "../route";
+import { PUT } from "../../../route";
+import { createTestRequest } from "../../../../../../src/__tests__/api-test-helpers";
+import { testContext } from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
+
+const context = testContext();
+
+/**
+ * Helper to create a model provider for testing
+ */
+async function createModelProvider(
+  type: string,
+  credential: string,
+  selectedModel?: string,
+): Promise<{
+  provider: { id: string; type: string; selectedModel: string | null };
+}> {
+  const request = createTestRequest(
+    "http://localhost:3000/api/model-providers",
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type, credential, selectedModel }),
+    },
+  );
+  const response = await PUT(request);
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(`Failed to create provider: ${error.error?.message}`);
+  }
+  return response.json();
+}
+
+describe("PATCH /api/model-providers/:type/model - Update Model Selection", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
+  });
+
+  it("should require authentication", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/model-providers/moonshot-api-key/model",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ selectedModel: "kimi-k2.5" }),
+      },
+    );
+    const response = await PATCH(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.message).toContain("Not authenticated");
+  });
+
+  it("should update model selection for existing provider", async () => {
+    // Create provider first
+    await createModelProvider("moonshot-api-key", "test-key", "kimi-k2.5");
+
+    // Update model
+    const request = createTestRequest(
+      "http://localhost:3000/api/model-providers/moonshot-api-key/model",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ selectedModel: "kimi-k2-thinking-turbo" }),
+      },
+    );
+    const response = await PATCH(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.type).toBe("moonshot-api-key");
+    expect(data.selectedModel).toBe("kimi-k2-thinking-turbo");
+  });
+
+  it("should set model to null when selectedModel not provided", async () => {
+    // Create provider with model
+    await createModelProvider("moonshot-api-key", "test-key", "kimi-k2.5");
+
+    // Update without model
+    const request = createTestRequest(
+      "http://localhost:3000/api/model-providers/moonshot-api-key/model",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      },
+    );
+    const response = await PATCH(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.selectedModel).toBeNull();
+  });
+
+  it("should return 404 for nonexistent provider", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/model-providers/anthropic-api-key/model",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ selectedModel: "some-model" }),
+      },
+    );
+    const response = await PATCH(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should preserve isDefault flag", async () => {
+    // Create provider (will be default)
+    const { provider } = await createModelProvider(
+      "moonshot-api-key",
+      "test-key",
+      "kimi-k2.5",
+    );
+    expect(provider.id).toBeDefined();
+
+    // Update model
+    const request = createTestRequest(
+      "http://localhost:3000/api/model-providers/moonshot-api-key/model",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ selectedModel: "kimi-k2-thinking-turbo" }),
+      },
+    );
+    const response = await PATCH(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.isDefault).toBe(true);
+  });
+});

--- a/turbo/apps/web/app/api/model-providers/[type]/model/route.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/model/route.ts
@@ -1,0 +1,69 @@
+import {
+  createHandler,
+  tsr,
+  validationErrorHandler,
+} from "../../../../../src/lib/ts-rest-handler";
+import {
+  modelProvidersUpdateModelContract,
+  createErrorResponse,
+} from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import { updateModelProviderModel } from "../../../../../src/lib/model-provider/model-provider-service";
+import { logger } from "../../../../../src/lib/logger";
+import { isNotFound } from "../../../../../src/lib/errors";
+
+const log = logger("api:model-providers");
+
+const router = tsr.router(modelProvidersUpdateModelContract, {
+  /**
+   * PATCH /api/model-providers/:type/model - Update model selection
+   */
+  updateModel: async ({ params, body, headers }) => {
+    initServices();
+
+    const userId = await getUserId(headers.authorization);
+    if (!userId) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+
+    log.debug("updating model provider model", {
+      userId,
+      type: params.type,
+      selectedModel: body.selectedModel,
+    });
+
+    try {
+      const provider = await updateModelProviderModel(
+        userId,
+        params.type,
+        body.selectedModel,
+      );
+
+      return {
+        status: 200 as const,
+        body: {
+          id: provider.id,
+          type: provider.type,
+          framework: provider.framework,
+          credentialName: provider.credentialName,
+          isDefault: provider.isDefault,
+          selectedModel: provider.selectedModel,
+          createdAt: provider.createdAt.toISOString(),
+          updatedAt: provider.updatedAt.toISOString(),
+        },
+      };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return createErrorResponse("NOT_FOUND", error.message);
+      }
+      throw error;
+    }
+  },
+});
+
+const handler = createHandler(modelProvidersUpdateModelContract, router, {
+  errorHandler: validationErrorHandler,
+});
+
+export { handler as PATCH };

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -191,6 +191,7 @@ export {
   modelProvidersByTypeContract,
   modelProvidersConvertContract,
   modelProvidersSetDefaultContract,
+  modelProvidersUpdateModelContract,
   modelProviderTypeSchema,
   modelProviderFrameworkSchema,
   modelProviderResponseSchema,
@@ -198,6 +199,7 @@ export {
   upsertModelProviderRequestSchema,
   upsertModelProviderResponseSchema,
   checkCredentialResponseSchema,
+  updateModelRequestSchema,
   MODEL_PROVIDER_TYPES,
   getFrameworkForType,
   getCredentialNameForType,
@@ -210,6 +212,7 @@ export {
   type ModelProvidersByTypeContract,
   type ModelProvidersConvertContract,
   type ModelProvidersSetDefaultContract,
+  type ModelProvidersUpdateModelContract,
   type ModelProviderType,
   type ModelProviderFramework,
   type ModelProviderResponse,
@@ -217,6 +220,7 @@ export {
   type UpsertModelProviderRequest,
   type UpsertModelProviderResponse,
   type CheckCredentialResponse,
+  type UpdateModelRequest,
 } from "./model-providers";
 export {
   sessionsByIdContract,

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -360,3 +360,37 @@ export const modelProvidersSetDefaultContract = c.router({
 
 export type ModelProvidersSetDefaultContract =
   typeof modelProvidersSetDefaultContract;
+
+/**
+ * Update model request schema
+ */
+export const updateModelRequestSchema = z.object({
+  selectedModel: z.string().optional(),
+});
+
+export type UpdateModelRequest = z.infer<typeof updateModelRequestSchema>;
+
+/**
+ * Update model contract for /api/model-providers/[type]/model
+ */
+export const modelProvidersUpdateModelContract = c.router({
+  updateModel: {
+    method: "PATCH",
+    path: "/api/model-providers/:type/model",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      type: modelProviderTypeSchema,
+    }),
+    body: updateModelRequestSchema,
+    responses: {
+      200: modelProviderResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Update model selection for an existing provider",
+  },
+});
+
+export type ModelProvidersUpdateModelContract =
+  typeof modelProvidersUpdateModelContract;


### PR DESCRIPTION
## Summary

- Show ✓ indicator for already-configured providers in the selection list
- When selecting a configured provider, offer choice to keep existing credential or update it
- Allow model selection changes without re-entering API keys via new PATCH endpoint

## Test plan

- [ ] Run `vm0 model-provider setup` interactively
  - [ ] Verify ✓ appears next to configured providers
  - [ ] Select a configured provider, verify "Keep existing credential" / "Update credential" options appear
  - [ ] Test "Keep existing credential" flow - should update model without asking for API key
  - [ ] Test "Update credential" flow - should prompt for new API key
- [ ] Verify non-interactive mode (`--type` and `--credential` flags) still works
- [ ] Run CLI unit tests: `pnpm test -t model-provider`

Closes #2180

🤖 Generated with [Claude Code](https://claude.com/claude-code)