### PR TITLE
fix(lefthook): merge turbo tasks to avoid cache deadlock

### DIFF
--- a/turbo/lefthook.yml
+++ b/turbo/lefthook.yml
@@ -1,21 +1,16 @@
 pre-commit:
   parallel: true
   commands:
-    lint:
+    turbo-checks:
       root: turbo/
-      # Only lint packages affected by staged changes (much faster than full lint)
-      run: pnpm turbo run lint --filter='...[HEAD]'
+      # Run lint and check-types together to avoid turbo cache deadlock
+      run: pnpm turbo run lint check-types --filter='...[HEAD]' --ui=stream
       glob: "turbo/**/*.{js,ts,tsx,jsx,mjs,cjs}"
     prettier:
       root: turbo/
       run: pnpm prettier --write --ignore-unknown {staged_files}
       glob: "turbo/**/*"
       stage_fixed: true
-    check-types:
-      root: turbo/
-      # Only type-check packages affected by staged changes (much faster than full check)
-      run: pnpm turbo run check-types --filter='...[HEAD]'
-      glob: "turbo/**/*.{ts,tsx}"
     knip:
       root: turbo/
       run: pnpm knip --cache


### PR DESCRIPTION
## Summary
- Combine `lint` and `check-types` into a single `turbo-checks` command
- Prevents potential turbo cache deadlock when running parallel tasks
- Turbo handles internal task scheduling and caching more efficiently in a single invocation

## Test plan
- [ ] Verify pre-commit hook runs successfully with staged TypeScript files

🤖 Generated with [Claude Code](https://claude.com/claude-code)