### PR TITLE
fix: exclude connector-provided secrets from missing-secrets checks

### DIFF
--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -52,6 +52,11 @@ export const apiHandlers = [
     return HttpResponse.json({ variables: [] }, { status: 200 });
   }),
 
+  // GET /api/connectors - listConnectors
+  http.get("http://localhost:3000/api/connectors", () => {
+    return HttpResponse.json({ connectors: [] }, { status: 200 });
+  }),
+
   // GET /api/scope - getScope
   http.get("http://localhost:3000/api/scope", () => {
     return HttpResponse.json(

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { eq, and, inArray } from "drizzle-orm";
-import { extractVariableReferences, groupVariablesBySource } from "@vm0/core";
+import {
+  extractVariableReferences,
+  groupVariablesBySource,
+  getConnectorProvidedSecretNames,
+} from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { env } from "../../../../src/env";
 import {
@@ -37,6 +41,7 @@ import { slackComposeRequests } from "../../../../src/db/schema/slack-compose-re
 import { generateEphemeralCliToken } from "../../../../src/lib/auth/cli-token-service";
 import { triggerComposeJob } from "../../../../src/lib/compose/trigger-compose-job";
 import { listModelProviders } from "../../../../src/lib/model-provider/model-provider-service";
+import { listConnectors } from "../../../../src/lib/connector/connector-service";
 
 const log = logger("slack:interactive");
 
@@ -220,12 +225,19 @@ async function fetchAvailableAgents(
           .where(inArray(agentComposeVersions.id, versionIds))
       : [];
 
-  // Get user's existing secrets and variables
-  const [userSecrets, userVars] = await Promise.all([
+  // Get user's existing secrets, variables, and connectors
+  const [userSecrets, userVars, userConnectors] = await Promise.all([
     listSecrets(vm0UserId),
     listVariables(vm0UserId),
+    listConnectors(vm0UserId),
   ]);
-  const existingSecretNames = new Set(userSecrets.map((s) => s.name));
+  const connectorProvided = getConnectorProvidedSecretNames(
+    userConnectors.map((c) => c.type),
+  );
+  const existingSecretNames = new Set([
+    ...userSecrets.map((s) => s.name),
+    ...connectorProvided,
+  ]);
   const existingVarNames = new Set(userVars.map((v) => v.name));
 
   // Build map of compose ID to required secrets and vars
@@ -305,12 +317,19 @@ async function fetchBoundAgents(
           .where(inArray(agentComposeVersions.id, versionIds))
       : [];
 
-  // Get user's existing secrets and variables
-  const [userSecrets, userVars] = await Promise.all([
+  // Get user's existing secrets, variables, and connectors
+  const [userSecrets, userVars, userConnectors] = await Promise.all([
     listSecrets(vm0UserId),
     listVariables(vm0UserId),
+    listConnectors(vm0UserId),
   ]);
-  const existingSecretNames = new Set(userSecrets.map((s) => s.name));
+  const connectorProvided = getConnectorProvidedSecretNames(
+    userConnectors.map((c) => c.type),
+  );
+  const existingSecretNames = new Set([
+    ...userSecrets.map((s) => s.name),
+    ...connectorProvided,
+  ]);
   const existingVarNames = new Set(userVars.map((v) => v.name));
 
   // Build map of compose ID to required secrets and vars

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -169,6 +169,32 @@ export function getConnectorDerivedNames(
 }
 
 /**
+ * Get the set of environment variable names that connected connectors can provide.
+ * Used by pre-run checks to exclude connector-provided secrets from "missing" lists.
+ *
+ * Example: getConnectorProvidedSecretNames(["github"])
+ * → Set { "GH_TOKEN", "GITHUB_TOKEN" }
+ */
+export function getConnectorProvidedSecretNames(
+  connectedTypes: string[],
+): Set<string> {
+  const provided = new Set<string>();
+
+  for (const rawType of connectedTypes) {
+    const parsed = connectorTypeSchema.safeParse(rawType);
+    if (!parsed.success) {
+      continue;
+    }
+    const mapping = getConnectorEnvironmentMapping(parsed.data);
+    for (const envVar of Object.keys(mapping)) {
+      provided.add(envVar);
+    }
+  }
+
+  return provided;
+}
+
+/**
  * Get OAuth configuration for a connector type
  */
 export function getConnectorOAuthConfig(

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -403,6 +403,7 @@ export {
   getConnectorSecretNames,
   getConnectorEnvironmentMapping,
   getConnectorDerivedNames,
+  getConnectorProvidedSecretNames,
   getConnectorOAuthConfig,
   type ConnectorsMainContract,
   type ConnectorsByTypeContract,


### PR DESCRIPTION
## Summary

- Added `getConnectorProvidedSecretNames()` utility to `@vm0/core` that maps connected connector types to the env var names they provide at runtime
- Updated CLI `compose` command to fetch user connectors and exclude connector-mapped secrets (e.g., `GH_TOKEN`, `GITHUB_TOKEN` from GitHub connector) from the missing-secrets warning
- Updated Slack `agent link` and `agent update` flows in both `commands/route.ts` and `interactive/route.ts` to include connector-provided secrets in the "existing" set
- Added default `/api/connectors` MSW handler and `createConnector` test helper

Closes #2747

## Test plan

- [x] CLI compose: agent with `${{ secrets.GH_TOKEN }}` + GitHub connector connected → no missing warning
- [x] CLI compose: agent with `${{ secrets.GH_TOKEN }}` + no connector → still shows missing warning
- [x] All existing CLI compose tests pass (89 tests)
- [x] All existing Slack commands tests pass (17 tests)
- [x] All existing Slack interactive tests pass (22 tests)
- [x] Type check, lint, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)