### PR TITLE
fix(site): override canonical URL on blog pages to fix Safari sharing

### DIFF
--- a/turbo/apps/site/app/[locale]/blog/page.tsx
+++ b/turbo/apps/site/app/[locale]/blog/page.tsx
@@ -21,6 +21,9 @@ export async function generateMetadata({
   return {
     title: t("title"),
     description: t("description"),
+    alternates: {
+      canonical: `https://vm0.ai/${locale}/blog`,
+    },
     openGraph: {
       title: `VM0 ${t("title")}`,
       description: t("description"),

--- a/turbo/apps/site/app/[locale]/blog/posts/[slug]/page.tsx
+++ b/turbo/apps/site/app/[locale]/blog/posts/[slug]/page.tsx
@@ -37,6 +37,9 @@ export async function generateMetadata({
   return {
     title: post.title,
     description: post.excerpt,
+    alternates: {
+      canonical: postUrl,
+    },
     openGraph: {
       title: post.title,
       description: post.excerpt,

--- a/turbo/apps/web/app/[locale]/blog/__tests__/page.test.ts
+++ b/turbo/apps/web/app/[locale]/blog/__tests__/page.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Set env vars before any module loads
+vi.hoisted(() => {
+  vi.stubEnv("NEXT_PUBLIC_BASE_URL", "https://test.vm0.ai");
+  vi.stubEnv("NEXT_PUBLIC_STRAPI_URL", "https://test-strapi.example.com");
+});
+
+// External: next-intl/server (used by page.tsx and i18n.ts)
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn(async () => (key: string) => `mock-${key}`),
+  getRequestConfig: vi.fn((fn: unknown) => fn),
+}));
+
+// External: next-intl/navigation (used by navigation.ts)
+vi.mock("next-intl/navigation", () => ({
+  createNavigation: vi.fn(() => ({
+    Link: () => null,
+    redirect: vi.fn(),
+    usePathname: vi.fn(),
+    useRouter: vi.fn(),
+  })),
+}));
+
+// External: next-intl (used by Navbar, Footer, BlogContent, ShareButtons)
+vi.mock("next-intl", () => ({
+  useTranslations: vi.fn(() => (key: string) => `mock-${key}`),
+}));
+
+// External: @clerk/nextjs (used by Navbar)
+vi.mock("@clerk/nextjs", () => ({
+  useUser: vi.fn(() => ({ user: null, isLoaded: true })),
+  useClerk: vi.fn(() => ({ signOut: vi.fn() })),
+}));
+
+// External: next/navigation (used by BlogContent)
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+  useParams: vi.fn(() => ({})),
+  useRouter: vi.fn(() => ({})),
+}));
+
+import { generateMetadata } from "../page";
+
+describe("blog list page metadata", () => {
+  it("includes canonical URL with locale", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "en" }),
+    });
+
+    expect(metadata.alternates?.canonical).toBe("https://test.vm0.ai/en/blog");
+  });
+
+  it("constructs canonical URL for non-English locale", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "ja" }),
+    });
+
+    expect(metadata.alternates?.canonical).toBe("https://test.vm0.ai/ja/blog");
+  });
+});

