### PR TITLE
fix(crates): remove dead code and fix type inconsistency

### DIFF
--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -85,7 +85,7 @@ impl SecretMasker {
                 }
             }
             Value::Object(map) => {
-                for (_key, v) in map.iter_mut() {
+                for v in map.values_mut() {
                     self.mask_value(v);
                 }
             }
@@ -97,9 +97,7 @@ impl SecretMasker {
     pub fn mask_string(&self, s: &str) -> String {
         let mut result = s.to_string();
         for pattern in &self.patterns {
-            if result.contains(pattern.as_str()) {
-                result = result.replace(pattern.as_str(), "***");
-            }
+            result = result.replace(pattern.as_str(), "***");
         }
         result
     }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -205,7 +205,7 @@ async fn download_storages(
     if result.exit_code != 0 {
         return Err(crate::error::RunnerError::Internal(format!(
             "storage download failed: {}",
-            result.stderr
+            String::from_utf8_lossy(&result.stderr)
         )));
     }
     Ok(())

--- a/crates/sandbox-fc/examples/sandbox-fc.rs
+++ b/crates/sandbox-fc/examples/sandbox-fc.rs
@@ -235,8 +235,8 @@ async fn run_exec(
         .await?;
 
     println!("exit_code: {}", result.exit_code);
-    println!("stdout: {}", result.stdout);
-    println!("stderr: {}", result.stderr);
+    println!("stdout: {}", String::from_utf8_lossy(&result.stdout));
+    println!("stderr: {}", String::from_utf8_lossy(&result.stderr));
 
     sandbox.stop().await?;
     factory.destroy(sandbox).await;

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -426,8 +426,8 @@ impl Sandbox for FirecrackerSandbox {
 
         Ok(ExecResult {
             exit_code: result.exit_code,
-            stdout: String::from_utf8_lossy(&result.stdout).into_owned(),
-            stderr: String::from_utf8_lossy(&result.stderr).into_owned(),
+            stdout: result.stdout,
+            stderr: result.stderr,
         })
     }
 

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -12,9 +12,6 @@ pub enum SandboxError {
     #[error("execution failed: {0}")]
     ExecFailed(String),
 
-    #[error("timeout after {0}ms")]
-    Timeout(u64),
-
     #[error("invalid configuration: {0}")]
     InvalidConfig(String),
 

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -15,8 +15,8 @@ impl ExecRequest<'_> {
 
 pub struct ExecResult {
     pub exit_code: i32,
-    pub stdout: String,
-    pub stderr: String,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
 }
 
 pub struct SpawnHandle {


### PR DESCRIPTION
## Summary
- Remove unused `SandboxError::Timeout` variant (dead code)
- Change `ExecResult` stdout/stderr from `String` to `Vec<u8>` for consistency with `vsock_host::ExecResult`, deferring lossy UTF-8 conversion to display sites
- Remove redundant `contains()` check before `replace()` in `SecretMasker::mask_string`
- Use `values_mut()` instead of `iter_mut()` in masker Object branch

## Test plan
- [x] `cargo clippy` passes with zero warnings
- [x] All 85 existing tests pass (guest-agent: 17, sandbox-fc: 68)
- [x] No new tests needed — these are dead code removal, type alignment, and redundant logic removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)