### PR TITLE
refactor(e2e): remove mutually exclusive options error tests from telemetry

### DIFF
--- a/e2e/tests/02-parallel/t15-vm0-telemetry.bats
+++ b/e2e/tests/02-parallel/t15-vm0-telemetry.bats
@@ -154,11 +154,8 @@ teardown() {
     # If more exist, should see "Use --tail to see more"
     echo "# Tail option works correctly"
 
-    # Step 9: Verify mutually exclusive options are enforced
-    echo "# Step 9: Testing mutually exclusive options..."
-    run $CLI_COMMAND logs "$RUN_ID" --agent --system
-
-    assert_failure
-    assert_output --partial "mutually exclusive"
-    echo "# Mutually exclusive options enforced correctly"
+    # Note: Mutually exclusive options validation (--agent, --system, etc.)
+    # is tested in CLI integration tests:
+    # turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+    #   - "should exit with error when multiple log types specified"
 }

--- a/e2e/tests/03-experimental-runner/t07-runner-telemetry.bats
+++ b/e2e/tests/03-experimental-runner/t07-runner-telemetry.bats
@@ -183,11 +183,8 @@ teardown() {
     assert_success
     echo "# Tail option OK"
 
-    # Step 9: Verify mutually exclusive options
-    echo "# Step 9: Testing mutually exclusive options..."
-    run $CLI_COMMAND logs "$RUN_ID" --agent --system
-
-    assert_failure
-    assert_output --partial "mutually exclusive"
-    echo "# Mutually exclusive OK"
+    # Note: Mutually exclusive options validation (--agent, --system, etc.)
+    # is tested in CLI integration tests:
+    # turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+    #   - "should exit with error when multiple log types specified"
 }


### PR DESCRIPTION
## Summary
Remove Step 9 error tests from telemetry E2E tests per testing guidelines (AP-4).

## Changes
| File | Change |
|------|--------|
| `t15-vm0-telemetry.bats` | Remove Step 9 (mutually exclusive options test) |
| `t07-runner-telemetry.bats` | Remove Step 9 (same) |

## Integration Test Coverage
The removed tests validated `--agent --system` mutually exclusive options, which is covered by:
- `logs/__tests__/index.test.ts:507-522` - "should exit with error when multiple log types specified"

Both test the same code path: `getLogType()` function in `logs/index.ts:146-166`.

## Test plan
- [x] Verified integration test passes: `pnpm vitest run -t "multiple log types"`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)