### PR TITLE
feat(runner): implement rust runner crate for job polling and execution

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -79,6 +79,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +150,7 @@ checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-link",
 ]
 
@@ -229,6 +236,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,14 +296,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -295,9 +358,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -347,10 +412,94 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -374,6 +523,124 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -450,10 +717,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
@@ -543,12 +822,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -567,12 +925,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -588,6 +1013,32 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "runner"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "chrono",
+ "clap",
+ "nix",
+ "reqwest",
+ "sandbox",
+ "sandbox-fc",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -635,6 +1086,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -681,6 +1133,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -796,6 +1254,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +1297,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +1317,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -863,6 +1345,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -939,6 +1441,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +1491,61 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1023,6 +1605,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,10 +1653,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1084,6 +1690,7 @@ checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -1133,6 +1740,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1774,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1190,6 +1820,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1524,6 +2174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,10 +2190,107 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1027,6 +1027,7 @@ dependencies = [
  "sandbox-fc",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["vsock-guest", "vsock-proto", "vsock-host", "vsock-test", "guest-init", "guest-common", "guest-download", "sandbox", "sandbox-fc"]
+members = ["vsock-guest", "vsock-proto", "vsock-host", "vsock-test", "guest-init", "guest-common", "guest-download", "sandbox", "sandbox-fc", "runner"]
 
 [workspace.package]
 edition = "2024"
@@ -16,6 +16,7 @@ vsock-proto = { path = "vsock-proto" }
 
 # External dependencies
 async-trait = "0.1"
+base64 = "0.22"
 clap = "4"
 chrono = { version = "0.4", default-features = false }
 flate2 = "1"
@@ -32,6 +33,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 which = "8"
 ureq = "3"
+reqwest = { version = "0.12", default-features = false }
 
 [profile.release]
 lto = true

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -20,5 +20,8 @@ tracing-subscriber = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 uuid = { workspace = true, features = ["v4", "serde"] }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "runner"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+sandbox = { workspace = true }
+sandbox-fc = { workspace = true }
+
+base64 = { workspace = true }
+chrono = { workspace = true, features = ["serde", "now"] }
+clap = { workspace = true, features = ["derive", "env"] }
+nix = { workspace = true, features = ["user", "signal"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "signal", "time", "fs"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+uuid = { workspace = true, features = ["v4", "serde"] }
+
+[lints]
+workspace = true

--- a/crates/runner/src/api.rs
+++ b/crates/runner/src/api.rs
@@ -1,0 +1,144 @@
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use tracing::{debug, warn};
+
+use crate::error::{RunnerError, RunnerResult};
+use crate::types::{CompleteRequest, ExecutionContext, Job, PollResponse};
+
+/// Timeout for API requests.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Async HTTP client for the vm0 API.
+#[derive(Clone)]
+pub struct ApiClient {
+    client: Client,
+    api_url: String,
+    token: String,
+    vercel_bypass: Option<String>,
+}
+
+impl ApiClient {
+    pub fn new(api_url: String, token: String) -> RunnerResult<Self> {
+        let client = Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(|e| RunnerError::Internal(format!("http client: {e}")))?;
+
+        let vercel_bypass = std::env::var("VERCEL_AUTOMATION_BYPASS_SECRET").ok();
+
+        Ok(Self {
+            client,
+            api_url,
+            token,
+            vercel_bypass,
+        })
+    }
+
+    /// Poll for a pending job. Returns `Ok(None)` when no work is available.
+    pub async fn poll(&self, group: &str) -> RunnerResult<Option<Job>> {
+        let url = format!("{}/api/runners/poll", self.api_url);
+        debug!(url = %url, "polling for jobs");
+
+        let resp = self
+            .auth_request(reqwest::Method::POST, &url, &self.token)
+            .json(&serde_json::json!({ "group": group }))
+            .send()
+            .await
+            .map_err(|e| RunnerError::Api(format!("poll: {e}")))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(RunnerError::Api(format!("poll {status}: {body}")));
+        }
+
+        let poll: PollResponse = resp
+            .json()
+            .await
+            .map_err(|e| RunnerError::Api(format!("poll decode: {e}")))?;
+
+        Ok(poll.job)
+    }
+
+    /// Claim a job for execution. Returns [`RunnerError::AlreadyClaimed`] on
+    /// HTTP 409 so callers can continue gracefully.
+    pub async fn claim(&self, run_id: uuid::Uuid) -> RunnerResult<ExecutionContext> {
+        let url = format!("{}/api/runners/jobs/{}/claim", self.api_url, run_id);
+        debug!(url = %url, "claiming job");
+
+        let resp = self
+            .auth_request(reqwest::Method::POST, &url, &self.token)
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .map_err(|e| RunnerError::Api(format!("claim: {e}")))?;
+
+        if resp.status() == StatusCode::CONFLICT {
+            return Err(RunnerError::AlreadyClaimed);
+        }
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(RunnerError::Api(format!("claim {status}: {body}")));
+        }
+
+        let ctx: ExecutionContext = resp
+            .json()
+            .await
+            .map_err(|e| RunnerError::Api(format!("claim decode: {e}")))?;
+
+        Ok(ctx)
+    }
+
+    /// Report job completion. Uses the per-job **sandbox token** for auth.
+    pub async fn complete(
+        &self,
+        sandbox_token: &str,
+        run_id: uuid::Uuid,
+        exit_code: i32,
+        error: Option<String>,
+    ) -> RunnerResult<()> {
+        let url = format!("{}/api/webhooks/agent/complete", self.api_url);
+        debug!(url = %url, "completing job");
+
+        let body = CompleteRequest {
+            run_id,
+            exit_code,
+            error,
+        };
+
+        let resp = self
+            .auth_request(reqwest::Method::POST, &url, sandbox_token)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| RunnerError::Api(format!("complete: {e}")))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            warn!(status = %status, "complete request failed: {body}");
+            return Err(RunnerError::Api(format!("complete {status}: {body}")));
+        }
+
+        Ok(())
+    }
+
+    /// Build an authenticated request with common headers.
+    fn auth_request(
+        &self,
+        method: reqwest::Method,
+        url: &str,
+        token: &str,
+    ) -> reqwest::RequestBuilder {
+        let mut req = self.client.request(method, url).bearer_auth(token);
+
+        if let Some(bypass) = &self.vercel_bypass {
+            req = req.header("x-vercel-protection-bypass", bypass);
+        }
+
+        req
+    }
+}

