### PR TITLE
fix(ci): use releases_created output for production e2b template build

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
       cli_release_created: ${{ steps.release.outputs['turbo/apps/cli--release_created'] }}
       web_release_created: ${{ steps.release.outputs['turbo/apps/web--release_created'] }}
       site_release_created: ${{ steps.release.outputs['turbo/apps/site--release_created'] }}
@@ -638,7 +638,7 @@ jobs:
   build-e2b-template-production:
     needs: [release-please]
     # Build when any release is created
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260203


### PR DESCRIPTION
## Summary

- Fix `build-e2b-template-production` job which has **never run** since it was introduced in #2306
- Root cause: `release_created` (singular) is only set for root-path components in release-please-action v4 monorepo mode. Since all packages have non-root paths (e.g. `turbo/apps/cli`), this output was never `true`
- Fix: switch to `releases_created` (plural) which is set to `true` whenever any package release is created

This is the direct cause of `vm0 dev-tool compose` failing with `404: template 'vm0-cli' not found` in production — the template was built to the dev E2B account but never to production.

## Test plan

- [ ] Verify CI passes on this PR
- [ ] After merge, confirm `build-e2b-template-production` runs on the next release-please workflow that creates a release
- [ ] Verify `vm0 dev-tool compose` works in production after the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)