### PR TITLE
fix(ci): add shell: bash for cache retry steps

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -590,6 +590,7 @@ jobs:
           submodules: recursive # For BATS test framework
 
       - name: Wait for cache availability with exponential backoff
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -669,6 +670,7 @@ jobs:
         run: cd turbo/apps/cli && pnpm link --global
 
       - name: Wait for cache availability with exponential backoff
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Fix shell syntax error in cache retry steps for E2E tests.

## Problem

The `api-e2e-test` and `cli-e2e-01-serial` jobs run in a container (`ghcr.io/vm0-ai/vm0-toolchain:20260202`) where the default shell is `sh` (POSIX shell), not `bash`.

The cache retry script uses bash-specific array syntax:
```bash
DELAYS=(0 2 4 8)           # bash array declaration
for i in "${!DELAYS[@]}"   # bash array index iteration
${DELAYS[$i]}              # bash array element access
```

This syntax is not supported in `sh`, causing:
```
Syntax error: "(" unexpected
```

## Fix

Added explicit `shell: bash` to both cache retry steps to ensure bash is used even in container environments.

## Test plan

- [x] Verify the CI workflow runs successfully with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)