### PR TITLE
feat(core): enable platform agents feature switch by default

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -26,7 +26,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   },
   [FeatureSwitchKey.PlatformAgents]: {
     maintainer: "ethan@vm0.ai",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.PlatformSecrets]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- Enable `platformAgents` feature switch by default (changed from `false` to `true`)

## Test plan
- [ ] Verify platform agents feature is now enabled by default
- [ ] Check sidebar shows agents navigation when feature is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)