### PR TITLE
feat(cli): add --check-env flag to vm0 run commands

### DIFF
--- a/turbo/apps/cli/src/commands/run/continue.ts
+++ b/turbo/apps/cli/src/commands/run/continue.ts
@@ -44,6 +44,7 @@ export const continueCommand = new Command()
     "Override model provider (e.g., anthropic-api-key)",
   )
   .option("--verbose", "Show full tool inputs and outputs")
+  .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .action(
     async (
@@ -56,6 +57,7 @@ export const continueCommand = new Command()
         experimentalRealtime?: boolean;
         modelProvider?: string;
         verbose?: boolean;
+        checkEnv?: boolean;
         debugNoMockClaude?: boolean;
       },
       command: { optsWithGlobals: () => Record<string, unknown> },
@@ -69,6 +71,7 @@ export const continueCommand = new Command()
         experimentalRealtime?: boolean;
         modelProvider?: string;
         verbose?: boolean;
+        checkEnv?: boolean;
         debugNoMockClaude?: boolean;
       };
 
@@ -103,6 +106,7 @@ export const continueCommand = new Command()
           vars: Object.keys(vars).length > 0 ? vars : undefined,
           secrets: loadedSecrets,
           modelProvider: options.modelProvider || allOpts.modelProvider,
+          checkEnv: options.checkEnv || allOpts.checkEnv || undefined,
           debugNoMockClaude:
             options.debugNoMockClaude || allOpts.debugNoMockClaude || undefined,
         });

--- a/turbo/apps/cli/src/commands/run/resume.ts
+++ b/turbo/apps/cli/src/commands/run/resume.ts
@@ -49,6 +49,7 @@ export const resumeCommand = new Command()
     "Override model provider (e.g., anthropic-api-key)",
   )
   .option("--verbose", "Show full tool inputs and outputs")
+  .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .action(
     async (
@@ -61,6 +62,7 @@ export const resumeCommand = new Command()
         experimentalRealtime?: boolean;
         modelProvider?: string;
         verbose?: boolean;
+        checkEnv?: boolean;
         debugNoMockClaude?: boolean;
       },
       command: { optsWithGlobals: () => Record<string, unknown> },
@@ -75,6 +77,7 @@ export const resumeCommand = new Command()
         experimentalRealtime?: boolean;
         modelProvider?: string;
         verbose?: boolean;
+        checkEnv?: boolean;
         debugNoMockClaude?: boolean;
       };
 
@@ -114,6 +117,7 @@ export const resumeCommand = new Command()
               ? allOpts.volumeVersion
               : undefined,
           modelProvider: options.modelProvider || allOpts.modelProvider,
+          checkEnv: options.checkEnv || allOpts.checkEnv || undefined,
           debugNoMockClaude:
             options.debugNoMockClaude || allOpts.debugNoMockClaude || undefined,
         });

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -80,6 +80,7 @@ export const mainRunCommand = new Command()
     "--experimental-shared-agent",
     "Allow running agents shared by other users (required when running scope/agent format)",
   )
+  .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .addOption(new Option("--no-auto-update").hideHelp())
   .action(
@@ -98,6 +99,7 @@ export const mainRunCommand = new Command()
         modelProvider?: string;
         verbose?: boolean;
         experimentalSharedAgent?: boolean;
+        checkEnv?: boolean;
         debugNoMockClaude?: boolean;
         autoUpdate?: boolean;
       },
@@ -210,6 +212,7 @@ export const mainRunCommand = new Command()
               : undefined,
           conversationId: options.conversation,
           modelProvider: options.modelProvider,
+          checkEnv: options.checkEnv || undefined,
           debugNoMockClaude: options.debugNoMockClaude || undefined,
         });
 

--- a/turbo/apps/cli/src/lib/api/domains/runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/runs.ts
@@ -31,6 +31,8 @@ export async function createRun(body: {
   modelProvider?: string;
   // Debug flag (internal use only)
   debugNoMockClaude?: boolean;
+  // Environment validation flag - when true, validates secrets/vars before running
+  checkEnv?: boolean;
   // Required
   prompt: string;
 }): Promise<CreateRunResponse> {

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -151,7 +151,14 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       );
 
       // Try to create run WITHOUT providing required secrets
