### PR TITLE
chore: add mailmap to consolidate author identities

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,19 @@
+# Ethan Zhang
+Ethan Zhang <ethan@vm0.ai> <ethan@uspark.ai>
+Ethan Zhang <ethan@vm0.ai> <perfectworks@gmail.com>
+
+# Lancy
+Lancy <lancy@vm0.ai> Lan Chenyu <lancy@vm0.ai>
+Lancy <lancy@vm0.ai> lancy <lancy@vm0.ai>
+Lancy <lancy@vm0.ai> Lan Chenyu <lancy1014@gmail.com>
+
+# Liang You
+seven332 <liangyou@vm0.ai> Liang You <liangyou@vm0.ai>
+seven332 <liangyou@vm0.ai> seven332 <seven332@163.com>
+
+# Linghan Hu
+Linghan Hu <yuma@vm0.ai> Linghan Hu <hulinghan122@gmail.com>
+
+# Ming
+Lunarivibe <ming@vm0.ai> Ming <ming@vm0.ai>
+Lunarivibe <ming@vm0.ai> mingvm <ming@vm0.ai>


### PR DESCRIPTION
## Summary
- Add `.mailmap` file to consolidate author identities across the repository
- Maps multiple email addresses to canonical names for contributors (Ethan Zhang, Lancy, seven332, Linghan Hu, Ming)
- Improves git log and git shortlog output by unifying contributor entries

## Test plan
- [x] Verify `.mailmap` syntax is correct
- [x] No code changes required - configuration file only

🤖 Generated with [Claude Code](https://claude.com/claude-code)