### PR TITLE
fix(runner): use runner-specific path for vm registry

### DIFF
--- a/turbo/apps/runner/src/commands/benchmark.ts
+++ b/turbo/apps/runner/src/commands/benchmark.ts
@@ -12,6 +12,7 @@ import {
   initNetnsPool,
   cleanupNetnsPool,
 } from "../lib/firecracker/netns-pool.js";
+import { initVMRegistry } from "../lib/proxy/index.js";
 import { Timer } from "../lib/timing.js";
 import { setGlobalLogger } from "../lib/logger.js";
 import { runnerPaths } from "../lib/paths.js";
@@ -87,6 +88,9 @@ export const benchmarkCommand = new Command("benchmark")
         }
         process.exit(1);
       }
+
+      // Initialize VM registry for proxy IP → run mapping
+      initVMRegistry(runnerPaths.vmRegistry(config.base_dir));
 
       // Initialize pools for VM resources
       // - With snapshot: copies golden overlay (preserves snapshot disk state)

--- a/turbo/apps/runner/src/lib/paths.ts
+++ b/turbo/apps/runner/src/lib/paths.ts
@@ -60,6 +60,9 @@ export const runnerPaths = {
   /** Extract vmId from workspace directory name */
   extractVmId: (dirname: string): VmId =>
     createVmId(dirname.replace(VM_WORKSPACE_PREFIX, "")),
+
+  /** VM registry file for proxy IP → run mapping */
+  vmRegistry: (baseDir: string) => path.join(baseDir, "vm-registry.json"),
 };
 
 /**
@@ -105,9 +108,6 @@ export const snapshotOutputPaths = {
 export const tempPaths = {
   /** Default proxy CA directory */
   proxyDir: `${VM0_TMP_PREFIX}-proxy`,
-
-  /** VM registry for proxy */
-  vmRegistry: `${VM0_TMP_PREFIX}-vm-registry.json`,
 
   /** Network log file for a run */
   networkLog: (runId: string) => `${VM0_TMP_PREFIX}-network-${runId}.jsonl`,

--- a/turbo/apps/runner/src/lib/proxy/__tests__/proxy-manager.test.ts
+++ b/turbo/apps/runner/src/lib/proxy/__tests__/proxy-manager.test.ts
@@ -24,6 +24,7 @@ describe("ProxyManager", () => {
       caDir: path.join(tempDir, "proxy"),
       port: 8080,
       apiUrl: "https://test.api.com",
+      registryPath: path.join(tempDir, "vm-registry.json"),
     });
   });
 
@@ -49,6 +50,7 @@ describe("ProxyManager", () => {
         caDir: customDir,
         port: 9090,
         apiUrl: "https://custom.api.com",
+        registryPath: path.join(tempDir, "custom-registry.json"),
       });
 
       const config = customManager.getConfig();
