### PR TITLE
fix(sandbox-fc): check /dev/kvm read-write permission in prerequisites

### DIFF
--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -51,6 +51,8 @@ fn check_kvm(errors: &mut Vec<String>) {
     let kvm = Path::new("/dev/kvm");
     if !kvm.exists() {
         errors.push("/dev/kvm not found (KVM not available)".to_string());
+    } else if let Err(e) = std::fs::File::options().read(true).write(true).open(kvm) {
+        errors.push(format!("/dev/kvm not accessible: {e}"));
     }
 }
 


### PR DESCRIPTION
## Summary
- Check that `/dev/kvm` is readable and writable, not just that it exists
- Without this, users not in the `kvm` group get a confusing Firecracker start-time error instead of a clear prerequisites failure

## Test plan
- [x] `cargo clippy -p sandbox-fc` passes
- [x] `cargo test -p sandbox-fc` passes (47 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)