### PR TITLE
feat(web): add rate limiting to CLI device auth endpoint

### DIFF
--- a/turbo/apps/web/app/api/cli/auth/device/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/device/route.ts
@@ -3,6 +3,15 @@ import { cliAuthDeviceContract } from "@vm0/core";
 import crypto from "crypto";
 import { initServices } from "../../../../../src/lib/init-services";
 import { deviceCodes } from "../../../../../src/db/schema/device-codes";
+import {
+  checkRateLimit,
+  getClientIp,
+} from "../../../../../src/lib/rate-limit";
+import { NextResponse } from "next/server";
+
+// Rate limit: 10 requests per minute per IP
+const RATE_LIMIT_MAX = 10;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 
 // Characters that are easy to read (excluding 0/O, 1/I/L)
 const CHARS = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
@@ -50,6 +59,40 @@ const router = tsr.router(cliAuthDeviceContract, {
   },
 });
 
-const handler = createHandler(cliAuthDeviceContract, router);
+const tsRestHandler = createHandler(cliAuthDeviceContract, router);
 
-export { handler as POST };
+/**
+ * POST handler with rate limiting.
+ *
+ * Rate limiting is applied before the ts-rest handler to prevent
+ * abuse of device code creation. Uses OAuth "slow_down" error format.
+ */
+async function POST(request: Request): Promise<Response> {
+  const clientIp = getClientIp(request);
+  const rateLimitKey = `device:${clientIp}`;
+
+  const { allowed, retryAfter } = checkRateLimit(
+    rateLimitKey,
+    RATE_LIMIT_MAX,
+    RATE_LIMIT_WINDOW_MS,
+  );
+
+  if (!allowed) {
+    return NextResponse.json(
+      {
+        error: "slow_down",
+        error_description: `Rate limit exceeded. Please try again in ${retryAfter} seconds.`,
+      },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(retryAfter),
+        },
+      },
+    );
+  }
+
+  return tsRestHandler(request);
+}
+
+export { POST };

--- a/turbo/apps/web/src/lib/rate-limit.ts
+++ b/turbo/apps/web/src/lib/rate-limit.ts
@@ -1,0 +1,40 @@
+/**
+ * Simple in-memory rate limiter.
+ *
+ * Note: Not shared across serverless instances. For stronger guarantees,
+ * consider Redis-based rate limiting (e.g., @upstash/ratelimit).
+ */
+
+const store = new Map<string, { count: number; resetAt: number }>();
+
+export function checkRateLimit(
+  key: string,
+  maxRequests: number,
+  windowMs: number,
+): { allowed: boolean; retryAfter?: number } {
+  const now = Date.now();
+  const record = store.get(key);
+
+  if (!record || now > record.resetAt) {
+    store.set(key, { count: 1, resetAt: now + windowMs });
+    return { allowed: true };
+  }
+
+  if (record.count >= maxRequests) {
+    return {
+      allowed: false,
+      retryAfter: Math.ceil((record.resetAt - now) / 1000),
+    };
+  }
+
+  record.count++;
+  return { allowed: true };
+}
+
+export function getClientIp(request: Request): string {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    "unknown"
+  );
+}


### PR DESCRIPTION
## Summary

Add rate limiting to CLI device auth endpoint to prevent abuse.

## Changes

- Add `src/lib/rate-limit.ts` - Simple in-memory rate limiter
- Update `/api/cli/auth/device` - Apply 10 req/min per IP limit

## Implementation

- Uses OAuth `slow_down` error with `Retry-After` header
- Only `/device` endpoint; `/token` relies on device code expiration

## Limitations (for discussion)

This is a starting point. Known limitations:

1. In-memory store not shared across serverless instances
2. Users behind NAT share the same IP

Possible improvements: Redis-based rate limiting, database-backed, or configurable limits via env vars.