### PR TITLE
feat(sandbox-fc): add test binary for manual lifecycle testing

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -313,6 +313,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +384,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -583,6 +598,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "vsock-host",
  "which",
@@ -664,6 +680,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +709,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -777,6 +808,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +872,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -892,6 +958,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vsock-guest"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -28,6 +28,7 @@ tempfile = "3"
 tokio = "1"
 uuid = "1"
 tracing = "0.1"
+tracing-subscriber = "0.3"
 which = "8"
 ureq = "3"
 

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -9,8 +9,9 @@ nix = { workspace = true, features = ["user"] }
 sandbox.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["process", "fs", "rt", "macros", "sync", "io-util"] }
+tokio = { workspace = true, features = ["process", "fs", "rt", "rt-multi-thread", "macros", "sync", "io-util"] }
 tracing.workspace = true
+tracing-subscriber.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 vsock-host.workspace = true
 which.workspace = true

--- a/crates/sandbox-fc/src/main.rs
+++ b/crates/sandbox-fc/src/main.rs
@@ -1,0 +1,93 @@
+use std::fmt;
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::time::Instant;
+
+use sandbox::{ExecRequest, ResourceLimits, SandboxConfig, SandboxFactory};
+use tracing_subscriber::fmt::time::FormatTime;
+use uuid::Uuid;
+
+use sandbox_fc::FirecrackerConfig;
+
+struct Elapsed(Instant);
+
+impl FormatTime for Elapsed {
+    fn format_time(&self, w: &mut tracing_subscriber::fmt::format::Writer<'_>) -> fmt::Result {
+        let d = self.0.elapsed();
+        let total_secs = d.as_secs();
+        let mins = total_secs / 60;
+        let secs = total_secs % 60;
+        let millis = d.subsec_millis();
+        write!(w, "[{mins:02}:{secs:02}:{millis:03}]")
+    }
+}
+
+/// Usage: sandbox-fc <firecracker> <kernel> <rootfs> <base_dir> <cmd>
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_timer(Elapsed(Instant::now()))
+        .init();
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.len() < 5 {
+        eprintln!("usage: sandbox-fc <firecracker> <kernel> <rootfs> <base_dir> <cmd>");
+        return ExitCode::FAILURE;
+    }
+
+    if let Err(e) = run(&args).await {
+        eprintln!("error: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    ExitCode::SUCCESS
+}
+
+fn arg(args: &[String], idx: usize) -> Result<&String, &'static str> {
+    args.get(idx).ok_or("missing argument")
+}
+
+async fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let config = FirecrackerConfig {
+        binary_path: PathBuf::from(arg(args, 0)?),
+        kernel_path: PathBuf::from(arg(args, 1)?),
+        rootfs_path: PathBuf::from(arg(args, 2)?),
+        base_dir: PathBuf::from(arg(args, 3)?),
+        instance_index: 0,
+        concurrency: 1,
+        proxy_port: None,
+        snapshot: None,
+    };
+    let cmd = arg(args, 4)?;
+
+    let factory = sandbox_fc::FirecrackerFactory::new(config).await?;
+
+    let sandbox_config = SandboxConfig {
+        id: Uuid::new_v4(),
+        resources: ResourceLimits {
+            cpu_count: 1,
+            memory_mb: 256,
+            timeout_secs: 30,
+        },
+    };
+
+    let mut sandbox = factory.create(sandbox_config).await?;
+    sandbox.start().await?;
+
+    let result = sandbox
+        .exec(&ExecRequest {
+            cmd,
+            timeout_ms: 5000,
+        })
+        .await?;
+
+    println!("exit_code: {}", result.exit_code);
+    println!("stdout: {}", result.stdout);
+    println!("stderr: {}", result.stderr);
+
+    sandbox.stop().await?;
+    factory.destroy(sandbox).await;
+    factory.cleanup().await;
+
+    Ok(())
+}

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -8,7 +8,7 @@ use sandbox::{
     ExecRequest, ExecResult, ProcessExit, Sandbox, SandboxConfig, SandboxError, SpawnHandle,
 };
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 use vsock_host::VsockHost;
 
 use crate::config::FirecrackerConfig;
@@ -311,7 +311,7 @@ fn monitor_process(
             let mut lines = BufReader::new(stdout).lines();
             while let Ok(Some(line)) = lines.next_line().await {
                 if !line.is_empty() {
-                    debug!(id = %id, "{line}");
+                    info!(id = %id, "{line}");
                 }
             }
             // Pipe closed — process exited.


### PR DESCRIPTION
## Summary
- Adds a CLI binary (`sandbox-fc`) for manually testing the full sandbox lifecycle on Firecracker-equipped machines
- Usage: `sandbox-fc <firecracker> <kernel> <rootfs> <base_dir> <cmd>`
- Runs: factory → create → start → exec → stop → destroy → cleanup with elapsed-time tracing

## Test plan
- [x] `cargo build -p sandbox-fc` passes
- [x] `cargo clippy -p sandbox-fc` passes (no warnings)
- [x] Tested on `dev-2.aws.vm3.ai` (aarch64) — `echo hello` and `curl https://httpbin.org/get` both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)