### PR TITLE
refactor(runner): move graceful kill process to lib/utils

### DIFF
--- a/turbo/apps/runner/src/commands/kill.ts
+++ b/turbo/apps/runner/src/commands/kill.ts
@@ -12,7 +12,8 @@ import { existsSync, readFileSync, writeFileSync, rmSync } from "fs";
 import * as readline from "readline";
 import { loadConfig } from "../lib/config.js";
 import { runnerPaths } from "../lib/paths.js";
-import { findProcessByVmId, killProcess } from "../lib/firecracker/process.js";
+import { findProcessByVmId } from "../lib/firecracker/process.js";
+import { gracefulKillProcess } from "../lib/utils/process.js";
 import { type VmId, createVmId } from "../lib/firecracker/vm-id.js";
 import { RunnerStatusSchema } from "../lib/runner/types.js";
 
@@ -74,7 +75,7 @@ export const killCommand = new Command("kill")
 
         // 1. Kill process
         if (proc) {
-          const killed = await killProcess(proc.pid);
+          const killed = await gracefulKillProcess(proc.pid);
           results.push({
             step: "Firecracker process",
             success: killed,

--- a/turbo/apps/runner/src/lib/firecracker/process.ts
+++ b/turbo/apps/runner/src/lib/firecracker/process.ts
@@ -8,7 +8,6 @@
 import { readdirSync, readFileSync, existsSync } from "fs";
 import path from "path";
 import { type VmId, createVmId, vmIdValue } from "./vm-id.js";
-import { isProcessRunning } from "../utils/process.js";
 
 export interface FirecrackerProcess {
   pid: number;
@@ -128,38 +127,6 @@ export function findProcessByVmId(vmId: VmId): FirecrackerProcess | null {
   const processes = findFirecrackerProcesses();
   const vmIdStr = vmIdValue(vmId);
   return processes.find((p) => vmIdValue(p.vmId) === vmIdStr) || null;
-}
-
-/**
- * Kill a process with SIGTERM, wait, then SIGKILL if needed
- */
-export async function killProcess(
-  pid: number,
-  timeoutMs: number = 5000,
-): Promise<boolean> {
-  if (!isProcessRunning(pid)) return true;
-
-  try {
-    process.kill(pid, "SIGTERM");
-  } catch {
-    return !isProcessRunning(pid);
-  }
-
-  const startTime = Date.now();
-  while (Date.now() - startTime < timeoutMs) {
-    if (!isProcessRunning(pid)) return true;
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
-
-  if (isProcessRunning(pid)) {
-    try {
-      process.kill(pid, "SIGKILL");
-    } catch {
-      // Ignore - process may have exited
-    }
-  }
-
-  return !isProcessRunning(pid);
 }
 
 interface MitmproxyProcess {


### PR DESCRIPTION
## Summary

- Move `gracefulKillProcess` from `lib/firecracker/process.ts` to `lib/utils/process.ts`
- Rename from `killProcess` to `gracefulKillProcess` for clarity
- This is a general utility function, not specific to Firecracker

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>