### PR TITLE
style: improve logs page layout and spacing

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -49,20 +49,20 @@
     ) !important; /* sidebar color (gray-50) */
     border-bottom: 1px solid hsl(var(--gray-200)) !important; /* border token (gray-200) */
   }
+}
 
-  /* Markdown preview spacing overrides */
-  .wmde-markdown li > p {
-    margin-top: 4px !important;
-  }
+/* Markdown preview spacing overrides - outside @layer for higher specificity */
+.wmde-markdown li > p {
+  margin-top: 6px;
+}
 
-  .wmde-markdown p,
-  .wmde-markdown blockquote,
-  .wmde-markdown ul,
-  .wmde-markdown ol,
-  .wmde-markdown dl,
-  .wmde-markdown table,
-  .wmde-markdown pre,
-  .wmde-markdown details {
-    margin-bottom: 4px !important;
-  }
+.wmde-markdown p,
+.wmde-markdown blockquote,
+.wmde-markdown ul,
+.wmde-markdown ol,
+.wmde-markdown dl,
+.wmde-markdown table,
+.wmde-markdown pre,
+.wmde-markdown details {
+  margin-bottom: 6px;
 }

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -49,4 +49,20 @@
     ) !important; /* sidebar color (gray-50) */
     border-bottom: 1px solid hsl(var(--gray-200)) !important; /* border token (gray-200) */
   }
+
+  /* Markdown preview spacing overrides */
+  .wmde-markdown li > p {
+    margin-top: 4px !important;
+  }
+
+  .wmde-markdown p,
+  .wmde-markdown blockquote,
+  .wmde-markdown ul,
+  .wmde-markdown ol,
+  .wmde-markdown dl,
+  .wmde-markdown table,
+  .wmde-markdown pre,
+  .wmde-markdown details {
+    margin-bottom: 4px !important;
+  }
 }

--- a/turbo/apps/platform/src/views/logs-page/components/grouped-message-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/grouped-message-card.tsx
@@ -18,6 +18,9 @@ interface GroupedMessageCardProps {
   matchStartIndex?: number;
 }
 
+// Layout constants
+const MESSAGE_SPACING = "py-2";
+
 // Auto-collapse thresholds
 const TEXT_COLLAPSE_CHARS = 500;
 const TEXT_COLLAPSE_LINES = 8;
