### PR TITLE
refactor(runner): redesign doctor command with auto discovery

### DIFF
--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -577,7 +577,7 @@
       tags: [start]
 
     - name: Verify runner health
-      command: node index.js doctor --config ./runner.yaml
+      command: node index.js doctor
       args:
         chdir: "{{ runner_base_dir }}"
       become: no

--- a/ansible/playbooks/templates/ecosystem.config.cjs.j2
+++ b/ansible/playbooks/templates/ecosystem.config.cjs.j2
@@ -16,6 +16,7 @@ module.exports = {
     log_date_format: 'YYYY-MM-DD HH:mm:ss',
 
     // Process management
+    exec_mode: 'fork',
     instances: 1,
     autorestart: true,
     watch: false,

--- a/turbo/apps/runner/src/commands/doctor.ts
+++ b/turbo/apps/runner/src/commands/doctor.ts
@@ -1,7 +1,8 @@
 /**
  * Runner Doctor Command
  *
- * Comprehensive health check for the runner, including:
+ * Comprehensive health check for all runners on the host, including:
+ * - Auto-discovery of runner processes
  * - API connectivity
  * - Network status (proxy)
  * - Active jobs
@@ -17,11 +18,11 @@ import { pollForJob } from "../lib/api.js";
 import {
   findFirecrackerProcesses,
   findMitmproxyProcesses,
+  findRunnerProcesses,
   type FirecrackerProcess,
 } from "../lib/process.js";
 import { withFileLock } from "../lib/utils/file-lock.js";
 import { isProcessRunning } from "../lib/utils/process.js";
-import { SNAPSHOT_NETWORK } from "../lib/firecracker/netns.js";
 import { NS_PREFIX, RegistrySchema } from "../lib/firecracker/netns-pool.js";
 import { type VmId, createVmId } from "../lib/firecracker/vm-id.js";
 import { type RunnerStatus, RunnerStatusSchema } from "../lib/runner/types.js";
@@ -36,31 +37,28 @@ interface Warning {
   message: string;
 }
 
+interface DiscoveredRunner {
+  pid: number;
+  config: RunnerConfig;
+  mode: "start" | "benchmark";
+}
+
 /**
- * Display runner status from status.json
+ * Get runner status from status.json
  */
-function displayRunnerStatus(
+function getRunnerStatus(
   statusFilePath: string,
   warnings: Warning[],
 ): RunnerStatus | null {
   if (!existsSync(statusFilePath)) {
-    console.log("Mode: unknown (no status.json)");
     return null;
   }
 
   try {
-    const status = RunnerStatusSchema.parse(
+    return RunnerStatusSchema.parse(
       JSON.parse(readFileSync(statusFilePath, "utf-8")),
     );
-    console.log(`Mode: ${status.mode}`);
-    if (status.started_at) {
-      const started = new Date(status.started_at);
-      const uptime = formatUptime(Date.now() - started.getTime());
-      console.log(`Started: ${started.toLocaleString()} (uptime: ${uptime})`);
-    }
-    return status;
   } catch {
-    console.log("Mode: unknown (status.json unreadable)");
     warnings.push({ message: "status.json exists but cannot be parsed" });
     return null;
   }
@@ -72,44 +70,16 @@ function displayRunnerStatus(
 async function checkApiConnectivity(
   config: RunnerConfig,
   warnings: Warning[],
-): Promise<void> {
-  console.log("API Connectivity:");
+): Promise<boolean> {
   try {
     await pollForJob(config.server, config.group);
-    console.log(`  ✓ Connected to ${config.server.url}`);
-    console.log("  ✓ Authentication: OK");
+    return true;
   } catch (error) {
-    console.log(`  ✗ Cannot connect to ${config.server.url}`);
-    console.log(
-      `    Error: ${error instanceof Error ? error.message : "Unknown error"}`,
-    );
     warnings.push({
       message: `Cannot connect to API: ${error instanceof Error ? error.message : "Unknown error"}`,
     });
+    return false;
   }
-}
-
-/**
- * Check network status (proxy)
- */
-function checkNetwork(config: RunnerConfig, warnings: Warning[]): void {
-  console.log("Network:");
-
-  const mitmProcesses = findMitmproxyProcesses();
-  const mitmProc = mitmProcesses.find((p) => p.baseDir === config.base_dir);
-
-  if (mitmProc) {
-    console.log(
-      `  ✓ Proxy mitmproxy (PID ${mitmProc.pid}) on :${config.proxy.port}`,
-    );
-  } else {
-    console.log(`  ✗ Proxy mitmproxy not running`);
-    warnings.push({ message: "Proxy mitmproxy is not running" });
-  }
-
-  console.log(
-    `  ℹ Namespaces: each VM runs in isolated namespace with IP ${SNAPSHOT_NETWORK.guestIp}`,
-  );
 }
 
 /**
@@ -118,15 +88,19 @@ function checkNetwork(config: RunnerConfig, warnings: Warning[]): void {
 function buildJobInfo(
   status: RunnerStatus | null,
   processes: FirecrackerProcess[],
+  baseDir: string,
 ): { jobs: JobInfo[]; statusVmIds: Set<VmId> } {
   const jobs: JobInfo[] = [];
   const statusVmIds = new Set<VmId>();
+
+  // Filter processes to this runner's baseDir
+  const runnerProcesses = processes.filter((p) => p.baseDir === baseDir);
 
   if (status?.active_run_ids) {
     for (const runId of status.active_run_ids) {
       const vmId = createVmId(runId);
       statusVmIds.add(vmId);
-      const proc = processes.find((p) => p.vmId === vmId);
+      const proc = runnerProcesses.find((p) => p.vmId === vmId);
 
       jobs.push({
         runId,
@@ -137,27 +111,6 @@ function buildJobInfo(
   }
 
   return { jobs, statusVmIds };
-}
-
-/**
- * Display active runs
- */
-function displayRuns(jobs: JobInfo[], maxConcurrent: number): void {
-  console.log(`Runs (${jobs.length} active, max ${maxConcurrent}):`);
-
-  if (jobs.length === 0) {
-    console.log("  No active runs");
-    return;
-  }
-
-  console.log("  Run ID                                VM ID       Status");
-  for (const job of jobs) {
-    const statusText = job.firecrackerPid
-      ? `✓ Running (PID ${job.firecrackerPid})`
-      : "⚠️ No process";
-
-    console.log(`  ${job.runId}  ${job.vmId}    ${statusText}`);
-  }
 }
 
 /**
@@ -228,16 +181,16 @@ async function findOrphanNetworkNamespaces(
 }
 
 /**
- * Detect orphan resources and add warnings
+ * Detect orphan resources for a specific runner
  */
-async function detectOrphanResources(
+function detectRunnerOrphanResources(
   jobs: JobInfo[],
   allProcesses: FirecrackerProcess[],
   workspaces: string[],
   statusVmIds: Set<VmId>,
   baseDir: string,
   warnings: Warning[],
-): Promise<void> {
+): void {
   // Filter processes to only include those belonging to this runner
   const processes = allProcesses.filter((p) => p.baseDir === baseDir);
 
@@ -245,7 +198,7 @@ async function detectOrphanResources(
   for (const job of jobs) {
     if (!job.firecrackerPid) {
       warnings.push({
-        message: `Run ${job.vmId} in status.json but no Firecracker process running`,
+        message: `Run ${job.vmId} in status.json but no Firecracker process`,
       });
     }
   }
@@ -260,35 +213,13 @@ async function detectOrphanResources(
     }
   }
 
-  // Orphan network namespaces
-  const orphanNetns = await findOrphanNetworkNamespaces(warnings);
-  for (const ns of orphanNetns) {
-    warnings.push({
-      message: `Orphan network namespace: ${ns} (runner process not running)`,
-    });
-  }
-
   // Orphan workspaces
   for (const ws of workspaces) {
     const vmId = runnerPaths.extractVmId(ws);
     if (!processVmIds.has(vmId) && !statusVmIds.has(vmId)) {
       warnings.push({
-        message: `Orphan workspace: ${ws} (no matching job or process)`,
+        message: `Orphan workspace: ${ws}`,
       });
-    }
-  }
-}
-
-/**
- * Display warnings
- */
-function displayWarnings(warnings: Warning[]): void {
-  console.log("Warnings:");
-  if (warnings.length === 0) {
-    console.log("  None");
-  } else {
-    for (const w of warnings) {
-      console.log(`  - ${w.message}`);
     }
   }
 }
@@ -308,54 +239,224 @@ function formatUptime(ms: number): string {
   return `${seconds}s`;
 }
 
+/**
+ * Display a single runner's health status
+ */
+async function displayRunnerHealth(
+  runner: DiscoveredRunner,
+  index: number,
+  allFirecrackerProcesses: FirecrackerProcess[],
+  allMitmproxyProcesses: { pid: number; baseDir: string }[],
+): Promise<Warning[]> {
+  const warnings: Warning[] = [];
+  const { config, pid, mode } = runner;
+  const baseDir = config.base_dir;
+
+  // Header
+  console.log(`[${index}] ${baseDir} (PID ${pid}) [${mode}]`);
+
+  // Status from status.json
+  const statusFilePath = runnerPaths.statusFile(baseDir);
+  const status = getRunnerStatus(statusFilePath, warnings);
+
+  if (status) {
+    let statusLine = `    Mode: ${status.mode}`;
+    if (status.started_at) {
+      const started = new Date(status.started_at);
+      const uptime = formatUptime(Date.now() - started.getTime());
+      statusLine += `, uptime: ${uptime}`;
+    }
+    console.log(statusLine);
+  } else {
+    console.log("    Mode: unknown (no status.json)");
+  }
+
+  // API connectivity
+  const apiOk = await checkApiConnectivity(config, warnings);
+  if (apiOk) {
+    console.log(`    API: ✓ Connected to ${config.server.url}`);
+  } else {
+    console.log(`    API: ✗ Cannot connect to ${config.server.url}`);
+  }
+
+  // Proxy status
+  const mitmProc = allMitmproxyProcesses.find((p) => p.baseDir === baseDir);
+  if (mitmProc) {
+    console.log(
+      `    Proxy: ✓ mitmproxy (PID ${mitmProc.pid}) on :${config.proxy.port}`,
+    );
+  } else if (mode === "start") {
+    console.log("    Proxy: ✗ not running");
+    warnings.push({ message: "Proxy mitmproxy is not running" });
+  } else {
+    // benchmark mode - proxy is optional
+    console.log("    Proxy: - (not running)");
+  }
+
+  // Active runs
+  const { jobs, statusVmIds } = buildJobInfo(
+    status,
+    allFirecrackerProcesses,
+    baseDir,
+  );
+  console.log(
+    `    Runs (${jobs.length} active, max ${config.sandbox.max_concurrent}):`,
+  );
+
+  if (jobs.length === 0) {
+    console.log("      No active runs");
+  } else {
+    for (const job of jobs) {
+      const statusText = job.firecrackerPid
+        ? `✓ Running (PID ${job.firecrackerPid})`
+        : "⚠️ No process";
+      console.log(`      ${job.vmId}  ${statusText}`);
+    }
+  }
+
+  // Detect orphan resources for this runner
+  const workspacesDir = runnerPaths.workspacesDir(baseDir);
+  const workspaces = existsSync(workspacesDir)
+    ? readdirSync(workspacesDir).filter(runnerPaths.isVmWorkspace)
+    : [];
+
+  detectRunnerOrphanResources(
+    jobs,
+    allFirecrackerProcesses,
+    workspaces,
+    statusVmIds,
+    baseDir,
+    warnings,
+  );
+
+  // Display warnings
+  console.log(`    Warnings:`);
+  if (warnings.length === 0) {
+    console.log("      None");
+  } else {
+    for (const w of warnings) {
+      console.log(`      - ${w.message}`);
+    }
+  }
+
+  return warnings;
+}
+
+/**
+ * Detect global orphan resources (not belonging to any discovered runner)
+ */
+async function detectGlobalOrphans(
+  discoveredRunners: DiscoveredRunner[],
+  allFirecrackerProcesses: FirecrackerProcess[],
+  allMitmproxyProcesses: { pid: number; baseDir: string }[],
+  globalWarnings: Warning[],
+): Promise<void> {
+  const runnerBaseDirs = new Set(
+    discoveredRunners.map((r) => r.config.base_dir),
+  );
+
+  // Orphan mitmproxy processes
+  for (const mitm of allMitmproxyProcesses) {
+    if (!runnerBaseDirs.has(mitm.baseDir)) {
+      globalWarnings.push({
+        message: `Orphan mitmproxy: PID ${mitm.pid} (baseDir ${mitm.baseDir}, runner not running)`,
+      });
+    }
+  }
+
+  // Orphan Firecracker processes
+  for (const fc of allFirecrackerProcesses) {
+    if (!runnerBaseDirs.has(fc.baseDir)) {
+      globalWarnings.push({
+        message: `Orphan Firecracker: PID ${fc.pid} (vmId ${fc.vmId}, baseDir ${fc.baseDir}, runner not running)`,
+      });
+    }
+  }
+
+  // Orphan network namespaces
+  const orphanNetns = await findOrphanNetworkNamespaces(globalWarnings);
+  for (const ns of orphanNetns) {
+    globalWarnings.push({
+      message: `Orphan namespace: ${ns} (runner process not running)`,
+    });
+  }
+}
+
 export const doctorCommand = new Command("doctor")
-  .description("Diagnose runner health, check network, and detect issues")
-  .option("--config <path>", "Config file path", "./runner.yaml")
-  .action(async (options: { config: string }): Promise<void> => {
+  .description("Diagnose health of all runners on this host")
+  .action(async (): Promise<void> => {
     try {
-      const config = loadConfig(options.config);
-      const statusFilePath = runnerPaths.statusFile(config.base_dir);
-      const workspacesDir = runnerPaths.workspacesDir(config.base_dir);
-      const warnings: Warning[] = [];
+      // Discover all runner processes
+      const runnerProcesses = findRunnerProcesses();
 
-      // Runner info
-      console.log(`Runner: ${config.name}`);
-      const status = displayRunnerStatus(statusFilePath, warnings);
+      if (runnerProcesses.length === 0) {
+        console.error("No runner processes found on this host");
+        process.exit(1);
+      }
+
+      // Load config for each runner
+      const discoveredRunners: DiscoveredRunner[] = [];
+      for (const rp of runnerProcesses) {
+        try {
+          const config = loadConfig(rp.configPath);
+          discoveredRunners.push({
+            pid: rp.pid,
+            config,
+            mode: rp.mode,
+          });
+        } catch (err) {
+          console.error(
+            `Warning: Failed to load config ${rp.configPath}: ${err instanceof Error ? err.message : "Unknown error"}`,
+          );
+        }
+      }
+
+      if (discoveredRunners.length === 0) {
+        console.error("No runners with valid configuration found");
+        process.exit(1);
+      }
+
+      // Scan all processes once
+      const allFirecrackerProcesses = findFirecrackerProcesses();
+      const allMitmproxyProcesses = findMitmproxyProcesses();
+
+      // Display header
+      console.log(`Runners (${discoveredRunners.length} found):`);
       console.log("");
 
-      // API Connectivity
-      await checkApiConnectivity(config, warnings);
-      console.log("");
+      // Check each runner
+      let totalWarnings = 0;
+      for (let i = 0; i < discoveredRunners.length; i++) {
+        const warnings = await displayRunnerHealth(
+          discoveredRunners[i]!,
+          i + 1,
+          allFirecrackerProcesses,
+          allMitmproxyProcesses,
+        );
+        totalWarnings += warnings.length;
+        console.log("");
+      }
 
-      // Network status
-      checkNetwork(config, warnings);
-      console.log("");
-
-      // Scan resources
-      const processes = findFirecrackerProcesses();
-      const workspaces = existsSync(workspacesDir)
-        ? readdirSync(workspacesDir).filter(runnerPaths.isVmWorkspace)
-        : [];
-
-      // Build and display job info
-      const { jobs, statusVmIds } = buildJobInfo(status, processes);
-      displayRuns(jobs, config.sandbox.max_concurrent);
-      console.log("");
-
-      // Detect warnings
-      await detectOrphanResources(
-        jobs,
-        processes,
-        workspaces,
-        statusVmIds,
-        config.base_dir,
-        warnings,
+      // Global orphan detection
+      const globalWarnings: Warning[] = [];
+      await detectGlobalOrphans(
+        discoveredRunners,
+        allFirecrackerProcesses,
+        allMitmproxyProcesses,
+        globalWarnings,
       );
 
-      // Display warnings
-      displayWarnings(warnings);
+      console.log("Global:");
+      if (globalWarnings.length === 0) {
+        console.log("    No orphan resources");
+      } else {
+        for (const w of globalWarnings) {
+          console.log(`    ${w.message}`);
+        }
+      }
 
-      process.exit(warnings.length > 0 ? 1 : 0);
+      totalWarnings += globalWarnings.length;
+      process.exit(totalWarnings > 0 ? 1 : 0);
     } catch (error) {
       console.error(
         `Error: ${error instanceof Error ? error.message : "Unknown error"}`,

--- a/turbo/apps/runner/src/commands/doctor.ts
+++ b/turbo/apps/runner/src/commands/doctor.ts
@@ -18,7 +18,7 @@ import {
   findFirecrackerProcesses,
   findMitmproxyProcesses,
   type FirecrackerProcess,
-} from "../lib/firecracker/process.js";
+} from "../lib/process.js";
 import { withFileLock } from "../lib/utils/file-lock.js";
 import { isProcessRunning } from "../lib/utils/process.js";
 import { SNAPSHOT_NETWORK } from "../lib/firecracker/netns.js";

--- a/turbo/apps/runner/src/commands/doctor.ts
+++ b/turbo/apps/runner/src/commands/doctor.ts
@@ -20,6 +20,7 @@ import {
   findMitmproxyProcesses,
   findRunnerProcesses,
   type FirecrackerProcess,
+  type MitmproxyProcess,
 } from "../lib/process.js";
 import { withFileLock } from "../lib/utils/file-lock.js";
 import { isProcessRunning } from "../lib/utils/process.js";
@@ -246,7 +247,7 @@ async function displayRunnerHealth(
   runner: DiscoveredRunner,
   index: number,
   allFirecrackerProcesses: FirecrackerProcess[],
-  allMitmproxyProcesses: { pid: number; baseDir: string }[],
+  allMitmproxyProcesses: MitmproxyProcess[],
 ): Promise<Warning[]> {
   const warnings: Warning[] = [];
   const { config, pid, mode } = runner;
@@ -348,7 +349,7 @@ async function displayRunnerHealth(
 async function detectGlobalOrphans(
   discoveredRunners: DiscoveredRunner[],
   allFirecrackerProcesses: FirecrackerProcess[],
-  allMitmproxyProcesses: { pid: number; baseDir: string }[],
+  allMitmproxyProcesses: MitmproxyProcess[],
   globalWarnings: Warning[],
 ): Promise<void> {
   const runnerBaseDirs = new Set(
@@ -357,7 +358,11 @@ async function detectGlobalOrphans(
 
   // Orphan mitmproxy processes
   for (const mitm of allMitmproxyProcesses) {
-    if (!runnerBaseDirs.has(mitm.baseDir)) {
+    if (mitm.isOrphan) {
+      globalWarnings.push({
+        message: `Orphan mitmproxy: PID ${mitm.pid} (PPID=1, parent process dead)`,
+      });
+    } else if (!runnerBaseDirs.has(mitm.baseDir)) {
       globalWarnings.push({
         message: `Orphan mitmproxy: PID ${mitm.pid} (baseDir ${mitm.baseDir}, runner not running)`,
       });
@@ -366,7 +371,11 @@ async function detectGlobalOrphans(
 
   // Orphan Firecracker processes
   for (const fc of allFirecrackerProcesses) {
-    if (!runnerBaseDirs.has(fc.baseDir)) {
+    if (fc.isOrphan) {
+      globalWarnings.push({
+        message: `Orphan Firecracker: PID ${fc.pid} (vmId ${fc.vmId}, PPID=1, parent process dead)`,
+      });
+    } else if (!runnerBaseDirs.has(fc.baseDir)) {
       globalWarnings.push({
         message: `Orphan Firecracker: PID ${fc.pid} (vmId ${fc.vmId}, baseDir ${fc.baseDir}, runner not running)`,
       });

--- a/turbo/apps/runner/src/commands/doctor.ts
+++ b/turbo/apps/runner/src/commands/doctor.ts
@@ -386,13 +386,15 @@ export const doctorCommand = new Command("doctor")
   .description("Diagnose health of all runners on this host")
   .action(async (): Promise<void> => {
     try {
+      const globalWarnings: Warning[] = [];
+      let totalWarnings = 0;
+
+      // Scan all processes once
+      const allFirecrackerProcesses = findFirecrackerProcesses();
+      const allMitmproxyProcesses = findMitmproxyProcesses();
+
       // Discover all runner processes
       const runnerProcesses = findRunnerProcesses();
-
-      if (runnerProcesses.length === 0) {
-        console.error("No runner processes found on this host");
-        process.exit(1);
-      }
 
       // Load config for each runner
       const discoveredRunners: DiscoveredRunner[] = [];
@@ -405,40 +407,34 @@ export const doctorCommand = new Command("doctor")
             mode: rp.mode,
           });
         } catch (err) {
-          console.error(
-            `Warning: Failed to load config ${rp.configPath}: ${err instanceof Error ? err.message : "Unknown error"}`,
-          );
+          globalWarnings.push({
+            message: `Failed to load config ${rp.configPath}: ${err instanceof Error ? err.message : "Unknown error"}`,
+          });
         }
       }
 
-      if (discoveredRunners.length === 0) {
-        console.error("No runners with valid configuration found");
-        process.exit(1);
-      }
-
-      // Scan all processes once
-      const allFirecrackerProcesses = findFirecrackerProcesses();
-      const allMitmproxyProcesses = findMitmproxyProcesses();
-
-      // Display header
+      // Display runners
       console.log(`Runners (${discoveredRunners.length} found):`);
       console.log("");
 
-      // Check each runner
-      let totalWarnings = 0;
-      for (let i = 0; i < discoveredRunners.length; i++) {
-        const warnings = await displayRunnerHealth(
-          discoveredRunners[i]!,
-          i + 1,
-          allFirecrackerProcesses,
-          allMitmproxyProcesses,
-        );
-        totalWarnings += warnings.length;
+      if (discoveredRunners.length === 0) {
+        console.log("    No runner processes found");
         console.log("");
+      } else {
+        // Check each runner
+        for (let i = 0; i < discoveredRunners.length; i++) {
+          const warnings = await displayRunnerHealth(
+            discoveredRunners[i]!,
+            i + 1,
+            allFirecrackerProcesses,
+            allMitmproxyProcesses,
+          );
+          totalWarnings += warnings.length;
+          console.log("");
+        }
       }
 
       // Global orphan detection
-      const globalWarnings: Warning[] = [];
       await detectGlobalOrphans(
         discoveredRunners,
         allFirecrackerProcesses,

--- a/turbo/apps/runner/src/commands/kill.ts
+++ b/turbo/apps/runner/src/commands/kill.ts
@@ -12,7 +12,7 @@ import { existsSync, readFileSync, writeFileSync, rmSync } from "fs";
 import * as readline from "readline";
 import { loadConfig } from "../lib/config.js";
 import { runnerPaths } from "../lib/paths.js";
-import { findProcessByVmId } from "../lib/firecracker/process.js";
+import { findProcessByVmId } from "../lib/process.js";
 import { gracefulKillProcess } from "../lib/utils/process.js";
 import { type VmId, createVmId } from "../lib/firecracker/vm-id.js";
 import { RunnerStatusSchema } from "../lib/runner/types.js";

--- a/turbo/apps/runner/src/lib/__tests__/process.test.ts
+++ b/turbo/apps/runner/src/lib/__tests__/process.test.ts
@@ -22,6 +22,12 @@ function cmdline(...args: string[]): string {
   return args.join("\x00") + "\x00";
 }
 
+// Helper to build /proc/{pid}/stat content
+// Format: pid (comm) state ppid ...
+function procStat(pid: number, ppid: number): string {
+  return `${pid} (process) S ${ppid} ${pid} ${pid} 0 -1 4194304 0 0 0 0 0 0 0 0 20 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0`;
+}
+
 describe("process discovery", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -213,6 +219,7 @@ describe("process discovery", () => {
           "--api-sock",
           "/opt/runner/workspaces/vm0-aaaabbbb/api.sock",
         ),
+        "/proc/1234/stat": procStat(1234, 100), // PPID=100, not orphan
         "/proc/5678/cmdline": cmdline("nginx", "-c", "/etc/nginx.conf"),
       });
 
@@ -223,7 +230,24 @@ describe("process discovery", () => {
         pid: 1234,
         vmId: vmId("aaaabbbb"),
         baseDir: "/opt/runner",
+        isOrphan: false,
       });
+    });
+
+    it("detects orphan firecracker process (PPID=1)", () => {
+      vol.fromJSON({
+        "/proc/1234/cmdline": cmdline(
+          "firecracker",
+          "--api-sock",
+          "/opt/runner/workspaces/vm0-aaaabbbb/api.sock",
+        ),
+        "/proc/1234/stat": procStat(1234, 1), // PPID=1, orphan
+      });
+
+      const result = findFirecrackerProcesses();
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.isOrphan).toBe(true);
     });
 
     it("returns empty array when /proc is empty", () => {
@@ -239,11 +263,13 @@ describe("process discovery", () => {
           "--api-sock",
           "/opt/runner-a/workspaces/vm0-11112222/api.sock",
         ),
+        "/proc/100/stat": procStat(100, 50),
         "/proc/200/cmdline": cmdline(
           "firecracker",
           "--api-sock",
           "/opt/runner-b/workspaces/vm0-33334444/api.sock",
         ),
+        "/proc/200/stat": procStat(200, 50),
       });
 
       const result = findFirecrackerProcesses();
@@ -253,11 +279,13 @@ describe("process discovery", () => {
         pid: 100,
         vmId: vmId("11112222"),
         baseDir: "/opt/runner-a",
+        isOrphan: false,
       });
       expect(result).toContainEqual({
         pid: 200,
         vmId: vmId("33334444"),
         baseDir: "/opt/runner-b",
+        isOrphan: false,
       });
     });
 
@@ -270,6 +298,7 @@ describe("process discovery", () => {
           "--api-sock",
           "/opt/runner/workspaces/vm0-eeeeeeee/api.sock",
         ),
+        "/proc/1234/stat": procStat(1234, 100),
       });
 
       const result = findFirecrackerProcesses();
@@ -295,6 +324,7 @@ describe("process discovery", () => {
           "--api-sock",
           "/opt/runner/workspaces/vm0-aaaabbbb/api.sock",
         ),
+        "/proc/1234/stat": procStat(1234, 100),
         "/proc/5678/cmdline": "will be mocked to throw",
       });
 
@@ -326,11 +356,13 @@ describe("process discovery", () => {
           "--api-sock",
           "/opt/runner/workspaces/vm0-aaaaaaaa/api.sock",
         ),
+        "/proc/100/stat": procStat(100, 50),
         "/proc/200/cmdline": cmdline(
           "firecracker",
           "--api-sock",
           "/opt/runner/workspaces/vm0-bbbbbbbb/api.sock",
         ),
+        "/proc/200/stat": procStat(200, 50),
       });
 
       const result = findProcessByVmId(vmId("bbbbbbbb"));
@@ -339,6 +371,7 @@ describe("process discovery", () => {
         pid: 200,
         vmId: vmId("bbbbbbbb"),
         baseDir: "/opt/runner",
+        isOrphan: false,
       });
     });
 
@@ -349,6 +382,7 @@ describe("process discovery", () => {
           "--api-sock",
           "/opt/runner/workspaces/vm0-aaaaaaaa/api.sock",
         ),
+        "/proc/100/stat": procStat(100, 50),
       });
 
       const result = findProcessByVmId(vmId("notfound"));
@@ -366,19 +400,37 @@ describe("process discovery", () => {
           "--set",
           "vm0_registry_path=/opt/runner-a/vm-registry.json",
         ),
+        "/proc/2000/stat": procStat(2000, 50),
         "/proc/3000/cmdline": cmdline(
           "mitmdump",
           "--set",
           "vm0_registry_path=/opt/runner-b/vm-registry.json",
         ),
+        "/proc/3000/stat": procStat(3000, 50),
       });
 
       const result = findMitmproxyProcesses();
 
       expect(result).toEqual([
-        { pid: 2000, baseDir: "/opt/runner-a" },
-        { pid: 3000, baseDir: "/opt/runner-b" },
+        { pid: 2000, baseDir: "/opt/runner-a", isOrphan: false },
+        { pid: 3000, baseDir: "/opt/runner-b", isOrphan: false },
       ]);
+    });
+
+    it("detects orphan mitmproxy process (PPID=1)", () => {
+      vol.fromJSON({
+        "/proc/2000/cmdline": cmdline(
+          "mitmdump",
+          "--set",
+          "vm0_registry_path=/opt/runner/vm-registry.json",
+        ),
+        "/proc/2000/stat": procStat(2000, 1), // PPID=1, orphan
+      });
+
+      const result = findMitmproxyProcesses();
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.isOrphan).toBe(true);
     });
 
     it("returns empty array when no mitmproxy process found", () => {

--- a/turbo/apps/runner/src/lib/__tests__/process.test.ts
+++ b/turbo/apps/runner/src/lib/__tests__/process.test.ts
@@ -152,75 +152,49 @@ describe("process discovery", () => {
   });
 
   describe("parseRunnerCmdline", () => {
-    it("parses runner start command", () => {
+    it("parses start command with yaml config", () => {
       const input = cmdline(
         "node",
-        "/opt/runner/dist/cli.js",
-        "runner",
+        "./index.js",
         "start",
         "--config",
-        "/opt/runner/runner.yaml",
+        "./runner.yaml",
       );
       expect(parseRunnerCmdline(input)).toEqual({
-        configPath: "/opt/runner/runner.yaml",
+        configPath: "./runner.yaml",
         mode: "start",
       });
     });
 
-    it("parses runner benchmark command", () => {
+    it("parses benchmark command with yaml config", () => {
       const input = cmdline(
         "node",
-        "/opt/runner/dist/cli.js",
-        "runner",
+        "./index.js",
         "benchmark",
         "--config",
-        "/opt/runner/runner.yaml",
+        "./benchmark.yaml",
       );
       expect(parseRunnerCmdline(input)).toEqual({
-        configPath: "/opt/runner/runner.yaml",
+        configPath: "./benchmark.yaml",
         mode: "benchmark",
       });
     });
 
-    it("parses runner command with additional args", () => {
-      const input = cmdline(
-        "node",
-        "/opt/runner/dist/cli.js",
-        "runner",
-        "start",
-        "--config",
-        "/opt/runner/runner.yaml",
-        "--verbose",
-      );
+    it("parses with .yml extension", () => {
+      const input = cmdline("node", "x.js", "start", "--config", "runner.yml");
       expect(parseRunnerCmdline(input)).toEqual({
-        configPath: "/opt/runner/runner.yaml",
+        configPath: "runner.yml",
         mode: "start",
       });
     });
 
-    it("returns null for non-runner process", () => {
-      const input = cmdline("node", "server.js", "start");
+    it("returns null without --config", () => {
+      const input = cmdline("node", "./index.js", "start");
       expect(parseRunnerCmdline(input)).toBeNull();
     });
 
-    it("returns null for runner without mode", () => {
-      const input = cmdline(
-        "node",
-        "/opt/runner/dist/cli.js",
-        "runner",
-        "--config",
-        "/opt/runner/runner.yaml",
-      );
-      expect(parseRunnerCmdline(input)).toBeNull();
-    });
-
-    it("returns null for runner without --config", () => {
-      const input = cmdline(
-        "node",
-        "/opt/runner/dist/cli.js",
-        "runner",
-        "start",
-      );
+    it("returns null with non-yaml config", () => {
+      const input = cmdline("node", "x.js", "start", "--config", "config.json");
       expect(parseRunnerCmdline(input)).toBeNull();
     });
 
@@ -441,19 +415,17 @@ describe("process discovery", () => {
       vol.fromJSON({
         "/proc/1000/cmdline": cmdline(
           "node",
-          "/opt/runner/dist/cli.js",
-          "runner",
+          "index.js",
           "start",
           "--config",
           "/opt/runner-a/runner.yaml",
         ),
         "/proc/2000/cmdline": cmdline(
           "node",
-          "/opt/runner/dist/cli.js",
-          "runner",
+          "index.js",
           "benchmark",
           "--config",
-          "/opt/runner-b/runner.yaml",
+          "/opt/runner-b/benchmark.yaml",
         ),
         "/proc/3000/cmdline": cmdline("nginx", "-c", "/etc/nginx.conf"),
       });
@@ -468,7 +440,7 @@ describe("process discovery", () => {
       });
       expect(result).toContainEqual({
         pid: 2000,
-        configPath: "/opt/runner-b/runner.yaml",
+        configPath: "/opt/runner-b/benchmark.yaml",
         mode: "benchmark",
       });
     });

--- a/turbo/apps/runner/src/lib/__tests__/process.test.ts
+++ b/turbo/apps/runner/src/lib/__tests__/process.test.ts
@@ -7,7 +7,7 @@ import {
   findMitmproxyProcesses,
   findProcessByVmId,
 } from "../process.js";
-import { createVmId as vmId } from "../vm-id.js";
+import { createVmId as vmId } from "../firecracker/vm-id.js";
 
 // Use memfs for filesystem simulation
 vi.mock("fs", async () => {

--- a/turbo/apps/runner/src/lib/__tests__/process.test.ts
+++ b/turbo/apps/runner/src/lib/__tests__/process.test.ts
@@ -514,5 +514,39 @@ describe("process discovery", () => {
 
       expect(result).toEqual([]);
     });
+
+    it("finds PM2 runner via cwd symlink", () => {
+      vol.fromJSON({
+        // PM2 mode: node index.js without args, but cwd has runner.yaml
+        "/proc/4000/cmdline": cmdline(
+          "node",
+          "/opt/vm0-runner/pr-123/index.js",
+        ),
+        "/opt/vm0-runner/pr-123/runner.yaml": "# runner config",
+      });
+      // Create symlink for cwd
+      vol.symlinkSync("/opt/vm0-runner/pr-123", "/proc/4000/cwd");
+
+      const result = findRunnerProcesses();
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        pid: 4000,
+        configPath: "/opt/vm0-runner/pr-123/runner.yaml",
+        mode: "start",
+      });
+    });
+
+    it("ignores node index.js without runner.yaml in cwd", () => {
+      vol.fromJSON({
+        "/proc/5000/cmdline": cmdline("node", "/opt/some-app/index.js"),
+        "/opt/some-app/package.json": "{}",
+      });
+      vol.symlinkSync("/opt/some-app", "/proc/5000/cwd");
+
+      const result = findRunnerProcesses();
+
+      expect(result).toEqual([]);
+    });
   });
 });

--- a/turbo/apps/runner/src/lib/__tests__/process.test.ts
+++ b/turbo/apps/runner/src/lib/__tests__/process.test.ts
@@ -3,9 +3,11 @@ import { vol } from "memfs";
 import {
   parseFirecrackerCmdline,
   parseMitmproxyCmdline,
+  parseRunnerCmdline,
   findFirecrackerProcesses,
   findMitmproxyProcesses,
   findProcessByVmId,
+  findRunnerProcesses,
 } from "../process.js";
 import { createVmId as vmId } from "../firecracker/vm-id.js";
 
@@ -146,6 +148,84 @@ describe("process discovery", () => {
 
     it("returns null for empty cmdline", () => {
       expect(parseMitmproxyCmdline("")).toBeNull();
+    });
+  });
+
+  describe("parseRunnerCmdline", () => {
+    it("parses runner start command", () => {
+      const input = cmdline(
+        "node",
+        "/opt/runner/dist/cli.js",
+        "runner",
+        "start",
+        "--config",
+        "/opt/runner/runner.yaml",
+      );
+      expect(parseRunnerCmdline(input)).toEqual({
+        configPath: "/opt/runner/runner.yaml",
+        mode: "start",
+      });
+    });
+
+    it("parses runner benchmark command", () => {
+      const input = cmdline(
+        "node",
+        "/opt/runner/dist/cli.js",
+        "runner",
+        "benchmark",
+        "--config",
+        "/opt/runner/runner.yaml",
+      );
+      expect(parseRunnerCmdline(input)).toEqual({
+        configPath: "/opt/runner/runner.yaml",
+        mode: "benchmark",
+      });
+    });
+
+    it("parses runner command with additional args", () => {
+      const input = cmdline(
+        "node",
+        "/opt/runner/dist/cli.js",
+        "runner",
+        "start",
+        "--config",
+        "/opt/runner/runner.yaml",
+        "--verbose",
+      );
+      expect(parseRunnerCmdline(input)).toEqual({
+        configPath: "/opt/runner/runner.yaml",
+        mode: "start",
+      });
+    });
+
+    it("returns null for non-runner process", () => {
+      const input = cmdline("node", "server.js", "start");
+      expect(parseRunnerCmdline(input)).toBeNull();
+    });
+
+    it("returns null for runner without mode", () => {
+      const input = cmdline(
+        "node",
+        "/opt/runner/dist/cli.js",
+        "runner",
+        "--config",
+        "/opt/runner/runner.yaml",
+      );
+      expect(parseRunnerCmdline(input)).toBeNull();
+    });
+
+    it("returns null for runner without --config", () => {
+      const input = cmdline(
+        "node",
+        "/opt/runner/dist/cli.js",
+        "runner",
+        "start",
+      );
+      expect(parseRunnerCmdline(input)).toBeNull();
+    });
+
+    it("returns null for empty cmdline", () => {
+      expect(parseRunnerCmdline("")).toBeNull();
     });
   });
 
@@ -351,6 +431,62 @@ describe("process discovery", () => {
       });
 
       const result = findMitmproxyProcesses();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("findRunnerProcesses", () => {
+    it("finds runner processes from /proc", () => {
+      vol.fromJSON({
+        "/proc/1000/cmdline": cmdline(
+          "node",
+          "/opt/runner/dist/cli.js",
+          "runner",
+          "start",
+          "--config",
+          "/opt/runner-a/runner.yaml",
+        ),
+        "/proc/2000/cmdline": cmdline(
+          "node",
+          "/opt/runner/dist/cli.js",
+          "runner",
+          "benchmark",
+          "--config",
+          "/opt/runner-b/runner.yaml",
+        ),
+        "/proc/3000/cmdline": cmdline("nginx", "-c", "/etc/nginx.conf"),
+      });
+
+      const result = findRunnerProcesses();
+
+      expect(result).toHaveLength(2);
+      expect(result).toContainEqual({
+        pid: 1000,
+        configPath: "/opt/runner-a/runner.yaml",
+        mode: "start",
+      });
+      expect(result).toContainEqual({
+        pid: 2000,
+        configPath: "/opt/runner-b/runner.yaml",
+        mode: "benchmark",
+      });
+    });
+
+    it("returns empty array when no runner processes found", () => {
+      vol.fromJSON({
+        "/proc/1000/cmdline": cmdline("nginx", "-c", "/etc/nginx.conf"),
+      });
+
+      const result = findRunnerProcesses();
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when /proc is empty", () => {
+      vol.fromJSON({ "/proc/.keep": "" });
+
+      const result = findRunnerProcesses();
 
       expect(result).toEqual([]);
     });

--- a/turbo/apps/runner/src/lib/firecracker/index.ts
+++ b/turbo/apps/runner/src/lib/firecracker/index.ts
@@ -8,6 +8,6 @@ export * from "./network.js";
 export * from "./vm.js";
 export * from "./guest.js";
 export * from "./vsock.js";
-export * from "./process.js";
+export * from "../process.js";
 export * from "./netns-pool.js";
 export * from "./client.js";

--- a/turbo/apps/runner/src/lib/process.ts
+++ b/turbo/apps/runner/src/lib/process.ts
@@ -103,50 +103,30 @@ export function parseMitmproxyCmdline(cmdline: string): string | null {
  * Parse /proc/{pid}/cmdline content to extract runner process info.
  * Pure function for easy testing.
  *
- * Parses: node ... runner start --config /path/to/runner.yaml
- * Parses: node ... runner benchmark --config /path/to/runner.yaml
+ * Looks for pattern: ... (start|benchmark) --config <path> ...
+ * where config path ends with .yaml or .yml
  */
 export function parseRunnerCmdline(
   cmdline: string,
 ): { configPath: string; mode: "start" | "benchmark" } | null {
-  const args = cmdline.split("\0");
+  const args = cmdline.split("\0").filter((a) => a !== "");
 
-  // Find "start" or "benchmark" mode
-  const startIdx = args.indexOf("start");
-  const benchmarkIdx = args.indexOf("benchmark");
+  // Find "start" or "benchmark" followed by "--config <yaml file>"
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg !== "start" && arg !== "benchmark") continue;
 
-  let mode: "start" | "benchmark";
-  let modeIdx: number;
+    // Look for --config after mode
+    const configIdx = args.indexOf("--config", i + 1);
+    if (configIdx === -1 || configIdx >= args.length - 1) continue;
 
-  if (startIdx !== -1 && (benchmarkIdx === -1 || startIdx < benchmarkIdx)) {
-    mode = "start";
-    modeIdx = startIdx;
-  } else if (benchmarkIdx !== -1) {
-    mode = "benchmark";
-    modeIdx = benchmarkIdx;
-  } else {
-    return null;
+    const configPath = args[configIdx + 1];
+    if (!configPath?.match(/\.ya?ml$/)) continue;
+
+    return { configPath, mode: arg };
   }
 
-  // Check that this looks like a runner command (node ... runner start/benchmark)
-  // The arg before mode should be "runner" or end with "/runner"
-  const prevArg = args[modeIdx - 1];
-  if (!prevArg || (!prevArg.endsWith("runner") && prevArg !== "runner")) {
-    return null;
-  }
-
-  // Find --config argument
-  const configIdx = args.indexOf("--config");
-  if (configIdx === -1 || configIdx >= args.length - 1) {
-    return null;
-  }
-
-  const configPath = args[configIdx + 1];
-  if (!configPath) {
-    return null;
-  }
-
-  return { configPath, mode };
+  return null;
 }
 
 // ==================== Process Finders ====================

--- a/turbo/apps/runner/src/lib/process.ts
+++ b/turbo/apps/runner/src/lib/process.ts
@@ -15,17 +15,44 @@ export interface FirecrackerProcess {
   pid: number;
   vmId: VmId;
   baseDir: string;
+  isOrphan: boolean;
 }
 
 interface MitmproxyProcess {
   pid: number;
   baseDir: string;
+  isOrphan: boolean;
 }
 
 interface RunnerProcess {
   pid: number;
   configPath: string;
   mode: "start" | "benchmark";
+}
+
+// ==================== Helpers ====================
+
+/**
+ * Check if a process is orphan (adopted by init, PPID == 1)
+ */
+function isOrphanProcess(pid: number): boolean {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
+    // Format: pid (comm) state ppid ...
+    // comm can contain ')' so find the last ')' to locate end of comm
+    const lastParen = stat.lastIndexOf(")");
+    if (lastParen === -1) return false;
+
+    // After comm: " state ppid ..."
+    const fields = stat
+      .slice(lastParen + 1)
+      .trim()
+      .split(/\s+/);
+    // fields[0] = state, fields[1] = ppid
+    return fields[1] === "1";
+  } catch {
+    return false;
+  }
 }
 
 // ==================== Cmdline Parsers ====================
@@ -157,7 +184,12 @@ export function findFirecrackerProcesses(): FirecrackerProcess[] {
       const cmdline = readFileSync(cmdlinePath, "utf-8");
       const parsed = parseFirecrackerCmdline(cmdline);
       if (parsed) {
-        processes.push({ pid, vmId: parsed.vmId, baseDir: parsed.baseDir });
+        processes.push({
+          pid,
+          vmId: parsed.vmId,
+          baseDir: parsed.baseDir,
+          isOrphan: isOrphanProcess(pid),
+        });
       }
     } catch {
       continue;
@@ -202,7 +234,7 @@ export function findMitmproxyProcesses(): MitmproxyProcess[] {
       const cmdline = readFileSync(cmdlinePath, "utf-8");
       const baseDir = parseMitmproxyCmdline(cmdline);
       if (baseDir) {
-        processes.push({ pid, baseDir });
+        processes.push({ pid, baseDir, isOrphan: isOrphanProcess(pid) });
       }
     } catch {
       continue;

--- a/turbo/apps/runner/src/lib/process.ts
+++ b/turbo/apps/runner/src/lib/process.ts
@@ -1,13 +1,13 @@
 /**
- * Firecracker Process Discovery
+ * Process Discovery
  *
- * Utilities for finding and managing Firecracker and mitmproxy processes.
- * Used by maintenance CLI commands (doctor, kill) to discover running VMs.
+ * Utilities for finding runner, Firecracker, and mitmproxy processes.
+ * Used by maintenance CLI commands (doctor, kill) to discover running processes.
  */
 
 import { readdirSync, readFileSync, existsSync } from "fs";
 import path from "path";
-import { type VmId, createVmId, vmIdValue } from "./vm-id.js";
+import { type VmId, createVmId, vmIdValue } from "./firecracker/vm-id.js";
 
 export interface FirecrackerProcess {
   pid: number;

--- a/turbo/apps/runner/src/lib/process.ts
+++ b/turbo/apps/runner/src/lib/process.ts
@@ -5,7 +5,7 @@
  * Used by maintenance CLI commands (doctor, kill) to discover running processes.
  */
 
-import { readdirSync, readFileSync, existsSync } from "fs";
+import { readdirSync, readFileSync, readlinkSync, existsSync } from "fs";
 import path from "path";
 import { type VmId, createVmId, vmIdValue } from "./firecracker/vm-id.js";
 
@@ -253,7 +253,25 @@ export function findMitmproxyProcesses(): MitmproxyProcess[] {
 }
 
 /**
+ * Check if cmdline looks like a node process running index.js
+ */
+function isNodeIndexJs(cmdline: string): boolean {
+  const args = cmdline.split("\0").filter((a) => a !== "");
+  if (args.length < 2) return false;
+
+  // First arg should be node
+  if (!args[0]?.includes("node")) return false;
+
+  // Second arg should be index.js (with optional path)
+  return args[1]?.endsWith("index.js") ?? false;
+}
+
+/**
  * Find all runner processes
+ *
+ * Detection strategies:
+ * 1. Direct CLI: "start/benchmark --config xxx.yaml" in cmdline
+ * 2. PM2 mode: "node index.js" with runner.yaml in cwd
  */
 export function findRunnerProcesses(): RunnerProcess[] {
   const processes: RunnerProcess[] = [];
@@ -276,6 +294,8 @@ export function findRunnerProcesses(): RunnerProcess[] {
 
     try {
       const cmdline = readFileSync(cmdlinePath, "utf-8");
+
+      // Strategy 1: Direct CLI mode (args in cmdline)
       const parsed = parseRunnerCmdline(cmdline);
       if (parsed) {
         processes.push({
@@ -283,6 +303,21 @@ export function findRunnerProcesses(): RunnerProcess[] {
           configPath: parsed.configPath,
           mode: parsed.mode,
         });
+        continue;
+      }
+
+      // Strategy 2: PM2 mode (node index.js, check cwd for runner.yaml)
+      if (isNodeIndexJs(cmdline)) {
+        const cwdPath = path.join(procDir, entry, "cwd");
+        const cwd = readlinkSync(cwdPath);
+        const configPath = path.join(cwd, "runner.yaml");
+        if (existsSync(configPath)) {
+          processes.push({
+            pid,
+            configPath,
+            mode: "start", // Default to start mode (cannot determine from cmdline)
+          });
+        }
       }
     } catch {
       continue;

--- a/turbo/apps/runner/src/lib/process.ts
+++ b/turbo/apps/runner/src/lib/process.ts
@@ -134,6 +134,62 @@ interface MitmproxyProcess {
   baseDir: string;
 }
 
+interface RunnerProcess {
+  pid: number;
+  configPath: string;
+  mode: "start" | "benchmark";
+}
+
+/**
+ * Parse /proc/{pid}/cmdline content to extract runner process info.
+ * Pure function for easy testing.
+ *
+ * Parses: node ... runner start --config /path/to/runner.yaml
+ * Parses: node ... runner benchmark --config /path/to/runner.yaml
+ */
+export function parseRunnerCmdline(
+  cmdline: string,
+): { configPath: string; mode: "start" | "benchmark" } | null {
+  const args = cmdline.split("\0");
+
+  // Find "start" or "benchmark" mode
+  const startIdx = args.indexOf("start");
+  const benchmarkIdx = args.indexOf("benchmark");
+
+  let mode: "start" | "benchmark";
+  let modeIdx: number;
+
+  if (startIdx !== -1 && (benchmarkIdx === -1 || startIdx < benchmarkIdx)) {
+    mode = "start";
+    modeIdx = startIdx;
+  } else if (benchmarkIdx !== -1) {
+    mode = "benchmark";
+    modeIdx = benchmarkIdx;
+  } else {
+    return null;
+  }
+
+  // Check that this looks like a runner command (node ... runner start/benchmark)
+  // The arg before mode should be "runner" or end with "/runner"
+  const prevArg = args[modeIdx - 1];
+  if (!prevArg || (!prevArg.endsWith("runner") && prevArg !== "runner")) {
+    return null;
+  }
+
+  // Find --config argument
+  const configIdx = args.indexOf("--config");
+  if (configIdx === -1 || configIdx >= args.length - 1) {
+    return null;
+  }
+
+  const configPath = args[configIdx + 1];
+  if (!configPath) {
+    return null;
+  }
+
+  return { configPath, mode };
+}
+
 /**
  * Find all mitmproxy processes
  */
@@ -161,6 +217,46 @@ export function findMitmproxyProcesses(): MitmproxyProcess[] {
       const baseDir = parseMitmproxyCmdline(cmdline);
       if (baseDir) {
         processes.push({ pid, baseDir });
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return processes;
+}
+
+/**
+ * Find all runner processes
+ */
+export function findRunnerProcesses(): RunnerProcess[] {
+  const processes: RunnerProcess[] = [];
+  const procDir = "/proc";
+
+  let entries: string[];
+  try {
+    entries = readdirSync(procDir);
+  } catch {
+    return [];
+  }
+
+  for (const entry of entries) {
+    if (!/^\d+$/.test(entry)) continue;
+
+    const pid = parseInt(entry, 10);
+    const cmdlinePath = path.join(procDir, entry, "cmdline");
+
+    if (!existsSync(cmdlinePath)) continue;
+
+    try {
+      const cmdline = readFileSync(cmdlinePath, "utf-8");
+      const parsed = parseRunnerCmdline(cmdline);
+      if (parsed) {
+        processes.push({
+          pid,
+          configPath: parsed.configPath,
+          mode: parsed.mode,
+        });
       }
     } catch {
       continue;

--- a/turbo/apps/runner/src/lib/process.ts
+++ b/turbo/apps/runner/src/lib/process.ts
@@ -130,25 +130,32 @@ export function parseMitmproxyCmdline(cmdline: string): string | null {
  * Parse /proc/{pid}/cmdline content to extract runner process info.
  * Pure function for easy testing.
  *
- * Looks for: "start" or "benchmark" mode AND "--config <path>.yaml"
- * Order doesn't matter (PM2 cluster mode may reorder args)
+ * Looks for: "start" or "benchmark" followed by "--config <path>.yaml"
  */
 export function parseRunnerCmdline(
   cmdline: string,
 ): { configPath: string; mode: "start" | "benchmark" } | null {
   const args = cmdline.split("\0").filter((a) => a !== "");
 
-  // Find mode
-  let mode: "start" | "benchmark" | null = null;
-  if (args.includes("start")) {
-    mode = "start";
-  } else if (args.includes("benchmark")) {
-    mode = "benchmark";
-  }
-  if (!mode) return null;
+  // Find mode (start or benchmark)
+  const startIdx = args.indexOf("start");
+  const benchmarkIdx = args.indexOf("benchmark");
 
-  // Find --config with .yaml/.yml file
-  const configIdx = args.indexOf("--config");
+  let mode: "start" | "benchmark";
+  let modeIdx: number;
+
+  if (startIdx !== -1 && (benchmarkIdx === -1 || startIdx < benchmarkIdx)) {
+    mode = "start";
+    modeIdx = startIdx;
+  } else if (benchmarkIdx !== -1) {
+    mode = "benchmark";
+    modeIdx = benchmarkIdx;
+  } else {
+    return null;
+  }
+
+  // Find --config after mode
+  const configIdx = args.indexOf("--config", modeIdx + 1);
   if (configIdx === -1 || configIdx >= args.length - 1) return null;
 
   const configPath = args[configIdx + 1];

--- a/turbo/apps/runner/src/lib/process.ts
+++ b/turbo/apps/runner/src/lib/process.ts
@@ -9,11 +9,26 @@ import { readdirSync, readFileSync, existsSync } from "fs";
 import path from "path";
 import { type VmId, createVmId, vmIdValue } from "./firecracker/vm-id.js";
 
+// ==================== Interfaces ====================
+
 export interface FirecrackerProcess {
   pid: number;
   vmId: VmId;
   baseDir: string;
 }
+
+interface MitmproxyProcess {
+  pid: number;
+  baseDir: string;
+}
+
+interface RunnerProcess {
+  pid: number;
+  configPath: string;
+  mode: "start" | "benchmark";
+}
+
+// ==================== Cmdline Parsers ====================
 
 /**
  * Parse /proc/{pid}/cmdline content to extract Firecracker process info.
@@ -85,62 +100,6 @@ export function parseMitmproxyCmdline(cmdline: string): string | null {
 }
 
 /**
- * Find all running Firecracker processes by scanning /proc
- */
-export function findFirecrackerProcesses(): FirecrackerProcess[] {
-  const processes: FirecrackerProcess[] = [];
-  const procDir = "/proc";
-
-  let entries: string[];
-  try {
-    entries = readdirSync(procDir);
-  } catch {
-    return [];
-  }
-
-  for (const entry of entries) {
-    if (!/^\d+$/.test(entry)) continue;
-
-    const pid = parseInt(entry, 10);
-    const cmdlinePath = path.join(procDir, entry, "cmdline");
-
-    if (!existsSync(cmdlinePath)) continue;
-
-    try {
-      const cmdline = readFileSync(cmdlinePath, "utf-8");
-      const parsed = parseFirecrackerCmdline(cmdline);
-      if (parsed) {
-        processes.push({ pid, vmId: parsed.vmId, baseDir: parsed.baseDir });
-      }
-    } catch {
-      continue;
-    }
-  }
-
-  return processes;
-}
-
-/**
- * Find a specific Firecracker process by vmId
- */
-export function findProcessByVmId(vmId: VmId): FirecrackerProcess | null {
-  const processes = findFirecrackerProcesses();
-  const vmIdStr = vmIdValue(vmId);
-  return processes.find((p) => vmIdValue(p.vmId) === vmIdStr) || null;
-}
-
-interface MitmproxyProcess {
-  pid: number;
-  baseDir: string;
-}
-
-interface RunnerProcess {
-  pid: number;
-  configPath: string;
-  mode: "start" | "benchmark";
-}
-
-/**
  * Parse /proc/{pid}/cmdline content to extract runner process info.
  * Pure function for easy testing.
  *
@@ -188,6 +147,53 @@ export function parseRunnerCmdline(
   }
 
   return { configPath, mode };
+}
+
+// ==================== Process Finders ====================
+
+/**
+ * Find all running Firecracker processes by scanning /proc
+ */
+export function findFirecrackerProcesses(): FirecrackerProcess[] {
+  const processes: FirecrackerProcess[] = [];
+  const procDir = "/proc";
+
+  let entries: string[];
+  try {
+    entries = readdirSync(procDir);
+  } catch {
+    return [];
+  }
+
+  for (const entry of entries) {
+    if (!/^\d+$/.test(entry)) continue;
+
+    const pid = parseInt(entry, 10);
+    const cmdlinePath = path.join(procDir, entry, "cmdline");
+
+    if (!existsSync(cmdlinePath)) continue;
+
+    try {
+      const cmdline = readFileSync(cmdlinePath, "utf-8");
+      const parsed = parseFirecrackerCmdline(cmdline);
+      if (parsed) {
+        processes.push({ pid, vmId: parsed.vmId, baseDir: parsed.baseDir });
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return processes;
+}
+
+/**
+ * Find a specific Firecracker process by vmId
+ */
+export function findProcessByVmId(vmId: VmId): FirecrackerProcess | null {
+  const processes = findFirecrackerProcesses();
+  const vmIdStr = vmIdValue(vmId);
+  return processes.find((p) => vmIdValue(p.vmId) === vmIdStr) || null;
 }
 
 /**

--- a/turbo/apps/runner/src/lib/process.ts
+++ b/turbo/apps/runner/src/lib/process.ts
@@ -130,30 +130,31 @@ export function parseMitmproxyCmdline(cmdline: string): string | null {
  * Parse /proc/{pid}/cmdline content to extract runner process info.
  * Pure function for easy testing.
  *
- * Looks for pattern: ... (start|benchmark) --config <path> ...
- * where config path ends with .yaml or .yml
+ * Looks for: "start" or "benchmark" mode AND "--config <path>.yaml"
+ * Order doesn't matter (PM2 cluster mode may reorder args)
  */
 export function parseRunnerCmdline(
   cmdline: string,
 ): { configPath: string; mode: "start" | "benchmark" } | null {
   const args = cmdline.split("\0").filter((a) => a !== "");
 
-  // Find "start" or "benchmark" followed by "--config <yaml file>"
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg !== "start" && arg !== "benchmark") continue;
-
-    // Look for --config after mode
-    const configIdx = args.indexOf("--config", i + 1);
-    if (configIdx === -1 || configIdx >= args.length - 1) continue;
-
-    const configPath = args[configIdx + 1];
-    if (!configPath?.match(/\.ya?ml$/)) continue;
-
-    return { configPath, mode: arg };
+  // Find mode
+  let mode: "start" | "benchmark" | null = null;
+  if (args.includes("start")) {
+    mode = "start";
+  } else if (args.includes("benchmark")) {
+    mode = "benchmark";
   }
+  if (!mode) return null;
 
-  return null;
+  // Find --config with .yaml/.yml file
+  const configIdx = args.indexOf("--config");
+  if (configIdx === -1 || configIdx >= args.length - 1) return null;
+
+  const configPath = args[configIdx + 1];
+  if (!configPath?.match(/\.ya?ml$/)) return null;
+
+  return { configPath, mode };
 }
 
 // ==================== Process Finders ====================

--- a/turbo/apps/runner/src/lib/process.ts
+++ b/turbo/apps/runner/src/lib/process.ts
@@ -18,7 +18,7 @@ export interface FirecrackerProcess {
   isOrphan: boolean;
 }
 
-interface MitmproxyProcess {
+export interface MitmproxyProcess {
   pid: number;
   baseDir: string;
   isOrphan: boolean;


### PR DESCRIPTION
## Summary

Closes #2367

Redesign the `runner doctor` command to auto-discover all runners on the host without requiring the `--config` flag.

### Changes:
- Remove `--config` flag from doctor command
- Auto-discover all runner processes by scanning `/proc` for `runner start` and `runner benchmark` commands
- Move process discovery utilities from `lib/firecracker/process.ts` to `lib/process.ts`
- Add `findRunnerProcesses()` and `parseRunnerCmdline()` functions
- Support both `start` and `benchmark` modes
- For benchmark mode, proxy is optional (no warning if mitmproxy is not running)
- Add global orphan resource detection (processes and namespaces not belonging to any discovered runner)

### Doctor output now shows:
- All discovered runners with their PIDs and modes
- Uptime, API connectivity status
- Proxy status (mode-aware)
- Active runs with Firecracker process status
- Per-runner warnings
- Global orphan resources

## Test plan
- [x] Type check passes
- [x] Lint passes  
- [x] Unit tests pass (including new tests for `parseRunnerCmdline` and `findRunnerProcesses`)
- [ ] Manual test on a host with running runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)