### PR TITLE
fix(web): add missing job ID filter in cleanup-compose-jobs cron

### DIFF
--- a/turbo/apps/web/app/api/cron/cleanup-compose-jobs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-compose-jobs/__tests__/route.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GET } from "../route";
+import { testContext } from "../../../../../src/__tests__/test-helpers";
+import {
+  createTestComposeJob,
+  findTestComposeJob,
+} from "../../../../../src/__tests__/api-test-helpers";
+
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
+
+vi.hoisted(() => {
+  vi.stubEnv("CRON_SECRET", "test-cron-secret");
+});
+
+const context = testContext();
+
+function cronRequest(secret?: string) {
+  return new Request("http://localhost:3000/api/cron/cleanup-compose-jobs", {
+    method: "GET",
+    headers: secret ? { authorization: `Bearer ${secret}` } : {},
+  });
+}
+
+describe("GET /api/cron/cleanup-compose-jobs", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return 401 with invalid cron secret", async () => {
+    const response = await GET(cronRequest("wrong-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return empty results when no stale jobs exist", async () => {
+    const response = await GET(cronRequest("test-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.cleaned).toBe(0);
+    expect(body.results).toEqual([]);
+  });
+
+  it("should clean up stale pending and running jobs", async () => {
+    const staleTime = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    const pendingId = await createTestComposeJob({
+      status: "pending",
+      createdAt: staleTime,
+    });
+    const runningId = await createTestComposeJob({
+      status: "running",
+      createdAt: staleTime,
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.cleaned).toBe(2);
+
+    const pending = await findTestComposeJob(pendingId);
+    expect(pending?.status).toBe("failed");
+    expect(pending?.error).toContain("timed out");
+
+    const running = await findTestComposeJob(runningId);
+    expect(running?.status).toBe("failed");
+  });
+
+  it("should not touch recent or already-completed jobs", async () => {
+    const recentTime = new Date();
+    const staleTime = new Date(Date.now() - 25 * 60 * 60 * 1000);
+
+    const recentId = await createTestComposeJob({
+      status: "pending",
+      createdAt: recentTime,
+    });
+    const completedId = await createTestComposeJob({
+      status: "completed",
+      createdAt: staleTime,
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.cleaned).toBe(0);
+
+    const recent = await findTestComposeJob(recentId);
+    expect(recent?.status).toBe("pending");
+
+    const completed = await findTestComposeJob(completedId);
+    expect(completed?.status).toBe("completed");
+  });
+
+  it("should update each job individually", async () => {
+    const staleTime = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    const id1 = await createTestComposeJob({
+      status: "pending",
+      createdAt: staleTime,
+    });
+    const id2 = await createTestComposeJob({
+      status: "running",
+      createdAt: staleTime,
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    const body = await response.json();
+
+    expect(body.cleaned).toBe(2);
+    expect(body.results).toHaveLength(2);
+
+    const jobIds = body.results.map((r: { jobId: string }) => r.jobId);
+    expect(jobIds).toContain(id1);
+    expect(jobIds).toContain(id2);
+
+    for (const result of body.results) {
+      expect(result.status).toBe("cleaned");
+    }
+  });
+});

--- a/turbo/apps/web/app/api/cron/cleanup-compose-jobs/route.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-compose-jobs/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { initServices } from "../../../../src/lib/init-services";
 import { composeJobs } from "../../../../src/db/schema/compose-job";
-import { and, lt, inArray } from "drizzle-orm";
+import { and, eq, lt, inArray } from "drizzle-orm";
 import { logger } from "../../../../src/lib/logger";
 
 const log = logger("cron:cleanup-compose-jobs");
@@ -77,8 +77,8 @@ export async function GET(request: Request): Promise<Response> {
         })
         .where(
           and(
+            eq(composeJobs.id, job.id),
             inArray(composeJobs.status, ["pending", "running"]),
-            lt(composeJobs.createdAt, cutoffTime),
           ),
         );
 


### PR DESCRIPTION
## Summary
- Fixed a bug in the `cleanup-compose-jobs` cron route where the per-job UPDATE was missing `eq(composeJobs.id, job.id)` in its WHERE clause, causing each loop iteration to update **all** stale jobs instead of just the target job
- Added 5 integration tests covering auth, empty results, stale job cleanup, skipping recent/completed jobs, and individual job updates
- Added `createTestComposeJob` and `findTestComposeJob` helpers to `api-test-helpers.ts`

## Bug Details
The cleanup loop iterates over stale jobs and updates each one individually. However, the WHERE clause only filtered by status and creation time — not by `job.id`. This meant every iteration would re-update all stale rows, leading to incorrect `completedAt` timestamps and potentially duplicate result entries.

**Before:**
```typescript
.where(
  and(
    inArray(composeJobs.status, ["pending", "running"]),
    lt(composeJobs.createdAt, cutoffTime),
  ),
)
```

**After:**
```typescript
.where(
  and(
    eq(composeJobs.id, job.id),
    inArray(composeJobs.status, ["pending", "running"]),
  ),
)
```

## Test plan
- [ ] `GET /api/cron/cleanup-compose-jobs` returns 401 with invalid cron secret
- [ ] Returns empty results when no stale jobs exist
- [ ] Cleans up stale pending and running jobs (verifies status changed to "failed" with timeout error)
- [ ] Does not touch recent or already-completed jobs
- [ ] Updates each job individually with correct result entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)