### PR TITLE
feat(cli): support github url for vm0 compose command

### DIFF
--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -4,13 +4,13 @@ import { server } from "../../../mocks/server";
 import { createMockChildProcess } from "../../../mocks/spawn-helpers";
 import { composeCommand, getSecretsFromComposeContent } from "../index";
 import * as fs from "fs/promises";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import * as path from "path";
 import * as os from "os";
 import * as yaml from "yaml";
 import chalk from "chalk";
 
-// Mock downloadGitHubSkill since it uses git commands (external system call)
+// Mock downloadGitHubSkill and downloadGitHubDirectory since they use git commands (external system call)
 // This is the actual external boundary - git sparse-checkout via child_process.exec
 vi.mock("../../../lib/domain/github-skills", async (importOriginal) => {
   const original =
@@ -18,6 +18,7 @@ vi.mock("../../../lib/domain/github-skills", async (importOriginal) => {
   return {
     ...original,
     downloadGitHubSkill: vi.fn(),
+    downloadGitHubDirectory: vi.fn(),
   };
 });
 
@@ -31,8 +32,12 @@ vi.mock("child_process", async (importOriginal) => {
   };
 });
 
-import { downloadGitHubSkill } from "../../../lib/domain/github-skills";
+import {
+  downloadGitHubSkill,
+  downloadGitHubDirectory,
+} from "../../../lib/domain/github-skills";
 const mockDownloadGitHubSkill = vi.mocked(downloadGitHubSkill);
+const mockDownloadGitHubDirectory = vi.mocked(downloadGitHubDirectory);
 
 import { spawn } from "child_process";
 const mockSpawn = vi.mocked(spawn);
@@ -1527,6 +1532,331 @@ agents:
         }),
       );
     });
