### PR TITLE
refactor(web): replace deprecated --porcelain with --json in compose sandbox script

### DIFF
--- a/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
+++ b/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
@@ -118,14 +118,14 @@ async function main() {
     process.exit(1);
   }
 
-  // Execute vm0 compose with --porcelain for structured output
+  // Execute vm0 compose with --json for structured output
   // CLI is pre-installed in the vm0-cli template
   log('INFO', 'Running vm0 compose...');
   const result = spawnSync('vm0', [
     'compose',
     GITHUB_URL,
     '--experimental-shared-compose',
-    '--porcelain',
+    '--json',
   ], {
     env: {
       ...process.env,


### PR DESCRIPTION
## Summary
- Update the E2B sandbox script in `trigger-compose-job.ts` to use `--json` instead of the deprecated `--porcelain` flag
- The CLI already migrated from `--porcelain` to `--json` in #2613; this aligns the web server with that change

## Test plan
- [ ] Verify CI passes (lint, type-check)
- [ ] The change is a simple string replacement (`--porcelain` → `--json`) with identical behavior since the CLI internally maps `--porcelain` to `--json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)