### PR TITLE
refactor(runner): improve doctor command and extract shared utilities

### DIFF
--- a/turbo/apps/runner/src/commands/kill.ts
+++ b/turbo/apps/runner/src/commands/kill.ts
@@ -14,14 +14,7 @@ import { loadConfig } from "../lib/config.js";
 import { runnerPaths } from "../lib/paths.js";
 import { findProcessByVmId, killProcess } from "../lib/firecracker/process.js";
 import { type VmId, createVmId } from "../lib/firecracker/vm-id.js";
-
-interface RunnerStatus {
-  mode: string;
-  active_runs: number;
-  active_run_ids: string[];
-  started_at: string;
-  updated_at: string;
-}
+import { RunnerStatusSchema } from "../lib/runner/types.js";
 
 interface CleanupResult {
   step: string;
@@ -126,9 +119,9 @@ export const killCommand = new Command("kill")
         // 3. Update status.json
         if (runId && existsSync(statusFilePath)) {
           try {
-            const status: RunnerStatus = JSON.parse(
-              readFileSync(statusFilePath, "utf-8"),
-            ) as RunnerStatus;
+            const status = RunnerStatusSchema.parse(
+              JSON.parse(readFileSync(statusFilePath, "utf-8")),
+            );
             const oldCount = status.active_runs;
             status.active_run_ids = status.active_run_ids.filter(
               (id: string) => id !== runId,
@@ -193,9 +186,9 @@ function resolveRunId(
 
   if (existsSync(statusFilePath)) {
     try {
-      const status: RunnerStatus = JSON.parse(
-        readFileSync(statusFilePath, "utf-8"),
-      ) as RunnerStatus;
+      const status = RunnerStatusSchema.parse(
+        JSON.parse(readFileSync(statusFilePath, "utf-8")),
+      );
       const match = status.active_run_ids.find((id: string) =>
         id.startsWith(input),
       );

--- a/turbo/apps/runner/src/lib/firecracker/process.ts
+++ b/turbo/apps/runner/src/lib/firecracker/process.ts
@@ -8,6 +8,7 @@
 import { readdirSync, readFileSync, existsSync } from "fs";
 import path from "path";
 import { type VmId, createVmId, vmIdValue } from "./vm-id.js";
+import { isProcessRunning } from "../utils/process.js";
 
 interface FirecrackerProcess {
   pid: number;
@@ -113,18 +114,6 @@ export function findProcessByVmId(vmId: VmId): FirecrackerProcess | null {
   const processes = findFirecrackerProcesses();
   const vmIdStr = vmIdValue(vmId);
   return processes.find((p) => vmIdValue(p.vmId) === vmIdStr) || null;
-}
-
-/**
- * Check if a process is still running
- */
-function isProcessRunning(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 /**

--- a/turbo/apps/runner/src/lib/runner/runner-lock.ts
+++ b/turbo/apps/runner/src/lib/runner/runner-lock.ts
@@ -10,6 +10,7 @@ import path from "node:path";
 
 import { createLogger } from "../logger.js";
 import { runtimePaths } from "../paths.js";
+import { isProcessRunning } from "../utils/process.js";
 
 const logger = createLogger("RunnerLock");
 
@@ -21,28 +22,6 @@ let currentPidFile: string | null = null;
 interface RunnerLockOptions {
   /** Custom PID file path (for testing). Defaults to /var/run/vm0/runner.pid */
   pidFile?: string;
-}
-
-/**
- * Check if a process is running
- *
- * Uses kill(pid, 0) which checks process existence without sending a signal.
- * - Returns true if process exists (signal would be deliverable)
- * - Returns true if EPERM (process exists but we lack permission)
- * - Returns false if ESRCH (no such process)
- */
-function isProcessRunning(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err: unknown) {
-    // EPERM means process exists but we don't have permission to signal it
-    if (err instanceof Error && "code" in err && err.code === "EPERM") {
-      return true;
-    }
-    // ESRCH or other errors mean process doesn't exist
-    return false;
-  }
 }
 
 /**

--- a/turbo/apps/runner/src/lib/runner/types.ts
+++ b/turbo/apps/runner/src/lib/runner/types.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 /**
  * Runner mode for lifecycle management
  *
@@ -7,7 +9,21 @@
  * - draining -> stopping (all jobs completed)
  * - stopping -> stopped (cleanup completed)
  */
-export type RunnerMode = "running" | "draining" | "stopping" | "stopped";
+const RunnerModeSchema = z.enum(["running", "draining", "stopping", "stopped"]);
+export type RunnerMode = z.infer<typeof RunnerModeSchema>;
+
+/**
+ * Runner status for external monitoring (written to status.json)
+ * Used by deployment tools (Ansible) to track drain progress
+ */
+export const RunnerStatusSchema = z.object({
+  mode: RunnerModeSchema,
+  active_runs: z.number(),
+  active_run_ids: z.array(z.string()),
+  started_at: z.string(),
+  updated_at: z.string(),
+});
+export type RunnerStatus = z.infer<typeof RunnerStatusSchema>;
 
 /**
  * Internal runner state shared across modules
@@ -17,18 +33,6 @@ export interface RunnerState {
   activeRuns: Set<string>;
   jobPromises: Set<Promise<void>>;
   startedAt: Date;
-}
-
-/**
- * Runner status for external monitoring (written to status.json)
- * Used by deployment tools (Ansible) to track drain progress
- */
-export interface RunnerStatus {
-  mode: RunnerMode;
-  active_runs: number;
-  active_run_ids: string[];
-  started_at: string;
-  updated_at: string;
 }
 
 /**

--- a/turbo/apps/runner/src/lib/utils/process.ts
+++ b/turbo/apps/runner/src/lib/utils/process.ts
@@ -1,0 +1,21 @@
+/**
+ * Check if a process is running
+ *
+ * Uses kill(pid, 0) which checks process existence without sending a signal.
+ * - Returns true if process exists (signal would be deliverable)
+ * - Returns true if EPERM (process exists but we lack permission)
+ * - Returns false if ESRCH (no such process)
+ */
+export function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err: unknown) {
+    // EPERM means process exists but we don't have permission to signal it
+    if (err instanceof Error && "code" in err && err.code === "EPERM") {
+      return true;
+    }
+    // ESRCH or other errors mean process doesn't exist
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Convert `RunnerStatus` to zod schema for runtime validation
- Remove duplicate `RunnerStatus` definitions from doctor.ts and kill.ts
- Add orphan network namespace detection to doctor command
- Extract `isProcessRunning` to `lib/utils/process.ts` for reuse
- Use shared `isProcessRunning` in netns-pool, process, runner-lock
- Add warnings when registry or namespace listing fails
- Use file lock when reading netns registry

## Changes
- **lib/utils/process.ts** (new): Shared `isProcessRunning` function with EPERM handling
- **lib/runner/types.ts**: Add `RunnerStatusSchema` zod schema
- **commands/doctor.ts**: Use shared types, add netns orphan detection, add warnings
- **commands/kill.ts**: Use shared types
- **lib/firecracker/netns-pool.ts**: Export `NS_PREFIX` and `RegistrySchema`, use shared `isProcessRunning`
- **lib/firecracker/process.ts**: Use shared `isProcessRunning`
- **lib/runner/runner-lock.ts**: Use shared `isProcessRunning`

🤖 Generated with [Claude Code](https://claude.ai/code)