### PR TITLE
fix(web): inject connector secrets into agent execution environment

### DIFF
--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -9,6 +9,7 @@ import {
   hasAuthMethods,
   getSecretNamesForAuthMethod,
   getConnectorEnvironmentMapping,
+  connectorTypeSchema,
   MODEL_PROVIDER_TYPES,
   type ModelProviderType,
   type ModelProviderFramework,
@@ -29,7 +30,7 @@ import { getUserScopeByClerkId } from "../scope/scope-service";
 import { getSecretValue, getSecretValues } from "../secret/secret-service";
 import { getVariableValues } from "../variable/variable-service";
 import { getDefaultModelProvider } from "../model-provider/model-provider-service";
-import { listConnectors } from "../connector/connector-service";
+import { connectors } from "../../db/schema/connector";
 
 const log = logger("run:build-context");
 
@@ -319,6 +320,9 @@ interface ConnectorCredentialResult {
  * Resolve and inject connector credentials if any connectors are connected.
  * For each connected connector, resolves its environmentMapping to produce
  * environment variables (e.g., GH_TOKEN, GITHUB_TOKEN for GitHub connector).
+ *
+ * Resolves scope once and queries both connectors and secrets directly,
+ * avoiding redundant getUserScopeByClerkId calls.
  */
 async function resolveConnectorCredentials(
   userId: string,
@@ -326,13 +330,18 @@ async function resolveConnectorCredentials(
 ): Promise<ConnectorCredentialResult> {
   let credentials = existingCredentials;
 
-  const userConnectors = await listConnectors(userId);
-  if (userConnectors.length === 0) {
+  const userScope = await getUserScopeByClerkId(userId);
+  if (!userScope) {
     return { credentials, injectedEnvVars: undefined };
   }
 
-  const userScope = await getUserScopeByClerkId(userId);
-  if (!userScope) {
+  // Query connected connectors directly (only need the type for environmentMapping)
+  const userConnectors = await globalThis.services.db
+    .select({ type: connectors.type })
+    .from(connectors)
+    .where(eq(connectors.scopeId, userScope.id));
+
+  if (userConnectors.length === 0) {
     return { credentials, injectedEnvVars: undefined };
   }
 
@@ -344,7 +353,12 @@ async function resolveConnectorCredentials(
   const allInjectedEnvVars: Record<string, string> = {};
 
   for (const connector of userConnectors) {
-    const mapping = getConnectorEnvironmentMapping(connector.type);
+    const connectorType = connectorTypeSchema.safeParse(connector.type);
+    if (!connectorType.success) {
+      continue;
+    }
+
+    const mapping = getConnectorEnvironmentMapping(connectorType.data);
 
     for (const [envVar, valueRef] of Object.entries(mapping)) {
       if (valueRef.startsWith("$secrets.")) {
@@ -421,14 +435,17 @@ function mergeSecrets(
 }
 
 /**
- * Auto-inject model provider environment variables into environment
- * Returns the potentially modified environment
+ * Auto-inject environment variables from a provider source (model provider, connector, etc.)
+ * Returns the potentially modified environment.
  *
- * Only injects variables not already set (user-defined environment takes precedence)
+ * Only injects variables not already set (user-defined environment takes precedence).
+ *
+ * @param source - Label for logging (e.g., "model provider", "connector")
  */
 function autoInjectEnvVarsToEnvironment(
   environment: Record<string, string> | undefined,
   injectedEnvVars: Record<string, string> | undefined,
+  source: string = "provider",
 ): Record<string, string> | undefined {
   if (!injectedEnvVars || Object.keys(injectedEnvVars).length === 0) {
     return environment;
@@ -447,7 +464,7 @@ function autoInjectEnvVarsToEnvironment(
 
   if (injectedKeys.length > 0) {
     log.debug(
-      `Auto-injected model provider env vars to environment: ${injectedKeys.join(", ")}`,
+      `Auto-injected ${source} env vars to environment: ${injectedKeys.join(", ")}`,
     );
   }
 
@@ -718,12 +735,17 @@ export async function buildExecutionContext(
   );
 
   // Step 5b: Auto-inject model provider and connector env vars into environment
-  // User-defined environment takes precedence over auto-injected values
+  // Precedence: user-defined env > model provider > connector
   let environment = autoInjectEnvVarsToEnvironment(
     expandedEnvironment,
     modelProviderEnvVars,
+    "model provider",
   );
-  environment = autoInjectEnvVarsToEnvironment(environment, connectorEnvVars);
+  environment = autoInjectEnvVarsToEnvironment(
+    environment,
+    connectorEnvVars,
+    "connector",
+  );
 
   // Step 6: Merge credentials into secrets for client-side log masking
   // Credentials are server-stored user-level secrets and must be masked like CLI secrets

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -8,6 +8,7 @@ import {
   getDefaultModel,
   hasAuthMethods,
   getSecretNamesForAuthMethod,
+  getConnectorEnvironmentMapping,
   MODEL_PROVIDER_TYPES,
   type ModelProviderType,
   type ModelProviderFramework,
@@ -28,6 +29,7 @@ import { getUserScopeByClerkId } from "../scope/scope-service";
 import { getSecretValue, getSecretValues } from "../secret/secret-service";
 import { getVariableValues } from "../variable/variable-service";
 import { getDefaultModelProvider } from "../model-provider/model-provider-service";
+import { listConnectors } from "../connector/connector-service";
 
 const log = logger("run:build-context");
 
@@ -302,6 +304,70 @@ async function resolveModelProviderCredential(
   );
 
   return { credentials, injectedEnvVars };
+}
+
+/**
+ * Result of connector credential resolution
+ */
+interface ConnectorCredentialResult {
+  credentials: Record<string, string> | undefined;
+  /** Environment variables to inject from connected connectors */
+  injectedEnvVars: Record<string, string> | undefined;
+}
+
+/**
+ * Resolve and inject connector credentials if any connectors are connected.
+ * For each connected connector, resolves its environmentMapping to produce
+ * environment variables (e.g., GH_TOKEN, GITHUB_TOKEN for GitHub connector).
+ */
+async function resolveConnectorCredentials(
+  userId: string,
+  existingCredentials: Record<string, string> | undefined,
+): Promise<ConnectorCredentialResult> {
+  let credentials = existingCredentials;
+
+  const userConnectors = await listConnectors(userId);
+  if (userConnectors.length === 0) {
+    return { credentials, injectedEnvVars: undefined };
+  }
+
+  const userScope = await getUserScopeByClerkId(userId);
+  if (!userScope) {
+    return { credentials, injectedEnvVars: undefined };
+  }
+
+  const connectorSecrets = await getSecretValues(userScope.id, "connector");
+  if (Object.keys(connectorSecrets).length === 0) {
+    return { credentials, injectedEnvVars: undefined };
+  }
+
+  const allInjectedEnvVars: Record<string, string> = {};
+
+  for (const connector of userConnectors) {
+    const mapping = getConnectorEnvironmentMapping(connector.type);
+
+    for (const [envVar, valueRef] of Object.entries(mapping)) {
+      if (valueRef.startsWith("$secrets.")) {
+        const secretName = valueRef.slice("$secrets.".length);
+        const secretValue = connectorSecrets[secretName];
+        if (secretValue) {
+          allInjectedEnvVars[envVar] = secretValue;
+          credentials = credentials || {};
+          credentials[secretName] = secretValue;
+        }
+      } else {
+        allInjectedEnvVars[envVar] = valueRef;
+      }
+    }
+  }
+
+  if (Object.keys(allInjectedEnvVars).length > 0) {
+    log.debug(
+      `Resolved connector env vars: ${Object.keys(allInjectedEnvVars).join(", ")}`,
+    );
+  }
+
+  return { credentials, injectedEnvVars: allInjectedEnvVars };
 }
 
 /**
@@ -626,7 +692,15 @@ export async function buildExecutionContext(
     params.modelProvider,
   );
   credentials = modelProviderResult.credentials;
-  const injectedEnvVars = modelProviderResult.injectedEnvVars;
+  const modelProviderEnvVars = modelProviderResult.injectedEnvVars;
+
+  // Step 4b2: Connector credential injection (auto-inject GH_TOKEN, GITHUB_TOKEN, etc.)
+  const connectorResult = await resolveConnectorCredentials(
+    params.userId,
+    credentials,
+  );
+  credentials = connectorResult.credentials;
+  const connectorEnvVars = connectorResult.injectedEnvVars;
 
   // Step 4c: Fetch server-stored variables and merge with CLI vars
   // Priority: CLI --vars > server-stored variables
@@ -643,11 +717,13 @@ export async function buildExecutionContext(
     params.runId,
   );
 
-  // Step 5b: Auto-inject model provider env vars into environment
-  const environment = autoInjectEnvVarsToEnvironment(
+  // Step 5b: Auto-inject model provider and connector env vars into environment
+  // User-defined environment takes precedence over auto-injected values
+  let environment = autoInjectEnvVarsToEnvironment(
     expandedEnvironment,
-    injectedEnvVars,
+    modelProviderEnvVars,
   );
+  environment = autoInjectEnvVarsToEnvironment(environment, connectorEnvVars);
 
   // Step 6: Merge credentials into secrets for client-side log masking
   // Credentials are server-stored user-level secrets and must be masked like CLI secrets

--- a/turbo/packages/core/src/contracts/secrets.ts
+++ b/turbo/packages/core/src/contracts/secrets.ts
@@ -24,7 +24,7 @@ export const secretNameSchema = z
 /**
  * Secret type schema
  */
-export const secretTypeSchema = z.enum(["user", "model-provider"]);
+export const secretTypeSchema = z.enum(["user", "model-provider", "connector"]);
 
 export type SecretType = z.infer<typeof secretTypeSchema>;
 


### PR DESCRIPTION
## Summary

- Fix connector secrets (e.g., GitHub OAuth tokens from `vm0 connector connect`) not being injected into agent sandbox environment
- Add `resolveConnectorCredentials()` in `build-context.ts` mirroring the existing model-provider injection pattern
- Add `"connector"` to `SecretType` enum for type safety
- Fix `createTestConnector` test helper to use proper encryption

## Changes

| File | Change |
|------|--------|
| `packages/core/src/contracts/secrets.ts` | Add `"connector"` to `secretTypeSchema` |
| `apps/web/src/lib/run/build-context.ts` | Add `resolveConnectorCredentials()` + integrate into `buildExecutionContext()` |
| `apps/web/src/__tests__/api-test-helpers.ts` | Fix `createTestConnector()` to use real encryption |
| `apps/web/app/api/agent/runs/__tests__/route.test.ts` | Add 3 connector injection integration tests |

## How it works

1. After model-provider injection (Step 4b), a new Step 4b2 queries the user's connected connectors
2. For each connector, resolves its `environmentMapping` (e.g., `GH_TOKEN: "$secrets.GITHUB_ACCESS_TOKEN"`)
3. Auto-injects resolved env vars via `autoInjectEnvVarsToEnvironment()` — user-defined env vars take precedence
4. Adds connector secret values to credentials map for log masking

## Test plan

- [x] Verify GH_TOKEN and GITHUB_TOKEN are auto-injected when GitHub connector is connected
- [x] Verify user-defined GH_TOKEN takes precedence over connector token
- [x] Verify existing behavior unchanged when no connectors are connected
- [x] All 185 connector + runs tests passing
- [x] Lint, format, knip all clean

Closes #2583

🤖 Generated with [Claude Code](https://claude.com/claude-code)