### PR TITLE
chore: remove unused axiom token from runner deploy config

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -590,7 +590,6 @@ jobs:
           AWS_METAL_RUNNER_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           AWS_METAL_RUNNER_SSH_KEY: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-          AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
         run: |
           # Setup SSH key
           mkdir -p ~/.ssh
@@ -607,7 +606,6 @@ jobs:
             -e "official_runner_secret=${OFFICIAL_RUNNER_SECRET}" \
             -e "api_url=https://www.vm0.ai" \
             -e "runner_bundle_path=/tmp/vm0-runner-bundle.tar.gz" \
-            -e '{"extra_env": {"AXIOM_TOKEN": "'"${AXIOM_TOKEN}"'", "AXIOM_DATASET_SUFFIX": "prod"}}' \
             -v
 
       - name: Notify Slack - Success

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1299,7 +1299,6 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           PREVIEW_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-          AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
         run: |
           mkdir -p "$HOME/.ssh"
           echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
@@ -1323,7 +1322,7 @@ jobs:
             -e "rootfs_path=${RUNNER_DIR}/rootfs.squashfs" \
             -e "snapshot_path=${RUNNER_DIR}/snapshot" \
             -e "proxy_port=${PROXY_PORT}" \
-            -e '{"extra_env": {"VERCEL_AUTOMATION_BYPASS_SECRET": "'"${VERCEL_BYPASS}"'", "USE_MOCK_CLAUDE": "true", "AXIOM_TOKEN": "'"${AXIOM_TOKEN}"'", "AXIOM_DATASET_SUFFIX": "dev"}}' \
+            -e '{"extra_env": {"VERCEL_AUTOMATION_BYPASS_SECRET": "'"${VERCEL_BYPASS}"'", "USE_MOCK_CLAUDE": "true"}}' \
             -v
 
           echo "runner-deployed=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Remove `AXIOM_TOKEN` and `AXIOM_DATASET_SUFFIX` from Runner deploy `extra_env` in both CI workflows
- Remove corresponding step-level `env:` entries that only existed to feed those values
- Runner code has zero references to these variables — all Axiom integration lives in the web app

Closes #2568

## Test plan

- [x] YAML syntax validated with `yaml.safe_load()`
- [x] Remaining `extra_env` JSON validated
- [ ] CI pipeline runs successfully (workflow YAML is parseable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)