### PR TITLE
refactor(test): add unique id helper function for test isolation

### DIFF
--- a/turbo/apps/web/app/api/agent/checkpoints/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/checkpoints/[id]/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
@@ -30,9 +31,7 @@ describe("GET /api/agent/checkpoints/:id", () => {
     user = await context.setupUser();
 
     // Create test compose
-    const { composeId } = await createTestCompose(
-      `checkpoint-${randomUUID().slice(0, 8)}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("checkpoint"));
     testComposeId = composeId;
   });
 

--- a/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "crypto";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET } from "../route";
 import {
@@ -7,6 +6,7 @@ import {
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
@@ -139,7 +139,7 @@ describe("GET /api/agent/composes/list", () => {
     const otherUser = await context.setupUser({ prefix: "forbidden-user" });
 
     // Create a compose for the other user
-    await createTestCompose(`forbidden-compose-${randomUUID().slice(0, 8)}`);
+    await createTestCompose(uniqueId("forbidden-compose"));
 
     // Derive the other user's scope slug from their userId
     // userId format: {prefix}-{timestamp}-{uuid}

--- a/turbo/apps/web/app/api/agent/composes/versions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/versions/__tests__/route.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "crypto";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET } from "../route";
 import { POST } from "../../route";
@@ -9,6 +8,7 @@ import {
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
@@ -215,9 +215,7 @@ describe("GET /api/agent/composes/versions", () => {
   it("should resolve version with full hash for cross-compose scenario", async () => {
     // Similar test - create second compose and test full hash resolution
     const { composeId: thirdComposeId, versionId: thirdVersionId } =
-      await createTestCompose(
-        `test-version-agent-c-${randomUUID().slice(0, 8)}`,
-      );
+      await createTestCompose(uniqueId("test-version-agent-c"));
 
     // Test with full 64-char hash
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
@@ -27,9 +28,7 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
     context.setupMocks();
     user = await context.setupUser();
 
-    const { composeId } = await createTestCompose(
-      `agent-${randomUUID().slice(0, 8)}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("agent"));
     testComposeId = composeId;
   });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
