### PR TITLE
fix(ci): install python3 and pip3 before ansible in cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -72,6 +72,7 @@ jobs:
 
               # Install Ansible if not present
               if ! command -v ansible-playbook &> /dev/null; then
+                apt-get update && apt-get install -y python3 python3-pip
                 pip3 install ansible
               fi
 


### PR DESCRIPTION
## Summary

- Install python3 and pip3 via apt before running `pip3 install ansible`
- Fixes cleanup workflow failure: `pip3: command not found`

## Context

The cleanup workflow runs in the toolchain container which doesn't have pip3 installed. This caused the workflow to fail when trying to install Ansible.

**Failed run:** https://github.com/vm0-ai/vm0/actions/runs/21661018866/job/62445731689

🤖 Generated with [Claude Code](https://claude.com/claude-code)