### PR TITLE
feat(platform): polish logs page ui with skeletons and refined copy

### DIFF
--- a/turbo/apps/docs/content/docs/product-philosophy.mdx
+++ b/turbo/apps/docs/content/docs/product-philosophy.mdx
@@ -41,8 +41,6 @@ Security must exist at the foundation. We treat security as a first-order concer
 
 Every system shapes how people act and decide. What it encourages gets reinforced, and what it ignores slowly fades. So, the way VM0 guide agents toward best practices matters. The way VM0 structure defaults matters. The way builders are encouraged to compose agents matters.
 
-VM0 attempts to guide people and agents toward doing the right things more naturally.
-
 ## **Iterative**
 
 ### **Built for long-running work**

--- a/turbo/apps/platform/src/views/agents-page/agents-list-skeleton.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-list-skeleton.tsx
@@ -1,0 +1,46 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@vm0/ui/components/ui/table";
+import { Skeleton } from "@vm0/ui/components/ui/skeleton";
+
+export function AgentsListSkeleton() {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="h-10">Your agents</TableHead>
+          <TableHead className="h-10">Provider</TableHead>
+          <TableHead className="h-10">Schedule status</TableHead>
+          <TableHead className="h-10">Last edit</TableHead>
+          <TableHead className="h-10 w-12" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {Array.from({ length: 12 }, (_, i) => (
+          <TableRow key={`skeleton-${i}`} className="h-[53px]">
+            <TableCell className="px-3 py-2">
+              <Skeleton className="h-5 w-32" />
+            </TableCell>
+            <TableCell className="px-3 py-2">
+              <Skeleton className="h-4 w-24" />
+            </TableCell>
+            <TableCell className="px-3 py-2">
+              <Skeleton className="h-7 w-28 rounded-lg" />
+            </TableCell>
+            <TableCell className="px-3 py-2">
+              <Skeleton className="h-4 w-28" />
+            </TableCell>
+            <TableCell className="px-2 py-2">
+              <Skeleton className="h-9 w-9 rounded-lg" />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/turbo/apps/platform/src/views/agents-page/agents-list-skeleton.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-list-skeleton.tsx
@@ -21,7 +21,7 @@ export function AgentsListSkeleton() {
         </TableRow>
       </TableHeader>
       <TableBody>
-        {Array.from({ length: 12 }, (_, i) => (
+        {Array.from({ length: 8 }, (_, i) => (
           <TableRow key={`skeleton-${i}`} className="h-[53px]">
             <TableCell className="px-3 py-2">
               <Skeleton className="h-5 w-32" />

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -41,7 +41,7 @@ export function AgentsPage() {
     <AppShell
       breadcrumb={["Agents"]}
       title="Agents"
-      subtitle="A list of all your active agents"
+      subtitle="Your agents, their schedules, and when they were last updated"
     >
       <div className="flex flex-col gap-5 px-6 pb-8">
         <AgentsListSection />
@@ -64,7 +64,7 @@ function AgentsListSection() {
     return (
       <div className="rounded-lg border border-border bg-card overflow-hidden">
         <div className="p-8 text-center">
-          <p className="text-sm text-destructive">Error: {error}</p>
+          <p className="text-sm text-destructive">Whoops! {error}</p>
         </div>
       </div>
     );
@@ -73,10 +73,16 @@ function AgentsListSection() {
   if (agents.length === 0) {
     return (
       <div className="rounded-lg border border-border bg-card overflow-hidden">
-        <div className="p-8 text-center">
+        <div className="p-8 text-center space-y-4">
           <p className="text-sm text-muted-foreground">
-            No agents found. Create your first agent with the CLI.
+            No agents yet. Time to create your first one.
           </p>
+          <div className="flex flex-col items-center gap-2">
+            <p className="text-xs text-muted-foreground">Get started:</p>
+            <code className="px-3 py-2 text-xs bg-muted rounded-md font-mono text-foreground">
+              npm install -g @vm0/cli && vm0 onboard
+            </code>
+          </div>
         </div>
       </div>
     );

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -24,6 +24,7 @@ import {
   TableRow,
 } from "@vm0/ui/components/ui/table";
 import { AppShell } from "../layout/app-shell.tsx";
+import { AgentsListSkeleton } from "./agents-list-skeleton.tsx";
 import { useGet } from "ccstate-react";
 import {
   agentsList$,
@@ -42,7 +43,7 @@ export function AgentsPage() {
       title="Agents"
       subtitle="A list of all your active agents"
     >
-      <div className="flex flex-col gap-5 px-8 pb-8">
+      <div className="flex flex-col gap-5 px-6 pb-8">
         <AgentsListSection />
       </div>
     </AppShell>
@@ -56,13 +57,7 @@ function AgentsListSection() {
   const error = useGet(agentsError$);
 
   if (loading) {
-    return (
-      <div className="rounded-lg border border-border bg-card overflow-hidden">
-        <div className="p-8 text-center">
-          <p className="text-sm text-muted-foreground">Loading agents...</p>
-        </div>
-      </div>
-    );
+    return <AgentsListSkeleton />;
   }
 
   if (error) {
@@ -91,11 +86,11 @@ function AgentsListSection() {
     <Table>
       <TableHeader>
         <TableRow>
-          <TableHead>Your agents</TableHead>
-          <TableHead>Provider</TableHead>
-          <TableHead>Schedule status</TableHead>
-          <TableHead>Last edit</TableHead>
-          <TableHead className="w-12" />
+          <TableHead className="h-10">Your agents</TableHead>
+          <TableHead className="h-10">Provider</TableHead>
+          <TableHead className="h-10">Schedule status</TableHead>
+          <TableHead className="h-10">Last edit</TableHead>
+          <TableHead className="h-10 w-12" />
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -103,13 +98,13 @@ function AgentsListSection() {
           const hasSchedule = getAgentScheduleStatus(agent.name, schedules);
           return (
             <TableRow key={agent.name} className="h-[53px]">
-              <TableCell>
+              <TableCell className="px-3 py-2">
                 <span className="font-medium">{agent.name}</span>
               </TableCell>
-              <TableCell>
+              <TableCell className="px-3 py-2">
                 <span className="text-sm">Claude code</span>
               </TableCell>
-              <TableCell>
+              <TableCell className="px-3 py-2">
                 {hasSchedule ? (
                   <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
                     <Clock className="h-3 w-3 text-sky-600" />
@@ -122,7 +117,7 @@ function AgentsListSection() {
                   </span>
                 )}
               </TableCell>
-              <TableCell>
+              <TableCell className="px-3 py-2">
                 <span className="text-sm">
                   {new Date(agent.updatedAt).toLocaleDateString("en-US", {
                     month: "short",
@@ -131,7 +126,7 @@ function AgentsListSection() {
                   })}
                 </span>
               </TableCell>
-              <TableCell>
+              <TableCell className="px-2 py-2">
                 <Dialog>
                   <TooltipProvider>
                     <Tooltip>

--- a/turbo/apps/platform/src/views/components/pagination.tsx
+++ b/turbo/apps/platform/src/views/components/pagination.tsx
@@ -60,7 +60,7 @@ export function Pagination({
           value={String(rowsPerPage)}
           onValueChange={handleRowsPerPageChange}
         >
-          <SelectTrigger className="w-20">
+          <SelectTrigger className="w-[80px]">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -85,41 +85,41 @@ export function Pagination({
         <Button
           variant="outline"
           size="icon"
-          className="size-8"
+          className="size-7 bg-card"
           onClick={onBackTwoPages}
           disabled={!canGoBackTwo}
         >
-          <IconChevronsLeft className="size-6" />
+          <IconChevronsLeft className="size-4" />
         </Button>
         {/* Previous page */}
         <Button
           variant="outline"
           size="icon"
-          className="size-8"
+          className="size-7 bg-card"
           onClick={onPrevPage}
           disabled={!hasPrev}
         >
-          <IconChevronLeft className="size-6" />
+          <IconChevronLeft className="size-4" />
         </Button>
         {/* Next page */}
         <Button
           variant="outline"
           size="icon"
-          className="size-8"
+          className="size-7 bg-card"
           onClick={onNextPage}
           disabled={!hasNext || isLoading}
         >
-          <IconChevronRight className="size-6" />
+          <IconChevronRight className="size-4" />
         </Button>
         {/* Forward two pages */}
         <Button
           variant="outline"
           size="icon"
-          className="size-8"
+          className="size-7 bg-card"
           onClick={onForwardTwoPages}
           disabled={!hasNext || isLoading}
         >
-          <IconChevronsRight className="size-6" />
+          <IconChevronsRight className="size-4" />
         </Button>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -52,10 +52,15 @@
 }
 
 /* Markdown preview spacing overrides - outside @layer for higher specificity */
-.wmde-markdown li > p {
-  margin-top: 6px;
-}
 
+/* Unified spacing for all elements */
+.wmde-markdown p,
+.wmde-markdown h1,
+.wmde-markdown h2,
+.wmde-markdown h3,
+.wmde-markdown h4,
+.wmde-markdown h5,
+.wmde-markdown h6,
 .wmde-markdown blockquote,
 .wmde-markdown ul,
 .wmde-markdown ol,
@@ -63,18 +68,87 @@
 .wmde-markdown table,
 .wmde-markdown pre,
 .wmde-markdown details {
+  margin-top: 6px;
   margin-bottom: 6px;
 }
 
-.wmde-markdown h2 {
+.wmde-markdown li > p {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* Heading sizes - H1 max 16px, others smaller */
+.wmde-markdown h1 {
   font-size: 16px;
-  margin-top: 16px;
   padding-bottom: 0;
   border-bottom: none;
+  font-weight: 600;
+}
+
+.wmde-markdown h2 {
+  font-size: 15px;
+  padding-bottom: 0;
+  border-bottom: none;
+  font-weight: 600;
+}
+
+.wmde-markdown h3 {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.wmde-markdown h4 {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.wmde-markdown h5 {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.wmde-markdown h6 {
+  font-size: 12px;
+  font-weight: 500;
+}
+
+/* Reduce list indentation */
+.wmde-markdown ul,
+.wmde-markdown ol {
+  padding-left: 8px;
+}
+
+.wmde-markdown ul ul,
+.wmde-markdown ol ul,
+.wmde-markdown ul ol,
+.wmde-markdown ol ol {
+  padding-left: 6px;
+}
+
+/* Ensure list markers are visible */
+.wmde-markdown ul {
+  list-style-type: disc;
+  padding-left: 20px;
 }
 
 .wmde-markdown ol {
-  padding-left: 0px;
+  list-style-type: decimal;
+  padding-left: 24px;
+}
+
+.wmde-markdown ul ul {
+  list-style-type: circle;
+  padding-left: 18px;
+}
+
+.wmde-markdown ol ol {
+  list-style-type: lower-alpha;
+  padding-left: 22px;
+}
+
+/* Reduce blockquote indentation */
+.wmde-markdown blockquote {
+  padding-left: 6px;
 }
 
 /* Details/summary animation */

--- a/turbo/apps/platform/src/views/default-error-boundary.tsx
+++ b/turbo/apps/platform/src/views/default-error-boundary.tsx
@@ -12,11 +12,11 @@ export function DefaultErrorFallback(_props: ErrorFallbackProps) {
       <div className="flex flex-col items-center">
         <div className="mt-12">
           <div className="w-80 text-center text-base font-semibold text-gray-900">
-            Something went wrong.
+            Oops! Something went sideways
           </div>
 
           <div className="mt-2 w-80 text-center text-sm text-gray-500">
-            Please try again or get in touch with our team for further help.
+            Give it another try or reach out—we&apos;re here to help.
           </div>
         </div>
       </div>

--- a/turbo/apps/platform/src/views/home/home-page.tsx
+++ b/turbo/apps/platform/src/views/home/home-page.tsx
@@ -17,7 +17,7 @@ export function HomePage() {
         subtitle="Follow the steps below and let it run."
         gradientBackground
       >
-        <div className="flex flex-col gap-10 px-8 pb-8">
+        <div className="flex flex-col gap-10 px-6 pb-8">
           <>
             <Step1InstallSkill />
             <Step2SampleAgents />

--- a/turbo/apps/platform/src/views/layout/app-shell.tsx
+++ b/turbo/apps/platform/src/views/layout/app-shell.tsx
@@ -38,7 +38,7 @@ export function AppShell({
       <div className="flex flex-1 flex-col min-w-0">
         <Navbar breadcrumb={normalizedBreadcrumb} />
         <main
-          className={`flex-1 overflow-auto ${gradientBackground ? "bg-background" : ""}`}
+          className={`flex-1 overflow-auto pt-1 ${gradientBackground ? "bg-background" : ""}`}
         >
           {title && <PageHeader title={title} subtitle={subtitle} />}
           {children}

--- a/turbo/apps/platform/src/views/layout/page-header.tsx
+++ b/turbo/apps/platform/src/views/layout/page-header.tsx
@@ -5,7 +5,7 @@ interface PageHeaderProps {
 
 export function PageHeader({ title, subtitle }: PageHeaderProps) {
   return (
-    <div className="px-4 sm:px-8 pt-6 sm:pt-8 pb-4 sm:pb-5">
+    <div className="px-4 sm:px-6 pt-6 sm:pt-6 pb-4 sm:pb-5">
       <h1 className="text-xl sm:text-2xl font-semibold tracking-tight">
         {title}
       </h1>

--- a/turbo/apps/platform/src/views/logs-page/__tests__/log-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/logs-page/__tests__/log-detail-page.test.tsx
@@ -348,7 +348,7 @@ describe("log detail page", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/Error:/)).toBeInTheDocument();
+      expect(screen.getByText(/Hmm, couldn't load that/)).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/logs-page/__tests__/logs-page.test.tsx
+++ b/turbo/apps/platform/src/views/logs-page/__tests__/logs-page.test.tsx
@@ -69,7 +69,7 @@ describe("logs page", () => {
 
     // Wait for empty state to render
     await waitFor(() => {
-      expect(screen.getByText("No runs found")).toBeInTheDocument();
+      expect(screen.getByText("Nothing here yet")).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/logs-page/components/grouped-message-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/grouped-message-card.tsx
@@ -124,7 +124,7 @@ function SystemMessageCard({
     <div className={`${MESSAGE_SPACING} relative`}>
       {showConnector && (
         <div
-          className="absolute left-[3px] top-6 bottom-[-8px] w-[1px] bg-border/40"
+          className="absolute left-[3px] top-6 bottom-[-8px] w-[1px] bg-border/70"
           aria-hidden="true"
         />
       )}
@@ -161,11 +161,11 @@ function ResultMessageCard({
     <div className="relative">
       {showConnector && (
         <div
-          className="absolute left-[3px] top-6 bottom-[-8px] w-[1px] bg-border/40"
+          className="absolute left-[3px] top-6 bottom-[-8px] w-[1px] bg-border/70"
           aria-hidden="true"
         />
       )}
-      <details className="group" open>
+      <details className="group relative" open>
         <summary className="cursor-pointer list-none relative py-2">
           <div className="flex gap-2 items-center">
             <StatusDot variant="primary" />
@@ -181,7 +181,9 @@ function ResultMessageCard({
             {timestamp}
           </div>
         </summary>
-        <div className="mt-2 ml-[18px]">
+        {/* Vertical line from dot to content */}
+        <div className="absolute left-[2px] top-[2.25rem] bottom-0 w-[1px] bg-border/70 group-open:block hidden" />
+        <div className="ml-[16px] mt-2 relative">
           <ResultEventContent eventData={eventData} />
         </div>
       </details>
@@ -248,7 +250,7 @@ function TodoCard({
     <div className={`${MESSAGE_SPACING} relative`}>
       {showConnector && (
         <div
-          className="absolute left-[3px] top-6 bottom-[-8px] w-[1px] bg-border/40"
+          className="absolute left-[3px] top-6 bottom-[-8px] w-[1px] bg-border/70"
           aria-hidden="true"
         />
       )}
@@ -330,8 +332,8 @@ function Connector({ isDashed }: { isDashed: boolean }) {
     <div
       className={`absolute left-[3px] top-6 bottom-[-8px] w-[1px] ${
         isDashed
-          ? "border-l border-dashed border-border/60 bg-transparent"
-          : "bg-border/40"
+          ? "border-l border-dashed border-border/70 bg-transparent"
+          : "bg-border/70"
       }`}
       aria-hidden="true"
     />

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
@@ -196,9 +196,11 @@ export function AgentEventsCard({
     : `${events.length}`;
 
   return (
-    <div className={`flex flex-col ${className ?? ""}`}>
-      {/* Fixed header with search */}
-      <div className="px-4 sm:px-8 pt-1 pb-4 shrink-0">
+    <div className={`flex flex-col gap-4 ${className ?? ""}`}>
+      <div
+        id={EVENTS_CONTAINER_ID}
+        className="px-4 sm:px-8 pt-1 flex flex-col gap-4 pb-8"
+      >
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <div className="flex items-center gap-3">
             <span className="text-base font-medium text-foreground whitespace-nowrap">
@@ -235,13 +237,7 @@ export function AgentEventsCard({
             )}
           </div>
         </div>
-      </div>
 
-      {/* Scrollable content */}
-      <div
-        id={EVENTS_CONTAINER_ID}
-        className="px-4 sm:px-8 flex flex-col gap-4 pb-8 flex-1 min-h-0 overflow-auto"
-      >
         <div>
           {events.length === 0 ? (
             <div className="py-8 text-center text-muted-foreground">

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
@@ -199,7 +199,7 @@ export function AgentEventsCard({
     <div className={`flex flex-col gap-4 ${className ?? ""}`}>
       <div
         id={EVENTS_CONTAINER_ID}
-        className="px-4 sm:px-8 flex flex-col gap-4 pb-8"
+        className="px-4 sm:px-8 pt-1 flex flex-col gap-4 pb-8"
       >
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <div className="flex items-center gap-3">

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
@@ -196,11 +196,9 @@ export function AgentEventsCard({
     : `${events.length}`;
 
   return (
-    <div className={`flex flex-col gap-4 ${className ?? ""}`}>
-      <div
-        id={EVENTS_CONTAINER_ID}
-        className="px-4 sm:px-8 pt-1 flex flex-col gap-4 pb-8"
-      >
+    <div className={`flex flex-col ${className ?? ""}`}>
+      {/* Fixed header with search */}
+      <div className="px-4 sm:px-8 pt-1 pb-4 shrink-0">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <div className="flex items-center gap-3">
             <span className="text-base font-medium text-foreground whitespace-nowrap">
@@ -237,7 +235,13 @@ export function AgentEventsCard({
             )}
           </div>
         </div>
+      </div>
 
+      {/* Scrollable content */}
+      <div
+        id={EVENTS_CONTAINER_ID}
+        className="px-4 sm:px-8 flex flex-col gap-4 pb-8 flex-1 min-h-0 overflow-auto"
+      >
         <div>
           {events.length === 0 ? (
             <div className="py-8 text-center text-muted-foreground">

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
@@ -231,13 +231,7 @@ export function AgentEventsCard({
               />
             </div>
             {!isCodex && (
-              <>
-                <div className="h-4 w-px bg-border hidden sm:block" />
-                <ViewModeToggle
-                  mode={viewMode}
-                  setMode={handleViewModeChange}
-                />
-              </>
+              <ViewModeToggle mode={viewMode} setMode={handleViewModeChange} />
             )}
           </div>
         </div>

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -47,7 +47,7 @@ export function LogDetailContent({ logId }: { logId: string }) {
     <div className="flex flex-col gap-4 h-full min-h-0">
       {/* Info Card - Grid layout with dividers */}
       <div className="p-4 pb-0 sm:px-8 sm:pt-4 sm:pb-0">
-        <div className="shrink-0 grid grid-cols-2 md:grid-cols-4 gap-y-2 text-sm px-2 sm:px-4 py-3 bg-card rounded-lg border border-border">
+        <div className="shrink-0 grid grid-cols-2 lg:grid-cols-4 gap-y-2 text-sm px-2 sm:px-4 py-3 bg-card rounded-lg border border-border">
           <InfoItem label="Status" showDivider>
             <StatusBadge status={detail.status} />
           </InfoItem>
@@ -145,7 +145,7 @@ function InfoItem({
   showDivider?: boolean;
 }) {
   return (
-    <div className="flex items-center gap-2 px-2 sm:px-4 [&:nth-child(2n+1)]:pl-0 md:[&:nth-child(2n+1)]:pl-4 md:[&:nth-child(4n+1)]:pl-0 relative overflow-hidden [&:nth-child(2n)>.divider]:hidden md:[&:nth-child(2n)>.divider]:block md:[&:nth-child(4n)>.divider]:hidden">
+    <div className="flex items-center gap-2 px-2 sm:px-4 [&:nth-child(2n+1)]:pl-0 lg:[&:nth-child(2n+1)]:pl-4 lg:[&:nth-child(4n+1)]:pl-0 relative overflow-hidden [&:nth-child(2n)>.divider]:hidden lg:[&:nth-child(2n)>.divider]:block lg:[&:nth-child(4n)>.divider]:hidden">
       <span className="text-sm text-muted-foreground shrink-0">{label}</span>
       <div className="flex items-center text-sm min-w-0 overflow-hidden">
         {children}

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -123,7 +123,7 @@ export function LogDetailContent({ logId }: { logId: string }) {
         framework={detail.framework}
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
-        className="flex-1 min-h-0 overflow-auto"
+        className="flex-1 min-h-0"
       />
     </div>
   );

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -161,7 +161,7 @@ function CopyableId({ label, value }: { label?: string; value: string }) {
   return (
     <span className="inline-flex items-center gap-1.5 min-w-0 max-w-full">
       {label && <span className="text-muted-foreground text-sm">{label}</span>}
-      <code className="font-mono text-xs sm:text-sm text-foreground bg-gray-50 px-1.5 sm:px-3 py-1 rounded-lg inline-flex items-center gap-1 truncate">
+      <code className="font-mono text-xs sm:text-sm text-foreground bg-gray-50 px-1.5 sm:px-3 py-1 rounded-lg inline-flex items-center gap-1 min-w-0">
         <span className="truncate">{value.slice(0, 8)}...</span>
         <CopyButton text={value} className="h-4 w-4 p-0 ml-0.5 shrink-0" />
       </code>

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -52,7 +52,7 @@ export function LogDetailContent({ logId }: { logId: string }) {
             <StatusBadge status={detail.status} />
           </InfoItem>
 
-          <InfoItem label="Agent" showDivider={false}>
+          <InfoItem label="Agent" showDivider>
             <span className="font-medium text-foreground truncate">
               {detail.agentName}
             </span>

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -85,7 +85,7 @@ export function LogDetailContent({ logId }: { logId: string }) {
             </span>
           </InfoItem>
 
-          <InfoItem label="Session ID" showDivider={false}>
+          <InfoItem label="Session ID" showDivider>
             <CopyableId value={detail.sessionId || detail.id} />
           </InfoItem>
 

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -47,7 +47,7 @@ export function LogDetailContent({ logId }: { logId: string }) {
     <div className="flex flex-col gap-4 h-full min-h-0">
       {/* Info Card - Grid layout with dividers */}
       <div className="p-4 pb-0 sm:px-8 sm:pt-4 sm:pb-0">
-        <div className="shrink-0 grid grid-cols-2 md:grid-cols-4 gap-y-3 text-sm px-2 sm:px-4 py-3 bg-card rounded-lg border border-border">
+        <div className="shrink-0 grid grid-cols-2 md:grid-cols-4 gap-y-2 text-sm px-2 sm:px-4 py-3 bg-card rounded-lg border border-border">
           <InfoItem label="Status" showDivider>
             <StatusBadge status={detail.status} />
           </InfoItem>

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -59,7 +59,9 @@ export function LogDetailContent({ logId }: { logId: string }) {
           </InfoItem>
 
           <InfoItem label="Framework" showDivider>
-            <span className="text-foreground">{detail.framework || "-"}</span>
+            <span className="text-foreground truncate">
+              {detail.framework || "-"}
+            </span>
           </InfoItem>
 
           <InfoItem label="Duration" showDivider={false}>
@@ -109,11 +111,15 @@ export function LogDetailContent({ logId }: { logId: string }) {
       {/* Error Banner */}
       {detail.error && (
         <div className="px-4 sm:px-8">
-          <div className="shrink-0 px-4 py-3 bg-destructive/10 rounded-lg border border-destructive/30">
-            <span className="text-sm font-medium text-destructive">
-              Error:{" "}
-            </span>
-            <span className="text-sm text-destructive">{detail.error}</span>
+          <div className="shrink-0 px-4 py-3 bg-destructive/10 rounded-lg border border-destructive/30 overflow-hidden">
+            <div className="flex items-start gap-1 min-w-0">
+              <span className="text-sm font-medium text-destructive shrink-0">
+                Error:{" "}
+              </span>
+              <span className="text-sm text-destructive truncate">
+                {detail.error}
+              </span>
+            </div>
           </div>
         </div>
       )}

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -35,7 +35,7 @@ export function LogDetailContent({ logId }: { logId: string }) {
     return (
       <div className="p-4 sm:p-8">
         <div className="p-8 text-center text-destructive">
-          Error: {errorMessage}
+          Hmm, couldn&apos;t load that... {errorMessage}
         </div>
       </div>
     );

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -12,6 +12,7 @@ import { getOrCreateLogDetail$ } from "../../../../signals/logs-page/logs-signal
 import { StatusBadge } from "../../status-badge.tsx";
 import { ArtifactDownloadButton } from "./artifact-download-button.tsx";
 import { AgentEventsCard } from "./agent-events-card.tsx";
+import { LogDetailSkeleton } from "../log-detail-skeleton.tsx";
 import { formatTime, formatTimeShort, formatDuration } from "../utils.ts";
 
 export function LogDetailContent({ logId }: { logId: string }) {
@@ -23,11 +24,7 @@ export function LogDetailContent({ logId }: { logId: string }) {
   const loadable = useLoadable(detail$);
 
   if (loadable.state === "loading") {
-    return (
-      <div className="p-4 sm:p-8">
-        <div className="p-8 text-center text-muted-foreground">Loading...</div>
-      </div>
-    );
+    return <LogDetailSkeleton />;
   }
 
   if (loadable.state === "hasError") {
@@ -48,15 +45,15 @@ export function LogDetailContent({ logId }: { logId: string }) {
 
   return (
     <div className="flex flex-col gap-4 h-full min-h-0">
-      {/* Info Card - Grid layout similar to table card */}
+      {/* Info Card - Grid layout with dividers */}
       <div className="p-4 pb-0 sm:px-8 sm:pt-4 sm:pb-0">
-        <div className="shrink-0 grid grid-cols-2 md:grid-cols-4 gap-y-3 text-sm px-4 py-3 bg-card rounded-lg border border-border">
+        <div className="shrink-0 grid grid-cols-2 lg:grid-cols-4 gap-x-0 gap-y-2 text-sm px-2 py-2 bg-card rounded-lg border border-border">
           <InfoItem label="Status" showDivider>
             <StatusBadge status={detail.status} />
           </InfoItem>
 
-          <InfoItem label="Agent" showDivider>
-            <span className="font-medium text-foreground">
+          <InfoItem label="Agent" showDivider={false} showDividerLg>
+            <span className="font-medium text-foreground truncate">
               {detail.agentName}
             </span>
           </InfoItem>
@@ -66,7 +63,7 @@ export function LogDetailContent({ logId }: { logId: string }) {
           </InfoItem>
 
           <InfoItem label="Duration" showDivider={false}>
-            <span className="text-foreground">
+            <span className="text-foreground whitespace-nowrap">
               {formatDuration(detail.startedAt, detail.completedAt)}
             </span>
           </InfoItem>
@@ -88,7 +85,7 @@ export function LogDetailContent({ logId }: { logId: string }) {
             </span>
           </InfoItem>
 
-          <InfoItem label="Session ID" showDivider>
+          <InfoItem label="Session ID" showDivider={false} showDividerLg>
             <CopyableId value={detail.sessionId || detail.id} />
           </InfoItem>
 
@@ -135,17 +132,31 @@ function InfoItem({
   label,
   children,
   showDivider = true,
+  showDividerLg = false,
 }: {
   label: string;
   children: ReactNode;
   showDivider?: boolean;
+  showDividerLg?: boolean;
 }) {
+  // 如果 showDividerLg 为 true，表示只在大屏幕显示分割线
+  // 如果 showDivider 为 true，表示在小屏幕和大屏幕都显示分割线
+  const dividerClass = showDividerLg
+    ? "hidden lg:block" // 只在大屏幕显示
+    : showDivider
+      ? "block" // 小屏幕和大屏幕都显示
+      : "hidden"; // 都不显示
+
   return (
-    <div className="flex items-center gap-2 px-4 [&:nth-child(4n+1)]:pl-0 relative">
+    <div className="flex items-center gap-2 px-3 relative min-w-0">
       <span className="text-sm text-muted-foreground shrink-0">{label}</span>
-      <div className="flex items-center text-sm min-w-0">{children}</div>
-      {showDivider && (
-        <div className="absolute right-0 top-1/2 -translate-y-1/2 h-4 w-px bg-border" />
+      <div className="flex items-center text-sm min-w-0 overflow-hidden">
+        {children}
+      </div>
+      {(showDivider || showDividerLg) && (
+        <div
+          className={`absolute right-0 top-1/2 -translate-y-1/2 h-4 w-px bg-border ${dividerClass}`}
+        />
       )}
     </div>
   );

--- a/turbo/apps/platform/src/views/logs-page/log-detail/log-detail-skeleton.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/log-detail-skeleton.tsx
@@ -82,10 +82,10 @@ export function LogDetailSkeleton() {
 
         {/* Event items - one line per event with status dot */}
         <div>
-          {Array.from({ length: 15 }, (_, i) => (
+          {Array.from({ length: 8 }, (_, i) => (
             <div key={`event-${i}`} className="py-2 relative">
               {/* Connector line (except for last item) */}
-              {i < 14 && (
+              {i < 7 && (
                 <div
                   className="absolute left-[3px] top-6 bottom-[-8px] w-[1px] bg-border/40"
                   aria-hidden="true"

--- a/turbo/apps/platform/src/views/logs-page/log-detail/log-detail-skeleton.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/log-detail-skeleton.tsx
@@ -1,0 +1,112 @@
+import { Skeleton } from "@vm0/ui/components/ui/skeleton";
+
+export function LogDetailSkeleton() {
+  return (
+    <div className="flex flex-col gap-4 h-full min-h-0">
+      {/* Info Card Skeleton */}
+      <div className="p-4 pb-0 sm:px-8 sm:pt-4 sm:pb-0">
+        <div className="shrink-0 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-x-0 gap-y-2 text-sm px-4 py-3 bg-card rounded-lg border border-border">
+          {/* Status */}
+          <div className="flex items-center gap-2 px-3 relative min-w-0">
+            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-6 w-20 rounded-full" />
+            <div className="absolute right-0 top-1/2 -translate-y-1/2 h-4 w-px bg-border hidden lg:block" />
+          </div>
+
+          {/* Agent */}
+          <div className="flex items-center gap-2 px-3 relative min-w-0">
+            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-4 w-24" />
+            <div className="absolute right-0 top-1/2 -translate-y-1/2 h-4 w-px bg-border hidden lg:block" />
+          </div>
+
+          {/* Framework */}
+          <div className="flex items-center gap-2 px-3 relative min-w-0">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-4 w-16" />
+            <div className="absolute right-0 top-1/2 -translate-y-1/2 h-4 w-px bg-border hidden lg:block" />
+          </div>
+
+          {/* Duration */}
+          <div className="flex items-center gap-2 px-3 relative min-w-0">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-12" />
+          </div>
+
+          {/* Time */}
+          <div className="flex items-center gap-2 px-3 relative min-w-0">
+            <Skeleton className="h-4 w-10" />
+            <Skeleton className="h-4 w-28" />
+            <div className="absolute right-0 top-1/2 -translate-y-1/2 h-4 w-px bg-border hidden lg:block" />
+          </div>
+
+          {/* Session ID */}
+          <div className="flex items-center gap-2 px-3 relative min-w-0">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-7 w-24 rounded-lg" />
+            <div className="absolute right-0 top-1/2 -translate-y-1/2 h-4 w-px bg-border hidden lg:block" />
+          </div>
+
+          {/* Run ID */}
+          <div className="flex items-center gap-2 px-3 relative min-w-0">
+            <Skeleton className="h-4 w-14" />
+            <Skeleton className="h-7 w-24 rounded-lg" />
+            <div className="absolute right-0 top-1/2 -translate-y-1/2 h-4 w-px bg-border hidden lg:block" />
+          </div>
+
+          {/* Artifacts */}
+          <div className="flex items-center gap-2 px-3 relative min-w-0">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-8 w-8 rounded-lg" />
+          </div>
+        </div>
+      </div>
+
+      {/* Agent Events Section */}
+      <div className="px-4 sm:px-8 flex flex-col gap-4 pb-8">
+        {/* Header with search and controls */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-5 w-28" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+          <div className="flex items-center gap-2 sm:gap-3">
+            <div className="relative flex h-9 flex-1 sm:flex-none items-center rounded-lg border border-border bg-card px-3 gap-2">
+              <Skeleton className="h-4 w-4" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+            <div className="h-4 w-px bg-border hidden sm:block" />
+            <Skeleton className="h-9 w-24 rounded-lg" />
+          </div>
+        </div>
+
+        {/* Event items - one line per event with status dot */}
+        <div>
+          {Array.from({ length: 15 }, (_, i) => (
+            <div key={`event-${i}`} className="py-2 relative">
+              {/* Connector line (except for last item) */}
+              {i < 14 && (
+                <div
+                  className="absolute left-[3px] top-6 bottom-[-8px] w-[1px] bg-border/40"
+                  aria-hidden="true"
+                />
+              )}
+              <div className="flex gap-2 items-start relative">
+                {/* Status dot */}
+                <div className="shrink-0 relative z-10">
+                  <Skeleton className="h-[7px] w-[7px] rounded-full mt-1.5" />
+                </div>
+                {/* Content */}
+                <div className="flex-1 min-w-0">
+                  <Skeleton className="h-4 w-full max-w-2xl" />
+                </div>
+                {/* Timestamp */}
+                <Skeleton className="h-3 w-16 shrink-0 ml-4 hidden sm:block" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/logs-page/log-detail/log-detail.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/log-detail.tsx
@@ -18,7 +18,7 @@ export function LogDetailPage() {
           <LogDetailContent logId={logId} />
         ) : (
           <div className="p-8 text-center text-muted-foreground">
-            Log ID not found
+            Can&apos;t find that run
           </div>
         )}
       </div>

--- a/turbo/apps/platform/src/views/logs-page/logs-empty-state.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-empty-state.tsx
@@ -1,9 +1,9 @@
 export function LogsEmptyState() {
   return (
     <div className="flex flex-col items-center justify-center p-8 text-center text-muted-foreground">
-      <p className="text-lg">No runs found</p>
+      <p className="text-lg">Nothing here yet</p>
       <p className="text-sm mt-2">
-        Runs will appear here once you execute agents.
+        Your agent runs will show up here once they start working their magic.
       </p>
     </div>
   );

--- a/turbo/apps/platform/src/views/logs-page/logs-page.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-page.tsx
@@ -10,7 +10,7 @@ export function LogsPage() {
       title="Logs"
       subtitle="View all agent runs and execution history."
     >
-      <div className="flex flex-col gap-6 px-4 sm:px-6 mb-8">
+      <div className="flex flex-col gap-4 px-4 sm:px-6 mb-8">
         {/* Search */}
         <LogsSearch />
 

--- a/turbo/apps/platform/src/views/logs-page/logs-table-row.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-table-row.tsx
@@ -41,27 +41,37 @@ export function LogsTableRow({ entry }: LogsTableRowProps) {
       className="h-[53px] cursor-pointer hover:bg-muted/50"
       onClick={handleRowClick}
     >
-      <TableCell className="max-w-[180px] px-3 py-2 text-sm font-medium">
-        <span className="block truncate">{entry.id}</span>
+      <TableCell className="px-3 py-2 text-sm font-medium w-[20%] min-w-[80px]">
+        <span className="block truncate whitespace-nowrap">{entry.id}</span>
       </TableCell>
-      <TableCell className="max-w-[180px] px-3 py-2 text-sm">
-        <span className="block truncate">{entry.sessionId ?? "-"}</span>
+      <TableCell className="px-3 py-2 text-sm w-[20%] min-w-[80px]">
+        <span className="block truncate whitespace-nowrap">
+          {entry.sessionId ?? "-"}
+        </span>
       </TableCell>
-      <TableCell className="w-[120px] truncate px-3 py-2 text-sm">
-        {entry.agentName}
+      <TableCell className="px-3 py-2 text-sm w-[15%] min-w-[80px]">
+        <span className="block truncate whitespace-nowrap">
+          {entry.agentName}
+        </span>
       </TableCell>
-      <TableCell className="w-[180px] truncate px-3 py-2 text-sm">
-        {entry.framework ?? "-"}
+      <TableCell className="px-3 py-2 text-sm w-[12%] min-w-[70px]">
+        <span className="block truncate whitespace-nowrap">
+          {entry.framework ?? "-"}
+        </span>
       </TableCell>
-      <TableCell className="w-[100px] px-3 py-2">
-        <StatusBadge status={entry.status} />
+      <TableCell className="px-3 py-2 w-[13%] min-w-[80px]">
+        <div className="truncate whitespace-nowrap">
+          <StatusBadge status={entry.status} />
+        </div>
       </TableCell>
-      <TableCell className="px-3 py-2 text-sm">
-        {formatTime(entry.createdAt)}
+      <TableCell className="px-3 py-2 text-sm w-[15%] min-w-[120px]">
+        <span className="block truncate whitespace-nowrap">
+          {formatTime(entry.createdAt)}
+        </span>
       </TableCell>
-      <TableCell className="w-[50px] px-2 py-2">
-        <div className="flex size-8 items-center justify-center">
-          <IconChevronRight className="size-6 text-muted-foreground" />
+      <TableCell className="w-[44px] px-2 py-2">
+        <div className="flex size-full items-center justify-end pr-[12px]">
+          <IconChevronRight className="size-4 flex-shrink-0" />
         </div>
       </TableCell>
     </TableRow>

--- a/turbo/apps/platform/src/views/logs-page/logs-table-skeleton.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-table-skeleton.tsx
@@ -43,7 +43,7 @@ export function LogsTableSkeleton() {
     <Table>
       <LogsTableHeader />
       <TableBody>
-        {Array.from({ length: 15 }, (_, i) => (
+        {Array.from({ length: 8 }, (_, i) => (
           <TableRow key={`skeleton-${i}`} className="h-[49px]">
             <TableCell className="px-3 py-2">
               <Skeleton className="h-4 w-24" />

--- a/turbo/apps/platform/src/views/logs-page/logs-table-skeleton.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-table-skeleton.tsx
@@ -1,0 +1,74 @@
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from "@vm0/ui";
+import { Skeleton } from "@vm0/ui/components/ui/skeleton";
+
+function LogsTableHeader() {
+  return (
+    <TableHeader className="bg-muted">
+      <TableRow className="hover:bg-transparent">
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[20%] min-w-[80px]">
+          <span className="block truncate whitespace-nowrap">Run ID</span>
+        </TableHead>
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[20%] min-w-[80px]">
+          <span className="block truncate whitespace-nowrap">Session ID</span>
+        </TableHead>
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[15%] min-w-[80px]">
+          <span className="block truncate whitespace-nowrap">Agent</span>
+        </TableHead>
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[12%] min-w-[70px]">
+          <span className="block truncate whitespace-nowrap">Framework</span>
+        </TableHead>
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[13%] min-w-[80px]">
+          <span className="block truncate whitespace-nowrap">Status</span>
+        </TableHead>
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[15%] min-w-[120px]">
+          <span className="block truncate whitespace-nowrap">
+            Generate time
+          </span>
+        </TableHead>
+        <TableHead className="h-10 w-[44px] px-2" />
+      </TableRow>
+    </TableHeader>
+  );
+}
+
+export function LogsTableSkeleton() {
+  return (
+    <Table>
+      <LogsTableHeader />
+      <TableBody>
+        {Array.from({ length: 15 }, (_, i) => (
+          <TableRow key={`skeleton-${i}`} className="h-[49px]">
+            <TableCell className="px-3 py-2">
+              <Skeleton className="h-4 w-24" />
+            </TableCell>
+            <TableCell className="px-3 py-2">
+              <Skeleton className="h-4 w-28" />
+            </TableCell>
+            <TableCell className="px-3 py-2">
+              <Skeleton className="h-4 w-20" />
+            </TableCell>
+            <TableCell className="px-3 py-2">
+              <Skeleton className="h-4 w-16" />
+            </TableCell>
+            <TableCell className="px-3 py-2">
+              <Skeleton className="h-6 w-20 rounded-full" />
+            </TableCell>
+            <TableCell className="px-3 py-2">
+              <Skeleton className="h-4 w-32" />
+            </TableCell>
+            <TableCell className="px-2 py-2">
+              <Skeleton className="h-8 w-8 rounded-lg" />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/turbo/apps/platform/src/views/logs-page/logs-table.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-table.tsx
@@ -3,6 +3,7 @@ import type { Computed } from "ccstate";
 import { currentPageLogs$ } from "../../signals/logs-page/logs-signals.ts";
 import { LogsTableRow } from "./logs-table-row.tsx";
 import { LogsEmptyState } from "./logs-empty-state.tsx";
+import { LogsTableSkeleton } from "./logs-table-skeleton.tsx";
 import { Table, TableHeader, TableBody, TableHead, TableRow } from "@vm0/ui";
 import type { LogsListResponse } from "../../signals/logs-page/types.ts";
 
@@ -10,45 +11,34 @@ function LogsTableHeader() {
   return (
     <TableHeader className="bg-muted">
       <TableRow className="hover:bg-transparent">
-        <TableHead className="h-10 w-[180px] px-3 text-sm font-medium text-foreground">
-          Run ID
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[20%] min-w-[80px]">
+          <span className="block truncate whitespace-nowrap">Run ID</span>
         </TableHead>
-        <TableHead className="h-10 w-[180px] px-3 text-sm font-medium text-foreground">
-          Session ID
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[20%] min-w-[80px]">
+          <span className="block truncate whitespace-nowrap">Session ID</span>
         </TableHead>
-        <TableHead className="h-10 w-[120px] px-3 text-sm font-medium text-foreground">
-          Agent
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[15%] min-w-[80px]">
+          <span className="block truncate whitespace-nowrap">Agent</span>
         </TableHead>
-        <TableHead className="h-10 w-[180px] px-3 text-sm font-medium text-foreground">
-          Framework
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[12%] min-w-[70px]">
+          <span className="block truncate whitespace-nowrap">Framework</span>
         </TableHead>
-        <TableHead className="h-10 w-[100px] px-3 text-sm font-medium text-foreground">
-          Status
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[13%] min-w-[80px]">
+          <span className="block truncate whitespace-nowrap">Status</span>
         </TableHead>
-        <TableHead className="h-10 px-3 text-sm font-medium text-foreground">
-          Generate time
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[15%] min-w-[120px]">
+          <span className="block truncate whitespace-nowrap">
+            Generate time
+          </span>
         </TableHead>
-        <TableHead className="h-10 w-[50px] px-2" />
+        <TableHead className="h-10 w-[44px] px-2" />
       </TableRow>
     </TableHeader>
   );
 }
 
 function LoadingTable() {
-  return (
-    <div className="overflow-x-auto">
-      <Table className="min-w-[800px]">
-        <LogsTableHeader />
-        <TableBody>
-          <TableRow>
-            <td colSpan={7} className="p-4 text-center">
-              Loading...
-            </td>
-          </TableRow>
-        </TableBody>
-      </Table>
-    </div>
-  );
+  return <LogsTableSkeleton />;
 }
 
 export function LogsTable() {
@@ -64,18 +54,16 @@ export function LogsTable() {
         ? currentPage.error.message
         : "Failed to load logs";
     return (
-      <div className="overflow-x-auto">
-        <Table className="min-w-[800px]">
-          <LogsTableHeader />
-          <TableBody>
-            <TableRow>
-              <td colSpan={7} className="p-4 text-center text-destructive">
-                Error: {errorMessage}
-              </td>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </div>
+      <Table>
+        <LogsTableHeader />
+        <TableBody>
+          <TableRow>
+            <td colSpan={7} className="p-4 text-center text-destructive">
+              Error: {errorMessage}
+            </td>
+          </TableRow>
+        </TableBody>
+      </Table>
     );
   }
 
@@ -103,18 +91,16 @@ function LogsTableData({ pageComputed }: LogsTableDataProps) {
         ? dataLoadable.error.message
         : "Failed to load logs";
     return (
-      <div className="overflow-x-auto">
-        <Table className="min-w-[800px]">
-          <LogsTableHeader />
-          <TableBody>
-            <TableRow>
-              <td colSpan={7} className="p-4 text-center text-destructive">
-                Error: {errorMessage}
-              </td>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </div>
+      <Table>
+        <LogsTableHeader />
+        <TableBody>
+          <TableRow>
+            <td colSpan={7} className="p-4 text-center text-destructive">
+              Error: {errorMessage}
+            </td>
+          </TableRow>
+        </TableBody>
+      </Table>
     );
   }
 
@@ -123,15 +109,13 @@ function LogsTableData({ pageComputed }: LogsTableDataProps) {
   }
 
   return (
-    <div className="overflow-x-auto">
-      <Table className="min-w-[800px]">
-        <LogsTableHeader />
-        <TableBody>
-          {dataLoadable.data.data.map((entry) => (
-            <LogsTableRow key={entry.id} entry={entry} />
-          ))}
-        </TableBody>
-      </Table>
-    </div>
+    <Table>
+      <LogsTableHeader />
+      <TableBody>
+        {dataLoadable.data.data.map((entry) => (
+          <LogsTableRow key={entry.id} entry={entry} />
+        ))}
+      </TableBody>
+    </Table>
   );
 }

--- a/turbo/apps/platform/src/views/logs-page/status-badge.tsx
+++ b/turbo/apps/platform/src/views/logs-page/status-badge.tsx
@@ -1,10 +1,17 @@
-import { IconCircleCheck } from "@tabler/icons-react";
+import {
+  IconCircleCheck,
+  IconClock,
+  IconPlayerPlay,
+  IconCircleX,
+  IconClockExclamation,
+  IconBan,
+} from "@tabler/icons-react";
 import type { LogStatus } from "../../signals/logs-page/types.ts";
 
 interface StatusBadgeConfig {
   label: string;
-  className: string;
-  iconClassName?: string;
+  icon: typeof IconCircleCheck;
+  iconClassName: string;
 }
 
 interface StatusBadgeProps {
@@ -13,31 +20,47 @@ interface StatusBadgeProps {
 
 function getStatusConfig(): Record<LogStatus, StatusBadgeConfig> {
   return {
-    pending: { label: "Pending", className: "bg-yellow-100 text-yellow-800" },
-    running: { label: "Running", className: "bg-sky-100 text-sky-800" },
+    pending: {
+      label: "Pending",
+      icon: IconClock,
+      iconClassName: "text-yellow-600",
+    },
+    running: {
+      label: "Running",
+      icon: IconPlayerPlay,
+      iconClassName: "text-sky-600",
+    },
     completed: {
       label: "Done",
-      className: "border border-border bg-background text-muted-foreground",
+      icon: IconCircleCheck,
       iconClassName: "text-green-600",
     },
-    failed: { label: "Failed", className: "bg-red-100 text-red-800" },
-    timeout: { label: "Timeout", className: "bg-orange-100 text-orange-800" },
-    cancelled: { label: "Cancelled", className: "bg-gray-100 text-gray-800" },
+    failed: {
+      label: "Failed",
+      icon: IconCircleX,
+      iconClassName: "text-red-600",
+    },
+    timeout: {
+      label: "Timeout",
+      icon: IconClockExclamation,
+      iconClassName: "text-orange-600",
+    },
+    cancelled: {
+      label: "Cancelled",
+      icon: IconBan,
+      iconClassName: "text-gray-600",
+    },
   };
 }
 
 export function StatusBadge({ status }: StatusBadgeProps) {
   const statusConfig = getStatusConfig();
   const config = statusConfig[status];
-  const showIcon = config.iconClassName;
+  const Icon = config.icon;
 
   return (
-    <span
-      className={`inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium ${config.className}`}
-    >
-      {showIcon && (
-        <IconCircleCheck className={`h-3 w-3 ${config.iconClassName}`} />
-      )}
+    <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
+      <Icon className={`h-3 w-3 ${config.iconClassName}`} />
       {config.label}
     </span>
   );

--- a/turbo/packages/ui/src/components/ui/input.tsx
+++ b/turbo/packages/ui/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 disabled:cursor-not-allowed disabled:opacity-50 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground",
+          "flex h-9 w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 disabled:cursor-not-allowed disabled:opacity-50 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground",
           type === "password" && "font-mono tracking-wider",
           className,
         )}

--- a/turbo/packages/ui/src/components/ui/select.tsx
+++ b/turbo/packages/ui/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between gap-2 rounded-lg border border-border bg-input px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-8 w-full items-center justify-between gap-2 rounded-lg border border-border bg-input px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className,
     )}
     {...props}

--- a/turbo/packages/ui/src/components/ui/skeleton.tsx
+++ b/turbo/packages/ui/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "../../lib/utils";
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-lg bg-muted/30", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/turbo/packages/ui/src/components/ui/table.tsx
+++ b/turbo/packages/ui/src/components/ui/table.tsx
@@ -25,7 +25,7 @@ const Table = React.forwardRef<
     <div className="table-wrapper">
       <table
         ref={ref}
-        className={cn("w-full caption-bottom text-sm", className)}
+        className={cn("w-full caption-bottom text-sm table-fixed", className)}
         {...props}
       />
     </div>

--- a/turbo/packages/ui/src/index.ts
+++ b/turbo/packages/ui/src/index.ts
@@ -7,6 +7,7 @@ export * from "./components/ui/input";
 export * from "./components/ui/dialog";
 export * from "./components/ui/popover";
 export * from "./components/ui/select";
+export * from "./components/ui/skeleton";
 export * from "./components/ui/table";
 export * from "./components/ui/tabs";
 export * from "./components/ui/tooltip";

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -206,7 +206,7 @@
       --on-filled
     ); /* on-filled - white text on destructive */
 
-    --border: var(--gray-300); /* gray-300 */
+    --border: var(--gray-200); /* gray-200 - primary border color (lighter) */
     --input: var(--white); /* white - same as card */
     --ring: var(--primary-600); /* primary-600 */
 
@@ -304,7 +304,7 @@
       --on-filled
     ); /* on-filled - white text on destructive */
 
-    --border: var(--gray-300); /* gray-300 */
+    --border: var(--gray-200); /* gray-200 - primary border color (lighter) */
     --input: var(
       --white
     ); /* white - same as light theme, adapts to dark value */


### PR DESCRIPTION
## Summary

This PR polishes the platform UI with improved loading states, refined styling, and better user-facing copy.

### Changes

**Loading States & Skeletons**
- Add skeleton components for agents, logs table, and log detail pages
- Reduce skeleton rows from 12-15 to 8 to prevent scrollbars during loading
- Improve visual consistency across loading states

**UI Styling Refinements**
- Refine logs page connector line styling with consistent 70% opacity
- Adjust vertical line positioning in ResultMessageCard for better alignment with status dots
- Align content margins to match summary text positioning
- Polish table, status badge, and layout components

**Copy Improvements**
- Update all user-facing text to natural, personality-driven English
- Replace generic error messages with friendlier, more specific language
- Add onboarding guidance in agents empty state with CLI command
- Make page descriptions more concrete and actionable

**Examples:**
- Empty state: "Nothing here yet" → "Your agent runs will show up here once they start working their magic."
- Error: "Something went wrong" → "Oops! Something went sideways"
- Agents empty: Now includes `npm install -g @vm0/cli && vm0 onboard` guidance

## Test Plan

- [x] Verify skeleton components render without scrollbars
- [x] Check all empty states display proper guidance
- [x] Confirm error messages are clear and actionable
- [x] Validate connector lines align correctly
- [x] Test responsive layouts on different screen sizes

Made with [Cursor](https://cursor.com)