### PR TITLE
feat(cli): add connector status command for detailed connector view

### DIFF
--- a/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for connector status command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { statusCommand } from "../status";
+import chalk from "chalk";
+
+describe("connector status command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("connected connector", () => {
+    it("should display all connector details", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/connectors/github", () => {
+          return HttpResponse.json({
+            id: "1",
+            type: "github",
+            authMethod: "oauth",
+            externalId: "12345",
+            externalUsername: "octocat",
+            externalEmail: "octocat@github.com",
+            oauthScopes: ["repo", "user"],
+            createdAt: "2025-01-01T00:00:00Z",
+            updatedAt: "2025-01-15T00:00:00Z",
+          });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "github"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Connector:");
+      expect(logCalls).toContain("github");
+      expect(logCalls).toContain("Status:");
+      expect(logCalls).toContain("connected");
+      expect(logCalls).toContain("Account:");
+      expect(logCalls).toContain("@octocat");
+      expect(logCalls).toContain("Auth Method:");
+      expect(logCalls).toContain("oauth");
+      expect(logCalls).toContain("OAuth Scopes:");
+      expect(logCalls).toContain("repo, user");
+      expect(logCalls).toContain("Connected:");
+      expect(logCalls).toContain("Last Updated:");
+    });
+
+    it("should show disconnect hint when connected", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/connectors/github", () => {
+          return HttpResponse.json({
+            id: "1",
+            type: "github",
+            authMethod: "oauth",
+            externalId: "12345",
+            externalUsername: "octocat",
+            externalEmail: null,
+            oauthScopes: ["repo"],
+            createdAt: "2025-01-01T00:00:00Z",
+            updatedAt: "2025-01-01T00:00:00Z",
+          });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "github"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("To disconnect:");
+      expect(logCalls).toContain("vm0 connector disconnect github");
+    });
+
+    it("should not show Last Updated when same as Connected", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/connectors/github", () => {
+          return HttpResponse.json({
+            id: "1",
+            type: "github",
+            authMethod: "oauth",
+            externalId: "12345",
+            externalUsername: "octocat",
+            externalEmail: null,
+            oauthScopes: ["repo"],
+            createdAt: "2025-01-01T00:00:00Z",
+            updatedAt: "2025-01-01T00:00:00Z",
+          });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "github"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Connected:");
+      expect(logCalls).not.toContain("Last Updated:");
+    });
+  });
+
+  describe("not connected", () => {
+    it("should show not connected status on 404", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/connectors/github", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Connector not found",
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "github"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Connector:");
+      expect(logCalls).toContain("github");
+      expect(logCalls).toContain("Status:");
+      expect(logCalls).toContain("not connected");
+    });
+
+    it("should show connect hint when not connected", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/connectors/github", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Connector not found",
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "github"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("To connect:");
+      expect(logCalls).toContain("vm0 connector connect github");
+    });
+  });
+
+  describe("invalid type", () => {
+    it("should show error with available types", async () => {
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli", "invalid"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unknown connector type: invalid"),
+      );
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Available connectors:");
+      expect(logCalls).toContain("github");
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/connectors/github", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli", "github"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle server error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/connectors/github", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli", "github"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/connector/index.ts
+++ b/turbo/apps/cli/src/commands/connector/index.ts
@@ -1,11 +1,13 @@
 import { Command } from "commander";
 import { connectCommand } from "./connect";
 import { listCommand } from "./list";
+import { statusCommand } from "./status";
 import { disconnectCommand } from "./disconnect";
 
 export const connectorCommand = new Command()
   .name("connector")
   .description("Manage third-party service connections")
   .addCommand(listCommand)
+  .addCommand(statusCommand)
   .addCommand(connectCommand)
   .addCommand(disconnectCommand);

--- a/turbo/apps/cli/src/commands/connector/status.ts
+++ b/turbo/apps/cli/src/commands/connector/status.ts
@@ -1,0 +1,81 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { CONNECTOR_TYPES, connectorTypeSchema } from "@vm0/core";
+import { getConnector } from "../../lib/api";
+import { formatDateTime } from "../../lib/domain/schedule-utils";
+
+const LABEL_WIDTH = 16;
+
+export const statusCommand = new Command()
+  .name("status")
+  .description("Show detailed status of a connector")
+  .argument("<type>", "Connector type (e.g., github)")
+  .action(async (type: string) => {
+    try {
+      const parseResult = connectorTypeSchema.safeParse(type);
+      if (!parseResult.success) {
+        console.error(chalk.red(`✗ Unknown connector type: ${type}`));
+        console.log();
+        console.log("Available connectors:");
+        for (const [t, config] of Object.entries(CONNECTOR_TYPES)) {
+          console.log(`  ${chalk.cyan(t)} - ${config.label}`);
+        }
+        process.exit(1);
+      }
+
+      const connector = await getConnector(parseResult.data);
+
+      console.log(`Connector: ${chalk.cyan(type)}`);
+      console.log();
+
+      if (connector) {
+        console.log(
+          `${"Status:".padEnd(LABEL_WIDTH)}${chalk.green("connected")}`,
+        );
+        console.log(
+          `${"Account:".padEnd(LABEL_WIDTH)}@${connector.externalUsername}`,
+        );
+        console.log(
+          `${"Auth Method:".padEnd(LABEL_WIDTH)}${connector.authMethod}`,
+        );
+
+        if (connector.oauthScopes && connector.oauthScopes.length > 0) {
+          console.log(
+            `${"OAuth Scopes:".padEnd(LABEL_WIDTH)}${connector.oauthScopes.join(", ")}`,
+          );
+        }
+
+        console.log(
+          `${"Connected:".padEnd(LABEL_WIDTH)}${formatDateTime(connector.createdAt)}`,
+        );
+
+        if (connector.updatedAt !== connector.createdAt) {
+          console.log(
+            `${"Last Updated:".padEnd(LABEL_WIDTH)}${formatDateTime(connector.updatedAt)}`,
+          );
+        }
+
+        console.log();
+        console.log(chalk.dim("To disconnect:"));
+        console.log(chalk.dim(`  vm0 connector disconnect ${type}`));
+      } else {
+        console.log(
+          `${"Status:".padEnd(LABEL_WIDTH)}${chalk.dim("not connected")}`,
+        );
+        console.log();
+        console.log(chalk.dim("To connect:"));
+        console.log(chalk.dim(`  vm0 connector connect ${type}`));
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes("Not authenticated")) {
+          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
+        } else {
+          console.error(chalk.red(`✗ ${error.message}`));
+        }
+      } else {
+        console.error(chalk.red("✗ An unexpected error occurred"));
+      }
+      process.exit(1);
+    }
+  });

--- a/turbo/apps/cli/src/lib/api/domains/connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/connectors.ts
@@ -4,6 +4,7 @@ import {
   connectorsByTypeContract,
   type ConnectorType,
   type ConnectorListResponse,
+  type ConnectorResponse,
 } from "@vm0/core";
 import { getClientConfig, handleError } from "../core/client-factory";
 
@@ -39,4 +40,30 @@ export async function deleteConnector(type: ConnectorType): Promise<void> {
   }
 
   handleError(result, `Connector "${type}" not found`);
+}
+
+/**
+ * Get a connector by type
+ * Returns null if not connected (404 response)
+ */
+export async function getConnector(
+  type: ConnectorType,
+): Promise<ConnectorResponse | null> {
+  const config = await getClientConfig();
+  const client = initClient(connectorsByTypeContract, config);
+
+  const result = await client.get({
+    params: { type },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  // 404 means not connected - return null instead of throwing
+  if (result.status === 404) {
+    return null;
+  }
+
+  handleError(result, `Failed to get connector "${type}"`);
 }

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -70,7 +70,11 @@ export {
 } from "./domains/model-providers";
 
 // Domain modules - Connectors
-export { listConnectors, deleteConnector } from "./domains/connectors";
+export {
+  listConnectors,
+  deleteConnector,
+  getConnector,
+} from "./domains/connectors";
 
 // Domain modules - Usage
 export { getUsage } from "./domains/usage";


### PR DESCRIPTION
## Summary

- Add `vm0 connector status <type>` command to show detailed information about a specific connector
- Add `getConnector()` function to API domain module
- Include comprehensive integration tests

## Output Examples

**When connected:**
```
Connector: github

Status:         connected
Account:        @octocat
Auth Method:    oauth
OAuth Scopes:   repo
Connected:      2024-01-15 10:30 (2 months ago)
Last Updated:   2024-03-10 14:22 (3 days ago)

To disconnect:
  vm0 connector disconnect github
```

**When not connected:**
```
Connector: github

Status:         not connected

To connect:
  vm0 connector connect github
```

## Test plan

- [x] `vm0 connector status github` shows detailed connector info when connected
- [x] `vm0 connector status github` shows "not connected" state when not connected
- [x] `vm0 connector status invalid` shows error with available connector types
- [x] All integration tests pass (8 tests)
- [x] Existing `list` and `disconnect` commands unaffected

Closes #2571

🤖 Generated with [Claude Code](https://claude.ai/code)