### PR TITLE
fix(guest-agent): address review followup items

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -123,6 +123,9 @@ pub fn setup_codex() -> Result<(), AgentError> {
             child.wait_with_output()
         });
 
+    // Login failure is non-fatal: OPENAI_API_KEY is already in the environment
+    // and `codex exec` will use it directly. Some Codex versions may not support
+    // the `login` subcommand. We log + record the failure but continue.
     let success = match &output {
         Ok(o) if o.status.success() => {
             log_info!(LOG_TAG, "Codex authenticated with API key");


### PR DESCRIPTION
## Summary

Addresses the three non-blocking items from the PR #2759 review:

- **Document `setup_codex()` behavior**: Added comment explaining why login failure is intentionally swallowed (non-fatal: `OPENAI_API_KEY` is in env, `codex exec` uses it directly)
- **Add tests for `checkpoint.rs`**: 4 tests covering `find_codex_session_file` (match by ID, fallback to most recent, empty dir) and `find_jsonl_files` (recursive discovery)
- **Add tests for `telemetry.rs`**: 6 tests covering `read_file_delta` (initial, incremental, no new data, missing file), `read_jsonl_delta` (parses valid lines, skips invalid), and `save_position`
- **Verified `continue.test.ts`**: Already covers the "Missing required secrets" error case (line 316-346), no change needed

Test count: 7 → 17

## Test plan

- [x] `cargo test -p guest-agent` — 17/17 passed
- [x] `cargo clippy -p guest-agent` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)