### PR TITLE
feat(web): handle agent timeout with user notification in Slack threads

### DIFF
--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../../src/__tests__/slack/api-helpers";
 import { handlers, http } from "../../../../../src/__tests__/msw";
 import { POST } from "../route";
+import * as runAgentModule from "../../../../../src/lib/slack/handlers/run-agent";
 
 vi.mock("@clerk/nextjs/server");
 vi.mock("@e2b/code-interpreter");
@@ -369,6 +370,59 @@ describe("POST /api/slack/events", () => {
         .join("");
       expect(sectionTexts).not.toContain(":warning:");
       expect(sectionTexts).not.toContain("Agent timed out");
+    });
+
+    it("should include timeout warning prefix when agent times out", async () => {
+      // Given I am a linked Slack user with one agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      await givenUserHasAgent(userLink, {
+        agentName: "my-helper",
+        description: "A helpful assistant",
+      });
+
+      // And runAgentForSlack returns a timeout result
+      vi.spyOn(runAgentModule, "runAgentForSlack").mockResolvedValueOnce({
+        status: "timeout",
+        response:
+          "The agent timed out after 30 minutes. You can check the logs for more details.",
+        sessionId: undefined,
+        runId: "test-run-id",
+      });
+
+      // When I @mention the VM0 bot
+      const request = createSlackEventRequest({
+        teamId: installation.slackWorkspaceId,
+        channelId: "C123",
+        userId: userLink.slackUserId,
+        text: `<@${installation.botUserId}> help me with this code`,
+        ts: "1234567890.123456",
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // Then the response should include the timeout warning prefix
+      expect(slackHandlers.mocked.postMessage).toHaveBeenCalledTimes(1);
+      const data = await getFormData(slackHandlers.mocked.postMessage);
+      const text = (data.text as string) ?? "";
+      expect(text).toContain(":warning:");
+      expect(text).toContain("Agent timed out");
+      expect(text).toContain("timed out after 30 minutes");
+
+      // And the blocks should contain the agent name and logs link
+      const blocks = JSON.parse((data.blocks as string) ?? "[]") as Array<{
+        type: string;
+        elements?: Array<{ text?: string }>;
+      }>;
+      const contextBlocks = blocks.filter((b) => b.type === "context");
+      // First context block: agent name
+      expect(contextBlocks[0]!.elements?.[0]?.text).toContain("my-helper");
+      // Last context block: logs link
+      const logsBlock = contextBlocks[contextBlocks.length - 1]!;
+      expect(logsBlock.elements?.[0]?.text).toContain("test-run-id");
+
+      // And the thinking reaction should still be removed
+      expect(slackHandlers.mocked.reactionsRemove).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -651,6 +651,88 @@ describe("POST /api/slack/events", () => {
       // 4. Thinking reaction should be removed
       expect(slackHandlers.mocked.reactionsRemove).toHaveBeenCalledTimes(1);
     });
+
+    it("should not include timeout warning prefix when agent fails", async () => {
+      // Given I am a linked Slack user with one agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      await givenUserHasAgent(userLink, {
+        agentName: "my-helper",
+        description: "A helpful assistant",
+      });
+
+      // When I send a DM to the bot (agent will fail due to test environment)
+      const request = createSlackDmEventRequest({
+        teamId: installation.slackWorkspaceId,
+        channelId: "D123",
+        userId: userLink.slackUserId,
+        text: "help me with this code",
+        ts: "1234567890.123456",
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // Then the response should contain an error message (failed status)
+      expect(slackHandlers.mocked.postMessage).toHaveBeenCalledTimes(1);
+      const data = await getFormData(slackHandlers.mocked.postMessage);
+      const text = (data.text as string) ?? "";
+      expect(text).toContain("Error");
+
+      // And the response should NOT include the timeout warning prefix
+      expect(text).not.toContain(":warning:");
+      expect(text).not.toContain("Agent timed out");
+    });
+
+    it("should include timeout warning prefix when agent times out", async () => {
+      // Given I am a linked Slack user with one agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      await givenUserHasAgent(userLink, {
+        agentName: "my-helper",
+        description: "A helpful assistant",
+      });
+
+      // And runAgentForSlack returns a timeout result
+      vi.spyOn(runAgentModule, "runAgentForSlack").mockResolvedValueOnce({
+        status: "timeout",
+        response:
+          "The agent timed out after 30 minutes. You can check the logs for more details.",
+        sessionId: undefined,
+        runId: "test-run-id",
+      });
+
+      // When I send a DM to the bot
+      const request = createSlackDmEventRequest({
+        teamId: installation.slackWorkspaceId,
+        channelId: "D123",
+        userId: userLink.slackUserId,
+        text: "help me with this code",
+        ts: "1234567890.123456",
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // Then the response should include the timeout warning prefix
+      expect(slackHandlers.mocked.postMessage).toHaveBeenCalledTimes(1);
+      const data = await getFormData(slackHandlers.mocked.postMessage);
+      const text = (data.text as string) ?? "";
+      expect(text).toContain(":warning:");
+      expect(text).toContain("Agent timed out");
+      expect(text).toContain("timed out after 30 minutes");
+
+      // And the blocks should contain the agent name and logs link
+      const blocks = JSON.parse((data.blocks as string) ?? "[]") as Array<{
+        type: string;
+        elements?: Array<{ text?: string }>;
+      }>;
+      const contextBlocks = blocks.filter((b) => b.type === "context");
+      expect(contextBlocks[0]!.elements?.[0]?.text).toContain("my-helper");
+      const logsBlock = contextBlocks[contextBlocks.length - 1]!;
+      expect(logsBlock.elements?.[0]?.text).toContain("test-run-id");
+
+      // And the thinking reaction should still be removed
+      expect(slackHandlers.mocked.reactionsRemove).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("Scenario: DM bot with greeting message", () => {

--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -326,6 +326,50 @@ describe("POST /api/slack/events", () => {
       // 4. Thinking reaction should be removed
       expect(slackHandlers.mocked.reactionsRemove).toHaveBeenCalledTimes(1);
     });
+
+    it("should not include timeout warning prefix when agent fails", async () => {
+      // Given I am a linked Slack user with one agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      await givenUserHasAgent(userLink, {
+        agentName: "my-helper",
+        description: "A helpful assistant",
+      });
+
+      // When I @mention the VM0 bot (agent will fail due to test environment)
+      const request = createSlackEventRequest({
+        teamId: installation.slackWorkspaceId,
+        channelId: "C123",
+        userId: userLink.slackUserId,
+        text: `<@${installation.botUserId}> help me with this code`,
+        ts: "1234567890.123456",
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // Then the response should contain an error message (failed status)
+      expect(slackHandlers.mocked.postMessage).toHaveBeenCalledTimes(1);
+      const data = await getFormData(slackHandlers.mocked.postMessage);
+      const text = (data.text as string) ?? "";
+      expect(text).toContain("Error");
+
+      // And the response should NOT include the timeout warning prefix
+      // (timeout prefix ":warning: *Agent timed out*" is only added for timeout status)
+      expect(text).not.toContain(":warning:");
+      expect(text).not.toContain("Agent timed out");
+
+      // And the blocks should also not contain timeout warning
+      const blocks = JSON.parse((data.blocks as string) ?? "[]") as Array<{
+        type: string;
+        text?: { text?: string };
+      }>;
+      const sectionTexts = blocks
+        .filter((b) => b.type === "section")
+        .map((b) => b.text?.text ?? "")
+        .join("");
+      expect(sectionTexts).not.toContain(":warning:");
+      expect(sectionTexts).not.toContain("Agent timed out");
+    });
   });
 
   describe("Scenario: Mention bot with multiple agents (explicit selection)", () => {

--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -216,6 +216,7 @@ export async function handleDirectMessage(
     try {
       // 9. Execute agent
       const {
+        status: runStatus,
         response: agentResponse,
         sessionId: newSessionId,
         runId,
@@ -242,10 +243,14 @@ export async function handleDirectMessage(
 
       // 11. Post response message
       const logsUrl = runId ? buildLogsUrl(runId) : undefined;
-      await postMessage(client, context.channelId, agentResponse, {
+      const responseText =
+        runStatus === "timeout"
+          ? `:warning: *Agent timed out*\n${agentResponse}`
+          : agentResponse;
+      await postMessage(client, context.channelId, responseText, {
         threadTs,
         blocks: buildAgentResponseMessage(
-          agentResponse,
+          responseText,
           selectedAgentName,
           logsUrl,
         ),


### PR DESCRIPTION
## Summary
- Add `status` field (`completed` | `failed` | `timeout`) to `RunAgentResult` in `run-agent.ts` so callers can distinguish timeout from success/error
- Update timeout message to clearly indicate the 30-minute timeout occurred
- In `mention.ts`, prefix timeout responses with `:warning: *Agent timed out*` for clear visual indication
- Reuse existing `buildAgentResponseMessage()` to display agent name and logs URL in timeout notifications

Closes #2471

## Test plan
- [ ] Verify type check and lint pass (`pnpm turbo run check-types lint --filter=web`)
- [ ] Verify existing Slack tests pass (`pnpm vitest run apps/web/src/lib/slack`)
- [ ] Manual test: trigger agent timeout in Slack and verify notification appears with agent name, warning, and logs link

🤖 Generated with [Claude Code](https://claude.com/claude-code)