--- a/turbo/apps/web/app/[locale]/blog/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/page.tsx
@@ -26,6 +26,9 @@ export async function generateMetadata({
   return {
     title: t("title"),
     description: t("description"),
+    alternates: {
+      canonical: `${BLOG_BASE_URL}/${locale}/blog`,
+    },
     openGraph: {
       title: `VM0 ${t("title")}`,
       description: t("description"),

--- a/turbo/apps/web/app/[locale]/blog/posts/[slug]/__tests__/page.test.ts
+++ b/turbo/apps/web/app/[locale]/blog/posts/[slug]/__tests__/page.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../../../src/mocks/server";
+
+const STRAPI_URL = "https://test-strapi.example.com" as const;
+
+const mockArticle = {
+  id: 1,
+  documentId: "doc-1",
+  title: "Test Post",
+  description: "Test excerpt",
+  slug: "test-post",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+  publishedAt: "2024-01-01T00:00:00.000Z",
+  cover: { url: "/covers/test.jpg" },
+  author: { name: "Test Author" },
+  category: { name: "Technology", slug: "technology" },
+  blocks: [{ __component: "shared.rich-text", id: 1, body: "Test content" }],
+};
+
+// Set env vars before any module loads
+vi.hoisted(() => {
+  vi.stubEnv("NEXT_PUBLIC_BASE_URL", "https://test.vm0.ai");
+  vi.stubEnv("NEXT_PUBLIC_STRAPI_URL", "https://test-strapi.example.com");
+});
+
+// External: next-intl/server (used by page.tsx and i18n.ts)
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn(async () => (key: string) => `mock-${key}`),
+  getRequestConfig: vi.fn((fn: unknown) => fn),
+}));
+
+// External: next-intl/navigation (used by navigation.ts → Link)
+vi.mock("next-intl/navigation", () => ({
+  createNavigation: vi.fn(() => ({
+    Link: () => null,
+    redirect: vi.fn(),
+    usePathname: vi.fn(),
+    useRouter: vi.fn(),
+  })),
+}));
+
+// External: next-intl (used by Navbar, Footer, ShareButtons)
+vi.mock("next-intl", () => ({
+  useTranslations: vi.fn(() => (key: string) => `mock-${key}`),
+}));
+
+// External: @clerk/nextjs (used by Navbar)
+vi.mock("@clerk/nextjs", () => ({
+  useUser: vi.fn(() => ({ user: null, isLoaded: true })),
+  useClerk: vi.fn(() => ({ signOut: vi.fn() })),
+}));
+
+// External: next/navigation (used by BlogContent, notFound)
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+  useParams: vi.fn(() => ({})),
+  useRouter: vi.fn(() => ({})),
+}));
+
+import { generateMetadata } from "../page";
+
+describe("blog post page metadata", () => {
+  beforeEach(() => {
+    server.use(
+      http.get(`${STRAPI_URL}/api/articles`, ({ request }) => {
+        const url = new URL(request.url);
+        const slug = url.searchParams.get("filters[slug][$eq]");
+        if (slug === "test-post") {
+          return HttpResponse.json({ data: [mockArticle], meta: {} });
+        }
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+    );
+  });
+
+  it("includes canonical URL for existing post", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "test-post", locale: "en" }),
+    });
+
+    expect(metadata.alternates?.canonical).toBe(
+      "https://test.vm0.ai/en/blog/posts/test-post",
+    );
+  });
+
+  it("uses locale in canonical URL", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "test-post", locale: "ja" }),
+    });
+
+    expect(metadata.alternates?.canonical).toBe(
+      "https://test.vm0.ai/ja/blog/posts/test-post",
+    );
+  });
+
+  it("returns no canonical URL when post does not exist", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "non-existent", locale: "en" }),
+    });
+
+    expect(metadata.title).toBe("Post Not Found");
+    expect(metadata.alternates).toBeUndefined();
+  });
+});

--- a/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
+++ b/turbo/apps/web/app/[locale]/blog/posts/[slug]/page.tsx
@@ -37,6 +37,9 @@ export async function generateMetadata({
   return {
     title: post.title,
     description: post.excerpt,
+    alternates: {
+      canonical: postUrl,
+    },
     openGraph: {
       title: post.title,
       description: post.excerpt,


### PR DESCRIPTION
## Summary

- Add `alternates.canonical` to blog list and blog post `generateMetadata` in both `web` and `site` apps, overriding the parent locale layout's generic canonical URL (`https://vm0.ai/{locale}`)
- Safari's share feature reads `<link rel="canonical">` over `og:url`, which caused blog posts to share the base locale URL instead of the full post URL
- Fixes all 4 blog page files (2 apps × 2 page types)

Closes #2510

## Test plan

- [ ] Navigate to `https://www.vm0.ai/en/blog/posts/vm0-public-beta` in Safari
- [ ] Use Safari's share feature and verify the shared URL is the full blog post URL
- [ ] Repeat with blog list page (`/en/blog`) to confirm correct canonical
- [ ] Verify `<link rel="canonical">` in page source points to the correct URL
- [ ] Test with multiple locales (en, ja, etc.) to ensure canonical includes locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)