### PR TITLE
refactor: hoist edition to workspace package config

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -2,6 +2,9 @@
 resolver = "2"
 members = ["vsock-guest", "vsock-proto", "vsock-host", "vsock-test", "guest-init", "guest-common", "guest-download", "sandbox", "sandbox-fc"]
 
+[workspace.package]
+edition = "2024"
+
 [workspace.dependencies]
 # Internal crates
 guest-common = { path = "guest-common" }

--- a/crates/guest-common/Cargo.toml
+++ b/crates/guest-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "guest-common"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [dependencies]
 chrono = { workspace = true, features = ["std", "clock"] }

--- a/crates/guest-download/Cargo.toml
+++ b/crates/guest-download/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "guest-download"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [dependencies]
 flate2.workspace = true

--- a/crates/guest-init/Cargo.toml
+++ b/crates/guest-init/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "guest-init"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 description = "Guest init process for Firecracker - filesystem setup, PID 1, and vsock-guest"
 
 [dependencies]

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sandbox-fc"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [dependencies]
 async-trait.workspace = true

--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sandbox"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [dependencies]
 async-trait.workspace = true

--- a/crates/vsock-guest/Cargo.toml
+++ b/crates/vsock-guest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vsock-guest"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [dependencies]
 libc.workspace = true

--- a/crates/vsock-host/Cargo.toml
+++ b/crates/vsock-host/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vsock-host"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 description = "Vsock host client for Firecracker VM communication"
 
 [dependencies]

--- a/crates/vsock-proto/Cargo.toml
+++ b/crates/vsock-proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vsock-proto"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 description = "Vsock binary protocol for host-guest communication"
 
 [lints]

--- a/crates/vsock-test/Cargo.toml
+++ b/crates/vsock-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vsock-test"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [dev-dependencies]
 vsock-guest.workspace = true


### PR DESCRIPTION
## Summary

- Add `[workspace.package]` with `edition = "2024"` to workspace `Cargo.toml`
- Replace `edition = "2024"` with `edition.workspace = true` in all 9 crates

## Test plan

- [x] `cargo clippy --all` passes
- [x] All pre-commit hooks pass (fmt, clippy, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)