### PR TITLE
refactor(runner): extract firecracker config builder to separate module

### DIFF
--- a/turbo/apps/runner/src/lib/firecracker/config.ts
+++ b/turbo/apps/runner/src/lib/firecracker/config.ts
@@ -1,0 +1,128 @@
+/**
+ * Firecracker Configuration Types and Builders
+ *
+ * Shared types and utilities for building Firecracker VM configurations.
+ */
+
+import { SNAPSHOT_NETWORK, generateSnapshotNetworkBootArgs } from "./netns.js";
+
+/**
+ * Firecracker static configuration format
+ * See: https://github.com/firecracker-microvm/firecracker/blob/main/docs/getting-started.md
+ */
+export interface FirecrackerConfig {
+  "boot-source": {
+    kernel_image_path: string;
+    boot_args: string;
+  };
+  drives: Array<{
+    drive_id: string;
+    path_on_host: string;
+    is_root_device: boolean;
+    is_read_only: boolean;
+  }>;
+  "machine-config": {
+    vcpu_count: number;
+    mem_size_mib: number;
+  };
+  "network-interfaces": Array<{
+    iface_id: string;
+    guest_mac: string;
+    host_dev_name: string;
+  }>;
+  vsock: {
+    guest_cid: number;
+    uds_path: string;
+  };
+}
+
+/**
+ * Parameters for building Firecracker configuration
+ */
+interface FirecrackerConfigParams {
+  kernelPath: string;
+  rootfsPath: string;
+  overlayPath: string;
+  vsockPath: string;
+  vcpus: number;
+  memoryMb: number;
+}
+
+/**
+ * Build kernel boot arguments
+ *
+ * Boot args:
+ *   - console=ttyS0: serial console output
+ *   - reboot=k: use keyboard controller for reboot
+ *   - panic=1: reboot after 1 second on kernel panic
+ *   - pci=off: disable PCI bus (not needed in microVM)
+ *   - nomodules: skip module loading (not needed in microVM)
+ *   - random.trust_cpu=on: trust CPU RNG, skip entropy wait
+ *   - quiet loglevel=0: minimize kernel log output
+ *   - nokaslr: disable kernel address space randomization
+ *   - audit=0: disable kernel auditing
+ *   - numa=off: disable NUMA (single node)
+ *   - mitigations=off: disable CPU vulnerability mitigations
+ *   - noresume: skip hibernation resume check
+ *   - init=/sbin/vm-init: use vm-init (Rust binary) for filesystem setup and vsock-agent
+ *   - ip=...: network configuration (fixed IPs from SNAPSHOT_NETWORK)
+ */
+function buildBootArgs(): string {
+  const networkBootArgs = generateSnapshotNetworkBootArgs();
+  return `console=ttyS0 reboot=k panic=1 pci=off nomodules random.trust_cpu=on quiet loglevel=0 nokaslr audit=0 numa=off mitigations=off noresume init=/sbin/vm-init ${networkBootArgs}`;
+}
+
+/**
+ * Build Firecracker configuration
+ *
+ * Creates the JSON configuration for Firecracker's --config-file option.
+ */
+export function buildFirecrackerConfig(
+  params: FirecrackerConfigParams,
+): FirecrackerConfig {
+  const bootArgs = buildBootArgs();
+
+  return {
+    "boot-source": {
+      kernel_image_path: params.kernelPath,
+      boot_args: bootArgs,
+    },
+    drives: [
+      // Base drive (squashfs, read-only, shared across VMs)
+      // Mounted as /dev/vda inside the VM
+      {
+        drive_id: "rootfs",
+        path_on_host: params.rootfsPath,
+        is_root_device: true,
+        is_read_only: true,
+      },
+      // Overlay drive (ext4, read-write, per-VM)
+      // Mounted as /dev/vdb inside the VM
+      // The vm-init script combines these using overlayfs
+      {
+        drive_id: "overlay",
+        path_on_host: params.overlayPath,
+        is_root_device: false,
+        is_read_only: false,
+      },
+    ],
+    "machine-config": {
+      vcpu_count: params.vcpus,
+      mem_size_mib: params.memoryMb,
+    },
+    "network-interfaces": [
+      {
+        // Network interface uses fixed config from SNAPSHOT_NETWORK
+        // TAP device is inside the namespace, created by netns-pool
+        iface_id: "eth0",
+        guest_mac: SNAPSHOT_NETWORK.guestMac,
+        host_dev_name: SNAPSHOT_NETWORK.tapName,
+      },
+    ],
+    // Guest CID 3 is the standard guest identifier (CID 0=hypervisor, 1=local, 2=host)
+    vsock: {
+      guest_cid: 3,
+      uds_path: params.vsockPath,
+    },
+  };
+}

