### PR TITLE
feat(docs): update environment variables documentation to reflect current implementation

### DIFF
--- a/turbo/apps/docs/content/docs/agent-skills/apify.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/apify.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "scrape product data from amazon" \
-  --secrets APIFY_API_TOKEN=apify_api_xxx # [!code highlight]
+vm0 secret set APIFY_API_TOKEN your-apify-api-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "scrape product data from amazon"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets APIFY_API_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/axiom.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/axiom.mdx
@@ -27,10 +27,22 @@ agents:
 
 ## Run
 
+Store your secrets on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "query error logs from last hour" \
-  --secrets AXIOM_API_TOKEN=xaat-xxx # [!code highlight]
+vm0 secret set AXIOM_API_TOKEN your-axiom-api-token
+vm0 secret set AXIOM_PERSONAL_ACCESS_TOKEN your-axiom-personal-access-token
 ```
+
+Then run your agent - secrets are automatically loaded:
+
+```bash
+vm0 run my-agent "query error logs from last hour"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets AXIOM_API_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/bitrix.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/bitrix.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "create a new lead in CRM" \
-  --secrets BITRIX_WEBHOOK_URL=https://your-domain.bitrix24.com/rest/1/xxx # [!code highlight]
+vm0 secret set BITRIX_WEBHOOK_URL your-bitrix-webhook-url
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "create a new lead in CRM"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets BITRIX_WEBHOOK_URL=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/brave-search.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/brave-search.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "search for latest AI news" \
-  --secrets BRAVE_API_KEY=xxx # [!code highlight]
+vm0 secret set BRAVE_API_KEY your-brave-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "search for latest AI news"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets BRAVE_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/bright-data.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/bright-data.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "scrape social media data" \
-  --secrets BRIGHTDATA_API_KEY=xxx # [!code highlight]
+vm0 secret set BRIGHTDATA_API_KEY your-brightdata-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "scrape social media data"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets BRIGHTDATA_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/browserbase.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/browserbase.mdx
@@ -26,10 +26,22 @@ agents:
 
 ## Run
 
+Store your secrets on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "automate browser tasks" \
-  --secrets BROWSERBASE_API_KEY=xxx --secrets BROWSERBASE_PROJECT_ID=xxx # [!code highlight]
+vm0 secret set BROWSERBASE_API_KEY your-browserbase-api-key
+vm0 secret set BROWSERBASE_PROJECT_ID your-browserbase-project-id
 ```
+
+Then run your agent - secrets are automatically loaded:
+
+```bash
+vm0 run my-agent "automate browser tasks"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets BROWSERBASE_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/browserless.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/browserless.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "take a screenshot of example.com" \
-  --secrets BROWSERLESS_API_TOKEN=xxx # [!code highlight]
+vm0 secret set BROWSERLESS_API_TOKEN your-browserless-api-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "take a screenshot of example.com"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets BROWSERLESS_API_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/chatwoot.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/chatwoot.mdx
@@ -27,10 +27,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "list open conversations" \
-  --secrets CHATWOOT_API_TOKEN=xxx --vars CHATWOOT_ACCOUNT_ID=xxx --vars CHATWOOT_BASE_URL=xxx # [!code highlight]
+vm0 secret set CHATWOOT_API_TOKEN your-chatwoot-api-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "list open conversations"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets CHATWOOT_API_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/cloudinary.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/cloudinary.mdx
@@ -27,10 +27,22 @@ agents:
 
 ## Run
 
+Store your secrets on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "upload and optimize this image" \
-  --secrets CLOUDINARY_API_KEY=xxx CLOUDINARY_API_SECRET=xxx --vars CLOUDINARY_CLOUD_NAME=xxx # [!code highlight]
+vm0 secret set CLOUDINARY_API_KEY your-cloudinary-api-key
+vm0 secret set CLOUDINARY_API_SECRET your-cloudinary-api-secret
 ```
+
+Then run your agent - secrets are automatically loaded:
+
+```bash
+vm0 run my-agent "upload and optimize this image"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets CLOUDINARY_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/cronlytic.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/cronlytic.mdx
@@ -26,10 +26,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "create a daily backup job" \
-  --secrets CRONLYTIC_API_KEY=xxx --vars CRONLYTIC_USER_ID=xxx # [!code highlight]
+vm0 secret set CRONLYTIC_API_KEY your-cronlytic-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "create a daily backup job"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets CRONLYTIC_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/deepseek.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/deepseek.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "generate code using DeepSeek" \
-  --secrets DEEPSEEK_API_KEY=sk-xxx # [!code highlight]
+vm0 secret set DEEPSEEK_API_KEY your-deepseek-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "generate code using DeepSeek"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets DEEPSEEK_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/devto.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/devto.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "publish article to Dev.to" \
-  --secrets DEVTO_API_KEY=xxx # [!code highlight]
+vm0 secret set DEVTO_API_KEY your-devto-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "publish article to Dev.to"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets DEVTO_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/discord-webhook.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/discord-webhook.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "send deployment notification to Discord" \
-  --secrets DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/xxx # [!code highlight]
+vm0 secret set DISCORD_WEBHOOK_URL your-discord-webhook-url
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "send deployment notification to Discord"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets DISCORD_WEBHOOK_URL=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/discord.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/discord.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "post an announcement" \
-  --secrets DISCORD_BOT_TOKEN=xxx # [!code highlight]
+vm0 secret set DISCORD_BOT_TOKEN your-discord-bot-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "post an announcement"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets DISCORD_BOT_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/elevenlabs.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/elevenlabs.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "convert text to speech" \
-  --secrets ELEVENLABS_API_KEY=xxx # [!code highlight]
+vm0 secret set ELEVENLABS_API_KEY your-elevenlabs-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "convert text to speech"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets ELEVENLABS_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/fal-ai.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/fal-ai.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "generate an image of a sunset" \
-  --secrets FAL_KEY=xxx # [!code highlight]
+vm0 secret set FAL_KEY your-fal-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "generate an image of a sunset"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets FAL_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/figma.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/figma.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "export frames from Figma file" \
-  --secrets FIGMA_API_TOKEN=figd_xxx # [!code highlight]
+vm0 secret set FIGMA_API_TOKEN your-figma-api-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "export frames from Figma file"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets FIGMA_API_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/firecrawl.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/firecrawl.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "scrape the website" \
-  --secrets FIRECRAWL_API_KEY=fc-xxx # [!code highlight]
+vm0 secret set FIRECRAWL_API_KEY your-firecrawl-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "scrape the website"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets FIRECRAWL_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/github-copilot.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/github-copilot.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "get Copilot usage metrics" \
-  --secrets GITHUB_TOKEN=ghp_xxx # [!code highlight]
+vm0 secret set GITHUB_TOKEN your-github-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "get Copilot usage metrics"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets GITHUB_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/github.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/github.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "list open PRs" \
-  --secrets GH_TOKEN=ghp_xxx # [!code highlight]
+vm0 secret set GH_TOKEN your-gh-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "list open PRs"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets GH_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/gitlab.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/gitlab.mdx
@@ -26,10 +26,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "create an issue in GitLab" \
-  --secrets GITLAB_TOKEN=glpat-xxx --vars GITLAB_HOST=gitlab.com # [!code highlight]
+vm0 secret set GITLAB_TOKEN your-gitlab-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "create an issue in GitLab"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets GITLAB_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/gmail.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/gmail.mdx
@@ -36,10 +36,22 @@ agents:
 
 ## Run
 
