### PR TITLE
feat(runner): add `setup` command to download firecracker and kernel

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1197,6 +1197,7 @@ dependencies = [
  "sandbox-fc",
  "serde",
  "serde_json",
+ "sha2",
  "tar",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -386,12 +386,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,11 +415,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1109,7 +1101,6 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1130,14 +1121,12 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
 ]
 
@@ -2076,19 +2065,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -386,6 +386,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,9 +421,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1101,6 +1109,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1121,12 +1130,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -1179,18 +1190,21 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "flate2",
  "nix",
  "reqwest",
  "sandbox",
  "sandbox-fc",
  "serde",
  "serde_json",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "which",
 ]
 
 [[package]]
@@ -2061,6 +2075,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -17,8 +17,11 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "signal", "time", "fs"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-reqwest = { workspace = true, features = ["json", "rustls-tls-native-roots"] }
+flate2 = { workspace = true }
+reqwest = { workspace = true, features = ["json", "rustls-tls-native-roots", "stream"] }
+tar = { workspace = true }
 uuid = { workspace = true, features = ["v4", "serde"] }
+which = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -19,6 +19,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 flate2 = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls-native-roots", "stream"] }
+sha2 = { workspace = true }
 tar = { workspace = true }
 uuid = { workspace = true, features = ["v4", "serde"] }
 which = { workspace = true }

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "si
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 flate2 = { workspace = true }
-reqwest = { workspace = true, features = ["json", "rustls-tls-native-roots", "stream"] }
+reqwest = { workspace = true, features = ["json", "rustls-tls-native-roots"] }
 sha2 = { workspace = true }
 tar = { workspace = true }
 uuid = { workspace = true, features = ["v4", "serde"] }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -46,7 +46,7 @@ enum Command {
     /// Start the runner and poll for jobs
     Start(Box<StartArgs>),
     /// Download Firecracker, kernel, and verify host prerequisites
-    Setup,
+    Setup(SetupArgs),
 }
 
 #[derive(Args)]
@@ -89,6 +89,13 @@ struct StartArgs {
     proxy_port: Option<u16>,
 }
 
