### PR TITLE
refactor: extract reusable tunnel script and simplify dev server setup

### DIFF
--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# Start a Cloudflare Tunnel to expose a local service.
+# Outputs the tunnel URL to stdout. All other messages go to stderr.
+# Writes the cloudflared PID to /tmp/cloudflared-<port>.pid for cleanup.
+#
+# Usage: scripts/tunnel.sh <port>
+# Example: TUNNEL_URL=$(scripts/tunnel.sh 3000)
+#
+# If git email is @vm0.ai, creates a named tunnel with fixed domain:
+#   tunnel-<username>-<hostname>-<service>.vm7.ai
+# Port-to-service mapping: 3000=web, 3001=docs, 3002=platform, 3003=site
+# Otherwise, creates an anonymous quick tunnel:
+#   <random>.trycloudflare.com
+
+set -euo pipefail
+
+TUNNEL_BASE_DOMAIN="vm7.ai"
+MAX_WAIT=30
+
+log() { echo -e "[tunnel] $1" >&2; }
+
+# --- Args ---
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <port>" >&2
+  exit 1
+fi
+
+PORT="$1"
+if ! [[ "$PORT" =~ ^[0-9]+$ ]]; then
+  echo "Error: port must be a number, got '$PORT'" >&2
+  exit 1
+fi
+
+TUNNEL_LOG="/tmp/cloudflared-${PORT}.log"
+TUNNEL_PIDFILE="/tmp/cloudflared-${PORT}.pid"
+
+# --- Determine mode based on git email ---
+EMAIL=$(git config user.email 2>/dev/null || true)
+DOMAIN="${EMAIL##*@}"
+
+if [[ "$DOMAIN" == "vm0.ai" ]]; then
+  MODE="named"
+  USERNAME="${EMAIL%%@*}"
+  MACHINE_HOSTNAME=$(hostname)
+
+  # Map well-known ports to service names
+  case "$PORT" in
+    3000) SERVICE="www" ;;
+    3001) SERVICE="docs" ;;
+    3002) SERVICE="platform" ;;
+    3003) SERVICE="site" ;;
+    *)    SERVICE="$PORT" ;;
+  esac
+
+  FQDN="tunnel-${USERNAME}-${MACHINE_HOSTNAME}-${SERVICE}.${TUNNEL_BASE_DOMAIN}"
+  TUNNEL_NAME="tunnel-${USERNAME}-${MACHINE_HOSTNAME}-${SERVICE}"
+  TUNNEL_URL="https://${FQDN}"
+else
+  MODE="anonymous"
+fi
+
+# --- Named tunnel setup ---
+if [[ "$MODE" == "named" ]]; then
+  log "Named tunnel: ${FQDN} -> localhost:${PORT}"
+
+  # Ensure authenticated
+  if [[ ! -f "$HOME/.cloudflared/cert.pem" ]]; then
+    log "Not authenticated. Running cloudflared tunnel login..."
+    cloudflared tunnel login >&2
+  fi
+
+  # Reuse existing tunnel or create a new one
+  TUNNEL_ID=$(cloudflared tunnel list --name "$TUNNEL_NAME" 2>/dev/null | { grep "$TUNNEL_NAME" || true; } | awk '{print $1}')
+  if [[ -n "$TUNNEL_ID" && -f "$HOME/.cloudflared/${TUNNEL_ID}.json" ]]; then
+    log "Reusing existing tunnel: ${TUNNEL_NAME}"
+  else
+    # Credentials missing — clean up and recreate
+    if [[ -n "$TUNNEL_ID" ]]; then
+      cloudflared tunnel cleanup "$TUNNEL_NAME" >/dev/null 2>&1 || true
+      cloudflared tunnel delete "$TUNNEL_NAME" >/dev/null 2>&1 || true
+    fi
+    log "Creating tunnel: ${TUNNEL_NAME}"
+    cloudflared tunnel create "$TUNNEL_NAME" >&2
+    TUNNEL_ID=$(cloudflared tunnel list --name "$TUNNEL_NAME" 2>/dev/null | { grep "$TUNNEL_NAME" || true; } | awk '{print $1}')
+  fi
+  if [[ -z "$TUNNEL_ID" ]]; then
+    log "Error: failed to get tunnel ID"
+    exit 1
+  fi
+
+  CREDENTIALS_FILE="$HOME/.cloudflared/${TUNNEL_ID}.json"
+
+  # Write config
+  CONFIG_FILE="$HOME/.cloudflared/config-${TUNNEL_NAME}.yml"
+  cat > "$CONFIG_FILE" <<EOF
+tunnel: ${TUNNEL_ID}
+credentials-file: ${CREDENTIALS_FILE}
+
+ingress:
+  - hostname: ${FQDN}
+    service: http://localhost:${PORT}
+  - service: http_status:404
+EOF
+
+  # Create DNS route
+  cloudflared tunnel route dns --overwrite-dns "$TUNNEL_NAME" "$FQDN" >/dev/null 2>&1 || true
+
+  # Start tunnel in background
+  # QUIC fails in devcontainer environment, must use HTTP/2
+  cloudflared tunnel --config "$CONFIG_FILE" --protocol http2 run "$TUNNEL_NAME" > "$TUNNEL_LOG" 2>&1 &
+
+else
+  log "Anonymous tunnel: localhost:${PORT}"
+
+  # Start quick tunnel in background
+  # QUIC fails in devcontainer environment, must use HTTP/2
+  cloudflared tunnel --url "http://localhost:${PORT}" --protocol http2 > "$TUNNEL_LOG" 2>&1 &
+fi
+
+TUNNEL_PID=$!
+echo "$TUNNEL_PID" > "$TUNNEL_PIDFILE"
+
+# --- Wait for tunnel to be ready ---
+log "Waiting for tunnel connection..."
+ATTEMPT=0
+
+while [[ $ATTEMPT -lt $MAX_WAIT ]]; do
+  if ! kill -0 "$TUNNEL_PID" 2>/dev/null; then
+    log "Error: cloudflared process died unexpectedly"
+    cat "$TUNNEL_LOG" >&2
+    exit 1
+  fi
+
+  if [[ "$MODE" == "named" ]]; then
+    # Named tunnel: wait for "Registered tunnel connection"
+    if grep -q "Registered tunnel connection" "$TUNNEL_LOG" 2>/dev/null; then
+      break
+    fi
+  else
+    # Anonymous tunnel: wait for trycloudflare.com URL
+    TUNNEL_URL=$(grep -o 'https://[a-z0-9-]*\.trycloudflare\.com' "$TUNNEL_LOG" 2>/dev/null | head -n 1)
+    if [[ -n "$TUNNEL_URL" ]]; then
+      break
+    fi
+  fi
+
+  ATTEMPT=$((ATTEMPT + 1))
+  sleep 1
+done
+
+if [[ "$MODE" == "anonymous" && -z "${TUNNEL_URL:-}" ]]; then
+  log "Error: failed to get tunnel URL after ${MAX_WAIT}s"
+  cat "$TUNNEL_LOG" >&2
+  exit 1
+fi
+
+if [[ "$MODE" == "named" ]] && ! grep -q "Registered tunnel connection" "$TUNNEL_LOG" 2>/dev/null; then
+  log "Error: tunnel failed to connect after ${MAX_WAIT}s"
+  cat "$TUNNEL_LOG" >&2
+  exit 1
+fi
+
+log "Tunnel ready: ${TUNNEL_URL} -> localhost:${PORT} (pid: ${TUNNEL_PID})"
+
+# Output URL to stdout
+echo "$TUNNEL_URL"

