### PR TITLE
fix(ci): add retry mechanism for vercel alias propagation delay

### DIFF
--- a/e2e/scripts/generate-test-token.sh
+++ b/e2e/scripts/generate-test-token.sh
@@ -14,6 +14,10 @@
 
 set -euo pipefail
 
+# Retry configuration
+MAX_RETRIES=5
+INITIAL_DELAY=2
+
 echo "=== Generating Test CLI Token ==="
 
 # Validate environment
@@ -30,21 +34,68 @@ if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
   CURL_HEADERS+=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
 fi
 
-# Call test-token endpoint
-echo "Calling test-token endpoint..."
-RESPONSE=$(curl -s -w "\n%{http_code}" \
-  "${CURL_HEADERS[@]}" \
-  -X POST \
-  "${VM0_API_URL}/api/cli/auth/test-token")
+# Check if error is retryable (Vercel alias propagation delay)
+is_retryable_error() {
+  local http_code="$1"
+  local body="$2"
 
-HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-BODY=$(echo "$RESPONSE" | head -n-1)
+  # Retry on 404 with DEPLOYMENT_NOT_FOUND (Vercel alias not yet propagated)
+  if [[ "$http_code" == "404" ]] && [[ "$body" == *"DEPLOYMENT_NOT_FOUND"* ]]; then
+    return 0
+  fi
 
-if [[ "$HTTP_CODE" != "200" ]]; then
-  echo "Error: test-token endpoint returned $HTTP_CODE"
-  echo "Response: $BODY"
-  exit 1
-fi
+  # Not retryable
+  return 1
+}
+
+# Call test-token endpoint with retry logic
+call_test_token_endpoint() {
+  local attempt=1
+  local delay=$INITIAL_DELAY
+  local response http_code body
+
+  while [[ $attempt -le $MAX_RETRIES ]]; do
+    echo "Calling test-token endpoint (attempt $attempt/$MAX_RETRIES)..."
+
+    response=$(curl -s -w "\n%{http_code}" \
+      "${CURL_HEADERS[@]}" \
+      -X POST \
+      "${VM0_API_URL}/api/cli/auth/test-token" 2>&1) || true
+
+    http_code=$(echo "$response" | tail -n1)
+    body=$(echo "$response" | head -n-1)
+
+    # Success
+    if [[ "$http_code" == "200" ]]; then
+      if [[ $attempt -gt 1 ]]; then
+        echo "Attempt $attempt/$MAX_RETRIES succeeded"
+      fi
+      echo "$body"
+      return 0
+    fi
+
+    # Check if error is retryable
+    if is_retryable_error "$http_code" "$body"; then
+      if [[ $attempt -lt $MAX_RETRIES ]]; then
+        echo "Attempt $attempt/$MAX_RETRIES failed (DEPLOYMENT_NOT_FOUND), retrying in ${delay}s..."
+        sleep "$delay"
+        delay=$((delay * 2))
+        attempt=$((attempt + 1))
+        continue
+      fi
+    fi
+
+    # Non-retryable error or max retries exhausted
+    echo "Error: test-token endpoint returned $http_code"
+    echo "Response: $body"
+    return 1
+  done
+
+  return 1
+}
+
+# Call endpoint with retry
+BODY=$(call_test_token_endpoint) || exit 1
 
 # Extract token from response
 TOKEN=$(echo "$BODY" | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)


### PR DESCRIPTION
## Summary
- Add exponential backoff retry logic to `generate-test-token.sh` to handle transient `DEPLOYMENT_NOT_FOUND` errors
- Only retry on specific Vercel alias propagation errors (404 with DEPLOYMENT_NOT_FOUND)
- Fail immediately on other errors (real API issues)

## Changes
- Add `is_retryable_error()` function to detect retryable 404 errors
- Add `call_test_token_endpoint()` with retry loop (max 5 attempts)
- Exponential backoff: 2s → 4s → 8s → 16s → 32s (max ~62s total)

## Test plan
- [x] Script syntax validated
- [x] Pre-commit checks pass
- [ ] CI pipeline passes
- [ ] Monitor for DEPLOYMENT_NOT_FOUND failures in future PR runs

Fixes #2212

🤖 Generated with [Claude Code](https://claude.com/claude-code)