### PR TITLE
perf(platform): skip rendering in signal-only tests

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
@@ -43,6 +43,7 @@ describe("fetch$ signal integration tests", () => {
     await setupPage({
       context,
       path: "/",
+      withoutRender: true,
     });
 
     const captured: { request: CapturedRequest | null } = { request: null };
@@ -73,6 +74,7 @@ describe("fetch$ signal integration tests", () => {
       context,
       path: "/",
       session: { token: mockToken },
+      withoutRender: true,
     });
 
     const captured: { request: CapturedRequest | null } = { request: null };
@@ -115,6 +117,7 @@ describe("fetch$ signal integration tests", () => {
       context,
       path: "/",
       session: { token: mockToken },
+      withoutRender: true,
     });
 
     const captured: { request: CapturedRequest | null } = { request: null };
@@ -148,6 +151,7 @@ describe("fetch$ signal integration tests", () => {
       context,
       path: "/",
       session: { token: mockToken },
+      withoutRender: true,
     });
 
     const captured: { request: CapturedRequest | null } = { request: null };

--- a/turbo/apps/platform/src/signals/__tests__/global-method.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/global-method.test.ts
@@ -11,13 +11,13 @@ beforeAll(() => {
 
 describe("global debug loggers", () => {
   it("should has vm0 method after init", async () => {
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     expect(window._vm0).toBeDefined();
   });
 
   it("should init all loggers in info level", async () => {
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     const loggers = window._vm0?.loggers;
     expect(loggers).toBeDefined();
@@ -29,7 +29,7 @@ describe("global debug loggers", () => {
   });
 
   it("should set logger to debug level when set debug to true", async () => {
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     const loggers = window._vm0?.loggers;
     expect(loggers).toBeDefined();
@@ -46,6 +46,7 @@ describe("global debug loggers", () => {
       context,
       path: "/",
       debugLoggers: ["Promise"],
+      withoutRender: true,
     });
 
     const loggers = window._vm0?.loggers;
@@ -60,14 +61,19 @@ describe("global debug loggers", () => {
 
 describe("global feature switches", () => {
   it("should have featureSwitches after init", async () => {
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     expect(window._vm0).toBeDefined();
     expect(window._vm0?.featureSwitches.dummy).toBeTruthy();
   });
 
   it("should override feature switch when set value", async () => {
-    await setupPage({ context, path: "/", featureSwitches: { dummy: false } });
+    await setupPage({
+      context,
+      path: "/",
+      featureSwitches: { dummy: false },
+      withoutRender: true,
+    });
 
     expect(window._vm0?.featureSwitches.dummy).toBeFalsy();
   });

--- a/turbo/apps/platform/src/signals/__tests__/onboarding.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/onboarding.test.ts
@@ -32,6 +32,7 @@ describe("startOnboarding$", () => {
     await setupPage({
       context,
       path: "/logs",
+      withoutRender: true,
     });
 
     expect(context.store.get(pathname$)).toBe("/");
@@ -49,7 +50,7 @@ describe("needsOnboarding$", () => {
       }),
     );
 
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     const needsOnboarding = await context.store.get(needsOnboarding$);
     expect(needsOnboarding).toBeTruthy();
@@ -62,7 +63,7 @@ describe("needsOnboarding$", () => {
       }),
     );
 
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     const needsOnboarding = await context.store.get(needsOnboarding$);
     expect(needsOnboarding).toBeTruthy();
@@ -70,7 +71,7 @@ describe("needsOnboarding$", () => {
 
   it("should return false when both scope and a model provider exist", async () => {
     // Default mocks have both scope and oauth token
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     const needsOnboarding = await context.store.get(needsOnboarding$);
     expect(needsOnboarding).toBeFalsy();
@@ -110,7 +111,7 @@ describe("saveOnboardingConfig$", () => {
       }),
     );
 
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     act(() => {
       context.store.set(setOnboardingSecret$, "test-oauth-token");
@@ -149,7 +150,7 @@ describe("saveOnboardingConfig$", () => {
       }),
     );
 
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     act(() => {
       context.store.set(setOnboardingProviderType$, "anthropic-api-key");
@@ -193,7 +194,7 @@ describe("saveOnboardingConfig$", () => {
       }),
     );
 
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     act(() => {
       context.store.set(setOnboardingProviderType$, "aws-bedrock");
@@ -239,7 +240,7 @@ describe("saveOnboardingConfig$", () => {
       }),
     );
 
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     await act(async () => {
       await context.store.set(saveOnboardingConfig$, context.signal);
@@ -268,7 +269,7 @@ describe("closeOnboardingModal$", () => {
       }),
     );
 
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     act(() => {
       context.store.set(closeOnboardingModal$);
@@ -290,7 +291,7 @@ describe("closeOnboardingModal$", () => {
     );
 
     // Default mock has scope
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     act(() => {
       context.store.set(closeOnboardingModal$);

--- a/turbo/apps/platform/src/signals/agents-page/__tests__/agents-list.test.ts
+++ b/turbo/apps/platform/src/signals/agents-page/__tests__/agents-list.test.ts
@@ -40,7 +40,7 @@ describe("agents-list signals", () => {
         }),
       );
 
-      await setupPage({ context, path: "/" });
+      await setupPage({ context, path: "/", withoutRender: true });
 
       await context.store.set(fetchAgentsList$);
 
@@ -65,7 +65,7 @@ describe("agents-list signals", () => {
         }),
       );
 
-      await setupPage({ context, path: "/" });
+      await setupPage({ context, path: "/", withoutRender: true });
 
       await context.store.set(fetchAgentsList$);
 
@@ -93,7 +93,7 @@ describe("agents-list signals", () => {
         }),
       );
 
-      await setupPage({ context, path: "/" });
+      await setupPage({ context, path: "/", withoutRender: true });
 
       await context.store.set(fetchAgentsList$);
 

--- a/turbo/apps/platform/src/signals/external/__tests__/feature-switch.test.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/feature-switch.test.ts
@@ -7,7 +7,7 @@ const context = testContext();
 
 describe("feature switch", () => {
   it("should support dummy switch", async () => {
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     await expect(context.store.get(featureSwitch$)).resolves.toHaveProperty(
       "dummy",
@@ -16,7 +16,12 @@ describe("feature switch", () => {
   });
 
   it("should override dummy switch", async () => {
-    await setupPage({ context, path: "/", featureSwitches: { dummy: false } });
+    await setupPage({
+      context,
+      path: "/",
+      featureSwitches: { dummy: false },
+      withoutRender: true,
+    });
 
     await expect(context.store.get(featureSwitch$)).resolves.toHaveProperty(
       "dummy",
@@ -27,7 +32,12 @@ describe("feature switch", () => {
   it("should not override keys not present in localStorage", async () => {
     // When localStorage only has partial overrides, other keys should keep their default values
     // Setting an empty object should not affect the default value of 'dummy' (which is true)
-    await setupPage({ context, path: "/", featureSwitches: {} });
+    await setupPage({
+      context,
+      path: "/",
+      featureSwitches: {},
+      withoutRender: true,
+    });
 
     await expect(context.store.get(featureSwitch$)).resolves.toHaveProperty(
       "dummy",

--- a/turbo/apps/platform/src/signals/external/__tests__/local-storage.test.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/local-storage.test.ts
@@ -7,7 +7,7 @@ const context = testContext();
 
 describe("local storage signal", () => {
   it("can read and write to local storage", async () => {
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     const { get$, set$, clear$ } = localStorageSignals("foo");
     expect(context.store.get(get$)).toBeNull();
@@ -20,7 +20,7 @@ describe("local storage signal", () => {
   });
 
   it("should clear after last test", async () => {
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/", withoutRender: true });
 
     const { get$ } = localStorageSignals("foo");
     expect(context.store.get(get$)).toBeNull();

--- a/turbo/apps/platform/src/signals/external/__tests__/model-providers.test.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/model-providers.test.ts
@@ -16,6 +16,7 @@ describe("test model providers", () => {
     await setupPage({
       context,
       path: "/",
+      withoutRender: true,
     });
 
     await expect(context.store.get(modelProviders$)).resolves.toHaveProperty(


### PR DESCRIPTION
## Summary
- Add `withoutRender` option to `setupPage()` that passes a no-op render callback to `bootstrap$`, skipping React rendering, route registration, and DOM setup
- Apply it to all 7 signal test files under `src/signals/` that only assert on store values and never touch the DOM

## Performance improvement

| Test file | Before | After | Speedup |
|-----------|-------:|------:|--------:|
| onboarding.test.ts (10) | 1300ms | 43ms | **30x** |
| global-method.test.ts (6) | 408ms | 29ms | **14x** |
| fetch.test.ts (11) | 325ms | 37ms | **9x** |
| feature-switch.test.ts (3) | 216ms | 23ms | **9x** |
| agents-list.test.ts (7) | 230ms | 35ms | **7x** |
| local-storage.test.ts (2) | 138ms | 20ms | **7x** |
| model-providers.test.ts (6) | 711ms | 352ms | **2x** |

## Test plan
- [x] All 276 platform tests pass
- [x] Lint and type check pass
- [x] Knip finds no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)