+Store your secrets on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "check my inbox" \
-  --secrets GMAIL_CLIENT_ID=xxx --secrets GMAIL_CLIENT_SECRET=xxx --secrets GMAIL_REFRESH_TOKEN=xxx # [!code highlight]
+vm0 secret set GMAIL_CLIENT_SECRET your-gmail-client-secret
+vm0 secret set GMAIL_REFRESH_TOKEN your-gmail-refresh-token
 ```
+
+Then run your agent - secrets are automatically loaded:
+
+```bash
+vm0 run my-agent "check my inbox"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets GMAIL_CLIENT_SECRET=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/google-sheets.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/google-sheets.mdx
@@ -34,10 +34,22 @@ agents:
 
 ## Run
 
+Store your secrets on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "update the spreadsheet" \
-  --secrets GOOGLE_SHEETS_CLIENT_ID=xxx --secrets GOOGLE_SHEETS_CLIENT_SECRET=xxx --secrets GOOGLE_SHEETS_REFRESH_TOKEN=xxx # [!code highlight]
+vm0 secret set GOOGLE_SHEETS_CLIENT_SECRET your-google-sheets-client-secret
+vm0 secret set GOOGLE_SHEETS_REFRESH_TOKEN your-google-sheets-refresh-token
 ```
+
+Then run your agent - secrets are automatically loaded:
+
+```bash
+vm0 run my-agent "update the spreadsheet"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets GOOGLE_SHEETS_CLIENT_SECRET=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/htmlcsstoimage.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/htmlcsstoimage.mdx
@@ -26,10 +26,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "generate OG image from HTML" \
-  --secrets HCTI_API_KEY=xxx --vars HCTI_USER_ID=xxx # [!code highlight]
+vm0 secret set HCTI_API_KEY your-hcti-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "generate OG image from HTML"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets HCTI_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/imgur.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/imgur.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "upload image to Imgur" \
-  --secrets IMGUR_CLIENT_ID=xxx # [!code highlight]
+vm0 secret set IMGUR_CLIENT_ID your-imgur-client-id
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "upload image to Imgur"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets IMGUR_CLIENT_ID=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/instagram.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/instagram.mdx
@@ -26,10 +26,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "fetch recent Instagram posts" \
-  --secrets INSTAGRAM_ACCESS_TOKEN=EAAG... --vars INSTAGRAM_BUSINESS_ACCOUNT_ID=xxx # [!code highlight]
+vm0 secret set INSTAGRAM_ACCESS_TOKEN your-instagram-access-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "fetch recent Instagram posts"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets INSTAGRAM_ACCESS_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/instantly.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/instantly.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "create email campaign" \
-  --secrets INSTANTLY_API_KEY=xxx # [!code highlight]
+vm0 secret set INSTANTLY_API_KEY your-instantly-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "create email campaign"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets INSTANTLY_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/intercom.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/intercom.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "list open conversations" \
-  --secrets INTERCOM_ACCESS_TOKEN=xxx # [!code highlight]
+vm0 secret set INTERCOM_ACCESS_TOKEN your-intercom-access-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "list open conversations"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets INTERCOM_ACCESS_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/jira.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/jira.mdx
@@ -27,10 +27,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "create a bug ticket in Jira" \
-  --secrets JIRA_API_TOKEN=xxx --vars JIRA_DOMAIN=xxx --vars JIRA_EMAIL=xxx # [!code highlight]
+vm0 secret set JIRA_API_TOKEN your-jira-api-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "create a bug ticket in Jira"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets JIRA_API_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/kommo.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/kommo.mdx
@@ -26,10 +26,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "create a new lead" \
-  --secrets KOMMO_API_KEY=xxx --vars KOMMO_SUBDOMAIN=xxx # [!code highlight]
+vm0 secret set KOMMO_API_KEY your-kommo-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "create a new lead"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets KOMMO_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/lark.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/lark.mdx
@@ -26,10 +26,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "send message to Lark group" \
-  --secrets LARK_APP_SECRET=xxx --vars LARK_APP_ID=xxx # [!code highlight]
+vm0 secret set LARK_APP_SECRET your-lark-app-secret
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "send message to Lark group"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets LARK_APP_SECRET=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/linear.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/linear.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "create an issue" \
-  --secrets LINEAR_API_KEY=lin_api_xxx # [!code highlight]
+vm0 secret set LINEAR_API_KEY your-linear-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "create an issue"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets LINEAR_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/mercury.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/mercury.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "check account balance" \
-  --secrets MERCURY_API_TOKEN=xxx # [!code highlight]
+vm0 secret set MERCURY_API_TOKEN your-mercury-api-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "check account balance"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets MERCURY_API_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/minimax.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/minimax.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "generate Chinese speech" \
-  --secrets MINIMAX_API_KEY=xxx # [!code highlight]
+vm0 secret set MINIMAX_API_KEY your-minimax-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "generate Chinese speech"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets MINIMAX_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/minio.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/minio.mdx
@@ -27,10 +27,22 @@ agents:
 
 ## Run
 
