### PR TITLE
fix(vsock-agent): improve error handling (mutex poison + decoder protocol errors)

### DIFF
--- a/crates/vsock-agent/src/lib.rs
+++ b/crates/vsock-agent/src/lib.rs
@@ -543,7 +543,8 @@ impl Decoder {
         }
     }
 
-    fn decode(&mut self, data: &[u8]) -> Vec<(u8, u32, Vec<u8>)> {
+    /// Decode messages from data. Returns Err on protocol error (caller should reconnect).
+    fn decode(&mut self, data: &[u8]) -> std::io::Result<Vec<(u8, u32, Vec<u8>)>> {
         self.buf.extend_from_slice(data);
         let mut messages = Vec::new();
 
@@ -554,13 +555,19 @@ impl Decoder {
             if length > MAX_MESSAGE_SIZE {
                 log("ERROR", &format!("Message too large: {}", length));
                 self.buf.clear();
-                break;
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Message too large: {}", length),
+                ));
             }
 
             if length < 5 {
                 log("ERROR", &format!("Message too small: {}", length));
                 self.buf.clear();
-                break;
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Message too small: {}", length),
+                ));
             }
 
             let total = HEADER_SIZE + length;
@@ -576,7 +583,7 @@ impl Decoder {
             self.buf.drain(..total);
         }
 
-        messages
+        Ok(messages)
     }
 }
 
@@ -655,7 +662,7 @@ pub fn handle_connection(stream: UnixStream) -> std::io::Result<()> {
             break;
         }
 
-        for (msg_type, seq, payload) in decoder.decode(&buf[..n]) {
+        for (msg_type, seq, payload) in decoder.decode(&buf[..n])? {
             // Handle spawn_watch separately since it needs the writer Arc
             let response = if msg_type == MSG_SPAWN_WATCH {
                 Some(handle_spawn_watch(&payload, seq, Arc::clone(&writer)))

--- a/crates/vsock-agent/src/lib.rs
+++ b/crates/vsock-agent/src/lib.rs
@@ -491,9 +491,8 @@ fn handle_spawn_watch(payload: &[u8], seq: u32, writer: Arc<Mutex<UnixStream>>) 
 
                 // Send process_exit notification
                 let exit_msg = encode_process_exit(pid, result.0, &result.1, &result.2);
-                if let Ok(mut w) = writer.lock()
-                    && let Err(e) = w.write_all(&exit_msg)
-                {
+                let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
+                if let Err(e) = w.write_all(&exit_msg) {
                     log("ERROR", &format!("Failed to send process_exit: {}", e));
                 }
             });
@@ -642,7 +641,7 @@ pub fn handle_connection(stream: UnixStream) -> std::io::Result<()> {
     // Send ready signal
     {
         let ready = encode(MSG_READY, 0, &[]);
-        let mut w = writer.lock().unwrap();
+        let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
         w.write_all(&ready)?;
     }
     log("INFO", "Sent ready signal");
@@ -665,7 +664,7 @@ pub fn handle_connection(stream: UnixStream) -> std::io::Result<()> {
             };
 
             if let Some(msg) = response {
-                let mut w = writer.lock().unwrap();
+                let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
                 w.write_all(&msg)?;
             }
         }

--- a/turbo/apps/runner/src/lib/firecracker/vsock.ts
+++ b/turbo/apps/runner/src/lib/firecracker/vsock.ts
@@ -819,4 +819,19 @@ export class VsockClient implements GuestClient {
     // Clean up cached exits
     this.cachedExits.clear();
   }
+
+  /**
+   * Send raw bytes directly to the socket (for testing only)
+   *
+   * This allows tests to send malformed messages to verify the agent's
+   * protocol error handling (e.g., oversized messages).
+   *
+   * @internal This method is only for testing purposes
+   */
+  sendRawForTesting(data: Buffer): void {
+    if (!this.connected || !this.socket) {
+      throw new Error("Not connected - call waitForGuestConnection() first");
+    }
+    this.socket.write(data);
+  }
 }


### PR DESCRIPTION
## Summary
Part of #2284 - addresses two high/medium priority issues from vsock-agent code review:

1. **Mutex Poison Handling** - Standardize to use `unwrap_or_else(|e| e.into_inner())` for consistent recovery
2. **Decoder Protocol Errors** - Return `Result` instead of silently clearing buffer, enabling clean reconnection

## Changes

### Mutex Poison Fix
- Line 498: Background thread sending `process_exit` - was silently skipping, now recovers
- Line 645: Send ready signal - was panicking, now recovers  
- Line 668: Main loop sending response - was panicking, now recovers

### Decoder Protocol Error Fix
- `decode()` now returns `std::io::Result<Vec<...>>` instead of `Vec<...>`
- On protocol errors (oversized/undersized messages), returns `Err` which propagates via `?`
- Caller disconnects cleanly, triggering agent reconnection

## Test Plan
- [x] Added `sendRawForTesting()` method to VsockClient for testing
- [x] Added integration test that sends malformed message and verifies reconnection
- [x] All 68 vsock tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)