### PR TITLE
fix(web): improve e2b config documentation

### DIFF
--- a/turbo/apps/web/src/lib/e2b/config.ts
+++ b/turbo/apps/web/src/lib/e2b/config.ts
@@ -1,11 +1,15 @@
 /**
- * E2B configuration
+ * E2B sandbox configuration
+ *
+ * Templates are built via CI and pushed to separate E2B accounts:
+ * - Development: Uses repository-level E2B_API_KEY secret
+ * - Production: Uses production environment E2B_API_KEY secret
+ *
+ * The same template names exist in both accounts, isolated by the API key.
  */
-
 export const e2bConfig = {
-  defaultTimeout: 0, // No timeout - allows indefinite execution
-  // Default template name for E2B sandbox with Claude Code CLI
-  // Templates are built via CI and pushed to separate E2B accounts (dev/prod)
-  // The same template name exists in both accounts, isolated by E2B_API_KEY
+  /** Sandbox timeout in ms. 0 = no timeout (indefinite execution) */
+  defaultTimeout: 0,
+  /** Default E2B template for Claude Code CLI sandbox */
   defaultTemplate: "vm0-claude-code",
 } as const;


### PR DESCRIPTION
## Summary

Improve E2B configuration documentation to clarify the environment separation:
- Development uses repository-level E2B_API_KEY secret
- Production uses production environment E2B_API_KEY secret

This triggers a web release to deploy with the new production E2B API key.

## Test plan

- [ ] CI passes
- [ ] Production deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)