### PR TITLE
feat(web): enhance slack agent management with dynamic modals

### DIFF
--- a/turbo/apps/web/app/api/slack/commands/route.ts
+++ b/turbo/apps/web/app/api/slack/commands/route.ts
@@ -15,7 +15,10 @@ import {
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
 import { decryptCredentialValue } from "../../../../src/lib/crypto/secrets-encryption";
-import { createSlackClient } from "../../../../src/lib/slack";
+import {
+  createSlackClient,
+  getSlackRedirectBaseUrl,
+} from "../../../../src/lib/slack";
 import {
   buildAgentAddModal,
   buildAgentListMessage,
@@ -146,6 +149,7 @@ function handleLoginCommand(
   payload: SlackCommandPayload,
   installation: { encryptedBotToken: string } | undefined,
   userLink: { id: string; vm0UserId: string } | undefined,
+  requestUrl: string,
 ): NextResponse {
   // Already logged in
   if (userLink) {
@@ -157,8 +161,7 @@ function handleLoginCommand(
     });
   }
 
-  const { SLACK_REDIRECT_BASE_URL } = env();
-  const baseUrl = SLACK_REDIRECT_BASE_URL ?? "https://www.vm0.ai";
+  const baseUrl = getSlackRedirectBaseUrl(requestUrl);
 
   if (installation) {
     // Workspace already installed, go directly to link page
@@ -205,9 +208,11 @@ async function handleLogoutCommand(
 /**
  * Build login URL for unauthenticated users
  */
-function buildLoginUrl(payload: SlackCommandPayload): string {
-  const { SLACK_REDIRECT_BASE_URL } = env();
-  const baseUrl = SLACK_REDIRECT_BASE_URL ?? "https://www.vm0.ai";
+function buildLoginUrl(
+  payload: SlackCommandPayload,
+  requestUrl: string,
+): string {
+  const baseUrl = getSlackRedirectBaseUrl(requestUrl);
   return `${baseUrl}/api/slack/oauth/install?w=${encodeURIComponent(payload.team_id)}&u=${encodeURIComponent(payload.user_id)}`;
 }
 
@@ -268,14 +273,14 @@ export async function POST(request: Request) {
 
   // Handle login command
   if (subCommand === "login") {
-    return handleLoginCommand(payload, installation, userLink);
+    return handleLoginCommand(payload, installation, userLink, request.url);
   }
 
   // Check installation for other commands
   if (!installation) {
     return NextResponse.json({
       response_type: "ephemeral",
-      blocks: buildLoginMessage(buildLoginUrl(payload)),
+      blocks: buildLoginMessage(buildLoginUrl(payload, request.url)),
     });
   }
 
@@ -294,7 +299,7 @@ export async function POST(request: Request) {
   if (!userLink) {
     return NextResponse.json({
       response_type: "ephemeral",
-      blocks: buildLoginMessage(buildLoginUrl(payload)),
+      blocks: buildLoginMessage(buildLoginUrl(payload, request.url)),
     });
   }
 

--- a/turbo/apps/web/app/api/slack/commands/route.ts
+++ b/turbo/apps/web/app/api/slack/commands/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
+import { extractVariableReferences, groupVariablesBySource } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { env } from "../../../../src/env";
 import {
@@ -9,7 +10,10 @@ import {
 import { slackInstallations } from "../../../../src/db/schema/slack-installation";
 import { slackUserLinks } from "../../../../src/db/schema/slack-user-link";
 import { slackBindings } from "../../../../src/db/schema/slack-binding";
-import { agentComposes } from "../../../../src/db/schema/agent-compose";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../src/db/schema/agent-compose";
 import { decryptCredentialValue } from "../../../../src/lib/crypto/secrets-encryption";
 import { createSlackClient } from "../../../../src/lib/slack";
 import {
@@ -18,7 +22,9 @@ import {
   buildHelpMessage,
   buildErrorMessage,
   buildSuccessMessage,
-  buildLinkAccountMessage,
+  buildLoginMessage,
+  buildAgentRemoveModal,
+  buildAgentUpdateModal,
 } from "../../../../src/lib/slack/blocks";
 
 /**
@@ -112,32 +118,97 @@ async function handleAgentCommand(
 ): Promise<NextResponse> {
   switch (action) {
     case "add":
-      return handleAgentAdd(client, payload, vm0UserId);
+      return handleAgentAdd(client, payload, vm0UserId, userLinkId);
 
     case "list":
       return handleAgentList(userLinkId);
 
-    case "remove": {
-      const agentName = args[2];
-      if (!agentName) {
-        return NextResponse.json({
-          response_type: "ephemeral",
-          blocks: buildErrorMessage(
-            "Please specify an agent name: `/vm0 agent remove <name>`",
-          ),
-        });
-      }
-      return handleAgentRemove(userLinkId, agentName);
-    }
+    case "remove":
+      return handleAgentRemove(client, payload, userLinkId);
+
+    case "update":
+      return handleAgentUpdate(client, payload, vm0UserId, userLinkId);
 
     default:
       return NextResponse.json({
         response_type: "ephemeral",
         blocks: buildErrorMessage(
-          `Unknown agent command: \`${action}\`\n\nAvailable commands:\n• \`/vm0 agent add\`\n• \`/vm0 agent list\`\n• \`/vm0 agent remove <name>\``,
+          `Unknown agent command: \`${action}\`\n\nAvailable commands:\n• \`/vm0 agent add\`\n• \`/vm0 agent list\`\n• \`/vm0 agent update\`\n• \`/vm0 agent remove\``,
         ),
       });
   }
+}
+
+/**
+ * Handle /vm0 login command
+ */
+function handleLoginCommand(
+  payload: SlackCommandPayload,
+  installation: { encryptedBotToken: string } | undefined,
+  userLink: { id: string; vm0UserId: string } | undefined,
+): NextResponse {
+  // Already logged in
+  if (userLink) {
+    return NextResponse.json({
+      response_type: "ephemeral",
+      blocks: buildSuccessMessage(
+        "You are already logged in.\n\nUse `/vm0 agent add` to add an agent or `/vm0 help` for more commands.",
+      ),
+    });
+  }
+
+  const { SLACK_REDIRECT_BASE_URL } = env();
+  const baseUrl = SLACK_REDIRECT_BASE_URL ?? "https://www.vm0.ai";
+
+  if (installation) {
+    // Workspace already installed, go directly to link page
+    const linkUrl = `${baseUrl}/slack/link?w=${encodeURIComponent(payload.team_id)}&u=${encodeURIComponent(payload.user_id)}&c=${encodeURIComponent(payload.channel_id)}`;
+    return NextResponse.json({
+      response_type: "ephemeral",
+      blocks: buildLoginMessage(linkUrl),
+    });
+  }
+
+  // Workspace not installed, need OAuth flow
+  const installUrl = `${baseUrl}/api/slack/oauth/install?w=${encodeURIComponent(payload.team_id)}&u=${encodeURIComponent(payload.user_id)}&c=${encodeURIComponent(payload.channel_id)}`;
+  return NextResponse.json({
+    response_type: "ephemeral",
+    blocks: buildLoginMessage(installUrl),
+  });
+}
+
+/**
+ * Handle /vm0 logout command
+ */
+async function handleLogoutCommand(
+  userLink: { id: string } | undefined,
+): Promise<NextResponse> {
+  if (!userLink) {
+    return NextResponse.json({
+      response_type: "ephemeral",
+      blocks: buildErrorMessage("You are not logged in."),
+    });
+  }
+  // Delete user link and associated bindings
+  await globalThis.services.db
+    .delete(slackBindings)
+    .where(eq(slackBindings.slackUserLinkId, userLink.id));
+  await globalThis.services.db
+    .delete(slackUserLinks)
+    .where(eq(slackUserLinks.id, userLink.id));
+  return NextResponse.json({
+    response_type: "ephemeral",
+    blocks: buildSuccessMessage("You have been logged out successfully."),
+  });
+}
+
+/**
+ * Build login URL for unauthenticated users
+ */
+function buildLoginUrl(payload: SlackCommandPayload): string {
+  const { SLACK_REDIRECT_BASE_URL } = env();
+  const baseUrl = SLACK_REDIRECT_BASE_URL ?? "https://www.vm0.ai";
+  return `${baseUrl}/api/slack/oauth/install?w=${encodeURIComponent(payload.team_id)}&u=${encodeURIComponent(payload.user_id)}`;
 }
 
 export async function POST(request: Request) {
@@ -161,6 +232,19 @@ export async function POST(request: Request) {
 
   initServices();
 
+  // Parse command text first (before checking installation)
+  const args = payload.text.trim().split(/\s+/);
+  const subCommand = args[0]?.toLowerCase() ?? "";
+  const action = args[1]?.toLowerCase() ?? "";
+
+  // Handle help command (doesn't require installation or linking)
+  if (subCommand === "help" || subCommand === "") {
+    return NextResponse.json({
+      response_type: "ephemeral",
+      blocks: buildHelpMessage(),
+    });
+  }
+
   // Get workspace installation
   const [installation] = await globalThis.services.db
     .select()
@@ -168,10 +252,30 @@ export async function POST(request: Request) {
     .where(eq(slackInstallations.slackWorkspaceId, payload.team_id))
     .limit(1);
 
+  // Check if user is already linked
+  const [userLink] = installation
+    ? await globalThis.services.db
+        .select()
+        .from(slackUserLinks)
+        .where(
+          and(
+            eq(slackUserLinks.slackUserId, payload.user_id),
+            eq(slackUserLinks.slackWorkspaceId, payload.team_id),
+          ),
+        )
+        .limit(1)
+    : [];
+
+  // Handle login command
+  if (subCommand === "login") {
+    return handleLoginCommand(payload, installation, userLink);
+  }
+
+  // Check installation for other commands
   if (!installation) {
     return NextResponse.json({
       response_type: "ephemeral",
-      text: "VM0 is not installed in this workspace.",
+      blocks: buildLoginMessage(buildLoginUrl(payload)),
     });
   }
 
@@ -181,40 +285,16 @@ export async function POST(request: Request) {
   );
   const client = createSlackClient(botToken);
 
-  // Check if user is linked
-  const [userLink] = await globalThis.services.db
-    .select()
-    .from(slackUserLinks)
-    .where(
-      and(
-        eq(slackUserLinks.slackUserId, payload.user_id),
-        eq(slackUserLinks.slackWorkspaceId, payload.team_id),
-      ),
-    )
-    .limit(1);
-
-  // Parse command text
-  const args = payload.text.trim().split(/\s+/);
-  const subCommand = args[0]?.toLowerCase() ?? "";
-  const action = args[1]?.toLowerCase() ?? "";
-
-  // Handle help command (doesn't require linking)
-  if (subCommand === "help" || subCommand === "") {
-    return NextResponse.json({
-      response_type: "ephemeral",
-      blocks: buildHelpMessage(),
-    });
+  // Handle logout command
+  if (subCommand === "logout") {
+    return handleLogoutCommand(userLink);
   }
 
   // Check if user needs to link account
   if (!userLink) {
-    const { SLACK_REDIRECT_BASE_URL } = env();
-    const baseUrl = SLACK_REDIRECT_BASE_URL ?? "https://www.vm0.ai";
-    const linkUrl = `${baseUrl}/slack/link?w=${payload.team_id}&u=${payload.user_id}`;
-
     return NextResponse.json({
       response_type: "ephemeral",
-      blocks: buildLinkAccountMessage(linkUrl),
+      blocks: buildLoginMessage(buildLoginUrl(payload)),
     });
   }
 
@@ -244,12 +324,14 @@ async function handleAgentAdd(
   client: ReturnType<typeof createSlackClient>,
   payload: SlackCommandPayload,
   vm0UserId: string,
+  userLinkId: string,
 ): Promise<NextResponse> {
-  // Fetch user's available agents
+  // Fetch user's available agents with their head version
   const composes = await globalThis.services.db
     .select({
       id: agentComposes.id,
       name: agentComposes.name,
+      headVersionId: agentComposes.headVersionId,
     })
     .from(agentComposes)
     .where(eq(agentComposes.userId, vm0UserId));
@@ -263,9 +345,62 @@ async function handleAgentAdd(
     });
   }
 
-  // Open modal
+  // Get already bound agent names
+  const existingBindings = await globalThis.services.db
+    .select({ agentName: slackBindings.agentName })
+    .from(slackBindings)
+    .where(eq(slackBindings.slackUserLinkId, userLinkId));
+
+  const boundNames = new Set(existingBindings.map((b) => b.agentName));
+
+  // Filter out already bound agents
+  const availableComposes = composes.filter(
+    (c) => !boundNames.has(c.name.toLowerCase()),
+  );
+
+  if (availableComposes.length === 0) {
+    return NextResponse.json({
+      response_type: "ephemeral",
+      blocks: buildErrorMessage(
+        "All your agents are already added.\n\nUse `/vm0 agent list` to see them or `/vm0 agent remove <name>` to remove one.",
+      ),
+    });
+  }
+
+  // Get compose versions to extract required secrets
+  const versionIds = availableComposes
+    .map((c) => c.headVersionId)
+    .filter((id): id is string => id !== null);
+
+  const versions =
+    versionIds.length > 0
+      ? await globalThis.services.db
+          .select({
+            id: agentComposeVersions.id,
+            content: agentComposeVersions.content,
+          })
+          .from(agentComposeVersions)
+          .where(inArray(agentComposeVersions.id, versionIds))
+      : [];
+
+  // Build map of compose ID to required secrets
+  const versionMap = new Map(versions.map((v) => [v.id, v.content]));
+  const agentsWithSecrets = availableComposes.map((c) => {
+    const content = c.headVersionId ? versionMap.get(c.headVersionId) : null;
+    const refs = content ? extractVariableReferences(content) : [];
+    const grouped = groupVariablesBySource(refs);
+    return {
+      id: c.id,
+      name: c.name,
+      requiredSecrets: grouped.secrets.map((s) => s.name),
+    };
+  });
+
+  // Open modal with channel_id for confirmation message
   const modal = buildAgentAddModal(
-    composes.map((c) => ({ id: c.id, name: c.name })),
+    agentsWithSecrets,
+    undefined,
+    payload.channel_id,
   );
 
   await client.views.open({
@@ -274,7 +409,7 @@ async function handleAgentAdd(
   });
 
   // Return empty response (Slack expects this when opening modal)
-  return NextResponse.json({});
+  return new NextResponse(null, { status: 200 });
 }
 
 /**
@@ -297,40 +432,127 @@ async function handleAgentList(userLinkId: string): Promise<NextResponse> {
 }
 
 /**
- * Handle /vm0 agent remove - Remove agent binding
+ * Handle /vm0 agent remove - Open modal to select agents to remove
  */
 async function handleAgentRemove(
+  client: ReturnType<typeof createSlackClient>,
+  payload: SlackCommandPayload,
   userLinkId: string,
-  agentName: string,
 ): Promise<NextResponse> {
-  // Find binding
-  const [binding] = await globalThis.services.db
-    .select()
+  // Get user's bound agents
+  const bindings = await globalThis.services.db
+    .select({
+      id: slackBindings.id,
+      agentName: slackBindings.agentName,
+    })
     .from(slackBindings)
-    .where(
-      and(
-        eq(slackBindings.slackUserLinkId, userLinkId),
-        eq(slackBindings.agentName, agentName.toLowerCase()),
-      ),
-    )
-    .limit(1);
+    .where(eq(slackBindings.slackUserLinkId, userLinkId));
 
-  if (!binding) {
+  if (bindings.length === 0) {
     return NextResponse.json({
       response_type: "ephemeral",
       blocks: buildErrorMessage(
-        `Agent "${agentName}" not found.\n\nUse \`/vm0 agent list\` to see your agents.`,
+        "You don't have any agents to remove.\n\nUse `/vm0 agent add` to add one first.",
       ),
     });
   }
 
-  // Delete binding
-  await globalThis.services.db
-    .delete(slackBindings)
-    .where(eq(slackBindings.id, binding.id));
+  // Open modal with multi-select
+  const modal = buildAgentRemoveModal(bindings, payload.channel_id);
 
-  return NextResponse.json({
-    response_type: "ephemeral",
-    blocks: buildSuccessMessage(`Agent "${agentName}" has been removed.`),
+  await client.views.open({
+    trigger_id: payload.trigger_id,
+    view: modal,
   });
+
+  // Return empty response (Slack expects this when opening modal)
+  return new NextResponse(null, { status: 200 });
+}
+
+/**
+ * Handle /vm0 agent update - Open modal to update agent secrets
+ */
+async function handleAgentUpdate(
+  client: ReturnType<typeof createSlackClient>,
+  payload: SlackCommandPayload,
+  vm0UserId: string,
+  userLinkId: string,
+): Promise<NextResponse> {
+  // Get user's bound agents with their compose IDs
+  const bindings = await globalThis.services.db
+    .select({
+      id: slackBindings.id,
+      agentName: slackBindings.agentName,
+      composeId: slackBindings.composeId,
+    })
+    .from(slackBindings)
+    .where(eq(slackBindings.slackUserLinkId, userLinkId));
+
+  if (bindings.length === 0) {
+    return NextResponse.json({
+      response_type: "ephemeral",
+      blocks: buildErrorMessage(
+        "You don't have any agents to update.\n\nUse `/vm0 agent add` to add one first.",
+      ),
+    });
+  }
+
+  // Get compose versions to extract required secrets
+  const composeIds = bindings.map((b) => b.composeId);
+  const composes = await globalThis.services.db
+    .select({
+      id: agentComposes.id,
+      headVersionId: agentComposes.headVersionId,
+    })
+    .from(agentComposes)
+    .where(inArray(agentComposes.id, composeIds));
+
+  const versionIds = composes
+    .map((c) => c.headVersionId)
+    .filter((id): id is string => id !== null);
+
+  const versions =
+    versionIds.length > 0
+      ? await globalThis.services.db
+          .select({
+            id: agentComposeVersions.id,
+            composeId: agentComposeVersions.composeId,
+            content: agentComposeVersions.content,
+          })
+          .from(agentComposeVersions)
+          .where(inArray(agentComposeVersions.id, versionIds))
+      : [];
+
+  // Build map of compose ID to required secrets
+  const composeToVersion = new Map(
+    composes.map((c) => [c.id, c.headVersionId]),
+  );
+  const versionMap = new Map(versions.map((v) => [v.id, v.content]));
+
+  const agentsWithSecrets = bindings.map((b) => {
+    const versionId = composeToVersion.get(b.composeId);
+    const content = versionId ? versionMap.get(versionId) : null;
+    const refs = content ? extractVariableReferences(content) : [];
+    const grouped = groupVariablesBySource(refs);
+    return {
+      id: b.id,
+      name: b.agentName,
+      requiredSecrets: grouped.secrets.map((s) => s.name),
+    };
+  });
+
+  // Open modal
+  const modal = buildAgentUpdateModal(
+    agentsWithSecrets,
+    undefined,
+    payload.channel_id,
+  );
+
+  await client.views.open({
+    trigger_id: payload.trigger_id,
+    view: modal,
+  });
+
+  // Return empty response (Slack expects this when opening modal)
+  return new NextResponse(null, { status: 200 });
 }

--- a/turbo/apps/web/app/api/slack/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/slack/oauth/callback/route.ts
@@ -34,6 +34,23 @@ export async function GET(request: Request) {
   const url = new URL(request.url);
   const code = url.searchParams.get("code");
   const error = url.searchParams.get("error");
+  const state = url.searchParams.get("state");
+
+  // Parse state to get Slack user info (for combined install + link flow)
+  let slackUserId: string | null = null;
+  let channelId: string | null = null;
+  if (state) {
+    try {
+      const parsed = JSON.parse(state) as {
+        u?: string;
+        c?: string;
+      };
+      slackUserId = parsed.u ?? null;
+      channelId = parsed.c ?? null;
+    } catch {
+      // Ignore parse errors
+    }
+  }
 
   // Use configured base URL or fall back to request URL
   const baseUrl = SLACK_REDIRECT_BASE_URL ?? `${url.protocol}//${url.host}`;
@@ -88,7 +105,21 @@ export async function GET(request: Request) {
         },
       });
 
-    // Redirect to success page with workspace info
+    // If we have user info from state, redirect to link page for combined flow
+    if (slackUserId) {
+      const linkParams = new URLSearchParams({
+        w: oauthResult.teamId,
+        u: slackUserId,
+      });
+      if (channelId) {
+        linkParams.set("c", channelId);
+      }
+      return NextResponse.redirect(
+        `${baseUrl}/slack/link?${linkParams.toString()}`,
+      );
+    }
+
+    // Otherwise redirect to success page
     return NextResponse.redirect(
       `${baseUrl}/slack/success?workspace=${encodeURIComponent(oauthResult.teamName)}&workspace_id=${encodeURIComponent(oauthResult.teamId)}`,
     );

--- a/turbo/apps/web/app/api/slack/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/slack/oauth/callback/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
 import { initServices } from "../../../../../src/lib/init-services";
 import { env } from "../../../../../src/env";
-import { exchangeOAuthCode } from "../../../../../src/lib/slack/client";
+import {
+  exchangeOAuthCode,
+  getSlackRedirectBaseUrl,
+} from "../../../../../src/lib/slack";
 import { encryptCredentialValue } from "../../../../../src/lib/crypto/secrets-encryption";
 import { slackInstallations } from "../../../../../src/db/schema/slack-installation";
 
@@ -17,12 +20,8 @@ import { slackInstallations } from "../../../../../src/db/schema/slack-installat
 export async function GET(request: Request) {
   initServices();
 
-  const {
-    SLACK_CLIENT_ID,
-    SLACK_CLIENT_SECRET,
-    SECRETS_ENCRYPTION_KEY,
-    SLACK_REDIRECT_BASE_URL,
-  } = env();
+  const { SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, SECRETS_ENCRYPTION_KEY } =
+    env();
 
   if (!SLACK_CLIENT_ID || !SLACK_CLIENT_SECRET) {
     return NextResponse.json(
@@ -53,7 +52,7 @@ export async function GET(request: Request) {
   }
 
   // Use configured base URL or fall back to request URL
-  const baseUrl = SLACK_REDIRECT_BASE_URL ?? `${url.protocol}//${url.host}`;
+  const baseUrl = getSlackRedirectBaseUrl(request.url);
 
   // Handle user cancellation or error
   if (error) {

--- a/turbo/apps/web/app/api/slack/oauth/install/route.ts
+++ b/turbo/apps/web/app/api/slack/oauth/install/route.ts
@@ -19,8 +19,10 @@ const BOT_SCOPES = [
   "channels:history", // Read channel messages for thread context
   "groups:history", // Read private channel messages
   "im:history", // Read direct messages
+  "im:write", // Send direct messages
   "commands", // Handle slash commands
   "users:read", // Get user info
+  "reactions:write", // Add reactions to messages (for thinking indicator)
 ].join(",");
 
 export async function GET(request: Request) {
@@ -38,11 +40,27 @@ export async function GET(request: Request) {
   const baseUrl = SLACK_REDIRECT_BASE_URL ?? `${url.protocol}//${url.host}`;
   const redirectUri = `${baseUrl}/api/slack/oauth/callback`;
 
+  // Get optional Slack user info from query params (for combined install + link flow)
+  const slackUserId = url.searchParams.get("u");
+  const slackWorkspaceId = url.searchParams.get("w");
+  const channelId = url.searchParams.get("c");
+
+  // Build state with user info if provided
+  const stateObj: { u?: string; w?: string; c?: string } = {};
+  if (slackUserId) stateObj.u = slackUserId;
+  if (slackWorkspaceId) stateObj.w = slackWorkspaceId;
+  if (channelId) stateObj.c = channelId;
+  const state =
+    Object.keys(stateObj).length > 0 ? JSON.stringify(stateObj) : "";
+
   // Build the Slack OAuth URL
   const authUrl = new URL(SLACK_OAUTH_URL);
   authUrl.searchParams.set("client_id", SLACK_CLIENT_ID);
   authUrl.searchParams.set("scope", BOT_SCOPES);
   authUrl.searchParams.set("redirect_uri", redirectUri);
+  if (state) {
+    authUrl.searchParams.set("state", state);
+  }
 
   return NextResponse.redirect(authUrl.toString());
 }

--- a/turbo/apps/web/app/api/slack/oauth/install/route.ts
+++ b/turbo/apps/web/app/api/slack/oauth/install/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { env } from "../../../../../src/env";
+import { getSlackRedirectBaseUrl } from "../../../../../src/lib/slack";
 
 /**
  * Slack OAuth Install Endpoint
@@ -26,7 +27,7 @@ const BOT_SCOPES = [
 ].join(",");
 
 export async function GET(request: Request) {
-  const { SLACK_CLIENT_ID, SLACK_REDIRECT_BASE_URL } = env();
+  const { SLACK_CLIENT_ID } = env();
 
   if (!SLACK_CLIENT_ID) {
     return NextResponse.json(
@@ -37,7 +38,7 @@ export async function GET(request: Request) {
 
   // Get the base URL for the redirect URI
   const url = new URL(request.url);
-  const baseUrl = SLACK_REDIRECT_BASE_URL ?? `${url.protocol}//${url.host}`;
+  const baseUrl = getSlackRedirectBaseUrl(request.url);
   const redirectUri = `${baseUrl}/api/slack/oauth/callback`;
 
   // Get optional Slack user info from query params (for combined install + link flow)

--- a/turbo/apps/web/app/slack/link/page.tsx
+++ b/turbo/apps/web/app/slack/link/page.tsx
@@ -18,6 +18,7 @@ function SlackLinkContent(): React.JSX.Element {
 
   const slackUserId = searchParams.get("u");
   const workspaceId = searchParams.get("w");
+  const channelId = searchParams.get("c");
 
   useEffect(() => {
     if (!slackUserId || !workspaceId) {
@@ -47,12 +48,13 @@ function SlackLinkContent(): React.JSX.Element {
     setLoading(true);
     setError("");
 
-    const result = await linkSlackAccount(slackUserId, workspaceId);
+    const result = await linkSlackAccount(slackUserId, workspaceId, channelId);
 
     if (result.success) {
-      router.push(
-        `/slack/success?linked=true${workspaceId ? `&workspace_id=${workspaceId}` : ""}`,
-      );
+      const params = new URLSearchParams({ linked: "true" });
+      if (workspaceId) params.set("workspace_id", workspaceId);
+      if (channelId) params.set("channel_id", channelId);
+      router.push(`/slack/success?${params.toString()}`);
     } else {
       setError(result.error ?? "Failed to link account");
       setLoading(false);
@@ -190,7 +192,12 @@ function SlackLinkContent(): React.JSX.Element {
                 </p>
               </div>
               <button
-                onClick={() => router.push("/slack/success?linked=true")}
+                onClick={() => {
+                  const params = new URLSearchParams({ linked: "true" });
+                  if (workspaceId) params.set("workspace_id", workspaceId);
+                  if (channelId) params.set("channel_id", channelId);
+                  router.push(`/slack/success?${params.toString()}`);
+                }}
                 className="mt-2 h-9 w-full rounded-md bg-primary text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
               >
                 Continue

--- a/turbo/apps/web/app/slack/success/page.tsx
+++ b/turbo/apps/web/app/slack/success/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 import Image from "next/image";
+import { Button } from "@vm0/ui";
 import { useTheme } from "../../components/ThemeProvider";
 import { IconCheck } from "@tabler/icons-react";
 
@@ -11,9 +12,22 @@ function SlackSuccessContent(): React.JSX.Element {
   const { theme, toggleTheme } = useTheme();
 
   const workspace = searchParams.get("workspace");
+  const workspaceId = searchParams.get("workspace_id");
+  const channelId = searchParams.get("channel_id");
   const linked = searchParams.get("linked");
 
   const isLinked = linked === "true";
+
+  // Build Slack deep link to open the channel
+  const slackDeepLink =
+    workspaceId && channelId
+      ? `slack://channel?team=${workspaceId}&id=${channelId}`
+      : "slack://open";
+
+  // Auto-open Slack on page load
+  useEffect(() => {
+    window.location.href = slackDeepLink;
+  }, [slackDeepLink]);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-6">
@@ -86,7 +100,9 @@ function SlackSuccessContent(): React.JSX.Element {
               priority
               className="hidden dark:block"
             />
-            <span className="text-2xl text-foreground">+ Slack</span>
+            <span className="text-2xl font-medium text-foreground">
+              + Slack
+            </span>
           </div>
 
           {/* Content */}
@@ -121,15 +137,37 @@ function SlackSuccessContent(): React.JSX.Element {
               )}
             </div>
 
+            {/* Open Slack Button */}
+            <Button asChild className="mt-4 w-full">
+              <a href={slackDeepLink} className="!text-primary-foreground">
+                Open Slack
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                >
+                  <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zm10.124 2.521a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.52 2.521h-2.522V8.834zm-1.271 0a2.528 2.528 0 0 1-2.521 2.521 2.528 2.528 0 0 1-2.521-2.521V2.522A2.528 2.528 0 0 1 15.166 0a2.528 2.528 0 0 1 2.521 2.522v6.312zm-2.521 10.124a2.528 2.528 0 0 1 2.521 2.522A2.528 2.528 0 0 1 15.166 24a2.528 2.528 0 0 1-2.521-2.52v-2.522h2.521zm0-1.271a2.528 2.528 0 0 1-2.521-2.521 2.528 2.528 0 0 1 2.521-2.521h6.312A2.528 2.528 0 0 1 24 15.166a2.528 2.528 0 0 1-2.52 2.521h-6.313z" />
+                </svg>
+              </a>
+            </Button>
+
             {/* Instructions */}
             <div className="mt-4 w-full rounded-lg bg-muted/50 p-4">
               <p className="text-xs text-muted-foreground">
                 <strong className="text-foreground">Next steps:</strong>
               </p>
               <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
-                <li>1. Go to any Slack channel</li>
-                <li>2. Mention @VM0 with your question</li>
-                <li>3. The bot will respond using your configured agents</li>
+                <li>
+                  • Use{" "}
+                  <code className="rounded bg-muted px-1">/vm0 agent add</code>{" "}
+                  to add an agent
+                </li>
+                <li>
+                  • Mention <code className="rounded bg-muted px-1">@VM0</code>{" "}
+                  to chat with your agents
+                </li>
               </ul>
             </div>
           </div>

--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -17,23 +17,39 @@ import {
 describe("buildAgentAddModal", () => {
   it("should create a valid modal structure", () => {
     const agents = [
-      { id: "agent-1", name: "My Coder" },
-      { id: "agent-2", name: "My Analyst" },
+      { id: "agent-1", name: "My Coder", requiredSecrets: [] },
+      { id: "agent-2", name: "My Analyst", requiredSecrets: [] },
     ];
 
-    const modal = buildAgentAddModal(agents) as ModalView;
+    // Without selected agent, submit button is not shown
+    const modalWithoutSelection = buildAgentAddModal(agents) as ModalView;
+    expect(modalWithoutSelection.type).toBe("modal");
+    expect(modalWithoutSelection.callback_id).toBe("agent_add_modal");
+    expect(modalWithoutSelection.title).toEqual({
+      type: "plain_text",
+      text: "Add Agent",
+    });
+    expect(modalWithoutSelection.submit).toBeUndefined();
+    expect(modalWithoutSelection.close).toEqual({
+      type: "plain_text",
+      text: "Cancel",
+    });
 
-    expect(modal.type).toBe("modal");
-    expect(modal.callback_id).toBe("agent_add_modal");
-    expect(modal.title).toEqual({ type: "plain_text", text: "Add Agent" });
-    expect(modal.submit).toEqual({ type: "plain_text", text: "Add" });
-    expect(modal.close).toEqual({ type: "plain_text", text: "Cancel" });
+    // With selected agent, submit button is shown
+    const modalWithSelection = buildAgentAddModal(
+      agents,
+      "agent-1",
+    ) as ModalView;
+    expect(modalWithSelection.submit).toEqual({
+      type: "plain_text",
+      text: "Add",
+    });
   });
 
   it("should include agent options in select", () => {
     const agents = [
-      { id: "agent-1", name: "My Coder" },
-      { id: "agent-2", name: "My Analyst" },
+      { id: "agent-1", name: "My Coder", requiredSecrets: [] },
+      { id: "agent-2", name: "My Analyst", requiredSecrets: [] },
     ];
 
     const modal = buildAgentAddModal(agents);

--- a/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
@@ -22,7 +22,7 @@ describe("formatContextForAgent", () => {
     const botUserId = "BBOT123";
     const messages = [
       { user: "U123", text: "Hello" },
-      { bot_id: "BBOT123", text: "Bot response" },
+      { user: "BBOT123", text: "Bot response" },
       { user: "U456", text: "Thanks" },
     ];
 

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -15,6 +15,7 @@ import {
   buildLinkAccountMessage,
   buildErrorMessage,
   buildMarkdownMessage,
+  getSlackRedirectBaseUrl,
 } from "../index";
 import { routeToAgent } from "../router";
 import { runAgentForSlack } from "./run-agent";
@@ -290,9 +291,7 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
  * Build the account linking URL
  */
 function buildLinkUrl(workspaceId: string, slackUserId: string): string {
-  // Use SLACK_REDIRECT_BASE_URL if set, otherwise fallback to production URL
-  const { SLACK_REDIRECT_BASE_URL } = env();
-  const baseUrl = SLACK_REDIRECT_BASE_URL ?? "https://www.vm0.ai";
+  const baseUrl = getSlackRedirectBaseUrl();
   const params = new URLSearchParams({
     w: workspaceId,
     u: slackUserId,

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -2,8 +2,6 @@ import { eq, and } from "drizzle-orm";
 import { slackInstallations } from "../../../db/schema/slack-installation";
 import { slackUserLinks } from "../../../db/schema/slack-user-link";
 import { slackBindings } from "../../../db/schema/slack-binding";
-import { slackThreadSessions } from "../../../db/schema/slack-thread-session";
-import { agentSessions } from "../../../db/schema/agent-session";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import {
@@ -11,10 +9,12 @@ import {
   postMessage,
   extractMessageContent,
   fetchThreadContext,
+  fetchChannelContext,
   formatContextForAgent,
   parseExplicitAgentSelection,
   buildLinkAccountMessage,
   buildErrorMessage,
+  buildMarkdownMessage,
 } from "../index";
 import { routeToAgent } from "../router";
 import { runAgentForSlack } from "./run-agent";
@@ -191,38 +191,95 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       (b) => b.agentName === selectedAgentName,
     )!;
 
-    // 7. Fetch thread context
+    // 7. Fetch context (thread messages or recent channel messages)
     let formattedContext = "";
     if (context.threadTs) {
+      // In a thread - fetch thread replies
       const messages = await fetchThreadContext(
         client,
         context.channelId,
         context.threadTs,
       );
-      formattedContext = formatContextForAgent(messages, botUserId);
+      formattedContext = formatContextForAgent(messages, botUserId, "thread");
+    } else {
+      // Not in a thread - fetch recent channel messages
+      const messages = await fetchChannelContext(client, context.channelId, 10);
+      formattedContext = formatContextForAgent(messages, botUserId, "channel");
     }
 
-    // 8. Find or create thread session
-    const session = await findOrCreateThreadSession(
-      selectedBinding.id,
-      selectedBinding.composeId,
+    // 8. Add thinking reaction to user's message (non-critical, ignore errors)
+    const reactionAdded = await client.reactions
+      .add({
+        channel: context.channelId,
+        timestamp: context.messageTs,
+        name: "hourglass_flowing_sand",
+      })
+      .then(() => true)
+      .catch(() => false);
+
+    // 9. Post thinking message (will be updated with response)
+    const thinkingTs = await postMessage(
+      client,
       context.channelId,
-      threadTs,
-      userLink.vm0UserId,
+      "Thinking...",
+      {
+        threadTs,
+        blocks: [
+          {
+            type: "context",
+            elements: [
+              {
+                type: "mrkdwn",
+                text: `:hourglass_flowing_sand: *Thinking...* (using \`${selectedAgentName}\`)`,
+              },
+            ],
+          },
+        ],
+      },
     );
 
-    // 9. Execute agent
-    const agentResponse = await runAgentForSlack({
-      binding: selectedBinding,
-      sessionId: session.agentSessionId,
-      prompt: promptText,
-      threadContext: formattedContext,
-      userId: userLink.vm0UserId,
-      encryptionKey: SECRETS_ENCRYPTION_KEY,
-    });
+    try {
+      // 10. Execute agent
+      // Don't use session continuation - rely on Slack thread context instead
+      // This avoids complexity of syncing Slack threads with agent sessions
+      const agentResponse = await runAgentForSlack({
+        binding: selectedBinding,
+        sessionId: undefined,
+        prompt: promptText,
+        threadContext: formattedContext,
+        userId: userLink.vm0UserId,
+        encryptionKey: SECRETS_ENCRYPTION_KEY,
+      });
 
-    // 10. Post response to Slack thread
-    await postMessage(client, context.channelId, agentResponse, { threadTs });
+      // 11. Update thinking message with actual response
+      if (thinkingTs) {
+        await client.chat.update({
+          channel: context.channelId,
+          ts: thinkingTs,
+          text: agentResponse,
+          blocks: buildMarkdownMessage(agentResponse),
+        });
+      } else {
+        // Fallback: post new message if we don't have the thinking message ts
+        await postMessage(client, context.channelId, agentResponse, {
+          threadTs,
+          blocks: buildMarkdownMessage(agentResponse),
+        });
+      }
+    } finally {
+      // 12. Remove thinking reaction (only if it was added)
+      if (reactionAdded) {
+        await client.reactions
+          .remove({
+            channel: context.channelId,
+            timestamp: context.messageTs,
+            name: "hourglass_flowing_sand",
+          })
+          .catch(() => {
+            // Ignore errors when removing reaction
+          });
+      }
+    }
   } catch (error) {
     console.error("Error handling app_mention:", error);
     // Don't throw - we don't want to retry
@@ -241,55 +298,4 @@ function buildLinkUrl(workspaceId: string, slackUserId: string): string {
     u: slackUserId,
   });
   return `${baseUrl}/slack/link?${params.toString()}`;
-}
-
-/**
- * Find or create a thread session for maintaining conversation context
- */
-async function findOrCreateThreadSession(
-  bindingId: string,
-  composeId: string,
-  channelId: string,
-  threadTs: string,
-  userId: string,
-): Promise<{ agentSessionId: string }> {
-  // Try to find existing session for this thread
-  const [existingSession] = await globalThis.services.db
-    .select()
-    .from(slackThreadSessions)
-    .where(
-      and(
-        eq(slackThreadSessions.slackBindingId, bindingId),
-        eq(slackThreadSessions.slackChannelId, channelId),
-        eq(slackThreadSessions.slackThreadTs, threadTs),
-      ),
-    )
-    .limit(1);
-
-  if (existingSession) {
-    return { agentSessionId: existingSession.agentSessionId };
-  }
-
-  // Create new agent session
-  const [newAgentSession] = await globalThis.services.db
-    .insert(agentSessions)
-    .values({
-      userId,
-      agentComposeId: composeId,
-    })
-    .returning({ id: agentSessions.id });
-
-  if (!newAgentSession) {
-    throw new Error("Failed to create agent session");
-  }
-
-  // Create thread session mapping
-  await globalThis.services.db.insert(slackThreadSessions).values({
-    slackBindingId: bindingId,
-    slackChannelId: channelId,
-    slackThreadTs: threadTs,
-    agentSessionId: newAgentSession.id,
-  });
-
-  return { agentSessionId: newAgentSession.id };
 }

--- a/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
@@ -18,7 +18,7 @@ interface RunAgentParams {
     composeId: string;
     encryptedSecrets: string | null;
   };
-  sessionId: string;
+  sessionId: string | undefined;
   prompt: string;
   threadContext: string;
   userId: string;

--- a/turbo/apps/web/src/lib/slack/index.ts
+++ b/turbo/apps/web/src/lib/slack/index.ts
@@ -1,5 +1,32 @@
 // Slack integration utilities
 
+import { env } from "../../env";
+
+/**
+ * Get the base URL for Slack OAuth redirects
+ * Uses SLACK_REDIRECT_BASE_URL env var, or derives from request URL
+ *
+ * @param requestUrl - Optional request URL to derive base URL from
+ * @returns Base URL for redirects
+ * @throws Error if no URL can be determined
+ */
+export function getSlackRedirectBaseUrl(requestUrl?: string): string {
+  const { SLACK_REDIRECT_BASE_URL } = env();
+
+  if (SLACK_REDIRECT_BASE_URL) {
+    return SLACK_REDIRECT_BASE_URL;
+  }
+
+  if (requestUrl) {
+    const url = new URL(requestUrl);
+    return `${url.protocol}//${url.host}`;
+  }
+
+  throw new Error(
+    "SLACK_REDIRECT_BASE_URL environment variable is required for Slack integration",
+  );
+}
+
 // Signature verification
 export { verifySlackSignature, getSlackSignatureHeaders } from "./verify";
 

--- a/turbo/apps/web/src/lib/slack/index.ts
+++ b/turbo/apps/web/src/lib/slack/index.ts
@@ -20,11 +20,13 @@ export {
   buildLinkAccountMessage,
   buildHelpMessage,
   buildSuccessMessage,
+  buildMarkdownMessage,
 } from "./blocks";
 
 // Thread context
 export {
   fetchThreadContext,
+  fetchChannelContext,
   formatContextForAgent,
   extractMessageContent,
   parseExplicitAgentSelection,


### PR DESCRIPTION
## Summary

- Add dynamic agent add/update/remove modals with secrets handling
- Add channel context fetching alongside thread context for better agent awareness
- Add thinking indicator (hourglass reaction) during agent execution
- Add markdown message formatting for agent responses
- Add login/logout commands for account linking
- Refactor code to reduce complexity and extract helper functions

## Test plan

- [ ] Test adding an agent with required secrets via `/vm0 agent add`
- [ ] Test updating agent secrets via `/vm0 agent update`
- [ ] Test removing agents via `/vm0 agent remove`
- [ ] Test login/logout flows via `/vm0 login` and `/vm0 logout`
- [ ] Verify thinking indicator appears during agent execution
- [ ] Verify agent responses are formatted correctly in Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)