### PR TITLE
feat(vsock-agent): execute commands as user instead of root

### DIFF
--- a/crates/vsock-agent/src/lib.rs
+++ b/crates/vsock-agent/src/lib.rs
@@ -36,8 +36,8 @@ use std::os::unix::net::UnixStream;
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
+use std::thread;
 use std::time::{Duration, Instant};
-use std::{fs, thread};
 
 /// Flag indicating shutdown was received (don't reconnect after shutdown)
 static SHUTDOWN_RECEIVED: AtomicBool = AtomicBool::new(false);
@@ -73,6 +73,37 @@ const EXIT_CODE_TIMEOUT: i32 = 124;
 
 /// Maximum length for command preview in logs
 const COMMAND_PREVIEW_MAX_LEN: usize = 100;
+
+/// Get the user to execute commands as
+/// - Debug builds: None (run as current user via sh -c)
+/// - Release builds: Some("user") (run as user via su - user -c)
+fn get_exec_user() -> Option<String> {
+    #[cfg(debug_assertions)]
+    {
+        None
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        Some("user".to_string())
+    }
+}
+
+/// Build a Command to execute a shell command as the appropriate user
+fn build_exec_command(command: &str) -> Command {
+    match get_exec_user() {
+        Some(user) => {
+            let mut c = Command::new("su");
+            c.arg("-").arg(user).arg("-c").arg(command);
+            c
+        }
+        None => {
+            let mut c = Command::new("sh");
+            c.arg("-c").arg(command);
+            c
+        }
+    }
+}
 
 static START_TIME: OnceLock<Instant> = OnceLock::new();
 
@@ -267,18 +298,14 @@ fn handle_exec(payload: &[u8]) -> (i32, Vec<u8>, Vec<u8>) {
     #[cfg(unix)]
     let child = {
         use std::os::unix::process::CommandExt;
-        Command::new("sh")
-            .arg("-c")
-            .arg(command)
+        build_exec_command(command)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .process_group(0) // Create new process group (like tini's setpgid(0,0))
+            .process_group(0)
             .spawn()
     };
     #[cfg(not(unix))]
-    let child = Command::new("sh")
-        .arg("-c")
-        .arg(command)
+    let child = build_exec_command(command)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn();
@@ -349,56 +376,60 @@ fn handle_write_file(payload: &[u8]) -> (bool, String) {
         ),
     );
 
