### PR TITLE
feat(slack): deduplicate context messages across thread turns

### DIFF
--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -1151,11 +1151,12 @@ describe("POST /api/slack/events", () => {
       await POST(request1);
       await flushAfterCallbacks();
 
-      // Then the agent should receive full context (both messages)
+      // Then the agent should receive context excluding the current message
+      // (current message is already sent as the prompt)
       expect(runAgentSpy).toHaveBeenCalledTimes(1);
       const firstCallContext = runAgentSpy.mock.calls[0]![0].threadContext;
       expect(firstCallContext).toContain("First message");
-      expect(firstCallContext).toContain("Second message");
+      expect(firstCallContext).not.toContain("Second message");
 
       // Reset mocks for second turn
       runAgentSpy.mockClear();
@@ -1198,12 +1199,13 @@ describe("POST /api/slack/events", () => {
       await POST(request2);
       await flushAfterCallbacks();
 
-      // Then the agent should receive only the new message (deduplication)
+      // Then the agent should receive empty context (all prior messages already processed,
+      // and "Third message" is the current mention excluded from context)
       expect(runAgentSpy).toHaveBeenCalledTimes(1);
       const secondCallContext = runAgentSpy.mock.calls[0]![0].threadContext;
       expect(secondCallContext).not.toContain("First message");
       expect(secondCallContext).not.toContain("Second message");
-      expect(secondCallContext).toContain("Third message");
+      expect(secondCallContext).not.toContain("Third message");
     });
 
     it("should not update lastProcessedMessageTs when agent run fails", async () => {
@@ -1365,7 +1367,8 @@ describe("POST /api/slack/events", () => {
       const thirdCallContext = runAgentSpy.mock.calls[0]![0].threadContext;
       // Second message should be resent since the failed run didn't update lastProcessedMessageTs
       expect(thirdCallContext).toContain("Second message");
-      expect(thirdCallContext).toContain("Third message");
+      // Third message is the current mention, excluded from context (sent as prompt)
+      expect(thirdCallContext).not.toContain("Third message");
       // First message was already processed in the successful first turn
       expect(thirdCallContext).not.toContain("First message");
     });

--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../../src/__tests__/slack/api-helpers";
 import { handlers, http } from "../../../../../src/__tests__/msw";
 import { POST } from "../route";
+import { createTestAgentSession } from "../../../../../src/__tests__/api-test-helpers";
 import * as runAgentModule from "../../../../../src/lib/slack/handlers/run-agent";
 
 vi.mock("@clerk/nextjs/server");
@@ -1088,6 +1089,285 @@ describe("POST /api/slack/events", () => {
 
       // Then no duplicate message should be sent
       expect(slackHandlers.mocked.postMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Scenario: Context deduplication across thread turns", () => {
+    it("should send only new messages on second turn in same thread", async () => {
+      // Given I am a linked Slack user with one agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { binding } = await givenUserHasAgent(userLink, {
+        agentName: "my-helper",
+        description: "A helpful assistant",
+      });
+
+      // Use unique channel/thread IDs to avoid collisions with stale DB data
+      const channelId = `C-dedup-${Date.now()}`;
+      const threadTs = "1000000000.000000";
+
+      // Create an agent session so the FK constraint is satisfied
+      const agentSession = await createTestAgentSession(
+        userLink.vm0UserId,
+        binding.composeId,
+      );
+
+      // And runAgentForSlack returns a completed result with that session ID
+      const runAgentSpy = vi
+        .spyOn(runAgentModule, "runAgentForSlack")
+        .mockResolvedValue({
+          status: "completed",
+          response: "Done!",
+          sessionId: agentSession.id,
+          runId: "test-run-id",
+        });
+
+      // And the thread has 2 messages
+      const repliesHandler1 = http.post(
+        "https://slack.com/api/conversations.replies",
+        () =>
+          HttpResponse.json({
+            ok: true,
+            messages: [
+              { user: "U111", text: "First message", ts: "1000000000.000000" },
+              {
+                user: userLink.slackUserId,
+                text: "Second message",
+                ts: "1000000001.000000",
+              },
+            ],
+          }),
+      );
+      server.use(repliesHandler1.handler);
+
+      // When I send the first mention in a thread
+      const request1 = createSlackEventRequest({
+        teamId: installation.slackWorkspaceId,
+        channelId,
+        userId: userLink.slackUserId,
+        text: `<@${installation.botUserId}> help me`,
+        ts: "1000000001.000000",
+        threadTs,
+      });
+      await POST(request1);
+      await flushAfterCallbacks();
+
+      // Then the agent should receive full context (both messages)
+      expect(runAgentSpy).toHaveBeenCalledTimes(1);
+      const firstCallContext = runAgentSpy.mock.calls[0]![0].threadContext;
+      expect(firstCallContext).toContain("First message");
+      expect(firstCallContext).toContain("Second message");
+
+      // Reset mocks for second turn
+      runAgentSpy.mockClear();
+      vi.mocked(slackHandlers.mocked.postMessage).mockClear();
+      vi.mocked(slackHandlers.mocked.reactionsAdd).mockClear();
+      vi.mocked(slackHandlers.mocked.reactionsRemove).mockClear();
+
+      // And the thread now has 3 messages (one new)
+      const repliesHandler2 = http.post(
+        "https://slack.com/api/conversations.replies",
+        () =>
+          HttpResponse.json({
+            ok: true,
+            messages: [
+              { user: "U111", text: "First message", ts: "1000000000.000000" },
+              {
+                user: userLink.slackUserId,
+                text: "Second message",
+                ts: "1000000001.000000",
+              },
+              {
+                user: userLink.slackUserId,
+                text: "Third message",
+                ts: "1000000002.000000",
+              },
+            ],
+          }),
+      );
+      server.use(repliesHandler2.handler);
+
+      // When I send the second mention in the same thread
+      const request2 = createSlackEventRequest({
+        teamId: installation.slackWorkspaceId,
+        channelId,
+        userId: userLink.slackUserId,
+        text: `<@${installation.botUserId}> do more`,
+        ts: "1000000002.000000",
+        threadTs,
+      });
+      await POST(request2);
+      await flushAfterCallbacks();
+
+      // Then the agent should receive only the new message (deduplication)
+      expect(runAgentSpy).toHaveBeenCalledTimes(1);
+      const secondCallContext = runAgentSpy.mock.calls[0]![0].threadContext;
+      expect(secondCallContext).not.toContain("First message");
+      expect(secondCallContext).not.toContain("Second message");
+      expect(secondCallContext).toContain("Third message");
+    });
+
+    it("should not update lastProcessedMessageTs when agent run fails", async () => {
+      // Given I am a linked Slack user with one agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { binding } = await givenUserHasAgent(userLink, {
+        agentName: "my-helper",
+        description: "A helpful assistant",
+      });
+
+      // Use unique channel/thread IDs to avoid collisions with stale DB data
+      const channelId = `C-dedup-fail-${Date.now()}`;
+      const threadTs = "2000000000.000000";
+
+      // Create an agent session so the FK constraint is satisfied
+      const agentSession = await createTestAgentSession(
+        userLink.vm0UserId,
+        binding.composeId,
+      );
+
+      // And runAgentForSlack returns completed on first call, failed on second
+      const runAgentSpy = vi.spyOn(runAgentModule, "runAgentForSlack");
+      runAgentSpy.mockResolvedValueOnce({
+        status: "completed",
+        response: "Done!",
+        sessionId: agentSession.id,
+        runId: "test-run-id-1",
+      });
+
+      // Thread has 1 message
+      const repliesHandler = http.post(
+        "https://slack.com/api/conversations.replies",
+        () =>
+          HttpResponse.json({
+            ok: true,
+            messages: [
+              {
+                user: userLink.slackUserId,
+                text: "First message",
+                ts: "2000000000.000000",
+              },
+            ],
+          }),
+      );
+      server.use(repliesHandler.handler);
+
+      // First turn (succeeds) — establishes lastProcessedMessageTs
+      const request1 = createSlackEventRequest({
+        teamId: installation.slackWorkspaceId,
+        channelId,
+        userId: userLink.slackUserId,
+        text: `<@${installation.botUserId}> help`,
+        ts: "2000000000.000000",
+        threadTs,
+      });
+      await POST(request1);
+      await flushAfterCallbacks();
+
+      // Now runAgentForSlack fails on the second call
+      runAgentSpy.mockResolvedValueOnce({
+        status: "failed",
+        response: "Error: something broke",
+        sessionId: agentSession.id,
+        runId: "test-run-id-2",
+      });
+
+      // Thread now has 2 messages
+      const repliesHandler2 = http.post(
+        "https://slack.com/api/conversations.replies",
+        () =>
+          HttpResponse.json({
+            ok: true,
+            messages: [
+              {
+                user: userLink.slackUserId,
+                text: "First message",
+                ts: "2000000000.000000",
+              },
+              {
+                user: userLink.slackUserId,
+                text: "Second message",
+                ts: "2000000001.000000",
+              },
+            ],
+          }),
+      );
+      server.use(repliesHandler2.handler);
+
+      // Reset spy for second turn
+      runAgentSpy.mockClear();
+      runAgentSpy.mockResolvedValueOnce({
+        status: "failed",
+        response: "Error: something broke",
+        sessionId: agentSession.id,
+        runId: "test-run-id-2",
+      });
+
+      // Second turn (fails)
+      const request2 = createSlackEventRequest({
+        teamId: installation.slackWorkspaceId,
+        channelId,
+        userId: userLink.slackUserId,
+        text: `<@${installation.botUserId}> help again`,
+        ts: "2000000001.000000",
+        threadTs,
+      });
+      await POST(request2);
+      await flushAfterCallbacks();
+
+      // Reset for third turn
+      runAgentSpy.mockClear();
+      runAgentSpy.mockResolvedValueOnce({
+        status: "completed",
+        response: "Done!",
+        sessionId: agentSession.id,
+        runId: "test-run-id-3",
+      });
+
+      // Thread now has 3 messages
+      const repliesHandler3 = http.post(
+        "https://slack.com/api/conversations.replies",
+        () =>
+          HttpResponse.json({
+            ok: true,
+            messages: [
+              {
+                user: userLink.slackUserId,
+                text: "First message",
+                ts: "2000000000.000000",
+              },
+              {
+                user: userLink.slackUserId,
+                text: "Second message",
+                ts: "2000000001.000000",
+              },
+              {
+                user: userLink.slackUserId,
+                text: "Third message",
+                ts: "2000000002.000000",
+              },
+            ],
+          }),
+      );
+      server.use(repliesHandler3.handler);
+
+      // Third turn — should include "Second message" since the failed run didn't update the ts
+      const request3 = createSlackEventRequest({
+        teamId: installation.slackWorkspaceId,
+        channelId,
+        userId: userLink.slackUserId,
+        text: `<@${installation.botUserId}> retry`,
+        ts: "2000000002.000000",
+        threadTs,
+      });
+      await POST(request3);
+      await flushAfterCallbacks();
+
+      expect(runAgentSpy).toHaveBeenCalledTimes(1);
+      const thirdCallContext = runAgentSpy.mock.calls[0]![0].threadContext;
+      // Second message should be resent since the failed run didn't update lastProcessedMessageTs
+      expect(thirdCallContext).toContain("Second message");
+      expect(thirdCallContext).toContain("Third message");
+      // First message was already processed in the successful first turn
+      expect(thirdCallContext).not.toContain("First message");
     });
   });
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -56,6 +56,7 @@ import { connectorSessions } from "../db/schema/connector-session";
 import { secrets } from "../db/schema/secret";
 import { encryptCredentialValue } from "../lib/crypto/secrets-encryption";
 import type { ConnectorType } from "@vm0/core";
+import { agentSessions } from "../db/schema/agent-session";
 
 /**
  * Helper to create a NextRequest for testing.
@@ -411,6 +412,17 @@ export async function createTestMultiAuthModelProvider(
  * @param options - Optional run parameters
  * @returns The created run with runId and status
  */
+export async function createTestAgentSession(
+  userId: string,
+  agentComposeId: string,
+): Promise<{ id: string }> {
+  const [session] = await globalThis.services.db
+    .insert(agentSessions)
+    .values({ userId, agentComposeId })
+    .returning({ id: agentSessions.id });
+  return session!;
+}
+
 export async function createTestRun(
   agentComposeId: string,
   prompt: string,

--- a/turbo/apps/web/src/db/migrations/0075_add_last_processed_message_ts.sql
+++ b/turbo/apps/web/src/db/migrations/0075_add_last_processed_message_ts.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "slack_thread_sessions"
+ADD COLUMN "last_processed_message_ts" varchar(255);

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1769900000000,
       "tag": "0074_add_slack_compose_requests",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1770000000000,
+      "tag": "0075_add_last_processed_message_ts",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/slack-thread-session.ts
+++ b/turbo/apps/web/src/db/schema/slack-thread-session.ts
@@ -26,6 +26,9 @@ export const slackThreadSessions = pgTable(
     agentSessionId: uuid("agent_session_id")
       .notNull()
       .references(() => agentSessions.id, { onDelete: "cascade" }),
+    lastProcessedMessageTs: varchar("last_processed_message_ts", {
+      length: 255,
+    }),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },

--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -2,7 +2,6 @@ import { eq, and } from "drizzle-orm";
 import { slackInstallations } from "../../../db/schema/slack-installation";
 import { slackUserLinks } from "../../../db/schema/slack-user-link";
 import { slackBindings } from "../../../db/schema/slack-binding";
-import { slackThreadSessions } from "../../../db/schema/slack-thread-session";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import {
@@ -15,8 +14,10 @@ import {
 import { runAgentForSlack } from "./run-agent";
 import {
   removeThinkingReaction,
-  fetchConversationContext,
+  fetchConversationContexts,
   routeMessageToAgent,
+  lookupThreadSession,
+  saveThreadSession,
   buildLoginUrl,
   buildLogsUrl,
 } from "./shared";
@@ -142,20 +143,35 @@ export async function handleDirectMessage(
     // Use message text directly (no mention prefix to strip in DMs)
     const messageContent = context.messageText;
 
-    // Fetch Slack context early (needed for routing and agent execution)
-    const formattedContext = await fetchConversationContext(
-      client,
-      context.channelId,
-      context.threadTs,
-      botUserId,
-      botToken,
-    );
+    // 7. Look up existing thread session for deduplication
+    let existingSessionId: string | undefined;
+    let lastProcessedMessageTs: string | undefined;
+    if (threadTs) {
+      const session = await lookupThreadSession(context.channelId, threadTs);
+      existingSessionId = session.existingSessionId;
+      lastProcessedMessageTs = session.lastProcessedMessageTs;
+      log.debug("Thread session lookup", {
+        existingSessionId,
+        lastProcessedMessageTs,
+      });
+    }
 
-    // 7. Route to agent (with context for LLM routing)
+    // Fetch context: routing gets full text, execution gets deduplicated with images
+    const { routingContext, executionContext } =
+      await fetchConversationContexts(
+        client,
+        context.channelId,
+        context.threadTs,
+        botUserId,
+        botToken,
+        lastProcessedMessageTs,
+      );
+
+    // 8. Route to agent (with full context for LLM routing)
     const routeResult = await routeMessageToAgent(
       messageContent,
       bindings,
-      formattedContext,
+      routingContext,
     );
 
     // In DMs, not_request routes to the first/single agent (user deliberately DM'd the bot)
@@ -195,26 +211,18 @@ export async function handleDirectMessage(
       return;
     }
 
-    // 8. Find existing thread session
-    let existingSessionId: string | undefined;
-    if (threadTs) {
-      const [threadSession] = await globalThis.services.db
-        .select({ agentSessionId: slackThreadSessions.agentSessionId })
-        .from(slackThreadSessions)
-        .where(
-          and(
-            eq(slackThreadSessions.slackBindingId, selectedBinding.id),
-            eq(slackThreadSessions.slackChannelId, context.channelId),
-            eq(slackThreadSessions.slackThreadTs, threadTs),
-          ),
-        )
-        .limit(1);
-
-      existingSessionId = threadSession?.agentSessionId;
+    // Refine session lookup with binding ID if not yet matched
+    if (threadTs && !existingSessionId) {
+      const refined = await lookupThreadSession(
+        context.channelId,
+        threadTs,
+        selectedBinding.id,
+      );
+      existingSessionId = refined.existingSessionId;
     }
 
     try {
-      // 9. Execute agent
+      // 9. Execute agent with deduplicated context
       const {
         status: runStatus,
         response: agentResponse,
@@ -224,21 +232,21 @@ export async function handleDirectMessage(
         binding: selectedBinding,
         sessionId: existingSessionId,
         prompt: promptText,
-        threadContext: formattedContext,
+        threadContext: executionContext,
         userId: userLink.vm0UserId,
       });
 
-      // 10. Create thread session mapping if new thread
-      if (threadTs && !existingSessionId && newSessionId) {
-        await globalThis.services.db
-          .insert(slackThreadSessions)
-          .values({
-            slackBindingId: selectedBinding.id,
-            slackChannelId: context.channelId,
-            slackThreadTs: threadTs,
-            agentSessionId: newSessionId,
-          })
-          .onConflictDoNothing();
+      // 10. Create or update thread session mapping
+      if (threadTs) {
+        await saveThreadSession({
+          bindingId: selectedBinding.id,
+          channelId: context.channelId,
+          threadTs,
+          existingSessionId,
+          newSessionId,
+          messageTs: context.messageTs,
+          runStatus,
+        });
       }
 
       // 11. Post response message

--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -157,6 +157,7 @@ export async function handleDirectMessage(
     }
 
     // Fetch context: routing gets full text, execution gets deduplicated with images
+    // Pass currentMessageTs to exclude it from context (it's already the prompt)
     const { routingContext, executionContext } =
       await fetchConversationContexts(
         client,
@@ -165,6 +166,7 @@ export async function handleDirectMessage(
         botUserId,
         botToken,
         lastProcessedMessageTs,
+        context.messageTs,
       );
 
     // 8. Route to agent (with full context for LLM routing)

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -170,6 +170,7 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
     }
 
     // Fetch context: routing gets full text, execution gets deduplicated with images
+    // Pass currentMessageTs to exclude it from context (it's already the prompt)
     const { routingContext, executionContext } =
       await fetchConversationContexts(
         client,
@@ -178,6 +179,7 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
         botUserId,
         botToken,
         lastProcessedMessageTs,
+        context.messageTs,
       );
 
     // 8. Route to agent (with full context for LLM routing)

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -2,7 +2,6 @@ import { eq, and } from "drizzle-orm";
 import { slackInstallations } from "../../../db/schema/slack-installation";
 import { slackUserLinks } from "../../../db/schema/slack-user-link";
 import { slackBindings } from "../../../db/schema/slack-binding";
-import { slackThreadSessions } from "../../../db/schema/slack-thread-session";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import {
@@ -17,8 +16,10 @@ import {
 import { runAgentForSlack } from "./run-agent";
 import {
   removeThinkingReaction,
-  fetchConversationContext,
+  fetchConversationContexts,
   routeMessageToAgent,
+  lookupThreadSession,
+  saveThreadSession,
   buildLoginUrl,
   buildLogsUrl,
 } from "./shared";
@@ -155,21 +156,35 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       botUserId,
     );
 
-    // Fetch Slack context early (needed for routing and agent execution)
-    // Uses bot token to download and embed images from Slack
-    const formattedContext = await fetchConversationContext(
-      client,
-      context.channelId,
-      context.threadTs,
-      botUserId,
-      botToken,
-    );
+    // 7. Look up existing thread session for deduplication
+    let existingSessionId: string | undefined;
+    let lastProcessedMessageTs: string | undefined;
+    if (threadTs) {
+      const session = await lookupThreadSession(context.channelId, threadTs);
+      existingSessionId = session.existingSessionId;
+      lastProcessedMessageTs = session.lastProcessedMessageTs;
+      log.debug("Thread session lookup", {
+        existingSessionId,
+        lastProcessedMessageTs,
+      });
+    }
 
-    // 7. Route to agent (with context for LLM routing)
+    // Fetch context: routing gets full text, execution gets deduplicated with images
+    const { routingContext, executionContext } =
+      await fetchConversationContexts(
+        client,
+        context.channelId,
+        context.threadTs,
+        botUserId,
+        botToken,
+        lastProcessedMessageTs,
+      );
+
+    // 8. Route to agent (with full context for LLM routing)
     const routeResult = await routeMessageToAgent(
       messageContent,
       bindings,
-      formattedContext,
+      routingContext,
     );
 
     if (routeResult.type === "not_request") {
@@ -211,8 +226,6 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       (b) => b.agentName === selectedAgentName,
     );
     if (!selectedBinding) {
-      // This should never happen since routeMessageToAgent only returns success
-      // with an agent name that exists in bindings
       log.error("Selected binding not found after successful route", {
         selectedAgentName,
         availableBindings: bindings.map((b) => b.agentName),
@@ -220,35 +233,18 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       return;
     }
 
-    // 8. Find existing thread session for this binding (if in a thread)
-    let existingSessionId: string | undefined;
-    log.debug("Looking for thread session", {
-      threadTs,
-      contextThreadTs: context.threadTs,
-      bindingId: selectedBinding.id,
-      channelId: context.channelId,
-    });
-    if (threadTs) {
-      const [threadSession] = await globalThis.services.db
-        .select({ agentSessionId: slackThreadSessions.agentSessionId })
-        .from(slackThreadSessions)
-        .where(
-          and(
-            eq(slackThreadSessions.slackBindingId, selectedBinding.id),
-            eq(slackThreadSessions.slackChannelId, context.channelId),
-            eq(slackThreadSessions.slackThreadTs, threadTs),
-          ),
-        )
-        .limit(1);
-
-      existingSessionId = threadSession?.agentSessionId;
-      log.debug("Thread session query result", { existingSessionId });
+    // Refine session lookup with binding ID if not yet matched
+    if (threadTs && !existingSessionId) {
+      const refined = await lookupThreadSession(
+        context.channelId,
+        threadTs,
+        selectedBinding.id,
+      );
+      existingSessionId = refined.existingSessionId;
     }
 
-    // Context already fetched earlier for routing
-
     try {
-      // 10. Execute agent with session continuation
+      // 9. Execute agent with deduplicated context
       log.debug("Calling runAgentForSlack", { existingSessionId });
       const {
         status: runStatus,
@@ -259,33 +255,24 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
         binding: selectedBinding,
         sessionId: existingSessionId,
         prompt: promptText,
-        threadContext: formattedContext,
+        threadContext: executionContext,
         userId: userLink.vm0UserId,
       });
-      log.debug("runAgentForSlack returned", {
-        runStatus,
-        newSessionId,
-        runId,
-      });
 
-      // 11. Create thread session mapping if this is a new thread (no existing session)
-      if (threadTs && !existingSessionId && newSessionId) {
-        log.debug("Creating thread session mapping", {
+      // 10. Create or update thread session mapping
+      if (threadTs) {
+        await saveThreadSession({
+          bindingId: selectedBinding.id,
+          channelId: context.channelId,
           threadTs,
+          existingSessionId,
           newSessionId,
+          messageTs: context.messageTs,
+          runStatus,
         });
-        await globalThis.services.db
-          .insert(slackThreadSessions)
-          .values({
-            slackBindingId: selectedBinding.id,
-            slackChannelId: context.channelId,
-            slackThreadTs: threadTs,
-            agentSessionId: newSessionId,
-          })
-          .onConflictDoNothing();
       }
 
-      // 12. Post response message with agent name and logs link
+      // 11. Post response message with agent name and logs link
       const logsUrl = runId ? buildLogsUrl(runId) : undefined;
       const responseText =
         runStatus === "timeout"

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -1,11 +1,14 @@
+import { eq, and } from "drizzle-orm";
 import {
   createSlackClient,
   fetchThreadContext,
   fetchChannelContext,
+  formatContextForAgent,
   formatContextForAgentWithImages,
   parseExplicitAgentSelection,
   getSlackRedirectBaseUrl,
 } from "../index";
+import { slackThreadSessions } from "../../../db/schema/slack-thread-session";
 import { routeToAgent, type RouteResult } from "../router";
 import { getPlatformUrl } from "../../url";
 
@@ -48,37 +51,53 @@ export async function removeThinkingReaction(
 }
 
 /**
- * Fetch conversation context for the agent with uploaded images
- * Images are uploaded to R2 and presigned URLs are provided in the context
+ * Fetch conversation context with deduplication support.
+ * Returns separate contexts for routing (text-only, full history) and
+ * execution (with images, only new messages since lastProcessedMessageTs).
+ *
+ * Single Slack API call — messages are fetched once and filtered in-memory.
  */
-export async function fetchConversationContext(
+export async function fetchConversationContexts(
   client: SlackClient,
   channelId: string,
   threadTs: string | undefined,
   botUserId: string,
   botToken: string,
-): Promise<string> {
-  // Use channel-thread as session ID for organizing uploaded images
+  lastProcessedMessageTs?: string,
+): Promise<{ routingContext: string; executionContext: string }> {
   const imageSessionId = `${channelId}-${threadTs ?? "channel"}`;
+  const contextType = threadTs ? "thread" : "channel";
 
-  if (threadTs) {
-    const messages = await fetchThreadContext(client, channelId, threadTs);
-    return formatContextForAgentWithImages(
-      messages,
-      botToken,
-      imageSessionId,
-      botUserId,
-      "thread",
-    );
-  }
-  const messages = await fetchChannelContext(client, channelId, 10);
-  return formatContextForAgentWithImages(
-    messages,
-    botToken,
-    imageSessionId,
+  // Fetch all messages once (single Slack API call)
+  const allMessages = threadTs
+    ? await fetchThreadContext(client, channelId, threadTs)
+    : await fetchChannelContext(client, channelId, 10);
+
+  // Text-only full context for routing (no image uploads needed)
+  const routingContext = formatContextForAgent(
+    allMessages,
     botUserId,
-    "channel",
+    contextType,
   );
+
+  // Filter to only new messages for execution context
+  const executionMessages = lastProcessedMessageTs
+    ? allMessages.filter((m) => !m.ts || m.ts > lastProcessedMessageTs)
+    : allMessages;
+
+  // Format execution context with images (only uploads images for new messages)
+  const executionContext =
+    executionMessages.length > 0
+      ? await formatContextForAgentWithImages(
+          executionMessages,
+          botToken,
+          imageSessionId,
+          botUserId,
+          contextType,
+        )
+      : "";
+
+  return { routingContext, executionContext };
 }
 
 /**
@@ -142,6 +161,102 @@ export async function routeMessageToAgent(
       };
     }
   }
+}
+
+interface ThreadSessionLookup {
+  existingSessionId: string | undefined;
+  lastProcessedMessageTs: string | undefined;
+}
+
+/**
+ * Look up an existing thread session by channel + thread.
+ * Optionally refines with bindingId if provided.
+ */
+export async function lookupThreadSession(
+  channelId: string,
+  threadTs: string,
+  bindingId?: string,
+): Promise<ThreadSessionLookup> {
+  const conditions = bindingId
+    ? [
+        eq(slackThreadSessions.slackBindingId, bindingId),
+        eq(slackThreadSessions.slackChannelId, channelId),
+        eq(slackThreadSessions.slackThreadTs, threadTs),
+      ]
+    : [
+        eq(slackThreadSessions.slackChannelId, channelId),
+        eq(slackThreadSessions.slackThreadTs, threadTs),
+      ];
+
+  const [session] = await globalThis.services.db
+    .select({
+      agentSessionId: slackThreadSessions.agentSessionId,
+      lastProcessedMessageTs: slackThreadSessions.lastProcessedMessageTs,
+    })
+    .from(slackThreadSessions)
+    .where(and(...conditions))
+    .limit(1);
+
+  return {
+    existingSessionId: session?.agentSessionId,
+    lastProcessedMessageTs: session?.lastProcessedMessageTs ?? undefined,
+  };
+}
+
+/**
+ * Create or update a thread session mapping after agent execution.
+ */
+export async function saveThreadSession(opts: {
+  bindingId: string;
+  channelId: string;
+  threadTs: string;
+  existingSessionId: string | undefined;
+  newSessionId: string | undefined;
+  messageTs: string;
+  runStatus: string;
+}): Promise<void> {
+  const {
+    bindingId,
+    channelId,
+    threadTs,
+    existingSessionId,
+    newSessionId,
+    messageTs,
+    runStatus,
+  } = opts;
+
+  if (!existingSessionId && newSessionId) {
+    // New thread — create mapping
+    await globalThis.services.db
+      .insert(slackThreadSessions)
+      .values({
+        slackBindingId: bindingId,
+        slackChannelId: channelId,
+        slackThreadTs: threadTs,
+        agentSessionId: newSessionId,
+        lastProcessedMessageTs: messageTs,
+      })
+      .onConflictDoNothing();
+  } else if (
+    existingSessionId &&
+    (runStatus === "completed" || runStatus === "timeout")
+  ) {
+    // Existing thread, successful run — update lastProcessedMessageTs
+    await globalThis.services.db
+      .update(slackThreadSessions)
+      .set({
+        lastProcessedMessageTs: messageTs,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(slackThreadSessions.slackBindingId, bindingId),
+          eq(slackThreadSessions.slackChannelId, channelId),
+          eq(slackThreadSessions.slackThreadTs, threadTs),
+        ),
+      );
+  }
+  // Failed runs — do not update lastProcessedMessageTs (allows retry with same context)
 }
 
 /**

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -64,6 +64,7 @@ export async function fetchConversationContexts(
   botUserId: string,
   botToken: string,
   lastProcessedMessageTs?: string,
+  currentMessageTs?: string,
 ): Promise<{ routingContext: string; executionContext: string }> {
   const imageSessionId = `${channelId}-${threadTs ?? "channel"}`;
   const contextType = threadTs ? "thread" : "channel";
@@ -73,17 +74,22 @@ export async function fetchConversationContexts(
     ? await fetchThreadContext(client, channelId, threadTs)
     : await fetchChannelContext(client, channelId, 10);
 
+  // Exclude the current message (it's already sent as the prompt)
+  const contextMessages = currentMessageTs
+    ? allMessages.filter((m) => m.ts !== currentMessageTs)
+    : allMessages;
+
   // Text-only full context for routing (no image uploads needed)
   const routingContext = formatContextForAgent(
-    allMessages,
+    contextMessages,
     botUserId,
     contextType,
   );
 
   // Filter to only new messages for execution context
   const executionMessages = lastProcessedMessageTs
-    ? allMessages.filter((m) => !m.ts || m.ts > lastProcessedMessageTs)
-    : allMessages;
+    ? contextMessages.filter((m) => !m.ts || m.ts > lastProcessedMessageTs)
+    : contextMessages;
 
   // Format execution context with images (only uploads images for new messages)
   const executionContext =


### PR DESCRIPTION
## Summary

- Track `lastProcessedMessageTs` per thread session to avoid resending full conversation history on each turn
- Routing context (text-only) still receives the full thread for accurate agent selection
- Execution context (with images) only includes messages newer than the last successful run
- Failed runs do not update the timestamp, allowing retry with the same context
- Extract `lookupThreadSession` and `saveThreadSession` helpers into `shared.ts` to reduce handler complexity

Closes #2629

## Test plan

- [x] New integration test: "should send only new messages on second turn in same thread" — verifies deduplication works across two turns
- [x] New integration test: "should not update lastProcessedMessageTs when agent run fails" — verifies failed runs allow retry with same context
- [x] All 26 existing Slack event route tests pass
- [x] All 71 Slack tests pass (events + interactive + commands)
- [x] All 79 Slack lib tests pass (context, router, verify, format)
- [x] Lint, type-check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)