### PR TITLE
fix(web): include platform-managed secrets in schedule validation

### DIFF
--- a/turbo/apps/web/app/api/agent/schedules/__tests__/platform-secrets.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/__tests__/platform-secrets.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { POST } from "../route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestSecret,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../src/__tests__/test-helpers";
+
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
+
+const context = testContext();
+
+function deployScheduleRequest(
+  composeId: string,
+  name: string,
+  options?: { secrets?: Record<string, string> },
+) {
+  return createTestRequest("http://localhost:3000/api/agent/schedules", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      composeId,
+      name,
+      cronExpression: "0 9 * * *",
+      timezone: "UTC",
+      prompt: "Test prompt",
+      secrets: options?.secrets,
+    }),
+  });
+}
+
+describe("POST /api/agent/schedules - Platform-managed secrets", () => {
+  let composeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
+
+    // Create compose that requires secrets via ${{ secrets.XXX }} references
+    const result = await createTestCompose(uniqueId("secret-agent"), {
+      overrides: {
+        environment: {
+          SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}",
+          PERPLEXITY_API_KEY: "${{ secrets.PERPLEXITY_API_KEY }}",
+        },
+      },
+    });
+    composeId = result.composeId;
+  });
+
+  it("should succeed when secrets exist as platform-managed secrets", async () => {
+    // Store secrets via platform (simulates `vm0 secret set`)
+    await createTestSecret("SLACK_WEBHOOK_URL", "https://hooks.slack.com/xxx");
+    await createTestSecret("PERPLEXITY_API_KEY", "pplx-test-key");
+
+    const response = await POST(
+      deployScheduleRequest(composeId, uniqueId("schedule")),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.created).toBe(true);
+    expect(data.schedule.name).toBeDefined();
+  });
+
+  it("should fail when secrets are missing from both CLI and platform", async () => {
+    // No CLI secrets, no platform secrets
+    const response = await POST(
+      deployScheduleRequest(composeId, uniqueId("schedule")),
+    );
+    const data = await response.json();
+
+    // BadRequestError from service is mapped to 409 in route handler
+    expect(response.status).toBe(409);
+    expect(data.error.message).toContain("SLACK_WEBHOOK_URL");
+    expect(data.error.message).toContain("PERPLEXITY_API_KEY");
+  });
+
+  it("should succeed when secrets are provided via CLI", async () => {
+    const response = await POST(
+      deployScheduleRequest(composeId, uniqueId("schedule"), {
+        secrets: {
+          SLACK_WEBHOOK_URL: "https://hooks.slack.com/xxx",
+          PERPLEXITY_API_KEY: "pplx-test-key",
+        },
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.created).toBe(true);
+  });
+
+  it("should succeed with mix of CLI and platform secrets", async () => {
+    // One secret via platform, one via CLI
+    await createTestSecret("SLACK_WEBHOOK_URL", "https://hooks.slack.com/xxx");
+
+    const response = await POST(
+      deployScheduleRequest(composeId, uniqueId("schedule"), {
+        secrets: {
+          PERPLEXITY_API_KEY: "pplx-test-key",
+        },
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.created).toBe(true);
+  });
+
+  it("should fail when only some platform secrets exist", async () => {
+    // Only one of the two required secrets is stored
+    await createTestSecret("SLACK_WEBHOOK_URL", "https://hooks.slack.com/xxx");
+
+    const response = await POST(
+      deployScheduleRequest(composeId, uniqueId("schedule")),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(data.error.message).toContain("PERPLEXITY_API_KEY");
+    expect(data.error.message).not.toContain("SLACK_WEBHOOK_URL");
+  });
+});

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -42,7 +42,10 @@ import { POST as storagePrepareRoute } from "../../app/api/storages/prepare/rout
 import { POST as storageCommitRoute } from "../../app/api/storages/commit/route";
 import { DELETE as deleteModelProviderRoute } from "../../app/api/model-providers/[type]/route";
 import { GET as listModelProvidersRoute } from "../../app/api/model-providers/route";
-import { GET as listSecretsRoute } from "../../app/api/secrets/route";
+import {
+  GET as listSecretsRoute,
+  PUT as setSecretRoute,
+} from "../../app/api/secrets/route";
 import { POST as addPermissionRoute } from "../../app/api/agent/composes/[id]/permissions/route";
 import { connectors } from "../db/schema/connector";
 import { connectorSessions } from "../db/schema/connector-session";
@@ -1035,6 +1038,28 @@ export async function listTestSecrets(): Promise<
   }
   const data = await response.json();
   return data.secrets;
+}
+
+/**
+ * Create a platform-managed secret via PUT /api/secrets.
+ * Simulates `vm0 secret set NAME VALUE`.
+ */
+export async function createTestSecret(
+  name: string,
+  value: string,
+): Promise<void> {
+  const request = createTestRequest("http://localhost:3000/api/secrets", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, value }),
+  });
+  const response = await setSecretRoute(request);
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(
+      `Failed to create secret: ${error.error?.message || response.status}`,
+    );
+  }
 }
 
 /**

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -23,6 +23,8 @@ import {
   prepareAndDispatchRun,
 } from "../run/run-service";
 import { generateSandboxToken } from "../auth/sandbox-token";
+import { getUserScopeByClerkId } from "../scope/scope-service";
+import { getSecretValues } from "../secret/secret-service";
 
 const log = logger("service:schedule");
 
@@ -300,6 +302,7 @@ export async function deploySchedule(
       // Determine effective secrets for validation:
       // - If request.secrets is provided, use those
       // - If request.secrets is undefined AND updating, use existing schedule's secrets
+      // - Also include platform-managed secrets (stored via `vm0 secret set`)
       const providedSecrets = request.secrets
         ? Object.keys(request.secrets)
         : [];
@@ -316,10 +319,18 @@ export async function deploySchedule(
         }
       }
 
+      // Fetch platform-managed user secrets from DB
+      let platformSecretNames: string[] = [];
+      const userScope = await getUserScopeByClerkId(userId);
+      if (userScope) {
+        const platformSecrets = await getSecretValues(userScope.id, "user");
+        platformSecretNames = Object.keys(platformSecrets);
+      }
+
       const effectiveSecretNames =
         request.secrets === undefined && existing
-          ? existingSecretNames
-          : providedSecrets;
+          ? [...existingSecretNames, ...platformSecretNames]
+          : [...providedSecrets, ...platformSecretNames];
 
       const missingSecrets = required.secrets.filter(
         (name) => !effectiveSecretNames.includes(name),


### PR DESCRIPTION
## Summary
- Fixed `vm0 schedule setup` failing with "Missing required configuration" when secrets were stored via `vm0 secret set` (platform-managed secrets)
- The `deploySchedule` validation now fetches platform-managed user secrets via `getUserScopeByClerkId` + `getSecretValues` and includes them in the effective secret name list
- Added `createTestSecret` helper to `api-test-helpers.ts`
- Added 5 integration tests covering platform secrets, CLI secrets, mixed, partial, and missing scenarios

## Bug Details
The validation logic in `schedule-service.ts` only checked:
1. Secrets passed via CLI (`request.secrets`)
2. Existing schedule's stored secrets (when updating)

It did **not** query platform-managed secrets from the database, causing all schedules for agents using `${{ secrets.XXX }}` references to fail when secrets were stored via `vm0 secret set`.

The `vm0 run` path already correctly fetches platform secrets in `build-context.ts` — this fix brings schedule validation in line with that behavior.

Closes #2543

## Test plan
- [ ] Schedule setup succeeds when secrets exist as platform-managed secrets (no CLI secrets provided)
- [ ] Schedule setup still fails when secrets are missing from both CLI and platform
- [ ] Schedule setup succeeds when secrets are provided via CLI
- [ ] Schedule setup succeeds with mix of CLI and platform secrets
- [ ] Schedule setup fails when only some platform secrets exist (reports only the missing ones)
- [ ] All existing schedule tests still pass (17 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)