### PR TITLE
refactor(ci): update workflows to use slim toolchain images

### DIFF
--- a/.docker/toolchain/Dockerfile
+++ b/.docker/toolchain/Dockerfile
@@ -37,10 +37,13 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN apt-get update && apt-get install -y \
     musl-tools \
     gcc-aarch64-linux-gnu \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal \
     && rustup target add aarch64-unknown-linux-musl \
     && rustup component add rustfmt clippy \
+    && rm -rf /usr/local/rustup/toolchains/*/share/doc \
+    && rm -rf /usr/local/rustup/toolchains/*/share/man \
     && rustc --version && cargo --version
 
 # Stage 3: Development environment with additional tools

--- a/.github/actions/neon-branch/action.yml
+++ b/.github/actions/neon-branch/action.yml
@@ -35,6 +35,15 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Install neonctl
+      shell: bash
+      run: |
+        if ! command -v neonctl &> /dev/null; then
+          echo "Installing neonctl..."
+          npm install -g neonctl@2.15.0
+        fi
+        neonctl --version
+
     - name: Start deployment
       id: deployment
       if: inputs.action == 'create'

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -17,8 +17,11 @@ jobs:
   cleanup-neon-branches:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
+      - name: Install neonctl
+        run: npm install -g neonctl@2.15.0
+
       - name: Cleanup Stale Neon Branches
         shell: bash
         env:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -12,7 +12,7 @@ jobs:
   cleanup-runner:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
       - uses: actions/checkout@v4
 
@@ -70,6 +70,11 @@ jobs:
             if [ "$lock_pr" = "$PR_NUMBER" ] || [ "$runner_exists" = "yes" ]; then
               echo "Found PR $PR_NUMBER on $host, cleaning up..."
 
+              # Install Ansible if not present
+              if ! command -v ansible-playbook &> /dev/null; then
+                pip3 install ansible
+              fi
+
               # Run Ansible cleanup
               cd ansible
               ansible-playbook \
@@ -99,7 +104,7 @@ jobs:
   cleanup-database:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,12 +42,15 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
+
+      - name: Install neonctl
+        run: npm install -g neonctl@2.15.0
 
       - name: Notify Slack - Starting
         id: slack-start
@@ -105,7 +108,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     permissions:
       contents: read
       deployments: write
@@ -113,6 +116,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
+
+      - name: Install neonctl
+        run: npm install -g neonctl@2.15.0
 
       - name: Notify Slack - Starting
         id: slack-start
@@ -195,7 +201,7 @@ jobs:
     if: ${{ needs.release-please.outputs.docs_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     permissions:
       contents: read
       deployments: write
@@ -253,7 +259,7 @@ jobs:
     if: ${{ needs.release-please.outputs.site_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     permissions:
       contents: read
       deployments: write
@@ -315,7 +321,7 @@ jobs:
     if: ${{ needs.release-please.outputs.platform_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     permissions:
       contents: read
       deployments: write
@@ -510,13 +516,16 @@ jobs:
     if: ${{ needs.release-please.outputs.runner_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
     permissions:
       contents: read
     environment: production
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
+
+      - name: Install Ansible
+        run: pip3 install ansible
 
       - name: Notify Slack - Starting
         id: slack-start

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -16,7 +16,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     outputs:
       job-ref: ${{ steps.set-job-ref.outputs.job-ref }}
       web-preview-url: ${{ steps.preview-urls.outputs.web-url }}
@@ -225,7 +225,7 @@ jobs:
     # Skip for release-please commits (only version bumps and changelogs)
     if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
@@ -239,7 +239,7 @@ jobs:
   lint-types:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
@@ -253,7 +253,7 @@ jobs:
   lint-format:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
@@ -264,7 +264,7 @@ jobs:
   lint-knip:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
@@ -281,7 +281,7 @@ jobs:
     # Skip for release-please commits (only version bumps and changelogs)
     if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     services:
       postgres:
         image: postgres:17-alpine
@@ -322,7 +322,7 @@ jobs:
   test-cli:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
@@ -336,7 +336,7 @@ jobs:
   test-platform:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
@@ -350,7 +350,7 @@ jobs:
   test-other:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init
@@ -367,7 +367,7 @@ jobs:
   deploy-web:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and web, CLI, runner, site, or platform changed
     if: |
@@ -466,7 +466,7 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and docs changed
     if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.docs-changed == 'true' }}"
@@ -508,7 +508,7 @@ jobs:
   deploy-site:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and site changed
     if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.site-changed == 'true' }}"
@@ -554,7 +554,7 @@ jobs:
   deploy-platform:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and platform changed
     if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.platform-changed == 'true' }}"
@@ -601,7 +601,7 @@ jobs:
   e2e-auth:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     needs: [prepare, deploy-web]
     if: |
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -634,6 +634,9 @@ jobs:
       - name: Install E2E dependencies
         run: cd e2e && npm install
 
+      - name: Install Playwright system dependencies
+        run: npx playwright install-deps chromium
+
       - name: Install Playwright browsers
         run: cd e2e && npx playwright install chromium
 
@@ -651,7 +654,7 @@ jobs:
   api-e2e-test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     needs: [prepare, deploy-web]
     if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.web-changed == 'true' }}"
     timeout-minutes: 5
