### PR TITLE
feat(docs): refine product philosophy content

### DIFF
--- a/turbo/apps/docs/content/docs/product-philosophy.mdx
+++ b/turbo/apps/docs/content/docs/product-philosophy.mdx
@@ -41,8 +41,6 @@ Security must exist at the foundation. We treat security as a first-order concer
 
 Every system shapes how people act and decide. What it encourages gets reinforced, and what it ignores slowly fades. So, the way VM0 guide agents toward best practices matters. The way VM0 structure defaults matters. The way builders are encouraged to compose agents matters.
 
-VM0 attempts to guide people and agents toward doing the right things more naturally.
-
 ## **Iterative**
 
 ### **Built for long-running work**


### PR DESCRIPTION
## Summary

Remove a redundant sentence from the "Systems teach behavior" section that duplicated the concept already expressed in the paragraph.

### Changes
- Removed the sentence: "VM0 attempts to guide people and agents toward doing the right things more naturally."
- This concept was already covered in the preceding paragraph discussing how systems shape behavior and the importance of defaults and composition

### Reasoning
The paragraph already clearly explains:
- How systems shape behavior
- The importance of guiding agents toward best practices
- The significance of structure and composition

The removed sentence was redundant and didn't add new information.

## Test Plan

- [x] Review updated content reads smoothly without the sentence
- [x] Verify paragraph flow remains coherent
- [x] Confirm no other references to this concept need updating


Made with [Cursor](https://cursor.com)