### PR TITLE
refactor(docker): slim down toolchain image and add toolchain-rust stage

### DIFF
--- a/.docker/toolchain/Dockerfile
+++ b/.docker/toolchain/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:22.04 AS toolchain
 # Avoid prompts from apt
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install base dependencies
+# Install base dependencies and jq
 RUN apt-get update && apt-get install -y \
     curl \
     git \
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
     lsb-release \
     ca-certificates \
     wget \
+    jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 22
@@ -21,19 +22,12 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 
 RUN node --version
 
-# Install jq for JSON processing
-RUN curl -sL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 -o /usr/local/bin/jq \
-    && chmod +x /usr/local/bin/jq
-
 # Install global npm packages for CI/CD
-RUN npm install -g pnpm@10.15.0 lefthook@1.12.3 vercel@48.11.0 neonctl@2.15.0
+# Note: vercel and neonctl are installed in jobs that need them
+RUN npm install -g pnpm@10.15.0 lefthook@1.12.3
 
-# Install Ansible for runner deployment
-# Using pip3 to ensure all ansible commands (ansible, ansible-playbook, etc.) are available
-RUN apt-get update && apt-get install -y \
-    python3-pip \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip3 install ansible
+# Stage 2: Toolchain with Rust for cross-compilation
+FROM toolchain AS toolchain-rust
 
 # Install Rust toolchain with ARM64 cross-compilation support
 # Used for building vm-init for Firecracker VMs (ARM64 metal runners)
@@ -49,12 +43,8 @@ RUN apt-get update && apt-get install -y \
     && rustup component add rustfmt clippy \
     && rustc --version && cargo --version
 
-# Install Playwright system dependencies for Chromium
-# This is needed for e2e tests in CI
-RUN npx playwright install-deps chromium
-
-# Stage 2: Development environment with additional tools
-FROM toolchain AS development
+# Stage 3: Development environment with additional tools
+FROM toolchain-rust AS development
 
 # Install development tools and user requirements
 RUN apt-get update && apt-get install -y \
@@ -63,6 +53,9 @@ RUN apt-get update && apt-get install -y \
     vim \
     ripgrep \
     && rm -rf /var/lib/apt/lists/*
+
+# Install vercel and neonctl for development
+RUN npm install -g vercel@48.11.0 neonctl@2.15.0
 
 # Install Playwright dependencies
 # These are required for running browser automation tests

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -34,6 +34,17 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build toolchain-rust image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./.docker/toolchain
+          file: ./.docker/toolchain/Dockerfile
+          target: toolchain-rust
+          push: false
+          tags: vm0-toolchain-rust:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Build development image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,6 +63,24 @@ jobs:
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.revision=${{ github.sha }}
 
+      - name: Build and push toolchain-rust image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./.docker/toolchain
+          file: ./.docker/toolchain/Dockerfile
+          target: toolchain-rust
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/vm0-ai/vm0-toolchain-rust:latest
+            ${{ env.REGISTRY }}/vm0-ai/vm0-toolchain-rust:${{ steps.meta.outputs.sha_short }}
+            ${{ env.REGISTRY }}/vm0-ai/vm0-toolchain-rust:${{ steps.meta.outputs.date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
       - name: Build and push development image
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## Summary

- Slim down base `toolchain` image from ~3.2GB to ~830MB
- Add new `toolchain-rust` stage for jobs that need Rust cross-compilation
- Move `development` stage to inherit from `toolchain-rust`

## Changes

**Removed from base toolchain (to be installed on-the-fly in CI jobs):**
- Ansible (~661MB)
- Playwright chromium deps (~401MB)
- vercel and neonctl

**New image structure:**
```
toolchain (base: ~830MB)
└── toolchain-rust (+Rust: ~2.1GB)
    └── development (+dev tools)
```

**Other changes:**
- jq: moved from separate download to apt-get install
- development stage now installs vercel and neonctl

## Test plan

- [ ] Docker build workflow passes (builds all stages)
- [ ] Docker publish workflow publishes new images
- [ ] After images are published, update CI jobs to use appropriate images and install deps on-the-fly

## Next steps (separate PR after images are built)

1. Update `turbo.yml` jobs to use `toolchain-rust` where needed
2. Add ansible/playwright installation steps to jobs that need them
3. Update devcontainer to use new `vm0-dev` image

🤖 Generated with [Claude Code](https://claude.com/claude-code)