### PR TITLE
feat(cli): show connector-derived secret names in secret list

### DIFF
--- a/turbo/apps/cli/src/commands/secret/list.ts
+++ b/turbo/apps/cli/src/commands/secret/list.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import { getConnectorDerivedNames } from "@vm0/core";
 import { listSecrets } from "../../lib/api";
 
 export const listCommand = new Command()
@@ -22,11 +23,27 @@ export const listCommand = new Command()
       console.log();
 
       for (const secret of result.secrets) {
-        const typeIndicator =
-          secret.type === "model-provider"
-            ? chalk.dim(" [model-provider]")
-            : "";
+        let typeIndicator = "";
+        let derivedLine: string | null = null;
+
+        if (secret.type === "model-provider") {
+          typeIndicator = chalk.dim(" [model-provider]");
+        } else if (secret.type === "connector") {
+          const derived = getConnectorDerivedNames(secret.name);
+          if (derived) {
+            typeIndicator = chalk.dim(` [${derived.connectorLabel} connector]`);
+            derivedLine = chalk.dim(
+              `Available as: ${derived.envVarNames.join(", ")}`,
+            );
+          } else {
+            typeIndicator = chalk.dim(" [connector]");
+          }
+        }
+
         console.log(`  ${chalk.cyan(secret.name)}${typeIndicator}`);
+        if (derivedLine) {
+          console.log(`    ${derivedLine}`);
+        }
         if (secret.description) {
           console.log(`    ${chalk.dim(secret.description)}`);
         }

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -415,6 +415,7 @@ export {
   getConnectorSecretsForAuthMethod,
   getConnectorSecretNames,
   getConnectorEnvironmentMapping,
+  getConnectorDerivedNames,
   getConnectorOAuthConfig,
   type ConnectorsMainContract,
   type ConnectorsByTypeContract,


### PR DESCRIPTION
## Summary

- Add `getConnectorDerivedNames()` reverse-lookup helper to `@vm0/core` that maps connector secret names to their derived env var names
- Enhance `vm0 secret list` display for connector secrets: shows `[GitHub connector]` type indicator and `Available as: GH_TOKEN, GITHUB_TOKEN` line
- CLI-only change, no API or contract modifications needed

Closes #2601

## Test plan

- [x] New CLI integration tests: connector secret with derived names, connector secret without mapping, mixed secret types
- [x] All 7 existing + new tests passing
- [x] Lint, type-check, format, knip all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)