### PR TITLE
refactor(web): add msw wrapper with mock tracking for test assertions

### DIFF
--- a/turbo/apps/web/src/__tests__/msw.ts
+++ b/turbo/apps/web/src/__tests__/msw.ts
@@ -1,0 +1,79 @@
+import {
+  http as mswHttp,
+  type HttpHandler,
+  type HttpResponseResolver,
+} from "msw";
+import type {
+  DefaultBodyType,
+  HttpRequestHandler,
+  PathParams,
+  RequestHandlerOptions,
+} from "msw";
+import { type Mock, vi } from "vitest";
+
+type HttpRequestPredicate<Params extends PathParams> = Parameters<
+  typeof mswHttp.post<Params, DefaultBodyType, DefaultBodyType>
+>[0];
+
+function wrapMswHandler(handler: HttpRequestHandler) {
+  return <
+    Params extends PathParams<keyof Params> = PathParams,
+    RequestBodyType extends DefaultBodyType = DefaultBodyType,
+    ResponseBodyType extends DefaultBodyType = undefined,
+  >(
+    predicate: HttpRequestPredicate<Params>,
+    resolver: HttpResponseResolver<Params, RequestBodyType, ResponseBodyType>,
+    options?: RequestHandlerOptions,
+  ): {
+    handler: HttpHandler;
+    mocked: Mock<
+      HttpResponseResolver<Params, RequestBodyType, ResponseBodyType>
+    >;
+  } => {
+    const wrappedResolver: HttpResponseResolver<
+      Params,
+      RequestBodyType,
+      ResponseBodyType
+    > = (info) => {
+      return resolver({
+        ...info,
+        request: info.request.clone(),
+      });
+    };
+
+    const mocked = vi.fn(wrappedResolver);
+
+    return {
+      handler: handler(predicate, mocked, options),
+      mocked,
+    };
+  };
+}
+
+export const http = {
+  post: wrapMswHandler(mswHttp.post),
+  get: wrapMswHandler(mswHttp.get),
+  put: wrapMswHandler(mswHttp.put),
+  delete: wrapMswHandler(mswHttp.delete),
+};
+
+export function handlers<
+  T extends Record<
+    string,
+    { handler: HttpHandler; mocked: Mock<HttpResponseResolver> }
+  >,
+>(
+  mockedHandlers: T,
+): {
+  mocked: { [K in keyof T]: T[K]["mocked"] };
+  handlers: HttpHandler[];
+} {
+  const mocks = {} as { [K in keyof T]: T[K]["mocked"] };
+  for (const key of Object.keys(mockedHandlers) as Array<keyof T>) {
+    mocks[key] = mockedHandlers[key]!.mocked;
+  }
+  return {
+    mocked: mocks,
+    handlers: Object.values(mockedHandlers).map((h) => h.handler),
+  };
+}

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -39,6 +39,7 @@ vi.hoisted(() => {
   );
   // OpenRouter API key for LLM chat
   vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-api-key");
+  vi.stubEnv("SLACK_REDIRECT_BASE_URL", "https://test.example.com");
 });
 
 // Mock server-only package (no-op in tests)


### PR DESCRIPTION
## Summary
- Add a custom MSW wrapper (`src/__tests__/msw.ts`) that provides automatic request cloning, mock tracking with `vi.fn()`, and type-safe handler keys
- Refactor Slack handler tests (`mention.test.ts`, `run-agent.test.ts`) to use the new pattern, reducing boilerplate and removing manual API call tracking arrays
- Add missing `SLACK_REDIRECT_BASE_URL` env stub to test setup
- Update testing documentation with MSW wrapper usage examples

## Test plan
- [x] Run `pnpm vitest run --project=web` for the affected test files - all 10 tests pass
- [x] Verify lint passes with `pnpm turbo run lint`
- [x] Verify type check passes with `pnpm check-types`
- [x] Verify knip finds no unused exports

🤖 Generated with [Claude Code](https://claude.ai/code)