### PR TITLE
fix(cli): remove session code display from connector connect

### DIFF
--- a/turbo/apps/cli/src/commands/connector/connect.ts
+++ b/turbo/apps/cli/src/commands/connector/connect.ts
@@ -76,7 +76,6 @@ export const connectCommand = new Command()
 
     console.log(chalk.green("\nSession created"));
     console.log(chalk.cyan(`\nTo connect, visit: ${verificationUrl}`));
-    console.log(`Session code: ${chalk.bold(session.code)}`);
     console.log(
       `\nThe session expires in ${Math.floor(session.expiresIn / 60)} minutes.`,
     );


### PR DESCRIPTION
## Summary
- Remove unnecessary session code display from `vm0 connector connect` command
- Web OAuth flow authenticates directly through the browser, making session code redundant

## Test plan
- [ ] Run `vm0 connector connect github` and verify session code line is no longer shown
- [ ] Verify OAuth flow still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)