### PR TITLE
fix(platform): wrap error messages to prevent horizontal scroll

### DIFF
--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -111,12 +111,12 @@ export function LogDetailContent({ logId }: { logId: string }) {
       {/* Error Banner */}
       {detail.error && (
         <div className="px-4 sm:px-8">
-          <div className="shrink-0 px-4 py-3 bg-destructive/10 rounded-lg border border-destructive/30 overflow-hidden">
+          <div className="shrink-0 px-4 py-3 bg-destructive/10 rounded-lg border border-destructive/30">
             <div className="flex items-start gap-1 min-w-0">
               <span className="text-sm font-medium text-destructive shrink-0">
                 Error:{" "}
               </span>
-              <span className="text-sm text-destructive truncate">
+              <span className="text-sm text-destructive whitespace-pre-wrap break-words">
                 {detail.error}
               </span>
             </div>


### PR DESCRIPTION
## Summary
- Replace `truncate` class with `whitespace-pre-wrap break-words` on error banner text to allow long bash error messages to wrap within the viewport
- Remove `overflow-hidden` from the error banner container to allow proper text display
- Prevents horizontal scrolling on mobile devices when viewing logs with long error messages

## Test plan
- [ ] Navigate to logs detail page with a run that has bash command errors
- [ ] Verify error messages wrap properly instead of causing horizontal scroll
- [ ] Test on mobile viewport to ensure no horizontal scrollbar appears

Fixes #2450

🤖 Generated with [Claude Code](https://claude.com/claude-code)