### PR TITLE
fix(platform): only override feature switches when value is explicitly set in localStorage

### DIFF
--- a/turbo/apps/platform/src/signals/external/__tests__/feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/feature-switch.test.ts
@@ -23,4 +23,15 @@ describe("feature switch", () => {
       false,
     );
   });
+
+  it("should not override keys not present in localStorage", async () => {
+    // When localStorage only has partial overrides, other keys should keep their default values
+    // Setting an empty object should not affect the default value of 'dummy' (which is true)
+    await setupPage({ context, path: "/", featureSwitches: {} });
+
+    await expect(context.store.get(featureSwitch$)).resolves.toHaveProperty(
+      "dummy",
+      true,
+    );
+  });
 });

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -30,7 +30,9 @@ export const featureSwitch$ = computed(async (get) => {
       L.debugGroup("Loaded feature switches from localStorage:");
       for (const key of Object.values(FeatureSwitchKey)) {
         const value = parsed[key];
-        result[key] = Boolean(value);
+        if (value !== undefined) {
+          result[key] = Boolean(value);
+        }
       }
       L.debugGroupEnd();
     }


### PR DESCRIPTION
## Summary

- Fix bug where localStorage feature switch overrides incorrectly set undefined keys to `false`
- Add test case to verify partial overrides preserve default values

## Problem

When localStorage only contains partial feature switch overrides, all keys not present were being forced to `false` because `Boolean(undefined)` returns `false`. This overwrote the default values obtained via `isFeatureEnabled()`.

## Solution

Only override the default value when `parsed[key]` is not `undefined`.

## Test plan

- [x] Added test case: "should not override keys not present in localStorage"
- [x] All existing feature switch tests pass

Closes #2289

🤖 Generated with [Claude Code](https://claude.com/claude-code)