### PR TITLE
refactor(storage): implement dual-scope resolution for volumes and artifacts

### DIFF
--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -93,7 +93,8 @@ async function resolveVersion(
  *
  * @param agentConfig - Agent configuration containing volume definitions
  * @param vars - Template variables for placeholder replacement
- * @param scopeId - Scope ID for storage access
+ * @param volumeScopeId - Scope ID for volume resolution (agent owner's scope)
+ * @param artifactScopeId - Scope ID for artifact resolution (runner's scope)
  * @param artifactName - Artifact storage name
  * @param artifactVersion - Artifact version (defaults to "latest")
  * @param volumeVersionOverrides - Optional volume version overrides
@@ -104,7 +105,8 @@ async function resolveVersion(
 export async function prepareStorageManifest(
   agentConfig: AgentVolumeConfig | undefined,
   vars: Record<string, string>,
-  scopeId: string,
+  volumeScopeId: string,
+  artifactScopeId: string,
   artifactName?: string,
   artifactVersion?: string,
   volumeVersionOverrides?: Record<string, string>,
@@ -148,7 +150,7 @@ export async function prepareStorageManifest(
   // Process all volumes and artifact in parallel
   const volumePromises = volumeResult.volumes.map(async (volume) => {
     const { versionId, s3Key } = await resolveVersion(
-      scopeId,
+      volumeScopeId,
       volume.vasStorageName,
       "volume",
       volume.vasVersion,
@@ -196,7 +198,7 @@ export async function prepareStorageManifest(
   const artifactPromise = artifactSource
     ? (async () => {
         const { versionId, s3Key } = await resolveVersion(
-          scopeId,
+          artifactScopeId,
           artifactSource.vasStorageName,
           "artifact",
           artifactSource.vasVersion,


### PR DESCRIPTION
## Summary

- Modify `prepareStorageManifest()` to accept separate scope IDs for volumes and artifacts
- Update `execution-preparer.ts` to query owner's scope from compose and pass dual scopes
- Volumes are now resolved from agent owner's scope (via compose.scopeId)
- Artifacts are resolved from runner's scope (current user)

## Motivation

This is a prerequisite for agent sharing (#2251). Currently, all storage is resolved using the runner's scope, which breaks when User B tries to run User A's agent - volumes can't be found because they belong to User A's scope.

## Backward Compatibility

This change is **fully backward compatible** because when users run their own agents, owner scope equals runner scope, resulting in identical behavior.

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] Pre-commit hooks pass
- [ ] CI tests pass (existing tests verify no regression)

Closes #2369

🤖 Generated with [Claude Code](https://claude.com/claude-code)