### PR TITLE
fix(cli): route error messages and hints to stderr across all commands

### DIFF
--- a/turbo/apps/cli/src/commands/connector/__tests__/disconnect.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/disconnect.test.ts
@@ -59,7 +59,7 @@ describe("connector disconnect command", () => {
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Unknown connector type: invalid-type"),
       );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Available connectors:"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);

--- a/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
@@ -174,9 +174,9 @@ describe("connector status command", () => {
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Unknown connector type: invalid"),
       );
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("Available connectors:");
-      expect(logCalls).toContain("github");
+      const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+      expect(errorCalls).toContain("Available connectors:");
+      expect(errorCalls).toContain("github");
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });

--- a/turbo/apps/cli/src/commands/connector/connect.ts
+++ b/turbo/apps/cli/src/commands/connector/connect.ts
@@ -122,14 +122,14 @@ export const connectCommand = new Command()
           return;
 
         case "expired":
-          console.log(chalk.red("\nSession expired. Please try again."));
+          console.error(chalk.red("\n✗ Session expired. Please try again"));
           process.exit(1);
           break;
 
         case "error":
-          console.log(
+          console.error(
             chalk.red(
-              `\nConnection failed: ${status.errorMessage || "Unknown error"}`,
+              `\n✗ Connection failed: ${status.errorMessage || "Unknown error"}`,
             ),
           );
           process.exit(1);
@@ -143,6 +143,6 @@ export const connectCommand = new Command()
     }
 
     // Timeout
-    console.log(chalk.red("\nSession timed out. Please try again."));
+    console.error(chalk.red("\n✗ Session timed out. Please try again"));
     process.exit(1);
   });

--- a/turbo/apps/cli/src/commands/connector/disconnect.ts
+++ b/turbo/apps/cli/src/commands/connector/disconnect.ts
@@ -12,10 +12,10 @@ export const disconnectCommand = new Command()
       const parseResult = connectorTypeSchema.safeParse(type);
       if (!parseResult.success) {
         console.error(chalk.red(`✗ Unknown connector type: ${type}`));
-        console.log();
-        console.log("Available connectors:");
+        console.error();
+        console.error("Available connectors:");
         for (const [t, config] of Object.entries(CONNECTOR_TYPES)) {
-          console.log(`  ${chalk.cyan(t)} - ${config.label}`);
+          console.error(`  ${chalk.cyan(t)} - ${config.label}`);
         }
         process.exit(1);
       }

--- a/turbo/apps/cli/src/commands/connector/status.ts
+++ b/turbo/apps/cli/src/commands/connector/status.ts
@@ -15,10 +15,10 @@ export const statusCommand = new Command()
       const parseResult = connectorTypeSchema.safeParse(type);
       if (!parseResult.success) {
         console.error(chalk.red(`✗ Unknown connector type: ${type}`));
-        console.log();
-        console.log("Available connectors:");
+        console.error();
+        console.error("Available connectors:");
         for (const [t, config] of Object.entries(CONNECTOR_TYPES)) {
-          console.log(`  ${chalk.cyan(t)} - ${config.label}`);
+          console.error(`  ${chalk.cyan(t)} - ${config.label}`);
         }
         process.exit(1);
       }

--- a/turbo/apps/cli/src/commands/cook/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/cook/__tests__/index.test.ts
@@ -593,18 +593,20 @@ agents:
         await cookCommand.parseAsync(["node", "cli", "test prompt"]);
       }).rejects.toThrow("process.exit called");
 
-      const allLogs = mockConsoleLog.mock.calls
+      const allErrors = mockConsoleError.mock.calls
         .map((call) => call[0])
         .filter((log): log is string => typeof log === "string");
 
       // Should show upgrade failed message
-      expect(allLogs.some((log) => log.includes("Upgrade failed"))).toBe(true);
+      expect(allErrors.some((log) => log.includes("Upgrade failed"))).toBe(
+        true,
+      );
       // Should show manual command
       expect(
-        allLogs.some((log) => log.includes("npm install -g @vm0/cli@latest")),
+        allErrors.some((log) => log.includes("npm install -g @vm0/cli@latest")),
       ).toBe(true);
       // Should show re-run command
