### PR TITLE
refactor(ci): migrate ci_ prefixed secrets to environment-based separation

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Check if cleanup needed
         id: check
         env:
-          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
-          SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          SSH_KEY: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
         run: |
           if [ -z "$SSH_KEY" ] || [ -z "$METAL_HOSTS" ]; then
             echo "Metal secrets not available, skipping runner cleanup"
@@ -32,7 +32,7 @@ jobs:
       - name: Setup SSH key
         if: steps.check.outputs.should-cleanup == 'true'
         env:
-          SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
+          SSH_KEY: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
         run: |
           SSH_DIR="$HOME/.ssh"
           SSH_KEY_FILE="$SSH_DIR/metal.pem"
@@ -46,8 +46,8 @@ jobs:
         shell: bash
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
-          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
+          METAL_USER: ${{ secrets.AWS_METAL_RUNNER_USER }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
         run: |
           SSH_KEY_FILE="$HOME/.ssh/metal.pem"
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $SSH_KEY_FILE"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -314,8 +314,8 @@ jobs:
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_USER_STORAGES_BUCKET_NAME: ${{ secrets.CI_R2_USER_STORAGES_BUCKET_NAME }}
-          SECRETS_ENCRYPTION_KEY: ${{ secrets.CI_SECRETS_ENCRYPTION_KEY }}
+          R2_USER_STORAGES_BUCKET_NAME: ${{ secrets.R2_USER_STORAGES_BUCKET_NAME }}
+          SECRETS_ENCRYPTION_KEY: ${{ secrets.SECRETS_ENCRYPTION_KEY }}
           AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
         run: pnpm vitest run --project=web
 
@@ -419,14 +419,14 @@ jobs:
             R2_ACCOUNT_ID=${{ secrets.R2_ACCOUNT_ID }}
             R2_ACCESS_KEY_ID=${{ secrets.R2_ACCESS_KEY_ID }}
             R2_SECRET_ACCESS_KEY=${{ secrets.R2_SECRET_ACCESS_KEY }}
-            R2_USER_STORAGES_BUCKET_NAME=${{ secrets.CI_R2_USER_STORAGES_BUCKET_NAME }}
-            SECRETS_ENCRYPTION_KEY=${{ secrets.CI_SECRETS_ENCRYPTION_KEY }}
+            R2_USER_STORAGES_BUCKET_NAME=${{ secrets.R2_USER_STORAGES_BUCKET_NAME }}
+            SECRETS_ENCRYPTION_KEY=${{ secrets.SECRETS_ENCRYPTION_KEY }}
             OFFICIAL_RUNNER_SECRET=${{ secrets.OFFICIAL_RUNNER_SECRET }}
             AXIOM_TOKEN=${{ secrets.AXIOM_TOKEN }}
             AXIOM_DATASET_SUFFIX=dev
             USE_MOCK_CLAUDE=true
             CRON_SECRET=${{ secrets.CRON_SECRET }}
-            ABLY_API_KEY=${{ secrets.CI_ABLY_API_KEY }}
+            ABLY_API_KEY=${{ secrets.ABLY_API_KEY }}
             CONCURRENT_RUN_LIMIT=0
             DEBUG=*
             CLAUDE_CODE_VERSION_URL=${{ vars.CLAUDE_CODE_VERSION_URL }}
@@ -953,9 +953,9 @@ jobs:
         shell: bash
         env:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
-          METAL_HOSTS: ${{ secrets.CI_AWS_METAL_RUNNER_HOSTS }}
-          METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
-          SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_USER: ${{ secrets.AWS_METAL_RUNNER_USER }}
+          SSH_KEY: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
         run: |
           # Parse hosts into array
           IFS=',' read -ra HOSTS <<< "$METAL_HOSTS"
@@ -1109,9 +1109,9 @@ jobs:
         id: prepare
         env:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
-          METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
+          METAL_USER: ${{ secrets.AWS_METAL_RUNNER_USER }}
           RUNNER_HOST: ${{ steps.lock.outputs.host }}
-          SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
+          SSH_KEY: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
         run: |
           RUNNER_DIR="/opt/vm0-runner/${JOB_REF}"
           # Use numeric hash of job-ref for proxy port to ensure consistency
@@ -1163,11 +1163,11 @@ jobs:
 
       - name: Run benchmark command for VM performance testing
         env:
-          METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
+          METAL_USER: ${{ secrets.AWS_METAL_RUNNER_USER }}
           RUNNER_HOST: ${{ needs.deploy-runner-prepare.outputs.runner-host }}
           RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
           PROXY_PORT: ${{ needs.deploy-runner-prepare.outputs.proxy-port }}
-          SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
+          SSH_KEY: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
         run: |
           mkdir -p "$HOME/.ssh"
           echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
@@ -1229,11 +1229,11 @@ jobs:
         id: start
         env:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
-          METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
+          METAL_USER: ${{ secrets.AWS_METAL_RUNNER_USER }}
           RUNNER_HOST: ${{ needs.deploy-runner-prepare.outputs.runner-host }}
           RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
           PROXY_PORT: ${{ needs.deploy-runner-prepare.outputs.proxy-port }}
-          SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
+          SSH_KEY: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           PREVIEW_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
@@ -1278,8 +1278,8 @@ jobs:
         env:
           RUNNER_HOST: ${{ needs.deploy-runner-prepare.outputs.runner-host }}
           RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
-          METAL_USER: ${{ secrets.CI_AWS_METAL_RUNNER_USER }}
-          SSH_KEY: ${{ secrets.CI_AWS_METAL_RUNNER_SSH_KEY }}
+          METAL_USER: ${{ secrets.AWS_METAL_RUNNER_USER }}
+          SSH_KEY: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
         run: |
           mkdir -p "$HOME/.ssh"
           echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -1,4 +1,4 @@
-// CLI entry point
+// VM0 CLI entry point
 import { Command } from "commander";
 import { authCommand } from "./commands/auth";
 import { infoCommand } from "./commands/info";


### PR DESCRIPTION
## Summary

- Remove `CI_` prefix from secret references in `turbo.yml` (16 occurrences) and `cleanup.yml` (5 occurrences)
- Secrets are now resolved based on GitHub Environment scoping:
  - Production jobs with `environment: production` → get production environment values
  - CI jobs without environment specified → get repository-level values (dev)

## Changes

| Secret | Occurrences |
|--------|-------------|
| `CI_R2_USER_STORAGES_BUCKET_NAME` → `R2_USER_STORAGES_BUCKET_NAME` | 2 |
| `CI_SECRETS_ENCRYPTION_KEY` → `SECRETS_ENCRYPTION_KEY` | 2 |
| `CI_ABLY_API_KEY` → `ABLY_API_KEY` | 1 |
| `CI_AWS_METAL_RUNNER_HOSTS` → `AWS_METAL_RUNNER_HOSTS` | 3 |
| `CI_AWS_METAL_RUNNER_USER` → `AWS_METAL_RUNNER_USER` | 6 |
| `CI_AWS_METAL_RUNNER_SSH_KEY` → `AWS_METAL_RUNNER_SSH_KEY` | 7 |

## Prerequisites (already completed)

- [x] Added 6 secrets to `production` environment with production values
- [x] Updated repository-level secrets with dev values

## Test plan

- [ ] CI pipeline passes with new secret references
- [ ] Production release uses production environment secrets correctly

Closes #2157

🤖 Generated with [Claude Code](https://claude.com/claude-code)