### PR TITLE
feat(cli): add dashboard command with guided help

### DIFF
--- a/turbo/apps/cli/src/commands/dashboard/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/dashboard/__tests__/index.test.ts
@@ -19,14 +19,19 @@ describe("dashboard command", () => {
     expect(output).toContain("Account");
   });
 
-  it("should display guided commands", async () => {
+  it("should display query commands only", async () => {
     await dashboardCommand.parseAsync(["node", "cli"]);
 
     const output = mockConsoleLog.mock.calls.map((call) => call[0]).join("\n");
     expect(output).toContain("vm0 agent list");
     expect(output).toContain("vm0 run list");
+    expect(output).toContain("vm0 logs");
     expect(output).toContain("vm0 schedule list");
     expect(output).toContain("vm0 usage");
+    expect(output).toContain("vm0 secret list");
+    expect(output).toContain("vm0 variable list");
+    expect(output).not.toContain("compose");
+    expect(output).not.toContain("setup");
   });
 
   it("should display auth login hint", async () => {

--- a/turbo/apps/cli/src/commands/dashboard/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/dashboard/__tests__/index.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { dashboardCommand } from "../index";
+
+describe("dashboard command", () => {
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  afterEach(() => {
+    mockConsoleLog.mockClear();
+  });
+
+  it("should display section headers", async () => {
+    await dashboardCommand.parseAsync(["node", "cli"]);
+
+    const output = mockConsoleLog.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain("VM0 Dashboard");
+    expect(output).toContain("Agents");
+    expect(output).toContain("Runs");
+    expect(output).toContain("Schedules");
+    expect(output).toContain("Account");
+  });
+
+  it("should display guided commands", async () => {
+    await dashboardCommand.parseAsync(["node", "cli"]);
+
+    const output = mockConsoleLog.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain("vm0 agent list");
+    expect(output).toContain("vm0 run list");
+    expect(output).toContain("vm0 schedule list");
+    expect(output).toContain("vm0 usage");
+  });
+
+  it("should display auth login hint", async () => {
+    await dashboardCommand.parseAsync(["node", "cli"]);
+
+    const output = mockConsoleLog.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain("vm0 auth login");
+  });
+
+  it("should succeed without any arguments", async () => {
+    await expect(
+      dashboardCommand.parseAsync(["node", "cli"]),
+    ).resolves.not.toThrow();
+  });
+});

--- a/turbo/apps/cli/src/commands/dashboard/index.ts
+++ b/turbo/apps/cli/src/commands/dashboard/index.ts
@@ -3,34 +3,29 @@ import chalk from "chalk";
 
 export const dashboardCommand = new Command()
   .name("dashboard")
-  .description("Quick status overview and guided help")
+  .description("Quick reference for common query commands")
   .action(() => {
     console.log();
     console.log(chalk.bold("VM0 Dashboard"));
     console.log();
 
     console.log(chalk.bold("Agents"));
-    console.log(chalk.dim("  List agents:        ") + "vm0 agent list");
-    console.log(chalk.dim("  Deploy an agent:    ") + "vm0 compose push");
-    console.log(chalk.dim("  Run an agent:       ") + "vm0 run start <agent>");
+    console.log(chalk.dim("  List agents:      ") + "vm0 agent list");
     console.log();
 
     console.log(chalk.bold("Runs"));
-    console.log(chalk.dim("  Recent runs:        ") + "vm0 run list");
-    console.log(chalk.dim("  View run logs:      ") + "vm0 logs <run-id>");
+    console.log(chalk.dim("  Recent runs:      ") + "vm0 run list");
+    console.log(chalk.dim("  View run logs:    ") + "vm0 logs <run-id>");
     console.log();
 
     console.log(chalk.bold("Schedules"));
-    console.log(chalk.dim("  List schedules:     ") + "vm0 schedule list");
-    console.log(
-      chalk.dim("  Create a schedule:  ") + "vm0 schedule setup <agent>",
-    );
+    console.log(chalk.dim("  List schedules:   ") + "vm0 schedule list");
     console.log();
 
     console.log(chalk.bold("Account"));
-    console.log(chalk.dim("  Usage stats:        ") + "vm0 usage");
-    console.log(chalk.dim("  Manage secrets:     ") + "vm0 secret list");
-    console.log(chalk.dim("  Manage variables:   ") + "vm0 variable list");
+    console.log(chalk.dim("  Usage stats:      ") + "vm0 usage");
+    console.log(chalk.dim("  List secrets:     ") + "vm0 secret list");
+    console.log(chalk.dim("  List variables:   ") + "vm0 variable list");
     console.log();
 
     console.log(

--- a/turbo/apps/cli/src/commands/dashboard/index.ts
+++ b/turbo/apps/cli/src/commands/dashboard/index.ts
@@ -1,0 +1,40 @@
+import { Command } from "commander";
+import chalk from "chalk";
+
+export const dashboardCommand = new Command()
+  .name("dashboard")
+  .description("Quick status overview and guided help")
+  .action(() => {
+    console.log();
+    console.log(chalk.bold("VM0 Dashboard"));
+    console.log();
+
+    console.log(chalk.bold("Agents"));
+    console.log(chalk.dim("  List agents:        ") + "vm0 agent list");
+    console.log(chalk.dim("  Deploy an agent:    ") + "vm0 compose push");
+    console.log(chalk.dim("  Run an agent:       ") + "vm0 run start <agent>");
+    console.log();
+
+    console.log(chalk.bold("Runs"));
+    console.log(chalk.dim("  Recent runs:        ") + "vm0 run list");
+    console.log(chalk.dim("  View run logs:      ") + "vm0 logs <run-id>");
+    console.log();
+
+    console.log(chalk.bold("Schedules"));
+    console.log(chalk.dim("  List schedules:     ") + "vm0 schedule list");
+    console.log(
+      chalk.dim("  Create a schedule:  ") + "vm0 schedule setup <agent>",
+    );
+    console.log();
+
+    console.log(chalk.bold("Account"));
+    console.log(chalk.dim("  Usage stats:        ") + "vm0 usage");
+    console.log(chalk.dim("  Manage secrets:     ") + "vm0 secret list");
+    console.log(chalk.dim("  Manage variables:   ") + "vm0 variable list");
+    console.log();
+
+    console.log(
+      chalk.dim("Not logged in? Run: ") + chalk.cyan("vm0 auth login"),
+    );
+    console.log();
+  });

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -21,6 +21,7 @@ import { modelProviderCommand } from "./commands/model-provider";
 import { connectorCommand } from "./commands/connector";
 import { onboardCommand } from "./commands/onboard";
 import { setupClaudeCommand } from "./commands/setup-claude";
+import { dashboardCommand } from "./commands/dashboard";
 import { devToolCommand } from "./commands/dev-tool";
 
 const program = new Command();
@@ -52,6 +53,7 @@ program.addCommand(modelProviderCommand);
 program.addCommand(connectorCommand);
 program.addCommand(onboardCommand);
 program.addCommand(setupClaudeCommand);
+program.addCommand(dashboardCommand);
 program.addCommand(devToolCommand, { hidden: true });
 
 export { program };


### PR DESCRIPTION
## Summary

- Add `vm0 dashboard` command that displays organized quick-reference sections
- Sections: Agents, Runs, Schedules, Account — each with commonly used commands
- Phase 1: static guided output (no API calls), accessible to unauthenticated users
- Includes auth login hint for users who haven't logged in yet

Closes #2533

## Test plan

- [x] `vm0 dashboard` succeeds without arguments
- [x] Output contains all section headers (Agents, Runs, Schedules, Account)
- [x] Output contains guided commands (vm0 agent list, vm0 run list, etc.)
- [x] Output contains auth login hint
- [x] All 4 tests pass
- [x] lint, type-check, prettier all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)