### PR TITLE
feat(sandbox-fc): implement sandbox lifecycle with state machine and resource management

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -574,6 +574,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
@@ -581,7 +582,9 @@ name = "sandbox-fc"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "nix",
  "sandbox",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -5,9 +5,11 @@ edition = "2024"
 
 [dependencies]
 async-trait.workspace = true
+nix = { workspace = true, features = ["user"] }
 sandbox.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["process", "fs", "rt", "macros", "sync"] }
+tokio = { workspace = true, features = ["process", "fs", "rt", "macros", "sync", "io-util"] }
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 vsock-host.workspace = true

--- a/crates/sandbox-fc/src/config.rs
+++ b/crates/sandbox-fc/src/config.rs
@@ -5,14 +5,28 @@ pub struct FirecrackerConfig {
     pub binary_path: PathBuf,
     pub kernel_path: PathBuf,
     pub rootfs_path: PathBuf,
-    pub workspaces_dir: PathBuf,
+    /// Base directory for runtime data (workspaces, overlays, etc.).
+    pub base_dir: PathBuf,
+    /// Per-host unique index (0–63) for network isolation. Can be reused after shutdown.
+    pub instance_index: u32,
+    /// Number of VMs that can run concurrently (determines pool pre-warm size).
+    pub concurrency: usize,
+    /// Port of the HTTP/HTTPS proxy. When set, iptables rules redirect traffic through it.
     pub proxy_port: Option<u16>,
+    /// Snapshot to restore from. When set, VMs boot via snapshot restore instead of fresh boot.
     pub snapshot: Option<SnapshotConfig>,
 }
 
 #[derive(Debug, Clone)]
 pub struct SnapshotConfig {
+    /// Path to the snapshot state file.
     pub snapshot_path: PathBuf,
+    /// Path to the memory dump file.
     pub memory_path: PathBuf,
+    /// Path to the base overlay file shipped with the snapshot.
     pub overlay_path: PathBuf,
+    /// Overlay path recorded in the snapshot's Firecracker config (bind mount target).
+    pub overlay_bind_path: PathBuf,
+    /// Vsock directory recorded in the snapshot's Firecracker config (bind mount target).
+    pub vsock_bind_dir: PathBuf,
 }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -1,19 +1,86 @@
-use std::fs;
-
 use async_trait::async_trait;
 use sandbox::{Sandbox, SandboxConfig, SandboxError, SandboxFactory};
-use uuid::Uuid;
+use tracing::{info, warn};
 
 use crate::config::FirecrackerConfig;
