### PR TITLE
fix(runner): detect firecracker processes in both api-sock and config-file modes

### DIFF
--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -2,6 +2,7 @@
 // Deployment: Added buildkit cache retry mechanism (issue #1328)
 // CI: Refactored E2E tests with setup_file() - parallel tests use 45s timeout (issue #1555)
 // Perf: Replaced Python vsock-agent with Rust for 16x faster VM startup (issue #1668)
+// Perf: Added snapshot support for fast VM boot from pre-warmed state (issue #1600)
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { doctorCommand } from "./commands/doctor.js";


### PR DESCRIPTION
## Summary

- Fix `parseFirecrackerCmdline` to detect both startup modes:
  - `--api-sock` (snapshot restore mode)
  - `--config-file` (fresh boot mode)
- Change return type from `socketPath` to `workDir` (more generic)
- Previously, orphan firecracker processes started with `--config-file --no-api` went undetected by the doctor command

## Test plan

- [x] All existing tests updated and passing
- [x] Added test for `--config-file` mode parsing
- [x] Added test for precedence when both flags present

🤖 Generated with [Claude Code](https://claude.com/claude-code)