### PR TITLE
docs: remove waitlist link from readme header

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   </p>
 </h2>
 
-[Documentation](https://docs.vm0.ai) / [Website](https://www.vm0.ai) / [Join Waitlist](https://www.vm0.ai/sign-up) / [Discord](https://discord.gg/WMpAmHFfp6)
+[Documentation](https://docs.vm0.ai) / [Website](https://www.vm0.ai) / [Discord](https://discord.gg/WMpAmHFfp6)
 
 `VM0` runs natural language-described workflows automatically on schedule in remote sandbox environments.
 


### PR DESCRIPTION
## Summary
- Remove the "Join Waitlist" link from the README header navigation

## Test plan
- [x] README renders correctly with updated links

🤖 Generated with [Claude Code](https://claude.com/claude-code)