### PR TITLE
feat(web): add db:reset script for local development

### DIFF
--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -14,7 +14,8 @@
     "db:migrate": "tsx scripts/migrate.ts",
     "db:generate": "drizzle-kit generate",
     "db:seed": "tsx scripts/seed.ts",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "db:reset": "tsx scripts/reset-db.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.985.0",

--- a/turbo/apps/web/scripts/reset-db.ts
+++ b/turbo/apps/web/scripts/reset-db.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env tsx
+
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import { sql as rawSql } from "drizzle-orm";
+import postgres from "postgres";
+import { DRIZZLE_MIGRATE_OUT } from "../drizzle.config";
+
+async function resetDatabase() {
+  if (!process.env.DATABASE_URL) {
+    throw new Error("invalid DATABASE_URL");
+  }
+
+  const sql = postgres(process.env.DATABASE_URL, { max: 1 });
+  const db = drizzle(sql);
+
+  try {
+    console.log("Dropping all tables...");
+    await db.execute(rawSql`DROP SCHEMA public CASCADE`);
+    await db.execute(rawSql`CREATE SCHEMA public`);
+    await db.execute(rawSql`DROP SCHEMA IF EXISTS drizzle CASCADE`);
+
+    console.log("Running migrations...");
+    await migrate(db, {
+      migrationsFolder: DRIZZLE_MIGRATE_OUT,
+    });
+
+    console.log("Database reset complete");
+  } finally {
+    await sql.end();
+  }
+}
+
+await resetDatabase();


### PR DESCRIPTION
## Summary
- Add `db:reset` script that drops all schemas and re-runs migrations from scratch
- Useful when migrations fail due to stale data in the local database (e.g. `scope_id` NOT NULL constraint on existing rows)
- Usage: `pnpm -F web db:reset`

## Test plan
- [x] Ran `pnpm -F web db:reset` locally — drops all tables and re-runs all migrations successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)