### PR TITLE
fix(cli): route error messages to stderr in init command

### DIFF
--- a/turbo/apps/cli/src/commands/init/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/init/__tests__/index.test.ts
@@ -56,10 +56,10 @@ describe("init command", () => {
         await initCommand.parseAsync(["node", "cli", "--name", "my-agent"]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("vm0.yaml already exists"),
       );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("vm0 init --force"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -72,7 +72,7 @@ describe("init command", () => {
         await initCommand.parseAsync(["node", "cli", "--name", "my-agent"]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("AGENTS.md already exists"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -86,10 +86,10 @@ describe("init command", () => {
         await initCommand.parseAsync(["node", "cli", "--name", "my-agent"]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("vm0.yaml already exists"),
       );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("AGENTS.md already exists"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -102,7 +102,7 @@ describe("init command", () => {
         await initCommand.parseAsync(["node", "cli", "--name", "ab"]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Invalid agent name"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -113,7 +113,7 @@ describe("init command", () => {
         await initCommand.parseAsync(["node", "cli", "--name", "my_agent"]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Invalid agent name"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -124,7 +124,7 @@ describe("init command", () => {
         await initCommand.parseAsync(["node", "cli", "--name", "-my-agent"]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Invalid agent name"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -135,7 +135,7 @@ describe("init command", () => {
         await initCommand.parseAsync(["node", "cli", "--name", "ab"]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("3-64 characters"),
       );
     });
@@ -279,7 +279,7 @@ describe("init command", () => {
         await initCommand.parseAsync(["node", "cli", "--name", "ab"]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Invalid agent name"),
       );
     });

--- a/turbo/apps/cli/src/commands/init/index.ts
+++ b/turbo/apps/cli/src/commands/init/index.ts
@@ -54,10 +54,10 @@ export const initCommand = new Command()
     const existingFiles = checkExistingFiles();
     if (existingFiles.length > 0 && !options.force) {
       for (const file of existingFiles) {
-        console.log(chalk.red(`✗ ${file} already exists`));
+        console.error(chalk.red(`✗ ${file} already exists`));
       }
-      console.log();
-      console.log(`To overwrite: ${chalk.cyan("vm0 init --force")}`);
+      console.error();
+      console.error(`To overwrite: ${chalk.cyan("vm0 init --force")}`);
       process.exit(1);
     }
 
@@ -99,11 +99,11 @@ export const initCommand = new Command()
 
     // Validate agent name
     if (!agentName || !validateAgentName(agentName)) {
-      console.log(chalk.red("✗ Invalid agent name"));
-      console.log(
+      console.error(chalk.red("✗ Invalid agent name"));
+      console.error(
         chalk.dim("  Must be 3-64 characters, alphanumeric and hyphens only"),
       );
-      console.log(chalk.dim("  Must start and end with letter or number"));
+      console.error(chalk.dim("  Must start and end with letter or number"));
       process.exit(1);
     }
 


### PR DESCRIPTION
## Summary

- Fix `commands/init/index.ts`: error messages for file-exists and invalid-agent-name were sent to stdout via `console.log()` instead of stderr via `console.error()`
- Update 10 test assertions in `init/__tests__/index.test.ts` to check `mockConsoleError`

## Files changed

| File | Changes |
|------|---------|
| `apps/cli/src/commands/init/index.ts` | 6x `console.log` → `console.error` in error paths |
| `apps/cli/src/commands/init/__tests__/index.test.ts` | 10x `mockConsoleLog` → `mockConsoleError` |

## Test plan

- [x] `init/__tests__/index.test.ts` — 19 tests pass locally
- [ ] CI lint, type-check, and test-cli pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)