### PR TITLE
feat(docs): add ecosystem section with slack integration guide

### DIFF
--- a/turbo/apps/docs/content/docs/ecosystem/index.mdx
+++ b/turbo/apps/docs/content/docs/ecosystem/index.mdx
@@ -1,0 +1,18 @@
+---
+title: Overview
+description: Bring VM0 agents into the platforms you already use
+---
+
+VM0 agents don't have to stay in the terminal. Ecosystem integrations let you connect your agents to the platforms you already use, with more to come.
+
+Once connected, your agent becomes a native part of that platform. Ask it a question, trigger a workflow, or have a conversation — all without leaving the tools you know.
+
+## Available Integrations
+
+<Cards>
+  <Card
+    title="Slack"
+    href="/docs/ecosystem/slack"
+    description="Link any VM0 agent to Slack and chat with it in any channel"
+  />
+</Cards>

--- a/turbo/apps/docs/content/docs/ecosystem/meta.json
+++ b/turbo/apps/docs/content/docs/ecosystem/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Ecosystem",
+  "pages": ["index", "slack"]
+}

--- a/turbo/apps/docs/content/docs/ecosystem/slack.mdx
+++ b/turbo/apps/docs/content/docs/ecosystem/slack.mdx
@@ -1,0 +1,109 @@
+---
+title: Slack
+description: Link VM0 agents to Slack and chat with them in any channel
+---
+
+The VM0 Slack integration brings your agents directly into Slack. Once connected, you can mention `@VM0` in any channel or send a direct message to interact with your agents through natural conversation.
+
+## Use Cases
+
+- **Team Q&A** — Link a knowledge-base agent and let anyone in the channel ask questions
+- **Automated workflows** — Trigger agent tasks from Slack conversations without switching to the terminal
+- **Collaborative debugging** — Share context in a thread and let the agent help investigate
+- **Parallel task execution** — Kick off agent tasks in Slack while you continue other work
+
+## Prerequisites
+
+| Requirement | Details |
+| :--- | :--- |
+| VM0 Account | A VM0 account with at least one agent or compose |
+| Slack Workspace | Admin access to install the VM0 app |
+
+## Setup
+
+### 1. Install the VM0 App in Slack
+
+A workspace administrator must install the VM0 app from the Slack App Directory.
+
+### 2. Connect Your VM0 Account
+
+After the app is installed, connect your VM0 account:
+
+```
+/vm0 connect
+```
+
+This opens a browser flow to link your Slack identity with your VM0 account.
+
+### 3. Link an Agent
+
+Link an agent from your VM0 account to your Slack workspace:
+
+```
+/vm0 agent link
+```
+
+This opens a dialog where you select an agent. If the agent requires secrets or environment variables (e.g. API keys), you'll be prompted to configure them during this step.
+
+Once linked, the agent is available to you in any channel where `@VM0` is present.
+
+<Callout type="info">
+Don't have an agent yet? Run `/vm0 agent compose` to create one from any public GitHub URL, like [this Hacker News agent](https://github.com/vm0-ai/vm0-cookbooks/tree/main/examples/201-hackernews).
+</Callout>
+
+### 4. Invite VM0 to a Channel
+
+VM0 is not added to channels automatically. Invite it to any channel where you want to use it:
+
+```
+/invite @VM0
+```
+
+## How It Works
+
+### Mention in Channels
+
+Mention `@VM0` in any channel with your message. VM0 analyzes your request, routes it to the appropriate agent, and replies in the same thread.
+
+```
+@VM0 summarize the latest support tickets
+```
+
+A thinking reaction appears while the agent processes your request.
+
+### Direct Messages
+
+You can also DM the VM0 bot directly for private, one-on-one interactions. In DMs, all messages are routed to your linked agent automatically.
+
+### Thread Context
+
+When you mention `@VM0` in a thread, it gathers context from all messages in that thread. This lets the agent understand the full conversation and provide more relevant responses.
+
+## Slash Commands
+
+| Command | Description |
+| :--- | :--- |
+| `/vm0 connect` | Connect your Slack account to VM0 |
+| `/vm0 disconnect` | Disconnect your VM0 account |
+| `/vm0 agent compose` | Compose an agent from a GitHub URL |
+| `/vm0 agent link` | Link an existing agent |
+| `/vm0 agent unlink` | Unlink an agent |
+| `/vm0 agent update` | Update agent configuration |
+| `/vm0 help` | Show available commands |
+
+## App Home
+
+The App Home tab in Slack shows your connection status, linked agents, and quick-reference commands. Open it by clicking "VM0" in your Slack Apps section.
+
+## Troubleshooting
+
+### Agent not responding
+
+1. Verify your VM0 account is connected — run `/vm0 connect`
+2. Check that you have at least one agent linked — run `/vm0 agent link`
+3. Make sure `@VM0` has been invited to the channel
+
+### Authentication errors
+
+1. Run `/vm0 disconnect` then `/vm0 connect` to re-link your account
+2. Verify your VM0 account is active

