### PR TITLE
docs: add vhs tape files for cli demo gifs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,7 @@ turbo/apps/runner/scripts/deploy/proxy-ca/
 *.pem
 .mozilla
 turbo/apps/storybook/storybook-static/
+
+# VHS tape generated GIFs (regenerate with `vhs <name>.tape`)
+docs/tapes/**/*.gif
+docs/tapes/*.gif

--- a/docs/tapes/CLAUDE.md
+++ b/docs/tapes/CLAUDE.md
@@ -1,0 +1,139 @@
+# Tapes
+
+This folder contains VHS tape files for generating VM0 CLI demo GIFs.
+
+## Recording Principles
+
+- **Prefer interactive mode**: When a command supports interactive prompts (e.g., `vm0 init`, `vm0 artifact init`), use interactive mode instead of flags. Press `Enter` to accept defaults rather than using `-n` or `--name` flags.
+- **Use comments**: Add comment lines (e.g., `Type "# Step description"`) to explain what each step does.
+- **Every command needs a subtitle**: Each command should be preceded by a `# comment` explaining what it does, helping viewers understand each step.
+- **Allow sufficient pauses**: Add adequate `Sleep` durations between commands for readability, especially after long-running commands (8s+ after agent runs).
+- **Reference sample**: See `welcome/welcome.tape` as the best example that follows all conventions.
+
+## Timing Conventions
+
+### Comments (# subtitles)
+
+```tape
+Enter
+Type "# Step description"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "command"
+```
+
+- Add empty line (`Enter`) before starting a new comment section
+- `Sleep 1s` after typing comment to let viewers read it
+- Single `Enter` after comment (no extra blank line)
+- `Sleep 300ms` before typing the command
+- **No empty line between comment and command**
+
+### Commands
+
+```tape
+Type "vm0 init"
+Sleep 1s
+Enter
+Sleep 2s
+```
+
+- `Sleep 1s` before `Enter` to let viewers see the full command
+- `Sleep` after `Enter` to show command output (duration varies by command)
+
+### Example Flow
+
+```tape
+Enter
+Type "# Create a new agent"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 init"
+Sleep 1s
+Enter
+Sleep 2s
+
+Enter
+Type "# Edit the workflow"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vim AGENTS.md"
+Sleep 1s
+Enter
+Sleep 5s
+```
+
+## Creating New Tapes
+
+Reference `template.tape` for base styling:
+
+```tape
+# Terminal settings
+Set Shell bash
+Set FontSize 22
+Set FontFamily "Menlo"
+Set Width 1200
+Set Height 900
+Set Padding 30
+Set Theme "Dracula"
+Set TypingSpeed 50ms
+```
+
+## Waiting for `vm0 run` to Complete
+
+When running agents with `vm0 run`, use `Wait+Screen` to wait for completion:
+
+```tape
+Type "vm0 run my-agent 'do something'"
+Enter
+Wait+Screen@120s /Run completed successfully/
+Sleep 8s
+```
+
+- **Use `Wait+Screen` not `Wait+Line`**: `Wait+Line` only checks the last line, but after "Run completed successfully" prints, the cursor moves to a new line with the prompt, so `Wait+Line` will timeout.
+- Use the exact pattern `/Run completed successfully/` - do not use partial matches like `/Run completed/` which may trigger early
+- Set a reasonable timeout (e.g., `@120s` for 2 minutes)
+- Add a `Sleep` after the wait to let viewers see the result before the next command
+- **Multiple runs**: If running multiple agents sequentially, clear the screen between runs with `Ctrl+l` so the second `Wait+Screen` doesn't immediately match the first agent's completion message still visible on screen
+
+## Setup and Cleanup with record.sh
+
+VHS doesn't support setup/cleanup hooks. For tapes that need environment preparation (e.g., pre-creating files, composing agents), create a `record.sh` script in the tape folder:
+
+```bash
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+# Setup (not recorded)
+echo "Setting up..."
+rm -f vm0.yaml AGENTS.md
+vm0 init -n demo-agent
+
+# Record
+echo "Recording..."
+~/Developer/vhs/vhs my-tape.tape
+
+# Cleanup
+echo "Cleaning up..."
+rm -f vm0.yaml AGENTS.md
+
+echo "Done!"
+```
+
+Run with `./record.sh` instead of calling `vhs` directly.
+
+## Generate GIF
+
+For simple tapes without setup/cleanup:
+```bash
+vhs <name>.tape
+```
+
+For tapes with setup/cleanup:
+```bash
+./record.sh
+```

--- a/docs/tapes/artifact/artifact.tape
+++ b/docs/tapes/artifact/artifact.tape
@@ -1,0 +1,79 @@
+# VM0 Artifact Demo
+Output artifact.gif
+
+# Terminal settings
+Set Shell bash
+Set FontSize 22
+Set FontFamily "Menlo"
+Set Width 1200
+Set Height 900
+Set Padding 30
+Set Theme "Dracula"
+Set TypingSpeed 50ms
+
+# Start demo
+Sleep 500ms
+
+Type "# 1. Create artifact directory"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "mkdir my-artifact && cd my-artifact"
+Sleep 1s
+Enter
+Sleep 2s
+
+Enter
+Type "# 2. Initialize artifact"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 artifact init"
+Sleep 1s
+Enter
+Sleep 2s
+
+# Accept default name
+Enter
+Sleep 3s
+
+Enter
+Type "# 3. Push artifact to cloud"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 artifact push"
+Sleep 1s
+Enter
+Sleep 4s
+
+Enter
+Type "# 4. Run agent with artifact"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 run compose-demo --artifact-name my-artifact 'Write hello world to hello.txt'"
+Sleep 1s
+Enter
+Wait+Screen@120s /Run completed successfully/
+Sleep 8s
+
+Enter
+Type "# 5. Pull artifact to get result"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 artifact pull"
+Sleep 1s
+Enter
+Sleep 4s
+
+Enter
+Type "# 6. View the result"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "cat hello.txt"
+Sleep 1s
+Enter
+Sleep 4s

--- a/docs/tapes/artifact/record.sh
+++ b/docs/tapes/artifact/record.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+# Setup
+echo "Setting up..."
+rm -rf my-artifact
+
+# Ensure compose-demo is composed
+echo "Composing compose-demo..."
+(cd /tmp && rm -rf compose-demo && mkdir compose-demo && cd compose-demo && vm0 init -n compose-demo && vm0 compose vm0.yaml)
+
+# Record
+echo "Recording..."
+~/Developer/vhs/vhs artifact.tape
+
+# Cleanup
+echo "Cleaning up..."
+rm -rf my-artifact
+
+echo "Done!"

--- a/docs/tapes/multi-agents/multi-agents.tape
+++ b/docs/tapes/multi-agents/multi-agents.tape
@@ -1,0 +1,103 @@
+# VM0 Multi-Agents Demo
+Output multi-agents.gif
+
+# Terminal settings
+Set Shell bash
+Set FontSize 22
+Set FontFamily "Menlo"
+Set Width 1200
+Set Height 900
+Set Padding 30
+Set Theme "Dracula"
+Set TypingSpeed 50ms
+
+# Start demo
+Sleep 500ms
+
+Type "# 1. Create shared artifact"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "mkdir my-artifact && cd my-artifact"
+Sleep 1s
+Enter
+Sleep 2s
+
+Enter
+Type "# 2. Initialize artifact"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 artifact init"
+Sleep 1s
+Enter
+Sleep 2s
+
+# Accept default name
+Enter
+Sleep 3s
+
+Enter
+Type "# 3. Push artifact to cloud"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 artifact push"
+Sleep 1s
+Enter
+Sleep 4s
+
+Enter
+Type "# 4. Agent-1 writes a question"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 run agent-1 --artifact-name my-artifact 'Write 1+1=? to question.md'"
+Sleep 1s
+Enter
+Wait+Screen@120s /Run completed successfully/
+Sleep 8s
+
+# Clear screen so agent-2's Wait+Screen doesn't match agent-1's output
+Ctrl+l
+Sleep 1s
+
+Type "# 5. Agent-2 reads and answers"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 run agent-2 --artifact-name my-artifact 'Read question.md and answer it in answer.md'"
+Sleep 1s
+Enter
+Wait+Screen@120s /Run completed successfully/
+Sleep 8s
+
+Enter
+Type "# 6. Pull artifact to get results"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 artifact pull"
+Sleep 1s
+Enter
+Sleep 4s
+
+Enter
+Type "# 7. View the question"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "cat question.md"
+Sleep 1s
+Enter
+Sleep 5s
+
+Enter
+Type "# 8. View the answer"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "cat answer.md"
+Sleep 1s
+Enter
+Sleep 5s

--- a/docs/tapes/multi-agents/record.sh
+++ b/docs/tapes/multi-agents/record.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+# Setup
+echo "Setting up..."
+rm -rf my-artifact
+
+# Ensure agent-1 and agent-2 are composed (run from /tmp to avoid polluting this folder)
+echo "Composing agent-1..."
+(cd /tmp && rm -rf agent-1 && mkdir agent-1 && cd agent-1 && vm0 init -n agent-1 && vm0 compose vm0.yaml)
+
+echo "Composing agent-2..."
+(cd /tmp && rm -rf agent-2 && mkdir agent-2 && cd agent-2 && vm0 init -n agent-2 && vm0 compose vm0.yaml)
+
+# Record
+echo "Recording..."
+~/Developer/vhs/vhs multi-agents.tape
+
+# Cleanup
+echo "Cleaning up..."
+rm -rf my-artifact
+
+echo "Done!"

--- a/docs/tapes/quickstart/quickstart.tape
+++ b/docs/tapes/quickstart/quickstart.tape
@@ -1,0 +1,75 @@
+# VM0 Quickstart Demo
+Output quickstart.gif
+
+# Terminal settings
+Set Shell bash
+Set FontSize 22
+Set FontFamily "Menlo"
+Set Width 1200
+Set Height 900
+Set Padding 30
+Set Theme "Dracula"
+Set TypingSpeed 50ms
+
+# Start demo
+Sleep 500ms
+
+Type "# 1. Initialize a new agent"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 init"
+Sleep 1s
+Enter
+Sleep 2s
+
+# Accept default name
+Enter
+Sleep 2s
+
+Enter
+Type "# 2. Edit AGENTS.md with natural language"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vim AGENTS.md"
+Sleep 1s
+Enter
+Sleep 3s
+
+# Delete all content and enter insert mode
+Type "ggdGi"
+Sleep 500ms
+
+# Type the new content
+Type "Fetch top 10 articles from HackerNews and show me the best one"
+Sleep 500ms
+
+# Exit insert mode and save
+Escape
+Sleep 300ms
+Type ":wq"
+Enter
+Sleep 1s
+
+Enter
+Type "# 3. Upload to VM0 cloud"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 compose vm0.yaml"
+Sleep 1s
+Enter
+Wait+Screen@60s /Compose created|Compose version exists/
+Sleep 3s
+
+Enter
+Type "# 4. Run the agent"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 run quickstart 'start working'"
+Sleep 1s
+Enter
+Wait+Screen@120s /Run completed successfully/
+Sleep 8s

--- a/docs/tapes/quickstart/record.sh
+++ b/docs/tapes/quickstart/record.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+# Setup
+echo "Setting up..."
+rm -f vm0.yaml AGENTS.md
+
+# Record
+echo "Recording..."
+~/Developer/vhs/vhs quickstart.tape
+
+# Cleanup
+echo "Cleaning up..."
+rm -f vm0.yaml AGENTS.md
+
+echo "Done!"

--- a/docs/tapes/schedule/record.sh
+++ b/docs/tapes/schedule/record.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+# Setup
+echo "Setting up..."
+rm -f vm0.yaml schedule.yaml AGENTS.md
+vm0 init -n demo-agent
+
+# Record
+echo "Recording..."
+~/Developer/vhs/vhs schedule.tape
+
+# Cleanup
+echo "Cleaning up..."
+rm -f vm0.yaml schedule.yaml AGENTS.md
+
+echo "Done!"

--- a/docs/tapes/schedule/schedule.tape
+++ b/docs/tapes/schedule/schedule.tape
@@ -1,0 +1,76 @@
+# VM0 Schedule Demo
+Output schedule.gif
+
+# Terminal settings
+Set Shell bash
+Set FontSize 22
+Set FontFamily "Menlo"
+Set Width 1200
+Set Height 900
+Set Padding 30
+Set Theme "Dracula"
+Set TypingSpeed 50ms
+
+# Start demo
+Sleep 500ms
+
+Type "# 1. Initialize schedule"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 schedule init"
+Sleep 1s
+Enter
+Sleep 2s
+
+# Accept all interactive prompts with defaults
+Enter
+Sleep 1500ms
+Enter
+Sleep 1500ms
+Enter
+Sleep 1500ms
+Enter
+Sleep 1500ms
+Enter
+Sleep 2s
+
+Enter
+Type "# 2. View generated schedule.yaml"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "cat schedule.yaml"
+Sleep 1s
+Enter
+Sleep 3s
+
+Enter
+Type "# 3. Deploy the schedule"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 schedule deploy"
+Sleep 1s
+Enter
+Sleep 4s
+
+Enter
+Type "# 4. List all schedules"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 schedule list"
+Sleep 1s
+Enter
+Sleep 3s
+
+Enter
+Type "# 5. Check schedule status"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 schedule status"
+Sleep 1s
+Enter
+Sleep 4s

--- a/docs/tapes/template.tape
+++ b/docs/tapes/template.tape
@@ -1,0 +1,24 @@
+# VM0 CLI Demo
+Output template.gif
+
+# Terminal settings
+Set Shell bash
+Set FontSize 22
+Set FontFamily "Menlo"
+Set Width 1200
+Set Height 900
+Set Padding 30
+Set Theme "Dracula"
+Set TypingSpeed 50ms
+
+# Start demo
+Sleep 500ms
+
+Type "# VM0 CLI - Build and run agents with natural language"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 --help"
+Sleep 1s
+Enter
+Sleep 3s

--- a/docs/tapes/usage/record.sh
+++ b/docs/tapes/usage/record.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+# Setup
+echo "Setting up..."
+# No setup needed for usage commands
+
+# Record
+echo "Recording..."
+~/Developer/vhs/vhs usage.tape
+
+# Cleanup
+echo "Cleaning up..."
+# No cleanup needed
+
+echo "Done!"

--- a/docs/tapes/usage/usage.tape
+++ b/docs/tapes/usage/usage.tape
@@ -1,0 +1,44 @@
+# VM0 Usage Demo
+Output usage.gif
+
+# Terminal settings
+Set Shell bash
+Set FontSize 22
+Set FontFamily "Menlo"
+Set Width 1200
+Set Height 900
+Set Padding 30
+Set Theme "Dracula"
+Set TypingSpeed 50ms
+
+# Start demo
+Sleep 500ms
+
+Type "# 1. View usage statistics"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 usage"
+Sleep 1s
+Enter
+Sleep 3s
+
+Enter
+Type "# 2. Filter by relative date"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 usage --since 3d"
+Sleep 1s
+Enter
+Sleep 3s
+
+Enter
+Type "# 3. Filter by date range"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 usage --since 2026-01-01 --until 2026-01-15"
+Sleep 1s
+Enter
+Sleep 3s

--- a/docs/tapes/welcome/record.sh
+++ b/docs/tapes/welcome/record.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+# Setup
+echo "Setting up..."
+rm -rf vm0.yaml AGENTS.md artifact
+
+# Record
+echo "Recording..."
+~/Developer/vhs/vhs welcome.tape
+
+# Cleanup
+echo "Cleaning up..."
+rm -rf vm0.yaml AGENTS.md artifact
+
+echo "Done!"

--- a/docs/tapes/welcome/welcome.tape
+++ b/docs/tapes/welcome/welcome.tape
@@ -1,0 +1,74 @@
+# VM0 Welcome Demo
+Output welcome.gif
+
+# Terminal settings
+Set Shell bash
+Set FontSize 22
+Set FontFamily "Menlo"
+Set Width 1200
+Set Height 900
+Set Padding 30
+Set Theme "Dracula"
+Set TypingSpeed 50ms
+
+# Start demo
+Sleep 500ms
+
+Type "# Create a new VM0 agent"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 init"
+Sleep 1s
+Enter
+Sleep 2s
+
+# Accept default name
+Enter
+Sleep 2s
+
+Enter
+Type "# Edit AGENTS.md with natural language"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vim AGENTS.md"
+Sleep 1s
+Enter
+Sleep 5s
+
+# Delete all content and enter insert mode
+Type "ggdGi"
+Sleep 500ms
+
+# Type the new content
+Type "Get the first article from HackerNews and write its title to result.md"
+Sleep 500ms
+
+# Exit insert mode and save
+Escape
+Sleep 300ms
+Type ":wq"
+Enter
+Sleep 1s
+Enter
+
+Type "# Start the agent"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "vm0 cook start"
+Sleep 1s
+Enter
+Wait+Screen@120s /Run completed successfully/
+Sleep 8s
+
+Enter
+Type "# View the result"
+Sleep 1s
+Enter
+Sleep 300ms
+Type "cat artifact/result.md"
+Sleep 1s
+Enter
+Sleep 5s


### PR DESCRIPTION
## Summary
- Add VHS tape files for generating VM0 CLI demo GIFs
- Include six demo scenarios: welcome, quickstart, usage, schedule, artifact, and multi-agents
- Add recording scripts (record.sh) for setup/cleanup and CLAUDE.md with recording guidelines

## Details
This PR adds VHS tape files for creating CLI demo GIFs. VHS is a terminal session recorder that uses `.tape` files to define recordings.

**Contents:**
- `template.tape` - Base styling template (Dracula theme, Menlo font)
- Demo scenarios with their tape files and record.sh scripts:
  - `welcome/` - Introduction to VM0 CLI
  - `quickstart/` - Quick start guide
  - `usage/` - Basic usage examples
  - `schedule/` - Scheduled runs
  - `artifact/` - Artifact management
  - `multi-agents/` - Multi-agent workflows
- `CLAUDE.md` - Recording guidelines and conventions

**Note:** GIF files are gitignored since they exceed the 1MB file size limit. They can be regenerated locally using `vhs <name>.tape` or the `record.sh` scripts.

## Test plan
- [x] Pre-commit checks pass
- [x] All tests pass (2318 tests)
- [ ] Verify tape files can generate GIFs with VHS installed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)