### PR TITLE
feat(agent): add agent sharing with acl-based access control

### DIFF
--- a/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Tests for agent sharing commands (public, private, share, unshare, permissions)
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { publicCommand } from "../public";
+import { privateCommand } from "../private";
+import { shareCommand } from "../share";
+import { unshareCommand } from "../unshare";
+import { permissionsCommand } from "../permissions";
+import chalk from "chalk";
+
+describe("Agent Sharing Commands", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  const testComposeId = "test-compose-123";
+  const testAgentName = "my-agent";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+
+    // Default handler to resolve agent name to compose ID
+    server.use(
+      http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+        const url = new URL(request.url);
+        const name = url.searchParams.get("name");
+        if (name === testAgentName) {
+          return HttpResponse.json({
+            id: testComposeId,
+            name: testAgentName,
+          });
+        }
+        return HttpResponse.json(
+          { error: { message: "Agent compose not found", code: "NOT_FOUND" } },
+          { status: 404 },
+        );
+      }),
+    );
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  describe("vm0 agent public", () => {
+    it("should make agent public successfully", async () => {
+      server.use(
+        http.post(
+          `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+          async ({ request }) => {
+            const body = (await request.json()) as Record<string, unknown>;
+            expect(body.granteeType).toBe("public");
+            return HttpResponse.json({
+              permission: {
+                id: "perm-123",
+                granteeType: "public",
+                grantedBy: "user-123",
+              },
+            });
+          },
+        ),
+      );
+
+      await publicCommand.parseAsync(["node", "cli", testAgentName]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("now public"),
+      );
+    });
+
+    it("should handle already public agent", async () => {
+      server.use(
+        http.post(
+          `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Permission already exists",
+                  code: "CONFLICT",
+                },
+              },
+              { status: 409 },
+            );
+          },
+        ),
+      );
+
+      await publicCommand.parseAsync(["node", "cli", testAgentName]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("already public"),
+      );
+    });
+
+    it("should handle agent not found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(
+            {
+              error: { message: "Agent compose not found", code: "NOT_FOUND" },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await publicCommand.parseAsync(["node", "cli", "nonexistent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Agent not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("vm0 agent private", () => {
+    it("should make agent private successfully", async () => {
+      server.use(
+        http.delete(
+          `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+          ({ request }) => {
+            const url = new URL(request.url);
+            expect(url.searchParams.get("type")).toBe("public");
+            return HttpResponse.json({ message: "Permission removed" });
+          },
+        ),
+      );
+
+      await privateCommand.parseAsync(["node", "cli", testAgentName]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("now private"),
+      );
+    });
+
+    it("should handle already private agent", async () => {
+      server.use(
+        http.delete(
+          `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+          () => {
+            return HttpResponse.json(
+              { error: { message: "Permission not found", code: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          },
+        ),
+      );
+
+      await privateCommand.parseAsync(["node", "cli", testAgentName]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("already private"),
+      );
+    });
+  });
+
+  describe("vm0 agent share", () => {
+    it("should share agent with email successfully", async () => {
+      const shareEmail = "user@example.com";
+
+      server.use(
+        http.post(
+          `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+          async ({ request }) => {
+            const body = (await request.json()) as Record<string, unknown>;
+            expect(body.granteeType).toBe("email");
+            expect(body.granteeEmail).toBe(shareEmail);
+            return HttpResponse.json({
+              permission: {
+                id: "perm-456",
+                granteeType: "email",
+                granteeEmail: shareEmail,
+              },
+            });
+          },
+        ),
+      );
+
+      await shareCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentName,
+        "--email",
+        shareEmail,
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("shared with"),
+      );
+    });
+
+    it("should handle already shared with same email", async () => {
+      server.use(
+        http.post(
+          `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Permission already exists",
+                  code: "CONFLICT",
+                },
+              },
+              { status: 409 },
+            );
+          },
+        ),
+      );
+
+      await shareCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentName,
+        "--email",
+        "user@example.com",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("already shared"),
+      );
+    });
+  });
+
+  describe("vm0 agent unshare", () => {
+    it("should unshare agent from email successfully", async () => {
+      const unshareEmail = "user@example.com";
+
+      server.use(
+        http.delete(
+          `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+          ({ request }) => {
+            const url = new URL(request.url);
+            expect(url.searchParams.get("type")).toBe("email");
+            expect(url.searchParams.get("email")).toBe(unshareEmail);
+            return HttpResponse.json({ message: "Permission removed" });
+          },
+        ),
+      );
+
+      await unshareCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentName,
+        "--email",
+        unshareEmail,
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Removed sharing"),
+      );
+    });
+
+    it("should handle not shared with email", async () => {
+      server.use(
+        http.delete(
+          `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+          () => {
+            return HttpResponse.json(
+              { error: { message: "Permission not found", code: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          },
+        ),
+      );
+
+      await unshareCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentName,
+        "--email",
+        "user@example.com",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("not shared"),
+      );
+    });
+  });
+
+  describe("vm0 agent permissions", () => {
+    it("should list permissions for agent", async () => {
+      server.use(
+        http.get(
+          `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+          () => {
+            return HttpResponse.json({
+              permissions: [
+                {
+                  id: "perm-1",
+                  granteeType: "public",
+                  granteeEmail: null,
+                  permission: "run_view",
+                  grantedBy: "user-123",
+                  createdAt: new Date().toISOString(),
+                },
+                {
+                  id: "perm-2",
+                  granteeType: "email",
+                  granteeEmail: "user@example.com",
+                  permission: "run_view",
+                  grantedBy: "user-123",
+                  createdAt: new Date().toISOString(),
+                },
+              ],
+            });
+          },
+        ),
+      );
+
+      await permissionsCommand.parseAsync(["node", "cli", testAgentName]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("public");
+      expect(logCalls).toContain("user@example.com");
+    });
+
+    it("should show message when no permissions", async () => {
+      server.use(
+        http.get(
+          `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+          () => {
+            return HttpResponse.json({ permissions: [] });
+          },
+        ),
+      );
+
+      await permissionsCommand.parseAsync(["node", "cli", testAgentName]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("No permissions"),
+      );
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await permissionsCommand.parseAsync(["node", "cli", testAgentName]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to list permissions"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for agent sharing commands (public, private, share, unshare, permissions)
+ * Tests for agent sharing commands (public, private, share, unshare, permission)
  *
  * Tests command-level behavior via parseAsync() following CLI testing principles:
  * - Entry point: command.parseAsync()
@@ -14,7 +14,7 @@ import { publicCommand } from "../public";
 import { privateCommand } from "../private";
 import { shareCommand } from "../share";
 import { unshareCommand } from "../unshare";
-import { permissionsCommand } from "../permissions";
+import { permissionCommand } from "../permission";
 import chalk from "chalk";
 
 describe("Agent Sharing Commands", () => {
@@ -299,7 +299,7 @@ describe("Agent Sharing Commands", () => {
     });
   });
 
-  describe("vm0 agent permissions", () => {
+  describe("vm0 agent permission", () => {
     it("should list permissions for agent", async () => {
       server.use(
         http.get(
@@ -329,7 +329,7 @@ describe("Agent Sharing Commands", () => {
         ),
       );
 
-      await permissionsCommand.parseAsync(["node", "cli", testAgentName]);
+      await permissionCommand.parseAsync(["node", "cli", testAgentName]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("public");
@@ -346,7 +346,7 @@ describe("Agent Sharing Commands", () => {
         ),
       );
 
-      await permissionsCommand.parseAsync(["node", "cli", testAgentName]);
+      await permissionCommand.parseAsync(["node", "cli", testAgentName]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("No permissions"),
@@ -364,7 +364,7 @@ describe("Agent Sharing Commands", () => {
       );
 
       await expect(async () => {
-        await permissionsCommand.parseAsync(["node", "cli", testAgentName]);
+        await permissionCommand.parseAsync(["node", "cli", testAgentName]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(

--- a/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
@@ -28,6 +28,7 @@ describe("Agent Sharing Commands", () => {
 
   const testComposeId = "test-compose-123";
   const testAgentName = "my-agent";
+  const testScopeSlug = "test-user";
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -50,6 +51,16 @@ describe("Agent Sharing Commands", () => {
           { error: { message: "Agent compose not found", code: "NOT_FOUND" } },
           { status: 404 },
         );
+      }),
+      // Default handler for scope API
+      http.get("http://localhost:3000/api/scope", () => {
+        return HttpResponse.json({
+          id: "scope-123",
+          slug: testScopeSlug,
+          type: "personal",
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
       }),
     );
   });
@@ -84,6 +95,10 @@ describe("Agent Sharing Commands", () => {
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("now public"),
+      );
+      // Check for run command hint
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(`vm0 run ${testScopeSlug}/${testAgentName}`),
       );
     });
 
@@ -208,6 +223,10 @@ describe("Agent Sharing Commands", () => {
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("shared with"),
+      );
+      // Check for run command hint
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(`vm0 run ${testScopeSlug}/${testAgentName}`),
       );
     });
 

--- a/turbo/apps/cli/src/commands/agent/index.ts
+++ b/turbo/apps/cli/src/commands/agent/index.ts
@@ -2,10 +2,20 @@ import { Command } from "commander";
 import { cloneCommand } from "./clone";
 import { listCommand } from "./list";
 import { statusCommand } from "./status";
+import { publicCommand } from "./public";
+import { privateCommand } from "./private";
+import { shareCommand } from "./share";
+import { unshareCommand } from "./unshare";
+import { permissionsCommand } from "./permissions";
 
 export const agentCommand = new Command()
   .name("agent")
   .description("Manage agent composes")
   .addCommand(cloneCommand)
   .addCommand(listCommand)
-  .addCommand(statusCommand);
+  .addCommand(statusCommand)
+  .addCommand(publicCommand)
+  .addCommand(privateCommand)
+  .addCommand(shareCommand)
+  .addCommand(unshareCommand)
+  .addCommand(permissionsCommand);

--- a/turbo/apps/cli/src/commands/agent/index.ts
+++ b/turbo/apps/cli/src/commands/agent/index.ts
@@ -6,7 +6,7 @@ import { publicCommand } from "./public";
 import { privateCommand } from "./private";
 import { shareCommand } from "./share";
 import { unshareCommand } from "./unshare";
-import { permissionsCommand } from "./permissions";
+import { permissionCommand } from "./permission";
 
 export const agentCommand = new Command()
   .name("agent")
@@ -18,4 +18,4 @@ export const agentCommand = new Command()
   .addCommand(privateCommand)
   .addCommand(shareCommand)
   .addCommand(unshareCommand)
-  .addCommand(permissionsCommand);
+  .addCommand(permissionCommand);

--- a/turbo/apps/cli/src/commands/agent/permission.ts
+++ b/turbo/apps/cli/src/commands/agent/permission.ts
@@ -16,8 +16,8 @@ interface PermissionsResponse {
   permissions: Permission[];
 }
 
-export const permissionsCommand = new Command()
-  .name("permissions")
+export const permissionCommand = new Command()
+  .name("permission")
   .description("List all permissions for an agent")
   .argument("<name>", "Agent name")
   .action(async (name: string) => {

--- a/turbo/apps/cli/src/commands/agent/permissions.ts
+++ b/turbo/apps/cli/src/commands/agent/permissions.ts
@@ -1,0 +1,76 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getComposeByName, httpGet, type ApiError } from "../../lib/api";
+import { formatRelativeTime } from "../../lib/utils/file-utils";
+
+interface Permission {
+  id: string;
+  granteeType: string;
+  granteeEmail: string | null;
+  permission: string;
+  grantedBy: string;
+  createdAt: string;
+}
+
+interface PermissionsResponse {
+  permissions: Permission[];
+}
+
+export const permissionsCommand = new Command()
+  .name("permissions")
+  .description("List all permissions for an agent")
+  .argument("<name>", "Agent name")
+  .action(async (name: string) => {
+    try {
+      // Resolve compose by name
+      const compose = await getComposeByName(name);
+      if (!compose) {
+        console.error(chalk.red(`✗ Agent not found: ${name}`));
+        process.exit(1);
+      }
+
+      // Get permissions
+      const response = await httpGet(
+        `/api/agent/composes/${compose.id}/permissions`,
+      );
+
+      if (!response.ok) {
+        const error = (await response.json()) as ApiError;
+        throw new Error(error.error?.message || "Failed to list permissions");
+      }
+
+      const data = (await response.json()) as PermissionsResponse;
+
+      if (data.permissions.length === 0) {
+        console.log(chalk.dim("No permissions set (private agent)"));
+        return;
+      }
+
+      // Print header
+      console.log(
+        chalk.dim(
+          "TYPE     EMAIL                          PERMISSION  GRANTED",
+        ),
+      );
+      console.log(
+        chalk.dim(
+          "-------  -----------------------------  ----------  ----------",
+        ),
+      );
+
+      // Print rows
+      for (const p of data.permissions) {
+        const type = p.granteeType.padEnd(7);
+        const email = (p.granteeEmail ?? "-").padEnd(29);
+        const permission = p.permission.padEnd(10);
+        const granted = formatRelativeTime(p.createdAt);
+        console.log(`${type}  ${email}  ${permission}  ${granted}`);
+      }
+    } catch (error) {
+      console.error(chalk.red("✗ Failed to list permissions"));
+      if (error instanceof Error) {
+        console.error(chalk.dim(`  ${error.message}`));
+      }
+      process.exit(1);
+    }
+  });

--- a/turbo/apps/cli/src/commands/agent/private.ts
+++ b/turbo/apps/cli/src/commands/agent/private.ts
@@ -1,0 +1,40 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getComposeByName, httpDelete, type ApiError } from "../../lib/api";
+
+export const privateCommand = new Command()
+  .name("private")
+  .description("Make an agent private (remove public access)")
+  .argument("<name>", "Agent name")
+  .action(async (name: string) => {
+    try {
+      // Resolve compose by name
+      const compose = await getComposeByName(name);
+      if (!compose) {
+        console.error(chalk.red(`✗ Agent not found: ${name}`));
+        process.exit(1);
+      }
+
+      // Remove public permission
+      const response = await httpDelete(
+        `/api/agent/composes/${compose.id}/permissions?type=public`,
+      );
+
+      if (!response.ok) {
+        const error = (await response.json()) as ApiError;
+        if (response.status === 404) {
+          console.log(chalk.yellow(`Agent "${name}" is already private`));
+          return;
+        }
+        throw new Error(error.error?.message || "Failed to make agent private");
+      }
+
+      console.log(chalk.green(`✓ Agent "${name}" is now private`));
+    } catch (error) {
+      console.error(chalk.red("✗ Failed to make agent private"));
+      if (error instanceof Error) {
+        console.error(chalk.dim(`  ${error.message}`));
+      }
+      process.exit(1);
+    }
+  });

--- a/turbo/apps/cli/src/commands/agent/public.ts
+++ b/turbo/apps/cli/src/commands/agent/public.ts
@@ -1,6 +1,11 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { getComposeByName, httpPost, type ApiError } from "../../lib/api";
+import {
+  getComposeByName,
+  getScope,
+  httpPost,
+  type ApiError,
+} from "../../lib/api";
 
 export const publicCommand = new Command()
   .name("public")
@@ -14,6 +19,9 @@ export const publicCommand = new Command()
         console.error(chalk.red(`✗ Agent not found: ${name}`));
         process.exit(1);
       }
+
+      // Get scope for display
+      const scope = await getScope();
 
       // Add public permission
       const response = await httpPost(
@@ -30,7 +38,11 @@ export const publicCommand = new Command()
         throw new Error(error.error?.message || "Failed to make agent public");
       }
 
+      const fullName = `${scope.slug}/${name}`;
       console.log(chalk.green(`✓ Agent "${name}" is now public`));
+      console.log();
+      console.log("Others can now run your agent with:");
+      console.log(chalk.cyan(`  vm0 run ${fullName} "your prompt"`));
     } catch (error) {
       console.error(chalk.red("✗ Failed to make agent public"));
       if (error instanceof Error) {

--- a/turbo/apps/cli/src/commands/agent/public.ts
+++ b/turbo/apps/cli/src/commands/agent/public.ts
@@ -1,0 +1,41 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getComposeByName, httpPost, type ApiError } from "../../lib/api";
+
+export const publicCommand = new Command()
+  .name("public")
+  .description("Make an agent public (accessible to all authenticated users)")
+  .argument("<name>", "Agent name")
+  .action(async (name: string) => {
+    try {
+      // Resolve compose by name
+      const compose = await getComposeByName(name);
+      if (!compose) {
+        console.error(chalk.red(`✗ Agent not found: ${name}`));
+        process.exit(1);
+      }
+
+      // Add public permission
+      const response = await httpPost(
+        `/api/agent/composes/${compose.id}/permissions`,
+        { granteeType: "public" },
+      );
+
+      if (!response.ok) {
+        const error = (await response.json()) as ApiError;
+        if (response.status === 409) {
+          console.log(chalk.yellow(`Agent "${name}" is already public`));
+          return;
+        }
+        throw new Error(error.error?.message || "Failed to make agent public");
+      }
+
+      console.log(chalk.green(`✓ Agent "${name}" is now public`));
+    } catch (error) {
+      console.error(chalk.red("✗ Failed to make agent public"));
+      if (error instanceof Error) {
+        console.error(chalk.dim(`  ${error.message}`));
+      }
+      process.exit(1);
+    }
+  });

--- a/turbo/apps/cli/src/commands/agent/share.ts
+++ b/turbo/apps/cli/src/commands/agent/share.ts
@@ -1,6 +1,11 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { getComposeByName, httpPost, type ApiError } from "../../lib/api";
+import {
+  getComposeByName,
+  getScope,
+  httpPost,
+  type ApiError,
+} from "../../lib/api";
 
 export const shareCommand = new Command()
   .name("share")
@@ -15,6 +20,9 @@ export const shareCommand = new Command()
         console.error(chalk.red(`✗ Agent not found: ${name}`));
         process.exit(1);
       }
+
+      // Get scope for display
+      const scope = await getScope();
 
       // Add email permission
       const response = await httpPost(
@@ -35,9 +43,13 @@ export const shareCommand = new Command()
         throw new Error(error.error?.message || "Failed to share agent");
       }
 
+      const fullName = `${scope.slug}/${name}`;
       console.log(
         chalk.green(`✓ Agent "${name}" shared with ${options.email}`),
       );
+      console.log();
+      console.log("They can now run your agent with:");
+      console.log(chalk.cyan(`  vm0 run ${fullName} "your prompt"`));
     } catch (error) {
       console.error(chalk.red("✗ Failed to share agent"));
       if (error instanceof Error) {

--- a/turbo/apps/cli/src/commands/agent/share.ts
+++ b/turbo/apps/cli/src/commands/agent/share.ts
@@ -1,0 +1,48 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getComposeByName, httpPost, type ApiError } from "../../lib/api";
+
+export const shareCommand = new Command()
+  .name("share")
+  .description("Share an agent with a user by email")
+  .argument("<name>", "Agent name")
+  .requiredOption("--email <email>", "Email address to share with")
+  .action(async (name: string, options: { email: string }) => {
+    try {
+      // Resolve compose by name
+      const compose = await getComposeByName(name);
+      if (!compose) {
+        console.error(chalk.red(`✗ Agent not found: ${name}`));
+        process.exit(1);
+      }
+
+      // Add email permission
+      const response = await httpPost(
+        `/api/agent/composes/${compose.id}/permissions`,
+        { granteeType: "email", granteeEmail: options.email },
+      );
+
+      if (!response.ok) {
+        const error = (await response.json()) as ApiError;
+        if (response.status === 409) {
+          console.log(
+            chalk.yellow(
+              `Agent "${name}" is already shared with ${options.email}`,
+            ),
+          );
+          return;
+        }
+        throw new Error(error.error?.message || "Failed to share agent");
+      }
+
+      console.log(
+        chalk.green(`✓ Agent "${name}" shared with ${options.email}`),
+      );
+    } catch (error) {
+      console.error(chalk.red("✗ Failed to share agent"));
+      if (error instanceof Error) {
+        console.error(chalk.dim(`  ${error.message}`));
+      }
+      process.exit(1);
+    }
+  });

--- a/turbo/apps/cli/src/commands/agent/unshare.ts
+++ b/turbo/apps/cli/src/commands/agent/unshare.ts
@@ -1,0 +1,45 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getComposeByName, httpDelete, type ApiError } from "../../lib/api";
+
+export const unshareCommand = new Command()
+  .name("unshare")
+  .description("Remove sharing from a user")
+  .argument("<name>", "Agent name")
+  .requiredOption("--email <email>", "Email address to unshare")
+  .action(async (name: string, options: { email: string }) => {
+    try {
+      // Resolve compose by name
+      const compose = await getComposeByName(name);
+      if (!compose) {
+        console.error(chalk.red(`✗ Agent not found: ${name}`));
+        process.exit(1);
+      }
+
+      // Remove email permission
+      const response = await httpDelete(
+        `/api/agent/composes/${compose.id}/permissions?type=email&email=${encodeURIComponent(options.email)}`,
+      );
+
+      if (!response.ok) {
+        const error = (await response.json()) as ApiError;
+        if (response.status === 404) {
+          console.log(
+            chalk.yellow(`Agent "${name}" is not shared with ${options.email}`),
+          );
+          return;
+        }
+        throw new Error(error.error?.message || "Failed to unshare agent");
+      }
+
+      console.log(
+        chalk.green(`✓ Removed sharing of "${name}" from ${options.email}`),
+      );
+    } catch (error) {
+      console.error(chalk.red("✗ Failed to unshare agent"));
+      if (error instanceof Error) {
+        console.error(chalk.dim(`  ${error.message}`));
+      }
+      process.exit(1);
+    }
+  });

--- a/turbo/apps/cli/src/lib/api/core/http.ts
+++ b/turbo/apps/cli/src/lib/api/core/http.ts
@@ -35,3 +35,33 @@ export async function httpGet(path: string): Promise<Response> {
     headers,
   });
 }
+
+/**
+ * Generic POST request
+ */
+export async function httpPost(path: string, body: unknown): Promise<Response> {
+  const baseUrl = await getBaseUrl();
+  const headers = await getRawHeaders();
+
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: {
+      ...headers,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Generic DELETE request
+ */
+export async function httpDelete(path: string): Promise<Response> {
+  const baseUrl = await getBaseUrl();
+  const headers = await getRawHeaders();
+
+  return fetch(`${baseUrl}${path}`, {
+    method: "DELETE",
+    headers,
+  });
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -5,7 +5,7 @@ export type { ApiError, RunResult } from "./core/types";
 export { ApiRequestError } from "./core/client-factory";
 
 // HTTP utilities (only export what's actually used)
-export { httpGet } from "./core/http";
+export { httpGet, httpPost, httpDelete } from "./core/http";
 
 // Domain modules - Composes
 export {

--- a/turbo/apps/runner/src/lib/firecracker/__tests__/vsock.test.ts
+++ b/turbo/apps/runner/src/lib/firecracker/__tests__/vsock.test.ts
@@ -284,9 +284,10 @@ describe("VsockClient Integration Tests", () => {
         await client!.exec(`rm -f ${testPath}`);
       } else {
         // No passwordless sudo - verify it fails with expected error
+        // The error can be sudo-related, password prompt, or broken pipe (when sudo terminates)
         await expect(
           client!.writeFileWithSudo(testPath, content),
-        ).rejects.toThrow(/sudo|password/i);
+        ).rejects.toThrow(/sudo|password|broken pipe/i);
       }
     });
   });

--- a/turbo/apps/web/app/api/agent/composes/[id]/__tests__/permission.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/__tests__/permission.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GET as getCompose } from "../route";
+import { POST as addPermission } from "../permissions/route";
+import {
+  createTestRequest,
+  createTestCompose,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
+
+const context = testContext();
+
+describe("Agent Compose Permission Checks", () => {
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
+
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    testComposeId = composeId;
+  });
+
+  describe("Cross-User Access Control", () => {
+    // Note: API returns 404 (not 403) for unauthorized access to prevent
+    // information leakage about existence of private agents
+    it("should deny access to another user's private compose (returns 404)", async () => {
+      // Switch to another user
+      await context.setupUser({ prefix: "other-user" });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}`,
+        { method: "GET" },
+      );
+
+      const response = await getCompose(request);
+      const data = await response.json();
+
+      // API returns 404 instead of 403 for security (don't leak existence of private agents)
+      expect(response.status).toBe(404);
+      expect(data.error.message).toContain("not found");
+    });
+
+    it("should allow access when compose is public", async () => {
+      // Make compose public (as owner)
+      const addRequest = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ granteeType: "public" }),
+        },
+      );
+      await addPermission(addRequest, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+
+      // Switch to another user
+      await context.setupUser({ prefix: "other-user" });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}`,
+        { method: "GET" },
+      );
+
+      const response = await getCompose(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.id).toBe(testComposeId);
+    });
+
+    it("should allow access when user email is in permission list", async () => {
+      // Share with the default mock email (test@example.com)
+      const addRequest = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            granteeType: "email",
+            granteeEmail: "test@example.com", // This is what mockClerk returns
+          }),
+        },
+      );
+      await addPermission(addRequest, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+
+      // Switch to another user (who has email test@example.com via mock)
+      mockClerk({ userId: "other-user-123" });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}`,
+        { method: "GET" },
+      );
+
+      const response = await getCompose(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.id).toBe(testComposeId);
+    });
+
+    it("should still deny access when email does not match (returns 404)", async () => {
+      const sharedEmail = "different@example.com";
+
+      // Share with different email (as owner)
+      const addRequest = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            granteeType: "email",
+            granteeEmail: sharedEmail,
+          }),
+        },
+      );
+      await addPermission(addRequest, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+
+      // Switch to another user (with test@example.com email - doesn't match)
+      mockClerk({ userId: "other-user-123" });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}`,
+        { method: "GET" },
+      );
+
+      const response = await getCompose(request);
+      const data = await response.json();
+
+      // API returns 404 instead of 403 for security
+      expect(response.status).toBe(404);
+      expect(data.error.message).toContain("not found");
+    });
+
+    it("should always allow owner to access their compose", async () => {
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}`,
+        { method: "GET" },
+      );
+
+      const response = await getCompose(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.id).toBe(testComposeId);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/agent/composes/[id]/permissions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/permissions/__tests__/route.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GET, POST, DELETE } from "../route";
+import {
+  createTestRequest,
+  createTestCompose,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
+
+const context = testContext();
+
+describe("Permission Management API", () => {
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
+
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    testComposeId = composeId;
+  });
+
+  describe("GET /api/agent/composes/:id/permissions - List Permissions", () => {
+    it("should return empty array for compose with no permissions", async () => {
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        { method: "GET" },
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.permissions).toEqual([]);
+    });
+
+    it("should list all permissions for compose", async () => {
+      // Add a public permission first
+      const addRequest = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ granteeType: "public" }),
+        },
+      );
+      await POST(addRequest, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+
+      // List permissions
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        { method: "GET" },
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.permissions).toHaveLength(1);
+      expect(data.permissions[0].granteeType).toBe("public");
+    });
+
+    it("should return 401 for unauthenticated request", async () => {
+      mockClerk({ userId: null });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        { method: "GET" },
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.message).toBe("Unauthorized");
+    });
+
+    it("should return 404 for non-existent compose", async () => {
+      const fakeId = "00000000-0000-0000-0000-000000000000";
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${fakeId}/permissions`,
+        { method: "GET" },
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ id: fakeId }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.message).toContain("not found");
+    });
+
+    it("should return 403 for compose owned by another user", async () => {
+      // Switch to another user
+      await context.setupUser({ prefix: "other-user" });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        { method: "GET" },
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error.message).toContain("owner");
+    });
+  });
+
+  describe("POST /api/agent/composes/:id/permissions - Add Permission", () => {
+    it("should add public permission", async () => {
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ granteeType: "public" }),
+        },
+      );
+
+      const response = await POST(request, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.success).toBe(true);
+    });
+
+    it("should add email permission", async () => {
+      const email = "test@example.com";
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ granteeType: "email", granteeEmail: email }),
+        },
+      );
+
+      const response = await POST(request, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.success).toBe(true);
+    });
+
+    it("should return 400 when email permission is missing granteeEmail", async () => {
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ granteeType: "email" }),
+        },
+      );
+
+      const response = await POST(request, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain("email");
+    });
+
+    it("should return 409 for duplicate email permission", async () => {
+      const email = "duplicate@example.com";
+
+      // Add permission first time
+      const request1 = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ granteeType: "email", granteeEmail: email }),
+        },
+      );
+      await POST(request1, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+
+      // Try to add same permission again
+      const request2 = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ granteeType: "email", granteeEmail: email }),
+        },
+      );
+      const response = await POST(request2, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data.error.message).toContain("already exists");
+    });
+
+    it("should return 401 for unauthenticated request", async () => {
+      mockClerk({ userId: null });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ granteeType: "public" }),
+        },
+      );
+
+      const response = await POST(request, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.message).toBe("Unauthorized");
+    });
+
+    it("should return 403 for compose owned by another user", async () => {
+      // Switch to another user
+      await context.setupUser({ prefix: "other-user" });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ granteeType: "public" }),
+        },
+      );
+
+      const response = await POST(request, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error.message).toContain("owner");
+    });
+  });
+
+  describe("DELETE /api/agent/composes/:id/permissions - Remove Permission", () => {
+    it("should remove public permission", async () => {
+      // Add permission first
+      const addRequest = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ granteeType: "public" }),
+        },
+      );
+      await POST(addRequest, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+
+      // Remove permission
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions?type=public`,
+        { method: "DELETE" },
+      );
+
+      const response = await DELETE(request, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+
+      expect(response.status).toBe(204);
+
+      // Verify permission is gone
+      const listRequest = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        { method: "GET" },
+      );
+      const listResponse = await GET(listRequest, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+      const listData = await listResponse.json();
+
+      expect(listData.permissions).toHaveLength(0);
+    });
+
+    it("should remove email permission", async () => {
+      const email = "test@example.com";
+
+      // Add permission first
+      const addRequest = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ granteeType: "email", granteeEmail: email }),
+        },
+      );
+      await POST(addRequest, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+
+      // Remove permission
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions?type=email&email=${encodeURIComponent(email)}`,
+        { method: "DELETE" },
+      );
+
+      const response = await DELETE(request, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+
+      expect(response.status).toBe(204);
+    });
+
+    it("should return 404 when permission does not exist", async () => {
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions?type=public`,
+        { method: "DELETE" },
+      );
+
+      const response = await DELETE(request, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.message).toContain("not found");
+    });
+
+    it("should return 400 when type is missing", async () => {
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions`,
+        { method: "DELETE" },
+      );
+
+      const response = await DELETE(request, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain("type");
+    });
+
+    it("should return 401 for unauthenticated request", async () => {
+      mockClerk({ userId: null });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions?type=public`,
+        { method: "DELETE" },
+      );
+
+      const response = await DELETE(request, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.message).toBe("Unauthorized");
+    });
+
+    it("should return 403 for compose owned by another user", async () => {
+      // Switch to another user
+      await context.setupUser({ prefix: "other-user" });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${testComposeId}/permissions?type=public`,
+        { method: "DELETE" },
+      );
+
+      const response = await DELETE(request, {
+        params: Promise.resolve({ id: testComposeId }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error.message).toContain("owner");
+    });
+  });
+});