+Store your secrets on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "upload file to MinIO" \
-  --secrets MINIO_ACCESS_KEY=xxx MINIO_SECRET_KEY=xxx --vars MINIO_ENDPOINT=xxx # [!code highlight]
+vm0 secret set MINIO_ACCESS_KEY your-minio-access-key
+vm0 secret set MINIO_SECRET_KEY your-minio-secret-key
 ```
+
+Then run your agent - secrets are automatically loaded:
+
+```bash
+vm0 run my-agent "upload file to MinIO"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets MINIO_ACCESS_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/monday.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/monday.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "create item in Monday board" \
-  --secrets MONDAY_API_KEY=xxx # [!code highlight]
+vm0 secret set MONDAY_API_KEY your-monday-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "create item in Monday board"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets MONDAY_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/notion.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/notion.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "create a new page" \
-  --secrets NOTION_API_KEY=ntn_xxx # [!code highlight]
+vm0 secret set NOTION_API_KEY your-notion-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "create a new page"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets NOTION_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/openai.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/openai.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "generate an image" \
-  --secrets OPENAI_API_KEY=sk-xxx # [!code highlight]
+vm0 secret set OPENAI_API_KEY your-openai-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "generate an image"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets OPENAI_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/pdf4me.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/pdf4me.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "merge PDF files" \
-  --secrets PDF4ME_API_KEY=xxx # [!code highlight]
+vm0 secret set PDF4ME_API_KEY your-pdf4me-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "merge PDF files"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets PDF4ME_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/pdfco.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/pdfco.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "extract text from PDF" \
-  --secrets PDFCO_API_KEY=xxx # [!code highlight]
+vm0 secret set PDFCO_API_KEY your-pdfco-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "extract text from PDF"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets PDFCO_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/pdforge.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/pdforge.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "generate PDF from template" \
-  --secrets PDFORGE_API_KEY=pdfnoodle_api_xxx # [!code highlight]
+vm0 secret set PDFORGE_API_KEY your-pdforge-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "generate PDF from template"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets PDFORGE_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/perplexity.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/perplexity.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "search for latest tech news" \
-  --secrets PERPLEXITY_API_KEY=pplx-xxx # [!code highlight]
+vm0 secret set PERPLEXITY_API_KEY your-perplexity-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "search for latest tech news"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets PERPLEXITY_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/plausible.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/plausible.mdx
@@ -26,10 +26,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "get website analytics" \
-  --secrets PLAUSIBLE_API_KEY=xxx --vars PLAUSIBLE_SITE_ID=xxx # [!code highlight]
+vm0 secret set PLAUSIBLE_API_KEY your-plausible-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "get website analytics"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets PLAUSIBLE_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/podchaser.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/podchaser.mdx
@@ -26,10 +26,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "search podcasts about technology" \
-  --secrets PODCHASER_CLIENT_SECRET=xxx --vars PODCHASER_CLIENT_ID=xxx # [!code highlight]
+vm0 secret set PODCHASER_CLIENT_SECRET your-podchaser-client-secret
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "search podcasts about technology"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets PODCHASER_CLIENT_SECRET=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/pushinator.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/pushinator.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "send push notification" \
-  --secrets PUSHINATOR_API_KEY=xxx # [!code highlight]
+vm0 secret set PUSHINATOR_API_KEY your-pushinator-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "send push notification"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets PUSHINATOR_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/qdrant.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/qdrant.mdx
@@ -26,10 +26,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "search similar documents" \
-  --secrets QDRANT_API_KEY=xxx --vars QDRANT_URL=xxx # [!code highlight]
+vm0 secret set QDRANT_API_KEY your-qdrant-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "search similar documents"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets QDRANT_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/qiita.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/qiita.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "search Qiita articles about React" \
-  --secrets QIITA_ACCESS_TOKEN=xxx # [!code highlight]
+vm0 secret set QIITA_ACCESS_TOKEN your-qiita-access-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "search Qiita articles about React"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets QIITA_ACCESS_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/reportei.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/reportei.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "generate marketing report" \
-  --secrets REPORTEI_API_TOKEN=xxx # [!code highlight]
+vm0 secret set REPORTEI_API_TOKEN your-reportei-api-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "generate marketing report"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets REPORTEI_API_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/resend.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/resend.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "send welcome email" \
-  --secrets RESEND_API_KEY=re_xxx # [!code highlight]
+vm0 secret set RESEND_API_KEY your-resend-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "send welcome email"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets RESEND_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/runway.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/runway.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "generate a video" \
-  --secrets RUNWAY_API_KEY=xxx # [!code highlight]
+vm0 secret set RUNWAY_API_KEY your-runway-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "generate a video"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets RUNWAY_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/scrapeninja.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/scrapeninja.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "scrape website data" \
-  --secrets SCRAPENINJA_API_KEY=xxx # [!code highlight]
+vm0 secret set SCRAPENINJA_API_KEY your-scrapeninja-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "scrape website data"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets SCRAPENINJA_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/sentry.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/sentry.mdx
@@ -27,10 +27,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "list recent errors" \
-  --secrets SENTRY_TOKEN=sntrys_xxx --vars SENTRY_HOST=xxx SENTRY_ORG=xxx # [!code highlight]
+vm0 secret set SENTRY_TOKEN your-sentry-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "list recent errors"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets SENTRY_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/serpapi.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/serpapi.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "get Google search results" \
-  --secrets SERPAPI_API_KEY=xxx # [!code highlight]
+vm0 secret set SERPAPI_API_KEY your-serpapi-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "get Google search results"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets SERPAPI_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/shortio.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/shortio.mdx
@@ -27,10 +27,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "create short link" \
-  --secrets SHORTIO_API_KEY=xxx --vars SHORTIO_DOMAIN=xxx SHORTIO_DOMAIN_ID=xxx # [!code highlight]
+vm0 secret set SHORTIO_API_KEY your-shortio-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "create short link"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets SHORTIO_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/slack-webhook.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/slack-webhook.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "send status update to Slack" \
-  --secrets SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxx # [!code highlight]
+vm0 secret set SLACK_WEBHOOK_URL your-slack-webhook-url
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "send status update to Slack"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets SLACK_WEBHOOK_URL=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/slack.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/slack.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "send a message to #general" \
-  --secrets SLACK_BOT_TOKEN=xoxb-xxx # [!code highlight]
+vm0 secret set SLACK_BOT_TOKEN your-slack-bot-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "send a message to #general"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets SLACK_BOT_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/streak.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/streak.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "create deal in Streak" \
-  --secrets STREAK_API_KEY=xxx # [!code highlight]
+vm0 secret set STREAK_API_KEY your-streak-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "create deal in Streak"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets STREAK_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/supabase.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/supabase.mdx
@@ -27,10 +27,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "query database" \
-  --secrets SUPABASE_SECRET_KEY=xxx --vars SUPABASE_URL=xxx SUPABASE_PUBLISHABLE_KEY=xxx # [!code highlight]
+vm0 secret set SUPABASE_SECRET_KEY your-supabase-secret-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "query database"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets SUPABASE_SECRET_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/supadata.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/supadata.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "extract YouTube transcript" \
-  --secrets SUPADATA_API_KEY=xxx # [!code highlight]
+vm0 secret set SUPADATA_API_KEY your-supadata-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "extract YouTube transcript"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets SUPADATA_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/tavily.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/tavily.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "search for latest news" \
-  --secrets TAVILY_API_KEY=tvly-xxx # [!code highlight]
+vm0 secret set TAVILY_API_KEY your-tavily-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "search for latest news"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets TAVILY_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/twenty.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/twenty.mdx
@@ -26,10 +26,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "create contact in CRM" \
-  --secrets TWENTY_API_KEY=xxx --vars TWENTY_API_URL=xxx # [!code highlight]
+vm0 secret set TWENTY_API_KEY your-twenty-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "create contact in CRM"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets TWENTY_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/youtube.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/youtube.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "search YouTube videos" \
-  --secrets YOUTUBE_API_KEY=xxx # [!code highlight]
+vm0 secret set YOUTUBE_API_KEY your-youtube-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "search YouTube videos"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets YOUTUBE_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/zapsign.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/zapsign.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "create document for signature" \
-  --secrets ZAPSIGN_API_TOKEN=xxx # [!code highlight]
+vm0 secret set ZAPSIGN_API_TOKEN your-zapsign-api-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "create document for signature"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets ZAPSIGN_API_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/zendesk.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/zendesk.mdx
@@ -27,10 +27,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "create support ticket" \
-  --secrets ZENDESK_API_TOKEN=xxx --vars ZENDESK_EMAIL=xxx ZENDESK_SUBDOMAIN=xxx # [!code highlight]
+vm0 secret set ZENDESK_API_TOKEN your-zendesk-api-token
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "create support ticket"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets ZENDESK_API_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/agent-skills/zeptomail.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/zeptomail.mdx
@@ -25,10 +25,21 @@ agents:
 
 ## Run
 
