### PR TITLE
ci(e2b): split workflow into dev and prod jobs with environment separation

### DIFF
--- a/.github/workflows/e2b-template.yml
+++ b/.github/workflows/e2b-template.yml
@@ -21,9 +21,56 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  build-e2b-template:
+  # Development builds - triggered on PRs
+  # Uses repository-level E2B_API_KEY secret (development account after migration)
+  build-e2b-template-dev:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.0
+
+      - name: Install dependencies
+        working-directory: ./turbo
+        run: pnpm install --frozen-lockfile
+
+      - name: Build E2B claude-code template (dev)
+        working-directory: ./turbo
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+        run: pnpm e2b:build:dev
+
+      - name: Build E2B codex template (dev)
+        working-directory: ./turbo
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+        run: pnpm e2b:codex:build:dev
+
+      - name: Build E2B claude-code-github template (dev)
+        working-directory: ./turbo
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+        run: pnpm e2b:claude-code-github:build:dev
+
+      - name: Build summary
+        run: echo "✅ E2B templates built successfully (dev account)"
+
+  # Production builds - triggered on push to main
+  # Uses production environment E2B_API_KEY secret (production account)
+  build-e2b-template-prod:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: production
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -43,53 +90,22 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build E2B claude-code template (production)
-        if: github.ref == 'refs/heads/main'
         working-directory: ./turbo
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
         run: pnpm e2b:build:prod
 
-      - name: Build E2B claude-code template (dev)
-        if: github.ref != 'refs/heads/main'
-        working-directory: ./turbo
-        env:
-          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-        run: pnpm e2b:build:dev
-
       - name: Build E2B codex template (production)
-        if: github.ref == 'refs/heads/main'
         working-directory: ./turbo
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
         run: pnpm e2b:codex:build:prod
 
-      - name: Build E2B codex template (dev)
-        if: github.ref != 'refs/heads/main'
-        working-directory: ./turbo
-        env:
-          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-        run: pnpm e2b:codex:build:dev
-
       - name: Build E2B claude-code-github template (production)
-        if: github.ref == 'refs/heads/main'
         working-directory: ./turbo
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
         run: pnpm e2b:claude-code-github:build:prod
 
-      - name: Build E2B claude-code-github template (dev)
-        if: github.ref != 'refs/heads/main'
-        working-directory: ./turbo
-        env:
-          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-        run: pnpm e2b:claude-code-github:build:dev
-
       - name: Build summary
-        if: success()
-        run: |
-          echo "✅ E2B templates built successfully"
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "Templates: vm0-claude-code, vm0-claude-code-github, vm0-codex (production)"
-          else
-            echo "Templates: vm0-claude-code-dev, vm0-claude-code-github-dev, vm0-codex-dev (dev)"
-          fi
+        run: echo "✅ E2B templates built successfully (production account)"


### PR DESCRIPTION
## Summary

Split the E2B template build workflow into two separate jobs to enable using different E2B accounts for development and production.

**Changes:**
- `build-e2b-template-dev`: Triggered on PRs, uses repository-level `E2B_API_KEY` secret
- `build-e2b-template-prod`: Triggered on main push, uses `production` environment secret

## Why

This is **Phase 0** of the E2B environment separation migration (#2298):

1. **Phase 0 (this PR)**: Add `environment: production` to separate secret sources
2. **Phase 1**: Update repository `E2B_API_KEY` to dev account key
3. **Phase 2**: Code refactoring (remove `-dev` suffix, hardcode template names, etc.)

## Behavior

| Trigger | Job | Secret Source | E2B Account |
|---------|-----|---------------|-------------|
| PR | `build-e2b-template-dev` | Repository secret | Dev (after Phase 1) |
| Main push | `build-e2b-template-prod` | Production environment | Production |

**Before Phase 1**: Both jobs use the same production key (current behavior preserved)
**After Phase 1**: Jobs use different keys from different E2B accounts

## Test plan

- [ ] PR triggers only `build-e2b-template-dev` job
- [ ] Merge to main triggers only `build-e2b-template-prod` job
- [ ] Templates build successfully with existing secrets

Closes #2298

🤖 Generated with [Claude Code](https://claude.com/claude-code)