### PR TITLE
feat(platform): add lint rule enforcing render mode in tests

### DIFF
--- a/turbo/apps/platform/custom-eslint/__tests__/setup-page-render.test.ts
+++ b/turbo/apps/platform/custom-eslint/__tests__/setup-page-render.test.ts
@@ -1,0 +1,68 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { describe, it, afterAll } from "vitest";
+import rule from "../rules/setup-page-render.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("setup-page-render", rule, {
+  valid: [
+    // Signal tests with withoutRender: true
+    {
+      code: 'setupPage({ context, path: "/", withoutRender: true })',
+      filename: "/project/src/signals/__tests__/fetch.test.ts",
+    },
+    {
+      code: 'setupPage({ context, path: "/", session: { token: "t" }, withoutRender: true })',
+      filename:
+        "/project/src/signals/external/__tests__/model-providers.test.ts",
+    },
+    // View tests without withoutRender
+    {
+      code: 'setupPage({ context, path: "/" })',
+      filename: "/project/src/views/home/__tests__/home-page.test.tsx",
+    },
+    {
+      code: 'setupPage({ context, path: "/logs" })',
+      filename: "/project/src/views/logs-page/__tests__/logs-page.test.tsx",
+    },
+    // Other directories are not checked
+    {
+      code: 'setupPage({ context, path: "/" })',
+      filename: "/project/src/__tests__/setup-page.test.ts",
+    },
+    {
+      code: 'setupPage({ context, path: "/", withoutRender: true })',
+      filename: "/project/src/__tests__/other.test.ts",
+    },
+  ],
+  invalid: [
+    // Signal tests missing withoutRender
+    {
+      code: 'setupPage({ context, path: "/" })',
+      filename: "/project/src/signals/__tests__/onboarding.test.ts",
+      errors: [{ messageId: "missingWithoutRender" }],
+    },
+    {
+      code: 'setupPage({ context, path: "/", session: { token: "t" } })',
+      filename:
+        "/project/src/signals/agents-page/__tests__/agents-list.test.ts",
+      errors: [{ messageId: "missingWithoutRender" }],
+    },
+    // View tests with withoutRender
+    {
+      code: 'setupPage({ context, path: "/", withoutRender: true })',
+      filename: "/project/src/views/home/__tests__/home-page.test.tsx",
+      errors: [{ messageId: "forbiddenWithoutRender" }],
+    },
+    {
+      code: 'setupPage({ context, path: "/logs", withoutRender: true })',
+      filename:
+        "/project/src/views/logs-page/__tests__/log-detail-page.test.tsx",
+      errors: [{ messageId: "forbiddenWithoutRender" }],
+    },
+  ],
+});

--- a/turbo/apps/platform/custom-eslint/index.ts
+++ b/turbo/apps/platform/custom-eslint/index.ts
@@ -24,6 +24,7 @@ import noGetSignal from "./rules/no-get-signal.ts";
 import testContextInHooks from "./rules/test-context-in-hooks.ts";
 import computedConstArgsPackageScope from "./rules/computed-const-args-package-scope.ts";
 import noStoreInParams from "./rules/no-store-in-params.ts";
