### PR TITLE
feat(sandbox-fc): add overlay filesystem pool for pre-warmed vm images

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -155,6 +155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +582,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "sandbox",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -717,6 +724,19 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -21,7 +21,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = "0.4"
 thiserror = "2"
-tokio = { version = "1", features = ["net", "io-util", "time", "rt", "macros", "process", "sync"] }
+tempfile = "3"
+tokio = { version = "1", features = ["net", "io-util", "time", "rt", "macros", "process", "sync", "fs"] }
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
 which = "7"

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -13,5 +13,8 @@ uuid.workspace = true
 vsock-host.workspace = true
 which.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -2,9 +2,11 @@ pub(crate) mod command;
 mod config;
 mod factory;
 pub(crate) mod network;
+pub(crate) mod overlay;
 mod sandbox;
 
 pub use config::{FirecrackerConfig, SnapshotConfig};
 pub use factory::FirecrackerFactory;
 pub use network::{NetnsPool, NetnsPoolConfig, PooledNetns, cleanup_namespaces_by_index};
+pub use overlay::{Ext4Creator, OverlayCreator, OverlayError, OverlayPool, OverlayPoolConfig};
 pub use sandbox::FirecrackerSandbox;

--- a/crates/sandbox-fc/src/overlay/error.rs
+++ b/crates/sandbox-fc/src/overlay/error.rs
@@ -1,15 +1,13 @@
-use crate::command::CommandError;
-
 pub type Result<T> = std::result::Result<T, OverlayError>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum OverlayError {
-    #[error(transparent)]
-    Command(#[from] CommandError),
-
     #[error("overlay pool not initialized")]
     NotInitialized,
 
     #[error("failed to create overlay file: {0}")]
     FileCreation(String),
+
+    #[error("all pre-warm tasks failed")]
+    PreWarmFailed,
 }

--- a/crates/sandbox-fc/src/overlay/error.rs
+++ b/crates/sandbox-fc/src/overlay/error.rs
@@ -1,0 +1,15 @@
+use crate::command::CommandError;
+
+pub type Result<T> = std::result::Result<T, OverlayError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum OverlayError {
+    #[error(transparent)]
+    Command(#[from] CommandError),
+
+    #[error("overlay pool not initialized")]
+    NotInitialized,
+
+    #[error("failed to create overlay file: {0}")]
+    FileCreation(String),
+}

--- a/crates/sandbox-fc/src/overlay/error.rs
+++ b/crates/sandbox-fc/src/overlay/error.rs
@@ -7,7 +7,4 @@ pub enum OverlayError {
 
     #[error("failed to create overlay file: {0}")]
     FileCreation(String),
-
-    #[error("all pre-warm tasks failed")]
-    PreWarmFailed,
 }

--- a/crates/sandbox-fc/src/overlay/mod.rs
+++ b/crates/sandbox-fc/src/overlay/mod.rs
@@ -1,0 +1,5 @@
+mod error;
+mod pool;
+
+pub use error::OverlayError;
+pub use pool::{Ext4Creator, OverlayCreator, OverlayPool, OverlayPoolConfig};

--- a/crates/sandbox-fc/src/overlay/pool.rs
+++ b/crates/sandbox-fc/src/overlay/pool.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tracing::{error, info, warn};
 
-use crate::command::{Privilege, exec_command};
-
 use super::error::{OverlayError, Result};
 
 // ---------------------------------------------------------------------------
@@ -51,8 +49,22 @@ impl OverlayCreator for Ext4Creator {
             .await
             .map_err(|e| OverlayError::FileCreation(format!("truncate {path_str}: {e}")))?;
 
-        let cmd = format!("mkfs.ext4 -F -q \"{path_str}\"");
-        exec_command(&cmd, Privilege::User).await?;
+        // Use Command directly to avoid shell injection via path.
+        let output = tokio::process::Command::new("mkfs.ext4")
+            .args(["-F", "-q"])
+            .arg(path)
+            .output()
+            .await
+            .map_err(|e| OverlayError::FileCreation(format!("mkfs.ext4: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(OverlayError::FileCreation(format!(
+                "mkfs.ext4 failed: {}",
+                stderr.trim()
+            )));
+        }
+
         Ok(())
     }
 }
@@ -175,6 +187,9 @@ impl OverlayPool {
         }
 
         let available = queue.len();
