### PR TITLE
fix(slack): download and upload images to R2 for Claude Code access

### DIFF
--- a/turbo/apps/web/app/api/slack/oauth/install/route.ts
+++ b/turbo/apps/web/app/api/slack/oauth/install/route.ts
@@ -24,6 +24,7 @@ const BOT_SCOPES = [
   "commands", // Handle slash commands
   "users:read", // Get user info
   "reactions:write", // Add reactions to messages (for thinking indicator)
+  "files:read", // Download files shared in messages (images, etc.)
 ].join(",");
 
 export async function GET(request: Request) {

--- a/turbo/apps/web/src/lib/s3/s3-client.ts
+++ b/turbo/apps/web/src/lib/s3/s3-client.ts
@@ -82,11 +82,13 @@ export async function listS3Objects(
  * @param bucket - S3 bucket name
  * @param key - S3 object key
  * @param data - Buffer data to upload
+ * @param contentType - Optional MIME type for the file
  */
 export async function uploadS3Buffer(
   bucket: string,
   key: string,
   data: Buffer,
+  contentType?: string,
 ): Promise<void> {
   const client = getS3Client();
 
@@ -95,6 +97,7 @@ export async function uploadS3Buffer(
       Bucket: bucket,
       Key: key,
       Body: data,
+      ...(contentType && { ContentType: contentType }),
     });
 
     await client.send(command);

--- a/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
@@ -422,6 +422,13 @@ describe("Feature: Format Context With Image Upload", () => {
         },
       );
       expect(uploadS3BufferMock).toHaveBeenCalled();
+      // Verify contentType is passed when uploading
+      expect(uploadS3BufferMock).toHaveBeenCalledWith(
+        "test-bucket",
+        expect.stringContaining("slack-images/test-session-123/"),
+        expect.any(Buffer),
+        "image/png",
+      );
       expect(generatePresignedUrlMock).toHaveBeenCalled();
       expect(result).toContain("[file]: screenshot.png (image/png)");
       expect(result).toContain("Dimensions: 1920x1080");
@@ -461,6 +468,13 @@ describe("Feature: Format Context With Image Upload", () => {
 
       expect(result).toContain(
         "Image URL: https://r2.example.com/presigned-url",
+      );
+      // Verify contentType is passed for JPEG
+      expect(uploadS3BufferMock).toHaveBeenCalledWith(
+        "test-bucket",
+        expect.stringContaining("slack-images/test-session-123/"),
+        expect.any(Buffer),
+        "image/jpeg",
       );
     });
   });

--- a/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   formatContextForAgent,
+  formatContextForAgentWithImages,
   extractMessageContent,
   parseExplicitAgentSelection,
 } from "../context";
