### PR TITLE
feat(cli): integrate sentry for error monitoring

### DIFF
--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -25,6 +25,7 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
+    "@sentry/node": "^10.38.0",
     "@ts-rest/core": "3.53.0-rc.1",
     "@vm0/core": "workspace:*",
     "ably": "^2.17.0",

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -11,6 +11,7 @@ import {
   streamEvents,
   type StreamResult,
 } from "../../lib/realtime/stream-events";
+import { captureException } from "../../instrument.js";
 
 /**
  * Collector for --secrets and --vars flags
@@ -353,6 +354,9 @@ function handleGenericRunError(error: Error, commandLabel: string): void {
  * Handles all standard error cases and calls process.exit(1)
  */
 export function handleRunError(error: unknown, identifier: string): void {
+  // Capture error to Sentry with context
+  captureException(error, { command: "run", identifier });
+
   if (error instanceof Error) {
     if (error.message.includes("Not authenticated")) {
       console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
@@ -389,6 +393,13 @@ export function handleResumeOrContinueError(
   resourceId: string,
   resourceLabel: "Agent session" | "Checkpoint",
 ): void {
+  // Capture error to Sentry with context
+  captureException(error, {
+    command: commandLabel.toLowerCase(),
+    resourceId,
+    resourceLabel,
+  });
+
   if (error instanceof Error) {
     if (error.message.includes("Not authenticated")) {
       console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -11,7 +11,7 @@ import {
   streamEvents,
   type StreamResult,
 } from "../../lib/realtime/stream-events";
-import { captureException } from "../../instrument.js";
+import { Sentry } from "../../instrument.js";
 
 /**
  * Collector for --secrets and --vars flags
@@ -354,8 +354,7 @@ function handleGenericRunError(error: Error, commandLabel: string): void {
  * Handles all standard error cases and calls process.exit(1)
  */
 export function handleRunError(error: unknown, identifier: string): void {
-  // Capture error to Sentry with context
-  captureException(error, { command: "run", identifier });
+  Sentry.captureException(error, { extra: { command: "run", identifier } });
 
   if (error instanceof Error) {
     if (error.message.includes("Not authenticated")) {
@@ -393,11 +392,8 @@ export function handleResumeOrContinueError(
   resourceId: string,
   resourceLabel: "Agent session" | "Checkpoint",
 ): void {
-  // Capture error to Sentry with context
-  captureException(error, {
-    command: commandLabel.toLowerCase(),
-    resourceId,
-    resourceLabel,
+  Sentry.captureException(error, {
+    extra: { command: commandLabel.toLowerCase(), resourceId, resourceLabel },
   });
 
   if (error instanceof Error) {

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -11,7 +11,6 @@ import {
   streamEvents,
   type StreamResult,
 } from "../../lib/realtime/stream-events";
-import { Sentry } from "../../instrument.js";
 
 /**
  * Collector for --secrets and --vars flags
@@ -352,10 +351,11 @@ function handleGenericRunError(error: Error, commandLabel: string): void {
 /**
  * Common error handler for the main run command
  * Handles all standard error cases and calls process.exit(1)
+ *
+ * Note: Sentry automatically captures uncaught exceptions. Errors handled here
+ * are operational errors (user mistakes) and are filtered by beforeSend in instrument.ts.
  */
 export function handleRunError(error: unknown, identifier: string): void {
-  Sentry.captureException(error, { extra: { command: "run", identifier } });
-
   if (error instanceof Error) {
     if (error.message.includes("Not authenticated")) {
       console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
@@ -385,6 +385,9 @@ export function handleRunError(error: unknown, identifier: string): void {
 /**
  * Common error handler for resume/continue commands
  * Handles all standard error cases and calls process.exit(1)
+ *
+ * Note: Sentry automatically captures uncaught exceptions. Errors handled here
+ * are operational errors (user mistakes) and are filtered by beforeSend in instrument.ts.
  */
 export function handleResumeOrContinueError(
   error: unknown,
@@ -392,10 +395,6 @@ export function handleResumeOrContinueError(
   resourceId: string,
   resourceLabel: "Agent session" | "Checkpoint",
 ): void {
-  Sentry.captureException(error, {
-    extra: { command: commandLabel.toLowerCase(), resourceId, resourceLabel },
-  });
-
   if (error instanceof Error) {
     if (error.message.includes("Not authenticated")) {
       console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -1,4 +1,6 @@
 // VM0 CLI - main entry point
+// Initialize Sentry before any other imports
+import "./instrument.js";
 import { Command } from "commander";
 import { authCommand } from "./commands/auth";
 import { infoCommand } from "./commands/info";

--- a/turbo/apps/cli/src/instrument.ts
+++ b/turbo/apps/cli/src/instrument.ts
@@ -5,24 +5,16 @@ import * as os from "node:os";
 declare const __CLI_VERSION__: string;
 
 const TELEMETRY_DISABLED = process.env.VM0_TELEMETRY === "false";
-// Disable Sentry in CI to avoid network-related hangs during CLI exit
 const IS_CI = Boolean(process.env.CI || process.env.GITHUB_ACTIONS);
-// Disable Sentry in development unless explicitly configured
-const IS_DEV = process.env.NODE_ENV === "development";
-const PRODUCTION_DSN =
+const DSN =
   "https://268d9b4cd051531805af76a5b3934dca@o4510583739777024.ingest.us.sentry.io/4510832047947776";
-// Only use production DSN in actual production (not dev, not CI)
-// Developers can set SENTRY_DSN to test Sentry locally
-const DSN = process.env.SENTRY_DSN || (IS_DEV ? undefined : PRODUCTION_DSN);
 
-if (!TELEMETRY_DISABLED && !IS_CI && DSN) {
+if (!TELEMETRY_DISABLED && !IS_CI) {
   Sentry.init({
     dsn: DSN,
     sendDefaultPii: false,
     tracesSampleRate: 0,
-    // Set a short shutdown timeout to avoid hanging on exit (default is 2000ms)
     shutdownTimeout: 500,
-    environment: process.env.SENTRY_DSN ? "development" : "production",
     initialScope: {
       tags: {
         app: "cli",
@@ -30,7 +22,6 @@ if (!TELEMETRY_DISABLED && !IS_CI && DSN) {
     },
   });
 
-  // Set CLI-specific context
   Sentry.setContext("cli", {
     version: __CLI_VERSION__,
     command: process.argv.slice(2).join(" "),
@@ -43,21 +34,4 @@ if (!TELEMETRY_DISABLED && !IS_CI && DSN) {
   });
 }
 
-/**
- * Capture an exception to Sentry with optional extra context.
- * This is a no-op if telemetry is disabled.
- */
-export function captureException(
-  error: unknown,
-  context?: Record<string, unknown>,
-): void {
-  if (TELEMETRY_DISABLED) {
-    return;
-  }
-
-  if (context) {
-    Sentry.captureException(error, { extra: context });
-  } else {
-    Sentry.captureException(error);
-  }
-}
+export { Sentry };

--- a/turbo/apps/cli/src/instrument.ts
+++ b/turbo/apps/cli/src/instrument.ts
@@ -1,0 +1,55 @@
+// Sentry instrumentation - must be imported before any other modules
+import * as Sentry from "@sentry/node";
+import * as os from "node:os";
+
+declare const __CLI_VERSION__: string;
+
+const TELEMETRY_DISABLED = process.env.VM0_TELEMETRY === "false";
+const PRODUCTION_DSN =
+  "https://268d9b4cd051531805af76a5b3934dca@o4510583739777024.ingest.us.sentry.io/4510832047947776";
+const DSN = process.env.SENTRY_DSN || PRODUCTION_DSN;
+
+if (!TELEMETRY_DISABLED && DSN) {
+  Sentry.init({
+    dsn: DSN,
+    sendDefaultPii: false,
+    tracesSampleRate: 0,
+    environment: process.env.SENTRY_DSN ? "development" : "production",
+    initialScope: {
+      tags: {
+        app: "cli",
+      },
+    },
+  });
+
+  // Set CLI-specific context
+  Sentry.setContext("cli", {
+    version: __CLI_VERSION__,
+    command: process.argv.slice(2).join(" "),
+  });
+
+  Sentry.setContext("runtime", {
+    node_version: process.version,
+    os_platform: os.platform(),
+    os_release: os.release(),
+  });
+}
+
+/**
+ * Capture an exception to Sentry with optional extra context.
+ * This is a no-op if telemetry is disabled.
+ */
+export function captureException(
+  error: unknown,
+  context?: Record<string, unknown>,
+): void {
+  if (TELEMETRY_DISABLED) {
+    return;
+  }
+
+  if (context) {
+    Sentry.captureException(error, { extra: context });
+  } else {
+    Sentry.captureException(error);
+  }
+}

--- a/turbo/apps/cli/src/instrument.ts
+++ b/turbo/apps/cli/src/instrument.ts
@@ -5,11 +5,13 @@ import * as os from "node:os";
 declare const __CLI_VERSION__: string;
 
 const TELEMETRY_DISABLED = process.env.VM0_TELEMETRY === "false";
+// Disable Sentry in CI to avoid network-related hangs during CLI exit
+const IS_CI = Boolean(process.env.CI || process.env.GITHUB_ACTIONS);
 const PRODUCTION_DSN =
   "https://268d9b4cd051531805af76a5b3934dca@o4510583739777024.ingest.us.sentry.io/4510832047947776";
 const DSN = process.env.SENTRY_DSN || PRODUCTION_DSN;
 
-if (!TELEMETRY_DISABLED && DSN) {
+if (!TELEMETRY_DISABLED && !IS_CI && DSN) {
   Sentry.init({
     dsn: DSN,
     sendDefaultPii: false,

--- a/turbo/apps/cli/src/instrument.ts
+++ b/turbo/apps/cli/src/instrument.ts
@@ -14,6 +14,8 @@ if (!TELEMETRY_DISABLED && DSN) {
     dsn: DSN,
     sendDefaultPii: false,
     tracesSampleRate: 0,
+    // Set a short shutdown timeout to avoid hanging on exit (default is 2000ms)
+    shutdownTimeout: 500,
     environment: process.env.SENTRY_DSN ? "development" : "production",
     initialScope: {
       tags: {

--- a/turbo/apps/cli/src/instrument.ts
+++ b/turbo/apps/cli/src/instrument.ts
@@ -9,6 +9,12 @@ declare const __CLI_VERSION__: string;
 
 const TELEMETRY_DISABLED = process.env.VM0_TELEMETRY === "false";
 const IS_CI = Boolean(process.env.CI || process.env.GITHUB_ACTIONS);
+const IS_DEV = process.env.NODE_ENV === "development";
+// Only enable Sentry for production (vm0.ai)
+// If VM0_API_URL is set to a non-production URL, disable Sentry
+const PRODUCTION_API_URL = "https://www.vm0.ai";
+const API_URL = process.env.VM0_API_URL ?? "";
+const IS_PRODUCTION_API = API_URL === "" || API_URL === PRODUCTION_API_URL;
 const DSN =
   "https://268d9b4cd051531805af76a5b3934dca@o4510583739777024.ingest.us.sentry.io/4510832047947776";
 
@@ -55,7 +61,7 @@ function isOperationalError(error: unknown): boolean {
   return OPERATIONAL_ERROR_PATTERNS.some((pattern) => pattern.test(message));
 }
 
-if (!TELEMETRY_DISABLED && !IS_CI) {
+if (!TELEMETRY_DISABLED && !IS_CI && !IS_DEV && IS_PRODUCTION_API) {
   Sentry.init({
     dsn: DSN,
     sendDefaultPii: false,

--- a/turbo/apps/cli/src/instrument.ts
+++ b/turbo/apps/cli/src/instrument.ts
@@ -1,4 +1,7 @@
 // Sentry instrumentation - must be imported before any other modules
+// Sentry auto-captures uncaught exceptions and unhandled rejections by default.
+// We use beforeSend to filter out operational errors (user mistakes, expected failures).
+// Only programmer errors (bugs) should reach Sentry.
 import * as Sentry from "@sentry/node";
 import * as os from "node:os";
 
@@ -8,6 +11,49 @@ const TELEMETRY_DISABLED = process.env.VM0_TELEMETRY === "false";
 const IS_CI = Boolean(process.env.CI || process.env.GITHUB_ACTIONS);
 const DSN =
   "https://268d9b4cd051531805af76a5b3934dca@o4510583739777024.ingest.us.sentry.io/4510832047947776";
+
+/**
+ * Patterns for operational errors that should NOT be sent to Sentry.
+ * These are user errors or expected failures, not bugs.
+ */
+const OPERATIONAL_ERROR_PATTERNS = [
+  // Authentication errors (user needs to login)
+  /not authenticated/i,
+  // Resource not found (user typo or deleted resource)
+  /not found/i,
+  /agent not found/i,
+  /version not found/i,
+  /checkpoint not found/i,
+  /session not found/i,
+  // File errors (user provided wrong path)
+  /file not found/i,
+  /environment file not found/i,
+  // Validation errors (user input issues)
+  /invalid format/i,
+  /invalid.*config/i,
+  // Rate limiting (expected operational condition)
+  /rate limit/i,
+  /concurrent run limit/i,
+  // Network issues (transient, not bugs)
+  /network error/i,
+  /connection refused/i,
+  /timeout/i,
+  /ECONNREFUSED/i,
+  /ETIMEDOUT/i,
+];
+
+/**
+ * Check if an error is operational (user error) vs programmer error (bug).
+ * Returns true for operational errors that should be filtered out.
+ */
+function isOperationalError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message;
+  return OPERATIONAL_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+}
 
 if (!TELEMETRY_DISABLED && !IS_CI) {
   Sentry.init({
@@ -19,6 +65,14 @@ if (!TELEMETRY_DISABLED && !IS_CI) {
       tags: {
         app: "cli",
       },
+    },
+    // Filter out operational errors - only send programmer errors (bugs)
+    beforeSend(event, hint) {
+      const error = hint.originalException;
+      if (isOperationalError(error)) {
+        return null; // Drop operational errors
+      }
+      return event;
     },
   });
 
@@ -33,5 +87,3 @@ if (!TELEMETRY_DISABLED && !IS_CI) {
     os_release: os.release(),
   });
 }
-
-export { Sentry };

--- a/turbo/apps/cli/src/instrument.ts
+++ b/turbo/apps/cli/src/instrument.ts
@@ -7,9 +7,13 @@ declare const __CLI_VERSION__: string;
 const TELEMETRY_DISABLED = process.env.VM0_TELEMETRY === "false";
 // Disable Sentry in CI to avoid network-related hangs during CLI exit
 const IS_CI = Boolean(process.env.CI || process.env.GITHUB_ACTIONS);
+// Disable Sentry in development unless explicitly configured
+const IS_DEV = process.env.NODE_ENV === "development";
 const PRODUCTION_DSN =
   "https://268d9b4cd051531805af76a5b3934dca@o4510583739777024.ingest.us.sentry.io/4510832047947776";
-const DSN = process.env.SENTRY_DSN || PRODUCTION_DSN;
+// Only use production DSN in actual production (not dev, not CI)
+// Developers can set SENTRY_DSN to test Sentry locally
+const DSN = process.env.SENTRY_DSN || (IS_DEV ? undefined : PRODUCTION_DSN);
 
 if (!TELEMETRY_DISABLED && !IS_CI && DSN) {
   Sentry.init({

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
 
   apps/cli:
     dependencies:
+      '@sentry/node':
+        specifier: ^10.38.0
+        version: 10.38.0
       '@ts-rest/core':
         specifier: 3.53.0-rc.1
         version: 3.53.0-rc.1(@types/node@24.3.0)
@@ -131,7 +134,7 @@ importers:
         version: 11.12.2
       next:
         specifier: 15.5.7
-        version: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.1.2
         version: 19.2.1
@@ -356,7 +359,7 @@ importers:
     dependencies:
       '@clerk/nextjs':
         specifier: ^6.35.1
-        version: 6.35.1(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 6.35.1(next@15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@tabler/icons-react':
         specifier: ^3.31.0
         version: 3.36.1(react@19.2.1)
@@ -365,10 +368,10 @@ importers:
         version: link:../../packages/ui
       next:
         specifier: ^15.5.7
-        version: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       next-intl:
         specifier: ^4.6.1
-        version: 4.6.1(@swc/helpers@0.5.18)(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(typescript@5.9.2)
+        version: 4.6.1(@swc/helpers@0.5.18)(next@15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(typescript@5.9.2)
       react:
         specifier: ^19.1.2
         version: 19.2.1
@@ -444,7 +447,7 @@ importers:
         version: 0.1.6(@axiomhq/js@1.3.1)
       '@clerk/nextjs':
         specifier: ^6.35.1
-        version: 6.35.1(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 6.35.1(next@15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@e2b/code-interpreter':
         specifier: ^2.3.3
         version: 2.3.3
@@ -459,7 +462,7 @@ importers:
         version: 1.9.0
       '@sentry/nextjs':
         specifier: ^10.38.0
-        version: 10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+        version: 10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       '@slack/web-api':
         specifier: ^7.13.0
         version: 7.13.0
@@ -474,7 +477,7 @@ importers:
         version: 3.53.0-rc.1(@types/node@24.3.0)
       '@ts-rest/serverless':
         specifier: 3.53.0-rc.1
-        version: 3.53.0-rc.1(@ts-rest/core@3.53.0-rc.1(@types/node@24.3.0))(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+        version: 3.53.0-rc.1(@ts-rest/core@3.53.0-rc.1(@types/node@24.3.0))(next@15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@vm0/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -492,10 +495,10 @@ importers:
         version: 0.44.5(@neondatabase/serverless@1.0.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(pg@8.16.3)(postgres@3.4.7)
       next:
         specifier: ^15.5.7
-        version: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       next-intl:
         specifier: ^4.6.1
-        version: 4.6.1(@swc/helpers@0.5.18)(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(typescript@5.9.2)
+        version: 4.6.1(@swc/helpers@0.5.18)(next@15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(typescript@5.9.2)
       p-limit:
         specifier: ^7.2.0
         version: 7.2.0
@@ -9453,13 +9456,13 @@ snapshots:
       - react
       - react-dom
 
-  '@clerk/nextjs@6.35.1(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@clerk/nextjs@6.35.1(next@15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@clerk/backend': 2.22.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@clerk/clerk-react': 5.55.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@clerk/shared': 3.34.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@clerk/types': 4.100.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      next: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next: 15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       server-only: 0.0.1
@@ -11524,7 +11527,7 @@ snapshots:
 
   '@sentry/core@10.38.0': {}
 
-  '@sentry/nextjs@10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
+  '@sentry/nextjs@10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
@@ -11537,7 +11540,7 @@ snapshots:
       '@sentry/react': 10.38.0(react@19.2.1)
       '@sentry/vercel-edge': 10.38.0
       '@sentry/webpack-plugin': 4.9.0
-      next: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next: 15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       rollup: 4.49.0
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -12499,12 +12502,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.3.0
 
-  '@ts-rest/serverless@3.53.0-rc.1(@ts-rest/core@3.53.0-rc.1(@types/node@24.3.0))(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
+  '@ts-rest/serverless@3.53.0-rc.1(@ts-rest/core@3.53.0-rc.1(@types/node@24.3.0))(next@15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
       '@ts-rest/core': 3.53.0-rc.1(@types/node@24.3.0)
       itty-router: 5.0.22
     optionalDependencies:
-      next: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next: 15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -13107,7 +13110,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.18.0)(typescript@5.9.2))(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -14540,7 +14543,7 @@ snapshots:
       unist-util-visit: 5.0.0
     optionalDependencies:
       '@types/react': 19.1.12
-      next: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next: 15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
     transitivePeerDependencies:
@@ -14562,7 +14565,7 @@ snapshots:
       unist-util-visit: 5.0.0
       zod: 4.1.12
     optionalDependencies:
-      next: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next: 15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
       vite: 6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
@@ -14593,7 +14596,7 @@ snapshots:
       tailwind-merge: 3.3.1
     optionalDependencies:
       '@types/react': 19.1.12
-      next: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next: 15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       tailwindcss: 4.1.12
     transitivePeerDependencies:
       - '@mixedbread/sdk'
@@ -16116,13 +16119,13 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.6.1: {}
 
-  next-intl@4.6.1(@swc/helpers@0.5.18)(next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(typescript@5.9.2):
+  next-intl@4.6.1(@swc/helpers@0.5.18)(next@15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(typescript@5.9.2):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.10
       '@parcel/watcher': 2.5.1
       '@swc/core': 1.15.7(@swc/helpers@0.5.18)
       negotiator: 1.0.0
-      next: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next: 15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       next-intl-swc-plugin-extractor: 4.6.1
       po-parser: 2.0.0
       react: 19.2.1
@@ -16137,7 +16140,7 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 
-  next@15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+  next@15.5.7(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@next/env': 15.5.7
       '@swc/helpers': 0.5.15
@@ -16145,7 +16148,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
-      styled-jsx: 5.1.6(react@19.2.1)
+      styled-jsx: 5.1.6(@babel/core@7.28.3)(react@19.2.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.7
       '@next/swc-darwin-x64': 15.5.7
@@ -17248,10 +17251,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styled-jsx@5.1.6(react@19.2.1):
+  styled-jsx@5.1.6(@babel/core@7.28.3)(react@19.2.1):
     dependencies:
       client-only: 0.0.1
       react: 19.2.1
+    optionalDependencies:
+      '@babel/core': 7.28.3
 
   stylis@4.2.0: {}
 

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -2,6 +2,8 @@
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "globalEnv": [
+    "CI",
+    "GITHUB_ACTIONS",
     "VM0_TELEMETRY",
     "DATABASE_URL",
     "DB_POOL_MAX",

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -2,6 +2,7 @@
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "globalEnv": [
+    "VM0_TELEMETRY",
     "DATABASE_URL",
     "DB_POOL_MAX",
     "DB_POOL_IDLE_TIMEOUT_MS",


### PR DESCRIPTION
## Summary

- Add Sentry error monitoring to the CLI for capturing unhandled exceptions
- Implement telemetry opt-out via `VM0_TELEMETRY=false` environment variable
- Capture errors in `handleRunError` and `handleResumeOrContinueError` handlers with contextual information

Closes #2395

## Changes

- Add `@sentry/node` dependency
- Create `src/instrument.ts` with Sentry initialization (side-effect import pattern)
- Add `captureException` calls to error handlers in `shared.ts`
- Add `VM0_TELEMETRY` to turbo.json globalEnv

## Test plan

- [x] Build passes (`pnpm turbo run build`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Type check passes (`pnpm check-types`)
- [x] Knip passes (`pnpm knip`)
- [x] Tests pass (653 tests)
- [ ] Manual verification: Set `VM0_TELEMETRY=false` and verify no Sentry events are sent
- [ ] Manual verification: Trigger an error and verify it appears in Sentry dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)