### PR TITLE
feat(web): make database pool settings configurable via env vars

### DIFF
--- a/turbo/apps/web/src/env.ts
+++ b/turbo/apps/web/src/env.ts
@@ -8,6 +8,14 @@ function initEnv() {
       NODE_ENV: z
         .enum(["development", "test", "production"])
         .default("development"),
+      // Database pool configuration
+      DB_POOL_MAX: z.coerce.number().int().positive().default(10),
+      DB_POOL_IDLE_TIMEOUT_MS: z.coerce.number().int().nonnegative().optional(),
+      DB_POOL_CONNECT_TIMEOUT_MS: z.coerce
+        .number()
+        .int()
+        .positive()
+        .default(10000),
       CLERK_SECRET_KEY: z.string().min(1),
       E2B_API_KEY: z.string().min(1),
       VM0_API_URL: z.string().url().optional(),
@@ -35,6 +43,9 @@ function initEnv() {
     runtimeEnv: {
       DATABASE_URL: process.env.DATABASE_URL,
       NODE_ENV: process.env.NODE_ENV,
+      DB_POOL_MAX: process.env.DB_POOL_MAX,
+      DB_POOL_IDLE_TIMEOUT_MS: process.env.DB_POOL_IDLE_TIMEOUT_MS,
+      DB_POOL_CONNECT_TIMEOUT_MS: process.env.DB_POOL_CONNECT_TIMEOUT_MS,
       CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
       E2B_API_KEY: process.env.E2B_API_KEY,
       VM0_API_URL: process.env.VM0_API_URL,

--- a/turbo/apps/web/src/lib/init-services.ts
+++ b/turbo/apps/web/src/lib/init-services.ts
@@ -51,17 +51,17 @@ export function initServices(): void {
           // See: https://vercel.com/guides/connection-pooling-with-functions
           _pool = new NeonPool({
             connectionString: this.env.DATABASE_URL,
-            max: 10,
-            idleTimeoutMillis: 10000,
-            connectionTimeoutMillis: 10000,
+            max: this.env.DB_POOL_MAX,
+            idleTimeoutMillis: this.env.DB_POOL_IDLE_TIMEOUT_MS ?? 10000,
+            connectionTimeoutMillis: this.env.DB_POOL_CONNECT_TIMEOUT_MS,
           });
         } else {
           // Use regular pg driver for local development
           _pool = new PgPool({
             connectionString: this.env.DATABASE_URL,
-            max: 10,
-            idleTimeoutMillis: 30000,
-            connectionTimeoutMillis: 10000,
+            max: this.env.DB_POOL_MAX,
+            idleTimeoutMillis: this.env.DB_POOL_IDLE_TIMEOUT_MS ?? 30000,
+            connectionTimeoutMillis: this.env.DB_POOL_CONNECT_TIMEOUT_MS,
           });
         }
       }

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -3,6 +3,9 @@
   "ui": "tui",
   "globalEnv": [
     "DATABASE_URL",
+    "DB_POOL_MAX",
+    "DB_POOL_IDLE_TIMEOUT_MS",
+    "DB_POOL_CONNECT_TIMEOUT_MS",
     "VM0_DEBUG",
     "NODE_ENV",
     "SKIP_ENV_VALIDATION",


### PR DESCRIPTION
## Summary

This PR makes database connection pool settings configurable via environment variables instead of being hardcoded.

## Changes

- Add `DB_POOL_MAX` env var to configure maximum pool size (default: 10)
- Add `DB_POOL_IDLE_TIMEOUT_MS` env var to configure idle timeout (default varies by environment)
- Add `DB_POOL_CONNECT_TIMEOUT_MS` env var to configure connection timeout (default: 10000ms)

## Motivation

Currently, the pool settings are hardcoded in `init-services.ts`. This makes it difficult for operators to tune the pool based on their specific workload characteristics without forking the codebase.

By exposing these as environment variables, operators can:
- Increase `DB_POOL_MAX` for high-concurrency workloads
- Adjust timeouts based on their database latency

## Testing

- [x] TypeScript types check passes
- [x] Existing behavior unchanged when env vars are not set (uses defaults)