### PR TITLE
test(web): add integration tests for cli auth token exchange endpoint

### DIFF
--- a/turbo/apps/web/app/api/cli/auth/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/__tests__/route.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { POST } from "../route";
+import {
+  createTestRequest,
+  createTestDeviceCode,
+  findTestDeviceCode,
+  findTestCliToken,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../../src/__tests__/test-helpers";
+
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
+
+const context = testContext();
+
+/** Generate a unique device code in XXXX-XXXX format */
+function generateTestCode(): string {
+  const chars = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+  let code = "";
+  for (let i = 0; i < 8; i++) {
+    if (i === 4) code += "-";
+    code += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return code;
+}
+
+/** Make a token exchange request */
+async function exchangeDeviceCode(deviceCode: string) {
+  const request = createTestRequest(
+    "http://localhost:3000/api/cli/auth/token",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ device_code: deviceCode }),
+    },
+  );
+  return POST(request);
+}
+
+describe("POST /api/cli/auth/token", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("should return error for invalid device code", async () => {
+    const response = await exchangeDeviceCode(generateTestCode());
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("invalid_request");
+  });
+
+  it("should return authorization_pending for pending device code", async () => {
+    const code = generateTestCode();
+    await createTestDeviceCode({ code, status: "pending" });
+
+    const response = await exchangeDeviceCode(code);
+
+    expect(response.status).toBe(202);
+    const body = await response.json();
+    expect(body.error).toBe("authorization_pending");
+  });
+
+  it("should return expired_token for expired device code", async () => {
+    const code = generateTestCode();
+    await createTestDeviceCode({
+      code,
+      status: "pending",
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    const response = await exchangeDeviceCode(code);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("expired_token");
+  });
+
+  it("should return access_denied and clean up denied device code", async () => {
+    const code = generateTestCode();
+    await createTestDeviceCode({ code, status: "denied" });
+
+    const response = await exchangeDeviceCode(code);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("access_denied");
+
+    // Verify device code was cleaned up
+    const remaining = await findTestDeviceCode(code);
+    expect(remaining).toBeUndefined();
+  });
+
+  it("should exchange authenticated device code for CLI token", async () => {
+    const code = generateTestCode();
+    await createTestDeviceCode({
+      code,
+      status: "authenticated",
+      userId: user.userId,
+    });
+
+    const response = await exchangeDeviceCode(code);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.access_token).toMatch(/^vm0_live_/);
+    expect(body.token_type).toBe("Bearer");
+    expect(body.expires_in).toBe(90 * 24 * 60 * 60);
+
+    // Verify token persisted in DB
+    const token = await findTestCliToken(body.access_token);
+    expect(token).toBeDefined();
+    expect(token!.userId).toBe(user.userId);
+
+    // Verify device code cleaned up
+    const remaining = await findTestDeviceCode(code);
+    expect(remaining).toBeUndefined();
+  });
+
+  it("should auto-create scope for user without existing scope", async () => {
+    const newUserId = `no-scope-${Date.now()}`;
+    const code = generateTestCode();
+    await createTestDeviceCode({
+      code,
+      status: "authenticated",
+      userId: newUserId,
+    });
+
+    const response = await exchangeDeviceCode(code);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.access_token).toMatch(/^vm0_live_/);
+  });
+});

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -10,6 +10,7 @@ import type { AgentComposeYaml } from "../types/agent-compose";
 import { generateSandboxToken } from "../lib/auth/sandbox-token";
 import { cliTokens } from "../db/schema/cli-tokens";
 import { agentRuns } from "../db/schema/agent-run";
+import { deviceCodes } from "../db/schema/device-codes";
 import { eq } from "drizzle-orm";
 
 // Route handlers - imported here so callers don't need to pass them
@@ -128,6 +129,70 @@ export async function createTestSandboxToken(
 ): Promise<string> {
   return generateSandboxToken(userId, runId);
 }
+
+// ============================================================================
+// Device Code Test Helpers
+// ============================================================================
+
+/**
+ * Insert a device code directly into DB for test setup.
+ * Used by CLI auth token tests to set up various device code states.
+ *
+ * @param options - Device code configuration
+ */
+export async function createTestDeviceCode(options: {
+  code: string;
+  status: "pending" | "authenticated" | "denied";
+  userId?: string;
+  expiresAt?: Date;
+}): Promise<void> {
+  await globalThis.services.db.insert(deviceCodes).values({
+    code: options.code,
+    status: options.status,
+    userId: options.userId ?? null,
+    expiresAt: options.expiresAt ?? new Date(Date.now() + 900_000),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+}
+
+/**
+ * Look up a device code in the database for verification.
+ *
+ * @param code - The device code string
+ * @returns The device code record, or undefined if not found
+ */
+export async function findTestDeviceCode(
+  code: string,
+): Promise<
+  { code: string; status: string; userId: string | null } | undefined
+> {
+  const [row] = await globalThis.services.db
+    .select()
+    .from(deviceCodes)
+    .where(eq(deviceCodes.code, code));
+  return row;
+}
+
+/**
+ * Look up a CLI token in the database for verification.
+ *
+ * @param token - The token string
+ * @returns The CLI token record, or undefined if not found
+ */
+export async function findTestCliToken(
+  token: string,
+): Promise<{ token: string; userId: string } | undefined> {
+  const [row] = await globalThis.services.db
+    .select()
+    .from(cliTokens)
+    .where(eq(cliTokens.token, token));
+  return row;
+}
+
+// ============================================================================
+// CLI Token Test Helpers
+// ============================================================================
 
 /**
  * Create a test CLI token in the database for authentication testing


### PR DESCRIPTION
## Summary
- Add 6 integration tests for `POST /api/cli/auth/token` covering all device code status branches: invalid, pending, expired, denied, authenticated, and auto-create scope
- Add 3 device code test helpers (`createTestDeviceCode`, `findTestDeviceCode`, `findTestCliToken`) to `api-test-helpers.ts`

## Test plan
- [x] All 6 tests pass locally (`pnpm vitest run`)
- [x] Format check passed (`pnpm format`)
- [x] Lint passed (`pnpm turbo run lint --filter=web`)
- [x] Type check passed (`pnpm turbo run check-types --filter=web`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)