### PR TITLE
feat(cli): add --json flag and deprecate --porcelain

### DIFF
--- a/docs/cli-design-guideline.md
+++ b/docs/cli-design-guideline.md
@@ -238,6 +238,36 @@ console.log(chalk.dim("  Name: MY_API_KEY"));
 console.log(chalk.red("✗ Not authenticated"));
 ```
 
+### Machine-Readable Output (--json)
+
+For commands where scripts need to parse the result, provide a `--json` flag. This flag:
+
+- **Suppresses progress messages** — no "Uploading...", "Processing..." output
+- **Outputs only the final result** — in JSON format
+- **Writes to stdout** — so it can be captured or piped
+
+```bash
+# Human-readable (default)
+$ vm0 compose vm0.yaml
+Uploading compose...
+✓ Compose created: user/my-agent:a1b2c3d4
+
+Run your agent:
+  vm0 run user/my-agent:a1b2c3d4 "your prompt"
+
+# Machine-readable
+$ vm0 compose vm0.yaml --json
+{"composeId":"user/my-agent:a1b2c3d4","version":"a1b2c3d4"}
+```
+
+**When to add --json:**
+
+- Commands that create resources (return the created ID)
+- Commands that query data (return structured results)
+- Commands where scripts need to extract specific values
+
+**Note:** AI agents can read human-readable output effectively, so `--json` is optional and only needed when traditional scripts require structured parsing.
+
 ### Spacing Rules
 
 - **Two-space indentation** for all secondary information


### PR DESCRIPTION
## Summary

- Add `--json` flag to `vm0 compose` command for machine-readable JSON output
- Deprecate `--porcelain` flag with warning message (still works for backward compatibility)
- Update CLI design guideline to document the `--json` flag pattern

## Why --json instead of --porcelain?

- `--json` is more intuitive and widely used (gh CLI, jq, many other tools)
- `--porcelain` comes from git's terminology which may not be familiar to all users

## Migration Path

This is step 1 of a multi-step migration:
1. **This PR**: Add `--json` flag, deprecate `--porcelain` in CLI
2. Update e2b template to use `--json`
3. Update server-side API
4. Remove `--porcelain` from CLI

## Test plan

- [x] Tests updated to use `--json` flag
- [x] Added test to verify `--porcelain` shows deprecation warning
- [x] Type check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)