### PR TITLE
feat(web): add slack session continuation and binding preservation

### DIFF
--- a/turbo/apps/web/app/api/slack/commands/route.ts
+++ b/turbo/apps/web/app/api/slack/commands/route.ts
@@ -193,16 +193,16 @@ async function handleLogoutCommand(
       blocks: buildErrorMessage("You are not logged in."),
     });
   }
-  // Delete user link and associated bindings
-  await globalThis.services.db
-    .delete(slackBindings)
-    .where(eq(slackBindings.slackUserLinkId, userLink.id));
+  // Delete user link only - bindings will be orphaned (slackUserLinkId set to NULL)
+  // They will be restored when the user logs in again
   await globalThis.services.db
     .delete(slackUserLinks)
     .where(eq(slackUserLinks.id, userLink.id));
   return NextResponse.json({
     response_type: "ephemeral",
-    blocks: buildSuccessMessage("You have been logged out successfully."),
+    blocks: buildSuccessMessage(
+      "You have been logged out successfully.\n\nYour agent configurations have been preserved and will be restored when you log in again.",
+    ),
   });
 }
 

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -687,10 +687,9 @@ async function handleAgentAddSubmission(
     enabled: true,
   });
 
-  // Fire-and-forget: confirmation message is non-critical, failure should not
-  // affect the binding creation. Log errors for debugging but don't propagate.
+  // Await message to prevent serverless function from terminating before it's sent
   if (channelId) {
-    sendConfirmationMessage(
+    await sendConfirmationMessage(
       payload.team.id,
       agentName,
       channelId,
@@ -752,9 +751,9 @@ async function handleAgentRemoveSubmission(
     .delete(slackBindings)
     .where(inArray(slackBindings.id, selectedAgentIds));
 
-  // Send confirmation message to channel
+  // Await message to prevent serverless function from terminating before it's sent
   if (channelId && agentNames.length > 0) {
-    sendRemovalConfirmationMessage(
+    await sendRemovalConfirmationMessage(
       payload.team.id,
       agentNames,
       channelId,
@@ -930,9 +929,9 @@ async function handleAgentUpdateSubmission(
     .set({ encryptedSecrets })
     .where(eq(slackBindings.id, bindingId));
 
-  // Send confirmation message
+  // Await message to prevent serverless function from terminating before it's sent
   if (channelId) {
-    sendUpdateConfirmationMessage(
+    await sendUpdateConfirmationMessage(
       payload.team.id,
       binding.agentName,
       Object.keys(newSecrets),

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -679,6 +679,8 @@ async function handleAgentAddSubmission(
   // Create binding
   await globalThis.services.db.insert(slackBindings).values({
     slackUserLinkId: userLink.id,
+    vm0UserId: userLink.vm0UserId,
+    slackWorkspaceId: payload.team.id,
     composeId: formValues.composeId,
     agentName,
     encryptedSecrets,

--- a/turbo/apps/web/app/slack/link/actions.ts
+++ b/turbo/apps/web/app/slack/link/actions.ts
@@ -1,11 +1,12 @@
 "use server";
 
 import { auth } from "@clerk/nextjs/server";
-import { eq, and } from "drizzle-orm";
+import { eq, and, isNull } from "drizzle-orm";
 import { initServices } from "../../../src/lib/init-services";
 import { env } from "../../../src/env";
 import { slackUserLinks } from "../../../src/db/schema/slack-user-link";
 import { slackInstallations } from "../../../src/db/schema/slack-installation";
+import { slackBindings } from "../../../src/db/schema/slack-binding";
 import { decryptCredentialValue } from "../../../src/lib/crypto/secrets-encryption";
 import { createSlackClient } from "../../../src/lib/slack";
 
@@ -108,6 +109,16 @@ export async function linkSlackAccount(
 
   if (existingLink) {
     if (existingLink.vm0UserId === userId) {
+      // Send success message even for already linked users
+      if (channelId) {
+        sendSuccessMessage(
+          installation.encryptedBotToken,
+          channelId,
+          slackUserId,
+        ).catch((error) => {
+          console.error("Error sending Slack message:", error);
+        });
+      }
       return { success: true, alreadyLinked: true };
     }
     return {
@@ -117,11 +128,35 @@ export async function linkSlackAccount(
   }
 
   // Create the link
-  await globalThis.services.db.insert(slackUserLinks).values({
-    slackUserId,
-    slackWorkspaceId: workspaceId,
-    vm0UserId: userId,
-  });
+  const [newUserLink] = await globalThis.services.db
+    .insert(slackUserLinks)
+    .values({
+      slackUserId,
+      slackWorkspaceId: workspaceId,
+      vm0UserId: userId,
+    })
+    .returning({ id: slackUserLinks.id });
+
+  // Restore orphaned bindings from previous logout
+  if (newUserLink) {
+    const restoredCount = await globalThis.services.db
+      .update(slackBindings)
+      .set({ slackUserLinkId: newUserLink.id })
+      .where(
+        and(
+          eq(slackBindings.vm0UserId, userId),
+          eq(slackBindings.slackWorkspaceId, workspaceId),
+          isNull(slackBindings.slackUserLinkId),
+        ),
+      )
+      .then((result) => result.rowCount ?? 0);
+
+    if (restoredCount > 0) {
+      console.log(
+        `Restored ${restoredCount} orphaned bindings for user ${userId} in workspace ${workspaceId}`,
+      );
+    }
+  }
 
   // Send success message to the Slack channel
   if (channelId) {

--- a/turbo/apps/web/app/slack/link/actions.ts
+++ b/turbo/apps/web/app/slack/link/actions.ts
@@ -110,8 +110,9 @@ export async function linkSlackAccount(
   if (existingLink) {
     if (existingLink.vm0UserId === userId) {
       // Send success message even for already linked users
+      // Must await to prevent serverless function from terminating before message is sent
       if (channelId) {
-        sendSuccessMessage(
+        await sendSuccessMessage(
           installation.encryptedBotToken,
           channelId,
           slackUserId,
@@ -159,8 +160,9 @@ export async function linkSlackAccount(
   }
 
   // Send success message to the Slack channel
+  // Must await to prevent serverless function from terminating before message is sent
   if (channelId) {
-    sendSuccessMessage(
+    await sendSuccessMessage(
       installation.encryptedBotToken,
       channelId,
       slackUserId,

--- a/turbo/apps/web/app/slack/link/page.tsx
+++ b/turbo/apps/web/app/slack/link/page.tsx
@@ -193,6 +193,14 @@ function SlackLinkContent(): React.JSX.Element {
               </div>
               <button
                 onClick={() => {
+                  // Call linkSlackAccount to send success message to Slack
+                  if (slackUserId && workspaceId) {
+                    linkSlackAccount(slackUserId, workspaceId, channelId).catch(
+                      (error) => {
+                        console.error("Error sending Slack message:", error);
+                      },
+                    );
+                  }
                   const params = new URLSearchParams({ linked: "true" });
                   if (workspaceId) params.set("workspace_id", workspaceId);
                   if (channelId) params.set("channel_id", channelId);

--- a/turbo/apps/web/app/slack/link/page.tsx
+++ b/turbo/apps/web/app/slack/link/page.tsx
@@ -192,23 +192,11 @@ function SlackLinkContent(): React.JSX.Element {
                 </p>
               </div>
               <button
-                onClick={() => {
-                  // Call linkSlackAccount to send success message to Slack
-                  if (slackUserId && workspaceId) {
-                    linkSlackAccount(slackUserId, workspaceId, channelId).catch(
-                      (error) => {
-                        console.error("Error sending Slack message:", error);
-                      },
-                    );
-                  }
-                  const params = new URLSearchParams({ linked: "true" });
-                  if (workspaceId) params.set("workspace_id", workspaceId);
-                  if (channelId) params.set("channel_id", channelId);
-                  router.push(`/slack/success?${params.toString()}`);
-                }}
-                className="mt-2 h-9 w-full rounded-md bg-primary text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                onClick={() => void handleLink()}
+                disabled={loading}
+                className="mt-2 h-9 w-full rounded-md bg-primary text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
               >
-                Continue
+                {loading ? "Continuing..." : "Continue"}
               </button>
             </div>
           ) : (

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -567,6 +567,8 @@ export function testContext(): TestContext {
       .insert(slackBindings)
       .values({
         slackUserLinkId: userLinkId,
+        vm0UserId: link.vm0UserId,
+        slackWorkspaceId: link.slackWorkspaceId,
         composeId: compose.id,
         agentName,
         description,

--- a/turbo/apps/web/src/db/migrations/0062_update_slack_thread_sessions_index.sql
+++ b/turbo/apps/web/src/db/migrations/0062_update_slack_thread_sessions_index.sql
@@ -1,0 +1,9 @@
+-- Update slack_thread_sessions unique index to include binding_id
+-- This allows different agents to have separate sessions in the same thread
+
+-- Drop the old index
+DROP INDEX IF EXISTS "idx_slack_thread_sessions_thread";
+
+-- Create new unique index including binding_id
+CREATE UNIQUE INDEX "idx_slack_thread_sessions_thread_binding"
+  ON "slack_thread_sessions"("slack_binding_id", "slack_channel_id", "slack_thread_ts");

--- a/turbo/apps/web/src/db/migrations/0063_slack_bindings_orphan_support.sql
+++ b/turbo/apps/web/src/db/migrations/0063_slack_bindings_orphan_support.sql
@@ -1,0 +1,37 @@
+-- Support orphaned bindings during logout/login cycle
+-- This allows users to retain their agent configurations after logout
+
+-- Add vm0_user_id column to identify binding owner
+ALTER TABLE "slack_bindings" ADD COLUMN "vm0_user_id" text;
+
+-- Add slack_workspace_id column for scoping lookups
+ALTER TABLE "slack_bindings" ADD COLUMN "slack_workspace_id" varchar(255);
+
+-- Backfill existing records from slack_user_links
+UPDATE "slack_bindings" b
+SET
+  "vm0_user_id" = l."vm0_user_id",
+  "slack_workspace_id" = l."slack_workspace_id"
+FROM "slack_user_links" l
+WHERE b."slack_user_link_id" = l."id";
+
+-- Make columns NOT NULL after backfill
+ALTER TABLE "slack_bindings" ALTER COLUMN "vm0_user_id" SET NOT NULL;
+ALTER TABLE "slack_bindings" ALTER COLUMN "slack_workspace_id" SET NOT NULL;
+
+-- Drop the existing foreign key constraint
+ALTER TABLE "slack_bindings" DROP CONSTRAINT IF EXISTS "slack_bindings_slack_user_link_id_slack_user_links_id_fk";
+
+-- Allow slack_user_link_id to be NULL
+ALTER TABLE "slack_bindings" ALTER COLUMN "slack_user_link_id" DROP NOT NULL;
+
+-- Re-add foreign key with SET NULL on delete
+ALTER TABLE "slack_bindings"
+  ADD CONSTRAINT "slack_bindings_slack_user_link_id_slack_user_links_id_fk"
+  FOREIGN KEY ("slack_user_link_id")
+  REFERENCES "slack_user_links"("id")
+  ON DELETE SET NULL;
+
+-- Add index for finding orphaned bindings by user
+CREATE INDEX "idx_slack_bindings_vm0_user_workspace"
+  ON "slack_bindings"("vm0_user_id", "slack_workspace_id");

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -435,6 +435,20 @@
       "when": 1768600000000,
       "tag": "0061_add_scope_id_to_storages",
       "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1768700000000,
+      "tag": "0062_update_slack_thread_sessions_index",
+      "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1768800000000,
+      "tag": "0063_slack_bindings_orphan_support",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/slack-binding.ts
+++ b/turbo/apps/web/src/db/schema/slack-binding.ts
@@ -20,9 +20,15 @@ export const slackBindings = pgTable(
   "slack_bindings",
   {
     id: uuid("id").defaultRandom().primaryKey(),
-    slackUserLinkId: uuid("slack_user_link_id")
-      .notNull()
-      .references(() => slackUserLinks.id, { onDelete: "cascade" }),
+    // Nullable to support orphaned bindings during logout/login cycle
+    slackUserLinkId: uuid("slack_user_link_id").references(
+      () => slackUserLinks.id,
+      { onDelete: "set null" },
+    ),
+    // VM0 user ID for restoring bindings after logout/login
+    vm0UserId: text("vm0_user_id").notNull(),
+    // Slack workspace ID for scoping orphaned bindings lookup
+    slackWorkspaceId: varchar("slack_workspace_id", { length: 255 }).notNull(),
     composeId: uuid("compose_id")
       .notNull()
       .references(() => agentComposes.id, { onDelete: "cascade" }),

--- a/turbo/apps/web/src/db/schema/slack-thread-session.ts
+++ b/turbo/apps/web/src/db/schema/slack-thread-session.ts
@@ -30,8 +30,9 @@ export const slackThreadSessions = pgTable(
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => [
-    // Each thread can only have one session
-    uniqueIndex("idx_slack_thread_sessions_thread").on(
+    // Each thread + binding combination can only have one session
+    uniqueIndex("idx_slack_thread_sessions_thread_binding").on(
+      table.slackBindingId,
       table.slackChannelId,
       table.slackThreadTs,
     ),

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -1,7 +1,9 @@
-import { eq, and } from "drizzle-orm";
+import { eq, and, desc } from "drizzle-orm";
 import { slackInstallations } from "../../../db/schema/slack-installation";
 import { slackUserLinks } from "../../../db/schema/slack-user-link";
 import { slackBindings } from "../../../db/schema/slack-binding";
+import { slackThreadSessions } from "../../../db/schema/slack-thread-session";
+import { agentSessions } from "../../../db/schema/agent-session";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import {
@@ -39,10 +41,14 @@ interface MentionContext {
  * 4. Get user's bindings
  * 5. If no bindings, prompt to add agent
  * 6. Route to agent (explicit or LLM)
- * 7. Fetch thread context
- * 8. Find or create thread session
- * 9. Execute agent
- * 10. Post response to Slack thread
+ * 7. Find existing thread session (for session continuation)
+ * 8. Fetch thread context
+ * 9. Add thinking reaction
+ * 10. Post thinking message
+ * 11. Execute agent with session continuation
+ * 12. Create thread session mapping (if new thread)
+ * 13. Update thinking message with response
+ * 14. Remove thinking reaction
  */
 export async function handleAppMention(context: MentionContext): Promise<void> {
   const { SECRETS_ENCRYPTION_KEY } = env();
@@ -192,7 +198,25 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       (b) => b.agentName === selectedAgentName,
     )!;
 
-    // 7. Fetch context (thread messages or recent channel messages)
+    // 7. Find existing thread session for this binding (if in a thread)
+    let existingSessionId: string | undefined;
+    if (threadTs) {
+      const [threadSession] = await globalThis.services.db
+        .select({ agentSessionId: slackThreadSessions.agentSessionId })
+        .from(slackThreadSessions)
+        .where(
+          and(
+            eq(slackThreadSessions.slackBindingId, selectedBinding.id),
+            eq(slackThreadSessions.slackChannelId, context.channelId),
+            eq(slackThreadSessions.slackThreadTs, threadTs),
+          ),
+        )
+        .limit(1);
+
+      existingSessionId = threadSession?.agentSessionId;
+    }
+
+    // 8. Fetch Slack context (thread messages or recent channel messages)
     let formattedContext = "";
     if (context.threadTs) {
       // In a thread - fetch thread replies
@@ -208,7 +232,7 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       formattedContext = formatContextForAgent(messages, botUserId, "channel");
     }
 
-    // 8. Add thinking reaction to user's message (non-critical, ignore errors)
+    // 9. Add thinking reaction to user's message (non-critical, ignore errors)
     const reactionAdded = await client.reactions
       .add({
         channel: context.channelId,
@@ -218,7 +242,7 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       .then(() => true)
       .catch(() => false);
 
-    // 9. Post thinking message (will be updated with response)
+    // 10. Post thinking message (will be updated with response)
     const thinkingTs = await postMessage(
       client,
       context.channelId,
@@ -240,19 +264,46 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
     );
 
     try {
-      // 10. Execute agent
-      // Don't use session continuation - rely on Slack thread context instead
-      // This avoids complexity of syncing Slack threads with agent sessions
+      // 11. Execute agent with session continuation (if in thread with same agent)
       const agentResponse = await runAgentForSlack({
         binding: selectedBinding,
-        sessionId: undefined,
+        sessionId: existingSessionId,
         prompt: promptText,
         threadContext: formattedContext,
         userId: userLink.vm0UserId,
         encryptionKey: SECRETS_ENCRYPTION_KEY,
       });
 
-      // 11. Update thinking message with actual response
+      // 12. Create thread session mapping if this is a new thread (no existing session)
+      if (threadTs && !existingSessionId) {
+        // Find the session that was just created for this user/compose
+        const [newSession] = await globalThis.services.db
+          .select({ id: agentSessions.id })
+          .from(agentSessions)
+          .where(
+            and(
+              eq(agentSessions.userId, userLink.vm0UserId),
+              eq(agentSessions.agentComposeId, selectedBinding.composeId),
+            ),
+          )
+          .orderBy(desc(agentSessions.updatedAt))
+          .limit(1);
+
+        if (newSession) {
+          // Create the thread session mapping
+          await globalThis.services.db
+            .insert(slackThreadSessions)
+            .values({
+              slackBindingId: selectedBinding.id,
+              slackChannelId: context.channelId,
+              slackThreadTs: threadTs,
+              agentSessionId: newSession.id,
+            })
+            .onConflictDoNothing();
+        }
+      }
+
+      // 13. Update thinking message with actual response
       if (thinkingTs) {
         await client.chat.update({
           channel: context.channelId,
@@ -268,7 +319,7 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
         });
       }
     } finally {
-      // 12. Remove thinking reaction (only if it was added)
+      // 14. Remove thinking reaction (only if it was added)
       if (reactionAdded) {
         await client.reactions
           .remove({

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -1,9 +1,8 @@
-import { eq, and, desc } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { slackInstallations } from "../../../db/schema/slack-installation";
 import { slackUserLinks } from "../../../db/schema/slack-user-link";
 import { slackBindings } from "../../../db/schema/slack-binding";
 import { slackThreadSessions } from "../../../db/schema/slack-thread-session";
-import { agentSessions } from "../../../db/schema/agent-session";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import {
@@ -265,42 +264,27 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
 
     try {
       // 11. Execute agent with session continuation (if in thread with same agent)
-      const agentResponse = await runAgentForSlack({
-        binding: selectedBinding,
-        sessionId: existingSessionId,
-        prompt: promptText,
-        threadContext: formattedContext,
-        userId: userLink.vm0UserId,
-        encryptionKey: SECRETS_ENCRYPTION_KEY,
-      });
+      const { response: agentResponse, sessionId: newSessionId } =
+        await runAgentForSlack({
+          binding: selectedBinding,
+          sessionId: existingSessionId,
+          prompt: promptText,
+          threadContext: formattedContext,
+          userId: userLink.vm0UserId,
+          encryptionKey: SECRETS_ENCRYPTION_KEY,
+        });
 
       // 12. Create thread session mapping if this is a new thread (no existing session)
-      if (threadTs && !existingSessionId) {
-        // Find the session that was just created for this user/compose
-        const [newSession] = await globalThis.services.db
-          .select({ id: agentSessions.id })
-          .from(agentSessions)
-          .where(
-            and(
-              eq(agentSessions.userId, userLink.vm0UserId),
-              eq(agentSessions.agentComposeId, selectedBinding.composeId),
-            ),
-          )
-          .orderBy(desc(agentSessions.updatedAt))
-          .limit(1);
-
-        if (newSession) {
-          // Create the thread session mapping
-          await globalThis.services.db
-            .insert(slackThreadSessions)
-            .values({
-              slackBindingId: selectedBinding.id,
-              slackChannelId: context.channelId,
-              slackThreadTs: threadTs,
-              agentSessionId: newSession.id,
-            })
-            .onConflictDoNothing();
-        }
+      if (threadTs && !existingSessionId && newSessionId) {
+        await globalThis.services.db
+          .insert(slackThreadSessions)
+          .values({
+            slackBindingId: selectedBinding.id,
+            slackChannelId: context.channelId,
+            slackThreadTs: threadTs,
+            agentSessionId: newSessionId,
+          })
+          .onConflictDoNothing();
       }
 
       // 13. Update thinking message with actual response

--- a/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
@@ -131,8 +131,8 @@ export async function runAgentForSlack(
 
     // Wait for run completion
     const result = await waitForRunCompletion(run.id, {
-      timeoutMs: 5 * 60 * 1000, // 5 minute timeout
-      pollIntervalMs: 1000,
+      timeoutMs: 30 * 60 * 1000, // 30 minute timeout
+      pollIntervalMs: 5000, // 5 second polling interval
     });
 
     if (result.status === "completed") {

--- a/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
@@ -1,9 +1,10 @@
-import { eq, desc } from "drizzle-orm";
+import { eq, desc, and, gte, asc } from "drizzle-orm";
 import {
   agentComposes,
   agentComposeVersions,
 } from "../../../db/schema/agent-compose";
 import { agentRuns } from "../../../db/schema/agent-run";
+import { agentSessions } from "../../../db/schema/agent-session";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { generateSandboxToken } from "../../auth/sandbox-token";
 import { buildExecutionContext, prepareAndDispatchRun } from "../../run";
@@ -36,6 +37,11 @@ interface WaitResult {
   error?: string;
 }
 
+interface RunAgentResult {
+  response: string;
+  sessionId: string | undefined;
+}
+
 /**
  * Execute an agent run for Slack
  *
@@ -43,7 +49,7 @@ interface WaitResult {
  */
 export async function runAgentForSlack(
   params: RunAgentParams,
-): Promise<string> {
+): Promise<RunAgentResult> {
   const { binding, sessionId, prompt, threadContext, userId, encryptionKey } =
     params;
 
@@ -56,7 +62,7 @@ export async function runAgentForSlack(
       .limit(1);
 
     if (!compose) {
-      return "Error: Agent configuration not found.";
+      return { response: "Error: Agent configuration not found.", sessionId };
     }
 
     // Get latest version (using headVersionId if available, otherwise query)
@@ -70,7 +76,10 @@ export async function runAgentForSlack(
         .limit(1);
 
       if (!latestVersion) {
-        return "Error: Agent has no versions configured.";
+        return {
+          response: "Error: Agent has no versions configured.",
+          sessionId,
+        };
       }
       versionId = latestVersion.id;
     }
@@ -105,7 +114,7 @@ export async function runAgentForSlack(
       .returning();
 
     if (!run) {
-      return "Error: Failed to create run.";
+      return { response: "Error: Failed to create run.", sessionId };
     }
 
     log.debug(`Created run ${run.id} for Slack binding ${binding.id}`);
@@ -135,17 +144,47 @@ export async function runAgentForSlack(
       pollIntervalMs: 5000, // 5 second polling interval
     });
 
+    // If no existing session, find the session created for this run
+    // Use run.createdAt to avoid race conditions with concurrent runs
+    let resultSessionId = sessionId;
+    if (!sessionId && result.status === "completed") {
+      const [newSession] = await globalThis.services.db
+        .select({ id: agentSessions.id })
+        .from(agentSessions)
+        .where(
+          and(
+            eq(agentSessions.userId, userId),
+            eq(agentSessions.agentComposeId, binding.composeId),
+            gte(agentSessions.createdAt, run.createdAt),
+          ),
+        )
+        .orderBy(asc(agentSessions.createdAt))
+        .limit(1);
+
+      resultSessionId = newSession?.id;
+    }
+
     if (result.status === "completed") {
-      return result.output ?? "Task completed successfully.";
+      return {
+        response: result.output ?? "Task completed successfully.",
+        sessionId: resultSessionId,
+      };
     } else if (result.status === "failed") {
-      return `Error: ${result.error ?? "Agent execution failed."}`;
+      return {
+        response: `Error: ${result.error ?? "Agent execution failed."}`,
+        sessionId: resultSessionId,
+      };
     } else {
-      return "The agent is still working on your request. Check back later.";
+      return {
+        response:
+          "The agent is still working on your request. Check back later.",
+        sessionId: resultSessionId,
+      };
     }
   } catch (error) {
     log.error("Error running agent for Slack:", error);
     const message = error instanceof Error ? error.message : "Unknown error";
-    return `Error executing agent: ${message}`;
+    return { response: `Error executing agent: ${message}`, sessionId };
   }
 }
 


### PR DESCRIPTION
## Summary
- Enable session continuation for Slack thread conversations, allowing agents to maintain context across messages in the same thread
- Preserve agent bindings when users logout (orphaned bindings) and automatically restore them when users log back in
- Update thread session index to include binding_id for multi-agent thread support
- Increase agent run timeout from 5 to 30 minutes with 5s polling interval

## Key Changes

### Session Continuation
- When a user mentions an agent in a thread, the system now looks up any existing agent session for that thread/binding combination
- If found, the session is continued rather than starting fresh, preserving conversation context
- New thread sessions are created and mapped after the first message

### Binding Preservation
- When users logout, their agent bindings are no longer deleted
- Instead, the `slack_user_link_id` is set to NULL (orphaned state)
- New columns `vm0_user_id` and `slack_workspace_id` added to enable restoration
- When users log back in, orphaned bindings are automatically restored

### Database Migrations
- `0062_update_slack_thread_sessions_index.sql`: Updates unique index to include `slack_binding_id`
- `0063_slack_bindings_orphan_support.sql`: Adds orphan support columns and changes FK behavior

## Test plan
- [ ] Test creating new agent binding in Slack
- [ ] Test agent conversation in a thread maintains context across multiple messages
- [ ] Test different agents in same thread maintain separate sessions
- [ ] Test logout command preserves bindings (shows confirmation message)
- [ ] Test login after logout restores previous agent configurations
- [ ] Verify long-running agent tasks complete within 30 minute timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)