### PR TITLE
fix(cli): remove shell option from claude command spawn

### DIFF
--- a/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
@@ -33,7 +33,6 @@ async function runClaudeCommand(
 ): Promise<ClaudeCommandResult> {
   return new Promise((resolve) => {
     const child = spawn("claude", args, {
-      shell: true,
       stdio: ["inherit", "pipe", "pipe"],
       cwd,
     });


### PR DESCRIPTION
## Summary
- Remove `shell: true` from spawn options when running claude command during onboarding
- Prevents shell interpretation issues and improves cross-platform compatibility

## Test plan
- [ ] Run `vm0 onboard` to verify claude command spawning works correctly
- [ ] Test on different platforms (macOS, Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)