+        if available == 0 && config.size > 0 {
+            return Err(OverlayError::PreWarmFailed);
+        }
         if available < config.size {
             warn!(
                 requested = config.size,
@@ -291,6 +306,18 @@ impl OverlayPool {
         }
         if needed > 0 {
             info!(needed, "spawned overlay replenish tasks");
+        }
+    }
+}
+
+impl Drop for OverlayPool {
+    fn drop(&mut self) {
+        if self.active {
+            warn!(
+                queued = self.queue.len(),
+                pending = self.pending.len(),
+                "OverlayPool dropped without calling cleanup()"
+            );
         }
     }
 }
@@ -431,6 +458,27 @@ mod tests {
         // This should create on-demand.
         let on_demand = pool.acquire().await.expect("acquire on-demand");
         assert!(on_demand.exists());
+    }
+
+    #[tokio::test]
+    async fn acquire_from_replenished_pending() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // size=2, threshold=2: acquiring the first file triggers replenishment,
+        // so the second acquire should come from a pending task (Tier 2).
+        let mut pool = OverlayPool::create(test_config(tmp.path(), 2, 2))
+            .await
+            .expect("create");
+
+        let first = pool.acquire().await.expect("acquire 1 (pooled)");
+        assert!(first.exists());
+
+        // Queue is now empty, but maybe_replenish() should have spawned tasks.
+        // The second acquire hits Tier 2 (pending JoinSet).
+        let second = pool.acquire().await.expect("acquire 2 (replenished)");
+        assert!(second.exists());
+        assert_ne!(first, second);
+
+        pool.cleanup().await;
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/overlay/pool.rs
+++ b/crates/sandbox-fc/src/overlay/pool.rs
@@ -340,6 +340,16 @@ mod tests {
         }
     }
 
