### PR TITLE
refactor(web): rename debug env var to vm0_debug

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -428,7 +428,7 @@ jobs:
             CRON_SECRET=${{ secrets.CRON_SECRET }}
             ABLY_API_KEY=${{ secrets.ABLY_API_KEY }}
             CONCURRENT_RUN_LIMIT=0
-            DEBUG=*
+            VM0_DEBUG=*
             CLAUDE_CODE_VERSION_URL=${{ vars.CLAUDE_CODE_VERSION_URL }}
           meta-branch: ${{ github.head_ref || github.ref_name }}
           meta-pr: ${{ needs.prepare.outputs.job-ref }}

--- a/turbo/apps/web/src/lib/logger.ts
+++ b/turbo/apps/web/src/lib/logger.ts
@@ -1,24 +1,24 @@
 /**
- * Lightweight structured logging system with DEBUG environment variable support.
+ * Lightweight structured logging system with VM0_DEBUG environment variable support.
  *
  * Usage:
  *   const log = logger('service:e2b')
- *   log.debug('sandbox created', { id: '123' })  // Only when DEBUG matches
+ *   log.debug('sandbox created', { id: '123' })  // Only when VM0_DEBUG matches
  *   log.warn('slow response')                     // Always output
  *   log.error('failed', error)                    // Always output
  *
  * Environment:
- *   DEBUG=service:e2b     - Enable specific logger
- *   DEBUG=service:*       - Enable all service loggers (wildcard)
- *   DEBUG=*               - Enable all debug output
- *   DEBUG=a,b,c           - Enable multiple loggers
+ *   VM0_DEBUG=service:e2b     - Enable specific logger
+ *   VM0_DEBUG=service:*       - Enable all service loggers (wildcard)
+ *   VM0_DEBUG=*               - Enable all debug output
+ *   VM0_DEBUG=a,b,c           - Enable multiple loggers
  *
  * Auto-enabled:
- *   - Local development (NODE_ENV=development) automatically enables DEBUG=*
+ *   - Local development (NODE_ENV=development) automatically enables VM0_DEBUG=*
  *
  * Production/Preview:
- *   - DEBUG must be explicitly set via environment variables
- *   - Preview deployments: DEBUG=* is set via GitHub Actions workflow
+ *   - VM0_DEBUG must be explicitly set via environment variables
+ *   - Preview deployments: VM0_DEBUG=* is set via GitHub Actions workflow
  *
  * Axiom Integration:
  *   - When AXIOM_TOKEN is configured, logs are also sent to Axiom
@@ -105,9 +105,9 @@ function isAutoDebugEnabled(): boolean {
 }
 
 function getDebugPatterns(): string[] {
-  const debug = process.env.DEBUG;
+  const debug = process.env.VM0_DEBUG;
 
-  // If DEBUG is explicitly set, use it
+  // If VM0_DEBUG is explicitly set, use it
   if (debug) {
     return debug.split(",").map((p) => p.trim());
   }

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -3,7 +3,7 @@
   "ui": "tui",
   "globalEnv": [
     "DATABASE_URL",
-    "DEBUG",
+    "VM0_DEBUG",
     "NODE_ENV",
     "SKIP_ENV_VALIDATION",
     "VERCEL",


### PR DESCRIPTION
## Summary

- Rename `DEBUG` environment variable to `VM0_DEBUG` to prevent conflicts with the npm `debug` package during `next build`
- The standard `DEBUG` variable triggers verbose output from many npm packages (micromark, eslint, vitest, etc.), impacting build performance
- With `VM0_DEBUG`, vm0's internal debug logging is isolated from third-party library debug output

## Changes

| File | Change |
|------|--------|
| `turbo/apps/web/src/lib/logger.ts` | Read `VM0_DEBUG` instead of `DEBUG` + update docs |
| `turbo/turbo.json` | Update globalEnv to use `VM0_DEBUG` |
| `.github/workflows/turbo.yml` | Set `VM0_DEBUG=*` for preview deployments |

## Test plan

- [ ] Verify `VM0_DEBUG=*` enables all vm0 debug logs
- [ ] Verify `VM0_DEBUG=service:*` enables namespace filtering
- [ ] Verify `DEBUG=*` no longer triggers vm0 debug logs
- [ ] Verify development auto-enable behavior preserved (NODE_ENV=development)
- [ ] Verify preview deployments have debug logging enabled

Closes #2218

🤖 Generated with [Claude Code](https://claude.com/claude-code)