### PR TITLE
feat(cli): run auto-upgrade in parallel with command execution

### DIFF
--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -1340,7 +1340,7 @@ agents:
     });
   });
 
-  describe("silent auto-upgrade after successful compose", () => {
+  describe("parallel auto-upgrade", () => {
     const originalArgv = process.argv;
 
     beforeEach(async () => {

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -22,7 +22,10 @@ import {
   type SkillUploadResult,
 } from "../../lib/storage/system-storage";
 import { isInteractive, promptConfirm } from "../../lib/utils/prompt-utils";
-import { silentUpgradeAfterCommand } from "../../lib/utils/update-checker";
+import {
+  startSilentUpgrade,
+  waitForSilentUpgrade,
+} from "../../lib/utils/update-checker";
 
 declare const __CLI_VERSION__: string;
 
@@ -438,9 +441,9 @@ async function finalizeCompose(
     );
   }
 
-  // Silent upgrade after successful command completion
+  // Wait for upgrade at command end (shows warning if failed)
   if (options.autoUpdate !== false) {
-    await silentUpgradeAfterCommand(__CLI_VERSION__);
+    await waitForSilentUpgrade();
   }
 
   return result;
@@ -626,6 +629,11 @@ export const composeCommand = new Command()
       if (options.json) {
         options.yes = true;
         options.autoUpdate = false;
+      }
+
+      // Start upgrade in background at command start (runs in parallel)
+      if (options.autoUpdate !== false) {
+        await startSilentUpgrade(__CLI_VERSION__);
       }
 
       try {

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -21,7 +21,10 @@ import {
   showNextSteps,
   handleRunError,
 } from "./shared";
-import { silentUpgradeAfterCommand } from "../../lib/utils/update-checker";
+import {
+  startSilentUpgrade,
+  waitForSilentUpgrade,
+} from "../../lib/utils/update-checker";
 
 declare const __CLI_VERSION__: string;
 
@@ -100,6 +103,11 @@ export const mainRunCommand = new Command()
       },
     ) => {
       try {
+        // Start upgrade in background at command start (runs in parallel)
+        if (options.autoUpdate !== false) {
+          await startSilentUpgrade(__CLI_VERSION__);
+        }
+
         // 1. Parse identifier for optional scope and version specifier
         const { scope, name, version } = parseIdentifier(identifier);
 
@@ -231,9 +239,9 @@ export const mainRunCommand = new Command()
         }
         showNextSteps(result);
 
-        // Silent upgrade after successful command completion
+        // Wait for upgrade at command end (shows warning if failed)
         if (options.autoUpdate !== false) {
-          await silentUpgradeAfterCommand(__CLI_VERSION__);
+          await waitForSilentUpgrade();
         }
       } catch (error) {
         handleRunError(error, identifier);

--- a/turbo/apps/cli/src/lib/utils/update-checker.ts
+++ b/turbo/apps/cli/src/lib/utils/update-checker.ts
@@ -1,4 +1,4 @@
-import { spawn } from "child_process";
+import { spawn, ChildProcess } from "child_process";
 import chalk from "chalk";
 
 const PACKAGE_NAME = "@vm0/cli";
@@ -6,6 +6,18 @@ const NPM_REGISTRY_URL = `https://registry.npmjs.org/${encodeURIComponent(PACKAG
 const TIMEOUT_MS = 5000;
 
 type PackageManager = "npm" | "pnpm" | "bun" | "yarn" | "unknown";
+
+/**
+ * Internal state for pending upgrade process
+ */
+interface UpgradeHandle {
+  promise: Promise<boolean>;
+  child: ChildProcess;
+  packageManager: "npm" | "pnpm";
+}
+
+// Module-level state for pending upgrade
+let pendingUpgrade: UpgradeHandle | null = null;
 
 /**
  * Detect which package manager was used to install the CLI
@@ -229,18 +241,19 @@ export async function checkAndUpgrade(
 }
 
 /**
- * Perform silent upgrade after command completion.
- * - Checks for new version
- * - Spawns upgrade process
- * - Waits up to 5s for result
- * - Shows whisper message only on failure
+ * Start silent upgrade in background.
+ * Call this at command start. Does NOT block after spawning.
+ * The upgrade runs in parallel with command execution.
  *
  * @param currentVersion - Current CLI version
- * @returns Promise that resolves when upgrade check/attempt is complete
+ * @returns Promise that resolves after starting upgrade (or determining no upgrade needed)
  */
-export async function silentUpgradeAfterCommand(
+export async function startSilentUpgrade(
   currentVersion: string,
 ): Promise<void> {
+  // Reset any previous state
+  pendingUpgrade = null;
+
   // Check for new version
   const latestVersion = await getLatestVersion();
 
@@ -257,7 +270,7 @@ export async function silentUpgradeAfterCommand(
     return;
   }
 
-  // Spawn upgrade process and wait for result with timeout
+  // Spawn upgrade process (don't wait for completion)
   const isWindows = process.platform === "win32";
   const command = isWindows ? `${packageManager}.cmd` : packageManager;
   const args =
@@ -265,33 +278,51 @@ export async function silentUpgradeAfterCommand(
       ? ["add", "-g", `${PACKAGE_NAME}@latest`]
       : ["install", "-g", `${PACKAGE_NAME}@latest`];
 
-  const upgradeResult = await new Promise<boolean>((resolve) => {
-    const child = spawn(command, args, {
-      stdio: "pipe", // Capture output instead of inheriting
-      shell: isWindows,
-      detached: !isWindows, // Detach on non-Windows
-      windowsHide: true,
-    });
-
-    // Set up timeout - kill child process to prevent orphaned processes
-    const timeoutId = setTimeout(() => {
-      child.kill();
-      resolve(false); // Timeout = failure
-    }, TIMEOUT_MS);
-
-    child.on("close", (code) => {
-      clearTimeout(timeoutId);
-      resolve(code === 0);
-    });
-
-    child.on("error", () => {
-      clearTimeout(timeoutId);
-      resolve(false);
-    });
+  const child = spawn(command, args, {
+    stdio: "pipe", // Capture output instead of inheriting
+    shell: isWindows,
+    detached: !isWindows, // Detach on non-Windows
+    windowsHide: true,
   });
 
+  const promise = new Promise<boolean>((resolve) => {
+    child.on("close", (code) => resolve(code === 0));
+    child.on("error", () => resolve(false));
+  });
+
+  pendingUpgrade = { promise, child, packageManager };
+}
+
+/**
+ * Wait for pending upgrade to complete and show warning if failed.
+ * Call this at command end.
+ *
+ * @param timeout - Max time to wait if upgrade still running (ms)
+ * @returns Promise that resolves when upgrade completes or times out
+ */
+export async function waitForSilentUpgrade(
+  timeout: number = TIMEOUT_MS,
+): Promise<void> {
+  if (!pendingUpgrade) {
+    return;
+  }
+
+  const { promise, child, packageManager } = pendingUpgrade;
+  pendingUpgrade = null; // Clear state
+
+  // Race between upgrade completion and timeout
+  const result = await Promise.race([
+    promise,
+    new Promise<false>((resolve) => {
+      setTimeout(() => {
+        child.kill();
+        resolve(false);
+      }, timeout);
+    }),
+  ]);
+
   // Show whisper message only on failure
-  if (!upgradeResult) {
+  if (!result) {
     console.log(
       chalk.yellow(
         `\n⚠ vm0 auto upgrade failed. Please run: ${getManualUpgradeCommand(packageManager)}`,


### PR DESCRIPTION
## Summary

- Refactor auto-upgrade to run in parallel with command execution instead of after
- Add `startSilentUpgrade()` to begin upgrade at command start
- Add `waitForSilentUpgrade()` to check result at command end
- Remove `silentUpgradeAfterCommand()` (replaced by new functions)
- Update `run` and `compose` commands to use parallel upgrade

## Problem

The current auto-upgrade runs **after** command completion with a 5-second timeout. `npm install -g` typically takes 3-12 seconds, causing frequent false "upgrade failed" warnings.

## Solution

Run the auto-upgrade **in parallel** with command execution:

```
Current flow:
├─ Command executes (e.g., 30s)
├─ Command completes
├─ Start upgrade, wait up to 5s
└─ Show warning if failed

New flow:
├─ Start upgrade in background (non-blocking)
├─ Command executes in parallel (e.g., 30s)
├─ Command completes
├─ Check upgrade status:
│   ├─ If completed: done (no extra wait)
│   └─ If still running: wait up to 5s more
└─ Show warning if failed
```

## Benefits

| Scenario | Before | After |
|----------|--------|-------|
| Long command (30s) | Command + 5s wait | No extra wait (upgrade runs in parallel) |
| Short command (2s) | Command + 5s wait | Same (2s + up to 5s) |
| Upgrade success rate | Low (only 5s) | High (command time + 5s) |

## Test plan

- [x] All existing compose auto-upgrade tests pass
- [x] `--no-auto-update` flag still works
- [x] JSON mode disables auto-update
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes

Closes #2636

🤖 Generated with [Claude Code](https://claude.com/claude-code)