### PR TITLE
test: use randomuuid for unique test identifiers

### DIFF
--- a/turbo/apps/web/app/api/agent/checkpoints/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/checkpoints/[id]/__tests__/route.test.ts
@@ -30,7 +30,9 @@ describe("GET /api/agent/checkpoints/:id", () => {
     user = await context.setupUser();
 
     // Create test compose
-    const { composeId } = await createTestCompose(`checkpoint-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `checkpoint-${randomUUID().slice(0, 8)}`,
+    );
     testComposeId = composeId;
   });
 

--- a/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET } from "../route";
 import {
@@ -138,7 +139,7 @@ describe("GET /api/agent/composes/list", () => {
     const otherUser = await context.setupUser({ prefix: "forbidden-user" });
 
     // Create a compose for the other user
-    await createTestCompose(`forbidden-compose-${Date.now()}`);
+    await createTestCompose(`forbidden-compose-${randomUUID().slice(0, 8)}`);
 
     // Derive the other user's scope slug from their userId
     // userId format: {prefix}-{timestamp}-{uuid}

--- a/turbo/apps/web/app/api/agent/composes/versions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/versions/__tests__/route.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET } from "../route";
 import { POST } from "../../route";
@@ -214,7 +215,9 @@ describe("GET /api/agent/composes/versions", () => {
   it("should resolve version with full hash for cross-compose scenario", async () => {
     // Similar test - create second compose and test full hash resolution
     const { composeId: thirdComposeId, versionId: thirdVersionId } =
-      await createTestCompose(`test-version-agent-c-${Date.now()}`);
+      await createTestCompose(
+        `test-version-agent-c-${randomUUID().slice(0, 8)}`,
+      );
 
     // Test with full 64-char hash
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
@@ -27,7 +27,9 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
     context.setupMocks();
     user = await context.setupUser();
 
-    const { composeId } = await createTestCompose(`agent-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `agent-${randomUUID().slice(0, 8)}`,
+    );
     testComposeId = composeId;
   });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/__tests__/route.test.ts
@@ -28,7 +28,9 @@ describe("GET /api/agent/runs/:id/telemetry", () => {
     context.setupMocks();
     user = await context.setupUser();
 
-    const { composeId } = await createTestCompose(`telemetry-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `telemetry-${randomUUID().slice(0, 8)}`,
+    );
     testComposeId = composeId;
   });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/__tests__/route.test.ts
@@ -58,7 +58,9 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
     user = await context.setupUser();
 
     // Create test compose and run
-    const { composeId } = await createTestCompose(`metrics-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `metrics-${randomUUID().slice(0, 8)}`,
+    );
 
     const { runId } = await createTestRun(composeId, "Test prompt");
     testRunId = runId;

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts
@@ -62,7 +62,9 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
     user = await context.setupUser();
 
     // Create test compose and run
-    const { composeId } = await createTestCompose(`network-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `network-${randomUUID().slice(0, 8)}`,
+    );
 
     const { runId } = await createTestRun(composeId, "Test prompt");
     testRunId = runId;

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/__tests__/route.test.ts
@@ -29,7 +29,9 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
     user = await context.setupUser();
 
     // Create test compose and run
-    const { composeId } = await createTestCompose(`system-log-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `system-log-${randomUUID().slice(0, 8)}`,
+    );
 
     const { runId } = await createTestRun(composeId, "Test prompt");
     testRunId = runId;

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -34,8 +34,10 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
     context.setupMocks();
     user = await context.setupUser();
 
-    // Create test compose
-    const { composeId } = await createTestCompose(`agent-${Date.now()}`);
+    // Create test compose with unique name to avoid conflicts between parallel tests
+    const { composeId } = await createTestCompose(
+      `agent-${randomUUID().slice(0, 8)}`,
+    );
     testComposeId = composeId;
   });
 
@@ -561,9 +563,12 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       await createTestModelProvider("anthropic-api-key", "test-api-key");
 
       // Create compose without API key
-      const { composeId } = await createTestCompose(`mp-agent-${Date.now()}`, {
-        skipDefaultApiKey: true,
-      });
+      const { composeId } = await createTestCompose(
+        `mp-agent-${randomUUID().slice(0, 8)}`,
+        {
+          skipDefaultApiKey: true,
+        },
+      );
 
       const data = await createTestRun(composeId, "Test with model provider");
 
