### PR TITLE
refactor(runner): identify processes by base dir for multi-runner support

### DIFF
--- a/turbo/apps/runner/src/commands/doctor.ts
+++ b/turbo/apps/runner/src/commands/doctor.ts
@@ -21,7 +21,6 @@ import {
 } from "../lib/firecracker/process.js";
 import { withFileLock } from "../lib/utils/file-lock.js";
 import { isProcessRunning } from "../lib/utils/process.js";
-import { isPortInUse } from "../lib/firecracker/network.js";
 import { SNAPSHOT_NETWORK } from "../lib/firecracker/netns.js";
 import { NS_PREFIX, RegistrySchema } from "../lib/firecracker/netns-pool.js";
 import { type VmId, createVmId } from "../lib/firecracker/vm-id.js";
@@ -93,26 +92,16 @@ async function checkApiConnectivity(
 /**
  * Check network status (proxy)
  */
-async function checkNetwork(
-  config: RunnerConfig,
-  warnings: Warning[],
-): Promise<void> {
+function checkNetwork(config: RunnerConfig, warnings: Warning[]): void {
   console.log("Network:");
 
-  const proxyPort = config.proxy.port;
   const mitmProcesses = findMitmproxyProcesses();
   const mitmProc = mitmProcesses.find((p) => p.baseDir === config.base_dir);
-  const portInUse = await isPortInUse(proxyPort);
 
   if (mitmProc) {
-    console.log(`  ✓ Proxy mitmproxy (PID ${mitmProc.pid}) on :${proxyPort}`);
-  } else if (portInUse) {
     console.log(
-      `  ⚠️ Proxy port :${proxyPort} in use but mitmproxy process not found`,
+      `  ✓ Proxy mitmproxy (PID ${mitmProc.pid}) on :${config.proxy.port}`,
     );
-    warnings.push({
-      message: `Port ${proxyPort} is in use but mitmproxy process not detected`,
-    });
   } else {
     console.log(`  ✗ Proxy mitmproxy not running`);
     warnings.push({ message: "Proxy mitmproxy is not running" });
@@ -339,7 +328,7 @@ export const doctorCommand = new Command("doctor")
       console.log("");
 
       // Network status
-      await checkNetwork(config, warnings);
+      checkNetwork(config, warnings);
       console.log("");
 
       // Scan resources

--- a/turbo/apps/runner/src/commands/doctor.ts
+++ b/turbo/apps/runner/src/commands/doctor.ts
@@ -16,7 +16,7 @@ import { runnerPaths, runtimePaths } from "../lib/paths.js";
 import { pollForJob } from "../lib/api.js";
 import {
   findFirecrackerProcesses,
-  findMitmproxyProcess,
+  findMitmproxyProcesses,
 } from "../lib/firecracker/process.js";
 import { withFileLock } from "../lib/utils/file-lock.js";
 import { isProcessRunning } from "../lib/utils/process.js";
@@ -104,7 +104,9 @@ async function checkNetwork(
   console.log("Network:");
 
   const proxyPort = config.proxy.port;
-  const mitmProc = findMitmproxyProcess();
+  const registryPath = runnerPaths.vmRegistry(config.base_dir);
+  const mitmProcesses = findMitmproxyProcesses();
+  const mitmProc = mitmProcesses.find((p) => p.registryPath === registryPath);
   const portInUse = await isPortInUse(proxyPort);
 
   if (mitmProc) {

--- a/turbo/apps/runner/src/commands/doctor.ts
+++ b/turbo/apps/runner/src/commands/doctor.ts
@@ -17,6 +17,7 @@ import { pollForJob } from "../lib/api.js";
 import {
   findFirecrackerProcesses,
   findMitmproxyProcesses,
+  type FirecrackerProcess,
 } from "../lib/firecracker/process.js";
 import { withFileLock } from "../lib/utils/file-lock.js";
 import { isProcessRunning } from "../lib/utils/process.js";
@@ -30,11 +31,6 @@ interface JobInfo {
   runId: string;
   vmId: VmId;
   firecrackerPid?: number;
-}
-
-interface FirecrackerProcess {
-  pid: number;
-  vmId: VmId;
 }
 
 interface Warning {
@@ -104,9 +100,8 @@ async function checkNetwork(
   console.log("Network:");
 
   const proxyPort = config.proxy.port;
-  const registryPath = runnerPaths.vmRegistry(config.base_dir);
   const mitmProcesses = findMitmproxyProcesses();
-  const mitmProc = mitmProcesses.find((p) => p.registryPath === registryPath);
+  const mitmProc = mitmProcesses.find((p) => p.baseDir === config.base_dir);
   const portInUse = await isPortInUse(proxyPort);
 
   if (mitmProc) {
@@ -248,11 +243,15 @@ async function findOrphanNetworkNamespaces(
  */
 async function detectOrphanResources(
   jobs: JobInfo[],
-  processes: FirecrackerProcess[],
+  allProcesses: FirecrackerProcess[],
   workspaces: string[],
   statusVmIds: Set<VmId>,
+  baseDir: string,
   warnings: Warning[],
 ): Promise<void> {
+  // Filter processes to only include those belonging to this runner
+  const processes = allProcesses.filter((p) => p.baseDir === baseDir);
+
   // Runs without process
   for (const job of jobs) {
     if (!job.firecrackerPid) {
@@ -262,7 +261,7 @@ async function detectOrphanResources(
     }
   }
 
-  // Orphan processes
+  // Orphan processes (only for this runner)
   const processVmIds = new Set(processes.map((p) => p.vmId));
   for (const proc of processes) {
     if (!statusVmIds.has(proc.vmId)) {
@@ -360,6 +359,7 @@ export const doctorCommand = new Command("doctor")
         processes,
         workspaces,
         statusVmIds,
+        config.base_dir,
         warnings,
       );
 

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/process.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/process.test.ts
@@ -37,9 +37,13 @@ describe("process discovery", () => {
       const input = cmdline(
         "firecracker",
         "--api-sock",
-        "/tmp/vm0-abcd1234/api.sock",
+        "/opt/runner/workspaces/vm0-abcd1234/api.sock",
       );
-      expect(parseFirecrackerCmdline(input)).toBe("abcd1234");
+      const result = parseFirecrackerCmdline(input);
+      expect(result).toEqual({
+        vmId: vmId("abcd1234"),
+        baseDir: "/opt/runner",
+      });
     });
 
     it("parses --config-file mode (fresh boot)", () => {
@@ -49,18 +53,26 @@ describe("process discovery", () => {
         "/opt/vm0-runner/workspaces/vm0-12345678/config.json",
         "--no-api",
       );
-      expect(parseFirecrackerCmdline(input)).toBe("12345678");
+      const result = parseFirecrackerCmdline(input);
+      expect(result).toEqual({
+        vmId: vmId("12345678"),
+        baseDir: "/opt/vm0-runner",
+      });
     });
 
     it("prefers --api-sock over --config-file when both present", () => {
       const input = cmdline(
         "/usr/bin/firecracker",
         "--api-sock",
-        "/var/run/vm0-aaaaaaaa/api.sock",
+        "/var/run/runner/workspaces/vm0-aaaaaaaa/api.sock",
         "--config-file",
         "/etc/fc.json",
       );
-      expect(parseFirecrackerCmdline(input)).toBe("aaaaaaaa");
+      const result = parseFirecrackerCmdline(input);
+      expect(result).toEqual({
+        vmId: vmId("aaaaaaaa"),
+        baseDir: "/var/run/runner",
+      });
     });
 
     it("returns null for non-firecracker process", () => {
@@ -82,6 +94,15 @@ describe("process discovery", () => {
       expect(parseFirecrackerCmdline(input)).toBeNull();
     });
 
+    it("returns null for path without workspaces directory", () => {
+      const input = cmdline(
+        "firecracker",
+        "--api-sock",
+        "/tmp/vm0-abcd1234/api.sock",
+      );
+      expect(parseFirecrackerCmdline(input)).toBeNull();
+    });
+
     it("returns null for empty cmdline", () => {
       expect(parseFirecrackerCmdline("")).toBeNull();
     });
@@ -94,7 +115,7 @@ describe("process discovery", () => {
         "--set",
         "vm0_registry_path=/opt/runner/vm-registry.json",
       );
-      expect(parseMitmproxyCmdline(input)).toBe("/opt/runner/vm-registry.json");
+      expect(parseMitmproxyCmdline(input)).toBe("/opt/runner");
     });
 
     it("parses mitmproxy with vm0_registry_path among other args", () => {
@@ -109,9 +130,7 @@ describe("process discovery", () => {
         "-s",
         "addon.py",
       );
-      expect(parseMitmproxyCmdline(input)).toBe(
-        "/opt/runner/pr-123/vm-registry.json",
-      );
+      expect(parseMitmproxyCmdline(input)).toBe("/opt/runner/pr-123");
     });
 
     it("returns null for mitmproxy without vm0_registry_path", () => {
@@ -138,7 +157,7 @@ describe("process discovery", () => {
         "/proc/1234/cmdline": cmdline(
           "firecracker",
           "--api-sock",
-          "/tmp/vm0-aaaabbbb/api.sock",
+          "/opt/runner/workspaces/vm0-aaaabbbb/api.sock",
         ),
         "/proc/5678/cmdline": cmdline("nginx", "-c", "/etc/nginx.conf"),
       });
@@ -148,7 +167,8 @@ describe("process discovery", () => {
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
         pid: 1234,
-        vmId: "aaaabbbb",
+        vmId: vmId("aaaabbbb"),
+        baseDir: "/opt/runner",
       });
     });
 
@@ -158,27 +178,33 @@ describe("process discovery", () => {
       expect(findFirecrackerProcesses()).toEqual([]);
     });
 
-    it("handles multiple firecracker processes", () => {
+    it("handles multiple firecracker processes from different runners", () => {
       vol.fromJSON({
         "/proc/100/cmdline": cmdline(
           "firecracker",
           "--api-sock",
-          "/tmp/vm0-11112222/api.sock",
+          "/opt/runner-a/workspaces/vm0-11112222/api.sock",
         ),
         "/proc/200/cmdline": cmdline(
           "firecracker",
           "--api-sock",
-          "/tmp/vm0-33334444/api.sock",
+          "/opt/runner-b/workspaces/vm0-33334444/api.sock",
         ),
       });
 
       const result = findFirecrackerProcesses();
 
       expect(result).toHaveLength(2);
-      expect(result.map((p) => p.vmId).sort()).toEqual([
-        "11112222",
-        "33334444",
-      ]);
+      expect(result).toContainEqual({
+        pid: 100,
+        vmId: vmId("11112222"),
+        baseDir: "/opt/runner-a",
+      });
+      expect(result).toContainEqual({
+        pid: 200,
+        vmId: vmId("33334444"),
+        baseDir: "/opt/runner-b",
+      });
     });
 
     it("skips non-numeric entries in /proc", () => {
@@ -188,14 +214,14 @@ describe("process discovery", () => {
         "/proc/1234/cmdline": cmdline(
           "firecracker",
           "--api-sock",
-          "/tmp/vm0-eeeeeeee/api.sock",
+          "/opt/runner/workspaces/vm0-eeeeeeee/api.sock",
         ),
       });
 
       const result = findFirecrackerProcesses();
 
       expect(result).toHaveLength(1);
-      expect(result[0]?.vmId).toBe("eeeeeeee");
+      expect(result[0]?.vmId).toEqual(vmId("eeeeeeee"));
     });
 
     it("skips when cmdline file does not exist", () => {
@@ -213,7 +239,7 @@ describe("process discovery", () => {
         "/proc/1234/cmdline": cmdline(
           "firecracker",
           "--api-sock",
-          "/tmp/vm0-aaaabbbb/api.sock",
+          "/opt/runner/workspaces/vm0-aaaabbbb/api.sock",
         ),
         "/proc/5678/cmdline": "will be mocked to throw",
       });
@@ -234,7 +260,7 @@ describe("process discovery", () => {
 
       // Should find the readable process and skip the unreadable one
       expect(result).toHaveLength(1);
-      expect(result[0]?.vmId).toBe("aaaabbbb");
+      expect(result[0]?.vmId).toEqual(vmId("aaaabbbb"));
     });
   });
 
@@ -244,12 +270,12 @@ describe("process discovery", () => {
         "/proc/100/cmdline": cmdline(
           "firecracker",
           "--api-sock",
-          "/tmp/vm0-aaaaaaaa/api.sock",
+          "/opt/runner/workspaces/vm0-aaaaaaaa/api.sock",
         ),
         "/proc/200/cmdline": cmdline(
           "firecracker",
           "--api-sock",
-          "/tmp/vm0-bbbbbbbb/api.sock",
+          "/opt/runner/workspaces/vm0-bbbbbbbb/api.sock",
         ),
       });
 
@@ -257,7 +283,8 @@ describe("process discovery", () => {
 
       expect(result).toEqual({
         pid: 200,
-        vmId: "bbbbbbbb",
+        vmId: vmId("bbbbbbbb"),
+        baseDir: "/opt/runner",
       });
     });
 
@@ -266,7 +293,7 @@ describe("process discovery", () => {
         "/proc/100/cmdline": cmdline(
           "firecracker",
           "--api-sock",
-          "/tmp/vm0-aaaaaaaa/api.sock",
+          "/opt/runner/workspaces/vm0-aaaaaaaa/api.sock",
         ),
       });
 
@@ -295,8 +322,8 @@ describe("process discovery", () => {
       const result = findMitmproxyProcesses();
 
       expect(result).toEqual([
-        { pid: 2000, registryPath: "/opt/runner-a/vm-registry.json" },
-        { pid: 3000, registryPath: "/opt/runner-b/vm-registry.json" },
+        { pid: 2000, baseDir: "/opt/runner-a" },
+        { pid: 3000, baseDir: "/opt/runner-b" },
       ]);
     });
 

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/process.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/process.test.ts
@@ -4,7 +4,7 @@ import {
   parseFirecrackerCmdline,
   parseMitmproxyCmdline,
   findFirecrackerProcesses,
-  findMitmproxyProcess,
+  findMitmproxyProcesses,
   findProcessByVmId,
 } from "../process.js";
 import { createVmId as vmId } from "../vm-id.js";
@@ -88,25 +88,35 @@ describe("process discovery", () => {
   });
 
   describe("parseMitmproxyCmdline", () => {
-    it("parses mitmproxy with -p flag", () => {
-      const input = cmdline("mitmproxy", "-p", "8080");
-      expect(parseMitmproxyCmdline(input)).toEqual({ port: 8080 });
+    it("parses mitmdump with vm0_registry_path", () => {
+      const input = cmdline(
+        "mitmdump",
+        "--set",
+        "vm0_registry_path=/opt/runner/vm-registry.json",
+      );
+      expect(parseMitmproxyCmdline(input)).toBe("/opt/runner/vm-registry.json");
     });
 
-    it("parses mitmdump with --listen-port flag", () => {
+    it("parses mitmproxy with vm0_registry_path among other args", () => {
       const input = cmdline(
         "mitmdump",
         "--listen-port",
-        "9090",
+        "8080",
+        "--set",
+        "confdir=/opt/proxy",
+        "--set",
+        "vm0_registry_path=/opt/runner/pr-123/vm-registry.json",
         "-s",
         "addon.py",
       );
-      expect(parseMitmproxyCmdline(input)).toEqual({ port: 9090 });
+      expect(parseMitmproxyCmdline(input)).toBe(
+        "/opt/runner/pr-123/vm-registry.json",
+      );
     });
 
-    it("parses mitmproxy without port flag", () => {
-      const input = cmdline("mitmproxy", "-s", "addon.py");
-      expect(parseMitmproxyCmdline(input)).toEqual({ port: undefined });
+    it("returns null for mitmproxy without vm0_registry_path", () => {
+      const input = cmdline("mitmdump", "--listen-port", "8080");
+      expect(parseMitmproxyCmdline(input)).toBeNull();
     });
 
     it("returns null for non-mitmproxy process", () => {
@@ -117,11 +127,6 @@ describe("process discovery", () => {
 
     it("returns null for empty cmdline", () => {
       expect(parseMitmproxyCmdline("")).toBeNull();
-    });
-
-    it("handles mitmproxy in path", () => {
-      const input = cmdline("/usr/bin/mitmproxy", "-p", "7777");
-      expect(parseMitmproxyCmdline(input)).toEqual({ port: 7777 });
     });
   });
 
@@ -271,50 +276,56 @@ describe("process discovery", () => {
     });
   });
 
-  describe("findMitmproxyProcess", () => {
-    it("finds mitmproxy process", () => {
+  describe("findMitmproxyProcesses", () => {
+    it("finds mitmproxy processes with registry path", () => {
       vol.fromJSON({
         "/proc/1000/cmdline": cmdline("nginx", "-c", "/etc/nginx.conf"),
         "/proc/2000/cmdline": cmdline(
           "mitmdump",
-          "-p",
-          "8080",
-          "-s",
-          "addon.py",
+          "--set",
+          "vm0_registry_path=/opt/runner-a/vm-registry.json",
+        ),
+        "/proc/3000/cmdline": cmdline(
+          "mitmdump",
+          "--set",
+          "vm0_registry_path=/opt/runner-b/vm-registry.json",
         ),
       });
 
-      const result = findMitmproxyProcess();
+      const result = findMitmproxyProcesses();
 
-      expect(result).toEqual({ pid: 2000, port: 8080 });
+      expect(result).toEqual([
+        { pid: 2000, registryPath: "/opt/runner-a/vm-registry.json" },
+        { pid: 3000, registryPath: "/opt/runner-b/vm-registry.json" },
+      ]);
     });
 
-    it("returns null when no mitmproxy process found", () => {
+    it("returns empty array when no mitmproxy process found", () => {
       vol.fromJSON({
         "/proc/1000/cmdline": cmdline("nginx", "-c", "/etc/nginx.conf"),
       });
 
-      const result = findMitmproxyProcess();
+      const result = findMitmproxyProcesses();
 
-      expect(result).toBeNull();
+      expect(result).toEqual([]);
     });
 
-    it("returns null when /proc is empty", () => {
+    it("returns empty array when /proc is empty", () => {
       vol.fromJSON({ "/proc/.keep": "" });
 
-      const result = findMitmproxyProcess();
+      const result = findMitmproxyProcesses();
 
-      expect(result).toBeNull();
+      expect(result).toEqual([]);
     });
 
-    it("finds mitmproxy without port", () => {
+    it("ignores mitmproxy without registry path", () => {
       vol.fromJSON({
-        "/proc/1000/cmdline": cmdline("mitmproxy", "-s", "addon.py"),
+        "/proc/1000/cmdline": cmdline("mitmdump", "-p", "8080"),
       });
 
-      const result = findMitmproxyProcess();
+      const result = findMitmproxyProcesses();
 
-      expect(result).toEqual({ pid: 1000, port: undefined });
+      expect(result).toEqual([]);
     });
   });
 });

--- a/turbo/apps/runner/src/lib/firecracker/process.ts
+++ b/turbo/apps/runner/src/lib/firecracker/process.ts
@@ -53,22 +53,27 @@ export function parseFirecrackerCmdline(cmdline: string): VmId | null {
 }
 
 /**
- * Parse /proc/{pid}/cmdline content to extract mitmproxy process info.
+ * Parse /proc/{pid}/cmdline content to extract mitmproxy registry path.
  * Pure function for easy testing.
+ *
+ * Returns registryPath from --set vm0_registry_path=xxx (unique per runner)
  */
-export function parseMitmproxyCmdline(
-  cmdline: string,
-): { port?: number } | null {
+export function parseMitmproxyCmdline(cmdline: string): string | null {
   if (!cmdline.includes("mitmproxy") && !cmdline.includes("mitmdump")) {
     return null;
   }
 
   const args = cmdline.split("\0");
-  const portIdx = args.findIndex((a) => a === "-p" || a === "--listen-port");
-  const portArg = args[portIdx + 1];
-  const port = portIdx !== -1 && portArg ? parseInt(portArg, 10) : undefined;
 
-  return { port };
+  // Parse --set vm0_registry_path=xxx (unique per runner)
+  for (const arg of args) {
+    const match = arg.match(/^vm0_registry_path=(.+)$/);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+
+  return null;
 }
 
 /**
@@ -148,17 +153,23 @@ export async function killProcess(
   return !isProcessRunning(pid);
 }
 
+interface MitmproxyProcess {
+  pid: number;
+  registryPath: string;
+}
+
 /**
- * Find mitmproxy process
+ * Find all mitmproxy processes
  */
-export function findMitmproxyProcess(): { pid: number; port?: number } | null {
+export function findMitmproxyProcesses(): MitmproxyProcess[] {
+  const processes: MitmproxyProcess[] = [];
   const procDir = "/proc";
 
   let entries: string[];
   try {
     entries = readdirSync(procDir);
   } catch {
-    return null;
+    return [];
   }
 
   for (const entry of entries) {
@@ -171,14 +182,14 @@ export function findMitmproxyProcess(): { pid: number; port?: number } | null {
 
     try {
       const cmdline = readFileSync(cmdlinePath, "utf-8");
-      const parsed = parseMitmproxyCmdline(cmdline);
-      if (parsed) {
-        return { pid, port: parsed.port };
+      const registryPath = parseMitmproxyCmdline(cmdline);
+      if (registryPath) {
+        processes.push({ pid, registryPath });
       }
     } catch {
       continue;
     }
   }
 
-  return null;
+  return processes;
 }

--- a/turbo/apps/runner/src/lib/firecracker/process.ts
+++ b/turbo/apps/runner/src/lib/firecracker/process.ts
@@ -10,9 +10,10 @@ import path from "path";
 import { type VmId, createVmId, vmIdValue } from "./vm-id.js";
 import { isProcessRunning } from "../utils/process.js";
 
-interface FirecrackerProcess {
+export interface FirecrackerProcess {
   pid: number;
   vmId: VmId;
+  baseDir: string;
 }
 
 /**
@@ -22,8 +23,12 @@ interface FirecrackerProcess {
  * Supports two modes:
  * - Snapshot restore: --api-sock /path/to/vm0-{vmId}/api.sock
  * - Fresh boot: --config-file /path/to/vm0-{vmId}/config.json
+ *
+ * Returns vmId and baseDir (runner's base directory)
  */
-export function parseFirecrackerCmdline(cmdline: string): VmId | null {
+export function parseFirecrackerCmdline(
+  cmdline: string,
+): { vmId: VmId; baseDir: string } | null {
   const args = cmdline.split("\0");
 
   if (!args[0]?.includes("firecracker")) return null;
@@ -46,17 +51,21 @@ export function parseFirecrackerCmdline(cmdline: string): VmId | null {
   if (!filePath) return null;
 
   // Extract vmId from path: .../vm0-{vmId}/...
-  const match = filePath.match(/vm0-([a-f0-9]+)\//);
-  if (!match?.[1]) return null;
+  const vmIdMatch = filePath.match(/vm0-([a-f0-9]+)\//);
+  if (!vmIdMatch?.[1]) return null;
 
-  return createVmId(match[1]);
+  // Extract baseDir: everything before /workspaces/
+  const baseDirMatch = filePath.match(/^(.+)\/workspaces\/vm0-[a-f0-9]+\//);
+  if (!baseDirMatch?.[1]) return null;
+
+  return { vmId: createVmId(vmIdMatch[1]), baseDir: baseDirMatch[1] };
 }
 
 /**
- * Parse /proc/{pid}/cmdline content to extract mitmproxy registry path.
+ * Parse /proc/{pid}/cmdline content to extract mitmproxy base directory.
  * Pure function for easy testing.
  *
- * Returns registryPath from --set vm0_registry_path=xxx (unique per runner)
+ * Extracts baseDir from --set vm0_registry_path={baseDir}/vm-registry.json
  */
 export function parseMitmproxyCmdline(cmdline: string): string | null {
   if (!cmdline.includes("mitmproxy") && !cmdline.includes("mitmdump")) {
@@ -67,7 +76,7 @@ export function parseMitmproxyCmdline(cmdline: string): string | null {
 
   // Parse --set vm0_registry_path=xxx (unique per runner)
   for (const arg of args) {
-    const match = arg.match(/^vm0_registry_path=(.+)$/);
+    const match = arg.match(/^vm0_registry_path=(.+)\/vm-registry\.json$/);
     if (match?.[1]) {
       return match[1];
     }
@@ -100,9 +109,9 @@ export function findFirecrackerProcesses(): FirecrackerProcess[] {
 
     try {
       const cmdline = readFileSync(cmdlinePath, "utf-8");
-      const vmId = parseFirecrackerCmdline(cmdline);
-      if (vmId) {
-        processes.push({ pid, vmId });
+      const parsed = parseFirecrackerCmdline(cmdline);
+      if (parsed) {
+        processes.push({ pid, vmId: parsed.vmId, baseDir: parsed.baseDir });
       }
     } catch {
       continue;
@@ -155,7 +164,7 @@ export async function killProcess(
 
 interface MitmproxyProcess {
   pid: number;
-  registryPath: string;
+  baseDir: string;
 }
 
 /**
@@ -182,9 +191,9 @@ export function findMitmproxyProcesses(): MitmproxyProcess[] {
 
     try {
       const cmdline = readFileSync(cmdlinePath, "utf-8");
-      const registryPath = parseMitmproxyCmdline(cmdline);
-      if (registryPath) {
-        processes.push({ pid, registryPath });
+      const baseDir = parseMitmproxyCmdline(cmdline);
+      if (baseDir) {
+        processes.push({ pid, baseDir });
       }
     } catch {
       continue;


### PR DESCRIPTION
## Summary

- Refactor process identification to use `baseDir` to distinguish processes from different runners
- `parseFirecrackerCmdline` now returns `{ vmId, baseDir }` instead of just `vmId`
- `parseMitmproxyCmdline` extracts `baseDir` from registry path
- `detectOrphanResources` filters by `baseDir` to only detect orphans for the current runner
- Export `FirecrackerProcess` interface to avoid duplicate definitions

## Test plan

- [x] Unit tests pass
- [x] Type check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>