### PR TITLE
refactor(guest-agent): remove dead network log upload code

### DIFF
--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -31,8 +31,6 @@ static AGENT_LOG_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-agent-{}.log", env::run_id()));
 static METRICS_LOG_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-metrics-{}.jsonl", env::run_id()));
-static NETWORK_LOG_FILE: LazyLock<String> =
-    LazyLock::new(|| format!("/tmp/vm0-network-{}.jsonl", env::run_id()));
 
 pub fn event_error_flag() -> &'static str {
     &EVENT_ERROR_FLAG
@@ -46,9 +44,6 @@ pub fn agent_log_file() -> &'static str {
 pub fn metrics_log_file() -> &'static str {
     &METRICS_LOG_FILE
 }
-pub fn network_log_file() -> &'static str {
-    &NETWORK_LOG_FILE
-}
 
 // ---------------------------------------------------------------------------
 // Telemetry position tracking
@@ -58,8 +53,6 @@ static TELEMETRY_LOG_POS_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-telemetry-log-pos-{}.txt", env::run_id()));
 static TELEMETRY_METRICS_POS_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-telemetry-metrics-pos-{}.txt", env::run_id()));
-static TELEMETRY_NETWORK_POS_FILE: LazyLock<String> =
-    LazyLock::new(|| format!("/tmp/vm0-telemetry-network-pos-{}.txt", env::run_id()));
 static TELEMETRY_SANDBOX_OPS_POS_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-telemetry-sandbox-ops-pos-{}.txt", env::run_id()));
 
@@ -68,9 +61,6 @@ pub fn telemetry_log_pos_file() -> &'static str {
 }
 pub fn telemetry_metrics_pos_file() -> &'static str {
     &TELEMETRY_METRICS_POS_FILE
-}
-pub fn telemetry_network_pos_file() -> &'static str {
-    &TELEMETRY_NETWORK_POS_FILE
 }
 pub fn telemetry_sandbox_ops_pos_file() -> &'static str {
     &TELEMETRY_SANDBOX_OPS_POS_FILE

--- a/turbo/packages/sandbox-scripts/src/scripts/lib/common.ts
+++ b/turbo/packages/sandbox-scripts/src/scripts/lib/common.ts
@@ -68,13 +68,9 @@ export const AGENT_LOG_FILE = `/tmp/vm0-agent-${RUN_ID}.log`;
 // Metrics log file for system resource metrics (JSONL format)
 export const METRICS_LOG_FILE = `/tmp/vm0-metrics-${RUN_ID}.jsonl`;
 
-// Network log file for proxy request logs (JSONL format)
-export const NETWORK_LOG_FILE = `/tmp/vm0-network-${RUN_ID}.jsonl`;
-
 // Telemetry position tracking files (to avoid duplicate uploads)
 export const TELEMETRY_LOG_POS_FILE = `/tmp/vm0-telemetry-log-pos-${RUN_ID}.txt`;
 export const TELEMETRY_METRICS_POS_FILE = `/tmp/vm0-telemetry-metrics-pos-${RUN_ID}.txt`;
-export const TELEMETRY_NETWORK_POS_FILE = `/tmp/vm0-telemetry-network-pos-${RUN_ID}.txt`;
 export const TELEMETRY_SANDBOX_OPS_POS_FILE = `/tmp/vm0-telemetry-sandbox-ops-pos-${RUN_ID}.txt`;
 
 // Sandbox operations log file (JSONL format)


### PR DESCRIPTION
## Summary

- Remove dead network log reading/uploading code from both Rust guest-agent and TypeScript sandbox-scripts
- Network logs (`/tmp/vm0-network-{runId}.jsonl`) are written by mitmproxy on the **host side** and already uploaded by the host-side runner — the guest-side agents tried to read this file from inside the VM where it never exists

## Changes

**Rust (`crates/guest-agent/src/`):**
- `paths.rs`: Remove `NETWORK_LOG_FILE`, `network_log_file()`, `TELEMETRY_NETWORK_POS_FILE`, `telemetry_network_pos_file()`
- `telemetry.rs`: Remove network log delta reading, masking, payload field, and position tracking

**TypeScript (`turbo/packages/sandbox-scripts/src/scripts/lib/`):**
- `common.ts`: Remove `NETWORK_LOG_FILE` and `TELEMETRY_NETWORK_POS_FILE` constants
- `upload-telemetry.ts`: Remove `readNetworkLogsFromPosition()`, network log reading, masking, payload field, and position tracking

## Test plan

- [x] `cargo build` — Rust compiles
- [x] `cargo test -p guest-agent` — 17/17 tests pass
- [x] `pnpm turbo run build --filter=@vm0/sandbox-scripts` — TS builds
- [x] `pnpm turbo run lint --filter=@vm0/sandbox-scripts` — Lint passes
- [x] `pnpm knip` — No new unused exports

Closes #2768

🤖 Generated with [Claude Code](https://claude.com/claude-code)