+Store your secret on the platform (recommended, one-time setup):
+
 ```bash
-vm0 run my-agent "send transactional email" \
-  --secrets ZEPTOMAIL_API_KEY=xxx # [!code highlight]
+vm0 secret set ZEPTOMAIL_API_KEY your-zeptomail-api-key
 ```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "send transactional email"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets ZEPTOMAIL_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Example Instructions
 

--- a/turbo/apps/docs/content/docs/core-concept/environment-variable.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/environment-variable.mdx
@@ -1,41 +1,23 @@
 ---
 title: Environment Variables
-description: Configure secrets, variables, and credentials for VM0 agents
+description: Configure variables and secrets for VM0 agents
 ---
 
-This guide explains how to use template variables in your `vm0.yaml` configuration and pass values when running agents.
+This guide explains how to configure environment variables for your agents using `vm0.yaml` and manage them via CLI.
 
-## Template Variables
+## Overview
 
-VM0 supports three types of template variables in your configuration:
+VM0 provides two types of environment values:
 
-| Type            | Syntax                      | Storage             | Purpose                              |
-| --------------- | --------------------------- | ------------------- | ------------------------------------ |
-| **Vars**        | `${{ vars.NAME }}`          | CLI (ephemeral)     | Non-sensitive configuration values   |
-| **Secrets**     | `${{ secrets.NAME }}`       | CLI (ephemeral)     | Sensitive data passed at runtime     |
-| **Credentials** | `${{ credentials.NAME }}`   | Platform (persistent) | Sensitive data stored on VM0       |
+| Type | Syntax | Purpose | Storage |
+|------|--------|---------|---------|
+| **Variables** | `${{ vars.NAME }}` | Non-sensitive configuration | Platform (plaintext) |
+| **Secrets** | `${{ secrets.NAME }}` | Sensitive data (API keys, passwords) | Platform (encrypted) |
 
