### PR TITLE
fix(ci): update platform deployment to use unified clerk env var

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -357,7 +357,7 @@ jobs:
           environment: production
           deployment-env: platform
           environment-variables: |
-            VITE_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
             VITE_API_URL=https://www.vm0.ai
             VITE_SENTRY_DSN=${{ secrets.SENTRY_DSN_PLATFORM }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -607,7 +607,7 @@ jobs:
           environment: preview
           deployment-env: platform
           environment-variables: |
-            VITE_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
             VITE_API_URL=${{ needs.prepare.outputs.web-preview-url }}
             VITE_SENTRY_DSN=${{ secrets.SENTRY_DSN_PLATFORM }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/turbo/apps/platform/src/signals/theme.ts
+++ b/turbo/apps/platform/src/signals/theme.ts
@@ -1,8 +1,5 @@
 import { command, computed, state } from "ccstate";
 
-/**
- * Internal state for theme (light or dark).
- */
 const internalTheme$ = state<"light" | "dark">("light");
 
 /**


### PR DESCRIPTION
## Summary

Update platform deployment configuration in both release and preview workflows to use `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` instead of `VITE_CLERK_PUBLISHABLE_KEY`, matching the recent unification of Clerk publishable key environment variable names.

## Changes

- Updated `.github/workflows/release-please.yml` to use unified env var
- Updated `.github/workflows/turbo.yml` to use unified env var
- Removed redundant comment in `platform/src/signals/theme.ts`

## Test Plan

- [ ] Verify CI workflows pass with updated env var name
- [ ] Confirm platform deployments use correct Clerk configuration

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)