### PR TITLE
test(web): add integration tests for webhook storage commit and prepare endpoints

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/storages/commit/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/commit/__tests__/route.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { POST } from "../route";
+import { POST as preparePOST } from "../../prepare/route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestRun,
+  createTestSandboxToken,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
+
+vi.hoisted(() => {
+  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
+});
+
+const context = testContext();
+
+function makeCommitRequest(
+  runId: string,
+  token: string | null,
+  body: Record<string, unknown>,
+) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return createTestRequest(
+    "http://localhost:3000/api/webhooks/agent/storages/commit",
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ runId, ...body }),
+    },
+  );
+}
+
+/** Prepare a storage via webhook route and return the versionId */
+async function prepareStorage(
+  runId: string,
+  token: string,
+  storageName: string,
+  storageType: string,
+  files: Array<{ path: string; hash: string; size: number }>,
+): Promise<string> {
+  const request = createTestRequest(
+    "http://localhost:3000/api/webhooks/agent/storages/prepare",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ runId, storageName, storageType, files }),
+    },
+  );
+  const response = await preparePOST(request);
+  const data = await response.json();
+  return data.versionId;
+}
+
+describe("POST /api/webhooks/agent/storages/commit", () => {
+  let user: UserContext;
+  let testRunId: string;
+  let testToken: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    const { composeId } = await createTestCompose(uniqueId("storage-commit"));
+    const { runId } = await createTestRun(composeId, "Test prompt");
+    testRunId = runId;
+    testToken = await createTestSandboxToken(user.userId, testRunId);
+
+    mockClerk({ userId: null });
+  });
+
+  it("should return 401 without authentication", async () => {
+    const request = makeCommitRequest(testRunId, null, {
+      storageName: "test",
+      storageType: "volume",
+      versionId: "abc123",
+      files: [],
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+    const json = await response.json();
+    expect(json.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 404 when storage does not exist", async () => {
+    const request = makeCommitRequest(testRunId, testToken, {
+      storageName: `nonexistent-${Date.now()}`,
+      storageType: "volume",
+      versionId: "abc123",
+      files: [],
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(404);
+    const json = await response.json();
+    expect(json.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return 400 when versionId does not match", async () => {
+    const storageName = `webhook-mismatch-${Date.now()}`;
+    const files = [{ path: "test.txt", hash: "a".repeat(64), size: 100 }];
+
+    // Create storage via webhook prepare
+    await prepareStorage(testRunId, testToken, storageName, "volume", files);
+
+    // Commit with wrong versionId
+    const request = makeCommitRequest(testRunId, testToken, {
+      storageName,
+      storageType: "volume",
+      versionId: "wrong_version_id",
+      files,
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error.message).toContain("mismatch");
+  });
+
+  it("should commit version and return success", async () => {
+    const storageName = `webhook-success-${Date.now()}`;
+    const files = [
+      { path: "file1.txt", hash: "c".repeat(64), size: 100 },
+      { path: "file2.txt", hash: "d".repeat(64), size: 200 },
+    ];
+
+    const versionId = await prepareStorage(
+      testRunId,
+      testToken,
+      storageName,
+      "artifact",
+      files,
+    );
+
+    const request = makeCommitRequest(testRunId, testToken, {
+      storageName,
+      storageType: "artifact",
+      versionId,
+      files,
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.success).toBe(true);
+    expect(json.versionId).toBe(versionId);
+    expect(json.fileCount).toBe(2);
+    expect(json.size).toBe(300);
+    expect(json).not.toHaveProperty("error");
+  });
+
+  it("should return deduplicated=true for idempotent re-commit", async () => {
+    const storageName = `webhook-idempotent-${Date.now()}`;
+    const files = [{ path: "test.txt", hash: "e".repeat(64), size: 100 }];
+
+    const versionId = await prepareStorage(
+      testRunId,
+      testToken,
+      storageName,
+      "volume",
+      files,
+    );
+
+    // First commit
+    await POST(
+      makeCommitRequest(testRunId, testToken, {
+        storageName,
+        storageType: "volume",
+        versionId,
+        files,
+      }),
+    );
+
+    // Re-commit (idempotent)
+    const response = await POST(
+      makeCommitRequest(testRunId, testToken, {
+        storageName,
+        storageType: "volume",
+        versionId,
+        files,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.success).toBe(true);
+    expect(json.deduplicated).toBe(true);
+  });
+});

--- a/turbo/apps/web/app/api/webhooks/agent/storages/commit/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/commit/__tests__/route.test.ts
@@ -105,7 +105,7 @@ describe("POST /api/webhooks/agent/storages/commit", () => {
 
   it("should return 404 when storage does not exist", async () => {
     const request = makeCommitRequest(testRunId, testToken, {
-      storageName: `nonexistent-${Date.now()}`,
+      storageName: uniqueId("nonexistent"),
       storageType: "volume",
       versionId: "abc123",
       files: [],
@@ -119,7 +119,7 @@ describe("POST /api/webhooks/agent/storages/commit", () => {
   });
 
   it("should return 400 when versionId does not match", async () => {
-    const storageName = `webhook-mismatch-${Date.now()}`;
+    const storageName = uniqueId("webhook-mismatch");
     const files = [{ path: "test.txt", hash: "a".repeat(64), size: 100 }];
 
     // Create storage via webhook prepare
@@ -141,7 +141,7 @@ describe("POST /api/webhooks/agent/storages/commit", () => {
   });
 
   it("should commit version and return success", async () => {
-    const storageName = `webhook-success-${Date.now()}`;
+    const storageName = uniqueId("webhook-success");
     const files = [
       { path: "file1.txt", hash: "c".repeat(64), size: 100 },
       { path: "file2.txt", hash: "d".repeat(64), size: 200 },
@@ -174,7 +174,7 @@ describe("POST /api/webhooks/agent/storages/commit", () => {
   });
 
   it("should return deduplicated=true for idempotent re-commit", async () => {
-    const storageName = `webhook-idempotent-${Date.now()}`;
+    const storageName = uniqueId("webhook-idempotent");
     const files = [{ path: "test.txt", hash: "e".repeat(64), size: 100 }];
 
     const versionId = await prepareStorage(

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/__tests__/route.test.ts
@@ -100,7 +100,7 @@ describe("POST /api/webhooks/agent/storages/prepare", () => {
   });
 
   it("should create new storage and return upload URLs", async () => {
-    const storageName = `webhook-new-${Date.now()}`;
+    const storageName = uniqueId("webhook-new");
     const files = [{ path: "test.txt", hash: "a".repeat(64), size: 100 }];
 
     const request = makePrepareRequest(testRunId, testToken, {
@@ -124,7 +124,7 @@ describe("POST /api/webhooks/agent/storages/prepare", () => {
   });
 
   it("should return existing=true for deduplicated version", async () => {
-    const storageName = `webhook-dedup-${Date.now()}`;
+    const storageName = uniqueId("webhook-dedup");
     const files = [{ path: "test.txt", hash: "b".repeat(64), size: 100 }];
 
     // Prepare → get versionId

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/__tests__/route.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { POST } from "../route";
+import { POST as commitPOST } from "../../commit/route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestRun,
+  createTestSandboxToken,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { randomUUID } from "crypto";
+
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
+
+vi.hoisted(() => {
+  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
+});
+
+const context = testContext();
+
+function makePrepareRequest(
+  runId: string,
+  token: string | null,
+  body: Record<string, unknown>,
+) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return createTestRequest(
+    "http://localhost:3000/api/webhooks/agent/storages/prepare",
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ runId, ...body }),
+    },
+  );
+}
+
+describe("POST /api/webhooks/agent/storages/prepare", () => {
+  let user: UserContext;
+  let testRunId: string;
+  let testToken: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    const { composeId } = await createTestCompose(uniqueId("storage-prep"));
+    const { runId } = await createTestRun(composeId, "Test prompt");
+    testRunId = runId;
+    testToken = await createTestSandboxToken(user.userId, testRunId);
+
+    mockClerk({ userId: null });
+  });
+
+  it("should return 401 without authentication", async () => {
+    const request = makePrepareRequest(testRunId, null, {
+      storageName: "test",
+      storageType: "volume",
+      files: [],
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+    const json = await response.json();
+    expect(json.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 404 for non-existent run", async () => {
+    const nonExistentRunId = randomUUID();
+    const tokenForNonExistent = await createTestSandboxToken(
+      user.userId,
+      nonExistentRunId,
+    );
+
+    const request = makePrepareRequest(nonExistentRunId, tokenForNonExistent, {
+      storageName: "test",
+      storageType: "volume",
+      files: [],
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(404);
+    const json = await response.json();
+    expect(json.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should create new storage and return upload URLs", async () => {
+    const storageName = `webhook-new-${Date.now()}`;
+    const files = [{ path: "test.txt", hash: "a".repeat(64), size: 100 }];
+
+    const request = makePrepareRequest(testRunId, testToken, {
+      storageName,
+      storageType: "volume",
+      files,
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.versionId).toHaveLength(64);
+    expect(json.existing).toBe(false);
+    expect(json.uploads.archive.presignedUrl).toBe(
+      "https://mock-presigned-put-url",
+    );
+    expect(json.uploads.manifest.presignedUrl).toBe(
+      "https://mock-presigned-put-url",
+    );
+  });
+
+  it("should return existing=true for deduplicated version", async () => {
+    const storageName = `webhook-dedup-${Date.now()}`;
+    const files = [{ path: "test.txt", hash: "b".repeat(64), size: 100 }];
+
+    // Prepare → get versionId
+    const prepareResponse = await POST(
+      makePrepareRequest(testRunId, testToken, {
+        storageName,
+        storageType: "volume",
+        files,
+      }),
+    );
+    const { versionId } = await prepareResponse.json();
+
+    // Commit → persist version in DB
+    const commitRequest = createTestRequest(
+      "http://localhost:3000/api/webhooks/agent/storages/commit",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testToken}`,
+        },
+        body: JSON.stringify({
+          runId: testRunId,
+          storageName,
+          storageType: "volume",
+          versionId,
+          files,
+        }),
+      },
+    );
+    await commitPOST(commitRequest);
+
+    // Prepare again with same files → should be deduplicated
+    const response = await POST(
+      makePrepareRequest(testRunId, testToken, {
+        storageName,
+        storageType: "volume",
+        files,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.existing).toBe(true);
+    expect(json).not.toHaveProperty("uploads");
+  });
+});


### PR DESCRIPTION
## Summary

- Add 9 integration tests for the two most complex untested webhook routes (`/api/webhooks/agent/storages/commit` and `/api/webhooks/agent/storages/prepare`)
- Tests cover sandbox JWT auth boundaries and critical storage flows
- Follows existing webhook test patterns (`createTestSandboxToken`, `context.setupMocks()`)

### Prepare route (4 tests)
| Test | Status |
|------|--------|
| No auth header | 401 |
| Non-existent run | 404 |
| New storage with upload URLs | 200 |
| Deduplication (same files after commit) | 200 |

### Commit route (5 tests)
| Test | Status |
|------|--------|
| No auth header | 401 |
| Storage not found | 404 |
| Version ID mismatch | 400 |
| Successful commit | 200 |
| Idempotent re-commit | 200 |

## Test plan

- [x] `pnpm vitest run` — 9 tests pass
- [x] `pnpm turbo run lint` — no warnings
- [x] `pnpm prettier --check` — formatted
- [x] `pnpm check-types` — no errors

Closes #2515

🤖 Generated with [Claude Code](https://claude.com/claude-code)