### PR TITLE
fix(web): exclude stale pending runs from concurrency check

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -15,6 +15,7 @@ import {
   getTestRun,
   completeTestRun,
   createTestPermission,
+  insertStalePendingRun,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -22,7 +23,6 @@ import {
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
-import { agentRuns } from "../../../../../src/db/schema/agent-run";
 
 vi.mock("@clerk/nextjs/server");
 vi.mock("@e2b/code-interpreter");
@@ -717,66 +717,48 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
     it("should not count stale pending runs toward concurrency limit", async () => {
       vi.stubEnv("CONCURRENT_RUN_LIMIT", "1");
 
-      try {
-        // Get a valid agentComposeVersionId from an existing compose
-        const { versionId } = await createTestCompose(uniqueId("stale"));
+      // Get a valid agentComposeVersionId from an existing compose
+      const { versionId } = await createTestCompose(uniqueId("stale"));
 
-        // Insert a "pending" run directly into DB with old createdAt (20 minutes ago)
-        // This simulates a run stuck in pending state past the TTL
-        const staleCreatedAt = new Date(Date.now() - 20 * 60 * 1000);
-        await globalThis.services.db.insert(agentRuns).values({
-          userId: user.userId,
-          agentComposeVersionId: versionId,
-          status: "pending",
-          prompt: "Stale pending run",
-          createdAt: staleCreatedAt,
-          lastHeartbeatAt: staleCreatedAt,
-        });
+      // Insert a stale "pending" run (20 minutes old, past the 15-min TTL)
+      // This simulates a run stuck in pending state that the cron job missed
+      await insertStalePendingRun(user.userId, versionId);
 
-        // New run should succeed because the stale pending run (>15min) is excluded
-        const run = await createTestRun(testComposeId, "Should not be blocked");
-        expect(run.status).toBe("running");
-      } finally {
-        vi.unstubAllEnvs();
-      }
+      // New run should succeed because the stale pending run (>15min) is excluded
+      const run = await createTestRun(testComposeId, "Should not be blocked");
+      expect(run.status).toBe("running");
     });
 
     it("should still count running runs older than TTL toward concurrency limit", async () => {
       vi.stubEnv("CONCURRENT_RUN_LIMIT", "1");
 
-      try {
-        // Record time when run is created
-        const runCreationTime = Date.now();
+      // Record time when run is created
+      const runCreationTime = Date.now();
 
-        // First run should succeed and stay running
-        const run1 = await createTestRun(testComposeId, "Long running task");
-        expect(run1.status).toBe("running");
+      // First run should succeed and stay running
+      const run1 = await createTestRun(testComposeId, "Long running task");
+      expect(run1.status).toBe("running");
 
-        // Advance time past the pending TTL (16 minutes)
-        // Running runs should STILL count regardless of age
-        context.mocks.dateNow.mockReturnValue(
-          runCreationTime + 16 * 60 * 1000,
-        );
+      // Advance time past the pending TTL (16 minutes)
+      // Running runs should STILL count regardless of age
+      context.mocks.dateNow.mockReturnValue(runCreationTime + 16 * 60 * 1000);
 
-        // Second run should still fail because the first run is "running"
-        // (running runs are always counted, even if older than TTL)
-        const request = createTestRequest(
-          "http://localhost:3000/api/agent/runs",
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              agentComposeId: testComposeId,
-              prompt: "Should be blocked",
-            }),
-          },
-        );
+      // Second run should still fail because the first run is "running"
+      // (running runs are always counted, even if older than TTL)
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentComposeId: testComposeId,
+            prompt: "Should be blocked",
+          }),
+        },
+      );
 
