### PR TITLE
refactor(runner): simplify overlay pool by removing background replenish

### DIFF
--- a/turbo/apps/runner/src/commands/benchmark.ts
+++ b/turbo/apps/runner/src/commands/benchmark.ts
@@ -91,7 +91,6 @@ export const benchmarkCommand = new Command("benchmark")
       timer.log("Initializing pools...");
       await initOverlayPool({
         size: 2,
-        replenishThreshold: 1,
         poolDir: runnerPaths.overlayPool(config.base_dir),
       });
       await initNetnsPool({ name: config.name, size: 2 });

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/overlay-pool.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/overlay-pool.test.ts
@@ -28,7 +28,6 @@ describe("OverlayPool", () => {
       const pool = new OverlayPool({
         poolDir,
         size: 3,
-        replenishThreshold: 1,
         createFile: testCreateFile,
       });
 
@@ -55,7 +54,6 @@ describe("OverlayPool", () => {
       const pool = new OverlayPool({
         poolDir,
         size: 2,
-        replenishThreshold: 1,
         createFile: testCreateFile,
       });
       await pool.init();
@@ -70,6 +68,31 @@ describe("OverlayPool", () => {
 
       pool.cleanup();
     });
+
+    it("handles creation failures gracefully", async () => {
+      const poolDir = path.join(tempDir, "pool");
+      let callCount = 0;
+      const failingCreateFile = async (filePath: string): Promise<void> => {
+        callCount++;
+        if (callCount === 2) {
+          throw new Error("Creation failed");
+        }
+        fs.writeFileSync(filePath, "test-overlay");
+      };
+
+      const pool = new OverlayPool({
+        poolDir,
+        size: 3,
+        createFile: failingCreateFile,
+      });
+
+      await pool.init();
+
+      // Should have 2 files (one failed)
+      expect(pool.getAvailableCount()).toBe(2);
+
+      pool.cleanup();
+    });
   });
 
   describe("acquire", () => {
@@ -78,7 +101,6 @@ describe("OverlayPool", () => {
       const pool = new OverlayPool({
         poolDir,
         size: 2,
-        replenishThreshold: 1,
         createFile: testCreateFile,
       });
 
@@ -92,7 +114,6 @@ describe("OverlayPool", () => {
       const pool = new OverlayPool({
         poolDir,
         size: 2,
-        replenishThreshold: 1,
         createFile: testCreateFile,
       });
       await pool.init();
@@ -110,13 +131,16 @@ describe("OverlayPool", () => {
 
     it("creates on-demand when pool exhausted", async () => {
       const poolDir = path.join(tempDir, "pool");
+      const createFileSpy = vi.fn(testCreateFile);
       const pool = new OverlayPool({
         poolDir,
         size: 1,
-        replenishThreshold: 0,
-        createFile: testCreateFile,
+        createFile: createFileSpy,
       });
       await pool.init();
+
+      // Initial creation: 1 file
+      expect(createFileSpy).toHaveBeenCalledTimes(1);
 
       // Acquire the only pre-warmed file
       const file1 = await pool.acquire();
@@ -126,34 +150,7 @@ describe("OverlayPool", () => {
       const file2 = await pool.acquire();
       expect(file2).not.toBe(file1);
       expect(fs.existsSync(file2)).toBe(true);
-
-      pool.cleanup();
-    });
-
-    it("triggers background replenishment when below threshold", async () => {
-      const poolDir = path.join(tempDir, "pool");
-      const createFileSpy = vi.fn(testCreateFile);
-      const pool = new OverlayPool({
-        poolDir,
-        size: 3,
-        replenishThreshold: 2,
-        createFile: createFileSpy,
-      });
-      await pool.init();
-
-      // Initial creation: 3 files
-      expect(createFileSpy).toHaveBeenCalledTimes(3);
-
-      // Acquire one, drops to 2 (at threshold, no replenish yet)
-      await pool.acquire();
-
-      // Acquire another, drops to 1 (below threshold, triggers replenish)
-      await pool.acquire();
-
-      // Wait for background replenishment
-      await vi.waitFor(() => {
-        expect(createFileSpy.mock.calls.length).toBeGreaterThan(3);
-      });
+      expect(createFileSpy).toHaveBeenCalledTimes(2);
 
       pool.cleanup();
     });
@@ -165,7 +162,6 @@ describe("OverlayPool", () => {
       const pool = new OverlayPool({
         poolDir,
         size: 3,
-        replenishThreshold: 1,
         createFile: testCreateFile,
       });
       await pool.init();
@@ -183,7 +179,6 @@ describe("OverlayPool", () => {
       const pool = new OverlayPool({
         poolDir,
         size: 2,
-        replenishThreshold: 1,
         createFile: testCreateFile,
       });
       await pool.init();
@@ -201,12 +196,33 @@ describe("OverlayPool", () => {
       const pool = new OverlayPool({
         poolDir,
         size: 2,
-        replenishThreshold: 1,
         createFile: testCreateFile,
       });
 
       // Should not throw
       expect(() => pool.cleanup()).not.toThrow();
+    });
+  });
+
+  describe("getAvailableCount", () => {
+    it("returns correct count", async () => {
+      const poolDir = path.join(tempDir, "pool");
+      const pool = new OverlayPool({
+        poolDir,
+        size: 3,
+        createFile: testCreateFile,
+      });
+      await pool.init();
+
+      expect(pool.getAvailableCount()).toBe(3);
+
+      await pool.acquire();
+      expect(pool.getAvailableCount()).toBe(2);
+
+      await pool.acquire();
+      expect(pool.getAvailableCount()).toBe(1);
+
+      pool.cleanup();
     });
   });
 });

--- a/turbo/apps/runner/src/lib/firecracker/overlay-pool.ts
+++ b/turbo/apps/runner/src/lib/firecracker/overlay-pool.ts
@@ -6,10 +6,10 @@
  * pre-created files from a pool (~0ms).
  *
  * Design:
- * - Pool maintains a queue of pre-created overlay file paths
+ * - Pool creates fixed number of overlays at init (parallel)
  * - acquire() returns a path from the pool (VM owns the file)
  * - VM deletes the file when done
- * - Pool replenishes in background when below threshold
+ * - Falls back to on-demand creation if pool is exhausted
  */
 
 import { exec } from "node:child_process";
@@ -31,10 +31,8 @@ const OVERLAY_SIZE = 2 * 1024 * 1024 * 1024; // 2GB sparse file
  * Pool configuration
  */
 interface OverlayPoolConfig {
-  /** Number of overlay files to maintain in pool */
+  /** Number of overlay files to pre-create */
   size: number;
-  /** Start replenishing when pool drops below this count */
-  replenishThreshold: number;
   /** Pool directory for overlay files */
   poolDir: string;
   /** Custom file creator function (optional, for testing) */
@@ -42,10 +40,9 @@ interface OverlayPoolConfig {
 }
 
 /**
- * Default overlay file creator
- * Creates a sparse ext4 file
+ * Create a sparse ext4 overlay file
  */
-async function defaultCreateFile(filePath: string): Promise<void> {
+async function createOverlayFile(filePath: string): Promise<void> {
   const fd = fs.openSync(filePath, "w");
   fs.ftruncateSync(fd, OVERLAY_SIZE);
   fs.closeSync(fd);
@@ -60,15 +57,13 @@ async function defaultCreateFile(filePath: string): Promise<void> {
 export class OverlayPool {
   private initialized = false;
   private queue: string[] = [];
-  private replenishing = false;
   private readonly config: Required<OverlayPoolConfig>;
 
   constructor(config: OverlayPoolConfig) {
     this.config = {
       size: config.size,
-      replenishThreshold: config.replenishThreshold,
       poolDir: config.poolDir,
-      createFile: config.createFile ?? defaultCreateFile,
+      createFile: config.createFile ?? createOverlayFile,
     };
   }
 
@@ -107,54 +102,12 @@ export class OverlayPool {
   }
 
   /**
-   * Replenish the pool in background
-   */
-  private async replenish(): Promise<void> {
-    if (this.replenishing || !this.initialized) {
-      return;
-    }
-
-    const needed = this.config.size - this.queue.length;
-    if (needed <= 0) {
-      return;
-    }
-
-    this.replenishing = true;
-    logger.log(`Replenishing pool: creating ${needed} overlay(s)...`);
-
-    try {
-      const promises = [];
-      for (let i = 0; i < needed; i++) {
-        const filePath = path.join(
-          this.config.poolDir,
-          this.generateFileName(),
-        );
-        promises.push(
-          this.config.createFile(filePath).then(() => {
-            this.queue.push(filePath);
-          }),
-        );
-      }
-      await Promise.all(promises);
-      logger.log(`Pool replenished: ${this.queue.length} available`);
-    } catch (err) {
-      logger.error(
-        `Replenish failed: ${err instanceof Error ? err.message : "Unknown"}`,
-      );
-    } finally {
-      this.replenishing = false;
-    }
-  }
-
-  /**
    * Initialize the overlay pool
    */
   async init(): Promise<void> {
     this.queue = [];
 
-    logger.log(
-      `Initializing overlay pool (size=${this.config.size}, threshold=${this.config.replenishThreshold})...`,
-    );
+    logger.log(`Initializing overlay pool (size=${this.config.size})...`);
 
     await this.ensurePoolDir();
 
@@ -168,8 +121,30 @@ export class OverlayPool {
     }
 
     this.initialized = true;
-    await this.replenish();
-    logger.log("Overlay pool initialized");
+
+    // Create all overlays in parallel
+    if (this.config.size > 0) {
+      const results = await Promise.all(
+        Array.from({ length: this.config.size }, async () => {
+          const filePath = path.join(
+            this.config.poolDir,
+            this.generateFileName(),
+          );
+          try {
+            await this.config.createFile(filePath);
+            return filePath;
+          } catch (err) {
+            logger.error(
+              `Failed to create overlay: ${err instanceof Error ? err.message : "Unknown"}`,
+            );
+            return null;
+          }
+        }),
+      );
+      this.queue = results.filter((f): f is string => f !== null);
+    }
+
+    logger.log(`Overlay pool initialized: ${this.queue.length} available`);
   }
 
   /**
@@ -187,16 +162,6 @@ export class OverlayPool {
 
     if (filePath) {
       logger.log(`Acquired overlay from pool (${this.queue.length} remaining)`);
-
-      // Trigger background replenishment if below threshold
-      if (this.queue.length < this.config.replenishThreshold) {
-        this.replenish().catch((err) => {
-          logger.error(
-            `Background replenish failed: ${err instanceof Error ? err.message : "Unknown"}`,
-          );
-        });
-      }
-
       return filePath;
     }
 
@@ -205,6 +170,13 @@ export class OverlayPool {
     const newPath = path.join(this.config.poolDir, this.generateFileName());
     await this.config.createFile(newPath);
     return newPath;
+  }
+
+  /**
+   * Get the number of available overlays in the pool
+   */
+  getAvailableCount(): number {
+    return this.queue.length;
   }
 
   /**
@@ -241,7 +213,6 @@ export class OverlayPool {
     }
 
     this.initialized = false;
-    this.replenishing = false;
     logger.log("Overlay pool cleaned up");
   }
 }

--- a/turbo/apps/runner/src/lib/runner/setup.ts
+++ b/turbo/apps/runner/src/lib/runner/setup.ts
@@ -73,7 +73,6 @@ export async function setupEnvironment(
   logger.log("Initializing overlay pool...");
   await initOverlayPool({
     size: config.sandbox.max_concurrent + 2,
-    replenishThreshold: config.sandbox.max_concurrent,
     poolDir: runnerPaths.overlayPool(config.base_dir),
   });
 


### PR DESCRIPTION
## Summary

Align overlay-pool with netns-pool design by removing background replenishment:

- Remove `replenishThreshold` config option
- Remove background replenishment logic
- Create all overlays at init time (parallel)
- Fall back to on-demand creation if pool exhausted
- Add `getAvailableCount()` method for consistency with netns-pool

## Rationale

The background replenishment added unnecessary complexity. The simpler approach (matching netns-pool) is:
1. Pre-create fixed number of resources at init
2. On-demand fallback when exhausted

## Test plan

- [x] All existing tests pass
- [x] Added test for `getAvailableCount()`
- [x] Added test for creation failure handling

🤖 Generated with [Claude Code](https://claude.ai/code)