+#[derive(Args)]
+struct SetupArgs {
+    /// Fail on missing optional dependencies (for CI)
+    #[arg(long)]
+    strict: bool,
+}
+
 #[tokio::main]
 async fn main() -> ExitCode {
     tracing_subscriber::fmt()
@@ -104,7 +111,7 @@ async fn main() -> ExitCode {
 
     let result = match cli.command {
         Command::Start(args) => run_start(*args).await,
-        Command::Setup => setup::run_setup().await,
+        Command::Setup(args) => setup::run_setup(args.strict).await,
     };
 
     if let Err(e) = result {

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -3,6 +3,7 @@ mod error;
 mod executor;
 mod paths;
 mod runner;
+mod setup;
 mod status;
 mod types;
 
@@ -43,7 +44,9 @@ struct Cli {
 #[derive(Subcommand)]
 enum Command {
     /// Start the runner and poll for jobs
-    Start(StartArgs),
+    Start(Box<StartArgs>),
+    /// Download Firecracker, kernel, and verify host prerequisites
+    Setup,
 }
 
 #[derive(Args)]
@@ -100,7 +103,8 @@ async fn main() -> ExitCode {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Command::Start(args) => run_start(args).await,
+        Command::Start(args) => run_start(*args).await,
+        Command::Setup => setup::run_setup().await,
     };
 
     if let Err(e) = result {

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use crate::error::{RunnerError, RunnerResult};
+
 /// Guest paths (must match rootfs layout).
 pub mod guest {
     pub const STORAGE_MANIFEST: &str = "/tmp/storage-manifest.json";
@@ -19,5 +21,41 @@ impl RunnerPaths {
 
     pub fn status(&self) -> PathBuf {
         self.base_dir.join("status.json")
+    }
+}
+
+/// Paths rooted at ~/.vm0-runner/.
+pub struct HomePaths {
+    root: PathBuf,
+}
+
+impl HomePaths {
+    pub fn new() -> RunnerResult<Self> {
+        let home = std::env::var("HOME")
+            .map_err(|_| RunnerError::Config("HOME environment variable not set".into()))?;
+        Ok(Self {
+            root: PathBuf::from(home).join(".vm0-runner"),
+        })
+    }
+
+    pub fn bin_dir(&self) -> PathBuf {
+        self.root.join("bin")
+    }
+
+    pub fn firecracker_dir(&self, version: &str) -> PathBuf {
+        self.root.join("firecracker").join(version)
+    }
+
+    pub fn firecracker_bin(&self, version: &str) -> PathBuf {
+        self.firecracker_dir(version).join("firecracker")
+    }
+
+    pub fn kernel_bin(&self, fc_version: &str, kernel_version: &str) -> PathBuf {
+        let kernel_name = format!("vmlinux-{kernel_version}");
+        self.firecracker_dir(fc_version).join(kernel_name)
+    }
+
+    pub fn runners_dir(&self) -> PathBuf {
+        self.root.join("runners")
     }
 }

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -3,6 +3,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
@@ -115,37 +116,56 @@ async fn create_directories(paths: &HomePaths, fc_version: &str) -> RunnerResult
     Ok(())
 }
 
-/// Write contents to a PID-unique temp file, set permissions, then atomically rename.
-/// Cleans up the temp file on failure.
-async fn atomic_install(target: &Path, contents: &[u8], mode: Option<u32>) -> RunnerResult<()> {
-    let tmp_path = target.with_extension(format!("tmp.{}", std::process::id()));
+/// Stream an HTTP response to a file, computing SHA256 incrementally.
+/// Returns the hex-encoded digest.
+async fn stream_to_file(mut response: reqwest::Response, path: &Path) -> RunnerResult<String> {
+    let mut file = tokio::fs::File::create(path)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("create {}: {e}", path.display())))?;
+    let mut hasher = Sha256::new();
 
-    let result = async {
-        tokio::fs::write(&tmp_path, contents)
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("read response chunk: {e}")))?
+    {
+        hasher.update(&chunk);
+        file.write_all(&chunk)
             .await
-            .map_err(|e| RunnerError::Internal(format!("write {}: {e}", target.display())))?;
+            .map_err(|e| RunnerError::Internal(format!("write {}: {e}", path.display())))?;
+    }
+
+    file.flush()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("flush {}: {e}", path.display())))?;
+
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Set permissions then atomically rename to target. Cleans up temp on failure.
+async fn atomic_rename(tmp_path: &Path, target: &Path, mode: Option<u32>) -> RunnerResult<()> {
+    let result = async {
         if let Some(mode) = mode {
-            tokio::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(mode))
+            tokio::fs::set_permissions(tmp_path, std::fs::Permissions::from_mode(mode))
                 .await
                 .map_err(|e| RunnerError::Internal(format!("chmod {}: {e}", target.display())))?;
         }
-        tokio::fs::rename(&tmp_path, target)
+        tokio::fs::rename(tmp_path, target)
             .await
             .map_err(|e| RunnerError::Internal(format!("rename to {}: {e}", target.display())))
     }
     .await;
 
     if result.is_err() {
-        let _ = tokio::fs::remove_file(&tmp_path).await;
+        let _ = tokio::fs::remove_file(tmp_path).await;
     }
     result
 }
 
-fn verify_sha256(data: &[u8], expected_hex: &str, label: &str) -> RunnerResult<()> {
-    let actual = format!("{:x}", Sha256::digest(data));
-    if actual != expected_hex {
+fn verify_sha256(actual_hex: &str, expected_hex: &str, label: &str) -> RunnerResult<()> {
+    if actual_hex != expected_hex {
         return Err(RunnerError::Internal(format!(
-            "{label} SHA256 mismatch: expected {expected_hex}, got {actual}"
+            "{label} SHA256 mismatch: expected {expected_hex}, got {actual_hex}"
         )));
     }
     tracing::info!("[OK] {label} SHA256 verified");
@@ -196,64 +216,34 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
         )));
     }
 
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("read firecracker response: {e}")))?;
-
-    // Extract the firecracker binary from the tarball
-    let decoder = flate2::read::GzDecoder::new(&bytes[..]);
-    let mut archive = tar::Archive::new(decoder);
-
-    let expected_name = format!("firecracker-{FIRECRACKER_VERSION}-{arch}");
-
-    let entries = archive
-        .entries()
-        .map_err(|e| RunnerError::Internal(format!("read tarball entries: {e}")))?;
-
-    let mut contents = None;
-    for entry in entries {
-        let mut entry =
-            entry.map_err(|e| RunnerError::Internal(format!("read tarball entry: {e}")))?;
-
-        let path = entry
-            .path()
-            .map_err(|e| RunnerError::Internal(format!("read entry path: {e}")))?;
-
-        let file_name = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or_default();
-
-        if file_name == expected_name {
-            let mut buf = Vec::new();
-            entry
-                .read_to_end(&mut buf)
-                .map_err(|e| RunnerError::Internal(format!("read firecracker binary: {e}")))?;
-            contents = Some(buf);
-            break;
-        }
+    // Stream tarball to a temp file
+    let tarball_path = bin_path.with_extension(format!("tgz.{}", std::process::id()));
+    if let Err(e) = stream_to_file(response, &tarball_path).await {
+        let _ = tokio::fs::remove_file(&tarball_path).await;
+        return Err(e);
     }
 
-    let contents = contents.ok_or_else(|| {
-        RunnerError::Internal(format!(
-            "firecracker binary '{expected_name}' not found in tarball"
-        ))
-    })?;
+    // Extract the firecracker binary from the tarball on disk
+    let tmp_path = bin_path.with_extension(format!("tmp.{}", std::process::id()));
+    let result = extract_firecracker(&tarball_path, &tmp_path, arch).await;
+    let _ = tokio::fs::remove_file(&tarball_path).await;
+    let sha_hex = result?;
 
     let expected_sha = match arch {
         "x86_64" => FIRECRACKER_SHA256_X86_64,
         _ => FIRECRACKER_SHA256_AARCH64,
     };
-    verify_sha256(&contents, expected_sha, "firecracker binary")?;
+    if let Err(e) = verify_sha256(&sha_hex, expected_sha, "firecracker binary") {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(e);
+    }
 
-    match atomic_install(&bin_path, &contents, Some(0o755)).await {
+    match atomic_rename(&tmp_path, &bin_path, Some(0o755)).await {
         Ok(()) => {
             tracing::info!("[OK] firecracker {FIRECRACKER_VERSION} installed");
             Ok(())
         }
         Err(e) => {
-            // Another runner may have completed the install
             if is_firecracker_installed(&bin_path).await {
                 tracing::info!(
                     "[OK] firecracker {FIRECRACKER_VERSION} installed by another process"
@@ -263,6 +253,74 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
             Err(e)
         }
     }
+}
+
+/// Extract the firecracker binary from a tarball, writing to tmp_path.
+/// Returns the SHA256 hex digest of the extracted binary.
+async fn extract_firecracker(
+    tarball_path: &Path,
+    tmp_path: &Path,
+    arch: &str,
+) -> RunnerResult<String> {
+    let tarball = tarball_path.to_owned();
+    let tmp = tmp_path.to_owned();
+    let arch = arch.to_owned();
+
+    // Sync I/O on local files — fine for a setup command
+    tokio::task::spawn_blocking(move || {
+        let file = std::fs::File::open(&tarball)
+            .map_err(|e| RunnerError::Internal(format!("open tarball: {e}")))?;
+        let decoder = flate2::read::GzDecoder::new(file);
+        let mut archive = tar::Archive::new(decoder);
+
+        let expected_name = format!("firecracker-{FIRECRACKER_VERSION}-{arch}");
+
+        let entries = archive
+            .entries()
+            .map_err(|e| RunnerError::Internal(format!("read tarball entries: {e}")))?;
+
+        for entry in entries {
+            let mut entry =
+                entry.map_err(|e| RunnerError::Internal(format!("read tarball entry: {e}")))?;
+
+            let path = entry
+                .path()
+                .map_err(|e| RunnerError::Internal(format!("read entry path: {e}")))?;
+
+            let file_name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default();
+
+            if file_name == expected_name {
+                let mut out = std::fs::File::create(&tmp)
+                    .map_err(|e| RunnerError::Internal(format!("create temp binary: {e}")))?;
+                let mut hasher = Sha256::new();
+                let mut buf = [0u8; 64 * 1024];
+                loop {
+                    let n = entry
+                        .read(&mut buf)
+                        .map_err(|e| RunnerError::Internal(format!("read tar entry: {e}")))?;
+                    if n == 0 {
+                        break;
+                    }
+                    let chunk = buf.get(..n).ok_or_else(|| {
+                        RunnerError::Internal("read returned invalid length".into())
+                    })?;
+                    hasher.update(chunk);
+                    std::io::Write::write_all(&mut out, chunk)
+                        .map_err(|e| RunnerError::Internal(format!("write binary: {e}")))?;
+                }
+                return Ok(format!("{:x}", hasher.finalize()));
+            }
+        }
+
+        Err(RunnerError::Internal(format!(
+            "firecracker binary '{expected_name}' not found in tarball"
+        )))
+    })
+    .await
+    .map_err(|e| RunnerError::Internal(format!("extract task failed: {e}")))?
 }
 
 async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
@@ -289,24 +347,31 @@ async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
         )));
     }
 
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("read kernel response: {e}")))?;
+    // Stream directly to temp file, computing SHA256 incrementally
+    let tmp_path = kernel_path.with_extension(format!("tmp.{}", std::process::id()));
+    let sha_hex = match stream_to_file(response, &tmp_path).await {
+        Ok(sha) => sha,
+        Err(e) => {
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            return Err(e);
+        }
+    };
 
     let expected_sha = match arch {
         "x86_64" => KERNEL_SHA256_X86_64,
         _ => KERNEL_SHA256_AARCH64,
     };