--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -39,6 +39,7 @@ const nextConfig = {
   experimental: {
     optimizePackageImports: ["next-intl"],
   },
+  allowedDevOrigins: ["*.vm7.ai"],
   serverExternalPackages: ["ably"],
 };
 

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -37,6 +37,7 @@
     "ably": "^2.17.0",
     "croner": "^9.1.0",
     "drizzle-orm": "^0.44.5",
+    "import-in-the-middle": "^2.0.6",
     "next": "^15.5.7",
     "next-intl": "^4.6.1",
     "p-limit": "^7.2.0",
@@ -47,6 +48,7 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
+    "require-in-the-middle": "^8.0.1",
     "server-only": "^0.0.1",
     "zod": "^4.1.12"
   },

--- a/turbo/apps/web/scripts/dev.sh
+++ b/turbo/apps/web/scripts/dev.sh
@@ -2,9 +2,8 @@
 # Start Cloudflare Tunnel and then exec Next.js dev server
 #
 # This script enables E2B webhooks to reach localhost by:
-# 1. Starting a Cloudflare Tunnel to expose localhost:3000
-# 2. Extracting the public tunnel URL
-# 3. Executing Next.js dev server with VM0_API_URL set to tunnel URL
+# 1. Starting a Cloudflare Tunnel via scripts/tunnel.sh
+# 2. Executing Next.js dev server with VM0_API_URL set to tunnel URL
 #
 # Related: https://github.com/vm0-ai/vm0/issues/1726
 
