### PR TITLE
feat(cli): add agent delete command

### DIFF
--- a/turbo/apps/cli/src/commands/agent/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/delete.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for agent delete command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { deleteCommand } from "../delete";
+
+describe("agent delete command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful delete", () => {
+    it("should delete agent with --yes flag", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("name") === "test-agent") {
+            return HttpResponse.json({
+              id: "cmp-123",
+              name: "test-agent",
+              headVersionId:
+                "abc123def456789012345678901234567890123456789012345678901234",
+              content: {
+                version: "1",
+                agents: {
+                  "test-agent": {
+                    framework: "claude-code",
+                  },
+                },
+              },
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            });
+          }
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 400 },
+          );
+        }),
+        http.delete("http://localhost:3000/api/agent/composes/:id", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await deleteCommand.parseAsync(["node", "cli", "test-agent", "--yes"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("deleted");
+    });
+
+    it("should work with -y short flag", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("name") === "test-agent") {
+            return HttpResponse.json({
+              id: "cmp-456",
+              name: "test-agent",
+              headVersionId: "def456",
+              content: {
+                version: "1",
+                agents: { "test-agent": { framework: "claude-code" } },
+              },
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            });
+          }
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 400 },
+          );
+        }),
+        http.delete("http://localhost:3000/api/agent/composes/:id", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await deleteCommand.parseAsync(["node", "cli", "test-agent", "-y"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("deleted");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should fail when agent not found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 400 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync([
+          "node",
+          "cli",
+          "nonexistent-agent",
+          "--yes",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+      const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+      expect(errorCalls.toLowerCase()).toContain("not found");
+    });
+
+    it("should fail when agent is currently running", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("name") === "running-agent") {
+            return HttpResponse.json({
+              id: "cmp-789",
+              name: "running-agent",
+              headVersionId: "abc789",
+              content: {
+                version: "1",
+                agents: { "running-agent": { framework: "claude-code" } },
+              },
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            });
+          }
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 400 },
+          );
+        }),
+        http.delete("http://localhost:3000/api/agent/composes/:id", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Cannot delete agent: agent is currently running",
+                code: "CONFLICT",
+              },
+            },
+            { status: 409 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync([
+          "node",
+          "cli",
+          "running-agent",
+          "--yes",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+      const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+      expect(errorCalls).toContain("currently running");
+      expect(errorCalls).toContain("vm0 run list");
+    });
+
+    it("should handle authentication error", async () => {
+      vi.stubEnv("VM0_TOKEN", "");
+      vi.stubEnv("HOME", "/tmp/test-no-config");
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "test-agent", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+      const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+      expect(errorCalls).toContain("Not authenticated");
+      expect(errorCalls).toContain("vm0 auth login");
+    });
+
+    it("should require --yes flag in non-interactive mode", async () => {
+      // Simulate non-interactive mode by not providing a TTY
+      vi.stubEnv("CI", "true");
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("name") === "test-agent") {
+            return HttpResponse.json({
+              id: "cmp-123",
+              name: "test-agent",
+              headVersionId: "abc123",
+              content: {
+                version: "1",
+                agents: { "test-agent": { framework: "claude-code" } },
+              },
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            });
+          }
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 400 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "test-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--yes flag is required"),
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/agent/delete.ts
+++ b/turbo/apps/cli/src/commands/agent/delete.ts
@@ -1,0 +1,58 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getComposeByName, deleteCompose } from "../../lib/api";
+import { isInteractive, promptConfirm } from "../../lib/utils/prompt-utils";
+
+export const deleteCommand = new Command()
+  .name("delete")
+  .alias("rm")
+  .description("Delete an agent")
+  .argument("<name>", "Agent name to delete")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(async (name: string, options: { yes?: boolean }) => {
+    try {
+      // 1. Resolve agent name to compose
+      const compose = await getComposeByName(name);
+      if (!compose) {
+        console.error(chalk.red(`✗ Agent '${name}' not found`));
+        console.error(chalk.dim("  Run: vm0 agent list"));
+        process.exit(1);
+      }
+
+      // 2. Confirm deletion
+      if (!options.yes) {
+        if (!isInteractive()) {
+          console.error(
+            chalk.red("✗ --yes flag is required in non-interactive mode"),
+          );
+          process.exit(1);
+        }
+        const confirmed = await promptConfirm(`Delete agent '${name}'?`, false);
+        if (!confirmed) {
+          console.log(chalk.dim("Cancelled"));
+          return;
+        }
+      }
+
+      // 3. Call delete API
+      await deleteCompose(compose.id);
+      console.log(chalk.green(`✓ Agent '${name}' deleted`));
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes("Not authenticated")) {
+          console.error(chalk.red("✗ Not authenticated"));
+          console.error(chalk.dim("  Run: vm0 auth login"));
+        } else if (error.message.includes("currently running")) {
+          console.error(
+            chalk.red("✗ Cannot delete agent: agent is currently running"),
+          );
+          console.error(chalk.dim("  Run: vm0 run list"));
+        } else {
+          console.error(chalk.red(`✗ ${error.message}`));
+        }
+      } else {
+        console.error(chalk.red("✗ An unexpected error occurred"));
+      }
+      process.exit(1);
+    }
+  });