+import setupPageRender from "./rules/setup-page-render.ts";
 
 const plugin = {
   meta: {
@@ -41,6 +42,7 @@ const plugin = {
     "test-context-in-hooks": testContextInHooks,
     "computed-const-args-package-scope": computedConstArgsPackageScope,
     "no-store-in-params": noStoreInParams,
+    "setup-page-render": setupPageRender,
   },
 };
 

--- a/turbo/apps/platform/custom-eslint/rules/setup-page-render.ts
+++ b/turbo/apps/platform/custom-eslint/rules/setup-page-render.ts
@@ -1,0 +1,78 @@
+/**
+ * ESLint rule: setup-page-render
+ *
+ * Enforces correct usage of setupPage's withoutRender option:
+ * - In src/signals/ tests: setupPage must use withoutRender: true
+ * - In src/views/ tests: setupPage must NOT use withoutRender
+ *
+ * Signal tests should never render React components. View tests must
+ * render to test the actual UI.
+ */
+
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { createRule } from "../utils.ts";
+
+export default createRule({
+  name: "setup-page-render",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Enforce withoutRender in signal tests and forbid it in view tests",
+    },
+    schema: [],
+    messages: {
+      missingWithoutRender:
+        "setupPage in src/signals/ tests must use withoutRender: true. Signal tests should not render React components.",
+      forbiddenWithoutRender:
+        "setupPage in src/views/ tests must not use withoutRender. View tests need React rendering to test the UI.",
+    },
+  },
+  create(context) {
+    const filename = context.filename.replace(/\\/g, "/");
+    const isSignalTest = /\/src\/signals\/.*__tests__/.test(filename);
+    const isViewTest = /\/src\/views\/.*__tests__/.test(filename);
+
+    if (!isSignalTest && !isViewTest) {
+      return {};
+    }
+
+    return {
+      CallExpression(node: TSESTree.CallExpression) {
+        if (
+          node.callee.type !== AST_NODE_TYPES.Identifier ||
+          node.callee.name !== "setupPage"
+        ) {
+          return;
+        }
+
+        const firstArg = node.arguments[0];
+        if (!firstArg || firstArg.type !== AST_NODE_TYPES.ObjectExpression) {
+          return;
+        }
+
+        const withoutRenderProp = firstArg.properties.find(
+          (prop): prop is TSESTree.Property =>
+            prop.type === AST_NODE_TYPES.Property &&
+            prop.key.type === AST_NODE_TYPES.Identifier &&
+            prop.key.name === "withoutRender",
+        );
+
+        if (isSignalTest && !withoutRenderProp) {
+          context.report({
+            node,
+            messageId: "missingWithoutRender",
+          });
+        }
+
+        if (isViewTest && withoutRenderProp) {
+          context.report({
+            node: withoutRenderProp,
+            messageId: "forbiddenWithoutRender",
+          });
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -25,6 +25,7 @@ export default [
       "ccstate/tsx-in-views": "error",
       "ccstate/no-catch-abort": "error",
       "ccstate/test-context-in-hooks": "error",
+      "ccstate/setup-page-render": "error",
     },
   },
   // Type-aware rules (only for TypeScript files)

--- a/turbo/apps/platform/src/signals/external/__tests__/model-providers.test.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/model-providers.test.ts
@@ -27,7 +27,7 @@ describe("test model providers", () => {
 
   describe("hasClaudeCodeOAuthToken$", () => {
     it("should return true when claude-code-oauth-token provider exists", async () => {
-      await setupPage({ context, path: "/" });
+      await setupPage({ context, path: "/", withoutRender: true });
 
       const hasToken = await context.store.get(hasClaudeCodeOAuthToken$);
       expect(hasToken).toBeTruthy();
@@ -40,7 +40,7 @@ describe("test model providers", () => {
         }),
       );
 
-      await setupPage({ context, path: "/" });
+      await setupPage({ context, path: "/", withoutRender: true });
 
       const hasToken = await context.store.get(hasClaudeCodeOAuthToken$);
       expect(hasToken).toBeFalsy();
@@ -65,7 +65,7 @@ describe("test model providers", () => {
         }),
       );
 
-      await setupPage({ context, path: "/" });
+      await setupPage({ context, path: "/", withoutRender: true });
 
       const hasToken = await context.store.get(hasClaudeCodeOAuthToken$);
       expect(hasToken).toBeFalsy();
@@ -82,7 +82,7 @@ describe("test model providers", () => {
         }),
       );
 
-      await setupPage({ context, path: "/" });
+      await setupPage({ context, path: "/", withoutRender: true });
 
       // First fetch
       await context.store.get(modelProviders$);
@@ -123,7 +123,7 @@ describe("test model providers", () => {
         }),
       );
 
-      await setupPage({ context, path: "/" });
+      await setupPage({ context, path: "/", withoutRender: true });
 
       await context.store.set(createModelProvider$, {
         type: "claude-code-oauth-token",


### PR DESCRIPTION
## Summary
- Add `ccstate/setup-page-render` ESLint rule that enforces correct `withoutRender` usage in `setupPage` calls
- `src/signals/` tests must use `withoutRender: true` (signal tests should not render React components)
- `src/views/` tests must NOT use `withoutRender` (view tests need rendering to test the UI)

## Test plan
- [x] Rule test covers 6 valid and 4 invalid cases
- [x] All platform tests pass
- [x] Lint passes with no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)