### PR TITLE
fix(slack): resolve connection timeout in @mention handler

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -432,6 +432,10 @@ jobs:
             VM0_DEBUG=*
             CLAUDE_CODE_VERSION_URL=${{ vars.CLAUDE_CODE_VERSION_URL }}
             OPENROUTER_API_KEY=${{ secrets.OPENROUTER_API_KEY }}
+            SLACK_CLIENT_ID=${{ secrets.SLACK_CLIENT_ID }}
+            SLACK_CLIENT_SECRET=${{ secrets.SLACK_CLIENT_SECRET }}
+            SLACK_SIGNING_SECRET=${{ secrets.SLACK_SIGNING_SECRET }}
+            SLACK_REDIRECT_BASE_URL=${{ needs.prepare.outputs.web-preview-url }}
           meta-branch: ${{ github.head_ref || github.ref_name }}
           meta-pr: ${{ needs.prepare.outputs.job-ref }}
           skip-finish: ${{ github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '' }}

--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -13,6 +13,15 @@ vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
 vi.mock("@axiomhq/js");
 
+// Mock next/server's after() function which requires a request scope
+vi.mock("next/server", async (importOriginal) => {
+  const original = await importOriginal<typeof import("next/server")>();
+  return {
+    ...original,
+    after: vi.fn(),
+  };
+});
+
 const context = testContext();
 
 // Use the same signing secret as configured in setup.ts


### PR DESCRIPTION
## Summary

- Use Next.js `after()` instead of fire-and-forget pattern to prevent Vercel from freezing the function and closing DB connections
- Optimize UX by posting "Thinking..." message immediately after auth, then updating with agent name once routing completes
- Extract `routeMessageToAgent` helper to reduce function complexity
- Add Slack env vars to preview CI for testing integration

## Root Cause

The error `Connection terminated due to connection timeout` was caused by the Neon serverless driver using WebSocket connections. In the Slack events handler, the fire-and-forget pattern (`handleAppMention().catch(...)`) returns HTTP 200 immediately while the background task continues. Vercel may freeze the function after responding, and Neon closes idle WebSocket connections, causing the timeout.

## Changes

1. **`app/api/slack/events/route.ts`**: Use `after()` to keep function alive until background task completes
2. **`src/lib/slack/handlers/mention.ts`**: 
   - Post "Thinking..." message immediately after auth
   - Update to "Thinking... (using agent-name)" after routing
   - Extract agent routing logic to reduce complexity
3. **`.github/workflows/turbo.yml`**: Add Slack env vars for preview deployments

## Test plan

- [ ] Deploy to preview environment
- [ ] Test Slack @mention with single agent binding
- [ ] Test Slack @mention with multiple agent bindings (LLM router)
- [ ] Verify "Thinking..." message appears immediately
- [ ] Verify message updates with agent name after routing

🤖 Generated with [Claude Code](https://claude.ai/code)