@@ -28,9 +29,7 @@ describe("GET /api/agent/runs/:id/telemetry", () => {
     context.setupMocks();
     user = await context.setupUser();
 
-    const { composeId } = await createTestCompose(
-      `telemetry-${randomUUID().slice(0, 8)}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("telemetry"));
     testComposeId = composeId;
   });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../../src/__tests__/clerk-mock";
@@ -58,9 +59,7 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
     user = await context.setupUser();
 
     // Create test compose and run
-    const { composeId } = await createTestCompose(
-      `metrics-${randomUUID().slice(0, 8)}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("metrics"));
 
     const { runId } = await createTestRun(composeId, "Test prompt");
     testRunId = runId;

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../../src/__tests__/clerk-mock";
@@ -62,9 +63,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
     user = await context.setupUser();
 
     // Create test compose and run
-    const { composeId } = await createTestCompose(
-      `network-${randomUUID().slice(0, 8)}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("network"));
 
     const { runId } = await createTestRun(composeId, "Test prompt");
     testRunId = runId;

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../../src/__tests__/clerk-mock";
@@ -29,9 +30,7 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
     user = await context.setupUser();
 
     // Create test compose and run
-    const { composeId } = await createTestCompose(
-      `system-log-${randomUUID().slice(0, 8)}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("system-log"));
 
     const { runId } = await createTestRun(composeId, "Test prompt");
     testRunId = runId;

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
@@ -35,9 +36,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
     user = await context.setupUser();
 
     // Create test compose with unique name to avoid conflicts between parallel tests
-    const { composeId } = await createTestCompose(
-      `agent-${randomUUID().slice(0, 8)}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("agent"));
     testComposeId = composeId;
   });
 
@@ -563,12 +562,9 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       await createTestModelProvider("anthropic-api-key", "test-api-key");
 
       // Create compose without API key
-      const { composeId } = await createTestCompose(
-        `mp-agent-${randomUUID().slice(0, 8)}`,
-        {
-          skipDefaultApiKey: true,
-        },
-      );
+      const { composeId } = await createTestCompose(uniqueId("mp-agent"), {
+        skipDefaultApiKey: true,
+      });
 
       const data = await createTestRun(composeId, "Test with model provider");
 
@@ -577,12 +573,9 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
     it("should fail run when no model provider and no API key in compose", async () => {
       // Create compose without API key and no environment block
-      const { composeId } = await createTestCompose(
-        `no-mp-${randomUUID().slice(0, 8)}`,
-        {
-          noEnvironmentBlock: true,
-        },
-      );
+      const { composeId } = await createTestCompose(uniqueId("no-mp"), {
+        noEnvironmentBlock: true,
+      });
 
       const data = await createTestRun(
         composeId,
@@ -610,12 +603,9 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       await createTestModelProvider("anthropic-api-key", "test-api-key");
 
       // Create compose without API key
-      const { composeId } = await createTestCompose(
-        `mp-select-${randomUUID().slice(0, 8)}`,
-        {
-          skipDefaultApiKey: true,
-        },
-      );
+      const { composeId } = await createTestCompose(uniqueId("mp-select"), {
+        skipDefaultApiKey: true,
+      });
 
       const data = await createTestRun(
         composeId,
@@ -630,15 +620,12 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
     it("should skip injection when compose has explicit OPENAI_API_KEY (codex)", async () => {
       // Create compose with OPENAI_API_KEY for codex framework
-      const { composeId } = await createTestCompose(
-        `codex-${randomUUID().slice(0, 8)}`,
-        {
-          overrides: {
-            framework: "codex",
-            environment: { OPENAI_API_KEY: "explicit-openai-key" },
-          },
+      const { composeId } = await createTestCompose(uniqueId("codex"), {
+        overrides: {
+          framework: "codex",
+          environment: { OPENAI_API_KEY: "explicit-openai-key" },
         },
-      );
+      });
 
       const data = await createTestRun(composeId, "Test codex with key");
 
@@ -647,15 +634,12 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
     it("should skip injection when compose has CLAUDE_CODE_USE_FOUNDRY", async () => {
       // Create compose with alternative auth method
-      const { composeId } = await createTestCompose(
-        `foundry-${randomUUID().slice(0, 8)}`,
-        {
-          overrides: {
-            framework: "claude-code",
-            environment: { CLAUDE_CODE_USE_FOUNDRY: "1" },
-          },
+      const { composeId } = await createTestCompose(uniqueId("foundry"), {
+        overrides: {
+          framework: "claude-code",
+          environment: { CLAUDE_CODE_USE_FOUNDRY: "1" },
         },
-      );
+      });
 
       const data = await createTestRun(composeId, "Test with Foundry auth");
 
@@ -664,12 +648,9 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
     it("should fail when specified model provider type is invalid", async () => {
       // Create compose without API key
-      const { composeId } = await createTestCompose(
-        `invalid-mp-${randomUUID().slice(0, 8)}`,
-        {
-          skipDefaultApiKey: true,
-        },
-      );
+      const { composeId } = await createTestCompose(uniqueId("invalid-mp"), {
+        skipDefaultApiKey: true,
+      });
 
       const data = await createTestRun(
         composeId,

--- a/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
@@ -403,9 +404,7 @@ describe("GET /api/agent/schedules - List Schedules", () => {
 
   it("should return list of user's schedules", async () => {
     // Create compose and schedule
-    const { composeId } = await createTestCompose(
-      `list-agent-${randomUUID().slice(0, 8)}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("list-agent"));
     await createTestSchedule(composeId, "list-test-schedule", {
       cronExpression: "0 9 * * *",
       prompt: "Test prompt",
@@ -421,9 +420,7 @@ describe("GET /api/agent/schedules - List Schedules", () => {
 
   it("should not return other users' schedules", async () => {
     // Create compose and schedule as current user
-    const { composeId } = await createTestCompose(
-      `my-agent-${randomUUID().slice(0, 8)}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("my-agent"));
     await createTestSchedule(composeId, "my-schedule", {
       cronExpression: "0 9 * * *",
       prompt: "My prompt",

--- a/turbo/apps/web/app/api/agent/sessions/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/sessions/[id]/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
@@ -29,9 +30,7 @@ describe("GET /api/agent/sessions/:id", () => {
     context.setupMocks();
     user = await context.setupUser();
 
-    const { composeId } = await createTestCompose(
-      `session-${randomUUID().slice(0, 8)}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("session"));
     testComposeId = composeId;
   });
 

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "crypto";
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { GET } from "../route";
 import {
@@ -9,6 +8,7 @@ import {
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 
@@ -33,9 +33,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     vi.stubEnv("CRON_SECRET", cronSecret);
 
     // Create test compose
-    const { composeId } = await createTestCompose(
-      `cleanup-${randomUUID().slice(0, 8)}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("cleanup"));
     testComposeId = composeId;
   });
 

--- a/turbo/apps/web/app/api/usage/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/usage/__tests__/route.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "crypto";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET } from "../route";
 import {
@@ -9,6 +8,7 @@ import {
 } from "../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../src/__tests__/clerk-mock";
@@ -29,9 +29,7 @@ describe("GET /api/usage", () => {
     context.setupMocks();
     user = await context.setupUser();
 
-    const { composeId } = await createTestCompose(
-      `usage-${randomUUID().slice(0, 8)}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("usage"));
     testComposeId = composeId;
   });
 

--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
@@ -32,9 +33,7 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
     user = await context.setupUser();
 
     // Create compose for test runs
-    const { composeId } = await createTestCompose(
-      `checkpoint-${randomUUID().slice(0, 8)}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("checkpoint"));
     testComposeId = composeId;
 
     // Create a running run

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
@@ -34,9 +35,7 @@ describe("POST /api/webhooks/agent/complete", () => {
     user = await context.setupUser();
 
     // Create compose for test runs
-    const { composeId } = await createTestCompose(
-      `complete-${randomUUID().slice(0, 8)}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("complete"));
     testComposeId = composeId;
 
     // Create a running run

--- a/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
@@ -43,9 +44,7 @@ describe("POST /api/webhooks/agent/events", () => {
     user = await context.setupUser();
 
     // Create test compose via API
-    const { composeId } = await createTestCompose(
-      `agent-events-${randomUUID().slice(0, 8)}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("agent-events"));
     testComposeId = composeId;
 
     // Create test run via API (status automatically set to running)

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
@@ -434,7 +434,7 @@ describe("POST /api/webhooks/agent/telemetry", () => {
 
   describe("Sandbox type detection", () => {
     it("should detect E2B sandbox type when run has sandboxId", async () => {
-      // E2B runs have sandboxId set by E2B executor (mock returns test-sandbox-123)
+      // E2B runs have sandboxId set by E2B executor (mock returns unique sandboxId per test)
       const { runId } = await createRunForWebhook(
         testComposeId,
         "Test E2B run",

--- a/turbo/apps/web/app/v1/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/v1/runs/__tests__/route.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
+  uniqueId,
   type UserContext,
 } from "../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../src/__tests__/clerk-mock";
@@ -39,7 +40,7 @@ describe("Public API v1 - Runs Endpoints", () => {
     user = await context.setupUser();
 
     // Create test agent with compose (use UUID to avoid name conflicts between tests)
-    testAgentName = `agent-${randomUUID().slice(0, 8)}`;
+    testAgentName = uniqueId("agent");
     const { composeId } = await createTestCompose(testAgentName);
     testAgentId = composeId;
 
@@ -141,7 +142,7 @@ describe("Public API v1 - Runs Endpoints", () => {
       // Create another user and their run
       const otherUser = await context.setupUser({ prefix: "other-user" });
       const { composeId: otherComposeId } = await createTestCompose(
-        `other-agent-${randomUUID().slice(0, 8)}`,
+        uniqueId("other-agent"),
       );
 
       // Create run as other user


### PR DESCRIPTION
## Summary

- Introduces a `uniqueId(prefix)` helper function in test-helpers.ts that generates unique IDs for test isolation
- Replaces inline `${prefix}-${randomUUID().slice(0,8)}` patterns throughout test files with the centralized helper
- Changes the internal `uniqueSuffix()` helper from public to private (was unused externally, identified by knip)

## Test plan

- [x] All existing tests pass (ran `pnpm test`)
- [x] Format, lint, and type checks pass
- [x] No new unused exports (verified with knip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)