### PR TITLE
feat(docs): rewrite model provider documentation

### DIFF
--- a/turbo/apps/docs/content/docs/model-selection/aws-bedrock.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/aws-bedrock.mdx
@@ -1,0 +1,106 @@
+---
+title: AWS Bedrock
+description: Run Claude on AWS Bedrock
+---
+
+<Callout type="warning">
+AWS Bedrock support is experimental and may change in future releases.
+</Callout>
+
+[AWS Bedrock](https://aws.amazon.com/bedrock/) allows you to run Claude models on AWS infrastructure.
+
+## Quick Setup
+
+```bash
+vm0 model-provider setup --type aws-bedrock
+```
+
+You'll be prompted to choose an authentication method and provide the required credentials.
+
+## Authentication Methods
+
+### API Key (Recommended)
+
+Use a Bedrock API key for simple authentication.
+
+**Required credentials:**
+- **AWS_BEARER_TOKEN_BEDROCK** - Bedrock API key from AWS console
+- **AWS_REGION** - AWS region (e.g., `us-east-1`, `us-west-2`)
+
+```bash
+vm0 model-provider setup --type aws-bedrock --auth-method api-key \
+  --credential AWS_BEARER_TOKEN_BEDROCK=your-api-key \
+  --credential AWS_REGION=us-east-1
+```
+
+### IAM Access Keys
+
+Use IAM credentials for authentication.
+
+**Required credentials:**
+- **AWS_ACCESS_KEY_ID** - IAM access key ID
+- **AWS_SECRET_ACCESS_KEY** - IAM secret access key
+- **AWS_REGION** - AWS region
+
+**Optional credentials:**
+- **AWS_SESSION_TOKEN** - For temporary credentials (e.g., from STS)
+
+```bash
+vm0 model-provider setup --type aws-bedrock --auth-method access-keys \
+  --credential AWS_ACCESS_KEY_ID=your-access-key \
+  --credential AWS_SECRET_ACCESS_KEY=your-secret-key \
+  --credential AWS_REGION=us-east-1
+```
+
+With session token (temporary credentials):
+
+```bash
+vm0 model-provider setup --type aws-bedrock --auth-method access-keys \
+  --credential AWS_ACCESS_KEY_ID=your-access-key \
+  --credential AWS_SECRET_ACCESS_KEY=your-secret-key \
+  --credential AWS_SESSION_TOKEN=your-session-token \
+  --credential AWS_REGION=us-east-1
+```
+
+## Model Selection
+
+AWS Bedrock supports custom model IDs. During setup, you can specify a model:
+
+```bash
+vm0 model-provider setup --type aws-bedrock --auth-method api-key \
+  --credential AWS_BEARER_TOKEN_BEDROCK=xxx \
+  --credential AWS_REGION=us-east-1 \
+  --model anthropic.claude-sonnet-4-20250514-v1:0
+```
+
+## Get Credentials
+
+### For API Key method:
+1. Go to the [AWS Console](https://console.aws.amazon.com)
+2. Navigate to Amazon Bedrock
+3. Find your API key in the service settings
+
+### For IAM Access Keys method:
+1. Go to IAM in AWS Console
+2. Create or select a user with Bedrock permissions
+3. Generate access keys under Security credentials
+
+## Run
+
+Once configured, run agents as usual:
+
+```bash
+vm0 run my-agent "build a todo app"
+```
+
+Or specify the provider explicitly:
+
+```bash
+vm0 run my-agent "build a todo app" --model-provider aws-bedrock
+```
+
+## Resources
+
+- [Claude Code Bedrock Setup Guide](https://docs.anthropic.com/en/docs/claude-code/bedrock)
+- [AWS Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)
+- [AWS Bedrock Pricing](https://aws.amazon.com/bedrock/pricing/)

--- a/turbo/apps/docs/content/docs/model-selection/azure-foundry.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/azure-foundry.mdx
@@ -1,0 +1,56 @@
+---
+title: Azure Foundry
+description: Run Claude on Microsoft Azure Foundry
+---
+
+<Callout type="warning">
+Azure Foundry support is experimental and may change in future releases.
+</Callout>
+
+[Azure Foundry](https://azure.microsoft.com/en-us/products/ai-foundry) allows you to run Claude models on Microsoft Azure infrastructure.
+
+## Quick Setup
+
+```bash
+vm0 model-provider setup --type azure-foundry
+```
+
+You'll be prompted for:
+1. **ANTHROPIC_FOUNDRY_API_KEY** - API key from Azure Foundry portal (Endpoints and keys)
+2. **ANTHROPIC_FOUNDRY_RESOURCE** - Azure resource name (from portal URL)
+3. **Model** - Custom model ID (e.g., `claude-sonnet-4-5`)
+
+## Get Credentials
+
+1. Go to the [Azure Portal](https://portal.azure.com)
+2. Navigate to your Azure Foundry resource
+3. Find **Endpoints and keys** section
+4. Copy the API key and resource name
+
+## Non-Interactive Setup
+
+```bash
+vm0 model-provider setup --type azure-foundry \
+  --credential ANTHROPIC_FOUNDRY_API_KEY=your-api-key \
+  --credential ANTHROPIC_FOUNDRY_RESOURCE=your-resource-name \
+  --model claude-sonnet-4-5
+```
+
+## Run
+
+Once configured, run agents as usual:
+
+```bash
+vm0 run my-agent "build a todo app"
+```
+
+Or specify the provider explicitly:
+
+```bash
+vm0 run my-agent "build a todo app" --model-provider azure-foundry
+```
+
+## Resources
+
+- [Claude Code Foundry Setup Guide](https://code.claude.com/docs/en/microsoft-foundry)
+- [Azure AI Foundry Documentation](https://learn.microsoft.com/en-us/azure/ai-foundry/)

--- a/turbo/apps/docs/content/docs/model-selection/claude.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/claude.mdx
@@ -1,13 +1,11 @@
 ---
 title: Claude
-description: Use Claude models with full control over Opus, Sonnet, and Haiku selection
+description: Use Claude models directly from Anthropic
 ---
 
-Use Claude models with Claude Code. This gives you full control over model selection for different tasks and provides access to the latest Claude models.
+Use Claude models directly from Anthropic with full control over model selection.
 
 ## Quick Setup
-
-Configure Claude authentication with a single command:
 
 ```bash
 # Using OAuth token (requires Claude Pro/Max subscription)
@@ -17,57 +15,36 @@ vm0 model-provider setup --type claude-code-oauth-token
 vm0 model-provider setup --type anthropic-api-key
 ```
 
-Once configured, you can run agents without any environment configuration in `vm0.yaml`.
+Once configured, run agents without any additional configuration.
 
 ## Authentication Options
 
-VM0 supports two authentication methods for Claude Code. We recommend using `vm0 model-provider setup` to configure these.
+| Method | Type | Pricing |
+|--------|------|---------|
+| OAuth Token | `claude-code-oauth-token` | Fixed monthly (Pro/Max subscription) |
+| API Key | `anthropic-api-key` | Pay-per-token |
 
-| Method | Command | Pricing |
-|--------|---------|---------|
-| OAuth Token | `vm0 model-provider setup --type claude-code-oauth-token` | Fixed monthly (Pro/Max) |
-| API Key | `vm0 model-provider setup --type anthropic-api-key` | Pay-per-token |
+**OAuth Token (Subscription):** Get your OAuth token by running `claude setup-token` in your terminal. Requires Claude Pro or Max subscription.
 
-**OAuth Token (Subscription):** Get your OAuth token by running `claude setup-token` in your terminal. This uses your Claude Pro or Max subscription with unlimited usage.
-
-**API Key (Pay-per-use):** Get your API key from the [Anthropic Console](https://console.anthropic.com/settings/keys). You'll be charged based on token usage.
+**API Key (Pay-per-use):** Get your API key from the [Anthropic Console](https://console.anthropic.com/settings/keys).
 
 <Callout type="warning">
-Do not set both `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` at the same time. This will cause authentication conflicts.
+Do not set both OAuth token and API key at the same time. This will cause authentication conflicts.
 </Callout>
 
-## Advanced Configuration
+## Non-Interactive Setup
 
-For most users, the model provider setup above is sufficient. Use manual configuration when you need:
-- Custom model tier selection (Opus, Sonnet, Haiku)
-- Alternative base URLs
-- Per-agent authentication overrides
+```bash
+# OAuth token
+vm0 model-provider setup --type claude-code-oauth-token --credential "your-oauth-token"
 
-### Manual Environment Variables
-
-Configure authentication directly in your `vm0.yaml`:
-
-```yaml title="vm0.yaml"
-version: "1.0"
-
-agents:
-  my-agent:
-    framework: claude-code
-    environment:
-      # Option 1: OAuth token
-      CLAUDE_CODE_OAUTH_TOKEN: "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
-
-      # Option 2: API key
-      # ANTHROPIC_API_KEY: "${{ secrets.ANTHROPIC_API_KEY }}"
+# API key
+vm0 model-provider setup --type anthropic-api-key --credential "sk-ant-xxx"
 ```
 
-<Callout type="warning">
-When you set authentication environment variables in `vm0.yaml`, they take precedence over model providers.
-</Callout>
+## Model Tier Configuration
 
-### Model Tier Configuration
-
-Customize which Claude models to use for different tasks:
+For advanced users who want to customize which Claude models are used for different tasks, you can configure model tiers in your `vm0.yaml`:
 
 ```yaml title="vm0.yaml"
 version: "1.0"
@@ -90,85 +67,16 @@ agents:
 | `CLAUDE_CODE_SUBAGENT_MODEL` | Model for subagents | Latest Sonnet |
 
 <Callout type="info">
-If you don't specify these variables, Claude Code will automatically use the latest available models for each tier.
+If you don't specify these variables, Claude Code automatically uses the latest available models for each tier.
 </Callout>
-
-## Available Models
-
-See the complete list of available Claude models and their specifications in the [Anthropic documentation](https://docs.anthropic.com/en/docs/about-claude/models).
 
 <Callout type="warning">
-You must use the **full model name** (e.g., `claude-sonnet-4-5-20250929`) in the environment variables, not aliases like `opus`, `sonnet`, or `haiku`.
+You must use the **full model name** (e.g., `claude-sonnet-4-5-20250929`) in environment variables, not aliases like `opus`, `sonnet`, or `haiku`.
 </Callout>
-
-## Usage Examples
-
-### Use Latest Models (Default)
-
-With model provider configured, no environment variables needed:
-
-```yaml title="vm0.yaml"
-version: "1.0"
-
-agents:
-  my-agent:
-    framework: claude-code
-```
-
-### Use All Opus Models
-
-For maximum intelligence across all tasks:
-
-```yaml title="vm0.yaml"
-version: "1.0"
-
-agents:
-  my-agent:
-    framework: claude-code
-    environment:
-      ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-5-20251101" # [!code highlight]
-      ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-opus-4-5-20251101" # [!code highlight]
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-opus-4-5-20251101" # [!code highlight]
-      CLAUDE_CODE_SUBAGENT_MODEL: "claude-opus-4-5-20251101" # [!code highlight]
-```
-
-### Use All Sonnet Models
-
-For balanced performance and cost:
-
-```yaml title="vm0.yaml"
-version: "1.0"
-
-agents:
-  my-agent:
-    framework: claude-code
-    environment:
-      ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-sonnet-4-5-20250929" # [!code highlight]
-      ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-5-20250929" # [!code highlight]
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-sonnet-4-5-20250929" # [!code highlight]
-      CLAUDE_CODE_SUBAGENT_MODEL: "claude-sonnet-4-5-20250929" # [!code highlight]
-```
-
-### Use All Haiku Models
-
-For maximum speed and cost-efficiency:
-
-```yaml title="vm0.yaml"
-version: "1.0"
-
-agents:
-  my-agent:
-    framework: claude-code
-    environment:
-      ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-haiku-4-5-20251001" # [!code highlight]
-      ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-haiku-4-5-20251001" # [!code highlight]
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001" # [!code highlight]
-      CLAUDE_CODE_SUBAGENT_MODEL: "claude-haiku-4-5-20251001" # [!code highlight]
-```
 
 ## Resources
 
-- [Claude Code Documentation](https://code.claude.com/docs/en/model-config) - Model configuration guide
+- [Claude Code Model Configuration](https://code.claude.com/docs/en/model-config)
 - [Claude API Documentation](https://docs.anthropic.com/en/api/getting-started)
 - [Model Comparison](https://docs.anthropic.com/en/docs/about-claude/models)
 - [Pricing](https://www.anthropic.com/pricing)

--- a/turbo/apps/docs/content/docs/model-selection/deepseek.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/deepseek.mdx
@@ -3,31 +3,38 @@ title: DeepSeek
 description: Use DeepSeek models with VM0
 ---
 
-[DeepSeek](https://api-docs.deepseek.com/guides/anthropic_api) provides cost-effective models with strong coding capabilities.
+[DeepSeek](https://platform.deepseek.com) provides cost-effective models with strong coding capabilities.
+
+## Quick Setup
+
+```bash
+vm0 model-provider setup --type deepseek-api-key
+```
+
+You'll be prompted for your API key.
 
 ## Get API Key
 
-Visit the [DeepSeek Platform](https://platform.deepseek.com/api_keys) to create and obtain an API Key.
+Visit the [DeepSeek Platform](https://platform.deepseek.com/api_keys) to create and obtain an API key.
 
-## Configuration
+## Available Models
 
-```yaml title="vm0.yaml"
-version: "1.0"
+| Model | Description |
+|-------|-------------|
+| `deepseek-chat` | DeepSeek chat model (default) |
 
-agents:
-  my-agent:
-    framework: claude-code
-    environment:
-      ANTHROPIC_BASE_URL: "https://api.deepseek.com/anthropic" # [!code highlight]
-      ANTHROPIC_AUTH_TOKEN: "${{ secrets.DEEPSEEK_API_KEY }}" # [!code highlight]
-      API_TIMEOUT_MS: "600000" # [!code highlight]
-      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1" # [!code highlight]
-      ANTHROPIC_MODEL: "deepseek-chat" # [!code highlight]
-      ANTHROPIC_SMALL_FAST_MODEL: "deepseek-chat" # [!code highlight]
+## Non-Interactive Setup
+
+```bash
+vm0 model-provider setup --type deepseek-api-key --credential "sk-xxx"
 ```
 
 ## Run
 
 ```bash
-vm0 run my-agent "build a todo app" --secrets DEEPSEEK_API_KEY=sk-xxx
+vm0 run my-agent "build a todo app"
 ```
+
+## Resources
+
+- [DeepSeek Anthropic API Guide](https://api-docs.deepseek.com/guides/anthropic_api)

--- a/turbo/apps/docs/content/docs/model-selection/index.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/index.mdx
@@ -1,83 +1,105 @@
 ---
 title: Overview
-description: Configure different model providers for your agents
+description: Configure model providers for your VM0 agents
 ---
 
-VM0 uses **Claude Code** as the primary agent framework. You can also use alternative model providers with Claude Code.
+VM0 agents use model providers to connect to AI models. The **model provider system** securely stores your credentials and automatically injects them when running agents.
 
-## Quick Start with Model Provider
+## Quick Start
 
-The fastest way to configure model authentication is using the model provider system:
+Configure a model provider with a single command:
 
 ```bash
 vm0 model-provider setup
 ```
 
 This interactive command will:
-1. Prompt you to select a provider type
-2. Ask for your credential (OAuth token or API key)
-3. Store it securely on the VM0 platform
+1. Show available provider types
+2. Prompt for your credential (API key or OAuth token)
+3. Allow model selection (for providers that support it)
+4. Store credentials securely on the VM0 platform
 
-Once configured, your credential is automatically injected when running agents.
+Once configured, credentials are automatically injected when running agents.
 
-### Available Provider Types
+## Available Providers
 
-| Type | Framework | How to Get |
-|------|-----------|------------|
-| `claude-code-oauth-token` | Claude Code | Run `claude setup-token` |
-| `anthropic-api-key` | Claude Code | [Anthropic Console](https://console.anthropic.com/settings/keys) |
+| Provider | Type | Models | How to Get Credential |
+|----------|------|--------|----------------------|
+| [Claude (OAuth)](/docs/model-selection/claude) | `claude-code-oauth-token` | Latest Claude | Run `claude setup-token` |
+| [Claude (API)](/docs/model-selection/claude) | `anthropic-api-key` | Latest Claude | [Anthropic Console](https://console.anthropic.com/settings/keys) |
+| [OpenRouter](/docs/model-selection/openrouter) | `openrouter-api-key` | Claude Sonnet/Opus/Haiku | [OpenRouter Keys](https://openrouter.ai/settings/keys) |
+| [Moonshot](/docs/model-selection/moonshot) | `moonshot-api-key` | Kimi K2 models | [Moonshot Platform](https://platform.moonshot.ai/console/api-keys) |
+| [MiniMax](/docs/model-selection/minimax) | `minimax-api-key` | MiniMax-M2.1 | [MiniMax Platform](https://platform.minimax.io/user-center/basic-information/interface-key) |
+| [DeepSeek](/docs/model-selection/deepseek) | `deepseek-api-key` | deepseek-chat | [DeepSeek Platform](https://platform.deepseek.com/api_keys) |
+| [Z.AI](/docs/model-selection/zai) | `zai-api-key` | GLM-4.7, GLM-4.5-Air | [Z.AI Platform](https://z.ai/model-api) |
+| [Azure Foundry](/docs/model-selection/azure-foundry) | `azure-foundry` | Custom | [Azure Portal](https://portal.azure.com) |
+| [AWS Bedrock](/docs/model-selection/aws-bedrock) | `aws-bedrock` | Custom | [AWS Console](https://console.aws.amazon.com) |
 
-### Managing Model Providers
+<Callout type="info">
+Azure Foundry and AWS Bedrock are experimental features with multi-credential authentication.
+</Callout>
+
+## Non-Interactive Setup
+
+For CI/CD or scripting, provide credentials via flags:
+
+```bash
+# Simple providers (single credential)
+vm0 model-provider setup --type anthropic-api-key --credential "sk-xxx"
+
+# With model selection
+vm0 model-provider setup --type openrouter-api-key --credential "sk-xxx" --model "anthropic/claude-sonnet-4.5"
+```
+
+## Model Selection
+
+Some providers support choosing specific models. During setup, you'll be prompted to select a model:
+
+| Provider | Available Models | Default |
+|----------|-----------------|---------|
+| OpenRouter | `anthropic/claude-sonnet-4.5`, `anthropic/claude-opus-4.5`, `anthropic/claude-haiku-4.5` | auto |
+| Moonshot | `kimi-k2.5`, `kimi-k2-thinking-turbo`, `kimi-k2-thinking` | `kimi-k2.5` |
+| Z.AI | `GLM-4.7`, `GLM-4.5-Air` | `GLM-4.7` |
+| MiniMax | `MiniMax-M2.1` | `MiniMax-M2.1` |
+| DeepSeek | `deepseek-chat` | `deepseek-chat` |
+| Azure Foundry | Custom input | - |
+| AWS Bedrock | Custom input | - |
+
+## Managing Model Providers
 
 ```bash
 # List all configured providers
 vm0 model-provider list
 
-# Set a different default
-vm0 model-provider set-default anthropic-api-key
+# Set a provider as default
+vm0 model-provider set-default openrouter-api-key
 
 # Delete a provider
-vm0 model-provider delete claude-code-oauth-token
+vm0 model-provider delete anthropic-api-key
 ```
 
-### Non-Interactive Setup
+<Callout type="info" title="How Credential Injection Works">
+When you run an agent:
+1. If your `vm0.yaml` has explicit auth environment variables, those are used
+2. Otherwise, your default model provider credential is injected automatically
+3. You can override at runtime with: `vm0 run agent "prompt" --model-provider <type>`
+</Callout>
 
-For CI/CD or scripting, use flags instead of prompts:
+## Runtime Override
+
+Override your default provider for a single run:
 
 ```bash
-vm0 model-provider setup --type anthropic-api-key --credential "sk-xxx"
+vm0 run my-agent "build a todo app" --model-provider openrouter-api-key
 ```
 
-<Callout type="info" title="How Model Selection Works">
-When you run an agent:
-1. If your `vm0.yaml` has explicit auth environment variables → those are used
-2. Otherwise → your default model provider credential is injected automatically
-3. Override with: `vm0 run agent "prompt" --model-provider <type>`
-</Callout>
-
-## Framework Selection
-
-Claude Code is the default and recommended agent framework. If you've configured a model provider above, authentication is handled automatically.
-
-### Claude Code (Default)
-
-Claude Code is the default framework, using Anthropic's Claude model:
-
-```yaml title="vm0.yaml"
-version: "1.0"
-
-agents:
-  my-agent:
-    framework: claude-code # [!code highlight]
-```
-
-## Alternative Model Providers
+## Advanced: Manual Configuration
 
 <Callout type="warning">
-Alternative model providers require manual configuration.
+For most users, `vm0 model-provider setup` is the recommended approach. Manual configuration is only needed for advanced use cases.
 </Callout>
 
-If you need to use providers other than Anthropic directly (like OpenRouter or DeepSeek), configure them manually in your `vm0.yaml`:
+If you need per-agent authentication overrides or custom configurations, you can set environment variables directly in your `vm0.yaml`:
 
 ```yaml title="vm0.yaml"
 version: "1.0"
@@ -86,16 +108,9 @@ agents:
   my-agent:
     framework: claude-code
     environment:
-      ANTHROPIC_BASE_URL: "https://api.example.com/anthropic" # [!code highlight]
-      ANTHROPIC_AUTH_TOKEN: "${{ secrets.API_KEY }}" # [!code highlight]
-      ANTHROPIC_MODEL: "model-name" # [!code highlight]
+      ANTHROPIC_BASE_URL: "https://api.example.com/anthropic"
+      ANTHROPIC_AUTH_TOKEN: "${{ secrets.MY_API_KEY }}"
+      ANTHROPIC_MODEL: "model-name"
 ```
 
-**Supported Providers:**
-
-- [Claude](/docs/model-selection/claude)
-- [OpenRouter](/docs/model-selection/openrouter)
-- [Moonshot (Kimi)](/docs/model-selection/moonshot)
-- [MiniMax](/docs/model-selection/minimax)
-- [DeepSeek](/docs/model-selection/deepseek)
-- [Z.AI (GLM)](/docs/model-selection/zai)
+See individual provider pages for specific environment variable details.

--- a/turbo/apps/docs/content/docs/model-selection/meta.json
+++ b/turbo/apps/docs/content/docs/model-selection/meta.json
@@ -7,6 +7,8 @@
     "moonshot",
     "minimax",
     "deepseek",
-    "zai"
+    "zai",
+    "azure-foundry",
+    "aws-bedrock"
   ]
 }

--- a/turbo/apps/docs/content/docs/model-selection/minimax.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/minimax.mdx
@@ -3,34 +3,38 @@ title: MiniMax
 description: Use MiniMax M2.1 model with VM0
 ---
 
-[MiniMax](https://platform.minimax.io/docs/guides/text-ai-coding-tools) offers the M2.1 model with strong code understanding and multi-turn dialogue capabilities.
+[MiniMax](https://platform.minimax.io) offers the M2.1 model with strong code understanding and multi-turn dialogue capabilities.
+
+## Quick Setup
+
+```bash
+vm0 model-provider setup --type minimax-api-key
+```
+
+You'll be prompted for your API key.
 
 ## Get API Key
 
-Visit the [MiniMax Coding Plan](https://platform.minimax.io/user-center/payment/coding-plan) page to get your Coding Plan API Key.
+Visit the [MiniMax Platform](https://platform.minimax.io/user-center/basic-information/interface-key) to get your API key.
 
-## Configuration
+## Available Models
 
-```yaml title="vm0.yaml"
-version: "1.0"
+| Model | Description |
+|-------|-------------|
+| `MiniMax-M2.1` | Latest MiniMax model (default) |
 
-agents:
-  my-agent:
-    framework: claude-code
-    environment:
-      ANTHROPIC_BASE_URL: "https://api.minimax.io/anthropic" # [!code highlight]
-      ANTHROPIC_AUTH_TOKEN: "${{ secrets.MINIMAX_API_KEY }}" # [!code highlight]
-      API_TIMEOUT_MS: "3000000" # [!code highlight]
-      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1" # [!code highlight]
-      ANTHROPIC_MODEL: "MiniMax-M2.1" # [!code highlight]
-      ANTHROPIC_SMALL_FAST_MODEL: "MiniMax-M2.1" # [!code highlight]
-      ANTHROPIC_DEFAULT_SONNET_MODEL: "MiniMax-M2.1" # [!code highlight]
-      ANTHROPIC_DEFAULT_OPUS_MODEL: "MiniMax-M2.1" # [!code highlight]
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: "MiniMax-M2.1" # [!code highlight]
+## Non-Interactive Setup
+
+```bash
+vm0 model-provider setup --type minimax-api-key --credential "xxx"
 ```
 
 ## Run
 
 ```bash
-vm0 run my-agent "build a todo app" --secrets MINIMAX_API_KEY=xxx
+vm0 run my-agent "build a todo app"
 ```
+
+## Resources
+
+- [MiniMax AI Coding Tools Documentation](https://platform.minimax.io/docs/guides/text-ai-coding-tools)

--- a/turbo/apps/docs/content/docs/model-selection/moonshot.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/moonshot.mdx
@@ -1,34 +1,46 @@
 ---
 title: Moonshot (Kimi)
-description: Use Kimi K2 model with VM0
+description: Use Kimi K2 models with VM0
 ---
 
-[Moonshot](https://platform.moonshot.ai/docs/guide/agent-support) provides the Kimi K2 model with strong reasoning capabilities.
+[Moonshot](https://platform.moonshot.ai) provides the Kimi K2 model with strong reasoning capabilities.
+
+## Quick Setup
+
+```bash
+vm0 model-provider setup --type moonshot-api-key
+```
+
+You'll be prompted for your API key and model selection.
 
 ## Get API Key
 
-Visit the [Moonshot Open Platform](https://platform.moonshot.ai/console/api-keys) to create and obtain an API Key.
+Visit the [Moonshot Platform](https://platform.moonshot.ai/console/api-keys) to create and obtain an API key.
 
-## Configuration
+## Available Models
 
-```yaml title="vm0.yaml"
-version: "1.0"
+| Model | Description |
+|-------|-------------|
+| `kimi-k2.5` | Latest Kimi model (default) |
+| `kimi-k2-thinking-turbo` | Fast thinking model |
+| `kimi-k2-thinking` | Standard thinking model |
 
-agents:
-  my-agent:
-    framework: claude-code
-    environment:
-      ANTHROPIC_BASE_URL: "https://api.moonshot.ai/anthropic" # [!code highlight]
-      ANTHROPIC_AUTH_TOKEN: "${{ secrets.MOONSHOT_API_KEY }}" # [!code highlight]
-      ANTHROPIC_MODEL: "kimi-k2-thinking-turbo" # [!code highlight]
-      ANTHROPIC_DEFAULT_OPUS_MODEL: "kimi-k2-thinking-turbo" # [!code highlight]
-      ANTHROPIC_DEFAULT_SONNET_MODEL: "kimi-k2-thinking-turbo" # [!code highlight]
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: "kimi-k2-thinking-turbo" # [!code highlight]
-      CLAUDE_CODE_SUBAGENT_MODEL: "kimi-k2-thinking-turbo" # [!code highlight]
+## Non-Interactive Setup
+
+```bash
+# With default model
+vm0 model-provider setup --type moonshot-api-key --credential "sk-xxx"
+
+# With specific model
+vm0 model-provider setup --type moonshot-api-key --credential "sk-xxx" --model "kimi-k2-thinking-turbo"
 ```
 
 ## Run
 
 ```bash
-vm0 run my-agent "build a todo app" --secrets MOONSHOT_API_KEY=sk-xxx
+vm0 run my-agent "build a todo app"
 ```
+
+## Resources
+
+- [Moonshot Agent Support Documentation](https://platform.moonshot.ai/docs/guide/agent-support)

--- a/turbo/apps/docs/content/docs/model-selection/openrouter.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/openrouter.mdx
@@ -1,33 +1,48 @@
 ---
 title: OpenRouter
-description: Use multiple model providers through OpenRouter
+description: Use Claude models through OpenRouter
 ---
 
-[OpenRouter](https://openrouter.ai/docs/guides/guides/claude-code-integration) provides access to multiple model providers through a unified API, allowing you to use models from OpenAI, Anthropic, Google, and others.
+[OpenRouter](https://openrouter.ai) provides access to Claude models through a unified API.
 
-## Configuration
+## Quick Setup
 
-```yaml title="vm0.yaml"
-version: "1.0"
-
-agents:
-  my-agent:
-    framework: claude-code
-    environment:
-      ANTHROPIC_BASE_URL: "https://openrouter.ai/api" # [!code highlight]
-      ANTHROPIC_AUTH_TOKEN: "${{ secrets.OPENROUTER_API_KEY }}" # [!code highlight]
-      ANTHROPIC_API_KEY: "" # [!code highlight]
-      ANTHROPIC_DEFAULT_SONNET_MODEL: "anthropic/claude-sonnet-4" # [!code highlight]
-      ANTHROPIC_DEFAULT_OPUS_MODEL: "anthropic/claude-opus-4" # [!code highlight]
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: "anthropic/claude-haiku-3.5" # [!code highlight]
+```bash
+vm0 model-provider setup --type openrouter-api-key
 ```
 
-`ANTHROPIC_API_KEY` must be explicitly set to an empty string to prevent conflicts.
+You'll be prompted for your API key and model selection.
+
+## Get API Key
+
+Visit [OpenRouter Settings](https://openrouter.ai/settings/keys) to create and obtain an API key.
+
+## Available Models
+
+| Model | Description |
+|-------|-------------|
+| `anthropic/claude-sonnet-4.5` | Balanced performance |
+| `anthropic/claude-opus-4.5` | Highest capability |
+| `anthropic/claude-haiku-4.5` | Fastest response |
+| auto | Automatic model selection (default) |
+
+## Non-Interactive Setup
+
+```bash
+# With default model (auto)
+vm0 model-provider setup --type openrouter-api-key --credential "sk-or-xxx"
+
+# With specific model
+vm0 model-provider setup --type openrouter-api-key --credential "sk-or-xxx" --model "anthropic/claude-sonnet-4.5"
+```
 
 ## Run
 
 ```bash
-vm0 run my-agent "build a todo app" --secrets OPENROUTER_API_KEY=sk-xxx
+vm0 run my-agent "build a todo app"
 ```
 
-For available models and configuration options, see [OpenRouter Claude Code Integration](https://openrouter.ai/docs/guides/guides/claude-code-integration#changing-models).
+## Resources
+
+- [OpenRouter Claude Code Integration](https://openrouter.ai/docs/guides/guides/claude-code-integration)
+- [OpenRouter Documentation](https://openrouter.ai/docs)

--- a/turbo/apps/docs/content/docs/model-selection/zai.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/zai.mdx
@@ -3,31 +3,43 @@ title: Z.AI (GLM)
 description: Use GLM models with VM0
 ---
 
-[Z.AI](https://docs.z.ai/devpack/tool/claude) provides access to GLM models with strong coding capabilities.
+[Z.AI](https://z.ai) provides access to GLM models with strong coding capabilities.
+
+## Quick Setup
+
+```bash
+vm0 model-provider setup --type zai-api-key
+```
+
+You'll be prompted for your API key and model selection.
 
 ## Get API Key
 
-Visit the [Z.AI Open Platform](https://z.ai/manage-apikey/apikey-list) to create and obtain an API Key.
+Visit the [Z.AI Platform](https://z.ai/model-api) to create and obtain an API key.
 
-## Configuration
+## Available Models
 
-```yaml title="vm0.yaml"
-version: "1.0"
+| Model | Description |
+|-------|-------------|
+| `GLM-4.7` | Latest GLM model (default) |
+| `GLM-4.5-Air` | Lighter, faster variant |
 
-agents:
-  my-agent:
-    framework: claude-code
-    environment:
-      ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic" # [!code highlight]
-      ANTHROPIC_AUTH_TOKEN: "${{ secrets.ZAI_API_KEY }}" # [!code highlight]
-      API_TIMEOUT_MS: "3000000" # [!code highlight]
-      ANTHROPIC_DEFAULT_OPUS_MODEL: "GLM-4.7" # [!code highlight]
-      ANTHROPIC_DEFAULT_SONNET_MODEL: "GLM-4.7" # [!code highlight]
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: "GLM-4.5-Air" # [!code highlight]
+## Non-Interactive Setup
+
+```bash
+# With default model
+vm0 model-provider setup --type zai-api-key --credential "xxx"
+
+# With specific model
+vm0 model-provider setup --type zai-api-key --credential "xxx" --model "GLM-4.5-Air"
 ```
 
 ## Run
 
 ```bash
-vm0 run my-agent "build a todo app" --secrets ZAI_API_KEY=xxx
+vm0 run my-agent "build a todo app"
 ```
+
+## Resources
+
+- [Z.AI Claude Integration Documentation](https://docs.z.ai/devpack/tool/claude)


### PR DESCRIPTION
## Summary

- Rewrite Overview page to comprehensively document all 9 model providers
- Add Azure Foundry documentation page (experimental)
- Add AWS Bedrock documentation page (experimental, with two auth methods)
- Update all provider pages to use `vm0 model-provider setup` as primary method
- Document model selection feature for providers that support it
- Move manual configuration to brief advanced section at end of Overview

## Changes

| File | Change |
|------|--------|
| `index.mdx` | Complete rewrite with all 9 providers, model selection, management commands |
| `claude.mdx` | Simplified, focused on CLI setup and model tier configuration |
| `openrouter.mdx` | Updated to use CLI setup, added model selection info |
| `moonshot.mdx` | Updated to use CLI setup, added model selection info |
| `minimax.mdx` | Updated to use CLI setup |
| `deepseek.mdx` | Updated to use CLI setup |
| `zai.mdx` | Updated to use CLI setup, added model selection info |
| `azure-foundry.mdx` | **New** - experimental cloud provider |
| `aws-bedrock.mdx` | **New** - experimental cloud provider with two auth methods |
| `meta.json` | Added new pages to navigation |

## Test plan

- [ ] Verify all internal links work correctly
- [ ] Review documentation renders correctly on docs site
- [ ] Confirm CLI commands in examples are accurate

🤖 Generated with [Claude Code](https://claude.ai/code)