### PR TITLE
fix(web): handle invalid slack auth errors with auto-cleanup

### DIFF
--- a/turbo/apps/web/src/lib/slack/client.ts
+++ b/turbo/apps/web/src/lib/slack/client.ts
@@ -1,5 +1,23 @@
-import { WebClient } from "@slack/web-api";
+import { WebClient, type WebAPICallResult } from "@slack/web-api";
 import type { Block, KnownBlock, View } from "@slack/web-api";
+
+/**
+ * Check if an error is a Slack invalid_auth error
+ * This happens when the bot token is revoked, expired, or invalid
+ */
+export function isSlackInvalidAuthError(error: unknown): boolean {
+  if (
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    error.code === "slack_webapi_platform_error" &&
+    "data" in error
+  ) {
+    const data = error.data as WebAPICallResult;
+    return data.error === "invalid_auth";
+  }
+  return false;
+}
 
 /**
  * Create a Slack Web API client

--- a/turbo/apps/web/src/lib/slack/index.ts
+++ b/turbo/apps/web/src/lib/slack/index.ts
@@ -37,6 +37,7 @@ export {
   openModal,
   updateModal,
   exchangeOAuthCode,
+  isSlackInvalidAuthError,
 } from "./client";
 
 // Block Kit builders


### PR DESCRIPTION
## Summary
- Add `isSlackInvalidAuthError` helper to detect Slack `invalid_auth` errors when bot tokens are revoked or expired
- Automatically delete invalid Slack installations when auth errors occur, prompting users to re-login
- Make confirmation messages ephemeral (only visible to the user who triggered the action) for agent add/remove/update operations
- Pass `channel_id` to login URL for better UX after re-authentication
- Refactor modal update handling with dedicated `updateModalView`, `handleAgentAddSelection`, and `handleAgentUpdateSelection` helper functions

## Test plan
- [ ] Manually test Slack commands work normally with valid bot token
- [ ] Verify confirmation messages are only visible to the user who triggered them
- [ ] Test that invalid auth errors clear the installation and prompt for re-login
- [ ] Verify modal updates still work correctly after refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)