### PR TITLE
feat(cli): mark agent sharing as experimental with safety flag

### DIFF
--- a/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
@@ -72,7 +72,7 @@ describe("Agent Sharing Commands", () => {
     vi.unstubAllEnvs();
   });
 
-  describe("vm0 agent public", () => {
+  describe("vm0 agent experimental-public", () => {
     it("should make agent public successfully", async () => {
       server.use(
         http.post(
@@ -96,9 +96,11 @@ describe("Agent Sharing Commands", () => {
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("now public"),
       );
-      // Check for run command hint
+      // Check for run command hint with experimental flag
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining(`vm0 run ${testScopeSlug}/${testAgentName}`),
+        expect.stringContaining(
+          `vm0 run ${testScopeSlug}/${testAgentName} --experimental-shared-agent`,
+        ),
       );
     });
 
@@ -150,7 +152,7 @@ describe("Agent Sharing Commands", () => {
     });
   });
 
-  describe("vm0 agent private", () => {
+  describe("vm0 agent experimental-private", () => {
     it("should make agent private successfully", async () => {
       server.use(
         http.delete(
@@ -191,7 +193,7 @@ describe("Agent Sharing Commands", () => {
     });
   });
 
-  describe("vm0 agent share", () => {
+  describe("vm0 agent experimental-share", () => {
     it("should share agent with email successfully", async () => {
       const shareEmail = "user@example.com";
 
@@ -224,9 +226,11 @@ describe("Agent Sharing Commands", () => {
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("shared with"),
       );
-      // Check for run command hint
+      // Check for run command hint with experimental flag
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining(`vm0 run ${testScopeSlug}/${testAgentName}`),
+        expect.stringContaining(
+          `vm0 run ${testScopeSlug}/${testAgentName} --experimental-shared-agent`,
+        ),
       );
     });
 
@@ -262,7 +266,7 @@ describe("Agent Sharing Commands", () => {
     });
   });
 
-  describe("vm0 agent unshare", () => {
+  describe("vm0 agent experimental-unshare", () => {
     it("should unshare agent from email successfully", async () => {
       const unshareEmail = "user@example.com";
 
@@ -318,7 +322,7 @@ describe("Agent Sharing Commands", () => {
     });
   });
 
-  describe("vm0 agent permission", () => {
+  describe("vm0 agent experimental-permission", () => {
     it("should list permissions for agent", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
@@ -66,9 +66,6 @@ describe("Agent Sharing Commands", () => {
   });
 
   afterEach(() => {
-    mockExit.mockClear();
-    mockConsoleLog.mockClear();
-    mockConsoleError.mockClear();
     vi.unstubAllEnvs();
   });
 

--- a/turbo/apps/cli/src/commands/agent/permission.ts
+++ b/turbo/apps/cli/src/commands/agent/permission.ts
@@ -17,7 +17,7 @@ interface PermissionsResponse {
 }
 
 export const permissionCommand = new Command()
-  .name("permission")
+  .name("experimental-permission")
   .description("List all permissions for an agent")
   .argument("<name>", "Agent name")
   .action(async (name: string) => {

--- a/turbo/apps/cli/src/commands/agent/private.ts
+++ b/turbo/apps/cli/src/commands/agent/private.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { getComposeByName, httpDelete, type ApiError } from "../../lib/api";
 
 export const privateCommand = new Command()
-  .name("private")
+  .name("experimental-private")
   .description("Make an agent private (remove public access)")
   .argument("<name>", "Agent name")
   .action(async (name: string) => {

--- a/turbo/apps/cli/src/commands/agent/public.ts
+++ b/turbo/apps/cli/src/commands/agent/public.ts
@@ -8,7 +8,7 @@ import {
 } from "../../lib/api";
 
 export const publicCommand = new Command()
-  .name("public")
+  .name("experimental-public")
   .description("Make an agent public (accessible to all authenticated users)")
   .argument("<name>", "Agent name")
   .action(async (name: string) => {
@@ -42,7 +42,11 @@ export const publicCommand = new Command()
       console.log(chalk.green(`✓ Agent "${name}" is now public`));
       console.log();
       console.log("Others can now run your agent with:");
-      console.log(chalk.cyan(`  vm0 run ${fullName} "your prompt"`));
+      console.log(
+        chalk.cyan(
+          `  vm0 run ${fullName} --experimental-shared-agent "your prompt"`,
+        ),
+      );
     } catch (error) {
       console.error(chalk.red("✗ Failed to make agent public"));
       if (error instanceof Error) {

--- a/turbo/apps/cli/src/commands/agent/share.ts
+++ b/turbo/apps/cli/src/commands/agent/share.ts
@@ -8,7 +8,7 @@ import {
 } from "../../lib/api";
 
 export const shareCommand = new Command()
-  .name("share")
+  .name("experimental-share")
   .description("Share an agent with a user by email")
   .argument("<name>", "Agent name")
   .requiredOption("--email <email>", "Email address to share with")
@@ -49,7 +49,11 @@ export const shareCommand = new Command()
       );
       console.log();
       console.log("They can now run your agent with:");
-      console.log(chalk.cyan(`  vm0 run ${fullName} "your prompt"`));
+      console.log(
+        chalk.cyan(
+          `  vm0 run ${fullName} --experimental-shared-agent "your prompt"`,
+        ),
+      );
     } catch (error) {
       console.error(chalk.red("✗ Failed to share agent"));
       if (error instanceof Error) {

--- a/turbo/apps/cli/src/commands/agent/unshare.ts
+++ b/turbo/apps/cli/src/commands/agent/unshare.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { getComposeByName, httpDelete, type ApiError } from "../../lib/api";
 
 export const unshareCommand = new Command()
-  .name("unshare")
+  .name("experimental-unshare")
   .description("Remove sharing from a user")
   .argument("<name>", "Agent name")
   .requiredOption("--email <email>", "Email address to unshare")

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -99,6 +99,16 @@ describe("run command", () => {
       http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
         return HttpResponse.json(defaultEventsResponse);
       }),
+      // Default scope handler for experimental-dangerously-allow-shared validation
+      http.get("http://localhost:3000/api/scope", () => {
+        return HttpResponse.json({
+          id: "scope-123",
+          slug: "test-user",
+          type: "personal",
+          createdAt: "2025-01-01T00:00:00Z",
+          updatedAt: "2025-01-01T00:00:00Z",
+        });
+      }),
       // Default npm registry handler - return same version to skip upgrade
       http.get("https://registry.npmjs.org/*/latest", () => {
         return HttpResponse.json({ version: "0.0.0-test" });
@@ -463,6 +473,7 @@ describe("run command", () => {
         "node",
         "cli",
         "user-abc123/my-agent",
+        "--experimental-dangerously-allow-shared",
         "test prompt",
         "--artifact-name",
         "test-artifact",
@@ -540,6 +551,7 @@ describe("run command", () => {
         "node",
         "cli",
         "user-abc123/my-agent:abc12345",
+        "--experimental-dangerously-allow-shared",
         "test prompt",
         "--artifact-name",
         "test-artifact",
@@ -1275,6 +1287,116 @@ describe("run command", () => {
     });
   });
 
+  describe("--experimental-dangerously-allow-shared flag", () => {
+    it("should require flag when running agent from another user's scope", async () => {
+      await expect(async () => {
+        await runCommand.parseAsync([
+          "node",
+          "cli",
+          "other-user/my-agent",
+          "test prompt",
+          "--artifact-name",
+          "test-artifact",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--experimental-dangerously-allow-shared"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("security risks"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should allow running agent from own scope without flag", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          const name = url.searchParams.get("name");
+          const scope = url.searchParams.get("scope");
+
+          if (scope === "test-user" && name === "my-agent") {
+            return HttpResponse.json({
+              id: "compose-123",
+              name: "my-agent",
+              headVersionId: "version-123",
+              content: {
+                version: "1",
+                agents: { "my-agent": { provider: "claude" } },
+              },
+              createdAt: "2025-01-01T00:00:00Z",
+              updatedAt: "2025-01-01T00:00:00Z",
+            });
+          }
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
+      );
+
+      // Should not throw - own scope doesn't require the flag
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        "test-user/my-agent",
+        "test prompt",
+        "--artifact-name",
+        "test-artifact",
+      ]);
+
+      // Should not have error about the flag
+      expect(mockConsoleError).not.toHaveBeenCalledWith(
+        expect.stringContaining("--experimental-dangerously-allow-shared"),
+      );
+    });
+
+    it("should allow running agent from another scope with flag", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          const name = url.searchParams.get("name");
+          const scope = url.searchParams.get("scope");
+
+          if (scope === "other-user" && name === "shared-agent") {
+            return HttpResponse.json({
+              id: "compose-456",
+              name: "shared-agent",
+              headVersionId: "version-456",
+              content: {
+                version: "1",
+                agents: { "shared-agent": { provider: "claude" } },
+              },
+              createdAt: "2025-01-01T00:00:00Z",
+              updatedAt: "2025-01-01T00:00:00Z",
+            });
+          }
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
+      );
+
+      // Should not throw - flag is provided
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        "other-user/shared-agent",
+        "--experimental-dangerously-allow-shared",
+        "test prompt",
+        "--artifact-name",
+        "test-artifact",
+      ]);
+
+      // Should not have error about the flag
+      expect(mockConsoleError).not.toHaveBeenCalledWith(
+        expect.stringContaining("--experimental-dangerously-allow-shared"),
+      );
+    });
+  });
+
   describe("scope error handling", () => {
     it("should show error when scope does not exist", async () => {
       server.use(
@@ -1305,6 +1427,7 @@ describe("run command", () => {
           "node",
           "cli",
           "nonexistent-scope-xyz123/my-agent",
+          "--experimental-dangerously-allow-shared",
           "test prompt",
           "--artifact-name",
           "test-artifact",
@@ -1337,6 +1460,7 @@ describe("run command", () => {
           "node",
           "cli",
           "invalid-scope/test-agent",
+          "--experimental-dangerously-allow-shared",
           "test prompt",
           "--artifact-name",
           "test-artifact",
@@ -1385,6 +1509,7 @@ describe("run command", () => {
           "node",
           "cli",
           "user-abc12345/nonexistent-agent-xyz123",
+          "--experimental-dangerously-allow-shared",
           "test prompt",
           "--artifact-name",
           "test-artifact",
@@ -1417,6 +1542,7 @@ describe("run command", () => {
           "node",
           "cli",
           "user-scope/missing-agent",
+          "--experimental-dangerously-allow-shared",
           "test prompt",
           "--artifact-name",
           "test-artifact",
@@ -1459,6 +1585,7 @@ describe("run command", () => {
           "node",
           "cli",
           "other-user-scope/my-agent",
+          "--experimental-dangerously-allow-shared",
           "test prompt",
           "--artifact-name",
           "test-artifact",
@@ -1491,6 +1618,7 @@ describe("run command", () => {
           "node",
           "cli",
           "another-scope/secret-agent",
+          "--experimental-dangerously-allow-shared",
           "test prompt",
           "--artifact-name",
           "test-artifact",

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -99,7 +99,7 @@ describe("run command", () => {
       http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
         return HttpResponse.json(defaultEventsResponse);
       }),
-      // Default scope handler for experimental-dangerously-allow-shared validation
+      // Default scope handler for experimental-shared-agent validation
       http.get("http://localhost:3000/api/scope", () => {
         return HttpResponse.json({
           id: "scope-123",
@@ -473,7 +473,7 @@ describe("run command", () => {
         "node",
         "cli",
         "user-abc123/my-agent",
-        "--experimental-dangerously-allow-shared",
+        "--experimental-shared-agent",
         "test prompt",
         "--artifact-name",
         "test-artifact",
@@ -551,7 +551,7 @@ describe("run command", () => {
         "node",
         "cli",
         "user-abc123/my-agent:abc12345",
-        "--experimental-dangerously-allow-shared",
+        "--experimental-shared-agent",
         "test prompt",
         "--artifact-name",
         "test-artifact",
@@ -1287,7 +1287,7 @@ describe("run command", () => {
     });
   });
 
-  describe("--experimental-dangerously-allow-shared flag", () => {
+  describe("--experimental-shared-agent flag", () => {
     it("should require flag when running agent from another user's scope", async () => {
       await expect(async () => {
         await runCommand.parseAsync([
@@ -1301,7 +1301,7 @@ describe("run command", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("--experimental-dangerously-allow-shared"),
+        expect.stringContaining("--experimental-shared-agent"),
       );
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("security risks"),
@@ -1348,7 +1348,7 @@ describe("run command", () => {
 
       // Should not have error about the flag
       expect(mockConsoleError).not.toHaveBeenCalledWith(
-        expect.stringContaining("--experimental-dangerously-allow-shared"),
+        expect.stringContaining("--experimental-shared-agent"),
       );
     });
 
@@ -1384,7 +1384,7 @@ describe("run command", () => {
         "node",
         "cli",
         "other-user/shared-agent",
-        "--experimental-dangerously-allow-shared",
+        "--experimental-shared-agent",
         "test prompt",
         "--artifact-name",
         "test-artifact",
@@ -1392,7 +1392,7 @@ describe("run command", () => {
 
       // Should not have error about the flag
       expect(mockConsoleError).not.toHaveBeenCalledWith(
-        expect.stringContaining("--experimental-dangerously-allow-shared"),
+        expect.stringContaining("--experimental-shared-agent"),
       );
     });
   });
@@ -1427,7 +1427,7 @@ describe("run command", () => {
           "node",
           "cli",
           "nonexistent-scope-xyz123/my-agent",
-          "--experimental-dangerously-allow-shared",
+          "--experimental-shared-agent",
           "test prompt",
           "--artifact-name",
           "test-artifact",
@@ -1460,7 +1460,7 @@ describe("run command", () => {
           "node",
           "cli",
           "invalid-scope/test-agent",
-          "--experimental-dangerously-allow-shared",
+          "--experimental-shared-agent",
           "test prompt",
           "--artifact-name",
           "test-artifact",
@@ -1509,7 +1509,7 @@ describe("run command", () => {
           "node",
           "cli",
           "user-abc12345/nonexistent-agent-xyz123",
-          "--experimental-dangerously-allow-shared",
+          "--experimental-shared-agent",
           "test prompt",
           "--artifact-name",
           "test-artifact",
@@ -1542,7 +1542,7 @@ describe("run command", () => {
           "node",
           "cli",
           "user-scope/missing-agent",
-          "--experimental-dangerously-allow-shared",
+          "--experimental-shared-agent",
           "test prompt",
           "--artifact-name",
           "test-artifact",
@@ -1585,7 +1585,7 @@ describe("run command", () => {
           "node",
           "cli",
           "other-user-scope/my-agent",
-          "--experimental-dangerously-allow-shared",
+          "--experimental-shared-agent",
           "test prompt",
           "--artifact-name",
           "test-artifact",
@@ -1618,7 +1618,7 @@ describe("run command", () => {
           "node",
           "cli",
           "another-scope/secret-agent",
-          "--experimental-dangerously-allow-shared",
+          "--experimental-shared-agent",
           "test prompt",
           "--artifact-name",
           "test-artifact",

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -74,7 +74,7 @@ export const mainRunCommand = new Command()
   )
   .option("--verbose", "Show full tool inputs and outputs")
   .option(
-    "--experimental-dangerously-allow-shared",
+    "--experimental-shared-agent",
     "Allow running agents shared by other users (required when running scope/agent format)",
   )
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
@@ -94,7 +94,7 @@ export const mainRunCommand = new Command()
         experimentalRealtime?: boolean;
         modelProvider?: string;
         verbose?: boolean;
-        experimentalDangerouslyAllowShared?: boolean;
+        experimentalSharedAgent?: boolean;
         debugNoMockClaude?: boolean;
         autoUpdate?: boolean;
       },
@@ -104,7 +104,7 @@ export const mainRunCommand = new Command()
         const { scope, name, version } = parseIdentifier(identifier);
 
         // 1.5. Validate: running another user's agent requires explicit opt-in
-        if (scope && !options.experimentalDangerouslyAllowShared) {
+        if (scope && !options.experimentalSharedAgent) {
           // Check if it's the user's own scope
           const userScope = await getScope();
           const isOwnScope = userScope.slug === scope;
@@ -112,7 +112,7 @@ export const mainRunCommand = new Command()
           if (!isOwnScope) {
             console.error(
               chalk.red(
-                `✗ Running shared agents requires --experimental-dangerously-allow-shared flag`,
+                `✗ Running shared agents requires --experimental-shared-agent flag`,
               ),
             );
             console.error();
@@ -126,7 +126,7 @@ export const mainRunCommand = new Command()
             console.error("Example:");
             console.error(
               chalk.cyan(
-                `  vm0 run ${identifier} --experimental-dangerously-allow-shared "your prompt"`,
+                `  vm0 run ${identifier} --experimental-shared-agent "your prompt"`,
               ),
             );
             process.exit(1);

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -4,6 +4,7 @@ import {
   getComposeById,
   getComposeByName,
   getComposeVersion,
+  getScope,
   createRun,
 } from "../../lib/api";
 import { EventRenderer } from "../../lib/events/event-renderer";
@@ -72,6 +73,10 @@ export const mainRunCommand = new Command()
     "Override model provider (e.g., anthropic-api-key)",
   )
   .option("--verbose", "Show full tool inputs and outputs")
+  .option(
+    "--experimental-dangerously-allow-shared",
+    "Allow running agents shared by other users (required when running scope/agent format)",
+  )
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .addOption(new Option("--no-auto-update").hideHelp())
   .action(
@@ -89,6 +94,7 @@ export const mainRunCommand = new Command()
         experimentalRealtime?: boolean;
         modelProvider?: string;
         verbose?: boolean;
+        experimentalDangerouslyAllowShared?: boolean;
         debugNoMockClaude?: boolean;
         autoUpdate?: boolean;
       },
@@ -96,6 +102,36 @@ export const mainRunCommand = new Command()
       try {
         // 1. Parse identifier for optional scope and version specifier
         const { scope, name, version } = parseIdentifier(identifier);
+
+        // 1.5. Validate: running another user's agent requires explicit opt-in
+        if (scope && !options.experimentalDangerouslyAllowShared) {
+          // Check if it's the user's own scope
+          const userScope = await getScope();
+          const isOwnScope = userScope.slug === scope;
+
+          if (!isOwnScope) {
+            console.error(
+              chalk.red(
+                `✗ Running shared agents requires --experimental-dangerously-allow-shared flag`,
+              ),
+            );
+            console.error();
+            console.error(
+              chalk.dim(
+                "  Running code from other users carries security risks.",
+              ),
+            );
+            console.error(chalk.dim("  Only run agents from users you trust."));
+            console.error();
+            console.error("Example:");
+            console.error(
+              chalk.cyan(
+                `  vm0 run ${identifier} --experimental-dangerously-allow-shared "your prompt"`,
+              ),
+            );
+            process.exit(1);
+          }
+        }
 
         // 2. Resolve name to composeId and get compose content
         let composeId: string;

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -118,7 +118,7 @@ export const mainRunCommand = new Command()
             console.error();
             console.error(
               chalk.dim(
-                "  Running code from other users carries security risks.",
+                "  Running agent from other users carries security risks.",
               ),
             );
             console.error(chalk.dim("  Only run agents from users you trust."));


### PR DESCRIPTION
## Summary

- Rename agent sharing commands to `experimental-*` prefix:
  - `vm0 agent experimental-share`
  - `vm0 agent experimental-unshare`
  - `vm0 agent experimental-public`
  - `vm0 agent experimental-private`
  - `vm0 agent experimental-permission`

- Add `--experimental-shared-agent` flag to `vm0 run`:
  - Required when running agents from other users' scopes
  - Not required when running own scope's agents
  - Shows security warning when flag is missing

## Error Message (when flag is missing)

```
✗ Running shared agents requires --experimental-shared-agent flag

  Running code from other users carries security risks.
  Only run agents from users you trust.

Example:
  vm0 run other-user/agent --experimental-shared-agent "your prompt"
```

## Example Usage

```bash
# Share an agent
vm0 agent experimental-share my-agent --email user@example.com

# Run another user's shared agent (requires flag)
vm0 run other-user/shared-agent --experimental-shared-agent "prompt"

# Run own agent with scope prefix (no flag needed)
vm0 run my-scope/my-agent "prompt"
```

## Test plan

- [x] All 643 CLI tests pass
- [x] New tests for `--experimental-shared-agent` validation
- [x] Updated existing scope tests to include the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)