### PR TITLE
feat(runner): add snapshot command for fast vm startup

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1144,6 +1144,7 @@ jobs:
             -e "pm2_process_name=vm0-runner-${JOB_REF}" \
             -e "runner_bundle_path=/tmp/vm0-runner-bundle.tar.gz" \
             -e "rootfs_path=${RUNNER_DIR}/rootfs.squashfs" \
+            -e "snapshot_path=${RUNNER_DIR}/snapshot" \
             -e "force_rebuild_rootfs=true" \
             -e "proxy_port=${PROXY_PORT}" \
             -e '{"enable_drain": true, "drain_timeout": 300}' \
@@ -1190,13 +1191,17 @@ jobs:
           echo "Proxy port: ${PROXY_PORT}"
           echo ""
 
-          # Create benchmark config with proxy settings (firewall + mitm enabled by default)
+          # Create benchmark config with proxy settings and snapshot (firewall + mitm enabled by default)
           ssh $SSH_OPTS ${METAL_USER}@${RUNNER_HOST} "
             echo 'base_dir: ${RUNNER_DIR}/benchmark' > ${RUNNER_DIR}/benchmark.yaml
             echo 'firecracker:' >> ${RUNNER_DIR}/benchmark.yaml
             echo '  binary: /usr/local/bin/firecracker' >> ${RUNNER_DIR}/benchmark.yaml
             echo '  kernel: /opt/firecracker/vmlinux' >> ${RUNNER_DIR}/benchmark.yaml
             echo '  rootfs: ${RUNNER_DIR}/rootfs.squashfs' >> ${RUNNER_DIR}/benchmark.yaml
+            echo '  snapshot:' >> ${RUNNER_DIR}/benchmark.yaml
+            echo '    snapshot: ${RUNNER_DIR}/snapshot/snapshot.bin' >> ${RUNNER_DIR}/benchmark.yaml
+            echo '    memory: ${RUNNER_DIR}/snapshot/memory.bin' >> ${RUNNER_DIR}/benchmark.yaml
+            echo '    overlay: ${RUNNER_DIR}/snapshot/overlay.ext4' >> ${RUNNER_DIR}/benchmark.yaml
             echo 'proxy:' >> ${RUNNER_DIR}/benchmark.yaml
             echo '  port: ${PROXY_PORT}' >> ${RUNNER_DIR}/benchmark.yaml
             echo '  ca_dir: ${RUNNER_DIR}/proxy' >> ${RUNNER_DIR}/benchmark.yaml
@@ -1274,6 +1279,7 @@ jobs:
             -e "official_runner_secret=${OFFICIAL_RUNNER_SECRET}" \
             -e "api_url=${PREVIEW_URL}" \
             -e "rootfs_path=${RUNNER_DIR}/rootfs.squashfs" \
+            -e "snapshot_path=${RUNNER_DIR}/snapshot" \
             -e "proxy_port=${PROXY_PORT}" \
             -e '{"extra_env": {"VERCEL_AUTOMATION_BYPASS_SECRET": "'"${VERCEL_BYPASS}"'", "USE_MOCK_CLAUDE": "true", "AXIOM_TOKEN": "'"${AXIOM_TOKEN}"'", "AXIOM_DATASET_SUFFIX": "dev"}}' \
             -v

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -68,9 +68,15 @@
     enable_drain: true
     drain_timeout: 7200  # 2 hours
     extra_env: {}
-    # Rootfs configuration - CI should override for per-PR isolation
+    # Rootfs and snapshot configuration - CI should override for per-PR isolation
     rootfs_path: /opt/firecracker/rootfs.squashfs
+    snapshot_path: /opt/firecracker/snapshot
     force_rebuild_rootfs: false
+    force_rebuild_snapshot: false
+    enable_snapshot: true
+    # VM resource configuration
+    vcpu: 2
+    memory_mb: 1024
     # Proxy port - CI should override for per-PR isolation (8080 + PR_NUMBER % 1000)
     proxy_port: 8080
 
@@ -402,6 +408,110 @@
       become: no
       ignore_errors: yes
       when: kvm_group_result.changed