@@ -12,96 +11,38 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WEB_APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-TUNNEL_LOG="/tmp/cloudflared-dev.log"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+PORT=3000
 
-# Colors for output
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m' # No Color
-
-log_info() {
-  echo -e "${GREEN}[tunnel]${NC} $1"
-}
-
-log_warn() {
-  echo -e "${YELLOW}[tunnel]${NC} $1"
-}
-
-log_error() {
-  echo -e "${RED}[tunnel]${NC} $1"
-}
-
-# Cleanup function - only need to kill cloudflared since next dev runs via exec
+# Cleanup cloudflared on exit
 cleanup() {
-  if [ ! -z "$TUNNEL_PID" ] && kill -0 $TUNNEL_PID 2>/dev/null; then
-    kill $TUNNEL_PID 2>/dev/null || true
+  TUNNEL_PID=$(cat "/tmp/cloudflared-${PORT}.pid" 2>/dev/null || true)
+  if [[ -n "$TUNNEL_PID" ]] && kill -0 "$TUNNEL_PID" 2>/dev/null; then
+    kill "$TUNNEL_PID" 2>/dev/null || true
     sleep 1
-    kill -9 $TUNNEL_PID 2>/dev/null || true
+    kill -9 "$TUNNEL_PID" 2>/dev/null || true
   fi
 }
-
 trap cleanup EXIT INT TERM
 
-log_info "Starting Cloudflare Tunnel..."
-
-# Start cloudflared tunnel in background with HTTP/2 protocol
-# Note: HTTP/2 protocol is required - QUIC fails in devcontainer environment
-cloudflared tunnel --url http://localhost:3000 --protocol http2 > "$TUNNEL_LOG" 2>&1 &
-TUNNEL_PID=$!
-
-# Wait for tunnel URL to be available
-log_info "Waiting for tunnel URL (this may take 10-15 seconds)..."
-MAX_ATTEMPTS=30
-ATTEMPT=0
-TUNNEL_URL=""
-
-while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-  # Check if cloudflared is still running
-  if ! kill -0 $TUNNEL_PID 2>/dev/null; then
-    log_error "Cloudflared process died unexpectedly!"
-    log_error "Check logs: $TUNNEL_LOG"
-    cat "$TUNNEL_LOG"
-    exit 1
-  fi
-
-  # Try to extract tunnel URL
-  TUNNEL_URL=$(grep -o 'https://[a-z0-9-]*\.trycloudflare\.com' "$TUNNEL_LOG" 2>/dev/null | head -n 1)
-
-  if [ ! -z "$TUNNEL_URL" ]; then
-    break
-  fi
-
-  ATTEMPT=$((ATTEMPT + 1))
-  sleep 1
-done
-
-if [ -z "$TUNNEL_URL" ]; then
-  log_error "Failed to get tunnel URL after ${MAX_ATTEMPTS} seconds"
-  log_error "Cloudflared log:"
-  cat "$TUNNEL_LOG"
-  exit 1
-fi
+# Start tunnel and capture URL
+TUNNEL_URL=$("$REPO_ROOT/scripts/tunnel.sh" "$PORT")
 
 echo ""
