### PR TITLE
docs: update dev workflow with current skill commands

### DIFF
--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -1,4 +1,4 @@
-# Issue Development Workflow
+# Development Workflow
 
 This document describes the standard workflow for developing features and fixing bugs using Claude Code's integrated issue management system.
 
@@ -12,40 +12,40 @@ This document describes the standard workflow for developing features and fixing
 │  /deep-research ───────────┼──────────────────┐                     │
 │         │                  │                  │                     │
 │         v                  │                  v                     │
-│  Create Issue ─────────────┴──────────> Create Issue                │
+│  /deep-innovate ───────────┴──────────> /issue-create               │
 └─────────────────────────────────────────────────────────────────────┘
                               │
                               v
 ┌─────────────────────────────────────────────────────────────────────┐
-│                      /issue-todo                                     │
+│                        /issue-plan                                   │
 │              (Auto-generate work plan)                               │
 └─────────────────────────────────────────────────────────────────────┘
                               │
                               v
 ┌─────────────────────────────────────────────────────────────────────┐
-│                     Human Review                                     │
+│                       Human Review                                   │
 │          (Review issue link and work plan)                           │
 ├─────────────────────────────────────────────────────────────────────┤
 │     Approved?                                                        │
-│     ├── Yes ──> /issue-continue                                      │
+│     ├── Yes ──> /issue-action                                        │
 │     └── No ───> Add comments, revise plan                            │
 └─────────────────────────────────────────────────────────────────────┘
                               │
                               v
 ┌─────────────────────────────────────────────────────────────────────┐
-│                    /issue-continue                                   │
+│                      /issue-action                                   │
 │         (Implementation → PR → CI passes)                            │
 └─────────────────────────────────────────────────────────────────────┘
                               │
                               v
 ┌─────────────────────────────────────────────────────────────────────┐
-│                  /pr-review-and-comment                              │
+│                        /pr-review                                    │
 │            (Automated code review + Human review)                    │
 └─────────────────────────────────────────────────────────────────────┘
                               │
                               v
 ┌─────────────────────────────────────────────────────────────────────┐
-│                       Merge PR                                       │
+│                         Merge PR                                     │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -58,19 +58,19 @@ This document describes the standard workflow for developing features and fixing
 When dealing with complex features, architectural changes, or unclear requirements:
 
 1. Start with `/deep-research` to explore the problem space
-2. Discuss requirements, constraints, and potential approaches
-3. Once the scope is clear, create the issue with well-defined acceptance criteria
+2. Run `/deep-innovate` to explore 2-3 approaches with trade-offs
+3. Once the scope is clear, run `/issue-create` with well-defined acceptance criteria
 
 #### For Simple Work
 
 When the task is straightforward (bug fixes, small features, clear requirements):
 
 1. Describe the work to Claude
-2. Create the issue directly based on the description
+2. Run `/issue-create` directly based on the description
 
 ### 2. Generate Work Plan
 
-Run `/issue-todo` to:
+Run `/issue-plan` to:
 - Analyze the issue requirements
 - Break down the work into actionable tasks
 - Create a structured implementation plan
@@ -78,7 +78,7 @@ Run `/issue-todo` to:
 
 ### 3. Human Review of Work Plan
 
-After `/issue-todo` completes:
+After `/issue-plan` completes:
 
 1. Claude provides the **issue link**
 2. Review the generated work plan in the issue
@@ -97,7 +97,7 @@ Proceed to step 4.
 
 ### 4. Implementation
 
-Run `/issue-continue` to:
+Run `/issue-action` to:
 - Implement the work plan
 - Create commits following conventional commit format
 - Create a pull request
@@ -107,7 +107,7 @@ This command handles the entire implementation cycle automatically.
 
 ### 5. Code Review
 
-Run `/pr-review-and-comment` to:
+Run `/pr-review` to:
 - Perform automated code review
 - Post review comments on the PR
 - Identify potential issues or improvements
@@ -129,9 +129,12 @@ Once both automated and human reviews are complete:
 | Step | Command | Description |
 |------|---------|-------------|
 | Research | `/deep-research` | Explore complex problems before creating issues |
-| Plan | `/issue-todo` | Generate work plan for an issue |
-| Implement | `/issue-continue` | Continue working on issue until PR is ready |
-| Review | `/pr-review-and-comment` | Automated code review with PR comments |
+| Innovate | `/deep-innovate` | Explore 2-3 approaches with trade-offs |
+| Create | `/issue-create` | Create GitHub issue from conversation |
+| Work Plan | `/issue-plan` | Generate work plan for an issue |
+| Implement | `/issue-action` | Continue working on issue until PR is ready |
+| Review | `/pr-review` | Automated code review with PR comments |
+| CI Fix | `/pr-check` | Monitor CI pipeline, auto-fix failures |
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary
- Rename `issue-workflow.md` to `dev-workflow.md` to better reflect the document scope
- Update all commands to match current available skills
- Simplify complex work flow diagram

## Changes
| Old Command | New Command |
|-------------|-------------|
| `/issue-todo` | `/issue-plan` |
| `/issue-continue` | `/issue-action` |
| `/pr-review-and-comment` | `/pr-review` |

New commands added to quick reference:
- `/deep-innovate` - Explore 2-3 approaches with trade-offs
- `/issue-create` - Create GitHub issue from conversation
- `/pr-check` - Monitor CI pipeline, auto-fix failures

## Test plan
- [ ] Verify all referenced commands exist as skills
- [ ] Review workflow diagram for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)