### PR TITLE
fix(devcontainer): add cloudflared dir to ownership fix in setup

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -22,7 +22,7 @@ echo "✓ Locale configured"
 
 # Setup directories - fix ownership for all mounted volumes
 sudo mkdir -p /home/vscode/.local/bin /home/vscode/.pki
-sudo chown -R vscode:vscode /home/vscode/.config /home/vscode/.cache /home/vscode/.local /home/vscode/.pki
+sudo chown -R vscode:vscode /home/vscode/.config /home/vscode/.cache /home/vscode/.local /home/vscode/.pki /home/vscode/.cloudflared
 
 # Create ~/.claude symlink to ~/.config/claude for Claude Code IDE integration
 # The VS Code extension uses ~/.claude/ide/ while CLI respects CLAUDE_CONFIG_DIR


### PR DESCRIPTION
## Summary
- Adds `/home/vscode/.cloudflared` to the `chown` command in `.devcontainer/setup.sh` so the cloudflared volume mount (added in #2476) has correct ownership for the `vscode` user

## Test plan
- [ ] Verify devcontainer builds and starts successfully
- [ ] Verify cloudflared directory has correct `vscode:vscode` ownership after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)