### PR TITLE
refactor(web): fetch agents dynamically for slack modals

### DIFF
--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -118,7 +118,7 @@ export function buildAgentAddModal(
   return {
     type: "modal",
     callback_id: "agent_add_modal",
-    private_metadata: JSON.stringify({ agents, channelId }),
+    private_metadata: JSON.stringify({ channelId }),
     title: {
       type: "plain_text",
       text: "Add Agent",
@@ -255,7 +255,7 @@ export function buildAgentUpdateModal(
   return {
     type: "modal",
     callback_id: "agent_update_modal",
-    private_metadata: JSON.stringify({ agents, channelId }),
+    private_metadata: JSON.stringify({ channelId }),
     title: {
       type: "plain_text",
       text: "Update Agent",


### PR DESCRIPTION
## Summary
- Refactored Slack modal agent selection to fetch agents dynamically from database
- Removed full agent list from modal `private_metadata` to reduce payload size
- Added `fetchAvailableAgents()` and `fetchBoundAgents()` helper functions
- Ensures fresh agent data is retrieved when selection changes

## Test plan
- [x] Verified all Slack-related tests pass
- [x] Verified lint, type-check, and knip pass
- [ ] Manual testing: Open add/update agent modal in Slack, verify agent dropdown works correctly
- [ ] Manual testing: Verify secret input fields appear when agent with secrets is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)