-    verify_sha256(&bytes, expected_sha, "kernel")?;
+    if let Err(e) = verify_sha256(&sha_hex, expected_sha, "kernel") {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(e);
+    }
 
-    match atomic_install(&kernel_path, &bytes, None).await {
+    match atomic_rename(&tmp_path, &kernel_path, None).await {
         Ok(()) => {
             tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} installed");
             Ok(())
         }
         Err(e) => {
-            // Another runner may have completed the install
             if tokio::fs::try_exists(&kernel_path).await.unwrap_or(false) {
                 tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} installed by another process");
                 return Ok(());

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -229,9 +229,11 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
     let _ = tokio::fs::remove_file(&tarball_path).await;
     let sha_hex = result?;
 
+    #[allow(clippy::unreachable)] // arch validated by check_architecture
     let expected_sha = match arch {
         "x86_64" => FIRECRACKER_SHA256_X86_64,
-        _ => FIRECRACKER_SHA256_AARCH64,
+        "aarch64" => FIRECRACKER_SHA256_AARCH64,
+        _ => unreachable!(),
     };
     if let Err(e) = verify_sha256(&sha_hex, expected_sha, "firecracker binary") {
         let _ = tokio::fs::remove_file(&tmp_path).await;
@@ -357,9 +359,11 @@ async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
         }
     };
 
+    #[allow(clippy::unreachable)] // arch validated by check_architecture
     let expected_sha = match arch {
         "x86_64" => KERNEL_SHA256_X86_64,
-        _ => KERNEL_SHA256_AARCH64,
+        "aarch64" => KERNEL_SHA256_AARCH64,
+        _ => unreachable!(),
     };
     if let Err(e) = verify_sha256(&sha_hex, expected_sha, "kernel") {
         let _ = tokio::fs::remove_file(&tmp_path).await;

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -227,7 +227,13 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
     let tmp_path = bin_path.with_extension(format!("tmp.{}", std::process::id()));
     let result = extract_firecracker(&tarball_path, &tmp_path, arch).await;
     let _ = tokio::fs::remove_file(&tarball_path).await;
-    let sha_hex = result?;
+    let sha_hex = match result {
+        Ok(sha) => sha,
+        Err(e) => {
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            return Err(e);
+        }
+    };
 
     #[allow(clippy::unreachable)] // arch validated by check_architecture
     let expected_sha = match arch {

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -2,11 +2,23 @@ use std::io::Read;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
+use sha2::{Digest, Sha256};
+
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
 
 const FIRECRACKER_VERSION: &str = "v1.14.1";
 const KERNEL_VERSION: &str = "6.1.155";
+
+// SHA256 checksums for installed artifacts, keyed by arch.
+const FIRECRACKER_SHA256_X86_64: &str =
+    "ef68f03e2dcaa4c07347a4b11989bedb350c982e62da7a3f74bc40f4f840e0ce";
+const FIRECRACKER_SHA256_AARCH64: &str =
+    "d1bc4cbd166a3b572cdb55019634aed48a5426e2253f126b18654596367d2bf4";
+const KERNEL_SHA256_X86_64: &str =
+    "e41c7048bd2475e7e788153823fcb9166a7e0b78c4c443bd6446d015fa735f53";
+const KERNEL_SHA256_AARCH64: &str =
+    "61baeae1ac6197be4fc5c71fa78df266acdc33c54570290d2f611c2b42c105be";
 
 /// "v1.14.1" → "v1.14"
 const FIRECRACKER_MINOR: &str = strip_patch(FIRECRACKER_VERSION);
@@ -129,6 +141,17 @@ async fn atomic_install(target: &Path, contents: &[u8], mode: Option<u32>) -> Ru
     result
 }
 
+fn verify_sha256(data: &[u8], expected_hex: &str, label: &str) -> RunnerResult<()> {
+    let actual = format!("{:x}", Sha256::digest(data));
+    if actual != expected_hex {
+        return Err(RunnerError::Internal(format!(
+            "{label} SHA256 mismatch: expected {expected_hex}, got {actual}"
+        )));
+    }
+    tracing::info!("[OK] {label} SHA256 verified");
+    Ok(())
+}
+
 async fn is_firecracker_installed(bin_path: &Path) -> bool {
     if !tokio::fs::try_exists(bin_path).await.unwrap_or(false) {
         return false;
@@ -218,6 +241,12 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
         ))
     })?;
 