@@ -323,6 +324,296 @@ describe("Feature: Extract Message Content", () => {
       const result = extractMessageContent(text, botUserId);
 
       expect(result).toBe("hello");
+    });
+  });
+});
+
+describe("Feature: Format Context With Image Embedding", () => {
+  const mockFetch = vi.fn();
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = mockFetch;
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("Scenario: Embed supported image types as base64", () => {
+    it("should download and embed PNG image as base64 data URL", async () => {
+      const imageBuffer = Buffer.from("fake-png-image-content");
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => imageBuffer,
+      });
+
+      const messages = [
+        {
+          user: "U123",
+          text: "Check this screenshot",
+          files: [
+            {
+              id: "F123",
+              name: "screenshot.png",
+              mimetype: "image/png",
+              original_w: "1920",
+              original_h: "1080",
+              url_private_download:
+                "https://files.slack.com/files-pri/T123-F123/download/screenshot.png",
+            },
+          ],
+        },
+      ];
+
+      const result = await formatContextForAgentWithImages(
+        messages,
+        "xoxb-test-token",
+        "BBOT123",
+        "thread",
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://files.slack.com/files-pri/T123-F123/download/screenshot.png",
+        {
+          headers: {
+            Authorization: "Bearer xoxb-test-token",
+          },
+        },
+      );
+      expect(result).toContain("[file]: screenshot.png (image/png)");
+      expect(result).toContain("Dimensions: 1920x1080");
+      expect(result).toContain("Image Data: data:image/png;base64,");
+      expect(result).not.toContain("URL:");
+    });
+
+    it("should embed JPEG images", async () => {
+      const imageBuffer = Buffer.from("fake-jpeg-image-content");
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => imageBuffer,
+      });
+
+      const messages = [
+        {
+          user: "U123",
+          text: "Photo",
+          files: [
+            {
+              id: "F456",
+              name: "photo.jpg",
+              mimetype: "image/jpeg",
+              url_private_download:
+                "https://files.slack.com/download/photo.jpg",
+            },
+          ],
+        },
+      ];
+
+      const result = await formatContextForAgentWithImages(
+        messages,
+        "xoxb-test-token",
+      );
+
+      expect(result).toContain("Image Data: data:image/jpeg;base64,");
+    });
+  });
+
+  describe("Scenario: Fall back to URL for unsupported types", () => {
+    it("should not embed PDF files, use URL fallback", async () => {
+      const messages = [
+        {
+          user: "U123",
+          text: "Document",
+          files: [
+            {
+              name: "report.pdf",
+              mimetype: "application/pdf",
+              url_private_download:
+                "https://files.slack.com/download/report.pdf",
+              permalink: "https://slack.com/files/report.pdf",
+            },
+          ],
+        },
+      ];
+
+      const result = await formatContextForAgentWithImages(
+        messages,
+        "xoxb-test-token",
+      );
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result).toContain("[file]: report.pdf (application/pdf)");
+      expect(result).toContain("URL: https://slack.com/files/report.pdf");
+      expect(result).not.toContain("Image Data:");
+    });
+  });
+
+  describe("Scenario: Handle download failures gracefully", () => {
+    it("should fall back to URL when download fails", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+      });
+
+      const messages = [
+        {
+          user: "U123",
+          text: "Screenshot",
+          files: [
+            {
+              id: "F123",
+              name: "screenshot.png",
+              mimetype: "image/png",
+              url_private_download:
+                "https://files.slack.com/download/screenshot.png",
+              permalink: "https://slack.com/files/screenshot.png",
+            },
+          ],
+        },
+      ];
+
+      const result = await formatContextForAgentWithImages(
+        messages,
+        "xoxb-test-token",
+      );
+
+      expect(result).toContain("URL: https://slack.com/files/screenshot.png");
+      expect(result).not.toContain("Image Data:");
+    });
+
+    it("should fall back to URL when fetch throws", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      const messages = [
+        {
+          user: "U123",
+          text: "Screenshot",
+          files: [
+            {
+              name: "screenshot.png",
+              mimetype: "image/png",
+              url_private_download:
+                "https://files.slack.com/download/screenshot.png",
+              thumb_480: "https://files.slack.com/thumb/screenshot.png",
+            },
+          ],
+        },
+      ];
+
+      const result = await formatContextForAgentWithImages(
+        messages,
+        "xoxb-test-token",
+      );
+
+      expect(result).toContain(
+        "URL: https://files.slack.com/thumb/screenshot.png",
+      );
+      expect(result).not.toContain("Image Data:");
+    });
+  });
+
+  describe("Scenario: Respect file size limits", () => {
+    it("should not embed files larger than 5MB", async () => {
+      const messages = [
+        {
+          user: "U123",
+          text: "Large image",
+          files: [
+            {
+              name: "large.png",
+              mimetype: "image/png",
+              size: 10 * 1024 * 1024, // 10MB
+              url_private_download:
+                "https://files.slack.com/download/large.png",
+              permalink: "https://slack.com/files/large.png",
+            },
+          ],
+        },
+      ];
+
+      const result = await formatContextForAgentWithImages(
+        messages,
+        "xoxb-test-token",
+      );
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result).toContain("URL: https://slack.com/files/large.png");
+      expect(result).not.toContain("Image Data:");
+    });
+  });
+
+  describe("Scenario: Handle files without url_private_download", () => {
+    it("should use URL fallback when no download URL available", async () => {
+      const messages = [
+        {
+          user: "U123",
+          text: "Old image",
+          files: [
+            {
+              name: "old.png",
+              mimetype: "image/png",
+              permalink_public: "https://files.slack.com/public/old.png",
+            },
+          ],
+        },
+      ];
+
+      const result = await formatContextForAgentWithImages(
+        messages,
+        "xoxb-test-token",
+      );
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result).toContain("URL: https://files.slack.com/public/old.png");
+    });
+  });
+
+  describe("Scenario: Handle multiple files in one message", () => {
+    it("should embed multiple images concurrently", async () => {
+      const imageBuffer1 = Buffer.from("image1");
+      const imageBuffer2 = Buffer.from("image2");
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          arrayBuffer: async () => imageBuffer1,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          arrayBuffer: async () => imageBuffer2,
+        });
+
+      const messages = [
+        {
+          user: "U123",
+          text: "Two images",
+          files: [
+            {
+              name: "img1.png",
+              mimetype: "image/png",
+              url_private_download: "https://files.slack.com/download/img1.png",
+            },
+            {
+              name: "img2.png",
+              mimetype: "image/png",
+              url_private_download: "https://files.slack.com/download/img2.png",
+            },
+          ],
+        },
+      ];
+
+      const result = await formatContextForAgentWithImages(
+        messages,
+        "xoxb-test-token",
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result).toContain("[file]: img1.png");
+      expect(result).toContain("[file]: img2.png");
+      // Both should have embedded data
+      expect((result.match(/Image Data:/g) || []).length).toBe(2);
     });
   });
 });

--- a/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
@@ -1,10 +1,33 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "vitest";
 import {
   formatContextForAgent,
   formatContextForAgentWithImages,
   extractMessageContent,
   parseExplicitAgentSelection,
 } from "../context";
