### PR TITLE
fix(cli): use nullish coalescing for sentry environment fallback

### DIFF
--- a/turbo/apps/cli/src/instrument.ts
+++ b/turbo/apps/cli/src/instrument.ts
@@ -62,7 +62,7 @@ function isOperationalError(error: unknown): boolean {
 if (DSN) {
   Sentry.init({
     dsn: DSN,
-    environment: process.env.SENTRY_ENVIRONMENT || "production",
+    environment: process.env.SENTRY_ENVIRONMENT ?? "production",
     release: __CLI_VERSION__,
     sendDefaultPii: false,
     tracesSampleRate: 0,


### PR DESCRIPTION
## Summary
- Replace `||` with `??` in `instrument.ts` for `SENTRY_ENVIRONMENT` fallback so only `undefined`/`null` triggers the `"production"` default

## Test plan
- [x] One-character change (`||` → `??`), no behavioral difference in normal usage
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)