### PR TITLE
chore: remove turbo-checks from pre-commit hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,10 +15,6 @@ pre-commit:
             root: turbo/
             glob: "turbo/**/*"
             stage_fixed: true
-          - name: turbo-checks
-            run: pnpm turbo run lint check-types --filter='...[HEAD]' --ui=stream
-            root: turbo/
-            glob: "turbo/**/*.{js,ts,tsx,jsx,mjs,cjs}"
           - name: knip
             run: pnpm knip --cache
             root: turbo/


### PR DESCRIPTION
## Summary

- Remove the `turbo-checks` pre-commit hook step that ran `pnpm turbo run lint check-types` on every commit
- These checks are already enforced in CI, making the pre-commit step redundant
- Reduces pre-commit hook execution time for a faster developer experience

## Test plan

- [x] Verified `lefthook.yml` is valid and all remaining hooks work correctly (commit passed all hooks)
- [x] Confirmed lint, type-check, and format checks still pass independently
- [x] CI pipeline continues to run lint and check-types on all PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)