-### When to Use Each Type
+Both types support two storage modes:
 
-**Vars** are for general configuration:
-
-- Feature flags
-- Environment names
-- Non-sensitive settings
-
-**Secrets** are for sensitive data passed at runtime:
-
-- API keys from CI/CD systems
-- One-off sensitive values
-- Values that change per-run
-
-**Credentials** are for sensitive data stored on the platform:
-
-- API keys you use repeatedly
-- Tokens shared across multiple runs
-- Secrets managed via CLI
-
-The key difference between secrets and credentials is **persistence**: secrets are passed each time you run, while credentials are stored once and automatically loaded.
+- **Platform Storage** (recommended): Store once with CLI, automatically loaded on every run
+- **Runtime Override**: Pass at runtime with `--vars` or `--secrets` flags
 
 ## Using Variables in vm0.yaml
 
@@ -48,29 +30,72 @@ agents:
   my-agent:
     framework: claude-code
     environment: # [!code highlight]
-      # Secrets for runtime sensitive data
-      ANTHROPIC_AUTH_TOKEN: "${{ secrets.API_KEY }}" # [!code highlight]
+      # Secrets for sensitive data
+      ANTHROPIC_AUTH_TOKEN: "${{ secrets.ANTHROPIC_API_KEY }}" # [!code highlight]
       DATABASE_PASSWORD: "${{ secrets.DB_PASSWORD }}" # [!code highlight]
 
-      # Vars for configuration
+      # Variables for configuration
       ENVIRONMENT: "${{ vars.ENV_NAME }}" # [!code highlight]
       DEBUG_MODE: "${{ vars.DEBUG }}" # [!code highlight]
-
-      # Credentials for platform-stored secrets
-      GITHUB_TOKEN: "${{ credentials.GITHUB_TOKEN }}" # [!code highlight]
 ```
 
-## Passing Values
+## Platform Storage (Recommended)
+
+Store values once and use them across all agent runs.
+
+### Managing Secrets
+
+```bash
+# Store a secret
+vm0 secret set MY_API_KEY sk-xxx
+
+# With optional description
+vm0 secret set MY_API_KEY sk-xxx -d "OpenAI API key for production"
+
+# List all secrets (values are hidden)
+vm0 secret list
+
+# Delete a secret
+vm0 secret delete MY_API_KEY
+```
+
+### Managing Variables
+
+```bash
+# Store a variable
+vm0 variable set ENV_NAME production
+
+# With optional description
+vm0 variable set ENV_NAME production -d "Current environment"
+
+# List all variables
+vm0 variable list
+
+# Delete a variable
+vm0 variable delete ENV_NAME
+```
+
+### Naming Rules
+
+Names must use uppercase letters, numbers, and underscores only:
+
+- `MY_API_KEY`
+- `GITHUB_TOKEN`
+- `AWS_ACCESS_KEY_ID`
+
+Names like `my-api-key` or `myApiKey` are not allowed.
+
+## Runtime Override
+
+Pass values at runtime to override or supplement stored values.
 
 ### CLI Flags
-
-Pass values directly using `--secrets` and `--vars` flags:
 
 ```bash
 # Pass secrets
 vm0 run my-agent "your prompt" --secrets API_KEY=sk-xxx --secrets DB_PASSWORD=mypassword
 
-# Pass vars
+# Pass variables
 vm0 run my-agent "your prompt" --vars ENV_NAME=production --vars DEBUG=true
 
 # Combine both
@@ -99,107 +124,54 @@ ENV_NAME=production
 Environment files are **not** automatically loaded. You must explicitly specify the file path with `--env-file`.
 </Callout>
 
-### Shell Environment
-
-Values can also be read from shell environment variables:
-
-```bash
-# Export variables
-export API_KEY=sk-xxx
-export ENV_NAME=production
-
-# Run the agent
-vm0 run my-agent "your prompt"
-```
-
 ## Value Resolution Priority
 
-When the same variable is defined in multiple places, VM0 uses this priority order:
+When the same value is defined in multiple places, VM0 uses this priority order:
 
 1. **CLI flags** (`--vars`, `--secrets`) - highest priority
-2. **`--env-file`** values - medium priority
-3. **Shell environment** (`process.env`) - lowest priority
+2. **Platform-stored values** - medium priority
+3. **`--env-file`** values - lowest priority
 
 Example:
 
 ```bash
+# Platform has: vm0 secret set API_KEY stored-value
 # .env file contains: API_KEY=from-env-file
-# Shell has: export API_KEY=from-shell
 
-# CLI value wins
+# CLI value wins over everything
 vm0 run my-agent "prompt" --secrets API_KEY=from-cli --env-file .env
 # Result: API_KEY = "from-cli"
 
-# Without CLI flag, --env-file wins over shell
+# Without CLI flag, Platform-stored value wins
+vm0 run my-agent "prompt" --env-file .env
+# Result: API_KEY = "stored-value"
+
+# Without Platform-stored value, --env-file is used
 vm0 run my-agent "prompt" --env-file .env
 # Result: API_KEY = "from-env-file"
-
-# Without --env-file, shell environment is used
-vm0 run my-agent "prompt"
-# Result: API_KEY = "from-shell"
 ```
