### PR TITLE
feat(cli): add filtering options to run list command

### DIFF
--- a/turbo/apps/cli/src/commands/run/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/list.test.ts
@@ -110,6 +110,211 @@ describe("run list command", () => {
     });
   });
 
+  describe("filtering options", () => {
+    it("should pass --status filter to API", async () => {
+      let capturedUrl: URL | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs", ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--status", "completed"]);
+
+      expect(capturedUrl?.searchParams.get("status")).toBe("completed");
+    });
+
+    it("should pass multiple statuses as comma-separated", async () => {
+      let capturedUrl: URL | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs", ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await listCommand.parseAsync([
+        "node",
+        "cli",
+        "--status",
+        "completed,failed",
+      ]);
+
+      expect(capturedUrl?.searchParams.get("status")).toBe("completed,failed");
+    });
+
+    it("should pass all statuses when --all is used", async () => {
+      let capturedUrl: URL | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs", ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--all"]);
+
+      expect(capturedUrl?.searchParams.get("status")).toBe(
+        "pending,running,completed,failed,timeout",
+      );
+    });
+
+    it("should pass --agent filter to API", async () => {
+      let capturedUrl: URL | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs", ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--agent", "my-agent"]);
+
+      expect(capturedUrl?.searchParams.get("agent")).toBe("my-agent");
+    });
+
+    it("should pass --limit to API", async () => {
+      let capturedUrl: URL | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs", ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--limit", "10"]);
+
+      expect(capturedUrl?.searchParams.get("limit")).toBe("10");
+    });
+
+    it("should pass --since as ISO timestamp to API", async () => {
+      let capturedUrl: URL | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs", ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--since", "7d"]);
+
+      const since = capturedUrl?.searchParams.get("since");
+      expect(since).toBeTruthy();
+      // Should be a valid ISO timestamp
+      expect(new Date(since!).toISOString()).toBe(since);
+    });
+
+    it("should use all statuses implicitly when --since is used", async () => {
+      let capturedUrl: URL | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs", ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--since", "7d"]);
+
+      expect(capturedUrl?.searchParams.get("status")).toBe(
+        "pending,running,completed,failed,timeout",
+      );
+    });
+
+    it("should allow explicit --status to override --since default", async () => {
+      let capturedUrl: URL | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs", ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await listCommand.parseAsync([
+        "node",
+        "cli",
+        "--since",
+        "7d",
+        "--status",
+        "failed",
+      ]);
+
+      expect(capturedUrl?.searchParams.get("status")).toBe("failed");
+    });
+
+    it("should show 'No runs found matching filters' when filters used and no results", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs", () => {
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--status", "completed"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No runs found matching filters");
+    });
+  });
+
+  describe("validation errors", () => {
+    it("should error when --all and --status are both specified", async () => {
+      await expect(async () => {
+        await listCommand.parseAsync([
+          "node",
+          "cli",
+          "--all",
+          "--status",
+          "running",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--all and --status are mutually exclusive"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should error on invalid status value", async () => {
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli", "--status", "invalid"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid status "invalid"'),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should error when --limit is out of range", async () => {
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli", "--limit", "200"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--limit must be between 1 and 100"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should error when --since is after --until", async () => {
+      await expect(async () => {
+        await listCommand.parseAsync([
+          "node",
+          "cli",
+          "--since",
+          "1d",
+          "--until",
+          "7d",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--since must be before --until"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
   describe("error handling", () => {
     it("should handle authentication error", async () => {
       server.use(

--- a/turbo/apps/cli/src/commands/run/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/list.test.ts
@@ -242,6 +242,23 @@ describe("run list command", () => {
       expect(capturedUrl?.searchParams.get("status")).toBe("failed");
     });
 
+    it("should pass --until as ISO timestamp to API", async () => {
+      let capturedUrl: URL | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs", ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--until", "1h"]);
+
+      const until = capturedUrl?.searchParams.get("until");
+      expect(until).toBeTruthy();
+      // Should be a valid ISO timestamp
+      expect(new Date(until!).toISOString()).toBe(until);
+    });
+
     it("should show 'No runs found matching filters' when filters used and no results", async () => {
       server.use(
         http.get("http://localhost:3000/api/agent/runs", () => {
@@ -285,9 +302,20 @@ describe("run list command", () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it("should error when --limit is out of range", async () => {
+    it("should error when --limit exceeds maximum", async () => {
       await expect(async () => {
         await listCommand.parseAsync(["node", "cli", "--limit", "200"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--limit must be between 1 and 100"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should error when --limit is zero or negative", async () => {
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli", "--limit", "0"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(

--- a/turbo/apps/cli/src/commands/run/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/list.test.ts
@@ -341,6 +341,17 @@ describe("run list command", () => {
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
+
+    it("should error on invalid time format", async () => {
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli", "--since", "invalid"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid --since format"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
   });
 
   describe("error handling", () => {

--- a/turbo/apps/cli/src/commands/run/list.ts
+++ b/turbo/apps/cli/src/commands/run/list.ts
@@ -2,10 +2,26 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { listRuns } from "../../lib/api";
 import { formatRelativeTime } from "../../lib/utils/file-utils";
-import type { RunStatus } from "@vm0/core";
+import { parseTime } from "../../lib/utils/time-parser";
+import { ALL_RUN_STATUSES, type RunStatus, type RunListItem } from "@vm0/core";
 
 /** Standard UUID string length (with hyphens) */
 const UUID_LENGTH = 36;
+
+/** All valid status values as a string for help text */
+const VALID_STATUSES = ALL_RUN_STATUSES.join(",");
+
+/**
+ * Command options type
+ */
+interface ListOptions {
+  status?: string;
+  all?: boolean;
+  agent?: string;
+  since?: string;
+  until?: string;
+  limit?: string;
+}
 
 /**
  * Format run status with color and optional padding
@@ -27,50 +43,171 @@ function formatRunStatus(status: RunStatus, width?: number): string {
   }
 }
 
+/**
+ * Validate and parse status filter from options
+ */
+function parseStatusFilter(options: ListOptions): string | undefined {
+  if (options.all) {
+    return VALID_STATUSES;
+  }
+
+  if (options.status) {
+    const values = options.status.split(",").map((s) => s.trim());
+    for (const v of values) {
+      if (!ALL_RUN_STATUSES.includes(v as RunStatus)) {
+        console.error(
+          chalk.red(
+            `Error: Invalid status "${v}". Valid values: ${VALID_STATUSES}`,
+          ),
+        );
+        process.exit(1);
+      }
+    }
+    return values.join(",");
+  }
+
+  if (options.since) {
+    // Implicit all when --since is used
+    return VALID_STATUSES;
+  }
+
+  // undefined = backend default (pending,running)
+  return undefined;
+}
+
+/**
+ * Parse time option to ISO string
+ */
+function parseTimeOption(value: string, optionName: string): string {
+  try {
+    return new Date(parseTime(value)).toISOString();
+  } catch {
+    console.error(
+      chalk.red(
+        `Error: Invalid ${optionName} format. Use ISO (2026-01-01) or relative (1h, 7d, 30d)`,
+      ),
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * Parse and validate limit option
+ */
+function parseLimit(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+
+  const limit = parseInt(value, 10);
+  if (isNaN(limit) || limit < 1 || limit > 100) {
+    console.error(chalk.red("Error: --limit must be between 1 and 100"));
+    process.exit(1);
+  }
+  return limit;
+}
+
+/**
+ * Display runs in table format
+ */
+function displayRuns(runs: RunListItem[]): void {
+  // Calculate column widths
+  const agentWidth = Math.max(5, ...runs.map((r) => r.agentName.length));
+  const statusWidth = Math.max(6, ...runs.map((r) => r.status.length));
+
+  // Print header
+  const header = [
+    "ID".padEnd(UUID_LENGTH),
+    "AGENT".padEnd(agentWidth),
+    "STATUS".padEnd(statusWidth),
+    "CREATED",
+  ].join("  ");
+  console.log(chalk.dim(header));
+
+  // Print rows
+  for (const run of runs) {
+    const row = [
+      run.id.padEnd(UUID_LENGTH),
+      run.agentName.padEnd(agentWidth),
+      formatRunStatus(run.status, statusWidth),
+      formatRelativeTime(run.createdAt),
+    ].join("  ");
+    console.log(row);
+  }
+}
+
+/**
+ * Display empty state message
+ */
+function displayEmptyState(hasFilters: boolean): void {
+  if (hasFilters) {
+    console.log(chalk.dim("No runs found matching filters"));
+  } else {
+    console.log(chalk.dim("No active runs"));
+    console.log(chalk.dim('  Run: vm0 run <agent> "<prompt>"'));
+  }
+}
+
 export const listCommand = new Command()
   .name("list")
   .alias("ls")
-  .description("List active runs (pending and running)")
-  .action(async () => {
+  .description("List runs")
+  .option(
+    "--status <status,...>",
+    `Filter by status: ${VALID_STATUSES} (default: pending,running)`,
+  )
+  .option("--all", "Show all statuses (mutually exclusive with --status)")
+  .option("--agent <name>", "Filter by agent name")
+  .option("--since <date>", "Start time (ISO format or relative: 1h, 7d, 30d)")
+  .option("--until <date>", "End time (defaults to now)")
+  .option("--limit <n>", "Maximum number of results (default: 50, max: 100)")
+  .action(async (options: ListOptions) => {
     try {
-      // Fetch pending and running runs (internal API filters by default)
-      const response = await listRuns({ limit: 100 });
+      // Validate mutual exclusion
+      if (options.all && options.status) {
+        console.error(
+          chalk.red("Error: --all and --status are mutually exclusive"),
+        );
+        process.exit(1);
+      }
 
-      // The internal API already filters to pending/running by default
-      const activeRuns = response.runs;
+      // Parse options
+      const statusFilter = parseStatusFilter(options);
+      const since = options.since
+        ? parseTimeOption(options.since, "--since")
+        : undefined;
+      const until = options.until
+        ? parseTimeOption(options.until, "--until")
+        : undefined;
+      const limit = parseLimit(options.limit);
 
-      if (activeRuns.length === 0) {
-        console.log(chalk.dim("No active runs"));
-        console.log(chalk.dim('  Run: vm0 run <agent> "<prompt>"'));
+      // Validate since < until
+      if (since && until && new Date(since) >= new Date(until)) {
+        console.error(chalk.red("Error: --since must be before --until"));
+        process.exit(1);
+      }
+
+      // Fetch runs with filters
+      const response = await listRuns({
+        status: statusFilter,
+        agent: options.agent,
+        since,
+        until,
+        limit,
+      });
+
+      const runs = response.runs;
+
+      if (runs.length === 0) {
+        const hasFilters = !!(
+          options.status ||
+          options.all ||
+          options.agent ||
+          options.since
+        );
+        displayEmptyState(hasFilters);
         return;
       }
 
-      // Calculate column widths
-      const agentWidth = Math.max(
-        5,
-        ...activeRuns.map((r) => r.agentName.length),
-      );
-      const statusWidth = 7; // "running" is longest active status
-
-      // Print header
-      const header = [
-        "ID".padEnd(UUID_LENGTH),
-        "AGENT".padEnd(agentWidth),
-        "STATUS".padEnd(statusWidth),
-        "CREATED",
-      ].join("  ");
-      console.log(chalk.dim(header));
-
-      // Print rows
-      for (const run of activeRuns) {
-        const row = [
-          run.id.padEnd(UUID_LENGTH),
-          run.agentName.padEnd(agentWidth),
-          formatRunStatus(run.status, statusWidth),
-          formatRelativeTime(run.createdAt),
-        ].join("  ");
-        console.log(row);
-      }
+      displayRuns(runs);
     } catch (error) {
       console.error(chalk.red("✗ Failed to list runs"));
       if (error instanceof Error) {

--- a/turbo/apps/cli/src/lib/api/domains/runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/runs.ts
@@ -5,7 +5,6 @@ import {
   runsCancelContract,
   type RunsListResponse,
   type CancelRunResponse,
-  type RunStatus,
 } from "@vm0/core";
 import { getClientConfig, handleError } from "../core/client-factory";
 import type { CreateRunResponse, GetEventsResponse } from "../core/types";
@@ -70,10 +69,13 @@ export async function getEvents(
 }
 
 /**
- * List runs with optional status filter
+ * List runs with optional filters
  */
 export async function listRuns(params?: {
-  status?: RunStatus;
+  status?: string; // comma-separated: "pending,running"
+  agent?: string;
+  since?: string; // ISO timestamp
+  until?: string; // ISO timestamp
   limit?: number;
 }): Promise<RunsListResponse> {
   const config = await getClientConfig();
@@ -82,6 +84,9 @@ export async function listRuns(params?: {
   const result = await client.list({
     query: {
       status: params?.status,
+      agent: params?.agent,
+      since: params?.since,
+      until: params?.until,
       limit: params?.limit ?? 50,
     },
   });

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -52,6 +52,7 @@ export {
   runMetricsContract,
   runAgentEventsContract,
   runNetworkLogsContract,
+  ALL_RUN_STATUSES,
   runStatusSchema,
   unifiedRunRequestSchema,
   createRunResponseSchema,

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -5,15 +5,20 @@ import { apiErrorSchema } from "./errors";
 const c = initContract();
 
 /**
- * Run status enum
+ * All valid run status values
  */
-const runStatusSchema = z.enum([
+export const ALL_RUN_STATUSES = [
   "pending",
   "running",
   "completed",
   "failed",
   "timeout",
-]);
+] as const;
+
+/**
+ * Run status enum
+ */
+const runStatusSchema = z.enum(ALL_RUN_STATUSES);
 
 /**
  * Unified run request schema - supports all run modes via optional parameters
@@ -152,11 +157,15 @@ export const runsMainContract = c.router({
     path: "/api/agent/runs",
     headers: authHeadersSchema,
     query: z.object({
-      status: runStatusSchema.optional(),
+      status: z.string().optional(), // comma-separated: "pending,running"
+      agent: z.string().optional(), // agent name filter
+      since: z.string().optional(), // ISO timestamp
+      until: z.string().optional(), // ISO timestamp
       limit: z.coerce.number().min(1).max(100).default(50),
     }),
     responses: {
       200: runsListResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
     },
     summary: "List agent runs",


### PR DESCRIPTION
## Summary

- Add `--status <status,...>` option to filter by run status (comma-separated)
- Add `--all` flag to show all statuses (mutually exclusive with `--status`)
- Add `--agent <name>` filter for agent name filtering
- Add `--since <date>` and `--until <date>` for time range filtering (ISO or relative: 1h, 7d, 30d)
- Add `--limit <n>` option for result pagination (1-100, default 50)
- When `--since` is used without explicit `--status`, implicitly shows all statuses

Default behavior remains unchanged: shows only `pending` and `running` runs.

## Test plan

- [x] Run CLI unit tests: `cd turbo/apps/cli && pnpm vitest run`
- [ ] Test filtering options manually with live server
- [ ] Verify CI pipeline passes

Closes #2634

🤖 Generated with [Claude Code](https://claude.com/claude-code)