### PR TITLE
test(cli): replace internal config mock with vi.stubEnv in scope tests

### DIFF
--- a/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
@@ -2,13 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
 import { setCommand } from "../set";
-import * as config from "../../../lib/api/config";
-
-// Mock the config module for auth
-vi.mock("../../../lib/api/config", () => ({
-  getApiUrl: vi.fn(),
-  getToken: vi.fn(),
-}));
 
 describe("scope set command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
@@ -21,8 +14,8 @@ describe("scope set command", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(config.getApiUrl).mockResolvedValue("http://localhost:3000");
-    vi.mocked(config.getToken).mockResolvedValue("test-token");
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
   afterEach(() => {
@@ -33,7 +26,9 @@ describe("scope set command", () => {
 
   describe("authentication", () => {
     it("should exit with error if not authenticated", async () => {
-      vi.mocked(config.getToken).mockResolvedValue(undefined);
+      vi.unstubAllEnvs();
+      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+      // VM0_TOKEN not set - simulates unauthenticated state
 
       await expect(async () => {
         await setCommand.parseAsync(["node", "cli", "testslug"]);

--- a/turbo/apps/cli/src/commands/scope/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/status.test.ts
@@ -2,13 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
 import { statusCommand } from "../status";
-import * as config from "../../../lib/api/config";
-
-// Mock the config module for auth
-vi.mock("../../../lib/api/config", () => ({
-  getApiUrl: vi.fn(),
-  getToken: vi.fn(),
-}));
 
 describe("scope status command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
@@ -21,8 +14,8 @@ describe("scope status command", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(config.getApiUrl).mockResolvedValue("http://localhost:3000");
-    vi.mocked(config.getToken).mockResolvedValue("test-token");
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
   afterEach(() => {
@@ -33,7 +26,9 @@ describe("scope status command", () => {
 
   describe("authentication", () => {
     it("should exit with error if not authenticated", async () => {
-      vi.mocked(config.getToken).mockResolvedValue(undefined);
+      vi.unstubAllEnvs();
+      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+      // VM0_TOKEN not set - simulates unauthenticated state
 
       await expect(async () => {
         await statusCommand.parseAsync(["node", "cli"]);


### PR DESCRIPTION
## Summary

Replace internal config module mock with `vi.stubEnv()` pattern in CLI scope tests.

## Problem

The scope tests (`status.test.ts`, `set.test.ts`) were using:
```typescript
vi.mock("../../../lib/api/config", () => ({...}));
```

This violates the project's testing guidelines:
> **Only Mock External Dependencies** - If `vi.mock()` path starts with `../../`, it's wrong

## Solution

Replace with environment variable stubbing:
```typescript
vi.stubEnv("VM0_API_URL", "http://localhost:3000");
vi.stubEnv("VM0_TOKEN", "test-token");
```

This follows the pattern used in other CLI tests and allows the real `config` module to run.

## Changes

- `apps/cli/src/commands/scope/__tests__/status.test.ts`
- `apps/cli/src/commands/scope/__tests__/set.test.ts`

## Testing

All 14 scope tests pass:
```
✓ scope status command (7 tests)
✓ scope set command (7 tests)
```