### PR TITLE
chore(runner): add log for firecracker socket wait

### DIFF
--- a/turbo/apps/runner/src/lib/firecracker/client.ts
+++ b/turbo/apps/runner/src/lib/firecracker/client.ts
@@ -245,6 +245,7 @@ export class FirecrackerClient {
     while (Date.now() - startTime < timeoutMs) {
       // First check if socket file exists
       if (!fs.existsSync(this.socketPath)) {
+        logger.log(`Waiting for socket file: ${this.socketPath}`);
         await this.sleep(intervalMs);
         continue;
       }


### PR DESCRIPTION
## Summary
- Add debug log when waiting for Firecracker socket file to exist in `waitForReady`

## Test plan
- [ ] Verify log appears when Firecracker socket is not immediately available

🤖 Generated with [Claude Code](https://claude.com/claude-code)