--- a/turbo/apps/runner/src/lib/firecracker/vm.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vm.ts
@@ -16,42 +16,13 @@ import { spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import readline from "node:readline";
 import { acquireNetns, releaseNetns, type PooledNetns } from "./netns-pool.js";
-import { SNAPSHOT_NETWORK, generateSnapshotNetworkBootArgs } from "./netns.js";
+import { SNAPSHOT_NETWORK } from "./netns.js";
 import { acquireOverlay } from "./overlay-pool.js";
 import { FirecrackerClient } from "./client.js";
 import { createLogger } from "../logger.js";
 import { vmPaths } from "../paths.js";
 import type { VmId } from "./vm-id.js";
-
-/**
- * Firecracker static configuration format
- * See: https://github.com/firecracker-microvm/firecracker/blob/main/docs/getting-started.md
- */
-interface FirecrackerConfig {
-  "boot-source": {
-    kernel_image_path: string;
-    boot_args: string;
-  };
-  drives: Array<{
-    drive_id: string;
-    path_on_host: string;
-    is_root_device: boolean;
-    is_read_only: boolean;
-  }>;
-  "machine-config": {
-    vcpu_count: number;
-    mem_size_mib: number;
-  };
-  "network-interfaces": Array<{
-    iface_id: string;
-    guest_mac: string;
-    host_dev_name: string;
-  }>;
-  vsock: {
-    guest_cid: number;
-    uds_path: string;
-  };
-}
+import { buildFirecrackerConfig, type FirecrackerConfig } from "./config.js";
 
 const logger = createLogger("VM");
 
@@ -372,78 +343,26 @@ export class FirecrackerVM {
 
   /**
    * Build Firecracker configuration object
-   *
-   * Creates the JSON configuration for Firecracker's --config-file option.
-   * Boot args:
-   *   - console=ttyS0: serial console output
-   *   - reboot=k: use keyboard controller for reboot
-   *   - panic=1: reboot after 1 second on kernel panic
-   *   - pci=off: disable PCI bus (not needed in microVM)
-   *   - nomodules: skip module loading (not needed in microVM)
-   *   - random.trust_cpu=on: trust CPU RNG, skip entropy wait
-   *   - quiet loglevel=0: minimize kernel log output
-   *   - nokaslr: disable kernel address space randomization
-   *   - audit=0: disable kernel auditing
-   *   - numa=off: disable NUMA (single node)
-   *   - mitigations=off: disable CPU vulnerability mitigations
-   *   - noresume: skip hibernation resume check
-   *   - init=/sbin/vm-init: use vm-init (Rust binary) for filesystem setup and vsock-agent
-   *   - ip=...: network configuration (fixed IPs from SNAPSHOT_NETWORK)
    */
   private buildConfig(): FirecrackerConfig {
     if (!this.netns || !this.vmOverlayPath) {
       throw new Error("VM not properly initialized");
     }
 
-    // Use fixed network boot args for snapshot compatibility
-    const networkBootArgs = generateSnapshotNetworkBootArgs();
-    const bootArgs = `console=ttyS0 reboot=k panic=1 pci=off nomodules random.trust_cpu=on quiet loglevel=0 nokaslr audit=0 numa=off mitigations=off noresume init=/sbin/vm-init ${networkBootArgs}`;
+    const config = buildFirecrackerConfig({
+      kernelPath: this.config.kernelPath,
+      rootfsPath: this.config.rootfsPath,
+      overlayPath: this.vmOverlayPath,
+      vsockPath: this.vsockPath,
+      vcpus: this.config.vcpus,
+      memoryMb: this.config.memoryMb,
+    });
 
-    logger.log(`[VM ${this.config.vmId}] Boot args: ${bootArgs}`);
+    logger.log(
+      `[VM ${this.config.vmId}] Boot args: ${config["boot-source"].boot_args}`,
+    );
 
-    return {
-      "boot-source": {
-        kernel_image_path: this.config.kernelPath,
-        boot_args: bootArgs,
-      },
-      drives: [
-        // Base drive (squashfs, read-only, shared across VMs)
-        // Mounted as /dev/vda inside the VM
-        {
-          drive_id: "rootfs",
-          path_on_host: this.config.rootfsPath,
-          is_root_device: true,
-          is_read_only: true,
-        },
-        // Overlay drive (ext4, read-write, per-VM)
-        // Mounted as /dev/vdb inside the VM
-        // The vm-init script combines these using overlayfs
-        {
-          drive_id: "overlay",
-          path_on_host: this.vmOverlayPath,
-          is_root_device: false,
-          is_read_only: false,
-        },
-      ],
-      "machine-config": {
-        vcpu_count: this.config.vcpus,
-        mem_size_mib: this.config.memoryMb,
-      },
-      "network-interfaces": [
-        {
-          // Network interface uses fixed config from SNAPSHOT_NETWORK
-          // TAP device is inside the namespace, created by netns-pool
-          iface_id: "eth0",
-          guest_mac: SNAPSHOT_NETWORK.guestMac,
-          host_dev_name: SNAPSHOT_NETWORK.tapName,
-        },
-      ],
-      // Guest CID 3 is the standard guest identifier (CID 0=hypervisor, 1=local, 2=host)
-      vsock: {
-        guest_cid: 3,
-        uds_path: this.vsockPath,
-      },
-    };
+    return config;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Extract `FirecrackerConfig` interface and config building logic from vm.ts to a new `config.ts` module
- This allows reuse by the snapshot command without duplicating code
- Simplifies vm.ts by delegating config building to the shared module

## Changes

- New file: `apps/runner/src/lib/firecracker/config.ts`
  - `FirecrackerConfig` interface (moved from vm.ts)
  - `buildBootArgs()` function (extracted boot args logic)
  - `buildFirecrackerConfig()` function (builds the complete config)

- Modified: `apps/runner/src/lib/firecracker/vm.ts`
  - Import `buildFirecrackerConfig` and `FirecrackerConfig` from config.ts
  - Simplified `buildConfig()` method to use shared function

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] Knip passes (no unused exports)
- [ ] CI build and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)