### PR TITLE
feat(slack): add app home tab, welcome message, and DM improvements

### DIFF
--- a/turbo/apps/web/app/api/slack/commands/route.ts
+++ b/turbo/apps/web/app/api/slack/commands/route.ts
@@ -32,6 +32,9 @@ import {
   buildAgentRemoveModal,
   buildAgentUpdateModal,
 } from "../../../../src/lib/slack/blocks";
+import { logger } from "../../../../src/lib/logger";
+
+const log = logger("slack:commands");
 
 /**
  * Slack Slash Commands Endpoint
@@ -221,9 +224,9 @@ async function handleLogoutCommand(
     .where(eq(slackUserLinks.id, userLink.id));
 
   // Refresh App Home tab to reflect disconnected state
-  await refreshAppHome(client, workspaceId, slackUserId).catch(() => {
-    // Best-effort — don't fail the disconnect response
-  });
+  await refreshAppHome(client, workspaceId, slackUserId).catch((e) =>
+    log.warn("Failed to refresh App Home after disconnect", { error: e }),
+  );
 
   return NextResponse.json({
     response_type: "ephemeral",

--- a/turbo/apps/web/app/api/slack/commands/route.ts
+++ b/turbo/apps/web/app/api/slack/commands/route.ts
@@ -19,6 +19,7 @@ import {
   createSlackClient,
   getSlackRedirectBaseUrl,
   isSlackInvalidAuthError,
+  refreshAppHome,
 } from "../../../../src/lib/slack";
 import { listSecrets } from "../../../../src/lib/secret/secret-service";
 import { listVariables } from "../../../../src/lib/variable/variable-service";
@@ -203,6 +204,9 @@ function handleLoginCommand(
  */
 async function handleLogoutCommand(
   userLink: { id: string } | undefined,
+  client: ReturnType<typeof createSlackClient>,
+  workspaceId: string,
+  slackUserId: string,
 ): Promise<NextResponse> {
   if (!userLink) {
     return NextResponse.json({
@@ -215,6 +219,12 @@ async function handleLogoutCommand(
   await globalThis.services.db
     .delete(slackUserLinks)
     .where(eq(slackUserLinks.id, userLink.id));
+
+  // Refresh App Home tab to reflect disconnected state
+  await refreshAppHome(client, workspaceId, slackUserId).catch(() => {
+    // Best-effort — don't fail the disconnect response
+  });
+
   return NextResponse.json({
     response_type: "ephemeral",
     blocks: buildSuccessMessage(
@@ -310,7 +320,12 @@ export async function POST(request: Request) {
 
   // Handle logout command
   if (subCommand === "disconnect") {
-    return handleLogoutCommand(userLink);
+    return handleLogoutCommand(
+      userLink,
+      client,
+      payload.team_id,
+      payload.user_id,
+    );
   }
 
   // Check if user needs to link account

--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -552,7 +552,7 @@ describe("POST /api/slack/events", () => {
   });
 
   describe("Scenario: DM bot with single agent", () => {
-    it("should post thinking message then update with agent response", async () => {
+    it("should execute agent and post response", async () => {
       // Given I am a linked Slack user with one agent
       const { userLink, installation } = await givenLinkedSlackUser();
       await givenUserHasAgent(userLink, {
@@ -576,17 +576,12 @@ describe("POST /api/slack/events", () => {
       // 1. Thinking reaction should be added
       expect(slackHandlers.mocked.reactionsAdd).toHaveBeenCalledTimes(1);
 
-      // 2. Thinking message should be posted first
+      // 2. Response message should be posted
       expect(slackHandlers.mocked.postMessage).toHaveBeenCalledTimes(1);
-      const thinkingData = await getFormData(slackHandlers.mocked.postMessage);
-      expect(thinkingData.text).toBe("_Thinking..._");
 
-      // 3. chatUpdate should replace thinking message with agent response
-      expect(slackHandlers.mocked.chatUpdate).toHaveBeenCalledTimes(1);
-      const updateData = await getFormData(slackHandlers.mocked.chatUpdate);
-      const blocks = JSON.parse(
-        (updateData.blocks as string) ?? "[]",
-      ) as Array<{
+      // 3. Response should include agent name in context block
+      const data = await getFormData(slackHandlers.mocked.postMessage);
+      const blocks = JSON.parse((data.blocks as string) ?? "[]") as Array<{
         type: string;
         elements?: Array<{ text?: string }>;
       }>;
@@ -621,22 +616,17 @@ describe("POST /api/slack/events", () => {
       expect(response.status).toBe(200);
       await flushAfterCallbacks();
 
-      // Then thinking message should be posted first
+      // Then the message should be routed to the agent (not show welcome card)
       expect(slackHandlers.mocked.postMessage).toHaveBeenCalledTimes(1);
-      const thinkingData = await getFormData(slackHandlers.mocked.postMessage);
-      expect(thinkingData.text).toBe("_Thinking..._");
 
-      // And chatUpdate should replace it with agent response (not welcome card)
-      expect(slackHandlers.mocked.chatUpdate).toHaveBeenCalledTimes(1);
-      const updateData = await getFormData(slackHandlers.mocked.chatUpdate);
-      const blocks = JSON.parse(
-        (updateData.blocks as string) ?? "[]",
-      ) as Array<{
+      const data = await getFormData(slackHandlers.mocked.postMessage);
+      const blocks = JSON.parse((data.blocks as string) ?? "[]") as Array<{
         type: string;
         elements?: Array<{ text?: string }>;
       }>;
       const contextBlocks = blocks.filter((b) => b.type === "context");
       expect(contextBlocks.length).toBeGreaterThanOrEqual(1);
+      // Agent name should be in the response (not a welcome card)
       const agentContext = contextBlocks[0]!.elements?.[0]?.text;
       expect(agentContext).toContain("my-helper");
     });

--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -229,6 +229,9 @@ describe("POST /api/slack/events", () => {
   beforeEach(() => {
     context.setupMocks();
     server.use(...slackHandlers.handlers);
+
+    // Clear viewsPublish mock so each test starts with a clean call count
+    vi.mocked(slackHandlers.mocked.viewsPublish).mockClear();
   });
 
   describe("Scenario: Mention bot as unlinked user", () => {
@@ -782,6 +785,10 @@ describe("POST /api/slack/events", () => {
     it("should publish home view with link prompt", async () => {
       // Given I am a linked Slack user with no agents
       const { userLink, installation } = await givenLinkedSlackUser();
+
+      // Clear viewsPublish calls from givenLinkedSlackUser (which refreshes
+      // App Home after linking) so we can assert on only the test's call.
+      vi.mocked(slackHandlers.mocked.viewsPublish).mockClear();
 
       // When I open the bot's Home tab
       const request = createSlackAppHomeOpenedRequest({

--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -139,6 +139,8 @@ function createSlackDmEventRequest(event: {
 function createSlackAppHomeOpenedRequest(event: {
   teamId: string;
   userId: string;
+  tab?: "home" | "messages";
+  channelId?: string;
 }): Request {
   const timestamp = Math.floor(Date.now() / 1000).toString();
   const payload = {
@@ -149,7 +151,8 @@ function createSlackAppHomeOpenedRequest(event: {
     event: {
       type: "app_home_opened",
       user: event.userId,
-      tab: "home",
+      tab: event.tab ?? "home",
+      channel: event.channelId ?? "D000",
     },
     event_id: "Ev789",
     event_time: parseInt(timestamp),
@@ -809,6 +812,116 @@ describe("POST /api/slack/events", () => {
         .map((b) => b.text.text);
       expect(texts.some((t) => t.includes("Connected to VM0"))).toBe(true);
       expect(texts.some((t) => t.includes("No agent linked yet"))).toBe(true);
+    });
+  });
+
+  describe("Scenario: Messages tab opened by linked user with agent", () => {
+    it("should send welcome message with agent info", async () => {
+      // Given I am a linked Slack user with one agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      await givenUserHasAgent(userLink, {
+        agentName: "my-helper",
+        description: "A helpful assistant",
+      });
+
+      // Reset and re-register test handlers
+      server.resetHandlers();
+      server.use(...slackHandlers.handlers);
+      vi.mocked(slackHandlers.mocked.postMessage).mockClear();
+
+      // When I open the Messages tab
+      const request = createSlackAppHomeOpenedRequest({
+        teamId: installation.slackWorkspaceId,
+        userId: userLink.slackUserId,
+        tab: "messages",
+        channelId: "D-dm-channel",
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // Then a welcome message should be posted
+      expect(slackHandlers.mocked.postMessage).toHaveBeenCalledTimes(1);
+
+      const data = await getFormData(slackHandlers.mocked.postMessage);
+      expect(data.channel).toBe("D-dm-channel");
+
+      // Blocks should include agent info
+      const blocks = JSON.parse((data.blocks as string) ?? "[]") as Array<{
+        type: string;
+        text?: { text: string };
+      }>;
+      const texts = blocks
+        .filter(
+          (b): b is { type: string; text: { text: string } } =>
+            b.type === "section" && !!b.text,
+        )
+        .map((b) => b.text.text);
+      expect(texts.some((t) => t.includes("my-helper"))).toBe(true);
+    });
+  });
+
+  describe("Scenario: Messages tab opened a second time (no duplicate)", () => {
+    it("should not send welcome message again", async () => {
+      // Given I am a linked Slack user with one agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      await givenUserHasAgent(userLink, {
+        agentName: "my-helper",
+        description: "A helpful assistant",
+      });
+
+      // Reset and re-register test handlers
+      server.resetHandlers();
+      server.use(...slackHandlers.handlers);
+      vi.mocked(slackHandlers.mocked.postMessage).mockClear();
+
+      // When I open the Messages tab the first time
+      const request1 = createSlackAppHomeOpenedRequest({
+        teamId: installation.slackWorkspaceId,
+        userId: userLink.slackUserId,
+        tab: "messages",
+        channelId: "D-dm-channel",
+      });
+      await POST(request1);
+      await flushAfterCallbacks();
+
+      // Then the welcome message should be sent once
+      expect(slackHandlers.mocked.postMessage).toHaveBeenCalledTimes(1);
+
+      // When I open the Messages tab again
+      vi.mocked(slackHandlers.mocked.postMessage).mockClear();
+      const request2 = createSlackAppHomeOpenedRequest({
+        teamId: installation.slackWorkspaceId,
+        userId: userLink.slackUserId,
+        tab: "messages",
+        channelId: "D-dm-channel",
+      });
+      await POST(request2);
+      await flushAfterCallbacks();
+
+      // Then no duplicate message should be sent
+      expect(slackHandlers.mocked.postMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Scenario: Messages tab opened by unlinked user", () => {
+    it("should not send any message", async () => {
+      // Given I am a Slack user without a linked account
+      const { installation } = await givenSlackWorkspaceInstalled();
+
+      // When I open the Messages tab
+      const request = createSlackAppHomeOpenedRequest({
+        teamId: installation.slackWorkspaceId,
+        userId: "U-unlinked-user",
+        tab: "messages",
+        channelId: "D-dm-channel",
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // Then no message should be sent
+      expect(slackHandlers.mocked.postMessage).not.toHaveBeenCalled();
     });
   });
 });

--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -726,6 +726,10 @@ describe("POST /api/slack/events", () => {
         agentName: "my-helper",
         description: "A helpful assistant",
       });
+      // Reset runtime handlers from givenUserHasAgent so the test's own
+      // viewsPublish handler takes priority, then re-register test handlers.
+      server.resetHandlers();
+      server.use(...slackHandlers.handlers);
       vi.mocked(slackHandlers.mocked.viewsPublish).mockClear();
 
       // When I open the bot's Home tab

--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -135,6 +135,43 @@ function createSlackDmEventRequest(event: {
   });
 }
 
+/** Create a signed Slack app_home_opened event request */
+function createSlackAppHomeOpenedRequest(event: {
+  teamId: string;
+  userId: string;
+}): Request {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const payload = {
+    type: "event_callback",
+    token: "test-token",
+    team_id: event.teamId,
+    api_app_id: "A123",
+    event: {
+      type: "app_home_opened",
+      user: event.userId,
+      tab: "home",
+    },
+    event_id: "Ev789",
+    event_time: parseInt(timestamp),
+  };
+  const body = JSON.stringify(payload);
+
+  // Generate signature
+  const baseString = `v0:${timestamp}:${body}`;
+  const hmac = crypto.createHmac("sha256", TEST_SIGNING_SECRET);
+  const signature = `v0=${hmac.update(baseString).digest("hex")}`;
+
+  return new Request("http://localhost/api/slack/events", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-slack-signature": signature,
+      "x-slack-request-timestamp": timestamp,
+    },
+    body,
+  });
+}
+
 const SLACK_API = "https://slack.com/api";
 
 const slackHandlers = handlers({
@@ -169,6 +206,9 @@ const slackHandlers = handlers({
   ),
   conversationsHistory: http.post(`${SLACK_API}/conversations.history`, () =>
     HttpResponse.json({ ok: true, messages: [] }),
+  ),
+  viewsPublish: http.post(`${SLACK_API}/views.publish`, () =>
+    HttpResponse.json({ ok: true }),
   ),
 });
 
@@ -512,7 +552,7 @@ describe("POST /api/slack/events", () => {
   });
 
   describe("Scenario: DM bot with single agent", () => {
-    it("should execute agent and post response", async () => {
+    it("should post thinking message then update with agent response", async () => {
       // Given I am a linked Slack user with one agent
       const { userLink, installation } = await givenLinkedSlackUser();
       await givenUserHasAgent(userLink, {
@@ -536,12 +576,17 @@ describe("POST /api/slack/events", () => {
       // 1. Thinking reaction should be added
       expect(slackHandlers.mocked.reactionsAdd).toHaveBeenCalledTimes(1);
 
-      // 2. Response message should be posted
+      // 2. Thinking message should be posted first
       expect(slackHandlers.mocked.postMessage).toHaveBeenCalledTimes(1);
+      const thinkingData = await getFormData(slackHandlers.mocked.postMessage);
+      expect(thinkingData.text).toBe("_Thinking..._");
 
-      // 3. Response should include agent name in context block
-      const data = await getFormData(slackHandlers.mocked.postMessage);
-      const blocks = JSON.parse((data.blocks as string) ?? "[]") as Array<{
+      // 3. chatUpdate should replace thinking message with agent response
+      expect(slackHandlers.mocked.chatUpdate).toHaveBeenCalledTimes(1);
+      const updateData = await getFormData(slackHandlers.mocked.chatUpdate);
+      const blocks = JSON.parse(
+        (updateData.blocks as string) ?? "[]",
+      ) as Array<{
         type: string;
         elements?: Array<{ text?: string }>;
       }>;
@@ -576,17 +621,22 @@ describe("POST /api/slack/events", () => {
       expect(response.status).toBe(200);
       await flushAfterCallbacks();
 
-      // Then the message should be routed to the agent (not show welcome card)
+      // Then thinking message should be posted first
       expect(slackHandlers.mocked.postMessage).toHaveBeenCalledTimes(1);
+      const thinkingData = await getFormData(slackHandlers.mocked.postMessage);
+      expect(thinkingData.text).toBe("_Thinking..._");
 
-      const data = await getFormData(slackHandlers.mocked.postMessage);
-      const blocks = JSON.parse((data.blocks as string) ?? "[]") as Array<{
+      // And chatUpdate should replace it with agent response (not welcome card)
+      expect(slackHandlers.mocked.chatUpdate).toHaveBeenCalledTimes(1);
+      const updateData = await getFormData(slackHandlers.mocked.chatUpdate);
+      const blocks = JSON.parse(
+        (updateData.blocks as string) ?? "[]",
+      ) as Array<{
         type: string;
         elements?: Array<{ text?: string }>;
       }>;
       const contextBlocks = blocks.filter((b) => b.type === "context");
       expect(contextBlocks.length).toBeGreaterThanOrEqual(1);
-      // Agent name should be in the response (not a welcome card)
       const agentContext = contextBlocks[0]!.elements?.[0]?.text;
       expect(agentContext).toContain("my-helper");
     });
@@ -635,6 +685,126 @@ describe("POST /api/slack/events", () => {
       // Then no handler should be called (message silently ignored at route level)
       expect(slackHandlers.mocked.postMessage).not.toHaveBeenCalled();
       expect(slackHandlers.mocked.postEphemeral).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Scenario: App Home opened by unlinked user", () => {
+    it("should publish home view with login prompt", async () => {
+      // Given I am a Slack user without a linked account
+      const { installation } = await givenSlackWorkspaceInstalled();
+
+      // When I open the bot's Home tab
+      const request = createSlackAppHomeOpenedRequest({
+        teamId: installation.slackWorkspaceId,
+        userId: "U-unlinked-user",
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // Then the home view should be published with login prompt
+      expect(slackHandlers.mocked.viewsPublish).toHaveBeenCalledTimes(1);
+
+      const data = await getFormData(slackHandlers.mocked.viewsPublish);
+      expect(data.user_id).toBe("U-unlinked-user");
+
+      // View should contain "not connected" and a login button
+      const view = JSON.parse((data.view as string) ?? "{}") as {
+        type: string;
+        blocks: Array<{
+          type: string;
+          text?: { text: string };
+          elements?: Array<{ action_id?: string; url?: string }>;
+        }>;
+      };
+      expect(view.type).toBe("home");
+      const texts = view.blocks
+        .filter(
+          (b): b is { type: string; text: { text: string } } =>
+            b.type === "section" && !!b.text,
+        )
+        .map((b) => b.text.text);
+      expect(texts.some((t) => t.includes("not connected"))).toBe(true);
+    });
+  });
+
+  describe("Scenario: App Home opened by linked user with agent", () => {
+    it("should publish home view with agent list", async () => {
+      // Given I am a linked Slack user with one agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      await givenUserHasAgent(userLink, {
+        agentName: "my-helper",
+        description: "A helpful assistant",
+      });
+
+      // When I open the bot's Home tab
+      const request = createSlackAppHomeOpenedRequest({
+        teamId: installation.slackWorkspaceId,
+        userId: userLink.slackUserId,
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // Then the home view should be published with agent info
+      expect(slackHandlers.mocked.viewsPublish).toHaveBeenCalledTimes(1);
+
+      const data = await getFormData(slackHandlers.mocked.viewsPublish);
+      expect(data.user_id).toBe(userLink.slackUserId);
+
+      const view = JSON.parse((data.view as string) ?? "{}") as {
+        type: string;
+        blocks: Array<{
+          type: string;
+          text?: { text: string };
+        }>;
+      };
+      expect(view.type).toBe("home");
+      const texts = view.blocks
+        .filter(
+          (b): b is { type: string; text: { text: string } } =>
+            b.type === "section" && !!b.text,
+        )
+        .map((b) => b.text.text);
+      expect(texts.some((t) => t.includes("Account connected"))).toBe(true);
+      expect(texts.some((t) => t.includes("my-helper"))).toBe(true);
+    });
+  });
+
+  describe("Scenario: App Home opened by linked user without agents", () => {
+    it("should publish home view with link prompt", async () => {
+      // Given I am a linked Slack user with no agents
+      const { userLink, installation } = await givenLinkedSlackUser();
+
+      // When I open the bot's Home tab
+      const request = createSlackAppHomeOpenedRequest({
+        teamId: installation.slackWorkspaceId,
+        userId: userLink.slackUserId,
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // Then the home view should be published with link prompt
+      expect(slackHandlers.mocked.viewsPublish).toHaveBeenCalledTimes(1);
+
+      const data = await getFormData(slackHandlers.mocked.viewsPublish);
+      const view = JSON.parse((data.view as string) ?? "{}") as {
+        type: string;
+        blocks: Array<{
+          type: string;
+          text?: { text: string };
+        }>;
+      };
+      expect(view.type).toBe("home");
+      const texts = view.blocks
+        .filter(
+          (b): b is { type: string; text: { text: string } } =>
+            b.type === "section" && !!b.text,
+        )
+        .map((b) => b.text.text);
+      expect(texts.some((t) => t.includes("Account connected"))).toBe(true);
+      expect(texts.some((t) => t.includes("No agents linked yet"))).toBe(true);
     });
   });
 });

--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -726,6 +726,7 @@ describe("POST /api/slack/events", () => {
         agentName: "my-helper",
         description: "A helpful assistant",
       });
+      vi.mocked(slackHandlers.mocked.viewsPublish).mockClear();
 
       // When I open the bot's Home tab
       const request = createSlackAppHomeOpenedRequest({
@@ -747,7 +748,7 @@ describe("POST /api/slack/events", () => {
         blocks: Array<{
           type: string;
           text?: { text: string };
-          accessory?: { action_id?: string };
+          elements?: Array<{ action_id?: string }>;
         }>;
       };
       expect(view.type).toBe("home");
@@ -757,12 +758,14 @@ describe("POST /api/slack/events", () => {
             b.type === "section" && !!b.text,
         )
         .map((b) => b.text.text);
-      expect(texts.some((t) => t.includes("Account connected"))).toBe(true);
+      expect(texts.some((t) => t.includes("Connected to VM0"))).toBe(true);
       expect(texts.some((t) => t.includes("my-helper"))).toBe(true);
 
       // Disconnect button should be present
       const disconnectBlock = view.blocks.find(
-        (b) => b.accessory?.action_id === "home_disconnect",
+        (b) =>
+          b.type === "section" &&
+          b.text?.text.includes("Disconnect VM0 Account"),
       );
       expect(disconnectBlock).toBeDefined();
     });
@@ -800,8 +803,8 @@ describe("POST /api/slack/events", () => {
             b.type === "section" && !!b.text,
         )
         .map((b) => b.text.text);
-      expect(texts.some((t) => t.includes("Account connected"))).toBe(true);
-      expect(texts.some((t) => t.includes("No agents linked yet"))).toBe(true);
+      expect(texts.some((t) => t.includes("Connected to VM0"))).toBe(true);
+      expect(texts.some((t) => t.includes("No agent linked yet"))).toBe(true);
     });
   });
 });

--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -747,6 +747,7 @@ describe("POST /api/slack/events", () => {
         blocks: Array<{
           type: string;
           text?: { text: string };
+          accessory?: { action_id?: string };
         }>;
       };
       expect(view.type).toBe("home");
@@ -758,6 +759,12 @@ describe("POST /api/slack/events", () => {
         .map((b) => b.text.text);
       expect(texts.some((t) => t.includes("Account connected"))).toBe(true);
       expect(texts.some((t) => t.includes("my-helper"))).toBe(true);
+
+      // Disconnect button should be present
+      const disconnectBlock = view.blocks.find(
+        (b) => b.accessory?.action_id === "home_disconnect",
+      );
+      expect(disconnectBlock).toBeDefined();
     });
   });
 

--- a/turbo/apps/web/app/api/slack/events/route.ts
+++ b/turbo/apps/web/app/api/slack/events/route.ts
@@ -11,6 +11,9 @@ import {
   handleAppHomeOpened,
   handleMessagesTabOpened,
 } from "../../../../src/lib/slack/handlers/app-home-opened";
+import { logger } from "../../../../src/lib/logger";
+
+const log = logger("slack:events");
 
 /**
  * Slack Events API Endpoint
@@ -153,7 +156,7 @@ export async function POST(request: Request) {
           messageTs: event.ts,
           threadTs: event.thread_ts,
         }).catch((error) => {
-          console.error("Error handling app_mention:", error);
+          log.error("Error handling app_mention", { error });
         }),
       );
     }
@@ -176,7 +179,7 @@ export async function POST(request: Request) {
           messageTs: event.ts,
           threadTs: event.thread_ts,
         }).catch((error) => {
-          console.error("Error handling direct_message:", error);
+          log.error("Error handling direct_message", { error });
         }),
       );
     }
@@ -190,7 +193,7 @@ export async function POST(request: Request) {
           workspaceId: payload.team_id,
           userId: event.user,
         }).catch((error) => {
-          console.error("Error handling app_home_opened:", error);
+          log.error("Error handling app_home_opened", { error });
         }),
       );
     }
@@ -199,13 +202,15 @@ export async function POST(request: Request) {
     if (event.type === "app_home_opened" && event.tab === "messages") {
       initServices();
 
-      await handleMessagesTabOpened({
-        workspaceId: payload.team_id,
-        userId: event.user,
-        channelId: event.channel,
-      }).catch((error) => {
-        console.error("Error handling messages_tab_opened:", error);
-      });
+      after(
+        handleMessagesTabOpened({
+          workspaceId: payload.team_id,
+          userId: event.user,
+          channelId: event.channel,
+        }).catch((error) => {
+          log.error("Error handling messages_tab_opened", { error });
+        }),
+      );
     }
 
     // Return 200 OK immediately

--- a/turbo/apps/web/app/api/slack/events/route.ts
+++ b/turbo/apps/web/app/api/slack/events/route.ts
@@ -7,7 +7,10 @@ import {
 } from "../../../../src/lib/slack/verify";
 import { handleAppMention } from "../../../../src/lib/slack/handlers/mention";
 import { handleDirectMessage } from "../../../../src/lib/slack/handlers/direct-message";
-import { handleAppHomeOpened } from "../../../../src/lib/slack/handlers/app-home-opened";
+import {
+  handleAppHomeOpened,
+  handleMessagesTabOpened,
+} from "../../../../src/lib/slack/handlers/app-home-opened";
 
 /**
  * Slack Events API Endpoint
@@ -57,6 +60,7 @@ interface SlackAppHomeOpenedEvent {
   type: "app_home_opened";
   user: string;
   tab: "home" | "messages";
+  channel: string;
 }
 
 interface SlackEventCallback {
@@ -177,7 +181,7 @@ export async function POST(request: Request) {
       );
     }
 
-    // Handle app_home_opened events
+    // Handle app_home_opened events (Home tab)
     if (event.type === "app_home_opened" && event.tab === "home") {
       initServices();
 
@@ -189,6 +193,19 @@ export async function POST(request: Request) {
           console.error("Error handling app_home_opened:", error);
         }),
       );
+    }
+
+    // Handle app_home_opened events (Messages tab)
+    if (event.type === "app_home_opened" && event.tab === "messages") {
+      initServices();
+
+      await handleMessagesTabOpened({
+        workspaceId: payload.team_id,
+        userId: event.user,
+        channelId: event.channel,
+      }).catch((error) => {
+        console.error("Error handling messages_tab_opened:", error);
+      });
     }
 
     // Return 200 OK immediately

--- a/turbo/apps/web/app/api/slack/events/route.ts
+++ b/turbo/apps/web/app/api/slack/events/route.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../src/lib/slack/verify";
 import { handleAppMention } from "../../../../src/lib/slack/handlers/mention";
 import { handleDirectMessage } from "../../../../src/lib/slack/handlers/direct-message";
+import { handleAppHomeOpened } from "../../../../src/lib/slack/handlers/app-home-opened";
 
 /**
  * Slack Events API Endpoint
@@ -52,12 +53,21 @@ interface SlackDirectMessageEvent {
   bot_id?: string;
 }
 
+interface SlackAppHomeOpenedEvent {
+  type: "app_home_opened";
+  user: string;
+  tab: "home" | "messages";
+}
+
 interface SlackEventCallback {
   type: "event_callback";
   token: string;
   team_id: string;
   api_app_id: string;
-  event: SlackAppMentionEvent | SlackDirectMessageEvent;
+  event:
+    | SlackAppMentionEvent
+    | SlackDirectMessageEvent
+    | SlackAppHomeOpenedEvent;
   event_id: string;
   event_time: number;
   authorizations?: Array<{
@@ -163,6 +173,20 @@ export async function POST(request: Request) {
           threadTs: event.thread_ts,
         }).catch((error) => {
           console.error("Error handling direct_message:", error);
+        }),
+      );
+    }
+
+    // Handle app_home_opened events
+    if (event.type === "app_home_opened" && event.tab === "home") {
+      initServices();
+
+      after(
+        handleAppHomeOpened({
+          workspaceId: payload.team_id,
+          userId: event.user,
+        }).catch((error) => {
+          console.error("Error handling app_home_opened:", error);
         }),
       );
     }

--- a/turbo/apps/web/app/api/slack/interactive/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/interactive/__tests__/route.test.ts
@@ -152,6 +152,144 @@ describe("POST /api/slack/interactive", () => {
     });
   });
 
+  describe("Block Actions - Home Tab", () => {
+    it("opens agent add modal when home_agent_link is clicked", async () => {
+      const { userLink, installation } = await givenLinkedSlackUser();
+      mockClerk({ userId: userLink.vm0UserId });
+      await createTestCompose("available-agent");
+
+      const slackMock = handlers({
+        viewsOpen: http.post("https://slack.com/api/views.open", () =>
+          HttpResponse.json({ ok: true, view: { id: "V123" } }),
+        ),
+      });
+      server.use(...slackMock.handlers);
+
+      const body = buildInteractiveBody({
+        type: "block_actions",
+        user: {
+          id: userLink.slackUserId,
+          username: "testuser",
+          team_id: installation.slackWorkspaceId,
+        },
+        team: { id: installation.slackWorkspaceId, domain: "test" },
+        trigger_id: "trigger-123",
+        actions: [{ action_id: "home_agent_link", block_id: "block-1" }],
+      });
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(slackMock.mocked.viewsOpen).toHaveBeenCalled();
+    });
+
+    it("opens agent update modal when home_agent_update is clicked", async () => {
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { binding } = await givenUserHasAgent(userLink, {
+        agentName: "my-agent",
+      });
+
+      const slackMock = handlers({
+        viewsOpen: http.post("https://slack.com/api/views.open", () =>
+          HttpResponse.json({ ok: true, view: { id: "V123" } }),
+        ),
+      });
+      server.use(...slackMock.handlers);
+
+      const body = buildInteractiveBody({
+        type: "block_actions",
+        user: {
+          id: userLink.slackUserId,
+          username: "testuser",
+          team_id: installation.slackWorkspaceId,
+        },
+        team: { id: installation.slackWorkspaceId, domain: "test" },
+        trigger_id: "trigger-456",
+        actions: [
+          {
+            action_id: "home_agent_update",
+            block_id: "block-1",
+            value: binding.id,
+          },
+        ],
+      });
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(slackMock.mocked.viewsOpen).toHaveBeenCalled();
+    });
+
+    it("deletes binding and refreshes home when home_agent_unlink is clicked", async () => {
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { binding } = await givenUserHasAgent(userLink, {
+        agentName: "unlink-agent",
+      });
+
+      const slackMock = handlers({
+        viewsPublish: http.post("https://slack.com/api/views.publish", () =>
+          HttpResponse.json({ ok: true }),
+        ),
+      });
+      server.use(...slackMock.handlers);
+
+      const body = buildInteractiveBody({
+        type: "block_actions",
+        user: {
+          id: userLink.slackUserId,
+          username: "testuser",
+          team_id: installation.slackWorkspaceId,
+        },
+        team: { id: installation.slackWorkspaceId, domain: "test" },
+        actions: [
+          {
+            action_id: "home_agent_unlink",
+            block_id: "block-1",
+            value: binding.id,
+          },
+        ],
+      });
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      // App Home was refreshed after unlink
+      expect(slackMock.mocked.viewsPublish).toHaveBeenCalled();
+    });
+
+    it("disconnects user and refreshes home when home_disconnect is clicked", async () => {
+      const { userLink, installation } = await givenLinkedSlackUser();
+
+      const slackMock = handlers({
+        viewsPublish: http.post("https://slack.com/api/views.publish", () =>
+          HttpResponse.json({ ok: true }),
+        ),
+      });
+      server.use(...slackMock.handlers);
+
+      const body = buildInteractiveBody({
+        type: "block_actions",
+        user: {
+          id: userLink.slackUserId,
+          username: "testuser",
+          team_id: installation.slackWorkspaceId,
+        },
+        team: { id: installation.slackWorkspaceId, domain: "test" },
+        actions: [{ action_id: "home_disconnect", block_id: "block-1" }],
+      });
+      const request = createSignedSlackRequest(body);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      // App Home was refreshed after disconnect
+      expect(slackMock.mocked.viewsPublish).toHaveBeenCalled();
+    });
+  });
+
   describe("View Submission - Agent Add Modal", () => {
     it("returns error when form values are missing", async () => {
       const body = buildInteractiveBody({

--- a/turbo/apps/web/app/api/slack/interactive/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/interactive/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createHmac } from "crypto";
+import { HttpResponse } from "msw";
 import { POST } from "../route";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
@@ -11,6 +12,8 @@ import {
   givenLinkedSlackUser,
   givenUserHasAgent,
 } from "../../../../../src/__tests__/slack/api-helpers";
+import { handlers, http } from "../../../../../src/__tests__/msw";
+import { server } from "../../../../../src/mocks/server";
 
 // Mock only external dependencies (third-party packages)
 vi.mock("@clerk/nextjs/server");
@@ -305,6 +308,14 @@ describe("POST /api/slack/interactive", () => {
       mockClerk({ userId: userLink.vm0UserId });
       const { composeId } = await createTestCompose("new-agent");
 
+      // Mock Slack API for App Home refresh after successful binding
+      const slackMock = handlers({
+        viewsPublish: http.post("https://slack.com/api/views.publish", () =>
+          HttpResponse.json({ ok: true }),
+        ),
+      });
+      server.use(...slackMock.handlers);
+
       const body = buildInteractiveBody({
         type: "view_submission",
         user: {
@@ -339,6 +350,14 @@ describe("POST /api/slack/interactive", () => {
       const { userLink, installation } = await givenLinkedSlackUser();
       mockClerk({ userId: userLink.vm0UserId });
       const { composeId } = await createTestCompose("secret-agent");
+
+      // Mock Slack API for App Home refresh after successful binding
+      const slackMock = handlers({
+        viewsPublish: http.post("https://slack.com/api/views.publish", () =>
+          HttpResponse.json({ ok: true }),
+        ),
+      });
+      server.use(...slackMock.handlers);
 
       const body = buildInteractiveBody({
         type: "view_submission",

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -660,7 +660,8 @@ async function handleHomeAgentLink(
   );
   const client = createSlackClient(botToken);
   const agents = await fetchAvailableAgents(userLink.vm0UserId, userLink.id);
-  const modal = buildAgentAddModal(agents);
+  const channelId = payload.channel?.id;
+  const modal = buildAgentAddModal(agents, undefined, channelId);
 
   await client.views.open({
     trigger_id: payload.trigger_id!,

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -91,7 +91,7 @@ interface SlackInteractivePayload {
 }
 
 export async function POST(request: Request) {
-  const { SLACK_SIGNING_SECRET, SECRETS_ENCRYPTION_KEY } = env();
+  const { SLACK_SIGNING_SECRET } = env();
 
   if (!SLACK_SIGNING_SECRET) {
     return NextResponse.json(
@@ -143,7 +143,7 @@ export async function POST(request: Request) {
   // Handle different interaction types
   switch (payload.type) {
     case "view_submission":
-      return handleViewSubmission(payload, SECRETS_ENCRYPTION_KEY);
+      return handleViewSubmission(payload);
 
     case "block_actions":
       return handleBlockActions(payload);
@@ -364,44 +364,62 @@ async function updateModalView(
 }
 
 /**
+ * Get an authenticated Slack client for a workspace
+ */
+async function getSlackClientForWorkspace(
+  workspaceId: string,
+): Promise<ReturnType<typeof createSlackClient> | null> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackInstallations)
+    .where(eq(slackInstallations.slackWorkspaceId, workspaceId))
+    .limit(1);
+
+  if (!installation) return null;
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  return createSlackClient(botToken);
+}
+
+/**
+ * Get a user link by Slack user ID and workspace ID
+ */
+async function getUserLink(slackUserId: string, workspaceId: string) {
+  const [userLink] = await globalThis.services.db
+    .select()
+    .from(slackUserLinks)
+    .where(
+      and(
+        eq(slackUserLinks.slackUserId, slackUserId),
+        eq(slackUserLinks.slackWorkspaceId, workspaceId),
+      ),
+    )
+    .limit(1);
+  return userLink ?? null;
+}
+
+/**
  * Handle agent selection in add modal
  */
 async function handleAgentAddSelection(
   payload: SlackInteractivePayload,
   selectedAgentId: string,
 ): Promise<void> {
-  const { SECRETS_ENCRYPTION_KEY } = env();
   const privateMetadata = payload.view?.private_metadata;
   const { channelId } = privateMetadata
     ? (JSON.parse(privateMetadata) as { channelId?: string })
     : { channelId: undefined };
 
-  const [installation] = await globalThis.services.db
-    .select()
-    .from(slackInstallations)
-    .where(eq(slackInstallations.slackWorkspaceId, payload.team.id))
-    .limit(1);
+  const client = await getSlackClientForWorkspace(payload.team.id);
+  if (!client) return;
 
-  if (!installation) return;
-
-  const [userLink] = await globalThis.services.db
-    .select()
-    .from(slackUserLinks)
-    .where(
-      and(
-        eq(slackUserLinks.slackUserId, payload.user.id),
-        eq(slackUserLinks.slackWorkspaceId, payload.team.id),
-      ),
-    )
-    .limit(1);
-
+  const userLink = await getUserLink(payload.user.id, payload.team.id);
   if (!userLink) return;
 
-  const botToken = decryptCredentialValue(
-    installation.encryptedBotToken,
-    SECRETS_ENCRYPTION_KEY,
-  );
-  const client = createSlackClient(botToken);
   const agents = await fetchAvailableAgents(userLink.vm0UserId, userLink.id);
   const updatedModal = buildAgentAddModal(agents, selectedAgentId, channelId);
 
@@ -420,38 +438,17 @@ async function handleAgentUpdateSelection(
   payload: SlackInteractivePayload,
   selectedAgentId: string,
 ): Promise<void> {
-  const { SECRETS_ENCRYPTION_KEY } = env();
   const privateMetadata = payload.view?.private_metadata;
   const { channelId } = privateMetadata
     ? (JSON.parse(privateMetadata) as { channelId?: string })
     : { channelId: undefined };
 
-  const [installation] = await globalThis.services.db
-    .select()
-    .from(slackInstallations)
-    .where(eq(slackInstallations.slackWorkspaceId, payload.team.id))
-    .limit(1);
+  const client = await getSlackClientForWorkspace(payload.team.id);
+  if (!client) return;
 
-  if (!installation) return;
-
-  const [userLink] = await globalThis.services.db
-    .select()
-    .from(slackUserLinks)
-    .where(
-      and(
-        eq(slackUserLinks.slackUserId, payload.user.id),
-        eq(slackUserLinks.slackWorkspaceId, payload.team.id),
-      ),
-    )
-    .limit(1);
-
+  const userLink = await getUserLink(payload.user.id, payload.team.id);
   if (!userLink) return;
 
-  const botToken = decryptCredentialValue(
-    installation.encryptedBotToken,
-    SECRETS_ENCRYPTION_KEY,
-  );
-  const client = createSlackClient(botToken);
   const agents = await fetchBoundAgents(userLink.vm0UserId, userLink.id);
   const updatedModal = buildAgentUpdateModal(
     agents,
@@ -502,7 +499,11 @@ async function dispatchBlockAction(
       break;
     case "home_agent_update":
       if (action.value && payload.trigger_id) {
-        await handleHomeAgentConfigure(payload, action.value);
+        await handleHomeAgentConfigure(
+          payload,
+          action.value,
+          payload.trigger_id,
+        );
       }
       break;
     case "home_agent_unlink":
@@ -512,7 +513,7 @@ async function dispatchBlockAction(
       break;
     case "home_agent_link":
       if (payload.trigger_id) {
-        await handleHomeAgentLink(payload);
+        await handleHomeAgentLink(payload, payload.trigger_id);
       }
       break;
     case "home_disconnect":
@@ -522,26 +523,14 @@ async function dispatchBlockAction(
 }
 
 /**
- * Refresh App Home for a user given workspace and encryption key
+ * Refresh App Home for a user given workspace ID
  */
 async function refreshAppHomeForUser(
   workspaceId: string,
   slackUserId: string,
-  encryptionKey: string,
 ): Promise<void> {
-  const [installation] = await globalThis.services.db
-    .select()
-    .from(slackInstallations)
-    .where(eq(slackInstallations.slackWorkspaceId, workspaceId))
-    .limit(1);
-
-  if (!installation) return;
-
-  const botToken = decryptCredentialValue(
-    installation.encryptedBotToken,
-    encryptionKey,
-  );
-  const client = createSlackClient(botToken);
+  const client = await getSlackClientForWorkspace(workspaceId);
+  if (!client) return;
   await refreshAppHome(client, workspaceId, slackUserId);
 }
 
@@ -553,40 +542,19 @@ async function refreshAppHomeForUser(
 async function handleHomeAgentConfigure(
   payload: SlackInteractivePayload,
   bindingId: string,
+  triggerId: string,
 ): Promise<void> {
-  const { SECRETS_ENCRYPTION_KEY } = env();
+  const client = await getSlackClientForWorkspace(payload.team.id);
+  if (!client) return;
 
-  const [installation] = await globalThis.services.db
-    .select()
-    .from(slackInstallations)
-    .where(eq(slackInstallations.slackWorkspaceId, payload.team.id))
-    .limit(1);
-
-  if (!installation) return;
-
-  const [userLink] = await globalThis.services.db
-    .select()
-    .from(slackUserLinks)
-    .where(
-      and(
-        eq(slackUserLinks.slackUserId, payload.user.id),
-        eq(slackUserLinks.slackWorkspaceId, payload.team.id),
-      ),
-    )
-    .limit(1);
-
+  const userLink = await getUserLink(payload.user.id, payload.team.id);
   if (!userLink) return;
 
-  const botToken = decryptCredentialValue(
-    installation.encryptedBotToken,
-    SECRETS_ENCRYPTION_KEY,
-  );
-  const client = createSlackClient(botToken);
   const agents = await fetchBoundAgents(userLink.vm0UserId, userLink.id);
   const modal = buildAgentUpdateModal(agents, bindingId);
 
   await client.views.open({
-    trigger_id: payload.trigger_id!,
+    trigger_id: triggerId,
     view: modal,
   });
 }
@@ -600,27 +568,11 @@ async function handleHomeAgentUnlink(
   payload: SlackInteractivePayload,
   bindingId: string,
 ): Promise<void> {
-  const { SECRETS_ENCRYPTION_KEY } = env();
-
   await globalThis.services.db
     .delete(slackBindings)
     .where(eq(slackBindings.id, bindingId));
 
-  // Refresh App Home
-  const [installation] = await globalThis.services.db
-    .select()
-    .from(slackInstallations)
-    .where(eq(slackInstallations.slackWorkspaceId, payload.team.id))
-    .limit(1);
-
-  if (!installation) return;
-
-  const botToken = decryptCredentialValue(
-    installation.encryptedBotToken,
-    SECRETS_ENCRYPTION_KEY,
-  );
-  const client = createSlackClient(botToken);
-  await refreshAppHome(client, payload.team.id, payload.user.id);
+  await refreshAppHomeForUser(payload.team.id, payload.user.id);
 }
 
 /**
@@ -630,41 +582,20 @@ async function handleHomeAgentUnlink(
  */
 async function handleHomeAgentLink(
   payload: SlackInteractivePayload,
+  triggerId: string,
 ): Promise<void> {
-  const { SECRETS_ENCRYPTION_KEY } = env();
+  const client = await getSlackClientForWorkspace(payload.team.id);
+  if (!client) return;
 
-  const [installation] = await globalThis.services.db
-    .select()
-    .from(slackInstallations)
-    .where(eq(slackInstallations.slackWorkspaceId, payload.team.id))
-    .limit(1);
-
-  if (!installation) return;
-
-  const [userLink] = await globalThis.services.db
-    .select()
-    .from(slackUserLinks)
-    .where(
-      and(
-        eq(slackUserLinks.slackUserId, payload.user.id),
-        eq(slackUserLinks.slackWorkspaceId, payload.team.id),
-      ),
-    )
-    .limit(1);
-
+  const userLink = await getUserLink(payload.user.id, payload.team.id);
   if (!userLink) return;
 
-  const botToken = decryptCredentialValue(
-    installation.encryptedBotToken,
-    SECRETS_ENCRYPTION_KEY,
-  );
-  const client = createSlackClient(botToken);
   const agents = await fetchAvailableAgents(userLink.vm0UserId, userLink.id);
   const channelId = payload.channel?.id;
   const modal = buildAgentAddModal(agents, undefined, channelId);
 
   await client.views.open({
-    trigger_id: payload.trigger_id!,
+    trigger_id: triggerId,
     view: modal,
   });
 }
@@ -675,19 +606,7 @@ async function handleHomeAgentLink(
 async function handleHomeDisconnect(
   payload: SlackInteractivePayload,
 ): Promise<void> {
-  const { SECRETS_ENCRYPTION_KEY } = env();
-
-  const [userLink] = await globalThis.services.db
-    .select()
-    .from(slackUserLinks)
-    .where(
-      and(
-        eq(slackUserLinks.slackUserId, payload.user.id),
-        eq(slackUserLinks.slackWorkspaceId, payload.team.id),
-      ),
-    )
-    .limit(1);
-
+  const userLink = await getUserLink(payload.user.id, payload.team.id);
   if (!userLink) return;
 
   // Delete user link (cascades to bindings)
@@ -696,20 +615,7 @@ async function handleHomeDisconnect(
     .where(eq(slackUserLinks.id, userLink.id));
 
   // Refresh App Home to show disconnected state
-  const [installation] = await globalThis.services.db
-    .select()
-    .from(slackInstallations)
-    .where(eq(slackInstallations.slackWorkspaceId, payload.team.id))
-    .limit(1);
-
-  if (!installation) return;
-
-  const botToken = decryptCredentialValue(
-    installation.encryptedBotToken,
-    SECRETS_ENCRYPTION_KEY,
-  );
-  const client = createSlackClient(botToken);
-  await refreshAppHome(client, payload.team.id, payload.user.id);
+  await refreshAppHomeForUser(payload.team.id, payload.user.id);
 }
 
 /**
@@ -717,20 +623,19 @@ async function handleHomeDisconnect(
  */
 async function handleViewSubmission(
   payload: SlackInteractivePayload,
-  encryptionKey: string,
 ): Promise<Response> {
   const callbackId = payload.view?.callback_id;
 
   if (callbackId === "agent_add_modal") {
-    return handleAgentAddSubmission(payload, encryptionKey);
+    return handleAgentAddSubmission(payload);
   }
 
   if (callbackId === "agent_remove_modal") {
-    return handleAgentRemoveSubmission(payload, encryptionKey);
+    return handleAgentRemoveSubmission(payload);
   }
 
   if (callbackId === "agent_update_modal") {
-    return handleAgentUpdateSubmission(payload, encryptionKey);
+    return handleAgentUpdateSubmission(payload);
   }
 
   // Unknown callback - just acknowledge
@@ -843,23 +748,9 @@ async function sendConfirmationMessage(
   savedVarNames: string[],
   channelId: string,
   slackUserId: string,
-  encryptionKey: string,
 ): Promise<void> {
-  const [installation] = await globalThis.services.db
-    .select()
-    .from(slackInstallations)
-    .where(eq(slackInstallations.slackWorkspaceId, workspaceId))
-    .limit(1);
-
-  if (!installation) {
-    return;
-  }
-
-  const botToken = decryptCredentialValue(
-    installation.encryptedBotToken,
-    encryptionKey,
-  );
-  const client = createSlackClient(botToken);
+  const client = await getSlackClientForWorkspace(workspaceId);
+  if (!client) return;
 
   let messageText = `:white_check_mark: *Agent \`${agentName}\` has been added successfully!*`;
 
@@ -896,7 +787,6 @@ async function sendConfirmationMessage(
  */
 async function handleAgentAddSubmission(
   payload: SlackInteractivePayload,
-  encryptionKey: string,
 ): Promise<Response> {
   const values = payload.view?.state?.values;
 
@@ -1029,14 +919,13 @@ async function handleAgentAddSubmission(
       savedVarNames,
       channelId,
       payload.user.id,
-      encryptionKey,
     ).catch((error) => {
       log.warn("Failed to send confirmation message (non-critical)", { error });
     });
   }
 
   // Refresh App Home to show newly linked agent
-  await refreshAppHomeForUser(payload.team.id, payload.user.id, encryptionKey);
+  await refreshAppHomeForUser(payload.team.id, payload.user.id);
 
   // Close modal
   return new Response("", { status: 200 });
@@ -1047,7 +936,6 @@ async function handleAgentAddSubmission(
  */
 async function handleAgentRemoveSubmission(
   payload: SlackInteractivePayload,
-  encryptionKey: string,
 ): Promise<Response> {
   const values = payload.view?.state?.values;
 
@@ -1096,7 +984,6 @@ async function handleAgentRemoveSubmission(
       agentNames,
       channelId,
       payload.user.id,
-      encryptionKey,
     ).catch((error) => {
       log.warn("Failed to send removal confirmation message (non-critical)", {
         error,
@@ -1105,7 +992,7 @@ async function handleAgentRemoveSubmission(
   }
 
   // Refresh App Home to reflect removed agents
-  await refreshAppHomeForUser(payload.team.id, payload.user.id, encryptionKey);
+  await refreshAppHomeForUser(payload.team.id, payload.user.id);
 
   // Close modal
   return new Response("", { status: 200 });
@@ -1119,23 +1006,9 @@ async function sendRemovalConfirmationMessage(
   agentNames: string[],
   channelId: string,
   slackUserId: string,
-  encryptionKey: string,
 ): Promise<void> {
-  const [installation] = await globalThis.services.db
-    .select()
-    .from(slackInstallations)
-    .where(eq(slackInstallations.slackWorkspaceId, workspaceId))
-    .limit(1);
-
-  if (!installation) {
-    return;
-  }
-
-  const botToken = decryptCredentialValue(
-    installation.encryptedBotToken,
-    encryptionKey,
-  );
-  const client = createSlackClient(botToken);
+  const client = await getSlackClientForWorkspace(workspaceId);
+  if (!client) return;
 
   const agentList = agentNames.map((n) => `\`${n}\``).join(", ");
   const plural = agentNames.length > 1 ? "s" : "";
@@ -1230,7 +1103,6 @@ async function saveVarsAndSecrets(
  */
 async function handleAgentUpdateSubmission(
   payload: SlackInteractivePayload,
-  encryptionKey: string,
 ): Promise<Response> {
   const values = payload.view?.state?.values;
   if (!values) {
@@ -1304,7 +1176,6 @@ async function handleAgentUpdateSubmission(
       descriptionChanged,
       channelId,
       payload.user.id,
-      encryptionKey,
     ).catch((error) => {
       log.warn("Failed to send update confirmation message (non-critical)", {
         error,
@@ -1313,7 +1184,7 @@ async function handleAgentUpdateSubmission(
   }
 
   // Refresh App Home to reflect updated agent
-  await refreshAppHomeForUser(payload.team.id, payload.user.id, encryptionKey);
+  await refreshAppHomeForUser(payload.team.id, payload.user.id);
 
   return new Response("", { status: 200 });
 }
@@ -1329,23 +1200,9 @@ async function sendUpdateConfirmationMessage(
   descriptionUpdated: boolean,
   channelId: string,
   slackUserId: string,
-  encryptionKey: string,
 ): Promise<void> {
-  const [installation] = await globalThis.services.db
-    .select()
-    .from(slackInstallations)
-    .where(eq(slackInstallations.slackWorkspaceId, workspaceId))
-    .limit(1);
-
-  if (!installation) {
-    return;
-  }
-
-  const botToken = decryptCredentialValue(
-    installation.encryptedBotToken,
-    encryptionKey,
-  );
-  const client = createSlackClient(botToken);
+  const client = await getSlackClientForWorkspace(workspaceId);
+  if (!client) return;
 
   // Build update summary
   const updates: string[] = [];

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -22,6 +22,7 @@ import { decryptCredentialValue } from "../../../../src/lib/crypto/secrets-encry
 import {
   createSlackClient,
   isSlackInvalidAuthError,
+  refreshAppHome,
 } from "../../../../src/lib/slack";
 import {
   listSecrets,
@@ -490,7 +491,55 @@ async function handleBlockActions(
     }
   }
 
+  // Handle disconnect button on App Home
+  if (action?.action_id === "home_disconnect") {
+    await handleHomeDisconnect(payload);
+  }
+
   return new Response("", { status: 200 });
+}
+
+/**
+ * Handle disconnect button click from App Home
+ */
+async function handleHomeDisconnect(
+  payload: SlackInteractivePayload,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  const [userLink] = await globalThis.services.db
+    .select()
+    .from(slackUserLinks)
+    .where(
+      and(
+        eq(slackUserLinks.slackUserId, payload.user.id),
+        eq(slackUserLinks.slackWorkspaceId, payload.team.id),
+      ),
+    )
+    .limit(1);
+
+  if (!userLink) return;
+
+  // Delete user link (cascades to bindings)
+  await globalThis.services.db
+    .delete(slackUserLinks)
+    .where(eq(slackUserLinks.id, userLink.id));
+
+  // Refresh App Home to show disconnected state
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackInstallations)
+    .where(eq(slackInstallations.slackWorkspaceId, payload.team.id))
+    .limit(1);
+
+  if (!installation) return;
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+  await refreshAppHome(client, payload.team.id, payload.user.id);
 }
 
 /**

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -475,28 +475,197 @@ async function handleBlockActions(
 ): Promise<Response> {
   const action = payload.actions?.[0];
 
-  // Handle agent selection in add modal
-  if (action?.action_id === "agent_select_action" && payload.view) {
-    const selectedAgentId = action.selected_option?.value;
-    if (selectedAgentId) {
-      await handleAgentAddSelection(payload, selectedAgentId);
-    }
-  }
-
-  // Handle agent selection in update modal
-  if (action?.action_id === "agent_update_select_action" && payload.view) {
-    const selectedAgentId = action.selected_option?.value;
-    if (selectedAgentId) {
-      await handleAgentUpdateSelection(payload, selectedAgentId);
-    }
-  }
-
-  // Handle disconnect button on App Home
-  if (action?.action_id === "home_disconnect") {
-    await handleHomeDisconnect(payload);
+  if (action) {
+    await dispatchBlockAction(payload, action);
   }
 
   return new Response("", { status: 200 });
+}
+
+/**
+ * Dispatch a single block action to the appropriate handler
+ */
+async function dispatchBlockAction(
+  payload: SlackInteractivePayload,
+  action: NonNullable<SlackInteractivePayload["actions"]>[0],
+): Promise<void> {
+  switch (action.action_id) {
+    case "agent_select_action":
+      if (payload.view && action.selected_option?.value) {
+        await handleAgentAddSelection(payload, action.selected_option.value);
+      }
+      break;
+    case "agent_update_select_action":
+      if (payload.view && action.selected_option?.value) {
+        await handleAgentUpdateSelection(payload, action.selected_option.value);
+      }
+      break;
+    case "home_agent_update":
+      if (action.value && payload.trigger_id) {
+        await handleHomeAgentConfigure(payload, action.value);
+      }
+      break;
+    case "home_agent_unlink":
+      if (action.value) {
+        await handleHomeAgentUnlink(payload, action.value);
+      }
+      break;
+    case "home_agent_link":
+      if (payload.trigger_id) {
+        await handleHomeAgentLink(payload);
+      }
+      break;
+    case "home_disconnect":
+      await handleHomeDisconnect(payload);
+      break;
+  }
+}
+
+/**
+ * Refresh App Home for a user given workspace and encryption key
+ */
+async function refreshAppHomeForUser(
+  workspaceId: string,
+  slackUserId: string,
+  encryptionKey: string,
+): Promise<void> {
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackInstallations)
+    .where(eq(slackInstallations.slackWorkspaceId, workspaceId))
+    .limit(1);
+
+  if (!installation) return;
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    encryptionKey,
+  );
+  const client = createSlackClient(botToken);
+  await refreshAppHome(client, workspaceId, slackUserId);
+}
+
+/**
+ * Handle agent configure select from App Home
+ *
+ * Opens the agent update modal pre-selected with the chosen agent.
+ */
+async function handleHomeAgentConfigure(
+  payload: SlackInteractivePayload,
+  bindingId: string,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackInstallations)
+    .where(eq(slackInstallations.slackWorkspaceId, payload.team.id))
+    .limit(1);
+
+  if (!installation) return;
+
+  const [userLink] = await globalThis.services.db
+    .select()
+    .from(slackUserLinks)
+    .where(
+      and(
+        eq(slackUserLinks.slackUserId, payload.user.id),
+        eq(slackUserLinks.slackWorkspaceId, payload.team.id),
+      ),
+    )
+    .limit(1);
+
+  if (!userLink) return;
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+  const agents = await fetchBoundAgents(userLink.vm0UserId, userLink.id);
+  const modal = buildAgentUpdateModal(agents, bindingId);
+
+  await client.views.open({
+    trigger_id: payload.trigger_id!,
+    view: modal,
+  });
+}
+
+/**
+ * Handle agent unlink button from App Home
+ *
+ * Deletes the binding and refreshes the Home tab.
+ */
+async function handleHomeAgentUnlink(
+  payload: SlackInteractivePayload,
+  bindingId: string,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  await globalThis.services.db
+    .delete(slackBindings)
+    .where(eq(slackBindings.id, bindingId));
+
+  // Refresh App Home
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackInstallations)
+    .where(eq(slackInstallations.slackWorkspaceId, payload.team.id))
+    .limit(1);
+
+  if (!installation) return;
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+  await refreshAppHome(client, payload.team.id, payload.user.id);
+}
+
+/**
+ * Handle agent link button from App Home
+ *
+ * Opens the agent add modal.
+ */
+async function handleHomeAgentLink(
+  payload: SlackInteractivePayload,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackInstallations)
+    .where(eq(slackInstallations.slackWorkspaceId, payload.team.id))
+    .limit(1);
+
+  if (!installation) return;
+
+  const [userLink] = await globalThis.services.db
+    .select()
+    .from(slackUserLinks)
+    .where(
+      and(
+        eq(slackUserLinks.slackUserId, payload.user.id),
+        eq(slackUserLinks.slackWorkspaceId, payload.team.id),
+      ),
+    )
+    .limit(1);
+
+  if (!userLink) return;
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+  const agents = await fetchAvailableAgents(userLink.vm0UserId, userLink.id);
+  const modal = buildAgentAddModal(agents);
+
+  await client.views.open({
+    trigger_id: payload.trigger_id!,
+    view: modal,
+  });
 }
 
 /**
@@ -865,6 +1034,9 @@ async function handleAgentAddSubmission(
     });
   }
 
+  // Refresh App Home to show newly linked agent
+  await refreshAppHomeForUser(payload.team.id, payload.user.id, encryptionKey);
+
   // Close modal
   return new Response("", { status: 200 });
 }
@@ -930,6 +1102,9 @@ async function handleAgentRemoveSubmission(
       });
     });
   }
+
+  // Refresh App Home to reflect removed agents
+  await refreshAppHomeForUser(payload.team.id, payload.user.id, encryptionKey);
 
   // Close modal
   return new Response("", { status: 200 });
@@ -1135,6 +1310,9 @@ async function handleAgentUpdateSubmission(
       });
     });
   }
+
+  // Refresh App Home to reflect updated agent
+  await refreshAppHomeForUser(payload.team.id, payload.user.id, encryptionKey);
 
   return new Response("", { status: 200 });
 }

--- a/turbo/apps/web/app/slack/link/actions.ts
+++ b/turbo/apps/web/app/slack/link/actions.ts
@@ -9,6 +9,9 @@ import { slackInstallations } from "../../../src/db/schema/slack-installation";
 import { slackBindings } from "../../../src/db/schema/slack-binding";
 import { decryptCredentialValue } from "../../../src/lib/crypto/secrets-encryption";
 import { createSlackClient, refreshAppHome } from "../../../src/lib/slack";
+import { logger } from "../../../src/lib/logger";
+
+const log = logger("slack:link");
 
 interface LinkResult {
   success: boolean;
@@ -117,7 +120,7 @@ export async function linkSlackAccount(
           channelId,
           slackUserId,
         ).catch((error) => {
-          console.error("Error sending Slack message:", error);
+          log.warn("Failed to send success message", { error });
         });
       }
       return { success: true, alreadyLinked: true };
@@ -153,9 +156,11 @@ export async function linkSlackAccount(
       .then((result) => result.rowCount ?? 0);
 
     if (restoredCount > 0) {
-      console.log(
-        `Restored ${restoredCount} orphaned bindings for user ${userId} in workspace ${workspaceId}`,
-      );
+      log.info("Restored orphaned bindings", {
+        count: restoredCount,
+        userId,
+        workspaceId,
+      });
     }
   }
 
@@ -167,7 +172,7 @@ export async function linkSlackAccount(
       channelId,
       slackUserId,
     ).catch((error) => {
-      console.error("Error sending Slack message:", error);
+      log.warn("Failed to send success message", { error });
     });
   }
 
@@ -179,7 +184,7 @@ export async function linkSlackAccount(
   );
   const client = createSlackClient(botToken);
   await refreshAppHome(client, workspaceId, slackUserId).catch((error) => {
-    console.error("Error refreshing App Home after link:", error);
+    log.warn("Failed to refresh App Home after link", { error });
   });
 
   return { success: true };

--- a/turbo/apps/web/app/slack/link/actions.ts
+++ b/turbo/apps/web/app/slack/link/actions.ts
@@ -8,7 +8,7 @@ import { slackUserLinks } from "../../../src/db/schema/slack-user-link";
 import { slackInstallations } from "../../../src/db/schema/slack-installation";
 import { slackBindings } from "../../../src/db/schema/slack-binding";
 import { decryptCredentialValue } from "../../../src/lib/crypto/secrets-encryption";
-import { createSlackClient } from "../../../src/lib/slack";
+import { createSlackClient, refreshAppHome } from "../../../src/lib/slack";
 
 interface LinkResult {
   success: boolean;
@@ -170,6 +170,17 @@ export async function linkSlackAccount(
       console.error("Error sending Slack message:", error);
     });
   }
+
+  // Refresh App Home to show linked state
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+  await refreshAppHome(client, workspaceId, slackUserId).catch((error) => {
+    console.error("Error refreshing App Home after link:", error);
+  });
 
   return { success: true };
 }

--- a/turbo/apps/web/src/__tests__/slack/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/slack/api-helpers.ts
@@ -285,10 +285,13 @@ export async function givenUserHasAgent(
     },
   };
 
-  // Mock Slack postEphemeral for confirmation message
+  // Mock Slack APIs used during agent add: confirmation message + App Home refresh
   const slackMock = handlers({
     postEphemeral: http.post(`${SLACK_API}/chat.postEphemeral`, () =>
       HttpResponse.json({ ok: true, message_ts: `${Date.now()}.000000` }),
+    ),
+    viewsPublish: http.post(`${SLACK_API}/views.publish`, () =>
+      HttpResponse.json({ ok: true }),
     ),
   });
   server.use(...slackMock.handlers);

--- a/turbo/apps/web/src/__tests__/slack/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/slack/api-helpers.ts
@@ -29,6 +29,69 @@ import { createTestScope } from "../api-test-helpers";
 const SLACK_API = "https://slack.com/api";
 
 /**
+ * Parse Slack Web API form-encoded body into an object.
+ * The `view` field is JSON-encoded within the form data.
+ */
+function parseSlackFormBody(body: string): Record<string, unknown> {
+  const params = new URLSearchParams(body);
+  const viewStr = params.get("view");
+  return {
+    user_id: params.get("user_id"),
+    view: viewStr ? JSON.parse(viewStr) : undefined,
+  };
+}
+
+/**
+ * Extract binding ID from a published App Home view by finding the Unlink button
+ * for a given agent name (the button value contains the binding UUID).
+ */
+function extractBindingIdFromView(
+  publishedView: Record<string, unknown> | undefined,
+  agentName: string,
+): string {
+  if (!publishedView) {
+    throw new Error("No App Home view was published during agent setup");
+  }
+
+  const view = publishedView.view as
+    | { blocks?: Array<Record<string, unknown>> }
+    | undefined;
+  const blocks = view?.blocks ?? [];
+
+  // Find the actions block that follows the agent's section block
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i]!;
+    if (
+      block.type === "section" &&
+      typeof block.text === "object" &&
+      block.text !== null &&
+      "text" in block.text &&
+      typeof block.text.text === "string" &&
+      block.text.text.includes(agentName)
+    ) {
+      // Next block should be actions with Update/Unlink buttons
+      const actionsBlock = blocks[i + 1];
+      if (actionsBlock?.type === "actions") {
+        const elements = actionsBlock.elements as Array<{
+          action_id: string;
+          value?: string;
+        }>;
+        const unlinkButton = elements?.find(
+          (el) => el.action_id === "home_agent_unlink",
+        );
+        if (unlinkButton?.value) {
+          return unlinkButton.value;
+        }
+      }
+    }
+  }
+
+  throw new Error(
+    `Could not find binding ID for agent "${agentName}" in published App Home view`,
+  );
+}
+
+/**
  * Result from givenSlackWorkspaceInstalled
  */
 interface WorkspaceInstallationResult {
@@ -56,6 +119,7 @@ interface LinkedUserResult extends WorkspaceInstallationResult {
  */
 interface AgentBindingResult {
   binding: {
+    id: string;
     agentName: string;
     composeId: string;
   };
@@ -304,8 +368,20 @@ export async function givenUserHasAgent(
     throw new Error(`Failed to create agent binding: ${error}`);
   }
 
+  // Extract binding ID from the published App Home view (captured by MSW mock)
+  const viewsPublishCall = slackMock.mocked.viewsPublish.mock.calls[0];
+  const publishedRequest = viewsPublishCall?.[0]?.request;
+  const publishedBody = publishedRequest
+    ? parseSlackFormBody(await publishedRequest.text())
+    : undefined;
+  const bindingId = extractBindingIdFromView(
+    publishedBody,
+    agentName.toLowerCase(),
+  );
+
   return {
     binding: {
+      id: bindingId,
       agentName: agentName.toLowerCase(),
       composeId,
     },

--- a/turbo/apps/web/src/db/migrations/0072_add_dm_welcome_sent.sql
+++ b/turbo/apps/web/src/db/migrations/0072_add_dm_welcome_sent.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "slack_user_links" ADD COLUMN "dm_welcome_sent" boolean DEFAULT false NOT NULL;

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -505,6 +505,13 @@
       "when": 1769600000000,
       "tag": "0071_simplify_agent_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 72,
+      "version": "7",
+      "when": 1769700000000,
+      "tag": "0072_add_dm_welcome_sent",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/slack-user-link.ts
+++ b/turbo/apps/web/src/db/schema/slack-user-link.ts
@@ -1,4 +1,5 @@
 import {
+  boolean,
   pgTable,
   uuid,
   varchar,
@@ -20,6 +21,7 @@ export const slackUserLinks = pgTable(
     slackWorkspaceId: varchar("slack_workspace_id", { length: 255 }).notNull(),
     // VM0 user ID (Clerk user ID)
     vm0UserId: text("vm0_user_id").notNull(),
+    dmWelcomeSent: boolean("dm_welcome_sent").default(false).notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },
   (table) => [

--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -160,11 +160,17 @@ describe("buildAgentListMessage", () => {
   it("should list bindings with status", () => {
     const bindings = [
       {
+        id: "binding-1",
         agentName: "my-coder",
         description: "Helps with coding",
         enabled: true,
       },
-      { agentName: "my-analyst", description: null, enabled: false },
+      {
+        id: "binding-2",
+        agentName: "my-analyst",
+        description: null,
+        enabled: false,
+      },
     ];
 
     const blocks = buildAgentListMessage(bindings);

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -16,7 +16,7 @@ interface AgentOption {
 }
 
 interface BindingInfo {
-  id?: string;
+  id: string;
   agentName: string;
   description: string | null;
   enabled: boolean;
@@ -324,26 +324,24 @@ export function buildAppHomeView(options: {
         },
       });
 
-      if (binding.id) {
-        blocks.push({
-          type: "actions",
-          elements: [
-            {
-              type: "button",
-              text: { type: "plain_text", text: "Update" },
-              action_id: "home_agent_update",
-              value: binding.id,
-            },
-            {
-              type: "button",
-              text: { type: "plain_text", text: "Unlink" },
-              action_id: "home_agent_unlink",
-              value: binding.id,
-              style: "danger",
-            },
-          ],
-        });
-      }
+      blocks.push({
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: { type: "plain_text", text: "Update" },
+            action_id: "home_agent_update",
+            value: binding.id,
+          },
+          {
+            type: "button",
+            text: { type: "plain_text", text: "Unlink" },
+            action_id: "home_agent_unlink",
+            value: binding.id,
+            style: "danger",
+          },
+        ],
+      });
     }
   } else {
     blocks.push({

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -261,6 +261,24 @@ export function buildAppHomeView(options: {
         type: "mrkdwn",
         text: `:white_check_mark: *Account connected*\n\`${options.vm0UserId}\``,
       },
+      accessory: {
+        type: "button",
+        text: {
+          type: "plain_text",
+          text: "Disconnect",
+        },
+        action_id: "home_disconnect",
+        style: "danger",
+        confirm: {
+          title: { type: "plain_text", text: "Disconnect account?" },
+          text: {
+            type: "mrkdwn",
+            text: "This will unlink your VM0 account and remove all agent bindings.",
+          },
+          confirm: { type: "plain_text", text: "Disconnect" },
+          deny: { type: "plain_text", text: "Cancel" },
+        },
+      },
     });
   } else {
     const connectBlocks: (Block | KnownBlock)[] = [

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -223,12 +223,6 @@ export function buildAgentAddModal(
   };
 }
 
-interface AppHomeBinding {
-  agentName: string;
-  description: string | null;
-  enabled: boolean;
-}
-
 /**
  * Build the App Home tab view
  *
@@ -238,7 +232,7 @@ interface AppHomeBinding {
 export function buildAppHomeView(options: {
   isLinked: boolean;
   vm0UserId?: string;
-  bindings?: AppHomeBinding[];
+  bindings?: BindingInfo[];
   loginUrl?: string;
 }): View {
   const blocks: (Block | KnownBlock)[] = [
@@ -296,6 +290,12 @@ export function buildAppHomeView(options: {
       });
     }
     blocks.push(...connectBlocks);
+
+    // Not connected — just show connect prompt, skip agents/commands
+    return {
+      type: "home",
+      blocks,
+    };
   }
 
   blocks.push({ type: "divider" });
@@ -338,7 +338,7 @@ export function buildAppHomeView(options: {
     type: "section",
     text: {
       type: "mrkdwn",
-      text: "*Commands*\n• `/vm0 help` — Show help\n• `/vm0 connect` — Connect your account\n• `/vm0 agent link` — Link an agent\n• `/vm0 agent unlink` — Unlink an agent\n• `/vm0 agent update` — Update agent configuration",
+      text: "*Commands*\n• `/vm0 help` — Show help\n• `/vm0 agent link` — Link an agent\n• `/vm0 agent unlink` — Unlink an agent\n• `/vm0 agent update` — Update agent configuration",
     },
   });
 

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -16,6 +16,7 @@ interface AgentOption {
 }
 
 interface BindingInfo {
+  id?: string;
   agentName: string;
   description: string | null;
   enabled: boolean;
@@ -240,7 +241,7 @@ export function buildAppHomeView(options: {
       type: "header",
       text: {
         type: "plain_text",
-        text: "Welcome to VM0!",
+        text: "Welcome to VM0! :wave:",
       },
     },
     {
@@ -259,25 +260,7 @@ export function buildAppHomeView(options: {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `:white_check_mark: *Account connected*\n\`${options.vm0UserId}\``,
-      },
-      accessory: {
-        type: "button",
-        text: {
-          type: "plain_text",
-          text: "Disconnect",
-        },
-        action_id: "home_disconnect",
-        style: "danger",
-        confirm: {
-          title: { type: "plain_text", text: "Disconnect account?" },
-          text: {
-            type: "mrkdwn",
-            text: "This will unlink your VM0 account and remove all agent bindings.",
-          },
-          confirm: { type: "plain_text", text: "Disconnect" },
-          deny: { type: "plain_text", text: "Cancel" },
-        },
+        text: `:white_check_mark: *Connected to VM0*\nAccount: ${options.vm0UserId}`,
       },
     });
   } else {
@@ -323,29 +306,63 @@ export function buildAppHomeView(options: {
     type: "section",
     text: {
       type: "mrkdwn",
-      text: "*Your Agents*",
+      text: ":robot_face: *Your Linked Agent*",
     },
   });
 
   if (options.bindings && options.bindings.length > 0) {
     for (const binding of options.bindings) {
-      const status = binding.enabled ? ":white_check_mark:" : ":x:";
-      const description = binding.description ?? "_No description_";
+      let agentText = `AgentName: *${binding.agentName}*`;
+      if (binding.description) {
+        agentText += `\nDescription: ${binding.description}`;
+      }
       blocks.push({
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `${status} *${binding.agentName}*\n${description}`,
+          text: agentText,
         },
       });
+
+      if (binding.id) {
+        blocks.push({
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Update" },
+              action_id: "home_agent_update",
+              value: binding.id,
+            },
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Unlink" },
+              action_id: "home_agent_unlink",
+              value: binding.id,
+              style: "danger",
+            },
+          ],
+        });
+      }
     }
   } else {
     blocks.push({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "_No agents linked yet._ Use `/vm0 agent link` to link one.",
+        text: "_No agent linked yet._",
       },
+    });
+    blocks.push({
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "Link Agent" },
+          action_id: "home_agent_link",
+          style: "primary",
+        },
+      ],
     });
   }
 
@@ -356,18 +373,52 @@ export function buildAppHomeView(options: {
     type: "section",
     text: {
       type: "mrkdwn",
-      text: "*Commands*\n• `/vm0 help` — Show help\n• `/vm0 agent link` — Link an agent\n• `/vm0 agent unlink` — Unlink an agent\n• `/vm0 agent update` — Update agent configuration",
+      text: ":bulb: *Here are some things you can do:*",
     },
   });
 
   blocks.push({
-    type: "context",
-    elements: [
-      {
-        type: "mrkdwn",
-        text: "Send me a DM or `@VM0` in any channel to start chatting with your agents!",
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: "*Chat with your agents*\nSend a DM or `@VM0` in any channel\n`@VM0 [your message]`",
+    },
+  });
+
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: "*Link and manage agents*\nLink an agent\n`/vm0 agent link`\nUnlink an agent\n`/vm0 agent unlink`\nUpdate agent configuration\n`/vm0 agent update`",
+    },
+  });
+
+  blocks.push({ type: "divider" });
+
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: "*Disconnect VM0 Account*\nThis will remove your VM0 account connection",
+    },
+    accessory: {
+      type: "button",
+      text: {
+        type: "plain_text",
+        text: "Disconnect",
       },
-    ],
+      action_id: "home_disconnect",
+      style: "danger",
+      confirm: {
+        title: { type: "plain_text", text: "Disconnect VM0 Account" },
+        text: {
+          type: "plain_text",
+          text: "This will remove your VM0 account connection",
+        },
+        confirm: { type: "plain_text", text: "Disconnect" },
+        deny: { type: "plain_text", text: "Cancel" },
+      },
+    },
   });
 
   return {
@@ -656,7 +707,7 @@ export function buildAgentListMessage(
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "*Your Linked Agent*",
+        text: ":robot_face: *Your Linked Agent*",
       },
     },
     {

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -799,16 +799,9 @@ interface WelcomeAgentInfo {
 export function buildWelcomeMessage(
   agents: WelcomeAgentInfo[],
 ): (Block | KnownBlock)[] {
-  const agentList =
-    agents.length > 0
-      ? agents
-          .map(
-            (a) => `• \`${a.agentName}\`: ${a.description ?? "No description"}`,
-          )
-          .join("\n")
-      : "_No agents configured yet._";
+  const hasAgents = agents.length > 0;
 
-  return [
+  const blocks: (Block | KnownBlock)[] = [
     {
       type: "section",
       text: {
@@ -819,21 +812,63 @@ export function buildWelcomeMessage(
     {
       type: "divider",
     },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: `*Your Available Agents*\n${agentList}`,
-      },
-    },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*How to Use*\n• Just describe what you need help with\n• Or use `@VM0 use <agent> <message>` to specify an agent",
-      },
-    },
   ];
+
+  if (hasAgents) {
+    const agentList = agents
+      .map((a) => `• \`${a.agentName}\`: ${a.description ?? "No description"}`)
+      .join("\n");
+
+    blocks.push(
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*Your Linked Agent*\n${agentList}`,
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*How to Use*\n• Just describe what you need help with",
+        },
+      },
+    );
+  } else {
+    blocks.push(
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*Your Linked Agent*\n_No agent linked yet._ Use the button below to link one.",
+        },
+      },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: {
+              type: "plain_text",
+              text: "Link Agent",
+            },
+            action_id: "home_agent_link",
+            style: "primary",
+          },
+        ],
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*How to Use*\n• Link an agent first, then describe what you need help with",
+        },
+      },
+    );
+  }
+
+  return blocks;
 }
 
 /**

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -223,6 +223,141 @@ export function buildAgentAddModal(
   };
 }
 
+interface AppHomeBinding {
+  agentName: string;
+  description: string | null;
+  enabled: boolean;
+}
+
+/**
+ * Build the App Home tab view
+ *
+ * @param options - Configuration for the home view
+ * @returns View definition for the Home tab
+ */
+export function buildAppHomeView(options: {
+  isLinked: boolean;
+  vm0UserId?: string;
+  bindings?: AppHomeBinding[];
+  loginUrl?: string;
+}): View {
+  const blocks: (Block | KnownBlock)[] = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "Welcome to VM0!",
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "Connect your AI agents to Slack and interact with them through messages.",
+      },
+    },
+    { type: "divider" },
+  ];
+
+  // Account status
+  if (options.isLinked) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:white_check_mark: *Account connected*\n\`${options.vm0UserId}\``,
+      },
+    });
+  } else {
+    const connectBlocks: (Block | KnownBlock)[] = [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: ":x: *Account not connected*",
+        },
+      },
+    ];
+    if (options.loginUrl) {
+      connectBlocks.push({
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: {
+              type: "plain_text",
+              text: "Connect",
+            },
+            url: options.loginUrl,
+            action_id: "home_login_prompt",
+            style: "primary",
+          },
+        ],
+      });
+    }
+    blocks.push(...connectBlocks);
+  }
+
+  blocks.push({ type: "divider" });
+
+  // Linked agents
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: "*Your Agents*",
+    },
+  });
+
+  if (options.bindings && options.bindings.length > 0) {
+    for (const binding of options.bindings) {
+      const status = binding.enabled ? ":white_check_mark:" : ":x:";
+      const description = binding.description ?? "_No description_";
+      blocks.push({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `${status} *${binding.agentName}*\n${description}`,
+        },
+      });
+    }
+  } else {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "_No agents linked yet._ Use `/vm0 agent link` to link one.",
+      },
+    });
+  }
+
+  blocks.push({ type: "divider" });
+
+  // Help section
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: "*Commands*\n• `/vm0 help` — Show help\n• `/vm0 connect` — Connect your account\n• `/vm0 agent link` — Link an agent\n• `/vm0 agent unlink` — Unlink an agent\n• `/vm0 agent update` — Update agent configuration",
+    },
+  });
+
+  blocks.push({
+    type: "context",
+    elements: [
+      {
+        type: "mrkdwn",
+        text: "Send me a DM or `@VM0` in any channel to start chatting with your agents!",
+      },
+    ],
+  });
+
+  return {
+    type: "home",
+    blocks,
+  };
+}
+
 interface AgentBinding {
   id: string;
   agentName: string;

--- a/turbo/apps/web/src/lib/slack/client.ts
+++ b/turbo/apps/web/src/lib/slack/client.ts
@@ -57,6 +57,48 @@ export async function postMessage(
 }
 
 /**
+ * Update an existing message in a Slack channel
+ *
+ * @param client - Slack WebClient
+ * @param channel - Channel ID
+ * @param ts - Timestamp of the message to update
+ * @param text - New message text (used as fallback for blocks)
+ * @param options - Additional options
+ */
+export async function updateMessage(
+  client: WebClient,
+  channel: string,
+  ts: string,
+  text: string,
+  options?: { blocks?: (Block | KnownBlock)[] },
+): Promise<void> {
+  await client.chat.update({
+    channel,
+    ts,
+    text,
+    blocks: options?.blocks,
+  });
+}
+
+/**
+ * Publish an App Home tab view for a user
+ *
+ * @param client - Slack WebClient
+ * @param userId - Slack user ID
+ * @param view - Home tab view definition
+ */
+export async function publishAppHome(
+  client: WebClient,
+  userId: string,
+  view: View,
+): Promise<void> {
+  await client.views.publish({
+    user_id: userId,
+    view,
+  });
+}
+
+/**
  * Open a modal in Slack
  *
  * @param client - Slack WebClient
@@ -103,48 +145,6 @@ export async function updateModal(
  * @param redirectUri - OAuth redirect URI
  * @returns OAuth response with tokens and team info
  */
-/**
- * Update an existing message in a Slack channel
- *
- * @param client - Slack WebClient
- * @param channel - Channel ID
- * @param ts - Timestamp of the message to update
- * @param text - New message text (used as fallback for blocks)
- * @param options - Additional options
- */
-export async function updateMessage(
-  client: WebClient,
-  channel: string,
-  ts: string,
-  text: string,
-  options?: { blocks?: (Block | KnownBlock)[] },
-): Promise<void> {
-  await client.chat.update({
-    channel,
-    ts,
-    text,
-    blocks: options?.blocks,
-  });
-}
-
-/**
- * Publish an App Home tab view for a user
- *
- * @param client - Slack WebClient
- * @param userId - Slack user ID
- * @param view - Home tab view definition
- */
-export async function publishAppHome(
-  client: WebClient,
-  userId: string,
-  view: View,
-): Promise<void> {
-  await client.views.publish({
-    user_id: userId,
-    view,
-  });
-}
-
 export async function exchangeOAuthCode(
   clientId: string,
   clientSecret: string,

--- a/turbo/apps/web/src/lib/slack/client.ts
+++ b/turbo/apps/web/src/lib/slack/client.ts
@@ -57,30 +57,6 @@ export async function postMessage(
 }
 
 /**
- * Update an existing message in a Slack channel
- *
- * @param client - Slack WebClient
- * @param channel - Channel ID
- * @param ts - Timestamp of the message to update
- * @param text - New message text (used as fallback for blocks)
- * @param options - Additional options
- */
-export async function updateMessage(
-  client: WebClient,
-  channel: string,
-  ts: string,
-  text: string,
-  options?: { blocks?: (Block | KnownBlock)[] },
-): Promise<void> {
-  await client.chat.update({
-    channel,
-    ts,
-    text,
-    blocks: options?.blocks,
-  });
-}
-
-/**
  * Publish an App Home tab view for a user
  *
  * @param client - Slack WebClient

--- a/turbo/apps/web/src/lib/slack/client.ts
+++ b/turbo/apps/web/src/lib/slack/client.ts
@@ -103,6 +103,48 @@ export async function updateModal(
  * @param redirectUri - OAuth redirect URI
  * @returns OAuth response with tokens and team info
  */
+/**
+ * Update an existing message in a Slack channel
+ *
+ * @param client - Slack WebClient
+ * @param channel - Channel ID
+ * @param ts - Timestamp of the message to update
+ * @param text - New message text (used as fallback for blocks)
+ * @param options - Additional options
+ */
+export async function updateMessage(
+  client: WebClient,
+  channel: string,
+  ts: string,
+  text: string,
+  options?: { blocks?: (Block | KnownBlock)[] },
+): Promise<void> {
+  await client.chat.update({
+    channel,
+    ts,
+    text,
+    blocks: options?.blocks,
+  });
+}
+
+/**
+ * Publish an App Home tab view for a user
+ *
+ * @param client - Slack WebClient
+ * @param userId - Slack user ID
+ * @param view - Home tab view definition
+ */
+export async function publishAppHome(
+  client: WebClient,
+  userId: string,
+  view: View,
+): Promise<void> {
+  await client.views.publish({
+    user_id: userId,
+    view,
+  });
+}
+
 export async function exchangeOAuthCode(
   clientId: string,
   clientSecret: string,

--- a/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
@@ -12,9 +12,6 @@ import {
   buildWelcomeMessage,
 } from "../index";
 import { buildLoginUrl } from "./shared";
-import { logger } from "../../logger";
-
-const log = logger("slack:app-home");
 
 interface AppHomeOpenedContext {
   workspaceId: string;
@@ -121,9 +118,6 @@ interface MessagesTabOpenedContext {
 export async function handleMessagesTabOpened(
   context: MessagesTabOpenedContext,
 ): Promise<void> {
-  const start = Date.now();
-  log.debug("messages_tab_opened start", { userId: context.userId });
-
   const { SECRETS_ENCRYPTION_KEY } = env();
 
   // 1. Get workspace installation
@@ -132,11 +126,6 @@ export async function handleMessagesTabOpened(
     .from(slackInstallations)
     .where(eq(slackInstallations.slackWorkspaceId, context.workspaceId))
     .limit(1);
-
-  log.debug("messages_tab_opened installation lookup", {
-    found: !!installation,
-    elapsed: Date.now() - start,
-  });
 
   if (!installation) {
     return;
@@ -154,11 +143,6 @@ export async function handleMessagesTabOpened(
     )
     .limit(1);
 
-  log.debug("messages_tab_opened user link lookup", {
-    found: !!userLink,
-    elapsed: Date.now() - start,
-  });
-
   if (!userLink) {
     return;
   }
@@ -174,11 +158,6 @@ export async function handleMessagesTabOpened(
       ),
     );
 
-  log.debug("messages_tab_opened atomic update", {
-    rowCount: updated.rowCount,
-    elapsed: Date.now() - start,
-  });
-
   if (updated.rowCount === 0) {
     // Already sent — skip
     return;
@@ -193,11 +172,6 @@ export async function handleMessagesTabOpened(
     .from(slackBindings)
     .where(eq(slackBindings.slackUserLinkId, userLink.id));
 
-  log.debug("messages_tab_opened bindings lookup", {
-    count: bindings.length,
-    elapsed: Date.now() - start,
-  });
-
   // 5. Send welcome message
   const botToken = decryptCredentialValue(
     installation.encryptedBotToken,
@@ -211,8 +185,4 @@ export async function handleMessagesTabOpened(
     "Hi! I'm VM0. I can connect you to AI agents to help with your tasks.",
     { blocks: buildWelcomeMessage(bindings) },
   );
-
-  log.debug("messages_tab_opened complete", {
-    elapsed: Date.now() - start,
-  });
 }

--- a/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
@@ -1,0 +1,93 @@
+import { eq, and } from "drizzle-orm";
+import { slackInstallations } from "../../../db/schema/slack-installation";
+import { slackUserLinks } from "../../../db/schema/slack-user-link";
+import { slackBindings } from "../../../db/schema/slack-binding";
+import { decryptCredentialValue } from "../../crypto/secrets-encryption";
+import { env } from "../../../env";
+import { createSlackClient, publishAppHome, buildAppHomeView } from "../index";
+import { buildLoginUrl } from "./shared";
+import { logger } from "../../logger";
+
+const log = logger("slack:app-home");
+
+interface AppHomeOpenedContext {
+  workspaceId: string;
+  userId: string;
+}
+
+/**
+ * Handle an app_home_opened event from Slack
+ *
+ * Publishes the Home tab with account status, linked agents, and help info.
+ */
+export async function handleAppHomeOpened(
+  context: AppHomeOpenedContext,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  try {
+    // 1. Get workspace installation
+    const [installation] = await globalThis.services.db
+      .select()
+      .from(slackInstallations)
+      .where(eq(slackInstallations.slackWorkspaceId, context.workspaceId))
+      .limit(1);
+
+    if (!installation) {
+      log.error("Slack installation not found for workspace", {
+        workspaceId: context.workspaceId,
+      });
+      return;
+    }
+
+    // Decrypt bot token
+    const botToken = decryptCredentialValue(
+      installation.encryptedBotToken,
+      SECRETS_ENCRYPTION_KEY,
+    );
+    const client = createSlackClient(botToken);
+
+    // 2. Check if user is linked
+    const [userLink] = await globalThis.services.db
+      .select()
+      .from(slackUserLinks)
+      .where(
+        and(
+          eq(slackUserLinks.slackUserId, context.userId),
+          eq(slackUserLinks.slackWorkspaceId, context.workspaceId),
+        ),
+      )
+      .limit(1);
+
+    if (!userLink) {
+      // User not linked — show login prompt
+      const loginUrl = buildLoginUrl(context.workspaceId, context.userId, "");
+      const view = buildAppHomeView({
+        isLinked: false,
+        loginUrl,
+      });
+      await publishAppHome(client, context.userId, view);
+      return;
+    }
+
+    // 3. Get user's bindings
+    const bindings = await globalThis.services.db
+      .select({
+        agentName: slackBindings.agentName,
+        description: slackBindings.description,
+        enabled: slackBindings.enabled,
+      })
+      .from(slackBindings)
+      .where(eq(slackBindings.slackUserLinkId, userLink.id));
+
+    // 4. Build and publish home view
+    const view = buildAppHomeView({
+      isLinked: true,
+      vm0UserId: userLink.vm0UserId,
+      bindings,
+    });
+    await publishAppHome(client, context.userId, view);
+  } catch (error) {
+    log.error("Error handling app_home_opened", { error });
+  }
+}

--- a/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
@@ -6,9 +6,6 @@ import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import { createSlackClient, publishAppHome, buildAppHomeView } from "../index";
 import { buildLoginUrl } from "./shared";
-import { logger } from "../../logger";
-
-const log = logger("slack:app-home");
 
 interface AppHomeOpenedContext {
   workspaceId: string;
@@ -25,69 +22,75 @@ export async function handleAppHomeOpened(
 ): Promise<void> {
   const { SECRETS_ENCRYPTION_KEY } = env();
 
-  try {
-    // 1. Get workspace installation
-    const [installation] = await globalThis.services.db
-      .select()
-      .from(slackInstallations)
-      .where(eq(slackInstallations.slackWorkspaceId, context.workspaceId))
-      .limit(1);
+  // 1. Get workspace installation
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackInstallations)
+    .where(eq(slackInstallations.slackWorkspaceId, context.workspaceId))
+    .limit(1);
 
-    if (!installation) {
-      log.error("Slack installation not found for workspace", {
-        workspaceId: context.workspaceId,
-      });
-      return;
-    }
-
-    // Decrypt bot token
-    const botToken = decryptCredentialValue(
-      installation.encryptedBotToken,
-      SECRETS_ENCRYPTION_KEY,
-    );
-    const client = createSlackClient(botToken);
-
-    // 2. Check if user is linked
-    const [userLink] = await globalThis.services.db
-      .select()
-      .from(slackUserLinks)
-      .where(
-        and(
-          eq(slackUserLinks.slackUserId, context.userId),
-          eq(slackUserLinks.slackWorkspaceId, context.workspaceId),
-        ),
-      )
-      .limit(1);
-
-    if (!userLink) {
-      // User not linked — show login prompt
-      const loginUrl = buildLoginUrl(context.workspaceId, context.userId, "");
-      const view = buildAppHomeView({
-        isLinked: false,
-        loginUrl,
-      });
-      await publishAppHome(client, context.userId, view);
-      return;
-    }
-
-    // 3. Get user's bindings
-    const bindings = await globalThis.services.db
-      .select({
-        agentName: slackBindings.agentName,
-        description: slackBindings.description,
-        enabled: slackBindings.enabled,
-      })
-      .from(slackBindings)
-      .where(eq(slackBindings.slackUserLinkId, userLink.id));
-
-    // 4. Build and publish home view
-    const view = buildAppHomeView({
-      isLinked: true,
-      vm0UserId: userLink.vm0UserId,
-      bindings,
-    });
-    await publishAppHome(client, context.userId, view);
-  } catch (error) {
-    log.error("Error handling app_home_opened", { error });
+  if (!installation) {
+    return;
   }
+
+  // Decrypt bot token
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+
+  await refreshAppHome(client, context.workspaceId, context.userId);
+}
+
+/**
+ * Refresh the App Home tab for a user
+ *
+ * Reusable by other handlers (e.g. after disconnect) to update the Home tab.
+ */
+export async function refreshAppHome(
+  client: ReturnType<typeof createSlackClient>,
+  workspaceId: string,
+  userId: string,
+): Promise<void> {
+  // Check if user is linked
+  const [userLink] = await globalThis.services.db
+    .select()
+    .from(slackUserLinks)
+    .where(
+      and(
+        eq(slackUserLinks.slackUserId, userId),
+        eq(slackUserLinks.slackWorkspaceId, workspaceId),
+      ),
+    )
+    .limit(1);
+
+  if (!userLink) {
+    // User not linked — show login prompt
+    const loginUrl = buildLoginUrl(workspaceId, userId, "");
+    const view = buildAppHomeView({
+      isLinked: false,
+      loginUrl,
+    });
+    await publishAppHome(client, userId, view);
+    return;
+  }
+
+  // Get user's bindings
+  const bindings = await globalThis.services.db
+    .select({
+      agentName: slackBindings.agentName,
+      description: slackBindings.description,
+      enabled: slackBindings.enabled,
+    })
+    .from(slackBindings)
+    .where(eq(slackBindings.slackUserLinkId, userLink.id));
+
+  // Build and publish home view
+  const view = buildAppHomeView({
+    isLinked: true,
+    vm0UserId: userLink.vm0UserId,
+    bindings,
+  });
+  await publishAppHome(client, userId, view);
 }

--- a/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
@@ -79,6 +79,7 @@ export async function refreshAppHome(
   // Get user's bindings
   const bindings = await globalThis.services.db
     .select({
+      id: slackBindings.id,
       agentName: slackBindings.agentName,
       description: slackBindings.description,
       enabled: slackBindings.enabled,

--- a/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
@@ -4,8 +4,17 @@ import { slackUserLinks } from "../../../db/schema/slack-user-link";
 import { slackBindings } from "../../../db/schema/slack-binding";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
-import { createSlackClient, publishAppHome, buildAppHomeView } from "../index";
+import {
+  createSlackClient,
+  publishAppHome,
+  buildAppHomeView,
+  postMessage,
+  buildWelcomeMessage,
+} from "../index";
 import { buildLoginUrl } from "./shared";
+import { logger } from "../../logger";
+
+const log = logger("slack:app-home");
 
 interface AppHomeOpenedContext {
   workspaceId: string;
@@ -94,4 +103,116 @@ export async function refreshAppHome(
     bindings,
   });
   await publishAppHome(client, userId, view);
+}
+
+interface MessagesTabOpenedContext {
+  workspaceId: string;
+  userId: string;
+  channelId: string;
+}
+
+/**
+ * Handle an app_home_opened event with tab === "messages"
+ *
+ * Sends a one-time welcome message to linked users when they first open
+ * the Messages tab. Uses an atomic UPDATE to prevent duplicate sends.
+ * Unlinked users are skipped — they already get a login prompt on first DM.
+ */
+export async function handleMessagesTabOpened(
+  context: MessagesTabOpenedContext,
+): Promise<void> {
+  const start = Date.now();
+  log.debug("messages_tab_opened start", { userId: context.userId });
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  // 1. Get workspace installation
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackInstallations)
+    .where(eq(slackInstallations.slackWorkspaceId, context.workspaceId))
+    .limit(1);
+
+  log.debug("messages_tab_opened installation lookup", {
+    found: !!installation,
+    elapsed: Date.now() - start,
+  });
+
+  if (!installation) {
+    return;
+  }
+
+  // 2. Check if user is linked (unlinked users skip — they get a login prompt on first DM)
+  const [userLink] = await globalThis.services.db
+    .select({ id: slackUserLinks.id })
+    .from(slackUserLinks)
+    .where(
+      and(
+        eq(slackUserLinks.slackUserId, context.userId),
+        eq(slackUserLinks.slackWorkspaceId, context.workspaceId),
+      ),
+    )
+    .limit(1);
+
+  log.debug("messages_tab_opened user link lookup", {
+    found: !!userLink,
+    elapsed: Date.now() - start,
+  });
+
+  if (!userLink) {
+    return;
+  }
+
+  // 3. Atomic UPDATE — only sets dm_welcome_sent if it was false
+  const updated = await globalThis.services.db
+    .update(slackUserLinks)
+    .set({ dmWelcomeSent: true })
+    .where(
+      and(
+        eq(slackUserLinks.id, userLink.id),
+        eq(slackUserLinks.dmWelcomeSent, false),
+      ),
+    );
+
+  log.debug("messages_tab_opened atomic update", {
+    rowCount: updated.rowCount,
+    elapsed: Date.now() - start,
+  });
+
+  if (updated.rowCount === 0) {
+    // Already sent — skip
+    return;
+  }
+
+  // 4. Fetch user's agent bindings
+  const bindings = await globalThis.services.db
+    .select({
+      agentName: slackBindings.agentName,
+      description: slackBindings.description,
+    })
+    .from(slackBindings)
+    .where(eq(slackBindings.slackUserLinkId, userLink.id));
+
+  log.debug("messages_tab_opened bindings lookup", {
+    count: bindings.length,
+    elapsed: Date.now() - start,
+  });
+
+  // 5. Send welcome message
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+
+  await postMessage(
+    client,
+    context.channelId,
+    "Hi! I'm VM0. I can connect you to AI agents to help with your tasks.",
+    { blocks: buildWelcomeMessage(bindings) },
+  );
+
+  log.debug("messages_tab_opened complete", {
+    elapsed: Date.now() - start,
+  });
 }

--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -297,11 +297,13 @@ export async function handleDirectMessage(
           context.channelId,
           thinkingTs,
           errorText,
-        ).catch(() => {});
+        ).catch((e) =>
+          log.warn("Failed to update error message", { error: e }),
+        );
       } else {
         await postMessage(client, context.channelId, errorText, {
           threadTs,
-        }).catch(() => {});
+        }).catch((e) => log.warn("Failed to post error message", { error: e }));
       }
     } finally {
       // 13. Remove thinking reaction

--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -8,7 +8,6 @@ import { env } from "../../../env";
 import {
   createSlackClient,
   postMessage,
-  updateMessage,
   buildLoginPromptMessage,
   buildErrorMessage,
   buildAgentResponseMessage,
@@ -140,14 +139,6 @@ export async function handleDirectMessage(
       .then(() => true)
       .catch(() => false);
 
-    // 7. Post thinking message
-    const thinkingTs = await postMessage(
-      client,
-      context.channelId,
-      "_Thinking..._",
-      { threadTs },
-    );
-
     // Use message text directly (no mention prefix to strip in DMs)
     const messageContent = context.messageText;
 
@@ -160,7 +151,7 @@ export async function handleDirectMessage(
       botToken,
     );
 
-    // 8. Route to agent (with context for LLM routing)
+    // 7. Route to agent (with context for LLM routing)
     const routeResult = await routeMessageToAgent(
       messageContent,
       bindings,
@@ -175,20 +166,10 @@ export async function handleDirectMessage(
       selectedAgentName = bindings[0]!.agentName;
       promptText = messageContent;
     } else if (routeResult.type === "failure") {
-      if (thinkingTs) {
-        await updateMessage(
-          client,
-          context.channelId,
-          thinkingTs,
-          routeResult.error,
-          { blocks: buildErrorMessage(routeResult.error) },
-        );
-      } else {
-        await postMessage(client, context.channelId, routeResult.error, {
-          threadTs,
-          blocks: buildErrorMessage(routeResult.error),
-        });
-      }
+      await postMessage(client, context.channelId, routeResult.error, {
+        threadTs,
+        blocks: buildErrorMessage(routeResult.error),
+      });
       if (reactionAdded) {
         await removeThinkingReaction(
           client,
@@ -214,7 +195,7 @@ export async function handleDirectMessage(
       return;
     }
 
-    // 9. Find existing thread session
+    // 8. Find existing thread session
     let existingSessionId: string | undefined;
     if (threadTs) {
       const [threadSession] = await globalThis.services.db
@@ -233,7 +214,7 @@ export async function handleDirectMessage(
     }
 
     try {
-      // 10. Execute agent
+      // 9. Execute agent
       const {
         response: agentResponse,
         sessionId: newSessionId,
@@ -246,7 +227,7 @@ export async function handleDirectMessage(
         userId: userLink.vm0UserId,
       });
 
-      // 11. Create thread session mapping if new thread
+      // 10. Create thread session mapping if new thread
       if (threadTs && !existingSessionId && newSessionId) {
         await globalThis.services.db
           .insert(slackThreadSessions)
@@ -259,54 +240,28 @@ export async function handleDirectMessage(
           .onConflictDoNothing();
       }
 
-      // 12. Replace thinking message with agent response
+      // 11. Post response message
       const logsUrl = runId ? buildLogsUrl(runId) : undefined;
-      if (thinkingTs) {
-        await updateMessage(
-          client,
-          context.channelId,
-          thinkingTs,
+      await postMessage(client, context.channelId, agentResponse, {
+        threadTs,
+        blocks: buildAgentResponseMessage(
           agentResponse,
-          {
-            blocks: buildAgentResponseMessage(
-              agentResponse,
-              selectedAgentName,
-              logsUrl,
-            ),
-          },
-        );
-      } else {
-        await postMessage(client, context.channelId, agentResponse, {
-          threadTs,
-          blocks: buildAgentResponseMessage(
-            agentResponse,
-            selectedAgentName,
-            logsUrl,
-          ),
-        });
-      }
+          selectedAgentName,
+          logsUrl,
+        ),
+      });
     } catch (innerError) {
       log.error("Error posting response or creating session", {
         error: innerError,
       });
-      const errorText =
-        "Sorry, an error occurred while sending the response. Please try again.";
-      if (thinkingTs) {
-        await updateMessage(
-          client,
-          context.channelId,
-          thinkingTs,
-          errorText,
-        ).catch((e) =>
-          log.warn("Failed to update error message", { error: e }),
-        );
-      } else {
-        await postMessage(client, context.channelId, errorText, {
-          threadTs,
-        }).catch((e) => log.warn("Failed to post error message", { error: e }));
-      }
+      await postMessage(
+        client,
+        context.channelId,
+        "Sorry, an error occurred while sending the response. Please try again.",
+        { threadTs },
+      ).catch((e) => log.warn("Failed to post error message", { error: e }));
     } finally {
-      // 13. Remove thinking reaction
+      // 12. Remove thinking reaction
       if (reactionAdded) {
         await removeThinkingReaction(
           client,

--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -8,6 +8,7 @@ import { env } from "../../../env";
 import {
   createSlackClient,
   postMessage,
+  updateMessage,
   buildLoginPromptMessage,
   buildErrorMessage,
   buildAgentResponseMessage,
@@ -139,6 +140,14 @@ export async function handleDirectMessage(
       .then(() => true)
       .catch(() => false);
 
+    // 7. Post thinking message
+    const thinkingTs = await postMessage(
+      client,
+      context.channelId,
+      "_Thinking..._",
+      { threadTs },
+    );
+
     // Use message text directly (no mention prefix to strip in DMs)
     const messageContent = context.messageText;
 
@@ -151,7 +160,7 @@ export async function handleDirectMessage(
       botToken,
     );
 
-    // 7. Route to agent (with context for LLM routing)
+    // 8. Route to agent (with context for LLM routing)
     const routeResult = await routeMessageToAgent(
       messageContent,
       bindings,
@@ -166,10 +175,20 @@ export async function handleDirectMessage(
       selectedAgentName = bindings[0]!.agentName;
       promptText = messageContent;
     } else if (routeResult.type === "failure") {
-      await postMessage(client, context.channelId, routeResult.error, {
-        threadTs,
-        blocks: buildErrorMessage(routeResult.error),
-      });
+      if (thinkingTs) {
+        await updateMessage(
+          client,
+          context.channelId,
+          thinkingTs,
+          routeResult.error,
+          { blocks: buildErrorMessage(routeResult.error) },
+        );
+      } else {
+        await postMessage(client, context.channelId, routeResult.error, {
+          threadTs,
+          blocks: buildErrorMessage(routeResult.error),
+        });
+      }
       if (reactionAdded) {
         await removeThinkingReaction(
           client,
@@ -195,7 +214,7 @@ export async function handleDirectMessage(
       return;
     }
 
-    // 8. Find existing thread session
+    // 9. Find existing thread session
     let existingSessionId: string | undefined;
     if (threadTs) {
       const [threadSession] = await globalThis.services.db
@@ -214,7 +233,7 @@ export async function handleDirectMessage(
     }
 
     try {
-      // 9. Execute agent
+      // 10. Execute agent
       const {
         response: agentResponse,
         sessionId: newSessionId,
@@ -227,7 +246,7 @@ export async function handleDirectMessage(
         userId: userLink.vm0UserId,
       });
 
-      // 10. Create thread session mapping if new thread
+      // 11. Create thread session mapping if new thread
       if (threadTs && !existingSessionId && newSessionId) {
         await globalThis.services.db
           .insert(slackThreadSessions)
@@ -240,30 +259,52 @@ export async function handleDirectMessage(
           .onConflictDoNothing();
       }
 
-      // 11. Post response message
+      // 12. Replace thinking message with agent response
       const logsUrl = runId ? buildLogsUrl(runId) : undefined;
-      await postMessage(client, context.channelId, agentResponse, {
-        threadTs,
-        blocks: buildAgentResponseMessage(
+      if (thinkingTs) {
+        await updateMessage(
+          client,
+          context.channelId,
+          thinkingTs,
           agentResponse,
-          selectedAgentName,
-          logsUrl,
-        ),
-      });
+          {
+            blocks: buildAgentResponseMessage(
+              agentResponse,
+              selectedAgentName,
+              logsUrl,
+            ),
+          },
+        );
+      } else {
+        await postMessage(client, context.channelId, agentResponse, {
+          threadTs,
+          blocks: buildAgentResponseMessage(
+            agentResponse,
+            selectedAgentName,
+            logsUrl,
+          ),
+        });
+      }
     } catch (innerError) {
       log.error("Error posting response or creating session", {
         error: innerError,
       });
-      await postMessage(
-        client,
-        context.channelId,
-        "Sorry, an error occurred while sending the response. Please try again.",
-        { threadTs },
-      ).catch(() => {
-        // If even the error message fails, we can't do anything more
-      });
+      const errorText =
+        "Sorry, an error occurred while sending the response. Please try again.";
+      if (thinkingTs) {
+        await updateMessage(
+          client,
+          context.channelId,
+          thinkingTs,
+          errorText,
+        ).catch(() => {});
+      } else {
+        await postMessage(client, context.channelId, errorText, {
+          threadTs,
+        }).catch(() => {});
+      }
     } finally {
-      // 12. Remove thinking reaction
+      // 13. Remove thinking reaction
       if (reactionAdded) {
         await removeThinkingReaction(
           client,

--- a/turbo/apps/web/src/lib/slack/index.ts
+++ b/turbo/apps/web/src/lib/slack/index.ts
@@ -69,5 +69,6 @@ export {
 export { handleDirectMessage } from "./handlers/direct-message";
 export {
   handleAppHomeOpened,
+  handleMessagesTabOpened,
   refreshAppHome,
 } from "./handlers/app-home-opened";

--- a/turbo/apps/web/src/lib/slack/index.ts
+++ b/turbo/apps/web/src/lib/slack/index.ts
@@ -34,8 +34,10 @@ export { verifySlackSignature, getSlackSignatureHeaders } from "./verify";
 export {
   createSlackClient,
   postMessage,
+  updateMessage,
   openModal,
   updateModal,
+  publishAppHome,
   exchangeOAuthCode,
   isSlackInvalidAuthError,
 } from "./client";
@@ -44,6 +46,7 @@ export {
 export {
   buildAgentAddModal,
   buildAgentListMessage,
+  buildAppHomeView,
   buildErrorMessage,
   buildLoginPromptMessage,
   buildHelpMessage,
@@ -65,3 +68,4 @@ export {
 
 // Handlers
 export { handleDirectMessage } from "./handlers/direct-message";
+export { handleAppHomeOpened } from "./handlers/app-home-opened";

--- a/turbo/apps/web/src/lib/slack/index.ts
+++ b/turbo/apps/web/src/lib/slack/index.ts
@@ -68,4 +68,7 @@ export {
 
 // Handlers
 export { handleDirectMessage } from "./handlers/direct-message";
-export { handleAppHomeOpened } from "./handlers/app-home-opened";
+export {
+  handleAppHomeOpened,
+  refreshAppHome,
+} from "./handlers/app-home-opened";

--- a/turbo/apps/web/src/lib/slack/index.ts
+++ b/turbo/apps/web/src/lib/slack/index.ts
@@ -34,7 +34,6 @@ export { verifySlackSignature, getSlackSignatureHeaders } from "./verify";
 export {
   createSlackClient,
   postMessage,
-  updateMessage,
   openModal,
   updateModal,
   publishAppHome,


### PR DESCRIPTION
## Summary

- **App Home tab**: Shows account status (connected/not connected), linked agents with configure/unlink buttons, and a "Link Agent" button when no agent is linked
- **Welcome message**: One-time DM welcome when linked users first open the Messages tab, with agent info or a "Link Agent" button
- **DM improvements**: Flat chat replies for top-level DMs (no unnecessary threading), typing indicator via thinking reaction
- **App Home refresh**: Auto-refresh after login, disconnect, agent link/unlink/update
- **Link confirmation**: Ephemeral confirmation message in DMs after linking an agent from the welcome message

## Test plan

- [x] Integration tests for app home opened (home tab: linked, unlinked, with agents, no agents)
- [x] Integration tests for messages tab opened (welcome message, dedup, unlinked user skip)
- [x] Integration tests for interactive route (agent link from home, agent unlink)
- [x] Existing mention and DM tests pass with new MSW mocks for `views.publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)