+      tags: [prepare]
+
+    # ========================================
+    # Phase 4.5: Generate Snapshot (optional)
+    # ========================================
+    - name: Ensure snapshot directory exists
+      file:
+        path: "{{ snapshot_path }}"
+        state: directory
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0755'
+      when: enable_snapshot
+      tags: [prepare]
+
+    - name: Check if snapshot files exist
+      shell: |
+        test -f "{{ snapshot_path }}/snapshot.bin" && \
+        test -f "{{ snapshot_path }}/memory.bin" && \
+        test -f "{{ snapshot_path }}/overlay.ext4"
+      register: snapshot_files_check
+      ignore_errors: yes
+      changed_when: false
+      when: enable_snapshot
+      tags: [prepare]
+
+    # Calculate hash of files that affect snapshot (rootfs + kernel + firecracker + runner + config)
+    - name: Calculate snapshot inputs hash
+      shell: |
+        (cat "{{ rootfs_path }}" /opt/firecracker/vmlinux /usr/local/bin/firecracker \
+             "{{ runner_base_dir }}/index.js" && \
+         echo "vcpu={{ vcpu }} memory_mb={{ memory_mb }}") 2>/dev/null | sha256sum | cut -d' ' -f1
+      args:
+        executable: /bin/bash
+      register: snapshot_inputs_hash
+      changed_when: false
+      when: enable_snapshot
+      tags: [prepare]
+
+    - name: Read stored snapshot hash
+      slurp:
+        src: "{{ snapshot_path }}/inputs.sha256"
+      register: stored_snapshot_hash
+      ignore_errors: yes
+      when: enable_snapshot
+      tags: [prepare]
+
+    - name: Determine if snapshot rebuild is needed
+      set_fact:
+        snapshot_needs_rebuild: >-
+          {{
+            (snapshot_files_check.rc | default(1)) != 0 or
+            force_rebuild_snapshot or
+            rootfs_needs_rebuild | default(false) or
+            stored_snapshot_hash.failed or
+            (stored_snapshot_hash.content | default('') | b64decode | trim) != snapshot_inputs_hash.stdout
+          }}
+      when: enable_snapshot
+      tags: [prepare]
+
+    - name: Create snapshot generation config
+      copy:
+        content: |
+          base_dir: {{ runner_base_dir }}/snapshot-gen
+          firecracker:
+            binary: /usr/local/bin/firecracker
+            kernel: /opt/firecracker/vmlinux
+            rootfs: {{ rootfs_path }}
+          sandbox:
+            vcpu: {{ vcpu }}
+            memory_mb: {{ memory_mb }}
+        dest: "{{ runner_base_dir }}/snapshot-gen.yaml"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0644'
+      when: enable_snapshot and snapshot_needs_rebuild
+      tags: [prepare]
+
+    - name: Generate snapshot for fast VM boot
+      command: >
+        node index.js snapshot {{ snapshot_path }}
+        --config {{ runner_base_dir }}/snapshot-gen.yaml
+      args:
+        chdir: "{{ runner_base_dir }}"
+      become: no
+      when: enable_snapshot and snapshot_needs_rebuild
+      tags: [prepare]
+
+    - name: Store snapshot inputs hash
+      copy:
+        content: "{{ snapshot_inputs_hash.stdout }}\n"
+        dest: "{{ snapshot_path }}/inputs.sha256"
+        mode: '0644'
+      when: enable_snapshot and snapshot_needs_rebuild
+      tags: [prepare]
+
+    - name: Clean up snapshot generation files
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ runner_base_dir }}/snapshot-gen.yaml"
+        - "{{ runner_base_dir }}/snapshot-gen"
+      when: enable_snapshot and snapshot_needs_rebuild
       tags: [prepare]
 
     # ========================================

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -511,7 +511,7 @@
       loop:
         - "{{ runner_base_dir }}/snapshot-gen.yaml"
         - "{{ runner_base_dir }}/snapshot-gen"
-      when: enable_snapshot and snapshot_needs_rebuild
+      when: enable_snapshot
       tags: [prepare]
 
     # ========================================

--- a/ansible/playbooks/templates/runner.yaml.j2
+++ b/ansible/playbooks/templates/runner.yaml.j2
@@ -11,15 +11,21 @@ server:
 
 sandbox:
   max_concurrent: {{ max_concurrent | default(8) }}
-  vcpu: {{ vcpu | default(2) }}
-  memory_mb: {{ memory_mb | default(1024) }}
+  vcpu: {{ vcpu }}
+  memory_mb: {{ memory_mb }}
   poll_interval_ms: {{ poll_interval_ms | default(30000) }}
 
 firecracker:
   binary: /usr/local/bin/firecracker
   kernel: /opt/firecracker/vmlinux