-      expect(allLogs.some((log) => log.includes("vm0 cook"))).toBe(true);
+      expect(allErrors.some((log) => log.includes("vm0 cook"))).toBe(true);
     });
 
     it("should escape special characters in rerun command", async () => {

--- a/turbo/apps/cli/src/commands/cook/cook.ts
+++ b/turbo/apps/cli/src/commands/cook/cook.ts
@@ -153,7 +153,7 @@ function validateEnvVariables(
     const missingVars = checkMissingVariables(requiredVarNames, envFile);
 
     if (missingVars.length > 0) {
-      console.log();
+      console.error();
       console.error(chalk.red("✗ Missing required variables:"));
       for (const varName of missingVars) {
         console.error(chalk.red(`  ${varName}`));

--- a/turbo/apps/cli/src/commands/dev-tool/__tests__/compose.test.ts
+++ b/turbo/apps/cli/src/commands/dev-tool/__tests__/compose.test.ts
@@ -184,7 +184,7 @@ describe("dev-tool compose command", () => {
       expect(mockExit).toHaveBeenCalledWith(1);
 
       // Should show error message
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Compose failed"),
       );
     });

--- a/turbo/apps/cli/src/commands/dev-tool/compose.ts
+++ b/turbo/apps/cli/src/commands/dev-tool/compose.ts
@@ -244,9 +244,9 @@ function displayResult(job: {
       }
     }
   } else if (job.status === "failed") {
-    console.log(chalk.red("✗ Compose failed!"));
+    console.error(chalk.red("✗ Compose failed"));
     if (job.error) {
-      console.log(`  Error: ${chalk.red(job.error)}`);
+      console.error(`  Error: ${chalk.red(job.error)}`);
     }
   } else {
     console.log(`Status: ${job.status}`);

--- a/turbo/apps/cli/src/commands/model-provider/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/setup.test.ts
@@ -64,7 +64,7 @@ describe("model-provider setup command", () => {
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining('Invalid type "invalid-type"'),
       );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Valid types:"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -115,7 +115,7 @@ describe("model-provider setup command", () => {
       }).rejects.toThrow("process.exit called");
 
       // Should show anthropic-api-key as a valid type
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("anthropic-api-key"),
       );
     });
@@ -391,7 +391,7 @@ describe("model-provider setup command", () => {
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining('Invalid model "invalid-model"'),
       );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Valid models:"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -453,10 +453,10 @@ describe("model-provider setup command", () => {
       }).rejects.toThrow("process.exit called");
 
       // Should show valid models
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("kimi-k2.5"),
       );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("kimi-k2-thinking-turbo"),
       );
     });
@@ -563,7 +563,7 @@ describe("model-provider setup command", () => {
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining('Invalid model "invalid/model"'),
       );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Valid models:"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -584,13 +584,13 @@ describe("model-provider setup command", () => {
       }).rejects.toThrow("process.exit called");
 
       // Should show available Anthropic models
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("anthropic/claude-sonnet-4.5"),
       );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("anthropic/claude-opus-4.5"),
       );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("anthropic/claude-haiku-4.5"),
       );
     });