@@ -681,7 +684,7 @@ jobs:
   cli-e2e-01-serial:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     needs:
       [
         prepare,
@@ -766,7 +769,7 @@ jobs:
   cli-e2e-02-parallel:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     needs: [prepare, cli-e2e-01-serial, deploy-web]
     if: |
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -846,7 +849,7 @@ jobs:
   cli-e2e-03-runner:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     needs:
       [
         prepare,
@@ -930,7 +933,7 @@ jobs:
   deploy-runner-prepare:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
     needs: [prepare]
     if: |
       contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&
@@ -1105,6 +1108,9 @@ jobs:
           tar -czf /tmp/vm0-runner-bundle.tar.gz -C /tmp vm0-runner-bundle
           echo "Bundle created: $(ls -lh /tmp/vm0-runner-bundle.tar.gz)"
 
+      - name: Install Ansible
+        run: pip3 install ansible
+
       - name: Prepare runner (deploy bundle, install deps)
         id: prepare
         env:
@@ -1148,7 +1154,7 @@ jobs:
   deploy-runner-benchmark:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     needs: [prepare, deploy-runner-prepare, deploy-runner-start]
     if: |
       contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&
@@ -1207,7 +1213,7 @@ jobs:
   deploy-runner-start:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260202
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     needs: [prepare, deploy-web, deploy-runner-prepare]
     if: |
       contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -7,9 +7,6 @@
 
 import { FeatureSwitchKey } from "./feature-switch-key";
 
-/**
- * Feature switch definition
- */
 export interface FeatureSwitch {
   readonly maintainer: string;
   readonly enabled: boolean;


### PR DESCRIPTION
## Summary

Follow-up to #2224. Updates all CI workflows to use the new slimmer toolchain images.

## Changes

**Image usage:**
- `toolchain:20260203` (~830MB) - Most jobs that only need Node.js/pnpm
- `toolchain-rust:20260203` (~2.1GB) - Jobs that need Rust cross-compilation

**Jobs using `toolchain-rust`:**
- `test-other` (builds vsock-agent)
- `deploy-runner-prepare` (builds vm-init for ARM64)
- `deploy-runner-production` (builds vm-init for ARM64)
- `crates/lint` (cargo fmt, clippy, build)

**On-the-fly installations added:**
| Tool | Jobs |
|------|------|
| Ansible | deploy-runner-prepare, cleanup-runner, deploy-runner-production |
| Playwright deps | e2e-auth |
| neonctl | migrate-production, deploy-web-production, cleanup-neon-branches |

**Actions updated:**
- `neon-branch` action now installs neonctl if not present

## Test plan

- [ ] All CI checks pass with new slim images
- [ ] On-the-fly installations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)