### PR TITLE
chore(e2b): bump @vm0/cli version from 9.22.0 to 9.27.2

### DIFF
--- a/turbo/scripts/e2b/vm0-cli/template.ts
+++ b/turbo/scripts/e2b/vm0-cli/template.ts
@@ -11,4 +11,4 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "jq"])
-  .npmInstall("@vm0/cli@9.22.0", { g: true });
+  .npmInstall("@vm0/cli@9.27.2", { g: true });


### PR DESCRIPTION
## Summary
- Update @vm0/cli version in E2B template from 9.22.0 to 9.27.2
- Keeps the sandbox CLI in sync with the latest release

## Test plan
- [ ] Verify E2B template builds successfully
- [ ] Confirm CLI version is correctly installed in sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)