### PR TITLE
feat(web): add eslint rule to forbid relative paths in vi.mock()

### DIFF
--- a/turbo/apps/web/custom-eslint/__tests__/no-relative-vi-mock.test.ts
+++ b/turbo/apps/web/custom-eslint/__tests__/no-relative-vi-mock.test.ts
@@ -1,0 +1,69 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { describe, it, afterAll } from "vitest";
+import rule from "../rules/no-relative-vi-mock.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-relative-vi-mock", rule, {
+  valid: [
+    {
+      code: 'vi.mock("@clerk/nextjs/server", () => ({}));',
+    },
+    {
+      code: 'vi.mock("next/server", () => ({}));',
+    },
+    {
+      code: 'vi.mock("ably", () => ({}));',
+    },
+    {
+      code: 'vi.mock("child_process");',
+    },
+    {
+      code: 'vi.mock("server-only", () => ({}));',
+    },
+    {
+      // doMock with package path is fine
+      code: 'vi.doMock("ably", () => ({}));',
+    },
+    {
+      // Not vi.mock - different object
+      code: 'jest.mock("../lib/utils");',
+    },
+    {
+      // Not vi.mock - different method
+      code: 'vi.fn("../lib/utils");',
+    },
+    {
+      // No arguments
+      code: "vi.mock();",
+    },
+  ],
+  invalid: [
+    {
+      code: 'vi.mock("../lib/utils", () => ({}));',
+      errors: [{ messageId: "noRelativeMock" }],
+    },
+    {
+      code: 'vi.mock("./helpers");',
+      errors: [{ messageId: "noRelativeMock" }],
+    },
+    {
+      code: 'vi.mock("../../services/auth", () => ({}));',
+      errors: [{ messageId: "noRelativeMock" }],
+    },
+    {
+      // doMock with relative path
+      code: 'vi.doMock("../lib/utils");',
+      errors: [{ messageId: "noRelativeMock" }],
+    },
+    {
+      // Template literal with relative path
+      code: "vi.mock(`../lib/utils`);",
+      errors: [{ messageId: "noRelativeMock" }],
+    },
+  ],
+});

--- a/turbo/apps/web/custom-eslint/index.ts
+++ b/turbo/apps/web/custom-eslint/index.ts
@@ -3,9 +3,11 @@
  *
  * Enforces testing best practices:
  * - no-direct-db-in-tests: Don't access database directly in test files
+ * - no-relative-vi-mock: Don't use relative paths in vi.mock()
  */
 
 import noDirectDbInTests from "./rules/no-direct-db-in-tests.ts";
+import noRelativeViMock from "./rules/no-relative-vi-mock.ts";
 
 const plugin = {
   meta: {
@@ -14,6 +16,7 @@ const plugin = {
   },
   rules: {
     "no-direct-db-in-tests": noDirectDbInTests,
+    "no-relative-vi-mock": noRelativeViMock,
   },
 };
 

--- a/turbo/apps/web/custom-eslint/rules/no-relative-vi-mock.ts
+++ b/turbo/apps/web/custom-eslint/rules/no-relative-vi-mock.ts
@@ -1,0 +1,85 @@
+/**
+ * ESLint rule: no-relative-vi-mock
+ *
+ * Prevents vi.mock() and vi.doMock() from using relative paths.
+ * Tests should only mock external dependencies (third-party packages,
+ * built-in Node.js modules), not internal project code.
+ *
+ * Good:
+ *   vi.mock("@clerk/nextjs/server", () => ({...}));
+ *   vi.mock("next/server", () => ({...}));
+ *   vi.mock("ably", () => ({...}));
+ *
+ * Bad:
+ *   vi.mock("../lib/utils", () => ({...}));
+ *   vi.mock("./helpers", () => ({...}));
+ *   vi.doMock("../../services/auth", () => ({...}));
+ */
+
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { createRule } from "../utils.ts";
+
+export default createRule({
+  name: "no-relative-vi-mock",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow relative paths in vi.mock(). Only external dependencies should be mocked.",
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      noRelativeMock:
+        "Do not use relative paths in vi.mock(). Only mock external dependencies (third-party packages, built-in modules). See CLAUDE.md testing guidelines.",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node: TSESTree.CallExpression) {
+        if (
+          node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+          node.callee.object.type !== AST_NODE_TYPES.Identifier ||
+          node.callee.object.name !== "vi" ||
+          node.callee.property.type !== AST_NODE_TYPES.Identifier ||
+          (node.callee.property.name !== "mock" &&
+            node.callee.property.name !== "doMock")
+        ) {
+          return;
+        }
+
+        const firstArg = node.arguments[0];
+        if (!firstArg) {
+          return;
+        }
+
+        let mockPath: string | undefined;
+
+        if (
+          firstArg.type === AST_NODE_TYPES.Literal &&
+          typeof firstArg.value === "string"
+        ) {
+          mockPath = firstArg.value;
+        } else if (firstArg.type === AST_NODE_TYPES.TemplateLiteral) {
+          if (
+            firstArg.quasis.length === 1 &&
+            firstArg.expressions.length === 0
+          ) {
+            mockPath = firstArg.quasis[0]?.value.cooked ?? undefined;
+          }
+        }
+
+        if (
+          mockPath &&
+          (mockPath.startsWith("./") || mockPath.startsWith("../"))
+        ) {
+          context.report({
+            node: firstArg,
+            messageId: "noRelativeMock",
+          });
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/web/eslint.config.js
+++ b/turbo/apps/web/eslint.config.js
@@ -28,6 +28,7 @@ export default [
     },
     rules: {
       "web/no-direct-db-in-tests": "error",
+      "web/no-relative-vi-mock": "error",
     },
   },
   {


### PR DESCRIPTION
## Summary

- Add custom ESLint rule `web/no-relative-vi-mock` that prevents `vi.mock()` and `vi.doMock()` from using relative paths
- Tests should only mock external dependencies (third-party packages, built-in modules), not internal project code
- Follows the existing `no-direct-db-in-tests` custom rule pattern
- Also detects template literal paths (`` vi.mock(`../foo`) ``)

## Test plan

- [x] 14 rule tests pass (valid + invalid cases)
- [x] Lint passes with zero warnings
- [x] Type check passes
- [x] Knip finds no unused code
- [x] No existing violations in web app (0 relative-path vi.mock calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)