### PR TITLE
fix(platform): improve logs page navigation behavior

### DIFF
--- a/turbo/apps/platform/src/views/layout/nav-link.tsx
+++ b/turbo/apps/platform/src/views/layout/nav-link.tsx
@@ -61,7 +61,8 @@ export function NavLink({ item, isActive, collapsed }: NavLinkProps) {
 
   const handleClick = () => {
     if (item.path) {
-      navigate(item.path);
+      // Clear search params to ensure navigation goes to base route with clean state
+      navigate(item.path, { searchParams: new URLSearchParams() });
     } else if (item.url) {
       if (item.newTab) {
         window.open(item.url, "_blank");

--- a/turbo/apps/platform/src/views/logs-page/logs-table-row.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-table-row.tsx
@@ -1,5 +1,6 @@
 import { useSet } from "ccstate-react";
 import { IconChevronRight } from "@tabler/icons-react";
+import type { MouseEvent } from "react";
 import { navigateInReact$ } from "../../signals/route.ts";
 import { TableRow, TableCell } from "@vm0/ui";
 import { StatusBadge } from "./status-badge.tsx";
@@ -24,8 +25,14 @@ interface LogsTableRowProps {
 
 export function LogsTableRow({ entry }: LogsTableRowProps) {
   const navigate = useSet(navigateInReact$);
+  const logDetailUrl = `/logs/${entry.id}`;
 
-  const handleRowClick = () => {
+  const handleRowClick = (event: MouseEvent<HTMLTableRowElement>) => {
+    // Open in new tab if Cmd (Mac) or Ctrl (Windows/Linux) is pressed
+    if (event.metaKey || event.ctrlKey) {
+      window.open(logDetailUrl, "_blank");
+      return;
+    }
     navigate("/logs/:id", { pathParams: { id: entry.id } });
   };
 


### PR DESCRIPTION
## Summary

- Clear search params when clicking sidebar nav links to ensure clean navigation state (fixes #2345)
- Support Cmd+click (Mac) and Ctrl+click (Windows/Linux) on log table rows to open log details in a new tab (fixes #2327)

## Test plan

- [ ] Click the Logs link in sidebar while on a filtered logs page - should navigate to `/logs` with no query params
- [ ] Click the Logs link from log detail page - should return to clean logs list
- [ ] Regular click on log row - should navigate to detail in same tab
- [ ] Cmd+click (Mac) or Ctrl+click (Windows/Linux) on log row - should open detail in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)