### PR TITLE
refactor(runner): move workdir creation and vsock listener before vm start

### DIFF
--- a/turbo/apps/runner/src/lib/firecracker/vm.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vm.ts
@@ -157,10 +157,6 @@ export class FirecrackerVM {
     }
 
     try {
-      // Create working directory and vsock subdirectory
-      fs.mkdirSync(this.workDir, { recursive: true });
-      fs.mkdirSync(vmPaths.vsockDir(this.workDir), { recursive: true });
-
       // Acquire overlay and namespace in parallel for faster startup
       // Both pools are pre-warmed, so acquisition should be near-instant
       // Use allSettled to handle partial failures and avoid resource leaks


### PR DESCRIPTION
## Summary
- Move workDir and vsockDir creation from `vm.start()` to `executeJob()`
- Start vsock listener BEFORE VM starts to avoid race condition
- Guest's vsock-agent connects immediately after boot/resume

This is a prerequisite for the snapshot feature PR.

## Test plan
- [ ] CI passes
- [ ] Runner benchmark passes

🤖 Generated with [Claude Code](https://claude.ai/code)