### PR TITLE
feat(crates): add sandbox crate with core traits and types

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -18,6 +18,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,7 +267,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -522,6 +533,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "sandbox"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,7 +671,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -660,6 +688,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -1,15 +1,17 @@
 [workspace]
 resolver = "2"
-members = ["vsock-guest", "vsock-proto", "vsock-host", "vsock-test", "guest-init", "guest-common", "guest-download"]
+members = ["vsock-guest", "vsock-proto", "vsock-host", "vsock-test", "guest-init", "guest-common", "guest-download", "sandbox"]
 
 [workspace.dependencies]
 # Internal crates
 guest-common = { path = "guest-common" }
+sandbox = { path = "sandbox" }
 vsock-guest = { path = "vsock-guest" }
 vsock-host = { path = "vsock-host" }
 vsock-proto = { path = "vsock-proto" }
 
 # External dependencies
+async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 flate2 = "1"
 libc = "0.2"
@@ -17,6 +19,7 @@ nix = { version = "0.31", default-features = false, features = ["mount", "fs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = "0.4"
+thiserror = "2"
 tokio = { version = "1", features = ["net", "io-util", "time", "rt", "macros"] }
 ureq = { version = "3", features = ["platform-verifier"] }
 

--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sandbox"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+async-trait.workspace = true
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -1,0 +1,9 @@
+pub struct ResourceLimits {
+    pub cpu_count: u32,
+    pub memory_mb: u64,
+    pub timeout_secs: u64,
+}
+
+pub struct SandboxConfig {
+    pub resources: ResourceLimits,
+}

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -1,0 +1,25 @@
+#[derive(Debug, thiserror::Error)]
+pub enum SandboxError {
+    #[error("backend not available: {0}")]
+    BackendNotAvailable(String),
+
+    #[error("sandbox creation failed: {0}")]
+    CreationFailed(String),
+
+    #[error("sandbox start failed: {0}")]
+    StartFailed(String),
+
+    #[error("execution failed: {0}")]
+    ExecFailed(String),
+
+    #[error("timeout after {0}ms")]
+    Timeout(u64),
+
+    #[error("invalid configuration: {0}")]
+    InvalidConfig(String),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub type Result<T> = std::result::Result<T, SandboxError>;

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -1,0 +1,12 @@
+use async_trait::async_trait;
+
+use crate::config::SandboxConfig;
+use crate::error::Result;
+use crate::sandbox::Sandbox;
+
+#[async_trait]
+pub trait SandboxFactory: Send + Sync {
+    fn name(&self) -> &str;
+    async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>>;
+    fn is_available(&self) -> bool;
+}

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -1,0 +1,11 @@
+mod config;
+mod error;
+mod factory;
+mod sandbox;
+mod types;
+
+pub use config::{ResourceLimits, SandboxConfig};
+pub use error::{Result, SandboxError};
+pub use factory::SandboxFactory;
+pub use sandbox::Sandbox;
+pub use types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle};

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -1,0 +1,16 @@
+use async_trait::async_trait;
+
+use crate::error::Result;
+use crate::types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle};
+
+#[async_trait]
+pub trait Sandbox: Send + Sync {
+    async fn start(&mut self) -> Result<()>;
+    async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult>;
+    async fn write_file(&self, path: &str, content: &[u8]) -> Result<()>;
+    async fn spawn_watch(&self, request: &ExecRequest<'_>) -> Result<SpawnHandle>;
+    async fn wait_exit(&self, handle: SpawnHandle) -> Result<ProcessExit>;
+    async fn stop(&mut self) -> Result<()>;
+    async fn kill(&mut self) -> Result<()>;
+    fn id(&self) -> &str;
+}

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -1,0 +1,25 @@
+use std::collections::HashMap;
+
+pub struct ExecRequest<'a> {
+    pub cmd: &'a str,
+    pub timeout_ms: u64,
+    pub working_dir: Option<&'a str>,
+    pub env: Option<&'a HashMap<String, String>>,
+}
+
+pub struct ExecResult {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub struct SpawnHandle {
+    pub pid: u32,
+}
+
+pub struct ProcessExit {
+    pub pid: u32,
+    pub exit_code: i32,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}


### PR DESCRIPTION
## Summary

Part of #2522.

- Add `sandbox` crate with core `Sandbox` and `SandboxFactory` async traits for backend implementations to depend on
- Define `SandboxError` (7 variants), `SandboxConfig`, `ResourceLimits`, and execution types (`ExecRequest`, `ExecResult`, `SpawnHandle`, `ProcessExit`)
- Add `async-trait` and `thiserror` as workspace dependencies

## Test plan

- [x] `cargo check -p sandbox` passes
- [x] `cargo clippy -p sandbox` passes with `clippy::all = "deny"`
- [x] Pre-commit hooks (cargo-fmt, cargo-clippy, commitlint) all pass
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)