### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -84,7 +84,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Cleanup Stale Deployments
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const dryRun = '${{ env.DRY_RUN }}' === 'true';
@@ -212,7 +212,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Cleanup Stale Git Branches
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const dryRun = '${{ env.DRY_RUN }}' === 'true';

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -14,7 +14,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check if cleanup needed
         id: check
@@ -107,7 +107,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Delete Neon Branch
         uses: ./.github/actions/neon-branch
@@ -123,7 +123,7 @@ jobs:
       deployments: write
     steps:
       - name: Delete PR Deployments
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const branchName = context.payload.pull_request.head.ref;

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -18,7 +18,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check formatting
         run: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
 
       - name: Install neonctl
@@ -114,7 +114,7 @@ jobs:
       deployments: write
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
 
       - name: Install neonctl
@@ -207,7 +207,7 @@ jobs:
       deployments: write
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
 
       - name: Notify Slack - Starting
@@ -265,7 +265,7 @@ jobs:
       deployments: write
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
 
       - name: Notify Slack - Starting
@@ -327,7 +327,7 @@ jobs:
       deployments: write
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
 
       - name: Notify Slack - Starting
@@ -385,7 +385,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Notify Slack - Starting
         id: slack-start
@@ -398,7 +398,7 @@ jobs:
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
             text: "*CLI* publishing to npm..."
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
@@ -452,7 +452,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Notify Slack - Starting
         id: slack-start
@@ -465,7 +465,7 @@ jobs:
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
             text: "*Runner* publishing to npm..."
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
@@ -521,7 +521,7 @@ jobs:
       contents: read
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
 
       - name: Install Python3 and Ansible
@@ -632,7 +632,7 @@ jobs:
       contents: read
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
 
       - name: Build E2B templates

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -29,7 +29,7 @@ jobs:
       e2b-changed: ${{ steps.detect-e2b.outputs.e2b-changed }}
       cli-e2e-parallel-matrix: ${{ steps.cli-e2e-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -209,7 +209,7 @@ jobs:
     # Skip for release-please commits (only version bumps and changelogs)
     if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -249,7 +249,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
       - name: Build Core Package
         working-directory: turbo
@@ -263,7 +263,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
       - name: Build Core Package
         working-directory: turbo
@@ -277,7 +277,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
       - name: Prettier
         working-directory: turbo
@@ -288,7 +288,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
       - name: Build Core Package
         working-directory: turbo
@@ -315,7 +315,7 @@ jobs:
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
       - name: Build Core Package
         working-directory: turbo
@@ -346,7 +346,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
       - name: Build Core Package
         working-directory: turbo
@@ -360,7 +360,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
       - name: Build Core Package
         working-directory: turbo
@@ -374,7 +374,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
       - name: Build Core Package
         working-directory: turbo
@@ -408,7 +408,7 @@ jobs:
       pull-requests: write
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
 
       # Step 1: Create Neon database branch
@@ -483,7 +483,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Save test token to cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.vm0
           key: e2e-token-${{ github.run_id }}-${{ github.run_attempt }}
@@ -501,7 +501,7 @@ jobs:
       pull-requests: write
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
 
       - name: Deploy Docs to Vercel
@@ -543,7 +543,7 @@ jobs:
       pull-requests: write
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
 
       - name: Deploy Site to Vercel
@@ -589,7 +589,7 @@ jobs:
       pull-requests: write
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
 
       - name: Deploy Platform to Vercel
@@ -637,7 +637,7 @@ jobs:
         needs.prepare.outputs.runner-changed == 'true'
       )
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
       - uses: ./.github/actions/toolchain-init
@@ -687,12 +687,12 @@ jobs:
     permissions:
       actions: read  # Required to query cache API
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive # For BATS test framework
 
       - name: Restore test token from cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.vm0
           key: e2e-token-${{ github.run_id }}-${{ github.run_attempt }}
@@ -735,7 +735,7 @@ jobs:
     permissions:
       actions: read  # Required to query cache API
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
       - uses: ./.github/actions/toolchain-init
@@ -756,7 +756,7 @@ jobs:
         run: cd turbo/apps/cli && pnpm link --global
 
       - name: Restore test token from cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.vm0
           key: e2e-token-${{ github.run_id }}-${{ github.run_attempt }}
@@ -810,7 +810,7 @@ jobs:
         include: ${{ fromJSON(needs.prepare.outputs.cli-e2e-parallel-matrix) }}
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
       - uses: ./.github/actions/toolchain-init
@@ -834,7 +834,7 @@ jobs:
         run: apt-get update && apt-get install -y parallel
 
       - name: Restore test token from cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.vm0
           key: e2e-token-${{ github.run_id }}-${{ github.run_attempt }}
@@ -894,7 +894,7 @@ jobs:
       )
     timeout-minutes: 8
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
       - uses: ./.github/actions/toolchain-init
@@ -918,7 +918,7 @@ jobs:
         run: apt-get update && apt-get install -y parallel
 
       - name: Restore test token from cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.vm0
           key: e2e-token-${{ github.run_id }}-${{ github.run_attempt }}
@@ -974,7 +974,7 @@ jobs:
       runner-dir: ${{ steps.prepare.outputs.runner-dir }}
       proxy-port: ${{ steps.prepare.outputs.proxy-port }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
 
       - name: Lock runner host
@@ -1194,7 +1194,7 @@ jobs:
         needs.prepare.outputs.runner-changed == 'true'
       )
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run benchmark command for VM performance testing
         env:
@@ -1261,7 +1261,7 @@ jobs:
       runner-dir: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
       runner-host: ${{ needs.deploy-runner-prepare.outputs.runner-host }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
 
       - name: Install Python3 and Ansible
@@ -1372,7 +1372,7 @@ jobs:
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
       needs.prepare.outputs.e2b-changed == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
 
       - name: Build E2B templates


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache/restore` | [`v4`](https://github.com/actions/cache/restore/releases/tag/v4) | [`v5`](https://github.com/actions/cache/restore/releases/tag/v5) | [Release](https://github.com/actions/cache/restore/releases/tag/v5) | turbo.yml |
| `actions/cache/save` | [`v4`](https://github.com/actions/cache/save/releases/tag/v4) | [`v5`](https://github.com/actions/cache/save/releases/tag/v5) | [Release](https://github.com/actions/cache/save/releases/tag/v5) | turbo.yml |
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | cleanup.yml, crates.yml, docker-build.yml, docker-publish.yml, release-please.yml, turbo.yml |
| `actions/github-script` | [`v7`](https://github.com/actions/github-script/releases/tag/v7) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) | cleanup-stale.yml, cleanup.yml |
| `actions/setup-node` | [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | release-please.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
