### PR TITLE
refactor(runner): extract netns module and enhance firecracker client

### DIFF
--- a/turbo/apps/runner/src/commands/doctor.ts
+++ b/turbo/apps/runner/src/commands/doctor.ts
@@ -18,7 +18,7 @@ import {
   findMitmproxyProcess,
 } from "../lib/firecracker/process.js";
 import { isPortInUse } from "../lib/firecracker/network.js";
-import { SNAPSHOT_NETWORK } from "../lib/firecracker/netns-pool.js";
+import { SNAPSHOT_NETWORK } from "../lib/firecracker/netns.js";
 import { type VmId, createVmId } from "../lib/firecracker/vm-id.js";
 
 interface RunnerStatus {

--- a/turbo/apps/runner/src/lib/firecracker/netns.ts
+++ b/turbo/apps/runner/src/lib/firecracker/netns.ts
@@ -1,0 +1,82 @@
+/**
+ * Network Namespace Utilities
+ *
+ * Low-level utilities for network namespace operations.
+ * Used by netns-pool.ts for pooled namespaces and snapshot command for one-off namespaces.
+ */
+
+import { execCommand } from "../utils/exec.js";
+
+// ============ Snapshot Network Constants ============
+
+/**
+ * Fixed network configuration for snapshot VMs.
+ * These values are baked into the base snapshot and must match
+ * the namespace TAP device configuration.
+ *
+ * Since each VM runs in an isolated namespace, we can use fixed values
+ * for all VMs - no conflicts possible.
+ */
+export const SNAPSHOT_NETWORK = {
+  /** TAP device name inside namespace (must match Firecracker config) */
+  tapName: "vm0-tap",
+  /** Guest MAC address (locally administered, fixed for all snapshots) */
+  guestMac: "02:00:00:00:00:01",
+  /** Guest IP inside the VM (baked into snapshot) */
+  guestIp: "192.168.241.2",
+  /** Gateway IP (TAP device in namespace) */
+  gatewayIp: "192.168.241.1",
+  /** Netmask for /29 subnet (dotted decimal for kernel boot args) */
+  netmask: "255.255.255.248",
+  /** CIDR prefix length (for ip commands) */
+  prefixLen: 29,
+} as const;
+
+/**
+ * Generate kernel boot args for creating base snapshot.
+ * Only used when creating the initial snapshot, not when restoring.
+ */
+export function generateSnapshotNetworkBootArgs(): string {
+  const { guestIp, gatewayIp, netmask } = SNAPSHOT_NETWORK;
+  return `ip=${guestIp}::${gatewayIp}:${netmask}:vm0-guest:eth0:off`;
+}
+
+/**
+ * TAP device configuration
+ */
+interface TapConfig {
+  /** TAP device name */
+  tapName: string;
+  /** Gateway IP address with prefix length (e.g., "192.168.241.1/29") */
+  gatewayIpWithPrefix: string;
+}
+
+/**
+ * Create a network namespace with TAP device
+ *
+ * Creates a minimal namespace suitable for running a Firecracker VM.
+ * Does not set up veth pairs or iptables - use netns-pool for full connectivity.
+ */
+export async function createNetnsWithTap(
+  nsName: string,
+  tap: TapConfig,
+): Promise<void> {
+  // Create namespace
+  await execCommand(`ip netns add ${nsName}`);
+
+  // Create TAP device inside namespace
+  await execCommand(
+    `ip netns exec ${nsName} ip tuntap add ${tap.tapName} mode tap`,
+  );
+
+  // Configure TAP with gateway IP
+  await execCommand(
+    `ip netns exec ${nsName} ip addr add ${tap.gatewayIpWithPrefix} dev ${tap.tapName}`,
+  );
+
+  // Bring up TAP device
+  await execCommand(`ip netns exec ${nsName} ip link set ${tap.tapName} up`);
+
+  // Bring up loopback
+  await execCommand(`ip netns exec ${nsName} ip link set lo up`);
+}

--- a/turbo/apps/runner/src/lib/firecracker/vm.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vm.ts
@@ -15,13 +15,8 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import readline from "node:readline";
-import {
-  SNAPSHOT_NETWORK,
-  generateSnapshotNetworkBootArgs,
-  acquireNetns,
-  releaseNetns,
-  type PooledNetns,
-} from "./netns-pool.js";
+import { acquireNetns, releaseNetns, type PooledNetns } from "./netns-pool.js";
+import { SNAPSHOT_NETWORK, generateSnapshotNetworkBootArgs } from "./netns.js";
 import { acquireOverlay } from "./overlay-pool.js";
 import { FirecrackerClient } from "./client.js";
 import { createLogger } from "../logger.js";
@@ -162,8 +157,9 @@ export class FirecrackerVM {
     }
 
     try {
-      // Create working directory
+      // Create working directory and vsock subdirectory
       fs.mkdirSync(this.workDir, { recursive: true });
+      fs.mkdirSync(vmPaths.vsockDir(this.workDir), { recursive: true });
 
       // Acquire overlay and namespace in parallel for faster startup
       // Both pools are pre-warmed, so acquisition should be near-instant

--- a/turbo/apps/runner/src/lib/paths.ts
+++ b/turbo/apps/runner/src/lib/paths.ts
@@ -34,6 +34,9 @@ const VM_WORKSPACE_PREFIX = "vm0-";
  * Each runner instance has its own base directory
  */
 export const runnerPaths = {
+  /** Base directory used for snapshot generation (baseDir + /snapshot-gen) */
+  snapshotBaseDir: (baseDir: string) => path.join(baseDir, "snapshot-gen"),
+
   /** Overlay pool directory for pre-warmed VM overlays */
   overlayPool: (baseDir: string) => path.join(baseDir, "overlay-pool"),
 
@@ -46,6 +49,10 @@ export const runnerPaths = {
 
   /** Runner status file */
   statusFile: (baseDir: string) => path.join(baseDir, "status.json"),
+
+  /** Snapshot generation work directory */
+  snapshotWorkDir: (baseDir: string) =>
+    path.join(baseDir, "workspaces", ".snapshot-work"),
 
   /** Check if a directory name is a VM workspace */
   isVmWorkspace: (dirname: string) => dirname.startsWith(VM_WORKSPACE_PREFIX),
@@ -60,11 +67,20 @@ export const runnerPaths = {
  * These are file names inside each VM's work directory
  */
 export const vmPaths = {
-  /** Firecracker config file (used with --config-file --no-api) */
+  /** Firecracker config file (used with --config-file) */
   config: (workDir: string) => path.join(workDir, "config.json"),
 
-  /** Vsock UDS for host-guest communication */
-  vsock: (workDir: string) => path.join(workDir, "vsock.sock"),
+  /** Vsock directory for host-guest communication */
+  vsockDir: (workDir: string) => path.join(workDir, "vsock"),
+
+  /** Vsock UDS path for host-guest communication */
+  vsock: (workDir: string) => path.join(workDir, "vsock", "vsock.sock"),
+
+  /** Firecracker API socket (used with --api-sock) */
+  apiSock: (workDir: string) => path.join(workDir, "api.sock"),
+
+  /** Overlay filesystem for VM writes */
+  overlay: (workDir: string) => path.join(workDir, "overlay.ext4"),
 };
 
 /**

--- a/turbo/apps/runner/src/lib/utils/exec.ts
+++ b/turbo/apps/runner/src/lib/utils/exec.ts
@@ -1,0 +1,32 @@
+/**
+ * Shell Command Execution Utilities
+ */
+
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+
+/**
+ * Execute a shell command with optional sudo
+ *
+ * @param cmd - Command to execute
+ * @param sudo - Whether to run with sudo (default: true)
+ * @returns Command stdout trimmed
+ * @throws Error with command and stderr on failure
+ */
+export async function execCommand(
+  cmd: string,
+  sudo: boolean = true,
+): Promise<string> {
+  const fullCmd = sudo ? `sudo ${cmd}` : cmd;
+  try {
+    const { stdout } = await execAsync(fullCmd);
+    return stdout.trim();
+  } catch (error) {
+    const execError = error as { stderr?: string; message?: string };
+    throw new Error(
+      `Command failed: ${fullCmd}\n${execError.stderr || execError.message}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Extract SNAPSHOT_NETWORK and createNetnsWithTap into dedicated netns.ts module
- Add execCommand utility for shell execution
- Enhance FirecrackerClient with VM configuration APIs (machine, boot-source, network, vsock, start)
- Add vsockDir and snapshotBaseDir path helpers
- Update imports in vm.ts and doctor.ts

This is a prerequisite cleanup for the snapshot feature PR.

## Test plan
- [ ] CI passes
- [ ] Runner starts and runs VMs correctly

🤖 Generated with [Claude Code](https://claude.ai/code)