### PR TITLE
fix(cli): align error symbols, color semantics, and message formatting with design guideline

### DIFF
--- a/turbo/apps/cli/src/commands/connector/connect.ts
+++ b/turbo/apps/cli/src/commands/connector/connect.ts
@@ -40,7 +40,7 @@ export const connectCommand = new Command()
     // Validate connector type with runtime validation
     const parseResult = connectorTypeSchema.safeParse(type);
     if (!parseResult.success) {
-      console.error(chalk.red(`Unknown connector type: ${type}`));
+      console.error(chalk.red(`✗ Unknown connector type: ${type}`));
       console.error("Available connectors: github");
       process.exit(1);
     }
@@ -66,7 +66,7 @@ export const connectCommand = new Command()
     if (createResult.status !== 200) {
       const errorBody = createResult.body as ApiErrorResponse;
       console.error(
-        chalk.red(`Failed to create session: ${errorBody.error?.message}`),
+        chalk.red(`✗ Failed to create session: ${errorBody.error?.message}`),
       );
       process.exit(1);
     }
@@ -109,7 +109,7 @@ export const connectCommand = new Command()
       if (statusResult.status !== 200) {
         const errorBody = statusResult.body as ApiErrorResponse;
         console.error(
-          chalk.red(`\nFailed to check status: ${errorBody.error?.message}`),
+          chalk.red(`\n✗ Failed to check status: ${errorBody.error?.message}`),
         );
         process.exit(1);
       }
@@ -122,7 +122,7 @@ export const connectCommand = new Command()
           return;
 
         case "expired":
-          console.error(chalk.red("\n✗ Session expired. Please try again"));
+          console.error(chalk.red("\n✗ Session expired, please try again"));
           process.exit(1);
           break;
 
@@ -143,6 +143,6 @@ export const connectCommand = new Command()
     }
 
     // Timeout
-    console.error(chalk.red("\n✗ Session timed out. Please try again"));
+    console.error(chalk.red("\n✗ Session timed out, please try again"));
     process.exit(1);
   });

