### PR TITLE
fix: improve vhs installation script with proper ttyd version

### DIFF
--- a/scripts/install-vhs.sh
+++ b/scripts/install-vhs.sh
@@ -1,9 +1,27 @@
 #!/usr/bin/env bash
 
-sudo apt update
-sudo apt install -y ffmpeg ttyd
+set -e
 
+# Install dependencies
+sudo apt update
+sudo apt install -y ffmpeg fontconfig unzip
+
+# Install VHS
 ARCH=$(dpkg --print-architecture)
 wget "https://github.com/charmbracelet/vhs/releases/download/v0.10.0/vhs_0.10.0_Linux_${ARCH}.tar.gz" -O /tmp/vhs.tar.gz
 tar zxvf /tmp/vhs.tar.gz -C /tmp
+mkdir -p ~/.local/bin
 mv /tmp/vhs_0.10.0_Linux_${ARCH}/vhs ~/.local/bin/
+
+# Install ttyd 1.7.7 (apt version is too old for VHS)
+TTYD_ARCH="arm"
+if [ "$ARCH" = "amd64" ]; then
+  TTYD_ARCH="x86_64"
+fi
+wget "https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.${TTYD_ARCH}" -O /tmp/ttyd
+chmod +x /tmp/ttyd
+sudo mv /tmp/ttyd /usr/local/bin/ttyd
+
+echo "VHS installation complete!"
+echo "  vhs version: $(~/.local/bin/vhs --version)"
+echo "  ttyd version: $(ttyd --version)"

--- a/vm0.code-workspace
+++ b/vm0.code-workspace
@@ -10,7 +10,7 @@
       "path": "e2e"
     },
     {
-      "path": "spec"
+      "path": "docs"
     },
     {
       "path": ".github"


### PR DESCRIPTION
## Summary
- Add `set -e` for fail-fast behavior on errors
- Install ttyd 1.7.7 directly from GitHub releases instead of apt (apt version is too old for VHS compatibility)
- Create `~/.local/bin` directory if it doesn't exist
- Add verification output showing installed versions of VHS and ttyd
- Update workspace config to reference docs folder instead of spec

## Test plan
- [ ] Run the updated `scripts/install-vhs.sh` script in a fresh environment
- [ ] Verify VHS and ttyd are correctly installed and their versions are printed
- [ ] Test VHS recording functionality works with the new ttyd version

🤖 Generated with [Claude Code](https://claude.com/claude-code)