### PR TITLE
refactor(web): rename slack login/logout commands to connect/disconnect

### DIFF
--- a/turbo/apps/web/app/api/slack/commands/route.ts
+++ b/turbo/apps/web/app/api/slack/commands/route.ts
@@ -161,7 +161,7 @@ async function handleAgentCommand(
 }
 
 /**
- * Handle /vm0 login command
+ * Handle /vm0 connect command
  */
 function handleLoginCommand(
   payload: SlackCommandPayload,
@@ -169,12 +169,12 @@ function handleLoginCommand(
   userLink: { id: string; vm0UserId: string } | undefined,
   requestUrl: string,
 ): NextResponse {
-  // Already logged in
+  // Already connected
   if (userLink) {
     return NextResponse.json({
       response_type: "ephemeral",
       blocks: buildSuccessMessage(
-        "You are already logged in.\n\nUse `/vm0 agent link` to link an agent or `/vm0 help` for more commands.",
+        "You are already connected.\n\nUse `/vm0 agent link` to link an agent or `/vm0 help` for more commands.",
       ),
     });
   }
@@ -199,7 +199,7 @@ function handleLoginCommand(
 }
 
 /**
- * Handle /vm0 logout command
+ * Handle /vm0 disconnect command
  */
 async function handleLogoutCommand(
   userLink: { id: string } | undefined,
@@ -207,7 +207,7 @@ async function handleLogoutCommand(
   if (!userLink) {
     return NextResponse.json({
       response_type: "ephemeral",
-      blocks: buildErrorMessage("You are not logged in."),
+      blocks: buildErrorMessage("You are not connected."),
     });
   }
   // Delete user link only - bindings will be orphaned (slackUserLinkId set to NULL)
@@ -218,7 +218,7 @@ async function handleLogoutCommand(
   return NextResponse.json({
     response_type: "ephemeral",
     blocks: buildSuccessMessage(
-      "You have been logged out successfully.\n\nYour agent configurations have been preserved and will be restored when you log in again.",
+      "You have been disconnected successfully.\n\nYour agent configurations have been preserved and will be restored when you connect again.",
     ),
   });
 }
@@ -290,7 +290,7 @@ export async function POST(request: Request) {
     : [];
 
   // Handle login command
-  if (subCommand === "login") {
+  if (subCommand === "connect") {
     return handleLoginCommand(payload, installation, userLink, request.url);
   }
 
@@ -309,7 +309,7 @@ export async function POST(request: Request) {
   const client = createSlackClient(botToken);
 
   // Handle logout command
-  if (subCommand === "logout") {
+  if (subCommand === "disconnect") {
     return handleLogoutCommand(userLink);
   }
 
@@ -342,7 +342,7 @@ export async function POST(request: Request) {
         return NextResponse.json({
           response_type: "ephemeral",
           blocks: buildErrorMessage(
-            "Your Slack app authorization has expired.\n\nPlease use `/vm0 login` to reconnect.",
+            "Your Slack app authorization has expired.\n\nPlease use `/vm0 connect` to reconnect.",
           ),
         });
       }

--- a/turbo/apps/web/app/slack/link/actions.ts
+++ b/turbo/apps/web/app/slack/link/actions.ts
@@ -138,7 +138,7 @@ export async function linkSlackAccount(
     })
     .returning({ id: slackUserLinks.id });
 
-  // Restore orphaned bindings from previous logout
+  // Restore orphaned bindings from previous disconnect
   if (newUserLink) {
     const restoredCount = await globalThis.services.db
       .update(slackBindings)
@@ -192,13 +192,13 @@ async function sendSuccessMessage(
   await client.chat.postEphemeral({
     channel: channelId,
     user: slackUserId,
-    text: `Successfully logged in to VM0!`,
+    text: `Successfully connected to VM0!`,
     blocks: [
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `:white_check_mark: *Successfully logged in to VM0!*\n\nYou can now:\n• Use \`/vm0 agent link\` to link an agent\n• Mention \`@VM0\` to interact with your agents`,
+          text: `:white_check_mark: *Successfully connected to VM0!*\n\nYou can now:\n• Use \`/vm0 agent link\` to link an agent\n• Mention \`@VM0\` to interact with your agents`,
         },
       },
     ],

--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -224,7 +224,7 @@ describe("buildLoginPromptMessage", () => {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: expect.stringContaining("login"),
+        text: expect.stringContaining("connect your account"),
       },
     });
     expect(blocks[1]).toMatchObject({
@@ -232,7 +232,7 @@ describe("buildLoginPromptMessage", () => {
       elements: [
         {
           type: "button",
-          text: { type: "plain_text", text: "Login" },
+          text: { type: "plain_text", text: "Connect" },
           url: loginUrl,
           style: "primary",
         },
@@ -264,7 +264,7 @@ describe("buildHelpMessage", () => {
     expect(usageBlock).toBeDefined();
   });
 
-  it("should use 'Log in' and 'Log out' descriptions for login/logout commands", () => {
+  it("should use 'Connect' and 'Disconnect' descriptions for connect/disconnect commands", () => {
     const blocks = buildHelpMessage();
 
     // Find the account section
@@ -272,17 +272,17 @@ describe("buildHelpMessage", () => {
       (b) =>
         b.type === "section" &&
         "text" in b &&
-        b.text?.text?.includes("/vm0 login"),
+        b.text?.text?.includes("/vm0 connect"),
     );
     expect(accountBlock).toBeDefined();
 
     const text = (accountBlock as SectionBlock).text?.text ?? "";
-    // Should use "Log in to VM0" not "Link your VM0 account"
-    expect(text).toContain("Log in to VM0");
-    expect(text).toContain("Log out of VM0");
+    // Should use "Connect to VM0" not "Log in to VM0"
+    expect(text).toContain("Connect to VM0");
+    expect(text).toContain("Disconnect from VM0");
     // Should NOT contain old descriptions
-    expect(text).not.toContain("Link your VM0 account");
-    expect(text).not.toContain("Unlink your account");
+    expect(text).not.toContain("Log in to VM0");
+    expect(text).not.toContain("Log out of VM0");
   });
 });
 

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -559,7 +559,7 @@ export function buildLoginPromptMessage(
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "To use VM0 in Slack, please login first.",
+        text: "To use VM0 in Slack, please connect your account first.",
       },
     },
     {
@@ -569,7 +569,7 @@ export function buildLoginPromptMessage(
           type: "button",
           text: {
             type: "plain_text",
-            text: "Login",
+            text: "Connect",
           },
           url: loginUrl,
           action_id: "login_prompt",
@@ -653,7 +653,7 @@ export function buildHelpMessage(): (Block | KnownBlock)[] {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "*Account*\n• `/vm0 login` - Log in to VM0\n• `/vm0 logout` - Log out of VM0",
+        text: "*Account*\n• `/vm0 connect` - Connect to VM0\n• `/vm0 disconnect` - Disconnect from VM0",
       },
     },
     {
@@ -819,7 +819,7 @@ export function buildLoginMessage(loginUrl: string): (Block | KnownBlock)[] {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "Please login to use VM0 in this workspace.",
+        text: "Please connect your account to use VM0 in this workspace.",
       },
     },
     {
@@ -829,7 +829,7 @@ export function buildLoginMessage(loginUrl: string): (Block | KnownBlock)[] {
           type: "button",
           text: {
             type: "plain_text",
-            text: "Login",
+            text: "Connect",
           },
           url: loginUrl,
           action_id: "login",

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -226,7 +226,7 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       .limit(1);
 
     if (!userLink) {
-      // 3. User not logged in - post ephemeral login message (only visible to user)
+      // 3. User not connected - post ephemeral connect message (only visible to user)
       const loginUrl = buildLoginUrl(
         context.workspaceId,
         context.userId,
@@ -236,7 +236,7 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       await client.chat.postEphemeral({
         channel: context.channelId,
         user: context.userId,
-        text: "Please login first",
+        text: "Please connect your account first",
         blocks: buildLoginPromptMessage(loginUrl),
       });
       return;


### PR DESCRIPTION
## Summary
- Renames `/vm0 login` and `/vm0 logout` Slack commands to `/vm0 connect` and `/vm0 disconnect`
- Updates all user-facing messages to use "connect/disconnect" terminology instead of "login/logout"
- Updates help text, button labels, error messages, and success messages across the Slack integration

## Changed files
- `apps/web/app/api/slack/commands/route.ts` - Command routing and handler messages
- `apps/web/app/slack/link/actions.ts` - Success message after account linking
- `apps/web/src/lib/slack/blocks.ts` - UI blocks (buttons, help text, login prompts)
- `apps/web/src/lib/slack/handlers/mention.ts` - App mention handler messages
- `apps/web/src/lib/slack/__tests__/blocks.test.ts` - Updated test assertions

## Test plan
- [x] All Slack blocks tests pass (10/10)
- [x] All Slack command route tests pass (16/16)
- [x] All Slack link actions tests pass (9/9)
- [x] Lint, type-check, format, and knip all pass