--- a/crates/runner/src/api.rs
+++ b/crates/runner/src/api.rs
@@ -98,7 +98,7 @@ impl ApiClient {
         sandbox_token: &str,
         run_id: uuid::Uuid,
         exit_code: i32,
-        error: Option<String>,
+        error: Option<&str>,
     ) -> RunnerResult<()> {
         let url = format!("{}/api/webhooks/agent/complete", self.api_url);
         debug!(url = %url, "completing job");
@@ -106,7 +106,7 @@ impl ApiClient {
         let body = CompleteRequest {
             run_id,
             exit_code,
-            error,
+            error: error.map(String::from),
         };
 
         let resp = self

--- a/crates/runner/src/api.rs
+++ b/crates/runner/src/api.rs
@@ -6,8 +6,8 @@ use tracing::{debug, warn};
 use crate::error::{RunnerError, RunnerResult};
 use crate::types::{CompleteRequest, ExecutionContext, Job, PollResponse};
 
-/// Timeout for API requests.
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(3);
+/// Timeout for API requests (covers large claim payloads).
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Async HTTP client for the vm0 API.
 #[derive(Clone)]

--- a/crates/runner/src/error.rs
+++ b/crates/runner/src/error.rs
@@ -1,0 +1,19 @@
+#[derive(Debug, thiserror::Error)]
+pub enum RunnerError {
+    #[error("api error: {0}")]
+    Api(String),
+
+    #[error("job already claimed by another runner")]
+    AlreadyClaimed,
+
+    #[error("sandbox error: {0}")]
+    Sandbox(#[from] sandbox::SandboxError),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub type RunnerResult<T> = Result<T, RunnerError>;

--- a/crates/runner/src/error.rs
+++ b/crates/runner/src/error.rs
@@ -9,6 +9,9 @@ pub enum RunnerError {
     #[error("sandbox error: {0}")]
     Sandbox(#[from] sandbox::SandboxError),
 
+    #[error("config error: {0}")]
+    Config(String),
+
     #[error("internal error: {0}")]
     Internal(String),
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -435,4 +435,35 @@ mod tests {
         assert_eq!(env.get("VM0_PROMPT").unwrap(), "overridden");
         assert_eq!(env.get("CUSTOM").unwrap(), "value");
     }
+
+    #[test]
+    fn build_env_json_with_environment() {
+        let mut ctx = minimal_context();
+        ctx.environment = Some(HashMap::from([
+            ("MY_VAR".into(), "123".into()),
+            ("OTHER".into(), "abc".into()),
+        ]));
+
+        let env = build_env_json(&ctx, "http://localhost");
+        assert_eq!(env.get("MY_VAR").unwrap(), "123");
+        assert_eq!(env.get("OTHER").unwrap(), "abc");
+    }
+
+    #[test]
+    fn build_env_json_with_api_start_time() {
+        let mut ctx = minimal_context();
+        ctx.api_start_time = Some(1_700_000_000.5);
+
+        let env = build_env_json(&ctx, "http://localhost");
+        assert_eq!(env.get("VM0_API_START_TIME").unwrap(), "1700000000.5");
+    }
+
+    #[test]
+    fn build_env_json_empty_secrets_omitted() {
+        let mut ctx = minimal_context();
+        ctx.secret_values = Some(vec![]);
+
+        let env = build_env_json(&ctx, "http://localhost");
+        assert!(!env.contains_key("VM0_SECRET_VALUES"));
+    }
 }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use sandbox::{ExecRequest, Sandbox, SandboxConfig, SandboxFactory};
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
 /// Maximum wall-clock time for a single job (2 hours).
-const JOB_TIMEOUT_MS: u32 = 7_200_000;
+const JOB_TIMEOUT: Duration = Duration::from_secs(7200);
 /// Default timeout for guest commands (5 minutes).
-const DEFAULT_EXEC_TIMEOUT_MS: u32 = 300_000;
+const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
 
 use crate::api::ApiClient;
 use crate::error::RunnerResult;
@@ -63,7 +64,6 @@ async fn execute_inner(
         resources: sandbox::ResourceLimits {
             cpu_count: config.vcpu,
             memory_mb: config.memory_mb,
-            timeout_ms: JOB_TIMEOUT_MS,
         },
     };
 
@@ -123,12 +123,12 @@ async fn run_in_sandbox(
     let handle = sandbox
         .spawn_watch(&ExecRequest {
             cmd: &agent_cmd,
-            timeout_ms: JOB_TIMEOUT_MS, // 2 hours
+            timeout: JOB_TIMEOUT,
         })
         .await?;
 
     // 6. Wait for exit
-    let exit = sandbox.wait_exit(handle).await?;
+    let exit = sandbox.wait_exit(handle, JOB_TIMEOUT).await?;
     let stderr = String::from_utf8_lossy(&exit.stderr).to_string();
 
     info!(
@@ -161,7 +161,7 @@ async fn fix_guest_clock(sandbox: &dyn Sandbox) -> RunnerResult<()> {
     sandbox
         .exec(&ExecRequest {
             cmd: &date_cmd,
-            timeout_ms: DEFAULT_EXEC_TIMEOUT_MS,
+            timeout: DEFAULT_EXEC_TIMEOUT,
         })
         .await?;
     Ok(())
@@ -184,7 +184,7 @@ async fn download_storages(
     let result = sandbox
         .exec(&ExecRequest {
             cmd: &download_cmd,
-            timeout_ms: DEFAULT_EXEC_TIMEOUT_MS,
+            timeout: DEFAULT_EXEC_TIMEOUT,
         })
         .await?;
 
@@ -220,7 +220,7 @@ async fn restore_session(
     sandbox
         .exec(&ExecRequest {
             cmd: &mkdir_cmd,
-            timeout_ms: DEFAULT_EXEC_TIMEOUT_MS,
+            timeout: DEFAULT_EXEC_TIMEOUT,
         })
         .await?;
     sandbox

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -46,13 +46,13 @@ pub async fn execute_job(
     info!(run_id = %run_id, exit_code, "job finished, reporting completion");
 
     if let Err(e) = api
-        .complete(&context.sandbox_token, run_id, exit_code, err.clone())
+        .complete(&context.sandbox_token, run_id, exit_code, err.as_deref())
         .await
     {
         warn!(run_id = %run_id, error = %e, "completion report failed, retrying");
         tokio::time::sleep(Duration::from_secs(2)).await;
         if let Err(e) = api
-            .complete(&context.sandbox_token, run_id, exit_code, err)
+            .complete(&context.sandbox_token, run_id, exit_code, err.as_deref())
             .await
         {
             error!(run_id = %run_id, error = %e, "failed to report completion after retry");
@@ -321,4 +321,118 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
     }
 
     env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ArtifactEntry, ResumeSession, StorageEntry, StorageManifest};
+
+    fn minimal_context() -> ExecutionContext {
+        ExecutionContext {
+            run_id: Uuid::nil(),
+            prompt: "test prompt".into(),
+            vars: None,
+            sandbox_token: "tok".into(),
+            working_dir: "/workspace".into(),
+            storage_manifest: None,
+            environment: None,
+            resume_session: None,
+            secret_values: None,
+            cli_agent_type: String::new(),
+            api_start_time: None,
+        }
+    }
+
+    #[test]
+    fn build_env_json_required_keys() {
+        let ctx = minimal_context();
+        let env = build_env_json(&ctx, "https://api.example.com");
+
+        assert_eq!(env.get("VM0_API_URL").unwrap(), "https://api.example.com");
+        assert_eq!(env.get("VM0_RUN_ID").unwrap(), &Uuid::nil().to_string());
+        assert_eq!(env.get("VM0_API_TOKEN").unwrap(), "tok");
+        assert_eq!(env.get("VM0_PROMPT").unwrap(), "test prompt");
+        assert_eq!(env.get("VM0_WORKING_DIR").unwrap(), "/workspace");
+    }
+
+    #[test]
+    fn build_env_json_empty_cli_agent_type_defaults_to_claude_code() {
+        let ctx = minimal_context();
+        let env = build_env_json(&ctx, "http://localhost");
+        assert_eq!(env.get("CLI_AGENT_TYPE").unwrap(), "claude-code");
+    }
+
+    #[test]
+    fn build_env_json_custom_cli_agent_type() {
+        let mut ctx = minimal_context();
+        ctx.cli_agent_type = "custom-agent".into();
+        let env = build_env_json(&ctx, "http://localhost");
+        assert_eq!(env.get("CLI_AGENT_TYPE").unwrap(), "custom-agent");
+    }
+
+    #[test]
+    fn build_env_json_with_artifact() {
+        let mut ctx = minimal_context();
+        ctx.storage_manifest = Some(StorageManifest {
+            storages: vec![StorageEntry {
+                mount_path: "/data".into(),
+                archive_url: None,
+            }],
+            artifact: Some(ArtifactEntry {
+                mount_path: "/artifacts".into(),
+                archive_url: None,
+                vas_storage_name: "my-vol".into(),
+                vas_version_id: "v1".into(),
+            }),
+        });
+
+        let env = build_env_json(&ctx, "http://localhost");
+        assert_eq!(env.get("VM0_ARTIFACT_DRIVER").unwrap(), "vas");
+        assert_eq!(env.get("VM0_ARTIFACT_MOUNT_PATH").unwrap(), "/artifacts");
+        assert_eq!(env.get("VM0_ARTIFACT_VOLUME_NAME").unwrap(), "my-vol");
+        assert_eq!(env.get("VM0_ARTIFACT_VERSION_ID").unwrap(), "v1");
+    }
+
+    #[test]
+    fn build_env_json_with_secrets() {
+        let mut ctx = minimal_context();
+        ctx.secret_values = Some(vec!["secret1".into(), "secret2".into()]);
+
+        let env = build_env_json(&ctx, "http://localhost");
+        let val = env.get("VM0_SECRET_VALUES").unwrap();
+
+        use base64::Engine as _;
+        let parts: Vec<&str> = val.split(',').collect();
+        assert_eq!(parts.len(), 2);
+        let decoded0 = base64::engine::general_purpose::STANDARD
+            .decode(parts[0])
+            .unwrap();
+        assert_eq!(decoded0, b"secret1");
+    }
+
+    #[test]
+    fn build_env_json_with_resume_session() {
+        let mut ctx = minimal_context();
+        ctx.resume_session = Some(ResumeSession {
+            session_id: "sess-123".into(),
+            session_history: "{}".into(),
+        });
+
+        let env = build_env_json(&ctx, "http://localhost");
+        assert_eq!(env.get("VM0_RESUME_SESSION_ID").unwrap(), "sess-123");
+    }
+
+    #[test]
+    fn build_env_json_user_vars_override() {
+        let mut ctx = minimal_context();
+        ctx.vars = Some(HashMap::from([
+            ("VM0_PROMPT".into(), "overridden".into()),
+            ("CUSTOM".into(), "value".into()),
+        ]));
+
+        let env = build_env_json(&ctx, "http://localhost");
+        assert_eq!(env.get("VM0_PROMPT").unwrap(), "overridden");
+        assert_eq!(env.get("CUSTOM").unwrap(), "value");
+    }
 }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -46,10 +46,17 @@ pub async fn execute_job(
     info!(run_id = %run_id, exit_code, "job finished, reporting completion");
 
     if let Err(e) = api
-        .complete(&context.sandbox_token, run_id, exit_code, err)
+        .complete(&context.sandbox_token, run_id, exit_code, err.clone())
         .await
     {
-        error!(run_id = %run_id, error = %e, "failed to report completion");
+        warn!(run_id = %run_id, error = %e, "completion report failed, retrying");
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        if let Err(e) = api
+            .complete(&context.sandbox_token, run_id, exit_code, err)
+            .await
+        {
+            error!(run_id = %run_id, error = %e, "failed to report completion after retry");
+        }
     }
 }
 
@@ -120,6 +127,8 @@ async fn run_in_sandbox(
     let agent_cmd = format!("node {} > {log_file} 2>&1", guest::ENV_LOADER);
     info!(run_id = %context.run_id, "spawning agent");
 
+    // JOB_TIMEOUT is used for both spawn_watch (guest-side kill) and wait_exit
+    // (host-side watchdog) so neither side outlives the other.
     let handle = sandbox
         .spawn_watch(&ExecRequest {
             cmd: &agent_cmd,
@@ -246,6 +255,7 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
             .map(|t| t.to_string())
             .unwrap_or_default(),
     );
+    // The API omits cli_agent_type for claude-code agents (the default).
     env.insert(
         "CLI_AGENT_TYPE".into(),
         if context.cli_agent_type.is_empty() {

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1,0 +1,314 @@
+use std::collections::HashMap;
+
+use sandbox::{ExecRequest, Sandbox, SandboxConfig, SandboxFactory};
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+/// Maximum wall-clock time for a single job (2 hours).
+const JOB_TIMEOUT_MS: u32 = 7_200_000;
+/// Default timeout for guest commands (5 minutes).
+const DEFAULT_EXEC_TIMEOUT_MS: u32 = 300_000;
+
+use crate::api::ApiClient;
+use crate::error::RunnerResult;
+use crate::paths::guest;
+use crate::types::ExecutionContext;
+
+/// Configuration for a single execution.
+pub struct ExecutorConfig {
+    pub api_url: String,
+    pub vcpu: u32,
+    pub memory_mb: u32,
+    pub is_snapshot: bool,
+}
+
+/// Execute a single job inside a Firecracker VM.
+///
+/// On failure before agent spawn, reports completion with `exit_code = 1`.
+/// Always calls `factory.destroy()` on the sandbox when done.
+pub async fn execute_job(
+    api: &ApiClient,
+    factory: &dyn SandboxFactory,
+    context: ExecutionContext,
+    config: &ExecutorConfig,
+) {
+    let run_id = context.run_id;
+
+    let (exit_code, err) = match execute_inner(factory, &context, config).await {
+        Ok((code, stderr)) => (code, stderr),
+        Err(e) => {
+            error!(run_id = %run_id, error = %e, "job execution failed");
+            (1, Some(e.to_string()))
+        }
+    };
+
+    info!(run_id = %run_id, exit_code, "job finished, reporting completion");
+
+    if let Err(e) = api
+        .complete(&context.sandbox_token, run_id, exit_code, err)
+        .await
+    {
+        error!(run_id = %run_id, error = %e, "failed to report completion");
+    }
+}
+
+async fn execute_inner(
+    factory: &dyn SandboxFactory,
+    context: &ExecutionContext,
+    config: &ExecutorConfig,
+) -> RunnerResult<(i32, Option<String>)> {
+    let sandbox_id = Uuid::new_v4();
+    let sandbox_config = SandboxConfig {
+        id: sandbox_id,
+        resources: sandbox::ResourceLimits {
+            cpu_count: config.vcpu,
+            memory_mb: config.memory_mb,
+            timeout_ms: JOB_TIMEOUT_MS,
+        },
+    };
+
+    // Create and start sandbox
+    info!(run_id = %context.run_id, sandbox_id = %sandbox_id, "creating sandbox");
+    let mut sandbox = factory.create(sandbox_config).await?;
+
+    if let Err(e) = sandbox.start().await {
+        factory.destroy(sandbox).await;
+        return Err(e.into());
+    }
+
+    // Run job inside sandbox, then destroy regardless of outcome
+    let result = run_in_sandbox(sandbox.as_ref(), context, config).await;
+
+    // Best-effort stop
+    if let Err(e) = sandbox.stop().await {
+        warn!(sandbox_id = %sandbox_id, error = %e, "sandbox stop failed");
+    }
+    factory.destroy(sandbox).await;
+
+    result
+}
+
+async fn run_in_sandbox(
+    sandbox: &dyn Sandbox,
+    context: &ExecutionContext,
+    config: &ExecutorConfig,
+) -> RunnerResult<(i32, Option<String>)> {
+    // 1. Fix guest clock after snapshot restore (must happen before HTTPS calls)
+    if config.is_snapshot {
+        fix_guest_clock(sandbox).await?;
+    }
+
+    // 2. Download storages
+    if let Some(manifest) = &context.storage_manifest {
+        download_storages(sandbox, context, manifest).await?;
+    }
+
+    // 3. Restore session history
+    if let Some(session) = &context.resume_session {
+        restore_session(sandbox, context, session).await?;
+    }
+
+    // 4. Write env JSON
+    let env_json = build_env_json(context, &config.api_url);
+    let env_bytes = serde_json::to_vec(&env_json)
+        .map_err(|e| crate::error::RunnerError::Internal(format!("env json: {e}")))?;
+    sandbox.write_file(guest::ENV_JSON, &env_bytes).await?;
+    info!(run_id = %context.run_id, bytes = env_bytes.len(), "wrote env json");
+
+    // 5. Spawn agent
+    let log_file = format!("/tmp/vm0-main-{}.log", context.run_id);
+    let agent_cmd = format!("node {} > {log_file} 2>&1", guest::ENV_LOADER);
+    info!(run_id = %context.run_id, "spawning agent");
+
+    let handle = sandbox
+        .spawn_watch(&ExecRequest {
+            cmd: &agent_cmd,
+            timeout_ms: JOB_TIMEOUT_MS, // 2 hours
+        })
+        .await?;
+
+    // 6. Wait for exit
+    let exit = sandbox.wait_exit(handle).await?;
+    let stderr = String::from_utf8_lossy(&exit.stderr).to_string();
+
+    info!(
+        run_id = %context.run_id,
+        exit_code = exit.exit_code,
+        "agent exited"
+    );
+
+    let error_msg = if exit.exit_code != 0 {
+        Some(stderr).filter(|s| !s.is_empty())
+    } else {
+        None
+    };
+
+    Ok((exit.exit_code, error_msg))
+}
+
+/// Sync guest clock to host time after snapshot restore.
+///
+/// Must run before any HTTPS calls — stale clock breaks TLS cert validation.
+async fn fix_guest_clock(sandbox: &dyn Sandbox) -> RunnerResult<()> {
+    let timestamp = format!(
+        "{:.3}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs_f64()
+    );
+    let date_cmd = format!("sudo date -s \"@{timestamp}\"");
+    sandbox
+        .exec(&ExecRequest {
+            cmd: &date_cmd,
+            timeout_ms: DEFAULT_EXEC_TIMEOUT_MS,
+        })
+        .await?;
+    Ok(())
+}
+
+/// Download storage volumes into the guest.
+async fn download_storages(
+    sandbox: &dyn Sandbox,
+    context: &ExecutionContext,
+    manifest: &crate::types::StorageManifest,
+) -> RunnerResult<()> {
+    let manifest_json = serde_json::to_vec(manifest)
+        .map_err(|e| crate::error::RunnerError::Internal(format!("manifest json: {e}")))?;
+    sandbox
+        .write_file(guest::STORAGE_MANIFEST, &manifest_json)
+        .await?;
+
+    let download_cmd = format!("{} {}", guest::DOWNLOAD_BIN, guest::STORAGE_MANIFEST);
+    info!(run_id = %context.run_id, "downloading storages");
+    let result = sandbox
+        .exec(&ExecRequest {
+            cmd: &download_cmd,
+            timeout_ms: DEFAULT_EXEC_TIMEOUT_MS,
+        })
+        .await?;
+
+    if result.exit_code != 0 {
+        return Err(crate::error::RunnerError::Internal(format!(
+            "storage download failed: {}",
+            result.stderr
+        )));
+    }
+    Ok(())
+}
+
+/// Write Claude Code session history into the guest filesystem.
+///
+/// Only Claude Code uses `.jsonl` session files; other agent types are skipped.
+async fn restore_session(
+    sandbox: &dyn Sandbox,
+    context: &ExecutionContext,
+    session: &crate::types::ResumeSession,
+) -> RunnerResult<()> {
+    if !(context.cli_agent_type.is_empty() || context.cli_agent_type == "claude-code") {
+        return Ok(());
+    }
+
+    let project_name = context
+        .working_dir
+        .trim_start_matches('/')
+        .replace('/', "-");
+    let session_dir = format!("/home/user/.claude/projects/-{project_name}");
+    let session_path = format!("{session_dir}/{}.jsonl", session.session_id);
+
+    let mkdir_cmd = format!("mkdir -p \"{session_dir}\"");
+    sandbox
+        .exec(&ExecRequest {
+            cmd: &mkdir_cmd,
+            timeout_ms: DEFAULT_EXEC_TIMEOUT_MS,
+        })
+        .await?;
+    sandbox
+        .write_file(&session_path, session.session_history.as_bytes())
+        .await?;
+    info!(run_id = %context.run_id, path = %session_path, "restored session history");
+    Ok(())
+}
+
+/// Build the environment variables JSON, matching the TS `buildEnvironmentVariables`.
+fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, String> {
+    let mut env = HashMap::new();
+
+    env.insert("VM0_API_URL".into(), api_url.into());
+    env.insert("VM0_RUN_ID".into(), context.run_id.to_string());
+    env.insert("VM0_API_TOKEN".into(), context.sandbox_token.clone());
+    env.insert("VM0_PROMPT".into(), context.prompt.clone());
+    env.insert("VM0_WORKING_DIR".into(), context.working_dir.clone());
+    env.insert(
+        "VM0_API_START_TIME".into(),
+        context
+            .api_start_time
+            .map(|t| t.to_string())
+            .unwrap_or_default(),
+    );
+    env.insert(
+        "CLI_AGENT_TYPE".into(),
+        if context.cli_agent_type.is_empty() {
+            "claude-code".into()
+        } else {
+            context.cli_agent_type.clone()
+        },
+    );
+
+    // Vercel bypass
+    if let Ok(bypass) = std::env::var("VERCEL_AUTOMATION_BYPASS_SECRET") {
+        env.insert("VERCEL_PROTECTION_BYPASS".into(), bypass);
+    }
+
+    // Artifact config
+    if let Some(manifest) = &context.storage_manifest
+        && let Some(artifact) = &manifest.artifact
+    {
+        env.insert("VM0_ARTIFACT_DRIVER".into(), "vas".into());
+        env.insert(
+            "VM0_ARTIFACT_MOUNT_PATH".into(),
+            artifact.mount_path.clone(),
+        );
+        env.insert(
+            "VM0_ARTIFACT_VOLUME_NAME".into(),
+            artifact.vas_storage_name.clone(),
+        );
+        env.insert(
+            "VM0_ARTIFACT_VERSION_ID".into(),
+            artifact.vas_version_id.clone(),
+        );
+    }
+
+    // Resume session ID
+    if let Some(session) = &context.resume_session {
+        env.insert("VM0_RESUME_SESSION_ID".into(), session.session_id.clone());
+    }
+
+    // User environment variables
+    if let Some(user_env) = &context.environment {
+        for (k, v) in user_env {
+            env.insert(k.clone(), v.clone());
+        }
+    }
+
+    // Secret values (base64-encoded, comma-separated)
+    if let Some(secrets) = &context.secret_values
+        && !secrets.is_empty()
+    {
+        use base64::Engine as _;
+        let encoded: Vec<String> = secrets
+            .iter()
+            .map(|s| base64::engine::general_purpose::STANDARD.encode(s))
+            .collect();
+        env.insert("VM0_SECRET_VALUES".into(), encoded.join(","));
+    }
+
+    // User vars (may override anything above, matching TS behavior)
+    if let Some(vars) = &context.vars {
+        for (k, v) in vars {
+            env.insert(k.clone(), v.clone());
+        }
+    }
+
+    env
+}

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -15,6 +15,7 @@ use std::time::Instant;
 use clap::{Args, Parser, Subcommand};
 use tracing_subscriber::fmt::time::FormatTime;
 
+use crate::error::{RunnerError, RunnerResult};
 use crate::paths::RunnerPaths;
 use crate::runner::RunConfig;
 use crate::status::StatusTracker;
@@ -110,7 +111,7 @@ async fn main() -> ExitCode {
     ExitCode::SUCCESS
 }
 
-async fn run_start(args: StartArgs) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_start(args: StartArgs) -> RunnerResult<()> {
     let firecracker = resolve_path(args.firecracker).await?;
     let kernel = resolve_path(args.kernel).await?;
     let rootfs = resolve_path(args.rootfs).await?;
@@ -161,13 +162,15 @@ async fn run_start(args: StartArgs) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-async fn resolve_path(path: PathBuf) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    Ok(tokio::fs::canonicalize(&path)
+async fn resolve_path(path: PathBuf) -> RunnerResult<PathBuf> {
+    tokio::fs::canonicalize(&path)
         .await
-        .map_err(|e| format!("resolve path {}: {e}", path.display()))?)
+        .map_err(|e| RunnerError::Config(format!("resolve path {}: {e}", path.display())))
 }
 
-async fn resolve_or_create(path: PathBuf) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    tokio::fs::create_dir_all(&path).await?;
+async fn resolve_or_create(path: PathBuf) -> RunnerResult<PathBuf> {
+    tokio::fs::create_dir_all(&path)
+        .await
+        .map_err(|e| RunnerError::Config(format!("create dir {}: {e}", path.display())))?;
     resolve_path(path).await
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1,0 +1,173 @@
+mod api;
+mod error;
+mod executor;
+mod paths;
+mod runner;
+mod status;
+mod types;
+
+use std::fmt;
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::sync::Arc;
+use std::time::Instant;
+
+use clap::{Args, Parser, Subcommand};
+use tracing_subscriber::fmt::time::FormatTime;
+
+use crate::paths::RunnerPaths;
+use crate::runner::RunConfig;
+use crate::status::StatusTracker;
+
+struct Elapsed(Instant);
+
+impl FormatTime for Elapsed {
+    fn format_time(&self, w: &mut tracing_subscriber::fmt::format::Writer<'_>) -> fmt::Result {
+        let d = self.0.elapsed();
+        let total_secs = d.as_secs();
+        let mins = total_secs / 60;
+        let secs = total_secs % 60;
+        let millis = d.subsec_millis();
+        write!(w, "[{mins:02}:{secs:02}:{millis:03}]")
+    }
+}
+
+#[derive(Parser)]
+#[command(name = "runner")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Start the runner and poll for jobs
+    Start(StartArgs),
+}
+
+#[derive(Args)]
+struct StartArgs {
+    /// Path to the Firecracker binary
+    #[arg(long)]
+    firecracker: PathBuf,
+    /// Path to the guest kernel image
+    #[arg(long)]
+    kernel: PathBuf,
+    /// Path to the root filesystem image
+    #[arg(long)]
+    rootfs: PathBuf,
+    /// vm0 API URL
+    #[arg(long, env = "VM0_API_URL")]
+    api_url: String,
+    /// Runner authentication token
+    #[arg(long, env = "VM0_RUNNER_TOKEN")]
+    token: String,
+    /// Runner group in scope/name format (e.g. "acme/production")
+    #[arg(long)]
+    group: String,
+    /// Base directory for runtime data
+    #[arg(long)]
+    base_dir: PathBuf,
+    /// Snapshot directory to restore from
+    #[arg(long)]
+    snapshot_dir: Option<PathBuf>,
+    /// Maximum concurrent job executions
+    #[arg(long, default_value_t = 1)]
+    max_concurrent: usize,
+    /// vCPUs per sandbox
+    #[arg(long, default_value_t = 2)]
+    vcpu: u32,
+    /// Memory (MiB) per sandbox
+    #[arg(long, default_value_t = 2048)]
+    memory_mb: u32,
+    /// HTTP/HTTPS proxy port for network security
+    #[arg(long)]
+    proxy_port: Option<u16>,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_timer(Elapsed(Instant::now()))
+        .init();
+
+    if nix::unistd::getuid().is_root() {
+        eprintln!("error: runner must not be run as root (it calls sudo internally as needed)");
+        return ExitCode::FAILURE;
+    }
+
+    let cli = Cli::parse();
+
+    let result = match cli.command {
+        Command::Start(args) => run_start(args).await,
+    };
+
+    if let Err(e) = result {
+        eprintln!("error: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    ExitCode::SUCCESS
+}
+
+async fn run_start(args: StartArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let firecracker = resolve_path(args.firecracker).await?;
+    let kernel = resolve_path(args.kernel).await?;
+    let rootfs = resolve_path(args.rootfs).await?;
+    let base_dir = resolve_or_create(args.base_dir).await?;
+
+    let snapshot = match args.snapshot_dir {
+        Some(dir) => {
+            let dir = resolve_path(dir).await?;
+            let output = sandbox_fc::SnapshotOutputPaths::new(dir.clone());
+            let work = sandbox_fc::SandboxPaths::new(dir.join("work"));
+            Some(sandbox_fc::SnapshotConfig {
+                snapshot_path: output.snapshot(),
+                memory_path: output.memory(),
+                overlay_path: output.overlay(),
+                overlay_bind_path: work.overlay(),
+                vsock_bind_dir: work.vsock_dir(),
+            })
+        }
+        None => None,
+    };
+
+    let fc_config = sandbox_fc::FirecrackerConfig {
+        binary_path: firecracker,
+        kernel_path: kernel,
+        rootfs_path: rootfs,
+        base_dir: base_dir.clone(),
+        concurrency: args.max_concurrent,
+        proxy_port: args.proxy_port,
+        snapshot,
+    };
+
+    let paths = RunnerPaths::new(base_dir);
+    let status = Arc::new(StatusTracker::new(paths.status()));
+
+    let config = RunConfig {
+        api_url: args.api_url,
+        token: args.token,
+        group: args.group,
+        fc_config,
+        max_concurrent: args.max_concurrent,
+        vcpu: args.vcpu,
+        memory_mb: args.memory_mb,
+        status,
+    };
+
+    runner::run(config).await?;
+
+    Ok(())
+}
+
+async fn resolve_path(path: PathBuf) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    Ok(tokio::fs::canonicalize(&path)
+        .await
+        .map_err(|e| format!("resolve path {}: {e}", path.display()))?)
+}
+
+async fn resolve_or_create(path: PathBuf) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    tokio::fs::create_dir_all(&path).await?;
+    resolve_path(path).await
+}

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -73,7 +73,7 @@ struct StartArgs {
     #[arg(long)]
     snapshot_dir: Option<PathBuf>,
     /// Maximum concurrent job executions
-    #[arg(long, default_value_t = 1)]
+    #[arg(long, default_value_t = 4)]
     max_concurrent: usize,
     /// vCPUs per sandbox
     #[arg(long, default_value_t = 2)]

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -1,0 +1,24 @@
+use std::path::PathBuf;
+
+/// Guest paths (must match rootfs layout).
+pub mod guest {
+    pub const ENV_JSON: &str = "/tmp/vm0-env.json";
+    pub const STORAGE_MANIFEST: &str = "/tmp/storage-manifest.json";
+    pub const DOWNLOAD_BIN: &str = "/usr/local/bin/guest-download";
+    pub const ENV_LOADER: &str = "/usr/local/bin/vm0-agent/env-loader.mjs";
+}
+
+/// Runner-level paths derived from the base directory.
+pub struct RunnerPaths {
+    base_dir: PathBuf,
+}
+
+impl RunnerPaths {
+    pub fn new(base_dir: PathBuf) -> Self {
+        Self { base_dir }
+    }
+
+    pub fn status(&self) -> PathBuf {
+        self.base_dir.join("status.json")
+    }
+}

--- a/crates/runner/src/runner.rs
+++ b/crates/runner/src/runner.rs
@@ -1,0 +1,229 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use sandbox_fc::FirecrackerFactory;
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+use tracing::{error, info};
+
+use crate::api::ApiClient;
+use crate::error::RunnerError;
+use crate::executor::{self, ExecutorConfig};
+use crate::status::{RunnerMode, StatusTracker};
+
+const POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Top-level configuration passed from CLI.
+pub struct RunConfig {
+    pub api_url: String,
+    pub token: String,
+    pub group: String,
+    pub fc_config: sandbox_fc::FirecrackerConfig,
+    pub max_concurrent: usize,
+    pub vcpu: u32,
+    pub memory_mb: u32,
+    pub status: Arc<StatusTracker>,
+}
+
+/// Run the main poll loop until a shutdown signal is received.
+pub async fn run(config: RunConfig) -> Result<(), RunnerError> {
+    let factory = FirecrackerFactory::new(config.fc_config.clone())
+        .await
+        .map_err(|e| RunnerError::Internal(format!("factory init: {e}")))?;
+    let factory = Arc::new(factory);
+
+    let api = ApiClient::new(config.api_url.clone(), config.token.clone())?;
+    let semaphore = Arc::new(Semaphore::new(config.max_concurrent));
+    let mut jobs = JoinSet::new();
+
+    let is_snapshot = config.fc_config.snapshot.is_some();
+    let exec_config = Arc::new(ExecutorConfig {
+        api_url: config.api_url.clone(),
+        vcpu: config.vcpu,
+        memory_mb: config.memory_mb,
+        is_snapshot,
+    });
+
+    config.status.write_initial().await;
+    info!(
+        group = %config.group,
+        max_concurrent = config.max_concurrent,
+        "runner started, polling for jobs"
+    );
+
+    // -----------------------------------------------------------------------
+    // Signal handling
+    // -----------------------------------------------------------------------
+    let (mode_tx, mut mode_rx) = tokio::sync::watch::channel(RunnerMode::Running);
+
+    tokio::spawn(async move {
+        use tokio::signal::unix::{SignalKind, signal};
+
+        let mut sigterm = signal(SignalKind::terminate()).ok();
+        let mut sigint = signal(SignalKind::interrupt()).ok();
+        let mut sigusr1 = signal(SignalKind::user_defined1()).ok();
+
+        loop {
+            tokio::select! {
+                _ = recv_signal(&mut sigterm) => {
+                    info!("received SIGTERM, stopping");
+                    let _ = mode_tx.send(RunnerMode::Stopping);
+                    return;
+                }
+                _ = recv_signal(&mut sigint) => {
+                    info!("received SIGINT, stopping");
+                    let _ = mode_tx.send(RunnerMode::Stopping);
+                    return;
+                }
+                _ = recv_signal(&mut sigusr1) => {
+                    info!("received SIGUSR1, draining (no new jobs)");
+                    let _ = mode_tx.send(RunnerMode::Draining);
+                }
+            }
+        }
+    });
+
+    // -----------------------------------------------------------------------
+    // Poll loop
+    // -----------------------------------------------------------------------
+    let mut current_mode = RunnerMode::Running;
+    loop {
+        let mode = *mode_rx.borrow_and_update();
+        if mode != current_mode {
+            current_mode = mode;
+            config.status.set_mode(mode).await;
+        }
+        match mode {
+            RunnerMode::Stopping | RunnerMode::Stopped => break,
+            RunnerMode::Draining => {
+                // Don't accept new jobs, wait for running ones to complete
+                if jobs.is_empty() {
+                    info!("all jobs drained");
+                    break;
+                }
+                tokio::select! {
+                    _ = mode_rx.changed() => {}
+                    result = jobs.join_next() => {
+                        if let Some(Err(e)) = result {
+                            error!(error = %e, "job task panicked");
+                        }
+                    }
+                }
+                continue;
+            }
+            RunnerMode::Running => {}
+        }
+
+        // If all permits are taken, wait for a job to finish or mode change
+        if semaphore.available_permits() == 0 {
+            tokio::select! {
+                _ = mode_rx.changed() => {}
+                result = jobs.join_next() => {
+                    if let Some(Err(e)) = result {
+                        error!(error = %e, "job task panicked");
+                    }
+                }
+            }
+            continue;
+        }
+
+        // Poll for a job
+        let poll_result = tokio::select! {
+            result = api.poll(&config.group) => result,
+            _ = mode_rx.changed() => continue,
+        };
+
+        let job = match poll_result {
+            Ok(Some(job)) => job,
+            Ok(None) => {
+                // No work available — wait before re-polling
+                tokio::select! {
+                    _ = tokio::time::sleep(POLL_INTERVAL) => {}
+                    _ = mode_rx.changed() => {}
+                }
+                continue;
+            }
+            Err(e) => {
+                error!(error = %e, "poll failed, retrying in 5s");
+                tokio::select! {
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {}
+                    _ = mode_rx.changed() => {}
+                }
+                continue;
+            }
+        };
+
+        let run_id = job.run_id;
+        info!(run_id = %run_id, "job received, claiming");
+
+        // Claim the job
+        let context = match api.claim(run_id).await {
+            Ok(ctx) => ctx,
+            Err(RunnerError::AlreadyClaimed) => {
+                info!(run_id = %run_id, "job already claimed, skipping");
+                continue;
+            }
+            Err(e) => {
+                error!(run_id = %run_id, error = %e, "claim failed");
+                continue;
+            }
+        };
+
+        info!(run_id = %run_id, "job claimed, spawning executor");
+
+        // Acquire semaphore permit
+        let permit = match semaphore.clone().acquire_owned().await {
+            Ok(p) => p,
+            Err(_) => {
+                error!("semaphore closed unexpectedly");
+                break;
+            }
+        };
+
+        // Track active run
+        config.status.add_run(run_id).await;
+
+        let api = api.clone();
+        let factory = Arc::clone(&factory);
+        let exec_config = Arc::clone(&exec_config);
+        let status = Arc::clone(&config.status);
+
+        jobs.spawn(async move {
+            executor::execute_job(&api, factory.as_ref(), context, &exec_config).await;
+            status.remove_run(run_id).await;
+            drop(permit);
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Drain running jobs (for Stopping — Draining already drained above)
+    // -----------------------------------------------------------------------
+    let remaining = jobs.len();
+    if remaining > 0 {
+        info!(remaining, "waiting for running jobs to finish");
+        while let Some(result) = jobs.join_next().await {
+            if let Err(e) = result {
+                error!(error = %e, "job task panicked during drain");
+            }
+        }
+    }
+
+    // Cleanup factory pools
+    info!("cleaning up factory");
+    factory.cleanup().await;
+
+    config.status.set_mode(RunnerMode::Stopped).await;
+    info!("runner stopped");
+
+    Ok(())
+}
+
+/// Await a signal if registered, or pend forever if registration failed.
+async fn recv_signal(sig: &mut Option<tokio::signal::unix::Signal>) {
+    match sig {
+        Some(s) => {
+            s.recv().await;
+        }
+        None => std::future::pending().await,
+    }
+}

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -61,29 +61,29 @@ impl StatusTracker {
     pub async fn set_mode(&self, mode: RunnerMode) {
         let mut state = self.state.lock().await;
         state.mode = mode;
-        self.write_status(&state);
+        self.write_status(&state).await;
     }
 
     pub async fn add_run(&self, run_id: Uuid) {
         let mut state = self.state.lock().await;
         state.active_run_ids.insert(run_id);
-        self.write_status(&state);
+        self.write_status(&state).await;
     }
 
     pub async fn remove_run(&self, run_id: Uuid) {
         let mut state = self.state.lock().await;
         state.active_run_ids.remove(&run_id);
-        self.write_status(&state);
+        self.write_status(&state).await;
     }
 
     /// Write the initial status file.
     pub async fn write_initial(&self) {
         let state = self.state.lock().await;
-        self.write_status(&state);
+        self.write_status(&state).await;
     }
 
     /// Atomic write: write to a temp file in the same directory, then rename.
-    fn write_status(&self, state: &MutableState) {
+    async fn write_status(&self, state: &MutableState) {
         let status = RunnerStatus {
             mode: state.mode,
             active_runs: state.active_run_ids.len(),
@@ -101,11 +101,11 @@ impl StatusTracker {
         };
 
         let tmp = self.path.with_extension("tmp");
-        if let Err(e) = std::fs::write(&tmp, json.as_bytes()) {
+        if let Err(e) = tokio::fs::write(&tmp, json.as_bytes()).await {
             warn!(error = %e, path = %tmp.display(), "failed to write status temp file");
             return;
         }
-        if let Err(e) = std::fs::rename(&tmp, &self.path) {
+        if let Err(e) = tokio::fs::rename(&tmp, &self.path).await {
             warn!(error = %e, "failed to rename status file");
         }
     }

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -1,0 +1,112 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use tokio::sync::Mutex;
+use tracing::warn;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RunnerMode {
+    Running,
+    Draining,
+    Stopping,
+    Stopped,
+}
+
+#[derive(Debug, Serialize)]
+struct RunnerStatus {
+    mode: RunnerMode,
+    active_runs: usize,
+    active_run_ids: Vec<Uuid>,
+    #[serde(serialize_with = "serialize_iso")]
+    started_at: DateTime<Utc>,
+    #[serde(serialize_with = "serialize_iso")]
+    updated_at: DateTime<Utc>,
+}
+
+/// Serialize as ISO 8601 with millisecond precision, matching JS `Date.toISOString()`.
+fn serialize_iso<S: serde::Serializer>(dt: &DateTime<Utc>, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_str(&dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
+}
+
+/// Thread-safe status tracker that persists state to a JSON file atomically.
+///
+/// Share via `Arc<StatusTracker>` — immutable fields live outside the mutex.
+pub struct StatusTracker {
+    started_at: DateTime<Utc>,
+    path: PathBuf,
+    state: Mutex<MutableState>,
+}
+
+struct MutableState {
+    mode: RunnerMode,
+    active_run_ids: HashSet<Uuid>,
+}
+
+impl StatusTracker {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            started_at: Utc::now(),
+            path,
+            state: Mutex::new(MutableState {
+                mode: RunnerMode::Running,
+                active_run_ids: HashSet::new(),
+            }),
+        }
+    }
+
+    pub async fn set_mode(&self, mode: RunnerMode) {
+        let mut state = self.state.lock().await;
+        state.mode = mode;
+        self.write_status(&state);
+    }
+
+    pub async fn add_run(&self, run_id: Uuid) {
+        let mut state = self.state.lock().await;
+        state.active_run_ids.insert(run_id);
+        self.write_status(&state);
+    }
+
+    pub async fn remove_run(&self, run_id: Uuid) {
+        let mut state = self.state.lock().await;
+        state.active_run_ids.remove(&run_id);
+        self.write_status(&state);
+    }
+
+    /// Write the initial status file.
+    pub async fn write_initial(&self) {
+        let state = self.state.lock().await;
+        self.write_status(&state);
+    }
+
+    /// Atomic write: write to a temp file in the same directory, then rename.
+    fn write_status(&self, state: &MutableState) {
+        let status = RunnerStatus {
+            mode: state.mode,
+            active_runs: state.active_run_ids.len(),
+            active_run_ids: state.active_run_ids.iter().copied().collect(),
+            started_at: self.started_at,
+            updated_at: Utc::now(),
+        };
+
+        let json = match serde_json::to_string_pretty(&status) {
+            Ok(j) => j,
+            Err(e) => {
+                warn!(error = %e, "failed to serialize status");
+                return;
+            }
+        };
+
+        let tmp = self.path.with_extension("tmp");
+        if let Err(e) = std::fs::write(&tmp, json.as_bytes()) {
+            warn!(error = %e, path = %tmp.display(), "failed to write status temp file");
+            return;
+        }
+        if let Err(e) = std::fs::rename(&tmp, &self.path) {
+            warn!(error = %e, "failed to rename status file");
+        }
+    }
+}

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -110,3 +110,90 @@ impl StatusTracker {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_status(path: &std::path::Path) -> serde_json::Value {
+        let content = std::fs::read_to_string(path).unwrap();
+        serde_json::from_str(&content).unwrap()
+    }
+
+    #[tokio::test]
+    async fn write_initial_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let tracker = StatusTracker::new(path.clone());
+
+        tracker.write_initial().await;
+
+        let status = read_status(&path);
+        assert_eq!(status["mode"], "running");
+        assert_eq!(status["active_runs"], 0);
+        assert!(status["active_run_ids"].as_array().unwrap().is_empty());
+        assert!(status["started_at"].as_str().is_some());
+        assert!(status["updated_at"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn set_mode_updates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let tracker = StatusTracker::new(path.clone());
+
+        tracker.write_initial().await;
+        tracker.set_mode(RunnerMode::Draining).await;
+
+        let status = read_status(&path);
+        assert_eq!(status["mode"], "draining");
+    }
+
+    #[tokio::test]
+    async fn add_and_remove_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let tracker = StatusTracker::new(path.clone());
+
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+
+        tracker.write_initial().await;
+        tracker.add_run(id1).await;
+        tracker.add_run(id2).await;
+
+        let status = read_status(&path);
+        assert_eq!(status["active_runs"], 2);
+        assert_eq!(status["active_run_ids"].as_array().unwrap().len(), 2);
+
+        tracker.remove_run(id1).await;
+
+        let status = read_status(&path);
+        assert_eq!(status["active_runs"], 1);
+
+        let ids: Vec<String> = status["active_run_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert!(ids.contains(&id2.to_string()));
+        assert!(!ids.contains(&id1.to_string()));
+    }
+
+    #[tokio::test]
+    async fn timestamps_are_iso8601() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let tracker = StatusTracker::new(path.clone());
+
+        tracker.write_initial().await;
+
+        let status = read_status(&path);
+        let started = status["started_at"].as_str().unwrap();
+        // ISO 8601 format: YYYY-MM-DDTHH:MM:SS.mmmZ
+        assert!(started.ends_with('Z'));
+        assert!(started.contains('T'));
+        assert_eq!(started.len(), 24); // "2026-02-10T12:34:56.789Z"
+    }
+}

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1,0 +1,92 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Poll
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PollResponse {
+    pub job: Option<Job>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Job {
+    pub run_id: Uuid,
+}
+
+// ---------------------------------------------------------------------------
+// Claim (execution context)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutionContext {
+    pub run_id: Uuid,
+    pub prompt: String,
+    #[serde(default)]
+    pub vars: Option<HashMap<String, String>>,
+    pub sandbox_token: String,
+    pub working_dir: String,
+    #[serde(default)]
+    pub storage_manifest: Option<StorageManifest>,
+    #[serde(default)]
+    pub environment: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub resume_session: Option<ResumeSession>,
+    #[serde(default)]
+    pub secret_values: Option<Vec<String>>,
+    pub cli_agent_type: String,
+    #[serde(default)]
+    pub api_start_time: Option<f64>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageManifest {
+    pub storages: Vec<StorageEntry>,
+    #[serde(default)]
+    pub artifact: Option<ArtifactEntry>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageEntry {
+    pub mount_path: String,
+    #[serde(default)]
+    pub archive_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactEntry {
+    pub mount_path: String,
+    #[serde(default)]
+    pub archive_url: Option<String>,
+    pub vas_storage_name: String,
+    pub vas_version_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResumeSession {
+    pub session_id: String,
+    pub session_history: String,
+}
+
+// ---------------------------------------------------------------------------
+// Complete
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompleteRequest {
+    pub run_id: Uuid,
+    pub exit_code: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}

--- a/crates/sandbox-fc/src/main.rs
+++ b/crates/sandbox-fc/src/main.rs
@@ -4,6 +4,8 @@ use std::process::ExitCode;
 use std::time::Instant;
 
 use clap::{Parser, Subcommand};
+use std::time::Duration;
+
 use sandbox::{ExecRequest, ResourceLimits, SandboxConfig, SandboxFactory};
 use tracing_subscriber::fmt::time::FormatTime;
 use uuid::Uuid;
@@ -220,8 +222,6 @@ async fn run_exec(
         resources: ResourceLimits {
             cpu_count: vcpu_count,
             memory_mb,
-            // Sandbox-level lifetime cap (distinct from per-exec timeout_ms).
-            timeout_ms: 30_000,
         },
     };
 
@@ -231,7 +231,7 @@ async fn run_exec(
     let result = sandbox
         .exec(&ExecRequest {
             cmd,
-            timeout_ms: timeout,
+            timeout: Duration::from_millis(u64::from(timeout)),
         })
         .await?;
 

--- a/crates/sandbox-fc/src/main.rs
+++ b/crates/sandbox-fc/src/main.rs
@@ -1,11 +1,9 @@
 use std::fmt;
 use std::path::PathBuf;
 use std::process::ExitCode;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use clap::{Parser, Subcommand};
-use std::time::Duration;
-
 use sandbox::{ExecRequest, ResourceLimits, SandboxConfig, SandboxFactory};
 use tracing_subscriber::fmt::time::FormatTime;
 use uuid::Uuid;

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -1,7 +1,6 @@
 pub struct ResourceLimits {
     pub cpu_count: u32,
     pub memory_mb: u32,
-    pub timeout_ms: u32,
 }
 
 pub struct SandboxConfig {

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -13,6 +13,7 @@ pub trait Sandbox: Send + Sync + Any {
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult>;
     async fn write_file(&self, path: &str, content: &[u8]) -> Result<()>;
     async fn spawn_watch(&self, request: &ExecRequest<'_>) -> Result<SpawnHandle>;
+    // TODO: add timeout parameter so ResourceLimits no longer needs timeout_ms
     async fn wait_exit(&self, handle: SpawnHandle) -> Result<ProcessExit>;
     async fn stop(&mut self) -> Result<()>;
     async fn kill(&mut self) -> Result<()>;

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::time::Duration;
 
 use async_trait::async_trait;
 
@@ -13,8 +14,7 @@ pub trait Sandbox: Send + Sync + Any {
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult>;
     async fn write_file(&self, path: &str, content: &[u8]) -> Result<()>;
     async fn spawn_watch(&self, request: &ExecRequest<'_>) -> Result<SpawnHandle>;
-    // TODO: add timeout parameter so ResourceLimits no longer needs timeout_ms
-    async fn wait_exit(&self, handle: SpawnHandle) -> Result<ProcessExit>;
+    async fn wait_exit(&self, handle: SpawnHandle, timeout: Duration) -> Result<ProcessExit>;
     async fn stop(&mut self) -> Result<()>;
     async fn kill(&mut self) -> Result<()>;
     fn id(&self) -> &str;

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -1,6 +1,15 @@
+use std::time::Duration;
+
 pub struct ExecRequest<'a> {
     pub cmd: &'a str,
-    pub timeout_ms: u32,
+    pub timeout: Duration,
+}
+
+impl ExecRequest<'_> {
+    /// Return the timeout as whole milliseconds, saturating at `u32::MAX`.
+    pub fn timeout_ms(&self) -> u32 {
+        u32::try_from(self.timeout.as_millis()).unwrap_or(u32::MAX)
+    }
 }
 
 pub struct ExecResult {


### PR DESCRIPTION
## Summary

- Add `runner` crate that replaces the TypeScript runner (`turbo/apps/runner`) with a Rust implementation
- Polls the vm0 API for jobs, claims them, executes inside Firecracker VMs via `sandbox`/`sandbox-fc` crates, and reports completion
- MVP scope: HTTP polling only (no Ably), multi-runner from day 1, no firewall/proxy

### Crate structure

| File | Purpose |
|------|---------|
| `main.rs` | CLI (clap), tracing init, entry point |
| `api.rs` | HTTP client: poll, claim, complete (reqwest) |
| `types.rs` | Serde structs matching TS contracts |
| `runner.rs` | Poll loop, concurrency (Semaphore + JoinSet), signal-based shutdown |
| `executor.rs` | Job execution: sandbox lifecycle, env setup, agent spawn |
| `status.rs` | Atomic JSON status file for monitoring |
| `paths.rs` | Host and guest path constants |
| `error.rs` | Error types |

### Key design decisions

- **Signal handling**: SIGTERM/SIGINT → Stopping (break loop, drain jobs), SIGUSR1 → Draining (stop polling, wait for jobs in-loop, can escalate to Stopping)
- **Concurrency**: `Semaphore` + `JoinSet` for bounded concurrent job execution
- **Session restore**: Only for `claude-code` agent type (whitelist), with empty `cli_agent_type` defaulting to `claude-code`
- **Timeouts**: `DEFAULT_EXEC_TIMEOUT_MS` (5min) for guest commands, `JOB_TIMEOUT_MS` (2h) for agent — matching TS values

## Test plan

- [ ] `cargo clippy -p runner` passes (verified)
- [ ] `cargo build -p runner` passes (verified)
- [ ] Manual test with Firecracker + API server

🤖 Generated with [Claude Code](https://claude.com/claude-code)