### PR TITLE
feat(slack): add vars input support in agent add/update flow

### DIFF
--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -22,12 +22,16 @@ describe("buildAgentAddModal", () => {
         name: "My Coder",
         requiredSecrets: [],
         existingSecrets: [],
+        requiredVars: [],
+        existingVars: [],
       },
       {
         id: "agent-2",
         name: "My Analyst",
         requiredSecrets: [],
         existingSecrets: [],
+        requiredVars: [],
+        existingVars: [],
       },
     ];
 
@@ -67,12 +71,16 @@ describe("buildAgentAddModal", () => {
         name: "My Coder",
         requiredSecrets: [],
         existingSecrets: [],
+        requiredVars: [],
+        existingVars: [],
       },
       {
         id: "agent-2",
         name: "My Analyst",
         requiredSecrets: [],
         existingSecrets: [],
+        requiredVars: [],
+        existingVars: [],
       },
     ];
 
@@ -99,6 +107,8 @@ describe("buildAgentAddModal", () => {
         name: "My Coder",
         requiredSecrets: ["API_KEY", "NEW_SECRET"],
         existingSecrets: ["API_KEY"],
+        requiredVars: [],
+        existingVars: [],
       },
     ];
 


### PR DESCRIPTION
## Summary

- Add support for `${{ vars.NAME }}` variable input in Slack agent add/update modals
- Variables are stored as plaintext (unlike encrypted secrets)
- Variables section appears before Secrets section in the modal UI

## Changes

- Update `AgentOption`/`AgentUpdateOption` interfaces to include `requiredVars`/`existingVars`
- Add Variables section to agent add/update modals
- Extract vars from compose content using `groupVariablesBySource().vars`
- Save variables via `setVariable()` on form submission
- Include saved variables in confirmation messages
- Add `buildValueInputBlock()` helper to reduce code duplication

## Test plan

- [ ] `/vm0 agent add` - select an agent with `${{ vars.NAME }}` references, verify Variables section appears
- [ ] Enter variable values and submit - verify variables saved to user's scope
- [ ] Existing variables show ✓ indicator and are optional
- [ ] Missing variables are required fields
- [ ] `/vm0 agent update` - verify same functionality for update modal
- [ ] Confirmation messages include saved variables

Closes #2387

🤖 Generated with [Claude Code](https://claude.ai/claude-code)