### PR TITLE
feat(slack): add typing indicator and app home tab

### DIFF
--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -135,6 +135,43 @@ function createSlackDmEventRequest(event: {
   });
 }
 
+/** Create a signed Slack app_home_opened event request */
+function createSlackAppHomeOpenedRequest(event: {
+  teamId: string;
+  userId: string;
+}): Request {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const payload = {
+    type: "event_callback",
+    token: "test-token",
+    team_id: event.teamId,
+    api_app_id: "A123",
+    event: {
+      type: "app_home_opened",
+      user: event.userId,
+      tab: "home",
+    },
+    event_id: "Ev789",
+    event_time: parseInt(timestamp),
+  };
+  const body = JSON.stringify(payload);
+
+  // Generate signature
+  const baseString = `v0:${timestamp}:${body}`;
+  const hmac = crypto.createHmac("sha256", TEST_SIGNING_SECRET);
+  const signature = `v0=${hmac.update(baseString).digest("hex")}`;
+
+  return new Request("http://localhost/api/slack/events", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-slack-signature": signature,
+      "x-slack-request-timestamp": timestamp,
+    },
+    body,
+  });
+}
+
 const SLACK_API = "https://slack.com/api";
 
 const slackHandlers = handlers({
@@ -169,6 +206,9 @@ const slackHandlers = handlers({
   ),
   conversationsHistory: http.post(`${SLACK_API}/conversations.history`, () =>
     HttpResponse.json({ ok: true, messages: [] }),
+  ),
+  viewsPublish: http.post(`${SLACK_API}/views.publish`, () =>
+    HttpResponse.json({ ok: true }),
   ),
 });
 
@@ -512,7 +552,7 @@ describe("POST /api/slack/events", () => {
   });
 
   describe("Scenario: DM bot with single agent", () => {
-    it("should execute agent and post response", async () => {
+    it("should post thinking message then update with agent response", async () => {
       // Given I am a linked Slack user with one agent
       const { userLink, installation } = await givenLinkedSlackUser();
       await givenUserHasAgent(userLink, {
@@ -536,12 +576,17 @@ describe("POST /api/slack/events", () => {
       // 1. Thinking reaction should be added
       expect(slackHandlers.mocked.reactionsAdd).toHaveBeenCalledTimes(1);
 
-      // 2. Response message should be posted
+      // 2. Thinking message should be posted first
       expect(slackHandlers.mocked.postMessage).toHaveBeenCalledTimes(1);
+      const thinkingData = await getFormData(slackHandlers.mocked.postMessage);
+      expect(thinkingData.text).toBe("_Thinking..._");
 
-      // 3. Response should include agent name in context block
-      const data = await getFormData(slackHandlers.mocked.postMessage);
-      const blocks = JSON.parse((data.blocks as string) ?? "[]") as Array<{
+      // 3. chatUpdate should replace thinking message with agent response
+      expect(slackHandlers.mocked.chatUpdate).toHaveBeenCalledTimes(1);
+      const updateData = await getFormData(slackHandlers.mocked.chatUpdate);
+      const blocks = JSON.parse(
+        (updateData.blocks as string) ?? "[]",
+      ) as Array<{
         type: string;
         elements?: Array<{ text?: string }>;
       }>;
@@ -576,17 +621,22 @@ describe("POST /api/slack/events", () => {
       expect(response.status).toBe(200);
       await flushAfterCallbacks();
 
-      // Then the message should be routed to the agent (not show welcome card)
+      // Then thinking message should be posted first
       expect(slackHandlers.mocked.postMessage).toHaveBeenCalledTimes(1);
+      const thinkingData = await getFormData(slackHandlers.mocked.postMessage);
+      expect(thinkingData.text).toBe("_Thinking..._");
 
-      const data = await getFormData(slackHandlers.mocked.postMessage);
-      const blocks = JSON.parse((data.blocks as string) ?? "[]") as Array<{
+      // And chatUpdate should replace it with agent response (not welcome card)
+      expect(slackHandlers.mocked.chatUpdate).toHaveBeenCalledTimes(1);
+      const updateData = await getFormData(slackHandlers.mocked.chatUpdate);
+      const blocks = JSON.parse(
+        (updateData.blocks as string) ?? "[]",
+      ) as Array<{
         type: string;
         elements?: Array<{ text?: string }>;
       }>;
       const contextBlocks = blocks.filter((b) => b.type === "context");
       expect(contextBlocks.length).toBeGreaterThanOrEqual(1);
-      // Agent name should be in the response (not a welcome card)
       const agentContext = contextBlocks[0]!.elements?.[0]?.text;
       expect(agentContext).toContain("my-helper");
     });
@@ -635,6 +685,126 @@ describe("POST /api/slack/events", () => {
       // Then no handler should be called (message silently ignored at route level)
       expect(slackHandlers.mocked.postMessage).not.toHaveBeenCalled();
       expect(slackHandlers.mocked.postEphemeral).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Scenario: App Home opened by unlinked user", () => {
+    it("should publish home view with login prompt", async () => {
+      // Given I am a Slack user without a linked account
+      const { installation } = await givenSlackWorkspaceInstalled();
+
+      // When I open the bot's Home tab
+      const request = createSlackAppHomeOpenedRequest({
+        teamId: installation.slackWorkspaceId,
+        userId: "U-unlinked-user",
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // Then the home view should be published with login prompt
+      expect(slackHandlers.mocked.viewsPublish).toHaveBeenCalledTimes(1);
+
+      const data = await getFormData(slackHandlers.mocked.viewsPublish);
+      expect(data.user_id).toBe("U-unlinked-user");
+
+      // View should contain "not connected" and a login button
+      const view = JSON.parse((data.view as string) ?? "{}") as {
+        type: string;
+        blocks: Array<{
+          type: string;
+          text?: { text: string };
+          elements?: Array<{ action_id?: string; url?: string }>;
+        }>;
+      };
+      expect(view.type).toBe("home");
+      const texts = view.blocks
+        .filter(
+          (b): b is { type: string; text: { text: string } } =>
+            b.type === "section" && !!b.text,
+        )
+        .map((b) => b.text.text);
+      expect(texts.some((t) => t.includes("not connected"))).toBe(true);
+    });
+  });
+
+  describe("Scenario: App Home opened by linked user with agent", () => {
+    it("should publish home view with agent list", async () => {
+      // Given I am a linked Slack user with one agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      await givenUserHasAgent(userLink, {
+        agentName: "my-helper",
+        description: "A helpful assistant",
+      });
+
+      // When I open the bot's Home tab
+      const request = createSlackAppHomeOpenedRequest({
+        teamId: installation.slackWorkspaceId,
+        userId: userLink.slackUserId,
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // Then the home view should be published with agent info
+      expect(slackHandlers.mocked.viewsPublish).toHaveBeenCalledTimes(1);
+
+      const data = await getFormData(slackHandlers.mocked.viewsPublish);
+      expect(data.user_id).toBe(userLink.slackUserId);
+
+      const view = JSON.parse((data.view as string) ?? "{}") as {
+        type: string;
+        blocks: Array<{
+          type: string;
+          text?: { text: string };
+        }>;
+      };
+      expect(view.type).toBe("home");
+      const texts = view.blocks
+        .filter(
+          (b): b is { type: string; text: { text: string } } =>
+            b.type === "section" && !!b.text,
+        )
+        .map((b) => b.text.text);
+      expect(texts.some((t) => t.includes("Account connected"))).toBe(true);
+      expect(texts.some((t) => t.includes("my-helper"))).toBe(true);
+    });
+  });
+
+  describe("Scenario: App Home opened by linked user without agents", () => {
+    it("should publish home view with link prompt", async () => {
+      // Given I am a linked Slack user with no agents
+      const { userLink, installation } = await givenLinkedSlackUser();
+
+      // When I open the bot's Home tab
+      const request = createSlackAppHomeOpenedRequest({
+        teamId: installation.slackWorkspaceId,
+        userId: userLink.slackUserId,
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // Then the home view should be published with link prompt
+      expect(slackHandlers.mocked.viewsPublish).toHaveBeenCalledTimes(1);
+
+      const data = await getFormData(slackHandlers.mocked.viewsPublish);
+      const view = JSON.parse((data.view as string) ?? "{}") as {
+        type: string;
+        blocks: Array<{
+          type: string;
+          text?: { text: string };
+        }>;
+      };
+      expect(view.type).toBe("home");
+      const texts = view.blocks
+        .filter(
+          (b): b is { type: string; text: { text: string } } =>
+            b.type === "section" && !!b.text,
+        )
+        .map((b) => b.text.text);
+      expect(texts.some((t) => t.includes("Account connected"))).toBe(true);
+      expect(texts.some((t) => t.includes("No agents linked yet"))).toBe(true);
     });
   });
 });

--- a/turbo/apps/web/app/api/slack/events/route.ts
+++ b/turbo/apps/web/app/api/slack/events/route.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../src/lib/slack/verify";
 import { handleAppMention } from "../../../../src/lib/slack/handlers/mention";
 import { handleDirectMessage } from "../../../../src/lib/slack/handlers/direct-message";
+import { handleAppHomeOpened } from "../../../../src/lib/slack/handlers/app-home-opened";
 
 /**
  * Slack Events API Endpoint
@@ -52,12 +53,21 @@ interface SlackDirectMessageEvent {
   bot_id?: string;
 }
 
+interface SlackAppHomeOpenedEvent {
+  type: "app_home_opened";
+  user: string;
+  tab: "home" | "messages";
+}
+
 interface SlackEventCallback {
   type: "event_callback";
   token: string;
   team_id: string;
   api_app_id: string;
-  event: SlackAppMentionEvent | SlackDirectMessageEvent;
+  event:
+    | SlackAppMentionEvent
+    | SlackDirectMessageEvent
+    | SlackAppHomeOpenedEvent;
   event_id: string;
   event_time: number;
   authorizations?: Array<{
@@ -163,6 +173,20 @@ export async function POST(request: Request) {
           threadTs: event.thread_ts,
         }).catch((error) => {
           console.error("Error handling direct_message:", error);
+        }),
+      );
+    }
+
+    // Handle app_home_opened events
+    if (event.type === "app_home_opened" && event.tab === "home") {
+      initServices();
+
+      after(
+        handleAppHomeOpened({
+          workspaceId: payload.team_id,
+          userId: event.user,
+        }).catch((error) => {
+          console.error("Error handling app_home_opened:", error);
         }),
       );
     }

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -223,6 +223,141 @@ export function buildAgentAddModal(
   };
 }
 
+interface AppHomeBinding {
+  agentName: string;
+  description: string | null;
+  enabled: boolean;
+}
+
+/**
+ * Build the App Home tab view
+ *
+ * @param options - Configuration for the home view
+ * @returns View definition for the Home tab
+ */
+export function buildAppHomeView(options: {
+  isLinked: boolean;
+  vm0UserId?: string;
+  bindings?: AppHomeBinding[];
+  loginUrl?: string;
+}): View {
+  const blocks: (Block | KnownBlock)[] = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "Welcome to VM0!",
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "Connect your AI agents to Slack and interact with them through messages.",
+      },
+    },
+    { type: "divider" },
+  ];
+
+  // Account status
+  if (options.isLinked) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:white_check_mark: *Account connected*\n\`${options.vm0UserId}\``,
+      },
+    });
+  } else {
+    const connectBlocks: (Block | KnownBlock)[] = [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: ":x: *Account not connected*",
+        },
+      },
+    ];
+    if (options.loginUrl) {
+      connectBlocks.push({
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: {
+              type: "plain_text",
+              text: "Connect",
+            },
+            url: options.loginUrl,
+            action_id: "home_login_prompt",
+            style: "primary",
+          },
+        ],
+      });
+    }
+    blocks.push(...connectBlocks);
+  }
+
+  blocks.push({ type: "divider" });
+
+  // Linked agents
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: "*Your Agents*",
+    },
+  });
+
+  if (options.bindings && options.bindings.length > 0) {
+    for (const binding of options.bindings) {
+      const status = binding.enabled ? ":white_check_mark:" : ":x:";
+      const description = binding.description ?? "_No description_";
+      blocks.push({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `${status} *${binding.agentName}*\n${description}`,
+        },
+      });
+    }
+  } else {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "_No agents linked yet._ Use `/vm0 agent link` to link one.",
+      },
+    });
+  }
+
+  blocks.push({ type: "divider" });
+
+  // Help section
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: "*Commands*\n• `/vm0 help` — Show help\n• `/vm0 connect` — Connect your account\n• `/vm0 agent link` — Link an agent\n• `/vm0 agent unlink` — Unlink an agent\n• `/vm0 agent update` — Update agent configuration",
+    },
+  });
+
+  blocks.push({
+    type: "context",
+    elements: [
+      {
+        type: "mrkdwn",
+        text: "Send me a DM or `@VM0` in any channel to start chatting with your agents!",
+      },
+    ],
+  });
+
+  return {
+    type: "home",
+    blocks,
+  };
+}
+
 interface AgentBinding {
   id: string;
   agentName: string;

--- a/turbo/apps/web/src/lib/slack/client.ts
+++ b/turbo/apps/web/src/lib/slack/client.ts
@@ -103,6 +103,48 @@ export async function updateModal(
  * @param redirectUri - OAuth redirect URI
  * @returns OAuth response with tokens and team info
  */
+/**
+ * Update an existing message in a Slack channel
+ *
+ * @param client - Slack WebClient
+ * @param channel - Channel ID
+ * @param ts - Timestamp of the message to update
+ * @param text - New message text (used as fallback for blocks)
+ * @param options - Additional options
+ */
+export async function updateMessage(
+  client: WebClient,
+  channel: string,
+  ts: string,
+  text: string,
+  options?: { blocks?: (Block | KnownBlock)[] },
+): Promise<void> {
+  await client.chat.update({
+    channel,
+    ts,
+    text,
+    blocks: options?.blocks,
+  });
+}
+
+/**
+ * Publish an App Home tab view for a user
+ *
+ * @param client - Slack WebClient
+ * @param userId - Slack user ID
+ * @param view - Home tab view definition
+ */
+export async function publishAppHome(
+  client: WebClient,
+  userId: string,
+  view: View,
+): Promise<void> {
+  await client.views.publish({
+    user_id: userId,
+    view,
+  });
+}
+
 export async function exchangeOAuthCode(
   clientId: string,
   clientSecret: string,

--- a/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
@@ -1,0 +1,93 @@
+import { eq, and } from "drizzle-orm";
+import { slackInstallations } from "../../../db/schema/slack-installation";
+import { slackUserLinks } from "../../../db/schema/slack-user-link";
+import { slackBindings } from "../../../db/schema/slack-binding";
+import { decryptCredentialValue } from "../../crypto/secrets-encryption";
+import { env } from "../../../env";
+import { createSlackClient, publishAppHome, buildAppHomeView } from "../index";
+import { buildLoginUrl } from "./shared";
+import { logger } from "../../logger";
+
+const log = logger("slack:app-home");
+
+interface AppHomeOpenedContext {
+  workspaceId: string;
+  userId: string;
+}
+
+/**
+ * Handle an app_home_opened event from Slack
+ *
+ * Publishes the Home tab with account status, linked agents, and help info.
+ */
+export async function handleAppHomeOpened(
+  context: AppHomeOpenedContext,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  try {
+    // 1. Get workspace installation
+    const [installation] = await globalThis.services.db
+      .select()
+      .from(slackInstallations)
+      .where(eq(slackInstallations.slackWorkspaceId, context.workspaceId))
+      .limit(1);
+
+    if (!installation) {
+      log.error("Slack installation not found for workspace", {
+        workspaceId: context.workspaceId,
+      });
+      return;
+    }
+
+    // Decrypt bot token
+    const botToken = decryptCredentialValue(
+      installation.encryptedBotToken,
+      SECRETS_ENCRYPTION_KEY,
+    );
+    const client = createSlackClient(botToken);
+
+    // 2. Check if user is linked
+    const [userLink] = await globalThis.services.db
+      .select()
+      .from(slackUserLinks)
+      .where(
+        and(
+          eq(slackUserLinks.slackUserId, context.userId),
+          eq(slackUserLinks.slackWorkspaceId, context.workspaceId),
+        ),
+      )
+      .limit(1);
+
+    if (!userLink) {
+      // User not linked — show login prompt
+      const loginUrl = buildLoginUrl(context.workspaceId, context.userId, "");
+      const view = buildAppHomeView({
+        isLinked: false,
+        loginUrl,
+      });
+      await publishAppHome(client, context.userId, view);
+      return;
+    }
+
+    // 3. Get user's bindings
+    const bindings = await globalThis.services.db
+      .select({
+        agentName: slackBindings.agentName,
+        description: slackBindings.description,
+        enabled: slackBindings.enabled,
+      })
+      .from(slackBindings)
+      .where(eq(slackBindings.slackUserLinkId, userLink.id));
+
+    // 4. Build and publish home view
+    const view = buildAppHomeView({
+      isLinked: true,
+      vm0UserId: userLink.vm0UserId,
+      bindings,
+    });
+    await publishAppHome(client, context.userId, view);
+  } catch (error) {
+    log.error("Error handling app_home_opened", { error });
+  }
+}

--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -8,6 +8,7 @@ import { env } from "../../../env";
 import {
   createSlackClient,
   postMessage,
+  updateMessage,
   buildLoginPromptMessage,
   buildErrorMessage,
   buildAgentResponseMessage,
@@ -139,6 +140,14 @@ export async function handleDirectMessage(
       .then(() => true)
       .catch(() => false);
 
+    // 7. Post thinking message
+    const thinkingTs = await postMessage(
+      client,
+      context.channelId,
+      "_Thinking..._",
+      { threadTs },
+    );
+
     // Use message text directly (no mention prefix to strip in DMs)
     const messageContent = context.messageText;
 
@@ -151,7 +160,7 @@ export async function handleDirectMessage(
       botToken,
     );
 
-    // 7. Route to agent (with context for LLM routing)
+    // 8. Route to agent (with context for LLM routing)
     const routeResult = await routeMessageToAgent(
       messageContent,
       bindings,
@@ -166,10 +175,20 @@ export async function handleDirectMessage(
       selectedAgentName = bindings[0]!.agentName;
       promptText = messageContent;
     } else if (routeResult.type === "failure") {
-      await postMessage(client, context.channelId, routeResult.error, {
-        threadTs,
-        blocks: buildErrorMessage(routeResult.error),
-      });
+      if (thinkingTs) {
+        await updateMessage(
+          client,
+          context.channelId,
+          thinkingTs,
+          routeResult.error,
+          { blocks: buildErrorMessage(routeResult.error) },
+        );
+      } else {
+        await postMessage(client, context.channelId, routeResult.error, {
+          threadTs,
+          blocks: buildErrorMessage(routeResult.error),
+        });
+      }
       if (reactionAdded) {
         await removeThinkingReaction(
           client,
@@ -195,7 +214,7 @@ export async function handleDirectMessage(
       return;
     }
 
-    // 8. Find existing thread session
+    // 9. Find existing thread session
     let existingSessionId: string | undefined;
     if (threadTs) {
       const [threadSession] = await globalThis.services.db
@@ -214,7 +233,7 @@ export async function handleDirectMessage(
     }
 
     try {
-      // 9. Execute agent
+      // 10. Execute agent
       const {
         response: agentResponse,
         sessionId: newSessionId,
@@ -227,7 +246,7 @@ export async function handleDirectMessage(
         userId: userLink.vm0UserId,
       });
 
-      // 10. Create thread session mapping if new thread
+      // 11. Create thread session mapping if new thread
       if (threadTs && !existingSessionId && newSessionId) {
         await globalThis.services.db
           .insert(slackThreadSessions)
@@ -240,30 +259,52 @@ export async function handleDirectMessage(
           .onConflictDoNothing();
       }
 
-      // 11. Post response message
+      // 12. Replace thinking message with agent response
       const logsUrl = runId ? buildLogsUrl(runId) : undefined;
-      await postMessage(client, context.channelId, agentResponse, {
-        threadTs,
-        blocks: buildAgentResponseMessage(
+      if (thinkingTs) {
+        await updateMessage(
+          client,
+          context.channelId,
+          thinkingTs,
           agentResponse,
-          selectedAgentName,
-          logsUrl,
-        ),
-      });
+          {
+            blocks: buildAgentResponseMessage(
+              agentResponse,
+              selectedAgentName,
+              logsUrl,
+            ),
+          },
+        );
+      } else {
+        await postMessage(client, context.channelId, agentResponse, {
+          threadTs,
+          blocks: buildAgentResponseMessage(
+            agentResponse,
+            selectedAgentName,
+            logsUrl,
+          ),
+        });
+      }
     } catch (innerError) {
       log.error("Error posting response or creating session", {
         error: innerError,
       });
-      await postMessage(
-        client,
-        context.channelId,
-        "Sorry, an error occurred while sending the response. Please try again.",
-        { threadTs },
-      ).catch(() => {
-        // If even the error message fails, we can't do anything more
-      });
+      const errorText =
+        "Sorry, an error occurred while sending the response. Please try again.";
+      if (thinkingTs) {
+        await updateMessage(
+          client,
+          context.channelId,
+          thinkingTs,
+          errorText,
+        ).catch(() => {});
+      } else {
+        await postMessage(client, context.channelId, errorText, {
+          threadTs,
+        }).catch(() => {});
+      }
     } finally {
-      // 12. Remove thinking reaction
+      // 13. Remove thinking reaction
       if (reactionAdded) {
         await removeThinkingReaction(
           client,

--- a/turbo/apps/web/src/lib/slack/index.ts
+++ b/turbo/apps/web/src/lib/slack/index.ts
@@ -34,8 +34,10 @@ export { verifySlackSignature, getSlackSignatureHeaders } from "./verify";
 export {
   createSlackClient,
   postMessage,
+  updateMessage,
   openModal,
   updateModal,
+  publishAppHome,
   exchangeOAuthCode,
   isSlackInvalidAuthError,
 } from "./client";
@@ -44,6 +46,7 @@ export {
 export {
   buildAgentAddModal,
   buildAgentListMessage,
+  buildAppHomeView,
   buildErrorMessage,
   buildLoginPromptMessage,
   buildHelpMessage,
@@ -65,3 +68,4 @@ export {
 
 // Handlers
 export { handleDirectMessage } from "./handlers/direct-message";
+export { handleAppHomeOpened } from "./handlers/app-home-opened";


### PR DESCRIPTION
## Summary

- **Typing indicator**: DM handler now posts a "_Thinking..._" placeholder message immediately, then replaces it with the agent response via `chat.update` for better UX feedback
- **App Home tab**: Publishes a Home tab view when users open the bot profile, showing account status, linked agents, and available commands
- **New event**: Handles `app_home_opened` events via `views.publish`

## Slack Dashboard Prerequisites

For App Home to work, these manual steps are needed:
1. **App Home** → Enable **Home Tab**
2. **Event Subscriptions** → Subscribe to `app_home_opened`
3. **Reinstall** app to workspace

## Test plan

- [x] All 17 integration tests pass (`pnpm vitest run apps/web/app/api/slack/events/__tests__/route.test.ts`)
- [x] Lint, type check, format, knip all clean
- [ ] Manual: send DM → see "Thinking..." then replaced with response
- [ ] Manual: open bot's Home tab → see account status + agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)