### PR TITLE
fix(crates): use system tls certificates instead of bundled webpki-roots

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -606,7 +606,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1129,7 +1128,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1694,11 +1692,11 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tungstenite",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1874,7 +1872,7 @@ dependencies = [
  "rustls-platform-verifier",
  "ureq-proto",
  "utf-8",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2092,15 +2090,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/crates/ably-subscriber/Cargo.toml
+++ b/crates/ably-subscriber/Cargo.toml
@@ -6,14 +6,14 @@ edition.workspace = true
 [dependencies]
 base64 = { workspace = true }
 futures-util = { workspace = true }
-reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+reqwest = { workspace = true, features = ["json", "rustls-tls-native-roots"] }
 rmp-serde = { workspace = true }
 rmpv = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
-tokio-tungstenite = { workspace = true, features = ["connect", "rustls-tls-webpki-roots"] }
+tokio-tungstenite = { workspace = true, features = ["connect", "rustls-tls-native-roots"] }
 tracing = { workspace = true }
 url = { workspace = true }
 

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "signal", "time", "fs"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+reqwest = { workspace = true, features = ["json", "rustls-tls-native-roots"] }
 uuid = { workspace = true, features = ["v4", "serde"] }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- Switch `runner` and `ably-subscriber` crates from bundled webpki-roots to system TLS certificates
- `runner`: `rustls-tls` → `rustls-tls-native-roots`
- `ably-subscriber`: `rustls-tls` → `rustls-tls-native-roots` (reqwest), `rustls-tls-webpki-roots` → `rustls-tls-native-roots` (tokio-tungstenite)
- `guest-agent` already uses `rustls-tls-native-roots`, no change needed

## Test plan
- [x] `cargo check --all-targets` passes
- [x] clippy passes (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)