### PR TITLE
feat(slack): add documentation link to app home and help command

### DIFF
--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -487,6 +487,16 @@ export function buildAppHomeView(options: {
     },
   });
 
+  blocks.push({
+    type: "context",
+    elements: [
+      {
+        type: "mrkdwn",
+        text: ":book: <https://docs.vm0.ai/docs/ecosystem/slack|View full documentation>",
+      },
+    ],
+  });
+
   blocks.push({ type: "divider" });
 
   blocks.push({
@@ -892,6 +902,15 @@ export function buildHelpMessage(): (Block | KnownBlock)[] {
         type: "mrkdwn",
         text: "*Usage*\n• `@VM0 <message>` - Send a message to your agent",
       },
+    },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: ":book: <https://docs.vm0.ai/docs/ecosystem/slack|View full documentation>",
+        },
+      ],
     },
   ];
 }


### PR DESCRIPTION
## Summary
- Add a link to the Slack integration documentation (`https://docs.vm0.ai/docs/ecosystem/slack`) in the App Home tab and `/vm0 help` command response

## Test plan
- [ ] Open the VM0 App Home in Slack and verify the documentation link appears
- [ ] Run `/vm0 help` and verify the documentation link appears at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)