### PR TITLE
fix(e2b): downgrade @vm0/cli from 9.27.2 to 9.27.0

### DIFF
--- a/turbo/scripts/e2b/vm0-cli/template.ts
+++ b/turbo/scripts/e2b/vm0-cli/template.ts
@@ -11,4 +11,4 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "jq"])
-  .npmInstall("@vm0/cli@9.27.2", { g: true });
+  .npmInstall("@vm0/cli@9.27.0", { g: true });


### PR DESCRIPTION
## Summary
- Downgrade @vm0/cli in E2B template from 9.27.2 to 9.27.0
- Version 9.27.2 has issues causing CI failures
- 9.27.0 is the first stable version with both `--json` and `--porcelain` flags

## Test plan
- [ ] Verify E2B template builds successfully
- [ ] Verify CLI E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)