### PR TITLE
feat(slack): display user email instead of user ID on app home page

### DIFF
--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -233,6 +233,7 @@ export function buildAgentAddModal(
 export function buildAppHomeView(options: {
   isLinked: boolean;
   vm0UserId?: string;
+  userEmail?: string;
   bindings?: BindingInfo[];
   loginUrl?: string;
 }): View {
@@ -260,7 +261,7 @@ export function buildAppHomeView(options: {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `:white_check_mark: *Connected to VM0*\nAccount: ${options.vm0UserId}`,
+        text: `:white_check_mark: *Connected to VM0*\nAccount: ${options.userEmail || options.vm0UserId}`,
       },
     });
   } else {

--- a/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
@@ -4,6 +4,7 @@ import { slackUserLinks } from "../../../db/schema/slack-user-link";
 import { slackBindings } from "../../../db/schema/slack-binding";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
+import { getUserEmail } from "../../auth/get-user-email";
 import {
   createSlackClient,
   publishAppHome,
@@ -93,10 +94,14 @@ export async function refreshAppHome(
     .from(slackBindings)
     .where(eq(slackBindings.slackUserLinkId, userLink.id));
 
+  // Fetch user email for display
+  const userEmail = await getUserEmail(userLink.vm0UserId);
+
   // Build and publish home view
   const view = buildAppHomeView({
     isLinked: true,
     vm0UserId: userLink.vm0UserId,
+    userEmail,
     bindings,
   });
   await publishAppHome(client, userId, view);

--- a/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
@@ -94,8 +94,9 @@ export async function refreshAppHome(
     .from(slackBindings)
     .where(eq(slackBindings.slackUserLinkId, userLink.id));
 
-  // Fetch user email for display
-  const userEmail = await getUserEmail(userLink.vm0UserId);
+  // Fetch user email for display (fallback to empty string if Clerk API fails,
+  // so the home tab still renders using vm0UserId as fallback)
+  const userEmail = await getUserEmail(userLink.vm0UserId).catch(() => "");
 
   // Build and publish home view
   const view = buildAppHomeView({

--- a/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/app-home-opened.ts
@@ -94,9 +94,8 @@ export async function refreshAppHome(
     .from(slackBindings)
     .where(eq(slackBindings.slackUserLinkId, userLink.id));
 
-  // Fetch user email for display (fallback to empty string if Clerk API fails,
-  // so the home tab still renders using vm0UserId as fallback)
-  const userEmail = await getUserEmail(userLink.vm0UserId).catch(() => "");
+  // Fetch user email for display
+  const userEmail = await getUserEmail(userLink.vm0UserId);
 
   // Build and publish home view
   const view = buildAppHomeView({


### PR DESCRIPTION
## Summary
- Display user's email address instead of Clerk user ID on the Slack app home page
- Uses existing `getUserEmail()` helper to fetch the primary email from Clerk when building the home view
- Falls back to user ID if email is not available

Closes #2580

## Test plan
- [ ] Open Slack app home tab with a linked account — verify email is displayed
- [ ] Verify fallback: if Clerk returns no email, user ID is shown instead
- [ ] Confirm no breaking changes to other home tab elements (bindings, help, disconnect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)