### PR TITLE
chore: format workspace members as multi-line sorted list

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -1,6 +1,19 @@
 [workspace]
 resolver = "2"
-members = ["vsock-guest", "vsock-proto", "vsock-host", "vsock-test", "guest-init", "guest-common", "guest-download", "guest-agent", "guest-mock-claude", "sandbox", "sandbox-fc", "runner"]
+members = [
+    "guest-agent",
+    "guest-common",
+    "guest-download",
+    "guest-init",
+    "guest-mock-claude",
+    "runner",
+    "sandbox",
+    "sandbox-fc",
+    "vsock-guest",
+    "vsock-host",
+    "vsock-proto",
+    "vsock-test",
+]
 
 [workspace.package]
 edition = "2024"


### PR DESCRIPTION
## Summary
- Break long single-line `members` array in `crates/Cargo.toml` into multi-line sorted list for better readability and cleaner diffs

## Test plan
- [x] No functional changes, formatting only

🤖 Generated with [Claude Code](https://claude.com/claude-code)