### PR TITLE
feat(model-provider): add Z.AI (GLM) support

### DIFF
--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -141,6 +141,25 @@ export const MODEL_PROVIDER_TYPES = {
     models: ["deepseek-chat"] as string[],
     defaultModel: "deepseek-chat",
   },
+  "zai-api-key": {
+    framework: "claude-code" as const,
+    credentialName: "ZAI_API_KEY",
+    label: "Z.AI (GLM)",
+    credentialLabel: "API key",
+    helpText: "Get your API key at: https://z.ai/model-api",
+    environmentMapping: {
+      ANTHROPIC_AUTH_TOKEN: "$credential",
+      ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic",
+      ANTHROPIC_MODEL: "$model",
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "$model",
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "$model",
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: "$model",
+      CLAUDE_CODE_SUBAGENT_MODEL: "$model",
+      API_TIMEOUT_MS: "3000000",
+    } as Record<string, string>,
+    models: ["GLM-4.7", "GLM-4.5-Air"] as string[],
+    defaultModel: "GLM-4.7",
+  },
   "aws-bedrock": {
     framework: "claude-code" as const,
     label: "AWS Bedrock",
@@ -219,6 +238,7 @@ export const modelProviderTypeSchema = z.enum([
   "moonshot-api-key",
   "minimax-api-key",
   "deepseek-api-key",
+  "zai-api-key",
   "aws-bedrock",
 ]);
 


### PR DESCRIPTION
## Summary

- Add Z.AI (GLM) as a new model provider with GLM-4.7 and GLM-4.5-Air models
- Uses Anthropic-compatible API endpoint at `api.z.ai/api/anthropic`
- Follows the established pattern from Kimi (Moonshot), MiniMax, and DeepSeek providers

## Changes

Only one file modified:
- `turbo/packages/core/src/contracts/model-providers.ts` - Added provider config and Zod schema entry

## Configuration

| Setting | Value |
|---------|-------|
| Provider Type | `zai-api-key` |
| Display Label | `Z.AI (GLM)` |
| Credential Name | `ZAI_API_KEY` |
| Base URL | `https://api.z.ai/api/anthropic` |
| Models | `GLM-4.7`, `GLM-4.5-Air` |
| Default Model | `GLM-4.7` |
| API Timeout | `3000000` |

## Test plan

- [ ] Verify type check passes
- [ ] Verify lint passes
- [ ] Verify existing tests pass
- [ ] Verify provider appears in CLI interactive setup menu
- [ ] Verify model selection works correctly

Closes #2283

🤖 Generated with [Claude Code](https://claude.com/claude-code)