### PR TITLE
refactor(crates): enforce panic-prevention clippy lints workspace-wide

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -30,3 +30,10 @@ warnings = "deny"
 
 [workspace.lints.clippy]
 all = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+indexing_slicing = "deny"
+todo = "deny"
+unimplemented = "deny"
+unreachable = "deny"

--- a/crates/clippy.toml
+++ b/crates/clippy.toml
@@ -1,0 +1,4 @@
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+allow-indexing-slicing-in-tests = true

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -113,9 +113,9 @@ fn run(manifest_path: &str) -> bool {
 
     // Download artifact if present (after storages complete)
     if let Some(artifact) = &manifest.artifact
-        && is_valid_url(&artifact.archive_url)
+        && let Some(url) = &artifact.archive_url
+        && url != "null"
     {
-        let url = artifact.archive_url.as_ref().unwrap();
         let start = Instant::now();
         log_info!(LOG_TAG, "Downloading artifact to {}", artifact.mount_path);
 
@@ -146,7 +146,11 @@ fn download_storages_parallel(storages: &[Storage]) -> bool {
         .iter()
         .enumerate()
         .filter(|(_, s)| is_valid_url(&s.archive_url))
-        .map(|(i, s)| (i, s.archive_url.clone().unwrap(), s.mount_path.clone()))
+        .filter_map(|(i, s)| {
+            s.archive_url
+                .clone()
+                .map(|url| (i, url, s.mount_path.clone()))
+        })
         .collect();
 
     if download_tasks.is_empty() {

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -519,7 +519,11 @@ pub fn handle_connection(stream: UnixStream) -> io::Result<()> {
             break;
         }
 
-        for msg in decoder.decode(&buf[..n]).map_err(to_io_error)? {
+        // n <= buf.len() is guaranteed by read()
+        for msg in decoder
+            .decode(buf.get(..n).unwrap_or_default())
+            .map_err(to_io_error)?
+        {
             // Handle spawn_watch separately since it needs the writer Arc
             let response = if msg.msg_type == MSG_SPAWN_WATCH {
                 let (timeout_ms, command) =

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -118,7 +118,8 @@ impl VsockHost {
 
         let messages = self
             .decoder
-            .decode(&self.read_buf[..n])
+            // n <= read_buf.len() is guaranteed by read()
+            .decode(self.read_buf.get(..n).unwrap_or_default())
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
         // Cache all unsolicited process_exit events, return remaining messages.

--- a/crates/vsock-test/tests/integration.rs
+++ b/crates/vsock-test/tests/integration.rs
@@ -1,3 +1,11 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::unreachable
+)]
+
 use std::io;
 use std::ops::{Deref, DerefMut};
 use std::thread::{self, JoinHandle};


### PR DESCRIPTION
## Summary

Part of #2522.

- Add 7 panic-prevention clippy lints (`unwrap_used`, `expect_used`, `panic`, `indexing_slicing`, `todo`, `unimplemented`, `unreachable`) as workspace-level `deny` in `crates/Cargo.toml`
- Add `crates/clippy.toml` with `allow-*-in-tests` to exempt `#[cfg(test)]` code
- Refactor `vsock-proto` decode functions to use safe `read_u8_at`/`read_u16_at`/`read_u32_at`/`read_i32_at` helpers and `.get()` instead of direct indexing
- Fix `vsock-guest` and `vsock-host` buf slicing (`buf[..n]` → `buf.get(..n).unwrap_or_default()`)
- Remove `.unwrap()` calls from `guest-download` artifact/storage download paths

## Test plan

- [x] `cargo clippy --workspace` passes with zero warnings
- [x] `cargo test --workspace` — all 68 tests pass
- [x] Pre-commit hooks (cargo-fmt, cargo-clippy, commitlint) all pass
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)