### PR TITLE
refactor: simplify session model - continue always uses head compose

### DIFF
--- a/turbo/apps/cli/src/commands/run/__tests__/continue.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/continue.test.ts
@@ -150,7 +150,7 @@ describe("run continue command", () => {
       );
     });
 
-    it("should pass volume versions to API", async () => {
+    it("should not send volumeVersions in API request", async () => {
       let capturedBody: Record<string, unknown> | undefined;
 
       server.use(
@@ -168,15 +168,9 @@ describe("run continue command", () => {
         "cli",
         testSessionId,
         "test prompt",
-        "--volume-version",
-        "data=v1.0.0",
       ]);
 
-      expect(capturedBody).toEqual(
-        expect.objectContaining({
-          volumeVersions: { data: "v1.0.0" },
-        }),
-      );
+      expect(capturedBody).not.toHaveProperty("volumeVersions");
     });
 
     it("should pass model provider option to API", async () => {

--- a/turbo/apps/cli/src/commands/run/__tests__/volume-version.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/volume-version.test.ts
@@ -270,8 +270,8 @@ describe("--volume-version option", () => {
     });
   });
 
-  describe("continue command with --volume-version", () => {
-    it("should pass volume versions to API", async () => {
+  describe("continue command does not support --volume-version", () => {
+    it("should not send volumeVersions in API request for continue", async () => {
       let capturedBody: unknown;
       server.use(
         http.post(
@@ -289,48 +289,16 @@ describe("--volume-version option", () => {
         "continue",
         testSessionId,
         "test prompt",
-        "--volume-version",
-        "data-volume=xyz789",
       ]);
 
       expect(capturedBody).toEqual(
         expect.objectContaining({
           sessionId: testSessionId,
-          volumeVersions: { "data-volume": "xyz789" },
         }),
       );
-    });
-
-    it("should pass multiple volume versions to API", async () => {
-      let capturedBody: unknown;
-      server.use(
-        http.post(
-          "http://localhost:3000/api/agent/runs",
-          async ({ request }) => {
-            capturedBody = await request.json();
-            return HttpResponse.json(defaultRunResponse, { status: 201 });
-          },
-        ),
-      );
-
-      await runCommand.parseAsync([
-        "node",
-        "cli",
-        "continue",
-        testSessionId,
-        "test prompt",
-        "--volume-version",
-        "vol1=v1",
-        "--volume-version",
-        "vol2=v2",
-      ]);
-
-      expect(capturedBody).toEqual(
-        expect.objectContaining({
-          sessionId: testSessionId,
-          volumeVersions: { vol1: "v1", vol2: "v2" },
-        }),
-      );
+      expect(
+        (capturedBody as Record<string, unknown>).volumeVersions,
+      ).toBeUndefined();
     });
   });
 

--- a/turbo/apps/cli/src/commands/run/continue.ts
+++ b/turbo/apps/cli/src/commands/run/continue.ts
@@ -4,7 +4,6 @@ import { getSession, createRun } from "../../lib/api";
 import { EventRenderer } from "../../lib/events/event-renderer";
 import {
   collectKeyValue,
-  collectVolumeVersions,
   isUUID,
   loadValues,
   pollEvents,
@@ -34,12 +33,6 @@ export const continueCommand = new Command()
     "--secrets <KEY=value>",
     "Secrets for ${{ secrets.xxx }} (repeatable, falls back to --env-file or env vars)",
     collectKeyValue,
-    {},
-  )
-  .option(
-    "--volume-version <name=version>",
-    "Volume version override (repeatable)",
-    collectVolumeVersions,
     {},
   )
   .option(
@@ -73,7 +66,6 @@ export const continueCommand = new Command()
         envFile?: string;
         vars: Record<string, string>;
         secrets: Record<string, string>;
-        volumeVersion: Record<string, string>;
         experimentalRealtime?: boolean;
         modelProvider?: string;
         verbose?: boolean;
@@ -110,10 +102,6 @@ export const continueCommand = new Command()
           prompt,
           vars: Object.keys(vars).length > 0 ? vars : undefined,
           secrets: loadedSecrets,
-          volumeVersions:
-            Object.keys(allOpts.volumeVersion).length > 0
-              ? allOpts.volumeVersion
-              : undefined,
           modelProvider: options.modelProvider || allOpts.modelProvider,
           debugNoMockClaude:
             options.debugNoMockClaude || allOpts.debugNoMockClaude || undefined,

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -446,16 +446,9 @@ const router = tsr.router(runsMainContract, {
         };
       }
 
-      agentComposeVersionId =
-        sessionData.agentComposeVersionId || compose.headVersionId;
+      // Always use HEAD compose version for session continue
+      agentComposeVersionId = compose.headVersionId;
       agentComposeName = compose.name || undefined;
-
-      if (!body.vars && sessionData.vars) {
-        varsFromSource = sessionData.vars;
-      }
-      if (!body.secrets && sessionData.secretNames) {
-        secretNamesFromSource = sessionData.secretNames;
-      }
     }
 
     log.debug(`Resolved agentComposeVersionId: ${agentComposeVersionId}`);

--- a/turbo/apps/web/app/api/agent/sessions/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/sessions/[id]/__tests__/route.test.ts
@@ -49,7 +49,6 @@ describe("GET /api/agent/sessions/:id", () => {
     expect(response.status).toBe(200);
     expect(data.id).toBe(agentSessionId);
     expect(data.agentComposeId).toBe(testComposeId);
-    expect(data.agentComposeVersionId).toBeDefined();
     expect(data.createdAt).toBeDefined();
     expect(data.updatedAt).toBeDefined();
   });

--- a/turbo/apps/web/app/v1/runs/route.ts
+++ b/turbo/apps/web/app/v1/runs/route.ts
@@ -224,8 +224,8 @@ const router = tsr.router(publicRunsListContract, {
         };
       }
 
-      agentComposeVersionId =
-        sessionData.agentComposeVersionId || compose.headVersionId;
+      // Always use HEAD compose version for session continue
+      agentComposeVersionId = compose.headVersionId;
       agentCompose = compose;
     } else if (body.agentId) {
       // Find by agent ID

--- a/turbo/apps/web/src/db/migrations/0071_simplify_agent_sessions.sql
+++ b/turbo/apps/web/src/db/migrations/0071_simplify_agent_sessions.sql
@@ -1,0 +1,11 @@
+-- Simplify agent_sessions: remove snapshotted fields
+-- Sessions now always use HEAD compose version at runtime
+-- Vars, secrets, and volumes are resolved from their respective services
+
+ALTER TABLE "agent_sessions" DROP COLUMN IF EXISTS "agent_compose_version_id";
+--> statement-breakpoint
+ALTER TABLE "agent_sessions" DROP COLUMN IF EXISTS "vars";
+--> statement-breakpoint
+ALTER TABLE "agent_sessions" DROP COLUMN IF EXISTS "secret_names";
+--> statement-breakpoint
+ALTER TABLE "agent_sessions" DROP COLUMN IF EXISTS "volume_versions";

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -498,6 +498,13 @@
       "when": 1769500000000,
       "tag": "0070_create_connector_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1769600000000,
+      "tag": "0071_simplify_agent_sessions",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/agent-session.ts
+++ b/turbo/apps/web/src/db/schema/agent-session.ts
@@ -4,7 +4,6 @@ import {
   varchar,
   text,
   timestamp,
-  jsonb,
   index,
 } from "drizzle-orm/pg-core";
 import { agentComposes } from "./agent-compose";
@@ -12,14 +11,8 @@ import { conversations } from "./conversation";
 
 /**
  * Agent Sessions table
- * VM0's concept of a persistent running context across multiple runs
- * Unlike checkpoints (immutable snapshots), sessions track the latest state
- *
- * Key fields for execution context:
- * - agentComposeVersionId: Immutable compose version (SHA-256) fixed at session creation
- * - volumeVersions: Volume versions snapshot at session creation
- * - vars: Template variables for compose expansion
- * - secretNames: Secret names for validation (values never stored)
+ * Lightweight compose ↔ conversation association for continue operations
+ * Sessions always use HEAD compose version at runtime — no snapshotting
  */
 export const agentSessions = pgTable(
   "agent_sessions",
@@ -29,18 +22,10 @@ export const agentSessions = pgTable(
     agentComposeId: uuid("agent_compose_id")
       .references(() => agentComposes.id, { onDelete: "cascade" })
       .notNull(),
-    // Immutable compose version ID (SHA-256 hash) fixed at session creation
-    // If null (legacy sessions), resolveSession falls back to HEAD version
-    agentComposeVersionId: varchar("agent_compose_version_id", { length: 255 }),
     conversationId: uuid("conversation_id").references(() => conversations.id, {
       onDelete: "set null",
     }),
     artifactName: varchar("artifact_name", { length: 255 }),
-    vars: jsonb("vars").$type<Record<string, string>>(),
-    // Secret names for validation (values never stored - must be provided at runtime)
-    secretNames: jsonb("secret_names").$type<string[]>(),
-    // Volume versions snapshot at session creation for reproducibility
-    volumeVersions: jsonb("volume_versions").$type<Record<string, string>>(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },

--- a/turbo/apps/web/src/lib/agent-session/agent-session-service.ts
+++ b/turbo/apps/web/src/lib/agent-session/agent-session-service.ts
@@ -6,12 +6,12 @@ import type {
   AgentSessionData,
   AgentSessionWithConversation,
   CreateAgentSessionInput,
-  UpdateAgentSessionInput,
 } from "./types";
 
 /**
  * Agent Session Service - Pure Functions
- * Manages VM0 agent sessions - persistent running contexts across multiple runs
+ * Manages VM0 agent sessions - lightweight compose ↔ conversation associations
+ * Sessions always use HEAD compose version at runtime — no snapshotting
  */
 
 /**
@@ -54,18 +54,12 @@ export async function getAgentSessionWithConversation(
  * Find existing session or create a new one
  * Used when checkpoint is created to ensure session exists
  * Note: artifactName is optional - sessions without artifact use (userId, composeId) as key
- * Note: agentComposeVersionId and volumeVersions are only set on creation, not updated
- * Note: secrets values are NEVER stored - only names for validation
  */
 export async function findOrCreateAgentSession(
   userId: string,
   agentComposeId: string,
   artifactName?: string,
   conversationId?: string,
-  vars?: Record<string, string>,
-  secretNames?: string[],
-  agentComposeVersionId?: string,
-  volumeVersions?: Record<string, string>,
 ): Promise<{ session: AgentSessionData; created: boolean }> {
   // Build query conditions - handle null artifactName for sessions without artifact
   // For sessions with artifact: match (userId, composeId, artifactName)
@@ -90,29 +84,20 @@ export async function findOrCreateAgentSession(
     .limit(1);
 
   if (existing) {
-    // Update conversation, vars, and secret names if provided
-    // Note: agentComposeVersionId and volumeVersions are NOT updated - they are fixed at creation
+    // Update conversation reference if provided
     if (conversationId) {
-      const updated = await updateAgentSession(existing.id, {
-        conversationId,
-        vars,
-        secretNames,
-      });
+      const updated = await updateAgentSession(existing.id, conversationId);
       return { session: updated, created: false };
     }
     return { session: mapToAgentSessionData(existing), created: false };
   }
 
-  // Create new session with version ID and volume versions fixed at creation
+  // Create new session
   const session = await createAgentSession({
     userId,
     agentComposeId,
-    agentComposeVersionId,
     artifactName,
     conversationId,
-    vars,
-    secretNames,
-    volumeVersions,
   });
 
   return { session, created: true };
@@ -120,7 +105,6 @@ export async function findOrCreateAgentSession(
 
 /**
  * Create a new agent session
- * Note: secrets values are NEVER stored - only names for validation
  */
 async function createAgentSession(
   input: CreateAgentSessionInput,
@@ -130,13 +114,8 @@ async function createAgentSession(
     .values({
       userId: input.userId,
       agentComposeId: input.agentComposeId,
-      agentComposeVersionId: input.agentComposeVersionId,
       artifactName: input.artifactName,
       conversationId: input.conversationId,
-      vars: input.vars,
-      // Store only secret names, never values
-      secretNames: input.secretNames,
-      volumeVersions: input.volumeVersions,
     })
     .returning();
 
@@ -148,35 +127,18 @@ async function createAgentSession(
 }
 
 /**
- * Update an existing agent session's conversation reference, vars and secret names
- * Note: secrets values are NEVER stored - only names for validation
+ * Update an existing agent session's conversation reference
  */
 async function updateAgentSession(
   id: string,
-  input: UpdateAgentSessionInput,
+  conversationId: string,
 ): Promise<AgentSessionData> {
-  const updateData: {
-    conversationId: string;
-    updatedAt: Date;
-    vars?: Record<string, string>;
-    secretNames?: string[];
-  } = {
-    conversationId: input.conversationId,
-    updatedAt: new Date(),
-  };
-
-  if (input.vars !== undefined) {
-    updateData.vars = input.vars;
-  }
-
-  // Store only secret names, never values
-  if (input.secretNames !== undefined) {
-    updateData.secretNames = input.secretNames;
-  }
-
   const [session] = await globalThis.services.db
     .update(agentSessions)
-    .set(updateData)
+    .set({
+      conversationId,
+      updatedAt: new Date(),
+    })
     .where(eq(agentSessions.id, id))
     .returning();
 
@@ -194,12 +156,8 @@ function mapToAgentSessionData(
     id: session.id,
     userId: session.userId,
     agentComposeId: session.agentComposeId,
-    agentComposeVersionId: session.agentComposeVersionId,
     conversationId: session.conversationId,
     artifactName: session.artifactName,
-    vars: session.vars,
-    secretNames: session.secretNames ?? null,
-    volumeVersions: session.volumeVersions,
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
   };

--- a/turbo/apps/web/src/lib/agent-session/agent-session-service.ts
+++ b/turbo/apps/web/src/lib/agent-session/agent-session-service.ts
@@ -40,6 +40,7 @@ export async function getAgentSessionWithConversation(
     conversation: result.conversation
       ? {
           id: result.conversation.id,
+          runId: result.conversation.runId,
           cliAgentType: result.conversation.cliAgentType,
           cliAgentSessionId: result.conversation.cliAgentSessionId,
           cliAgentSessionHistory: result.conversation.cliAgentSessionHistory,

--- a/turbo/apps/web/src/lib/agent-session/types.ts
+++ b/turbo/apps/web/src/lib/agent-session/types.ts
@@ -33,6 +33,7 @@ export interface CreateAgentSessionInput {
 export interface AgentSessionWithConversation extends AgentSessionData {
   conversation: {
     id: string;
+    runId: string;
     cliAgentType: string;
     cliAgentSessionId: string;
     /** @deprecated Legacy TEXT storage - use cliAgentSessionHistoryHash instead */

--- a/turbo/apps/web/src/lib/agent-session/types.ts
+++ b/turbo/apps/web/src/lib/agent-session/types.ts
@@ -1,6 +1,7 @@
 /**
  * Agent Session types
- * VM0's concept of a persistent running context across multiple runs
+ * Lightweight compose ↔ conversation association for continue operations
+ * Sessions always use HEAD compose version at runtime — no snapshotting
  */
 
 /**
@@ -10,16 +11,8 @@ export interface AgentSessionData {
   id: string;
   userId: string;
   agentComposeId: string;
-  // Immutable compose version ID (SHA-256) fixed at session creation
-  // Null for legacy sessions - resolveSession falls back to HEAD
-  agentComposeVersionId: string | null;
   conversationId: string | null;
   artifactName: string | null;
-  vars: Record<string, string> | null;
-  // Secret names for validation (values never stored - must be provided at runtime)
-  secretNames: string[] | null;
-  // Volume versions snapshot at session creation
-  volumeVersions: Record<string, string> | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -30,25 +23,8 @@ export interface AgentSessionData {
 export interface CreateAgentSessionInput {
   userId: string;
   agentComposeId: string;
-  // Compose version ID to fix at session creation (for reproducibility)
-  agentComposeVersionId?: string;
   artifactName?: string;
   conversationId?: string;
-  vars?: Record<string, string>;
-  // Secret names for validation (values never stored - must be provided at runtime)
-  secretNames?: string[];
-  // Volume versions to fix at session creation
-  volumeVersions?: Record<string, string>;
-}
-
-/**
- * Input for updating an existing agent session
- */
-export interface UpdateAgentSessionInput {
-  conversationId: string;
-  vars?: Record<string, string>;
-  // Secret names for validation (values never stored - must be provided at runtime)
-  secretNames?: string[];
 }
 
 /**

--- a/turbo/apps/web/src/lib/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/checkpoint/checkpoint-service.ts
@@ -173,14 +173,11 @@ export async function createCheckpoint(
   log.debug(`Checkpoint created successfully: ${checkpoint.id}`);
 
   // Find or create agent session
-  // Sessions now store compose version ID for reproducibility
+  // Sessions are lightweight compose ↔ conversation associations
   // artifactSnapshot may be undefined for runs without artifact
-  // Note: secrets values are NEVER stored - only names for validation
   const artifactSnapshot = request.artifactSnapshot as
     | ArtifactSnapshot
     | undefined;
-  const vars = (run.vars as Record<string, string>) || undefined;
-  const secretNames = (run.secretNames as string[]) || undefined;
   const volumeSnapshot = request.volumeVersionsSnapshot as
     | VolumeVersionsSnapshot
     | undefined;
@@ -189,10 +186,6 @@ export async function createCheckpoint(
     version.composeId,
     artifactSnapshot?.artifactName, // May be undefined for runs without artifact
     conversation.id,
-    vars,
-    secretNames,
-    run.agentComposeVersionId, // Pass version ID to fix at session creation
-    volumeSnapshot?.versions, // Pass volume versions to fix at session creation
   );
 
   log.debug(`Agent session updated/created: ${agentSession.id}`);

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -15,6 +15,7 @@ import {
   agentComposeVersions,
 } from "../../../db/schema/agent-compose";
 import type { ExperimentalFirewall as CoreExperimentalFirewall } from "@vm0/core";
+import { extractCliAgentType } from "../utils";
 
 const log = logger("context:preparer");
 
@@ -143,16 +144,6 @@ function extractWorkingDir(agentCompose: unknown): string {
     );
   }
   return workingDir;
-}
-
-/**
- * Extract CLI agent type from agent compose config
- */
-function extractCliAgentType(agentCompose: unknown): string {
-  const compose = agentCompose as AgentComposeYaml | undefined;
-  if (!compose?.agents) return "claude-code";
-  const agents = Object.values(compose.agents);
-  return agents[0]?.framework || "claude-code";
 }
 
 /**

--- a/turbo/apps/web/src/lib/run/resolvers/resolve-session.ts
+++ b/turbo/apps/web/src/lib/run/resolvers/resolve-session.ts
@@ -7,21 +7,21 @@ import { notFound, unauthorized, badRequest } from "../../errors";
 import { logger } from "../../logger";
 import { getAgentSessionWithConversation } from "../../agent-session";
 import type { ConversationResolution } from "./types";
-import { extractWorkingDir } from "../utils";
+import { extractWorkingDir, extractCliAgentType } from "../utils";
 import { resolveSessionHistory } from "./resolve-session-history";
 
 const log = logger("run:resolve-session");
 
 /**
  * Resolve session to ConversationResolution
- * Uses session's fixed compose version if available, falls back to HEAD for backwards compatibility
+ * Always uses HEAD compose version — continue behaves like a new run + conversation history
  *
  * @param sessionId Agent session ID to resolve
  * @param userId User ID for authorization
  * @returns ConversationResolution with all data needed to build execution context
  * @throws NotFoundError if session or related data not found
  * @throws UnauthorizedError if session doesn't belong to user
- * @throws BadRequestError if session data is invalid
+ * @throws BadRequestError if session data is invalid or framework changed
  */
 export async function resolveSession(
   sessionId: string,
@@ -64,9 +64,8 @@ export async function resolveSession(
     throw badRequest("Agent compose has no versions. Run 'vm0 build' first.");
   }
 
-  // Use session's fixed compose version if available, fall back to HEAD for backwards compatibility
-  // This ensures reproducibility: continue uses the same compose version as the original run
-  const versionId = session.agentComposeVersionId || compose.headVersionId;
+  // Always use HEAD compose version — continue behaves like a new run + conversation history
+  const versionId = compose.headVersionId;
 
   // Get compose version content
   const [version] = await globalThis.services.db
@@ -79,8 +78,15 @@ export async function resolveSession(
     throw notFound(`Agent compose version ${versionId} not found`);
   }
 
-  // Get secret names from session (values are NEVER stored)
-  const secretNames = session.secretNames ?? undefined;
+  // Framework compatibility check: block continue if framework changed
+  const headFramework = extractCliAgentType(version.content);
+  const sessionFramework = session.conversation.cliAgentType;
+  if (headFramework !== sessionFramework) {
+    throw badRequest(
+      `Cannot continue session: framework changed from "${sessionFramework}" to "${headFramework}". ` +
+        `Start a new run instead.`,
+    );
+  }
 
   // Resolve session history from R2 hash or legacy TEXT field
   const sessionHistory = await resolveSessionHistory(
@@ -97,12 +103,11 @@ export async function resolveSession(
       cliAgentSessionId: session.conversation.cliAgentSessionId,
       cliAgentSessionHistory: sessionHistory,
     },
-    artifactName: session.artifactName ?? undefined, // Convert null to undefined
-    artifactVersion: session.artifactName ? "latest" : undefined, // Only set version if artifact exists
-    vars: session.vars || {},
-    secretNames,
-    // Use session's volume versions if available for reproducibility
-    volumeVersions: session.volumeVersions || undefined,
-    buildResumeArtifact: !!session.artifactName, // Only build resumeArtifact if session has artifact
+    artifactName: session.artifactName ?? undefined,
+    artifactVersion: session.artifactName ? "latest" : undefined,
+    vars: {},
+    secretNames: undefined,
+    volumeVersions: undefined,
+    buildResumeArtifact: !!session.artifactName,
   };
 }

--- a/turbo/apps/web/src/lib/run/resolvers/resolve-session.ts
+++ b/turbo/apps/web/src/lib/run/resolvers/resolve-session.ts
@@ -3,6 +3,7 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../db/schema/agent-compose";
+import { agentRuns } from "../../../db/schema/agent-run";
 import { notFound, unauthorized, badRequest } from "../../errors";
 import { logger } from "../../logger";
 import { getAgentSessionWithConversation } from "../../agent-session";
@@ -94,6 +95,16 @@ export async function resolveSession(
     session.conversation.cliAgentSessionHistory,
   );
 
+  // Read vars from the last run as fallback for continue operations
+  const [lastRun] = await globalThis.services.db
+    .select({ vars: agentRuns.vars })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, session.conversation.runId))
+    .limit(1);
+
+  const lastRunVars =
+    (lastRun?.vars as Record<string, string> | null) ?? undefined;
+
   return {
     conversationId: session.conversationId,
     agentComposeVersionId: versionId,
@@ -105,7 +116,7 @@ export async function resolveSession(
     },
     artifactName: session.artifactName ?? undefined,
     artifactVersion: session.artifactName ? "latest" : undefined,
-    vars: {},
+    vars: lastRunVars,
     secretNames: undefined,
     volumeVersions: undefined,
     buildResumeArtifact: !!session.artifactName,

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -170,7 +170,7 @@ export async function validateCheckpoint(
  *
  * @param agentSessionId Agent session ID to validate
  * @param userId User ID for authorization check
- * @returns Session data with agentComposeId, vars, and secretNames
+ * @returns Session data with agentComposeId
  * @throws NotFoundError if session doesn't exist
  * @throws UnauthorizedError if session doesn't belong to user
  */
@@ -179,10 +179,6 @@ export async function validateAgentSession(
   userId: string,
 ): Promise<{
   agentComposeId: string;
-  agentComposeVersionId: string | null;
-  vars: Record<string, string> | null;
-  secretNames: string[] | null;
-  volumeVersions: Record<string, string> | null;
 }> {
   log.debug(`Validating agent session ${agentSessionId} for user ${userId}`);
 
@@ -205,16 +201,10 @@ export async function validateAgentSession(
     );
   }
 
-  log.debug(
-    `Session validated: agentComposeId=${session.agentComposeId}, agentComposeVersionId=${session.agentComposeVersionId}`,
-  );
+  log.debug(`Session validated: agentComposeId=${session.agentComposeId}`);
 
   return {
     agentComposeId: session.agentComposeId,
-    agentComposeVersionId: session.agentComposeVersionId,
-    vars: session.vars,
-    secretNames: session.secretNames,
-    volumeVersions: session.volumeVersions,
   };
 }
 

--- a/turbo/apps/web/src/lib/run/utils/extract-cli-agent-type.ts
+++ b/turbo/apps/web/src/lib/run/utils/extract-cli-agent-type.ts
@@ -1,0 +1,14 @@
+import type { AgentComposeYaml } from "../../../types/agent-compose";
+
+/**
+ * Extract CLI agent type (framework) from agent compose config
+ *
+ * @param config Agent compose configuration
+ * @returns CLI agent type string (defaults to "claude-code")
+ */
+export function extractCliAgentType(config: unknown): string {
+  const compose = config as AgentComposeYaml | undefined;
+  if (!compose?.agents) return "claude-code";
+  const agents = Object.values(compose.agents);
+  return agents[0]?.framework || "claude-code";
+}

--- a/turbo/apps/web/src/lib/run/utils/index.ts
+++ b/turbo/apps/web/src/lib/run/utils/index.ts
@@ -1,2 +1,3 @@
 export { extractWorkingDir } from "./extract-working-dir";
+export { extractCliAgentType } from "./extract-cli-agent-type";
 // calculateSessionHistoryPath is exported from run-service.ts for backward compatibility

--- a/turbo/packages/core/src/contracts/sessions.ts
+++ b/turbo/packages/core/src/contracts/sessions.ts
@@ -11,12 +11,9 @@ const c = initContract();
 const sessionResponseSchema = z.object({
   id: z.string(),
   agentComposeId: z.string(),
-  agentComposeVersionId: z.string().nullable(),
   conversationId: z.string().nullable(),
   artifactName: z.string().nullable(),
-  vars: z.record(z.string(), z.string()).nullable(),
   secretNames: z.array(z.string()).nullable(),
-  volumeVersions: z.record(z.string(), z.string()).nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });


### PR DESCRIPTION
## Summary

Closes #2530

- **Continue always uses HEAD compose version** instead of snapshotted version, making `continue` behave like a new run with conversation history
- **Remove session-stored state**: drop `agentComposeVersionId`, `vars`, `secretNames`, `volumeVersions` columns from `agent_sessions` table
- **Add framework compatibility guard**: block continue if framework changed between runs (e.g., Claude Code → Codex)
- **Remove `--volume-version` flag** from CLI `continue` command
- **Derive secretNames from HEAD compose** in session GET API instead of storing them

### Breaking Changes

- Session API response no longer includes `agentComposeVersionId`, `vars`, or `volumeVersions` fields
- CLI `continue` command no longer accepts `--volume-version` flag
- `resume` command is unchanged (still pinned to checkpoint snapshot)

### Migration

Includes migration `0071_simplify_agent_sessions.sql` to drop removed columns.

## Test plan

- [x] Existing integration tests updated and passing
- [x] Volume-version tests updated to verify `volumeVersions` is NOT sent for continue
- [x] Continue tests verify no volume versions in API request
- [x] Session GET API test updated for simplified response
- [x] All pre-commit checks pass (lint, type-check, format, knip)
- [ ] Manual testing: `vm0 run continue <session-id>` uses HEAD compose
- [ ] Manual testing: framework change between runs is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)