@@ -64,6 +66,7 @@ describe("ProxyManager", () => {
       const minimalManager = new ProxyManager({
         caDir: minimalDir,
         apiUrl: "https://test.api.com",
+        registryPath: path.join(tempDir, "minimal-registry.json"),
       });
 
       const config = minimalManager.getConfig();

--- a/turbo/apps/runner/src/lib/proxy/__tests__/vm-registry.test.ts
+++ b/turbo/apps/runner/src/lib/proxy/__tests__/vm-registry.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import { VMRegistry, DEFAULT_REGISTRY_PATH } from "../vm-registry";
+import { VMRegistry } from "../vm-registry";
 
 describe("VMRegistry", () => {
   let registry: VMRegistry;
@@ -20,12 +20,7 @@ describe("VMRegistry", () => {
   });
 
   describe("constructor", () => {
-    it("should use default path when not specified", () => {
-      const defaultRegistry = new VMRegistry();
-      expect(defaultRegistry["registryPath"]).toBe(DEFAULT_REGISTRY_PATH);
-    });
-
-    it("should use custom path when specified", () => {
+    it("should use the specified path", () => {
       expect(registry["registryPath"]).toBe(testRegistryPath);
     });
   });

--- a/turbo/apps/runner/src/lib/proxy/proxy-manager.ts
+++ b/turbo/apps/runner/src/lib/proxy/proxy-manager.ts
@@ -9,7 +9,7 @@
 import { spawn, ChildProcess } from "child_process";
 import fs from "fs";
 import path from "path";
-import { getVMRegistry, DEFAULT_REGISTRY_PATH } from "./vm-registry";
+import { getVMRegistry } from "./vm-registry";
 import { RUNNER_MITM_ADDON_SCRIPT } from "./mitm-addon-script";
 import { createLogger } from "../logger.js";
 
@@ -23,6 +23,8 @@ interface RequiredProxyConfig {
   caDir: string;
   /** VM0 API URL for the addon (from runner config server.url) */
   apiUrl: string;
+  /** Path to the VM registry file (per-runner isolation) */
+  registryPath: string;
 }
 
 /**
@@ -31,8 +33,6 @@ interface RequiredProxyConfig {
 interface OptionalProxyConfig {
   /** Port for mitmproxy to listen on */
   port: number;
-  /** Path to the VM registry file */
-  registryPath: string;
 }
 
 /**
@@ -53,7 +53,6 @@ type ProxyConfigInput = RequiredProxyConfig & Partial<OptionalProxyConfig>;
  */
 const DEFAULT_PROXY_OPTIONS: OptionalProxyConfig = {
   port: 8080,
-  registryPath: DEFAULT_REGISTRY_PATH,
 };
 
 /**

--- a/turbo/apps/runner/src/lib/proxy/vm-registry.ts
+++ b/turbo/apps/runner/src/lib/proxy/vm-registry.ts
@@ -9,7 +9,6 @@
  */
 import fs from "fs";
 import { createLogger } from "../logger.js";
-import { tempPaths } from "../paths.js";
 
 const logger = createLogger("VMRegistry");
 
@@ -53,20 +52,13 @@ interface RegistryData {
 }
 
 /**
- * Default path for the registry file
- * This path is read by the mitmproxy addon
- * TODO: Should use runnerPaths instead of tempPaths for proper isolation
- */
-export const DEFAULT_REGISTRY_PATH = tempPaths.vmRegistry;
-
-/**
  * VM Registry class for managing VM IP → RunId mappings
  */
 export class VMRegistry {
   private registryPath: string;
   private data: RegistryData;
 
-  constructor(registryPath: string = DEFAULT_REGISTRY_PATH) {
+  constructor(registryPath: string) {
     this.registryPath = registryPath;
     this.data = this.load();
   }
@@ -178,18 +170,21 @@ let globalRegistry: VMRegistry | null = null;
 
 /**
  * Get the global VM registry instance
+ * @throws Error if registry was not initialized with initVMRegistry
  */
 export function getVMRegistry(): VMRegistry {
   if (!globalRegistry) {
-    globalRegistry = new VMRegistry();
+    throw new Error(
+      "VMRegistry not initialized. Call initVMRegistry(registryPath) first.",
+    );
   }
   return globalRegistry;
 }
 
 /**
- * Initialize the VM registry with a custom path
+ * Initialize the VM registry with a registry path
  */
-export function initVMRegistry(registryPath?: string): VMRegistry {
+export function initVMRegistry(registryPath: string): VMRegistry {
   globalRegistry = new VMRegistry(registryPath);
   return globalRegistry;
 }

--- a/turbo/apps/runner/src/lib/runner/setup.ts
+++ b/turbo/apps/runner/src/lib/runner/setup.ts
@@ -47,11 +47,13 @@ export async function setupEnvironment(
   // The proxy is always started but only used when experimentalFirewall is enabled
   // Must initialize BEFORE netns pool so we know the proxy port
   logger.log("Initializing network proxy...");
-  initVMRegistry();
+  const registryPath = runnerPaths.vmRegistry(config.base_dir);
+  initVMRegistry(registryPath);
   const proxyManager = initProxyManager({
     apiUrl: config.server.url,
     port: config.proxy.port,
     caDir: config.proxy.ca_dir,
+    registryPath,
   });
 
   // Try to start proxy - if mitmproxy is not installed, continue without it


### PR DESCRIPTION
## Summary
- Move VMRegistry path from global `/tmp/vm0-vm-registry.json` to runner's `base_dir/vm-registry.json`
- Make `registryPath` a required parameter in `VMRegistry`, `initVMRegistry()`, and `initProxyManager()`
- Add `runnerPaths.vmRegistry()` function and remove `tempPaths.vmRegistry`

This enables multi-runner isolation on the same machine, preventing VM IP mapping conflicts and incorrect runId associations when multiple runners (e.g., PR tests) run concurrently.

Closes #2198

## Test plan
- [x] All existing runner tests pass (261 tests)
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes (no unused exports)
- [ ] Manual verification: Start runner and verify registry file is created in `base_dir` instead of `/tmp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)