@@ -184,7 +187,7 @@ function SystemMessageCard({
   const subtype = eventData.subtype;
   const timestamp = formatEventTime(message.createdAt);
   return (
-    <div className="py-2">
+    <div className={MESSAGE_SPACING}>
       <div className="flex gap-2 items-center">
         <StatusDot variant="neutral" />
         <span className="font-semibold text-sm text-foreground">
@@ -216,7 +219,7 @@ function ResultMessageCard({
   const bgColor = isError ? "bg-red-500/5" : "bg-lime-500/5";
 
   return (
-    <div className="py-2">
+    <div className={MESSAGE_SPACING}>
       <div className={`p-3 rounded-lg border ${borderColor} ${bgColor}`}>
         <ResultEventContent eventData={eventData} />
       </div>
@@ -278,7 +281,7 @@ function TodoCard({
 
   const timestamp = formatEventTime(message.createdAt);
   return (
-    <details className="py-2 group" open={hasSearchMatch}>
+    <details className={`${MESSAGE_SPACING} group`} open={hasSearchMatch}>
       <summary className="cursor-pointer list-none">
         <div className="flex gap-2 items-center">
           <StatusDot variant="todo" />
@@ -366,7 +369,7 @@ function AssistantMessageCard({
   const timestamp = formatEventTime(message.createdAt);
   if (textBefore) {
     elements.push(
-      <div key="text-before" className="py-2">
+      <div key="text-before" className={MESSAGE_SPACING}>
         <div className="flex gap-2 items-start">
           <StatusDot variant="neutral" className="mt-1.5" />
           <div className="flex-1 min-w-0">
@@ -393,7 +396,7 @@ function AssistantMessageCard({
     for (const op of toolOperations) {
       const toolMatchStart = currentOffset + textBeforeMatches;
       elements.push(
-        <div key={op.toolUseId} className="py-2">
+        <div key={op.toolUseId} className={MESSAGE_SPACING}>
           <ToolSummary
             operation={op}
             searchTerm={searchTerm}
@@ -409,7 +412,10 @@ function AssistantMessageCard({
   // Text after tools
   if (textAfter) {
     elements.push(
-      <div key="text-after" className="py-2 flex gap-2 items-start">
+      <div
+        key="text-after"
+        className={`${MESSAGE_SPACING} flex gap-2 items-start`}
+      >
         <StatusDot variant="neutral" className="mt-1.5" />
         <div className="flex-1 min-w-0">
           <CollapsibleMarkdown

--- a/turbo/apps/platform/src/views/logs-page/components/grouped-message-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/grouped-message-card.tsx
@@ -190,7 +190,9 @@ function SystemMessageCard({
         <span className="font-semibold text-sm text-foreground">
           {subtype === "init" ? "Initialize" : subtype}
         </span>
-        <span className="flex-1" />
+        <span className="flex-1">
+          {subtype === "init" && <SystemInitContent eventData={eventData} />}
+        </span>
         <span className="text-xs text-muted-foreground shrink-0 ml-4 whitespace-nowrap hidden sm:inline">
           {timestamp}
         </span>
@@ -198,11 +200,6 @@ function SystemMessageCard({
       <div className="text-xs text-muted-foreground pl-5 mt-1 sm:hidden">
         {timestamp}
       </div>
-      {subtype === "init" && (
-        <div className="pl-5 mt-2">
-          <SystemInitContent eventData={eventData} />
-        </div>
-      )}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
@@ -202,49 +202,54 @@ export function AgentEventsCard({
 
   return (
     <div className={`flex flex-col gap-4 ${className ?? ""}`}>
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 shrink-0">
-        <div className="flex items-center gap-3">
-          <span className="text-base font-medium text-foreground whitespace-nowrap">
-            Agent events
-          </span>
-          <span className="text-sm text-muted-foreground whitespace-nowrap">
-            {searchTerm.trim()
-              ? `(${matchingCount}/${events.length} matched)`
-              : `${totalCountDisplay} total`}
-          </span>
-        </div>
-        <div className="flex items-center gap-2 sm:gap-3">
-          <div className="relative flex h-9 flex-1 sm:flex-none items-center rounded-md border border-border bg-card focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background">
-            <div className="pl-2">
-              <IconSearch className="h-4 w-4 text-muted-foreground" />
-            </div>
-            <Input
-              placeholder="Search logs"
-              value={searchTerm}
-              onChange={(e) => handleSearchChange(e.target.value)}
-              onKeyDown={handleKeyDown}
-              className="h-full w-full sm:w-44 border-0 text-sm focus-visible:ring-0 focus-visible:ring-offset-0 pl-2 pr-20"
-            />
-            <SearchNavigation
-              currentIndex={currentMatchIdx}
-              totalCount={totalMatches}
-              onNext={handleNext}
-              onPrevious={handlePrevious}
-              hasSearchTerm={searchTerm.trim().length > 0}
-            />
+      <div className="px-4 sm:px-8">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 shrink-0">
+          <div className="flex items-center gap-3">
+            <span className="text-base font-medium text-foreground whitespace-nowrap">
+              Agent events
+            </span>
+            <span className="text-sm text-muted-foreground whitespace-nowrap">
+              {searchTerm.trim()
+                ? `(${matchingCount}/${events.length} matched)`
+                : `${totalCountDisplay} total`}
+            </span>
           </div>
-          {!isCodex && (
-            <>
-              <div className="h-5 w-px bg-border hidden sm:block" />
-              <ViewModeToggle mode={viewMode} setMode={handleViewModeChange} />
-            </>
-          )}
+          <div className="flex items-center gap-2 sm:gap-3">
+            <div className="relative flex h-9 flex-1 sm:flex-none items-center rounded-md border border-border bg-card focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background">
+              <div className="pl-2">
+                <IconSearch className="h-4 w-4 text-muted-foreground" />
+              </div>
+              <Input
+                placeholder="Search logs"
+                value={searchTerm}
+                onChange={(e) => handleSearchChange(e.target.value)}
+                onKeyDown={handleKeyDown}
+                className="h-full w-full sm:w-44 border-0 text-sm focus-visible:ring-0 focus-visible:ring-offset-0 pl-2 pr-20"
+              />
+              <SearchNavigation
+                currentIndex={currentMatchIdx}
+                totalCount={totalMatches}
+                onNext={handleNext}
+                onPrevious={handlePrevious}
+                hasSearchTerm={searchTerm.trim().length > 0}
+              />
+            </div>
+            {!isCodex && (
+              <>
+                <div className="h-5 w-px bg-border hidden sm:block" />
+                <ViewModeToggle
+                  mode={viewMode}
+                  setMode={handleViewModeChange}
+                />
+              </>
+            )}
+          </div>
         </div>
       </div>
 
       <div
         id={EVENTS_CONTAINER_ID}
-        className="flex-1 min-h-0 overflow-y-auto"
+        className="flex-1 min-h-0 overflow-y-auto px-4 pb-4 sm:px-8 sm:pb-8"
         style={{ scrollbarGutter: "stable" }}
       >
         {!isCodex && viewMode === "formatted" ? (

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/formatted-events-view.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/formatted-events-view.tsx
@@ -70,7 +70,7 @@ export function FormattedEventsView({
   let matchOffset = 0;
 
   return (
-    <div ref={containerRef} className="space-y-3">
+    <div ref={containerRef}>
       {visibleMessages.map((message) => {
         const messageMatchStart = matchOffset;
         const visibleText = getVisibleGroupedMessageText(message);

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -25,7 +25,9 @@ export function LogDetailContent({ logId }: { logId: string }) {
 
   if (loadable.state === "loading") {
     return (
-      <div className="p-8 text-center text-muted-foreground">Loading...</div>
+      <div className="p-4 sm:p-8">
+        <div className="p-8 text-center text-muted-foreground">Loading...</div>
+      </div>
     );
   }
 
@@ -35,8 +37,10 @@ export function LogDetailContent({ logId }: { logId: string }) {
         ? loadable.error.message
         : "Failed to load details";
     return (
-      <div className="p-8 text-center text-destructive">
-        Error: {errorMessage}
+      <div className="p-4 sm:p-8">
+        <div className="p-8 text-center text-destructive">
+          Error: {errorMessage}
+        </div>
       </div>
     );
   }
@@ -47,98 +51,102 @@ export function LogDetailContent({ logId }: { logId: string }) {
     <div className="flex flex-col gap-4 h-full min-h-0">
       {/* Info Card - Desktop: single row, Mobile: 2-column grid */}
       {/* Desktop version */}
-      <div className="shrink-0 hidden lg:flex flex-wrap items-center gap-x-4 gap-y-2 text-sm px-4 py-3 bg-muted/30 rounded-lg border border-border">
-        <StatusBadge status={detail.status} />
-        <span className="font-medium text-foreground">{detail.agentName}</span>
-        {detail.framework && (
-          <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
-            {detail.framework}
-          </span>
-        )}
-        <Separator />
-        <span className="flex items-center gap-1 text-muted-foreground">
-          <IconClock className="h-3.5 w-3.5" />
-          {formatDuration(detail.startedAt, detail.completedAt)}
-        </span>
-        <span className="text-muted-foreground">
-          {formatTime(detail.createdAt)}
-        </span>
-        <Separator />
-        <CopyableId label="Run" value={detail.id} />
-        {detail.sessionId && (
-          <CopyableId label="Session" value={detail.sessionId} />
-        )}
-        {detail.artifact.name && detail.artifact.version && (
-          <>
-            <Separator />
-            <ArtifactDownloadButton
-              name={detail.artifact.name}
-              version={detail.artifact.version}
-            />
-          </>
-        )}
-      </div>
-
-      {/* Mobile version */}
-      <div className="shrink-0 lg:hidden grid grid-cols-3 gap-x-4 gap-y-3 text-sm px-4 py-3 bg-muted/30 rounded-lg border border-border">
-        <InfoItem label="Status">
+      <div className="p-4 pb-0 sm:p-8 sm:pb-0">
+        <div className="shrink-0 hidden lg:flex flex-wrap items-center gap-x-4 gap-y-2 text-sm px-4 py-3 bg-muted/30 rounded-lg border border-border">
           <StatusBadge status={detail.status} />
-        </InfoItem>
-
-        <InfoItem label="Agent">
           <span className="font-medium text-foreground">
             {detail.agentName}
           </span>
-        </InfoItem>
-
-        {detail.framework && (
-          <InfoItem label="Framework">
+          {detail.framework && (
             <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
               {detail.framework}
             </span>
-          </InfoItem>
-        )}
-
-        <InfoItem label="Duration">
-          <span className="flex items-center gap-1 text-foreground">
-            <IconClock className="h-3.5 w-3.5 text-muted-foreground" />
+          )}
+          <Separator />
+          <span className="flex items-center gap-1 text-muted-foreground">
+            <IconClock className="h-3.5 w-3.5" />
             {formatDuration(detail.startedAt, detail.completedAt)}
           </span>
-        </InfoItem>
+          <span className="text-muted-foreground">
+            {formatTime(detail.createdAt)}
+          </span>
+          <Separator />
+          <CopyableId label="Run" value={detail.id} />
+          {detail.sessionId && (
+            <CopyableId label="Session" value={detail.sessionId} />
+          )}
+          {detail.artifact.name && detail.artifact.version && (
+            <>
+              <Separator />
+              <ArtifactDownloadButton
+                name={detail.artifact.name}
+                version={detail.artifact.version}
+              />
+            </>
+          )}
+        </div>
 
-        <InfoItem label="Created">
-          <TooltipProvider delayDuration={100}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="text-foreground whitespace-nowrap text-xs cursor-default">
-                  {formatTimeShort(detail.createdAt)}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p className="text-xs">{formatTime(detail.createdAt)}</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </InfoItem>
-
-        <InfoItem label="Run ID">
-          <CopyableId value={detail.id} />
-        </InfoItem>
-
-        {detail.sessionId && (
-          <InfoItem label="Session ID">
-            <CopyableId value={detail.sessionId} />
+        {/* Mobile version */}
+        <div className="shrink-0 lg:hidden grid grid-cols-3 gap-x-4 gap-y-3 text-sm px-4 py-3 bg-muted/30 rounded-lg border border-border">
+          <InfoItem label="Status">
+            <StatusBadge status={detail.status} />
           </InfoItem>
-        )}
 
-        {detail.artifact.name && detail.artifact.version && (
-          <InfoItem label="Artifact">
-            <ArtifactDownloadButton
-              name={detail.artifact.name}
-              version={detail.artifact.version}
-            />
+          <InfoItem label="Agent">
+            <span className="font-medium text-foreground">
+              {detail.agentName}
+            </span>
           </InfoItem>
-        )}
+
+          {detail.framework && (
+            <InfoItem label="Framework">
+              <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                {detail.framework}
+              </span>
+            </InfoItem>
+          )}
+
+          <InfoItem label="Duration">
+            <span className="flex items-center gap-1 text-foreground">
+              <IconClock className="h-3.5 w-3.5 text-muted-foreground" />
+              {formatDuration(detail.startedAt, detail.completedAt)}
+            </span>
+          </InfoItem>
+
+          <InfoItem label="Created">
+            <TooltipProvider delayDuration={100}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="text-foreground whitespace-nowrap text-xs cursor-default">
+                    {formatTimeShort(detail.createdAt)}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="text-xs">{formatTime(detail.createdAt)}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </InfoItem>
+
+          <InfoItem label="Run ID">
+            <CopyableId value={detail.id} />
+          </InfoItem>
+
+          {detail.sessionId && (
+            <InfoItem label="Session ID">
+              <CopyableId value={detail.sessionId} />
+            </InfoItem>
+          )}
+
+          {detail.artifact.name && detail.artifact.version && (
+            <InfoItem label="Artifact">
+              <ArtifactDownloadButton
+                name={detail.artifact.name}
+                version={detail.artifact.version}
+              />
+            </InfoItem>
+          )}
+        </div>
       </div>
 
       {/* Error Banner */}
@@ -154,7 +162,6 @@ export function LogDetailContent({ logId }: { logId: string }) {
         framework={detail.framework}
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
-        className="flex-1 min-h-0"
       />
     </div>
   );

--- a/turbo/apps/platform/src/views/logs-page/log-detail/log-detail.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/log-detail.tsx
@@ -13,7 +13,7 @@ export function LogDetailPage() {
 
   return (
     <AppShell breadcrumb={breadcrumb}>
-      <div className="p-4 pb-0 sm:p-8 h-full flex flex-col">
+      <div className="h-full flex flex-col">
         {logId ? (
           <LogDetailContent logId={logId} />
         ) : (

--- a/turbo/apps/platform/src/views/logs-page/log-detail/log-detail.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/log-detail.tsx
@@ -13,7 +13,7 @@ export function LogDetailPage() {
 
   return (
     <AppShell breadcrumb={breadcrumb}>
-      <div className="p-4 sm:p-8 h-full flex flex-col">
+      <div className="p-4 pb-0 sm:p-8 h-full flex flex-col">
         {logId ? (
           <LogDetailContent logId={logId} />
         ) : (


### PR DESCRIPTION
## Summary
- Move system init content inline within header row for cleaner display
- Remove excessive vertical spacing between message groups in formatted events view
- Reduce markdown preview paragraph spacing in CSS
- Adjust log detail page bottom padding for better content fit

## Test plan
- [ ] Verify logs page renders without excessive spacing between messages
- [ ] Check that system init content displays inline correctly
- [ ] Confirm markdown preview has appropriate paragraph spacing
- [ ] Test responsive behavior on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)