+
+// Mock S3 client
+vi.mock("../../s3/s3-client", () => ({
+  uploadS3Buffer: vi.fn().mockResolvedValue(undefined),
+  generatePresignedUrl: vi
+    .fn()
+    .mockResolvedValue("https://r2.example.com/presigned-url"),
+}));
+
+// Mock env
+vi.mock("../../../env", () => ({
+  env: () => ({
+    R2_USER_STORAGES_BUCKET_NAME: "test-bucket",
+  }),
+}));
 
 describe("Feature: Format Context For Agent", () => {
   describe("Scenario: Format thread messages into context string", () => {
@@ -328,21 +351,36 @@ describe("Feature: Extract Message Content", () => {
   });
 });
 
-describe("Feature: Format Context With Image Embedding", () => {
+describe("Feature: Format Context With Image Upload", () => {
   const mockFetch = vi.fn();
   const originalFetch = global.fetch;
 
-  beforeEach(() => {
+  // Import mocked S3 functions
+  let uploadS3BufferMock: Mock;
+  let generatePresignedUrlMock: Mock;
+
+  beforeEach(async () => {
     global.fetch = mockFetch;
     mockFetch.mockReset();
+
+    // Get mocked S3 functions
+    const s3Client = await import("../../s3/s3-client");
+    uploadS3BufferMock = s3Client.uploadS3Buffer as Mock;
+    generatePresignedUrlMock = s3Client.generatePresignedUrl as Mock;
+
+    uploadS3BufferMock.mockReset();
+    generatePresignedUrlMock.mockReset();
+    generatePresignedUrlMock.mockResolvedValue(
+      "https://r2.example.com/presigned-url",
+    );
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
   });
 
-  describe("Scenario: Embed supported image types as base64", () => {
-    it("should download and embed PNG image as base64 data URL", async () => {
+  describe("Scenario: Upload supported image types to R2", () => {
+    it("should download PNG image and upload to R2 with presigned URL", async () => {
       const imageBuffer = Buffer.from("fake-png-image-content");
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -370,6 +408,7 @@ describe("Feature: Format Context With Image Embedding", () => {
       const result = await formatContextForAgentWithImages(
         messages,
         "xoxb-test-token",
+        "test-session-123",
         "BBOT123",
         "thread",
       );
@@ -382,13 +421,16 @@ describe("Feature: Format Context With Image Embedding", () => {
           },
         },
       );
+      expect(uploadS3BufferMock).toHaveBeenCalled();
+      expect(generatePresignedUrlMock).toHaveBeenCalled();
       expect(result).toContain("[file]: screenshot.png (image/png)");
       expect(result).toContain("Dimensions: 1920x1080");
-      expect(result).toContain("Image Data: data:image/png;base64,");
-      expect(result).not.toContain("URL:");
+      expect(result).toContain(
+        "Image URL: https://r2.example.com/presigned-url",
+      );
     });
 
-    it("should embed JPEG images", async () => {
+    it("should upload JPEG images to R2", async () => {
       const imageBuffer = Buffer.from("fake-jpeg-image-content");
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -414,14 +456,17 @@ describe("Feature: Format Context With Image Embedding", () => {
       const result = await formatContextForAgentWithImages(
         messages,
         "xoxb-test-token",
+        "test-session-123",
       );
 
-      expect(result).toContain("Image Data: data:image/jpeg;base64,");
+      expect(result).toContain(
+        "Image URL: https://r2.example.com/presigned-url",
+      );
     });
   });
 
   describe("Scenario: Fall back to URL for unsupported types", () => {
-    it("should not embed PDF files, use URL fallback", async () => {
+    it("should not upload PDF files, use URL fallback", async () => {
       const messages = [
         {
           user: "U123",
@@ -441,12 +486,14 @@ describe("Feature: Format Context With Image Embedding", () => {
       const result = await formatContextForAgentWithImages(
         messages,
         "xoxb-test-token",
+        "test-session-123",
       );
 
       expect(mockFetch).not.toHaveBeenCalled();
+      expect(uploadS3BufferMock).not.toHaveBeenCalled();
       expect(result).toContain("[file]: report.pdf (application/pdf)");
       expect(result).toContain("URL: https://slack.com/files/report.pdf");
-      expect(result).not.toContain("Image Data:");
+      expect(result).not.toContain("Image URL:");
     });
   });
 
@@ -477,10 +524,11 @@ describe("Feature: Format Context With Image Embedding", () => {
       const result = await formatContextForAgentWithImages(
         messages,
         "xoxb-test-token",
+        "test-session-123",
       );
 
       expect(result).toContain("URL: https://slack.com/files/screenshot.png");
-      expect(result).not.toContain("Image Data:");
+      expect(result).not.toContain("Image URL:");
     });
 
     it("should fall back to URL when fetch throws", async () => {
@@ -505,17 +553,18 @@ describe("Feature: Format Context With Image Embedding", () => {
       const result = await formatContextForAgentWithImages(
         messages,
         "xoxb-test-token",
+        "test-session-123",
       );
 
       expect(result).toContain(
         "URL: https://files.slack.com/thumb/screenshot.png",
       );
-      expect(result).not.toContain("Image Data:");
+      expect(result).not.toContain("Image URL:");
     });
   });
 
   describe("Scenario: Respect file size limits", () => {
-    it("should not embed files larger than 5MB", async () => {
+    it("should not upload files larger than 10MB", async () => {
       const messages = [
         {
           user: "U123",
@@ -524,7 +573,7 @@ describe("Feature: Format Context With Image Embedding", () => {
             {
               name: "large.png",
               mimetype: "image/png",
-              size: 10 * 1024 * 1024, // 10MB
+              size: 15 * 1024 * 1024, // 15MB (exceeds 10MB limit)
               url_private_download:
                 "https://files.slack.com/download/large.png",
               permalink: "https://slack.com/files/large.png",
@@ -536,11 +585,13 @@ describe("Feature: Format Context With Image Embedding", () => {
       const result = await formatContextForAgentWithImages(
         messages,
         "xoxb-test-token",
+        "test-session-123",
       );
 
       expect(mockFetch).not.toHaveBeenCalled();
+      expect(uploadS3BufferMock).not.toHaveBeenCalled();
       expect(result).toContain("URL: https://slack.com/files/large.png");
-      expect(result).not.toContain("Image Data:");
+      expect(result).not.toContain("Image URL:");
     });
   });
 
@@ -563,15 +614,17 @@ describe("Feature: Format Context With Image Embedding", () => {
       const result = await formatContextForAgentWithImages(
         messages,
         "xoxb-test-token",
+        "test-session-123",
       );
 
       expect(mockFetch).not.toHaveBeenCalled();
+      expect(uploadS3BufferMock).not.toHaveBeenCalled();
       expect(result).toContain("URL: https://files.slack.com/public/old.png");
     });
   });
 
   describe("Scenario: Handle multiple files in one message", () => {
-    it("should embed multiple images concurrently", async () => {
+    it("should upload multiple images", async () => {
       const imageBuffer1 = Buffer.from("image1");
       const imageBuffer2 = Buffer.from("image2");
 
@@ -591,11 +644,13 @@ describe("Feature: Format Context With Image Embedding", () => {
           text: "Two images",
           files: [
             {
+              id: "F1",
               name: "img1.png",
               mimetype: "image/png",
               url_private_download: "https://files.slack.com/download/img1.png",
             },
             {
+              id: "F2",
               name: "img2.png",
               mimetype: "image/png",
               url_private_download: "https://files.slack.com/download/img2.png",
@@ -607,13 +662,15 @@ describe("Feature: Format Context With Image Embedding", () => {
       const result = await formatContextForAgentWithImages(
         messages,
         "xoxb-test-token",
+        "test-session-123",
       );
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(uploadS3BufferMock).toHaveBeenCalledTimes(2);
       expect(result).toContain("[file]: img1.png");
       expect(result).toContain("[file]: img2.png");
-      // Both should have embedded data
-      expect((result.match(/Image Data:/g) || []).length).toBe(2);
+      // Both should have presigned URLs
+      expect((result.match(/Image URL:/g) || []).length).toBe(2);
     });
   });
 });

--- a/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
@@ -381,9 +381,17 @@ describe("Feature: Format Context With Image Upload", () => {
 
   describe("Scenario: Upload supported image types to R2", () => {
     it("should download PNG image and upload to R2 with presigned URL", async () => {
-      const imageBuffer = Buffer.from("fake-png-image-content");
+      // PNG magic bytes: 89 50 4E 47 (0x89 P N G)
+      const pngMagic = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      const imageBuffer = Buffer.concat([
+        pngMagic,
+        Buffer.from("fake-content"),
+      ]);
       mockFetch.mockResolvedValueOnce({
         ok: true,
+        headers: {
+          get: (name: string) => (name === "content-type" ? "image/png" : null),
+        },
         arrayBuffer: async () => imageBuffer,
       });
 
@@ -438,9 +446,18 @@ describe("Feature: Format Context With Image Upload", () => {
     });
 
     it("should upload JPEG images to R2", async () => {
-      const imageBuffer = Buffer.from("fake-jpeg-image-content");
+      // JPEG magic bytes: FF D8 FF
+      const jpegMagic = Buffer.from([0xff, 0xd8, 0xff]);
+      const imageBuffer = Buffer.concat([
+        jpegMagic,
+        Buffer.from("fake-content"),
+      ]);
       mockFetch.mockResolvedValueOnce({
         ok: true,
+        headers: {
+          get: (name: string) =>
+            name === "content-type" ? "image/jpeg" : null,
+        },
         arrayBuffer: async () => imageBuffer,
       });
 
@@ -575,6 +592,86 @@ describe("Feature: Format Context With Image Upload", () => {
       );
       expect(result).not.toContain("Image URL:");
     });
+
+    it("should fall back to URL when Slack returns HTML instead of image", async () => {
+      // Simulate Slack returning a login page HTML instead of the actual image
+      const htmlContent = Buffer.from("<!DOCTYPE html><html>Login page</html>");
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: {
+          get: (name: string) => (name === "content-type" ? "text/html" : null),
+        },
+        arrayBuffer: async () => htmlContent,
+      });
+
+      const messages = [
+        {
+          user: "U123",
+          text: "Screenshot",
+          files: [
+            {
+              id: "F123",
+              name: "screenshot.png",
+              mimetype: "image/png",
+              url_private_download:
+                "https://files.slack.com/download/screenshot.png",
+              permalink: "https://slack.com/files/screenshot.png",
+            },
+          ],
+        },
+      ];
+
+      const result = await formatContextForAgentWithImages(
+        messages,
+        "xoxb-test-token",
+        "test-session-123",
+      );
+
+      // Should fall back to URL since the response was not an image
+      expect(uploadS3BufferMock).not.toHaveBeenCalled();
+      expect(result).toContain("URL: https://slack.com/files/screenshot.png");
+      expect(result).not.toContain("Image URL:");
+    });
+
+    it("should fall back to URL when content has invalid image magic bytes", async () => {
+      // Simulate Slack returning non-image content with image content-type
+      const invalidContent = Buffer.from("Not an image file content");
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: {
+          get: (name: string) => (name === "content-type" ? "image/png" : null),
+        },
+        arrayBuffer: async () => invalidContent,
+      });
+
+      const messages = [
+        {
+          user: "U123",
+          text: "Screenshot",
+          files: [
+            {
+              id: "F123",
+              name: "screenshot.png",
+              mimetype: "image/png",
+              url_private_download:
+                "https://files.slack.com/download/screenshot.png",
+              permalink: "https://slack.com/files/screenshot.png",
+            },
+          ],
+        },
+      ];
+
+      const result = await formatContextForAgentWithImages(
+        messages,
+        "xoxb-test-token",
+        "test-session-123",
+      );
+
+      // Should fall back to URL since the content is not a valid image
+      expect(uploadS3BufferMock).not.toHaveBeenCalled();
+      expect(result).toContain("URL: https://slack.com/files/screenshot.png");
+      expect(result).not.toContain("Image URL:");
+    });
   });
 
   describe("Scenario: Respect file size limits", () => {
@@ -639,16 +736,26 @@ describe("Feature: Format Context With Image Upload", () => {
 
   describe("Scenario: Handle multiple files in one message", () => {
     it("should upload multiple images", async () => {
-      const imageBuffer1 = Buffer.from("image1");
-      const imageBuffer2 = Buffer.from("image2");
+      // PNG magic bytes: 89 50 4E 47 (0x89 P N G)
+      const pngMagic = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      const imageBuffer1 = Buffer.concat([pngMagic, Buffer.from("image1")]);
+      const imageBuffer2 = Buffer.concat([pngMagic, Buffer.from("image2")]);
 
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
+          headers: {
+            get: (name: string) =>
+              name === "content-type" ? "image/png" : null,
+          },
           arrayBuffer: async () => imageBuffer1,
         })
         .mockResolvedValueOnce({
           ok: true,
+          headers: {
+            get: (name: string) =>
+              name === "content-type" ? "image/png" : null,
+          },
           arrayBuffer: async () => imageBuffer2,
         });
 

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -3,6 +3,18 @@ import { logger } from "../logger";
 
 const log = logger("slack:context");
 
+/** Maximum file size to download and embed as base64 (5MB) */
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+
+/** Image MIME types that can be embedded as base64 data URLs */
+const SUPPORTED_IMAGE_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/gif",
+  "image/webp",
+];
+
 interface SlackFile {
   id?: string;
   name?: string;
@@ -17,6 +29,7 @@ interface SlackFile {
   thumb_480?: string;
   permalink?: string;
   permalink_public?: string;
+  url_private_download?: string;
 }
 
 interface SlackAttachment {
@@ -86,7 +99,65 @@ export async function fetchChannelContext(
 }
 
 /**
- * Format file information for context
+ * Check if a file is a supported image type
+ */
+function isSupportedImageType(file: SlackFile): boolean {
+  const mimetype = file.mimetype?.toLowerCase();
+  return mimetype !== undefined && SUPPORTED_IMAGE_TYPES.includes(mimetype);
+}
+
+/**
+ * Download a Slack file using the bot token and return base64 data URL
+ * Returns null if download fails or file is too large
+ */
+async function downloadSlackFileAsBase64(
+  file: SlackFile,
+  botToken: string,
+): Promise<string | null> {
+  const downloadUrl = file.url_private_download;
+  if (!downloadUrl) {
+    log.debug("No url_private_download available", { fileId: file.id });
+    return null;
+  }
+
+  // Check file size before downloading
+  if (file.size && file.size > MAX_FILE_SIZE_BYTES) {
+    log.debug("File too large to embed", {
+      fileId: file.id,
+      size: file.size,
+      maxSize: MAX_FILE_SIZE_BYTES,
+    });
+    return null;
+  }
+
+  try {
+    const response = await fetch(downloadUrl, {
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      log.debug("Failed to download Slack file", {
+        fileId: file.id,
+        status: response.status,
+      });
+      return null;
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    const base64 = Buffer.from(arrayBuffer).toString("base64");
+    const mimetype = file.mimetype || "application/octet-stream";
+
+    return `data:${mimetype};base64,${base64}`;
+  } catch (error) {
+    log.debug("Error downloading Slack file", { fileId: file.id, error });
+    return null;
+  }
+}
+
+/**
+ * Format file information for context (sync version, metadata only)
  */
 function formatFileInfo(file: SlackFile): string {
   const parts: string[] = [];
@@ -99,6 +170,44 @@ function formatFileInfo(file: SlackFile): string {
     parts.push(`   Dimensions: ${file.original_w}x${file.original_h}`);
   }
 
+  const url =
+    file.permalink_public || file.thumb_480 || file.thumb_360 || file.permalink;
+  if (url) {
+    parts.push(`   URL: ${url}`);
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Format file information for context with optional image embedding
+ * Downloads and embeds supported image types as base64 data URLs
+ */
+async function formatFileInfoWithImage(
+  file: SlackFile,
+  botToken: string | undefined,
+): Promise<string> {
+  const parts: string[] = [];
+
+  const name = file.name || file.title || "Untitled";
+  const type = file.pretty_type || file.mimetype || "file";
+  parts.push(`[file]: ${name} (${type})`);
+
+  if (file.original_w && file.original_h) {
+    parts.push(`   Dimensions: ${file.original_w}x${file.original_h}`);
+  }
+
+  // Try to download and embed image if supported type and bot token available
+  if (botToken && isSupportedImageType(file)) {
+    const dataUrl = await downloadSlackFileAsBase64(file, botToken);
+    if (dataUrl) {
+      parts.push(`   Image Data: ${dataUrl}`);
+      log.debug("Embedded image as base64", { fileId: file.id, name });
+      return parts.join("\n");
+    }
+  }
+
+  // Fallback to URL reference
   const url =
     file.permalink_public || file.thumb_480 || file.thumb_360 || file.permalink;
   if (url) {
@@ -135,7 +244,7 @@ function formatAttachmentImage(attachment: SlackAttachment): string | null {
 }
 
 /**
- * Format messages into context for agent prompt
+ * Format messages into context for agent prompt (sync version, metadata only)
  *
  * @param messages - Array of Slack messages
  * @param botUserId - Bot user ID (kept for API compatibility, no longer used for filtering)
@@ -185,6 +294,70 @@ export function formatContextForAgent(
 
   const result = `${header}\n\n${formattedMessages.join("\n\n")}`;
   log.debug("Formatted messages for context", {
+    messageCount: formattedMessages.length,
+    contextType,
+    resultLength: result.length,
+  });
+  return result;
+}
+
+/**
+ * Format messages into context for agent prompt with image embedding
+ * Downloads and embeds supported image types as base64 data URLs
+ *
+ * @param messages - Array of Slack messages
+ * @param botToken - Bot token for downloading private files
+ * @param botUserId - Bot user ID (kept for API compatibility, no longer used for filtering)
+ * @param contextType - Type of context: "thread" or "channel"
+ * @returns Formatted context string with embedded images
+ */
+export async function formatContextForAgentWithImages(
+  messages: SlackMessage[],
+  botToken: string,
+  botUserId?: string,
+  contextType: "thread" | "channel" = "thread",
+): Promise<string> {
+  // Include all messages (don't filter bot messages)
+  const formattedMessages = await Promise.all(
+    messages.map(async (msg) => {
+      const user = msg.bot_id ? "bot" : (msg.user ?? "unknown");
+      const text = msg.text ?? "";
+
+      const parts: string[] = [`[${user}]: ${text}`];
+
+      // Format files with image embedding
+      if (msg.files && msg.files.length > 0) {
+        for (const file of msg.files) {
+          const fileInfo = await formatFileInfoWithImage(file, botToken);
+          parts.push(fileInfo);
+        }
+      }
+
+      // Format attachments with images (URL unfurls - these are usually public)
+      if (msg.attachments && msg.attachments.length > 0) {
+        for (const attachment of msg.attachments) {
+          const attachmentInfo = formatAttachmentImage(attachment);
+          if (attachmentInfo) {
+            parts.push(attachmentInfo);
+          }
+        }
+      }
+
+      return parts.join("\n");
+    }),
+  );
+
+  if (formattedMessages.length === 0) {
+    return "";
+  }
+
+  const header =
+    contextType === "thread"
+      ? "## Slack Thread Context"
+      : "## Recent Channel Messages";
+
+  const result = `${header}\n\n${formattedMessages.join("\n\n")}`;
+  log.debug("Formatted messages for context with images", {
     messageCount: formattedMessages.length,
     contextType,
     resultLength: result.length,

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -167,6 +167,7 @@ async function downloadAndUploadSlackFile(
       name: filename,
       size: buffer.length,
       s3Key,
+      presignedUrl,
     });
 
     return presignedUrl;

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -151,12 +151,13 @@ async function downloadAndUploadSlackFile(
     const arrayBuffer = await response.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
 
-    // Upload to R2 temporary storage
+    // Upload to R2 temporary storage with correct MIME type
     const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
     const filename = file.name || file.id || "image";
     const s3Key = `slack-images/${sessionId}/${file.id || Date.now()}-${filename}`;
+    const contentType = file.mimetype || "application/octet-stream";
 
-    await uploadS3Buffer(bucketName, s3Key, buffer);
+    await uploadS3Buffer(bucketName, s3Key, buffer, contentType);
 
     // Generate presigned URL (valid for 1 hour)
     const presignedUrl = await generatePresignedUrl(bucketName, s3Key, 3600);

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -134,10 +134,22 @@ async function downloadAndUploadSlackFile(
   }
 
   try {
+    log.debug("Downloading Slack file", {
+      fileId: file.id,
+      downloadUrl,
+    });
+
     const response = await fetch(downloadUrl, {
       headers: {
         Authorization: `Bearer ${botToken}`,
       },
+    });
+
+    log.debug("Slack download response", {
+      fileId: file.id,
+      status: response.status,
+      contentType: response.headers.get("content-type"),
+      contentLength: response.headers.get("content-length"),
     });
 
     if (!response.ok) {
@@ -148,8 +160,33 @@ async function downloadAndUploadSlackFile(
       return null;
     }
 
+    // Verify the response content type is an image
+    const responseContentType = response.headers.get("content-type");
+    if (!responseContentType || !responseContentType.startsWith("image/")) {
+      log.debug("Slack returned non-image content", {
+        fileId: file.id,
+        contentType: responseContentType,
+      });
+      return null;
+    }
+
     const arrayBuffer = await response.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
+
+    // Verify the content is actually an image (check magic bytes)
+    // PNG: 89 50 4E 47, JPEG: FF D8 FF, GIF: 47 49 46, WebP: 52 49 46 46
+    const isPng = buffer[0] === 0x89 && buffer[1] === 0x50;
+    const isJpeg = buffer[0] === 0xff && buffer[1] === 0xd8;
+    const isGif = buffer[0] === 0x47 && buffer[1] === 0x49;
+    const isWebp = buffer[0] === 0x52 && buffer[1] === 0x49;
+
+    if (!isPng && !isJpeg && !isGif && !isWebp) {
+      log.debug("Downloaded content is not a valid image", {
+        fileId: file.id,
+        firstBytes: buffer.slice(0, 10).toString("hex"),
+      });
+      return null;
+    }
 
     // Upload to R2 temporary storage with correct MIME type
     const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -1,12 +1,14 @@
 import type { WebClient } from "@slack/web-api";
 import { logger } from "../logger";
+import { uploadS3Buffer, generatePresignedUrl } from "../s3/s3-client";
+import { env } from "../../env";
 
 const log = logger("slack:context");
 
-/** Maximum file size to download and embed as base64 (5MB) */
-const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+/** Maximum file size to download and upload (10MB) */
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
-/** Image MIME types that can be embedded as base64 data URLs */
+/** Image MIME types that can be uploaded for agent access */
 const SUPPORTED_IMAGE_TYPES = [
   "image/png",
   "image/jpeg",
@@ -107,12 +109,13 @@ function isSupportedImageType(file: SlackFile): boolean {
 }
 
 /**
- * Download a Slack file using the bot token and return base64 data URL
- * Returns null if download fails or file is too large
+ * Download a Slack file and upload to R2 temporary storage
+ * Returns a presigned URL that Claude Code can access directly
  */
-async function downloadSlackFileAsBase64(
+async function downloadAndUploadSlackFile(
   file: SlackFile,
   botToken: string,
+  sessionId: string,
 ): Promise<string | null> {
   const downloadUrl = file.url_private_download;
   if (!downloadUrl) {
@@ -122,7 +125,7 @@ async function downloadSlackFileAsBase64(
 
   // Check file size before downloading
   if (file.size && file.size > MAX_FILE_SIZE_BYTES) {
-    log.debug("File too large to embed", {
+    log.debug("File too large to upload", {
       fileId: file.id,
       size: file.size,
       maxSize: MAX_FILE_SIZE_BYTES,
@@ -146,12 +149,31 @@ async function downloadSlackFileAsBase64(
     }
 
     const arrayBuffer = await response.arrayBuffer();
-    const base64 = Buffer.from(arrayBuffer).toString("base64");
-    const mimetype = file.mimetype || "application/octet-stream";
+    const buffer = Buffer.from(arrayBuffer);
 
-    return `data:${mimetype};base64,${base64}`;
+    // Upload to R2 temporary storage
+    const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
+    const filename = file.name || file.id || "image";
+    const s3Key = `slack-images/${sessionId}/${file.id || Date.now()}-${filename}`;
+
+    await uploadS3Buffer(bucketName, s3Key, buffer);
+
+    // Generate presigned URL (valid for 1 hour)
+    const presignedUrl = await generatePresignedUrl(bucketName, s3Key, 3600);
+
+    log.debug("Uploaded Slack image to R2", {
+      fileId: file.id,
+      name: filename,
+      size: buffer.length,
+      s3Key,
+    });
+
+    return presignedUrl;
   } catch (error) {
-    log.debug("Error downloading Slack file", { fileId: file.id, error });
+    log.debug("Error downloading/uploading Slack file", {
+      fileId: file.id,
+      error,
+    });
     return null;
   }
 }
@@ -180,12 +202,13 @@ function formatFileInfo(file: SlackFile): string {
 }
 
 /**
- * Format file information for context with optional image embedding
- * Downloads and embeds supported image types as base64 data URLs
+ * Format file information for context with image upload to R2
+ * Uploads supported image types to R2 and provides presigned URLs
  */
 async function formatFileInfoWithImage(
   file: SlackFile,
   botToken: string | undefined,
+  sessionId: string,
 ): Promise<string> {
   const parts: string[] = [];
 
@@ -197,17 +220,20 @@ async function formatFileInfoWithImage(
     parts.push(`   Dimensions: ${file.original_w}x${file.original_h}`);
   }
 
-  // Try to download and embed image if supported type and bot token available
+  // Try to upload image to R2 and get presigned URL
   if (botToken && isSupportedImageType(file)) {
-    const dataUrl = await downloadSlackFileAsBase64(file, botToken);
-    if (dataUrl) {
-      parts.push(`   Image Data: ${dataUrl}`);
-      log.debug("Embedded image as base64", { fileId: file.id, name });
+    const presignedUrl = await downloadAndUploadSlackFile(
+      file,
+      botToken,
+      sessionId,
+    );
+    if (presignedUrl) {
+      parts.push(`   Image URL: ${presignedUrl}`);
       return parts.join("\n");
     }
   }
 
-  // Fallback to URL reference
+  // Fallback to original URL reference (may not be accessible)
   const url =
     file.permalink_public || file.thumb_480 || file.thumb_360 || file.permalink;
   if (url) {
@@ -302,18 +328,20 @@ export function formatContextForAgent(
 }
 
 /**
- * Format messages into context for agent prompt with image embedding
- * Downloads and embeds supported image types as base64 data URLs
+ * Format messages into context for agent prompt with image upload
+ * Uploads supported image types to R2 and provides presigned URLs
  *
  * @param messages - Array of Slack messages
  * @param botToken - Bot token for downloading private files
+ * @param sessionId - Session ID for organizing uploaded images
  * @param botUserId - Bot user ID (kept for API compatibility, no longer used for filtering)
  * @param contextType - Type of context: "thread" or "channel"
- * @returns Formatted context string with embedded images
+ * @returns Formatted context string with image URLs
  */
 export async function formatContextForAgentWithImages(
   messages: SlackMessage[],
   botToken: string,
+  sessionId: string,
   botUserId?: string,
   contextType: "thread" | "channel" = "thread",
 ): Promise<string> {
@@ -325,10 +353,14 @@ export async function formatContextForAgentWithImages(
 
       const parts: string[] = [`[${user}]: ${text}`];
 
-      // Format files with image embedding
+      // Format files with image upload
       if (msg.files && msg.files.length > 0) {
         for (const file of msg.files) {
-          const fileInfo = await formatFileInfoWithImage(file, botToken);
+          const fileInfo = await formatFileInfoWithImage(
+            file,
+            botToken,
+            sessionId,
+          );
           parts.push(fileInfo);
         }
       }

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -11,7 +11,7 @@ import {
   extractMessageContent,
   fetchThreadContext,
   fetchChannelContext,
-  formatContextForAgent,
+  formatContextForAgentWithImages,
   parseExplicitAgentSelection,
   buildLoginPromptMessage,
   buildErrorMessage,
@@ -70,20 +70,31 @@ async function removeThinkingReaction(
 }
 
 /**
- * Fetch conversation context for the agent
+ * Fetch conversation context for the agent with embedded images
  */
 async function fetchConversationContext(
   client: SlackClient,
   channelId: string,
   threadTs: string | undefined,
   botUserId: string,
+  botToken: string,
 ): Promise<string> {
   if (threadTs) {
     const messages = await fetchThreadContext(client, channelId, threadTs);
-    return formatContextForAgent(messages, botUserId, "thread");
+    return formatContextForAgentWithImages(
+      messages,
+      botToken,
+      botUserId,
+      "thread",
+    );
   }
   const messages = await fetchChannelContext(client, channelId, 10);
-  return formatContextForAgent(messages, botUserId, "channel");
+  return formatContextForAgentWithImages(
+    messages,
+    botToken,
+    botUserId,
+    "channel",
+  );
 }
 
 /**
@@ -270,11 +281,13 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
     );
 
     // Fetch Slack context early (needed for routing and agent execution)
+    // Uses bot token to download and embed images from Slack
     const formattedContext = await fetchConversationContext(
       client,
       context.channelId,
       context.threadTs,
       botUserId,
+      botToken,
     );
 
     // 7. Route to agent (with context for LLM routing)

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -70,7 +70,8 @@ async function removeThinkingReaction(
 }
 
 /**
- * Fetch conversation context for the agent with embedded images
+ * Fetch conversation context for the agent with uploaded images
+ * Images are uploaded to R2 and presigned URLs are provided in the context
  */
 async function fetchConversationContext(
   client: SlackClient,
@@ -79,11 +80,15 @@ async function fetchConversationContext(
   botUserId: string,
   botToken: string,
 ): Promise<string> {
+  // Use channel-thread as session ID for organizing uploaded images
+  const imageSessionId = `${channelId}-${threadTs ?? "channel"}`;
+
   if (threadTs) {
     const messages = await fetchThreadContext(client, channelId, threadTs);
     return formatContextForAgentWithImages(
       messages,
       botToken,
+      imageSessionId,
       botUserId,
       "thread",
     );
@@ -92,6 +97,7 @@ async function fetchConversationContext(
   return formatContextForAgentWithImages(
     messages,
     botToken,
+    imageSessionId,
     botUserId,
     "channel",
   );

--- a/turbo/apps/web/src/lib/slack/index.ts
+++ b/turbo/apps/web/src/lib/slack/index.ts
@@ -58,6 +58,7 @@ export {
   fetchThreadContext,
   fetchChannelContext,
   formatContextForAgent,
+  formatContextForAgentWithImages,
   extractMessageContent,
   parseExplicitAgentSelection,
 } from "./context";


### PR DESCRIPTION
## Summary

- Download Slack images using authenticated bot token
- Upload images to R2 temporary storage with presigned URLs
- Fix issue where Claude Code could not read Slack images due to authentication requirements

## Changes

- Add `url_private_download` to `SlackFile` interface
- Add `downloadAndUploadSlackFile()` function to download files and upload to R2
- Add `formatContextForAgentWithImages()` async function for image upload
- Update mention handler to use the new image-upload context formatter
- Support PNG, JPEG, GIF, WebP images up to 10MB
- Fall back to URL reference when download fails or file type is unsupported
- Add comprehensive tests for image upload scenarios

## Technical Details

Slack file URLs (`url_private_download`) require authentication with the bot token in the `Authorization` header. Claude Code cannot provide this header when accessing URLs directly.

**Original approach (base64 embedding):** Downloads images and embeds them as base64 data URLs in the context. This was problematic because large images could cause the context to exceed token limits.

**New approach (R2 upload):** 
1. Download image using bot token authentication
2. Upload to R2 temporary storage (`slack-images/{sessionId}/{fileId}-{filename}`)
3. Generate presigned URL (valid for 1 hour)
4. Include presigned URL in context - Claude Code can access this directly

This keeps context size small while making images accessible to the agent.

## Test plan

- [x] Verified existing tests pass
- [x] Added new tests for image upload scenarios:
  - PNG/JPEG image upload to R2
  - Fallback to URL for unsupported types (PDF, etc.)
  - Graceful handling of download failures
  - File size limits (10MB max)
  - Multiple images in one message
- [ ] Manual testing with Slack integration

Closes #2410

🤖 Generated with [Claude Code](https://claude.com/claude-code)