### PR TITLE
refactor(ci): add environment: production to migrate-production job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,6 +45,7 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260203
     permissions:
       contents: read
+    environment: production
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init


### PR DESCRIPTION
## Summary

- Adds `environment: production` to the `migrate-production` job in release-please.yml
- This ensures the job uses `NEON_API_KEY` and `NEON_PROJECT_ID` from the production GitHub environment instead of falling back to repository-level secrets

## Context

The production environment now has its own `NEON_API_KEY` and `NEON_PROJECT_ID` configured, enabling proper isolation of production Neon credentials from CI/preview operations.

## Changes

- `.github/workflows/release-please.yml`: Added `environment: production` to `migrate-production` job

## Test plan

- [ ] Verify CI passes
- [ ] Next production deployment should use production environment secrets

Closes #2343

🤖 Generated with [Claude Code](https://claude.ai/code)