### PR TITLE
fix(deploy): update sandbox-scripts path after package extraction

### DIFF
--- a/.claude/skills/local-testing/skill.md
+++ b/.claude/skills/local-testing/skill.md
@@ -218,7 +218,7 @@ When `USE_MOCK_CLAUDE=true`:
 3. Instead of running real `claude` CLI, it runs `/usr/local/bin/vm0-agent/mock-claude.mjs`
 4. Mock Claude executes the prompt as a bash command and outputs Claude-compatible JSONL
 
-Mock Claude location: `turbo/packages/core/src/sandbox/scripts/src/mock-claude.ts`
+Mock Claude location: `turbo/packages/sandbox-scripts/src/scripts/mock-claude.ts`
 
 ---
 
@@ -385,5 +385,5 @@ vm0 run <agent-name> --artifact-name <artifact> "echo hello"
 
 - CLI E2E Testing Patterns: `.claude/skills/cli-e2e-testing/skill.md`
 - Dev Server Management: `.claude/skills/dev-server/skill.md`
-- Mock Claude Source: `turbo/packages/core/src/sandbox/scripts/src/mock-claude.ts`
+- Mock Claude Source: `turbo/packages/sandbox-scripts/src/scripts/mock-claude.ts`
 - E2B Executor: `turbo/apps/web/src/lib/run/executors/e2b-executor.ts`

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -239,7 +239,7 @@
         mode: '0644'
       with_fileglob:
         - "{{ playbook_dir }}/../../turbo/apps/runner/scripts/deploy/Dockerfile"
-        - "{{ playbook_dir }}/../../turbo/packages/core/src/sandbox/scripts/dist/*.mjs"
+        - "{{ playbook_dir }}/../../turbo/packages/sandbox-scripts/src/dist/*.mjs"
       tags: [prepare]
 
     # ========================================

--- a/turbo/.prettierignore
+++ b/turbo/.prettierignore
@@ -1,6 +1,6 @@
 node_modules
 dist
-packages/core/src/sandbox/scripts/bundled.ts
+packages/sandbox-scripts/src/dist/bundled.ts
 pnpm-lock.yaml
 coverage
 .claude


### PR DESCRIPTION
## Summary
- Sandbox scripts were moved from `@vm0/core` to `@vm0/sandbox-scripts` in #2734
- Ansible deploy playbook still referenced the old path `turbo/packages/core/src/sandbox/scripts/dist/*.mjs`
- This caused production deployment to fail: `cp: cannot stat '.../run-agent.mjs': No such file or directory`
- Updated path to `turbo/packages/sandbox-scripts/src/dist/*.mjs`

## Test plan
- [ ] Verify `deploy-runner-production` CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)