### PR TITLE
refactor(site): add vercel rewrites to proxy all paths to web

### DIFF
--- a/turbo/apps/site/vercel.json
+++ b/turbo/apps/site/vercel.json
@@ -1,5 +1,8 @@
 {
   "buildCommand": "cd ../.. && pnpm run build --filter=site",
   "installCommand": "cd ../.. && pnpm install",
-  "outputDirectory": ".next"
+  "outputDirectory": ".next",
+  "rewrites": [
+    { "source": "/:path*", "destination": "https://api.vm0.ai/:path*" }
+  ]
 }


### PR DESCRIPTION
## Summary

- Add Vercel rewrites configuration to proxy all unmatched paths from site to web app (`api.vm0.ai`)
- Part of progressive web/site migration (#2148), replacing the middleware-based approach with Vercel's native rewrites for better performance

## How it works

Site pages (e.g., `/privacy-policy`, `/terms-of-use`, `/[locale]/*`) are served by site app. All other paths are proxied to web app via Vercel's edge network.

## Test plan

- [ ] Deploy to preview and verify site pages still work
- [ ] Verify `/api/*` endpoints are proxied correctly to web
- [ ] Verify `/sign-in`, `/sign-up`, `/cli-auth/*` work through proxy

Closes #2148 Phase 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)