### PR TITLE
feat(sandbox-fc): implement snapshot creation workflow

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -18,6 +18,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +146,52 @@ dependencies = [
  "num-traits",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -235,6 +331,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +375,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -409,6 +517,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
@@ -591,6 +705,7 @@ name = "sandbox-fc"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "clap",
  "libc",
  "nix",
  "sandbox",
@@ -726,6 +841,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -948,6 +1069,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -16,6 +16,7 @@ vsock-proto = { path = "vsock-proto" }
 
 # External dependencies
 async-trait = "0.1"
+clap = "4"
 chrono = { version = "0.4", default-features = false }
 flate2 = "1"
 libc = "0.2"

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+clap = { workspace = true, features = ["derive"] }
 libc.workspace = true
 nix = { workspace = true, features = ["user", "inotify"] }
 sandbox.workspace = true

--- a/crates/sandbox-fc/src/api.rs
+++ b/crates/sandbox-fc/src/api.rs
@@ -98,6 +98,66 @@ impl<'a> ApiClient<'a> {
         Ok(())
     }
 
+    /// Pause the VM via PATCH /vm.
+    ///
+    /// The VM must be paused before creating a snapshot.
+    #[allow(dead_code)]
+    pub async fn pause(&self) -> Result<(), ApiError> {
+        let body = br#"{"state":"Paused"}"#;
+        tokio::time::timeout(REQUEST_TIMEOUT, self.request("PATCH", "/vm", Some(body)))
+            .await
+            .map_err(|_| ApiError {
+                status: 0,
+                body: format!("request timed out after {REQUEST_TIMEOUT:?}"),
+            })??;
+        Ok(())
+    }
+
+    /// Resume the VM via PATCH /vm.
+    #[allow(dead_code)]
+    pub async fn resume(&self) -> Result<(), ApiError> {
+        let body = br#"{"state":"Resumed"}"#;
+        tokio::time::timeout(REQUEST_TIMEOUT, self.request("PATCH", "/vm", Some(body)))
+            .await
+            .map_err(|_| ApiError {
+                status: 0,
+                body: format!("request timed out after {REQUEST_TIMEOUT:?}"),
+            })??;
+        Ok(())
+    }
+
+    /// Create a snapshot via PUT /snapshot/create.
+    ///
+    /// The VM must be paused first (see [`Self::pause`]).
+    #[allow(dead_code)]
+    pub async fn create_snapshot(
+        &self,
+        snapshot_path: &str,
+        mem_path: &str,
+    ) -> Result<(), ApiError> {
+        let body = serde_json::to_string(&serde_json::json!({
+            "snapshot_type": "Full",
+            "snapshot_path": snapshot_path,
+            "mem_file_path": mem_path,
+        }))
+        .map_err(|e| ApiError {
+            status: 0,
+            body: format!("serialize request: {e}"),
+        })?;
+
+        tokio::time::timeout(
+            REQUEST_TIMEOUT,
+            self.request("PUT", "/snapshot/create", Some(body.as_bytes())),
+        )
+        .await
+        .map_err(|_| ApiError {
+            status: 0,
+            body: format!("request timed out after {REQUEST_TIMEOUT:?}"),
+        })??;
+
+        Ok(())
+    }
+
     /// Send a raw HTTP/1.1 request over a Unix domain socket.
     ///
     /// Returns the response body on 2xx success, or an `ApiError` containing the
@@ -450,5 +510,135 @@ mod tests {
         assert_eq!(err.status, 400);
         // fault_message is extracted from JSON response (matches TS behavior).
         assert_eq!(err.body, "bad snapshot");
+    }
+
+    #[tokio::test]
+    async fn pause_succeeds_on_204() {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+        let sock_path = dir.path().join("test-pause.sock");
+
+        let listener = UnixListener::bind(&sock_path).unwrap_or_else(|e| {
+            panic!("bind {}: {e}", sock_path.display());
+        });
+
+        tokio::spawn(async move {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+
+            let req = String::from_utf8_lossy(&buf);
+            assert!(req.starts_with("PATCH /vm"), "got: {req}");
+            assert!(
+                req.contains(r#""state":"Paused""#),
+                "missing Paused in: {req}"
+            );
+
+            let response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+
+        let client = ApiClient::new(&sock_path);
+        let result = client.pause().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn resume_succeeds_on_204() {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+        let sock_path = dir.path().join("test-resume.sock");
+
+        let listener = UnixListener::bind(&sock_path).unwrap_or_else(|e| {
+            panic!("bind {}: {e}", sock_path.display());
+        });
+
+        tokio::spawn(async move {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+
+            let req = String::from_utf8_lossy(&buf);
+            assert!(req.starts_with("PATCH /vm"), "got: {req}");
+            assert!(
+                req.contains(r#""state":"Resumed""#),
+                "missing Resumed in: {req}"
+            );
+
+            let response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+
+        let client = ApiClient::new(&sock_path);
+        let result = client.resume().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn create_snapshot_succeeds_on_204() {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+        let sock_path = dir.path().join("test-create-snap.sock");
+
+        let listener = UnixListener::bind(&sock_path).unwrap_or_else(|e| {
+            panic!("bind {}: {e}", sock_path.display());
+        });
+
+        tokio::spawn(async move {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+
+            let req = String::from_utf8_lossy(&buf);
+            assert!(req.starts_with("PUT /snapshot/create"), "got: {req}");
+            assert!(
+                req.contains("snapshot_type"),
+                "missing snapshot_type in: {req}"
+            );
+            assert!(
+                req.contains("mem_file_path"),
+                "missing mem_file_path in: {req}"
+            );
+
+            let response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+
+        let client = ApiClient::new(&sock_path);
+        let result = client.create_snapshot("/snap/state", "/snap/memory").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn pause_returns_error_on_failure() {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+        let sock_path = dir.path().join("test-pause-err.sock");
+
+        let listener = UnixListener::bind(&sock_path).unwrap_or_else(|e| {
+            panic!("bind {}: {e}", sock_path.display());
+        });
+
+        tokio::spawn(async move {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+
+            let body = r#"{"fault_message":"cannot pause"}"#;
+            let response = format!(
+                "HTTP/1.1 400 Bad Request\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+
+        let client = ApiClient::new(&sock_path);
+        let err = client.pause().await.unwrap_err();
+        assert_eq!(err.status, 400);
+        assert_eq!(err.body, "cannot pause");
     }
 }

--- a/crates/sandbox-fc/src/api.rs
+++ b/crates/sandbox-fc/src/api.rs
@@ -72,90 +72,165 @@ impl<'a> ApiClient<'a> {
 
     /// Load a snapshot and resume the VM via PUT /snapshot/load.
     pub async fn load_snapshot(&self, snapshot_path: &str, mem_path: &str) -> Result<(), ApiError> {
-        let body = serde_json::to_string(&serde_json::json!({
-            "snapshot_path": snapshot_path,
-            "mem_backend": {
-                "backend_type": "File",
-                "backend_path": mem_path,
-            },
-            "resume_vm": true,
-        }))
-        .map_err(|e| ApiError {
-            status: 0,
-            body: format!("serialize request: {e}"),
-        })?;
-
-        tokio::time::timeout(
-            REQUEST_TIMEOUT,
-            self.request("PUT", "/snapshot/load", Some(body.as_bytes())),
+        self.put_json(
+            "/snapshot/load",
+            &serde_json::json!({
+                "snapshot_path": snapshot_path,
+                "mem_backend": {
+                    "backend_type": "File",
+                    "backend_path": mem_path,
+                },
+                "resume_vm": true,
+            }),
         )
         .await
-        .map_err(|_| ApiError {
-            status: 0,
-            body: format!("request timed out after {REQUEST_TIMEOUT:?}"),
-        })??;
-
-        Ok(())
     }
 
     /// Pause the VM via PATCH /vm.
     ///
     /// The VM must be paused before creating a snapshot.
-    #[allow(dead_code)]
     pub async fn pause(&self) -> Result<(), ApiError> {
-        let body = br#"{"state":"Paused"}"#;
-        tokio::time::timeout(REQUEST_TIMEOUT, self.request("PATCH", "/vm", Some(body)))
+        self.request_with_timeout("PATCH", "/vm", Some(br#"{"state":"Paused"}"#))
             .await
-            .map_err(|_| ApiError {
-                status: 0,
-                body: format!("request timed out after {REQUEST_TIMEOUT:?}"),
-            })??;
-        Ok(())
-    }
-
-    /// Resume the VM via PATCH /vm.
-    #[allow(dead_code)]
-    pub async fn resume(&self) -> Result<(), ApiError> {
-        let body = br#"{"state":"Resumed"}"#;
-        tokio::time::timeout(REQUEST_TIMEOUT, self.request("PATCH", "/vm", Some(body)))
-            .await
-            .map_err(|_| ApiError {
-                status: 0,
-                body: format!("request timed out after {REQUEST_TIMEOUT:?}"),
-            })??;
-        Ok(())
     }
 
     /// Create a snapshot via PUT /snapshot/create.
     ///
     /// The VM must be paused first (see [`Self::pause`]).
-    #[allow(dead_code)]
     pub async fn create_snapshot(
         &self,
         snapshot_path: &str,
         mem_path: &str,
     ) -> Result<(), ApiError> {
-        let body = serde_json::to_string(&serde_json::json!({
-            "snapshot_type": "Full",
-            "snapshot_path": snapshot_path,
-            "mem_file_path": mem_path,
-        }))
-        .map_err(|e| ApiError {
+        self.put_json(
+            "/snapshot/create",
+            &serde_json::json!({
+                "snapshot_type": "Full",
+                "snapshot_path": snapshot_path,
+                "mem_file_path": mem_path,
+            }),
+        )
+        .await
+    }
+
+    /// Configure the machine (vCPU count and memory) via PUT /machine-config.
+    pub async fn configure_machine(
+        &self,
+        vcpu_count: u32,
+        mem_size_mib: u32,
+    ) -> Result<(), ApiError> {
+        self.put_json(
+            "/machine-config",
+            &serde_json::json!({
+                "vcpu_count": vcpu_count,
+                "mem_size_mib": mem_size_mib,
+            }),
+        )
+        .await
+    }
+
+    /// Configure the boot source via PUT /boot-source.
+    pub async fn configure_boot_source(
+        &self,
+        kernel_image_path: &str,
+        boot_args: &str,
+    ) -> Result<(), ApiError> {
+        self.put_json(
+            "/boot-source",
+            &serde_json::json!({
+                "kernel_image_path": kernel_image_path,
+                "boot_args": boot_args,
+            }),
+        )
+        .await
+    }
+
+    /// Configure a drive via PUT /drives/{drive_id}.
+    pub async fn configure_drive(
+        &self,
+        drive_id: &str,
+        path_on_host: &str,
+        is_root_device: bool,
+        is_read_only: bool,
+    ) -> Result<(), ApiError> {
+        let path = format!("/drives/{drive_id}");
+        self.put_json(
+            &path,
+            &serde_json::json!({
+                "drive_id": drive_id,
+                "path_on_host": path_on_host,
+                "is_root_device": is_root_device,
+                "is_read_only": is_read_only,
+            }),
+        )
+        .await
+    }
+
+    /// Configure a network interface via PUT /network-interfaces/{iface_id}.
+    pub async fn configure_network_interface(
+        &self,
+        iface_id: &str,
+        guest_mac: &str,
+        host_dev_name: &str,
+    ) -> Result<(), ApiError> {
+        let path = format!("/network-interfaces/{iface_id}");
+        self.put_json(
+            &path,
+            &serde_json::json!({
+                "iface_id": iface_id,
+                "guest_mac": guest_mac,
+                "host_dev_name": host_dev_name,
+            }),
+        )
+        .await
+    }
+
+    /// Configure the vsock device via PUT /vsock.
+    pub async fn configure_vsock(&self, guest_cid: u32, uds_path: &str) -> Result<(), ApiError> {
+        self.put_json(
+            "/vsock",
+            &serde_json::json!({
+                "guest_cid": guest_cid,
+                "uds_path": uds_path,
+            }),
+        )
+        .await
+    }
+
+    /// Start the VM instance via PUT /actions.
+    pub async fn start_instance(&self) -> Result<(), ApiError> {
+        self.request_with_timeout(
+            "PUT",
+            "/actions",
+            Some(br#"{"action_type":"InstanceStart"}"#),
+        )
+        .await
+    }
+
+    /// Send a request with the standard timeout, discarding the response body.
+    async fn request_with_timeout(
+        &self,
+        method: &str,
+        path: &str,
+        body: Option<&[u8]>,
+    ) -> Result<(), ApiError> {
+        tokio::time::timeout(REQUEST_TIMEOUT, self.request(method, path, body))
+            .await
+            .map_err(|_| ApiError {
+                status: 0,
+                body: format!("request timed out after {REQUEST_TIMEOUT:?}"),
+            })??;
+        Ok(())
+    }
+
+    /// Serialize a JSON value and PUT it to the given path.
+    async fn put_json(&self, path: &str, value: &serde_json::Value) -> Result<(), ApiError> {
+        let body = serde_json::to_string(value).map_err(|e| ApiError {
             status: 0,
             body: format!("serialize request: {e}"),
         })?;
-
-        tokio::time::timeout(
-            REQUEST_TIMEOUT,
-            self.request("PUT", "/snapshot/create", Some(body.as_bytes())),
-        )
-        .await
-        .map_err(|_| ApiError {
-            status: 0,
-            body: format!("request timed out after {REQUEST_TIMEOUT:?}"),
-        })??;
-
-        Ok(())
+        self.request_with_timeout("PUT", path, Some(body.as_bytes()))
+            .await
     }
 
     /// Send a raw HTTP/1.1 request over a Unix domain socket.
@@ -545,38 +620,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resume_succeeds_on_204() {
-        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
-        let sock_path = dir.path().join("test-resume.sock");
-
-        let listener = UnixListener::bind(&sock_path).unwrap_or_else(|e| {
-            panic!("bind {}: {e}", sock_path.display());
-        });
-
-        tokio::spawn(async move {
-            let Ok((mut stream, _)) = listener.accept().await else {
-                return;
-            };
-            let mut buf = vec![0u8; 4096];
-            let _ = stream.read(&mut buf).await;
-
-            let req = String::from_utf8_lossy(&buf);
-            assert!(req.starts_with("PATCH /vm"), "got: {req}");
-            assert!(
-                req.contains(r#""state":"Resumed""#),
-                "missing Resumed in: {req}"
-            );
-
-            let response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
-            let _ = stream.write_all(response.as_bytes()).await;
-        });
-
-        let client = ApiClient::new(&sock_path);
-        let result = client.resume().await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
     async fn create_snapshot_succeeds_on_204() {
         let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
         let sock_path = dir.path().join("test-create-snap.sock");
@@ -640,5 +683,208 @@ mod tests {
         let err = client.pause().await.unwrap_err();
         assert_eq!(err.status, 400);
         assert_eq!(err.body, "cannot pause");
+    }
+
+    #[tokio::test]
+    async fn configure_machine_succeeds_on_204() {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+        let sock_path = dir.path().join("test-machine.sock");
+
+        let listener = UnixListener::bind(&sock_path).unwrap_or_else(|e| {
+            panic!("bind {}: {e}", sock_path.display());
+        });
+
+        tokio::spawn(async move {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+
+            let req = String::from_utf8_lossy(&buf);
+            assert!(req.starts_with("PUT /machine-config"), "got: {req}");
+            assert!(req.contains("vcpu_count"), "missing vcpu_count in: {req}");
+            assert!(
+                req.contains("mem_size_mib"),
+                "missing mem_size_mib in: {req}"
+            );
+
+            let response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+
+        let client = ApiClient::new(&sock_path);
+        let result = client.configure_machine(2, 256).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn configure_boot_source_succeeds_on_204() {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+        let sock_path = dir.path().join("test-boot.sock");
+
+        let listener = UnixListener::bind(&sock_path).unwrap_or_else(|e| {
+            panic!("bind {}: {e}", sock_path.display());
+        });
+
+        tokio::spawn(async move {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+
+            let req = String::from_utf8_lossy(&buf);
+            assert!(req.starts_with("PUT /boot-source"), "got: {req}");
+            assert!(
+                req.contains("kernel_image_path"),
+                "missing kernel_image_path in: {req}"
+            );
+            assert!(req.contains("boot_args"), "missing boot_args in: {req}");
+
+            let response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+
+        let client = ApiClient::new(&sock_path);
+        let result = client
+            .configure_boot_source("/path/to/kernel", "console=ttyS0")
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn configure_drive_succeeds_on_204() {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+        let sock_path = dir.path().join("test-drive.sock");
+
+        let listener = UnixListener::bind(&sock_path).unwrap_or_else(|e| {
+            panic!("bind {}: {e}", sock_path.display());
+        });
+
+        tokio::spawn(async move {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+
+            let req = String::from_utf8_lossy(&buf);
+            assert!(req.starts_with("PUT /drives/rootfs"), "got: {req}");
+            assert!(req.contains("drive_id"), "missing drive_id in: {req}");
+            assert!(
+                req.contains("path_on_host"),
+                "missing path_on_host in: {req}"
+            );
+
+            let response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+
+        let client = ApiClient::new(&sock_path);
+        let result = client
+            .configure_drive("rootfs", "/path/to/rootfs", true, true)
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn configure_network_interface_succeeds_on_204() {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+        let sock_path = dir.path().join("test-netif.sock");
+
+        let listener = UnixListener::bind(&sock_path).unwrap_or_else(|e| {
+            panic!("bind {}: {e}", sock_path.display());
+        });
+
+        tokio::spawn(async move {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+
+            let req = String::from_utf8_lossy(&buf);
+            assert!(
+                req.starts_with("PUT /network-interfaces/eth0"),
+                "got: {req}"
+            );
+            assert!(req.contains("guest_mac"), "missing guest_mac in: {req}");
+            assert!(
+                req.contains("host_dev_name"),
+                "missing host_dev_name in: {req}"
+            );
+
+            let response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+
+        let client = ApiClient::new(&sock_path);
+        let result = client
+            .configure_network_interface("eth0", "02:00:00:00:00:01", "vm0-tap")
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn configure_vsock_succeeds_on_204() {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+        let sock_path = dir.path().join("test-vsock.sock");
+
+        let listener = UnixListener::bind(&sock_path).unwrap_or_else(|e| {
+            panic!("bind {}: {e}", sock_path.display());
+        });
+
+        tokio::spawn(async move {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+
+            let req = String::from_utf8_lossy(&buf);
+            assert!(req.starts_with("PUT /vsock"), "got: {req}");
+            assert!(req.contains("guest_cid"), "missing guest_cid in: {req}");
+            assert!(req.contains("uds_path"), "missing uds_path in: {req}");
+
+            let response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+
+        let client = ApiClient::new(&sock_path);
+        let result = client.configure_vsock(3, "/tmp/vsock.sock").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn start_instance_succeeds_on_204() {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+        let sock_path = dir.path().join("test-start.sock");
+
+        let listener = UnixListener::bind(&sock_path).unwrap_or_else(|e| {
+            panic!("bind {}: {e}", sock_path.display());
+        });
+
+        tokio::spawn(async move {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+
+            let req = String::from_utf8_lossy(&buf);
+            assert!(req.starts_with("PUT /actions"), "got: {req}");
+            assert!(
+                req.contains("InstanceStart"),
+                "missing InstanceStart in: {req}"
+            );
+
+            let response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+
+        let client = ApiClient::new(&sock_path);
+        let result = client.start_instance().await;
+        assert!(result.is_ok());
     }
 }

--- a/crates/sandbox-fc/src/api.rs
+++ b/crates/sandbox-fc/src/api.rs
@@ -257,7 +257,6 @@ impl<'a> ApiClient<'a> {
                  Accept: application/json\r\n\
                  Content-Type: application/json\r\n\
                  Content-Length: {}\r\n\
-                 Connection: close\r\n\
                  \r\n",
                 b.len(),
             )
@@ -266,7 +265,6 @@ impl<'a> ApiClient<'a> {
                 "{method} {path} HTTP/1.1\r\n\
                  Host: localhost\r\n\
                  Accept: application/json\r\n\
-                 Connection: close\r\n\
                  \r\n"
             )
         };
@@ -286,37 +284,39 @@ impl<'a> ApiClient<'a> {
             })?;
         }
 
-        // Read response headers (up to \r\n\r\n). We read byte-by-byte into
-        // a buffer and stop as soon as we see the end-of-headers marker.  This
-        // avoids blocking on `read_to_end` when the server uses keep-alive.
+        // Read response into a buffer. Firecracker uses keep-alive so we
+        // cannot rely on connection close; instead we read until we find the
+        // header/body boundary (\r\n\r\n), parse Content-Length, then read
+        // exactly that many remaining body bytes.
+        let mut reader = tokio::io::BufReader::new(stream);
         let mut buf = Vec::with_capacity(4096);
-        let mut header_end = None;
+
+        // Phase 1: read until we have the full header block.
         loop {
-            let mut byte = [0u8; 1];
-            let n = stream.read(&mut byte).await.map_err(|e| ApiError {
+            let n = reader.read_buf(&mut buf).await.map_err(|e| ApiError {
                 status: 0,
                 body: format!("read response: {e}"),
             })?;
-            if n == 0 {
-                break; // connection closed
-            }
-            buf.push(byte[0]);
-            if buf.len() >= 4 && buf.get(buf.len() - 4..) == Some(b"\r\n\r\n".as_slice()) {
-                header_end = Some(buf.len());
+            if n == 0 || buf.windows(4).any(|w| w == b"\r\n\r\n") {
                 break;
             }
         }
 
-        let headers = String::from_utf8_lossy(&buf);
+        let response = String::from_utf8_lossy(&buf);
+
+        // Find where headers end.
+        let header_end = response.find("\r\n\r\n").unwrap_or(response.len());
 
         // Parse status code from "HTTP/1.1 204 No Content\r\n..."
-        let status = headers
+        let status = response
             .get(9..12)
             .and_then(|s| s.parse::<u16>().ok())
             .unwrap_or(0);
 
-        // Parse Content-Length and read body if present.
-        let content_length = headers
+        // Parse Content-Length from headers.
+        let content_length = response
+            .get(..header_end)
+            .unwrap_or_default()
             .lines()
             .find_map(|line| {
                 let (key, value) = line.split_once(':')?;
@@ -328,16 +328,22 @@ impl<'a> ApiClient<'a> {
             })
             .unwrap_or(0);
 
-        let body_str = if content_length > 0 && header_end.is_some() {
-            let mut body_buf = vec![0u8; content_length];
-            stream
-                .read_exact(&mut body_buf)
-                .await
-                .map_err(|e| ApiError {
+        // Body bytes already read (past the \r\n\r\n separator).
+        let body_start = header_end + 4;
+        let already_read = buf.len().saturating_sub(body_start);
+        let body_str = if content_length > 0 {
+            if already_read < content_length {
+                // Need to read remaining body bytes from the stream.
+                let remaining = content_length - already_read;
+                let mut tail = vec![0u8; remaining];
+                reader.read_exact(&mut tail).await.map_err(|e| ApiError {
                     status: 0,
                     body: format!("read body: {e}"),
                 })?;
-            String::from_utf8_lossy(&body_buf).to_string()
+                buf.extend_from_slice(&tail);
+            }
+            let end = body_start + content_length;
+            String::from_utf8_lossy(buf.get(body_start..end).unwrap_or_default()).to_string()
         } else {
             String::new()
         };

--- a/crates/sandbox-fc/src/api.rs
+++ b/crates/sandbox-fc/src/api.rs
@@ -286,26 +286,61 @@ impl<'a> ApiClient<'a> {
             })?;
         }
 
+        // Read response headers (up to \r\n\r\n). We read byte-by-byte into
+        // a buffer and stop as soon as we see the end-of-headers marker.  This
+        // avoids blocking on `read_to_end` when the server uses keep-alive.
         let mut buf = Vec::with_capacity(4096);
-        stream.read_to_end(&mut buf).await.map_err(|e| ApiError {
-            status: 0,
-            body: format!("read response: {e}"),
-        })?;
+        let mut header_end = None;
+        loop {
+            let mut byte = [0u8; 1];
+            let n = stream.read(&mut byte).await.map_err(|e| ApiError {
+                status: 0,
+                body: format!("read response: {e}"),
+            })?;
+            if n == 0 {
+                break; // connection closed
+            }
+            buf.push(byte[0]);
+            if buf.len() >= 4 && buf.get(buf.len() - 4..) == Some(b"\r\n\r\n".as_slice()) {
+                header_end = Some(buf.len());
+                break;
+            }
+        }
 
-        let response = String::from_utf8_lossy(&buf);
+        let headers = String::from_utf8_lossy(&buf);
 
         // Parse status code from "HTTP/1.1 204 No Content\r\n..."
-        let status = response
+        let status = headers
             .get(9..12)
             .and_then(|s| s.parse::<u16>().ok())
             .unwrap_or(0);
 
-        // Extract body after the \r\n\r\n header separator.
-        let body_str = response
-            .find("\r\n\r\n")
-            .and_then(|i| response.get(i + 4..))
-            .unwrap_or_default()
-            .to_string();
+        // Parse Content-Length and read body if present.
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (key, value) = line.split_once(':')?;
+                if key.trim().eq_ignore_ascii_case("content-length") {
+                    value.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        let body_str = if content_length > 0 && header_end.is_some() {
+            let mut body_buf = vec![0u8; content_length];
+            stream
+                .read_exact(&mut body_buf)
+                .await
+                .map_err(|e| ApiError {
+                    status: 0,
+                    body: format!("read body: {e}"),
+                })?;
+            String::from_utf8_lossy(&body_buf).to_string()
+        } else {
+            String::new()
+        };
 
         if (200..300).contains(&status) {
             Ok(body_str)

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -6,9 +6,12 @@ mod network;
 mod overlay;
 mod paths;
 mod prerequisites;
+mod process;
 mod sandbox;
+mod snapshot;
 
 pub use config::{FirecrackerConfig, SnapshotConfig};
 pub use factory::FirecrackerFactory;
-pub use paths::{FactoryPaths, SandboxPaths};
+pub use paths::{FactoryPaths, SandboxPaths, SnapshotOutputPaths};
 pub use sandbox::FirecrackerSandbox;
+pub use snapshot::{SnapshotCreateConfig, SnapshotError, create_snapshot};

--- a/crates/sandbox-fc/src/main.rs
+++ b/crates/sandbox-fc/src/main.rs
@@ -40,6 +40,12 @@ enum Command {
         rootfs: PathBuf,
         /// Directory where snapshot artifacts will be written
         output_dir: PathBuf,
+        /// Number of vCPUs for the VM
+        #[arg(long, default_value_t = 1)]
+        vcpu_count: u32,
+        /// Memory size in MiB for the VM
+        #[arg(long, default_value_t = 256)]
+        memory_mb: u32,
     },
     /// Boot a VM and execute a command
     Exec {
@@ -73,7 +79,19 @@ async fn main() -> ExitCode {
             kernel,
             rootfs,
             output_dir,
-        } => run_snapshot(firecracker, kernel, rootfs, output_dir).await,
+            vcpu_count,
+            memory_mb,
+        } => {
+            run_snapshot(
+                firecracker,
+                kernel,
+                rootfs,
+                output_dir,
+                vcpu_count,
+                memory_mb,
+            )
+            .await
+        }
         Command::Exec {
             firecracker,
             kernel,
@@ -111,14 +129,16 @@ async fn run_snapshot(
     kernel: PathBuf,
     rootfs: PathBuf,
     output_dir: PathBuf,
+    vcpu_count: u32,
+    memory_mb: u32,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = sandbox_fc::SnapshotCreateConfig {
         binary_path: resolve_path(firecracker).await?,
         kernel_path: resolve_path(kernel).await?,
         rootfs_path: resolve_path(rootfs).await?,
         output_dir: resolve_or_create(output_dir).await?,
-        vcpu_count: 1,
-        memory_mb: 256,
+        vcpu_count,
+        memory_mb,
     };
 
     let snapshot = sandbox_fc::create_snapshot(config).await?;

--- a/crates/sandbox-fc/src/main.rs
+++ b/crates/sandbox-fc/src/main.rs
@@ -3,11 +3,10 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use std::time::Instant;
 
+use clap::{Parser, Subcommand};
 use sandbox::{ExecRequest, ResourceLimits, SandboxConfig, SandboxFactory};
 use tracing_subscriber::fmt::time::FormatTime;
 use uuid::Uuid;
-
-use sandbox_fc::FirecrackerConfig;
 
 struct Elapsed(Instant);
 
@@ -22,20 +21,66 @@ impl FormatTime for Elapsed {
     }
 }
 
-/// Usage: sandbox-fc <firecracker> <kernel> <rootfs> <base_dir> <cmd>
+#[derive(Parser)]
+#[command(name = "sandbox-fc")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Create a snapshot from a fresh VM boot
+    Snapshot {
+        /// Path to the Firecracker binary
+        firecracker: PathBuf,
+        /// Path to the guest kernel image
+        kernel: PathBuf,
+        /// Path to the root filesystem image
+        rootfs: PathBuf,
+        /// Directory where snapshot artifacts will be written
+        output_dir: PathBuf,
+    },
+    /// Boot a VM and execute a command
+    Exec {
+        /// Path to the Firecracker binary
+        firecracker: PathBuf,
+        /// Path to the guest kernel image
+        kernel: PathBuf,
+        /// Path to the root filesystem image
+        rootfs: PathBuf,
+        /// Base directory for runtime data
+        base_dir: PathBuf,
+        /// Command to execute inside the VM
+        cmd: String,
+    },
+}
+
 #[tokio::main]
 async fn main() -> ExitCode {
     tracing_subscriber::fmt()
         .with_timer(Elapsed(Instant::now()))
         .init();
 
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    if args.len() < 5 {
-        eprintln!("usage: sandbox-fc <firecracker> <kernel> <rootfs> <base_dir> <cmd>");
-        return ExitCode::FAILURE;
-    }
+    let cli = Cli::parse();
 
-    if let Err(e) = run(&args).await {
+    let result = match cli.command {
+        Command::Snapshot {
+            firecracker,
+            kernel,
+            rootfs,
+            output_dir,
+        } => run_snapshot(firecracker, kernel, rootfs, output_dir).await,
+        Command::Exec {
+            firecracker,
+            kernel,
+            rootfs,
+            base_dir,
+            cmd,
+        } => run_exec(firecracker, kernel, rootfs, base_dir, &cmd).await,
+    };
+
+    if let Err(e) = result {
         eprintln!("error: {e}");
         return ExitCode::FAILURE;
     }
@@ -43,22 +88,49 @@ async fn main() -> ExitCode {
     ExitCode::SUCCESS
 }
 
-fn arg(args: &[String], idx: usize) -> Result<&String, &'static str> {
-    args.get(idx).ok_or("missing argument")
+async fn run_snapshot(
+    firecracker: PathBuf,
+    kernel: PathBuf,
+    rootfs: PathBuf,
+    output_dir: PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = sandbox_fc::SnapshotCreateConfig {
+        binary_path: firecracker,
+        kernel_path: kernel,
+        rootfs_path: rootfs,
+        output_dir,
+        vcpu_count: 1,
+        memory_mb: 256,
+    };
+
+    let snapshot = sandbox_fc::create_snapshot(config).await?;
+
+    println!("snapshot:       {}", snapshot.snapshot_path.display());
+    println!("memory:         {}", snapshot.memory_path.display());
+    println!("overlay:        {}", snapshot.overlay_path.display());
+    println!("overlay_bind:   {}", snapshot.overlay_bind_path.display());
+    println!("vsock_bind_dir: {}", snapshot.vsock_bind_dir.display());
+
+    Ok(())
 }
 
-async fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
-    let config = FirecrackerConfig {
-        binary_path: PathBuf::from(arg(args, 0)?),
-        kernel_path: PathBuf::from(arg(args, 1)?),
-        rootfs_path: PathBuf::from(arg(args, 2)?),
-        base_dir: PathBuf::from(arg(args, 3)?),
+async fn run_exec(
+    firecracker: PathBuf,
+    kernel: PathBuf,
+    rootfs: PathBuf,
+    base_dir: PathBuf,
+    cmd: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = sandbox_fc::FirecrackerConfig {
+        binary_path: firecracker,
+        kernel_path: kernel,
+        rootfs_path: rootfs,
+        base_dir,
         instance_index: 0,
         concurrency: 1,
         proxy_port: None,
         snapshot: None,
     };
-    let cmd = arg(args, 4)?;
 
     let factory = sandbox_fc::FirecrackerFactory::new(config).await?;
 

--- a/crates/sandbox-fc/src/main.rs
+++ b/crates/sandbox-fc/src/main.rs
@@ -53,6 +53,9 @@ enum Command {
         base_dir: PathBuf,
         /// Command to execute inside the VM
         cmd: String,
+        /// Snapshot directory to restore from (created by `snapshot` subcommand)
+        #[arg(long)]
+        snapshot_dir: Option<PathBuf>,
     },
 }
 
@@ -77,7 +80,8 @@ async fn main() -> ExitCode {
             rootfs,
             base_dir,
             cmd,
-        } => run_exec(firecracker, kernel, rootfs, base_dir, &cmd).await,
+            snapshot_dir,
+        } => run_exec(firecracker, kernel, rootfs, base_dir, &cmd, snapshot_dir).await,
     };
 
     if let Err(e) = result {
@@ -120,7 +124,20 @@ async fn run_exec(
     rootfs: PathBuf,
     base_dir: PathBuf,
     cmd: &str,
+    snapshot_dir: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let snapshot = snapshot_dir.map(|dir| {
+        let output = sandbox_fc::SnapshotOutputPaths::new(dir.clone());
+        let work = sandbox_fc::SandboxPaths::new(dir.join("work"));
+        sandbox_fc::SnapshotConfig {
+            snapshot_path: output.snapshot(),
+            memory_path: output.memory(),
+            overlay_path: output.overlay(),
+            overlay_bind_path: work.overlay(),
+            vsock_bind_dir: work.vsock_dir(),
+        }
+    });
+
     let config = sandbox_fc::FirecrackerConfig {
         binary_path: firecracker,
         kernel_path: kernel,
@@ -129,7 +146,7 @@ async fn run_exec(
         instance_index: 0,
         concurrency: 1,
         proxy_port: None,
-        snapshot: None,
+        snapshot,
     };
 
     let factory = sandbox_fc::FirecrackerFactory::new(config).await?;

--- a/crates/sandbox-fc/src/main.rs
+++ b/crates/sandbox-fc/src/main.rs
@@ -92,6 +92,20 @@ async fn main() -> ExitCode {
     ExitCode::SUCCESS
 }
 
+/// Resolve a path to absolute. Creates parent directories for `output_dir`-style
+/// paths that may not exist yet — callers should use [`resolve_or_create`] for those.
+async fn resolve_path(path: PathBuf) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    Ok(tokio::fs::canonicalize(&path)
+        .await
+        .map_err(|e| format!("resolve path {}: {e}", path.display()))?)
+}
+
+/// Create the directory if needed, then resolve to absolute.
+async fn resolve_or_create(path: PathBuf) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    tokio::fs::create_dir_all(&path).await?;
+    resolve_path(path).await
+}
+
 async fn run_snapshot(
     firecracker: PathBuf,
     kernel: PathBuf,
@@ -99,10 +113,10 @@ async fn run_snapshot(
     output_dir: PathBuf,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = sandbox_fc::SnapshotCreateConfig {
-        binary_path: firecracker,
-        kernel_path: kernel,
-        rootfs_path: rootfs,
-        output_dir,
+        binary_path: resolve_path(firecracker).await?,
+        kernel_path: resolve_path(kernel).await?,
+        rootfs_path: resolve_path(rootfs).await?,
+        output_dir: resolve_or_create(output_dir).await?,
         vcpu_count: 1,
         memory_mb: 256,
     };
@@ -126,6 +140,15 @@ async fn run_exec(
     cmd: &str,
     snapshot_dir: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let firecracker = resolve_path(firecracker).await?;
+    let kernel = resolve_path(kernel).await?;
+    let rootfs = resolve_path(rootfs).await?;
+    let base_dir = resolve_or_create(base_dir).await?;
+    let snapshot_dir = match snapshot_dir {
+        Some(d) => Some(resolve_path(d).await?),
+        None => None,
+    };
+
     let snapshot = snapshot_dir.map(|dir| {
         let output = sandbox_fc::SnapshotOutputPaths::new(dir.clone());
         let work = sandbox_fc::SandboxPaths::new(dir.join("work"));

--- a/crates/sandbox-fc/src/network/guest.rs
+++ b/crates/sandbox-fc/src/network/guest.rs
@@ -34,6 +34,16 @@ pub fn generate_guest_network_boot_args() -> String {
     )
 }
 
+/// Generate the full kernel boot args string (base flags + network config).
+pub fn generate_boot_args() -> String {
+    format!(
+        "console=ttyS0 reboot=k panic=1 pci=off nomodules random.trust_cpu=on \
+         quiet loglevel=0 nokaslr audit=0 numa=off mitigations=off noresume \
+         init=/sbin/guest-init {}",
+        generate_guest_network_boot_args(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/sandbox-fc/src/network/guest.rs
+++ b/crates/sandbox-fc/src/network/guest.rs
@@ -27,7 +27,7 @@ pub const GUEST_NETWORK: GuestNetwork = GuestNetwork {
 };
 
 /// Generate kernel boot args for guest network configuration.
-pub fn generate_guest_network_boot_args() -> String {
+pub(crate) fn generate_guest_network_boot_args() -> String {
     format!(
         "ip={}::{}:{}:vm0-guest:eth0:off",
         GUEST_NETWORK.guest_ip, GUEST_NETWORK.gateway_ip, GUEST_NETWORK.netmask,

--- a/crates/sandbox-fc/src/network/mod.rs
+++ b/crates/sandbox-fc/src/network/mod.rs
@@ -2,6 +2,6 @@ mod error;
 mod guest;
 mod pool;
 
-pub use guest::generate_guest_network_boot_args;
+pub use guest::generate_boot_args;
 pub use guest::{GUEST_NETWORK, GuestNetwork};
 pub use pool::{NetnsPool, NetnsPoolConfig, PooledNetns};

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -49,7 +49,34 @@ impl SandboxPaths {
         self.vsock_dir().join("vsock.sock")
     }
 
+    pub fn overlay(&self) -> PathBuf {
+        self.workspace.join("overlay.ext4")
+    }
+
     pub fn api_sock(&self) -> PathBuf {
         self.workspace.join("api.sock")
+    }
+}
+
+/// Paths for snapshot output artifacts within an output directory.
+pub struct SnapshotOutputPaths {
+    output_dir: PathBuf,
+}
+
+impl SnapshotOutputPaths {
+    pub fn new(output_dir: PathBuf) -> Self {
+        Self { output_dir }
+    }
+
+    pub fn snapshot(&self) -> PathBuf {
+        self.output_dir.join("snapshot.bin")
+    }
+
+    pub fn memory(&self) -> PathBuf {
+        self.output_dir.join("memory.bin")
+    }
+
+    pub fn overlay(&self) -> PathBuf {
+        self.output_dir.join("overlay.ext4")
     }
 }

--- a/crates/sandbox-fc/src/process.rs
+++ b/crates/sandbox-fc/src/process.rs
@@ -1,0 +1,30 @@
+use crate::command::{CommandError, Privilege, exec};
+
+/// Recursively kill a process and all its descendants (depth-first).
+pub(crate) async fn kill_process_tree(pid: u32) {
+    let pid_str = pid.to_string();
+    if let Ok(stdout) = exec("pgrep", &["-P", &pid_str], Privilege::User).await {
+        for line in stdout.lines() {
+            if let Ok(child_pid) = line.trim().parse::<u32>() {
+                Box::pin(kill_process_tree(child_pid)).await;
+            }
+        }
+    }
+
+    let _ = exec("kill", &["-9", &pid_str], Privilege::Sudo).await;
+}
+
+/// Get the current username via `getuid()`.
+pub(crate) fn current_username() -> Result<String, CommandError> {
+    let uid = nix::unistd::getuid();
+    let user = nix::unistd::User::from_uid(uid)
+        .map_err(|e| CommandError {
+            command: "getuid".into(),
+            detail: format!("lookup uid {uid}: {e}"),
+        })?
+        .ok_or_else(|| CommandError {
+            command: "getuid".into(),
+            detail: format!("no user for uid {uid}"),
+        })?;
+    Ok(user.name)
+}

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -1,0 +1,242 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tracing::info;
+
+use crate::api::ApiClient;
+use crate::config::SnapshotConfig;
+use crate::network::{GUEST_NETWORK, NetnsPool, NetnsPoolConfig, generate_boot_args};
+use crate::overlay::{Ext4Creator, OverlayCreator as _};
+use crate::paths::{SandboxPaths, SnapshotOutputPaths};
+use crate::process;
+
+/// Timeout for waiting for the Firecracker API socket after process spawn.
+const API_READY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Timeout for waiting for the guest to connect via vsock after start.
+const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Network namespace pool index used for snapshot creation (63 = last slot,
+/// avoids collision with running sandbox instances that use lower indices).
+const SNAPSHOT_POOL_INDEX: u32 = 63;
+
+/// Configuration for creating a snapshot.
+#[derive(Debug, Clone)]
+pub struct SnapshotCreateConfig {
+    /// Path to the Firecracker binary.
+    pub binary_path: PathBuf,
+    /// Path to the guest kernel image.
+    pub kernel_path: PathBuf,
+    /// Path to the root filesystem image.
+    pub rootfs_path: PathBuf,
+    /// Directory where snapshot artifacts will be written.
+    pub output_dir: PathBuf,
+    /// Number of vCPUs for the VM.
+    pub vcpu_count: u32,
+    /// Memory size in MiB for the VM.
+    pub memory_mb: u32,
+}
+
+/// Errors that can occur during snapshot creation.
+#[derive(Debug, thiserror::Error)]
+pub enum SnapshotError {
+    #[error("setup failed: {0}")]
+    Setup(String),
+    #[error("firecracker process failed: {0}")]
+    Process(String),
+    #[error("api error: {0}")]
+    Api(#[from] crate::api::ApiError),
+    #[error("vsock connection failed: {0}")]
+    Vsock(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Create a snapshot by booting a fresh VM, configuring it, and capturing state.
+///
+/// This is the Rust equivalent of the TS `commands/snapshot.ts` workflow:
+///  1. Create work directory
+///  2. Create ext4 overlay
+///  3. Create network namespace
+///  4. Spawn Firecracker with `--api-sock`
+///  5. Wait for API socket ready
+///  6. Configure VM via API (6 parallel PUT calls)
+///  7. Bind vsock listener
+///  8. Start instance
+///  9. Wait for guest vsock connection
+/// 10. Pause VM
+/// 11. Create snapshot
+/// 12. Move overlay to output dir
+/// 13. Cleanup (kill Firecracker, destroy netns)
+pub async fn create_snapshot(
+    config: SnapshotCreateConfig,
+) -> Result<SnapshotConfig, SnapshotError> {
+    // 1. Create work directory under output_dir.
+    //    Paths inside this directory get baked into the snapshot and are used
+    //    as bind-mount targets during restore, so they must be deterministic.
+    let work = config.output_dir.join("work");
+    tokio::fs::create_dir_all(&work).await?;
+
+    let paths = SandboxPaths::new(work);
+
+    info!(work_dir = %paths.workspace().display(), "starting snapshot creation");
+
+    // 2. Create ext4 overlay in work dir.
+    Ext4Creator
+        .create(&paths.overlay())
+        .await
+        .map_err(|e| SnapshotError::Setup(format!("create overlay: {e}")))?;
+
+    info!("overlay created");
+
+    // 3. Create network namespace (pool of 1, index 63 to avoid collision).
+    let mut netns_pool = NetnsPool::create(NetnsPoolConfig {
+        index: SNAPSHOT_POOL_INDEX,
+        size: 1,
+        proxy_port: None,
+    })
+    .await
+    .map_err(|e| SnapshotError::Setup(format!("netns pool: {e}")))?;
+
+    // Guard: ensure netns cleanup on any exit path.
+    let result = run_snapshot_workflow(&config, &paths, &mut netns_pool).await;
+
+    // Always cleanup netns.
+    if let Err(e) = netns_pool.cleanup().await {
+        tracing::warn!(error = %e, "failed to cleanup netns pool");
+    }
+
+    result
+}
+
+/// Inner workflow, separated so the caller can always run cleanup.
+async fn run_snapshot_workflow(
+    config: &SnapshotCreateConfig,
+    paths: &SandboxPaths,
+    netns_pool: &mut NetnsPool,
+) -> Result<SnapshotConfig, SnapshotError> {
+    let network = netns_pool
+        .acquire()
+        .await
+        .map_err(|e| SnapshotError::Setup(format!("acquire netns: {e}")))?;
+
+    info!(netns = %network.name, "namespace acquired");
+
+    // 4. Spawn Firecracker with --api-sock in the namespace.
+    let api_sock = paths.api_sock();
+    let username = process::current_username().map_err(|e| SnapshotError::Setup(e.to_string()))?;
+
+    let mut child = tokio::process::Command::new("sudo")
+        .arg("ip")
+        .arg("netns")
+        .arg("exec")
+        .arg(&network.name)
+        .arg("sudo")
+        .arg("-u")
+        .arg(&username)
+        .arg(&config.binary_path)
+        .arg("--api-sock")
+        .arg(&api_sock)
+        .current_dir(paths.workspace())
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| SnapshotError::Process(format!("spawn firecracker: {e}")))?;
+
+    // Guard: ensure process cleanup on any exit path.
+    let result = run_with_firecracker(config, paths).await;
+
+    // Always kill the process tree.
+    if let Some(pid) = child.id() {
+        process::kill_process_tree(pid).await;
+    }
+    let _ = child.wait().await;
+
+    result
+}
+
+/// Inner workflow that runs while Firecracker is alive.
+async fn run_with_firecracker(
+    config: &SnapshotCreateConfig,
+    paths: &SandboxPaths,
+) -> Result<SnapshotConfig, SnapshotError> {
+    // 5. Wait for API socket ready.
+    let api_sock = paths.api_sock();
+    let client = ApiClient::new(&api_sock);
+    client.wait_for_ready(API_READY_TIMEOUT).await?;
+
+    info!("firecracker API ready");
+
+    // 6. Configure VM via API (6 parallel PUT calls).
+    let kernel_path = config.kernel_path.display().to_string();
+    let rootfs_path = config.rootfs_path.display().to_string();
+    let overlay_path = paths.overlay().display().to_string();
+    tokio::fs::create_dir_all(&paths.vsock_dir()).await?;
+    let vsock_uds_str = paths.vsock().display().to_string();
+
+    let boot_args = generate_boot_args();
+
+    tokio::try_join!(
+        client.configure_machine(config.vcpu_count, config.memory_mb),
+        client.configure_boot_source(&kernel_path, &boot_args),
+        client.configure_drive("rootfs", &rootfs_path, true, true),
+        client.configure_drive("overlay", &overlay_path, false, false),
+        client.configure_network_interface("eth0", GUEST_NETWORK.guest_mac, GUEST_NETWORK.tap_name),
+        client.configure_vsock(3, &vsock_uds_str),
+    )?;
+
+    info!("VM configured");
+
+    // 7. Bind vsock listener BEFORE starting the instance (race: guest connects ~300ms after boot).
+    let vsock_path_for_listen = vsock_uds_str.clone();
+    let vsock_task = tokio::spawn(async move {
+        vsock_host::VsockHost::wait_for_connection(&vsock_path_for_listen, VSOCK_CONNECT_TIMEOUT)
+            .await
+    });
+
+    // 8. Start instance.
+    let start_result = client.start_instance().await;
+    if let Err(e) = start_result {
+        vsock_task.abort();
+        return Err(e.into());
+    }
+
+    info!("instance started, waiting for guest vsock connection");
+
+    // 9. Wait for guest to connect via vsock.
+    let _guest = match vsock_task.await {
+        Ok(Ok(g)) => g,
+        Ok(Err(e)) => return Err(SnapshotError::Vsock(e.to_string())),
+        Err(e) => return Err(SnapshotError::Vsock(format!("vsock task: {e}"))),
+    };
+
+    info!("guest connected");
+
+    // 10. Pause VM.
+    client.pause().await?;
+
+    info!("VM paused");
+
+    // 11. Create snapshot — Firecracker writes directly to output_dir.
+    let output = SnapshotOutputPaths::new(config.output_dir.clone());
+    let snapshot_str = output.snapshot().display().to_string();
+    let memory_str = output.memory().display().to_string();
+    client.create_snapshot(&snapshot_str, &memory_str).await?;
+
+    info!("snapshot created");
+
+    // 12. Move overlay to output dir (same filesystem, so rename is instant).
+    //     Keep the work dir structure — it serves as bind-mount targets on restore.
+    tokio::fs::rename(&paths.overlay(), &output.overlay()).await?;
+
+    info!(output_dir = %config.output_dir.display(), "snapshot creation complete");
+
+    Ok(SnapshotConfig {
+        snapshot_path: output.snapshot(),
+        memory_path: output.memory(),
+        overlay_path: output.overlay(),
+        overlay_bind_path: paths.overlay(),
+        vsock_bind_dir: paths.vsock_dir(),
+    })
+}

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use tokio::io::AsyncBufReadExt;
 use tracing::info;
 
 use crate::api::ApiClient;
@@ -126,6 +127,14 @@ async fn run_snapshot_workflow(
     let api_sock = paths.api_sock();
     let username = process::current_username().map_err(|e| SnapshotError::Setup(e.to_string()))?;
 
+    info!(
+        netns = %network.name,
+        binary = %config.binary_path.display(),
+        api_sock = %api_sock.display(),
+        user = %username,
+        "spawning firecracker"
+    );
+
     let mut child = tokio::process::Command::new("sudo")
         .arg("ip")
         .arg("netns")
@@ -139,10 +148,32 @@ async fn run_snapshot_workflow(
         .arg(&api_sock)
         .current_dir(paths.workspace())
         .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
         .spawn()
         .map_err(|e| SnapshotError::Process(format!("spawn firecracker: {e}")))?;
+
+    // Stream stdout/stderr lines to tracing (same pattern as sandbox.rs).
+    if let Some(stdout) = child.stdout.take() {
+        tokio::spawn(async move {
+            let mut lines = tokio::io::BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if !line.is_empty() {
+                    info!(target: "firecracker", "{line}");
+                }
+            }
+        });
+    }
+    if let Some(stderr) = child.stderr.take() {
+        tokio::spawn(async move {
+            let mut lines = tokio::io::BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if !line.is_empty() {
+                    tracing::warn!(target: "firecracker", "stderr: {line}");
+                }
+            }
+        });
+    }
 
     // Guard: ensure process cleanup on any exit path.
     let result = run_with_firecracker(config, paths).await;


### PR DESCRIPTION
## Summary

- Add snapshot creation orchestration (`create_snapshot`) that boots a fresh Firecracker VM, configures it via HTTP API (6 parallel PUT calls), waits for guest vsock connection, pauses, and captures snapshot state — the Rust equivalent of the TS `commands/snapshot.ts` workflow
- Add 6 VM configuration methods + `start_instance` to `ApiClient`, extract `put_json`/`request_with_timeout` helpers to reduce boilerplate, remove unused `resume()` method
- Extract shared utilities into `process.rs` (`kill_process_tree`, `current_username`) and `network/guest.rs` (`generate_boot_args`), add `SandboxPaths.overlay()` and `SnapshotOutputPaths` to centralize path definitions
- Add clap derive for CLI with `snapshot`/`exec` subcommands, return `SnapshotConfig` directly from `create_snapshot` so consumers can pass it straight to `FirecrackerConfig` for restore

## Test plan

- [x] `cargo build -p sandbox-fc` passes
- [x] `cargo clippy -p sandbox-fc` passes (strict lints: deny unwrap_used, expect_used, panic, indexing_slicing)
- [x] `cargo test -p sandbox-fc` — 63 tests pass (including 7 new API method tests)
- [x] Pre-commit hooks pass (cargo-fmt, cargo-clippy, commitlint)
- [ ] Full integration test requires Firecracker binary + kernel + rootfs: `sandbox-fc snapshot <firecracker> <kernel> <rootfs> <output_dir>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)