### PR TITLE
feat(cli): enable GitHub URL compose without experimental flag

### DIFF
--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -595,7 +595,7 @@ export const composeCommand = new Command()
   .option("-y, --yes", "Skip confirmation prompts for skill requirements")
   .option(
     "--experimental-shared-compose",
-    "Enable GitHub URL compose (experimental)",
+    "[deprecated] No longer required, kept for backward compatibility",
   )
   .option("--json", "Output JSON for scripts (suppresses interactive output)")
   .option(
@@ -641,33 +641,6 @@ export const composeCommand = new Command()
 
         // Branch based on input type
         if (isGitHubUrl(resolvedConfigFile)) {
-          // Require experimental flag for GitHub URLs
-          if (!options.experimentalSharedCompose) {
-            if (options.json) {
-              console.log(
-                JSON.stringify({
-                  error:
-                    "Composing shared agents requires --experimental-shared-compose flag",
-                }),
-              );
-            } else {
-              console.error(
-                chalk.red(
-                  "✗ Composing shared agents requires --experimental-shared-compose flag",
-                ),
-              );
-              console.error();
-              console.error(
-                chalk.dim(
-                  "  Composing agents from other users carries security risks.",
-                ),
-              );
-              console.error(
-                chalk.dim("  Only compose agents from users you trust."),
-              );
-            }
-            process.exit(1);
-          }
           result = await handleGitHubCompose(resolvedConfigFile, options);
         } else {
           // Existing local file flow


### PR DESCRIPTION
## Summary

- Remove `--experimental-shared-compose` flag requirement for GitHub URL compose
- Keep the flag as a deprecated no-op for backward compatibility
- Users can now run `vm0 compose https://github.com/owner/repo` directly

## Changes

- **CLI**: Updated option description to indicate deprecation, removed flag check logic
- **Tests**: Removed tests for flag requirement, added backward compatibility test, updated all test cases

## Test plan

- [x] All 81 compose tests pass
- [x] Lint passes
- [x] Type check passes (CLI package)
- [ ] CI pipeline

## Note

Server-side `trigger-compose-job.ts` will be updated in a future PR after E2B `vm0-cli` template is updated with this CLI version.

Closes #2724

🤖 Generated with [Claude Code](https://claude.com/claude-code)