+use crate::network::{NetnsPool, NetnsPoolConfig};
+use crate::overlay::{
+    Ext4Creator, OverlayCreator, OverlayPool, OverlayPoolConfig, SnapshotCopyCreator,
+};
+use crate::paths::{FactoryPaths, SandboxPaths};
 use crate::sandbox::FirecrackerSandbox;
 
 pub struct FirecrackerFactory {
     config: FirecrackerConfig,
+    paths: FactoryPaths,
+    netns_pool: tokio::sync::Mutex<NetnsPool>,
+    overlay_pool: tokio::sync::Mutex<OverlayPool>,
 }
 
 impl FirecrackerFactory {
-    pub fn new(config: FirecrackerConfig) -> Self {
-        Self { config }
+    /// Create a new factory, pre-warming the network namespace and overlay pools.
+    pub async fn new(config: FirecrackerConfig) -> Result<Self, SandboxError> {
+        let concurrency = config.concurrency.max(1);
+        let paths = FactoryPaths::new(config.base_dir.clone());
+
+        let mut netns_pool = NetnsPool::create(NetnsPoolConfig {
+            index: config.instance_index,
+            size: concurrency,
+            proxy_port: config.proxy_port,
+        })
+        .await
+        .map_err(|e| SandboxError::CreationFailed(format!("netns pool: {e}")))?;
+
+        let overlay_creator: Box<dyn OverlayCreator> = match &config.snapshot {
+            Some(snapshot) => Box::new(SnapshotCopyCreator::new(snapshot.overlay_path.clone())),
+            None => Box::new(Ext4Creator),
+        };
+
+        let overlay_pool = match OverlayPool::create(OverlayPoolConfig {
+            size: concurrency,
+            replenish_threshold: (concurrency / 2).max(1),
+            pool_dir: paths.overlays(),
+            creator: overlay_creator,
+        })
+        .await
+        {
+            Ok(pool) => pool,
+            Err(e) => {
+                if let Err(cleanup_err) = netns_pool.cleanup().await {
+                    warn!(error = %cleanup_err, "failed to cleanup netns pool during rollback");
+                }
+                return Err(SandboxError::CreationFailed(format!("overlay pool: {e}")));
+            }
+        };
+
+        let mode = if config.snapshot.is_some() {
+            "snapshot"
+        } else {
+            "fresh"
+        };
+        info!(concurrency, mode, "factory initialized");
+
+        Ok(Self {
+            config,
+            paths,
+            netns_pool: tokio::sync::Mutex::new(netns_pool),
+            overlay_pool: tokio::sync::Mutex::new(overlay_pool),
+        })
+    }
+
+    /// Clean up all factory-level resources (pools).
+    pub async fn cleanup(&self) {
+        let mut netns_pool = self.netns_pool.lock().await;
+        if let Err(e) = netns_pool.cleanup().await {
+            warn!(error = %e, "failed to cleanup netns pool");
+        }
+        drop(netns_pool);
+
+        let mut overlay_pool = self.overlay_pool.lock().await;
+        overlay_pool.cleanup().await;
+        drop(overlay_pool);
+
+        info!("factory cleanup complete");
     }
 }
 
@@ -23,18 +90,85 @@ impl SandboxFactory for FirecrackerFactory {
         "firecracker"
     }
 
-    fn is_available(&self) -> bool {
-        which::which(&self.config.binary_path).is_ok()
-    }
-
     async fn create(&self, config: SandboxConfig) -> sandbox::Result<Box<dyn Sandbox>> {
-        let id = Uuid::new_v4().to_string();
-        let workspace = self.config.workspaces_dir.join(&id);
+        let id = config.id.to_string();
+        let sandbox_paths = SandboxPaths::new(self.paths.workspace(&id));
 
-        fs::create_dir_all(&workspace).map_err(|e| SandboxError::CreationFailed(e.to_string()))?;
+        // Create workspace and vsock subdirectory.
+        tokio::fs::create_dir_all(sandbox_paths.vsock_dir())
+            .await
+            .map_err(|e| SandboxError::CreationFailed(format!("mkdir workspace: {e}")))?;
 
-        let sandbox = FirecrackerSandbox::new(id, config, self.config.clone(), workspace);
+        // Acquire a network namespace from the pool.
+        let network = self
+            .netns_pool
+            .lock()
+            .await
+            .acquire()
+            .await
+            .map_err(|e| SandboxError::CreationFailed(format!("acquire netns: {e}")))?;
+
+        // Acquire an overlay file from the pool.
+        let overlay = match self.overlay_pool.lock().await.acquire().await {
+            Ok(overlay) => overlay,
+            Err(e) => {
+                // Roll back: return netns to pool before propagating error.
+                let mut netns_pool = self.netns_pool.lock().await;
+                if let Err(rel_err) = netns_pool.release(network).await {
+                    warn!(error = %rel_err, "failed to release netns during rollback");
+                }
+                return Err(SandboxError::CreationFailed(format!(
+                    "acquire overlay: {e}"
+                )));
+            }
+        };
+
+        info!(id = %id, "sandbox created");
+
+        let sandbox = FirecrackerSandbox::new(
+            id,
+            config,
+            self.config.clone(),
+            sandbox_paths,
+            network,
+            overlay,
+        );
 
         Ok(Box::new(sandbox))
+    }
+
+    async fn destroy(&self, sandbox: Box<dyn Sandbox>) {
+        let mut sandbox = match (sandbox as Box<dyn std::any::Any>).downcast::<FirecrackerSandbox>()
+        {
+            Ok(s) => *s,
+            Err(_) => {
+                warn!("destroy called with non-firecracker sandbox, ignoring");
+                return;
+            }
+        };
+
+        // Ensure the sandbox is killed before releasing pool resources.
+        let _ = sandbox.kill().await;
+
+        let sandbox_id = sandbox.id;
+
+        // Return the network namespace to the pool.
+        let mut netns_pool = self.netns_pool.lock().await;
+        if let Err(e) = netns_pool.release(sandbox.network).await {
+            warn!(id = %sandbox_id, error = %e, "failed to release netns");
+        }
+        drop(netns_pool);
+
+        // Delete the overlay file.
+        let mut overlay_pool = self.overlay_pool.lock().await;
+        overlay_pool.release(sandbox.overlay).await;
+        drop(overlay_pool);
+
+        // Delete the workspace directory.
+        if let Err(e) = tokio::fs::remove_dir_all(sandbox.paths.workspace()).await {
+            warn!(id = %sandbox_id, error = %e, "failed to delete workspace");
+        }
+
+        info!(id = %sandbox_id, "sandbox destroyed");
     }
 }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -125,14 +125,8 @@ impl SandboxFactory for FirecrackerFactory {
 
         info!(id = %id, "sandbox created");
 
-        let sandbox = FirecrackerSandbox::new(
-            id,
-            config,
-            self.config.clone(),
-            sandbox_paths,
-            network,
-            overlay,
-        );
+        let sandbox =
+            FirecrackerSandbox::new(config, self.config.clone(), sandbox_paths, network, overlay);
 
         Ok(Box::new(sandbox))
     }

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -1,12 +1,12 @@
-pub(crate) mod command;
+mod command;
 mod config;
 mod factory;
-pub(crate) mod network;
-pub(crate) mod overlay;
+mod network;
+mod overlay;
+mod paths;
 mod sandbox;
 
 pub use config::{FirecrackerConfig, SnapshotConfig};
 pub use factory::FirecrackerFactory;
-pub use network::{NetnsPool, NetnsPoolConfig, PooledNetns, cleanup_namespaces_by_index};
-pub use overlay::{Ext4Creator, OverlayCreator, OverlayError, OverlayPool, OverlayPoolConfig};
+pub use paths::{FactoryPaths, SandboxPaths};
 pub use sandbox::FirecrackerSandbox;