-      const data = await createTestRun(secretComposeId, "Test without secrets");
+      // Pass checkEnv: true to enable server-side validation
+      const data = await createTestRun(
+        secretComposeId,
+        "Test without secrets",
+        {
+          checkEnv: true,
+        },
+      );
 
       // Route creates run first, then fails during preparation
       expect(data.status).toBe("failed");
@@ -180,10 +187,11 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       );
 
       // Try to create run with only one secret
+      // Pass checkEnv: true to enable server-side validation
       const data = await createTestRun(
         multiSecretComposeId,
         "Test with partial secrets",
-        { secrets: { SECRET_A: "value-a" } }, // Missing SECRET_B
+        { secrets: { SECRET_A: "value-a" }, checkEnv: true }, // Missing SECRET_B
       );
 
       // Route creates run first, then fails during preparation

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -558,6 +558,7 @@ const router = tsr.router(runsMainContract, {
         continuedFromSessionId: body.sessionId,
         debugNoMockClaude: body.debugNoMockClaude,
         modelProvider: body.modelProvider,
+        checkEnv: body.checkEnv,
         apiStartTime,
       });
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -432,6 +432,7 @@ export async function createTestRun(
     sessionId?: string;
     checkpointId?: string;
     modelProvider?: string;
+    checkEnv?: boolean;
   },
 ): Promise<{ runId: string; status: string }> {
   const request = createTestRequest("http://localhost:3000/api/agent/runs", {

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -579,6 +579,8 @@ export interface BuildContextParams {
   debugNoMockClaude?: boolean;
   // Model provider for automatic credential injection
   modelProvider?: string;
+  // Environment validation flag - when true, validates secrets/vars before running
+  checkEnv?: boolean;
   // API start time for E2E timing metrics
   apiStartTime?: number;
 }
@@ -645,6 +647,7 @@ async function resolveCredentialsAndEnvironment(
   cliSecrets: Record<string, string> | undefined,
   modelProvider: string | undefined,
   runId: string,
+  checkEnv: boolean | undefined,
 ): Promise<{
   secrets: Record<string, string> | undefined;
   credentials: Record<string, string> | undefined;
@@ -705,6 +708,7 @@ async function resolveCredentialsAndEnvironment(
     credentials,
     userId,
     runId,
+    checkEnv,
   );
 
   // Auto-inject model provider env vars into environment
@@ -831,6 +835,7 @@ export async function buildExecutionContext(
     params.secrets,
     params.modelProvider,
     params.runId,
+    params.checkEnv,
   );
   secrets = resolvedSecrets;
 

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -44,6 +44,9 @@ const unifiedRunRequestSchema = z.object({
   // Model provider for automatic credential injection
   modelProvider: z.string().optional(),
 
+  // Environment validation flag - when true, validates secrets/vars before running
+  checkEnv: z.boolean().optional(),
+
   // Required
   prompt: z.string().min(1, "Missing prompt"),
 });


### PR DESCRIPTION
## Summary

- Add optional `--check-env` flag to `vm0 run`, `vm0 run resume`, and `vm0 run continue` commands
- When enabled, server validates that all required secrets and vars are provided before running
- Default behavior: no validation (run proceeds even with missing secrets/vars)

## Changes

| File | Change |
|------|--------|
| `packages/core/src/contracts/runs.ts` | Add `checkEnv` field to request schema |
| `apps/cli/src/lib/api/domains/runs.ts` | Pass `checkEnv` in API call |
| `apps/cli/src/commands/run/run.ts` | Add `--check-env` option |
| `apps/cli/src/commands/run/resume.ts` | Add `--check-env` option |
| `apps/cli/src/commands/run/continue.ts` | Add `--check-env` option |
| `apps/web/app/api/agent/runs/route.ts` | Pass `checkEnv` to build context |
| `apps/web/src/lib/run/build-context.ts` | Accept and propagate `checkEnv` |
| `apps/web/src/lib/run/environment/expand-environment.ts` | Conditional validation based on flag |

## Usage

```bash
# Default: run without pre-check
vm0 run my-agent "prompt"

# With validation: check secrets/vars before running
vm0 run my-agent "prompt" --check-env

# Also works with resume/continue
vm0 run resume <checkpoint-id> "prompt" --check-env
vm0 run continue <session-id> "prompt" --check-env
```

## Test plan

- [x] CLI run command tests pass (127 tests)
- [x] Lint passes for CLI and web packages
- [ ] CI pipeline checks

Closes #2757

🤖 Generated with [Claude Code](https://claude.com/claude-code)