### PR TITLE
feat(platform): display user prompt in log detail page

### DIFF
--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -124,6 +124,20 @@ export function LogDetailContent({ logId }: { logId: string }) {
         </div>
       )}
 
+      {/* Prompt Section */}
+      {detail.prompt.trim().length > 0 && (
+        <div className="px-4 sm:px-8">
+          <div className="shrink-0 px-4 py-3 bg-card rounded-lg border border-border">
+            <span className="text-sm font-medium text-muted-foreground">
+              Prompt
+            </span>
+            <p className="mt-1 text-sm text-foreground whitespace-pre-wrap break-words">
+              {detail.prompt}
+            </p>
+          </div>
+        </div>
+      )}
+
       <AgentEventsCard
         logId={logId}
         framework={detail.framework}


### PR DESCRIPTION
## Summary

- Display the user prompt in a dedicated section on the log detail page when a prompt is present
- The prompt section renders above the agent events card with a styled card UI showing the prompt label and text
- Prompt section is conditionally hidden when the prompt is empty

Closes #2523

## Test plan

- [x] Added test: "should display user prompt when present" - verifies prompt label and content render
- [x] Added test: "should not display prompt section when prompt is empty" - verifies section is hidden for empty prompts
- [x] Updated existing search test comments to reflect the new prompt display behavior
- [x] All 20 log detail page tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)