--- a/turbo/apps/web/app/api/agent/composes/[id]/permissions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/permissions/route.ts
@@ -1,0 +1,236 @@
+import { NextResponse } from "next/server";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { eq } from "drizzle-orm";
+import { agentComposes } from "../../../../../../src/db/schema/agent-compose";
+import {
+  addPermission,
+  removePermission,
+  listPermissions,
+} from "../../../../../../src/lib/agent/permission-service";
+import { getUserId } from "../../../../../../src/lib/auth/get-user-id";
+
+/**
+ * GET /api/agent/composes/:id/permissions - List permissions
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  initServices();
+
+  const authorization = request.headers.get("authorization") ?? undefined;
+  const userId = await getUserId(authorization);
+  if (!userId) {
+    return NextResponse.json(
+      { error: { message: "Unauthorized", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const { id } = await params;
+
+  // Verify compose exists and user is owner
+  const [compose] = await globalThis.services.db
+    .select()
+    .from(agentComposes)
+    .where(eq(agentComposes.id, id))
+    .limit(1);
+
+  if (!compose) {
+    return NextResponse.json(
+      { error: { message: "Compose not found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  if (compose.userId !== userId) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Only owner can view permissions",
+          code: "FORBIDDEN",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  const permissions = await listPermissions(id);
+  return NextResponse.json({ permissions });
+}
+
+/**
+ * POST /api/agent/composes/:id/permissions - Add permission
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  initServices();
+
+  const authorization = request.headers.get("authorization") ?? undefined;
+  const userId = await getUserId(authorization);
+  if (!userId) {
+    return NextResponse.json(
+      { error: { message: "Unauthorized", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const { id } = await params;
+  const body = (await request.json()) as {
+    granteeType?: string;
+    granteeEmail?: string | null;
+  };
+
+  // Validate request
+  const { granteeType, granteeEmail } = body;
+  if (!granteeType || !["public", "email"].includes(granteeType)) {
+    return NextResponse.json(
+      { error: { message: "Invalid grantee_type", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+  if (granteeType === "email" && !granteeEmail) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "grantee_email required for email type",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  // Verify compose exists and user is owner
+  const [compose] = await globalThis.services.db
+    .select()
+    .from(agentComposes)
+    .where(eq(agentComposes.id, id))
+    .limit(1);
+
+  if (!compose) {
+    return NextResponse.json(
+      { error: { message: "Compose not found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  if (compose.userId !== userId) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Only owner can manage permissions",
+          code: "FORBIDDEN",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  try {
+    await addPermission(
+      id,
+      granteeType as "public" | "email",
+      userId,
+      granteeEmail ?? undefined,
+    );
+    return NextResponse.json({ success: true }, { status: 201 });
+  } catch (error) {
+    // Handle duplicate permission error
+    if (
+      error instanceof Error &&
+      error.message.includes("duplicate key value")
+    ) {
+      return NextResponse.json(
+        { error: { message: "Permission already exists", code: "CONFLICT" } },
+        { status: 409 },
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * DELETE /api/agent/composes/:id/permissions - Remove permission
+ */
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  initServices();
+
+  const authorization = request.headers.get("authorization") ?? undefined;
+  const userId = await getUserId(authorization);
+  if (!userId) {
+    return NextResponse.json(
+      { error: { message: "Unauthorized", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const { id } = await params;
+  const { searchParams } = new URL(request.url);
+  const granteeType = searchParams.get("type") as "public" | "email" | null;
+  const granteeEmail = searchParams.get("email");
+
+  if (!granteeType || !["public", "email"].includes(granteeType)) {
+    return NextResponse.json(
+      { error: { message: "type parameter required", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+
+  if (granteeType === "email" && !granteeEmail) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "email parameter required for email type",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  // Verify compose exists and user is owner
+  const [compose] = await globalThis.services.db
+    .select()
+    .from(agentComposes)
+    .where(eq(agentComposes.id, id))
+    .limit(1);
+
+  if (!compose) {
+    return NextResponse.json(
+      { error: { message: "Compose not found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  if (compose.userId !== userId) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Only owner can manage permissions",
+          code: "FORBIDDEN",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  const removed = await removePermission(
+    id,
+    granteeType,
+    granteeEmail ?? undefined,
+  );
+  if (!removed) {
+    return NextResponse.json(
+      { error: { message: "Permission not found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/turbo/apps/web/app/api/agent/composes/[id]/permissions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/permissions/route.ts
@@ -9,6 +9,18 @@ import {
 } from "../../../../../../src/lib/agent/permission-service";
 import { getUserId } from "../../../../../../src/lib/auth/get-user-id";
 
+// PostgreSQL error code 23505 = unique_violation
+function isDuplicateKeyError(error: unknown): boolean {
+  if (error instanceof Error) {
+    // Check the error message
+    if (error.message.includes("duplicate key value")) return true;
+    // Check for PostgreSQL error code in cause
+    const cause = (error as Error & { cause?: { code?: string } }).cause;
+    if (cause?.code === "23505") return true;
+  }
+  return false;
+}
+
 /**
  * GET /api/agent/composes/:id/permissions - List permissions
  */
@@ -138,11 +150,8 @@ export async function POST(
     );
     return NextResponse.json({ success: true }, { status: 201 });
   } catch (error) {
-    // Handle duplicate permission error
-    if (
-      error instanceof Error &&
-      error.message.includes("duplicate key value")
-    ) {
+    // Handle duplicate permission error (PostgreSQL error code 23505)
+    if (isDuplicateKeyError(error)) {
       return NextResponse.json(
         { error: { message: "Permission already exists", code: "CONFLICT" } },
         { status: 409 },

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -38,6 +38,7 @@ import { DELETE as deleteModelProviderRoute } from "../../app/api/model-provider
 import { GET as listModelProvidersRoute } from "../../app/api/model-providers/route";
 import { GET as listSecretsRoute } from "../../app/api/secrets/route";
 import { DELETE as deleteSecretRoute } from "../../app/api/secrets/[name]/route";
+import { POST as addPermissionRoute } from "../../app/api/agent/composes/[id]/permissions/route";
 
 /**
  * Helper to create a NextRequest for testing.
@@ -955,6 +956,42 @@ export async function deleteTestSecret(name: string): Promise<void> {
     const error = await response.json();
     throw new Error(
       `Failed to delete secret: ${error.error?.message || response.status}`,
+    );
+  }
+}
+
+/**
+ * Create a permission for an agent compose via API route handler.
+ *
+ * @param composeId - The compose ID to add permission to
+ * @param granteeType - The permission type ('public' or 'email')
+ * @param granteeEmail - The email address (required if granteeType is 'email')
+ */
+export async function createTestPermission(
+  composeId: string,
+  granteeType: "public" | "email",
+  granteeEmail?: string,
+): Promise<void> {
+  const body: { granteeType: string; granteeEmail?: string } = { granteeType };
+  if (granteeType === "email" && granteeEmail) {
+    body.granteeEmail = granteeEmail;
+  }
+
+  const request = createTestRequest(
+    `http://localhost:3000/api/agent/composes/${composeId}/permissions`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+  const response = await addPermissionRoute(request, {
+    params: Promise.resolve({ id: composeId }),
+  });
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(
+      `Failed to create permission: ${error.error?.message || response.status}`,
     );
   }
 }

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -1,5 +1,5 @@
 import { vi } from "vitest";
-import { auth } from "@clerk/nextjs/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
 
 /**
  * Mock Clerk auth for testing
@@ -24,6 +24,7 @@ import { auth } from "@clerk/nextjs/server";
  */
 
 const mockAuth = vi.mocked(auth);
+const mockClerkClient = vi.mocked(clerkClient);
 
 /**
  * Configure Clerk auth mock
@@ -34,6 +35,16 @@ export function mockClerk(options: { userId: string | null }) {
   mockAuth.mockResolvedValue({
     userId: options.userId,
   } as Awaited<ReturnType<typeof auth>>);
+
+  // Also set up clerkClient mock to return user data with email
+  mockClerkClient.mockResolvedValue({
+    users: {
+      getUser: vi.fn().mockResolvedValue({
+        emailAddresses: [{ id: "email_1", emailAddress: "test@example.com" }],
+        primaryEmailAddressId: "email_1",
+      }),
+    },
+  } as unknown as Awaited<ReturnType<typeof clerkClient>>);
 }
 
 /**
@@ -41,4 +52,5 @@ export function mockClerk(options: { userId: string | null }) {
  */
 export function clearClerkMock() {
   mockAuth.mockClear();
+  mockClerkClient.mockClear();
 }

--- a/turbo/apps/web/src/db/migrations/0066_add_agent_permissions.sql
+++ b/turbo/apps/web/src/db/migrations/0066_add_agent_permissions.sql
@@ -1,0 +1,18 @@
+-- Agent Permissions table (ACL)
+-- Stores access control entries for agent composes
+
+CREATE TABLE agent_permissions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_compose_id UUID NOT NULL REFERENCES agent_composes(id) ON DELETE CASCADE,
+  grantee_type VARCHAR(16) NOT NULL,
+  grantee_email TEXT,
+  permission VARCHAR(32) NOT NULL DEFAULT 'run_view',
+  granted_by TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT agent_permissions_compose_type_email_unique
+    UNIQUE(agent_compose_id, grantee_type, grantee_email)
+);
+
+CREATE INDEX idx_agent_permissions_compose ON agent_permissions(agent_compose_id);
+CREATE INDEX idx_agent_permissions_email ON agent_permissions(grantee_email)
+  WHERE grantee_email IS NOT NULL;

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -463,6 +463,13 @@
       "when": 1769000000000,
       "tag": "0065_add_variables",
       "breakpoints": true
+    },
+    {
+      "idx": 66,
+      "version": "7",
+      "when": 1769100000000,
+      "tag": "0066_add_agent_permissions",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/agent-permission.ts
+++ b/turbo/apps/web/src/db/schema/agent-permission.ts
@@ -1,0 +1,44 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  text,
+  timestamp,
+  unique,
+  index,
+} from "drizzle-orm/pg-core";
+import { agentComposes } from "./agent-compose";
+
+/**
+ * Agent Permissions table (ACL)
+ * Stores access control entries for agent composes
+ * - granteeType='public' means all authenticated users can access
+ * - granteeType='email' means specific user by email can access
+ */
+export const agentPermissions = pgTable(
+  "agent_permissions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    agentComposeId: uuid("agent_compose_id")
+      .notNull()
+      .references(() => agentComposes.id, { onDelete: "cascade" }),
+    granteeType: varchar("grantee_type", { length: 16 }).notNull(), // 'public', 'email'
+    granteeEmail: text("grantee_email"), // NULL for public
+    permission: varchar("permission", { length: 32 })
+      .notNull()
+      .default("run_view"),
+    grantedBy: text("granted_by").notNull(), // Clerk user ID
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    unique("agent_permissions_compose_type_email_unique").on(
+      table.agentComposeId,
+      table.granteeType,
+      table.granteeEmail,
+    ),
+    index("idx_agent_permissions_compose").on(table.agentComposeId),
+    index("idx_agent_permissions_email").on(table.granteeEmail),
+  ],
+);

--- a/turbo/apps/web/src/lib/agent/permission-service.ts
+++ b/turbo/apps/web/src/lib/agent/permission-service.ts
@@ -1,0 +1,118 @@
+import { eq, and, or } from "drizzle-orm";
+import { agentPermissions } from "../../db/schema/agent-permission";
+import { agentComposes } from "../../db/schema/agent-compose";
+import { scopes } from "../../db/schema/scope";
+import { logger } from "../logger";
+
+const log = logger("agent:permission");
+
+/**
+ * Check if a user can access an agent compose
+ *
+ * Access is granted if:
+ * 1. User is the owner of the compose
+ * 2. Compose is in a system scope (public)
+ * 3. Compose has a 'public' permission entry
+ * 4. User's email matches an 'email' permission entry
+ */
+export async function canAccessCompose(
+  userId: string,
+  userEmail: string,
+  composeId: string,
+): Promise<boolean> {
+  // 1. Get compose info
+  const [compose] = await globalThis.services.db
+    .select()
+    .from(agentComposes)
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+
+  if (!compose) return false;
+
+  // 2. Owner always has access
+  if (compose.userId === userId) return true;
+
+  // 3. Check if system scope (public)
+  const [scope] = await globalThis.services.db
+    .select()
+    .from(scopes)
+    .where(eq(scopes.id, compose.scopeId))
+    .limit(1);
+
+  if (scope?.type === "system") return true;
+
+  // 4. Check ACL table
+  const [permission] = await globalThis.services.db
+    .select()
+    .from(agentPermissions)
+    .where(
+      and(
+        eq(agentPermissions.agentComposeId, composeId),
+        or(
+          eq(agentPermissions.granteeType, "public"),
+          and(
+            eq(agentPermissions.granteeType, "email"),
+            eq(agentPermissions.granteeEmail, userEmail),
+          ),
+        ),
+      ),
+    )
+    .limit(1);
+
+  return !!permission;
+}
+
+/**
+ * Add a permission to an agent compose
+ */
+export async function addPermission(
+  composeId: string,
+  granteeType: "public" | "email",
+  grantedBy: string,
+  granteeEmail?: string,
+): Promise<void> {
+  await globalThis.services.db.insert(agentPermissions).values({
+    agentComposeId: composeId,
+    granteeType,
+    granteeEmail: granteeType === "email" ? granteeEmail : null,
+    grantedBy,
+  });
+  log.info(
+    `Permission added: ${granteeType} ${granteeEmail ?? ""} -> ${composeId}`,
+  );
+}
+
+/**
+ * Remove a permission from an agent compose
+ */
+export async function removePermission(
+  composeId: string,
+  granteeType: "public" | "email",
+  granteeEmail?: string,
+): Promise<boolean> {
+  const conditions = [
+    eq(agentPermissions.agentComposeId, composeId),
+    eq(agentPermissions.granteeType, granteeType),
+  ];
+
+  if (granteeType === "email" && granteeEmail) {
+    conditions.push(eq(agentPermissions.granteeEmail, granteeEmail));
+  }
+
+  const result = await globalThis.services.db
+    .delete(agentPermissions)
+    .where(and(...conditions));
+
+  return (result.rowCount ?? 0) > 0;
+}
+
+/**
+ * List all permissions for an agent compose
+ */
+export async function listPermissions(composeId: string) {
+  return globalThis.services.db
+    .select()
+    .from(agentPermissions)
+    .where(eq(agentPermissions.agentComposeId, composeId))
+    .orderBy(agentPermissions.createdAt);
+}

--- a/turbo/apps/web/src/lib/auth/get-user-email.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-email.ts
@@ -1,0 +1,15 @@
+import { clerkClient } from "@clerk/nextjs/server";
+
+/**
+ * Get user's primary email address from Clerk
+ */
+export async function getUserEmail(userId: string): Promise<string> {
+  const client = await clerkClient();
+  const user = await client.users.getUser(userId);
+
+  const email = user.emailAddresses.find(
+    (e) => e.id === user.primaryEmailAddressId,
+  )?.emailAddress;
+
+  return email || "";
+}

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -93,7 +93,8 @@ async function resolveVersion(
  *
  * @param agentConfig - Agent configuration containing volume definitions
  * @param vars - Template variables for placeholder replacement
- * @param scopeId - Scope ID for storage access
+ * @param volumeScopeId - Scope ID for volume resolution (agent owner's scope)
+ * @param artifactScopeId - Scope ID for artifact resolution (runner's scope)
  * @param artifactName - Artifact storage name
  * @param artifactVersion - Artifact version (defaults to "latest")
  * @param volumeVersionOverrides - Optional volume version overrides
@@ -104,7 +105,8 @@ async function resolveVersion(
 export async function prepareStorageManifest(
   agentConfig: AgentVolumeConfig | undefined,
   vars: Record<string, string>,
-  scopeId: string,
+  volumeScopeId: string,
+  artifactScopeId: string,
   artifactName?: string,
   artifactVersion?: string,
   volumeVersionOverrides?: Record<string, string>,
@@ -148,7 +150,7 @@ export async function prepareStorageManifest(
   // Process all volumes and artifact in parallel
   const volumePromises = volumeResult.volumes.map(async (volume) => {
     const { versionId, s3Key } = await resolveVersion(
-      scopeId,
+      volumeScopeId,
       volume.vasStorageName,
       "volume",
       volume.vasVersion,
@@ -196,7 +198,7 @@ export async function prepareStorageManifest(
   const artifactPromise = artifactSource
     ? (async () => {
         const { versionId, s3Key } = await resolveVersion(
-          scopeId,
+          artifactScopeId,
           artifactSource.vasStorageName,
           "artifact",
           artifactSource.vasVersion,


### PR DESCRIPTION
## Summary

- Add `agent_permissions` ACL table for storing access control entries
- Support public agents (accessible to all authenticated users) via `granteeType='public'`
- Support email-based sharing (share with specific users by email) via `granteeType='email'`
- Add permission checking middleware to API routes (`/api/agent/composes`, `/api/agent/runs`)
- Add new CLI commands: `vm0 agent public/private/share/unshare/permissions`

The permission model is simple and extensible:
- Owners always have access to their own agents
- System scope agents are always accessible (public by default)
- `granteeType='public'` grants access to all authenticated users
- `granteeType='email'` grants access to specific users by email

## New CLI Commands

```bash
# Make an agent public (accessible to all authenticated users)
vm0 agent public my-agent

# Make an agent private (remove public access)
vm0 agent private my-agent

# Share an agent with a specific user by email
vm0 agent share my-agent --email user@example.com

# Remove sharing from a specific user
vm0 agent unshare my-agent --email user@example.com

# List all permissions for an agent
vm0 agent permissions my-agent
```

## Test plan

- [ ] Verify agent owner can always access their own agents
- [ ] Verify `vm0 agent public` makes agent accessible to other users
- [ ] Verify `vm0 agent private` removes public access
- [ ] Verify `vm0 agent share --email` grants access to specific user
- [ ] Verify `vm0 agent unshare --email` removes access from specific user
- [ ] Verify `vm0 agent permissions` lists all permissions correctly
- [ ] Verify non-authorized users get 403 Forbidden when accessing shared agents

Closes #2251

🤖 Generated with [Claude Code](https://claude.com/claude-code)