### PR TITLE
fix(web): validate locale before dynamic import in i18n config

### DIFF
--- a/turbo/apps/web/i18n.ts
+++ b/turbo/apps/web/i18n.ts
@@ -16,8 +16,10 @@ export const languageNames: Record<Locale, string> = {
 };
 
 export default getRequestConfig(async ({ locale }) => {
-  // Fallback to default locale if undefined
-  const resolvedLocale = locale || defaultLocale;
+  // Validate locale and fallback to default if invalid
+  // This prevents errors from malformed URLs like /favicon.ico/blog
+  const resolvedLocale =
+    locale && locales.includes(locale as Locale) ? locale : defaultLocale;
 
   return {
     locale: resolvedLocale,


### PR DESCRIPTION
## Summary

Fixes error when crawler requests hit malformed URLs like `/favicon.ico/blog`. The invalid locale parameter was being passed directly to the dynamic import, causing a module not found error.

## Root Cause

In `i18n.ts`, the fallback logic `locale || defaultLocale` only handles falsy values. When `locale` is a non-empty string like `favicon.ico`, it bypasses the fallback and attempts to import `./messages/favicon.ico.json` which doesn't exist.

## Solution

Added locale validation before the dynamic import:

```typescript
const resolvedLocale =
  locale && locales.includes(locale as Locale) ? locale : defaultLocale;
```

This ensures any invalid locale (not in the supported `locales` array) falls back to the default locale.

## Test plan

- [x] Lint passes
- [x] Manually verify that valid locales (en, de, ja, es) still work
- [x] Invalid locales fall back to default locale instead of throwing errors

Closes #2452

🤖 Generated with [Claude Code](https://claude.com/claude-code)