### PR TITLE
refactor(cli): simplify sentry config to use dsn env var

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -428,7 +428,7 @@ jobs:
       - name: Build CLI
         run: cd turbo && pnpm --filter @vm0/cli build
         env:
-          DEFAULT_SENTRY_DSN: ${{ secrets.SENTRY_DSN_CLI }}
+          DEFAULT_SENTRY_DSN: ${{ vars.SENTRY_DSN_CLI }}
 
       - name: Publish to npm with OIDC
         run: cd turbo/apps/cli/dist && npm publish --access public

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -427,6 +427,8 @@ jobs:
 
       - name: Build CLI
         run: cd turbo && pnpm --filter @vm0/cli build
+        env:
+          DEFAULT_SENTRY_DSN: ${{ secrets.SENTRY_DSN_CLI }}
 
       - name: Publish to npm with OIDC
         run: cd turbo/apps/cli/dist && npm publish --access public

--- a/turbo/apps/cli/src/instrument.ts
+++ b/turbo/apps/cli/src/instrument.ts
@@ -6,17 +6,10 @@ import * as Sentry from "@sentry/node";
 import * as os from "node:os";
 
 declare const __CLI_VERSION__: string;
+declare const __DEFAULT_SENTRY_DSN__: string;
 
-const TELEMETRY_DISABLED = process.env.VM0_TELEMETRY === "false";
-const IS_CI = Boolean(process.env.CI || process.env.GITHUB_ACTIONS);
-const IS_DEV = process.env.NODE_ENV === "development";
-// Only enable Sentry for production (vm0.ai)
-// If VM0_API_URL is set to a non-production URL, disable Sentry
-const PRODUCTION_API_URL = "https://www.vm0.ai";
-const API_URL = process.env.VM0_API_URL ?? "";
-const IS_PRODUCTION_API = API_URL === "" || API_URL === PRODUCTION_API_URL;
-const DSN =
-  "https://268d9b4cd051531805af76a5b3934dca@o4510583739777024.ingest.us.sentry.io/4510832047947776";
+// Runtime SENTRY_DSN takes precedence, then build-time default
+const DSN = process.env.SENTRY_DSN ?? __DEFAULT_SENTRY_DSN__;
 
 /**
  * Patterns for operational errors that should NOT be sent to Sentry.
@@ -61,7 +54,7 @@ function isOperationalError(error: unknown): boolean {
   return OPERATIONAL_ERROR_PATTERNS.some((pattern) => pattern.test(message));
 }
 
-if (!TELEMETRY_DISABLED && !IS_CI && !IS_DEV && IS_PRODUCTION_API) {
+if (DSN) {
   Sentry.init({
     dsn: DSN,
     sendDefaultPii: false,

--- a/turbo/apps/cli/tsup.config.ts
+++ b/turbo/apps/cli/tsup.config.ts
@@ -22,9 +22,12 @@ export default defineConfig({
   },
   // Bundle workspace packages
   noExternal: [/@vm0\/.*/],
-  // Inject version from package.json at build time
+  // Inject version and default Sentry DSN from package.json/env at build time
   define: {
     __CLI_VERSION__: JSON.stringify(pkg.version),
+    __DEFAULT_SENTRY_DSN__: JSON.stringify(
+      process.env.DEFAULT_SENTRY_DSN ?? "",
+    ),
   },
   onSuccess: isWatchMode
     ? async () => {

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -2,9 +2,6 @@
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "globalEnv": [
-    "CI",
-    "GITHUB_ACTIONS",
-    "VM0_TELEMETRY",
     "DATABASE_URL",
     "DB_POOL_MAX",
     "DB_POOL_IDLE_TIMEOUT_MS",
@@ -45,6 +42,7 @@
     "SLACK_REDIRECT_BASE_URL",
     "CLAUDE_CODE_VERSION_URL",
     "OPENROUTER_API_KEY",
+    "DEFAULT_SENTRY_DSN",
     "SENTRY_DSN",
     "SENTRY_AUTH_TOKEN",
     "SENTRY_ORG",


### PR DESCRIPTION
## Summary
- Remove hardcoded Sentry DSN and multiple env var checks (`CI`, `GITHUB_ACTIONS`, `VM0_TELEMETRY`, `NODE_ENV`, `VM0_API_URL`)
- Use runtime `SENTRY_DSN` env var with fallback to build-time `DEFAULT_SENTRY_DSN`
- Sentry is disabled when neither is set — only production CLI builds receive `DEFAULT_SENTRY_DSN` via the release workflow (`secrets.SENTRY_DSN_CLI`)

## Test plan
- [x] CLI builds successfully
- [x] Type check passes
- [x] Lint passes
- [x] All 737 CLI tests pass
- [ ] Add `SENTRY_DSN_CLI` secret in GitHub with the DSN value

🤖 Generated with [Claude Code](https://claude.com/claude-code)