### PR TITLE
chore(web): update landing page model name from Sonnet 4.5 to Opus 4.6

### DIFF
--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -555,7 +555,7 @@ export default function LandingPage({ claudeCodeVersion }: LandingPageProps) {
                               {claudeCodeVersion && ` ${claudeCodeVersion}`}
                             </p>
                             <p className="m-0 text-[#827d77]">
-                              Sonnet 4.5 · Claude API
+                              Opus 4.6 · Claude API
                             </p>
                             <p className="m-0 text-[#827d77]">/Users/ming</p>
                           </div>
@@ -2582,7 +2582,7 @@ export default function LandingPage({ claudeCodeVersion }: LandingPageProps) {
                             {claudeCodeVersion && ` ${claudeCodeVersion}`}
                           </p>
                           <p className="m-0 text-[#827d77]">
-                            Sonnet 4.5 · Claude API
+                            Opus 4.6 · Claude API
                           </p>
                           <p className="m-0 text-[#827d77]">/Users/ming</p>
                         </div>


### PR DESCRIPTION
## Summary
- Update the displayed model name in the landing page terminal UI from "Sonnet 4.5" to "Opus 4.6" to reflect the latest Claude model

## Test plan
- [ ] Verify landing page renders correctly with the updated model name
- [ ] Check both desktop and mobile terminal UI sections display "Opus 4.6 · Claude API"

🤖 Generated with [Claude Code](https://claude.com/claude-code)