### PR TITLE
fix(platform): sort events by sequenceNumber before grouping to fix unknown tool results

### DIFF
--- a/turbo/apps/platform/src/views/logs-page/log-detail/utils.ts
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/utils.ts
@@ -633,13 +633,17 @@ function processUserEvent(
 export function groupEventsIntoMessages(
   events: AgentEvent[],
 ): GroupedMessage[] {
+  const sorted = [...events].sort(
+    (a, b) => a.sequenceNumber - b.sequenceNumber,
+  );
+
   const ctx: GroupingContext = {
     grouped: [],
     pendingToolUses: new Map(),
     todoState: new Map(),
   };
 
-  for (const event of events) {
+  for (const event of sorted) {
     const eventData = event.eventData as GroupingEventData;
 
     if (event.eventType === "system") {


### PR DESCRIPTION
## Summary

- Fix "unknown tool result" display bug in the log detail page by sorting events by `sequenceNumber` before grouping them into messages
- When events arrive out of order (e.g., `tool_result` before `tool_use`), the grouping logic failed to match results to their tool uses, causing them to appear as "unknown"
- Add integration test verifying correct tool result linking when events arrive out of sequence

## Test plan

- [x] New test: "should link tool_result to tool_use when events arrive out of order" passes
- [x] All 50 existing utils tests continue to pass
- [ ] Verify on staging that log detail pages no longer show "unknown" for tool results

🤖 Generated with [Claude Code](https://claude.com/claude-code)