### PR TITLE
fix(cli): map 403 forbidden to user-friendly message in auth flow

### DIFF
--- a/turbo/apps/cli/src/commands/auth/__tests__/login.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/login.test.ts
@@ -218,6 +218,26 @@ describe("auth login", () => {
       fetchSpy.mockRestore();
     });
 
+    it("should show user-friendly message for 403 Forbidden", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/cli/auth/device", () => {
+          return new HttpResponse(null, { status: 403 });
+        }),
+      );
+
+      await expect(async () => {
+        await loginCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Login failed"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("An unexpected network issue occurred"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
     it("should handle expired token error", async () => {
       server.use(
         http.post("http://localhost:3000/api/cli/auth/device", () => {

--- a/turbo/apps/cli/src/lib/api/auth.ts
+++ b/turbo/apps/cli/src/lib/api/auth.ts
@@ -39,6 +39,9 @@ async function requestDeviceCode(apiUrl: string): Promise<{
   });
 
   if (!response.ok) {
+    if (response.status === 403) {
+      throw new Error("An unexpected network issue occurred");
+    }
     throw new Error(`Failed to request device code: ${response.statusText}`);
   }
 

--- a/turbo/apps/cli/src/lib/domain/onboard/auth.ts
+++ b/turbo/apps/cli/src/lib/domain/onboard/auth.ts
@@ -50,6 +50,9 @@ async function requestDeviceCode(apiUrl: string): Promise<DeviceCodeResponse> {
   });
 
   if (!response.ok) {
+    if (response.status === 403) {
+      throw new Error("An unexpected network issue occurred");
+    }
     throw new Error(`Failed to request device code: ${response.statusText}`);
   }
 


### PR DESCRIPTION
## Summary
- Map 403 responses in `requestDeviceCode` to `"An unexpected network issue occurred"` in both login and onboard auth flows
- The `/api/cli/auth/device` endpoint requires no authentication, so 403 comes from infrastructure (e.g., Vercel deployment protection) not the application
- Aligns with the existing `handleError` pattern in `client-factory.ts` which already maps 403 to this message for other API calls

Fixes CLI-B

## Test plan
- [x] Added test: "should show user-friendly message for 403 Forbidden"
- [x] `pnpm vitest run` — 9/9 login tests pass
- [x] `pnpm turbo run lint --filter=@vm0/cli` — no warnings or errors
- [x] `pnpm turbo run check-types --filter=@vm0/cli` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)