### PR TITLE
feat(slack): extract /vm0 agent compose as standalone command

### DIFF
--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../../src/db/schema/agent-compose";
 import {
   buildAgentAddModal,
+  buildAgentComposeModal,
   buildAgentUpdateModal,
 } from "../../../../src/lib/slack/blocks";
 import { decryptCredentialValue } from "../../../../src/lib/crypto/secrets-encryption";
@@ -537,6 +538,11 @@ async function dispatchBlockAction(
         await handleHomeAgentLink(payload, payload.trigger_id);
       }
       break;
+    case "home_agent_compose":
+      if (payload.trigger_id) {
+        await handleHomeAgentCompose(payload, payload.trigger_id);
+      }
+      break;
     case "home_disconnect":
       await handleHomeDisconnect(payload);
       break;
@@ -614,6 +620,25 @@ async function handleHomeAgentLink(
   const agents = await fetchAvailableAgents(userLink.vm0UserId, userLink.id);
   const channelId = payload.channel?.id;
   const modal = buildAgentAddModal(agents, undefined, channelId);
+
+  await client.views.open({
+    trigger_id: triggerId,
+    view: modal,
+  });
+}
+
+/**
+ * Handle compose button click from App Home
+ */
+async function handleHomeAgentCompose(
+  payload: SlackInteractivePayload,
+  triggerId: string,
+): Promise<void> {
+  const client = await getSlackClientForWorkspace(payload.team.id);
+  if (!client) return;
+
+  const channelId = payload.channel?.id;
+  const modal = buildAgentComposeModal(channelId);
 
   await client.views.open({
     trigger_id: triggerId,

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -16,7 +16,6 @@ import {
 } from "../../../../src/db/schema/agent-compose";
 import {
   buildAgentAddModal,
-  buildAgentComposeModal,
   buildAgentUpdateModal,
 } from "../../../../src/lib/slack/blocks";
 import { decryptCredentialValue } from "../../../../src/lib/crypto/secrets-encryption";
@@ -538,11 +537,6 @@ async function dispatchBlockAction(
         await handleHomeAgentLink(payload, payload.trigger_id);
       }
       break;
-    case "home_agent_compose":
-      if (payload.trigger_id) {
-        await handleHomeAgentCompose(payload, payload.trigger_id);
-      }
-      break;
     case "home_disconnect":
       await handleHomeDisconnect(payload);
       break;
@@ -620,25 +614,6 @@ async function handleHomeAgentLink(
   const agents = await fetchAvailableAgents(userLink.vm0UserId, userLink.id);
   const channelId = payload.channel?.id;
   const modal = buildAgentAddModal(agents, undefined, channelId);
-
-  await client.views.open({
-    trigger_id: triggerId,
-    view: modal,
-  });
-}
-
-/**
- * Handle compose button click from App Home
- */
-async function handleHomeAgentCompose(
-  payload: SlackInteractivePayload,
-  triggerId: string,
-): Promise<void> {
-  const client = await getSlackClientForWorkspace(payload.team.id);
-  if (!client) return;
-
-  const channelId = payload.channel?.id;
-  const modal = buildAgentComposeModal(channelId);
 
   await client.views.open({
     trigger_id: triggerId,

--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -41,7 +41,7 @@ describe("buildAgentAddModal", () => {
     expect(modalWithoutSelection.callback_id).toBe("agent_add_modal");
     expect(modalWithoutSelection.title).toEqual({
       type: "plain_text",
-      text: "Add Agent",
+      text: "Link Agent",
     });
     // Submit button is always shown (required for input blocks)
     expect(modalWithoutSelection.submit).toEqual({

--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -46,7 +46,7 @@ describe("buildAgentAddModal", () => {
     // Submit button is always shown (required for input blocks)
     expect(modalWithoutSelection.submit).toEqual({
       type: "plain_text",
-      text: "Add",
+      text: "Link",
     });
     expect(modalWithoutSelection.close).toEqual({
       type: "plain_text",
@@ -60,7 +60,7 @@ describe("buildAgentAddModal", () => {
     ) as ModalView;
     expect(modalWithSelection.submit).toEqual({
       type: "plain_text",
-      text: "Add",
+      text: "Link",
     });
   });
 

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -451,7 +451,7 @@ export function buildAppHomeView(options: {
     type: "section",
     text: {
       type: "mrkdwn",
-      text: "*Compose and manage agents*\nCompose an agent from GitHub URL\n`/vm0 agent compose`\nLink an agent\n`/vm0 agent link`\nUnlink an agent\n`/vm0 agent unlink`\nUpdate agent configuration\n`/vm0 agent update`",
+      text: "*Link and manage agents*\nLink an agent\n`/vm0 agent link`\nUnlink an agent\n`/vm0 agent unlink`\nUpdate agent configuration\n`/vm0 agent update`\nCompose an agent from GitHub URL\n`/vm0 agent compose`",
     },
   });
 
@@ -961,7 +961,7 @@ export function buildHelpMessage(): (Block | KnownBlock)[] {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "*Agent*\n• `/vm0 agent compose` - Compose an agent from GitHub URL\n• `/vm0 agent link` - Link an agent\n• `/vm0 agent unlink` - Unlink your agent\n• `/vm0 agent update` - Update agent configuration",
+        text: "*Agent*\n• `/vm0 agent link` - Link an agent\n• `/vm0 agent unlink` - Unlink your agent\n• `/vm0 agent update` - Update agent configuration\n• `/vm0 agent compose` - Compose an agent from GitHub URL",
       },
     },
     {

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -273,11 +273,11 @@ export function buildAgentAddModal(
     private_metadata: JSON.stringify({ channelId }),
     title: {
       type: "plain_text",
-      text: "Add Agent",
+      text: "Link Agent",
     },
     submit: {
       type: "plain_text",
-      text: "Add",
+      text: "Link",
     },
     close: {
       type: "plain_text",

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -424,11 +424,6 @@ export function buildAppHomeView(options: {
           action_id: "home_agent_link",
           style: "primary",
         },
-        {
-          type: "button",
-          text: { type: "plain_text", text: "Compose Agent" },
-          action_id: "home_agent_compose",
-        },
       ],
     });
   }

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -196,129 +196,94 @@ function buildExistingAgentBlocks(
 }
 
 /**
- * Build blocks for the "GitHub URL" mode in the add modal
+ * Build blocks for the GitHub URL compose modal
  */
-function buildGithubUrlBlocks(hasAgents: boolean): (Block | KnownBlock)[] {
-  const blocks: (Block | KnownBlock)[] = [];
-
-  if (!hasAgents) {
-    blocks.push({
-      type: "context",
-      elements: [
-        {
-          type: "mrkdwn",
-          text: "You don't have any agents yet. Enter a GitHub URL to compose one.",
+function buildGithubUrlBlocks(): (Block | KnownBlock)[] {
+  return [
+    {
+      type: "input",
+      block_id: "github_url_input",
+      element: {
+        type: "plain_text_input",
+        action_id: "github_url_value",
+        placeholder: {
+          type: "plain_text",
+          text: "https://github.com/owner/repo",
         },
-      ],
-    });
-  }
-
-  blocks.push({
-    type: "input",
-    block_id: "github_url_input",
-    element: {
-      type: "plain_text_input",
-      action_id: "github_url_value",
-      placeholder: {
+      },
+      label: {
         type: "plain_text",
-        text: "https://github.com/owner/repo",
+        text: "GitHub URL",
+      },
+      hint: {
+        type: "plain_text",
+        text: "The repository must contain a vm0.yaml file",
       },
     },
-    label: {
-      type: "plain_text",
-      text: "GitHub URL",
-    },
-    hint: {
-      type: "plain_text",
-      text: "The repository must contain a vm0.yaml file",
-    },
-  });
+  ];
+}
 
-  return blocks;
+/**
+ * Build the "Compose Agent" modal view
+ *
+ * Opens a modal with a GitHub URL input to compose a new agent.
+ *
+ * @param channelId - Channel ID to send confirmation message to
+ * @returns Modal view definition
+ */
+export function buildAgentComposeModal(channelId?: string): View {
+  return {
+    type: "modal",
+    callback_id: "agent_compose_modal",
+    private_metadata: JSON.stringify({ channelId }),
+    title: {
+      type: "plain_text",
+      text: "Compose Agent",
+    },
+    submit: {
+      type: "plain_text",
+      text: "Compose",
+    },
+    close: {
+      type: "plain_text",
+      text: "Cancel",
+    },
+    blocks: buildGithubUrlBlocks(),
+  };
 }
 
 /**
  * Build the "Add Agent" modal view
  *
- * Supports two modes:
- * - "existing": Select from existing agents (default when agents are available)
- * - "github": Enter a GitHub URL to compose a new agent
+ * Shows a dropdown to select from existing agents and configure secrets/vars.
  *
  * @param agents - List of available agents
  * @param selectedAgentId - Currently selected agent ID
  * @param channelId - Channel ID to send confirmation message to
- * @param mode - Which mode to display ("existing" or "github")
  * @returns Modal view definition
  */
 export function buildAgentAddModal(
   agents: AgentOption[],
   selectedAgentId?: string,
   channelId?: string,
-  mode?: "existing" | "github",
 ): View {
-  const hasAgents = agents.length > 0;
-  const effectiveMode = mode ?? (hasAgents ? "existing" : "github");
-
-  const blocks: (Block | KnownBlock)[] = [];
-
-  // Show mode selector only when user has existing agents
-  if (hasAgents) {
-    blocks.push({
-      type: "actions",
-      block_id: "link_mode_select",
-      elements: [
-        {
-          type: "radio_buttons",
-          action_id: "link_mode_action",
-          options: [
-            {
-              text: { type: "plain_text", text: "Select existing agent" },
-              value: "existing",
-            },
-            {
-              text: { type: "plain_text", text: "Compose from GitHub URL" },
-              value: "github",
-            },
-          ],
-          initial_option: {
-            text: {
-              type: "plain_text",
-              text:
-                effectiveMode === "existing"
-                  ? "Select existing agent"
-                  : "Compose from GitHub URL",
-            },
-            value: effectiveMode,
-          },
-        },
-      ],
-    });
-    blocks.push({ type: "divider" });
-  }
-
-  if (effectiveMode === "github") {
-    blocks.push(...buildGithubUrlBlocks(hasAgents));
-  } else {
-    blocks.push(...buildExistingAgentBlocks(agents, selectedAgentId));
-  }
-
   return {
     type: "modal",
     callback_id: "agent_add_modal",
-    private_metadata: JSON.stringify({ channelId, mode: effectiveMode }),
+    private_metadata: JSON.stringify({ channelId }),
     title: {
       type: "plain_text",
-      text: effectiveMode === "github" ? "Compose Agent" : "Add Agent",
+      text: "Add Agent",
     },
     submit: {
       type: "plain_text",
-      text: effectiveMode === "github" ? "Compose" : "Add",
+      text: "Add",
     },
     close: {
       type: "plain_text",
       text: "Cancel",
     },
-    blocks,
+    blocks: buildExistingAgentBlocks(agents, selectedAgentId),
   };
 }
 
@@ -486,7 +451,7 @@ export function buildAppHomeView(options: {
     type: "section",
     text: {
       type: "mrkdwn",
-      text: "*Link and manage agents*\nLink an agent\n`/vm0 agent link`\nUnlink an agent\n`/vm0 agent unlink`\nUpdate agent configuration\n`/vm0 agent update`",
+      text: "*Compose and manage agents*\nCompose an agent from GitHub URL\n`/vm0 agent compose`\nLink an agent\n`/vm0 agent link`\nUnlink an agent\n`/vm0 agent unlink`\nUpdate agent configuration\n`/vm0 agent update`",
     },
   });
 
@@ -996,7 +961,7 @@ export function buildHelpMessage(): (Block | KnownBlock)[] {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "*Agent*\n• `/vm0 agent link` - Link an agent or compose from GitHub URL\n• `/vm0 agent unlink` - Unlink your agent\n• `/vm0 agent update` - Update agent configuration",
+        text: "*Agent*\n• `/vm0 agent compose` - Compose an agent from GitHub URL\n• `/vm0 agent link` - Link an agent\n• `/vm0 agent unlink` - Unlink your agent\n• `/vm0 agent update` - Update agent configuration",
       },
     },
     {

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -424,6 +424,11 @@ export function buildAppHomeView(options: {
           action_id: "home_agent_link",
           style: "primary",
         },
+        {
+          type: "button",
+          text: { type: "plain_text", text: "Compose Agent" },
+          action_id: "home_agent_compose",
+        },
       ],
     });
   }


### PR DESCRIPTION
## Summary

- Extract GitHub URL compose functionality from `/vm0 agent link` into a new standalone `/vm0 agent compose` Slack command
- `/vm0 agent link` now only shows existing agent dropdown (no more radio buttons or GitHub mode)
- When user has no agents, `/vm0 agent link` suggests using `/vm0 agent compose` first
- Updated help messages, App Home view, and error messages to include the new command

## Test plan

- [x] All 39 Slack tests pass (commands + interactive)
- [x] All 14 webhook compose/complete tests pass
- [x] New tests: `agent compose opens modal`, `agent link returns error when no agents`, `compose modal returns error when URL empty`
- [x] Updated tests: GitHub URL compose tests now use `agent_compose_modal` callback_id
- [x] Type check, lint, format, knip all pass

Closes #2632

🤖 Generated with [Claude Code](https://claude.com/claude-code)