### PR TITLE
ci: reduce cli e2e tests per chunk from 25 to 15

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -108,8 +108,8 @@ jobs:
         shell: bash
         run: |
           # Scan test files and distribute them across chunks using load balancing
-          # Dynamic chunk count: ~25 tests per chunk, max 10 chunks
-          TESTS_PER_CHUNK=25
+          # Dynamic chunk count: ~15 tests per chunk, max 10 chunks
+          TESTS_PER_CHUNK=15
           MAX_CHUNKS=10
 
           # Count tests per file


### PR DESCRIPTION
## Summary
- Reduce `TESTS_PER_CHUNK` from 25 to 15 in CLI E2E parallel test matrix
- This splits 126 tests across 9 chunks (~14 tests each) instead of 6 chunks (~21 tests each)
- Should improve CI execution time through better parallelization

## Test plan
- [ ] Verify CI workflow runs successfully
- [ ] Check that parallel test chunks are distributed evenly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)