### PR TITLE
fix(ci): skip main/staging deployments in cleanup

### DIFF
--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -117,6 +117,13 @@ jobs:
               if (!match) continue;
 
               const identifier = match[1];
+
+              // Skip main branch deployments (main, staging)
+              if (identifier === 'main' || identifier === 'staging') {
+                skipped++;
+                continue;
+              }
+
               let shouldDelete = false;
               let reason = '';
 


### PR DESCRIPTION
## Summary

- Fix deployment cleanup incorrectly deleting main branch deployments

## Problem

The cleanup was marking these deployments for deletion:
- `web/preview/main` - "branch main has no open PR"
- `neon/preview/staging` - "branch staging has no open PR"

These are legitimate deployments from main branch CI runs, not stale PR deployments.

## Solution

Skip deployments where identifier is `main` or `staging`.

## Test plan

- [ ] Re-run cleanup-stale workflow with dry-run
- [ ] Verify `web/preview/main` and `neon/preview/staging` are no longer in deletion list

🤖 Generated with [Claude Code](https://claude.com/claude-code)