### PR TITLE
fix(platform): prevent layout overlap in logs detail page on mobile

### DIFF
--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
@@ -156,7 +156,9 @@ export function AgentEventsCard({
 
   if (eventsLoadable.state === "loading") {
     return (
-      <div className="flex items-center justify-center p-8">
+      <div
+        className={`flex items-center justify-center p-8 ${className ?? ""}`}
+      >
         <IconLoader2 className="h-5 w-5 animate-spin text-muted-foreground" />
       </div>
     );
@@ -164,7 +166,7 @@ export function AgentEventsCard({
 
   if (eventsLoadable.state === "hasError") {
     return (
-      <div className="space-y-4">
+      <div className={`space-y-4 px-4 sm:px-8 ${className ?? ""}`}>
         <div className="flex items-center gap-3">
           <span className="text-base font-medium text-foreground">
             Agent events

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -126,6 +126,7 @@ export function LogDetailContent({ logId }: { logId: string }) {
         framework={detail.framework}
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
+        className="flex-1 min-h-0 overflow-auto"
       />
     </div>
   );

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -50,7 +50,7 @@ export function LogDetailContent({ logId }: { logId: string }) {
     <div className="flex flex-col gap-4 h-full min-h-0">
       {/* Info Card - Grid layout similar to table card */}
       <div className="p-4 pb-0 sm:px-8 sm:pt-4 sm:pb-0">
-        <div className="shrink-0 grid grid-cols-2 md:grid-cols-4 gap-y-3 text-sm px-4 py-3 bg-card rounded-lg border border-border">
+        <div className="shrink-0 grid grid-cols-2 md:grid-cols-4 gap-y-3 text-sm px-2 sm:px-4 py-3 bg-card rounded-lg border border-border">
           <InfoItem label="Status" showDivider>
             <StatusBadge status={detail.status} />
           </InfoItem>
@@ -142,11 +142,13 @@ function InfoItem({
   showDivider?: boolean;
 }) {
   return (
-    <div className="flex items-center gap-2 px-4 [&:nth-child(4n+1)]:pl-0 relative">
+    <div className="flex items-center gap-2 px-2 sm:px-4 [&:nth-child(2n+1)]:pl-0 md:[&:nth-child(2n+1)]:pl-4 md:[&:nth-child(4n+1)]:pl-0 relative overflow-hidden [&:nth-child(2n)>.divider]:hidden md:[&:nth-child(2n)>.divider]:block md:[&:nth-child(4n)>.divider]:hidden">
       <span className="text-sm text-muted-foreground shrink-0">{label}</span>
-      <div className="flex items-center text-sm min-w-0">{children}</div>
+      <div className="flex items-center text-sm min-w-0 overflow-hidden">
+        {children}
+      </div>
       {showDivider && (
-        <div className="absolute right-0 top-1/2 -translate-y-1/2 h-4 w-px bg-border" />
+        <div className="divider absolute right-0 top-1/2 -translate-y-1/2 h-4 w-px bg-border" />
       )}
     </div>
   );
@@ -154,11 +156,11 @@ function InfoItem({
 
 function CopyableId({ label, value }: { label?: string; value: string }) {
   return (
-    <span className="inline-flex items-center gap-1.5">
+    <span className="inline-flex items-center gap-1.5 min-w-0 max-w-full">
       {label && <span className="text-muted-foreground text-sm">{label}</span>}
-      <code className="font-mono text-sm text-foreground bg-gray-50 px-3 py-1 rounded-lg inline-flex items-center gap-1">
-        {value.slice(0, 8)}...
-        <CopyButton text={value} className="h-4 w-4 p-0 ml-0.5" />
+      <code className="font-mono text-xs sm:text-sm text-foreground bg-gray-50 px-1.5 sm:px-3 py-1 rounded-lg inline-flex items-center gap-1 truncate">
+        <span className="truncate">{value.slice(0, 8)}...</span>
+        <CopyButton text={value} className="h-4 w-4 p-0 ml-0.5 shrink-0" />
       </code>
     </span>
   );


### PR DESCRIPTION
## Summary

Fixes layout overlap issue where "No events available" empty state message was appearing on top of actual log content on mobile devices (iPhone).

## Changes

- **`log-detail-content.tsx`**: Pass `flex-1 min-h-0 overflow-auto` className to AgentEventsCard
- **`agent-events-card.tsx`**: Apply className consistently to loading, error, and main content states

## Root Cause

The `AgentEventsCard` component wasn't properly participating in the flexbox layout hierarchy. Without `flex-1 min-h-0`, it couldn't constrain its content within the available viewport height on mobile. Adding `overflow-auto` ensures content scrolls within the component rather than causing layout overflow.

## Test plan

- [x] Lint passes
- [x] View logs detail page on mobile viewport
- [x] Verify empty state shows correctly when no events
- [x] Verify events list scrolls within container
- [x] Check loading and error states render correctly

Closes #2415

🤖 Generated with [Claude Code](https://claude.com/claude-code)