### PR TITLE
fix(cli): add error handling to login command and fix sentry filter

### DIFF
--- a/turbo/apps/cli/src/commands/auth/__tests__/login.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/login.test.ts
@@ -168,11 +168,29 @@ describe("auth login", () => {
 
       await expect(async () => {
         await loginCommand.parseAsync(["node", "cli"]);
-      }).rejects.toThrow();
+      }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Initiating authentication"),
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Login failed"),
       );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle network failure", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/cli/auth/device", () => {
+          return HttpResponse.error();
+        }),
+      );
+
+      await expect(async () => {
+        await loginCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Login failed"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
     });
 
     it("should handle expired token error", async () => {

--- a/turbo/apps/cli/src/commands/auth/login.ts
+++ b/turbo/apps/cli/src/commands/auth/login.ts
@@ -1,9 +1,20 @@
 import { Command } from "commander";
+import chalk from "chalk";
 import { authenticate } from "../../lib/api/auth";
 
 export const loginCommand = new Command()
   .name("login")
   .description("Log in to VM0 (use VM0_API_URL env var to set API URL)")
   .action(async () => {
-    await authenticate();
+    try {
+      await authenticate();
+    } catch (error) {
+      if (error instanceof Error) {
+        console.error(chalk.red(`✗ Login failed`));
+        console.error(chalk.dim(`  ${error.message}`));
+      } else {
+        console.error(chalk.red("✗ An unexpected error occurred"));
+      }
+      process.exit(1);
+    }
   });

--- a/turbo/apps/cli/src/instrument.ts
+++ b/turbo/apps/cli/src/instrument.ts
@@ -36,6 +36,7 @@ const OPERATIONAL_ERROR_PATTERNS = [
   // Network issues (transient, not bugs)
   /network error/i,
   /network issue/i,
+  /fetch failed/i,
   /connection refused/i,
   /timeout/i,
   /ECONNREFUSED/i,

--- a/turbo/apps/cli/src/lib/api/auth.ts
+++ b/turbo/apps/cli/src/lib/api/auth.ts
@@ -141,23 +141,18 @@ export async function authenticate(apiUrl?: string): Promise<void> {
 
     // Handle other errors
     if (tokenResult.error === "expired_token") {
-      console.error(chalk.red("\n✗ Device code expired, please try again"));
-      process.exit(1);
+      throw new Error("Device code expired, please try again");
     }
 
     if (tokenResult.error) {
-      console.error(
-        chalk.red(
-          `\n✗ Authentication failed: ${tokenResult.error_description ?? tokenResult.error}`,
-        ),
+      throw new Error(
+        `Authentication failed: ${tokenResult.error_description ?? tokenResult.error}`,
       );
-      process.exit(1);
     }
   }
 
   // Timeout
-  console.error(chalk.red("\n✗ Authentication timed out, please try again"));
-  process.exit(1);
+  throw new Error("Authentication timed out, please try again");
 }
 
 export async function logout(): Promise<void> {


### PR DESCRIPTION
## Summary

- Add try/catch error handling to the `loginCommand` action, matching the pattern used by all other CLI commands (~50+)
- Add `/fetch failed/i` to Sentry `OPERATIONAL_ERROR_PATTERNS` to filter Node.js undici network errors
- Add network failure test case using `HttpResponse.error()`

Fixes [CLI-D](https://vm0.sentry.io/issues/CLI-D)

## Context

The Sentry issue CLI-D reported a `TypeError: fetch failed` as an unhandled promise rejection when `vm0 auth login` couldn't reach the API server. Two gaps caused this:

1. **Missing error handling** — `loginCommand` was the only command without try/catch, so network-level fetch errors propagated as unhandled rejections
2. **Sentry filter gap** — `OPERATIONAL_ERROR_PATTERNS` covered `network error`, `ECONNREFUSED`, `ETIMEDOUT` but not `fetch failed` (the message Node.js undici uses)

## Test plan

- [x] Existing login tests pass (7/7)
- [x] New network failure test added (`HttpResponse.error()`)
- [x] Lint, type check, format, knip all pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)