### PR TITLE
refactor(web): centralize next/server after() mock in shared test setup

### DIFF
--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -133,6 +133,8 @@ interface MockHelpers {
   dateNow: MockInstance<() => number>;
   /** Date mock for controlling new Date() and Date.now() */
   date: DateMocks;
+  /** Execute all captured Next.js after() callbacks */
+  flushAfter(): Promise<void>;
 }
 
 interface SetupUserOptions {
@@ -362,6 +364,11 @@ export function testContext(): TestContext {
       axiom: axiomMocks,
       dateNow: dateNowMock,
       date: dateMocks,
+      async flushAfter() {
+        const callbacks = [...globalThis.nextAfterCallbacks];
+        globalThis.nextAfterCallbacks = [];
+        await Promise.all(callbacks.map((fn) => fn()));
+      },
     };
     mockHelpers = helpers;
     return helpers;

--- a/turbo/apps/web/src/types/global.d.ts
+++ b/turbo/apps/web/src/types/global.d.ts
@@ -18,4 +18,6 @@ export type Services = {
 declare global {
   // getter ensures it's always defined after initServices()
   var services: Services;
+  // Captured Next.js after() callbacks for test assertions (see setup.ts)
+  var nextAfterCallbacks: Array<() => Promise<unknown>>;
 }


### PR DESCRIPTION
## Summary
- Move the Next.js `after()` mock from the complete webhook test into global `setup.ts`, so all tests that indirectly call `completeTestRun()` no longer hang on unresolved `after()` callbacks
- Expose `context.mocks.flushAfter()` via `testContext()` for tests that need to await and assert on `after()` side effects
- Fixes test timeouts in `v1/runs`, `agent/runs`, and `cron/execute-schedules` test suites

## Test plan
- [x] `app/api/webhooks/agent/complete/__tests__/route.test.ts` — 15 tests pass (previously owned the local mock)
- [x] `app/v1/runs/__tests__/route.test.ts` — 24 tests pass (previously timing out)
- [x] `app/api/agent/runs/__tests__/route.test.ts` — 64 tests pass (previously timing out)
- [x] `app/api/cron/execute-schedules/__tests__/route.test.ts` — 14 tests pass (previously timing out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)