### PR TITLE
feat(slack): integrate user secrets with agent modals

### DIFF
--- a/turbo/apps/platform/src/views/home/home-page.tsx
+++ b/turbo/apps/platform/src/views/home/home-page.tsx
@@ -1,7 +1,7 @@
 import { Card } from "@vm0/ui/components/ui/card";
 import { CopyButton } from "@vm0/ui/components/ui/copy-button";
 import { Button } from "@vm0/ui/components/ui/button";
-import { IconFileText, IconChevronRight } from "@tabler/icons-react";
+import { IconBook, IconChevronRight } from "@tabler/icons-react";
 import { AppShell } from "../layout/app-shell.tsx";
 import { OnboardingModal } from "./onboarding-modal.tsx";
 import { useGet } from "ccstate-react";
@@ -170,8 +170,8 @@ function ReferenceCard({
   href: string;
 }) {
   return (
-    <a href={href} target="_blank" rel="noopener noreferrer">
-      <Card className="flex items-center gap-3 p-4 hover:bg-muted/50 transition-colors cursor-pointer">
+    <a href={href} target="_blank" rel="noopener noreferrer" className="h-full">
+      <Card className="h-full flex items-center gap-3 p-4 hover:bg-muted/50 transition-colors cursor-pointer">
         <div
           className={`flex h-8 w-8 items-center justify-center rounded-lg ${iconBg}`}
         >
@@ -192,7 +192,7 @@ function UsefulReferences({ theme }: { theme: string }) {
       <h2 className="text-base font-medium text-foreground mb-4">
         Useful reference
       </h2>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         <ReferenceCard
           title="Explore our community"
           description="Join us on Discord"
@@ -224,11 +224,18 @@ function UsefulReferences({ theme }: { theme: string }) {
           href="https://github.com/vm0-ai/vm0"
         />
         <ReferenceCard
-          title="VM0 Professional Doc"
-          description="Professional docs and guides"
-          icon={<IconFileText className="h-8 w-8 text-primary" stroke={1.5} />}
+          title="Docs for developers"
+          description="Complete guides and CLI reference"
+          icon={<IconBook className="h-8 w-8 text-primary" stroke={1.5} />}
           iconBg=""
           href="https://docs.vm0.ai"
+        />
+        <ReferenceCard
+          title="Vibe coding quick start"
+          description="Build agents with Claude Code"
+          icon={<IconBook className="h-8 w-8 text-primary" stroke={1.5} />}
+          iconBg=""
+          href="https://docs.vm0.ai/docs/vibe-coder-quickstart"
         />
       </div>
     </section>

--- a/turbo/apps/web/app/api/slack/interactive/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/interactive/__tests__/route.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createHmac } from "crypto";
+import { eq } from "drizzle-orm";
 import { POST } from "../route";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { reloadEnv } from "../../../../../src/env";
 import { server } from "../../../../../src/mocks/server";
+import { slackBindings } from "../../../../../src/db/schema/slack-binding";
+import { listSecrets } from "../../../../../src/lib/secret/secret-service";
 
 // Mock only external dependencies (third-party packages)
 vi.mock("@clerk/nextjs/server");
@@ -295,18 +298,9 @@ describe("POST /api/slack/interactive", () => {
       // Update the binding's agentName to match the compose name (compose-existing-agent)
       // since the implementation uses compose.name as the agentName
       await globalThis.services.db
-        .update(
-          (await import("../../../../../src/db/schema/slack-binding"))
-            .slackBindings,
-        )
+        .update(slackBindings)
         .set({ agentName: `compose-${agentName}` })
-        .where(
-          (await import("drizzle-orm")).eq(
-            (await import("../../../../../src/db/schema/slack-binding"))
-              .slackBindings.slackUserLinkId,
-            userLink.id,
-          ),
-        );
+        .where(eq(slackBindings.slackUserLinkId, userLink.id));
 
       const body = buildInteractiveBody({
         type: "view_submission",
@@ -348,17 +342,8 @@ describe("POST /api/slack/interactive", () => {
       });
       // Delete this binding so we can create a new one
       await globalThis.services.db
-        .delete(
-          (await import("../../../../../src/db/schema/slack-binding"))
-            .slackBindings,
-        )
-        .where(
-          (await import("drizzle-orm")).eq(
-            (await import("../../../../../src/db/schema/slack-binding"))
-              .slackBindings.slackUserLinkId,
-            userLink.id,
-          ),
-        );
+        .delete(slackBindings)
+        .where(eq(slackBindings.slackUserLinkId, userLink.id));
 
       const body = buildInteractiveBody({
         type: "view_submission",
@@ -400,17 +385,8 @@ describe("POST /api/slack/interactive", () => {
       });
       // Delete this binding so we can create a new one
       await globalThis.services.db
-        .delete(
-          (await import("../../../../../src/db/schema/slack-binding"))
-            .slackBindings,
-        )
-        .where(
-          (await import("drizzle-orm")).eq(
-            (await import("../../../../../src/db/schema/slack-binding"))
-              .slackBindings.slackUserLinkId,
-            userLink.id,
-          ),
-        );
+        .delete(slackBindings)
+        .where(eq(slackBindings.slackUserLinkId, userLink.id));
 
       const body = buildInteractiveBody({
         type: "view_submission",
@@ -446,9 +422,6 @@ describe("POST /api/slack/interactive", () => {
       expect(response.status).toBe(200);
 
       // Verify secrets were saved to user's scope
-      const { listSecrets } = await import(
-        "../../../../../src/lib/secret/secret-service"
-      );
       const savedSecrets = await listSecrets(userLink.vm0UserId);
       const secretNames = savedSecrets.map((s) => s.name);
 

--- a/turbo/apps/web/app/api/slack/interactive/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/interactive/__tests__/route.test.ts
@@ -389,6 +389,72 @@ describe("POST /api/slack/interactive", () => {
       const text = await response.text();
       expect(text).toBe("");
     });
+
+    it("saves secrets to user scope when provided", async () => {
+      const { installation, userLink } = await context.createSlackInstallation({
+        withUserLink: true,
+      });
+      // Create a compose (via binding helper) to get a compose ID, then delete the binding
+      const { composeId } = await context.createSlackBinding(userLink.id, {
+        agentName: "secret-agent",
+      });
+      // Delete this binding so we can create a new one
+      await globalThis.services.db
+        .delete(
+          (await import("../../../../../src/db/schema/slack-binding"))
+            .slackBindings,
+        )
+        .where(
+          (await import("drizzle-orm")).eq(
+            (await import("../../../../../src/db/schema/slack-binding"))
+              .slackBindings.slackUserLinkId,
+            userLink.id,
+          ),
+        );
+
+      const body = buildInteractiveBody({
+        type: "view_submission",
+        user: {
+          id: userLink.slackUserId,
+          username: "testuser",
+          team_id: installation.slackWorkspaceId,
+        },
+        team: { id: installation.slackWorkspaceId, domain: "test" },
+        view: {
+          id: "V123",
+          callback_id: "agent_add_modal",
+          state: {
+            values: {
+              agent_select: {
+                agent_select_action: { selected_option: { value: composeId } },
+              },
+              secret_API_KEY: {
+                value: { value: "test-api-key-value" },
+              },
+              secret_OTHER_SECRET: {
+                value: { value: "test-other-secret" },
+              },
+            },
+          },
+        },
+      });
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+
+      // Success returns empty 200 to close the modal
+      expect(response.status).toBe(200);
+
+      // Verify secrets were saved to user's scope
+      const { listSecrets } = await import(
+        "../../../../../src/lib/secret/secret-service"
+      );
+      const savedSecrets = await listSecrets(userLink.vm0UserId);
+      const secretNames = savedSecrets.map((s) => s.name);
+
+      expect(secretNames).toContain("API_KEY");
+      expect(secretNames).toContain("OTHER_SECRET");
+    });
   });
 
   describe("Unknown Callback", () => {

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -27,6 +27,9 @@ import {
   listSecrets,
   setSecret,
 } from "../../../../src/lib/secret/secret-service";
+import { logger } from "../../../../src/lib/logger";
+
+const log = logger("slack:interactive");
 
 /**
  * Slack Interactive Components Endpoint
@@ -741,7 +744,7 @@ async function handleAgentAddSubmission(
       payload.user.id,
       encryptionKey,
     ).catch((error) => {
-      console.error("Error sending confirmation message:", error);
+      log.warn("Failed to send confirmation message (non-critical)", { error });
     });
   }
 
@@ -805,7 +808,9 @@ async function handleAgentRemoveSubmission(
       payload.user.id,
       encryptionKey,
     ).catch((error) => {
-      console.error("Error sending removal confirmation message:", error);
+      log.warn("Failed to send removal confirmation message (non-critical)", {
+        error,
+      });
     });
   }
 
@@ -957,7 +962,9 @@ async function handleAgentUpdateSubmission(
       payload.user.id,
       encryptionKey,
     ).catch((error) => {
-      console.error("Error sending update confirmation message:", error);
+      log.warn("Failed to send update confirmation message (non-critical)", {
+        error,
+      });
     });
   }
 

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -23,6 +23,10 @@ import {
   createSlackClient,
   isSlackInvalidAuthError,
 } from "../../../../src/lib/slack";
+import {
+  listSecrets,
+  setSecret,
+} from "../../../../src/lib/secret/secret-service";
 
 /**
  * Slack Interactive Components Endpoint
@@ -147,7 +151,14 @@ export async function POST(request: Request) {
 async function fetchAvailableAgents(
   vm0UserId: string,
   userLinkId: string,
-): Promise<Array<{ id: string; name: string; requiredSecrets: string[] }>> {
+): Promise<
+  Array<{
+    id: string;
+    name: string;
+    requiredSecrets: string[];
+    existingSecrets: string[];
+  }>
+> {
   // Fetch user's available agents with their head version
   const composes = await globalThis.services.db
     .select({
@@ -195,16 +206,24 @@ async function fetchAvailableAgents(
           .where(inArray(agentComposeVersions.id, versionIds))
       : [];
 
+  // Get user's existing secrets
+  const userSecrets = await listSecrets(vm0UserId);
+  const existingSecretNames = new Set(userSecrets.map((s) => s.name));
+
   // Build map of compose ID to required secrets
   const versionMap = new Map(versions.map((v) => [v.id, v.content]));
   return availableComposes.map((c) => {
     const content = c.headVersionId ? versionMap.get(c.headVersionId) : null;
     const refs = content ? extractVariableReferences(content) : [];
     const grouped = groupVariablesBySource(refs);
+    const requiredSecrets = grouped.secrets.map((s) => s.name);
     return {
       id: c.id,
       name: c.name,
-      requiredSecrets: grouped.secrets.map((s) => s.name),
+      requiredSecrets,
+      existingSecrets: requiredSecrets.filter((name) =>
+        existingSecretNames.has(name),
+      ),
     };
   });
 }
@@ -215,7 +234,14 @@ async function fetchAvailableAgents(
 async function fetchBoundAgents(
   vm0UserId: string,
   userLinkId: string,
-): Promise<Array<{ id: string; name: string; requiredSecrets: string[] }>> {
+): Promise<
+  Array<{
+    id: string;
+    name: string;
+    requiredSecrets: string[];
+    existingSecrets: string[];
+  }>
+> {
   // Get user's bound agents with their compose IDs
   const bindings = await globalThis.services.db
     .select({
@@ -256,6 +282,10 @@ async function fetchBoundAgents(
           .where(inArray(agentComposeVersions.id, versionIds))
       : [];
 
+  // Get user's existing secrets
+  const userSecrets = await listSecrets(vm0UserId);
+  const existingSecretNames = new Set(userSecrets.map((s) => s.name));
+
   // Build map of compose ID to required secrets
   const composeToVersion = new Map(
     composes.map((c) => [c.id, c.headVersionId]),
@@ -267,10 +297,14 @@ async function fetchBoundAgents(
     const content = versionId ? versionMap.get(versionId) : null;
     const refs = content ? extractVariableReferences(content) : [];
     const grouped = groupVariablesBySource(refs);
+    const requiredSecrets = grouped.secrets.map((s) => s.name);
     return {
       id: b.id,
       name: b.agentName,
-      requiredSecrets: grouped.secrets.map((s) => s.name),
+      requiredSecrets,
+      existingSecrets: requiredSecrets.filter((name) =>
+        existingSecretNames.has(name),
+      ),
     };
   });
 }
@@ -537,6 +571,7 @@ function extractChannelIdFromMetadata(
 async function sendConfirmationMessage(
   workspaceId: string,
   agentName: string,
+  savedSecretNames: string[],
   channelId: string,
   slackUserId: string,
   encryptionKey: string,
@@ -557,6 +592,15 @@ async function sendConfirmationMessage(
   );
   const client = createSlackClient(botToken);
 
+  let messageText = `:white_check_mark: *Agent \`${agentName}\` has been added successfully!*`;
+
+  if (savedSecretNames.length > 0) {
+    const secretsList = savedSecretNames.map((n) => `\`${n}\``).join(", ");
+    messageText += `\n\nSecrets saved to your account: ${secretsList}`;
+  }
+
+  messageText += `\n\nYou can now use it by mentioning \`@VM0 use ${agentName} <message>\``;
+
   await client.chat.postEphemeral({
     channel: channelId,
     user: slackUserId,
@@ -566,7 +610,7 @@ async function sendConfirmationMessage(
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `:white_check_mark: *Agent \`${agentName}\` has been added successfully!*\n\nYou can now use it by mentioning \`@VM0 use ${agentName} <message>\``,
+          text: messageText,
         },
       },
     ],
@@ -663,8 +707,21 @@ async function handleAgentAddSubmission(
     });
   }
 
+  // Save secrets to user's scope
+  const savedSecretNames: string[] = [];
+  for (const [name, value] of Object.entries(formValues.secrets)) {
+    if (value.trim()) {
+      await setSecret(
+        userLink.vm0UserId,
+        name,
+        value,
+        `Configured via Slack for ${agentName}`,
+      );
+      savedSecretNames.push(name);
+    }
+  }
+
   // Create binding
-  // Note: encryptedSecrets column has been removed; secrets are no longer stored per-binding
   await globalThis.services.db.insert(slackBindings).values({
     slackUserLinkId: userLink.id,
     vm0UserId: userLink.vm0UserId,
@@ -679,6 +736,7 @@ async function handleAgentAddSubmission(
     await sendConfirmationMessage(
       payload.team.id,
       agentName,
+      savedSecretNames,
       channelId,
       payload.user.id,
       encryptionKey,
@@ -870,12 +928,23 @@ async function handleAgentUpdateSubmission(
   const newSecrets = extractSecretsFromFormValues(values);
 
   // If no new secrets provided, nothing to update
-  // Note: encryptedSecrets column has been removed; secrets are no longer stored per-binding
   if (Object.keys(newSecrets).length === 0) {
     return NextResponse.json({
       response_action: "errors",
-      errors: { agent_select: "No secrets provided to update" },
+      errors: { agent_select: "No new secrets provided" },
     });
+  }
+
+  // Save secrets to user's scope
+  const savedSecretNames: string[] = [];
+  for (const [name, value] of Object.entries(newSecrets)) {
+    await setSecret(
+      binding.vm0UserId,
+      name,
+      value,
+      `Updated via Slack for ${binding.agentName}`,
+    );
+    savedSecretNames.push(name);
   }
 
   // Await message to prevent serverless function from terminating before it's sent
@@ -883,7 +952,7 @@ async function handleAgentUpdateSubmission(
     await sendUpdateConfirmationMessage(
       payload.team.id,
       binding.agentName,
-      Object.keys(newSecrets),
+      savedSecretNames,
       channelId,
       payload.user.id,
       encryptionKey,

--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -17,8 +17,18 @@ import {
 describe("buildAgentAddModal", () => {
   it("should create a valid modal structure", () => {
     const agents = [
-      { id: "agent-1", name: "My Coder", requiredSecrets: [] },
-      { id: "agent-2", name: "My Analyst", requiredSecrets: [] },
+      {
+        id: "agent-1",
+        name: "My Coder",
+        requiredSecrets: [],
+        existingSecrets: [],
+      },
+      {
+        id: "agent-2",
+        name: "My Analyst",
+        requiredSecrets: [],
+        existingSecrets: [],
+      },
     ];
 
     // Without selected agent, submit button is not shown
@@ -48,8 +58,18 @@ describe("buildAgentAddModal", () => {
 
   it("should include agent options in select", () => {
     const agents = [
-      { id: "agent-1", name: "My Coder", requiredSecrets: [] },
-      { id: "agent-2", name: "My Analyst", requiredSecrets: [] },
+      {
+        id: "agent-1",
+        name: "My Coder",
+        requiredSecrets: [],
+        existingSecrets: [],
+      },
+      {
+        id: "agent-2",
+        name: "My Analyst",
+        requiredSecrets: [],
+        existingSecrets: [],
+      },
     ];
 
     const modal = buildAgentAddModal(agents);
@@ -66,6 +86,46 @@ describe("buildAgentAddModal", () => {
       text: { type: "plain_text", text: "My Coder" },
       value: "agent-1",
     });
+  });
+
+  it("should mark existing secrets as optional with checkmark", () => {
+    const agents = [
+      {
+        id: "agent-1",
+        name: "My Coder",
+        requiredSecrets: ["API_KEY", "NEW_SECRET"],
+        existingSecrets: ["API_KEY"],
+      },
+    ];
+
+    const modal = buildAgentAddModal(agents, "agent-1") as ModalView;
+
+    // Find the existing secret input (API_KEY)
+    const existingSecretBlock = modal.blocks?.find(
+      (b) => "block_id" in b && b.block_id === "secret_API_KEY",
+    ) as InputBlock;
+    expect(existingSecretBlock).toBeDefined();
+    expect(existingSecretBlock.optional).toBe(true);
+    expect(existingSecretBlock.label).toMatchObject({
+      type: "plain_text",
+      text: "API_KEY ✓",
+    });
+    expect(existingSecretBlock.hint).toMatchObject({
+      type: "plain_text",
+      text: "Already configured in your account",
+    });
+
+    // Find the new secret input (NEW_SECRET)
+    const newSecretBlock = modal.blocks?.find(
+      (b) => "block_id" in b && b.block_id === "secret_NEW_SECRET",
+    ) as InputBlock;
+    expect(newSecretBlock).toBeDefined();
+    expect(newSecretBlock.optional).toBeUndefined();
+    expect(newSecretBlock.label).toMatchObject({
+      type: "plain_text",
+      text: "NEW_SECRET",
+    });
+    expect(newSecretBlock.hint).toBeUndefined();
   });
 });
 

--- a/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
@@ -5,123 +5,174 @@ import {
   parseExplicitAgentSelection,
 } from "../context";
 
-describe("formatContextForAgent", () => {
-  it("should format messages into context string", () => {
-    const messages = [
-      { user: "U123", text: "Hello, can you help me?" },
-      { user: "U456", text: "Sure, what do you need?" },
-    ];
+describe("Feature: Format Context For Agent", () => {
+  describe("Scenario: Format thread messages into context string", () => {
+    it("should include all messages with user IDs", () => {
+      const messages = [
+        { user: "U123", text: "Hello, can you help me?" },
+        { user: "U456", text: "Sure, what do you need?" },
+      ];
 
-    const result = formatContextForAgent(messages);
-    expect(result).toContain("## Slack Thread Context");
-    expect(result).toContain("[U123]: Hello, can you help me?");
-    expect(result).toContain("[U456]: Sure, what do you need?");
+      const result = formatContextForAgent(messages);
+
+      expect(result).toContain("## Slack Thread Context");
+      expect(result).toContain("[U123]: Hello, can you help me?");
+      expect(result).toContain("[U456]: Sure, what do you need?");
+    });
   });
 
-  it("should filter out bot messages when botUserId is provided", () => {
-    const botUserId = "BBOT123";
-    const messages = [
-      { user: "U123", text: "Hello" },
-      { user: "BBOT123", text: "Bot response" },
-      { user: "U456", text: "Thanks" },
-    ];
+  describe("Scenario: Include bot messages in context", () => {
+    it("should include bot messages labeled as 'bot'", () => {
+      const messages = [
+        { user: "U123", text: "Hello" },
+        { bot_id: "BBOT123", text: "Bot response" },
+        { user: "U456", text: "Thanks" },
+      ];
 
-    const result = formatContextForAgent(messages, botUserId);
-    expect(result).toContain("[U123]: Hello");
-    expect(result).not.toContain("Bot response");
-    expect(result).toContain("[U456]: Thanks");
+      const result = formatContextForAgent(messages);
+
+      expect(result).toContain("[U123]: Hello");
+      expect(result).toContain("[bot]: Bot response");
+      expect(result).toContain("[U456]: Thanks");
+    });
+
+    it("should not filter out any messages even when botUserId is provided", () => {
+      const botUserId = "BBOT123";
+      const messages = [
+        { user: "U123", text: "User message 1" },
+        { user: "BBOT123", text: "Bot message" },
+        { user: "U456", text: "User message 2" },
+      ];
+
+      const result = formatContextForAgent(messages, botUserId);
+
+      // All messages should be included
+      expect(result).toContain("[U123]: User message 1");
+      expect(result).toContain("[BBOT123]: Bot message");
+      expect(result).toContain("[U456]: User message 2");
+    });
   });
 
-  it("should return empty string for empty messages array", () => {
-    const result = formatContextForAgent([]);
-    expect(result).toBe("");
+  describe("Scenario: Handle edge cases", () => {
+    it("should return empty string for empty messages array", () => {
+      const result = formatContextForAgent([]);
+
+      expect(result).toBe("");
+    });
+
+    it("should handle messages with missing user or text", () => {
+      const messages = [{ text: "No user" }, { user: "U123" }];
+
+      const result = formatContextForAgent(messages);
+
+      expect(result).toContain("[unknown]: No user");
+      expect(result).toContain("[U123]: ");
+    });
   });
 
-  it("should handle messages with missing user or text", () => {
-    const messages = [{ text: "No user" }, { user: "U123" }];
+  describe("Scenario: Format channel messages", () => {
+    it("should use channel context header", () => {
+      const messages = [{ user: "U123", text: "Recent message" }];
 
-    const result = formatContextForAgent(messages);
-    expect(result).toContain("[unknown]: No user");
-    expect(result).toContain("[U123]: ");
+      const result = formatContextForAgent(messages, undefined, "channel");
+
+      expect(result).toContain("## Recent Channel Messages");
+      expect(result).toContain("[U123]: Recent message");
+    });
   });
 });
 
-describe("extractMessageContent", () => {
-  it("should remove bot mention from beginning of message", () => {
-    const botUserId = "U12345678";
-    const text = "<@U12345678> help me with this code";
+describe("Feature: Extract Message Content", () => {
+  describe("Scenario: Remove bot mention from message", () => {
+    it("should remove bot mention from beginning of message", () => {
+      const botUserId = "U12345678";
+      const text = "<@U12345678> help me with this code";
 
-    const result = extractMessageContent(text, botUserId);
-    expect(result).toBe("help me with this code");
-  });
+      const result = extractMessageContent(text, botUserId);
 
-  it("should handle message with only mention", () => {
-    const botUserId = "U12345678";
-    const text = "<@U12345678>";
+      expect(result).toBe("help me with this code");
+    });
 
-    const result = extractMessageContent(text, botUserId);
-    expect(result).toBe("");
-  });
+    it("should handle message with only mention", () => {
+      const botUserId = "U12345678";
+      const text = "<@U12345678>";
 
-  it("should handle message without mention", () => {
-    const botUserId = "U12345678";
-    const text = "just a regular message";
+      const result = extractMessageContent(text, botUserId);
 
-    const result = extractMessageContent(text, botUserId);
-    expect(result).toBe("just a regular message");
-  });
+      expect(result).toBe("");
+    });
 
-  it("should trim whitespace", () => {
-    const botUserId = "U12345678";
-    const text = "<@U12345678>    hello    ";
+    it("should handle message without mention", () => {
+      const botUserId = "U12345678";
+      const text = "just a regular message";
 
-    const result = extractMessageContent(text, botUserId);
-    expect(result).toBe("hello");
+      const result = extractMessageContent(text, botUserId);
+
+      expect(result).toBe("just a regular message");
+    });
+
+    it("should trim whitespace", () => {
+      const botUserId = "U12345678";
+      const text = "<@U12345678>    hello    ";
+
+      const result = extractMessageContent(text, botUserId);
+
+      expect(result).toBe("hello");
+    });
   });
 });
 
-describe("parseExplicitAgentSelection", () => {
-  it("should parse 'use <agent>' pattern", () => {
-    const message = "use my-coder fix this bug";
+describe("Feature: Parse Explicit Agent Selection", () => {
+  describe("Scenario: Parse 'use <agent>' pattern", () => {
+    it("should parse agent name and remaining message", () => {
+      const message = "use my-coder fix this bug";
 
-    const result = parseExplicitAgentSelection(message);
-    expect(result).toEqual({
-      agentName: "my-coder",
-      remainingMessage: "fix this bug",
+      const result = parseExplicitAgentSelection(message);
+
+      expect(result).toEqual({
+        agentName: "my-coder",
+        remainingMessage: "fix this bug",
+      });
+    });
+
+    it("should be case insensitive", () => {
+      const message = "USE My-Agent do something";
+
+      const result = parseExplicitAgentSelection(message);
+
+      expect(result).toEqual({
+        agentName: "My-Agent",
+        remainingMessage: "do something",
+      });
+    });
+
+    it("should handle agent name only (no remaining message)", () => {
+      const message = "use github-agent";
+
+      const result = parseExplicitAgentSelection(message);
+
+      expect(result).toEqual({
+        agentName: "github-agent",
+        remainingMessage: "",
+      });
     });
   });
 
-  it("should be case insensitive", () => {
-    const message = "USE My-Agent do something";
+  describe("Scenario: Handle invalid patterns", () => {
+    it("should return null for messages without 'use' pattern", () => {
+      const message = "just a regular message";
 
-    const result = parseExplicitAgentSelection(message);
-    expect(result).toEqual({
-      agentName: "My-Agent",
-      remainingMessage: "do something",
+      const result = parseExplicitAgentSelection(message);
+
+      expect(result).toBeNull();
     });
-  });
 
-  it("should return null for messages without 'use' pattern", () => {
-    const message = "just a regular message";
+    it("should return null for 'use' without agent name", () => {
+      const message = "use ";
 
-    const result = parseExplicitAgentSelection(message);
-    expect(result).toBeNull();
-  });
+      const result = parseExplicitAgentSelection(message);
 
-  it("should handle agent name only (no remaining message)", () => {
-    const message = "use github-agent";
-
-    const result = parseExplicitAgentSelection(message);
-    expect(result).toEqual({
-      agentName: "github-agent",
-      remainingMessage: "",
+      expect(result).toBeNull();
     });
-  });
-
-  it("should return null for 'use' without agent name", () => {
-    const message = "use ";
-
-    const result = parseExplicitAgentSelection(message);
-    expect(result).toBeNull();
   });
 });

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -13,14 +13,14 @@ interface SlackMessage {
  * @param client - Slack WebClient
  * @param channel - Channel ID
  * @param threadTs - Thread timestamp
- * @param limit - Maximum number of messages to fetch (default: 20)
+ * @param limit - Maximum number of messages to fetch (default: 100, fetch all)
  * @returns Array of messages
  */
 export async function fetchThreadContext(
   client: WebClient,
   channel: string,
   threadTs: string,
-  limit = 20,
+  limit = 100,
 ): Promise<SlackMessage[]> {
   const result = await client.conversations.replies({
     channel,
@@ -28,7 +28,9 @@ export async function fetchThreadContext(
     limit,
   });
 
-  return (result.messages ?? []) as SlackMessage[];
+  const messages = (result.messages ?? []) as SlackMessage[];
+  console.log(`[slack:context] Fetched ${messages.length} thread messages`);
+  return messages;
 }
 
 /**
@@ -57,7 +59,7 @@ export async function fetchChannelContext(
  * Format messages into context for agent prompt
  *
  * @param messages - Array of Slack messages
- * @param botUserId - Bot user ID to filter out bot messages (optional)
+ * @param botUserId - Bot user ID (kept for API compatibility, no longer used for filtering)
  * @param contextType - Type of context: "thread" or "channel"
  * @returns Formatted context string
  */
@@ -66,15 +68,12 @@ export function formatContextForAgent(
   botUserId?: string,
   contextType: "thread" | "channel" = "thread",
 ): string {
-  const formattedMessages = messages
-    // Filter out bot's own messages if botUserId is provided
-    .filter((msg) => !botUserId || msg.user !== botUserId)
-    // Format each message
-    .map((msg) => {
-      const user = msg.user ?? "unknown";
-      const text = msg.text ?? "";
-      return `[${user}]: ${text}`;
-    });
+  // Include all messages (don't filter bot messages)
+  const formattedMessages = messages.map((msg) => {
+    const user = msg.bot_id ? "bot" : (msg.user ?? "unknown");
+    const text = msg.text ?? "";
+    return `[${user}]: ${text}`;
+  });
 
   if (formattedMessages.length === 0) {
     return "";
@@ -85,7 +84,11 @@ export function formatContextForAgent(
       ? "## Slack Thread Context"
       : "## Recent Channel Messages";
 
-  return `${header}\n\n${formattedMessages.join("\n\n")}`;
+  const result = `${header}\n\n${formattedMessages.join("\n\n")}`;
+  console.log(
+    `[slack:context] Formatted ${formattedMessages.length} messages for ${contextType}, length=${result.length}`,
+  );
+  return result;
 }
 
 /**

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -1,4 +1,7 @@
 import type { WebClient } from "@slack/web-api";
+import { logger } from "../logger";
+
+const log = logger("slack:context");
 
 interface SlackMessage {
   user?: string;
@@ -29,7 +32,7 @@ export async function fetchThreadContext(
   });
 
   const messages = (result.messages ?? []) as SlackMessage[];
-  console.log(`[slack:context] Fetched ${messages.length} thread messages`);
+  log.debug("Fetched thread messages", { count: messages.length });
   return messages;
 }
 
@@ -85,9 +88,11 @@ export function formatContextForAgent(
       : "## Recent Channel Messages";
 
   const result = `${header}\n\n${formattedMessages.join("\n\n")}`;
-  console.log(
-    `[slack:context] Formatted ${formattedMessages.length} messages for ${contextType}, length=${result.length}`,
-  );
+  log.debug("Formatted messages for context", {
+    messageCount: formattedMessages.length,
+    contextType,
+    resultLength: result.length,
+  });
   return result;
 }
 

--- a/turbo/apps/web/src/lib/slack/handlers/__tests__/mention.test.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/__tests__/mention.test.ts
@@ -229,16 +229,11 @@ describe("Feature: App Mention Handling", () => {
         }),
       );
 
-      // 4. Thinking message should be updated (first with agent name, then with response)
-      const updateCalls = slackApiCalls.filter(
-        (c) => c.method === "chat.update",
-      );
-      // Two updates: first adds agent name, second adds final response
-      expect(updateCalls).toHaveLength(2);
-      // Final update should contain the response
-      expect((updateCalls[1]!.body as { text?: string }).text).toBe(
-        "Here is my helpful response!",
-      );
+      // 4. Response message should be posted with the agent's response
+      // Note: The new flow posts response directly without intermediate "Thinking..." message
+      expect(postCalls).toHaveLength(1);
+      const responseText = (postCalls[0]!.body as { text?: string }).text;
+      expect(responseText).toBe("Here is my helpful response!");
 
       // 5. Thinking reaction should be removed
       const reactionRemoveCalls = slackApiCalls.filter(
@@ -306,12 +301,12 @@ describe("Feature: App Mention Handling", () => {
       });
 
       // Then I should see list of available agents
-      // Note: The new flow posts "Thinking..." first, then updates it with the error
-      const updateCalls = slackApiCalls.filter(
-        (c) => c.method === "chat.update",
+      // Note: The new flow posts error message directly via postMessage
+      const postCalls = slackApiCalls.filter(
+        (c) => c.method === "chat.postMessage",
       );
-      expect(updateCalls).toHaveLength(1);
-      const text = (updateCalls[0]!.body as { text?: string }).text ?? "";
+      expect(postCalls).toHaveLength(1);
+      const text = (postCalls[0]!.body as { text?: string }).text ?? "";
       expect(text).toContain("couldn't determine which agent");
       expect(text).toContain("agent-a");
       expect(text).toContain("agent-b");
@@ -337,12 +332,12 @@ describe("Feature: App Mention Handling", () => {
       });
 
       // Then I should see error that "writer" not found
-      // Note: The new flow posts "Thinking..." first, then updates it with the error
-      const updateCalls = slackApiCalls.filter(
-        (c) => c.method === "chat.update",
+      // Note: The new flow posts error message directly via postMessage
+      const postCalls = slackApiCalls.filter(
+        (c) => c.method === "chat.postMessage",
       );
-      expect(updateCalls).toHaveLength(1);
-      const text = (updateCalls[0]!.body as { text?: string }).text ?? "";
+      expect(postCalls).toHaveLength(1);
+      const text = (postCalls[0]!.body as { text?: string }).text ?? "";
       expect(text).toContain('"writer" not found');
       // And I should see list of available agents
       expect(text).toContain("coder");

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -114,15 +114,14 @@ async function routeMessageToAgent(
  * 3. If not linked, post link message
  * 4. Get user's bindings
  * 5. If no bindings, prompt to add agent
- * 6. Add thinking reaction and post "Thinking..." message (early feedback)
+ * 6. Add thinking reaction (emoji only)
  * 7. Route to agent (explicit or LLM)
- * 8. Update thinking message with agent name
- * 9. Find existing thread session (for session continuation)
- * 10. Fetch thread context
- * 11. Execute agent with session continuation
- * 12. Create thread session mapping (if new thread)
- * 13. Update thinking message with response
- * 14. Remove thinking reaction
+ * 8. Find existing thread session (for session continuation)
+ * 9. Fetch thread context
+ * 10. Execute agent with session continuation
+ * 11. Create thread session mapping (if new thread)
+ * 12. Post response message
+ * 13. Remove thinking reaction
  */
 export async function handleAppMention(context: MentionContext): Promise<void> {
   const { SECRETS_ENCRYPTION_KEY } = env();
@@ -203,7 +202,7 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       return;
     }
 
-    // 6. Add thinking reaction and post early "Thinking..." message
+    // 6. Add thinking reaction (emoji only, no message)
     const reactionAdded = await client.reactions
       .add({
         channel: context.channelId,
@@ -212,26 +211,6 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       })
       .then(() => true)
       .catch(() => false);
-
-    const thinkingTs = await postMessage(
-      client,
-      context.channelId,
-      "Thinking...",
-      {
-        threadTs,
-        blocks: [
-          {
-            type: "context",
-            elements: [
-              {
-                type: "mrkdwn",
-                text: `:hourglass_flowing_sand: *Thinking...*`,
-              },
-            ],
-          },
-        ],
-      },
-    );
 
     // Extract message content (remove bot mention)
     const messageContent = extractMessageContent(
@@ -243,15 +222,11 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
     const routeResult = await routeMessageToAgent(messageContent, bindings);
 
     if (!routeResult.success) {
-      // Update thinking message with error and cleanup
-      if (thinkingTs) {
-        await client.chat.update({
-          channel: context.channelId,
-          ts: thinkingTs,
-          text: routeResult.error,
-          blocks: buildErrorMessage(routeResult.error),
-        });
-      }
+      // Post error message and cleanup reaction
+      await postMessage(client, context.channelId, routeResult.error, {
+        threadTs,
+        blocks: buildErrorMessage(routeResult.error),
+      });
       if (reactionAdded) {
         await client.reactions
           .remove({
@@ -266,35 +241,16 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
 
     const { agentName: selectedAgentName, promptText } = routeResult;
 
-    // 8. Update thinking message with selected agent
-    if (thinkingTs) {
-      await client.chat
-        .update({
-          channel: context.channelId,
-          ts: thinkingTs,
-          text: `Thinking... (using ${selectedAgentName})`,
-          blocks: [
-            {
-              type: "context",
-              elements: [
-                {
-                  type: "mrkdwn",
-                  text: `:hourglass_flowing_sand: *Thinking...* (using \`${selectedAgentName}\`)`,
-                },
-              ],
-            },
-          ],
-        })
-        .catch(() => {});
-    }
-
     // Get the selected binding
     const selectedBinding = bindings.find(
       (b) => b.agentName === selectedAgentName,
     )!;
 
-    // 9. Find existing thread session for this binding (if in a thread)
+    // 8. Find existing thread session for this binding (if in a thread)
     let existingSessionId: string | undefined;
+    console.log(
+      `[slack:mention] Looking for thread session: threadTs=${threadTs}, context.threadTs=${context.threadTs}, bindingId=${selectedBinding.id}, channelId=${context.channelId}`,
+    );
     if (threadTs) {
       const [threadSession] = await globalThis.services.db
         .select({ agentSessionId: slackThreadSessions.agentSessionId })
@@ -309,9 +265,12 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
         .limit(1);
 
       existingSessionId = threadSession?.agentSessionId;
+      console.log(
+        `[slack:mention] Thread session query result: existingSessionId=${existingSessionId}`,
+      );
     }
 
-    // 10. Fetch Slack context (thread messages or recent channel messages)
+    // 9. Fetch Slack context (thread messages or recent channel messages)
     let formattedContext = "";
     if (context.threadTs) {
       // In a thread - fetch thread replies
@@ -328,7 +287,10 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
     }
 
     try {
-      // 11. Execute agent with session continuation
+      // 10. Execute agent with session continuation
+      console.log(
+        `[slack:mention] Calling runAgentForSlack with existingSessionId=${existingSessionId}`,
+      );
       const { response: agentResponse, sessionId: newSessionId } =
         await runAgentForSlack({
           binding: selectedBinding,
@@ -337,9 +299,15 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
           threadContext: formattedContext,
           userId: userLink.vm0UserId,
         });
+      console.log(
+        `[slack:mention] runAgentForSlack returned newSessionId=${newSessionId}`,
+      );
 
-      // 12. Create thread session mapping if this is a new thread (no existing session)
+      // 11. Create thread session mapping if this is a new thread (no existing session)
       if (threadTs && !existingSessionId && newSessionId) {
+        console.log(
+          `[slack:mention] Creating thread session mapping: threadTs=${threadTs}, newSessionId=${newSessionId}`,
+        );
         await globalThis.services.db
           .insert(slackThreadSessions)
           .values({
@@ -351,23 +319,13 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
           .onConflictDoNothing();
       }
 
-      // 13. Update thinking message with actual response
-      if (thinkingTs) {
-        await client.chat.update({
-          channel: context.channelId,
-          ts: thinkingTs,
-          text: agentResponse,
-          blocks: buildMarkdownMessage(agentResponse),
-        });
-      } else {
-        // Fallback: post new message if we don't have the thinking message ts
-        await postMessage(client, context.channelId, agentResponse, {
-          threadTs,
-          blocks: buildMarkdownMessage(agentResponse),
-        });
-      }
+      // 12. Post response message
+      await postMessage(client, context.channelId, agentResponse, {
+        threadTs,
+        blocks: buildMarkdownMessage(agentResponse),
+      });
     } finally {
-      // 14. Remove thinking reaction
+      // 13. Remove thinking reaction
       if (reactionAdded) {
         await client.reactions
           .remove({

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -20,6 +20,9 @@ import {
 } from "../index";
 import { routeToAgent } from "../router";
 import { runAgentForSlack } from "./run-agent";
+import { logger } from "../../logger";
+
+const log = logger("slack:mention");
 
 interface MentionContext {
   workspaceId: string;
@@ -241,16 +244,28 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
 
     const { agentName: selectedAgentName, promptText } = routeResult;
 
-    // Get the selected binding
+    // Get the selected binding (guaranteed to exist since routeResult.success is true)
     const selectedBinding = bindings.find(
       (b) => b.agentName === selectedAgentName,
-    )!;
+    );
+    if (!selectedBinding) {
+      // This should never happen since routeMessageToAgent only returns success
+      // with an agent name that exists in bindings
+      log.error("Selected binding not found after successful route", {
+        selectedAgentName,
+        availableBindings: bindings.map((b) => b.agentName),
+      });
+      return;
+    }
 
     // 8. Find existing thread session for this binding (if in a thread)
     let existingSessionId: string | undefined;
-    console.log(
-      `[slack:mention] Looking for thread session: threadTs=${threadTs}, context.threadTs=${context.threadTs}, bindingId=${selectedBinding.id}, channelId=${context.channelId}`,
-    );
+    log.debug("Looking for thread session", {
+      threadTs,
+      contextThreadTs: context.threadTs,
+      bindingId: selectedBinding.id,
+      channelId: context.channelId,
+    });
     if (threadTs) {
       const [threadSession] = await globalThis.services.db
         .select({ agentSessionId: slackThreadSessions.agentSessionId })
@@ -265,9 +280,7 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
         .limit(1);
 
       existingSessionId = threadSession?.agentSessionId;
-      console.log(
-        `[slack:mention] Thread session query result: existingSessionId=${existingSessionId}`,
-      );
+      log.debug("Thread session query result", { existingSessionId });
     }
 
     // 9. Fetch Slack context (thread messages or recent channel messages)
@@ -288,9 +301,7 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
 
     try {
       // 10. Execute agent with session continuation
-      console.log(
-        `[slack:mention] Calling runAgentForSlack with existingSessionId=${existingSessionId}`,
-      );
+      log.debug("Calling runAgentForSlack", { existingSessionId });
       const { response: agentResponse, sessionId: newSessionId } =
         await runAgentForSlack({
           binding: selectedBinding,
@@ -299,15 +310,14 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
           threadContext: formattedContext,
           userId: userLink.vm0UserId,
         });
-      console.log(
-        `[slack:mention] runAgentForSlack returned newSessionId=${newSessionId}`,
-      );
+      log.debug("runAgentForSlack returned", { newSessionId });
 
       // 11. Create thread session mapping if this is a new thread (no existing session)
       if (threadTs && !existingSessionId && newSessionId) {
-        console.log(
-          `[slack:mention] Creating thread session mapping: threadTs=${threadTs}, newSessionId=${newSessionId}`,
-        );
+        log.debug("Creating thread session mapping", {
+          threadTs,
+          newSessionId,
+        });
         await globalThis.services.db
           .insert(slackThreadSessions)
           .values({
@@ -324,6 +334,19 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
         threadTs,
         blocks: buildMarkdownMessage(agentResponse),
       });
+    } catch (innerError) {
+      // If postMessage or session creation fails, still try to notify the user
+      log.error("Error posting response or creating session", {
+        error: innerError,
+      });
+      await postMessage(
+        client,
+        context.channelId,
+        "Sorry, an error occurred while sending the response. Please try again.",
+        { threadTs },
+      ).catch(() => {
+        // If even the error message fails, we can't do anything more
+      });
     } finally {
       // 13. Remove thinking reaction
       if (reactionAdded) {
@@ -339,8 +362,8 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       }
     }
   } catch (error) {
-    console.error("Error handling app_mention:", error);
-    // Don't throw - we don't want to retry
+    log.error("Error handling app_mention", { error });
+    // Don't throw - we don't want Slack to retry
   }
 }
 

--- a/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
@@ -9,6 +9,8 @@ import { generateSandboxToken } from "../../auth/sandbox-token";
 import { buildExecutionContext, prepareAndDispatchRun } from "../../run";
 import { queryAxiom, getDatasetName, DATASETS } from "../../axiom";
 import { logger } from "../../logger";
+import { getUserScopeByClerkId } from "../../scope/scope-service";
+import { getSecretValues } from "../../secret/secret-service";
 
 const log = logger("slack:run-agent");
 
@@ -80,9 +82,11 @@ export async function runAgentForSlack(
       versionId = latestVersion.id;
     }
 
-    // Note: encryptedSecrets column has been removed from slack_bindings
-    // Secrets are no longer stored per-binding; they will be resolved from the user's scope
-    const secrets: Record<string, string> = {};
+    // Load secrets from user's scope
+    const scope = await getUserScopeByClerkId(userId);
+    const secrets: Record<string, string> = scope
+      ? await getSecretValues(scope.id)
+      : {};
 
     // Build the full prompt with thread context
     const fullPrompt = threadContext

--- a/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
@@ -1,4 +1,4 @@
-import { eq, desc, and, gte, asc } from "drizzle-orm";
+import { eq, desc, and, gte } from "drizzle-orm";
 import {
   agentComposes,
   agentComposeVersions,
@@ -138,8 +138,8 @@ export async function runAgentForSlack(
       pollIntervalMs: 5000, // 5 second polling interval
     });
 
-    // If no existing session, find the session created for this run
-    // Use run.createdAt to avoid race conditions with concurrent runs
+    // If no existing session, find the session created/updated for this run
+    // Use updatedAt >= run.createdAt to catch both new and updated sessions
     let resultSessionId = sessionId;
     if (!sessionId && result.status === "completed") {
       const [newSession] = await globalThis.services.db
@@ -149,10 +149,10 @@ export async function runAgentForSlack(
           and(
             eq(agentSessions.userId, userId),
             eq(agentSessions.agentComposeId, binding.composeId),
-            gte(agentSessions.createdAt, run.createdAt),
+            gte(agentSessions.updatedAt, run.createdAt),
           ),
         )
-        .orderBy(asc(agentSessions.createdAt))
+        .orderBy(desc(agentSessions.updatedAt))
         .limit(1);
 
       resultSessionId = newSession?.id;


### PR DESCRIPTION
## Summary
- Show which secrets already exist in user's account when adding/updating Slack agents
- Mark existing secrets as optional with checkmark indicator in modal UI
- Save new secrets to user scope (not per-binding) when configured via Slack
- Include saved secrets in confirmation messages

## Test plan
- [x] Unit tests added for modal blocks with existing secrets
- [x] Integration test added for secret saving on agent add submission
- [x] All existing Slack tests pass

Generated with [Claude Code](https://claude.com/claude-code)