### PR TITLE
fix(platform): display actual model provider name in agents table

### DIFF
--- a/turbo/apps/platform/src/signals/external/model-providers.ts
+++ b/turbo/apps/platform/src/signals/external/model-providers.ts
@@ -39,6 +39,14 @@ export const hasAnyModelProvider$ = computed(async (get) => {
 });
 
 /**
+ * Get the default model provider.
+ */
+export const defaultModelProvider$ = computed(async (get) => {
+  const { modelProviders } = await get(modelProviders$);
+  return modelProviders.find((p) => p.isDefault);
+});
+
+/**
  * Trigger a reload of model providers data.
  */
 export const reloadModelProviders$ = command(({ set }) => {

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -45,7 +45,7 @@ export function AgentsPage() {
       title="Agents"
       subtitle="Your agents, their schedules, and when they were last updated"
     >
-      <div className="flex flex-col gap-5 px-6 pb-8">
+      <div className="flex flex-col gap-5 px-4 sm:px-6 pb-8">
         <AgentsListSection />
       </div>
     </AppShell>
@@ -95,12 +95,12 @@ function AgentsListSection() {
     <Table>
       <TableHeader>
         <TableRow>
-          <TableHead className="h-10 px-3 w-[30%] min-w-[120px]">
+          <TableHead className="h-10 px-3 w-[25%] min-w-[120px]">
             <span className="block truncate whitespace-nowrap">
               Your agents
             </span>
           </TableHead>
-          <TableHead className="h-10 px-3 w-[30%] min-w-[120px]">
+          <TableHead className="h-10 px-3 w-[25%] min-w-[120px]">
             <span className="block truncate whitespace-nowrap">
               Model provider
             </span>
@@ -110,10 +110,10 @@ function AgentsListSection() {
               Schedule status
             </span>
           </TableHead>
-          <TableHead className="h-10 px-3 w-[20%] min-w-[100px]">
+          <TableHead className="h-10 pl-3 pr-6 w-[20%] min-w-[100px]">
             <span className="block truncate whitespace-nowrap">Last edit</span>
           </TableHead>
-          <TableHead className="h-10 w-[44px] px-2" />
+          <TableHead className="h-10 w-12" />
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -148,14 +148,14 @@ function AgentRow({
     <Dialog>
       <TableRow className="h-[53px]">
         <DialogTrigger asChild>
-          <TableCell className="px-3 py-2 cursor-pointer w-[30%] min-w-[120px]">
+          <TableCell className="px-3 py-2 cursor-pointer w-[25%] min-w-[120px]">
             <span className="block truncate whitespace-nowrap font-medium">
               {agent.name}
             </span>
           </TableCell>
         </DialogTrigger>
         <DialogTrigger asChild>
-          <TableCell className="px-3 py-2 cursor-pointer w-[30%] min-w-[120px]">
+          <TableCell className="px-3 py-2 cursor-pointer w-[25%] min-w-[120px]">
             <span className="block truncate whitespace-nowrap text-sm">
               {modelProviderLabel}
             </span>
@@ -179,7 +179,7 @@ function AgentRow({
           </TableCell>
         </DialogTrigger>
         <DialogTrigger asChild>
-          <TableCell className="px-3 py-2 cursor-pointer w-[20%] min-w-[100px]">
+          <TableCell className="pl-3 pr-6 py-2 cursor-pointer w-[20%] min-w-[100px]">
             <span className="block truncate whitespace-nowrap text-sm">
               {new Date(agent.updatedAt).toLocaleDateString("en-US", {
                 month: "short",
@@ -189,7 +189,7 @@ function AgentRow({
             </span>
           </TableCell>
         </DialogTrigger>
-        <TableCell className="w-[44px] px-2 py-2">
+        <TableCell className="pl-0 pr-4 py-2 w-12">
           <TooltipProvider>
             <Tooltip>
               <DialogTrigger asChild>

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -25,7 +25,7 @@ import {
 } from "@vm0/ui/components/ui/table";
 import { AppShell } from "../layout/app-shell.tsx";
 import { AgentsListSkeleton } from "./agents-list-skeleton.tsx";
-import { useGet } from "ccstate-react";
+import { useGet, useResolved } from "ccstate-react";
 import {
   agentsList$,
   agentsLoading$,
@@ -33,6 +33,8 @@ import {
   schedules$,
   getAgentScheduleStatus,
 } from "../../signals/agents-page/agents-list.ts";
+import { defaultModelProvider$ } from "../../signals/external/model-providers.ts";
+import { getUILabel } from "../settings-page/provider-ui-config.ts";
 import { Bed, Settings, Clock } from "lucide-react";
 import type { ComposeListItem } from "@vm0/core";
 
@@ -55,6 +57,7 @@ function AgentsListSection() {
   const schedules = useGet(schedules$);
   const loading = useGet(agentsLoading$);
   const error = useGet(agentsError$);
+  const defaultProvider = useResolved(defaultModelProvider$);
 
   if (loading) {
     return <AgentsListSkeleton />;
@@ -93,7 +96,7 @@ function AgentsListSection() {
       <TableHeader>
         <TableRow>
           <TableHead className="h-10">Your agents</TableHead>
-          <TableHead className="h-10">Provider</TableHead>
+          <TableHead className="h-10">Model provider</TableHead>
           <TableHead className="h-10">Schedule status</TableHead>
           <TableHead className="h-10">Last edit</TableHead>
           <TableHead className="h-10 w-12" />
@@ -107,6 +110,9 @@ function AgentsListSection() {
               key={agent.name}
               agent={agent}
               hasSchedule={hasSchedule}
+              modelProviderLabel={
+                defaultProvider ? getUILabel(defaultProvider.type) : "N/A"
+              }
             />
           );
         })}
@@ -118,9 +124,11 @@ function AgentsListSection() {
 function AgentRow({
   agent,
   hasSchedule,
+  modelProviderLabel,
 }: {
   agent: ComposeListItem;
   hasSchedule: boolean;
+  modelProviderLabel: string;
 }) {
   return (
     <Dialog>
@@ -132,7 +140,7 @@ function AgentRow({
         </DialogTrigger>
         <DialogTrigger asChild>
           <TableCell className="px-3 py-2 cursor-pointer">
-            <span className="text-sm">Claude code</span>
+            <span className="text-sm">{modelProviderLabel}</span>
           </TableCell>
         </DialogTrigger>
         <DialogTrigger asChild>

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -95,10 +95,10 @@ function AgentsListSection() {
     <Table>
       <TableHeader>
         <TableRow>
-          <TableHead className="h-10">Your agents</TableHead>
-          <TableHead className="h-10">Model provider</TableHead>
-          <TableHead className="h-10">Schedule status</TableHead>
-          <TableHead className="h-10">Last edit</TableHead>
+          <TableHead className="h-10 px-3">Your agents</TableHead>
+          <TableHead className="h-10 px-3">Model provider</TableHead>
+          <TableHead className="h-10 px-3">Schedule status</TableHead>
+          <TableHead className="h-10 pl-3 pr-6">Last edit</TableHead>
           <TableHead className="h-10 w-12" />
         </TableRow>
       </TableHeader>

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -92,42 +92,46 @@ function AgentsListSection() {
   }
 
   return (
-    <div className="overflow-x-auto">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="h-10 px-3 whitespace-nowrap w-[30%] min-w-[150px]">
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="h-10 px-3 w-[25%] min-w-[120px]">
+            <span className="block truncate whitespace-nowrap">
               Your agents
-            </TableHead>
-            <TableHead className="h-10 px-3 whitespace-nowrap w-[25%] min-w-[150px]">
+            </span>
+          </TableHead>
+          <TableHead className="h-10 px-3 w-[25%] min-w-[120px]">
+            <span className="block truncate whitespace-nowrap">
               Model provider
-            </TableHead>
-            <TableHead className="h-10 px-3 whitespace-nowrap w-[20%] min-w-[140px]">
+            </span>
+          </TableHead>
+          <TableHead className="h-10 px-3 w-[20%] min-w-[120px]">
+            <span className="block truncate whitespace-nowrap">
               Schedule status
-            </TableHead>
-            <TableHead className="h-10 pl-3 pr-6 whitespace-nowrap w-[20%] min-w-[120px]">
-              Last edit
-            </TableHead>
-            <TableHead className="h-10 w-[5%] min-w-[48px]" />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {agents.map((agent) => {
-            const hasSchedule = getAgentScheduleStatus(agent.name, schedules);
-            return (
-              <AgentRow
-                key={agent.name}
-                agent={agent}
-                hasSchedule={hasSchedule}
-                modelProviderLabel={
-                  defaultProvider ? getUILabel(defaultProvider.type) : "N/A"
-                }
-              />
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
+            </span>
+          </TableHead>
+          <TableHead className="h-10 pl-3 pr-6 w-[20%] min-w-[100px]">
+            <span className="block truncate whitespace-nowrap">Last edit</span>
+          </TableHead>
+          <TableHead className="h-10 w-12" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {agents.map((agent) => {
+          const hasSchedule = getAgentScheduleStatus(agent.name, schedules);
+          return (
+            <AgentRow
+              key={agent.name}
+              agent={agent}
+              hasSchedule={hasSchedule}
+              modelProviderLabel={
+                defaultProvider ? getUILabel(defaultProvider.type) : "N/A"
+              }
+            />
+          );
+        })}
+      </TableBody>
+    </Table>
   );
 }
 
@@ -145,16 +149,12 @@ function AgentRow({
       <TableRow className="h-[53px]">
         <DialogTrigger asChild>
           <TableCell className="px-3 py-2 cursor-pointer">
-            <div className="truncate">
-              <span className="font-medium">{agent.name}</span>
-            </div>
+            <span className="font-medium">{agent.name}</span>
           </TableCell>
         </DialogTrigger>
         <DialogTrigger asChild>
           <TableCell className="px-3 py-2 cursor-pointer">
-            <span className="text-sm whitespace-nowrap">
-              {modelProviderLabel}
-            </span>
+            <span className="text-sm">{modelProviderLabel}</span>
           </TableCell>
         </DialogTrigger>
         <DialogTrigger asChild>
@@ -174,7 +174,7 @@ function AgentRow({
         </DialogTrigger>
         <DialogTrigger asChild>
           <TableCell className="pl-3 pr-6 py-2 cursor-pointer">
-            <span className="text-sm whitespace-nowrap">
+            <span className="text-sm">
               {new Date(agent.updatedAt).toLocaleDateString("en-US", {
                 month: "short",
                 day: "numeric",

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -92,40 +92,42 @@ function AgentsListSection() {
   }
 
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead className="h-10 px-3 whitespace-nowrap">
-            Your agents
-          </TableHead>
-          <TableHead className="h-10 px-3 whitespace-nowrap">
-            Model provider
-          </TableHead>
-          <TableHead className="h-10 px-3 whitespace-nowrap">
-            Schedule status
-          </TableHead>
-          <TableHead className="h-10 pl-3 pr-6 whitespace-nowrap">
-            Last edit
-          </TableHead>
-          <TableHead className="h-10 w-12" />
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {agents.map((agent) => {
-          const hasSchedule = getAgentScheduleStatus(agent.name, schedules);
-          return (
-            <AgentRow
-              key={agent.name}
-              agent={agent}
-              hasSchedule={hasSchedule}
-              modelProviderLabel={
-                defaultProvider ? getUILabel(defaultProvider.type) : "N/A"
-              }
-            />
-          );
-        })}
-      </TableBody>
-    </Table>
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="h-10 px-3 whitespace-nowrap w-[30%] min-w-[150px]">
+              Your agents
+            </TableHead>
+            <TableHead className="h-10 px-3 whitespace-nowrap w-[25%] min-w-[150px]">
+              Model provider
+            </TableHead>
+            <TableHead className="h-10 px-3 whitespace-nowrap w-[20%] min-w-[140px]">
+              Schedule status
+            </TableHead>
+            <TableHead className="h-10 pl-3 pr-6 whitespace-nowrap w-[20%] min-w-[120px]">
+              Last edit
+            </TableHead>
+            <TableHead className="h-10 w-[5%] min-w-[48px]" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {agents.map((agent) => {
+            const hasSchedule = getAgentScheduleStatus(agent.name, schedules);
+            return (
+              <AgentRow
+                key={agent.name}
+                agent={agent}
+                hasSchedule={hasSchedule}
+                modelProviderLabel={
+                  defaultProvider ? getUILabel(defaultProvider.type) : "N/A"
+                }
+              />
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
   );
 }
 

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -110,10 +110,10 @@ function AgentsListSection() {
               Schedule status
             </span>
           </TableHead>
-          <TableHead className="h-10 pl-3 pr-6 w-[20%] min-w-[100px]">
+          <TableHead className="h-10 px-3 w-[20%] min-w-[100px]">
             <span className="block truncate whitespace-nowrap">Last edit</span>
           </TableHead>
-          <TableHead className="h-10 w-12" />
+          <TableHead className="h-10 w-12 px-2" />
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -179,7 +179,7 @@ function AgentRow({
           </TableCell>
         </DialogTrigger>
         <DialogTrigger asChild>
-          <TableCell className="pl-3 pr-6 py-2 cursor-pointer w-[20%] min-w-[100px]">
+          <TableCell className="px-3 py-2 cursor-pointer w-[20%] min-w-[100px]">
             <span className="block truncate whitespace-nowrap text-sm">
               {new Date(agent.updatedAt).toLocaleDateString("en-US", {
                 month: "short",
@@ -189,7 +189,7 @@ function AgentRow({
             </span>
           </TableCell>
         </DialogTrigger>
-        <TableCell className="pl-0 pr-4 py-2 w-12">
+        <TableCell className="w-12 px-2 py-2">
           <TooltipProvider>
             <Tooltip>
               <DialogTrigger asChild>

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -95,10 +95,18 @@ function AgentsListSection() {
     <Table>
       <TableHeader>
         <TableRow>
-          <TableHead className="h-10 px-3">Your agents</TableHead>
-          <TableHead className="h-10 px-3">Model provider</TableHead>
-          <TableHead className="h-10 px-3">Schedule status</TableHead>
-          <TableHead className="h-10 pl-3 pr-6">Last edit</TableHead>
+          <TableHead className="h-10 px-3 whitespace-nowrap">
+            Your agents
+          </TableHead>
+          <TableHead className="h-10 px-3 whitespace-nowrap">
+            Model provider
+          </TableHead>
+          <TableHead className="h-10 px-3 whitespace-nowrap">
+            Schedule status
+          </TableHead>
+          <TableHead className="h-10 pl-3 pr-6 whitespace-nowrap">
+            Last edit
+          </TableHead>
           <TableHead className="h-10 w-12" />
         </TableRow>
       </TableHeader>
@@ -134,13 +142,15 @@ function AgentRow({
     <Dialog>
       <TableRow className="h-[53px]">
         <DialogTrigger asChild>
-          <TableCell className="px-3 py-2 cursor-pointer">
-            <span className="font-medium">{agent.name}</span>
+          <TableCell className="px-3 py-2 cursor-pointer max-w-[200px]">
+            <span className="font-medium truncate block">{agent.name}</span>
           </TableCell>
         </DialogTrigger>
         <DialogTrigger asChild>
           <TableCell className="px-3 py-2 cursor-pointer">
-            <span className="text-sm">{modelProviderLabel}</span>
+            <span className="text-sm whitespace-nowrap">
+              {modelProviderLabel}
+            </span>
           </TableCell>
         </DialogTrigger>
         <DialogTrigger asChild>
@@ -160,7 +170,7 @@ function AgentRow({
         </DialogTrigger>
         <DialogTrigger asChild>
           <TableCell className="pl-3 pr-6 py-2 cursor-pointer">
-            <span className="text-sm">
+            <span className="text-sm whitespace-nowrap">
               {new Date(agent.updatedAt).toLocaleDateString("en-US", {
                 month: "short",
                 day: "numeric",

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -142,8 +142,10 @@ function AgentRow({
     <Dialog>
       <TableRow className="h-[53px]">
         <DialogTrigger asChild>
-          <TableCell className="px-3 py-2 cursor-pointer max-w-[200px]">
-            <span className="font-medium truncate block">{agent.name}</span>
+          <TableCell className="px-3 py-2 cursor-pointer">
+            <div className="truncate">
+              <span className="font-medium">{agent.name}</span>
+            </div>
           </TableCell>
         </DialogTrigger>
         <DialogTrigger asChild>

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -148,33 +148,39 @@ function AgentRow({
     <Dialog>
       <TableRow className="h-[53px]">
         <DialogTrigger asChild>
-          <TableCell className="px-3 py-2 cursor-pointer">
-            <span className="font-medium">{agent.name}</span>
+          <TableCell className="px-3 py-2 cursor-pointer w-[25%] min-w-[120px]">
+            <span className="block truncate whitespace-nowrap font-medium">
+              {agent.name}
+            </span>
           </TableCell>
         </DialogTrigger>
         <DialogTrigger asChild>
-          <TableCell className="px-3 py-2 cursor-pointer">
-            <span className="text-sm">{modelProviderLabel}</span>
+          <TableCell className="px-3 py-2 cursor-pointer w-[25%] min-w-[120px]">
+            <span className="block truncate whitespace-nowrap text-sm">
+              {modelProviderLabel}
+            </span>
           </TableCell>
         </DialogTrigger>
         <DialogTrigger asChild>
-          <TableCell className="px-3 py-2 cursor-pointer">
-            {hasSchedule ? (
-              <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
-                <Clock className="h-3 w-3 text-sky-600" />
-                Scheduled
-              </span>
-            ) : (
-              <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
-                <Bed className="h-3 w-3 text-sky-600" />
-                No schedule
-              </span>
-            )}
+          <TableCell className="px-3 py-2 cursor-pointer w-[20%] min-w-[120px]">
+            <div className="truncate whitespace-nowrap">
+              {hasSchedule ? (
+                <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
+                  <Clock className="h-3 w-3 text-sky-600" />
+                  Scheduled
+                </span>
+              ) : (
+                <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
+                  <Bed className="h-3 w-3 text-sky-600" />
+                  No schedule
+                </span>
+              )}
+            </div>
           </TableCell>
         </DialogTrigger>
         <DialogTrigger asChild>
-          <TableCell className="pl-3 pr-6 py-2 cursor-pointer">
-            <span className="text-sm">
+          <TableCell className="pl-3 pr-6 py-2 cursor-pointer w-[20%] min-w-[100px]">
+            <span className="block truncate whitespace-nowrap text-sm">
               {new Date(agent.updatedAt).toLocaleDateString("en-US", {
                 month: "short",
                 day: "numeric",
@@ -183,7 +189,7 @@ function AgentRow({
             </span>
           </TableCell>
         </DialogTrigger>
-        <TableCell className="pl-0 pr-4 py-2">
+        <TableCell className="pl-0 pr-4 py-2 w-12">
           <TooltipProvider>
             <Tooltip>
               <DialogTrigger asChild>

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -95,12 +95,12 @@ function AgentsListSection() {
     <Table>
       <TableHeader>
         <TableRow>
-          <TableHead className="h-10 px-3 w-[25%] min-w-[120px]">
+          <TableHead className="h-10 px-3 w-[30%] min-w-[120px]">
             <span className="block truncate whitespace-nowrap">
               Your agents
             </span>
           </TableHead>
-          <TableHead className="h-10 px-3 w-[25%] min-w-[120px]">
+          <TableHead className="h-10 px-3 w-[30%] min-w-[120px]">
             <span className="block truncate whitespace-nowrap">
               Model provider
             </span>
@@ -113,7 +113,7 @@ function AgentsListSection() {
           <TableHead className="h-10 px-3 w-[20%] min-w-[100px]">
             <span className="block truncate whitespace-nowrap">Last edit</span>
           </TableHead>
-          <TableHead className="h-10 w-12 px-2" />
+          <TableHead className="h-10 w-[44px] px-2" />
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -148,14 +148,14 @@ function AgentRow({
     <Dialog>
       <TableRow className="h-[53px]">
         <DialogTrigger asChild>
-          <TableCell className="px-3 py-2 cursor-pointer w-[25%] min-w-[120px]">
+          <TableCell className="px-3 py-2 cursor-pointer w-[30%] min-w-[120px]">
             <span className="block truncate whitespace-nowrap font-medium">
               {agent.name}
             </span>
           </TableCell>
         </DialogTrigger>
         <DialogTrigger asChild>
-          <TableCell className="px-3 py-2 cursor-pointer w-[25%] min-w-[120px]">
+          <TableCell className="px-3 py-2 cursor-pointer w-[30%] min-w-[120px]">
             <span className="block truncate whitespace-nowrap text-sm">
               {modelProviderLabel}
             </span>
@@ -189,7 +189,7 @@ function AgentRow({
             </span>
           </TableCell>
         </DialogTrigger>
-        <TableCell className="w-12 px-2 py-2">
+        <TableCell className="w-[44px] px-2 py-2">
           <TooltipProvider>
             <Tooltip>
               <DialogTrigger asChild>


### PR DESCRIPTION
## Summary

Fixed the agents page to display the actual model provider name instead of showing hardcoded "Claude code" for all agents.

## Changes

- **Added `defaultModelProvider$` signal**: New computed signal to fetch the user's default model provider from the model providers list
- **Updated table header**: Changed "Provider" to "Model provider" for better clarity
- **Dynamic provider display**: Agents now show the actual configured model provider name using `getUILabel()` function
  - Examples: "Anthropic API key", "Azure foundry portal", "Claude Code OAuth token", etc.
  - Shows "N/A" if no default model provider is configured

## Technical Details

- Used `useResolved()` hook to properly handle the async computed signal
- Reused existing `getUILabel()` utility from settings page for consistent naming
- No breaking changes - purely display logic update

## Before
All agents showed "Claude code" regardless of actual configuration

## After
Each agent displays the user's actual default model provider name


Made with [Cursor](https://cursor.com)