### PR TITLE
feat(sandbox-fc): auto-allocate netns pool index via flock

### DIFF
--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 async-trait.workspace = true
 clap = { workspace = true, features = ["derive"] }
 libc.workspace = true
-nix = { workspace = true, features = ["user", "inotify"] }
+nix = { workspace = true, features = ["user", "inotify", "fs"] }
 sandbox.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/sandbox-fc/src/config.rs
+++ b/crates/sandbox-fc/src/config.rs
@@ -7,8 +7,6 @@ pub struct FirecrackerConfig {
     pub rootfs_path: PathBuf,
     /// Base directory for runtime data (workspaces, overlays, etc.).
     pub base_dir: PathBuf,
-    /// Per-host unique index (0–63) for network isolation. Can be reused after shutdown.
-    pub instance_index: u32,
     /// Number of VMs that can run concurrently (determines pool pre-warm size).
     pub concurrency: usize,
     /// Port of the HTTP/HTTPS proxy. When set, iptables rules redirect traffic through it.

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -26,7 +26,6 @@ impl FirecrackerFactory {
         let paths = FactoryPaths::new(config.base_dir.clone());
 
         let mut netns_pool = NetnsPool::create(NetnsPoolConfig {
-            index: config.instance_index,
             size: concurrency,
             proxy_port: config.proxy_port,
         })

--- a/crates/sandbox-fc/src/main.rs
+++ b/crates/sandbox-fc/src/main.rs
@@ -208,7 +208,6 @@ async fn run_exec(
         kernel_path: kernel,
         rootfs_path: rootfs,
         base_dir,
-        instance_index: 0,
         concurrency: 1,
         proxy_port: None,
         snapshot,

--- a/crates/sandbox-fc/src/network/error.rs
+++ b/crates/sandbox-fc/src/network/error.rs
@@ -7,12 +7,15 @@ pub enum NetworkError {
     #[error(transparent)]
     Command(#[from] CommandError),
 
-    #[error("pool index {index} out of range (max {max})")]
-    IndexOutOfRange { index: u32, max: u32 },
+    #[error("no pool index available (all slots are locked by other processes)")]
+    NoPoolIndexAvailable,
 
     #[error("namespace limit reached: max {max} namespaces allowed")]
     NamespaceLimitReached { max: u32 },
 
     #[error("failed to detect default network interface from: {0}")]
     NoDefaultInterface(String),
+
+    #[error("failed to open lock file: {0}")]
+    LockOpen(String),
 }

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -1,5 +1,9 @@
 use std::path::{Path, PathBuf};
 
+/// Directory for flock-based pool index allocation.
+/// `/var/lock` is the FHS-standard location for lock files (mode 1777).
+pub const LOCK_DIR: &str = "/var/lock";
+
 /// Factory-level paths derived from the base directory.
 pub struct FactoryPaths {
     base_dir: PathBuf,

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -17,10 +17,6 @@ const API_READY_TIMEOUT: Duration = Duration::from_secs(5);
 /// Timeout for waiting for the guest to connect via vsock after start.
 const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Network namespace pool index used for snapshot creation (63 = last slot,
-/// avoids collision with running sandbox instances that use lower indices).
-const SNAPSHOT_POOL_INDEX: u32 = 63;
-
 /// Configuration for creating a snapshot.
 #[derive(Debug, Clone)]
 pub struct SnapshotCreateConfig {
@@ -98,9 +94,8 @@ pub async fn create_snapshot(
 
     info!("overlay created");
 
-    // 3. Create network namespace (pool of 1, index 63 to avoid collision).
+    // 3. Create network namespace (pool of 1, index auto-allocated via flock).
     let mut netns_pool = NetnsPool::create(NetnsPoolConfig {
-        index: SNAPSHOT_POOL_INDEX,
         size: 1,
         proxy_port: None,
     })


### PR DESCRIPTION
## Summary

- Replace caller-provided `instance_index` with automatic flock-based allocation on `/var/lock`, eliminating the need for external index coordination between runner processes
- Each `NetnsPool::create` acquires the first available index (0–63) via `flock(LOCK_EX | LOCK_NB)` on per-index lock files, held for the pool's lifetime
- Remove `instance_index` from `FirecrackerConfig` and `SNAPSHOT_POOL_INDEX` constant, simplifying the public API

## Test plan

- [x] 4 new unit tests for `acquire_pool_lock`: first-available, skip-held, reuse-released, exhausted
- [x] All 68 existing tests pass
- [x] `cargo clippy -p sandbox-fc` clean
- [ ] Manual: run two `sandbox-fc exec` processes concurrently, verify they get different pool indices via log output

Closes #2704

🤖 Generated with [Claude Code](https://claude.com/claude-code)