### PR TITLE
ci(slack): add slack app env vars to production deployment

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -162,6 +162,10 @@ jobs:
             ABLY_API_KEY=${{ secrets.ABLY_API_KEY }}
             CONCURRENT_RUN_LIMIT=1
             CLAUDE_CODE_VERSION_URL=${{ vars.CLAUDE_CODE_VERSION_URL }}
+            SLACK_CLIENT_ID=${{ vars.SLACK_CLIENT_ID }}
+            SLACK_CLIENT_SECRET=${{ secrets.SLACK_CLIENT_SECRET }}
+            SLACK_SIGNING_SECRET=${{ secrets.SLACK_SIGNING_SECRET }}
+            SLACK_REDIRECT_BASE_URL=${{ vars.SLACK_REDIRECT_BASE_URL }}
 
       - name: Notify Slack - Success
         if: ${{ success() && steps.slack-start.outputs.ts }}


### PR DESCRIPTION
## Summary
- Add Slack app environment variables to web production deployment in release-please workflow
- Required for Slack bot integration to work in production (currently returns 503)

## Changes
- `SLACK_CLIENT_ID` - OAuth client ID
- `SLACK_CLIENT_SECRET` - OAuth client secret
- `SLACK_SIGNING_SECRET` - Request signature verification
- `SLACK_REDIRECT_BASE_URL` - OAuth redirect URL base

## Test plan
- [ ] Merge and trigger a web release
- [ ] Verify `https://www.vm0.ai/api/slack/events` no longer returns 503

🤖 Generated with [Claude Code](https://claude.ai/code)