### PR TITLE
fix(slack): update command naming and auto-configure dev environment

### DIFF
--- a/turbo/apps/web/app/slack/link/actions.ts
+++ b/turbo/apps/web/app/slack/link/actions.ts
@@ -198,7 +198,7 @@ async function sendSuccessMessage(
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `:white_check_mark: *Successfully logged in to VM0!*\n\nYou can now:\n• Use \`/vm0 agent add\` to add an agent\n• Mention \`@VM0\` to interact with your agents`,
+          text: `:white_check_mark: *Successfully logged in to VM0!*\n\nYou can now:\n• Use \`/vm0 agent link\` to link an agent\n• Mention \`@VM0\` to interact with your agents`,
         },
       },
     ],

--- a/turbo/apps/web/app/slack/success/page.tsx
+++ b/turbo/apps/web/app/slack/success/page.tsx
@@ -161,8 +161,8 @@ function SlackSuccessContent(): React.JSX.Element {
               <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
                 <li>
                   • Use{" "}
-                  <code className="rounded bg-muted px-1">/vm0 agent add</code>{" "}
-                  to add an agent
+                  <code className="rounded bg-muted px-1">/vm0 agent link</code>{" "}
+                  to link an agent
                 </li>
                 <li>
                   • Mention <code className="rounded bg-muted px-1">@VM0</code>{" "}

--- a/turbo/apps/web/scripts/dev.sh
+++ b/turbo/apps/web/scripts/dev.sh
@@ -88,6 +88,20 @@ log_info "Tunnel URL: ${GREEN}${TUNNEL_URL}${NC}"
 log_info "Webhooks: ${YELLOW}${TUNNEL_URL}/api/webhooks/agent-events${NC}"
 echo ""
 
+# Update SLACK_REDIRECT_BASE_URL in .env.local
+ENV_LOCAL_FILE="$WEB_APP_DIR/.env.local"
+if [ -f "$ENV_LOCAL_FILE" ]; then
+  if grep -q "^SLACK_REDIRECT_BASE_URL=" "$ENV_LOCAL_FILE"; then
+    # Update existing value
+    sed -i "s|^SLACK_REDIRECT_BASE_URL=.*|SLACK_REDIRECT_BASE_URL=${TUNNEL_URL}|" "$ENV_LOCAL_FILE"
+    log_info "Updated SLACK_REDIRECT_BASE_URL in .env.local"
+  else
+    # Append new value
+    echo "SLACK_REDIRECT_BASE_URL=${TUNNEL_URL}" >> "$ENV_LOCAL_FILE"
+    log_info "Added SLACK_REDIRECT_BASE_URL to .env.local"
+  fi
+fi
+
 # Change to web app directory and exec next dev with VM0_API_URL set
 cd "$WEB_APP_DIR"
 exec env VM0_API_URL="$TUNNEL_URL" npx next dev --turbopack --port 3000

--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -263,6 +263,27 @@ describe("buildHelpMessage", () => {
     );
     expect(usageBlock).toBeDefined();
   });
+
+  it("should use 'Log in' and 'Log out' descriptions for login/logout commands", () => {
+    const blocks = buildHelpMessage();
+
+    // Find the account section
+    const accountBlock = blocks.find(
+      (b) =>
+        b.type === "section" &&
+        "text" in b &&
+        b.text?.text?.includes("/vm0 login"),
+    );
+    expect(accountBlock).toBeDefined();
+
+    const text = (accountBlock as SectionBlock).text?.text ?? "";
+    // Should use "Log in to VM0" not "Link your VM0 account"
+    expect(text).toContain("Log in to VM0");
+    expect(text).toContain("Log out of VM0");
+    // Should NOT contain old descriptions
+    expect(text).not.toContain("Link your VM0 account");
+    expect(text).not.toContain("Unlink your account");
+  });
 });
 
 describe("buildSuccessMessage", () => {

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -653,7 +653,7 @@ export function buildHelpMessage(): (Block | KnownBlock)[] {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "*Account*\n• `/vm0 login` - Link your VM0 account\n• `/vm0 logout` - Unlink your account",
+        text: "*Account*\n• `/vm0 login` - Log in to VM0\n• `/vm0 logout` - Log out of VM0",
       },
     },
     {


### PR DESCRIPTION
## Summary
- Renamed `/vm0 agent add` command to `/vm0 agent link` for consistency with the actual operation
- Updated help text from "Link your VM0 account" / "Unlink your account" to "Log in to VM0" / "Log out of VM0" for clarity
- Added automatic `SLACK_REDIRECT_BASE_URL` configuration in dev.sh script to streamline local development with dev tunnel

## Test plan
- [ ] Verify `/vm0 help` shows "Log in to VM0" and "Log out of VM0" in the Account section
- [ ] Verify success message after login shows `/vm0 agent link` command
- [ ] Verify success page shows `/vm0 agent link` command
- [ ] Test dev.sh script updates SLACK_REDIRECT_BASE_URL in .env.local when starting dev tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)