### PR TITLE
feat(web): add blog public routes and fix list styling

### DIFF
--- a/turbo/apps/web/app/blog.css
+++ b/turbo/apps/web/app/blog.css
@@ -506,6 +506,16 @@
   padding-left: 24px;
 }
 
+.blog-post-content ul {
+  list-style-type: disc;
+  list-style-position: outside;
+}
+
+.blog-post-content ol {
+  list-style-type: decimal;
+  list-style-position: outside;
+}
+
 .blog-post-content li {
   font-family: "Noto Sans", sans-serif;
   font-size: 16px;
@@ -513,6 +523,7 @@
   line-height: 1.8;
   color: var(--text-secondary);
   margin-bottom: 12px;
+  padding-left: 8px;
 }
 
 .blog-post-content code {

--- a/turbo/apps/web/middleware.ts
+++ b/turbo/apps/web/middleware.ts
@@ -13,6 +13,8 @@ const isPublicRoute = createRouteMatcher([
   "/:locale/terms-of-use",
   "/:locale/privacy-policy",
   "/:locale/design-system",
+  "/:locale/blog",
+  "/:locale/blog/posts/:slug",
   "/sign-in(.*)",
   "/sign-up(.*)",
   "/api/cli/auth/device",


### PR DESCRIPTION
## Summary
- Add blog routes as public routes (no authentication required)
- Fix bullet points display in blog content

## Changes
### Middleware
- Add `/:locale/blog` route to public routes list
- Add `/:locale/blog/posts/:slug` route to public routes list

### Blog CSS
- Add `list-style-type: disc` for `<ul>` elements
- Add `list-style-type: decimal` for `<ol>` elements  
- Add padding-left to list items for better visual alignment

## Test Plan
- [x] Blog listing page is accessible without authentication
- [x] Blog detail pages are accessible without authentication
- [x] Bullet points display correctly in blog content
- [x] List styling works in both light and dark themes


Made with [Cursor](https://cursor.com)