### PR TITLE
fix(web): make slack login success message ephemeral and update wording

### DIFF
--- a/turbo/apps/web/app/slack/link/actions.ts
+++ b/turbo/apps/web/app/slack/link/actions.ts
@@ -138,7 +138,7 @@ export async function linkSlackAccount(
 }
 
 /**
- * Send success message to the Slack channel
+ * Send success message to the Slack channel (ephemeral - only visible to the user)
  */
 async function sendSuccessMessage(
   encryptedBotToken: string,
@@ -152,15 +152,16 @@ async function sendSuccessMessage(
   );
   const client = createSlackClient(botToken);
 
-  await client.chat.postMessage({
+  await client.chat.postEphemeral({
     channel: channelId,
-    text: `<@${slackUserId}> successfully logged in to VM0!`,
+    user: slackUserId,
+    text: `Successfully logged in to VM0!`,
     blocks: [
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `:white_check_mark: <@${slackUserId}> *successfully logged in to VM0!*\n\nYou can now:\n• Use \`/vm0 agent add\` to add an agent\n• Mention \`@VM0\` to interact with your agents`,
+          text: `:white_check_mark: *Successfully logged in to VM0!*\n\nYou can now:\n• Use \`/vm0 agent add\` to add an agent\n• Mention \`@VM0\` to interact with your agents`,
         },
       },
     ],

--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -9,7 +9,7 @@ import {
   buildAgentAddModal,
   buildAgentListMessage,
   buildErrorMessage,
-  buildLinkAccountMessage,
+  buildLoginPromptMessage,
   buildHelpMessage,
   buildSuccessMessage,
 } from "../blocks";
@@ -140,17 +140,17 @@ describe("buildErrorMessage", () => {
   });
 });
 
-describe("buildLinkAccountMessage", () => {
-  it("should create link account message with button", () => {
-    const linkUrl = "https://vm0.ai/slack/link?u=U123&w=T456";
-    const blocks = buildLinkAccountMessage(linkUrl);
+describe("buildLoginPromptMessage", () => {
+  it("should create login message with button", () => {
+    const loginUrl = "https://vm0.ai/slack/link?u=U123&w=T456";
+    const blocks = buildLoginPromptMessage(loginUrl);
 
     expect(blocks).toHaveLength(2);
     expect(blocks[0]).toMatchObject({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: expect.stringContaining("link your account"),
+        text: expect.stringContaining("login"),
       },
     });
     expect(blocks[1]).toMatchObject({
@@ -158,8 +158,8 @@ describe("buildLinkAccountMessage", () => {
       elements: [
         {
           type: "button",
-          text: { type: "plain_text", text: "Link Account" },
-          url: linkUrl,
+          text: { type: "plain_text", text: "Login" },
+          url: loginUrl,
           style: "primary",
         },
       ],

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -407,20 +407,20 @@ export function buildErrorMessage(error: string): (Block | KnownBlock)[] {
 }
 
 /**
- * Build a message prompting user to link their account
+ * Build a message prompting user to login
  *
- * @param linkUrl - URL to the linking page
+ * @param loginUrl - URL to the login page
  * @returns Block Kit blocks
  */
-export function buildLinkAccountMessage(
-  linkUrl: string,
+export function buildLoginPromptMessage(
+  loginUrl: string,
 ): (Block | KnownBlock)[] {
   return [
     {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "To use VM0 in Slack, please link your account first.",
+        text: "To use VM0 in Slack, please login first.",
       },
     },
     {
@@ -430,10 +430,10 @@ export function buildLinkAccountMessage(
           type: "button",
           text: {
             type: "plain_text",
-            text: "Link Account",
+            text: "Login",
           },
-          url: linkUrl,
-          action_id: "link_account",
+          url: loginUrl,
+          action_id: "login_prompt",
           style: "primary",
         },
       ],

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -12,7 +12,7 @@ import {
   fetchChannelContext,
   formatContextForAgent,
   parseExplicitAgentSelection,
-  buildLinkAccountMessage,
+  buildLoginPromptMessage,
   buildErrorMessage,
   buildMarkdownMessage,
   getSlackRedirectBaseUrl,
@@ -86,11 +86,11 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       .limit(1);
 
     if (!userLink) {
-      // 3. User not linked - post link message
-      const linkUrl = buildLinkUrl(context.workspaceId, context.userId);
-      await postMessage(client, context.channelId, "Please link your account", {
+      // 3. User not logged in - post login message
+      const loginUrl = buildLoginUrl(context.workspaceId, context.userId);
+      await postMessage(client, context.channelId, "Please login first", {
         threadTs,
-        blocks: buildLinkAccountMessage(linkUrl),
+        blocks: buildLoginPromptMessage(loginUrl),
       });
       return;
     }
@@ -288,9 +288,9 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
 }
 
 /**
- * Build the account linking URL
+ * Build the login URL
  */
-function buildLinkUrl(workspaceId: string, slackUserId: string): string {
+function buildLoginUrl(workspaceId: string, slackUserId: string): string {
   const baseUrl = getSlackRedirectBaseUrl();
   const params = new URLSearchParams({
     w: workspaceId,

--- a/turbo/apps/web/src/lib/slack/index.ts
+++ b/turbo/apps/web/src/lib/slack/index.ts
@@ -44,7 +44,7 @@ export {
   buildAgentAddModal,
   buildAgentListMessage,
   buildErrorMessage,
-  buildLinkAccountMessage,
+  buildLoginPromptMessage,
   buildHelpMessage,
   buildSuccessMessage,
   buildMarkdownMessage,


### PR DESCRIPTION
## Summary
- Change login success message to use `postEphemeral` so only the user sees it
- Rename `buildLinkAccountMessage` to `buildLoginPromptMessage`
- Update all "link" wording to "login" for consistency

## Test plan
- [ ] Test `/vm0 login` command - should show ephemeral success message
- [ ] Test `@VM0` mention when not logged in - should show login prompt with "Login" button
- [ ] Verify success message is only visible to the user who logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)