### PR TITLE
feat(platform): add session id and framework fields to logs list response

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/v1-runs.ts
+++ b/turbo/apps/platform/src/mocks/handlers/v1-runs.ts
@@ -65,7 +65,9 @@ export const platformLogsHandlers = [
     const response: LogsListResponse = {
       data: data.map((log) => ({
         id: log.id,
+        sessionId: log.sessionId,
         agentName: log.agentName,
+        framework: log.framework,
         status: log.status,
         createdAt: log.createdAt,
       })),

--- a/turbo/apps/platform/src/signals/logs-page/types.ts
+++ b/turbo/apps/platform/src/signals/logs-page/types.ts
@@ -12,7 +12,9 @@ export type LogStatus =
 // List response - contains basic fields for list display
 export interface LogEntry {
   id: string;
+  sessionId: string | null;
   agentName: string;
+  framework: string | null;
   status: LogStatus;
   createdAt: string;
 }

--- a/turbo/apps/platform/src/views/logs-page/__tests__/logs-page.test.tsx
+++ b/turbo/apps/platform/src/views/logs-page/__tests__/logs-page.test.tsx
@@ -47,10 +47,9 @@ describe("logs page", () => {
       expect(screen.getByText("Test Agent")).toBeInTheDocument();
     });
 
-    // Verify basic fields from list response are displayed
-    // Note: sessionId and framework are no longer in list response
-    // They show "-" placeholder in list view
-    expect(screen.getAllByText("-").length).toBeGreaterThan(0);
+    // Verify sessionId and framework fields from list response are displayed
+    expect(screen.getByText("session_1")).toBeInTheDocument();
+    expect(screen.getAllByText("claude-code").length).toBeGreaterThan(0);
   });
 
   it("should show empty state when no logs exist", async () => {
@@ -85,7 +84,9 @@ describe("logs page", () => {
             data: [
               {
                 id: "run_1",
+                sessionId: null,
                 agentName: "Agent run_1",
+                framework: null,
                 status: "completed",
                 createdAt: "2024-01-01T00:00:00Z",
               },
@@ -97,7 +98,9 @@ describe("logs page", () => {
           data: [
             {
               id: "run_2",
+              sessionId: null,
               agentName: "Agent run_2",
+              framework: null,
               status: "completed",
               createdAt: "2024-01-02T00:00:00Z",
             },
@@ -126,7 +129,9 @@ describe("logs page", () => {
           data: [
             {
               id: "run_first",
+              sessionId: null,
               agentName: "Agent run_first",
+              framework: null,
               status: "completed",
               createdAt: "2024-01-01T00:00:00Z",
             },
@@ -165,7 +170,9 @@ describe("logs page", () => {
           data: [
             {
               id: "run_no_session",
+              sessionId: null,
               agentName: "Test Agent",
+              framework: null,
               status: "pending",
               createdAt: "2024-01-01T00:00:00Z",
             },

--- a/turbo/apps/platform/src/views/logs-page/logs-table-row.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-table-row.tsx
@@ -38,13 +38,13 @@ export function LogsTableRow({ entry }: LogsTableRowProps) {
         <span className="block truncate">{entry.id}</span>
       </TableCell>
       <TableCell className="max-w-[180px] px-3 py-2 text-sm font-medium">
-        <span className="block truncate">-</span>
+        <span className="block truncate">{entry.sessionId ?? "-"}</span>
       </TableCell>
       <TableCell className="w-[120px] truncate px-3 py-2 text-sm font-medium">
         {entry.agentName}
       </TableCell>
       <TableCell className="w-[180px] truncate px-3 py-2 text-sm font-medium">
-        -
+        {entry.framework ?? "-"}
       </TableCell>
       <TableCell className="w-[100px] px-3 py-2">
         <StatusBadge status={entry.status} />

--- a/turbo/packages/core/src/contracts/platform.ts
+++ b/turbo/packages/core/src/contracts/platform.ts
@@ -31,7 +31,9 @@ const platformLogStatusSchema = z.enum([
  */
 const platformLogEntrySchema = z.object({
   id: z.string().uuid(),
+  sessionId: z.string().nullable(),
   agentName: z.string(),
+  framework: z.string().nullable(),
   status: platformLogStatusSchema,
   createdAt: z.string(),
 });


### PR DESCRIPTION
## Summary
- Add `sessionId` and `framework` fields to the platform logs list API endpoint
- Update the UI to display these values in the logs table columns
- Update mock handlers and tests to include the new fields

## Test plan
- [x] All pre-commit checks pass (lint, type-check, knip)
- [x] Updated logs page tests pass
- [x] Existing tests remain passing (some flaky tests unrelated to these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)