### PR TITLE
ci(crates): rename lint job to check

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -13,7 +13,7 @@ on:
       - '.github/workflows/crates.yml'
 
 jobs:
-  lint:
+  check:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203


### PR DESCRIPTION
## Summary
- Rename the `lint` job to `check` since it runs fmt, clippy, and tests — not just linting

## Test plan
- [x] No behavior change, only job name update

🤖 Generated with [Claude Code](https://claude.com/claude-code)