### PR TITLE
refactor(sandbox): clean up agent output logging in run-agent

### DIFF
--- a/turbo/packages/core/src/sandbox/scripts/src/run-agent.ts
+++ b/turbo/packages/core/src/sandbox/scripts/src/run-agent.ts
@@ -366,14 +366,6 @@ async function run(): Promise<[number, string]> {
           // Valid JSONL - send immediately with sequence number (0-based)
           await sendEvent(event, eventSequence);
           eventSequence++;
-
-          // Extract result from "result" event for stdout
-          if (event.type === "result") {
-            const resultContent = event.result as string | undefined;
-            if (resultContent) {
-              console.log(resultContent);
-            }
-          }
         } catch {
           // Not valid JSON - log at debug level and skip
           logDebug(`Non-JSON line from agent: ${stripped.slice(0, 100)}`);
@@ -454,7 +446,7 @@ async function run(): Promise<[number, string]> {
       } else if (stderrLines.length > 0) {
         // Captured stderr from agent process
         errorMessage = stderrLines.map((line) => line.trim()).join(" ");
-        logInfo(`Captured stderr: ${errorMessage}`);
+        logInfo(`Captured ${stderrLines.length} stderr lines`);
       } else {
         errorMessage = `Agent exited with code ${agentExitCode}`;
       }


### PR DESCRIPTION
## Summary
- Remove redundant `result` event stdout logging from `run-agent.ts` since events are already dispatched via `sendEvent` -- the `console.log` was duplicating output unnecessarily
- Reduce stderr log verbosity by logging the line count instead of the full stderr content, which could be excessively long or contain sensitive information

## Test plan
- [x] All 337 core package tests pass
- [x] Lint, type-check, prettier, and knip all pass
- [ ] Verify agent sandbox runs produce expected output without duplicate result lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)