-        const response = await POST(request);
-        expect(response.status).toBe(429);
-      } finally {
-        vi.unstubAllEnvs();
-      }
+      const response = await POST(request);
+      expect(response.status).toBe(429);
     });
 
     it("should fall back to default limit when CONCURRENT_RUN_LIMIT is invalid", async () => {

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -22,6 +22,7 @@ import {
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { agentRuns } from "../../../../../src/db/schema/agent-run";
 
 vi.mock("@clerk/nextjs/server");
 vi.mock("@e2b/code-interpreter");
@@ -702,6 +703,71 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
             body: JSON.stringify({
               agentComposeId: testComposeId,
               prompt: "Fourth run",
+            }),
+          },
+        );
+
+        const response = await POST(request);
+        expect(response.status).toBe(429);
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it("should not count stale pending runs toward concurrency limit", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT", "1");
+
+      try {
+        // Get a valid agentComposeVersionId from an existing compose
+        const { versionId } = await createTestCompose(uniqueId("stale"));
+
+        // Insert a "pending" run directly into DB with old createdAt (20 minutes ago)
+        // This simulates a run stuck in pending state past the TTL
+        const staleCreatedAt = new Date(Date.now() - 20 * 60 * 1000);
+        await globalThis.services.db.insert(agentRuns).values({
+          userId: user.userId,
+          agentComposeVersionId: versionId,
+          status: "pending",
+          prompt: "Stale pending run",
+          createdAt: staleCreatedAt,
+          lastHeartbeatAt: staleCreatedAt,
+        });
+
+        // New run should succeed because the stale pending run (>15min) is excluded
+        const run = await createTestRun(testComposeId, "Should not be blocked");
+        expect(run.status).toBe("running");
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it("should still count running runs older than TTL toward concurrency limit", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT", "1");
+
+      try {
+        // Record time when run is created
+        const runCreationTime = Date.now();
+
+        // First run should succeed and stay running
+        const run1 = await createTestRun(testComposeId, "Long running task");
+        expect(run1.status).toBe("running");
+
+        // Advance time past the pending TTL (16 minutes)
+        // Running runs should STILL count regardless of age
+        context.mocks.dateNow.mockReturnValue(
+          runCreationTime + 16 * 60 * 1000,
+        );
+
+        // Second run should still fail because the first run is "running"
+        // (running runs are always counted, even if older than TTL)
+        const request = createTestRequest(
+          "http://localhost:3000/api/agent/runs",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              agentComposeId: testComposeId,
+              prompt: "Should be blocked",
             }),
           },
         );

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -1,4 +1,4 @@
-import { eq, and, count, inArray, gt } from "drizzle-orm";
+import { eq, and, count, gt, or } from "drizzle-orm";
 import { checkpoints } from "../../db/schema/checkpoint";
 import { agentRuns } from "../../db/schema/agent-run";
 import {
@@ -22,8 +22,10 @@ import {
 
 const log = logger("service:run");
 
-// Pending runs older than this are considered stale and excluded from concurrency check
-const PENDING_RUN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+// Defense-in-depth: exclude pending runs older than this from concurrency check.
+// The cleanup-sandboxes cron job already transitions pending runs to "timeout" after 5 minutes,
+// so this TTL only matters if the cron job fails to run.
+const PENDING_RUN_TTL_MS = 15 * 60 * 1000; // 15 minutes
 
 // Re-export for backward compatibility
 export { calculateSessionHistoryPath } from "./utils/session-history-path";
@@ -63,7 +65,7 @@ export async function checkRunConcurrencyLimit(
     return;
   }
 
-  // Exclude stale pending runs (older than TTL) from concurrency check
+  // Count active runs: all "running" runs + "pending" runs within TTL
   const staleThreshold = new Date(Date.now() - PENDING_RUN_TTL_MS);
 
   const [result] = await globalThis.services.db
@@ -72,8 +74,13 @@ export async function checkRunConcurrencyLimit(
     .where(
       and(
         eq(agentRuns.userId, userId),
-        inArray(agentRuns.status, ["pending", "running"]),
-        gt(agentRuns.createdAt, staleThreshold),
+        or(
+          eq(agentRuns.status, "running"),
+          and(
+            eq(agentRuns.status, "pending"),
+            gt(agentRuns.createdAt, staleThreshold),
+          ),
+        ),
       ),
     );
 

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -1,4 +1,4 @@
-import { eq, and, count, inArray } from "drizzle-orm";
+import { eq, and, count, inArray, gt } from "drizzle-orm";
 import { checkpoints } from "../../db/schema/checkpoint";
 import { agentRuns } from "../../db/schema/agent-run";
 import {
@@ -22,6 +22,9 @@ import {
 
 const log = logger("service:run");
 
+// Pending runs older than this are considered stale and excluded from concurrency check
+const PENDING_RUN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
 // Re-export for backward compatibility
 export { calculateSessionHistoryPath } from "./utils/session-history-path";
 
@@ -31,10 +34,6 @@ export { calculateSessionHistoryPath } from "./utils/session-history-path";
  * @param userId User ID to check
  * @param limit Maximum allowed concurrent runs (default: 1, or CONCURRENT_RUN_LIMIT env var, 0 = no limit)
  * @throws ConcurrentRunLimitError if limit exceeded
- *
- * TODO: cleanup-sandboxes cron job only cleans up "running" runs, not "pending" runs.
- * If a run gets stuck in "pending" status, it will block the user's concurrent limit forever.
- * Need to add cleanup logic for stale pending runs.
  */
 export async function checkRunConcurrencyLimit(
   userId: string,
@@ -64,6 +63,9 @@ export async function checkRunConcurrencyLimit(
     return;
   }
 
+  // Exclude stale pending runs (older than TTL) from concurrency check
+  const staleThreshold = new Date(Date.now() - PENDING_RUN_TTL_MS);
+
   const [result] = await globalThis.services.db
     .select({ count: count() })
     .from(agentRuns)
@@ -71,6 +73,7 @@ export async function checkRunConcurrencyLimit(
       and(
         eq(agentRuns.userId, userId),
         inArray(agentRuns.status, ["pending", "running"]),
+        gt(agentRuns.createdAt, staleThreshold),
       ),
     );
 


### PR DESCRIPTION
## Summary

Add TTL (24 hours) to pending runs in concurrency check. 
This prevents stale pending runs from permanently blocking user's concurrent limit.

## Problem

As noted in the TODO comment at `run-service.ts:35-37`:
> cleanup-sandboxes cron job only cleans up "running" runs, not "pending" runs.
> If a run gets stuck in "pending" status, it will block the user's concurrent limit forever.

## Solution

- Add a 24-hour TTL filter to the concurrency check query
- Pending runs older than 24 hours are excluded from the count
- This allows users to create new runs even if old pending runs exist

## Testing

- [x] TypeScript types check passes
- [x] ESLint passes
- [x] Formatting passes