### PR TITLE
chore(scripts): add vhs installation script

### DIFF
--- a/scripts/install-vhs.sh
+++ b/scripts/install-vhs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+sudo apt update
+sudo apt install -y ffmpeg ttyd
+
+ARCH=$(dpkg --print-architecture)
+wget "https://github.com/charmbracelet/vhs/releases/download/v0.10.0/vhs_0.10.0_Linux_${ARCH}.tar.gz" -O /tmp/vhs.tar.gz
+tar zxvf /tmp/vhs.tar.gz -C /tmp
+mv /tmp/vhs_0.10.0_Linux_${ARCH}/vhs ~/.local/bin/


### PR DESCRIPTION
## Summary
- Adds a script to install VHS for terminal recording
- Installs required dependencies (ffmpeg, ttyd)
- Downloads and extracts VHS binary to ~/.local/bin

## Test plan
- [ ] Run the script on a clean environment
- [ ] Verify VHS is installed and working

🤖 Generated with [Claude Code](https://claude.com/claude-code)