### PR TITLE
refactor(sandbox-fc): convert api free functions to ApiClient struct

### DIFF
--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -1,4 +1,4 @@
-mod api_client;
+mod api;
 mod command;
 mod config;
 mod factory;

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -270,14 +270,17 @@ impl FirecrackerSandbox {
 
         // Wait for Firecracker API to be ready.
         let api_sock = self.paths.api_sock();
-        crate::api_client::wait_for_ready(&api_sock, API_READY_TIMEOUT)
+        let client = crate::api::ApiClient::new(&api_sock);
+        client
+            .wait_for_ready(API_READY_TIMEOUT)
             .await
             .map_err(|e| SandboxError::StartFailed(format!("API not ready: {e}")))?;
 
         // Load snapshot and resume VM.
         let snapshot_str = snapshot.snapshot_path.display().to_string();
         let memory_str = snapshot.memory_path.display().to_string();
-        crate::api_client::load_snapshot(&api_sock, &snapshot_str, &memory_str)
+        client
+            .load_snapshot(&snapshot_str, &memory_str)
             .await
             .map_err(|e| SandboxError::StartFailed(format!("snapshot load failed: {e}")))?;
 


### PR DESCRIPTION
## Summary
- Rename `api_client` module to `api`, converting free functions into methods on `ApiClient` struct
- `socket_path` is now held by the struct instead of passed to every function
- Rename `ApiError` stays as-is; `ApiClient` replaces the previous `wait_for_ready()` / `load_snapshot()` free functions
- Prepares for adding `pause()` and `create_snapshot()` methods

## Test plan
- [x] `cargo clippy -p sandbox-fc` passes
- [x] `cargo test -p sandbox-fc` — all 54 tests pass
- [x] No behavior changes — pure structural refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)