-  rootfs: {{ rootfs_path | default('/opt/firecracker/rootfs.squashfs') }}
+  rootfs: {{ rootfs_path }}
+{% if enable_snapshot %}
+  snapshot:
+    snapshot: {{ snapshot_path }}/snapshot.bin
+    memory: {{ snapshot_path }}/memory.bin
+    overlay: {{ snapshot_path }}/overlay.ext4
+{% endif %}
 
 proxy:
-  port: {{ proxy_port | default(8080) }}
+  port: {{ proxy_port }}
   ca_dir: {{ runner_base_dir }}/proxy

--- a/turbo/apps/runner/src/commands/snapshot.ts
+++ b/turbo/apps/runner/src/commands/snapshot.ts
@@ -1,0 +1,311 @@
+/**
+ * Snapshot Command
+ *
+ * Generates a Firecracker snapshot for fast VM startup.
+ * This is a one-time operation typically run during deployment/CI.
+ *
+ * Process:
+ * 1. Create network namespace with TAP device
+ * 2. Create overlay filesystem
+ * 3. Start Firecracker with --api-sock only
+ * 4. Configure VM via API (machine, boot-source, drives, network, vsock)
+ * 5. Start VM via API (InstanceStart)
+ * 6. Wait for guest to become ready (vsock)
+ * 7. Pause VM via API
+ * 8. Create snapshot (state + memory)
+ * 9. Copy overlay as golden overlay
+ * 10. Cleanup
+ *
+ * Outputs (in output directory):
+ * - snapshot.bin: VM state snapshot
+ * - memory.bin: VM memory snapshot
+ * - overlay.ext4: Golden overlay with guest state
+ */
+
+import { Command } from "commander";
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import readline from "node:readline";
+import { loadDebugConfig, validateFirecrackerPaths } from "../lib/config.js";
+import { Timer } from "../lib/timing.js";
+import { setGlobalLogger, createLogger } from "../lib/logger.js";
+import { VsockClient } from "../lib/firecracker/vsock.js";
+import { FirecrackerClient } from "../lib/firecracker/client.js";
+import {
+  SNAPSHOT_NETWORK,
+  createNetnsWithTap,
+  deleteNetns,
+} from "../lib/firecracker/netns.js";
+import { createOverlayFile } from "../lib/firecracker/overlay-pool.js";
+import { execCommand } from "../lib/utils/exec.js";
+import { buildBootArgs } from "../lib/firecracker/config.js";
+import { vmPaths, runnerPaths, snapshotOutputPaths } from "../lib/paths.js";
+
+interface SnapshotOptions {
+  config: string;
+  output: string;
+}
+
+const logger = createLogger("Snapshot");
+
+/**
+ * Start Firecracker process with API socket only (no config file)
+ *
+ * This allows us to configure the VM via API before starting it,
+ * avoiding race conditions with config-file mode.
+ */
+function startFirecracker(
+  nsName: string,
+  firecrackerBinary: string,
+  apiSocketPath: string,
+  workDir: string,
+): ChildProcess {
+  logger.log("Starting Firecracker with API socket...");
+
+  // Use sudo to enter netns, but run Firecracker as current user
+  // This ensures created files (sockets) are owned by current user, not root
+  const currentUser = os.userInfo().username;
+  const fcProcess = spawn(
+    "sudo",
+    [
+      "ip",
+      "netns",
+      "exec",
+      nsName,
+      "sudo",
+      "-u",
+      currentUser,
+      firecrackerBinary,
+      "--api-sock",
+      apiSocketPath,
+    ],
+    {
+      cwd: workDir,
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: false,
+    },
+  );
+
+  // Log stdout/stderr
+  if (fcProcess.stdout) {
+    const stdoutRL = readline.createInterface({ input: fcProcess.stdout });
+    stdoutRL.on("line", (line) => {
+      if (line.trim()) logger.log(`[FC] ${line}`);
+    });
+  }
+  if (fcProcess.stderr) {
+    const stderrRL = readline.createInterface({ input: fcProcess.stderr });
+    stderrRL.on("line", (line) => {
+      if (line.trim()) logger.log(`[FC stderr] ${line}`);
+    });
+  }
+
+  fcProcess.on("error", (err) => logger.log(`Firecracker error: ${err}`));
+  fcProcess.on("exit", (code, signal) =>
+    logger.log(`Firecracker exited: code=${code}, signal=${signal}`),
+  );
+
+  return fcProcess;
+}
+
+export const snapshotCommand = new Command("snapshot")
+  .description("Generate a Firecracker snapshot for fast VM startup")
+  .argument("<output-dir>", "Output directory for snapshot files")
+  .option("--config <path>", "Config file path", "./runner.yaml")
+  .action(
+    async (outputDir: string, opts: Record<string, string>): Promise<void> => {
+      const options: SnapshotOptions = {
+        config: opts.config ?? "./runner.yaml",
+        output: outputDir,
+      };
+
+      const timer = new Timer();
+      setGlobalLogger(timer.log.bind(timer));
+
+      // Load and validate config first (needed for base_dir)
+      logger.log("Loading configuration...");
+      const config = loadDebugConfig(options.config);
+      validateFirecrackerPaths(config.firecracker);
+
+      const nsName = "vm0-snapshot";
+      const workDir = runnerPaths.snapshotWorkDir(config.base_dir);
+      const overlayPath = vmPaths.overlay(workDir);
+      const vsockPath = vmPaths.vsock(workDir);
+      const apiSocketPath = vmPaths.apiSock(workDir);
+
+      // Output files
+      const outputSnapshot = snapshotOutputPaths.snapshot(options.output);
+      const outputMemory = snapshotOutputPaths.memory(options.output);
+      const outputOverlay = snapshotOutputPaths.overlay(options.output);
+
+      let fcProcess: ChildProcess | null = null;
+      let vsockClient: VsockClient | null = null;
+      let exitCode = 0;
+
+      try {
+        // Create directories
+        logger.log(`Creating directories...`);
+        fs.mkdirSync(options.output, { recursive: true });
+        fs.mkdirSync(workDir, { recursive: true });
+        fs.mkdirSync(vmPaths.vsockDir(workDir), { recursive: true });
+
+        // Create overlay
+        logger.log("Creating overlay filesystem...");
+        await createOverlayFile(overlayPath);
+        logger.log(`Overlay created: ${overlayPath}`);
+
+        // Create network namespace
+        logger.log(`Creating network namespace: ${nsName}`);
+        await deleteNetns(nsName); // Clean up any stale namespace
+        await createNetnsWithTap(nsName, {
+          tapName: SNAPSHOT_NETWORK.tapName,
+          gatewayIpWithPrefix: `${SNAPSHOT_NETWORK.gatewayIp}/${SNAPSHOT_NETWORK.prefixLen}`,
+        });
+        logger.log("Network namespace created");
+
+        // Start Firecracker with API socket only (no config file)
+        fcProcess = startFirecracker(
+          nsName,
+          config.firecracker.binary,
+          apiSocketPath,
+          workDir,
+        );
+
+        const apiClient = new FirecrackerClient(apiSocketPath);
+
+        // Wait for API to be ready
+        logger.log("Waiting for API to be ready...");
+        await apiClient.waitForReady();
+        logger.log("API ready");
+
+        // Configure VM via API (parallel - each request uses fresh connection)
+        logger.log("Configuring VM via API...");
+        await Promise.all([
+          apiClient.configureMachine({
+            vcpu_count: config.sandbox.vcpu,
+            mem_size_mib: config.sandbox.memory_mb,
+          }),
+          apiClient.configureBootSource({
+            kernel_image_path: config.firecracker.kernel,
+            boot_args: buildBootArgs(),
+          }),
+          apiClient.configureDrive({
+            drive_id: "rootfs",
+            path_on_host: config.firecracker.rootfs,
+            is_root_device: true,
+            is_read_only: true,
+          }),
+          apiClient.configureDrive({
+            drive_id: "overlay",
+            path_on_host: overlayPath,
+            is_root_device: false,
+            is_read_only: false,
+          }),
+          apiClient.configureNetworkInterface({
+            iface_id: "eth0",
+            guest_mac: SNAPSHOT_NETWORK.guestMac,
+            host_dev_name: SNAPSHOT_NETWORK.tapName,
+          }),
+          apiClient.configureVsock({
+            guest_cid: 3,
+            uds_path: vsockPath,
+          }),
+        ]);
+        logger.log("VM configured");
+
+        // Start vsock listener BEFORE starting VM to avoid race condition
+        // Guest's vsock-agent connects immediately after boot (~300ms)
+        logger.log("Starting vsock listener...");
+        vsockClient = new VsockClient(vsockPath);
+        const guestConnectionPromise =
+          vsockClient.waitForGuestConnection(60000);
+
+        // Start the VM via API
+        logger.log("Starting VM...");
+        await apiClient.startInstance();
+        logger.log("VM started");
+
+        // Wait for guest to connect via vsock
+        logger.log("Waiting for guest connection...");
+        await guestConnectionPromise;
+        logger.log("Guest connected");
+
+        // Verify guest is responsive
+        logger.log("Verifying guest is responsive...");
+        const reachable = await vsockClient.isReachable();
+        if (!reachable) {
+          throw new Error("Guest is not responsive");
+        }
+        logger.log("Guest is responsive");
+
+        // Pause the VM
+        logger.log("Pausing VM...");
+        await apiClient.pause();
+        logger.log("VM paused");
+
+        // Create snapshot
+        logger.log("Creating snapshot...");
+        await apiClient.createSnapshot({
+          snapshot_type: "Full",
+          snapshot_path: outputSnapshot,
+          mem_file_path: outputMemory,
+        });
+        logger.log("Snapshot created");
+
+        // Copy overlay as golden overlay (sparse copy for speed)
+        logger.log("Copying overlay as golden overlay...");
+        await execCommand(
+          `cp --sparse=always "${overlayPath}" "${outputOverlay}"`,
+          false,
+        );
+        logger.log("Golden overlay created");
+
+        // Success
+        logger.log("=".repeat(40));
+        logger.log("Snapshot generation complete!");
+        const lsOutput = await execCommand(`ls -lh "${options.output}"`, false);
+        logger.log(lsOutput);
+        logger.log("=".repeat(40));
+      } catch (error) {
+        logger.error(
+          `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
+        exitCode = 1;
+      } finally {
+        // Cleanup
+        logger.log("Cleaning up...");
+
+        // Close vsock
+        if (vsockClient) {
+          vsockClient.close();
+        }
+
+        // Kill Firecracker
+        // Note: fcProcess is the sudo process, not firecracker itself.
+        // Kill sudo first, then use pkill to ensure firecracker is terminated.
+        if (fcProcess && !fcProcess.killed) {
+          fcProcess.kill("SIGKILL");
+        }
+        // Ensure firecracker is killed (sudo may not propagate SIGKILL to children)
+        await execCommand(
+          `pkill -9 -f "firecracker.*${apiSocketPath}"`,
+          true,
+        ).catch(() => {});
+
+        // Delete network namespace
+        await deleteNetns(nsName);
+
+        // Clean up work directory
+        if (fs.existsSync(workDir)) {
+          fs.rmSync(workDir, { recursive: true, force: true });
+        }
+
+        logger.log("Cleanup complete");
+      }
+
+      if (exitCode !== 0) {
+        process.exit(exitCode);
+      }
+    },
+  );

--- a/turbo/apps/runner/src/commands/snapshot.ts
+++ b/turbo/apps/runner/src/commands/snapshot.ts
@@ -144,6 +144,12 @@ export const snapshotCommand = new Command("snapshot")
       let exitCode = 0;
 
       try {
+        // Clean up any stale work directory from previous run
+        if (fs.existsSync(workDir)) {
+          logger.log("Cleaning up stale work directory...");
+          fs.rmSync(workDir, { recursive: true, force: true });
+        }
+
         // Create directories
         logger.log(`Creating directories...`);
         fs.mkdirSync(options.output, { recursive: true });

--- a/turbo/apps/runner/src/commands/snapshot.ts
+++ b/turbo/apps/runner/src/commands/snapshot.ts
@@ -264,8 +264,15 @@ export const snapshotCommand = new Command("snapshot")
         // Success
         logger.log("=".repeat(40));
         logger.log("Snapshot generation complete!");
+        logger.log("Files (logical size):");
         const lsOutput = await execCommand(`ls -lh "${options.output}"`, false);
         logger.log(lsOutput);
+        logger.log("Actual disk usage:");
+        const duOutput = await execCommand(
+          `du -h "${options.output}"/*`,
+          false,
+        );
+        logger.log(duOutput);
         logger.log("=".repeat(40));
       } catch (error) {
         logger.error(

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -7,6 +7,7 @@ import { startCommand } from "./commands/start.js";
 import { doctorCommand } from "./commands/doctor.js";
 import { killCommand } from "./commands/kill.js";
 import { benchmarkCommand } from "./commands/benchmark.js";
+import { snapshotCommand } from "./commands/snapshot.js";
 
 // Version is injected at build time by tsup
 declare const __RUNNER_VERSION__: string;
@@ -22,5 +23,6 @@ program.addCommand(startCommand);
 program.addCommand(doctorCommand);
 program.addCommand(killCommand);
 program.addCommand(benchmarkCommand);
+program.addCommand(snapshotCommand);
 
 program.parse();

--- a/turbo/apps/runner/src/lib/config.ts
+++ b/turbo/apps/runner/src/lib/config.ts
@@ -55,6 +55,13 @@ export const runnerConfigSchema = z.object({
     binary: z.string().min(1, "Firecracker binary path is required"),
     kernel: z.string().min(1, "Kernel path is required"),
     rootfs: z.string().min(1, "Rootfs path is required"),
+    snapshot: z
+      .object({
+        snapshot: z.string().min(1, "Snapshot state file path is required"),
+        memory: z.string().min(1, "Snapshot memory file path is required"),
+        overlay: z.string().min(1, "Snapshot overlay file path is required"),
+      })
+      .optional(),
   }),
   proxy: z.object({
     // TODO: Allow 0 to auto-find available port
@@ -104,6 +111,13 @@ export const debugConfigSchema = z.object({
     binary: z.string().min(1, "Firecracker binary path is required"),
     kernel: z.string().min(1, "Kernel path is required"),
     rootfs: z.string().min(1, "Rootfs path is required"),
+    snapshot: z
+      .object({
+        snapshot: z.string().min(1, "Snapshot state file path is required"),
+        memory: z.string().min(1, "Snapshot memory file path is required"),
+        overlay: z.string().min(1, "Snapshot overlay file path is required"),
+      })
+      .optional(),
   }),
   proxy: z
     .object({
@@ -171,6 +185,15 @@ export function validateFirecrackerPaths(
     { path: config.kernel, name: "Kernel" },
     { path: config.rootfs, name: "Rootfs" },
   ];
+
+  // Add snapshot paths if configured
+  if (config.snapshot) {
+    checks.push(
+      { path: config.snapshot.snapshot, name: "Snapshot state file" },
+      { path: config.snapshot.memory, name: "Snapshot memory file" },
+      { path: config.snapshot.overlay, name: "Snapshot overlay file" },
+    );
+  }
 
   for (const check of checks) {
     if (!fs.existsSync(check.path)) {

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -169,6 +169,17 @@ export async function executeJob(
     await withSandboxTiming("guest_wait", () => guestConnectionPromise);
     logger.log(`Guest client ready`);
 
+    // Post-resume handling for snapshot restore
+    // After snapshot restore, guest time continues from snapshot creation time
+    // Entropy pool is handled by random.trust_cpu=on boot arg (CPU HWRNG auto-refills)
+    // ARP cache: not needed since each VM runs in fresh namespace with new TAP device
+    // See: https://github.com/firecracker-microvm/firecracker/blob/main/docs/snapshotting/snapshot-support.md
+    if (config.firecracker.snapshot) {
+      // Use host timestamp directly (faster than hwclock which accesses RTC device)
+      const timestamp = (Date.now() / 1000).toFixed(3);
+      await guest.exec(`date -s "@${timestamp}"`);
+    }
+
     // Download storages if manifest provided
     if (context.storageManifest) {
       await withSandboxTiming("storage_download", () =>

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -12,6 +12,7 @@
  */
 
 import fs from "node:fs";
+import path from "node:path";
 import { FirecrackerVM, type VMConfig } from "./firecracker/vm.js";
 import { createVmId } from "./firecracker/vm-id.js";
 import type { GuestClient } from "./firecracker/guest.js";
@@ -85,7 +86,6 @@ export async function executeJob(
       firecrackerBinary: config.firecracker.binary,
       workDir: runnerPaths.vmWorkDir(config.base_dir, vmId),
     };
-
     // Create workDir and vsock subdir before VM so vsock listener can be started before vm.start()
     fs.mkdirSync(vmConfig.workDir, { recursive: true });
     fs.mkdirSync(vmPaths.vsockDir(vmConfig.workDir), { recursive: true });
@@ -98,10 +98,33 @@ export async function executeJob(
     logger.log(`Starting vsock listener: ${vsockPath}`);
     const guestConnectionPromise = guest.waitForGuestConnection(30000);
 
-    // Create and start VM
+    // Create VM and start
+    // - With snapshot config: restore from snapshot (fast boot ~50ms)
+    // - Without snapshot: fresh boot (~362ms)
     logger.log(`Creating VM ${vmId}...`);
     vm = new FirecrackerVM(vmConfig);
-    await withSandboxTiming("vm_create", () => vm!.start());
+
+    // Start VM (Firecracker process begins, guest will connect to vsock)
+    // Derive snapshot workdir from snapshot config path:
+    // - Snapshot is at {original_base_dir}/snapshot/snapshot.bin
+    // - Snapshot was generated with workdir at {original_base_dir}/snapshot-gen/workspaces/.snapshot-work
+    // - Paths recorded in snapshot use that workdir
+    const snapshotConfig = config.firecracker.snapshot;
+    let snapshotPaths: Parameters<typeof vm.start>[0];
+    if (snapshotConfig) {
+      // Extract original base_dir from snapshot path (go up 2 levels: /snapshot/snapshot.bin)
+      const snapshotDir = path.dirname(snapshotConfig.snapshot);
+      const originalBaseDir = path.dirname(snapshotDir);
+      const snapshotBaseDir = runnerPaths.snapshotBaseDir(originalBaseDir);
+      const snapshotWorkDir = runnerPaths.snapshotWorkDir(snapshotBaseDir);
+      snapshotPaths = {
+        snapshot: snapshotConfig.snapshot,
+        memory: snapshotConfig.memory,
+        snapshotOverlay: vmPaths.overlay(snapshotWorkDir),
+        snapshotVsockDir: vmPaths.vsockDir(snapshotWorkDir),
+      };
+    }
+    await withSandboxTiming("vm_create", () => vm!.start(snapshotPaths));
 
     // Get VM IPs for logging and network security
     guestIp = vm.getGuestIp();

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -107,7 +107,7 @@ export async function executeJob(
     // Start VM (Firecracker process begins, guest will connect to vsock)
     // Derive snapshot workdir from snapshot config path:
     // - Snapshot is at {original_base_dir}/snapshot/snapshot.bin
-    // - Snapshot was generated with workdir at {original_base_dir}/snapshot-gen/workspaces/.snapshot-work
+    // - Snapshot was generated with workdir at {original_base_dir}/snapshot-gen/workspaces/snapshot
     // - Paths recorded in snapshot use that workdir
     const snapshotConfig = config.firecracker.snapshot;
     let snapshotPaths: Parameters<typeof vm.start>[0];

--- a/turbo/apps/runner/src/lib/firecracker/config.ts
+++ b/turbo/apps/runner/src/lib/firecracker/config.ts
@@ -67,7 +67,7 @@ interface FirecrackerConfigParams {
  *   - init=/sbin/vm-init: use vm-init (Rust binary) for filesystem setup and vsock-agent
  *   - ip=...: network configuration (fixed IPs from SNAPSHOT_NETWORK)
  */
-function buildBootArgs(): string {
+export function buildBootArgs(): string {
   const networkBootArgs = generateSnapshotNetworkBootArgs();
   return `console=ttyS0 reboot=k panic=1 pci=off nomodules random.trust_cpu=on quiet loglevel=0 nokaslr audit=0 numa=off mitigations=off noresume init=/sbin/vm-init ${networkBootArgs}`;
 }

--- a/turbo/apps/runner/src/lib/firecracker/netns.ts
+++ b/turbo/apps/runner/src/lib/firecracker/netns.ts
@@ -80,3 +80,12 @@ export async function createNetnsWithTap(
   // Bring up loopback
   await execCommand(`ip netns exec ${nsName} ip link set lo up`);
 }
+
+/**
+ * Delete a network namespace
+ *
+ * Silently ignores errors (namespace may not exist).
+ */
+export async function deleteNetns(nsName: string): Promise<void> {
+  await execCommand(`ip netns del ${nsName}`).catch(() => {});
+}

--- a/turbo/apps/runner/src/lib/firecracker/overlay-pool.ts
+++ b/turbo/apps/runner/src/lib/firecracker/overlay-pool.ts
@@ -43,8 +43,9 @@ interface OverlayPoolConfig {
 
 /**
  * Create a sparse ext4 overlay file
+ * Exported for use by snapshot command
  */
-async function createOverlayFile(filePath: string): Promise<void> {
+export async function createOverlayFile(filePath: string): Promise<void> {
   const fd = fs.openSync(filePath, "w");
   fs.ftruncateSync(fd, OVERLAY_SIZE);
   fs.closeSync(fd);

--- a/turbo/apps/runner/src/lib/paths.ts
+++ b/turbo/apps/runner/src/lib/paths.ts
@@ -84,6 +84,21 @@ export const vmPaths = {
 };
 
 /**
+ * Snapshot output paths (within output directory)
+ * These are the final snapshot artifacts
+ */
+export const snapshotOutputPaths = {
+  /** VM state snapshot */
+  snapshot: (outputDir: string) => path.join(outputDir, "snapshot.bin"),
+
+  /** VM memory snapshot */
+  memory: (outputDir: string) => path.join(outputDir, "memory.bin"),
+
+  /** Golden overlay with guest state */
+  overlay: (outputDir: string) => path.join(outputDir, "overlay.ext4"),
+};
+
+/**
  * Temporary file paths (/tmp/vm0-*)
  * These use runId for isolation
  */

--- a/turbo/apps/runner/src/lib/paths.ts
+++ b/turbo/apps/runner/src/lib/paths.ts
@@ -52,7 +52,7 @@ export const runnerPaths = {
 
   /** Snapshot generation work directory */
   snapshotWorkDir: (baseDir: string) =>
-    path.join(baseDir, "workspaces", ".snapshot-work"),
+    path.join(baseDir, "workspaces", "snapshot"),
 
   /** Check if a directory name is a VM workspace */
   isVmWorkspace: (dirname: string) => dirname.startsWith(VM_WORKSPACE_PREFIX),


### PR DESCRIPTION
## Summary

Implement Firecracker snapshot support for fast VM startup (Issue #1600 Phase 5 & 6).

### Phase 5: Snapshot Generation
- Add `runner snapshot` CLI command
- Extract shared modules: `config.ts`, `netns.ts`, `exec.ts`
- Centralize paths in `paths.ts`
- Show actual disk usage (sparse files) in output

### Phase 6: CI/CD Integration  
- Add snapshot generation to `deploy-runner.yml` (Phase 4.5)
- Add `snapshot_path` variable (default: `/opt/firecracker/snapshot`)
- Use inputs hash to detect when rebuild is needed
- Update `runner.yaml.j2` template to include snapshot config

### Snapshot Restore Support
- Add optional `firecracker.snapshot` config
- Copy golden overlay in overlay pool when snapshot configured
- Pass snapshot paths to `vm.start()` for restore mode
- **Post-resume handling**: Sync guest time after snapshot restore
  - Uses `date -s "@timestamp"` for fast time sync
  - Entropy pool handled by `random.trust_cpu=on` boot arg
  - ARP cache not needed (fresh network namespace per VM)

### Reliability Improvements
- Clean up stale work directory at start of snapshot generation
- Prevents issues from interrupted previous runs

## Usage

### Generate Snapshot
```bash
runner snapshot <output-dir> --config ./runner.yaml
```

### Ansible Variables
```yaml
# Defaults
rootfs_path: /opt/firecracker/rootfs.squashfs
snapshot_path: /opt/firecracker/snapshot
enable_snapshot: true
force_rebuild_snapshot: false
```

### runner.yaml (generated)
```yaml
firecracker:
  binary: /usr/local/bin/firecracker
  kernel: /opt/firecracker/vmlinux
  rootfs: /opt/firecracker/rootfs.squashfs
  snapshot:                              # Auto-added when enable_snapshot=true
    snapshot: /opt/firecracker/snapshot/snapshot.bin
    memory: /opt/firecracker/snapshot/memory.bin
    overlay: /opt/firecracker/snapshot/overlay.ext4
```

## Test plan

- [x] Run `runner snapshot ./snapshots` on dev-1
- [x] Verify all 3 output files are created
- [x] Run `runner benchmark` with snapshot config
- [x] Verify VM boots from snapshot
- [ ] Deploy with ansible and verify snapshot generation

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #1600