### PR TITLE
feat(slack): add compose agent button to app home

### DIFF
--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../../src/db/schema/agent-compose";
 import {
   buildAgentAddModal,
+  buildAgentComposeModal,
   buildAgentUpdateModal,
 } from "../../../../src/lib/slack/blocks";
 import { decryptCredentialValue } from "../../../../src/lib/crypto/secrets-encryption";
@@ -548,6 +549,11 @@ async function dispatchBlockAction(
         await handleModelProviderRefresh(payload);
       }
       break;
+    case "home_agent_compose":
+      if (payload.trigger_id) {
+        await handleHomeAgentCompose(payload, payload.trigger_id);
+      }
+      break;
     case "home_disconnect":
       await handleHomeDisconnect(payload);
       break;
@@ -635,6 +641,26 @@ async function handleHomeAgentLink(
     channelId,
     hasModelProvider,
   );
+
+  await client.views.open({
+    trigger_id: triggerId,
+    view: modal,
+  });
+}
+
+/**
+ * Handle compose button on App Home
+ */
+async function handleHomeAgentCompose(
+  payload: SlackInteractivePayload,
+  triggerId: string,
+): Promise<void> {
+  const client = await getSlackClientForWorkspace(payload.team.id);
+  if (!client) {
+    return;
+  }
+
+  const modal = buildAgentComposeModal();
 
   await client.views.open({
     trigger_id: triggerId,

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -462,6 +462,23 @@ export function buildAppHomeView(options: {
 
   blocks.push({ type: "divider" });
 
+  // Compose section
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: ":rocket: *Compose Agent*\nCreate a new agent from a GitHub repository.",
+    },
+    accessory: {
+      type: "button",
+      text: { type: "plain_text", text: "Compose" },
+      action_id: "home_agent_compose",
+      style: "primary",
+    },
+  });
+
+  blocks.push({ type: "divider" });
+
   // Help section
   blocks.push({
     type: "section",


### PR DESCRIPTION
## Summary
- Add a "Compose Agent" button to the Slack App Home view that opens the agent compose modal
- Wire up the `home_agent_compose` block action in the interactive route handler to open the compose modal via `buildAgentComposeModal()`
- Add the compose section with a primary-styled button between the existing agent list and help sections

## Test plan
- [ ] Verify the App Home view renders with the new "Compose Agent" button
- [ ] Click the "Compose" button and verify the agent compose modal opens
- [ ] Verify existing App Home functionality (agent list, disconnect, help) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)