-log_info "Tunnel URL: ${GREEN}${TUNNEL_URL}${NC}"
-log_info "Webhooks: ${YELLOW}${TUNNEL_URL}/api/webhooks/agent-events${NC}"
+echo -e "\033[0;32m[tunnel]\033[0m Tunnel URL: ${TUNNEL_URL}"
+echo -e "\033[0;32m[tunnel]\033[0m Webhooks: \033[1;33m${TUNNEL_URL}/api/webhooks/agent-events\033[0m"
 echo ""
 
 # Update SLACK_REDIRECT_BASE_URL in .env.local
 ENV_LOCAL_FILE="$WEB_APP_DIR/.env.local"
 if [ -f "$ENV_LOCAL_FILE" ]; then
   if grep -q "^SLACK_REDIRECT_BASE_URL=" "$ENV_LOCAL_FILE"; then
-    # Update existing value
     sed -i "s|^SLACK_REDIRECT_BASE_URL=.*|SLACK_REDIRECT_BASE_URL=${TUNNEL_URL}|" "$ENV_LOCAL_FILE"
-    log_info "Updated SLACK_REDIRECT_BASE_URL in .env.local"
   else
-    # Append new value
     echo "SLACK_REDIRECT_BASE_URL=${TUNNEL_URL}" >> "$ENV_LOCAL_FILE"
-    log_info "Added SLACK_REDIRECT_BASE_URL to .env.local"
   fi
 fi
 
-# Change to web app directory and exec next dev with VM0_API_URL set
+# Start Next.js dev server
 cd "$WEB_APP_DIR"
-exec env VM0_API_URL="$TUNNEL_URL" npx next dev --turbopack --port 3000
+exec env VM0_API_URL="$TUNNEL_URL" npx next dev --turbopack --port "$PORT"

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -21,7 +21,9 @@
         "e2b",
         "@testing-library/react",
         "@types/tar",
-        "@slack/web-api"
+        "@slack/web-api",
+        "import-in-the-middle",
+        "require-in-the-middle"
       ],
       "next": {
         "entry": ["next.config.{js,ts,mjs}"]

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -493,6 +493,9 @@ importers:
       drizzle-orm:
         specifier: ^0.44.5
         version: 0.44.5(@neondatabase/serverless@1.0.1)(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(pg@8.16.3)(postgres@3.4.7)
+      import-in-the-middle:
+        specifier: ^2.0.6
+        version: 2.0.6
       next:
         specifier: ^15.5.7
         version: 15.5.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -523,6 +526,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      require-in-the-middle:
+        specifier: ^8.0.1
+        version: 8.0.1
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -9247,7 +9253,7 @@ snapshots:
       '@babel/traverse': 7.28.3
       '@babel/types': 7.28.2
       convert-source-map: 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -15213,7 +15219,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
-      debug: 4.4.1
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary
- Extract tunnel logic from `turbo/apps/web/scripts/dev.sh` into a reusable `scripts/tunnel.sh` that supports both named tunnels (for @vm0.ai users with fixed `*.vm7.ai` domains) and anonymous quick tunnels
- Simplify `dev.sh` to delegate to the shared tunnel script, reducing ~90 lines of inline tunnel management to a single function call
- Add `allowedDevOrigins: ["*.vm7.ai"]` to `next.config.js` for named tunnel support
- Add `import-in-the-middle` and `require-in-the-middle` as explicit dependencies required by `@sentry/nextjs` runtime instrumentation
- Update knip config to ignore these Sentry instrumentation dependencies

## Test plan
- [ ] Verify `scripts/tunnel.sh 3000` starts an anonymous tunnel and outputs URL to stdout
- [ ] Verify `pnpm dev` in `apps/web` starts tunnel and Next.js dev server correctly
- [ ] Verify named tunnel mode works for @vm0.ai users with proper `*.vm7.ai` domain
- [ ] Verify cleanup kills cloudflared process on exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)