### PR TITLE
refactor(cli): rename agent sharing commands from experimental-xxx to flag-based

### DIFF
--- a/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
@@ -67,7 +67,18 @@ describe("Agent Sharing Commands", () => {
 
   afterEach(() => {});
 
-  describe("vm0 agent experimental-public", () => {
+  describe("vm0 agent public", () => {
+    it("should fail without --experimental-shared-agent flag", async () => {
+      await expect(async () => {
+        await publicCommand.parseAsync(["node", "cli", testAgentName]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--experimental-shared-agent"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
     it("should make agent public successfully", async () => {
       server.use(
         http.post(
@@ -86,7 +97,12 @@ describe("Agent Sharing Commands", () => {
         ),
       );
 
-      await publicCommand.parseAsync(["node", "cli", testAgentName]);
+      await publicCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentName,
+        "--experimental-shared-agent",
+      ]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("now public"),
@@ -117,7 +133,12 @@ describe("Agent Sharing Commands", () => {
         ),
       );
 
-      await publicCommand.parseAsync(["node", "cli", testAgentName]);
+      await publicCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentName,
+        "--experimental-shared-agent",
+      ]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("already public"),
@@ -137,7 +158,12 @@ describe("Agent Sharing Commands", () => {
       );
 
       await expect(async () => {
-        await publicCommand.parseAsync(["node", "cli", "nonexistent"]);
+        await publicCommand.parseAsync([
+          "node",
+          "cli",
+          "nonexistent",
+          "--experimental-shared-agent",
+        ]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
@@ -147,7 +173,18 @@ describe("Agent Sharing Commands", () => {
     });
   });
 
-  describe("vm0 agent experimental-private", () => {
+  describe("vm0 agent private", () => {
+    it("should fail without --experimental-shared-agent flag", async () => {
+      await expect(async () => {
+        await privateCommand.parseAsync(["node", "cli", testAgentName]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--experimental-shared-agent"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
     it("should make agent private successfully", async () => {
       server.use(
         http.delete(
@@ -160,7 +197,12 @@ describe("Agent Sharing Commands", () => {
         ),
       );
 
-      await privateCommand.parseAsync(["node", "cli", testAgentName]);
+      await privateCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentName,
+        "--experimental-shared-agent",
+      ]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("now private"),
@@ -180,7 +222,12 @@ describe("Agent Sharing Commands", () => {
         ),
       );
 
-      await privateCommand.parseAsync(["node", "cli", testAgentName]);
+      await privateCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentName,
+        "--experimental-shared-agent",
+      ]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("already private"),
@@ -188,7 +235,24 @@ describe("Agent Sharing Commands", () => {
     });
   });
 
-  describe("vm0 agent experimental-share", () => {
+  describe("vm0 agent share", () => {
+    it("should fail without --experimental-shared-agent flag", async () => {
+      await expect(async () => {
+        await shareCommand.parseAsync([
+          "node",
+          "cli",
+          testAgentName,
+          "--email",
+          "user@example.com",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--experimental-shared-agent"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
     it("should share agent with email successfully", async () => {
       const shareEmail = "user@example.com";
 
@@ -216,6 +280,7 @@ describe("Agent Sharing Commands", () => {
         testAgentName,
         "--email",
         shareEmail,
+        "--experimental-shared-agent",
       ]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
@@ -253,6 +318,7 @@ describe("Agent Sharing Commands", () => {
         testAgentName,
         "--email",
         "user@example.com",
+        "--experimental-shared-agent",
       ]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
@@ -261,7 +327,24 @@ describe("Agent Sharing Commands", () => {
     });
   });
 
-  describe("vm0 agent experimental-unshare", () => {
+  describe("vm0 agent unshare", () => {
+    it("should fail without --experimental-shared-agent flag", async () => {
+      await expect(async () => {
+        await unshareCommand.parseAsync([
+          "node",
+          "cli",
+          testAgentName,
+          "--email",
+          "user@example.com",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--experimental-shared-agent"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
     it("should unshare agent from email successfully", async () => {
       const unshareEmail = "user@example.com";
 
@@ -283,6 +366,7 @@ describe("Agent Sharing Commands", () => {
         testAgentName,
         "--email",
         unshareEmail,
+        "--experimental-shared-agent",
       ]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
@@ -309,6 +393,7 @@ describe("Agent Sharing Commands", () => {
         testAgentName,
         "--email",
         "user@example.com",
+        "--experimental-shared-agent",
       ]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
@@ -317,7 +402,18 @@ describe("Agent Sharing Commands", () => {
     });
   });
 
-  describe("vm0 agent experimental-permission", () => {
+  describe("vm0 agent permission", () => {
+    it("should fail without --experimental-shared-agent flag", async () => {
+      await expect(async () => {
+        await permissionCommand.parseAsync(["node", "cli", testAgentName]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--experimental-shared-agent"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
     it("should list permissions for agent", async () => {
       server.use(
         http.get(
@@ -347,7 +443,12 @@ describe("Agent Sharing Commands", () => {
         ),
       );
 
-      await permissionCommand.parseAsync(["node", "cli", testAgentName]);
+      await permissionCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentName,
+        "--experimental-shared-agent",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("public");
@@ -364,7 +465,12 @@ describe("Agent Sharing Commands", () => {
         ),
       );
 
-      await permissionCommand.parseAsync(["node", "cli", testAgentName]);
+      await permissionCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentName,
+        "--experimental-shared-agent",
+      ]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("No permissions"),
@@ -382,7 +488,12 @@ describe("Agent Sharing Commands", () => {
       );
 
       await expect(async () => {
-        await permissionCommand.parseAsync(["node", "cli", testAgentName]);
+        await permissionCommand.parseAsync([
+          "node",
+          "cli",
+          testAgentName,
+          "--experimental-shared-agent",
+        ]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(

--- a/turbo/apps/cli/src/commands/agent/permission.ts
+++ b/turbo/apps/cli/src/commands/agent/permission.ts
@@ -17,60 +17,83 @@ interface PermissionsResponse {
 }
 
 export const permissionCommand = new Command()
-  .name("experimental-permission")
+  .name("permission")
   .description("List all permissions for an agent")
   .argument("<name>", "Agent name")
-  .action(async (name: string) => {
-    try {
-      // Resolve compose by name
-      const compose = await getComposeByName(name);
-      if (!compose) {
-        console.error(chalk.red(`✗ Agent not found: ${name}`));
+  .option(
+    "--experimental-shared-agent",
+    "Enable experimental agent sharing feature",
+  )
+  .action(
+    async (name: string, options: { experimentalSharedAgent?: boolean }) => {
+      // Validate experimental flag
+      if (!options.experimentalSharedAgent) {
+        console.error(
+          chalk.red("✗ This command requires --experimental-shared-agent flag"),
+        );
+        console.error();
+        console.error(chalk.dim("  Agent sharing is an experimental feature."));
+        console.error();
+        console.error("Example:");
+        console.error(
+          chalk.cyan(
+            `  vm0 agent permission ${name} --experimental-shared-agent`,
+          ),
+        );
         process.exit(1);
       }
 
-      // Get permissions
-      const response = await httpGet(
-        `/api/agent/composes/${compose.id}/permissions`,
-      );
+      try {
+        // Resolve compose by name
+        const compose = await getComposeByName(name);
+        if (!compose) {
+          console.error(chalk.red(`✗ Agent not found: ${name}`));
+          process.exit(1);
+        }
 
-      if (!response.ok) {
-        const error = (await response.json()) as ApiError;
-        throw new Error(error.error?.message || "Failed to list permissions");
+        // Get permissions
+        const response = await httpGet(
+          `/api/agent/composes/${compose.id}/permissions`,
+        );
+
+        if (!response.ok) {
+          const error = (await response.json()) as ApiError;
+          throw new Error(error.error?.message || "Failed to list permissions");
+        }
+
+        const data = (await response.json()) as PermissionsResponse;
+
+        if (data.permissions.length === 0) {
+          console.log(chalk.dim("No permissions set (private agent)"));
+          return;
+        }
+
+        // Print header
+        console.log(
+          chalk.dim(
+            "TYPE     EMAIL                          PERMISSION  GRANTED",
+          ),
+        );
+        console.log(
+          chalk.dim(
+            "-------  -----------------------------  ----------  ----------",
+          ),
+        );
+
+        // Print rows
+        for (const p of data.permissions) {
+          const type = p.granteeType.padEnd(7);
+          const email = (p.granteeEmail ?? "-").padEnd(29);
+          const permission = p.permission.padEnd(10);
+          const granted = formatRelativeTime(p.createdAt);
+          console.log(`${type}  ${email}  ${permission}  ${granted}`);
+        }
+      } catch (error) {
+        console.error(chalk.red("✗ Failed to list permissions"));
+        if (error instanceof Error) {
+          console.error(chalk.dim(`  ${error.message}`));
+        }
+        process.exit(1);
       }
-
-      const data = (await response.json()) as PermissionsResponse;
-
-      if (data.permissions.length === 0) {
-        console.log(chalk.dim("No permissions set (private agent)"));
-        return;
-      }
-
-      // Print header
-      console.log(
-        chalk.dim(
-          "TYPE     EMAIL                          PERMISSION  GRANTED",
-        ),
-      );
-      console.log(
-        chalk.dim(
-          "-------  -----------------------------  ----------  ----------",
-        ),
-      );
-
-      // Print rows
-      for (const p of data.permissions) {
-        const type = p.granteeType.padEnd(7);
-        const email = (p.granteeEmail ?? "-").padEnd(29);
-        const permission = p.permission.padEnd(10);
-        const granted = formatRelativeTime(p.createdAt);
-        console.log(`${type}  ${email}  ${permission}  ${granted}`);
-      }
-    } catch (error) {
-      console.error(chalk.red("✗ Failed to list permissions"));
-      if (error instanceof Error) {
-        console.error(chalk.dim(`  ${error.message}`));
-      }
-      process.exit(1);
-    }
-  });
+    },
+  );

--- a/turbo/apps/cli/src/commands/agent/private.ts
+++ b/turbo/apps/cli/src/commands/agent/private.ts
@@ -3,38 +3,61 @@ import chalk from "chalk";
 import { getComposeByName, httpDelete, type ApiError } from "../../lib/api";
 
 export const privateCommand = new Command()
-  .name("experimental-private")
+  .name("private")
   .description("Make an agent private (remove public access)")
   .argument("<name>", "Agent name")
-  .action(async (name: string) => {
-    try {
-      // Resolve compose by name
-      const compose = await getComposeByName(name);
-      if (!compose) {
-        console.error(chalk.red(`✗ Agent not found: ${name}`));
+  .option(
+    "--experimental-shared-agent",
+    "Enable experimental agent sharing feature",
+  )
+  .action(
+    async (name: string, options: { experimentalSharedAgent?: boolean }) => {
+      // Validate experimental flag
+      if (!options.experimentalSharedAgent) {
+        console.error(
+          chalk.red("✗ This command requires --experimental-shared-agent flag"),
+        );
+        console.error();
+        console.error(chalk.dim("  Agent sharing is an experimental feature."));
+        console.error();
+        console.error("Example:");
+        console.error(
+          chalk.cyan(`  vm0 agent private ${name} --experimental-shared-agent`),
+        );
         process.exit(1);
       }
 
-      // Remove public permission
-      const response = await httpDelete(
-        `/api/agent/composes/${compose.id}/permissions?type=public`,
-      );
-
-      if (!response.ok) {
-        const error = (await response.json()) as ApiError;
-        if (response.status === 404) {
-          console.log(chalk.yellow(`Agent "${name}" is already private`));
-          return;
+      try {
+        // Resolve compose by name
+        const compose = await getComposeByName(name);
+        if (!compose) {
+          console.error(chalk.red(`✗ Agent not found: ${name}`));
+          process.exit(1);
         }
-        throw new Error(error.error?.message || "Failed to make agent private");
-      }
 
-      console.log(chalk.green(`✓ Agent "${name}" is now private`));
-    } catch (error) {
-      console.error(chalk.red("✗ Failed to make agent private"));
-      if (error instanceof Error) {
-        console.error(chalk.dim(`  ${error.message}`));
+        // Remove public permission
+        const response = await httpDelete(
+          `/api/agent/composes/${compose.id}/permissions?type=public`,
+        );
+
+        if (!response.ok) {
+          const error = (await response.json()) as ApiError;
+          if (response.status === 404) {
+            console.log(chalk.yellow(`Agent "${name}" is already private`));
+            return;
+          }
+          throw new Error(
+            error.error?.message || "Failed to make agent private",
+          );
+        }
+
+        console.log(chalk.green(`✓ Agent "${name}" is now private`));
+      } catch (error) {
+        console.error(chalk.red("✗ Failed to make agent private"));
+        if (error instanceof Error) {
+          console.error(chalk.dim(`  ${error.message}`));
+        }
+        process.exit(1);
       }
-      process.exit(1);
-    }
-  });
+    },
+  );

--- a/turbo/apps/cli/src/commands/agent/public.ts
+++ b/turbo/apps/cli/src/commands/agent/public.ts
@@ -8,50 +8,73 @@ import {
 } from "../../lib/api";
 
 export const publicCommand = new Command()
-  .name("experimental-public")
+  .name("public")
   .description("Make an agent public (accessible to all authenticated users)")
   .argument("<name>", "Agent name")
-  .action(async (name: string) => {
-    try {
-      // Resolve compose by name
-      const compose = await getComposeByName(name);
-      if (!compose) {
-        console.error(chalk.red(`✗ Agent not found: ${name}`));
+  .option(
+    "--experimental-shared-agent",
+    "Enable experimental agent sharing feature",
+  )
+  .action(
+    async (name: string, options: { experimentalSharedAgent?: boolean }) => {
+      // Validate experimental flag
+      if (!options.experimentalSharedAgent) {
+        console.error(
+          chalk.red("✗ This command requires --experimental-shared-agent flag"),
+        );
+        console.error();
+        console.error(chalk.dim("  Agent sharing is an experimental feature."));
+        console.error();
+        console.error("Example:");
+        console.error(
+          chalk.cyan(`  vm0 agent public ${name} --experimental-shared-agent`),
+        );
         process.exit(1);
       }
 
-      // Get scope for display
-      const scope = await getScope();
-
-      // Add public permission
-      const response = await httpPost(
-        `/api/agent/composes/${compose.id}/permissions`,
-        { granteeType: "public" },
-      );
-
-      if (!response.ok) {
-        const error = (await response.json()) as ApiError;
-        if (response.status === 409) {
-          console.log(chalk.yellow(`Agent "${name}" is already public`));
-          return;
+      try {
+        // Resolve compose by name
+        const compose = await getComposeByName(name);
+        if (!compose) {
+          console.error(chalk.red(`✗ Agent not found: ${name}`));
+          process.exit(1);
         }
-        throw new Error(error.error?.message || "Failed to make agent public");
-      }
 
-      const fullName = `${scope.slug}/${name}`;
-      console.log(chalk.green(`✓ Agent "${name}" is now public`));
-      console.log();
-      console.log("Others can now run your agent with:");
-      console.log(
-        chalk.cyan(
-          `  vm0 run ${fullName} --experimental-shared-agent "your prompt"`,
-        ),
-      );
-    } catch (error) {
-      console.error(chalk.red("✗ Failed to make agent public"));
-      if (error instanceof Error) {
-        console.error(chalk.dim(`  ${error.message}`));
+        // Get scope for display
+        const scope = await getScope();
+
+        // Add public permission
+        const response = await httpPost(
+          `/api/agent/composes/${compose.id}/permissions`,
+          { granteeType: "public" },
+        );
+
+        if (!response.ok) {
+          const error = (await response.json()) as ApiError;
+          if (response.status === 409) {
+            console.log(chalk.yellow(`Agent "${name}" is already public`));
+            return;
+          }
+          throw new Error(
+            error.error?.message || "Failed to make agent public",
+          );
+        }
+
+        const fullName = `${scope.slug}/${name}`;
+        console.log(chalk.green(`✓ Agent "${name}" is now public`));
+        console.log();
+        console.log("Others can now run your agent with:");
+        console.log(
+          chalk.cyan(
+            `  vm0 run ${fullName} --experimental-shared-agent "your prompt"`,
+          ),
+        );
+      } catch (error) {
+        console.error(chalk.red("✗ Failed to make agent public"));
+        if (error instanceof Error) {
+          console.error(chalk.dim(`  ${error.message}`));
+        }
+        process.exit(1);
       }
-      process.exit(1);
-    }
-  });
+    },
+  );

--- a/turbo/apps/cli/src/commands/agent/share.ts
+++ b/turbo/apps/cli/src/commands/agent/share.ts
@@ -8,57 +8,83 @@ import {
 } from "../../lib/api";
 
 export const shareCommand = new Command()
-  .name("experimental-share")
+  .name("share")
   .description("Share an agent with a user by email")
   .argument("<name>", "Agent name")
   .requiredOption("--email <email>", "Email address to share with")
-  .action(async (name: string, options: { email: string }) => {
-    try {
-      // Resolve compose by name
-      const compose = await getComposeByName(name);
-      if (!compose) {
-        console.error(chalk.red(`✗ Agent not found: ${name}`));
+  .option(
+    "--experimental-shared-agent",
+    "Enable experimental agent sharing feature",
+  )
+  .action(
+    async (
+      name: string,
+      options: { email: string; experimentalSharedAgent?: boolean },
+    ) => {
+      // Validate experimental flag
+      if (!options.experimentalSharedAgent) {
+        console.error(
+          chalk.red("✗ This command requires --experimental-shared-agent flag"),
+        );
+        console.error();
+        console.error(chalk.dim("  Agent sharing is an experimental feature."));
+        console.error();
+        console.error("Example:");
+        console.error(
+          chalk.cyan(
+            `  vm0 agent share ${name} --email ${options.email} --experimental-shared-agent`,
+          ),
+        );
         process.exit(1);
       }
 
-      // Get scope for display
-      const scope = await getScope();
-
-      // Add email permission
-      const response = await httpPost(
-        `/api/agent/composes/${compose.id}/permissions`,
-        { granteeType: "email", granteeEmail: options.email },
-      );
-
-      if (!response.ok) {
-        const error = (await response.json()) as ApiError;
-        if (response.status === 409) {
-          console.log(
-            chalk.yellow(
-              `Agent "${name}" is already shared with ${options.email}`,
-            ),
-          );
-          return;
+      try {
+        // Resolve compose by name
+        const compose = await getComposeByName(name);
+        if (!compose) {
+          console.error(chalk.red(`✗ Agent not found: ${name}`));
+          process.exit(1);
         }
-        throw new Error(error.error?.message || "Failed to share agent");
-      }
 
-      const fullName = `${scope.slug}/${name}`;
-      console.log(
-        chalk.green(`✓ Agent "${name}" shared with ${options.email}`),
-      );
-      console.log();
-      console.log("They can now run your agent with:");
-      console.log(
-        chalk.cyan(
-          `  vm0 run ${fullName} --experimental-shared-agent "your prompt"`,
-        ),
-      );
-    } catch (error) {
-      console.error(chalk.red("✗ Failed to share agent"));
-      if (error instanceof Error) {
-        console.error(chalk.dim(`  ${error.message}`));
+        // Get scope for display
+        const scope = await getScope();
+
+        // Add email permission
+        const response = await httpPost(
+          `/api/agent/composes/${compose.id}/permissions`,
+          { granteeType: "email", granteeEmail: options.email },
+        );
+
+        if (!response.ok) {
+          const error = (await response.json()) as ApiError;
+          if (response.status === 409) {
+            console.log(
+              chalk.yellow(
+                `Agent "${name}" is already shared with ${options.email}`,
+              ),
+            );
+            return;
+          }
+          throw new Error(error.error?.message || "Failed to share agent");
+        }
+
+        const fullName = `${scope.slug}/${name}`;
+        console.log(
+          chalk.green(`✓ Agent "${name}" shared with ${options.email}`),
+        );
+        console.log();
+        console.log("They can now run your agent with:");
+        console.log(
+          chalk.cyan(
+            `  vm0 run ${fullName} --experimental-shared-agent "your prompt"`,
+          ),
+        );
+      } catch (error) {
+        console.error(chalk.red("✗ Failed to share agent"));
+        if (error instanceof Error) {
+          console.error(chalk.dim(`  ${error.message}`));
+        }
+        process.exit(1);
       }
-      process.exit(1);
-    }
-  });
+    },
+  );

--- a/turbo/apps/cli/src/commands/agent/unshare.ts
+++ b/turbo/apps/cli/src/commands/agent/unshare.ts
@@ -3,43 +3,71 @@ import chalk from "chalk";
 import { getComposeByName, httpDelete, type ApiError } from "../../lib/api";
 
 export const unshareCommand = new Command()
-  .name("experimental-unshare")
+  .name("unshare")
   .description("Remove sharing from a user")
   .argument("<name>", "Agent name")
   .requiredOption("--email <email>", "Email address to unshare")
-  .action(async (name: string, options: { email: string }) => {
-    try {
-      // Resolve compose by name
-      const compose = await getComposeByName(name);
-      if (!compose) {
-        console.error(chalk.red(`✗ Agent not found: ${name}`));
+  .option(
+    "--experimental-shared-agent",
+    "Enable experimental agent sharing feature",
+  )
+  .action(
+    async (
+      name: string,
+      options: { email: string; experimentalSharedAgent?: boolean },
+    ) => {
+      // Validate experimental flag
+      if (!options.experimentalSharedAgent) {
+        console.error(
+          chalk.red("✗ This command requires --experimental-shared-agent flag"),
+        );
+        console.error();
+        console.error(chalk.dim("  Agent sharing is an experimental feature."));
+        console.error();
+        console.error("Example:");
+        console.error(
+          chalk.cyan(
+            `  vm0 agent unshare ${name} --email ${options.email} --experimental-shared-agent`,
+          ),
+        );
         process.exit(1);
       }
 
-      // Remove email permission
-      const response = await httpDelete(
-        `/api/agent/composes/${compose.id}/permissions?type=email&email=${encodeURIComponent(options.email)}`,
-      );
-
-      if (!response.ok) {
-        const error = (await response.json()) as ApiError;
-        if (response.status === 404) {
-          console.log(
-            chalk.yellow(`Agent "${name}" is not shared with ${options.email}`),
-          );
-          return;
+      try {
+        // Resolve compose by name
+        const compose = await getComposeByName(name);
+        if (!compose) {
+          console.error(chalk.red(`✗ Agent not found: ${name}`));
+          process.exit(1);
         }
-        throw new Error(error.error?.message || "Failed to unshare agent");
-      }
 
-      console.log(
-        chalk.green(`✓ Removed sharing of "${name}" from ${options.email}`),
-      );
-    } catch (error) {
-      console.error(chalk.red("✗ Failed to unshare agent"));
-      if (error instanceof Error) {
-        console.error(chalk.dim(`  ${error.message}`));
+        // Remove email permission
+        const response = await httpDelete(
+          `/api/agent/composes/${compose.id}/permissions?type=email&email=${encodeURIComponent(options.email)}`,
+        );
+
+        if (!response.ok) {
+          const error = (await response.json()) as ApiError;
+          if (response.status === 404) {
+            console.log(
+              chalk.yellow(
+                `Agent "${name}" is not shared with ${options.email}`,
+              ),
+            );
+            return;
+          }
+          throw new Error(error.error?.message || "Failed to unshare agent");
+        }
+
+        console.log(
+          chalk.green(`✓ Removed sharing of "${name}" from ${options.email}`),
+        );
+      } catch (error) {
+        console.error(chalk.red("✗ Failed to unshare agent"));
+        if (error instanceof Error) {
+          console.error(chalk.dim(`  ${error.message}`));
+        }
+        process.exit(1);
       }
-      process.exit(1);
-    }
-  });
+    },
+  );


### PR DESCRIPTION
## Summary

- Rename agent sharing subcommands from name-prefix style (`experimental-xxx`) to simple names gated by `--experimental-shared-agent` flag
- Reuses the existing `--experimental-shared-agent` flag name from the `run` command for consistency

**Before:** `vm0 agent experimental-public my-agent`
**After:** `vm0 agent public my-agent --experimental-shared-agent`

### Commands renamed:
| Old Name | New Name |
|----------|----------|
| `experimental-public` | `public` |
| `experimental-private` | `private` |
| `experimental-share` | `share` |
| `experimental-unshare` | `unshare` |
| `experimental-permission` | `permission` |

### Error message when flag is missing:
```
✗ This command requires --experimental-shared-agent flag

  Agent sharing is an experimental feature.

Example:
  vm0 agent public my-agent --experimental-shared-agent
```

## Test plan

- [x] All existing tests updated to include `--experimental-shared-agent` flag
- [x] Added new test cases for missing flag error on each command
- [x] All 17 tests pass
- [x] Lint passes
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)