### PR TITLE
fix(cli): route run-failed output to stderr

### DIFF
--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -2086,19 +2086,19 @@ describe("run command", () => {
         ]);
       }).rejects.toThrow("process.exit called");
 
-      const allLogs = mockConsoleLog.mock.calls
+      const allErrors = mockConsoleError.mock.calls
         .map((call) => call[0])
         .filter((log): log is string => typeof log === "string");
 
-      expect(allLogs.some((log) => log.includes("Run failed"))).toBe(true);
+      expect(allErrors.some((log) => log.includes("Run failed"))).toBe(true);
       expect(
-        allLogs.some((log) => log.includes("Could not resume session")),
+        allErrors.some((log) => log.includes("Could not resume session")),
       ).toBe(true);
       expect(
-        allLogs.some((log) => log.includes("Session history file not found")),
+        allErrors.some((log) => log.includes("Session history file not found")),
       ).toBe(true);
       expect(
-        allLogs.some((log) => log.includes("Agent exited with code 1")),
+        allErrors.some((log) => log.includes("Agent exited with code 1")),
       ).toBe(false);
       expect(mockExit).toHaveBeenCalledWith(1);
     });
@@ -2126,12 +2126,12 @@ describe("run command", () => {
         ]);
       }).rejects.toThrow("process.exit called");
 
-      const allLogs = mockConsoleLog.mock.calls
+      const allErrors = mockConsoleError.mock.calls
         .map((call) => call[0])
         .filter((log): log is string => typeof log === "string");
 
       expect(
-        allLogs.some((log) =>
+        allErrors.some((log) =>
           log.includes(`vm0 logs ${errorTestRunId} --system`),
         ),
       ).toBe(true);
@@ -2164,11 +2164,11 @@ describe("run command", () => {
         ]);
       }).rejects.toThrow("process.exit called");
 
-      const allLogs = mockConsoleLog.mock.calls
+      const allErrors = mockConsoleError.mock.calls
         .map((call) => call[0])
         .filter((log): log is string => typeof log === "string");
 
-      expect(allLogs.some((log) => log.includes("Unknown error"))).toBe(true);
+      expect(allErrors.some((log) => log.includes("Unknown error"))).toBe(true);
     });
 
     it("should display various error patterns correctly", async () => {
@@ -2213,11 +2213,11 @@ describe("run command", () => {
           ]);
         }).rejects.toThrow("process.exit called");
 
-        const allLogs = mockConsoleLog.mock.calls
+        const allErrors = mockConsoleError.mock.calls
           .map((call) => call[0])
           .filter((log): log is string => typeof log === "string");
 
-        expect(allLogs.some((log) => log.includes(expected))).toBe(true);
+        expect(allErrors.some((log) => log.includes(expected))).toBe(true);
       }
     });
   });

--- a/turbo/apps/cli/src/commands/run/__tests__/realtime.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/realtime.test.ts
@@ -306,8 +306,8 @@ describe("run command with --experimental-realtime", () => {
       await expect(runPromise).rejects.toThrow("process.exit called");
 
       expect(mockExit).toHaveBeenCalledWith(1);
-      // Error message is rendered via EventRenderer.renderRunFailed using console.log
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      // Error message is rendered via EventRenderer.renderRunFailed using console.error
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Something went wrong"),
       );
     });

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -145,10 +145,10 @@ export class EventRenderer {
    */
   static renderRunFailed(error: string | undefined, runId: string): void {
     // Visual separator to distinguish from event stream
-    console.log("");
-    console.log(chalk.red("✗ Run failed"));
-    console.log(`  Error: ${chalk.red(error || "Unknown error")}`);
-    console.log(
+    console.error("");
+    console.error(chalk.red("✗ Run failed"));
+    console.error(`  Error: ${chalk.red(error || "Unknown error")}`);
+    console.error(
       chalk.dim(`  (use "vm0 logs ${runId} --system" to view system logs)`),
     );
   }


### PR DESCRIPTION
## Summary

- Fix `EventRenderer.renderRunFailed()`: all 4 lines of output were incorrectly sent to stdout via `console.log()` instead of stderr via `console.error()`
- Update test assertion in `realtime.test.ts` to verify error message on stderr

## Files changed

| File | Changes |
|------|---------|
| `apps/cli/src/lib/events/event-renderer.ts` | 4x `console.log` → `console.error` in `renderRunFailed()` |
| `apps/cli/src/commands/run/__tests__/realtime.test.ts` | Update assertion from `mockConsoleLog` → `mockConsoleError` |

## Test plan

- [ ] `vm0 run` with a failing run shows error on stderr
- [ ] `realtime.test.ts` passes with updated assertion
- [ ] Lint and type check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)