### PR TITLE
chore: enable sentry plugin for claude code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "enabledPlugins": {
-    "deep-dive@team-skills": true
+    "deep-dive@team-skills": true,
+    "sentry@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary
- Enable the Sentry plugin for Claude Code in `.claude/settings.json`
- This allows Claude Code to access Sentry MCP tools for error tracking and debugging

## Test plan
- [x] Verify the JSON syntax is valid
- [ ] Verify the Sentry plugin loads correctly in Claude Code

---
Generated with [Claude Code](https://claude.ai/code)