-
-## Managing Credentials
-
-Credentials are stored securely on the VM0 platform and automatically loaded when your agent runs. Use the CLI to manage your credentials.
-
-### Setting a Credential
-
-```bash
-vm0 credential set MY_API_KEY sk-xxx
-```
-
-You can add an optional description:
-
-```bash
-vm0 credential set MY_API_KEY sk-xxx -d "OpenAI API key for production"
-```
-
-### Listing Credentials
-
-```bash
-vm0 credential list
-```
-
-This shows credential names and metadata. Values are never displayed for security.
-
-### Deleting a Credential
-
-```bash
-vm0 credential delete MY_API_KEY
-```
-
-### Naming Rules
-
-Credential names must use uppercase letters, numbers, and underscores only:
-
-- `MY_API_KEY`
-- `GITHUB_TOKEN`
-- `AWS_ACCESS_KEY_ID`
-
-Names like `my-api-key` or `myApiKey` are not allowed.
 
 ## Best Practices
 
-### Use Credentials for Reusable Secrets
+### Use Platform Storage for Reusable Secrets
 
-For API keys you use repeatedly across multiple runs, store them as credentials:
+For API keys you use repeatedly across multiple runs:
 
 ```bash
 # Set once
-vm0 credential set ANTHROPIC_API_KEY sk-xxx
+vm0 secret set ANTHROPIC_API_KEY sk-xxx
 ```
 
 Then use in any agent:
 
 ```yaml title="vm0.yaml"
 environment:
-  ANTHROPIC_AUTH_TOKEN: "${{ credentials.ANTHROPIC_API_KEY }}"
+  ANTHROPIC_AUTH_TOKEN: "${{ secrets.ANTHROPIC_API_KEY }}"
 ```
 
-### Use Secrets for CI/CD
+### Use Runtime Override for CI/CD
 
-For values that change per-run or come from CI/CD systems, use secrets:
+For values that change per-run or come from CI/CD systems:
 
 ```bash
 vm0 run my-agent "prompt" --secrets API_KEY=$CI_API_KEY
@@ -216,7 +188,7 @@ echo ".env" >> .gitignore
 
 ### Use Descriptive Names
 
-Choose clear, descriptive names for your variables:
+Choose clear, descriptive names for your values:
 
 ```yaml title="vm0.yaml"
 # Good
@@ -236,7 +208,7 @@ Organize your configuration logically:
 environment:
   # Model Provider Configuration
   ANTHROPIC_BASE_URL: "${{ vars.MODEL_PROVIDER_BASE_URL }}"
-  ANTHROPIC_AUTH_TOKEN: "${{ credentials.MODEL_PROVIDER_API_KEY }}"
+  ANTHROPIC_AUTH_TOKEN: "${{ secrets.MODEL_PROVIDER_API_KEY }}"
 
   # Database Configuration
   DATABASE_URL: "${{ secrets.DATABASE_URL }}"

--- a/turbo/apps/docs/content/docs/experimental/codex.mdx
+++ b/turbo/apps/docs/content/docs/experimental/codex.mdx
@@ -26,11 +26,21 @@ agents:
 
 ## Running Your Agent
 
-Run with your API key passed as a secret:
+First, store your API key on the platform (one-time setup):
 
 ```bash
-vm0 run my-agent "your prompt" --secrets OPENAI_API_KEY=sk-xxx
+vm0 secret set OPENAI_API_KEY sk-xxx
 ```
+
+Then run your agent - the secret is automatically loaded:
+
+```bash
+vm0 run my-agent "your prompt"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, you can pass the secret at runtime: `--secrets OPENAI_API_KEY=sk-xxx`
+</Callout>
 
 ## Instructions
 
@@ -47,8 +57,7 @@ When you specify an `instructions` file in your `vm0.yaml`, VM0 automatically mo
 
 Codex has some limitations compared to Claude Code:
 
-- **No model provider support** - You cannot use `vm0 model-provider setup` with Codex. You must pass the API key manually.
-- **Manual secret passing** - The `OPENAI_API_KEY` must be provided via the `--secrets` flag on every run.
+- **No model provider support** - You cannot use `vm0 model-provider setup` with Codex. Use `vm0 secret set OPENAI_API_KEY` instead.
 - **Experimental status** - The feature may have breaking changes in future releases.
 
 ## Getting an API Key
@@ -57,4 +66,4 @@ To use Codex, you need an OpenAI API key:
 
 1. Go to [OpenAI Platform](https://platform.openai.com/api-keys)
 2. Create a new API key
-3. Use it with the `--secrets` flag when running your agent
+3. Store it with `vm0 secret set OPENAI_API_KEY sk-xxx`

--- a/turbo/apps/docs/content/docs/reference/cli/index.mdx
+++ b/turbo/apps/docs/content/docs/reference/cli/index.mdx
@@ -45,27 +45,56 @@ vm0 model-provider setup --type anthropic-api-key --credential "sk-ant-xxx"
 vm0 model-provider setup --convert
 ```
 
-## Credential Management
+## Secret Management
 
-Store and manage credentials for use in agent runs.
+Store and manage secrets (sensitive data) for use in agent runs.
 
 | Command | Description | Options |
 | ------- | ----------- | ------- |
