### PR TITLE
chore: add root folder to vscode workspace

### DIFF
--- a/vm0.code-workspace
+++ b/vm0.code-workspace
@@ -32,6 +32,10 @@
     },
     {
       "path": "ansible"
+    },
+    {
+      "path": ".",
+      "name": "root"
     }
   ],
   "extensions": {


### PR DESCRIPTION
## Summary

- Add root folder to VS Code workspace

This allows Claude Code to correctly detect the IDE when running from the project root directory in a VS Code workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)