### PR TITLE
refactor(e2e): replace @clerk/testing with direct playwright auth flow

### DIFF
--- a/e2e/cli-auth-automation.ts
+++ b/e2e/cli-auth-automation.ts
@@ -145,7 +145,7 @@ export async function automateCliAuth(apiHost?: string) {
 
     // Navigate to sign-in page
     await page.goto(`${baseUrl}/sign-in`);
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Enter email address
     const emailInput = page.locator('input[name="identifier"]');
@@ -157,19 +157,37 @@ export async function automateCliAuth(apiHost?: string) {
     await page.locator('.cl-formButtonPrimary').click();
     console.log("➡️ Clicked Continue");
 
-    // Wait for OTP code input to appear and enter test code
-    const otpInput = page.locator('.cl-otpCodeFieldInput input').first();
-    await otpInput.waitFor({ state: "visible", timeout: 10000 });
-    // Type the code character by character to trigger Clerk's OTP input handling
+    // Clerk shows password by default; switch to email code method
+    const useAnotherMethod = page.locator('a:has-text("Use another method"), button:has-text("Use another method")');
+    await useAnotherMethod.waitFor({ state: "visible", timeout: 10000 });
+    await useAnotherMethod.click();
+    console.log("🔄 Clicked 'Use another method'");
+
+    // Select email code option
+    const emailCodeOption = page.locator('button:has-text("Email code")');
+    await emailCodeOption.waitFor({ state: "visible", timeout: 10000 });
+    await emailCodeOption.click();
+    console.log("📧 Selected 'Email code'");
+
+    // Wait for OTP input to appear and Clerk to finish sending the code
+    const otpInput = page.locator('input[data-input-otp="true"]');
+    await otpInput.waitFor({ state: "attached", timeout: 10000 });
+    // Wait for Clerk to complete the "prepare" step (sending the email)
+    await page.waitForTimeout(2000);
+
+    // Enter test OTP code 424242 (Clerk accepts this in development mode)
+    await otpInput.focus();
     await page.keyboard.type("424242");
     console.log("🔢 Entered OTP code");
 
-    console.log("✅ Clerk login successful");
+    // Wait for Clerk to complete authentication (should redirect away from /sign-in)
+    await page.waitForURL((url) => !url.pathname.includes('/sign-in'), { timeout: 15000 });
+    console.log(`✅ Clerk login successful (redirected to ${page.url()})`);
     console.log(`🔗 Visiting auth page: ${baseUrl}/cli-auth`);
 
     // Step 6: Visit CLI auth page
     await page.goto(`${baseUrl}/cli-auth`);
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Step 7: Enter device code
     // Device code format: XXXX-XXXX, entered into 8 separate input boxes

--- a/e2e/cli-auth-automation.ts
+++ b/e2e/cli-auth-automation.ts
@@ -1,5 +1,4 @@
 import { chromium } from "playwright";
-import { clerk, clerkSetup } from "@clerk/testing/playwright";
 import { spawn, ChildProcess } from "child_process";
 import * as dotenv from "dotenv";
 
@@ -132,27 +131,38 @@ export async function automateCliAuth(apiHost?: string) {
     const context = await browser.newContext();
     const page = await context.newPage();
 
-    // Step 4: Setup Clerk authentication
-    await clerkSetup();
-
-    // Step 5: Login to Clerk
-    // Use configured API URL
+    // Step 4: Login via Clerk email + OTP code
     const baseUrl = apiUrl;
 
     // If Vercel bypass secret is available, set bypass cookie via query parameter
     // This avoids CORS issues that occur when using HTTP headers
     const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-    let initialUrl = baseUrl;
     if (bypassSecret) {
-      initialUrl = `${baseUrl}?x-vercel-set-bypass-cookie=samesitenone&x-vercel-protection-bypass=${bypassSecret}`;
+      const bypassUrl = `${baseUrl}?x-vercel-set-bypass-cookie=samesitenone&x-vercel-protection-bypass=${bypassSecret}`;
       console.log("🔓 Setting Vercel bypass cookie via query parameter");
+      await page.goto(bypassUrl);
     }
 
-    await page.goto(initialUrl);
-    await clerk.signIn({
-      page,
-      emailAddress: "e2e+clerk_test@vm0.ai",
-    });
+    // Navigate to sign-in page
+    await page.goto(`${baseUrl}/sign-in`);
+    await page.waitForLoadState("networkidle");
+
+    // Enter email address
+    const emailInput = page.locator('input[name="identifier"]');
+    await emailInput.waitFor({ state: "visible", timeout: 10000 });
+    await emailInput.fill("e2e+clerk_test@vm0.ai");
+    console.log("📧 Entered email address");
+
+    // Click Continue button
+    await page.locator('.cl-formButtonPrimary').click();
+    console.log("➡️ Clicked Continue");
+
+    // Wait for OTP code input to appear and enter test code
+    const otpInput = page.locator('.cl-otpCodeFieldInput input').first();
+    await otpInput.waitFor({ state: "visible", timeout: 10000 });
+    // Type the code character by character to trigger Clerk's OTP input handling
+    await page.keyboard.type("424242");
+    console.log("🔢 Entered OTP code");
 
     console.log("✅ Clerk login successful");
     console.log(`🔗 Visiting auth page: ${baseUrl}/cli-auth`);

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,7 +14,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@clerk/testing": "^1.13.35",
     "@types/node": "^25.2.2",
     "dotenv": "^17.2.4",
     "playwright": "^1.58.2"

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@clerk/testing':
-        specifier: ^1.13.35
-        version: 1.13.35(react@19.2.0)
       '@types/node':
         specifier: ^25.2.2
         version: 25.2.2
@@ -26,38 +23,6 @@ importers:
         version: 4.21.0
 
 packages:
-
-  '@clerk/backend@2.30.1':
-    resolution: {integrity: sha512-GoxnJzVH0ycNPAGCDMfo3lPBFbo5nehpLSVFjgGEnzIRGGahBtAB8PQT7KM2zo58pD8apjb/+suhcB/WCiEasQ==}
-    engines: {node: '>=18.17.0'}
-
-  '@clerk/shared@3.44.0':
-    resolution: {integrity: sha512-kH+chNeZwqml3IDpWLgebWECfOZifyUQO4OISd/96w1EuCY1Bzw6cBq/ZbpsoO8jyG8/6bGr/MGXLhDzTrpPfA==}
-    engines: {node: '>=18.17.0'}
-    peerDependencies:
-      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
-      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
-  '@clerk/testing@1.13.35':
-    resolution: {integrity: sha512-y95kJZrMt0tvbNek1AWhWrNrgnOy+a53PSzHTHPF9d0kkOgzzu9l/Wq+Y0kBk6p64wtupYomeb7oVCQD7yCc0A==}
-    engines: {node: '>=18.17.0'}
-    peerDependencies:
-      '@playwright/test': ^1
-      cypress: ^13 || ^14
-    peerDependenciesMeta:
-      '@playwright/test':
-        optional: true
-      cypress:
-        optional: true
-
-  '@clerk/types@4.101.14':
-    resolution: {integrity: sha512-jl7DywmeaZx1IntgEXcjDZq2uyk+X/1yAZOjxOboeGTS0rNTiQNhv7xK8tFVjexsUAFrYlwC1AxhFuJiMDQjow==}
-    engines: {node: '>=18.17.0'}
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -215,22 +180,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@stablelib/base64@1.0.1':
-    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
-
   '@types/node@25.2.2':
     resolution: {integrity: sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==}
-
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-
-  dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
-
-  dotenv@17.2.2:
-    resolution: {integrity: sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==}
-    engines: {node: '>=12'}
 
   dotenv@17.2.4:
     resolution: {integrity: sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==}
@@ -240,9 +191,6 @@ packages:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
     hasBin: true
-
-  fast-sha256@1.3.0:
-    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -257,13 +205,6 @@ packages:
   get-tsconfig@4.13.1:
     resolution: {integrity: sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==}
 
-  glob-to-regexp@0.4.1:
-    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
-
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
-
   playwright-core@1.58.2:
     resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
     engines: {node: '>=18'}
@@ -274,26 +215,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  react@19.2.0:
-    resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
-    engines: {node: '>=0.10.0'}
-
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-
-  standardwebhooks@1.0.0:
-    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
-
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
-  swr@2.3.4:
-    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -303,50 +226,7 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
 snapshots:
-
-  '@clerk/backend@2.30.1(react@19.2.0)':
-    dependencies:
-      '@clerk/shared': 3.44.0(react@19.2.0)
-      '@clerk/types': 4.101.14(react@19.2.0)
-      standardwebhooks: 1.0.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - react
-      - react-dom
-
-  '@clerk/shared@3.44.0(react@19.2.0)':
-    dependencies:
-      csstype: 3.1.3
-      dequal: 2.0.3
-      glob-to-regexp: 0.4.1
-      js-cookie: 3.0.5
-      std-env: 3.10.0
-      swr: 2.3.4(react@19.2.0)
-    optionalDependencies:
-      react: 19.2.0
-
-  '@clerk/testing@1.13.35(react@19.2.0)':
-    dependencies:
-      '@clerk/backend': 2.30.1(react@19.2.0)
-      '@clerk/shared': 3.44.0(react@19.2.0)
-      '@clerk/types': 4.101.14(react@19.2.0)
-      dotenv: 17.2.2
-    transitivePeerDependencies:
-      - react
-      - react-dom
-
-  '@clerk/types@4.101.14(react@19.2.0)':
-    dependencies:
-      '@clerk/shared': 3.44.0(react@19.2.0)
-    transitivePeerDependencies:
-      - react
-      - react-dom
 
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
@@ -426,17 +306,9 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@stablelib/base64@1.0.1': {}
-
   '@types/node@25.2.2':
     dependencies:
       undici-types: 7.16.0
-
-  csstype@3.1.3: {}
-
-  dequal@2.0.3: {}
-
-  dotenv@17.2.2: {}
 
   dotenv@17.2.4: {}
 
@@ -469,8 +341,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
 
-  fast-sha256@1.3.0: {}
-
   fsevents@2.3.2:
     optional: true
 
@@ -481,10 +351,6 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  glob-to-regexp@0.4.1: {}
-
-  js-cookie@3.0.5: {}
-
   playwright-core@1.58.2: {}
 
   playwright@1.58.2:
@@ -493,24 +359,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  react@19.2.0: {}
-
   resolve-pkg-maps@1.0.0: {}
-
-  standardwebhooks@1.0.0:
-    dependencies:
-      '@stablelib/base64': 1.0.1
-      fast-sha256: 1.3.0
-
-  std-env@3.10.0: {}
-
-  swr@2.3.4(react@19.2.0):
-    dependencies:
-      dequal: 2.0.3
-      react: 19.2.0
-      use-sync-external-store: 1.6.0(react@19.2.0)
-
-  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:
@@ -520,7 +369,3 @@ snapshots:
       fsevents: 2.3.3
 
   undici-types@7.16.0: {}
-
-  use-sync-external-store@1.6.0(react@19.2.0):
-    dependencies:
-      react: 19.2.0


### PR DESCRIPTION
## Summary

- Remove `@clerk/testing` dependency and its transitive deps (react, swr, standardwebhooks, etc.) from the e2e package
- Replace the `clerk.signIn()` / `clerkSetup()` helpers with direct Playwright interactions: navigate to `/sign-in`, fill email, click Continue, enter OTP test code
- Fix package.json indentation issue caused by dependency removal

## Motivation

The `@clerk/testing` package pulled in a heavy dependency tree (`react`, `swr`, `@clerk/backend`, `@clerk/shared`, `@clerk/types`, etc.) for a single `signIn()` helper call. Replacing it with direct Playwright selectors:

1. Eliminates ~15 transitive dependencies from the e2e lockfile
2. Makes the authentication flow explicit and easier to debug
3. Removes the need for `clerkSetup()` initialization
4. Avoids potential version conflicts with the main app's Clerk packages

## Test plan

- [ ] Verify `pnpm install --frozen-lockfile` succeeds in e2e directory
- [ ] Run CLI E2E auth flow against a preview deployment to confirm login works
- [ ] Confirm the OTP code `424242` is accepted by Clerk's test mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)