### PR TITLE
chore: add cloudflared volume mount to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,8 @@
     "source=mkcert,target=/home/vscode/.local/share/mkcert",
     "source=claude,target=/home/vscode/.local/share/claude",
     "source=codex,target=/home/vscode/.codex",
-    "source=pki,target=/home/vscode/.pki"
+    "source=pki,target=/home/vscode/.pki",
+    "source=cloudflared,target=/home/vscode/.cloudflared"
   ],
   "postCreateCommand": "bash .devcontainer/setup.sh",
   "postStartCommand": "gh auth setup-git",


### PR DESCRIPTION
## Summary
- Add persistent `cloudflared` volume mount to devcontainer configuration, preserving cloudflared credentials and config across container rebuilds

## Test plan
- [ ] Rebuild devcontainer and verify the `cloudflared` volume is created and mounted at `~/.cloudflared`
- [ ] Verify existing volume mounts still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)