### PR TITLE
refactor(slack): improve context message formatting with structured metadata

### DIFF
--- a/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
@@ -99,7 +99,7 @@ export async function runAgentForSlack(
 
     // Build the full prompt with thread context
     const fullPrompt = threadContext
-      ? `${threadContext}\n\n---\n\nUser: ${prompt}`
+      ? `${threadContext}\n\n# User Prompt\n\n${prompt}`
       : prompt;
 
     // Create run record in database


### PR DESCRIPTION
## Summary

- Refactors Slack context message formatting to use structured markdown with `---` separators and key-value metadata (`RELATIVE_INDEX`, `MSG_ID`, `SENDER_ID`)
- Updates the User Prompt section to use `# User Prompt` heading instead of plain `--- User:` separator
- Updates all 36 tests to verify the new format

### Before
```
## Slack Thread Context

[U123]: Hello, can you help me?

[bot]: Sure, what do you need?
```

### After
```
# Slack Thread Context

---

- RELATIVE_INDEX: -2
- MSG_ID: 1234567890.001
- SENDER_ID: U123

Hello, can you help me?

---

- RELATIVE_INDEX: -1
- MSG_ID: 1234567890.002
- SENDER_ID: BOT

Sure, what do you need?

---

# User Prompt

What's the status?
```

Closes #2630

## Test plan

- [x] All 36 existing context tests updated and passing
- [x] New tests added for relative index calculation and structured metadata in image context
- [x] TypeScript type-check passes
- [x] Lint passes (oxlint + eslint)
- [x] Knip finds no unused code
- [x] Prettier formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)