### PR TITLE
refactor(secrets): isolate model-provider secrets from user secrets by type

### DIFF
--- a/turbo/apps/cli/src/commands/model-provider/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/setup.test.ts
@@ -196,15 +196,14 @@ describe("model-provider setup command", () => {
       );
     });
 
-    it("should handle credential already exists error", async () => {
+    it("should handle API error", async () => {
       server.use(
         http.put("http://localhost:3000/api/model-providers", () => {
           return HttpResponse.json(
             {
               error: {
-                message:
-                  'Credential "ANTHROPIC_API_KEY" already exists as user credential',
-                code: "CREDENTIAL_EXISTS",
+                message: "Something went wrong",
+                code: "BAD_REQUEST",
               },
             },
             { status: 400 },
@@ -224,10 +223,7 @@ describe("model-provider setup command", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("already exists"),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("vm0 model-provider setup --convert"),
+        expect.stringContaining("Something went wrong"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });

--- a/turbo/apps/cli/src/lib/api/domains/model-providers.ts
+++ b/turbo/apps/cli/src/lib/api/domains/model-providers.ts
@@ -3,7 +3,6 @@ import {
   modelProvidersMainContract,
   modelProvidersCheckContract,
   modelProvidersByTypeContract,
-  modelProvidersConvertContract,
   modelProvidersSetDefaultContract,
   modelProvidersUpdateModelContract,
   type ModelProviderType,
@@ -40,8 +39,6 @@ export async function upsertModelProvider(body: {
   // Multi-auth support
   authMethod?: string;
   credentials?: Record<string, string>;
-  // Common options
-  convert?: boolean;
   selectedModel?: string;
 }): Promise<UpsertModelProviderResponse> {
   const config = await getClientConfig();
@@ -94,26 +91,6 @@ export async function deleteModelProvider(
   }
 
   handleError(result, `Model provider "${type}" not found`);
-}
-
-/**
- * Convert existing user credential to model provider
- */
-export async function convertModelProviderCredential(
-  type: ModelProviderType,
-): Promise<ModelProviderResponse> {
-  const config = await getClientConfig();
-  const client = initClient(modelProvidersConvertContract, config);
-
-  const result = await client.convert({
-    params: { type },
-  });
-
-  if (result.status === 200) {
-    return result.body;
-  }
-
-  handleError(result, "Failed to convert credential");
 }
 
 /**

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -65,7 +65,6 @@ export {
   upsertModelProvider,
   checkModelProviderCredential,
   deleteModelProvider,
-  convertModelProviderCredential,
   setModelProviderDefault,
   updateModelProviderModel,
 } from "./domains/model-providers";

--- a/turbo/apps/cli/src/lib/domain/onboard/model-provider.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/model-provider.ts
@@ -83,12 +83,11 @@ export function getProviderChoices(): ProviderChoice[] {
 export async function setupModelProvider(
   type: ModelProviderType,
   credential: string,
-  options?: { convert?: boolean; selectedModel?: string },
+  options?: { selectedModel?: string },
 ): Promise<SetupResult> {
   const response: UpsertModelProviderResponse = await upsertModelProvider({
     type,
     credential,
-    convert: options?.convert,
     selectedModel: options?.selectedModel,
   });
 

--- a/turbo/apps/web/app/api/model-providers/[type]/convert/route.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/convert/route.ts
@@ -6,15 +6,14 @@ import {
 import { modelProvidersConvertContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getUserId } from "../../../../../src/lib/auth/get-user-id";
-import { convertCredentialToModelProvider } from "../../../../../src/lib/model-provider/model-provider-service";
 import { logger } from "../../../../../src/lib/logger";
-import { isNotFound, isBadRequest } from "../../../../../src/lib/errors";
 
 const log = logger("api:model-providers");
 
 const router = tsr.router(modelProvidersConvertContract, {
   /**
-   * POST /api/model-providers/:type/convert - Convert user credential to model provider
+   * POST /api/model-providers/:type/convert - DEPRECATED
+   * Credential conversion is no longer needed since user and model-provider secrets are isolated by type
    */
   convert: async ({ params, headers }) => {
     initServices();
@@ -24,41 +23,16 @@ const router = tsr.router(modelProvidersConvertContract, {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
 
-    log.debug("converting credential to model provider", {
+    log.debug("convert endpoint called (deprecated)", {
       userId,
       type: params.type,
     });
 
-    try {
-      const provider = await convertCredentialToModelProvider(
-        userId,
-        params.type,
-      );
-
-      return {
-        status: 200 as const,
-        body: {
-          id: provider.id,
-          type: provider.type,
-          framework: provider.framework,
-          credentialName: provider.credentialName,
-          authMethod: provider.authMethod ?? null,
-          credentialNames: provider.credentialNames ?? null,
-          isDefault: provider.isDefault,
-          selectedModel: provider.selectedModel,
-          createdAt: provider.createdAt.toISOString(),
-          updatedAt: provider.updatedAt.toISOString(),
-        },
-      };
-    } catch (error) {
-      if (isNotFound(error)) {
-        return createErrorResponse("NOT_FOUND", error.message);
-      }
-      if (isBadRequest(error)) {
-        return createErrorResponse("BAD_REQUEST", error.message);
-      }
-      throw error;
-    }
+    return createErrorResponse(
+      "BAD_REQUEST",
+      "Credential conversion is no longer needed. User secrets and model provider secrets are now isolated by type. " +
+        "Simply configure your model provider directly with `vm0 model-provider setup`.",
+    );
   },
 });
 

--- a/turbo/apps/web/app/api/model-providers/check/[type]/route.ts
+++ b/turbo/apps/web/app/api/model-providers/check/[type]/route.ts
@@ -31,7 +31,8 @@ const router = tsr.router(modelProvidersCheckContract, {
       body: {
         exists: result.exists,
         credentialName: getCredentialNameForType(params.type) ?? "",
-        currentType: result.currentType,
+        // Note: currentType is no longer relevant since user and model-provider secrets are isolated
+        currentType: result.exists ? "model-provider" : undefined,
       },
     };
   },

--- a/turbo/apps/web/app/api/model-providers/route.ts
+++ b/turbo/apps/web/app/api/model-providers/route.ts
@@ -6,7 +6,6 @@ import {
 import {
   modelProvidersMainContract,
   createErrorResponse,
-  getCredentialNameForType,
   hasAuthMethods,
 } from "@vm0/core";
 import { initServices } from "../../../src/lib/init-services";
@@ -17,7 +16,7 @@ import {
   upsertMultiAuthModelProvider,
 } from "../../../src/lib/model-provider/model-provider-service";
 import { logger } from "../../../src/lib/logger";
-import { isBadRequest, isConflict } from "../../../src/lib/errors";
+import { isBadRequest } from "../../../src/lib/errors";
 
 const log = logger("api:model-providers");
 
@@ -65,14 +64,7 @@ const router = tsr.router(modelProvidersMainContract, {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
 
-    const {
-      type,
-      credential,
-      authMethod,
-      credentials,
-      convert,
-      selectedModel,
-    } = body;
+    const { type, credential, authMethod, credentials, selectedModel } = body;
 
     log.debug("upserting model provider", { userId, type, selectedModel });
 
@@ -112,7 +104,6 @@ const router = tsr.router(modelProvidersMainContract, {
           userId,
           type,
           credential,
-          convert,
           selectedModel,
         );
         provider = result.provider;
@@ -140,18 +131,6 @@ const router = tsr.router(modelProvidersMainContract, {
     } catch (error) {
       if (isBadRequest(error)) {
         return createErrorResponse("BAD_REQUEST", error.message);
-      }
-      if (isConflict(error)) {
-        return {
-          status: 409 as const,
-          body: {
-            error: {
-              message: error.message,
-              code: "CONFLICT",
-              credentialName: getCredentialNameForType(type),
-            },
-          },
-        };
       }
       throw error;
     }

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -37,7 +37,6 @@ import { POST as storageCommitRoute } from "../../app/api/storages/commit/route"
 import { DELETE as deleteModelProviderRoute } from "../../app/api/model-providers/[type]/route";
 import { GET as listModelProvidersRoute } from "../../app/api/model-providers/route";
 import { GET as listSecretsRoute } from "../../app/api/secrets/route";
-import { DELETE as deleteSecretRoute } from "../../app/api/secrets/[name]/route";
 import { POST as addPermissionRoute } from "../../app/api/agent/composes/[id]/permissions/route";
 
 /**
@@ -939,25 +938,6 @@ export async function listTestSecrets(): Promise<
   }
   const data = await response.json();
   return data.secrets;
-}
-
-/**
- * Delete a secret via API route handler.
- *
- * @param name - The secret name to delete
- */
-export async function deleteTestSecret(name: string): Promise<void> {
-  const request = createTestRequest(
-    `http://localhost:3000/api/secrets/${name}`,
-    { method: "DELETE" },
-  );
-  const response = await deleteSecretRoute(request);
-  if (!response.ok && response.status !== 204) {
-    const error = await response.json();
-    throw new Error(
-      `Failed to delete secret: ${error.error?.message || response.status}`,
-    );
-  }
 }
 
 /**

--- a/turbo/apps/web/src/db/migrations/0067_isolate_secrets_by_type.sql
+++ b/turbo/apps/web/src/db/migrations/0067_isolate_secrets_by_type.sql
@@ -1,0 +1,10 @@
+-- Migration: Change unique constraint to include type
+-- This allows same secret name to exist with different types (user vs model-provider)
+-- Fixes: https://github.com/vm0-ai/vm0/issues/2432
+
+-- Drop the old unique index that only uses (scope_id, name)
+DROP INDEX IF EXISTS idx_secrets_scope_name;
+
+-- Create new unique index with type included
+-- This allows: (scope_123, "API_KEY", "user") and (scope_123, "API_KEY", "model-provider") to coexist
+CREATE UNIQUE INDEX idx_secrets_scope_name_type ON secrets (scope_id, name, type);

--- a/turbo/apps/web/src/db/migrations/0067_isolate_secrets_by_type.sql
+++ b/turbo/apps/web/src/db/migrations/0067_isolate_secrets_by_type.sql
@@ -5,6 +5,6 @@
 -- Drop the old unique index that only uses (scope_id, name)
 DROP INDEX IF EXISTS idx_secrets_scope_name;
 
--- Create new unique index with type included
+-- Create new unique index with type included (IF NOT EXISTS for idempotency)
 -- This allows: (scope_123, "API_KEY", "user") and (scope_123, "API_KEY", "model-provider") to coexist
-CREATE UNIQUE INDEX idx_secrets_scope_name_type ON secrets (scope_id, name, type);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_secrets_scope_name_type ON secrets (scope_id, name, type);

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -470,6 +470,13 @@
       "when": 1769100000000,
       "tag": "0066_add_agent_permissions",
       "breakpoints": true
+    },
+    {
+      "idx": 67,
+      "version": "7",
+      "when": 1769200000000,
+      "tag": "0067_isolate_secrets_by_type",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/secret.ts
+++ b/turbo/apps/web/src/db/schema/secret.ts
@@ -31,7 +31,13 @@ export const secrets = pgTable(
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => [
-    uniqueIndex("idx_secrets_scope_name").on(table.scopeId, table.name),
+    // Unique constraint includes type to allow same name with different types
+    // e.g., (scope_123, "API_KEY", "user") and (scope_123, "API_KEY", "model-provider") can coexist
+    uniqueIndex("idx_secrets_scope_name_type").on(
+      table.scopeId,
+      table.name,
+      table.type,
+    ),
     index("idx_secrets_scope").on(table.scopeId),
     index("idx_secrets_type").on(table.type),
   ],

--- a/turbo/apps/web/src/lib/errors.ts
+++ b/turbo/apps/web/src/lib/errors.ts
@@ -35,12 +35,6 @@ interface ForbiddenError extends ApiErrorBase {
   readonly code: "FORBIDDEN";
 }
 
-interface ConflictError extends ApiErrorBase {
-  readonly name: "ConflictError";
-  readonly statusCode: 409;
-  readonly code: "CONFLICT";
-}
-
 interface SchedulePastError extends ApiErrorBase {
   readonly name: "SchedulePastError";
   readonly statusCode: 400;
@@ -89,14 +83,6 @@ export function forbidden(message = "Forbidden"): ForbiddenError {
   return error;
 }
 
-export function conflict(message = "Conflict"): ConflictError {
-  const error = new Error(message) as ConflictError;
-  (error as { name: string }).name = "ConflictError";
-  (error as { statusCode: number }).statusCode = 409;
-  (error as { code: string }).code = "CONFLICT";
-  return error;
-}
-
 export function schedulePast(
   message = "Schedule time has already passed",
 ): SchedulePastError {
@@ -131,10 +117,6 @@ export function isBadRequest(e: unknown): e is BadRequestError {
 
 export function isForbidden(e: unknown): e is ForbiddenError {
   return e instanceof Error && e.name === "ForbiddenError";
-}
-
-export function isConflict(e: unknown): e is ConflictError {
-  return e instanceof Error && e.name === "ConflictError";
 }
 
 export function isSchedulePast(e: unknown): e is SchedulePastError {

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -227,8 +227,11 @@ async function resolveModelProviderCredential(
       return { credentials, injectedEnvVars: undefined };
     }
 
-    // Fetch all credentials by name
-    const allCredentialValues = await getSecretValues(userScope.id);
+    // Fetch all model-provider credentials by name
+    const allCredentialValues = await getSecretValues(
+      userScope.id,
+      "model-provider",
+    );
     const credentialsMap: Record<string, string> = {};
     let hasAllRequired = true;
 
@@ -273,7 +276,11 @@ async function resolveModelProviderCredential(
     return { credentials, injectedEnvVars: undefined };
   }
 
-  const credentialValue = await getSecretValue(userScope.id, credentialName);
+  const credentialValue = await getSecretValue(
+    userScope.id,
+    credentialName,
+    "model-provider",
+  );
 
   if (!credentialValue) {
     return { credentials, injectedEnvVars: undefined };
@@ -326,11 +333,12 @@ async function fetchReferencedCredentials(
     return undefined;
   }
 
-  const secrets = await getSecretValues(userScope.id);
+  // Only fetch user secrets for variable expansion (model-provider secrets are isolated)
+  const userSecrets = await getSecretValues(userScope.id, "user");
   log.debug(
-    `Fetched ${Object.keys(secrets).length} secret(s) from scope ${userScope.slug}`,
+    `Fetched ${Object.keys(userSecrets).length} user secret(s) from scope ${userScope.slug}`,
   );
-  return secrets;
+  return userSecrets;
 }
 
 /**

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -463,7 +463,6 @@ export const upsertModelProviderRequestSchema = z.object({
   credential: z.string().min(1).optional(), // Legacy single credential
   authMethod: z.string().optional(), // For multi-auth providers
   credentials: z.record(z.string(), z.string()).optional(), // For multi-auth providers
-  convert: z.boolean().optional(),
   selectedModel: z.string().optional(),
 });
 
@@ -489,7 +488,6 @@ export type UpsertModelProviderResponse = z.infer<
 export const checkCredentialResponseSchema = z.object({
   exists: z.boolean(),
   credentialName: z.string(),
-  currentType: z.enum(["user", "model-provider"]).optional(),
 });
 
 export type CheckCredentialResponse = z.infer<


### PR DESCRIPTION
## Summary

### Backend Changes
- Change unique constraint from `(scopeId, name)` to `(scopeId, name, type)` allowing same-named secrets with different types
- Add optional `type` parameter to `getSecretValue()` and `getSecretValues()` for type-based filtering
- Update `build-context.ts` to properly filter user secrets vs model-provider secrets
- Deprecate `convertCredentialToModelProvider()` - conversion is no longer needed
- Simplify `checkCredentialExists()` to only return `{ exists: boolean }`
- Remove `convertExisting` parameter from `upsertModelProvider()`

### CLI Changes
- Remove `--convert` flag from `vm0 model-provider setup` command
- Remove `convertModelProviderCredential` API function
- Remove `convert` field from request schema
- Remove `currentType` field from check response schema
- Update tests to reflect removed functionality

This enables users to have both user secrets and model-provider secrets with the same name (e.g., `ANTHROPIC_API_KEY`) without conflicts. Model providers can now be configured directly without requiring credential migration.

## Test plan

- [x] Run model-provider service tests (27 passed)
- [x] Run CLI model-provider tests (32 passed)
- [x] Type checking passes for web and cli apps
- [x] Lint passes for web and cli apps
- [ ] CI pipeline passes
- [ ] Verify migration runs correctly on staging

Closes #2432

🤖 Generated with [Claude Code](https://claude.com/claude-code)