--- a/turbo/apps/cli/src/commands/cook/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/cook/__tests__/index.test.ts
@@ -756,9 +756,7 @@ agents:
         .filter((log): log is string => typeof log === "string");
 
       expect(
-        allLogs.some((log) =>
-          log.includes("Warning: Could not check for updates"),
-        ),
+        allLogs.some((log) => log.includes("⚠ Could not check for updates")),
       ).toBe(true);
     });
 

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -391,16 +391,17 @@ async function showNetworkLogs(
 function handleError(error: unknown, runId: string): void {
   if (error instanceof Error) {
     if (error.message.includes("Not authenticated")) {
-      console.error(chalk.red("Not authenticated. Run: vm0 auth login"));
+      console.error(chalk.red("✗ Not authenticated"));
+      console.error(chalk.dim("  Run: vm0 auth login"));
     } else if (error.message.includes("not found")) {
-      console.error(chalk.red(`Run not found: ${runId}`));
+      console.error(chalk.red(`✗ Run not found: ${runId}`));
     } else if (error.message.includes("Invalid time format")) {
-      console.error(chalk.red(error.message));
+      console.error(chalk.red(`✗ ${error.message}`));
     } else {
-      console.error(chalk.red("Failed to fetch logs"));
+      console.error(chalk.red("✗ Failed to fetch logs"));
       console.error(chalk.dim(`  ${error.message}`));
     }
   } else {
-    console.error(chalk.red("An unexpected error occurred"));
+    console.error(chalk.red("✗ An unexpected error occurred"));
   }
 }

--- a/turbo/apps/cli/src/commands/model-provider/setup.ts
+++ b/turbo/apps/cli/src/commands/model-provider/setup.ts
@@ -509,7 +509,7 @@ async function handleInteractiveMode(): Promise<SetupInput | null> {
   // Handle existing model-provider secret
   if (checkResult.exists) {
     console.log();
-    console.log(`"${type}" is already configured.`);
+    console.log(`"${type}" is already configured`);
     console.log();
 
     const actionResponse = await prompts(
@@ -582,7 +582,8 @@ async function handleInteractiveMode(): Promise<SetupInput | null> {
 function handleSetupError(error: unknown): never {
   if (error instanceof Error) {
     if (error.message.includes("Not authenticated")) {
-      console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
+      console.error(chalk.red("✗ Not authenticated"));
+      console.error(chalk.dim("  Run: vm0 auth login"));
     } else {
       console.error(chalk.red(`✗ ${error.message}`));
     }

--- a/turbo/apps/cli/src/commands/onboard/index.ts
+++ b/turbo/apps/cli/src/commands/onboard/index.ts
@@ -50,7 +50,7 @@ async function handleAuthentication(ctx: OnboardContext): Promise<void> {
     }
 
     if (!ctx.interactive) {
-      console.error(chalk.red("Error: Not authenticated"));
+      console.error(chalk.red("✗ Not authenticated"));
       console.error("Run 'vm0 auth login' first or set VM0_TOKEN");
       process.exit(1);
     }
@@ -71,7 +71,7 @@ async function handleAuthentication(ctx: OnboardContext): Promise<void> {
         // Will be shown as completed step
       },
       onError: (error) => {
-        console.error(chalk.red(`\n${error.message}`));
+        console.error(chalk.red(`\n✗ ${error.message}`));
         process.exit(1);
       },
     });
@@ -86,7 +86,7 @@ async function handleModelProvider(ctx: OnboardContext): Promise<void> {
     }
 
     if (!ctx.interactive) {
-      console.error(chalk.red("Error: No model provider configured"));
+      console.error(chalk.red("✗ No model provider configured"));
       console.error("Run 'vm0 model-provider setup' first");
       process.exit(1);
     }
@@ -222,7 +222,7 @@ async function handleAgentCreation(ctx: OnboardContext): Promise<string> {
       }
 
       if (existsSync(agentName)) {
-        console.error(chalk.red(`${agentName}/ already exists`));
+        console.error(chalk.red(`✗ ${agentName}/ already exists`));
         console.error();
         console.error("Remove it first or choose a different name:");
         console.error(chalk.cyan(`  rm -rf ${agentName}`));

--- a/turbo/apps/cli/src/commands/run/list.ts
+++ b/turbo/apps/cli/src/commands/run/list.ts
@@ -18,7 +18,7 @@ function formatRunStatus(status: RunStatus, width?: number): string {
     case "pending":
       return chalk.yellow(paddedStatus);
     case "completed":
-      return chalk.blue(paddedStatus);
+      return chalk.dim(paddedStatus);
     case "failed":
     case "timeout":
       return chalk.red(paddedStatus);
@@ -41,6 +41,7 @@ export const listCommand = new Command()
 
       if (activeRuns.length === 0) {
         console.log(chalk.dim("No active runs"));
+        console.log(chalk.dim('  Run: vm0 run <agent> "<prompt>"'));
         return;
       }
 

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -121,7 +121,7 @@ export const mainRunCommand = new Command()
                 "  Running agent from other users carries security risks.",
               ),
             );
-            console.error(chalk.dim("  Only run agents from users you trust."));
+            console.error(chalk.dim("  Only run agents from users you trust"));
             console.error();
             console.error("Example:");
             console.error(

--- a/turbo/apps/cli/src/commands/schedule/status.ts
+++ b/turbo/apps/cli/src/commands/schedule/status.ts
@@ -43,7 +43,7 @@ function formatRunStatus(status: RunStatus): string {
     case "timeout":
       return chalk.red(status);
     case "running":
-      return chalk.blue(status);
+      return chalk.cyan(status);
     case "pending":
       return chalk.yellow(status);
     default:

--- a/turbo/apps/cli/src/lib/api/auth.ts
+++ b/turbo/apps/cli/src/lib/api/auth.ts
@@ -129,7 +129,7 @@ export async function authenticate(apiUrl?: string): Promise<void> {
       });
 
       console.log(chalk.green("\nAuthentication successful!"));
-      console.log("Your credentials have been saved.");
+      console.log("Your credentials have been saved");
       return;
     }
 
@@ -141,7 +141,7 @@ export async function authenticate(apiUrl?: string): Promise<void> {
 
     // Handle other errors
     if (tokenResult.error === "expired_token") {
-      console.error(chalk.red("\n✗ Device code expired. Please try again"));
+      console.error(chalk.red("\n✗ Device code expired, please try again"));
       process.exit(1);
     }
 
@@ -156,14 +156,14 @@ export async function authenticate(apiUrl?: string): Promise<void> {
   }
 
   // Timeout
-  console.error(chalk.red("\n✗ Authentication timed out. Please try again"));
+  console.error(chalk.red("\n✗ Authentication timed out, please try again"));
   process.exit(1);
 }
 
 export async function logout(): Promise<void> {
   await clearConfig();
   console.log(chalk.green("✓ Successfully logged out"));
-  console.log("Your credentials have been cleared.");
+  console.log("Your credentials have been cleared");
 }
 
 export async function checkAuthStatus(): Promise<void> {

--- a/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/claude-setup.ts
@@ -71,9 +71,9 @@ async function runClaudeCommand(
  */
 export function handlePluginError(error: unknown, context?: string): never {
   const displayContext = context ?? "Claude plugin";
-  console.error(chalk.red(`Failed to install ${displayContext}`));
+  console.error(chalk.red(`✗ Failed to install ${displayContext}`));
   if (error instanceof Error) {
-    console.error(chalk.red(error.message));
+    console.error(chalk.red(`✗ ${error.message}`));
   }
   console.error(
     chalk.dim("Please ensure Claude CLI is installed and accessible."),

--- a/turbo/apps/cli/src/lib/ui/welcome-box.ts
+++ b/turbo/apps/cli/src/lib/ui/welcome-box.ts
@@ -41,7 +41,7 @@ function renderVm0Banner(): void {
 export function renderOnboardWelcome(): void {
   renderVm0Banner();
   console.log(`  Build agentic workflows using natural language.`);
-  console.log(`  ${chalk.dim("Currently in beta, enjoy it free.")}`);
+  console.log(`  ${chalk.dim("Currently in beta, enjoy it free")}`);
   console.log(
     `  ${chalk.dim("Star us on GitHub: https://github.com/vm0-ai/vm0")}`,
   );

--- a/turbo/apps/cli/src/lib/utils/update-checker.ts
+++ b/turbo/apps/cli/src/lib/utils/update-checker.ts
@@ -162,7 +162,7 @@ export async function checkAndUpgrade(
 
   // If we couldn't check, warn and continue
   if (latestVersion === null) {
-    console.log(chalk.yellow("Warning: Could not check for updates"));
+    console.log(chalk.yellow("⚠ Could not check for updates"));
     console.log();
     return false;
   }


### PR DESCRIPTION
## Summary

- Replace `"Error:"` and `"Warning:"` text prefixes with standard symbols (`✗`, `⚠`)
- Add missing `✗` prefix to all `chalk.red()` error messages
- Replace `chalk.blue()` (not in guideline) with `chalk.dim()` / `chalk.cyan()`
- Remove trailing periods from CLI messages
- Split combined error+hint messages into separate lines (error on `chalk.red`, hint on `chalk.dim`)
- Add empty-state creation guide to `vm0 run list`

## Files changed (12)

- `commands/onboard/index.ts` — `"Error:"` → `✗`, add `✗` prefix
- `lib/domain/onboard/claude-setup.ts` — add `✗` prefix
- `commands/logs/index.ts` — add `✗` prefix, split error+hint
- `commands/connector/connect.ts` — add `✗` prefix, remove trailing periods
- `lib/api/auth.ts` — remove trailing periods
- `lib/utils/update-checker.ts` — `"Warning:"` → `⚠`
- `lib/ui/welcome-box.ts` — remove trailing period
- `commands/run/run.ts` — remove trailing period
- `commands/run/list.ts` — `chalk.blue` → `chalk.dim`, add empty-state hint
- `commands/schedule/status.ts` — `chalk.blue` → `chalk.cyan`
- `commands/model-provider/setup.ts` — remove trailing period, split error+hint
- `commands/cook/__tests__/index.test.ts` — update test assertion for `⚠` symbol

## Test plan

- [x] All 750 CLI tests pass (excluding 2 pre-existing scope test failures on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)