### PR TITLE
feat(slack): surface permission-denied questions in agent run output

### DIFF
--- a/turbo/apps/web/src/lib/slack/handlers/__tests__/format-ask-user-denials.test.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/__tests__/format-ask-user-denials.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { formatAskUserDenials } from "../run-agent";
+
+describe("formatAskUserDenials", () => {
+  it("should format a single question without options", () => {
+    const result = formatAskUserDenials([
+      {
+        tool_input: {
+          questions: [{ question: "Which database should I use?" }],
+        },
+      },
+    ]);
+
+    expect(result).toBe(
+      "The agent needs your input to proceed:\n\nWhich database should I use?",
+    );
+  });
+
+  it("should format a question with options", () => {
+    const result = formatAskUserDenials([
+      {
+        tool_input: {
+          questions: [
+            {
+              question: "Which framework do you prefer?",
+              options: [
+                { label: "React", description: "A UI library" },
+                { label: "Vue", description: "A progressive framework" },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(result).toContain("Which framework do you prefer?");
+    expect(result).toContain("  \u2022 React \u2014 A UI library");
+    expect(result).toContain("  \u2022 Vue \u2014 A progressive framework");
+  });
+
+  it("should format options without descriptions", () => {
+    const result = formatAskUserDenials([
+      {
+        tool_input: {
+          questions: [
+            {
+              question: "Pick one:",
+              options: [{ label: "Option A" }, { label: "Option B" }],
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(result).toContain("  \u2022 Option A");
+    expect(result).toContain("  \u2022 Option B");
+    expect(result).not.toContain("\u2014");
+  });
+
+  it("should format multiple questions from a single denial", () => {
+    const result = formatAskUserDenials([
+      {
+        tool_input: {
+          questions: [
+            { question: "First question?" },
+            { question: "Second question?" },
+          ],
+        },
+      },
+    ]);
+
+    expect(result).toContain("First question?");
+    expect(result).toContain("Second question?");
+  });
+
+  it("should format multiple denials", () => {
+    const result = formatAskUserDenials([
+      {
+        tool_input: {
+          questions: [{ question: "Question from denial 1" }],
+        },
+      },
+      {
+        tool_input: {
+          questions: [{ question: "Question from denial 2" }],
+        },
+      },
+    ]);
+
+    expect(result).toContain("Question from denial 1");
+    expect(result).toContain("Question from denial 2");
+  });
+
+  it("should return undefined for empty denials array", () => {
+    const result = formatAskUserDenials([]);
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when denials have no questions", () => {
+    const result = formatAskUserDenials([
+      { tool_input: { questions: [] } },
+      { tool_input: undefined },
+      {},
+    ]);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("should skip denials without tool_input and include ones with questions", () => {
+    const result = formatAskUserDenials([
+      {},
+      {
+        tool_input: {
+          questions: [{ question: "Valid question" }],
+        },
+      },
+    ]);
+
+    expect(result).toContain("Valid question");
+  });
+});

--- a/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
@@ -254,9 +254,22 @@ async function getRunOutput(runId: string): Promise<string | undefined> {
 | order by sequenceNumber desc
 | limit 1`;
 
+  interface PermissionDenial {
+    tool_name: string;
+    tool_input?: {
+      questions?: Array<{
+        question: string;
+        header?: string;
+        options?: Array<{ label: string; description?: string }>;
+        multiSelect?: boolean;
+      }>;
+    };
+  }
+
   interface ResultEvent {
     eventData: {
       result?: string;
+      permission_denials?: PermissionDenial[];
     };
   }
 
@@ -265,7 +278,56 @@ async function getRunOutput(runId: string): Promise<string | undefined> {
     return undefined;
   }
 
-  return events[0]?.eventData?.result;
+  const event = events[0];
+  const result = event?.eventData?.result;
+  const denials = event?.eventData?.permission_denials;
+
+  // When AskUserQuestion was denied (sandbox/non-interactive mode),
+  // format the questions as readable text so the Slack user can see
+  // what the agent wanted to ask.
+  const askDenials = denials?.filter((d) => d.tool_name === "AskUserQuestion");
+  if (askDenials && askDenials.length > 0) {
+    const formatted = formatAskUserDenials(askDenials);
+    if (formatted) {
+      return result ? `${result}\n\n${formatted}` : formatted;
+    }
+  }
+
+  return result;
+}
+
+function formatAskUserDenials(
+  denials: Array<{
+    tool_input?: {
+      questions?: Array<{
+        question: string;
+        header?: string;
+        options?: Array<{ label: string; description?: string }>;
+        multiSelect?: boolean;
+      }>;
+    };
+  }>,
+): string | undefined {
+  const parts: string[] = [];
+
+  for (const denial of denials) {
+    const questions = denial.tool_input?.questions;
+    if (!questions || questions.length === 0) continue;
+
+    for (const q of questions) {
+      parts.push(q.question);
+      if (q.options) {
+        for (const opt of q.options) {
+          const desc = opt.description ? ` — ${opt.description}` : "";
+          parts.push(`  • ${opt.label}${desc}`);
+        }
+      }
+    }
+  }
+
+  if (parts.length === 0) return undefined;
+
+  return `The agent needs your input to proceed:\n\n${parts.join("\n")}`;
 }
 
 /**

--- a/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
@@ -296,7 +296,7 @@ async function getRunOutput(runId: string): Promise<string | undefined> {
   return result;
 }
 
-function formatAskUserDenials(
+export function formatAskUserDenials(
   denials: Array<{
     tool_input?: {
       questions?: Array<{


### PR DESCRIPTION
## Summary

- When an agent run operates in non-interactive/sandbox mode, `AskUserQuestion` tool calls are denied via `permission_denials` in the result event
- This change parses those denied questions from the Axiom result event and formats them as readable text appended to the run output
- Slack users can now see what the agent wanted to ask, enabling them to respond with the needed information in a follow-up message

## Test plan

- [ ] Deploy to staging and trigger a Slack agent run that invokes `AskUserQuestion`
- [ ] Verify the denied questions appear formatted in the Slack response
- [ ] Verify normal runs without permission denials are unaffected
- [ ] Verify runs with only non-`AskUserQuestion` denials are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)