--- a/turbo/apps/cli/src/commands/agent/index.ts
+++ b/turbo/apps/cli/src/commands/agent/index.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { cloneCommand } from "./clone";
+import { deleteCommand } from "./delete";
 import { listCommand } from "./list";
 import { statusCommand } from "./status";
 import { publicCommand } from "./public";
@@ -12,6 +13,7 @@ export const agentCommand = new Command()
   .name("agent")
   .description("Manage agent composes")
   .addCommand(cloneCommand)
+  .addCommand(deleteCommand)
   .addCommand(listCommand)
   .addCommand(statusCommand)
   .addCommand(publicCommand)

--- a/turbo/apps/cli/src/lib/api/domains/composes.ts
+++ b/turbo/apps/cli/src/lib/api/domains/composes.ts
@@ -89,3 +89,22 @@ export async function createOrUpdateCompose(body: {
 
   handleError(result, "Failed to create compose");
 }
+
+/**
+ * Delete an agent compose by ID
+ * Returns void on success, throws on error
+ */
+export async function deleteCompose(id: string): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(composesByIdContract, config);
+
+  const result = await client.delete({
+    params: { id },
+  });
+
+  if (result.status === 204) {
+    return;
+  }
+
+  handleError(result, "Failed to delete agent");
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -13,6 +13,7 @@ export {
   getComposeById,
   getComposeVersion,
   createOrUpdateCompose,
+  deleteCompose,
 } from "./domains/composes";
 
 // Domain modules - Runs

--- a/turbo/apps/web/src/db/migrations/0077_allow_null_agent_compose_version.sql
+++ b/turbo/apps/web/src/db/migrations/0077_allow_null_agent_compose_version.sql
@@ -1,0 +1,8 @@
+-- Allow null on agent_compose_version_id to support agent deletion
+-- When an agent is deleted, historical runs should be preserved with null version reference
+ALTER TABLE "agent_runs" ALTER COLUMN "agent_compose_version_id" DROP NOT NULL;
+
+-- Modify FK constraint to set null on delete
+ALTER TABLE "agent_runs" DROP CONSTRAINT "agent_runs_agent_compose_version_id_fkey";
+ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_agent_compose_version_id_fkey"
+  FOREIGN KEY ("agent_compose_version_id") REFERENCES "agent_compose_versions"("id") ON DELETE SET NULL;

--- a/turbo/apps/web/src/db/schema/agent-run.ts
+++ b/turbo/apps/web/src/db/schema/agent-run.ts
@@ -21,9 +21,9 @@ export const agentRuns = pgTable(
   {
     id: uuid("id").defaultRandom().primaryKey(),
     userId: text("user_id").notNull(), // Clerk user ID - owner of this run
-    agentComposeVersionId: varchar("agent_compose_version_id", { length: 64 })
-      .references(() => agentComposeVersions.id)
-      .notNull(),
+    agentComposeVersionId: varchar("agent_compose_version_id", {
+      length: 64,
+    }).references(() => agentComposeVersions.id, { onDelete: "set null" }),
     resumedFromCheckpointId: uuid("resumed_from_checkpoint_id"),
     // References agent_schedules.id if this run was triggered by a schedule
     scheduleId: uuid("schedule_id").references(

--- a/turbo/apps/web/src/lib/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/checkpoint/checkpoint-service.ts
@@ -40,6 +40,14 @@ export async function createCheckpoint(
     throw notFound("Agent run not found");
   }
 
+  // agentComposeVersionId may be null if agent was deleted (historical runs)
+  // but during active run execution it should always be present
+  if (!run.agentComposeVersionId) {
+    throw notFound(
+      "Agent compose version not found (agent may have been deleted)",
+    );
+  }
+
   // Fetch agent compose version to get composeId for session
   const [version] = await globalThis.services.db
     .select()

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -269,6 +269,28 @@ export const composesByIdContract = c.router({
     },
     summary: "Get agent compose by ID",
   },
+
+  /**
+   * DELETE /api/agent/composes/:id
+   * Delete agent compose and all associated resources (versions, schedules, permissions, etc.)
+   * Returns 409 Conflict if agent has running or pending runs
+   */
+  delete: {
+    method: "DELETE",
+    path: "/api/agent/composes/:id",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      id: z.string().uuid("Compose ID is required"),
+    }),
+    body: c.noBody(),
+    responses: {
+      204: c.noBody(),
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+    },
+    summary: "Delete agent compose",
+  },
 });
 
 /**

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -46,7 +46,7 @@ export const runnerGroupSchema = z
 export const jobSchema = z.object({
   runId: z.string().uuid(),
   prompt: z.string(),
-  agentComposeVersionId: z.string(),
+  agentComposeVersionId: z.string().nullable(),
   vars: z.record(z.string(), z.string()).nullable(),
   secretNames: z.array(z.string()).nullable(),
   checkpointId: z.string().uuid().nullable(),
@@ -138,7 +138,7 @@ export const storedExecutionContextSchema = z.object({
 export const executionContextSchema = z.object({
   runId: z.string().uuid(),
   prompt: z.string(),
-  agentComposeVersionId: z.string(),
+  agentComposeVersionId: z.string().nullable(),
   vars: z.record(z.string(), z.string()).nullable(),
   secretNames: z.array(z.string()).nullable(),
   checkpointId: z.string().uuid().nullable(),

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -66,7 +66,7 @@ const createRunResponseSchema = z.object({
  */
 const getRunResponseSchema = z.object({
   runId: z.string(),
-  agentComposeVersionId: z.string(),
+  agentComposeVersionId: z.string().nullable(),
   status: runStatusSchema,
   prompt: z.string(),
   vars: z.record(z.string(), z.string()).optional(),


### PR DESCRIPTION
## Summary

Implements `vm0 agent delete <name>` command to delete an agent compose and all associated resources.

- Add DELETE /api/agent/composes/:id endpoint with server-side pre-flight check
- Return 409 Conflict if agent has running/pending runs with helpful error message
- Preserve historical runs with null `agentComposeVersionId` (ON DELETE SET NULL)
- Add database migration `0077_allow_null_agent_compose_version.sql`
- Update runs and runners contracts to allow nullable `agentComposeVersionId`
- CLI command supports `--yes` flag to skip confirmation prompt
- Alias `vm0 agent rm` also available

### Key Changes

| File | Change |
|------|--------|
| `apps/cli/src/commands/agent/delete.ts` | New CLI delete command |
| `apps/web/app/api/agent/composes/[id]/route.ts` | DELETE handler with ownership and running runs check |
| `packages/core/src/contracts/composes.ts` | Add delete contract |
| `packages/core/src/contracts/runs.ts` | Allow nullable `agentComposeVersionId` |
| `packages/core/src/contracts/runners.ts` | Allow nullable `agentComposeVersionId` |
| `apps/web/src/db/schema/agent-run.ts` | Remove NOT NULL, add ON DELETE SET NULL |
| `apps/web/src/db/migrations/0077_*.sql` | Database migration |

## Test plan

- [ ] Run `vm0 agent delete <name>` - should prompt for confirmation
- [ ] Run `vm0 agent delete <name> --yes` - should skip confirmation
- [ ] Delete agent with running runs - should show 409 error with guidance
- [ ] Delete agent with historical runs - runs should be preserved with null version
- [ ] Verify cascade delete for: versions, schedules, sessions, permissions, slack bindings

Closes #2763

🤖 Generated with [Claude Code](https://claude.com/claude-code)