### PR TITLE
perf(web): add vm0-cli e2b template for faster compose jobs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -656,6 +656,7 @@ jobs:
           pnpm e2b:build
           pnpm e2b:codex:build
           pnpm e2b:claude-code-github:build
+          pnpm e2b:cli:build
 
       - name: Build summary
         run: echo "✅ E2B templates built successfully (production account)"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1401,6 +1401,7 @@ jobs:
           pnpm e2b:build
           pnpm e2b:codex:build
           pnpm e2b:claude-code-github:build
+          pnpm e2b:cli:build
 
       - name: Build summary
         run: echo "✅ E2B templates built successfully (development account)"

--- a/turbo/apps/web/app/api/compose/from-github/route.ts
+++ b/turbo/apps/web/app/api/compose/from-github/route.ts
@@ -79,7 +79,7 @@ function formatJobResponse(job: {
  * - Instructions file handling
  */
 const COMPOSE_SANDBOX_SCRIPT = `
-const { execSync, spawnSync } = require('child_process');
+const { spawnSync } = require('child_process');
 
 // Environment variables
 const JOB_ID = process.env.VM0_JOB_ID || '';
@@ -152,17 +152,8 @@ async function main() {
     process.exit(1);
   }
 
-  // Install vm0 CLI
-  log('INFO', 'Installing vm0 CLI...');
-  try {
-    execSync('npm install -g @vm0/cli@latest', { stdio: 'inherit', timeout: 120000 });
-    log('INFO', 'CLI installed successfully');
-  } catch (error) {
-    await reportCompletion(false, null, 'Failed to install vm0 CLI: ' + error.message);
-    process.exit(1);
-  }
-
   // Execute vm0 compose with --porcelain for structured output
+  // CLI is pre-installed in the vm0-cli template
   log('INFO', 'Running vm0 compose...');
   const result = spawnSync('vm0', [
     'compose',
@@ -241,7 +232,8 @@ async function spawnComposeJobSandbox(
   log.debug(`Creating sandbox for job ${jobId}...`);
 
   // Create sandbox with 5-minute timeout
-  const sandbox = await Sandbox.create(e2bConfig.defaultTemplate, {
+  // Use vm0-cli template which has CLI pre-installed for faster execution
+  const sandbox = await Sandbox.create(e2bConfig.cliTemplate, {
     timeoutMs: 5 * 60 * 1000, // 5 minutes
     envs: {
       VM0_JOB_ID: jobId,

--- a/turbo/apps/web/src/lib/e2b/config.ts
+++ b/turbo/apps/web/src/lib/e2b/config.ts
@@ -12,4 +12,6 @@ export const e2bConfig = {
   defaultTimeout: 0,
   /** Default E2B template for Claude Code CLI sandbox */
   defaultTemplate: "vm0-claude-code",
+  /** E2B template with vm0 CLI pre-installed for compose jobs */
+  cliTemplate: "vm0-cli",
 } as const;

--- a/turbo/package.json
+++ b/turbo/package.json
@@ -19,7 +19,8 @@
     "check-certs": "node packages/proxy/scripts/check-certs.js",
     "e2b:build": "dotenv -e apps/web/.env.local -- npx tsx scripts/e2b/vm0-claude-code/build.ts",
     "e2b:codex:build": "dotenv -e apps/web/.env.local -- npx tsx scripts/e2b/vm0-codex/build.ts",
-    "e2b:claude-code-github:build": "dotenv -e apps/web/.env.local -- npx tsx scripts/e2b/vm0-claude-code-github/build.ts"
+    "e2b:claude-code-github:build": "dotenv -e apps/web/.env.local -- npx tsx scripts/e2b/vm0-claude-code-github/build.ts",
+    "e2b:cli:build": "dotenv -e apps/web/.env.local -- npx tsx scripts/e2b/vm0-cli/build.ts"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/turbo/scripts/e2b/vm0-cli/build.ts
+++ b/turbo/scripts/e2b/vm0-cli/build.ts
@@ -1,0 +1,22 @@
+import { Template, defaultBuildLogger } from "e2b";
+import { template } from "./template";
+
+// E2B_API_KEY should be set as an environment variable
+// In CI: from GitHub secrets (repository-level for dev, production environment for prod)
+// Locally: from turbo/apps/web/.env.local (loaded by build command)
+if (!process.env.E2B_API_KEY) {
+  console.error("Error: E2B_API_KEY environment variable is not set");
+  console.error(
+    "Please set E2B_API_KEY in turbo/apps/web/.env.local or as an environment variable",
+  );
+  process.exit(1);
+}
+
+async function main() {
+  await Template.build(template, {
+    alias: "vm0-cli",
+    onBuildLogs: defaultBuildLogger(),
+  });
+}
+
+main().catch(console.error);

--- a/turbo/scripts/e2b/vm0-cli/template.ts
+++ b/turbo/scripts/e2b/vm0-cli/template.ts
@@ -1,0 +1,14 @@
+import { Template } from "e2b";
+
+/**
+ * VM0 CLI E2B Template Configuration
+ *
+ * This template includes:
+ * - Node.js 24.x
+ * - vm0 CLI (globally installed as "vm0")
+ * - curl, git, jq for compose operations
+ */
+export const template = Template()
+  .fromNodeImage("24")
+  .aptInstall(["curl", "git", "jq"])
+  .npmInstall("@vm0/cli@9.22.0", { g: true });


### PR DESCRIPTION
## Summary

Create a new E2B template `vm0-cli` with the vm0 CLI pre-installed to reduce compose-from-github job execution time.

- Add `vm0-cli` template definition and build script following existing template patterns
- Add `e2b:cli:build` script to package.json
- Update CI workflows (turbo.yml, release-please.yml) to build vm0-cli template
- Update compose-from-github API to use `vm0-cli` template instead of `vm0-claude-code`
- Remove runtime `npm install -g @vm0/cli@latest` from sandbox script (CLI is now pre-installed)

## Performance Impact

- **Before**: ~28 seconds total compose job execution
  - ~12.5 seconds for CLI installation (45% of total time)
  - ~6.3 seconds for actual compose execution
- **After**: ~15 seconds expected
  - Eliminate CLI installation overhead
  - Direct compose execution with pre-installed CLI

## Test plan

- [x] Type check passes
- [x] Lint passes  
- [x] Existing compose API tests pass
- [ ] CI E2B template build works
- [ ] Compose job completes successfully with new template

Closes #2516

🤖 Generated with [Claude Code](https://claude.com/claude-code)