+    let expected_sha = match arch {
+        "x86_64" => FIRECRACKER_SHA256_X86_64,
+        _ => FIRECRACKER_SHA256_AARCH64,
+    };
+    verify_sha256(&contents, expected_sha, "firecracker binary")?;
+
     match atomic_install(&bin_path, &contents, Some(0o755)).await {
         Ok(()) => {
             tracing::info!("[OK] firecracker {FIRECRACKER_VERSION} installed");
@@ -264,6 +293,12 @@ async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
         .bytes()
         .await
         .map_err(|e| RunnerError::Internal(format!("read kernel response: {e}")))?;
+
+    let expected_sha = match arch {
+        "x86_64" => KERNEL_SHA256_X86_64,
+        _ => KERNEL_SHA256_AARCH64,
+    };
+    verify_sha256(&bytes, expected_sha, "kernel")?;
 
     match atomic_install(&kernel_path, &bytes, None).await {
         Ok(()) => {

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -40,7 +40,7 @@ const fn strip_patch(version: &str) -> &str {
     panic!("FIRECRACKER_VERSION must be in vMAJOR.MINOR.PATCH format")
 }
 
-pub async fn run_setup() -> RunnerResult<()> {
+pub async fn run_setup(strict: bool) -> RunnerResult<()> {
     let arch = check_architecture()?;
     let (missing_required, missing_optional) = check_system_dependencies();
 
@@ -50,21 +50,17 @@ pub async fn run_setup() -> RunnerResult<()> {
     download_kernel(&paths, arch).await?;
     check_kvm();
 
-    if !missing_required.is_empty() || !missing_optional.is_empty() {
-        let mut parts = Vec::new();
-        if !missing_required.is_empty() {
-            parts.push(format!(
-                "missing required dependencies: {}",
-                missing_required.join(", ")
-            ));
-        }
-        if !missing_optional.is_empty() {
-            parts.push(format!(
-                "missing optional dependencies: {}",
-                missing_optional.join(", ")
-            ));
-        }
-        return Err(RunnerError::Config(parts.join("; ")));
+    if !missing_required.is_empty() {
+        return Err(RunnerError::Config(format!(
+            "missing required dependencies: {}",
+            missing_required.join(", ")
+        )));
+    }
+    if strict && !missing_optional.is_empty() {
+        return Err(RunnerError::Config(format!(
+            "missing optional dependencies (strict mode): {}",
+            missing_optional.join(", ")
+        )));
     }
 
     tracing::info!("setup complete");

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -1,5 +1,6 @@
 use std::io::Read;
 use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
@@ -102,29 +103,58 @@ async fn create_directories(paths: &HomePaths, fc_version: &str) -> RunnerResult
     Ok(())
 }
 
+/// Write contents to a PID-unique temp file, set permissions, then atomically rename.
+/// Cleans up the temp file on failure.
+async fn atomic_install(target: &Path, contents: &[u8], mode: Option<u32>) -> RunnerResult<()> {
+    let tmp_path = target.with_extension(format!("tmp.{}", std::process::id()));
+
+    let result = async {
+        tokio::fs::write(&tmp_path, contents)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("write {}: {e}", target.display())))?;
+        if let Some(mode) = mode {
+            tokio::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(mode))
+                .await
+                .map_err(|e| RunnerError::Internal(format!("chmod {}: {e}", target.display())))?;
+        }
+        tokio::fs::rename(&tmp_path, target)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("rename to {}: {e}", target.display())))
+    }
+    .await;
+
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+    }
+    result
+}
+
+async fn is_firecracker_installed(bin_path: &Path) -> bool {
+    if !tokio::fs::try_exists(bin_path).await.unwrap_or(false) {
+        return false;
+    }
+    let Ok(output) = tokio::process::Command::new(bin_path)
+        .arg("--version")
+        .output()
+        .await
+    else {
+        return false;
+    };
+    let version_str = String::from_utf8_lossy(&output.stdout);
+    let version_no_prefix = FIRECRACKER_VERSION
+        .strip_prefix('v')
+        .unwrap_or(FIRECRACKER_VERSION);
+    version_str.contains(version_no_prefix)
+}
+
 async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let bin_path = paths.firecracker_bin(FIRECRACKER_VERSION);
 
-    // Check if already installed with correct version
-    if tokio::fs::try_exists(&bin_path).await.unwrap_or(false) {
-        let output = tokio::process::Command::new(&bin_path)
-            .arg("--version")
-            .output()
-            .await;
-        if let Ok(output) = output {
-            let version_str = String::from_utf8_lossy(&output.stdout);
-            // Firecracker prints "Firecracker v1.14.1", strip the 'v' prefix to match
-            let version_no_prefix = FIRECRACKER_VERSION
-                .strip_prefix('v')
-                .unwrap_or(FIRECRACKER_VERSION);
-            if version_str.contains(version_no_prefix) {
-                tracing::info!(
-                    "[OK] firecracker {FIRECRACKER_VERSION} already installed, skipping download"
-                );
-                return Ok(());
-            }
-            tracing::info!("firecracker version mismatch, re-downloading");
-        }
+    if is_firecracker_installed(&bin_path).await {
+        tracing::info!(
+            "[OK] firecracker {FIRECRACKER_VERSION} already installed, skipping download"
+        );
+        return Ok(());
     }
 
     let url = format!(
@@ -153,12 +183,12 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
     let mut archive = tar::Archive::new(decoder);
 
     let expected_name = format!("firecracker-{FIRECRACKER_VERSION}-{arch}");
-    let mut found = false;
 
     let entries = archive
         .entries()
         .map_err(|e| RunnerError::Internal(format!("read tarball entries: {e}")))?;
 
+    let mut contents = None;
     for entry in entries {
         let mut entry =
             entry.map_err(|e| RunnerError::Internal(format!("read tarball entry: {e}")))?;
@@ -173,36 +203,37 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
             .unwrap_or_default();
 
         if file_name == expected_name {
-            let mut contents = Vec::new();
+            let mut buf = Vec::new();
             entry
-                .read_to_end(&mut contents)
+                .read_to_end(&mut buf)
                 .map_err(|e| RunnerError::Internal(format!("read firecracker binary: {e}")))?;
-
-            // Write to a PID-unique temp file then rename for atomicity
-            let tmp_path = bin_path.with_extension(format!("tmp.{}", std::process::id()));
-            tokio::fs::write(&tmp_path, &contents)
-                .await
-                .map_err(|e| RunnerError::Internal(format!("write firecracker binary: {e}")))?;
-            tokio::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o755))
-                .await
-                .map_err(|e| RunnerError::Internal(format!("set firecracker permissions: {e}")))?;
-            tokio::fs::rename(&tmp_path, &bin_path)
-                .await
-                .map_err(|e| RunnerError::Internal(format!("rename firecracker binary: {e}")))?;
-
-            found = true;
+            contents = Some(buf);
             break;
         }
     }
 
-    if !found {
-        return Err(RunnerError::Internal(format!(
+    let contents = contents.ok_or_else(|| {
+        RunnerError::Internal(format!(
             "firecracker binary '{expected_name}' not found in tarball"
-        )));
-    }
+        ))
+    })?;
 
-    tracing::info!("[OK] firecracker {FIRECRACKER_VERSION} installed");
-    Ok(())
+    match atomic_install(&bin_path, &contents, Some(0o755)).await {
+        Ok(()) => {
+            tracing::info!("[OK] firecracker {FIRECRACKER_VERSION} installed");
+            Ok(())
+        }
+        Err(e) => {
+            // Another runner may have completed the install
+            if is_firecracker_installed(&bin_path).await {
+                tracing::info!(
+                    "[OK] firecracker {FIRECRACKER_VERSION} installed by another process"
+                );
+                return Ok(());
+            }
+            Err(e)
+        }
+    }
 }
 
 async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
