### PR TITLE
fix(api): pass authorization header in /v1/runs/:id/logs endpoint

### DIFF
--- a/turbo/apps/web/app/v1/runs/[id]/logs/route.ts
+++ b/turbo/apps/web/app/v1/runs/[id]/logs/route.ts
@@ -57,10 +57,10 @@ interface LogEntry {
 
 const router = tsr.router(publicRunLogsContract, {
   // eslint-disable-next-line complexity -- TODO: refactor complex function
-  getLogs: async ({ params, query }) => {
+  getLogs: async ({ params, query, headers }) => {
     initServices();
 
-    const auth = await authenticatePublicApi();
+    const auth = await authenticatePublicApi(headers.authorization);
     if (!isAuthSuccess(auth)) {
       return {
         status: 401 as const,

--- a/turbo/apps/web/app/v1/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/v1/runs/__tests__/route.test.ts
@@ -10,6 +10,7 @@ import {
   createTestCompose,
   createTestV1Run,
   completeTestRun,
+  createTestCliToken,
 } from "../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -274,6 +275,29 @@ describe("Public API v1 - Runs Endpoints", () => {
 
       expect(response.status).toBe(404);
       expect(data.error.type).toBe("not_found_error");
+    });
+
+    it("should authenticate with CLI token when no Clerk session", async () => {
+      // Mock Clerk to return no session
+      mockClerk({ userId: null });
+
+      // Create a CLI token for the test user
+      const token = await createTestCliToken(user.userId);
+
+      const request = createTestRequest(
+        `http://localhost:3000/v1/runs/${testRunId}/logs`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      );
+
+      const response = await getRunLogs(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data).toBeInstanceOf(Array);
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix authentication bug in `/v1/runs/:id/logs` endpoint
- Add `headers` destructuring to route handler
- Pass `headers.authorization` to `authenticatePublicApi()`
- Add integration test for CLI token authentication

## Root Cause
The logs endpoint was not destructuring `headers` from the request object and was calling `authenticatePublicApi()` without the authorization header. This caused CLI token authentication to fail because the token was never passed to the validation function.

## Test plan
- [x] Existing tests still pass (Clerk session auth)
- [x] New test verifies CLI token authentication works when no Clerk session
- [x] Lint, type check, and format checks pass

Fixes #2335

🤖 Generated with [Claude Code](https://claude.com/claude-code)