+  });
+});
+
+describe("GitHub URL compose", () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  const scopeResponse = {
+    id: "scope-123",
+    slug: "user-abc12345",
+    type: "personal",
+    displayName: null,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+  };
+
+  /**
+   * Helper to create a mock GitHub cookbook directory with vm0.yaml.
+   */
+  function createMockCookbookDir(
+    parentDir: string,
+    subPath: string,
+    vm0YamlContent: string,
+  ): string {
+    const cookbookDir = path.join(parentDir, subPath);
+    mkdirSync(cookbookDir, { recursive: true });
+    writeFileSync(path.join(cookbookDir, "vm0.yaml"), vm0YamlContent);
+    return cookbookDir;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "test-github-compose-"));
+    originalCwd = process.cwd();
+    process.chdir(tempDir);
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    chalk.level = 0;
+
+    // Default npm registry handler
+    server.use(
+      http.get("https://registry.npmjs.org/*/latest", () => {
+        return HttpResponse.json({ version: "0.0.0-test" });
+      }),
+    );
+
+    // Default spawn mock
+    mockSpawn.mockImplementation(() => createMockChildProcess(0) as never);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("should show security warning when GitHub URL used without --experimental-shared-compose flag", async () => {
+    await expect(async () => {
+      await composeCommand.parseAsync([
+        "node",
+        "cli",
+        "https://github.com/vm0-ai/vm0-cookbooks/tree/main/tutorials/101-intro",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Composing shared agents requires --experimental-shared-compose flag",
+      ),
+    );
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Composing agents from other users carries security risks.",
+      ),
+    );
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Only compose agents from users you trust."),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("should error when vm0.yaml not found in GitHub directory", async () => {
+    // Mock downloadGitHubDirectory to return an empty directory (no vm0.yaml)
+    const emptyDir = path.join(
+      tempDir,
+      "github-download",
+      "tutorials/101-intro",
+    );
+    mkdirSync(emptyDir, { recursive: true });
+    mockDownloadGitHubDirectory.mockResolvedValue(emptyDir);
+
+    await expect(async () => {
+      await composeCommand.parseAsync([
+        "node",
+        "cli",
+        "https://github.com/vm0-ai/vm0-cookbooks/tree/main/tutorials/101-intro",
+        "--experimental-shared-compose",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("vm0.yaml not found"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("should error when compose has volumes", async () => {
+    // Mock downloadGitHubDirectory to return a directory with vm0.yaml containing volumes
+    const cookbookDir = createMockCookbookDir(
+      path.join(tempDir, "github-download"),
+      "tutorials/104-intro-volume",
+      `version: "1.0"
+agents:
+  intro-volume:
+    framework: claude-code
+    volumes:
+      - claude-files:/home/user/.claude
+
+volumes:
+  claude-files:
+    name: claude-files
+    version: latest`,
+    );
+    mockDownloadGitHubDirectory.mockResolvedValue(cookbookDir);
+
+    await expect(async () => {
+      await composeCommand.parseAsync([
+        "node",
+        "cli",
+        "https://github.com/vm0-ai/vm0-cookbooks/tree/main/tutorials/104-intro-volume",
+        "--experimental-shared-compose",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Volumes are not supported for GitHub URL compose",
+      ),
+    );
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Clone the repository locally"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("should successfully compose from GitHub URL with flag", async () => {
+    // Mock downloadGitHubDirectory to return a valid cookbook
+    const cookbookDir = createMockCookbookDir(
+      path.join(tempDir, "github-download"),
+      "tutorials/101-intro",
+      `version: "1.0"
+agents:
+  intro:
+    framework: claude-code`,
+    );
+    mockDownloadGitHubDirectory.mockResolvedValue(cookbookDir);
+
+    server.use(
+      http.get("http://localhost:3000/api/agent/composes", () => {
+        return HttpResponse.json(
+          { error: { message: "Not found", code: "NOT_FOUND" } },
+          { status: 404 },
+        );
+      }),
+      http.post("http://localhost:3000/api/agent/composes", () => {
+        return HttpResponse.json({
+          composeId: "cmp-123",
+          name: "intro",
+          versionId: "a".repeat(64),
+          action: "created",
+        });
+      }),
+      http.get("http://localhost:3000/api/scope", () => {
+        return HttpResponse.json(scopeResponse);
+      }),
+    );
+
+    await composeCommand.parseAsync([
+      "node",
+      "cli",
+      "https://github.com/vm0-ai/vm0-cookbooks/tree/main/tutorials/101-intro",
+      "--experimental-shared-compose",
+    ]);
+
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect.stringContaining("Downloading from GitHub"),
+    );
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect.stringContaining("Compose created: user-abc12345/intro"),
+    );
+  });
+
+  it("should handle compose with instructions from GitHub URL", async () => {
+    // Create cookbook directory with instructions file
+    const cookbookDir = createMockCookbookDir(
+      path.join(tempDir, "github-download"),
+      "tutorials/101-intro",
+      `version: "1.0"
+agents:
+  intro:
+    framework: claude-code
+    instructions: AGENTS.md`,
+    );
+    writeFileSync(path.join(cookbookDir, "AGENTS.md"), "# Agent Instructions");
+    mockDownloadGitHubDirectory.mockResolvedValue(cookbookDir);
+
+    server.use(
+      http.post("http://localhost:3000/api/storages/prepare", () => {
+        return HttpResponse.json({
+          versionId: "a".repeat(64),
+          existing: true,
+        });
+      }),
+      http.post("http://localhost:3000/api/storages/commit", () => {
+        return HttpResponse.json({
+          success: true,
+          versionId: "a".repeat(64),
+          storageName: "test-storage",
+          size: 1000,
+          fileCount: 1,
+          deduplicated: true,
+        });
+      }),
+      http.get("http://localhost:3000/api/agent/composes", () => {
+        return HttpResponse.json(
+          { error: { message: "Not found", code: "NOT_FOUND" } },
+          { status: 404 },
+        );
+      }),
+      http.post("http://localhost:3000/api/agent/composes", () => {
+        return HttpResponse.json({
+          composeId: "cmp-123",
+          name: "intro",
+          versionId: "a".repeat(64),
+          action: "created",
+        });
+      }),
+      http.get("http://localhost:3000/api/scope", () => {
+        return HttpResponse.json(scopeResponse);
+      }),
+    );
+
+    await composeCommand.parseAsync([
+      "node",
+      "cli",
+      "https://github.com/vm0-ai/vm0-cookbooks/tree/main/tutorials/101-intro",
+      "--experimental-shared-compose",
+    ]);
+
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect.stringContaining("Uploading instructions"),
+    );
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect.stringContaining("Compose created"),
+    );
+  });
+
+  it("should cleanup temp directory after successful compose", async () => {
+    // Create a temp directory structure that matches what downloadGitHubDirectory returns
+    // The function returns: path.join(tempDir, parsed.path)
+    // So tempRoot = dirname(downloadedDir) would be the immediate parent
+    // For path "tutorials/101-intro", the returned path is tempDir/tutorials/101-intro
+    // And tempRoot = dirname(tempDir/tutorials/101-intro) = tempDir/tutorials
+    // But the cleanup uses dirname(downloadedDir) which should be the temp root
+
+    // Simulate the actual structure: vm0-github-xxx/tutorials/101-intro
+    const vm0TempRoot = mkdtempSync(path.join(tempDir, "vm0-github-"));
+    const cookbookDir = createMockCookbookDir(
+      vm0TempRoot,
+      "tutorials/101-intro",
+      `version: "1.0"
+agents:
+  intro:
+    framework: claude-code`,
+    );
+    mockDownloadGitHubDirectory.mockResolvedValue(cookbookDir);
+
+    server.use(
+      http.get("http://localhost:3000/api/agent/composes", () => {
+        return HttpResponse.json(
+          { error: { message: "Not found", code: "NOT_FOUND" } },
+          { status: 404 },
+        );
+      }),
+      http.post("http://localhost:3000/api/agent/composes", () => {
+        return HttpResponse.json({
+          composeId: "cmp-123",
+          name: "intro",
+          versionId: "a".repeat(64),
+          action: "created",
+        });
+      }),
+      http.get("http://localhost:3000/api/scope", () => {
+        return HttpResponse.json(scopeResponse);
+      }),
+    );
+
+    await composeCommand.parseAsync([
+      "node",
+      "cli",
+      "https://github.com/vm0-ai/vm0-cookbooks/tree/main/tutorials/101-intro",
+      "--experimental-shared-compose",
+    ]);
+
+    // The tempRoot (dirname of cookbookDir) should be cleaned up
+    // cookbookDir = vm0TempRoot/tutorials/101-intro
+    // dirname(cookbookDir) = vm0TempRoot/tutorials
+    // So tutorials dir gets removed, but vm0TempRoot may still exist
+    // Actually the cleanup code removes dirname(downloadedDir) which is vm0TempRoot/tutorials
+    expect(existsSync(path.dirname(cookbookDir))).toBe(false);
+  });
+
+  it("should detect GitHub tree URLs correctly", async () => {
+    // Non-GitHub URL should not trigger experimental flag check
+    await expect(async () => {
+      await composeCommand.parseAsync(["node", "cli", "vm0.yaml"]);
+    }).rejects.toThrow("process.exit called");
+
+    // Should show "not found" error, not the experimental flag error
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Config file not found"),
+    );
+    expect(mockConsoleError).not.toHaveBeenCalledWith(
+      expect.stringContaining("--experimental-shared-compose"),
+    );
   });
 });
 

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -1615,13 +1615,10 @@ describe("GitHub URL compose", () => {
 
   it("should error when vm0.yaml not found in GitHub directory", async () => {
     // Mock downloadGitHubDirectory to return an empty directory (no vm0.yaml)
-    const emptyDir = path.join(
-      tempDir,
-      "github-download",
-      "tutorials/101-intro",
-    );
+    const tempRoot = path.join(tempDir, "github-download");
+    const emptyDir = path.join(tempRoot, "tutorials/101-intro");
     mkdirSync(emptyDir, { recursive: true });
-    mockDownloadGitHubDirectory.mockResolvedValue(emptyDir);
+    mockDownloadGitHubDirectory.mockResolvedValue({ dir: emptyDir, tempRoot });
 
     await expect(async () => {
       await composeCommand.parseAsync([
@@ -1640,8 +1637,9 @@ describe("GitHub URL compose", () => {
 
   it("should error when compose has volumes", async () => {
     // Mock downloadGitHubDirectory to return a directory with vm0.yaml containing volumes
+    const tempRoot = path.join(tempDir, "github-download");
     const cookbookDir = createMockCookbookDir(
-      path.join(tempDir, "github-download"),
+      tempRoot,
       "tutorials/104-intro-volume",
       `version: "1.0"
 agents:
@@ -1655,7 +1653,10 @@ volumes:
     name: claude-files
     version: latest`,
     );
-    mockDownloadGitHubDirectory.mockResolvedValue(cookbookDir);
+    mockDownloadGitHubDirectory.mockResolvedValue({
+      dir: cookbookDir,
+      tempRoot,
+    });
 
     await expect(async () => {
       await composeCommand.parseAsync([
@@ -1679,15 +1680,19 @@ volumes:
 
   it("should successfully compose from GitHub URL with flag", async () => {
     // Mock downloadGitHubDirectory to return a valid cookbook
+    const tempRoot = path.join(tempDir, "github-download");
     const cookbookDir = createMockCookbookDir(
-      path.join(tempDir, "github-download"),
+      tempRoot,
       "tutorials/101-intro",
       `version: "1.0"
 agents:
   intro:
     framework: claude-code`,
     );
-    mockDownloadGitHubDirectory.mockResolvedValue(cookbookDir);
+    mockDownloadGitHubDirectory.mockResolvedValue({
+      dir: cookbookDir,
+      tempRoot,
+    });
 
     server.use(
       http.get("http://localhost:3000/api/agent/composes", () => {
@@ -1726,8 +1731,9 @@ agents:
 
   it("should handle compose with instructions from GitHub URL", async () => {
     // Create cookbook directory with instructions file
+    const tempRoot = path.join(tempDir, "github-download");
     const cookbookDir = createMockCookbookDir(
-      path.join(tempDir, "github-download"),
+      tempRoot,
       "tutorials/101-intro",
       `version: "1.0"
 agents:
@@ -1736,7 +1742,10 @@ agents:
     instructions: AGENTS.md`,
     );
     writeFileSync(path.join(cookbookDir, "AGENTS.md"), "# Agent Instructions");
-    mockDownloadGitHubDirectory.mockResolvedValue(cookbookDir);
+    mockDownloadGitHubDirectory.mockResolvedValue({
+      dir: cookbookDir,
+      tempRoot,
+    });
 
     server.use(
       http.post("http://localhost:3000/api/storages/prepare", () => {
@@ -1791,11 +1800,7 @@ agents:
 
   it("should cleanup temp directory after successful compose", async () => {
     // Create a temp directory structure that matches what downloadGitHubDirectory returns
-    // The function returns: path.join(tempDir, parsed.path)
-    // So tempRoot = dirname(downloadedDir) would be the immediate parent
-    // For path "tutorials/101-intro", the returned path is tempDir/tutorials/101-intro
-    // And tempRoot = dirname(tempDir/tutorials/101-intro) = tempDir/tutorials
-    // But the cleanup uses dirname(downloadedDir) which should be the temp root
+    // The function now returns { dir, tempRoot } so cleanup uses tempRoot directly
 
     // Simulate the actual structure: vm0-github-xxx/tutorials/101-intro
     const vm0TempRoot = mkdtempSync(path.join(tempDir, "vm0-github-"));
@@ -1807,7 +1812,10 @@ agents:
   intro:
     framework: claude-code`,
     );
-    mockDownloadGitHubDirectory.mockResolvedValue(cookbookDir);
+    mockDownloadGitHubDirectory.mockResolvedValue({
+      dir: cookbookDir,
+      tempRoot: vm0TempRoot,
+    });
 
     server.use(
       http.get("http://localhost:3000/api/agent/composes", () => {
@@ -1836,12 +1844,8 @@ agents:
       "--experimental-shared-compose",
     ]);
 
-    // The tempRoot (dirname of cookbookDir) should be cleaned up
-    // cookbookDir = vm0TempRoot/tutorials/101-intro
-    // dirname(cookbookDir) = vm0TempRoot/tutorials
-    // So tutorials dir gets removed, but vm0TempRoot may still exist
-    // Actually the cleanup code removes dirname(downloadedDir) which is vm0TempRoot/tutorials
-    expect(existsSync(path.dirname(cookbookDir))).toBe(false);
+    // The tempRoot should be fully cleaned up (including the .git folder)
+    expect(existsSync(vm0TempRoot)).toBe(false);
   });
 
   it("should detect GitHub tree URLs correctly", async () => {

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -1862,6 +1862,181 @@ agents:
       expect.stringContaining("--experimental-shared-compose"),
     );
   });
+
+  describe("existing agent overwrite confirmation", () => {
+    it("should prompt for confirmation when agent already exists (non-interactive without --yes)", async () => {
+      const tempRoot = path.join(tempDir, "github-download");
+      const cookbookDir = createMockCookbookDir(
+        tempRoot,
+        "tutorials/101-intro",
+        `version: "1.0"
+agents:
+  intro:
+    framework: claude-code`,
+      );
+      mockDownloadGitHubDirectory.mockResolvedValue({
+        dir: cookbookDir,
+        tempRoot,
+      });
+
+      // Mock existing compose
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json({
+            id: "existing-compose-id",
+            name: "intro",
+            headVersionId: "c".repeat(64),
+            content: {
+              version: "1.0",
+              agents: { intro: { framework: "claude-code" } },
+            },
+            createdAt: "2025-01-01T00:00:00Z",
+            updatedAt: "2025-01-01T00:00:00Z",
+          });
+        }),
+      );
+
+      // Non-interactive mode
+      vi.stubEnv("CI", "true");
+
+      await expect(async () => {
+        await composeCommand.parseAsync([
+          "node",
+          "cli",
+          "https://github.com/vm0-ai/vm0-cookbooks/tree/main/tutorials/101-intro",
+          "--experimental-shared-compose",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('An agent named "intro" already exists'),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Cannot overwrite existing agent in non-interactive mode",
+        ),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--yes"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should allow overwrite with --yes flag when agent exists (non-interactive)", async () => {
+      const tempRoot = path.join(tempDir, "github-download");
+      const cookbookDir = createMockCookbookDir(
+        tempRoot,
+        "tutorials/101-intro",
+        `version: "1.0"
+agents:
+  intro:
+    framework: claude-code`,
+      );
+      mockDownloadGitHubDirectory.mockResolvedValue({
+        dir: cookbookDir,
+        tempRoot,
+      });
+
+      // Mock existing compose for the name check
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json({
+            id: "existing-compose-id",
+            name: "intro",
+            headVersionId: "c".repeat(64),
+            content: {
+              version: "1.0",
+              agents: { intro: { framework: "claude-code" } },
+            },
+            createdAt: "2025-01-01T00:00:00Z",
+            updatedAt: "2025-01-01T00:00:00Z",
+          });
+        }),
+        http.post("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json({
+            composeId: "cmp-123",
+            name: "intro",
+            versionId: "a".repeat(64),
+            action: "existing",
+          });
+        }),
+        http.get("http://localhost:3000/api/scope", () => {
+          return HttpResponse.json(scopeResponse);
+        }),
+      );
+
+      // Non-interactive mode
+      vi.stubEnv("CI", "true");
+
+      await composeCommand.parseAsync([
+        "node",
+        "cli",
+        "https://github.com/vm0-ai/vm0-cookbooks/tree/main/tutorials/101-intro",
+        "--experimental-shared-compose",
+        "--yes",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('An agent named "intro" already exists'),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Compose version exists"),
+      );
+    });
+
+    it("should not prompt when agent does not exist", async () => {
+      const tempRoot = path.join(tempDir, "github-download");
+      const cookbookDir = createMockCookbookDir(
+        tempRoot,
+        "tutorials/101-intro",
+        `version: "1.0"
+agents:
+  new-agent:
+    framework: claude-code`,
+      );
+      mockDownloadGitHubDirectory.mockResolvedValue({
+        dir: cookbookDir,
+        tempRoot,
+      });
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
+        http.post("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json({
+            composeId: "cmp-123",
+            name: "new-agent",
+            versionId: "a".repeat(64),
+            action: "created",
+          });
+        }),
+        http.get("http://localhost:3000/api/scope", () => {
+          return HttpResponse.json(scopeResponse);
+        }),
+      );
+
+      await composeCommand.parseAsync([
+        "node",
+        "cli",
+        "https://github.com/vm0-ai/vm0-cookbooks/tree/main/tutorials/101-intro",
+        "--experimental-shared-compose",
+      ]);
+
+      // Should not show the "already exists" warning
+      const allLogs = mockConsoleLog.mock.calls
+        .map((call) => call[0])
+        .filter((log): log is string => typeof log === "string");
+      expect(allLogs.some((log) => log.includes("already exists"))).toBe(false);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("Compose created"),
+      );
+    });
+  });
 });
 
 describe("getSecretsFromComposeContent", () => {

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -335,6 +335,42 @@ async function handleGitHubCompose(
     const { config, agentName, agent, basePath } =
       await loadAndValidateConfig(configFile);
 
+    // Check if agent with same name already exists
+    const existingCompose = await getComposeByName(agentName);
+    if (existingCompose) {
+      console.log();
+      console.log(
+        chalk.yellow(`⚠ An agent named "${agentName}" already exists.`),
+      );
+
+      if (!isInteractive()) {
+        // Non-interactive mode: require --yes flag to overwrite
+        if (!options.yes) {
+          console.error(
+            chalk.red(
+              `✗ Cannot overwrite existing agent in non-interactive mode`,
+            ),
+          );
+          console.error(
+            chalk.dim(
+              `  Use --yes flag to confirm overwriting the existing agent.`,
+            ),
+          );
+          process.exit(1);
+        }
+      } else {
+        // Interactive mode: prompt user (default No)
+        const confirmed = await promptConfirm(
+          "Do you want to overwrite it?",
+          false,
+        );
+        if (!confirmed) {
+          console.log(chalk.yellow("Compose cancelled."));
+          process.exit(0);
+        }
+      }
+    }
+
     // Check for unsupported volumes
     const cfg = config as Record<string, unknown>;
     if (cfg.volumes && Object.keys(cfg.volumes as object).length > 0) {

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -1,8 +1,8 @@
 import { Command, Option } from "commander";
 import chalk from "chalk";
-import { readFile } from "fs/promises";
+import { readFile, rm } from "fs/promises";
 import { existsSync } from "fs";
-import { dirname } from "path";
+import { dirname, join } from "path";
 import { parse as parseYaml } from "yaml";
 import {
   getLegacySystemTemplateWarning,
@@ -15,6 +15,7 @@ import {
   getScope,
 } from "../../lib/api";
 import { validateAgentCompose } from "../../lib/domain/yaml-validator";
+import { downloadGitHubDirectory } from "../../lib/domain/github-skills";
 import {
   uploadInstructions,
   uploadSkill,
@@ -26,6 +27,13 @@ import { silentUpgradeAfterCommand } from "../../lib/utils/update-checker";
 declare const __CLI_VERSION__: string;
 
 const DEFAULT_CONFIG_FILE = "vm0.yaml";
+
+/**
+ * Check if input is a GitHub tree URL
+ */
+function isGitHubTreeUrl(input: string): boolean {
+  return input.startsWith("https://github.com/") && input.includes("/tree/");
+}
 
 /**
  * Extract secret names from compose content using variable references.
@@ -304,76 +312,208 @@ function mergeSkillVariables(
   }
 }
 
+/**
+ * Handle compose from GitHub URL
+ */
+async function handleGitHubCompose(
+  url: string,
+  options: { yes?: boolean; autoUpdate?: boolean },
+): Promise<void> {
+  console.log(`Downloading from GitHub: ${url}`);
+
+  const downloadedDir = await downloadGitHubDirectory(url);
+  const tempRoot = dirname(downloadedDir);
+  const configFile = join(downloadedDir, "vm0.yaml");
+
+  try {
+    if (!existsSync(configFile)) {
+      console.error(chalk.red(`✗ vm0.yaml not found in the GitHub directory`));
+      console.error(chalk.dim(`  URL: ${url}`));
+      process.exit(1);
+    }
+
+    // Load and validate config
+    const { config, agentName, agent, basePath } =
+      await loadAndValidateConfig(configFile);
+
+    // Check for unsupported volumes
+    const cfg = config as Record<string, unknown>;
+    if (cfg.volumes && Object.keys(cfg.volumes as object).length > 0) {
+      console.error(
+        chalk.red(`✗ Volumes are not supported for GitHub URL compose`),
+      );
+      console.error(
+        chalk.dim(
+          `  Clone the repository locally and run: vm0 compose ./path/to/vm0.yaml`,
+        ),
+      );
+      process.exit(1);
+    }
+
+    // Check for legacy image format
+    checkLegacyImageFormat(config);
+
+    // Upload instructions and skills
+    const skillResults = await uploadAssets(agentName, agent, basePath);
+
+    // Collect and process skill variables
+    const environment = agent.environment || {};
+    const variables = await collectSkillVariables(
+      skillResults,
+      environment,
+      agentName,
+    );
+
+    // Display variables and confirm with user
+    const confirmed = await displayAndConfirmVariables(variables, options);
+    if (!confirmed) {
+      process.exit(0);
+    }
+
+    // Merge skill variables into environment
+    mergeSkillVariables(agent, variables);
+
+    // Call API
+    console.log("Uploading compose...");
+    const response = await createOrUpdateCompose({ content: config });
+
+    // Display result
+    const scopeResponse = await getScope();
+    const shortVersionId = response.versionId.slice(0, 8);
+    const displayName = `${scopeResponse.slug}/${response.name}`;
+
+    if (response.action === "created") {
+      console.log(chalk.green(`✓ Compose created: ${displayName}`));
+    } else {
+      console.log(chalk.green(`✓ Compose version exists: ${displayName}`));
+    }
+
+    console.log(chalk.dim(`  Version: ${shortVersionId}`));
+    console.log();
+    console.log("  Run your agent:");
+    console.log(
+      chalk.cyan(
+        `    vm0 run ${displayName}:${shortVersionId} --artifact-name <artifact> "your prompt"`,
+      ),
+    );
+
+    // Silent upgrade after successful command completion
+    if (options.autoUpdate !== false) {
+      await silentUpgradeAfterCommand(__CLI_VERSION__);
+    }
+  } finally {
+    // Cleanup temp directory
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
 export const composeCommand = new Command()
   .name("compose")
   .description("Create or update agent compose (e.g., vm0.yaml)")
   .argument(
     "[agent-yaml]",
-    `Path to agent YAML file (default: ${DEFAULT_CONFIG_FILE})`,
+    `Path to agent YAML file or GitHub tree URL (default: ${DEFAULT_CONFIG_FILE})`,
   )
   .option("-y, --yes", "Skip confirmation prompts for skill requirements")
+  .option(
+    "--experimental-shared-compose",
+    "Enable GitHub URL compose (experimental)",
+  )
   .addOption(new Option("--no-auto-update").hideHelp())
   .action(
     async (
       configFile: string | undefined,
-      options: { yes?: boolean; autoUpdate?: boolean },
+      options: {
+        yes?: boolean;
+        autoUpdate?: boolean;
+        experimentalSharedCompose?: boolean;
+      },
     ) => {
       const resolvedConfigFile = configFile ?? DEFAULT_CONFIG_FILE;
       try {
-        // 1. Load and validate config
-        const { config, agentName, agent, basePath } =
-          await loadAndValidateConfig(resolvedConfigFile);
-
-        // 2. Check for legacy image format
-        checkLegacyImageFormat(config);
-
-        // 3. Upload instructions and skills
-        const skillResults = await uploadAssets(agentName, agent, basePath);
-
-        // 4. Collect and process skill variables
-        const environment = agent.environment || {};
-        const variables = await collectSkillVariables(
-          skillResults,
-          environment,
-          agentName,
-        );
-
-        // 5. Display variables and confirm with user
-        const confirmed = await displayAndConfirmVariables(variables, options);
-        if (!confirmed) {
-          process.exit(0);
-        }
-
-        // 6. Merge skill variables into environment
-        mergeSkillVariables(agent, variables);
-
-        // 7. Call API
-        console.log("Uploading compose...");
-        const response = await createOrUpdateCompose({ content: config });
-
-        // 8. Display result
-        const scopeResponse = await getScope();
-        const shortVersionId = response.versionId.slice(0, 8);
-        const displayName = `${scopeResponse.slug}/${response.name}`;
-
-        if (response.action === "created") {
-          console.log(chalk.green(`✓ Compose created: ${displayName}`));
+        // Branch based on input type
+        if (isGitHubTreeUrl(resolvedConfigFile)) {
+          // Require experimental flag for GitHub URLs
+          if (!options.experimentalSharedCompose) {
+            console.error(
+              chalk.red(
+                "✗ Composing shared agents requires --experimental-shared-compose flag",
+              ),
+            );
+            console.error();
+            console.error(
+              chalk.dim(
+                "  Composing agents from other users carries security risks.",
+              ),
+            );
+            console.error(
+              chalk.dim("  Only compose agents from users you trust."),
+            );
+            process.exit(1);
+          }
+          await handleGitHubCompose(resolvedConfigFile, options);
         } else {
-          console.log(chalk.green(`✓ Compose version exists: ${displayName}`));
-        }
+          // Existing local file flow
+          // 1. Load and validate config
+          const { config, agentName, agent, basePath } =
+            await loadAndValidateConfig(resolvedConfigFile);
 
-        console.log(chalk.dim(`  Version: ${shortVersionId}`));
-        console.log();
-        console.log("  Run your agent:");
-        console.log(
-          chalk.cyan(
-            `    vm0 run ${displayName}:${shortVersionId} --artifact-name <artifact> "your prompt"`,
-          ),
-        );
+          // 2. Check for legacy image format
+          checkLegacyImageFormat(config);
 
-        // Silent upgrade after successful command completion
-        if (options.autoUpdate !== false) {
-          await silentUpgradeAfterCommand(__CLI_VERSION__);
+          // 3. Upload instructions and skills
+          const skillResults = await uploadAssets(agentName, agent, basePath);
+
+          // 4. Collect and process skill variables
+          const environment = agent.environment || {};
+          const variables = await collectSkillVariables(
+            skillResults,
+            environment,
+            agentName,
+          );
+
+          // 5. Display variables and confirm with user
+          const confirmed = await displayAndConfirmVariables(
+            variables,
+            options,
+          );
+          if (!confirmed) {
+            process.exit(0);
+          }
+
+          // 6. Merge skill variables into environment
+          mergeSkillVariables(agent, variables);
+
+          // 7. Call API
+          console.log("Uploading compose...");
+          const response = await createOrUpdateCompose({ content: config });
+
+          // 8. Display result
+          const scopeResponse = await getScope();
+          const shortVersionId = response.versionId.slice(0, 8);
+          const displayName = `${scopeResponse.slug}/${response.name}`;
+
+          if (response.action === "created") {
+            console.log(chalk.green(`✓ Compose created: ${displayName}`));
+          } else {
+            console.log(
+              chalk.green(`✓ Compose version exists: ${displayName}`),
+            );
+          }
+
+          console.log(chalk.dim(`  Version: ${shortVersionId}`));
+          console.log();
+          console.log("  Run your agent:");
+          console.log(
+            chalk.cyan(
+              `    vm0 run ${displayName}:${shortVersionId} --artifact-name <artifact> "your prompt"`,
+            ),
+          );
+
+          // Silent upgrade after successful command completion
+          if (options.autoUpdate !== false) {
+            await silentUpgradeAfterCommand(__CLI_VERSION__);
+          }
         }
       } catch (error) {
         if (error instanceof Error) {

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -321,8 +321,7 @@ async function handleGitHubCompose(
 ): Promise<void> {
   console.log(`Downloading from GitHub: ${url}`);
 
-  const downloadedDir = await downloadGitHubDirectory(url);
-  const tempRoot = dirname(downloadedDir);
+  const { dir: downloadedDir, tempRoot } = await downloadGitHubDirectory(url);
   const configFile = join(downloadedDir, "vm0.yaml");
 
   try {

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -100,6 +100,22 @@ async function loadAndValidateConfig(
 }
 
 /**
+ * Type guard to check if config has a non-empty volumes field.
+ */
+function hasVolumes(config: unknown): boolean {
+  if (typeof config !== "object" || config === null) {
+    return false;
+  }
+  const cfg = config as Record<string, unknown>;
+  const volumes = cfg.volumes;
+  return (
+    typeof volumes === "object" &&
+    volumes !== null &&
+    Object.keys(volumes).length > 0
+  );
+}
+
+/**
  * Check for legacy image format and show deprecation warnings.
  */
 function checkLegacyImageFormat(config: unknown): void {
@@ -313,6 +329,55 @@ function mergeSkillVariables(
 }
 
 /**
+ * Finalize compose: confirm variables, merge into config, call API, and display result.
+ * Shared by both GitHub URL and local file flows.
+ */
+async function finalizeCompose(
+  config: unknown,
+  agent: AgentConfig,
+  variables: SkillVariables,
+  options: { yes?: boolean; autoUpdate?: boolean },
+): Promise<void> {
+  // Display variables and confirm with user
+  const confirmed = await displayAndConfirmVariables(variables, options);
+  if (!confirmed) {
+    process.exit(0);
+  }
+
+  // Merge skill variables into environment
+  mergeSkillVariables(agent, variables);
+
+  // Call API
+  console.log("Uploading compose...");
+  const response = await createOrUpdateCompose({ content: config });
+
+  // Display result
+  const scopeResponse = await getScope();
+  const shortVersionId = response.versionId.slice(0, 8);
+  const displayName = `${scopeResponse.slug}/${response.name}`;
+
+  if (response.action === "created") {
+    console.log(chalk.green(`✓ Compose created: ${displayName}`));
+  } else {
+    console.log(chalk.green(`✓ Compose version exists: ${displayName}`));
+  }
+
+  console.log(chalk.dim(`  Version: ${shortVersionId}`));
+  console.log();
+  console.log("  Run your agent:");
+  console.log(
+    chalk.cyan(
+      `    vm0 run ${displayName}:${shortVersionId} --artifact-name <artifact> "your prompt"`,
+    ),
+  );
+
+  // Silent upgrade after successful command completion
+  if (options.autoUpdate !== false) {
+    await silentUpgradeAfterCommand(__CLI_VERSION__);
+  }
+}
+
+/**
  * Handle compose from GitHub URL
  */
 async function handleGitHubCompose(
@@ -372,8 +437,7 @@ async function handleGitHubCompose(
     }
 
     // Check for unsupported volumes
-    const cfg = config as Record<string, unknown>;
-    if (cfg.volumes && Object.keys(cfg.volumes as object).length > 0) {
+    if (hasVolumes(config)) {
       console.error(
         chalk.red(`✗ Volumes are not supported for GitHub URL compose`),
       );
@@ -399,43 +463,8 @@ async function handleGitHubCompose(
       agentName,
     );
 
-    // Display variables and confirm with user
-    const confirmed = await displayAndConfirmVariables(variables, options);
-    if (!confirmed) {
-      process.exit(0);
-    }
-
-    // Merge skill variables into environment
-    mergeSkillVariables(agent, variables);
-
-    // Call API
-    console.log("Uploading compose...");
-    const response = await createOrUpdateCompose({ content: config });
-
-    // Display result
-    const scopeResponse = await getScope();
-    const shortVersionId = response.versionId.slice(0, 8);
-    const displayName = `${scopeResponse.slug}/${response.name}`;
-
-    if (response.action === "created") {
-      console.log(chalk.green(`✓ Compose created: ${displayName}`));
-    } else {
-      console.log(chalk.green(`✓ Compose version exists: ${displayName}`));
-    }
-
-    console.log(chalk.dim(`  Version: ${shortVersionId}`));
-    console.log();
-    console.log("  Run your agent:");
-    console.log(
-      chalk.cyan(
-        `    vm0 run ${displayName}:${shortVersionId} --artifact-name <artifact> "your prompt"`,
-      ),
-    );
-
-    // Silent upgrade after successful command completion
-    if (options.autoUpdate !== false) {
-      await silentUpgradeAfterCommand(__CLI_VERSION__);
-    }
+    // Finalize compose (confirm, merge, upload, display)
+    await finalizeCompose(config, agent, variables, options);
   } finally {
     // Cleanup temp directory
     await rm(tempRoot, { recursive: true, force: true });
@@ -507,48 +536,8 @@ export const composeCommand = new Command()
             agentName,
           );
 
-          // 5. Display variables and confirm with user
-          const confirmed = await displayAndConfirmVariables(
-            variables,
-            options,
-          );
-          if (!confirmed) {
-            process.exit(0);
-          }
-
-          // 6. Merge skill variables into environment
-          mergeSkillVariables(agent, variables);
-
-          // 7. Call API
-          console.log("Uploading compose...");
-          const response = await createOrUpdateCompose({ content: config });
-
-          // 8. Display result
-          const scopeResponse = await getScope();
-          const shortVersionId = response.versionId.slice(0, 8);
-          const displayName = `${scopeResponse.slug}/${response.name}`;
-
-          if (response.action === "created") {
-            console.log(chalk.green(`✓ Compose created: ${displayName}`));
-          } else {
-            console.log(
-              chalk.green(`✓ Compose version exists: ${displayName}`),
-            );
-          }
-
-          console.log(chalk.dim(`  Version: ${shortVersionId}`));
-          console.log();
-          console.log("  Run your agent:");
-          console.log(
-            chalk.cyan(
-              `    vm0 run ${displayName}:${shortVersionId} --artifact-name <artifact> "your prompt"`,
-            ),
-          );
-
-          // Silent upgrade after successful command completion
-          if (options.autoUpdate !== false) {
-            await silentUpgradeAfterCommand(__CLI_VERSION__);
-          }
+          // 5. Finalize compose (confirm, merge, upload, display)
+          await finalizeCompose(config, agent, variables, options);
         }
       } catch (error) {
         if (error instanceof Error) {

--- a/turbo/apps/cli/src/lib/domain/github-skills.ts
+++ b/turbo/apps/cli/src/lib/domain/github-skills.ts
@@ -97,14 +97,25 @@ export async function downloadGitHubSkill(
 }
 
 /**
+ * Result of downloading a GitHub directory
+ */
+interface GitHubDownloadResult {
+  /** Path to the downloaded directory */
+  dir: string;
+  /** Path to the temp root directory (for cleanup) */
+  tempRoot: string;
+}
+
+/**
  * Download a GitHub directory using git sparse-checkout.
- * Returns the path to the downloaded directory. Caller is responsible for
- * cleaning up the parent temp directory.
+ * Returns paths to both the downloaded directory and the temp root for cleanup.
  *
  * @param url - GitHub tree URL
- * @returns Path to downloaded directory (caller must cleanup parent)
+ * @returns Object with dir (downloaded path) and tempRoot (for cleanup)
  */
-export async function downloadGitHubDirectory(url: string): Promise<string> {
+export async function downloadGitHubDirectory(
+  url: string,
+): Promise<GitHubDownloadResult> {
   const parsed = parseGitHubTreeUrl(url);
   const repoUrl = `https://github.com/${parsed.owner}/${parsed.repo}.git`;
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vm0-github-"));
@@ -151,7 +162,10 @@ export async function downloadGitHubDirectory(url: string): Promise<string> {
 
     await execAsync(`git checkout "${parsed.branch}"`, { cwd: tempDir });
 
-    return path.join(tempDir, parsed.path);
+    return {
+      dir: path.join(tempDir, parsed.path),
+      tempRoot: tempDir,
+    };
   } catch (error) {
     // Clean up on error
     await fs.rm(tempDir, { recursive: true, force: true });

--- a/turbo/apps/cli/src/lib/domain/github-skills.ts
+++ b/turbo/apps/cli/src/lib/domain/github-skills.ts
@@ -97,6 +97,69 @@ export async function downloadGitHubSkill(
 }
 
 /**
+ * Download a GitHub directory using git sparse-checkout.
+ * Returns the path to the downloaded directory. Caller is responsible for
+ * cleaning up the parent temp directory.
+ *
+ * @param url - GitHub tree URL
+ * @returns Path to downloaded directory (caller must cleanup parent)
+ */
+export async function downloadGitHubDirectory(url: string): Promise<string> {
+  const parsed = parseGitHubTreeUrl(url);
+  const repoUrl = `https://github.com/${parsed.owner}/${parsed.repo}.git`;
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vm0-github-"));
+
+  try {
+    // Check git is available
+    try {
+      await execAsync("git --version");
+    } catch {
+      throw new Error(
+        "git command not found. Please install git to use GitHub URLs.",
+      );
+    }
+
+    // Initialize sparse checkout
+    await execAsync(`git init`, { cwd: tempDir });
+    await execAsync(`git remote add origin "${repoUrl}"`, { cwd: tempDir });
+    await execAsync(`git config core.sparseCheckout true`, { cwd: tempDir });
+
+    // Configure sparse checkout to only fetch the target path
+    const sparseFile = path.join(tempDir, ".git", "info", "sparse-checkout");
+    await fs.writeFile(sparseFile, parsed.path + "\n");
+
+    // Fetch only the required branch with better error handling
+    try {
+      await execAsync(`git fetch --depth 1 origin "${parsed.branch}"`, {
+        cwd: tempDir,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        message.includes("Authentication failed") ||
+        message.includes("could not read Username")
+      ) {
+        throw new Error(`Cannot access repository. Is it private? URL: ${url}`);
+      }
+      if (message.includes("couldn't find remote ref")) {
+        throw new Error(
+          `Branch "${parsed.branch}" not found in repository: ${url}`,
+        );
+      }
+      throw error;
+    }
+
+    await execAsync(`git checkout "${parsed.branch}"`, { cwd: tempDir });
+
+    return path.join(tempDir, parsed.path);
+  } catch (error) {
+    // Clean up on error
+    await fs.rm(tempDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+/**
  * Validate that a downloaded skill has the required SKILL.md file
  *
  * @param skillDir - Path to the downloaded skill directory


### PR DESCRIPTION
## Summary

Enable `vm0 compose` to accept a GitHub tree URL directly, using git sparse-checkout to download the cookbook directory.

**Example usage:**
```bash
vm0 compose https://github.com/vm0-ai/vm0-cookbooks/tree/main/tutorials/101-intro --experimental-shared-compose
```

**Changes:**
- Add `--experimental-shared-compose` flag for security gating
- Add `isGitHubTreeUrl()` helper for URL detection  
- Add `downloadGitHubDirectory()` in github-skills.ts for generic directory download
- Add `handleGitHubCompose()` handler with volume restriction
- Add integration tests for GitHub URL compose scenarios

## Security

The `--experimental-shared-compose` flag is required when composing from GitHub URLs. Without the flag, users see a security warning:

```
✗ Composing shared agents requires --experimental-shared-compose flag

  Composing agents from other users carries security risks.
  Only compose agents from users you trust.
```

## Limitations

- **Volumes not supported** - Shows error and suggests cloning the repo locally
- **Private repos not supported** - Will show authentication error from git

## Test plan

- [x] Integration tests for GitHub URL detection
- [x] Integration tests for security warning without flag
- [x] Integration tests for vm0.yaml not found error
- [x] Integration tests for volumes restriction error
- [x] Integration tests for successful compose with flag
- [x] Integration tests for compose with instructions
- [x] Integration tests for temp directory cleanup
- [ ] Manual E2E test with real cookbook

Closes #2282

🤖 Generated with [Claude Code](https://claude.com/claude-code)