--- a/turbo/apps/cli/src/commands/model-provider/setup.ts
+++ b/turbo/apps/cli/src/commands/model-provider/setup.ts
@@ -37,10 +37,10 @@ interface SetupInput {
 function validateProviderType(typeStr: string): ModelProviderType {
   if (!Object.keys(MODEL_PROVIDER_TYPES).includes(typeStr)) {
     console.error(chalk.red(`✗ Invalid type "${typeStr}"`));
-    console.log();
-    console.log("Valid types:");
+    console.error();
+    console.error("Valid types:");
     for (const [t, config] of Object.entries(MODEL_PROVIDER_TYPES)) {
-      console.log(`  ${chalk.cyan(t)} - ${config.label}`);
+      console.error(`  ${chalk.cyan(t)} - ${config.label}`);
     }
     process.exit(1);
   }
@@ -60,10 +60,10 @@ function validateModel(
 
   if (models && !models.includes(modelStr)) {
     console.error(chalk.red(`✗ Invalid model "${modelStr}"`));
-    console.log();
-    console.log("Valid models:");
+    console.error();
+    console.error("Valid models:");
     for (const m of models) {
-      console.log(`  ${chalk.cyan(m)}`);
+      console.error(`  ${chalk.cyan(m)}`);
     }
     process.exit(1);
   }
@@ -77,11 +77,11 @@ function validateAuthMethod(
   const authMethods = getAuthMethodsForType(type);
   if (!authMethods || !(authMethodStr in authMethods)) {
     console.error(chalk.red(`✗ Invalid auth method "${authMethodStr}"`));
-    console.log();
-    console.log("Valid auth methods:");
+    console.error();
+    console.error("Valid auth methods:");
     if (authMethods) {
       for (const [method, config] of Object.entries(authMethods)) {
-        console.log(`  ${chalk.cyan(method)} - ${config.label}`);
+        console.error(`  ${chalk.cyan(method)} - ${config.label}`);
       }
     }
     process.exit(1);
@@ -115,11 +115,11 @@ function parseSecrets(
       console.error(
         chalk.red("✗ Must use KEY=VALUE format for multi-secret auth methods"),
       );
-      console.log();
-      console.log("Required secrets:");
+      console.error();
+      console.error("Required secrets:");
       for (const [name, fieldConfig] of Object.entries(secretsConfig)) {
         const requiredNote = fieldConfig.required ? " (required)" : "";
-        console.log(`  ${chalk.cyan(name)}${requiredNote}`);
+        console.error(`  ${chalk.cyan(name)}${requiredNote}`);
       }
       process.exit(1);
     }
@@ -137,8 +137,8 @@ function parseSecrets(
     const eqIndex = arg.indexOf("=");
     if (eqIndex === -1) {
       console.error(chalk.red(`✗ Invalid secret format "${arg}"`));
-      console.log();
-      console.log("Use KEY=VALUE format (e.g., AWS_REGION=us-east-1)");
+      console.error();
+      console.error("Use KEY=VALUE format (e.g., AWS_REGION=us-east-1)");
       process.exit(1);
     }
     const key = arg.slice(0, eqIndex);
@@ -166,11 +166,11 @@ function validateSecrets(
   for (const [name, fieldConfig] of Object.entries(secretsConfig)) {
     if (fieldConfig.required && !secrets[name]) {
       console.error(chalk.red(`✗ Missing required secret: ${name}`));
-      console.log();
-      console.log("Required secrets:");
+      console.error();
+      console.error("Required secrets:");
       for (const [n, fc] of Object.entries(secretsConfig)) {
         if (fc.required) {
-          console.log(`  ${chalk.cyan(n)} - ${fc.label}`);
+          console.error(`  ${chalk.cyan(n)} - ${fc.label}`);
         }
       }
       process.exit(1);
@@ -181,11 +181,11 @@ function validateSecrets(
   for (const name of Object.keys(secrets)) {
     if (!(name in secretsConfig)) {
       console.error(chalk.red(`✗ Unknown secret: ${name}`));
-      console.log();
-      console.log("Valid secrets:");
+      console.error();
+      console.error("Valid secrets:");
       for (const [n, fc] of Object.entries(secretsConfig)) {
         const requiredNote = fc.required ? " (required)" : " (optional)";
-        console.log(`  ${chalk.cyan(n)}${requiredNote}`);
+        console.error(`  ${chalk.cyan(n)}${requiredNote}`);
       }
       process.exit(1);
     }
@@ -233,17 +233,17 @@ function handleNonInteractiveMode(options: {
             `✗ --auth-method is required for "${type}" (multiple auth methods available)`,
           ),
         );
-        console.log();
-        console.log("Available auth methods:");
+        console.error();
+        console.error("Available auth methods:");
         for (const [method, config] of Object.entries(authMethods)) {
           const defaultNote = method === defaultAuthMethod ? " (default)" : "";
-          console.log(
+          console.error(
             `  ${chalk.cyan(method)} - ${config.label}${defaultNote}`,
           );
         }
-        console.log();
-        console.log("Example:");
-        console.log(
+        console.error();
+        console.error("Example:");
+        console.error(
           chalk.cyan(
             `  vm0 model-provider setup --type ${type} --auth-method ${authMethodNames[0]} --secret KEY=VALUE`,
           ),
@@ -460,9 +460,9 @@ async function promptForSecrets(
 async function handleInteractiveMode(): Promise<SetupInput | null> {
   if (!isInteractive()) {
     console.error(chalk.red("✗ Interactive mode requires a TTY"));
-    console.log();
-    console.log("Use non-interactive mode:");
-    console.log(
+    console.error();
+    console.error("Use non-interactive mode:");
+    console.error(
       chalk.cyan('  vm0 model-provider setup --type <type> --secret "<value>"'),
     );
     process.exit(1);

--- a/turbo/apps/cli/src/commands/onboard/index.ts
+++ b/turbo/apps/cli/src/commands/onboard/index.ts
@@ -223,9 +223,9 @@ async function handleAgentCreation(ctx: OnboardContext): Promise<string> {
 
       if (existsSync(agentName)) {
         console.error(chalk.red(`${agentName}/ already exists`));
-        console.log();
-        console.log("Remove it first or choose a different name:");
-        console.log(chalk.cyan(`  rm -rf ${agentName}`));
+        console.error();
+        console.error("Remove it first or choose a different name:");
+        console.error(chalk.cyan(`  rm -rf ${agentName}`));
         process.exit(1);
       }
     }

--- a/turbo/apps/cli/src/commands/secret/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/secret/__tests__/set.test.ts
@@ -226,8 +226,8 @@ describe("secret set command", () => {
         await setCommand.parseAsync(["node", "cli", "MY_API_KEY"]);
       }).rejects.toThrow("process.exit called");
 
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("vm0 secret set MY_API_KEY --body");
+      const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+      expect(errorCalls).toContain("vm0 secret set MY_API_KEY --body");
     });
   });
 

--- a/turbo/apps/cli/src/commands/secret/set.ts
+++ b/turbo/apps/cli/src/commands/secret/set.ts
@@ -31,9 +31,9 @@ export const setCommand = new Command()
           console.error(
             chalk.red("✗ --body is required in non-interactive mode"),
           );
-          console.log();
-          console.log("Usage:");
-          console.log(
+          console.error();
+          console.error("Usage:");
+          console.error(
             chalk.cyan(`  vm0 secret set ${name} --body "your-secret-value"`),
           );
           process.exit(1);
@@ -58,11 +58,11 @@ export const setCommand = new Command()
             );
           } else if (error.message.includes("must contain only uppercase")) {
             console.error(chalk.red(`✗ ${error.message}`));
-            console.log();
-            console.log("Examples of valid secret names:");
-            console.log(chalk.dim("  MY_API_KEY"));
-            console.log(chalk.dim("  GITHUB_TOKEN"));
-            console.log(chalk.dim("  AWS_ACCESS_KEY_ID"));
+            console.error();
+            console.error("Examples of valid secret names:");
+            console.error(chalk.dim("  MY_API_KEY"));
+            console.error(chalk.dim("  GITHUB_TOKEN"));
+            console.error(chalk.dim("  AWS_ACCESS_KEY_ID"));
           } else {
             console.error(chalk.red(`✗ ${error.message}`));
           }

--- a/turbo/apps/cli/src/commands/variable/set.ts
+++ b/turbo/apps/cli/src/commands/variable/set.ts
@@ -30,11 +30,11 @@ export const setCommand = new Command()
             );
           } else if (error.message.includes("must contain only uppercase")) {
             console.error(chalk.red(`✗ ${error.message}`));
-            console.log();
-            console.log("Examples of valid variable names:");
-            console.log(chalk.dim("  MY_VAR"));
-            console.log(chalk.dim("  API_URL"));
-            console.log(chalk.dim("  DEBUG_MODE"));
+            console.error();
+            console.error("Examples of valid variable names:");
+            console.error(chalk.dim("  MY_VAR"));
+            console.error(chalk.dim("  API_URL"));
+            console.error(chalk.dim("  DEBUG_MODE"));
           } else {
             console.error(chalk.red(`✗ ${error.message}`));
           }

--- a/turbo/apps/cli/src/lib/utils/update-checker.ts
+++ b/turbo/apps/cli/src/lib/utils/update-checker.ts
@@ -219,12 +219,12 @@ export async function checkAndUpgrade(
   }
 
   // Upgrade failed - show manual instructions
-  console.log();
-  console.log(chalk.red("Upgrade failed. Please run manually:"));
-  console.log(chalk.cyan(`  ${getManualUpgradeCommand(packageManager)}`));
-  console.log();
-  console.log("Then re-run:");
-  console.log(chalk.cyan(`  ${buildRerunCommand(prompt)}`));
+  console.error();
+  console.error(chalk.red("✗ Upgrade failed. Please run manually:"));
+  console.error(chalk.cyan(`  ${getManualUpgradeCommand(packageManager)}`));
+  console.error();
+  console.error("Then re-run:");
+  console.error(chalk.cyan(`  ${buildRerunCommand(prompt)}`));
   return true;
 }
 


### PR DESCRIPTION
## Summary

- Fix mixed stdout/stderr streams across all CLI commands per [CLI design guideline](docs/cli-design-guideline.md)
- Error messages, error hints, and error-path context now consistently use `console.error()`
- Add missing `✗` prefix to error messages where absent
- Remove trailing periods on error messages per guideline

## Files changed

| File | Changes |
|------|---------|
| `connector/connect.ts` | 3x `console.log` → `console.error`, add `✗` prefix, remove trailing periods |
| `connector/disconnect.ts` | "Available connectors:" hint → `console.error` |
| `connector/status.ts` | "Available connectors:" hint → `console.error` |
| `secret/set.ts` | Usage hint and validation examples → `console.error` |
| `variable/set.ts` | Validation examples → `console.error` |
| `model-provider/setup.ts` | 11 mixed-stream fixes (Valid types/models/auth methods/secrets lists) |
| `dev-tool/compose.ts` | "Compose failed" → `console.error` |
| `update-checker.ts` | "Upgrade failed" block → `console.error`, add `✗` prefix |
| `onboard/index.ts` | "Remove it first" hint → `console.error` |
| `cook/cook.ts` | Blank line before error → `console.error` |

## Test plan

- [x] 126 tests pass locally across 8 affected test files
- [x] Pre-commit hooks pass (prettier, lint, type-check, knip, commitlint)
- [ ] CI lint, type-check, and test-cli pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)