### PR TITLE
fix(docs): update aws bedrock setup guide url

### DIFF
--- a/turbo/apps/docs/content/docs/model-selection/aws-bedrock.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/aws-bedrock.mdx
@@ -101,6 +101,6 @@ vm0 run my-agent "build a todo app" --model-provider aws-bedrock
 
 ## Resources
 
-- [Claude Code Bedrock Setup Guide](https://docs.anthropic.com/en/docs/claude-code/bedrock)
+- [Claude Code Bedrock Setup Guide](https://code.claude.com/docs/en/amazon-bedrock)
 - [AWS Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)
 - [AWS Bedrock Pricing](https://aws.amazon.com/bedrock/pricing/)

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -200,7 +200,7 @@ export const MODEL_PROVIDER_TYPES = {
     framework: "claude-code" as const,
     label: "AWS Bedrock",
     helpText:
-      "Run Claude on AWS Bedrock.\nSetup guide: https://docs.anthropic.com/en/docs/claude-code/bedrock",
+      "Run Claude on AWS Bedrock.\nSetup guide: https://code.claude.com/docs/en/amazon-bedrock",
     authMethods: {
       "api-key": {
         label: "Bedrock API Key",


### PR DESCRIPTION
## Summary
- Update the AWS Bedrock setup guide URL from `docs.anthropic.com/en/docs/claude-code/bedrock` (inaccessible) to `https://code.claude.com/docs/en/amazon-bedrock`
- Affected files: `model-providers.ts` (help text) and `aws-bedrock.mdx` (resources link)

## Test plan
- [ ] Verify the new URL `https://code.claude.com/docs/en/amazon-bedrock` is accessible
- [ ] Confirm no other references to the old URL remain in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)