-| `vm0 credential list` | List all stored credentials | Alias: `ls` |
-| `vm0 credential set <name> <value>` | Store a credential | - |
-| `vm0 credential delete <name>` | Delete a credential | `-y, --yes` |
+| `vm0 secret list` | List all stored secrets | Alias: `ls` |
+| `vm0 secret set <name> <value>` | Store a secret | `-d, --description` |
+| `vm0 secret delete <name>` | Delete a secret | - |
 
 ### Examples
 
 ```bash
-# Store a credential
-vm0 credential set MY_API_KEY sk-xxx
+# Store a secret
+vm0 secret set MY_API_KEY sk-xxx
 
-# List all credentials
-vm0 credential list
+# Store with description
+vm0 secret set MY_API_KEY sk-xxx -d "OpenAI API key"
 
-# Delete a credential
-vm0 credential delete MY_API_KEY --yes
+# List all secrets (values are hidden)
+vm0 secret list
+
+# Delete a secret
+vm0 secret delete MY_API_KEY
+```
+
+## Variable Management
+
+Store and manage variables (non-sensitive configuration) for use in agent runs.
+
+| Command | Description | Options |
+| ------- | ----------- | ------- |
+| `vm0 variable list` | List all stored variables | Alias: `ls` |
+| `vm0 variable set <name> <value>` | Store a variable | `-d, --description` |
+| `vm0 variable delete <name>` | Delete a variable | - |
+
+### Examples
+
+```bash
+# Store a variable
+vm0 variable set ENV_NAME production
+
+# Store with description
+vm0 variable set ENV_NAME production -d "Current environment"
+
+# List all variables
+vm0 variable list
+
+# Delete a variable
+vm0 variable delete ENV_NAME
 ```
 
 ## Scope Management

--- a/turbo/apps/docs/content/docs/reference/cli/index.mdx
+++ b/turbo/apps/docs/content/docs/reference/cli/index.mdx
@@ -343,7 +343,24 @@ Use `-y` flag to skip confirmation prompts.
 
 <Accordion title="How do I pass environment variables to an agent?">
 
-Use `--vars` for non-sensitive variables and `--secrets` for sensitive data:
+**Recommended: Store on Platform (one-time setup)**
+
+```bash
+vm0 variable set ENV production
+vm0 variable set REGION us-west
+vm0 secret set API_KEY sk-xxx
+vm0 secret set DB_PASSWORD pwd123
+```
+
+Then just run your agent - values are automatically loaded:
+
+```bash
+vm0 run my-agent "deploy"
+```
+
+**Alternative: Pass at Runtime**
+
+For CI/CD or temporary overrides:
 
 ```bash
 vm0 run my-agent "deploy" \

--- a/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
@@ -35,13 +35,17 @@ agents:
       - my-volume:/home/user/.config
     environment:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-      MY_VAR: "value"
+      MY_VAR: ${{ vars.MY_VAR }}
 
 volumes:
   my-volume:
     name: my-volume
     version: latest
 ```
+
+<Callout type="info">
+Template values like `${{ secrets.X }}` and `${{ vars.X }}` are resolved from Platform-stored secrets and variables. Store them once with `vm0 secret set` or `vm0 variable set`, and they're automatically loaded on every run. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Top-Level Fields
 

--- a/turbo/apps/docs/content/docs/tutorial/research-capabilities.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/research-capabilities.mdx
@@ -102,32 +102,29 @@ Skills require the following environment variables:
 
 VM0 is asking you to approve the new secrets required by these skills. This is a security confirmation since the secrets are implicitly passed through the skills. Type `y` and press Enter to continue.
 
-## Step 4: Run Your Agent
+## Step 4: Store Your API Keys
 
-Let's test it out:
+Before running, store your API keys on the platform (one-time setup):
+
+```bash
+vm0 secret set FIRECRAWL_API_KEY fc-xxx
+vm0 secret set TAVILY_API_KEY tvly-xxx
+```
+
+This stores your secrets securely on VM0's servers. They'll be automatically loaded whenever you run your agent.
+
+## Step 5: Run Your Agent
+
+Now let's test it out:
 
 ```bash
 vm0 run my-researcher --artifact-name artifact "research the latest developments in WebAssembly for 2025"
 ```
 
-You'll see an error asking for the API keys:
+Since your secrets are stored on the platform, you don't need to pass them every time!
 
-```
-✗ Run preparation failed
-  Missing required secrets: TAVILY_API_KEY, FIRECRAWL_API_KEY. Use '--secrets TAVILY_API_KEY=<value>' to provide them.
-```
-
-Run again with the API keys:
-
-```bash
-vm0 run my-researcher --artifact-name artifact \
-  --secrets FIRECRAWL_API_KEY=fc-xxx \
-  --secrets TAVILY_API_KEY=tvly-xxx \
-  "research the latest developments in WebAssembly for 2025"
-```
-
-<Callout type="tip">
-You can also store secrets in a `.env` file and load it with `--env-file .env` to avoid typing them each time.
+<Callout type="info">
+For CI/CD or temporary overrides, you can still pass secrets at runtime with `--secrets FIRECRAWL_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
 </Callout>
 
 This time it should work! You'll see the agent:

--- a/turbo/apps/docs/content/docs/usage/run-agent.mdx
+++ b/turbo/apps/docs/content/docs/usage/run-agent.mdx
@@ -32,6 +32,23 @@ vm0 run my-agent:abc123 "build a todo app"
 
 ### Passing Variables and Secrets
 
+**Recommended: Store on Platform (one-time setup)**
+
+```bash
+vm0 variable set ENV production
+vm0 secret set API_KEY sk-xxx
+```
+
+Then run your agent - values are automatically loaded:
+
+```bash
+vm0 run my-agent "deploy to production"
+```
+
+**Alternative: Pass at Runtime**
+
+For CI/CD or temporary overrides, pass values directly:
+
 ```bash
 vm0 run my-agent "deploy to production" \
   --vars ENV=production \
@@ -156,27 +173,33 @@ curl -H "Authorization: Bearer $VM0_TOKEN" \
 
 <Accordion title="How do I pass multiple environment variables?">
 
