### PR TITLE
perf(ci): speed up preview deploy with vercel prebuilt and skip sentry source maps

### DIFF
--- a/.github/actions/vercel-deploy/action.yml
+++ b/.github/actions/vercel-deploy/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: "Skip finishing the deployment (use when you need to set a custom env_url later)"
     required: false
     default: "false"
+  prebuilt:
+    description: "Build locally and deploy prebuilt artifacts (skips remote build on Vercel)"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -70,30 +74,75 @@ runs:
       id: deploy
       shell: bash
       run: |
-        # Build deployment command
-        DEPLOY_CMD="vercel deploy --token=${{ inputs.vercel-token }}"
-
-        # Add production flag if needed
-        if [ "${{ inputs.environment }}" == "production" ]; then
-          DEPLOY_CMD="$DEPLOY_CMD --prod"
-        fi
-
-        # Add environment variables for both build-time and runtime
         ENV_VARS="${{ inputs.environment-variables }}"
-        if [ -n "$ENV_VARS" ]; then
-          echo "Adding environment variables for build and runtime..."
-          while IFS= read -r line; do
-            # Skip empty lines
-            line=$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-            if [ -n "$line" ]; then
-              # Extract key and value
-              KEY="${line%%=*}"
-              VALUE="${line#*=}"
-              echo "Adding env: $KEY"
-              # Add as both build-time and runtime environment variable
-              DEPLOY_CMD="$DEPLOY_CMD --build-env $KEY=\"$VALUE\" --env $KEY=\"$VALUE\""
-            fi
-          done <<< "$ENV_VARS"
+
+        if [ "${{ inputs.prebuilt }}" == "true" ]; then
+          # === Prebuilt mode: build locally, deploy artifacts only ===
+
+          # Export environment variables for local build
+          if [ -n "$ENV_VARS" ]; then
+            echo "Exporting environment variables for local build..."
+            while IFS= read -r line; do
+              line=$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+              if [ -n "$line" ]; then
+                KEY="${line%%=*}"
+                VALUE="${line#*=}"
+                echo "Exporting env: $KEY"
+                export "$KEY=$VALUE"
+              fi
+            done <<< "$ENV_VARS"
+          fi
+
+          # Build locally using Vercel CLI
+          echo "Building locally with vercel build..."
+          BUILD_CMD="vercel build --token=${{ inputs.vercel-token }}"
+          if [ "${{ inputs.environment }}" == "production" ]; then
+            BUILD_CMD="$BUILD_CMD --prod"
+          fi
+          eval $BUILD_CMD
+
+          # Deploy prebuilt artifacts (no remote build)
+          echo "Deploying prebuilt artifacts..."
+          DEPLOY_CMD="vercel deploy --prebuilt --token=${{ inputs.vercel-token }}"
+
+          if [ "${{ inputs.environment }}" == "production" ]; then
+            DEPLOY_CMD="$DEPLOY_CMD --prod"
+          fi
+
+          # Add runtime environment variables
+          if [ -n "$ENV_VARS" ]; then
+            echo "Adding runtime environment variables..."
+            while IFS= read -r line; do
+              line=$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+              if [ -n "$line" ]; then
+                KEY="${line%%=*}"
+                VALUE="${line#*=}"
+                echo "Adding runtime env: $KEY"
+                DEPLOY_CMD="$DEPLOY_CMD --env $KEY=\"$VALUE\""
+              fi
+            done <<< "$ENV_VARS"
+          fi
+        else
+          # === Standard mode: remote build on Vercel ===
+          DEPLOY_CMD="vercel deploy --token=${{ inputs.vercel-token }}"
+
+          if [ "${{ inputs.environment }}" == "production" ]; then
+            DEPLOY_CMD="$DEPLOY_CMD --prod"
+          fi
+
+          # Add environment variables for both build-time and runtime
+          if [ -n "$ENV_VARS" ]; then
+            echo "Adding environment variables for build and runtime..."
+            while IFS= read -r line; do
+              line=$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+              if [ -n "$line" ]; then
+                KEY="${line%%=*}"
+                VALUE="${line#*=}"
+                echo "Adding env: $KEY"
+                DEPLOY_CMD="$DEPLOY_CMD --build-env $KEY=\"$VALUE\" --env $KEY=\"$VALUE\""
+              fi
+            done <<< "$ENV_VARS"
+          fi
         fi
 
         # Add metadata if provided

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -419,6 +419,7 @@ jobs:
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_WEB }}
           environment: preview
           deployment-env: web
+          prebuilt: "true"
           environment-variables: |
             DATABASE_URL=${{ steps.branch.outputs.database-url }}
             NEXT_PUBLIC_BASE_URL=${{ needs.prepare.outputs.web-preview-url }}
@@ -452,6 +453,7 @@ jobs:
             SENTRY_PROJECT=${{ vars.SENTRY_PROJECT_WEB }}
             GH_OAUTH_CLIENT_ID=${{ vars.GH_OAUTH_CLIENT_ID }}
             GH_OAUTH_CLIENT_SECRET=${{ secrets.GH_OAUTH_CLIENT_SECRET }}
+            NEXT_PUBLIC_STRAPI_URL=${{ vars.NEXT_PUBLIC_STRAPI_URL }}
           meta-branch: ${{ github.head_ref || github.ref_name }}
           meta-pr: ${{ needs.prepare.outputs.job-ref }}
           skip-finish: ${{ github.event_name == 'pull_request' && vars.PREVIEW_DOMAIN != '' }}

--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -43,6 +43,8 @@ const nextConfig = {
   serverExternalPackages: ["ably"],
 };
 
+const isProduction = process.env.VERCEL_ENV === "production";
+
 export default withSentryConfig(withNextIntl(nextConfig), {
   // Sentry organization and project
   org: process.env.SENTRY_ORG,
@@ -59,4 +61,9 @@ export default withSentryConfig(withNextIntl(nextConfig), {
 
   // Disable telemetry
   telemetry: false,
+
+  // Skip source map upload for non-production builds (preview deploys)
+  sourcemaps: {
+    disable: !isProduction,
+  },
 });

--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -37,7 +37,17 @@ const nextConfig = {
         : false,
   },
   experimental: {
-    optimizePackageImports: ["next-intl"],
+    optimizePackageImports: [
+      "next-intl",
+      "@tabler/icons-react",
+      "@aws-sdk/client-s3",
+      "@aws-sdk/s3-request-presigner",
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-popover",
+      "@radix-ui/react-select",
+      "@radix-ui/react-tooltip",
+      "@sentry/nextjs",
+    ],
   },
   allowedDevOrigins: ["*.vm7.ai"],
   serverExternalPackages: ["ably"],


### PR DESCRIPTION
## Summary

- Switch preview deployments from remote build (`vercel deploy`) to local pre-build + deploy artifacts (`vercel build` + `vercel deploy --prebuilt`), eliminating the remote `pnpm install` and remote `next build` on Vercel's infrastructure
- Skip Sentry source map generation/upload for non-production builds since preview environments don't need source maps
- Add backward-compatible `prebuilt` input to `vercel-deploy` action (default `false`, only `deploy-web` uses `true`)

## Test plan

- [ ] PR itself triggers `deploy-web` — verify the preview deployment succeeds
- [ ] Compare "Deploy Web to Vercel" step duration (target: < 2 min, down from 3–4.5 min)
- [ ] Verify preview URL is functional (pages load, API routes work)
- [ ] Verify E2E tests pass against the preview
- [ ] Verify `deploy-docs` and `deploy-platform` jobs are unaffected

Closes #2710

🤖 Generated with [Claude Code](https://claude.com/claude-code)