### PR TITLE
fix(slack): make login prompt ephemeral and restore bindings on re-link

### DIFF
--- a/turbo/apps/web/src/db/migrations/0063_slack_bindings_orphan_support.sql
+++ b/turbo/apps/web/src/db/migrations/0063_slack_bindings_orphan_support.sql
@@ -20,6 +20,10 @@ ALTER TABLE "slack_bindings" ALTER COLUMN "vm0_user_id" SET NOT NULL;
 ALTER TABLE "slack_bindings" ALTER COLUMN "slack_workspace_id" SET NOT NULL;
 
 -- Drop the existing foreign key constraint
+-- Handle both possible constraint names:
+-- - "slack_bindings_slack_user_link_id_fkey" (PostgreSQL auto-generated from inline REFERENCES)
+-- - "slack_bindings_slack_user_link_id_slack_user_links_id_fk" (Drizzle-style naming)
+ALTER TABLE "slack_bindings" DROP CONSTRAINT IF EXISTS "slack_bindings_slack_user_link_id_fkey";
 ALTER TABLE "slack_bindings" DROP CONSTRAINT IF EXISTS "slack_bindings_slack_user_link_id_slack_user_links_id_fk";
 
 -- Allow slack_user_link_id to be NULL

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -209,10 +209,17 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       .limit(1);
 
     if (!userLink) {
-      // 3. User not logged in - post login message
-      const loginUrl = buildLoginUrl(context.workspaceId, context.userId);
-      await postMessage(client, context.channelId, "Please login first", {
-        threadTs,
+      // 3. User not logged in - post ephemeral login message (only visible to user)
+      const loginUrl = buildLoginUrl(
+        context.workspaceId,
+        context.userId,
+        context.channelId,
+      );
+      await client.chat.postEphemeral({
+        channel: context.channelId,
+        user: context.userId,
+        thread_ts: threadTs,
+        text: "Please login first",
         blocks: buildLoginPromptMessage(loginUrl),
       });
       return;
@@ -427,11 +434,16 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
 /**
  * Build the login URL
  */
-function buildLoginUrl(workspaceId: string, slackUserId: string): string {
+function buildLoginUrl(
+  workspaceId: string,
+  slackUserId: string,
+  channelId: string,
+): string {
   const baseUrl = getSlackRedirectBaseUrl();
   const params = new URLSearchParams({
     w: workspaceId,
     u: slackUserId,
+    c: channelId,
   });
   return `${baseUrl}/slack/link?${params.toString()}`;
 }

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -17,6 +17,7 @@ import {
   buildErrorMessage,
   buildAgentResponseMessage,
   buildWelcomeMessage,
+  getSlackRedirectBaseUrl,
 } from "../index";
 import { routeToAgent, type RouteResult } from "../router";
 import { runAgentForSlack } from "./run-agent";
@@ -438,7 +439,7 @@ function buildLoginUrl(
   slackUserId: string,
   channelId: string,
 ): string {
-  const baseUrl = getPlatformUrl();
+  const baseUrl = getSlackRedirectBaseUrl();
   const params = new URLSearchParams({
     w: workspaceId,
     u: slackUserId,

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -17,7 +17,6 @@ import {
   buildErrorMessage,
   buildAgentResponseMessage,
   buildWelcomeMessage,
-  getSlackRedirectBaseUrl,
 } from "../index";
 import { routeToAgent, type RouteResult } from "../router";
 import { runAgentForSlack } from "./run-agent";
@@ -439,7 +438,7 @@ function buildLoginUrl(
   slackUserId: string,
   channelId: string,
 ): string {
-  const baseUrl = getSlackRedirectBaseUrl();
+  const baseUrl = getPlatformUrl();
   const params = new URLSearchParams({
     w: workspaceId,
     u: slackUserId,


### PR DESCRIPTION
## Summary
- Make login prompt ephemeral so it's only visible to the unlinked user who needs to login
- Include channel ID in login URL so we can redirect back after successful login
- Restore orphaned agent bindings when users re-link after logout

## Test plan
- [x] Test that unlinked users see an ephemeral login prompt when mentioning the bot
- [x] Test that the login URL includes the channel parameter
- [x] Test that orphaned bindings are restored when users re-link

🤖 Generated with [Claude Code](https://claude.com/claude-code)