### PR TITLE
feat(auth): environment-based access control for test-token endpoint

### DIFF
--- a/scripts/dev-auth.sh
+++ b/scripts/dev-auth.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Quick local authentication for development
+# Usage: pnpm dev:auth (from turbo directory)
+#
+# This script calls the test-token endpoint to generate a CLI token
+# and saves it to ~/.vm0/config.json for local development.
+#
+# Prerequisites:
+#   - Dev server must be running (pnpm dev)
+#   - Server must be in development mode (NODE_ENV=development)
+
+set -euo pipefail
+
+VM0_API_URL="${VM0_API_URL:-http://localhost:3000}"
+
+echo "=== Dev Authentication ==="
+echo "API URL: ${VM0_API_URL}"
+
+# Call test-token endpoint
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  "${VM0_API_URL}/api/cli/auth/test-token")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | head -n-1)
+
+if [[ "$HTTP_CODE" != "200" ]]; then
+  echo "❌ Error: test-token endpoint returned $HTTP_CODE"
+  echo "Response: $BODY"
+  echo ""
+  echo "Make sure the dev server is running (pnpm dev)"
+  exit 1
+fi
+
+# Extract token from response
+TOKEN=$(echo "$BODY" | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
+
+if [[ -z "$TOKEN" ]]; then
+  echo "❌ Error: Failed to extract token from response"
+  echo "Response: $BODY"
+  exit 1
+fi
+
+# Create config directory and file
+CONFIG_DIR="$HOME/.vm0"
+CONFIG_FILE="$CONFIG_DIR/config.json"
+
+mkdir -p "$CONFIG_DIR"
+
+cat > "$CONFIG_FILE" << EOF
+{
+  "token": "$TOKEN",
+  "apiUrl": "$VM0_API_URL"
+}
+EOF
+
+echo ""
+echo "✅ Authenticated successfully!"
+echo "Config saved to: $CONFIG_FILE"

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { POST } from "../route";
+import { createTestRequest } from "../../../../../../src/__tests__/api-test-helpers";
+import { testContext } from "../../../../../../src/__tests__/test-helpers";
+
+// Mock external dependencies
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
+
+// Mock Clerk Server API
+const mockGetUserList = vi.fn();
+vi.mock("@clerk/nextjs/server", () => ({
+  clerkClient: vi.fn(async () => ({
+    users: {
+      getUserList: mockGetUserList,
+    },
+  })),
+  auth: vi.fn(),
+}));
+
+const context = testContext();
+
+describe("/api/cli/auth/test-token", () => {
+  beforeEach(() => {
+    context.setupMocks();
+    vi.stubEnv("CLERK_SECRET_KEY", "test-secret-key");
+    mockGetUserList.mockReset();
+    mockGetUserList.mockResolvedValue({
+      data: [{ id: "user_test123" }],
+    });
+  });
+
+  describe("environment-based access control", () => {
+    it("allows access in local development (no VERCEL_ENV, NODE_ENV=development)", async () => {
+      vi.stubEnv("VERCEL_ENV", "");
+      vi.stubEnv("NODE_ENV", "development");
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-token",
+        { method: "POST" },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.access_token).toBeDefined();
+      expect(data.token_type).toBe("Bearer");
+    });
+
+    it("allows access in preview with valid bypass secret", async () => {
+      vi.stubEnv("VERCEL_ENV", "preview");
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "test-bypass-secret");
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-token",
+        {
+          method: "POST",
+          headers: { "x-vercel-protection-bypass": "test-bypass-secret" },
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+    });
+
+    it("denies access in preview without bypass header", async () => {
+      vi.stubEnv("VERCEL_ENV", "preview");
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "test-bypass-secret");
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-token",
+        { method: "POST" },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(404);
+    });
+
+    it("denies access in preview with invalid bypass secret", async () => {
+      vi.stubEnv("VERCEL_ENV", "preview");
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "test-bypass-secret");
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-token",
+        {
+          method: "POST",
+          headers: { "x-vercel-protection-bypass": "wrong-secret" },
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(404);
+    });
+
+    it("denies access in preview when bypass secret is not configured", async () => {
+      vi.stubEnv("VERCEL_ENV", "preview");
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "");
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-token",
+        {
+          method: "POST",
+          headers: { "x-vercel-protection-bypass": "any-secret" },
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(404);
+    });
+
+    it("denies access in production", async () => {
+      vi.stubEnv("VERCEL_ENV", "production");
+      vi.stubEnv("NODE_ENV", "production");
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-token",
+        { method: "POST" },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(404);
+    });
+
+    it("denies access in non-Vercel production (no VERCEL_ENV, NODE_ENV=production)", async () => {
+      vi.stubEnv("VERCEL_ENV", "");
+      vi.stubEnv("NODE_ENV", "production");
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-token",
+        { method: "POST" },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(404);
+    });
+
+    it("denies access in unknown environment", async () => {
+      vi.stubEnv("VERCEL_ENV", "unknown-env");
+      vi.stubEnv("NODE_ENV", "production");
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-token",
+        { method: "POST" },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("token generation", () => {
+    beforeEach(() => {
+      vi.stubEnv("VERCEL_ENV", "");
+      vi.stubEnv("NODE_ENV", "development");
+    });
+
+    it("returns token with correct format", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-token",
+        { method: "POST" },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(data.access_token).toMatch(/^vm0_live_/);
+      expect(data.token_type).toBe("Bearer");
+      expect(data.expires_in).toBe(90 * 24 * 60 * 60);
+      expect(data.user_id).toBe("user_test123");
+    });
+
+    it("returns 500 when test user is not found", async () => {
+      mockGetUserList.mockResolvedValue({ data: [] });
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-token",
+        { method: "POST" },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.error).toBe("Test user not found");
+    });
+
+    it("calls Clerk with correct email address", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-token",
+        { method: "POST" },
+      );
+
+      await POST(request);
+
+      expect(mockGetUserList).toHaveBeenCalledWith({
+        emailAddress: ["e2e+clerk_test@vm0.ai"],
+      });
+    });
+  });
+});

--- a/turbo/package.json
+++ b/turbo/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",
+    "dev:auth": "bash ../scripts/dev-auth.sh",
     "lint": "turbo run lint --concurrency=2",
     "format": "prettier --write --ignore-unknown .",
     "check-types": "turbo run check-types",


### PR DESCRIPTION
## Summary

- Replace `USE_MOCK_CLAUDE` check with environment-based access control for `/api/cli/auth/test-token`
- Add `pnpm dev:auth` script for quick local CLI authentication

## Changes

### Access Control Logic (deny by default)

| Environment | VERCEL_ENV | NODE_ENV | Result |
|-------------|------------|----------|--------|
| Local `pnpm dev` | undefined | development | ✅ Allow |
| Vercel preview | preview | production | ✅ Requires bypass secret |
| Vercel production | production | production | ❌ Deny |
| Other production | undefined | production | ❌ Deny |
| Unknown | * | * | ❌ Deny |

### Files Changed

- `turbo/apps/web/app/api/cli/auth/test-token/route.ts` - New `isTestTokenAllowed()` function
- `turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts` - 11 test cases for access control
- `scripts/dev-auth.sh` - Quick auth script for local development
- `turbo/package.json` - Added `dev:auth` script

## Test plan

- [x] All 11 new test cases pass
- [x] Existing test-approve tests still pass (21 total tests)
- [x] CI workflows continue to work (they already send bypass header)
- [ ] Manual test: `pnpm dev` then `pnpm dev:auth` generates valid token

Closes #2211

🤖 Generated with [Claude Code](https://claude.ai/code)