### PR TITLE
fix(vsock-agent): don't reconnect after shutdown, reduce reconnect delay

### DIFF
--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -2,7 +2,6 @@
 // Deployment: Added buildkit cache retry mechanism (issue #1328)
 // CI: Refactored E2E tests with setup_file() - parallel tests use 45s timeout (issue #1555)
 // Perf: Replaced Python vsock-agent with Rust for 16x faster VM startup (issue #1668)
-// CI: Use graceful shutdown for runner to prevent orphaned IP registry entries (issue #2060)
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { doctorCommand } from "./commands/doctor.js";


### PR DESCRIPTION
## Summary
- Add `SHUTDOWN_RECEIVED` flag to track when shutdown command is received
- After shutdown ack is sent and connection closes, exit gracefully instead of attempting to reconnect
- Reduce reconnect delay from 100ms to 10ms for faster reconnect after snapshot restore

## Problem
Previously, after host sent shutdown command and vsock-agent acknowledged it, the agent would detect "Host disconnected" and attempt to reconnect up to 50 times before the VM was killed. This caused unnecessary log noise and wasted CPU cycles.

## Solution
Set a flag when shutdown is received. After connection closes, check this flag and exit gracefully if shutdown was requested.

Also reduced reconnect delay from 100ms to 10ms to speed up reconnection after snapshot restore (total timeout: 50 × 10ms = 500ms instead of 5s).

## Test plan
- [ ] Run benchmark command and verify no reconnect attempts after shutdown
- [ ] Verify snapshot restore still works with faster reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)