### PR TITLE
fix(sandbox): remove prompt content from agent execution logs

### DIFF
--- a/turbo/packages/core/src/sandbox/scripts/src/run-agent.ts
+++ b/turbo/packages/core/src/sandbox/scripts/src/run-agent.ts
@@ -226,7 +226,6 @@ async function run(): Promise<[number, string]> {
 
   // Execute CLI agent with JSONL output
   logInfo(`Starting ${CLI_AGENT_TYPE} execution...`);
-  logInfo(`Prompt: ${PROMPT}`);
 
   // Build command based on CLI agent type
   const useMock = process.env.USE_MOCK_CLAUDE === "true";


### PR DESCRIPTION
## Summary
- Remove `logInfo(`Prompt: ${PROMPT}`)` from `run-agent.ts` to avoid logging potentially sensitive prompt content during sandbox agent execution
- The prompt is already passed to the CLI command and does not need to be echoed in logs

## Test plan
- [x] Verified lint passes for `@vm0/core`
- [x] Verified type check passes for `@vm0/core`
- [x] Change is a single line deletion with no functional impact beyond log output

> **Note:** Pre-existing `@vm0/ui` type check failure (`@radix-ui/react-switch` missing) exists on main and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)