### PR TITLE
docs(skills): use --body-file for gh cli commands

### DIFF
--- a/.claude/skills/issue-compact/SKILL.md
+++ b/.claude/skills/issue-compact/SKILL.md
@@ -70,14 +70,14 @@ Create a new issue body that:
 
 ### Step 5: Update Issue Body
 
-Use `gh issue edit {issue-id} --body "..."` to update with the synthesized content.
+Write the synthesized content to a temporary file, then use `--body-file` to update the issue:
 
-Use HEREDOC for the body to preserve formatting:
 ```bash
-gh issue edit {issue-id} --body "$(cat <<'EOF'
-[synthesized content here]
-EOF
-)"
+# Write synthesized content to temp file
+# (use Write tool to create /tmp/issue-{issue-id}-compact.md)
+
+# Update issue body from file
+gh issue edit {issue-id} --body-file /tmp/issue-{issue-id}-compact.md
 ```
 
 ### Step 6: Delete All Comments

--- a/.claude/skills/issue-plan/SKILL.md
+++ b/.claude/skills/issue-plan/SKILL.md
@@ -83,15 +83,7 @@ For each missing phase, execute in order, then post comments to the issue:
 
 2. **Post research comment to issue**:
    ```bash
-   gh issue comment {issue-id} --body "$(cat <<'EOF'
-   ## Research Phase
-
-   [Contents of research.md]
-
-   ---
-   *Phase 1/3 of deep-dive workflow*
-   EOF
-   )"
+   gh issue comment {issue-id} --body-file /tmp/deep-dive/{task-name}/research.md
    ```
    - **Update todo:** Mark "Post research comment to issue" as completed
 
@@ -106,15 +98,7 @@ For each missing phase, execute in order, then post comments to the issue:
 
 2. **Post innovation comment to issue**:
    ```bash
-   gh issue comment {issue-id} --body "$(cat <<'EOF'
-   ## Innovation Phase
-
-   [Contents of innovate.md]
-
-   ---
-   *Phase 2/3 of deep-dive workflow*
-   EOF
-   )"
+   gh issue comment {issue-id} --body-file /tmp/deep-dive/{task-name}/innovate.md
    ```
    - **Update todo:** Mark "Post innovate comment to issue" as completed
 
@@ -130,15 +114,7 @@ For each missing phase, execute in order, then post comments to the issue:
 
 2. **Post plan comment to issue**:
    ```bash
-   gh issue comment {issue-id} --body "$(cat <<'EOF'
-   ## Plan Phase
-
-   [Contents of plan.md]
-
-   ---
-   *Phase 3/3 - Ready for approval*
-   EOF
-   )"
+   gh issue comment {issue-id} --body-file /tmp/deep-dive/{task-name}/plan.md
    ```
    - **Update todo:** Mark "Post plan comment to issue" as completed
 

--- a/.claude/skills/tech-debt/SKILL.md
+++ b/.claude/skills/tech-debt/SKILL.md
@@ -534,7 +534,7 @@ If total content is under GitHub issue size limit (~65K characters):
 ```bash
 gh issue create \
   --title "[Tech Debt] Codebase Quality Scan - $(date +%Y-%m-%d)" \
-  --body "$(cat /tmp/tech-debt-{date}/github-issue-body.md)" \
+  --body-file /tmp/tech-debt-{date}/github-issue-body.md \
   --label "tech-debt,quality,refactoring"
 ```
 
@@ -546,26 +546,26 @@ If content exceeds size limit, create issue with summary and post detailed secti
 # 1. Create issue with executive summary
 ISSUE_URL=$(gh issue create \
   --title "[Tech Debt] Codebase Quality Scan - $(date +%Y-%m-%d)" \
-  --body "$(cat /tmp/tech-debt-{date}/github-issue-summary.md)" \
+  --body-file /tmp/tech-debt-{date}/github-issue-summary.md \
   --label "tech-debt,quality,refactoring")
 
 ISSUE_NUMBER=$(echo $ISSUE_URL | grep -oP '\d+$')
 
 # 2. Post critical issues as comment
 gh issue comment $ISSUE_NUMBER \
-  --body "$(cat /tmp/tech-debt-{date}/github-comment-critical.md)"
+  --body-file /tmp/tech-debt-{date}/github-comment-critical.md
 
 # 3. Post high priority issues as comment
 gh issue comment $ISSUE_NUMBER \
-  --body "$(cat /tmp/tech-debt-{date}/github-comment-high.md)"
+  --body-file /tmp/tech-debt-{date}/github-comment-high.md
 
 # 4. Post medium priority issues as comment
 gh issue comment $ISSUE_NUMBER \
-  --body "$(cat /tmp/tech-debt-{date}/github-comment-medium.md)"
+  --body-file /tmp/tech-debt-{date}/github-comment-medium.md
 
 # 5. Post action plan as comment
 gh issue comment $ISSUE_NUMBER \
-  --body "$(cat /tmp/tech-debt-{date}/github-comment-action-plan.md)"
+  --body-file /tmp/tech-debt-{date}/github-comment-action-plan.md
 ```
 
 **Comment Size Limits:**


### PR DESCRIPTION
## Summary
- Replace HEREDOC and `$(cat ...)` patterns with `--body-file` flag in skill documentation
- Affects `issue-compact`, `issue-plan`, and `tech-debt` skills
- Cleaner and more reliable approach for GitHub CLI operations

## Test plan
- [x] Documentation changes only - no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)