### PR TITLE
refactor(sandbox-fc): unify command execution into exec/exec_ignore_errors

### DIFF
--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -20,7 +20,7 @@ pub struct FirecrackerFactory {
 impl FirecrackerFactory {
     /// Create a new factory, pre-warming the network namespace and overlay pools.
     pub async fn new(config: FirecrackerConfig) -> Result<Self, SandboxError> {
-        crate::prerequisites::check_prerequisites(&config)?;
+        crate::prerequisites::check_prerequisites(&config).await?;
 
         let concurrency = config.concurrency.max(1);
         let paths = FactoryPaths::new(config.base_dir.clone());


### PR DESCRIPTION
## Summary

- Replace three scattered command execution patterns (`exec_command`/`sudo!` macro/raw `tokio::process::Command`) with a single `exec()`/`exec_ignore_errors()` pair in `command.rs`
- `exec()` invokes binaries directly without shell interpretation, eliminating unnecessary `sh -c` wrappers
- Migrate all call sites: `network/pool.rs` (25+ calls), `overlay/pool.rs`, `sandbox.rs`, `prerequisites.rs`, `factory.rs`
- Replace `iptables-save | grep` shell pipe with Rust-side `contains()` filtering

## Test plan

- [x] `cargo build -p sandbox-fc` passes
- [x] `cargo clippy -p sandbox-fc` passes with zero warnings
- [x] `cargo test -p sandbox-fc` — all 47 tests pass
- [x] Pre-commit hooks (cargo-fmt, cargo-clippy, commitlint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)