### PR TITLE
fix(cli): map 401/403 responses to user-friendly error messages

### DIFF
--- a/turbo/apps/cli/src/instrument.ts
+++ b/turbo/apps/cli/src/instrument.ts
@@ -42,10 +42,14 @@ const OPERATIONAL_ERROR_PATTERNS = [
   /concurrent run limit/i,
   // Network issues (transient, not bugs)
   /network error/i,
+  /network issue/i,
   /connection refused/i,
   /timeout/i,
   /ECONNREFUSED/i,
   /ETIMEDOUT/i,
+  // Permission/access errors (operational, not bugs)
+  /forbidden/i,
+  /access denied/i,
 ];
 
 /**

--- a/turbo/apps/cli/src/lib/api/domains/scopes.ts
+++ b/turbo/apps/cli/src/lib/api/domains/scopes.ts
@@ -34,7 +34,7 @@ export async function createScope(body: {
     return result.body;
   }
 
-  handleError(result, "Failed to create scope");
+  handleError(result, "Failed to create scope", { useServerMessage: true });
 }
 
 /**
@@ -53,5 +53,5 @@ export async function updateScope(body: {
     return result.body;
   }
 
-  handleError(result, "Failed to update scope");
+  handleError(result, "Failed to update scope", { useServerMessage: true });
 }

--- a/turbo/apps/cli/src/lib/api/domains/scopes.ts
+++ b/turbo/apps/cli/src/lib/api/domains/scopes.ts
@@ -16,7 +16,7 @@ export async function getScope(): Promise<ScopeResponse> {
     return result.body;
   }
 
-  handleError(result, "Failed to get scope");
+  handleError(result, "Failed to get scope", { useServerMessage: true });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Map 401/403 HTTP responses to user-friendly messages in the centralized `handleError` function, instead of exposing raw exceptions or stack traces
- 403 → "An unexpected network issue occurred", 401 → "Not authenticated. Run: vm0 auth login"
- Add `useServerMessage` option to `handleError` so domain-specific callers (e.g., scope slug reservation) can preserve the original server error
- Add `ApiRequestError.status` field to carry HTTP status code for downstream handling
- Filter 403-related errors from Sentry as operational errors (not bugs)

## Test plan
- [x] Existing `scope set` tests pass (reserved slug 403 still shows original server message via `useServerMessage: true`)
- [x] Type check passes
- [x] Lint passes
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)