--- a/crates/sandbox-fc/src/network/guest.rs
+++ b/crates/sandbox-fc/src/network/guest.rs
@@ -6,15 +6,12 @@ pub struct GuestNetwork {
     /// TAP device name inside namespace (must match Firecracker config).
     pub tap_name: &'static str,
     /// Guest MAC address (locally administered, fixed for all VMs).
-    #[allow(dead_code)]
     pub guest_mac: &'static str,
     /// Guest IP inside the VM.
-    #[allow(dead_code)]
     pub guest_ip: &'static str,
     /// Gateway IP (TAP device in namespace).
     pub gateway_ip: &'static str,
     /// Netmask for /29 subnet (dotted decimal for kernel boot args).
-    #[allow(dead_code)]
     pub netmask: &'static str,
     /// CIDR prefix length (for ip commands).
     pub prefix_len: u8,
@@ -29,7 +26,6 @@ pub const GUEST_NETWORK: GuestNetwork = GuestNetwork {
     prefix_len: 29,
 };
 
-#[allow(dead_code)]
 /// Generate kernel boot args for guest network configuration.
 pub fn generate_guest_network_boot_args() -> String {
     format!(

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -3,11 +3,6 @@ mod guest;
 mod pool;
 mod prerequisites;
 
-#[allow(unused_imports)]
-pub use error::NetworkError;
-#[allow(unused_imports)]
 pub use guest::generate_guest_network_boot_args;
 pub use guest::{GUEST_NETWORK, GuestNetwork};
-pub use pool::{NetnsPool, NetnsPoolConfig, PooledNetns, cleanup_namespaces_by_index};
-#[allow(unused_imports)]
-pub use prerequisites::{PrerequisiteCheck, check_network_prerequisites};
+pub use pool::{NetnsPool, NetnsPoolConfig, PooledNetns};

--- a/crates/sandbox-fc/src/overlay/mod.rs
+++ b/crates/sandbox-fc/src/overlay/mod.rs
@@ -1,5 +1,4 @@
 mod error;
 mod pool;
 
-pub use error::OverlayError;
-pub use pool::{Ext4Creator, OverlayCreator, OverlayPool, OverlayPoolConfig};
+pub use pool::{Ext4Creator, OverlayCreator, OverlayPool, OverlayPoolConfig, SnapshotCopyCreator};

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -1,0 +1,55 @@
+use std::path::{Path, PathBuf};
+
+/// Factory-level paths derived from the base directory.
+pub struct FactoryPaths {
+    base_dir: PathBuf,
+}
+
+impl FactoryPaths {
+    pub fn new(base_dir: PathBuf) -> Self {
+        Self { base_dir }
+    }
+
+    pub fn workspaces(&self) -> PathBuf {
+        self.base_dir.join("workspaces")
+    }
+
+    pub fn overlays(&self) -> PathBuf {
+        self.base_dir.join("overlays")
+    }
+
+    pub fn workspace(&self, id: &str) -> PathBuf {
+        self.workspaces().join(id)
+    }
+}
+
+/// Per-sandbox paths within a workspace directory.
+pub struct SandboxPaths {
+    workspace: PathBuf,
+}
+
+impl SandboxPaths {
+    pub fn new(workspace: PathBuf) -> Self {
+        Self { workspace }
+    }
+
+    pub fn workspace(&self) -> &Path {
+        &self.workspace
+    }
+
+    pub fn config(&self) -> PathBuf {
+        self.workspace.join("config.json")
+    }
+
+    pub fn vsock_dir(&self) -> PathBuf {
+        self.workspace.join("vsock")
+    }
+
+    pub fn vsock(&self) -> PathBuf {
+        self.vsock_dir().join("vsock.sock")
+    }
+
+    pub fn api_sock(&self) -> PathBuf {
+        self.workspace.join("api.sock")
+    }
+}

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1,27 +1,74 @@
-#![allow(clippy::todo)]
-
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::time::Duration;
 
 use async_trait::async_trait;
-use sandbox::{ExecRequest, ExecResult, ProcessExit, Sandbox, SandboxConfig, SpawnHandle};
+use sandbox::{
+    ExecRequest, ExecResult, ProcessExit, Sandbox, SandboxConfig, SandboxError, SpawnHandle,
+};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tracing::{debug, info, warn};
 use vsock_host::VsockHost;
 
 use crate::config::FirecrackerConfig;
-use crate::network::PooledNetns;
+use crate::network::{GUEST_NETWORK, PooledNetns, generate_guest_network_boot_args};
+use crate::paths::SandboxPaths;
+
+/// Timeout for waiting for the guest to connect via vsock after start.
+const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Timeout for graceful shutdown via vsock.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SandboxState {
+    Created = 0,
+    Running = 1,
+    Stopping = 2,
+    Stopped = 3,
+}
+
+impl SandboxState {
+    fn from_u8(v: u8) -> Self {
+        match v {
+            0 => Self::Created,
+            1 => Self::Running,
+            2 => Self::Stopping,
+            _ => Self::Stopped,
+        }
+    }
+}
+
+impl std::fmt::Display for SandboxState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Created => f.write_str("created"),
+            Self::Running => f.write_str("running"),
+            Self::Stopping => f.write_str("stopping"),
+            Self::Stopped => f.write_str("stopped"),
+        }
+    }
+}
 
 pub struct FirecrackerSandbox {
-    id: String,
-    #[allow(dead_code)]
+    /// Sandbox identifier (used by factory for resource cleanup).
+    pub(crate) id: String,
     config: SandboxConfig,
-    #[allow(dead_code)]
     factory_config: FirecrackerConfig,
-    workspace: PathBuf,
-    #[allow(dead_code)]
-    vm_process: Option<tokio::process::Child>,
-    #[allow(dead_code)]
-    guest: Option<tokio::sync::Mutex<VsockHost>>,
-    #[allow(dead_code)]
-    network: Option<PooledNetns>,
+    /// Workspace paths (used by factory to delete workspace on destroy).
+    pub(crate) paths: SandboxPaths,
+    /// Pooled network namespace (returned to pool on destroy).
+    pub(crate) network: PooledNetns,
+    /// Overlay file path (deleted on destroy).
+    pub(crate) overlay: PathBuf,
+    process: Option<tokio::process::Child>,
+    /// Lifecycle state, shared with background log tasks for crash detection.
+    state: Arc<AtomicU8>,
+    /// Vsock guest connection, shared with background log tasks so they can
+    /// drop the connection immediately when the process exits unexpectedly.
+    guest: Arc<tokio::sync::Mutex<Option<VsockHost>>>,
 }
 
 impl FirecrackerSandbox {
@@ -29,30 +76,298 @@ impl FirecrackerSandbox {
         id: String,
         config: SandboxConfig,
         factory_config: FirecrackerConfig,
-        workspace: PathBuf,
+        paths: SandboxPaths,
+        network: PooledNetns,
+        overlay: PathBuf,
     ) -> Self {
         Self {
             id,
             config,
             factory_config,
-            workspace,
-            vm_process: None,
-            guest: None,
-            network: None,
+            paths,
+            network,
+            overlay,
+            process: None,
+            state: Arc::new(AtomicU8::new(SandboxState::Created as u8)),
+            guest: Arc::new(tokio::sync::Mutex::new(None)),
         }
     }
 
-    pub fn socket_path(&self) -> PathBuf {
-        self.workspace.join("firecracker.sock")
+    fn current_state(&self) -> SandboxState {
+        SandboxState::from_u8(self.state.load(Ordering::Acquire))
     }
 
-    pub fn vsock_path(&self) -> PathBuf {
-        self.workspace.join("vm.vsock")
+    /// Atomically transition between states using CAS. Returns `true` if the
+    /// transition succeeded, `false` if the current state did not match `from`.
+    fn transition(&self, from: SandboxState, to: SandboxState) -> bool {
+        self.state
+            .compare_exchange(from as u8, to as u8, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
     }
 
-    pub fn config_path(&self) -> PathBuf {
-        self.workspace.join("config.json")
+    /// Build the Firecracker JSON configuration for fresh boot.
+    fn build_config(&self) -> serde_json::Value {
+        let kernel_path = self.factory_config.kernel_path.display().to_string();
+        let rootfs_path = self.factory_config.rootfs_path.display().to_string();
+        let overlay_path = self.overlay.display().to_string();
+        let vsock_path = self.paths.vsock().display().to_string();
+
+        let boot_args = format!(
+            "console=ttyS0 reboot=k panic=1 pci=off nomodules random.trust_cpu=on \
+             quiet loglevel=0 nokaslr audit=0 numa=off mitigations=off noresume \
+             init=/sbin/guest-init {network}",
+            network = generate_guest_network_boot_args(),
+        );
+
+        serde_json::json!({
+            "boot-source": {
+                "kernel_image_path": kernel_path,
+                "boot_args": boot_args,
+            },
+            "drives": [
+                {
+                    "drive_id": "rootfs",
+                    "path_on_host": rootfs_path,
+                    "is_root_device": true,
+                    "is_read_only": true,
+                },
+                {
+                    "drive_id": "overlay",
+                    "path_on_host": overlay_path,
+                    "is_root_device": false,
+                    "is_read_only": false,
+                },
+            ],
+            "machine-config": {
+                "vcpu_count": self.config.resources.cpu_count,
+                "mem_size_mib": self.config.resources.memory_mb,
+            },
+            "network-interfaces": [
+                {
+                    "iface_id": "eth0",
+                    "guest_mac": GUEST_NETWORK.guest_mac,
+                    "host_dev_name": GUEST_NETWORK.tap_name,
+                },
+            ],
+            "vsock": {
+                "guest_cid": 3,
+                "uds_path": vsock_path,
+            },
+        })
     }
+
+    /// Start using a fresh boot with `--config-file --no-api`.
+    async fn start_fresh(&mut self) -> sandbox::Result<()> {
+        let config = self.build_config();
+        let config_json = serde_json::to_string_pretty(&config)
+            .map_err(|e| SandboxError::StartFailed(format!("serialize config: {e}")))?;
+
+        tokio::fs::write(self.paths.config(), config_json.as_bytes())
+            .await
+            .map_err(|e| SandboxError::StartFailed(format!("write config: {e}")))?;
+
+        let username = current_username()?;
+
+        // sudo ip netns exec {ns} sudo -u {user} firecracker --config-file {path} --no-api
+        let mut child = tokio::process::Command::new("sudo")
+            .arg("ip")
+            .arg("netns")
+            .arg("exec")
+            .arg(&self.network.name)
+            .arg("sudo")
+            .arg("-u")
+            .arg(&username)
+            .arg(&self.factory_config.binary_path)
+            .arg("--config-file")
+            .arg(self.paths.config())
+            .arg("--no-api")
+            .current_dir(self.paths.workspace())
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| SandboxError::StartFailed(format!("spawn firecracker: {e}")))?;
+
+        monitor_process(
+            &self.id,
+            &mut child,
+            Arc::clone(&self.state),
+            Arc::clone(&self.guest),
+        );
+        self.process = Some(child);
+        info!(id = %self.id, "firecracker started (fresh boot)");
+        Ok(())
+    }
+
+    /// Start from a snapshot using `--api-sock` and bind mounts.
+    async fn start_from_snapshot(&mut self) -> sandbox::Result<()> {
+        let snapshot = self
+            .factory_config
+            .snapshot
+            .as_ref()
+            .ok_or_else(|| SandboxError::StartFailed("missing snapshot config".into()))?;
+
+        let username = current_username()?;
+
+        let actual_vsock_dir = self.paths.vsock_dir().display().to_string();
+        let actual_overlay = self.overlay.display().to_string();
+        let bind_vsock_dir = snapshot.vsock_bind_dir.display().to_string();
+        let bind_overlay = snapshot.overlay_bind_path.display().to_string();
+
+        // Ensure bind mount target directories exist.
+        tokio::fs::create_dir_all(&snapshot.vsock_bind_dir)
+            .await
+            .map_err(|e| SandboxError::StartFailed(format!("mkdir snapshot vsock: {e}")))?;
+
+        if let Some(parent) = snapshot.overlay_bind_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| SandboxError::StartFailed(format!("mkdir snapshot overlay: {e}")))?;
+        }
+
+        // Create empty file as bind mount target for the overlay.
+        if !tokio::fs::try_exists(&snapshot.overlay_bind_path)
+            .await
+            .unwrap_or(false)
+        {
+            tokio::fs::write(&snapshot.overlay_bind_path, b"")
+                .await
+                .map_err(|e| {
+                    SandboxError::StartFailed(format!("create overlay mount target: {e}"))
+                })?;
+        }
+
+        // unshare --mount bash -c "bind mounts && ip netns exec {ns} sudo -u {user} firecracker --api-sock {path}"
+        let fc_binary = self.factory_config.binary_path.display().to_string();
+        let api_sock = self.paths.api_sock().display().to_string();
+        let ns_name = &self.network.name;
+
+        let inner_cmd = format!(
+            "mount --bind \"{actual_vsock_dir}\" \"{bind_vsock_dir}\" && \
+             mount --bind \"{actual_overlay}\" \"{bind_overlay}\" && \
+             ip netns exec \"{ns_name}\" sudo -u \"{username}\" \"{fc_binary}\" --api-sock \"{api_sock}\""
+        );
+
+        let mut child = tokio::process::Command::new("sudo")
+            .args(["unshare", "--mount", "bash", "-c", &inner_cmd])
+            .current_dir(self.paths.workspace())
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| SandboxError::StartFailed(format!("spawn firecracker: {e}")))?;
+
+        monitor_process(
+            &self.id,
+            &mut child,
+            Arc::clone(&self.state),
+            Arc::clone(&self.guest),
+        );
+        self.process = Some(child);
+        info!(id = %self.id, "firecracker started (snapshot restore)");
+
+        // TODO: Wait for API socket ready, then load snapshot via Firecracker HTTP API.
+        // This requires a Firecracker API client (HTTP over Unix socket).
+        // For now, kill the process we just spawned and return an error.
+        self.kill_process().await;
+        Err(SandboxError::StartFailed(
+            "snapshot restore not yet implemented".into(),
+        ))
+    }
+
+    /// Kill the process tree.
+    ///
+    /// The process chain is `sudo -> ip netns exec -> sudo -> firecracker`.
+    /// We must kill the entire tree to avoid orphan processes.
+    async fn kill_process(&mut self) {
+        let Some(ref mut child) = self.process else {
+            return;
+        };
+
+        if let Some(pid) = child.id() {
+            kill_process_tree(pid).await;
+        }
+
+        // Reap the zombie process.
+        let _ = child.wait().await;
+        self.process = None;
+    }
+}
+
+/// Monitor the child process for unexpected exit and forward logs.
+///
+/// Spawns background tasks that read stdout/stderr until the pipes close.
+/// When stdout closes, if the state is still `Running`, the process exited
+/// unexpectedly — the task updates state to `Stopped` and drops the guest
+/// connection.
+fn monitor_process(
+    id: &str,
+    child: &mut tokio::process::Child,
+    state: Arc<AtomicU8>,
+    guest: Arc<tokio::sync::Mutex<Option<VsockHost>>>,
+) {
+    if let Some(stdout) = child.stdout.take() {
+        let id = id.to_owned();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if !line.is_empty() {
+                    debug!(id = %id, "{line}");
+                }
+            }
+            // Pipe closed — process exited.
+            let prev =
+                SandboxState::from_u8(state.swap(SandboxState::Stopped as u8, Ordering::AcqRel));
+            if prev == SandboxState::Running {
+                warn!(id = %id, "process exited unexpectedly");
+                guest.lock().await.take();
+            }
+        });
+    }
+    if let Some(stderr) = child.stderr.take() {
+        let id = id.to_owned();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if !line.is_empty() {
+                    warn!(id = %id, "stderr: {line}");
+                }
+            }
+        });
+    }
+}
+
+/// Recursively kill a process and all its descendants (depth-first).
+async fn kill_process_tree(pid: u32) {
+    // Find child PIDs.
+    let pid_str = pid.to_string();
+    if let Ok(output) = tokio::process::Command::new("pgrep")
+        .args(["-P", &pid_str])
+        .output()
+        .await
+    {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            if let Ok(child_pid) = line.trim().parse::<u32>() {
+                Box::pin(kill_process_tree(child_pid)).await;
+            }
+        }
+    }
+
+    // Kill this process.
+    let _ = tokio::process::Command::new("sudo")
+        .args(["kill", "-9", &pid_str])
+        .output()
+        .await;
+}
+
+/// Get the current username via `getuid()`.
+fn current_username() -> sandbox::Result<String> {
+    let uid = nix::unistd::getuid();
+    let user = nix::unistd::User::from_uid(uid)
+        .map_err(|e| SandboxError::StartFailed(format!("lookup uid {uid}: {e}")))?
+        .ok_or_else(|| SandboxError::StartFailed(format!("no user for uid {uid}")))?;
+    Ok(user.name)
 }
 
 #[async_trait]
