### PR TITLE
feat(storage): migrate storages from user-level to scope-level ownership

### DIFF
--- a/turbo/apps/web/app/v1/artifacts/[id]/versions/route.ts
+++ b/turbo/apps/web/app/v1/artifacts/[id]/versions/route.ts
@@ -13,6 +13,7 @@ import {
   authenticatePublicApi,
   isAuthSuccess,
 } from "../../../../../src/lib/public-api/auth";
+import { getUserScopeByClerkId } from "../../../../../src/lib/scope/scope-service";
 import {
   storages,
   storageVersions,
@@ -39,14 +40,30 @@ const router = tsr.router(publicArtifactVersionsContract, {
       };
     }
 
-    // Verify artifact exists and belongs to user
+    // Get user's scope
+    const userScope = await getUserScopeByClerkId(auth.userId);
+    if (!userScope) {
+      return {
+        status: 401 as const,
+        body: {
+          error: {
+            type: "authentication_error" as const,
+            code: "invalid_api_key",
+            message:
+              "Please set up your scope first. Login again with: vm0 login",
+          },
+        },
+      };
+    }
+
+    // Verify artifact exists and belongs to user's scope
     const [artifact] = await globalThis.services.db
       .select()
       .from(storages)
       .where(
         and(
           eq(storages.id, params.id),
-          eq(storages.userId, auth.userId),
+          eq(storages.scopeId, userScope.id),
           eq(storages.type, STORAGE_TYPE),
         ),
       )

--- a/turbo/apps/web/app/v1/artifacts/route.ts
+++ b/turbo/apps/web/app/v1/artifacts/route.ts
@@ -53,9 +53,9 @@ const router = tsr.router(publicArtifactsListContract, {
       };
     }
 
-    // Build query conditions - filter by user and type
+    // Build query conditions - filter by scope and type
     const conditions = [
-      eq(storages.userId, auth.userId),
+      eq(storages.scopeId, userScope.id),
       eq(storages.type, STORAGE_TYPE),
     ];
 

--- a/turbo/apps/web/app/v1/volumes/[id]/download/route.ts
+++ b/turbo/apps/web/app/v1/volumes/[id]/download/route.ts
@@ -9,6 +9,7 @@ import {
   authenticatePublicApi,
   isAuthSuccess,
 } from "../../../../../src/lib/public-api/auth";
+import { getUserScopeByClerkId } from "../../../../../src/lib/scope/scope-service";
 import {
   storages,
   storageVersions,
@@ -47,14 +48,30 @@ export async function GET(
     );
   }
 
-  // Verify volume exists and belongs to user
+  // Get user's scope
+  const userScope = await getUserScopeByClerkId(auth.userId);
+  if (!userScope) {
+    return NextResponse.json(
+      {
+        error: {
+          type: "authentication_error",
+          code: "invalid_api_key",
+          message:
+            "Please set up your scope first. Login again with: vm0 login",
+        },
+      },
+      { status: 401 },
+    );
+  }
+
+  // Verify volume exists and belongs to user's scope
   const [volume] = await globalThis.services.db
     .select()
     .from(storages)
     .where(
       and(
         eq(storages.id, id),
-        eq(storages.userId, auth.userId),
+        eq(storages.scopeId, userScope.id),
         eq(storages.type, STORAGE_TYPE),
       ),
     )

--- a/turbo/apps/web/app/v1/volumes/[id]/route.ts
+++ b/turbo/apps/web/app/v1/volumes/[id]/route.ts
@@ -13,6 +13,7 @@ import {
   authenticatePublicApi,
   isAuthSuccess,
 } from "../../../../src/lib/public-api/auth";
+import { getUserScopeByClerkId } from "../../../../src/lib/scope/scope-service";
 import { storages, storageVersions } from "../../../../src/db/schema/storage";
 import { eq, and } from "drizzle-orm";
 
@@ -36,6 +37,22 @@ const router = tsr.router(publicVolumeByIdContract, {
       };
     }
 
+    // Get user's scope
+    const userScope = await getUserScopeByClerkId(auth.userId);
+    if (!userScope) {
+      return {
+        status: 401 as const,
+        body: {
+          error: {
+            type: "authentication_error" as const,
+            code: "invalid_api_key",
+            message:
+              "Please set up your scope first. Login again with: vm0 login",
+          },
+        },
+      };
+    }
+
     // Find volume by ID
     const [volume] = await globalThis.services.db
       .select()
@@ -43,7 +60,7 @@ const router = tsr.router(publicVolumeByIdContract, {
       .where(
         and(
           eq(storages.id, params.id),
-          eq(storages.userId, auth.userId),
+          eq(storages.scopeId, userScope.id),
           eq(storages.type, STORAGE_TYPE),
         ),
       )

--- a/turbo/apps/web/app/v1/volumes/route.ts
+++ b/turbo/apps/web/app/v1/volumes/route.ts
@@ -53,9 +53,9 @@ const router = tsr.router(publicVolumesListContract, {
       };
     }
 
-    // Build query conditions - filter by user and type
+    // Build query conditions - filter by scope and type
     const conditions = [
-      eq(storages.userId, auth.userId),
+      eq(storages.scopeId, userScope.id),
       eq(storages.type, STORAGE_TYPE),
     ];
 

--- a/turbo/apps/web/src/db/migrations/0061_add_scope_id_to_storages.sql
+++ b/turbo/apps/web/src/db/migrations/0061_add_scope_id_to_storages.sql
@@ -1,0 +1,30 @@
+-- Add scope support to storages table
+-- Follows the same pattern as agent_composes migration (0046)
+-- This enables scope-based access control for storages (volumes and artifacts)
+
+-- Step 1: Add scope_id column (nullable initially)
+ALTER TABLE "storages" ADD COLUMN "scope_id" uuid REFERENCES "scopes"("id");
+--> statement-breakpoint
+
+-- Step 2: Create index for scope lookups
+CREATE INDEX IF NOT EXISTS "idx_storages_scope" ON "storages" USING btree ("scope_id");
+--> statement-breakpoint
+
+-- Step 3: Populate scope_id from user's personal scope
+UPDATE "storages" st
+SET "scope_id" = s.id
+FROM "scopes" s
+WHERE s.owner_id = st.user_id AND s.type = 'personal';
+--> statement-breakpoint
+
+-- Step 4: Make scope_id NOT NULL (all rows should have scope now)
+ALTER TABLE "storages" ALTER COLUMN "scope_id" SET NOT NULL;
+--> statement-breakpoint
+
+-- Step 5: Drop old unique index
+DROP INDEX IF EXISTS "idx_storages_user_name_type";
+--> statement-breakpoint
+
+-- Step 6: Create new unique index on (scope_id, name, type)
+CREATE UNIQUE INDEX "idx_storages_scope_name_type"
+  ON "storages" ("scope_id", "name", "type");

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -428,6 +428,13 @@
       "when": 1768500000000,
       "tag": "0060_add_auth_method_to_model_providers",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1768600000000,
+      "tag": "0061_add_scope_id_to_storages",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -17,14 +17,14 @@ const log = logger("storage");
 
 /**
  * Resolve version ID from version string
- * @param userId - User ID for storage access
+ * @param scopeId - Scope ID for storage access
  * @param storageName - Storage name
  * @param storageType - Storage type ("volume" or "artifact")
  * @param version - Version string ("latest" or specific hash)
  * @returns Version ID and S3 key
  */
 async function resolveVersion(
-  userId: string,
+  scopeId: string,
   storageName: string,
   storageType: "volume" | "artifact",
   version: string,
@@ -36,7 +36,7 @@ async function resolveVersion(
     .from(storages)
     .where(
       and(
-        eq(storages.userId, userId),
+        eq(storages.scopeId, scopeId),
         eq(storages.name, storageName),
         eq(storages.type, storageType),
       ),
@@ -93,7 +93,7 @@ async function resolveVersion(
  *
  * @param agentConfig - Agent configuration containing volume definitions
  * @param vars - Template variables for placeholder replacement
- * @param userId - User ID for storage access
+ * @param scopeId - Scope ID for storage access
  * @param artifactName - Artifact storage name
  * @param artifactVersion - Artifact version (defaults to "latest")
  * @param volumeVersionOverrides - Optional volume version overrides
@@ -104,7 +104,7 @@ async function resolveVersion(
 export async function prepareStorageManifest(
   agentConfig: AgentVolumeConfig | undefined,
   vars: Record<string, string>,
-  userId: string,
+  scopeId: string,
   artifactName?: string,
   artifactVersion?: string,
   volumeVersionOverrides?: Record<string, string>,
@@ -148,7 +148,7 @@ export async function prepareStorageManifest(
   // Process all volumes and artifact in parallel
   const volumePromises = volumeResult.volumes.map(async (volume) => {
     const { versionId, s3Key } = await resolveVersion(
-      userId,
+      scopeId,
       volume.vasStorageName,
       "volume",
       volume.vasVersion,
@@ -196,7 +196,7 @@ export async function prepareStorageManifest(
   const artifactPromise = artifactSource
     ? (async () => {
         const { versionId, s3Key } = await resolveVersion(
-          userId,
+          scopeId,
           artifactSource.vasStorageName,
           "artifact",
           artifactSource.vasVersion,


### PR DESCRIPTION
## Summary

This PR migrates storages (volumes and artifacts) from user-level to scope-level ownership, which is a prerequisite for the agent sharing feature.

- Added `scope_id` column to storages table with FK to scopes
- Updated unique index from `(user_id, name, type)` to `(scope_id, name, type)`
- Backfilled existing storages with scope from user's personal scope
- Updated all API routes to query and create storages by `scope_id`
- Kept `user_id` column for audit trail (who created the storage)
- S3 paths now use scope slug instead of user_id for better organization

The migration follows the proven pattern from agent_composes (0046).

## Test plan

- [x] All 839 existing tests pass
- [x] Storage API tests (prepare, commit, download, list) pass
- [x] Public API v1 tests for volumes and artifacts pass
- [x] Lint and format checks pass

Closes #2252

🤖 Generated with [Claude Code](https://claude.com/claude-code)