-    if use_sudo {
-        // Use sudo tee to write (30s timeout, same as Python)
-        const SUDO_TEE_TIMEOUT_MS: u32 = 30_000;
+    // Execute as 'user' (UID 1000) to match E2B sandbox behavior
+    // Use subprocess instead of direct fs::write to run as user
+    const WRITE_TIMEOUT_MS: u32 = 30_000;
 
-        let mut child = match Command::new("sudo")
-            .arg("tee")
-            .arg(path)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .spawn()
-        {
-            Ok(c) => c,
-            Err(e) => return (false, format!("Failed to spawn sudo tee: {}", e)),
-        };
-
-        // Write content to stdin and close it
-        if let Some(mut stdin) = child.stdin.take()
-            && let Err(e) = stdin.write_all(content)
-        {
-            let _ = child.kill();
-            let _ = child.wait(); // Prevent zombie process
-            return (false, format!("Failed to write to stdin: {}", e));
-        }
-        // stdin is dropped here, closing the pipe
-
-        // Wait with timeout
-        let (exit_code, _, stderr) = wait_with_timeout(child, SUDO_TEE_TIMEOUT_MS);
-        if exit_code == EXIT_CODE_TIMEOUT {
-            return (false, "sudo tee timed out".to_string());
-        }
-        if exit_code != 0 {
-            let stderr_str = String::from_utf8_lossy(&stderr);
-            return (false, format!("sudo tee failed: {}", stderr_str));
-        }
-        (true, String::new())
+    // Build the write command: use sudo tee for privileged writes, cat for normal writes
+    let write_cmd = if use_sudo {
+        format!("sudo tee '{}'", path.replace('\'', "'\\''"))
     } else {
-        // Direct write
-        if let Some(parent) = std::path::Path::new(path).parent()
-            && !parent.as_os_str().is_empty()
-            && let Err(e) = fs::create_dir_all(parent)
-        {
-            return (false, format!("Failed to create directory: {}", e));
+        // Create parent directory if needed, then write
+        if let Some(parent) = std::path::Path::new(path).parent() {
+            if !parent.as_os_str().is_empty() {
+                format!(
+                    "mkdir -p '{}' && cat > '{}'",
+                    parent.display().to_string().replace('\'', "'\\''"),
+                    path.replace('\'', "'\\''")
+                )
+            } else {
+                format!("cat > '{}'", path.replace('\'', "'\\''"))
+            }
+        } else {
+            format!("cat > '{}'", path.replace('\'', "'\\''"))
         }
+    };
 
-        match fs::write(path, content) {
-            Ok(_) => (true, String::new()),
-            Err(e) => (false, format!("Failed to write file: {}", e)),
-        }
+    let mut child = match build_exec_command(&write_cmd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => return (false, format!("Failed to spawn write command: {}", e)),
+    };
+
+    // Write content to stdin and close it
+    if let Some(mut stdin) = child.stdin.take()
+        && let Err(e) = stdin.write_all(content)
+    {
+        let _ = child.kill();
+        let _ = child.wait(); // Prevent zombie process
+        return (false, format!("Failed to write to stdin: {}", e));
     }
+    // stdin is dropped here, closing the pipe
+
+    // Wait with timeout
+    let (exit_code, _, stderr) = wait_with_timeout(child, WRITE_TIMEOUT_MS);
+    if exit_code == EXIT_CODE_TIMEOUT {
+        return (false, "write timed out".to_string());
+    }
+    if exit_code != 0 {
+        let stderr_str = String::from_utf8_lossy(&stderr);
+        return (false, format!("write failed: {}", stderr_str));
+    }
+    (true, String::new())
 }
 
 /// Handle shutdown message - sync filesystems and acknowledge
@@ -445,18 +476,14 @@ fn handle_spawn_watch(payload: &[u8], seq: u32, writer: Arc<Mutex<UnixStream>>) 
     #[cfg(unix)]
     let child = {
         use std::os::unix::process::CommandExt;
-        Command::new("sh")
-            .arg("-c")
-            .arg(&command)
+        build_exec_command(&command)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .process_group(0)
             .spawn()
     };
     #[cfg(not(unix))]
-    let child = Command::new("sh")
-        .arg("-c")
-        .arg(&command)
+    let child = build_exec_command(&command)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn();

--- a/crates/vsock-agent/src/lib.rs
+++ b/crates/vsock-agent/src/lib.rs
@@ -77,7 +77,10 @@ const COMMAND_PREVIEW_MAX_LEN: usize = 100;
 /// Get the user to execute commands as
 /// - Debug builds: None (run as current user via sh -c)
 /// - Release builds: Some("user") (run as user via su - user -c)
-fn get_exec_user() -> Option<String> {
+///
+/// The rootfs must have the "user" account (UID 1000) configured with passwordless sudo.
+/// See: turbo/apps/runner/scripts/deploy/Dockerfile for user account setup.
+fn get_exec_user() -> Option<&'static str> {
     #[cfg(debug_assertions)]
     {
         None
@@ -85,7 +88,8 @@ fn get_exec_user() -> Option<String> {
 
     #[cfg(not(debug_assertions))]
     {
-        Some("user".to_string())
+        // Default user for command execution (UID 1000, matching E2B sandbox)
+        Some("user")
     }
 }
 

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,4 +1,3 @@
-// VM0 Runner - Self-hosted runner that polls the VM0 API server and executes agent jobs in isolated Firecracker microVMs
 // Deployment: Added buildkit cache retry mechanism (issue #1328)
 // CI: Refactored E2E tests with setup_file() - parallel tests use 45s timeout (issue #1555)
 // Perf: Replaced Python vsock-agent with Rust for 16x faster VM startup (issue #1668)

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -177,7 +177,7 @@ export async function executeJob(
     if (config.firecracker.snapshot) {
       // Use host timestamp directly (faster than hwclock which accesses RTC device)
       const timestamp = (Date.now() / 1000).toFixed(3);
-      await guest.exec(`date -s "@${timestamp}"`);
+      await guest.exec(`sudo date -s "@${timestamp}"`);
     }
 
     // Download storages if manifest provided

--- a/turbo/apps/runner/src/lib/executor.ts
+++ b/turbo/apps/runner/src/lib/executor.ts
@@ -258,7 +258,7 @@ export async function executeJob(
     // Check for OOM kill (exit code 137 = 128 + SIGKILL)
     if (exitCode === 137 || exitCode === 9) {
       const dmesgCheck = await guest.exec(
-        `dmesg | tail -20 | grep -iE "killed|oom" 2>/dev/null`,
+        `sudo dmesg | tail -20 | grep -iE "killed|oom" 2>/dev/null`,
       );
       if (
         dmesgCheck.stdout.toLowerCase().includes("oom") ||


### PR DESCRIPTION
## Summary

- vsock-agent now executes all commands as `user` (UID 1000) in release builds, matching E2B sandbox behavior
- Debug builds run as current user for local testing (no `user` account needed)
- Added `build_exec_command()` helper to reduce code duplication

## Changes

- `get_exec_user()`: Returns `None` (debug) or `Some("user")` (release)
- `build_exec_command()`: Builds `sh -c` or `su - user -c` based on build mode
- Updated `handle_exec`, `handle_write_file`, `handle_spawn_watch` to use helper

## Test plan

- [x] `cargo build -p vsock-agent` passes
- [x] `cargo clippy -p vsock-agent -- -D warnings` passes
- [x] `pnpm vitest run --project=@vm0/runner -- vsock.test.ts` passes (261 tests)

Closes #2277

🤖 Generated with [Claude Code](https://claude.ai/code)