### PR TITLE
refactor(sandbox): rename timeout_secs to timeout_ms for consistent millisecond units

### DIFF
--- a/crates/sandbox-fc/src/main.rs
+++ b/crates/sandbox-fc/src/main.rs
@@ -222,7 +222,7 @@ async fn run_exec(
             cpu_count: vcpu_count,
             memory_mb,
             // Sandbox-level lifetime cap (distinct from per-exec timeout_ms).
-            timeout_secs: 30,
+            timeout_ms: 30_000,
         },
     };
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -474,7 +474,7 @@ impl Sandbox for FirecrackerSandbox {
             )));
         };
 
-        let timeout = Duration::from_secs(self.config.resources.timeout_secs);
+        let timeout = Duration::from_millis(u64::from(self.config.resources.timeout_ms));
         let event = guest
             .wait_for_exit(handle.pid, timeout)
             .await

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -1,7 +1,7 @@
 pub struct ResourceLimits {
     pub cpu_count: u32,
     pub memory_mb: u32,
-    pub timeout_secs: u64,
+    pub timeout_ms: u32,
 }
 
 pub struct SandboxConfig {


### PR DESCRIPTION
## Summary
- Rename `ResourceLimits.timeout_secs` (u64) to `timeout_ms` (u32) to use millisecond units consistently across the sandbox crate
- Update `FirecrackerSandbox` to use `Duration::from_millis` instead of `Duration::from_secs`
- Set the sandbox-level lifetime cap to `30_000` ms (30 seconds), matching the previous behavior

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` passes with strict sandbox-fc lints
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)