@@ -62,30 +377,171 @@ impl Sandbox for FirecrackerSandbox {
     }
 
     async fn start(&mut self) -> sandbox::Result<()> {
-        todo!()
+        if self.current_state() != SandboxState::Created {
+            return Err(SandboxError::StartFailed("sandbox already started".into()));
+        }
+
+        // Start the vsock listener BEFORE launching Firecracker.
+        // The UDS must be bound before the guest tries to connect.
+        let vsock_path = self.paths.vsock().display().to_string();
+        let vsock_task = tokio::spawn(async move {
+            VsockHost::wait_for_connection(&vsock_path, VSOCK_CONNECT_TIMEOUT).await
+        });
+
+        let start_result = if self.factory_config.snapshot.is_some() {
+            self.start_from_snapshot().await
+        } else {
+            self.start_fresh().await
+        };
+
+        if let Err(e) = start_result {
+            vsock_task.abort();
+            self.kill_process().await;
+            return Err(e);
+        }
+
+        // Wait for guest to connect via vsock.
+        let vsock_guest = match vsock_task.await {
+            Ok(Ok(g)) => g,
+            Ok(Err(e)) => {
+                self.kill_process().await;
+                return Err(SandboxError::StartFailed(format!("vsock connection: {e}")));
+            }
+            Err(e) => {
+                self.kill_process().await;
+                return Err(SandboxError::StartFailed(format!("vsock task: {e}")));
+            }
+        };
+
+        *self.guest.lock().await = Some(vsock_guest);
+
+        // Use CAS to avoid overwriting Stopped if the process crashed between
+        // spawn and vsock connect (the background log task may have already
+        // swapped the state to Stopped).
+        if !self.transition(SandboxState::Created, SandboxState::Running) {
+            self.guest.lock().await.take();
+            self.kill_process().await;
+            return Err(SandboxError::StartFailed(
+                "process exited during startup".into(),
+            ));
+        }
+
+        info!(id = %self.id, "sandbox started");
+        Ok(())
     }
 
