### PR TITLE
fix(platform): enforce MSW onUnhandledRequest error mode

### DIFF
--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -17,7 +17,7 @@ vi.hoisted(() => {
 
 // Start MSW server before all tests
 beforeAll(() => {
-  server.listen({ onUnhandledRequest: "bypass" });
+  server.listen({ onUnhandledRequest: "error" });
 });
 
 // Reset handlers after each test

--- a/turbo/packages/eslint-config/base.js
+++ b/turbo/packages/eslint-config/base.js
@@ -3,6 +3,39 @@ import eslintConfigPrettier from "eslint-config-prettier";
 import turboPlugin from "eslint-plugin-turbo";
 import tseslint from "typescript-eslint";
 
+const vm0Plugin = {
+  rules: {
+    "no-msw-bypass": {
+      meta: {
+        type: "problem",
+        docs: {
+          description:
+            'Disallow onUnhandledRequest: "bypass" in MSW server configuration',
+        },
+        messages: {
+          noBypass:
+            'Use onUnhandledRequest: "error" instead of "bypass". All MSW requests must be explicitly handled.',
+        },
+        schema: [],
+      },
+      create(context) {
+        return {
+          Property(node) {
+            if (
+              node.key.type === "Identifier" &&
+              node.key.name === "onUnhandledRequest" &&
+              node.value.type === "Literal" &&
+              node.value.value === "bypass"
+            ) {
+              context.report({ node: node.value, messageId: "noBypass" });
+            }
+          },
+        };
+      },
+    },
+  },
+};
+
 /**
  * A shared ESLint configuration for the repository.
  *
@@ -15,10 +48,12 @@ export const config = [
   {
     plugins: {
       turbo: turboPlugin,
+      vm0: vm0Plugin,
     },
     rules: {
       "turbo/no-undeclared-env-vars": "warn",
       complexity: ["error", { max: 20 }],
+      "vm0/no-msw-bypass": "error",
     },
   },
   {


### PR DESCRIPTION
## Summary
- Change platform test setup from `onUnhandledRequest: "bypass"` to `"error"` so unhandled requests fail loudly instead of silently hitting the network (was causing `ECONNREFUSED` errors)
- Add `vm0/no-msw-bypass` ESLint rule to the shared base config to prevent `"bypass"` from being reintroduced in any app
- Uses an inline plugin with a dedicated rule name to avoid `no-restricted-syntax` override issues in flat config

## Test plan
- [x] All 2845 tests pass with the new `"error"` mode
- [x] Lint passes across all 8 packages
- [x] Rule correctly flags `onUnhandledRequest: "bypass"` and ignores `"error"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)