### PR TITLE
fix(web): disable json query to fix flaky ambiguous-prefix test

### DIFF
--- a/turbo/apps/cli/src/commands/connector/connect.ts
+++ b/turbo/apps/cli/src/commands/connector/connect.ts
@@ -56,7 +56,7 @@ export const connectCommand = new Command()
       const sessionsClient = initClient(connectorSessionsContract, {
         baseUrl: apiUrl,
         baseHeaders: headers,
-        jsonQuery: true,
+        jsonQuery: false,
       });
 
       const createResult = await sessionsClient.create({
@@ -87,7 +87,7 @@ export const connectCommand = new Command()
       const sessionClient = initClient(connectorSessionByIdContract, {
         baseUrl: apiUrl,
         baseHeaders: headers,
-        jsonQuery: true,
+        jsonQuery: false,
       });
 
       const startTime = Date.now();

--- a/turbo/apps/cli/src/lib/api/api-client.ts
+++ b/turbo/apps/cli/src/lib/api/api-client.ts
@@ -162,7 +162,7 @@ class ApiClient {
     const client = initClient(composesMainContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.getByName({
@@ -191,7 +191,7 @@ class ApiClient {
     const client = initClient(composesByIdContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.getById({
@@ -221,11 +221,10 @@ class ApiClient {
     const headers = await this.getHeaders();
 
     // Create ts-rest client with config
-    // Note: jsonQuery: true handles scientific notation edge cases automatically
     const client = initClient(composesVersionsContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.resolveVersion({
@@ -256,7 +255,7 @@ class ApiClient {
     const client = initClient(composesMainContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.create({
@@ -305,7 +304,7 @@ class ApiClient {
     const client = initClient(runsMainContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.create({ body });
@@ -333,7 +332,7 @@ class ApiClient {
     const client = initClient(runEventsContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.getEvents({
@@ -366,7 +365,7 @@ class ApiClient {
     const client = initClient(runSystemLogContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.getSystemLog({
@@ -400,7 +399,7 @@ class ApiClient {
     const client = initClient(runMetricsContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.getMetrics({
@@ -434,7 +433,7 @@ class ApiClient {
     const client = initClient(runAgentEventsContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.getAgentEvents({
@@ -468,7 +467,7 @@ class ApiClient {
     const client = initClient(runNetworkLogsContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.getNetworkLogs({
@@ -502,7 +501,7 @@ class ApiClient {
     const client = initClient(scopeContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.get({ headers: {} });
@@ -532,7 +531,7 @@ class ApiClient {
     const client = initClient(scopeContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.create({ body });
@@ -562,7 +561,7 @@ class ApiClient {
     const client = initClient(scopeContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.update({ body });
@@ -590,7 +589,7 @@ class ApiClient {
     const client = initClient(sessionsByIdContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.getById({
@@ -621,7 +620,7 @@ class ApiClient {
     const client = initClient(checkpointsByIdContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.getById({
@@ -662,7 +661,7 @@ class ApiClient {
     const client = initClient(storagesPrepareContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.prepare({ body });
@@ -698,7 +697,7 @@ class ApiClient {
     const client = initClient(storagesCommitContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.commit({ body });
@@ -739,7 +738,7 @@ class ApiClient {
     const client = initClient(storagesDownloadContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.download({
@@ -777,7 +776,7 @@ class ApiClient {
     const client = initClient(storagesListContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.list({ query });
@@ -813,7 +812,7 @@ class ApiClient {
     const client = initClient(schedulesMainContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.deploy({ body });
@@ -837,7 +836,7 @@ class ApiClient {
     const client = initClient(schedulesMainContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.list({ headers: {} });
@@ -864,7 +863,7 @@ class ApiClient {
     const client = initClient(schedulesByNameContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.getByName({
@@ -895,7 +894,7 @@ class ApiClient {
     const client = initClient(schedulesByNameContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.delete({
@@ -927,7 +926,7 @@ class ApiClient {
     const client = initClient(schedulesEnableContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.enable({
@@ -958,7 +957,7 @@ class ApiClient {
     const client = initClient(schedulesEnableContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.disable({
@@ -990,7 +989,7 @@ class ApiClient {
     const client = initClient(scheduleRunsContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.listRuns({
@@ -1029,7 +1028,7 @@ class ApiClient {
     const client = initClient(publicAgentsListContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.list({ query: query ?? {} });
@@ -1059,7 +1058,7 @@ class ApiClient {
     const client = initClient(publicArtifactsListContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.list({ query: query ?? {} });
@@ -1083,7 +1082,7 @@ class ApiClient {
     const client = initClient(publicArtifactByIdContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.get({ params: { id } });
@@ -1113,7 +1112,7 @@ class ApiClient {
     const client = initClient(publicVolumesListContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.list({ query: query ?? {} });
@@ -1137,7 +1136,7 @@ class ApiClient {
     const client = initClient(publicVolumeByIdContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.get({ params: { id } });
@@ -1189,7 +1188,7 @@ class ApiClient {
     const client = initClient(credentialsMainContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.list({ headers: {} });
@@ -1213,7 +1212,7 @@ class ApiClient {
     const client = initClient(credentialsByNameContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.get({
@@ -1244,7 +1243,7 @@ class ApiClient {
     const client = initClient(credentialsMainContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.set({ body });
@@ -1268,7 +1267,7 @@ class ApiClient {
     const client = initClient(credentialsByNameContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.delete({
@@ -1295,7 +1294,7 @@ class ApiClient {
     const client = initClient(realtimeTokenContract, {
       baseUrl,
       baseHeaders: headers,
-      jsonQuery: true,
+      jsonQuery: false,
     });
 
     const result = await client.create({

--- a/turbo/apps/cli/src/lib/api/core/client-factory.ts
+++ b/turbo/apps/cli/src/lib/api/core/client-factory.ts
@@ -56,11 +56,11 @@ export async function getBaseUrl(): Promise<string> {
 export async function getClientConfig(): Promise<{
   baseUrl: string;
   baseHeaders: Record<string, string>;
-  jsonQuery: true;
+  jsonQuery: false;
 }> {
   const baseUrl = await getBaseUrl();
   const baseHeaders = await getHeaders();
-  return { baseUrl, baseHeaders, jsonQuery: true };
+  return { baseUrl, baseHeaders, jsonQuery: false };
 }
 
 /**

--- a/turbo/apps/web/src/lib/public-api/handler.ts
+++ b/turbo/apps/web/src/lib/public-api/handler.ts
@@ -55,7 +55,9 @@ export function createPublicApiHandler<T extends AppRouter>(
 ) {
   return createNextHandler(contract, router, {
     handlerType: "app-router",
-    jsonQuery: true,
+    // jsonQuery is intentionally disabled: JSON.parse() misinterprets hex strings
+    // like "846e3519" as scientific notation, corrupting version query params (#2666)
+    jsonQuery: false,
     errorHandler: options?.errorHandler ?? publicApiErrorHandler,
     requestMiddleware: [
       (request) => {

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -98,7 +98,9 @@ export function createHandler<T extends AppRouter>(
 ) {
   return createNextHandler(contract, router, {
     handlerType: "app-router",
-    jsonQuery: true,
+    // jsonQuery is intentionally disabled: JSON.parse() misinterprets hex strings
+    // like "846e3519" as scientific notation, corrupting version query params (#2666)
+    jsonQuery: false,
     ...options,
     requestMiddleware: [
       (request) => {

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -8,21 +8,15 @@ const c = initContract();
 /**
  * Version query parameter schema for compose versions
  *
- * Handles jsonQuery edge case where hex strings like "846e3519"
- * are parsed as JavaScript scientific notation numbers (e.g., 846e3519 = Infinity).
- *
  * Accepts: "latest" tag or 8-64 hex character version hash
  */
-const composeVersionQuerySchema = z.preprocess(
-  (val) => (val === undefined || val === null ? undefined : String(val)),
-  z
-    .string()
-    .min(1, "Missing version query parameter")
-    .regex(
-      /^[a-f0-9]{8,64}$|^latest$/i,
-      "Version must be 8-64 hex characters or 'latest'",
-    ),
-);
+const composeVersionQuerySchema = z
+  .string()
+  .min(1, "Missing version query parameter")
+  .regex(
+    /^[a-f0-9]{8,64}$|^latest$/i,
+    "Version must be 8-64 hex characters or 'latest'",
+  );
 
 /**
  * Agent name validation schema

--- a/turbo/packages/core/src/contracts/storages.ts
+++ b/turbo/packages/core/src/contracts/storages.ts
@@ -12,19 +12,12 @@ const storageTypeSchema = z.enum(["volume", "artifact"]);
 /**
  * Version ID query parameter schema
  *
- * Handles jsonQuery edge case where hex strings like "846e3519"
- * are parsed as JavaScript scientific notation numbers (e.g., 846e3519 = Infinity).
- *
- * The preprocess step converts any non-null/undefined value to string,
- * then validates it matches hex format (8-64 characters).
+ * Validates hex format (8-64 characters). Used for version prefix resolution.
  */
-const versionQuerySchema = z.preprocess(
-  (val) => (val === undefined || val === null ? undefined : String(val)),
-  z
-    .string()
-    .regex(/^[a-f0-9]{8,64}$/i, "Version must be 8-64 hex characters")
-    .optional(),
-);
+const versionQuerySchema = z
+  .string()
+  .regex(/^[a-f0-9]{8,64}$/i, "Version must be 8-64 hex characters")
+  .optional();
 
 /**
  * Upload storage response schema (JSON part of POST response)


### PR DESCRIPTION
## Summary
- Disable `jsonQuery` in both ts-rest handlers (`ts-rest-handler.ts` and `public-api/handler.ts`) to prevent `JSON.parse()` from misinterpreting hex version prefixes like `"846e3519"` as scientific notation
- Remove dead `z.preprocess` workarounds from `versionQuerySchema` and `composeVersionQuerySchema` that only existed to handle corrupted values from jsonQuery
- Add guard test that will fail if jsonQuery is ever re-enabled

Closes #2666

## Test plan
- [x] Schema tests pass (`version-query-schema.test.ts` — 19 tests)
- [x] Download route tests pass (`route.test.ts` — 15 tests, including new guard test)
- [x] Lint, type-check, knip all pass
- [x] The previously flaky "ambiguous prefix" test is now stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)