### PR TITLE
refactor(test): remove redundant error tests from agent status e2e

### DIFF
--- a/e2e/tests/02-parallel/t26-vm0-agent-list-status.bats
+++ b/e2e/tests/02-parallel/t26-vm0-agent-list-status.bats
@@ -2,12 +2,17 @@
 
 load '../../helpers/setup'
 
-# vm0 agent list and status command tests
+# vm0 agent list and status command tests (Happy Path Only)
 #
 # Note: Help/alias tests (command description, name, alias) have been moved to unit tests:
 # turbo/apps/cli/src/__tests__/agent-commands.test.ts
 #
-# This file contains integration tests that require actual API interaction.
+# Error handling tests have been moved to CLI integration tests:
+# turbo/apps/cli/src/commands/agent/__tests__/status.test.ts
+#   - "should exit with error when compose not found" (nonexistent agent)
+#   - "should exit with error when version not found" (nonexistent version)
+#
+# This file contains E2E tests that require actual API interaction.
 
 setup() {
     # Create temporary test directory
@@ -177,39 +182,6 @@ EOF
     run $CLI_COMMAND agent status "$AGENT_NAME" --no-sources
     assert_success
     assert_output --partial "Name:"
-}
-
-# ============================================
-# Error Handling Tests
-# ============================================
-
-@test "vm0 agent status fails for nonexistent agent" {
-    run $CLI_COMMAND agent status "nonexistent-agent-12345"
-    assert_failure
-    assert_output --partial "not found"
-}
-
-@test "vm0 agent status fails for nonexistent version" {
-    echo "# Step 1: Create vm0.yaml config file"
-    cat > "$TEST_DIR/vm0.yaml" <<EOF
-version: "1.0"
-
-agents:
-  $AGENT_NAME:
-    description: "Test agent for version error"
-    framework: claude-code
-    image: "vm0/claude-code:dev"
-    working_dir: /home/user/workspace
-EOF
-
-    echo "# Step 2: Run vm0 compose to create the agent"
-    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
-    assert_success
-
-    echo "# Step 3: Run vm0 agent status with nonexistent version"
-    run $CLI_COMMAND agent status "$AGENT_NAME:deadbeef"
-    assert_failure
-    assert_output --partial "Version not found"
 }
 
 # ============================================


### PR DESCRIPTION
## Summary
- Remove error handling tests from `t26-vm0-agent-list-status.bats` that are already covered by CLI integration tests
- Update file header to document the migration

## Removed E2E Tests
| E2E Test | Integration Test Coverage |
|----------|---------------------------|
| "vm0 agent status fails for nonexistent agent" | `status.test.ts` "should exit with error when compose not found" |
| "vm0 agent status fails for nonexistent version" | `status.test.ts` "should exit with error when version not found" |

## Why
Per testing guidelines (`docs/testing.md`):
- E2E tests should only cover happy path
- Error cases belong in integration tests where we can control the environment with MSW

## Test plan
- [x] Integration tests pass: `pnpm vitest run apps/cli/src/commands/agent/__tests__/status.test.ts`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)