### PR TITLE
feat(slack): allow composing agents from github in agent link command

### DIFF
--- a/turbo/apps/web/app/api/compose/from-github/route.ts
+++ b/turbo/apps/web/app/api/compose/from-github/route.ts
@@ -6,38 +6,13 @@ import {
 import { composeJobsMainContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { composeJobs } from "../../../../src/db/schema/compose-job";
-import { and, eq, inArray } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
-import { generateComposeJobToken } from "../../../../src/lib/auth/sandbox-token";
-import { Sandbox } from "@e2b/code-interpreter";
-import { e2bConfig } from "../../../../src/lib/e2b/config";
 import { logger } from "../../../../src/lib/logger";
+import { triggerComposeJob } from "../../../../src/lib/compose/trigger-compose-job";
 import type { ComposeJobResult } from "../../../../src/db/schema/compose-job";
 
 const log = logger("api:compose-from-github");
-
-/**
- * Get API URL for sandbox to call back.
- * Falls back based on environment: preview -> production -> localhost.
- */
-function getApiUrl(): string {
-  const envVars = globalThis.services?.env;
-  const vercelEnv = process.env.VERCEL_ENV;
-  const vercelUrl = process.env.VERCEL_URL;
-
-  let apiUrl = envVars?.VM0_API_URL || process.env.VM0_API_URL;
-  if (!apiUrl) {
-    if (vercelEnv === "preview" && vercelUrl) {
-      apiUrl = `https://${vercelUrl}`;
-    } else if (vercelEnv === "production") {
-      apiUrl = "https://www.vm0.ai";
-    } else {
-      apiUrl = "http://localhost:3000";
-    }
-  }
-
-  return apiUrl;
-}
 
 /**
  * Format job record for API response
@@ -46,11 +21,11 @@ function formatJobResponse(job: {
   id: string;
   status: string;
   githubUrl: string;
-  result: ComposeJobResult | null;
-  error: string | null;
+  result?: ComposeJobResult | null;
+  error?: string | null;
   createdAt: Date;
-  startedAt: Date | null;
-  completedAt: Date | null;
+  startedAt?: Date | null;
+  completedAt?: Date | null;
 }) {
   return {
     jobId: job.id,
@@ -62,239 +37,6 @@ function formatJobResponse(job: {
     startedAt: job.startedAt?.toISOString(),
     completedAt: job.completedAt?.toISOString(),
   };
-}
-
-/**
- * Inline sandbox script for compose-from-github.
- *
- * This script runs in E2B sandbox and:
- * 1. Installs vm0 CLI
- * 2. Executes `vm0 compose <github_url> --yes --experimental-shared-compose`
- * 3. Parses CLI output and sends result to webhook
- *
- * Using CLI ensures full feature parity including:
- * - Skills download and frontmatter parsing
- * - Automatic secrets/vars injection from skills
- * - Instructions file handling
- */
-const COMPOSE_SANDBOX_SCRIPT = `
-const { spawnSync } = require('child_process');
-
-// Environment variables
-const JOB_ID = process.env.VM0_JOB_ID || '';
-const GITHUB_URL = process.env.VM0_GITHUB_URL || '';
-const VM0_TOKEN = process.env.VM0_TOKEN || '';
-const VM0_API_URL = process.env.VM0_API_URL || '';
-const WEBHOOK_URL = process.env.VM0_WEBHOOK_URL || '';
-const WEBHOOK_TOKEN = process.env.VM0_WEBHOOK_TOKEN || '';
-const VERCEL_BYPASS = process.env.VERCEL_PROTECTION_BYPASS || '';
-
-function log(level, msg) {
-  const ts = new Date().toISOString();
-  console.error('[' + ts + '] [' + level + '] [compose-github] ' + msg);
-}
-
-async function httpPost(url, data) {
-  const headers = {
-    'Content-Type': 'application/json',
-    'Authorization': 'Bearer ' + WEBHOOK_TOKEN,
-  };
-  if (VERCEL_BYPASS) {
-    headers['x-vercel-protection-bypass'] = VERCEL_BYPASS;
-  }
-
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    try {
-      const response = await fetch(url, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(data),
-      });
-
-      if (response.ok) {
-        const text = await response.text();
-        return text ? JSON.parse(text) : {};
-      }
-
-      const errorText = await response.text().catch(() => '');
-      log('WARN', 'HTTP POST failed (attempt ' + attempt + '/3): HTTP ' + response.status + ' - ' + errorText);
-    } catch (error) {
-      log('WARN', 'HTTP POST failed (attempt ' + attempt + '/3): ' + error.message);
-    }
-    if (attempt < 3) await new Promise(r => setTimeout(r, 1000));
-  }
-  return null;
-}
-
-async function reportCompletion(success, result, error) {
-  const payload = { jobId: JOB_ID, success };
-  if (result) payload.result = result;
-  if (error) payload.error = error;
-
-  log('INFO', 'Reporting to webhook...');
-  const response = await httpPost(WEBHOOK_URL, payload);
-  if (response) {
-    log('INFO', 'Reported successfully');
-  } else {
-    log('ERROR', 'Failed to report to webhook');
-  }
-}
-
-async function main() {
-  log('INFO', 'Starting compose job: ' + JOB_ID);
-  log('INFO', 'GitHub URL: ' + GITHUB_URL);
-  log('INFO', 'API URL: ' + VM0_API_URL);
-
-  // Validate
-  if (!JOB_ID || !GITHUB_URL || !VM0_TOKEN || !VM0_API_URL || !WEBHOOK_URL || !WEBHOOK_TOKEN) {
-    await reportCompletion(false, null, 'Missing required environment variables');
-    process.exit(1);
-  }
-
-  // Execute vm0 compose with --porcelain for structured output
-  // CLI is pre-installed in the vm0-cli template
-  log('INFO', 'Running vm0 compose...');
-  const result = spawnSync('vm0', [
-    'compose',
-    GITHUB_URL,
-    '--experimental-shared-compose',
-    '--porcelain',
-  ], {
-    env: {
-      ...process.env,
-      VM0_TOKEN: VM0_TOKEN,
-      VM0_API_URL: VM0_API_URL,
-    },
-    encoding: 'utf-8',
-    timeout: 180000, // 3 minutes
-  });
-
-  const stdout = result.stdout || '';
-  const stderr = result.stderr || '';
-
-  log('INFO', 'CLI exit code: ' + result.status);
-  if (stderr) log('INFO', 'stderr: ' + stderr);
-
-  // Parse JSON output from CLI
-  let cliResult;
-  try {
-    cliResult = JSON.parse(stdout.trim());
-  } catch (parseError) {
-    log('ERROR', 'Failed to parse CLI JSON output: ' + stdout);
-    await reportCompletion(false, null, 'Failed to parse CLI output: ' + stdout.slice(0, 200));
-    process.exit(1);
-  }
-
-  // Check for error in CLI output
-  if (cliResult.error) {
-    log('ERROR', 'CLI error: ' + cliResult.error);
-    await reportCompletion(false, null, cliResult.error);
-    process.exit(1);
-  }
-
-  // Report success with structured result
-  log('INFO', 'Compose result: ' + JSON.stringify(cliResult));
-  await reportCompletion(true, {
-    composeId: cliResult.composeId,
-    composeName: cliResult.composeName,
-    versionId: cliResult.versionId,
-    warnings: [],
-  }, null);
-
-  log('INFO', 'Done!');
-}
-
-main().catch(async (error) => {
-  log('ERROR', 'Fatal: ' + error.message);
-  await reportCompletion(false, null, error.message);
-  process.exit(1);
-});
-`;
-
-/**
- * Spawn E2B sandbox for compose job (fire-and-forget)
- *
- * @param jobId - The compose job ID
- * @param githubUrl - GitHub URL to compose from
- * @param userToken - User's CLI token for API authentication
- * @param webhookToken - Short-lived token for webhook callback
- */
-async function spawnComposeJobSandbox(
-  jobId: string,
-  githubUrl: string,
-  userToken: string,
-  webhookToken: string,
-): Promise<void> {
-  const apiUrl = getApiUrl();
-  const webhookUrl = `${apiUrl}/api/webhooks/compose/complete`;
-
-  log.debug(`Creating sandbox for job ${jobId}...`);
-
-  // Create sandbox with 5-minute timeout
-  // Use vm0-cli template which has CLI pre-installed for faster execution
-  const sandbox = await Sandbox.create(e2bConfig.cliTemplate, {
-    timeoutMs: 5 * 60 * 1000, // 5 minutes
-    envs: {
-      VM0_JOB_ID: jobId,
-      VM0_GITHUB_URL: githubUrl,
-      VM0_TOKEN: userToken, // User's real token for CLI
-      VM0_API_URL: apiUrl,
-      VM0_WEBHOOK_URL: webhookUrl,
-      VM0_WEBHOOK_TOKEN: webhookToken, // Short-lived token for webhook
-      // Add Vercel protection bypass if available
-      ...(process.env.VERCEL_AUTOMATION_BYPASS_SECRET && {
-        VERCEL_PROTECTION_BYPASS: process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
-      }),
-    },
-  });
-
-  log.debug(`Sandbox created: ${sandbox.sandboxId}`);
-
-  // Update job with sandbox ID and set status to running
-  await globalThis.services.db
-    .update(composeJobs)
-    .set({
-      sandboxId: sandbox.sandboxId,
-      status: "running",
-      startedAt: new Date(),
-    })
-    .where(eq(composeJobs.id, jobId));
-
-  // Write and run inline script
-  const scriptPath = "/tmp/compose-github.js";
-  await sandbox.files.write(scriptPath, COMPOSE_SANDBOX_SCRIPT);
-
-  // Run in background - don't await
-  sandbox.commands
-    .run(`node ${scriptPath}`, { timeoutMs: 5 * 60 * 1000 })
-    .catch(async (error) => {
-      // Extract detailed error info from E2B command result
-      const errorResult = error as {
-        result?: { stdout?: string; stderr?: string };
-      };
-      const stdout = errorResult.result?.stdout || "";
-      const stderr = errorResult.result?.stderr || "";
-      const errorMessage =
-        stderr ||
-        stdout ||
-        (error instanceof Error ? error.message : "Unknown error");
-
-      log.error(`Sandbox script failed for job ${jobId}:`);
-      log.error(`  stdout: ${stdout}`);
-      log.error(`  stderr: ${stderr}`);
-
-      // Update job status to failed since webhook won't be called
-      await globalThis.services.db
-        .update(composeJobs)
-        .set({
-          status: "failed",
-          error: errorMessage.slice(0, 1000), // Limit error length
-          completedAt: new Date(),
-        })
-        .where(eq(composeJobs.id, jobId));
-    });
-
-  log.debug(`Compose script started for job ${jobId}`);
 }
 
 const router = tsr.router(composeJobsMainContract, {
@@ -313,41 +55,6 @@ const router = tsr.router(composeJobsMainContract, {
 
     const { githubUrl, overwrite } = body;
 
-    // Idempotency: Check for existing active job for this user
-    const [existingJob] = await globalThis.services.db
-      .select()
-      .from(composeJobs)
-      .where(
-        and(
-          eq(composeJobs.userId, userId),
-          inArray(composeJobs.status, ["pending", "running"]),
-        ),
-      )
-      .limit(1);
-
-    if (existingJob) {
-      log.debug(`Returning existing job ${existingJob.id} for user ${userId}`);
-      return {
-        status: 200 as const,
-        body: formatJobResponse(existingJob),
-      };
-    }
-
-    // Create new job
-    const jobId = crypto.randomUUID();
-    const [newJob] = await globalThis.services.db
-      .insert(composeJobs)
-      .values({
-        id: jobId,
-        userId,
-        githubUrl,
-        overwrite: overwrite ?? false,
-        status: "pending",
-      })
-      .returning();
-
-    log.debug(`Created new job ${jobId} for user ${userId}`);
-
     // Extract user token from Authorization header
     const userToken = headers.authorization?.substring(7); // Remove "Bearer "
     if (!userToken) {
@@ -362,31 +69,38 @@ const router = tsr.router(composeJobsMainContract, {
       };
     }
 
-    // Generate webhook token (short-lived, for callback only)
-    const webhookToken = await generateComposeJobToken(userId, jobId);
+    const result = await triggerComposeJob({
+      userId,
+      githubUrl,
+      userToken,
+      overwrite,
+    });
 
-    // Fire-and-forget: Spawn sandbox asynchronously
-    spawnComposeJobSandbox(jobId, githubUrl, userToken, webhookToken).catch(
-      async (error) => {
-        log.error(`Failed to spawn sandbox for job ${jobId}:`, error);
-        // Update job status to failed
-        await globalThis.services.db
-          .update(composeJobs)
-          .set({
-            status: "failed",
-            error:
-              error instanceof Error
-                ? error.message
-                : "Failed to create sandbox",
-            completedAt: new Date(),
-          })
-          .where(eq(composeJobs.id, jobId));
-      },
-    );
+    if (result.isExisting) {
+      // Fetch the full job record for the existing job response (may have result/error)
+      const [job] = await globalThis.services.db
+        .select()
+        .from(composeJobs)
+        .where(eq(composeJobs.id, result.jobId))
+        .limit(1);
 
+      log.debug(`Returning existing job ${result.jobId} for user ${userId}`);
+      return {
+        status: 200 as const,
+        body: formatJobResponse(job!),
+      };
+    }
+
+    // For new jobs, use the data from triggerComposeJob directly
+    // (avoids race condition where sandbox may have already updated status)
     return {
       status: 201 as const,
-      body: formatJobResponse(newJob!),
+      body: formatJobResponse({
+        id: result.jobId,
+        status: result.status,
+        githubUrl: result.githubUrl,
+        createdAt: result.createdAt,
+      }),
     };
   },
 });

--- a/turbo/apps/web/app/api/slack/commands/route.ts
+++ b/turbo/apps/web/app/api/slack/commands/route.ts
@@ -458,12 +458,20 @@ async function handleAgentAdd(
     .where(eq(agentComposes.userId, vm0UserId));
 
   if (composes.length === 0) {
-    return NextResponse.json({
-      response_type: "ephemeral",
-      blocks: buildErrorMessage(
-        "You don't have any agents in VM0 yet.\n\nCreate one first with the VM0 CLI: `vm0 build`",
-      ),
+    // No existing agents — open modal in GitHub URL mode so user can compose one
+    const modal = buildAgentAddModal(
+      [],
+      undefined,
+      payload.channel_id,
+      "github",
+    );
+
+    await client.views.open({
+      trigger_id: payload.trigger_id,
+      view: modal,
     });
+
+    return new NextResponse(null, { status: 200 });
   }
 
   // Get already bound agent names

--- a/turbo/apps/web/app/api/webhooks/compose/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/compose/complete/__tests__/route.test.ts
@@ -15,6 +15,8 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { givenLinkedSlackUser } from "../../../../../../src/__tests__/slack/api-helpers";
+import { triggerComposeJob } from "../../../../../../src/lib/compose/trigger-compose-job";
+import { Sandbox } from "@e2b/code-interpreter";
 import { randomUUID } from "crypto";
 import { handlers, http } from "../../../../../../src/__tests__/msw";
 import { server } from "../../../../../../src/mocks/server";
@@ -600,6 +602,67 @@ describe("POST /api/webhooks/compose/complete", () => {
 
       // Verify Slack notification was NOT sent
       expect(postEphemeralCalled).toBe(false);
+    });
+
+    it("should send Slack failure notification when sandbox creation fails", async () => {
+      // Set up a linked Slack user
+      const { userLink, installation } = await givenLinkedSlackUser();
+
+      // Use a deferred promise so we can control when Sandbox.create rejects.
+      // This ensures the slack_compose_requests record is inserted before the
+      // failure handler runs.
+      let rejectSandbox!: (err: Error) => void;
+      const sandboxPromise = new Promise<never>((_resolve, reject) => {
+        rejectSandbox = reject;
+      });
+      const mockCreate = vi.mocked(Sandbox.create);
+      mockCreate.mockReturnValueOnce(sandboxPromise);
+
+      // Mock Slack API for notification
+      let postEphemeralCalled = false;
+      const slackMock = handlers({
+        postEphemeral: http.post(
+          "https://slack.com/api/chat.postEphemeral",
+          () => {
+            postEphemeralCalled = true;
+            return HttpResponse.json({
+              ok: true,
+              message_ts: `${Date.now()}.000000`,
+            });
+          },
+        ),
+      });
+      server.use(...slackMock.handlers);
+
+      // Trigger compose job (sandbox creation is pending)
+      const result = await triggerComposeJob({
+        userId: userLink.vm0UserId,
+        githubUrl: "https://github.com/owner/failing-repo",
+        userToken: "test-token",
+      });
+
+      // Insert slack_compose_requests record (simulating what Slack handler does)
+      await createTestSlackComposeRequest({
+        composeJobId: result.jobId,
+        slackWorkspaceId: installation.slackWorkspaceId,
+        slackUserId: userLink.slackUserId,
+        slackChannelId: "C-test-channel",
+      });
+
+      // Now reject the sandbox creation — this triggers the failure handler
+      rejectSandbox(new Error("E2B API unavailable"));
+
+      // Wait for the fire-and-forget catch handler to complete
+      await vi.waitFor(
+        () => {
+          expect(postEphemeralCalled).toBe(true);
+        },
+        { timeout: 5000 },
+      );
+
+      // Verify slack_compose_requests record was cleaned up
+      const remaining = await findTestSlackComposeRequest(result.jobId);
+      expect(remaining).toBeUndefined();
     });
   });
 

--- a/turbo/apps/web/app/api/webhooks/compose/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/compose/complete/__tests__/route.test.ts
@@ -6,13 +6,19 @@ import {
   createTestRequest,
   createTestComposeJobToken,
   createTestCliToken,
+  createTestSlackComposeRequest,
+  findTestSlackComposeRequest,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { givenLinkedSlackUser } from "../../../../../../src/__tests__/slack/api-helpers";
 import { randomUUID } from "crypto";
+import { handlers, http } from "../../../../../../src/__tests__/msw";
+import { server } from "../../../../../../src/mocks/server";
+import { HttpResponse } from "msw";
 
 vi.mock("@clerk/nextjs/server");
 vi.mock("@e2b/code-interpreter");
@@ -454,6 +460,146 @@ describe("POST /api/webhooks/compose/complete", () => {
       const job = await getTestComposeJobViaApi(testJobId, user.userId);
 
       expect(job.error).toBe("Original error");
+    });
+  });
+
+  describe("Slack Notification", () => {
+    it("should send Slack notification on success for Slack-initiated job", async () => {
+      // Set up a linked Slack user
+      const { userLink, installation } = await givenLinkedSlackUser();
+
+      // Create a compose job for this user
+      const cliToken = await createTestCliToken(userLink.vm0UserId);
+      mockClerk({ userId: null });
+
+      const createRequest = createTestRequest(
+        "http://localhost:3000/api/compose/from-github",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${cliToken}`,
+          },
+          body: JSON.stringify({
+            githubUrl: "https://github.com/owner/slack-test-repo",
+          }),
+        },
+      );
+      const createResponse = await createComposeJob(createRequest);
+      const createData = await createResponse.json();
+      const jobId = createData.jobId;
+
+      // Insert slack_compose_requests record (simulating what the Slack handler does)
+      await createTestSlackComposeRequest({
+        composeJobId: jobId,
+        slackWorkspaceId: installation.slackWorkspaceId,
+        slackUserId: userLink.slackUserId,
+        slackChannelId: "C-test-channel",
+      });
+
+      // Mock Slack API for notification
+      let postEphemeralCalled = false;
+      let postEphemeralPayload: Record<string, unknown> = {};
+      const slackMock = handlers({
+        postEphemeral: http.post(
+          "https://slack.com/api/chat.postEphemeral",
+          async ({ request }) => {
+            postEphemeralCalled = true;
+            const body = await request.formData();
+            postEphemeralPayload = {
+              channel: body.get("channel"),
+              user: body.get("user"),
+            };
+            return HttpResponse.json({
+              ok: true,
+              message_ts: `${Date.now()}.000000`,
+            });
+          },
+        ),
+      });
+      server.use(...slackMock.handlers);
+
+      // Complete the job via webhook
+      const token = await createTestComposeJobToken(userLink.vm0UserId, jobId);
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/compose/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            jobId,
+            success: true,
+            result: {
+              composeId: "test-compose-id",
+              composeName: "my-agent",
+              versionId: "test-version-id",
+              warnings: [],
+            },
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      // Verify Slack notification was sent
+      expect(postEphemeralCalled).toBe(true);
+      expect(postEphemeralPayload.channel).toBe("C-test-channel");
+      expect(postEphemeralPayload.user).toBe(userLink.slackUserId);
+
+      // Verify slack_compose_requests record was cleaned up
+      const remaining = await findTestSlackComposeRequest(jobId);
+      expect(remaining).toBeUndefined();
+    });
+
+    it("should NOT send Slack notification for non-Slack jobs", async () => {
+      // This test uses the default testJobId which has no slack_compose_requests record
+      const result = {
+        composeId: "test-compose-id",
+        composeName: "test-compose",
+        versionId: "test-version-id",
+        warnings: [],
+      };
+
+      let postEphemeralCalled = false;
+      const slackMock = handlers({
+        postEphemeral: http.post(
+          "https://slack.com/api/chat.postEphemeral",
+          () => {
+            postEphemeralCalled = true;
+            return HttpResponse.json({
+              ok: true,
+              message_ts: `${Date.now()}.000000`,
+            });
+          },
+        ),
+      });
+      server.use(...slackMock.handlers);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/compose/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            jobId: testJobId,
+            success: true,
+            result,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      // Verify Slack notification was NOT sent
+      expect(postEphemeralCalled).toBe(false);
     });
   });
 

--- a/turbo/apps/web/src/db/db.ts
+++ b/turbo/apps/web/src/db/db.ts
@@ -20,6 +20,7 @@ import * as slackInstallationSchema from "./schema/slack-installation";
 import * as slackUserLinkSchema from "./schema/slack-user-link";
 import * as slackBindingSchema from "./schema/slack-binding";
 import * as slackThreadSessionSchema from "./schema/slack-thread-session";
+import * as slackComposeRequestSchema from "./schema/slack-compose-request";
 import * as variableSchema from "./schema/variable";
 import * as composeJobSchema from "./schema/compose-job";
 import * as connectorSchema from "./schema/connector";
@@ -48,6 +49,7 @@ export const schema = {
   ...slackUserLinkSchema,
   ...slackBindingSchema,
   ...slackThreadSessionSchema,
+  ...slackComposeRequestSchema,
   ...variableSchema,
   ...composeJobSchema,
   ...connectorSchema,

--- a/turbo/apps/web/src/db/migrations/0074_add_slack_compose_requests.sql
+++ b/turbo/apps/web/src/db/migrations/0074_add_slack_compose_requests.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "slack_compose_requests" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"compose_job_id" uuid NOT NULL,
+	"slack_workspace_id" varchar(255) NOT NULL,
+	"slack_user_id" varchar(255) NOT NULL,
+	"slack_channel_id" varchar(255) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_slack_compose_requests_job" ON "slack_compose_requests" USING btree ("compose_job_id");
+--> statement-breakpoint
+ALTER TABLE "slack_compose_requests" ADD CONSTRAINT "slack_compose_requests_compose_job_id_compose_jobs_id_fk" FOREIGN KEY ("compose_job_id") REFERENCES "public"."compose_jobs"("id") ON DELETE cascade ON UPDATE no action;

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -519,6 +519,13 @@
       "when": 1769800000000,
       "tag": "0073_add_usage_daily",
       "breakpoints": true
+    },
+    {
+      "idx": 74,
+      "version": "7",
+      "when": 1769900000000,
+      "tag": "0074_add_slack_compose_requests",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/slack-compose-request.ts
+++ b/turbo/apps/web/src/db/schema/slack-compose-request.ts
@@ -1,0 +1,30 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  timestamp,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { composeJobs } from "./compose-job";
+
+/**
+ * Slack Compose Requests table
+ * Tracks which compose jobs were initiated from Slack
+ * Keeps Slack context separate from the compose_jobs domain
+ */
+export const slackComposeRequests = pgTable(
+  "slack_compose_requests",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    composeJobId: uuid("compose_job_id")
+      .notNull()
+      .references(() => composeJobs.id, { onDelete: "cascade" }),
+    slackWorkspaceId: varchar("slack_workspace_id", { length: 255 }).notNull(),
+    slackUserId: varchar("slack_user_id", { length: 255 }).notNull(),
+    slackChannelId: varchar("slack_channel_id", { length: 255 }).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("idx_slack_compose_requests_job").on(table.composeJobId),
+  ],
+);

--- a/turbo/apps/web/src/lib/auth/cli-token-service.ts
+++ b/turbo/apps/web/src/lib/auth/cli-token-service.ts
@@ -1,0 +1,25 @@
+import crypto from "crypto";
+import { cliTokens } from "../../db/schema/cli-tokens";
+
+/**
+ * Generate an ephemeral CLI token for server-side operations.
+ * The token follows the standard vm0_live_* format and passes getUserId() validation.
+ *
+ * @param userId - The Clerk user ID to associate with the token
+ * @returns The generated token string (vm0_live_*)
+ */
+export async function generateEphemeralCliToken(
+  userId: string,
+): Promise<string> {
+  const token = `vm0_live_${crypto.randomBytes(32).toString("hex")}`;
+  const expiresAt = new Date(Date.now() + 10 * 60 * 1000); // 10 minutes
+
+  await globalThis.services.db.insert(cliTokens).values({
+    token,
+    userId,
+    name: "slack-compose-ephemeral",
+    expiresAt,
+  });
+
+  return token;
+}

--- a/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
+++ b/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
@@ -1,0 +1,339 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { composeJobs } from "../../db/schema/compose-job";
+import { generateComposeJobToken } from "../auth/sandbox-token";
+import { Sandbox } from "@e2b/code-interpreter";
+import { e2bConfig } from "../e2b/config";
+import { logger } from "../logger";
+
+const log = logger("compose:trigger");
+
+/**
+ * Get API URL for sandbox to call back.
+ * Falls back based on environment: preview -> production -> localhost.
+ */
+function getApiUrl(): string {
+  const envVars = globalThis.services?.env;
+  const vercelEnv = process.env.VERCEL_ENV;
+  const vercelUrl = process.env.VERCEL_URL;
+
+  let apiUrl = envVars?.VM0_API_URL || process.env.VM0_API_URL;
+  if (!apiUrl) {
+    if (vercelEnv === "preview" && vercelUrl) {
+      apiUrl = `https://${vercelUrl}`;
+    } else if (vercelEnv === "production") {
+      apiUrl = "https://www.vm0.ai";
+    } else {
+      apiUrl = "http://localhost:3000";
+    }
+  }
+
+  return apiUrl;
+}
+
+/**
+ * Inline sandbox script for compose-from-github.
+ *
+ * This script runs in E2B sandbox and:
+ * 1. Installs vm0 CLI
+ * 2. Executes `vm0 compose <github_url> --yes --experimental-shared-compose`
+ * 3. Parses CLI output and sends result to webhook
+ *
+ * Using CLI ensures full feature parity including:
+ * - Skills download and frontmatter parsing
+ * - Automatic secrets/vars injection from skills
+ * - Instructions file handling
+ */
+const COMPOSE_SANDBOX_SCRIPT = `
+const { spawnSync } = require('child_process');
+
+// Environment variables
+const JOB_ID = process.env.VM0_JOB_ID || '';
+const GITHUB_URL = process.env.VM0_GITHUB_URL || '';
+const VM0_TOKEN = process.env.VM0_TOKEN || '';
+const VM0_API_URL = process.env.VM0_API_URL || '';
+const WEBHOOK_URL = process.env.VM0_WEBHOOK_URL || '';
+const WEBHOOK_TOKEN = process.env.VM0_WEBHOOK_TOKEN || '';
+const VERCEL_BYPASS = process.env.VERCEL_PROTECTION_BYPASS || '';
+
+function log(level, msg) {
+  const ts = new Date().toISOString();
+  console.error('[' + ts + '] [' + level + '] [compose-github] ' + msg);
+}
+
+async function httpPost(url, data) {
+  const headers = {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer ' + WEBHOOK_TOKEN,
+  };
+  if (VERCEL_BYPASS) {
+    headers['x-vercel-protection-bypass'] = VERCEL_BYPASS;
+  }
+
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(data),
+      });
+
+      if (response.ok) {
+        const text = await response.text();
+        return text ? JSON.parse(text) : {};
+      }
+
+      const errorText = await response.text().catch(() => '');
+      log('WARN', 'HTTP POST failed (attempt ' + attempt + '/3): HTTP ' + response.status + ' - ' + errorText);
+    } catch (error) {
+      log('WARN', 'HTTP POST failed (attempt ' + attempt + '/3): ' + error.message);
+    }
+    if (attempt < 3) await new Promise(r => setTimeout(r, 1000));
+  }
+  return null;
+}
+
+async function reportCompletion(success, result, error) {
+  const payload = { jobId: JOB_ID, success };
+  if (result) payload.result = result;
+  if (error) payload.error = error;
+
+  log('INFO', 'Reporting to webhook...');
+  const response = await httpPost(WEBHOOK_URL, payload);
+  if (response) {
+    log('INFO', 'Reported successfully');
+  } else {
+    log('ERROR', 'Failed to report to webhook');
+  }
+}
+
+async function main() {
+  log('INFO', 'Starting compose job: ' + JOB_ID);
+  log('INFO', 'GitHub URL: ' + GITHUB_URL);
+  log('INFO', 'API URL: ' + VM0_API_URL);
+
+  // Validate
+  if (!JOB_ID || !GITHUB_URL || !VM0_TOKEN || !VM0_API_URL || !WEBHOOK_URL || !WEBHOOK_TOKEN) {
+    await reportCompletion(false, null, 'Missing required environment variables');
+    process.exit(1);
+  }
+
+  // Execute vm0 compose with --porcelain for structured output
+  // CLI is pre-installed in the vm0-cli template
+  log('INFO', 'Running vm0 compose...');
+  const result = spawnSync('vm0', [
+    'compose',
+    GITHUB_URL,
+    '--experimental-shared-compose',
+    '--porcelain',
+  ], {
+    env: {
+      ...process.env,
+      VM0_TOKEN: VM0_TOKEN,
+      VM0_API_URL: VM0_API_URL,
+    },
+    encoding: 'utf-8',
+    timeout: 180000, // 3 minutes
+  });
+
+  const stdout = result.stdout || '';
+  const stderr = result.stderr || '';
+
+  log('INFO', 'CLI exit code: ' + result.status);
+  if (stderr) log('INFO', 'stderr: ' + stderr);
+
+  // Parse JSON output from CLI
+  let cliResult;
+  try {
+    cliResult = JSON.parse(stdout.trim());
+  } catch (parseError) {
+    log('ERROR', 'Failed to parse CLI JSON output: ' + stdout);
+    await reportCompletion(false, null, 'Failed to parse CLI output: ' + stdout.slice(0, 200));
+    process.exit(1);
+  }
+
+  // Check for error in CLI output
+  if (cliResult.error) {
+    log('ERROR', 'CLI error: ' + cliResult.error);
+    await reportCompletion(false, null, cliResult.error);
+    process.exit(1);
+  }
+
+  // Report success with structured result
+  log('INFO', 'Compose result: ' + JSON.stringify(cliResult));
+  await reportCompletion(true, {
+    composeId: cliResult.composeId,
+    composeName: cliResult.composeName,
+    versionId: cliResult.versionId,
+    warnings: [],
+  }, null);
+
+  log('INFO', 'Done!');
+}
+
+main().catch(async (error) => {
+  log('ERROR', 'Fatal: ' + error.message);
+  await reportCompletion(false, null, error.message);
+  process.exit(1);
+});
+`;
+
+/**
+ * Spawn E2B sandbox for compose job (fire-and-forget)
+ */
+async function spawnComposeJobSandbox(
+  jobId: string,
+  githubUrl: string,
+  userToken: string,
+  webhookToken: string,
+): Promise<void> {
+  const apiUrl = getApiUrl();
+  const webhookUrl = `${apiUrl}/api/webhooks/compose/complete`;
+
+  log.debug(`Creating sandbox for job ${jobId}...`);
+
+  const sandbox = await Sandbox.create(e2bConfig.cliTemplate, {
+    timeoutMs: 5 * 60 * 1000,
+    envs: {
+      VM0_JOB_ID: jobId,
+      VM0_GITHUB_URL: githubUrl,
+      VM0_TOKEN: userToken,
+      VM0_API_URL: apiUrl,
+      VM0_WEBHOOK_URL: webhookUrl,
+      VM0_WEBHOOK_TOKEN: webhookToken,
+      ...(process.env.VERCEL_AUTOMATION_BYPASS_SECRET && {
+        VERCEL_PROTECTION_BYPASS: process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+      }),
+    },
+  });
+
+  log.debug(`Sandbox created: ${sandbox.sandboxId}`);
+
+  await globalThis.services.db
+    .update(composeJobs)
+    .set({
+      sandboxId: sandbox.sandboxId,
+      status: "running",
+      startedAt: new Date(),
+    })
+    .where(eq(composeJobs.id, jobId));
+
+  const scriptPath = "/tmp/compose-github.js";
+  await sandbox.files.write(scriptPath, COMPOSE_SANDBOX_SCRIPT);
+
+  sandbox.commands
+    .run(`node ${scriptPath}`, { timeoutMs: 5 * 60 * 1000 })
+    .catch(async (error) => {
+      const errorResult = error as {
+        result?: { stdout?: string; stderr?: string };
+      };
+      const stdout = errorResult.result?.stdout || "";
+      const stderr = errorResult.result?.stderr || "";
+      const errorMessage =
+        stderr ||
+        stdout ||
+        (error instanceof Error ? error.message : "Unknown error");
+
+      log.error(`Sandbox script failed for job ${jobId}:`);
+      log.error(`  stdout: ${stdout}`);
+      log.error(`  stderr: ${stderr}`);
+
+      await globalThis.services.db
+        .update(composeJobs)
+        .set({
+          status: "failed",
+          error: errorMessage.slice(0, 1000),
+          completedAt: new Date(),
+        })
+        .where(eq(composeJobs.id, jobId));
+    });
+
+  log.debug(`Compose script started for job ${jobId}`);
+}
+
+interface TriggerComposeJobResult {
+  jobId: string;
+  status: string;
+  githubUrl: string;
+  createdAt: Date;
+  isExisting: boolean;
+}
+
+/**
+ * Trigger a compose-from-github job.
+ * Reusable internal function callable from both the HTTP endpoint and Slack handler.
+ *
+ * No Slack-specific parameters — pure compose domain.
+ */
+export async function triggerComposeJob(params: {
+  userId: string;
+  githubUrl: string;
+  userToken: string;
+  overwrite?: boolean;
+}): Promise<TriggerComposeJobResult> {
+  const { userId, githubUrl, userToken, overwrite = false } = params;
+
+  // Idempotency: Check for existing active job for this user
+  const [existingJob] = await globalThis.services.db
+    .select()
+    .from(composeJobs)
+    .where(
+      and(
+        eq(composeJobs.userId, userId),
+        inArray(composeJobs.status, ["pending", "running"]),
+      ),
+    )
+    .limit(1);
+
+  if (existingJob) {
+    log.debug(`Returning existing job ${existingJob.id} for user ${userId}`);
+    return {
+      jobId: existingJob.id,
+      status: existingJob.status,
+      githubUrl: existingJob.githubUrl,
+      createdAt: existingJob.createdAt,
+      isExisting: true,
+    };
+  }
+
+  // Create new job
+  const jobId = crypto.randomUUID();
+  const [newJob] = await globalThis.services.db
+    .insert(composeJobs)
+    .values({
+      id: jobId,
+      userId,
+      githubUrl,
+      overwrite,
+      status: "pending",
+    })
+    .returning();
+
+  log.debug(`Created new job ${jobId} for user ${userId}`);
+
+  // Generate webhook token
+  const webhookToken = await generateComposeJobToken(userId, jobId);
+
+  // Fire-and-forget: Spawn sandbox asynchronously
+  spawnComposeJobSandbox(jobId, githubUrl, userToken, webhookToken).catch(
+    async (error) => {
+      log.error(`Failed to spawn sandbox for job ${jobId}:`, error);
+      await globalThis.services.db
+        .update(composeJobs)
+        .set({
+          status: "failed",
+          error:
+            error instanceof Error ? error.message : "Failed to create sandbox",
+          completedAt: new Date(),
+        })
+        .where(eq(composeJobs.id, jobId));
+    },
+  );
+
+  return {
+    jobId: newJob!.id,
+    status: "pending",
+    githubUrl: newJob!.githubUrl,
+    createdAt: newJob!.createdAt,
+    isExisting: false,
+  };
+}

--- a/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
+++ b/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
@@ -4,6 +4,7 @@ import { generateComposeJobToken } from "../auth/sandbox-token";
 import { Sandbox } from "@e2b/code-interpreter";
 import { e2bConfig } from "../e2b/config";
 import { logger } from "../logger";
+import { notifySlackComposeComplete } from "../slack/handlers/compose-notification";
 
 const log = logger("compose:trigger");
 
@@ -237,14 +238,23 @@ async function spawnComposeJobSandbox(
       log.error(`  stdout: ${stdout}`);
       log.error(`  stderr: ${stderr}`);
 
+      const truncatedError = errorMessage.slice(0, 1000);
       await globalThis.services.db
         .update(composeJobs)
         .set({
           status: "failed",
-          error: errorMessage.slice(0, 1000),
+          error: truncatedError,
           completedAt: new Date(),
         })
         .where(eq(composeJobs.id, jobId));
+
+      await notifySlackComposeComplete(jobId, null, truncatedError).catch(
+        (notifyError) => {
+          log.warn("Failed to send Slack failure notification", {
+            notifyError,
+          });
+        },
+      );
     });
 
   log.debug(`Compose script started for job ${jobId}`);
@@ -317,15 +327,24 @@ export async function triggerComposeJob(params: {
   spawnComposeJobSandbox(jobId, githubUrl, userToken, webhookToken).catch(
     async (error) => {
       log.error(`Failed to spawn sandbox for job ${jobId}:`, error);
+      const errorMessage =
+        error instanceof Error ? error.message : "Failed to create sandbox";
       await globalThis.services.db
         .update(composeJobs)
         .set({
           status: "failed",
-          error:
-            error instanceof Error ? error.message : "Failed to create sandbox",
+          error: errorMessage,
           completedAt: new Date(),
         })
         .where(eq(composeJobs.id, jobId));
+
+      await notifySlackComposeComplete(jobId, null, errorMessage).catch(
+        (notifyError) => {
+          log.warn("Failed to send Slack failure notification", {
+            notifyError,
+          });
+        },
+      );
     },
   );
 

--- a/turbo/apps/web/src/lib/slack/handlers/compose-notification.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/compose-notification.ts
@@ -1,0 +1,94 @@
+import { eq } from "drizzle-orm";
+import { slackComposeRequests } from "../../../db/schema/slack-compose-request";
+import { slackInstallations } from "../../../db/schema/slack-installation";
+import { decryptCredentialValue } from "../../crypto/secrets-encryption";
+import { createSlackClient } from "../index";
+import { env } from "../../../env";
+import { logger } from "../../logger";
+import type { ComposeJobResult } from "../../../db/schema/compose-job";
+
+const log = logger("slack:compose-notification");
+
+/**
+ * Notify Slack user when a compose job completes.
+ * Only sends a notification if the job was initiated from Slack (has a slack_compose_requests record).
+ */
+export async function notifySlackComposeComplete(
+  jobId: string,
+  result: ComposeJobResult | null,
+  error: string | null,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  // Look up Slack context for this compose job
+  const [request] = await globalThis.services.db
+    .select()
+    .from(slackComposeRequests)
+    .where(eq(slackComposeRequests.composeJobId, jobId))
+    .limit(1);
+
+  if (!request) {
+    // Not a Slack-initiated job, nothing to do
+    return;
+  }
+
+  // Look up bot token for the workspace
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackInstallations)
+    .where(eq(slackInstallations.slackWorkspaceId, request.slackWorkspaceId))
+    .limit(1);
+
+  if (!installation) {
+    log.warn(
+      `No Slack installation found for workspace ${request.slackWorkspaceId}`,
+    );
+    return;
+  }
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+
+  if (result) {
+    // Success notification
+    await client.chat.postEphemeral({
+      channel: request.slackChannelId,
+      user: request.slackUserId,
+      text: `Agent "${result.composeName}" composed successfully!`,
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `:white_check_mark: *Agent \`${result.composeName}\` composed successfully!*\n\nRun \`/vm0 agent link\` to configure and link it.`,
+          },
+        },
+      ],
+    });
+  } else {
+    // Failure notification
+    const errorMsg = error ?? "Unknown error";
+    await client.chat.postEphemeral({
+      channel: request.slackChannelId,
+      user: request.slackUserId,
+      text: `Failed to compose agent: ${errorMsg}`,
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `:x: *Failed to compose agent*\n\n${errorMsg}`,
+          },
+        },
+      ],
+    });
+  }
+
+  // Clean up the request record (one-time use)
+  await globalThis.services.db
+    .delete(slackComposeRequests)
+    .where(eq(slackComposeRequests.id, request.id));
+}


### PR DESCRIPTION
## Summary
- Add GitHub URL compose flow to the `/vm0 agent link` Slack command, allowing users to compose agents directly from a GitHub repository URL without needing the CLI
- When a user has no existing agents, the modal opens in GitHub URL mode by default; users with agents can toggle between "select existing" and "compose from GitHub"
- Extract compose job triggering into a shared `triggerComposeJob()` function (reused by both the HTTP API and Slack handler), add a `slack_compose_requests` table to track Slack-initiated jobs, and send ephemeral Slack notifications on compose completion

## Test plan
- [x] Integration tests for GitHub URL submission via Slack interactive endpoint (valid URL triggers compose, invalid URL returns validation error, existing agent flow still works)
- [x] Integration tests for Slack notification on compose webhook completion (success sends ephemeral message, non-Slack jobs do not trigger notification)
- [x] All pre-commit checks pass (lint, type-check, format, knip)

Generated with [Claude Code](https://claude.com/claude-code)