### PR TITLE
refactor(crates): deduplicate vsock port constant into vsock-proto

### DIFF
--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -28,8 +28,6 @@ static SHUTDOWN_RECEIVED: AtomicBool = AtomicBool::new(false);
 
 // Vsock constants (only used on Linux)
 #[cfg(target_os = "linux")]
-const VSOCK_PORT: u32 = 1000;
-#[cfg(target_os = "linux")]
 const VSOCK_CID_HOST: u32 = 2;
 
 /// Read buffer size for the connection event loop (local tuning constant).
@@ -451,7 +449,7 @@ pub fn connect_vsock() -> io::Result<UnixStream> {
     let addr = libc::sockaddr_vm {
         svm_family: libc::AF_VSOCK as u16,
         svm_reserved1: 0,
-        svm_port: VSOCK_PORT,
+        svm_port: vsock_proto::VSOCK_PORT,
         svm_cid: VSOCK_CID_HOST,
         svm_zero: [0; 4],
     };

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -25,7 +25,6 @@ use vsock_proto::{
     MSG_WRITE_FILE_RESULT, RawMessage,
 };
 
-const VSOCK_PORT: u32 = 1000;
 const READ_BUF_SIZE: usize = 64 * 1024;
 
 /// Result of executing a command on the guest.
@@ -66,7 +65,7 @@ impl VsockHost {
     /// Creates a UDS listener at `{vsock_path}_{port}`, accepts the first
     /// connection, and performs the ready/ping/pong handshake.
     pub async fn wait_for_connection(vsock_path: &str, timeout: Duration) -> io::Result<Self> {
-        let listener_path = format!("{vsock_path}_{VSOCK_PORT}");
+        let listener_path = format!("{vsock_path}_{}", vsock_proto::VSOCK_PORT);
 
         // Clean up stale socket
         let _ = std::fs::remove_file(&listener_path);

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -53,6 +53,9 @@ pub const MSG_SHUTDOWN: u8 = 0x0A;
 pub const MSG_SHUTDOWN_ACK: u8 = 0x0B;
 pub const MSG_ERROR: u8 = 0xFF;
 
+/// Default vsock port for host-guest communication.
+pub const VSOCK_PORT: u32 = 1000;
+
 /// Write-file flag: execute write with sudo.
 pub const FLAG_SUDO: u8 = 0x01;
 


### PR DESCRIPTION
## Summary
- Move `VSOCK_PORT` constant from `vsock-host` and `vsock-guest` (where it was independently defined) into `vsock-proto` as the single source of truth
- Both crates already depend on `vsock-proto`, so no new dependency needed

## Test plan
- [x] `cargo test --workspace` — all 68 tests pass
- [x] `cargo clippy --workspace` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)