--- a/turbo/apps/docs/content/docs/ecosystem/slack.mdx
+++ b/turbo/apps/docs/content/docs/ecosystem/slack.mdx
@@ -17,6 +17,7 @@ The VM0 Slack integration brings your agents directly into Slack. Once connected
 | Requirement | Details |
 | :--- | :--- |
 | VM0 Account | Sign up at [vm0.ai](https://www.vm0.ai) if you don't have one |
+| An Agent | Complete the [Quick Start](/docs/quick-start) guide to create your first agent |
 | Slack Workspace | Admin access to [install the VM0 app](https://www.vm0.ai/api/slack/oauth/install) in your workspace |
 
 ## Setup
@@ -55,7 +56,7 @@ This opens a dialog where you select an agent. If the agent requires secrets or 
 Once linked, the agent is available to you in any channel where `@VM0` is present.
 
 <Callout type="info">
-Don't have an agent yet? Use [`/vm0 agent compose`](#slash-commands) to create one from a public GitHub URL, like [this Hacker News agent](https://github.com/vm0-ai/vm0-cookbooks/tree/main/examples/201-hackernews).
+You can also use [`/vm0 agent compose`](#slash-commands) to create an agent directly from a public GitHub URL, like [this Hacker News agent](https://github.com/vm0-ai/vm0-cookbooks/tree/main/examples/201-hackernews).
 </Callout>
 
 ## How It Works

--- a/turbo/apps/docs/content/docs/ecosystem/slack.mdx
+++ b/turbo/apps/docs/content/docs/ecosystem/slack.mdx
@@ -30,17 +30,9 @@ A workspace administrator must [install the VM0 app](https://www.vm0.ai/api/slac
 - Handle slash commands
 - Read user information and shared files
 
-### 2. Invite VM0 to a Channel
+### 2. Connect Your VM0 Account
 
-VM0 is not added to channels automatically. Invite it to any channel where you want to use it:
-
-```
-/invite @VM0
-```
-
-### 3. Connect Your VM0 Account
-
-Connect your Slack identity with your VM0 account. You can do this either by running the slash command in any channel where VM0 is present:
+After the app is installed, connect your VM0 account in Slack. You can do this either by running the slash command in any channel where VM0 is present:
 
 ```
 /vm0 connect
@@ -50,7 +42,7 @@ Or by opening the VM0 App Home in Slack and clicking the **Connect** button.
 
 Both options open a browser flow to complete the authentication.
 
-### 4. Link an Agent
+### 3. Link an Agent
 
 Link an agent from your VM0 account to your Slack workspace:
 
@@ -63,14 +55,14 @@ This opens a dialog where you select an agent. If the agent requires secrets or 
 Once linked, the agent is available to you in any channel where `@VM0` is present.
 
 <Callout type="info">
-Don't have an agent yet? Run `/vm0 agent compose` to create one from any public GitHub URL, like [this Hacker News agent](https://github.com/vm0-ai/vm0-cookbooks/tree/main/examples/201-hackernews).
+Don't have an agent yet? Run `/vm0 agent compose` to create one from any public GitHub URL. The repository must contain a [`vm0.yaml`](/docs/reference/configuration/vm0-yaml) configuration file. See the [Quick Start](/docs/quick-start) guide for more details on creating agents.
 </Callout>
 
 ## How It Works
 
 ### Mention in Channels
 
-Mention `@VM0` in any channel with your message. Your linked agent processes the request and replies in the same thread.
+Mention `@VM0` in any channel with your message.
 
 ```
 @VM0 summarize the latest support tickets
@@ -92,7 +84,7 @@ When you mention `@VM0` in a thread, it gathers context from all messages in tha
 | :--- | :--- |
 | `/vm0 connect` | Connect your Slack account to VM0 |
 | `/vm0 disconnect` | Disconnect your VM0 account |
-| `/vm0 agent compose` | Compose an agent from a GitHub URL |
+| `/vm0 agent compose` | Compose an agent from a public GitHub URL containing a [`vm0.yaml`](/docs/reference/configuration/vm0-yaml) (e.g. `https://github.com/vm0-ai/vm0-cookbooks/tree/main/examples/201-hackernews`) |
 | `/vm0 agent link` | Link an existing agent |
 | `/vm0 agent unlink` | Unlink an agent |
 | `/vm0 agent update` | Update agent configuration |
@@ -107,8 +99,7 @@ The App Home tab in Slack shows your connection status, linked agents, and quick
 ### Agent not responding
 
 1. Verify your VM0 account is connected — run `/vm0 connect`
-2. Check that you have at least one agent linked — run `/vm0 agent link`
-3. Make sure `@VM0` has been invited to the channel
+2. Check that your agent is linked — run `/vm0 agent link`
 
 ### Authentication errors
 

--- a/turbo/apps/docs/content/docs/ecosystem/slack.mdx
+++ b/turbo/apps/docs/content/docs/ecosystem/slack.mdx
@@ -70,7 +70,7 @@ Don't have an agent yet? Run `/vm0 agent compose` to create one from any public 
 
 ### Mention in Channels
 
-Mention `@VM0` in any channel with your message. VM0 analyzes your request, routes it to the appropriate agent, and replies in the same thread.
+Mention `@VM0` in any channel with your message. Your linked agent processes the request and replies in the same thread.
 
 ```
 @VM0 summarize the latest support tickets

--- a/turbo/apps/docs/content/docs/ecosystem/slack.mdx
+++ b/turbo/apps/docs/content/docs/ecosystem/slack.mdx
@@ -16,26 +16,41 @@ The VM0 Slack integration brings your agents directly into Slack. Once connected
 
 | Requirement | Details |
 | :--- | :--- |
-| VM0 Account | A VM0 account with at least one agent or compose |
-| Slack Workspace | Admin access to install the VM0 app |
+| VM0 Account | Sign up at [vm0.ai](https://www.vm0.ai) if you don't have one |
+| Slack Workspace | Admin access to [install the VM0 app](https://www.vm0.ai/api/slack/oauth/install) in your workspace |
 
 ## Setup
 
 ### 1. Install the VM0 App in Slack
 
-A workspace administrator must install the VM0 app from the Slack App Directory.
+A workspace administrator must [install the VM0 app](https://www.vm0.ai/api/slack/oauth/install) to the workspace. During installation, Slack will ask you to authorize the following permissions:
 
-### 2. Connect Your VM0 Account
+- Read messages in channels and DMs where VM0 is added
+- Send messages and reactions
+- Handle slash commands
+- Read user information and shared files
 
-After the app is installed, connect your VM0 account:
+### 2. Invite VM0 to a Channel
+
+VM0 is not added to channels automatically. Invite it to any channel where you want to use it:
+
+```
+/invite @VM0
+```
+
+### 3. Connect Your VM0 Account
+
+Connect your Slack identity with your VM0 account. You can do this either by running the slash command in any channel where VM0 is present:
 
 ```
 /vm0 connect
 ```
 
-This opens a browser flow to link your Slack identity with your VM0 account.
+Or by opening the VM0 App Home in Slack and clicking the **Connect** button.
 
-### 3. Link an Agent
+Both options open a browser flow to complete the authentication.
+
+### 4. Link an Agent
 
 Link an agent from your VM0 account to your Slack workspace:
 
@@ -50,14 +65,6 @@ Once linked, the agent is available to you in any channel where `@VM0` is presen
 <Callout type="info">
 Don't have an agent yet? Run `/vm0 agent compose` to create one from any public GitHub URL, like [this Hacker News agent](https://github.com/vm0-ai/vm0-cookbooks/tree/main/examples/201-hackernews).
 </Callout>
-
-### 4. Invite VM0 to a Channel
-
-VM0 is not added to channels automatically. Invite it to any channel where you want to use it:
-
-```
-/invite @VM0
-```
 
 ## How It Works
 

--- a/turbo/apps/docs/content/docs/ecosystem/slack.mdx
+++ b/turbo/apps/docs/content/docs/ecosystem/slack.mdx
@@ -18,13 +18,13 @@ The VM0 Slack integration brings your agents directly into Slack. Once connected
 | :--- | :--- |
 | VM0 Account | Sign up at [vm0.ai](https://www.vm0.ai) if you don't have one |
 | An Agent | Complete the [Quick Start](/docs/quick-start) guide to create your first agent |
-| Slack Workspace | Admin access to [install the VM0 app](https://www.vm0.ai/api/slack/oauth/install) in your workspace |
+| Slack Workspace | Admin access to [install the VM0 app](https://slack.com/oauth/v2/authorize?client_id=9860643978390.10448672115104&scope=app_mentions:read,channels:history,channels:read,chat:write,commands,groups:history,im:history,im:write,reactions:write,users:read&user_scope=) in your workspace |
 
 ## Setup
 
 ### 1. Install the VM0 App in Slack
 
-A workspace administrator must [install the VM0 app](https://www.vm0.ai/api/slack/oauth/install) to the workspace. During installation, Slack will ask you to authorize the following permissions:
+A workspace administrator must [install the VM0 app](https://slack.com/oauth/v2/authorize?client_id=9860643978390.10448672115104&scope=app_mentions:read,channels:history,channels:read,chat:write,commands,groups:history,im:history,im:write,reactions:write,users:read&user_scope=) to the workspace. During installation, Slack will ask you to authorize the following permissions:
 
 - Read messages in channels and DMs where VM0 is added
 - Send messages and reactions
@@ -51,7 +51,7 @@ Link an agent from your VM0 account to your Slack workspace:
 /vm0 agent link
 ```
 
-This opens a dialog where you select an agent. If the agent requires secrets or environment variables (e.g. API keys), you'll be prompted to configure them during this step.
+This opens a dialog where you select an agent. If the agent requires a model provider, secrets, or environment variables (e.g. API keys), you'll be prompted to configure them during this step.
 
 Once linked, the agent is available to you in any channel where `@VM0` is present.
 

--- a/turbo/apps/docs/content/docs/ecosystem/slack.mdx
+++ b/turbo/apps/docs/content/docs/ecosystem/slack.mdx
@@ -55,7 +55,7 @@ This opens a dialog where you select an agent. If the agent requires secrets or 
 Once linked, the agent is available to you in any channel where `@VM0` is present.
 
 <Callout type="info">
-Don't have an agent yet? Run `/vm0 agent compose` to create one from any public GitHub URL. The repository must contain a [`vm0.yaml`](/docs/reference/configuration/vm0-yaml) configuration file. See the [Quick Start](/docs/quick-start) guide for more details on creating agents.
+Don't have an agent yet? Use [`/vm0 agent compose`](#slash-commands) to create one from a public GitHub URL, like [this Hacker News agent](https://github.com/vm0-ai/vm0-cookbooks/tree/main/examples/201-hackernews).
 </Callout>
 
 ## How It Works
@@ -84,7 +84,7 @@ When you mention `@VM0` in a thread, it gathers context from all messages in tha
 | :--- | :--- |
 | `/vm0 connect` | Connect your Slack account to VM0 |
 | `/vm0 disconnect` | Disconnect your VM0 account |
-| `/vm0 agent compose` | Compose an agent from a public GitHub URL containing a [`vm0.yaml`](/docs/reference/configuration/vm0-yaml) (e.g. `https://github.com/vm0-ai/vm0-cookbooks/tree/main/examples/201-hackernews`) |
+| `/vm0 agent compose` | Compose an agent from a public GitHub URL (e.g. [this Hacker News agent](https://github.com/vm0-ai/vm0-cookbooks/tree/main/examples/201-hackernews)). <br/> The repository must contain a [`vm0.yaml`](/docs/reference/configuration/vm0-yaml) configuration file — see the [Quick Start](/docs/quick-start) guide for details on creating agents. |
 | `/vm0 agent link` | Link an existing agent |
 | `/vm0 agent unlink` | Unlink an agent |
 | `/vm0 agent update` | Update agent configuration |

--- a/turbo/apps/docs/content/docs/meta.json
+++ b/turbo/apps/docs/content/docs/meta.json
@@ -10,6 +10,7 @@
     "model-selection",
     "agent-skills",
     "reference",
+    "ecosystem",
     "experimental"
   ]
 }


### PR DESCRIPTION
## Summary

- Adds a new **Ecosystem** documentation section to the docs site navigation
- Creates an overview page introducing ecosystem integrations
- Adds a comprehensive Slack integration guide covering setup, usage, slash commands, and troubleshooting

## Test plan

- [ ] Verify the docs site builds successfully
- [ ] Confirm the Ecosystem section appears in the sidebar navigation between "Reference" and "Experimental"
- [ ] Verify the Slack guide renders correctly with all sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)