### PR TITLE
fix(cli): route error messages to stderr per CLI design guideline

### DIFF
--- a/turbo/apps/cli/src/commands/auth/__tests__/login.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/login.test.ts
@@ -198,7 +198,7 @@ describe("auth login", () => {
         await loginCommand.parseAsync(["node", "cli"]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("expired"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -227,7 +227,7 @@ describe("auth login", () => {
         await loginCommand.parseAsync(["node", "cli"]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Authentication failed"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);

--- a/turbo/apps/cli/src/commands/auth/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/status.test.ts
@@ -27,6 +27,9 @@ vi.mock("os", async (importOriginal) => {
 
 describe("auth status", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -39,6 +42,7 @@ describe("auth status", () => {
 
   afterEach(async () => {
     mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
     vi.unstubAllEnvs();
 
     // Clean up config
@@ -71,10 +75,10 @@ describe("auth status", () => {
     it("should show not authenticated when no token exists", async () => {
       await statusCommand.parseAsync(["node", "cli"]);
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Not authenticated"),
       );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("vm0 auth login"),
       );
     });

--- a/turbo/apps/cli/src/lib/api/auth.ts
+++ b/turbo/apps/cli/src/lib/api/auth.ts
@@ -141,16 +141,14 @@ export async function authenticate(apiUrl?: string): Promise<void> {
 
     // Handle other errors
     if (tokenResult.error === "expired_token") {
-      console.log(
-        chalk.red("\nThe device code has expired. Please try again."),
-      );
+      console.error(chalk.red("\n✗ Device code expired. Please try again"));
       process.exit(1);
     }
 
     if (tokenResult.error) {
-      console.log(
+      console.error(
         chalk.red(
-          `\nAuthentication failed: ${tokenResult.error_description ?? tokenResult.error}`,
+          `\n✗ Authentication failed: ${tokenResult.error_description ?? tokenResult.error}`,
         ),
       );
       process.exit(1);
@@ -158,7 +156,7 @@ export async function authenticate(apiUrl?: string): Promise<void> {
   }
 
   // Timeout
-  console.log(chalk.red("\nAuthentication timed out. Please try again."));
+  console.error(chalk.red("\n✗ Authentication timed out. Please try again"));
   process.exit(1);
 }
 
@@ -175,8 +173,8 @@ export async function checkAuthStatus(): Promise<void> {
     console.log(chalk.green("✓ Authenticated"));
     console.log("You are logged in to VM0.");
   } else {
-    console.log(chalk.red("✗ Not authenticated"));
-    console.log("Run 'vm0 auth login' to authenticate.");
+    console.error(chalk.red("✗ Not authenticated"));
+    console.error(chalk.dim("  Run: vm0 auth login"));
   }
 
   // Also check for environment variable


### PR DESCRIPTION
## Summary

- Fix `lib/api/auth.ts`: error messages were incorrectly sent to stdout via `console.log()` instead of stderr via `console.error()`
- Add missing `✗` prefix to error messages (expired token, auth failed, timeout)
- Update "Not authenticated" status output to use `console.error()` with `chalk.dim()` hint per guideline pattern
- Remove trailing periods from error messages per guideline

This is the first of a series of fixes to align all CLI error output with the [CLI design guideline](docs/cli-design-guideline.md). Remaining files will be addressed in follow-up commits on this branch.

## Files changed

| File | Changes |
|------|---------|
| `apps/cli/src/lib/api/auth.ts` | 4x `console.log` → `console.error`, 3x add `✗` prefix |

## Test plan

- [ ] `vm0 auth login` with expired device code shows error on stderr
- [ ] `vm0 auth status` when not authenticated shows `✗ Not authenticated` on stderr
- [ ] Lint and type check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)