### PR TITLE
test(e2e): add model-provider credential injection test

### DIFF
--- a/e2e/tests/02-parallel/t30-vm0-model-provider-inject.bats
+++ b/e2e/tests/02-parallel/t30-vm0-model-provider-inject.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+
+# Test model-provider credential injection into container environment
+#
+# Verifies that the stable model-provider set by ser-t03 is correctly
+# injected into the container as CLAUDE_CODE_OAUTH_TOKEN.
+
+load '../../helpers/setup'
+
+setup() {
+    create_test_volume "e2e-vol-t30"
+
+    export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
+    export AGENT_NAME="mp-inject-${UNIQUE_ID}"
+    export ARTIFACT_NAME="e2e-mp-inject-${UNIQUE_ID}"
+    export TEST_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
+    cleanup_test_volume
+}
+
+@test "model-provider credential is injected into container" {
+    # Create config (uses default model-provider from ser-t03)
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  ${AGENT_NAME}:
+    description: "Test model-provider injection"
+    framework: claude-code
+    image: "vm0/claude-code:dev"
+    working_dir: /home/user/workspace
+    volumes:
+      - claude-files:/home/user/.claude
+
+volumes:
+  claude-files:
+    name: $VOLUME_NAME
+    version: latest
+EOF
+
+    # Create artifact
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME" >/dev/null 2>&1
+    echo "test" > test.txt
+    $CLI_COMMAND artifact push >/dev/null 2>&1
+
+    # Build and run
+    $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "echo INJECTED=\$CLAUDE_CODE_OAUTH_TOKEN"
+
+    assert_success
+    assert_output --partial "INJECTED=***"
+}

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -1,4 +1,4 @@
-// VM0 CLI entry point
+// VM0 CLI - main entry point
 import { Command } from "commander";
 import { authCommand } from "./commands/auth";
 import { infoCommand } from "./commands/info";


### PR DESCRIPTION
## Summary
- Add e2e test to verify model-provider credentials are correctly injected into container environment variables
- Test reuses the stable `claude-code-oauth-token` set by `ser-t03` and verifies `CLAUDE_CODE_OAUTH_TOKEN` is injected and masked in output

## Test plan
- [ ] CI passes (cli-e2e parallel tests)
- [ ] New test `t30-vm0-model-provider-inject.bats` verifies credential injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)