### PR TITLE
refactor(guest-common): accept duration type in record_sandbox_op

### DIFF
--- a/crates/guest-common/src/telemetry.rs
+++ b/crates/guest-common/src/telemetry.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::sync::LazyLock;
+use std::time::Duration;
 
 static RUN_ID: LazyLock<String> = LazyLock::new(|| std::env::var("VM0_RUN_ID").unwrap_or_default());
 
@@ -30,11 +31,16 @@ struct SandboxOpEntry {
 ///
 /// Writes a JSONL entry to `/tmp/vm0-sandbox-ops-{RUN_ID}.jsonl`.
 /// Format is compatible with the TypeScript version for consistency.
-pub fn record_sandbox_op(action_type: &str, duration_ms: u64, success: bool, error: Option<&str>) {
+pub fn record_sandbox_op(
+    action_type: &str,
+    duration: Duration,
+    success: bool,
+    error: Option<&str>,
+) {
     let entry = SandboxOpEntry {
         ts: log::timestamp(),
         action_type: action_type.to_string(),
-        duration_ms,
+        duration_ms: duration.as_millis() as u64,
         success,
         error: error.map(String::from),
     };

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -74,13 +74,13 @@ fn main() {
 
     let start = Instant::now();
     let success = run(manifest_path);
-    let duration_ms = start.elapsed().as_millis() as u64;
+    let elapsed = start.elapsed();
 
     if success {
-        record_sandbox_op("download_total", duration_ms, true, None);
-        log_info!(LOG_TAG, "Download completed in {duration_ms}ms");
+        record_sandbox_op("download_total", elapsed, true, None);
+        log_info!(LOG_TAG, "Download completed in {}ms", elapsed.as_millis());
     } else {
-        record_sandbox_op("download_total", duration_ms, false, None);
+        record_sandbox_op("download_total", elapsed, false, None);
         log_error!(LOG_TAG, "Download failed");
         std::process::exit(1);
     }
@@ -121,13 +121,12 @@ fn run(manifest_path: &str) -> bool {
 
         match download_with_retry(url, &artifact.mount_path) {
             Ok(()) => {
-                let duration_ms = start.elapsed().as_millis() as u64;
-                record_sandbox_op("artifact_download", duration_ms, true, None);
-                log_info!(LOG_TAG, "Artifact downloaded in {duration_ms}ms");
+                let elapsed = start.elapsed();
+                record_sandbox_op("artifact_download", elapsed, true, None);
+                log_info!(LOG_TAG, "Artifact downloaded in {}ms", elapsed.as_millis());
             }
             Err(e) => {
-                let duration_ms = start.elapsed().as_millis() as u64;
-                record_sandbox_op("artifact_download", duration_ms, false, Some(&e));
+                record_sandbox_op("artifact_download", start.elapsed(), false, Some(&e));
                 log_error!(LOG_TAG, "Artifact download failed: {e}");
                 all_success = false;
             }
@@ -181,20 +180,20 @@ fn download_storages_parallel(storages: &[Storage]) -> bool {
                     log_info!(LOG_TAG, "Downloading storage {} to {}", idx + 1, mount_path);
 
                     let result = download_with_retry(&url, &mount_path);
-                    let duration_ms = start.elapsed().as_millis() as u64;
+                    let elapsed = start.elapsed();
 
                     match &result {
                         Ok(()) => {
-                            record_sandbox_op("storage_download", duration_ms, true, None);
+                            record_sandbox_op("storage_download", elapsed, true, None);
                             log_info!(
                                 LOG_TAG,
                                 "Storage {} downloaded in {}ms",
                                 idx + 1,
-                                duration_ms
+                                elapsed.as_millis()
                             );
                         }
                         Err(e) => {
-                            record_sandbox_op("storage_download", duration_ms, false, Some(e));
+                            record_sandbox_op("storage_download", elapsed, false, Some(e));
                             log_error!(LOG_TAG, "Storage {} download failed: {}", idx + 1, e);
                         }
                     }


### PR DESCRIPTION
## Summary
- Change `record_sandbox_op` to accept `std::time::Duration` instead of raw `u64` milliseconds
- Update all call sites in `guest-download` to pass `start.elapsed()` directly
- Eliminates repetitive `.as_millis() as u64` conversions at every call site

## Test plan
- [x] `cargo clippy -p guest-common -p guest-download` passes
- [x] `cargo test -p guest-common -p guest-download` — all 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)