### PR TITLE
fix(test): remove vi.unstubAllEnvs from CLI tests and fix compose job race condition

### DIFF
--- a/turbo/apps/cli/src/commands/agent/__tests__/clone.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/clone.test.ts
@@ -37,7 +37,6 @@ describe("agent clone command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -382,9 +381,8 @@ describe("agent clone command", () => {
     });
 
     it("should handle authentication error", async () => {
-      vi.unstubAllEnvs();
-      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
-      // No token set
+      vi.stubEnv("VM0_TOKEN", "");
+      vi.stubEnv("HOME", "/tmp/test-no-config");
 
       const dest = path.join(tempDir, "test-agent");
       await expect(async () => {

--- a/turbo/apps/cli/src/commands/agent/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/list.test.ts
@@ -31,7 +31,6 @@ describe("agent list command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("successful list", () => {
@@ -104,9 +103,8 @@ describe("agent list command", () => {
 
   describe("error handling", () => {
     it("should handle authentication error", async () => {
-      vi.unstubAllEnvs();
-      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
-      // No token set
+      vi.stubEnv("VM0_TOKEN", "");
+      vi.stubEnv("HOME", "/tmp/test-no-config");
 
       await expect(async () => {
         await listCommand.parseAsync(["node", "cli"]);

--- a/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
@@ -65,9 +65,7 @@ describe("Agent Sharing Commands", () => {
     );
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+  afterEach(() => {});
 
   describe("vm0 agent experimental-public", () => {
     it("should make agent public successfully", async () => {

--- a/turbo/apps/cli/src/commands/agent/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/status.test.ts
@@ -31,7 +31,6 @@ describe("agent status command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("successful status", () => {
@@ -212,9 +211,8 @@ describe("agent status command", () => {
     });
 
     it("should handle authentication error", async () => {
-      vi.unstubAllEnvs();
-      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
-      // No token set
+      vi.stubEnv("VM0_TOKEN", "");
+      vi.stubEnv("HOME", "/tmp/test-no-config");
 
       await expect(async () => {
         await statusCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/artifact/__tests__/clone.test.ts
+++ b/turbo/apps/cli/src/commands/artifact/__tests__/clone.test.ts
@@ -46,7 +46,6 @@ describe("artifact clone", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("argument handling", () => {

--- a/turbo/apps/cli/src/commands/artifact/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/artifact/__tests__/list.test.ts
@@ -33,7 +33,6 @@ describe("artifact list", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("empty list", () => {

--- a/turbo/apps/cli/src/commands/artifact/__tests__/pull.test.ts
+++ b/turbo/apps/cli/src/commands/artifact/__tests__/pull.test.ts
@@ -51,7 +51,6 @@ describe("artifact pull", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   /**

--- a/turbo/apps/cli/src/commands/artifact/__tests__/push.test.ts
+++ b/turbo/apps/cli/src/commands/artifact/__tests__/push.test.ts
@@ -47,7 +47,6 @@ describe("artifact push", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("config validation", () => {

--- a/turbo/apps/cli/src/commands/artifact/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/artifact/__tests__/status.test.ts
@@ -47,7 +47,6 @@ describe("artifact status", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("config validation", () => {

--- a/turbo/apps/cli/src/commands/auth/__tests__/login.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/login.test.ts
@@ -54,7 +54,6 @@ describe("auth login", () => {
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
     mockStdoutWrite.mockClear();
-    vi.unstubAllEnvs();
 
     // Clean up config
     const configDir = path.join(TEST_HOME, ".vm0");

--- a/turbo/apps/cli/src/commands/auth/__tests__/logout.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/logout.test.ts
@@ -38,7 +38,6 @@ describe("auth logout", () => {
 
   afterEach(async () => {
     mockConsoleLog.mockClear();
-    vi.unstubAllEnvs();
 
     // Clean up config
     const configDir = path.join(TEST_HOME, ".vm0");

--- a/turbo/apps/cli/src/commands/auth/__tests__/setup-token.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/setup-token.test.ts
@@ -49,7 +49,6 @@ describe("auth setup-token", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
 
     // Clean up config
     const configDir = path.join(TEST_HOME, ".vm0");

--- a/turbo/apps/cli/src/commands/auth/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/status.test.ts
@@ -43,7 +43,6 @@ describe("auth status", () => {
   afterEach(async () => {
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
 
     // Clean up config
     const configDir = path.join(TEST_HOME, ".vm0");

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -125,7 +125,6 @@ describe("compose command", () => {
   afterEach(() => {
     process.chdir(originalCwd);
     rmSync(tempDir, { recursive: true, force: true });
-    vi.unstubAllEnvs();
   });
 
   describe("file validation", () => {
@@ -1784,7 +1783,6 @@ describe("GitHub URL compose", () => {
   afterEach(() => {
     process.chdir(originalCwd);
     rmSync(tempDir, { recursive: true, force: true });
-    vi.unstubAllEnvs();
   });
 
   it("should show security warning when GitHub URL used without --experimental-shared-compose flag", async () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/disconnect.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/disconnect.test.ts
@@ -29,9 +29,7 @@ describe("connector disconnect command", () => {
     vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+  afterEach(() => {});
 
   describe("successful disconnect", () => {
     it("should show success message on successful disconnect", async () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/index.test.ts
@@ -15,9 +15,7 @@ describe("connector command", () => {
     vi.clearAllMocks();
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+  afterEach(() => {});
 
   describe("help text", () => {
     it("should show command description and subcommands", async () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/list.test.ts
@@ -29,9 +29,7 @@ describe("connector list command", () => {
     vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+  afterEach(() => {});
 
   describe("successful list", () => {
     it("should show connected connector with status and account", async () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
@@ -29,9 +29,7 @@ describe("connector status command", () => {
     vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+  afterEach(() => {});
 
   describe("connected connector", () => {
     it("should display all connector details", async () => {

--- a/turbo/apps/cli/src/commands/cook/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/cook/__tests__/index.test.ts
@@ -93,7 +93,6 @@ describe("cook command", () => {
     } catch {
       // File may not exist
     }
-    vi.unstubAllEnvs();
   });
 
   describe("config file validation", () => {

--- a/turbo/apps/cli/src/commands/dev-tool/__tests__/compose.test.ts
+++ b/turbo/apps/cli/src/commands/dev-tool/__tests__/compose.test.ts
@@ -19,9 +19,7 @@ describe("dev-tool compose command", () => {
     vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+  afterEach(() => {});
 
   describe("successful compose", () => {
     it("should create job and poll until completed", async () => {

--- a/turbo/apps/cli/src/commands/info/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/info/__tests__/index.test.ts
@@ -41,7 +41,6 @@ describe("info command", () => {
 
   afterEach(() => {
     mockConsoleLog.mockClear();
-    vi.unstubAllEnvs();
 
     // Cleanup temp directory
     rmSync(tempDir, { recursive: true, force: true });

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -31,7 +31,6 @@ describe("logs command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("agent events (default)", () => {

--- a/turbo/apps/cli/src/commands/model-provider/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/delete.test.ts
@@ -18,9 +18,7 @@ describe("model-provider delete command", () => {
     vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+  afterEach(() => {});
 
   describe("successful deletion", () => {
     it("should show success message on successful deletion", async () => {

--- a/turbo/apps/cli/src/commands/model-provider/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/index.test.ts
@@ -15,9 +15,7 @@ describe("model-provider command", () => {
     vi.clearAllMocks();
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+  afterEach(() => {});
 
   describe("help text", () => {
     it("should show command description and subcommands", async () => {

--- a/turbo/apps/cli/src/commands/model-provider/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/list.test.ts
@@ -29,9 +29,7 @@ describe("model-provider list command", () => {
     vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+  afterEach(() => {});
 
   describe("successful list", () => {
     it("should list model providers grouped by framework", async () => {

--- a/turbo/apps/cli/src/commands/model-provider/__tests__/set-default.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/set-default.test.ts
@@ -27,9 +27,7 @@ describe("model-provider set-default command", () => {
     vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+  afterEach(() => {});
 
   describe("successful set-default", () => {
     it("should show success message on successful set-default", async () => {

--- a/turbo/apps/cli/src/commands/model-provider/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/setup.test.ts
@@ -38,7 +38,6 @@ describe("model-provider setup command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
 
     // Restore TTY state
     Object.defineProperty(process.stdout, "isTTY", {

--- a/turbo/apps/cli/src/commands/onboard/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/onboard/__tests__/index.test.ts
@@ -155,7 +155,6 @@ describe("onboard command", () => {
     process.chdir(originalCwd);
     rmSync(tempDir, { recursive: true, force: true });
     process.exit = originalExit;
-    vi.unstubAllEnvs();
     vi.restoreAllMocks();
 
     // Restore TTY state
@@ -216,9 +215,8 @@ describe("onboard command", () => {
     });
 
     it("should show error in non-interactive mode when no token", async () => {
-      vi.unstubAllEnvs();
-      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
-      delete process.env.VM0_TOKEN;
+      vi.stubEnv("VM0_TOKEN", "");
+      vi.stubEnv("HOME", "/tmp/test-no-config");
 
       // Set non-interactive mode
       Object.defineProperty(process.stdout, "isTTY", {

--- a/turbo/apps/cli/src/commands/run/__tests__/continue.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/continue.test.ts
@@ -81,9 +81,7 @@ describe("run continue command", () => {
     );
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+  afterEach(() => {});
 
   describe("successful continue", () => {
     it("should continue from session with prompt", async () => {

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -123,7 +123,6 @@ describe("run command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("composeId validation", () => {

--- a/turbo/apps/cli/src/commands/run/__tests__/kill.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/kill.test.ts
@@ -29,9 +29,7 @@ describe("run kill command", () => {
     vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+  afterEach(() => {});
 
   describe("successful kill", () => {
     it("should cancel a run successfully", async () => {

--- a/turbo/apps/cli/src/commands/run/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/list.test.ts
@@ -29,9 +29,7 @@ describe("run list command", () => {
     vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+  afterEach(() => {});
 
   describe("successful list", () => {
     it("should list active runs with formatted output", async () => {

--- a/turbo/apps/cli/src/commands/run/__tests__/realtime.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/realtime.test.ts
@@ -145,7 +145,6 @@ describe("run command with --experimental-realtime", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("successful streaming", () => {

--- a/turbo/apps/cli/src/commands/run/__tests__/resume.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/resume.test.ts
@@ -82,9 +82,7 @@ describe("run resume command", () => {
     );
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
+  afterEach(() => {});
 
   describe("successful resume", () => {
     it("should resume from checkpoint with prompt", async () => {

--- a/turbo/apps/cli/src/commands/run/__tests__/volume-version.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/volume-version.test.ts
@@ -142,7 +142,6 @@ describe("--volume-version option", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("collectVolumeVersions", () => {

--- a/turbo/apps/cli/src/commands/schedule/__tests__/delete-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/delete-command.test.ts
@@ -64,7 +64,6 @@ describe("schedule delete command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
 
     // Restore TTY state
     Object.defineProperty(process.stdout, "isTTY", {

--- a/turbo/apps/cli/src/commands/schedule/__tests__/disable-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/disable-command.test.ts
@@ -58,7 +58,6 @@ describe("schedule disable command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("help text", () => {

--- a/turbo/apps/cli/src/commands/schedule/__tests__/enable-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/enable-command.test.ts
@@ -58,7 +58,6 @@ describe("schedule enable command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("help text", () => {

--- a/turbo/apps/cli/src/commands/schedule/__tests__/list-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/list-command.test.ts
@@ -33,7 +33,6 @@ describe("schedule list command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("help text", () => {

--- a/turbo/apps/cli/src/commands/schedule/__tests__/setup-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/setup-command.test.ts
@@ -89,7 +89,6 @@ describe("schedule setup command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("help text", () => {

--- a/turbo/apps/cli/src/commands/schedule/__tests__/status-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/status-command.test.ts
@@ -58,7 +58,6 @@ describe("schedule status command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("help text", () => {

--- a/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
@@ -26,9 +26,8 @@ describe("scope set command", () => {
 
   describe("authentication", () => {
     it("should exit with error if not authenticated", async () => {
-      vi.unstubAllEnvs();
-      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
-      // VM0_TOKEN not set - simulates unauthenticated state
+      vi.stubEnv("VM0_TOKEN", "");
+      vi.stubEnv("HOME", "/tmp/test-no-config");
 
       await expect(async () => {
         await setCommand.parseAsync(["node", "cli", "testslug"]);

--- a/turbo/apps/cli/src/commands/scope/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/status.test.ts
@@ -26,9 +26,8 @@ describe("scope status command", () => {
 
   describe("authentication", () => {
     it("should exit with error if not authenticated", async () => {
-      vi.unstubAllEnvs();
-      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
-      // VM0_TOKEN not set - simulates unauthenticated state
+      vi.stubEnv("VM0_TOKEN", "");
+      vi.stubEnv("HOME", "/tmp/test-no-config");
 
       await expect(async () => {
         await statusCommand.parseAsync(["node", "cli"]);

--- a/turbo/apps/cli/src/commands/secret/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/secret/__tests__/delete.test.ts
@@ -33,7 +33,6 @@ describe("secret delete command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("successful delete", () => {

--- a/turbo/apps/cli/src/commands/secret/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/secret/__tests__/list.test.ts
@@ -33,7 +33,6 @@ describe("secret list command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("help text", () => {

--- a/turbo/apps/cli/src/commands/secret/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/secret/__tests__/set.test.ts
@@ -39,7 +39,6 @@ describe("secret set command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
 
     // Restore TTY state
     Object.defineProperty(process.stdout, "isTTY", {

--- a/turbo/apps/cli/src/commands/usage/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/usage/__tests__/index.test.ts
@@ -22,7 +22,6 @@ describe("usage command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("default behavior", () => {

--- a/turbo/apps/cli/src/commands/variable/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/variable/__tests__/delete.test.ts
@@ -33,7 +33,6 @@ describe("variable delete command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("successful delete", () => {

--- a/turbo/apps/cli/src/commands/variable/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/variable/__tests__/list.test.ts
@@ -33,7 +33,6 @@ describe("variable list command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("help text", () => {

--- a/turbo/apps/cli/src/commands/variable/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/variable/__tests__/set.test.ts
@@ -33,7 +33,6 @@ describe("variable set command", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("successful set", () => {

--- a/turbo/apps/cli/src/commands/volume/__tests__/clone.test.ts
+++ b/turbo/apps/cli/src/commands/volume/__tests__/clone.test.ts
@@ -46,7 +46,6 @@ describe("volume clone", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("argument handling", () => {

--- a/turbo/apps/cli/src/commands/volume/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/volume/__tests__/list.test.ts
@@ -33,7 +33,6 @@ describe("volume list", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("empty list", () => {

--- a/turbo/apps/cli/src/commands/volume/__tests__/pull.test.ts
+++ b/turbo/apps/cli/src/commands/volume/__tests__/pull.test.ts
@@ -48,7 +48,6 @@ describe("volume pull", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   /**

--- a/turbo/apps/cli/src/commands/volume/__tests__/push.test.ts
+++ b/turbo/apps/cli/src/commands/volume/__tests__/push.test.ts
@@ -47,7 +47,6 @@ describe("volume push", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("config validation", () => {

--- a/turbo/apps/cli/src/commands/volume/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/volume/__tests__/status.test.ts
@@ -47,7 +47,6 @@ describe("volume status", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.unstubAllEnvs();
   });
 
   describe("config validation", () => {

--- a/turbo/apps/cli/src/test/setup.ts
+++ b/turbo/apps/cli/src/test/setup.ts
@@ -6,8 +6,10 @@ beforeAll(() => {
   server.listen({ onUnhandledRequest: "error" });
 });
 
+// Baseline: no auth, no API URL. Test files override in their own beforeEach.
 beforeEach(() => {
   vi.stubEnv("VM0_API_URL", undefined);
+  vi.stubEnv("VM0_TOKEN", "");
 });
 
 // Reset handlers after each test

--- a/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
+++ b/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
@@ -216,7 +216,7 @@ async function spawnComposeJobSandbox(
       status: "running",
       startedAt: new Date(),
     })
-    .where(eq(composeJobs.id, jobId));
+    .where(and(eq(composeJobs.id, jobId), eq(composeJobs.status, "pending")));
 
   const scriptPath = "/tmp/compose-github.js";
   await sandbox.files.write(scriptPath, COMPOSE_SANDBOX_SCRIPT);


### PR DESCRIPTION
## Summary
- Move env baseline to `setup.ts` `beforeEach` (`VM0_TOKEN=""`, `VM0_API_URL=undefined`), test files override in their own `beforeEach`
- Remove all `vi.unstubAllEnvs()` from 55 CLI test files — `unstubAllEnvs` restores real env vars which is unpredictable in dev containers
- Auth tests use explicit `vi.stubEnv("VM0_TOKEN", "")` + `vi.stubEnv("HOME", "/tmp/test-no-config")` instead
- Fix race condition in `spawnComposeJobSandbox`: add `WHERE status='pending'` so fire-and-forget DB update doesn't overwrite webhook completion status

## Test plan
- [x] All 795 CLI tests pass
- [x] All 14 compose from-github tests pass
- [x] Zero `unstubAllEnvs` remaining in CLI codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)