### PR TITLE
ci: add github oauth env vars to web deployment workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -178,6 +178,8 @@ jobs:
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SENTRY_ORG=${{ vars.SENTRY_ORG }}
             SENTRY_PROJECT=${{ vars.SENTRY_PROJECT_WEB }}
+            GH_OAUTH_CLIENT_ID=${{ vars.GH_OAUTH_CLIENT_ID }}
+            GH_OAUTH_CLIENT_SECRET=${{ secrets.GH_OAUTH_CLIENT_SECRET }}
 
       - name: Notify Slack - Success
         if: ${{ success() && steps.slack-start.outputs.ts }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -461,6 +461,8 @@ jobs:
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SENTRY_ORG=${{ vars.SENTRY_ORG }}
             SENTRY_PROJECT=${{ vars.SENTRY_PROJECT_WEB }}
+            GH_OAUTH_CLIENT_ID=${{ vars.GH_OAUTH_CLIENT_ID }}
+            GH_OAUTH_CLIENT_SECRET=${{ secrets.GH_OAUTH_CLIENT_SECRET }}
           meta-branch: ${{ github.head_ref || github.ref_name }}
           meta-pr: ${{ needs.prepare.outputs.job-ref }}
           skip-finish: ${{ github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '' }}


### PR DESCRIPTION
## Summary
- Add `GH_OAUTH_CLIENT_ID` (`vars`) and `GH_OAUTH_CLIENT_SECRET` (`secrets`) to Vercel deploy environment variables in both `turbo.yml` (preview) and `release-please.yml` (production)
- These are required by the GitHub connector OAuth flow (`/api/connectors/github/authorize` and `/api/connectors/github/callback`) but were never passed to the deployment, causing 500 errors

## Test plan
- [ ] Verify preview deployment has `GH_OAUTH_CLIENT_ID` and `GH_OAUTH_CLIENT_SECRET` available
- [ ] Test `vm0 connector connect github` flow end-to-end on preview
- [ ] Verify production deployment includes the env vars after next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)