### PR TITLE
feat(cli): add interactive mode and --body flag for secret set command

### DIFF
--- a/e2e/tests/02-parallel/t29-vm0-secret.bats
+++ b/e2e/tests/02-parallel/t29-vm0-secret.bats
@@ -26,7 +26,7 @@ teardown() {
 }
 
 @test "vm0 secret set creates a secret" {
-    run $CLI_COMMAND secret set "$TEST_SECRET_NAME" "test-secret-value"
+    run $CLI_COMMAND secret set "$TEST_SECRET_NAME" --body "test-secret-value"
     assert_success
     assert_output --partial "Secret \"$TEST_SECRET_NAME\" saved"
     assert_output --partial "Use in vm0.yaml"
@@ -35,7 +35,7 @@ teardown() {
 
 @test "vm0 secret list shows created secret" {
     # First create a secret
-    $CLI_COMMAND secret set "$TEST_SECRET_NAME" "secret-value" --description "E2E test"
+    $CLI_COMMAND secret set "$TEST_SECRET_NAME" --body "secret-value" --description "E2E test"
 
     # Then list secrets
     run $CLI_COMMAND secret list
@@ -47,7 +47,7 @@ teardown() {
 
 @test "vm0 secret ls works as alias for list" {
     # First create a secret
-    $CLI_COMMAND secret set "$TEST_SECRET_NAME" "secret-value"
+    $CLI_COMMAND secret set "$TEST_SECRET_NAME" --body "secret-value"
 
     # List using ls alias
     run $CLI_COMMAND secret ls
@@ -57,10 +57,10 @@ teardown() {
 
 @test "vm0 secret set updates existing secret" {
     # Create initial secret
-    $CLI_COMMAND secret set "$TEST_SECRET_NAME" "initial-value"
+    $CLI_COMMAND secret set "$TEST_SECRET_NAME" --body "initial-value"
 
     # Update it
-    run $CLI_COMMAND secret set "$TEST_SECRET_NAME" "updated-value" --description "Updated"
+    run $CLI_COMMAND secret set "$TEST_SECRET_NAME" --body "updated-value" --description "Updated"
     assert_success
     assert_output --partial "Secret \"$TEST_SECRET_NAME\" saved"
 
@@ -71,7 +71,7 @@ teardown() {
 
 @test "vm0 secret delete removes secret" {
     # Create a secret
-    $CLI_COMMAND secret set "$TEST_SECRET_NAME" "to-be-deleted"
+    $CLI_COMMAND secret set "$TEST_SECRET_NAME" --body "to-be-deleted"
 
     # Delete it (use -y to skip confirmation)
     run $CLI_COMMAND secret delete -y "$TEST_SECRET_NAME"

--- a/turbo/apps/cli/src/commands/secret/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/secret/__tests__/set.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
 import { setCommand } from "../set";
+import prompts from "prompts";
 import chalk from "chalk";
 
 describe("secret set command", () => {
@@ -22,11 +23,16 @@ describe("secret set command", () => {
     .spyOn(console, "error")
     .mockImplementation(() => {});
 
+  let originalIsTTY: boolean | undefined;
+
   beforeEach(() => {
     vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
+
+    // Save original TTY state
+    originalIsTTY = process.stdout.isTTY;
   });
 
   afterEach(() => {
@@ -34,6 +40,13 @@ describe("secret set command", () => {
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
     vi.unstubAllEnvs();
+
+    // Restore TTY state
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: originalIsTTY,
+      writable: true,
+      configurable: true,
+    });
   });
 
   describe("--body flag", () => {
@@ -118,6 +131,80 @@ describe("secret set command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain('Secret "MY_API_KEY" saved');
+    });
+  });
+
+  describe("interactive mode", () => {
+    it("should prompt for secret value in interactive mode", async () => {
+      // Set TTY to true for interactive mode
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      server.use(
+        http.put("http://localhost:3000/api/secrets", async ({ request }) => {
+          const body = (await request.json()) as { value: string };
+          expect(body.value).toBe("interactive-secret-value");
+          return HttpResponse.json({
+            id: "1",
+            name: "MY_API_KEY",
+            description: null,
+            type: "user",
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+        }),
+      );
+
+      // Inject the password response
+      prompts.inject(["interactive-secret-value"]);
+
+      await setCommand.parseAsync(["node", "cli", "MY_API_KEY"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain('Secret "MY_API_KEY" saved');
+    });
+
+    it("should create secret with interactive input and description", async () => {
+      Object.defineProperty(process.stdout, "isTTY", {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      server.use(
+        http.put("http://localhost:3000/api/secrets", async ({ request }) => {
+          const body = (await request.json()) as {
+            value: string;
+            description?: string;
+          };
+          expect(body.value).toBe("my-secret");
+          expect(body.description).toBe("Test description");
+          return HttpResponse.json({
+            id: "1",
+            name: "TEST_SECRET",
+            description: "Test description",
+            type: "user",
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+        }),
+      );
+
+      prompts.inject(["my-secret"]);
+
+      await setCommand.parseAsync([
+        "node",
+        "cli",
+        "TEST_SECRET",
+        "-d",
+        "Test description",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain('Secret "TEST_SECRET" saved');
     });
   });
 

--- a/turbo/apps/cli/src/commands/secret/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/secret/__tests__/set.test.ts
@@ -36,8 +36,8 @@ describe("secret set command", () => {
     vi.unstubAllEnvs();
   });
 
-  describe("successful set", () => {
-    it("should create a new secret", async () => {
+  describe("--body flag", () => {
+    it("should create a new secret with --body", async () => {
       server.use(
         http.put("http://localhost:3000/api/secrets", () => {
           return HttpResponse.json({
@@ -55,6 +55,7 @@ describe("secret set command", () => {
         "node",
         "cli",
         "MY_API_KEY",
+        "--body",
         "secret-value",
       ]);
 
@@ -63,7 +64,33 @@ describe("secret set command", () => {
       expect(logCalls).toContain("secrets.MY_API_KEY");
     });
 
-    it("should create a secret with description", async () => {
+    it("should create a secret with -b short flag", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/secrets", () => {
+          return HttpResponse.json({
+            id: "1",
+            name: "MY_API_KEY",
+            description: null,
+            type: "user",
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+        }),
+      );
+
+      await setCommand.parseAsync([
+        "node",
+        "cli",
+        "MY_API_KEY",
+        "-b",
+        "secret-value",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain('Secret "MY_API_KEY" saved');
+    });
+
+    it("should create a secret with --body and --description", async () => {
       server.use(
         http.put("http://localhost:3000/api/secrets", async ({ request }) => {
           const body = (await request.json()) as { description?: string };
@@ -83,6 +110,7 @@ describe("secret set command", () => {
         "node",
         "cli",
         "MY_API_KEY",
+        "--body",
         "secret-value",
         "-d",
         "My API key",
@@ -90,6 +118,29 @@ describe("secret set command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain('Secret "MY_API_KEY" saved');
+    });
+  });
+
+  describe("non-interactive mode", () => {
+    it("should error when no --body provided in non-interactive mode", async () => {
+      // Tests run in non-interactive environment (no TTY)
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "MY_API_KEY"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--body is required in non-interactive mode"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should show usage hint in error message", async () => {
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "MY_API_KEY"]);
+      }).rejects.toThrow("process.exit called");
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("vm0 secret set MY_API_KEY --body");
     });
   });
 
@@ -110,7 +161,13 @@ describe("secret set command", () => {
       );
 
       await expect(async () => {
-        await setCommand.parseAsync(["node", "cli", "MY_API_KEY", "value"]);
+        await setCommand.parseAsync([
+          "node",
+          "cli",
+          "MY_API_KEY",
+          "--body",
+          "value",
+        ]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
@@ -136,7 +193,13 @@ describe("secret set command", () => {
       );
 
       await expect(async () => {
-        await setCommand.parseAsync(["node", "cli", "invalid-name", "value"]);
+        await setCommand.parseAsync([
+          "node",
+          "cli",
+          "invalid-name",
+          "--body",
+          "value",
+        ]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(

--- a/turbo/apps/cli/src/commands/secret/list.ts
+++ b/turbo/apps/cli/src/commands/secret/list.ts
@@ -14,7 +14,7 @@ export const listCommand = new Command()
         console.log(chalk.dim("No secrets found"));
         console.log();
         console.log("To add a secret:");
-        console.log(chalk.cyan("  vm0 secret set MY_API_KEY <value>"));
+        console.log(chalk.cyan("  vm0 secret set MY_API_KEY --body <value>"));
         return;
       }
 


### PR DESCRIPTION
## Summary

- Replace insecure positional argument with secure input methods for `vm0 secret set`
- Add `--body`/`-b` flag for scripted/CI usage
- Add interactive password prompt for terminal usage (masked input)
- Remove positional value argument (breaking change for security)

## Breaking Change

The old positional argument syntax is removed:

```bash
# Old (no longer works):
vm0 secret set MY_KEY my-secret-value

# New:
vm0 secret set MY_KEY --body my-secret-value
# Or interactive:
vm0 secret set MY_KEY
? Enter secret value: ********
```

## Test plan

- [x] `vm0 secret set KEY --body "value"` creates secret
- [x] `vm0 secret set KEY -b "value"` works with short flag
- [x] `vm0 secret set KEY --body "value" -d "desc"` works with description
- [x] `vm0 secret set KEY` in non-TTY shows helpful error
- [x] All tests pass

Closes #2405

🤖 Generated with [Claude Code](https://claude.ai/code)