### PR TITLE
style: remove height constraints from logs page content display

### DIFF
--- a/turbo/apps/platform/src/views/logs-page/components/tool-summary.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/tool-summary.tsx
@@ -230,7 +230,7 @@ function ToolInputDetails({
     const content = input.content as string | undefined;
     if (content) {
       return (
-        <pre className="font-mono text-xs text-muted-foreground whitespace-pre-wrap break-all max-h-60 overflow-y-auto">
+        <pre className="font-mono text-xs text-muted-foreground whitespace-pre-wrap break-all">
           {content}
         </pre>
       );
@@ -247,7 +247,7 @@ function ToolInputDetails({
           {oldString && (
             <div className="flex items-start gap-2">
               <span className="text-red-500 shrink-0">-</span>
-              <pre className="font-mono text-xs text-red-500/70 whitespace-pre-wrap break-all max-h-40 overflow-y-auto">
+              <pre className="font-mono text-xs text-red-500/70 whitespace-pre-wrap break-all">
                 {oldString}
               </pre>
             </div>
@@ -255,7 +255,7 @@ function ToolInputDetails({
           {newString && (
             <div className="flex items-start gap-2">
               <span className="text-lime-500 shrink-0">+</span>
-              <pre className="font-mono text-xs text-lime-500/70 whitespace-pre-wrap break-all max-h-40 overflow-y-auto">
+              <pre className="font-mono text-xs text-lime-500/70 whitespace-pre-wrap break-all">
                 {newString}
               </pre>
             </div>
@@ -340,7 +340,7 @@ function ToolResultDetails({
 
   if (isError) {
     return (
-      <pre className="text-xs text-red-500 whitespace-pre-wrap max-h-40 overflow-y-auto break-all">
+      <pre className="text-xs text-red-500 whitespace-pre-wrap break-all">
         {contentElement}
       </pre>
     );
@@ -360,7 +360,7 @@ function ToolResultDetails({
             +{remainingLines} lines
             {bytes ? ` (${(bytes / 1024).toFixed(1)} KB)` : ""}
           </summary>
-          <pre className="text-xs text-foreground whitespace-pre-wrap max-h-60 overflow-y-auto break-all">
+          <pre className="text-xs text-foreground whitespace-pre-wrap break-all">
             {lines.slice(3).join("\n")}
           </pre>
         </details>
@@ -369,7 +369,7 @@ function ToolResultDetails({
   }
 
   return (
-    <pre className="text-xs text-foreground whitespace-pre-wrap max-h-40 overflow-y-auto break-all">
+    <pre className="text-xs text-foreground whitespace-pre-wrap break-all">
       {contentElement}
     </pre>
   );

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
@@ -156,10 +156,8 @@ export function AgentEventsCard({
 
   if (eventsLoadable.state === "loading") {
     return (
-      <div className="px-4 sm:px-8">
-        <div className="flex items-center justify-center p-8">
-          <IconLoader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-        </div>
+      <div className="flex items-center justify-center p-8">
+        <IconLoader2 className="h-5 w-5 animate-spin text-muted-foreground" />
       </div>
     );
   }

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -182,10 +182,10 @@ function InfoItem({ label, children }: { label: string; children: ReactNode }) {
 
 function CopyableId({ label, value }: { label?: string; value: string }) {
   return (
-    <span className="inline-flex items-center gap-1 text-muted-foreground">
+    <span className="inline-flex items-baseline gap-1 text-muted-foreground">
       {label && <span>{label}:</span>}
       <span className="font-mono text-xs">{value.slice(0, 8)}</span>
-      <CopyButton text={value} className="h-4 w-4 p-0" />
+      <CopyButton text={value} className="h-4 w-4 p-0 self-center" />
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- Remove `max-h-*` and `overflow-y-auto` constraints from `<pre>` elements in tool summary to allow content to display fully
- Simplify loading state in agent events card by removing unnecessary wrapper div
- Fix alignment in CopyableId component using `items-baseline` and `self-center`

## Test plan
- [ ] Verify tool summary content displays without truncation
- [ ] Verify loading spinner appears correctly in agent events card
- [ ] Verify copy button alignment looks correct in log detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)