### PR TITLE
fix(cli): add homebrew arm64 path detection for auto-upgrade

### DIFF
--- a/turbo/apps/cli/src/lib/utils/update-checker.ts
+++ b/turbo/apps/cli/src/lib/utils/update-checker.ts
@@ -31,9 +31,10 @@ function detectPackageManager(): PackageManager {
   }
 
   // Check for npm (supported for auto-upgrade)
-  // Common npm paths: /usr/local/, nvm, fnm, volta, nodenv, n, or node_modules
+  // Common npm paths: Homebrew, nvm, fnm, volta, nodenv, n, or node_modules
   if (
-    execPath.includes("/usr/local/") ||
+    execPath.includes("/usr/local/") || // Homebrew on Intel Mac
+    execPath.includes("/opt/homebrew/") || // Homebrew on arm64 Mac
     execPath.includes("/.nvm/") ||
     execPath.includes("/.fnm/") ||
     execPath.includes("/.volta/") ||


### PR DESCRIPTION
## Summary

- Add `/opt/homebrew/` to npm path detection patterns in `detectPackageManager()` to support auto-upgrade for macOS arm64 (Apple Silicon) Homebrew users

## Context

The current `detectPackageManager()` function only recognizes `/usr/local/` as the Homebrew prefix, which is the default on Intel Macs. Apple Silicon Macs (M1/M2/M3) use `/opt/homebrew/` as the default Homebrew prefix, causing auto-upgrade to silently skip for these users.

## Changes

Added `/opt/homebrew/` pattern to the npm path detection list in `update-checker.ts`:
- `/usr/local/` - Homebrew on Intel Mac
- `/opt/homebrew/` - Homebrew on arm64 Mac (NEW)

## Test plan

- [x] Existing CLI tests pass (765 tests)
- [x] Lint, type-check, and format pass
- [x] Knip reports no new issues
- [ ] Manual verification on macOS arm64 hardware (post-merge)

Closes #2637

🤖 Generated with [Claude Code](https://claude.ai/code)