+    /// Creator that always fails — for testing pre-warm failure degradation.
+    struct FailingCreator;
+
+    #[async_trait]
+    impl OverlayCreator for FailingCreator {
+        async fn create(&self, _path: &Path) -> Result<()> {
+            Err(OverlayError::FileCreation("intentional failure".into()))
+        }
+    }
+
     fn test_config(dir: &Path, size: usize, threshold: usize) -> OverlayPoolConfig {
         OverlayPoolConfig {
             size,
@@ -378,7 +388,7 @@ mod tests {
     #[tokio::test]
     async fn create_prewarms_files() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let pool = OverlayPool::create(test_config(tmp.path(), 3, 1))
+        let mut pool = OverlayPool::create(test_config(tmp.path(), 3, 1))
             .await
             .expect("create");
 
@@ -392,6 +402,8 @@ mod tests {
         for entry in &entries {
             assert!(is_overlay_file(&entry.file_name().to_string_lossy()));
         }
+
+        pool.cleanup().await;
     }
 
     #[tokio::test]
@@ -403,13 +415,15 @@ mod tests {
         std::fs::write(&stale, b"stale").expect("write");
         assert!(stale.exists());
 
-        let pool = OverlayPool::create(test_config(tmp.path(), 1, 1))
+        let mut pool = OverlayPool::create(test_config(tmp.path(), 1, 1))
             .await
             .expect("create");
 
         // Stale file should be gone; only the newly created one remains.
         assert_eq!(pool.available_count(), 1);
         assert!(!stale.exists());
+
+        pool.cleanup().await;
     }
 
     #[tokio::test]
@@ -424,6 +438,8 @@ mod tests {
         assert!(is_overlay_file(
             path.file_name().expect("file_name").to_str().expect("str")
         ));
+
+        pool.cleanup().await;
     }
 
     #[tokio::test]
@@ -440,6 +456,8 @@ mod tests {
         assert_ne!(a, b);
         assert_ne!(b, c);
         assert_ne!(a, c);
+
+        pool.cleanup().await;
     }
 
     #[tokio::test]
@@ -455,6 +473,8 @@ mod tests {
         // This should create on-demand.
         let on_demand = pool.acquire().await.expect("acquire on-demand");
         assert!(on_demand.exists());
+
+        pool.cleanup().await;
     }
 
     #[tokio::test]
@@ -474,6 +494,39 @@ mod tests {
         let second = pool.acquire().await.expect("acquire 2 (replenished)");
         assert!(second.exists());
         assert_ne!(first, second);
+
+        pool.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn create_with_size_zero() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut pool = OverlayPool::create(test_config(tmp.path(), 0, 0))
+            .await
+            .expect("create");
+
+        assert_eq!(pool.available_count(), 0);
+
+        // acquire still works via on-demand (Tier 3).
+        let path = pool.acquire().await.expect("acquire on-demand");
+        assert!(path.exists());
+
+        pool.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn create_succeeds_when_all_prewarm_fail() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config = OverlayPoolConfig {
+            size: 3,
+            replenish_threshold: 1,
+            pool_dir: tmp.path().to_path_buf(),
+            creator: Box::new(FailingCreator),
+        };
+        let mut pool = OverlayPool::create(config).await.expect("create");
+
+        // Pool created successfully but with zero pre-warmed files.
+        assert_eq!(pool.available_count(), 0);
 
         pool.cleanup().await;
     }

--- a/crates/sandbox-fc/src/overlay/pool.rs
+++ b/crates/sandbox-fc/src/overlay/pool.rs
@@ -1,0 +1,483 @@
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tracing::{error, info, warn};
+
+use crate::command::{Privilege, exec_command};
+
+use super::error::{OverlayError, Result};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Size of each sparse overlay file (2 GiB).
+const OVERLAY_SIZE: u64 = 2 * 1024 * 1024 * 1024;
+
+/// File name prefix for overlay files.
+const OVERLAY_PREFIX: &str = "overlay-";
+
+/// File extension for overlay files.
+const OVERLAY_EXT: &str = ".ext4";
+
+// ---------------------------------------------------------------------------
+// OverlayCreator trait
+// ---------------------------------------------------------------------------
+
+/// Creates overlay filesystem images.
+///
+/// Abstracted as a trait so tests can inject a lightweight creator instead
+/// of calling `mkfs.ext4`.
+#[async_trait]
+pub trait OverlayCreator: Send + Sync {
+    async fn create(&self, path: &Path) -> Result<()>;
+}
+
+/// Default creator: sparse file + `mkfs.ext4`.
+pub struct Ext4Creator;
+
+#[async_trait]
+impl OverlayCreator for Ext4Creator {
+    async fn create(&self, path: &Path) -> Result<()> {
+        let path_str = path.to_string_lossy();
+
+        // Create a sparse file by writing nothing and truncating to size.
+        tokio::fs::File::create(path)
+            .await
+            .map_err(|e| OverlayError::FileCreation(format!("{path_str}: {e}")))?
+            .set_len(OVERLAY_SIZE)
+            .await
+            .map_err(|e| OverlayError::FileCreation(format!("truncate {path_str}: {e}")))?;
+
+        let cmd = format!("mkfs.ext4 -F -q \"{path_str}\"");
+        exec_command(&cmd, Privilege::User).await?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Generate a unique overlay file name: `overlay-{UUID}.ext4`.
+fn generate_file_name() -> String {
+    let id = uuid::Uuid::new_v4();
+    format!("{OVERLAY_PREFIX}{id}{OVERLAY_EXT}")
+}
+
+/// Check whether a file name matches the overlay naming convention.
+fn is_overlay_file(name: &str) -> bool {
+    name.starts_with(OVERLAY_PREFIX) && name.ends_with(OVERLAY_EXT)
+}
+
+/// Remove all overlay files from a directory (best-effort).
+async fn clean_stale_files(dir: &Path) {
+    let mut entries = match tokio::fs::read_dir(dir).await {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let name = entry.file_name();
+        if is_overlay_file(&name.to_string_lossy())
+            && let Err(e) = tokio::fs::remove_file(entry.path()).await
+        {
+            warn!(path = %entry.path().display(), error = %e, "failed to remove stale overlay");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OverlayPoolConfig
+// ---------------------------------------------------------------------------
+
+/// Configuration for creating an [`OverlayPool`].
+pub struct OverlayPoolConfig {
+    /// Number of overlay files to pre-create.
+    pub size: usize,
+    /// Start replenishment when available count drops below this.
+    pub replenish_threshold: usize,
+    /// Directory in which overlay files are stored.
+    pub pool_dir: PathBuf,
+    /// Strategy for creating overlay files.
+    pub creator: Box<dyn OverlayCreator>,
+}
+
+// ---------------------------------------------------------------------------
+// OverlayPool
+// ---------------------------------------------------------------------------
+
+/// Pre-warmed pool of overlay filesystem images for Firecracker VMs.
+///
+/// Maintains a two-tier buffer:
+/// - `queue`: ready-to-use files (pre-warmed), returned instantly
+/// - `pending`: in-flight background creation tasks
+///
+/// [`acquire`](Self::acquire) pops from `queue` first, then awaits
+/// `pending` results, and falls back to on-demand creation as a last
+/// resort. Spawned tasks are pure functions — they never touch pool
+/// state directly.
+pub struct OverlayPool {
+    active: bool,
+    queue: VecDeque<PathBuf>,
+    /// In-flight overlay creation tasks. Spawned tasks return their
+    /// result via the [`JoinSet`](tokio::task::JoinSet) and never
+    /// access pool state directly.
+    pending: tokio::task::JoinSet<Result<PathBuf>>,
+    pool_dir: PathBuf,
+    size: usize,
+    replenish_threshold: usize,
+    creator: Arc<dyn OverlayCreator>,
+}
+
+impl OverlayPool {
+    /// Create a new pool, pre-warming `config.size` overlay files.
+    ///
+    /// Creates the pool directory if it doesn't exist, removes stale files
+    /// from previous runs, and pre-creates overlay files in parallel.
+    pub async fn create(config: OverlayPoolConfig) -> Result<Self> {
+        info!(
+            size = config.size,
+            threshold = config.replenish_threshold,
+            dir = %config.pool_dir.display(),
+            "initializing overlay pool"
+        );
+
+        tokio::fs::create_dir_all(&config.pool_dir)
+            .await
+            .map_err(|e| OverlayError::FileCreation(format!("mkdir: {e}")))?;
+
+        clean_stale_files(&config.pool_dir).await;
+
+        let creator: Arc<dyn OverlayCreator> = Arc::from(config.creator);
+        let mut queue = VecDeque::with_capacity(config.size);
+
+        // Pre-warm via JoinSet
+        if config.size > 0 {
+            let mut join_set = tokio::task::JoinSet::new();
+            for _ in 0..config.size {
+                let dir = config.pool_dir.clone();
+                let c = Arc::clone(&creator);
+                join_set.spawn(async move {
+                    let path = dir.join(generate_file_name());
+                    c.create(&path).await.map(|()| path)
+                });
+            }
+            while let Some(result) = join_set.join_next().await {
+                match result {
+                    Ok(Ok(path)) => queue.push_back(path),
+                    Ok(Err(e)) => error!(error = %e, "failed to create overlay file"),
+                    Err(e) => error!(error = %e, "overlay creation task panicked"),
+                }
+            }
+        }
+
+        let available = queue.len();
+        if available < config.size {
+            warn!(
+                requested = config.size,
+                created = available,
+                "overlay pool initialized with fewer files than requested"
+            );
+        }
+        info!(available, "overlay pool initialized");
+
+        Ok(Self {
+            active: true,
+            queue,
+            pending: tokio::task::JoinSet::new(),
+            pool_dir: config.pool_dir,
+            size: config.size,
+            replenish_threshold: config.replenish_threshold,
+            creator,
+        })
+    }
+
+    /// Acquire an overlay file from the pool.
+    ///
+    /// Returns the file path. The caller owns the file and is responsible
+    /// for deleting it when the VM stops.
+    ///
+    /// Tries three tiers in order:
+    /// 1. Pop a ready file from the pre-warmed queue (instant)
+    /// 2. Await the next in-flight background creation
+    /// 3. Create on-demand as a last resort
+    pub async fn acquire(&mut self) -> Result<PathBuf> {
+        if !self.active {
+            return Err(OverlayError::NotInitialized);
+        }
+
+        // Tier 1: pre-warmed queue.
+        if let Some(path) = self.queue.pop_front() {
+            info!(remaining = self.queue.len(), "acquired overlay from pool");
+            self.maybe_replenish();
+            return Ok(path);
+        }
+
+        // Tier 2: wait for a pending background task.
+        while let Some(result) = self.pending.join_next().await {
+            match result {
+                Ok(Ok(path)) => {
+                    info!("acquired overlay from pending task");
+                    self.maybe_replenish();
+                    return Ok(path);
+                }
+                Ok(Err(e)) => error!(error = %e, "replenish: failed to create overlay"),
+                Err(e) => error!(error = %e, "replenish: task panicked"),
+            }
+        }
+
+        // Tier 3: on-demand.
+        info!("pool exhausted, creating overlay on-demand");
+        let path = self.pool_dir.join(generate_file_name());
+        self.creator.create(&path).await?;
+        self.maybe_replenish();
+        Ok(path)
+    }
+
+    /// Delete all queued overlay files and cancel in-flight creations.
+    pub async fn cleanup(&mut self) {
+        if !self.active {
+            return;
+        }
+        self.active = false;
+
+        // Cancel all in-flight creation tasks.
+        self.pending.abort_all();
+
+        // Wait for cancelled/completed tasks and delete their files.
+        while let Some(result) = self.pending.join_next().await {
+            if let Ok(Ok(path)) = result {
+                let _ = tokio::fs::remove_file(&path).await;
+            }
+        }
+
+        info!(count = self.queue.len(), "cleaning up overlay pool");
+
+        // Delete queued files.
+        for path in self.queue.drain(..) {
+            if let Err(e) = tokio::fs::remove_file(&path).await {
+                warn!(path = %path.display(), error = %e, "failed to delete queued overlay");
+            }
+        }
+
+        // Remove any orphaned files (e.g., partially created by aborted tasks).
+        clean_stale_files(&self.pool_dir).await;
+
+        info!("overlay pool cleanup complete");
+    }
+
+    /// Number of overlay files ready for immediate use.
+    pub fn available_count(&self) -> usize {
+        self.queue.len()
+    }
+
+    /// Spawn background creation tasks if the pool is running low.
+    fn maybe_replenish(&mut self) {
+        let total = self.queue.len() + self.pending.len();
+        if total >= self.replenish_threshold {
+            return;
+        }
+        let needed = self.size.saturating_sub(total);
+        for _ in 0..needed {
+            let dir = self.pool_dir.clone();
+            let c = Arc::clone(&self.creator);
+            self.pending.spawn(async move {
+                let path = dir.join(generate_file_name());
+                c.create(&path).await.map(|()| path)
+            });
+        }
+        if needed > 0 {
+            info!(needed, "spawned overlay replenish tasks");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Lightweight test creator — writes a tiny file instead of calling mkfs.ext4.
+    struct TestCreator;
+
+    #[async_trait]
+    impl OverlayCreator for TestCreator {
+        async fn create(&self, path: &Path) -> Result<()> {
+            tokio::fs::write(path, b"test-overlay")
+                .await
+                .map_err(|e| OverlayError::FileCreation(e.to_string()))?;
+            Ok(())
+        }
+    }
+
+    fn test_config(dir: &Path, size: usize, threshold: usize) -> OverlayPoolConfig {
+        OverlayPoolConfig {
+            size,
+            replenish_threshold: threshold,
+            pool_dir: dir.to_path_buf(),
+            creator: Box::new(TestCreator),
+        }
+    }
+
+    #[test]
+    fn generate_file_name_format() {
+        let name = generate_file_name();
+        assert!(name.starts_with(OVERLAY_PREFIX));
+        assert!(name.ends_with(OVERLAY_EXT));
+        // overlay- (8) + uuid (36) + .ext4 (5) = 49
+        assert_eq!(name.len(), 49);
+    }
+
+    #[test]
+    fn is_overlay_file_matches() {
+        assert!(is_overlay_file(
+            "overlay-550e8400-e29b-41d4-a716-446655440000.ext4"
+        ));
+        assert!(is_overlay_file("overlay-anything.ext4"));
+    }
+
+    #[test]
+    fn is_overlay_file_rejects() {
+        assert!(!is_overlay_file("rootfs.ext4"));
+        assert!(!is_overlay_file("overlay-.img"));
+        assert!(!is_overlay_file("something-overlay-.ext4"));
+        assert!(!is_overlay_file("overlay-test.ext3"));
+        assert!(!is_overlay_file(""));
+    }
+
+    #[tokio::test]
+    async fn create_prewarms_files() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let pool = OverlayPool::create(test_config(tmp.path(), 3, 1))
+            .await
+            .expect("create");
+
+        assert_eq!(pool.available_count(), 3);
+
+        let entries: Vec<_> = std::fs::read_dir(tmp.path())
+            .expect("read_dir")
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(entries.len(), 3);
+        for entry in &entries {
+            assert!(is_overlay_file(&entry.file_name().to_string_lossy()));
+        }
+    }
+
+    #[tokio::test]
+    async fn create_cleans_stale_files() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        // Plant stale files.
+        let stale = tmp.path().join("overlay-stale-id.ext4");
+        std::fs::write(&stale, b"stale").expect("write");
+        assert!(stale.exists());
+
+        let pool = OverlayPool::create(test_config(tmp.path(), 1, 1))
+            .await
+            .expect("create");
+
+        // Stale file should be gone; only the newly created one remains.
+        assert_eq!(pool.available_count(), 1);
+        assert!(!stale.exists());
+    }
+
+    #[tokio::test]
+    async fn acquire_returns_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut pool = OverlayPool::create(test_config(tmp.path(), 2, 1))
+            .await
+            .expect("create");
+
+        let path = pool.acquire().await.expect("acquire");
+        assert!(path.exists());
+        assert!(is_overlay_file(
+            path.file_name().expect("file_name").to_str().expect("str")
+        ));
+    }
+
+    #[tokio::test]
+    async fn acquire_returns_unique_files() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut pool = OverlayPool::create(test_config(tmp.path(), 3, 1))
+            .await
+            .expect("create");
+
+        let a = pool.acquire().await.expect("acquire 1");
+        let b = pool.acquire().await.expect("acquire 2");
+        let c = pool.acquire().await.expect("acquire 3");
+
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert_ne!(a, c);
+    }
+
+    #[tokio::test]
+    async fn acquire_on_demand_when_exhausted() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut pool = OverlayPool::create(test_config(tmp.path(), 1, 1))
+            .await
+            .expect("create");
+
+        let _first = pool.acquire().await.expect("acquire pooled");
+        assert_eq!(pool.available_count(), 0);
+
+        // This should create on-demand.
+        let on_demand = pool.acquire().await.expect("acquire on-demand");
+        assert!(on_demand.exists());
+    }
+
+    #[tokio::test]
+    async fn cleanup_deletes_files() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut pool = OverlayPool::create(test_config(tmp.path(), 3, 1))
+            .await
+            .expect("create");
+
+        pool.cleanup().await;
+
+        let entries: Vec<_> = std::fs::read_dir(tmp.path())
+            .expect("read_dir")
+            .filter_map(|e| e.ok())
+            .filter(|e| is_overlay_file(&e.file_name().to_string_lossy()))
+            .collect();
+        assert_eq!(entries.len(), 0);
+        assert_eq!(pool.available_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_noop_after_cleanup() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut pool = OverlayPool::create(test_config(tmp.path(), 2, 1))
+            .await
+            .expect("create");
+
+        pool.cleanup().await;
+        // Second cleanup should be a no-op, not panic.
+        pool.cleanup().await;
+        assert_eq!(pool.available_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn acquire_after_cleanup_errors() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut pool = OverlayPool::create(test_config(tmp.path(), 2, 1))
+            .await
+            .expect("create");
+
+        pool.cleanup().await;
+
+        let result = pool.acquire().await;
+        assert!(result.is_err());
+        assert!(
+            matches!(result, Err(OverlayError::NotInitialized)),
+            "expected NotInitialized, got {result:?}"
+        );
+    }
+}

--- a/crates/sandbox-fc/src/overlay/pool.rs
+++ b/crates/sandbox-fc/src/overlay/pool.rs
@@ -187,9 +187,6 @@ impl OverlayPool {
         }
 
         let available = queue.len();
-        if available == 0 && config.size > 0 {
-            return Err(OverlayError::PreWarmFailed);
-        }
         if available < config.size {
             warn!(
                 requested = config.size,


### PR DESCRIPTION
## Summary
- Port the TypeScript overlay pool to Rust in `sandbox-fc` crate
- Pre-creates sparse 2 GiB ext4 filesystem images so Firecracker VMs can boot instantly without waiting for on-demand `mkfs.ext4` (~26ms each)
- Three-tier acquire strategy: pre-warmed queue (instant) → pending JoinSet (await background task) → on-demand fallback
- Spawned tasks are pure functions returning `PathBuf` via `JoinSet` — no shared mutable state, no locks

## Changes
- **New** `crates/sandbox-fc/src/overlay/error.rs` — `OverlayError` enum
- **New** `crates/sandbox-fc/src/overlay/pool.rs` — `OverlayPool`, `OverlayPoolConfig`, `OverlayCreator` trait, `Ext4Creator`, 11 tests
- **New** `crates/sandbox-fc/src/overlay/mod.rs` — module re-exports
- **Modified** `crates/sandbox-fc/src/lib.rs` — add overlay module and public re-exports
- **Modified** `crates/sandbox-fc/Cargo.toml` — add `tempfile` dev-dependency
- **Modified** `crates/Cargo.toml` — add `tempfile` workspace dep, add `fs` feature to tokio

## Test plan
- [x] `cargo clippy -p sandbox-fc` passes with strict lints (no `unwrap`, `expect`, `panic`)
- [x] `cargo test -p sandbox-fc` — all 11 new overlay tests pass using lightweight `TestCreator`
- [ ] CI pipeline validates build + clippy + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)