-You can pass multiple `--vars` and `--secrets` flags:
+**Recommended: Store on Platform**
+
+Store values once and they're automatically loaded on every run:
+
+```bash
+vm0 variable set ENV production
+vm0 variable set REGION us-west
+vm0 secret set API_KEY sk-xxx
+vm0 secret set DB_PASSWORD pwd123
+```
+
+Then just run:
+
+```bash
+vm0 run my-agent "deploy"
+```
+
+**Alternative: Pass at Runtime**
+
+For CI/CD or overrides, pass multiple flags:
 
 ```bash
 vm0 run my-agent "deploy" \
   --vars ENV=production \
   --vars REGION=us-west \
-  --vars DEBUG=false \
   --secrets API_KEY=sk-xxx \
   --secrets DB_PASSWORD=pwd123
-```
-
-Or use a `.env` file with `vm0 cook`:
-
-```bash title=".env"
-ENV=production
-REGION=us-west
-API_KEY=sk-xxx
-```
-
-```bash
-vm0 cook "deploy to production"
 ```
 
 See [Environment Variables](/docs/core-concept/environment-variable) for more details.

--- a/turbo/apps/docs/content/docs/usage/schedule-agent.mdx
+++ b/turbo/apps/docs/content/docs/usage/schedule-agent.mdx
@@ -131,7 +131,27 @@ vm0 schedule delete my-agent
 
 ## Passing Variables and Secrets
 
-Schedules can include variables and secrets that are passed to each run:
+**Recommended: Use Platform Storage**
+
+Store secrets on the platform once, and they're automatically available for all scheduled runs:
+
+```bash
+vm0 variable set ENV production
+vm0 secret set API_KEY sk-xxx
+```
+
+Then set up your schedule without passing secrets:
+
+```bash
+vm0 schedule setup my-agent \
+  --frequency daily \
+  --time 09:00 \
+  --prompt "deploy to production"
+```
+
+**Alternative: Schedule-Specific Values**
+
+For schedule-specific overrides, pass values in the setup command:
 
 ```bash
 vm0 schedule setup my-agent \
@@ -141,6 +161,10 @@ vm0 schedule setup my-agent \
   --var ENV=production \
   --secret API_KEY=sk-xxx
 ```
+
+<Callout type="info">
+Schedule-specific values (`--var`, `--secret`) override Platform-stored values for that schedule only. Other schedules and manual runs still use Platform-stored values.
+</Callout>
 
 The agent can access these via `${{ vars.ENV }}` and `${{ secrets.API_KEY }}`.
 

--- a/turbo/apps/docs/content/docs/usage/using-skills.mdx
+++ b/turbo/apps/docs/content/docs/usage/using-skills.mdx
@@ -72,11 +72,18 @@ agents:
       - https://github.com/vm0-ai/vm0-skills/tree/main/slack
 ```
 
+First, store your secrets on the platform (one-time setup):
+
 ```bash
-vm0 run research-bot "research AI agent frameworks and create a comparison" \
-  --secrets FIRECRAWL_API_KEY=fc-xxx \
-  --secrets NOTION_API_KEY=secret_xxx \
-  --secrets SLACK_BOT_TOKEN=xoxb-xxx
+vm0 secret set FIRECRAWL_API_KEY fc-xxx
+vm0 secret set NOTION_API_KEY secret_xxx
+vm0 secret set SLACK_BOT_TOKEN xoxb-xxx
+```
+
+Then run your agent - secrets are automatically loaded:
+
+```bash
+vm0 run research-bot "research AI agent frameworks and create a comparison"
 ```
 
 ## Runtime Prompts
@@ -119,16 +126,23 @@ Help the agent understand where and how to use each skill:
 
 ### Handle Credentials
 
-Pass required credentials when running your agent:
+Store required credentials on the platform (recommended, one-time setup):
 
 ```bash
-vm0 run my-agent "sync data to sheets" \
-  --secrets GOOGLE_SHEETS_CLIENT_ID=xxx \
-  --secrets GOOGLE_SHEETS_CLIENT_SECRET=xxx \
-  --secrets GOOGLE_SHEETS_REFRESH_TOKEN=xxx
+vm0 secret set GOOGLE_SHEETS_CLIENT_ID xxx
+vm0 secret set GOOGLE_SHEETS_CLIENT_SECRET xxx
+vm0 secret set GOOGLE_SHEETS_REFRESH_TOKEN xxx
 ```
 
-See [Environment Variables](/docs/core-concept/environment-variable) for managing secrets.
+Then run your agent - secrets are automatically loaded:
+
+```bash
+vm0 run my-agent "sync data to sheets"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime with `--secrets KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
 
 ## Troubleshooting
 

--- a/turbo/apps/web/src/lib/run/environment/expand-environment.ts
+++ b/turbo/apps/web/src/lib/run/environment/expand-environment.ts
@@ -125,7 +125,7 @@ export function expandEnvironmentFromCompose(
     );
     if (missingCredentials.length > 0) {
       throw badRequest(
-        `Missing required credentials: ${missingCredentials.join(", ")}. Use 'vm0 credential set ${missingCredentials[0]} <value>' to add them.`,
+        `Missing required secrets: ${missingCredentials.join(", ")}. Use 'vm0 secret set ${missingCredentials[0]} <value>' to add them.`,
       );
     }
 


### PR DESCRIPTION
## Summary

- Rewrite `environment-variable.mdx` with "two storage modes" model (Platform Storage + Runtime Override)
- Replace outdated three-tier system (vars/secrets/credentials) with current two-tier (variables/secrets)
- Update CLI reference: remove non-existent `vm0 credential` commands, add `vm0 secret` and `vm0 variable` commands
- Fix error message in `expand-environment.ts`: `vm0 credential set` → `vm0 secret set`

## Background

The documentation described a system that no longer matches the codebase:

| Old Documentation | Current Codebase |
|-------------------|------------------|
| Vars: CLI ephemeral | Variables: Platform-stored |
| Secrets: CLI ephemeral | Secrets: Platform-stored (encrypted) |
| Credentials: Platform persistent | No `credential` command exists |

## Test plan

- [ ] Verify documentation renders correctly on docs site
- [ ] Verify CLI commands match documentation (`vm0 secret --help`, `vm0 variable --help`)

🤖 Generated with [Claude Code](https://claude.ai/code)