@@ -234,17 +265,20 @@ async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
         .await
         .map_err(|e| RunnerError::Internal(format!("read kernel response: {e}")))?;
 
-    // Write to a PID-unique temp file then rename for atomicity
-    let tmp_path = kernel_path.with_extension(format!("tmp.{}", std::process::id()));
-    tokio::fs::write(&tmp_path, &bytes)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("write kernel: {e}")))?;
-    tokio::fs::rename(&tmp_path, &kernel_path)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("rename kernel: {e}")))?;
-
-    tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} installed");
-    Ok(())
+    match atomic_install(&kernel_path, &bytes, None).await {
+        Ok(()) => {
+            tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} installed");
+            Ok(())
+        }
+        Err(e) => {
+            // Another runner may have completed the install
+            if tokio::fs::try_exists(&kernel_path).await.unwrap_or(false) {
+                tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} installed by another process");
+                return Ok(());
+            }
+            Err(e)
+        }
+    }
 }
 
 fn check_kvm() {

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -1,0 +1,267 @@
+use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
+
+use crate::error::{RunnerError, RunnerResult};
+use crate::paths::HomePaths;
+
+const FIRECRACKER_VERSION: &str = "v1.14.1";
+const KERNEL_VERSION: &str = "6.1.155";
+
+/// "v1.14.1" → "v1.14"
+const FIRECRACKER_MINOR: &str = strip_patch(FIRECRACKER_VERSION);
+
+#[allow(clippy::panic, clippy::indexing_slicing)] // compile-time only
+const fn strip_patch(version: &str) -> &str {
+    let bytes = version.as_bytes();
+    let mut i = bytes.len();
+    while i > 0 {
+        i -= 1;
+        if bytes[i] == b'.' {
+            // SAFETY: splitting a UTF-8 str at an ASCII '.' boundary yields valid UTF-8
+            return unsafe {
+                std::str::from_utf8_unchecked(std::slice::from_raw_parts(bytes.as_ptr(), i))
+            };
+        }
+    }
+    panic!("FIRECRACKER_VERSION must be in vMAJOR.MINOR.PATCH format")
+}
+
+pub async fn run_setup() -> RunnerResult<()> {
+    let arch = check_architecture()?;
+    check_system_dependencies();
+
+    let paths = HomePaths::new()?;
+    create_directories(&paths, FIRECRACKER_VERSION).await?;
+    download_firecracker(&paths, arch).await?;
+    download_kernel(&paths, arch).await?;
+    check_kvm();
+
+    tracing::info!("setup complete");
+    Ok(())
+}
+
+fn check_architecture() -> RunnerResult<&'static str> {
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => "x86_64",
+        "aarch64" => "aarch64",
+        other => {
+            return Err(RunnerError::Config(format!(
+                "unsupported architecture: {other}"
+            )));
+        }
+    };
+    tracing::info!("[OK] architecture: {arch}");
+    Ok(arch)
+}
+
+fn check_system_dependencies() {
+    // Required by `runner start` (sandbox networking)
+    let required = ["ip", "iptables", "iptables-save", "sysctl"];
+    // Only needed by specific commands (build-rootfs, etc.)
+    let optional = ["pgrep", "mkfs.ext4", "mksquashfs", "docker"];
+
+    let missing_required: Vec<&str> = required
+        .iter()
+        .filter(|dep| which::which(dep).is_err())
+        .copied()
+        .collect();
+    let missing_optional: Vec<&str> = optional
+        .iter()
+        .filter(|dep| which::which(dep).is_err())
+        .copied()
+        .collect();
+
+    if missing_required.is_empty() {
+        tracing::info!("[OK] all required system dependencies found");
+    } else {
+        tracing::warn!(
+            "missing required dependencies (needed by `runner start`): {}",
+            missing_required.join(", ")
+        );
+    }
+
+    if !missing_optional.is_empty() {
+        tracing::warn!(
+            "missing optional dependencies (needed by other commands): {}",
+            missing_optional.join(", ")
+        );
+    }
+}
+
+async fn create_directories(paths: &HomePaths, fc_version: &str) -> RunnerResult<()> {
+    tokio::fs::create_dir_all(paths.bin_dir())
+        .await
+        .map_err(|e| RunnerError::Internal(format!("create bin dir: {e}")))?;
+    tokio::fs::create_dir_all(paths.firecracker_dir(fc_version))
+        .await
+        .map_err(|e| RunnerError::Internal(format!("create firecracker dir: {e}")))?;
+    tokio::fs::create_dir_all(paths.runners_dir())
+        .await
+        .map_err(|e| RunnerError::Internal(format!("create runners dir: {e}")))?;
+    tracing::info!("[OK] directory structure created");
+    Ok(())
+}
+
+async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
+    let bin_path = paths.firecracker_bin(FIRECRACKER_VERSION);
+
+    // Check if already installed with correct version
+    if tokio::fs::try_exists(&bin_path).await.unwrap_or(false) {
+        let output = tokio::process::Command::new(&bin_path)
+            .arg("--version")
+            .output()
+            .await;
+        if let Ok(output) = output {
+            let version_str = String::from_utf8_lossy(&output.stdout);
+            // Firecracker prints "Firecracker v1.14.1", strip the 'v' prefix to match
+            let version_no_prefix = FIRECRACKER_VERSION
+                .strip_prefix('v')
+                .unwrap_or(FIRECRACKER_VERSION);
+            if version_str.contains(version_no_prefix) {
+                tracing::info!(
+                    "[OK] firecracker {FIRECRACKER_VERSION} already installed, skipping download"
+                );
+                return Ok(());
+            }
+            tracing::info!("firecracker version mismatch, re-downloading");
+        }
+    }
+
+    let url = format!(
+        "https://github.com/firecracker-microvm/firecracker/releases/download/{FIRECRACKER_VERSION}/firecracker-{FIRECRACKER_VERSION}-{arch}.tgz"
+    );
+    tracing::info!("downloading firecracker from {url}");
+
+    let response = reqwest::get(&url)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("download firecracker: {e}")))?;
+
+    if !response.status().is_success() {
+        return Err(RunnerError::Internal(format!(
+            "download firecracker: HTTP {}",
+            response.status()
+        )));
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("read firecracker response: {e}")))?;
+
+    // Extract the firecracker binary from the tarball
+    let decoder = flate2::read::GzDecoder::new(&bytes[..]);
+    let mut archive = tar::Archive::new(decoder);
+
+    let expected_name = format!("firecracker-{FIRECRACKER_VERSION}-{arch}");
+    let mut found = false;
+
+    let entries = archive
+        .entries()
+        .map_err(|e| RunnerError::Internal(format!("read tarball entries: {e}")))?;
+
+    for entry in entries {
+        let mut entry =
+            entry.map_err(|e| RunnerError::Internal(format!("read tarball entry: {e}")))?;
+
+        let path = entry
+            .path()
+            .map_err(|e| RunnerError::Internal(format!("read entry path: {e}")))?;
+
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+
+        if file_name == expected_name {
+            let mut contents = Vec::new();
+            entry
+                .read_to_end(&mut contents)
+                .map_err(|e| RunnerError::Internal(format!("read firecracker binary: {e}")))?;
+
+            // Write to a PID-unique temp file then rename for atomicity
+            let tmp_path = bin_path.with_extension(format!("tmp.{}", std::process::id()));
+            tokio::fs::write(&tmp_path, &contents)
+                .await
+                .map_err(|e| RunnerError::Internal(format!("write firecracker binary: {e}")))?;
+            tokio::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o755))
+                .await
+                .map_err(|e| RunnerError::Internal(format!("set firecracker permissions: {e}")))?;
+            tokio::fs::rename(&tmp_path, &bin_path)
+                .await
+                .map_err(|e| RunnerError::Internal(format!("rename firecracker binary: {e}")))?;
+
+            found = true;
+            break;
+        }
+    }
+
+    if !found {
+        return Err(RunnerError::Internal(format!(
+            "firecracker binary '{expected_name}' not found in tarball"
+        )));
+    }
+
+    tracing::info!("[OK] firecracker {FIRECRACKER_VERSION} installed");
+    Ok(())
+}
+
+async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
+    let kernel_path = paths.kernel_bin(FIRECRACKER_VERSION, KERNEL_VERSION);
+
+    if tokio::fs::try_exists(&kernel_path).await.unwrap_or(false) {
+        tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} already present, skipping download");
+        return Ok(());
+    }
+
+    let url = format!(
+        "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/{FIRECRACKER_MINOR}/{arch}/vmlinux-{KERNEL_VERSION}"
+    );
+    tracing::info!("downloading kernel from {url}");
+
+    let response = reqwest::get(&url)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("download kernel: {e}")))?;
+
+    if !response.status().is_success() {
+        return Err(RunnerError::Internal(format!(
+            "download kernel: HTTP {}",
+            response.status()
+        )));
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("read kernel response: {e}")))?;
+
+    // Write to a PID-unique temp file then rename for atomicity
+    let tmp_path = kernel_path.with_extension(format!("tmp.{}", std::process::id()));
+    tokio::fs::write(&tmp_path, &bytes)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("write kernel: {e}")))?;
+    tokio::fs::rename(&tmp_path, &kernel_path)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("rename kernel: {e}")))?;
+
+    tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} installed");
+    Ok(())
+}
+
+fn check_kvm() {
+    use std::fs::File;
+
+    match File::options().read(true).write(true).open("/dev/kvm") {
+        Ok(_) => {
+            tracing::info!("[OK] KVM accessible");
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::warn!("/dev/kvm not found — ensure bare-metal with KVM enabled");
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            tracing::warn!("/dev/kvm not accessible — run: sudo chmod 666 /dev/kvm");
+        }
+        Err(e) => {
+            tracing::warn!("/dev/kvm check failed: {e}");
+        }
+    }
+}

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -42,13 +42,30 @@ const fn strip_patch(version: &str) -> &str {
 
 pub async fn run_setup() -> RunnerResult<()> {
     let arch = check_architecture()?;
-    check_system_dependencies();
+    let (missing_required, missing_optional) = check_system_dependencies();
 
     let paths = HomePaths::new()?;
     create_directories(&paths, FIRECRACKER_VERSION).await?;
     download_firecracker(&paths, arch).await?;
     download_kernel(&paths, arch).await?;
     check_kvm();
+
+    if !missing_required.is_empty() || !missing_optional.is_empty() {
+        let mut parts = Vec::new();
+        if !missing_required.is_empty() {
+            parts.push(format!(
+                "missing required dependencies: {}",
+                missing_required.join(", ")
+            ));
+        }
+        if !missing_optional.is_empty() {
+            parts.push(format!(
+                "missing optional dependencies: {}",
+                missing_optional.join(", ")
+            ));
+        }
+        return Err(RunnerError::Config(parts.join("; ")));
+    }
 
     tracing::info!("setup complete");
     Ok(())
@@ -68,7 +85,8 @@ fn check_architecture() -> RunnerResult<&'static str> {
     Ok(arch)
 }
 
-fn check_system_dependencies() {
+/// Returns (missing_required, missing_optional) dependency names.
+fn check_system_dependencies() -> (Vec<&'static str>, Vec<&'static str>) {
     // Required by `runner start` (sandbox networking)
     let required = ["ip", "iptables", "iptables-save", "sysctl"];
     // Only needed by specific commands (build-rootfs, etc.)
@@ -100,6 +118,8 @@ fn check_system_dependencies() {
             missing_optional.join(", ")
         );
     }
+
+    (missing_required, missing_optional)
 }
 
 async fn create_directories(paths: &HomePaths, fc_version: &str) -> RunnerResult<()> {


### PR DESCRIPTION
## Summary

- Add `runner setup` subcommand that downloads Firecracker v1.14.1 + kernel 6.1.155 and verifies host prerequisites
- Add `HomePaths` struct for `~/.vm0-runner/` directory layout with version-parameterized paths
- Switch reqwest from `rustls-tls` to `rustls-tls-native-roots` to use system certificate store

### Setup steps
1. Check CPU architecture (x86_64/aarch64)
2. Verify required (`ip`, `iptables`, `iptables-save`, `sysctl`) and optional (`docker`, `mksquashfs`, etc.) system dependencies
3. Create `~/.vm0-runner/{bin,firecracker/v1.14.1,runners}` directory structure
4. Download Firecracker binary from GitHub releases (with version check, skips if already installed)
5. Download kernel from S3 (skips if already present)
6. Check `/dev/kvm` accessibility

### Design decisions
- Downloads are **idempotent** — re-running skips already-installed artifacts
- Writes are **atomic** — PID-unique temp file + rename to avoid corruption under concurrent setup
- `FIRECRACKER_MINOR` is a **compile-time const** derived from `FIRECRACKER_VERSION` via const fn
- No sudo required — everything installs under `~/.vm0-runner/`

Closes #2820

## Test plan

- [ ] `cargo clippy -p runner` passes with zero warnings
- [ ] `cargo run -p runner -- setup` downloads firecracker + kernel to `~/.vm0-runner/`
- [ ] Second `cargo run -p runner -- setup` skips downloads (idempotent)
- [ ] `cargo run -p runner -- setup --help` shows setup description
- [ ] Existing `start` subcommand still compiles and works

🤖 Generated with [Claude Code](https://claude.com/claude-code)