### PR TITLE
fix(ci): add shell: bash to neon cleanup job

### DIFF
--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -20,6 +20,7 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260202
     steps:
       - name: Cleanup Stale Neon Branches
+        shell: bash
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
           NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}


### PR DESCRIPTION
## Summary

- Fix neon cleanup job failing due to container defaulting to `sh` instead of `bash`

## Problem

The cleanup-stale workflow's neon-branches job uses bash-specific syntax (`[[ =~ ]]` and `BASH_REMATCH`) but the toolchain container defaults to `sh`.

Error from CI:
```
Syntax error: "(" unexpected (expecting "then")
```

## Solution

Add `shell: bash` to the step.

## Test plan

- [ ] Re-run cleanup-stale workflow with dry-run after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)