### PR TITLE
fix(slack): return caddy proxy address for platform in dev environment

### DIFF
--- a/turbo/apps/web/src/lib/__tests__/url.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/url.test.ts
@@ -51,8 +51,16 @@ describe("url", () => {
       expect(getPlatformUrl()).toBe("http://platform.localhost:3000");
     });
 
-    it("returns fallback URL when window is undefined (SSR)", () => {
+    it("returns Caddy URL when window is undefined in development", () => {
       vi.stubGlobal("window", undefined);
+      vi.stubEnv("NODE_ENV", "development");
+
+      expect(getPlatformUrl()).toBe("https://platform.vm7.ai:8443");
+    });
+
+    it("returns production URL when window is undefined in production", () => {
+      vi.stubGlobal("window", undefined);
+      vi.stubEnv("NODE_ENV", "production");
 
       expect(getPlatformUrl()).toBe("https://platform.vm0.ai");
     });

--- a/turbo/apps/web/src/lib/url.ts
+++ b/turbo/apps/web/src/lib/url.ts
@@ -20,7 +20,10 @@
  */
 export function getPlatformUrl(): string {
   if (typeof window === "undefined") {
-    // Fallback for server-side rendering
+    // Server-side: use Caddy proxy in dev, production URL otherwise
+    if (process.env.NODE_ENV === "development") {
+      return "https://platform.vm7.ai:8443";
+    }
     return "https://platform.vm0.ai";
   }
 


### PR DESCRIPTION
## Summary

- `getPlatformUrl()` server-side fallback was hardcoded to `https://platform.vm0.ai`, so Slack "View logs" links always pointed to production even during local development
- Now checks `NODE_ENV === "development"` and returns the Caddy proxy address `https://platform.vm7.ai:8443` in dev mode

## Test plan

- [x] Existing url tests updated: split SSR test into dev/production cases
- [x] All 6 url tests passing
- [x] Type-check, lint, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)