-    async fn exec(&self, _request: &ExecRequest<'_>) -> sandbox::Result<ExecResult> {
-        todo!()
+    async fn exec(&self, request: &ExecRequest<'_>) -> sandbox::Result<ExecResult> {
+        let mut guard = self.guest.lock().await;
+        let Some(ref mut guest) = *guard else {
+            return Err(SandboxError::ExecFailed(format!(
+                "sandbox not running (state: {})",
+                self.current_state()
+            )));
+        };
+
+        let timeout_ms = u32::try_from(request.timeout_ms).unwrap_or(u32::MAX);
+        let result = guest
+            .exec(request.cmd, timeout_ms)
+            .await
+            .map_err(|e| SandboxError::ExecFailed(e.to_string()))?;
+
+        Ok(ExecResult {
+            exit_code: result.exit_code,
+            stdout: String::from_utf8_lossy(&result.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&result.stderr).into_owned(),
+        })
     }
 
-    async fn write_file(&self, _path: &str, _content: &[u8]) -> sandbox::Result<()> {
-        todo!()
+    async fn write_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
+        let mut guard = self.guest.lock().await;
+        let Some(ref mut guest) = *guard else {
+            return Err(SandboxError::ExecFailed(format!(
+                "sandbox not running (state: {})",
+                self.current_state()
+            )));
+        };
+
+        guest
+            .write_file(path, content, false)
+            .await
+            .map_err(|e| SandboxError::ExecFailed(e.to_string()))?;
+
+        Ok(())
     }
 
-    async fn spawn_watch(&self, _request: &ExecRequest<'_>) -> sandbox::Result<SpawnHandle> {
-        todo!()
+    async fn spawn_watch(&self, request: &ExecRequest<'_>) -> sandbox::Result<SpawnHandle> {
+        let mut guard = self.guest.lock().await;
+        let Some(ref mut guest) = *guard else {
+            return Err(SandboxError::ExecFailed(format!(
+                "sandbox not running (state: {})",
+                self.current_state()
+            )));
+        };
+
+        let timeout_ms = u32::try_from(request.timeout_ms).unwrap_or(u32::MAX);
+        let pid = guest
+            .spawn_watch(request.cmd, timeout_ms)
+            .await
+            .map_err(|e| SandboxError::ExecFailed(e.to_string()))?;
+
+        Ok(SpawnHandle { pid })
     }
 
-    async fn wait_exit(&self, _handle: SpawnHandle) -> sandbox::Result<ProcessExit> {
-        todo!()
+    async fn wait_exit(&self, handle: SpawnHandle) -> sandbox::Result<ProcessExit> {
+        let mut guard = self.guest.lock().await;
+        let Some(ref mut guest) = *guard else {
+            return Err(SandboxError::ExecFailed(format!(
+                "sandbox not running (state: {})",
+                self.current_state()
+            )));
+        };
+
+        let timeout = Duration::from_secs(self.config.resources.timeout_secs);
+        let event = guest
+            .wait_for_exit(handle.pid, timeout)
+            .await
+            .map_err(|e| SandboxError::ExecFailed(e.to_string()))?;
+
+        Ok(ProcessExit {
+            pid: event.pid,
+            exit_code: event.exit_code,
+            stdout: event.stdout,
+            stderr: event.stderr,
+        })
     }
 
     async fn stop(&mut self) -> sandbox::Result<()> {
-        todo!()
+        if !self.transition(SandboxState::Running, SandboxState::Stopping) {
+            return Ok(());
+        }
+
+        // Try graceful shutdown via vsock.
+        {
+            let mut guard = self.guest.lock().await;
+            if let Some(ref mut guest) = *guard
+                && !guest.shutdown(SHUTDOWN_TIMEOUT).await
+            {
+                warn!(id = %self.id, "graceful shutdown timed out");
+            }
+            guard.take();
+        }
+
+        self.kill_process().await;
+        self.state
+            .store(SandboxState::Stopped as u8, Ordering::Release);
+        info!(id = %self.id, "sandbox stopped");
+        Ok(())
     }
 
     async fn kill(&mut self) -> sandbox::Result<()> {
-        todo!()
+        if !self.transition(SandboxState::Running, SandboxState::Stopping) {
+            return Ok(());
+        }
+        self.guest.lock().await.take();
+        self.kill_process().await;
+        self.state
+            .store(SandboxState::Stopped as u8, Ordering::Release);
+        info!(id = %self.id, "sandbox killed");
+        Ok(())
     }
 }

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -53,10 +53,10 @@ impl std::fmt::Display for SandboxState {
 }
 
 pub struct FirecrackerSandbox {
-    /// Sandbox identifier (used by factory for resource cleanup).
-    pub(crate) id: String,
     config: SandboxConfig,
     factory_config: FirecrackerConfig,
+    /// Cached `config.id.to_string()`.
+    pub(crate) id: String,
     /// Workspace paths (used by factory to delete workspace on destroy).
     pub(crate) paths: SandboxPaths,
     /// Pooled network namespace (returned to pool on destroy).
@@ -73,17 +73,17 @@ pub struct FirecrackerSandbox {
 
 impl FirecrackerSandbox {
     pub(crate) fn new(
-        id: String,
         config: SandboxConfig,
         factory_config: FirecrackerConfig,
         paths: SandboxPaths,
         network: PooledNetns,
         overlay: PathBuf,
     ) -> Self {
+        let id = config.id.to_string();
         Self {
-            id,
             config,
             factory_config,
+            id,
             paths,
             network,
             overlay,

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -32,6 +32,7 @@ enum SandboxState {
 
 impl SandboxState {
     fn from_u8(v: u8) -> Self {
+        debug_assert!(v <= 3, "invalid SandboxState: {v}");
         match v {
             0 => Self::Created,
             1 => Self::Running,

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -437,9 +437,8 @@ impl Sandbox for FirecrackerSandbox {
             )));
         };
 
-        let timeout_ms = u32::try_from(request.timeout_ms).unwrap_or(u32::MAX);
         let result = guest
-            .exec(request.cmd, timeout_ms)
+            .exec(request.cmd, request.timeout_ms)
             .await
             .map_err(|e| SandboxError::ExecFailed(e.to_string()))?;
 
@@ -476,9 +475,8 @@ impl Sandbox for FirecrackerSandbox {
             )));
         };
 
-        let timeout_ms = u32::try_from(request.timeout_ms).unwrap_or(u32::MAX);
         let pid = guest
-            .spawn_watch(request.cmd, timeout_ms)
+            .spawn_watch(request.cmd, request.timeout_ms)
             .await
             .map_err(|e| SandboxError::ExecFailed(e.to_string()))?;
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -209,11 +209,6 @@ impl FirecrackerSandbox {
 
         let username = current_username()?;
 
-        let actual_vsock_dir = self.paths.vsock_dir().display().to_string();
-        let actual_overlay = self.overlay.display().to_string();
-        let bind_vsock_dir = snapshot.vsock_bind_dir.display().to_string();
-        let bind_overlay = snapshot.overlay_bind_path.display().to_string();
-
         // Ensure bind mount target directories exist.
         tokio::fs::create_dir_all(&snapshot.vsock_bind_dir)
             .await
@@ -226,10 +221,13 @@ impl FirecrackerSandbox {
         }
 
         // Create empty file as bind mount target for the overlay.
-        if !tokio::fs::try_exists(&snapshot.overlay_bind_path)
+        let exists = tokio::fs::try_exists(&snapshot.overlay_bind_path)
             .await
-            .unwrap_or(false)
-        {
+            .unwrap_or_else(|e| {
+                warn!(error = %e, "failed to check overlay mount target");
+                false
+            });
+        if !exists {
             tokio::fs::write(&snapshot.overlay_bind_path, b"")
                 .await
                 .map_err(|e| {
@@ -237,19 +235,19 @@ impl FirecrackerSandbox {
                 })?;
         }
 
-        // unshare --mount bash -c "bind mounts && ip netns exec {ns} sudo -u {user} firecracker --api-sock {path}"
-        let fc_binary = self.factory_config.binary_path.display().to_string();
-        let api_sock = self.paths.api_sock().display().to_string();
-        let ns_name = &self.network.name;
-
-        let inner_cmd = format!(
-            "mount --bind \"{actual_vsock_dir}\" \"{bind_vsock_dir}\" && \
-             mount --bind \"{actual_overlay}\" \"{bind_overlay}\" && \
-             ip netns exec \"{ns_name}\" sudo -u \"{username}\" \"{fc_binary}\" --api-sock \"{api_sock}\""
-        );
+        // Use positional args ($1..$8) to avoid shell injection from paths.
+        let inner_cmd = r#"mount --bind "$1" "$2" && mount --bind "$3" "$4" && exec ip netns exec "$5" sudo -u "$6" "$7" --api-sock "$8""#;
 
         let mut child = tokio::process::Command::new("sudo")
-            .args(["unshare", "--mount", "bash", "-c", &inner_cmd])
+            .args(["unshare", "--mount", "bash", "-c", inner_cmd, "_"])
+            .arg(self.paths.vsock_dir()) // $1
+            .arg(&snapshot.vsock_bind_dir) // $2
+            .arg(&self.overlay) // $3
+            .arg(&snapshot.overlay_bind_path) // $4
+            .arg(&self.network.name) // $5
+            .arg(&username) // $6
+            .arg(&self.factory_config.binary_path) // $7
+            .arg(self.paths.api_sock()) // $8
             .current_dir(self.paths.workspace())
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())

--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 async-trait.workspace = true
 thiserror.workspace = true
+uuid = { workspace = true, features = ["v4"] }
 
 [lints]
 workspace = true

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -5,5 +5,6 @@ pub struct ResourceLimits {
 }
 
 pub struct SandboxConfig {
+    pub id: uuid::Uuid,
     pub resources: ResourceLimits,
 }

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -8,5 +8,5 @@ use crate::sandbox::Sandbox;
 pub trait SandboxFactory: Send + Sync {
     fn name(&self) -> &str;
     async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>>;
-    fn is_available(&self) -> bool;
+    async fn destroy(&self, sandbox: Box<dyn Sandbox>);
 }

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -5,6 +5,8 @@ use async_trait::async_trait;
 use crate::error::Result;
 use crate::types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle};
 
+/// The `Any` bound allows `SandboxFactory::destroy()` to downcast
+/// `Box<dyn Sandbox>` back to the concrete type for backend-specific cleanup.
 #[async_trait]
 pub trait Sandbox: Send + Sync + Any {
     async fn start(&mut self) -> Result<()>;

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -1,10 +1,12 @@
+use std::any::Any;
+
 use async_trait::async_trait;
 
 use crate::error::Result;
 use crate::types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle};
 
 #[async_trait]
-pub trait Sandbox: Send + Sync {
+pub trait Sandbox: Send + Sync + Any {
     async fn start(&mut self) -> Result<()>;
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult>;
     async fn write_file(&self, path: &str, content: &[u8]) -> Result<()>;

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -1,10 +1,6 @@
-use std::collections::HashMap;
-
 pub struct ExecRequest<'a> {
     pub cmd: &'a str,
-    pub timeout_ms: u64,
-    pub working_dir: Option<&'a str>,
-    pub env: Option<&'a HashMap<String, String>>,
+    pub timeout_ms: u32,
 }
 
 pub struct ExecResult {


### PR DESCRIPTION
## Summary

- Implement full Firecracker sandbox lifecycle: process spawning (fresh boot + snapshot restore stub), vsock guest connection, graceful stop/kill with process tree cleanup
- Add `SandboxState` state machine (`Created → Running → Stopping → Stopped`) using `Arc<AtomicU8>` with CAS transitions for race-free state management
- Add `monitor_process` background tasks that detect unexpected process exit via stdout pipe closure, atomically update state, and drop the guest connection
- Wire up factory `create()`/`destroy()` with netns + overlay pool resource acquisition, rollback on failure, and kill-before-release in destroy
- Add `FactoryPaths`/`SandboxPaths` for structured path management, `SnapshotCopyCreator` for sparse overlay copies
- Clean up unused exports and dead-code allows across modules

## Test plan

- [x] `cargo check -p sandbox-fc` passes
- [x] `cargo clippy -p sandbox-fc` passes (strict lints: no unwrap, expect, panic, indexing)
- [x] `cargo test -p sandbox-fc` — 44 tests pass
- [ ] Manual integration test with actual Firecracker binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)