### PR TITLE
fix(cli): display error.cause for fetch failures and fix onboard auth error handling

### DIFF
--- a/turbo/apps/cli/src/commands/auth/login.ts
+++ b/turbo/apps/cli/src/commands/auth/login.ts
@@ -12,6 +12,9 @@ export const loginCommand = new Command()
       if (error instanceof Error) {
         console.error(chalk.red(`✗ Login failed`));
         console.error(chalk.dim(`  ${error.message}`));
+        if (error.cause instanceof Error) {
+          console.error(chalk.dim(`  Cause: ${error.cause.message}`));
+        }
       } else {
         console.error(chalk.red("✗ An unexpected error occurred"));
       }

--- a/turbo/apps/cli/src/commands/onboard/index.ts
+++ b/turbo/apps/cli/src/commands/onboard/index.ts
@@ -72,6 +72,9 @@ async function handleAuthentication(ctx: OnboardContext): Promise<void> {
       },
       onError: (error) => {
         console.error(chalk.red(`\n✗ ${error.message}`));
+        if (error.cause instanceof Error) {
+          console.error(chalk.dim(`  Cause: ${error.cause.message}`));
+        }
         process.exit(1);
       },
     });

--- a/turbo/apps/cli/src/lib/domain/onboard/auth.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/auth.ts
@@ -153,18 +153,18 @@ export async function runAuthFlow(
 
   callbacks?.onInitiating?.();
 
-  const deviceAuth = await requestDeviceCode(targetApiUrl);
-
-  const verificationUrl = `${targetApiUrl}${deviceAuth.verification_path}`;
-  const expiresInMinutes = Math.floor(deviceAuth.expires_in / 60);
-
-  callbacks?.onDeviceCodeReady?.(
-    verificationUrl,
-    deviceAuth.user_code,
-    expiresInMinutes,
-  );
-
   try {
+    const deviceAuth = await requestDeviceCode(targetApiUrl);
+
+    const verificationUrl = `${targetApiUrl}${deviceAuth.verification_path}`;
+    const expiresInMinutes = Math.floor(deviceAuth.expires_in / 60);
+
+    callbacks?.onDeviceCodeReady?.(
+      verificationUrl,
+      deviceAuth.user_code,
+      expiresInMinutes,
+    );
+
     const accessToken = await pollForToken(targetApiUrl, deviceAuth, callbacks);
 
     await saveConfig({


### PR DESCRIPTION
## Summary
- Display `error.cause` message in login and onboard commands so users see actionable diagnostic info (e.g., DNS failure, connection refused) instead of just "fetch failed"
- Move `requestDeviceCode()` inside the try/catch block in onboard auth flow so network errors during device code request are properly caught and surfaced via `callbacks.onError`
- Add test for `error.cause` display in login command

## Test plan
- [x] `pnpm vitest run apps/cli/src/commands/auth/__tests__/login.test.ts` — 8/8 tests pass
- [x] `pnpm turbo run lint --filter=@vm0/cli` — no warnings or errors
- [x] `pnpm turbo run check-types --filter=@vm0/cli` — passes
- [x] Pre-commit hooks (prettier, lint, check-types, knip, commitlint) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)