@@ -572,9 +577,12 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
     it("should fail run when no model provider and no API key in compose", async () => {
       // Create compose without API key and no environment block
-      const { composeId } = await createTestCompose(`no-mp-${Date.now()}`, {
-        noEnvironmentBlock: true,
-      });
+      const { composeId } = await createTestCompose(
+        `no-mp-${randomUUID().slice(0, 8)}`,
+        {
+          noEnvironmentBlock: true,
+        },
+      );
 
       const data = await createTestRun(
         composeId,
@@ -602,9 +610,12 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       await createTestModelProvider("anthropic-api-key", "test-api-key");
 
       // Create compose without API key
-      const { composeId } = await createTestCompose(`mp-select-${Date.now()}`, {
-        skipDefaultApiKey: true,
-      });
+      const { composeId } = await createTestCompose(
+        `mp-select-${randomUUID().slice(0, 8)}`,
+        {
+          skipDefaultApiKey: true,
+        },
+      );
 
       const data = await createTestRun(
         composeId,
@@ -619,12 +630,15 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
     it("should skip injection when compose has explicit OPENAI_API_KEY (codex)", async () => {
       // Create compose with OPENAI_API_KEY for codex framework
-      const { composeId } = await createTestCompose(`codex-${Date.now()}`, {
-        overrides: {
-          framework: "codex",
-          environment: { OPENAI_API_KEY: "explicit-openai-key" },
+      const { composeId } = await createTestCompose(
+        `codex-${randomUUID().slice(0, 8)}`,
+        {
+          overrides: {
+            framework: "codex",
+            environment: { OPENAI_API_KEY: "explicit-openai-key" },
+          },
         },
-      });
+      );
 
       const data = await createTestRun(composeId, "Test codex with key");
 
@@ -633,12 +647,15 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
     it("should skip injection when compose has CLAUDE_CODE_USE_FOUNDRY", async () => {
       // Create compose with alternative auth method
-      const { composeId } = await createTestCompose(`foundry-${Date.now()}`, {
-        overrides: {
-          framework: "claude-code",
-          environment: { CLAUDE_CODE_USE_FOUNDRY: "1" },
+      const { composeId } = await createTestCompose(
+        `foundry-${randomUUID().slice(0, 8)}`,
+        {
+          overrides: {
+            framework: "claude-code",
+            environment: { CLAUDE_CODE_USE_FOUNDRY: "1" },
+          },
         },
-      });
+      );
 
       const data = await createTestRun(composeId, "Test with Foundry auth");
 
@@ -648,7 +665,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
     it("should fail when specified model provider type is invalid", async () => {
       // Create compose without API key
       const { composeId } = await createTestCompose(
-        `invalid-mp-${Date.now()}`,
+        `invalid-mp-${randomUUID().slice(0, 8)}`,
         {
           skipDefaultApiKey: true,
         },

--- a/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
@@ -403,7 +403,9 @@ describe("GET /api/agent/schedules - List Schedules", () => {
 
   it("should return list of user's schedules", async () => {
     // Create compose and schedule
-    const { composeId } = await createTestCompose(`list-agent-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `list-agent-${randomUUID().slice(0, 8)}`,
+    );
     await createTestSchedule(composeId, "list-test-schedule", {
       cronExpression: "0 9 * * *",
       prompt: "Test prompt",
@@ -419,7 +421,9 @@ describe("GET /api/agent/schedules - List Schedules", () => {
 
   it("should not return other users' schedules", async () => {
     // Create compose and schedule as current user
-    const { composeId } = await createTestCompose(`my-agent-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `my-agent-${randomUUID().slice(0, 8)}`,
+    );
     await createTestSchedule(composeId, "my-schedule", {
       cronExpression: "0 9 * * *",
       prompt: "My prompt",

--- a/turbo/apps/web/app/api/agent/sessions/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/sessions/[id]/__tests__/route.test.ts
@@ -29,7 +29,9 @@ describe("GET /api/agent/sessions/:id", () => {
     context.setupMocks();
     user = await context.setupUser();
 
-    const { composeId } = await createTestCompose(`session-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `session-${randomUUID().slice(0, 8)}`,
+    );
     testComposeId = composeId;
   });
 

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { GET } from "../route";
 import {
@@ -32,7 +33,9 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     vi.stubEnv("CRON_SECRET", cronSecret);
 
     // Create test compose
-    const { composeId } = await createTestCompose(`cleanup-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `cleanup-${randomUUID().slice(0, 8)}`,
+    );
     testComposeId = composeId;
   });
 

--- a/turbo/apps/web/app/api/platform/logs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/platform/logs/[id]/__tests__/route.test.ts
@@ -30,7 +30,9 @@ describe("GET /api/platform/logs/[id]", () => {
     user = await context.setupUser();
 
     // Create test compose
-    const { composeId } = await createTestCompose(`logs-detail-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `logs-detail-${randomUUID().slice(0, 8)}`,
+    );
     testComposeId = composeId;
   });
 

--- a/turbo/apps/web/app/api/platform/logs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/platform/logs/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { randomUUID } from "crypto";
 import { GET } from "../route";
 import {
   createTestRequest,
@@ -60,7 +61,9 @@ describe("GET /api/platform/logs", () => {
 
     beforeEach(async () => {
       // Create compose and multiple runs
-      const { composeId } = await createTestCompose(`logs-test-${Date.now()}`);
+      const { composeId } = await createTestCompose(
+        `logs-test-${randomUUID().slice(0, 8)}`,
+      );
       testComposeId = composeId;
 
       // Create 3 runs - order will be newest first due to createdAt
@@ -132,10 +135,10 @@ describe("GET /api/platform/logs", () => {
     beforeEach(async () => {
       // Create composes with different names
       const { composeId: compose1 } = await createTestCompose(
-        `search-alpha-${Date.now()}`,
+        `search-alpha-${randomUUID().slice(0, 8)}`,
       );
       const { composeId: compose2 } = await createTestCompose(
-        `search-beta-${Date.now()}`,
+        `search-beta-${randomUUID().slice(0, 8)}`,
       );
 
       // Create runs for each compose
@@ -184,7 +187,7 @@ describe("GET /api/platform/logs", () => {
   it("should not return runs from other users", async () => {
     // Create run for current user
     const { composeId } = await createTestCompose(
-      `isolation-test-${Date.now()}`,
+      `isolation-test-${randomUUID().slice(0, 8)}`,
     );
     const { runId: myRunId } = await createTestRun(composeId, "My prompt");
     await completeTestRun(user.userId, myRunId);
@@ -192,7 +195,7 @@ describe("GET /api/platform/logs", () => {
     // Create another user with different prefix to avoid caching
     const otherUser = await context.setupUser({ prefix: "other-user" });
     const { composeId: otherComposeId } = await createTestCompose(
-      `other-agent-${Date.now()}`,
+      `other-agent-${randomUUID().slice(0, 8)}`,
     );
     const { runId: otherRunId } = await createTestRun(
       otherComposeId,

--- a/turbo/apps/web/app/api/usage/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/usage/__tests__/route.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET } from "../route";
 import {
@@ -28,7 +29,9 @@ describe("GET /api/usage", () => {
     context.setupMocks();
     user = await context.setupUser();
 
-    const { composeId } = await createTestCompose(`usage-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `usage-${randomUUID().slice(0, 8)}`,
+    );
     testComposeId = composeId;
   });
 

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
@@ -32,7 +32,9 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
     user = await context.setupUser();
 
     // Create compose for test runs
-    const { composeId } = await createTestCompose(`checkpoint-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `checkpoint-${randomUUID().slice(0, 8)}`,
+    );
     testComposeId = composeId;
 
     // Create a running run

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -34,7 +34,9 @@ describe("POST /api/webhooks/agent/complete", () => {
     user = await context.setupUser();
 
     // Create compose for test runs
-    const { composeId } = await createTestCompose(`complete-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `complete-${randomUUID().slice(0, 8)}`,
+    );
     testComposeId = composeId;
 
     // Create a running run

--- a/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
@@ -43,7 +43,9 @@ describe("POST /api/webhooks/agent/events", () => {
     user = await context.setupUser();
 
     // Create test compose via API
-    const { composeId } = await createTestCompose(`agent-events-${Date.now()}`);
+    const { composeId } = await createTestCompose(
+      `agent-events-${randomUUID().slice(0, 8)}`,
+    );
     testComposeId = composeId;
 
     // Create test run via API (status automatically set to running)

--- a/turbo/apps/web/app/v1/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/v1/runs/__tests__/route.test.ts
@@ -38,8 +38,8 @@ describe("Public API v1 - Runs Endpoints", () => {
     // Create unique user for this test
     user = await context.setupUser();
 
-    // Create test agent with compose
-    testAgentName = `agent-${Date.now()}`;
+    // Create test agent with compose (use UUID to avoid name conflicts between tests)
+    testAgentName = `agent-${randomUUID().slice(0, 8)}`;
     const { composeId } = await createTestCompose(testAgentName);
     testAgentId = composeId;
 
@@ -141,7 +141,7 @@ describe("Public API v1 - Runs Endpoints", () => {
       // Create another user and their run
       const otherUser = await context.setupUser({ prefix: "other-user" });
       const { composeId: otherComposeId } = await createTestCompose(
-        `other-agent-${Date.now()}`,
+        `other-agent-${randomUUID().slice(0, 8)}`,
       );
 
       // Create run as other user


### PR DESCRIPTION
## Summary
- Replace `Date.now()` with `randomUUID().slice(0, 8)` for generating unique test identifiers across 19 test files
- This change improves uniqueness of test data to prevent potential collisions when tests run concurrently

## Test plan
- [x] All existing tests pass with the changes
- [x] Pre-commit checks (lint, type-check, format, knip) pass

🤖 Generated with [Claude Code](https://claude.ai/code)