### PR TITLE
feat: add webhook callback mechanism for agent run completion

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/__tests__/route.test.ts
@@ -1,0 +1,644 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { WebClient } from "@slack/web-api";
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+import { testContext } from "../../../../../../src/__tests__/test-helpers";
+import {
+  givenLinkedSlackUser,
+  givenUserHasAgent,
+} from "../../../../../../src/__tests__/slack/api-helpers";
+import {
+  createTestRun,
+  createTestCallback,
+  createTestAgentSession,
+  createTestRequest,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import { computeHmacSignature } from "../../../../../../src/lib/callback/hmac";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+// Get the WebClient mock singleton
+const mockClient = vi.mocked(new WebClient(), true);
+
+interface CallbackPayload {
+  workspaceId: string;
+  channelId: string;
+  threadTs: string;
+  messageTs: string;
+  userLinkId: string;
+  agentName: string;
+  composeId: string;
+  existingSessionId?: string;
+  reactionAdded: boolean;
+}
+
+/**
+ * Create a signed callback request
+ */
+function createCallbackRequest(
+  body: {
+    runId: string;
+    status: "completed" | "failed";
+    result?: Record<string, unknown>;
+    error?: string;
+    payload: CallbackPayload;
+  },
+  secret: string,
+  options?: { invalidSignature?: boolean; expiredTimestamp?: boolean },
+): NextRequest {
+  const bodyString = JSON.stringify(body);
+  const timestamp = options?.expiredTimestamp
+    ? Math.floor(Date.now() / 1000) - 600 // 10 minutes ago
+    : Math.floor(Date.now() / 1000);
+
+  const signature = options?.invalidSignature
+    ? "invalid-signature"
+    : computeHmacSignature(bodyString, secret, timestamp);
+
+  return createTestRequest("http://localhost/api/internal/callbacks/slack", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VM0-Signature": signature,
+      "X-VM0-Timestamp": timestamp.toString(),
+    },
+    body: bodyString,
+  });
+}
+
+describe("POST /api/internal/callbacks/slack", () => {
+  beforeEach(() => {
+    context.setupMocks();
+    mockClient.chat.postMessage.mockClear();
+    mockClient.reactions.remove.mockClear();
+  });
+
+  describe("Signature Verification", () => {
+    it("should reject request with invalid signature", async () => {
+      // Given a linked Slack user with an agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { binding } = await givenUserHasAgent(userLink, {
+        agentName: "test-agent",
+      });
+
+      // And a run with a registered callback
+      mockClerk({ userId: userLink.vm0UserId });
+      const { runId } = await createTestRun(binding.composeId, "Test prompt");
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/slack",
+        payload: {
+          workspaceId: installation.slackWorkspaceId,
+          channelId: "C123",
+          threadTs: "1234567890.000000",
+          messageTs: "1234567890.123456",
+          userLinkId: userLink.id,
+          agentName: "test-agent",
+          composeId: binding.composeId,
+          reactionAdded: true,
+        },
+      });
+
+      // When I send a request with an invalid signature
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "completed",
+          payload: {
+            workspaceId: installation.slackWorkspaceId,
+            channelId: "C123",
+            threadTs: "1234567890.000000",
+            messageTs: "1234567890.123456",
+            userLinkId: userLink.id,
+            agentName: "test-agent",
+            composeId: binding.composeId,
+            reactionAdded: true,
+          },
+        },
+        secret,
+        { invalidSignature: true },
+      );
+      const response = await POST(request);
+
+      // Then the request should be rejected
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toContain("signature");
+    });
+
+    it("should reject request with expired timestamp", async () => {
+      // Given a linked Slack user with an agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { binding } = await givenUserHasAgent(userLink, {
+        agentName: "test-agent",
+      });
+
+      // And a run with a registered callback
+      mockClerk({ userId: userLink.vm0UserId });
+      const { runId } = await createTestRun(binding.composeId, "Test prompt");
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/slack",
+        payload: {
+          workspaceId: installation.slackWorkspaceId,
+          channelId: "C123",
+          threadTs: "1234567890.000000",
+          messageTs: "1234567890.123456",
+          userLinkId: userLink.id,
+          agentName: "test-agent",
+          composeId: binding.composeId,
+          reactionAdded: true,
+        },
+      });
+
+      // When I send a request with an expired timestamp
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "completed",
+          payload: {
+            workspaceId: installation.slackWorkspaceId,
+            channelId: "C123",
+            threadTs: "1234567890.000000",
+            messageTs: "1234567890.123456",
+            userLinkId: userLink.id,
+            agentName: "test-agent",
+            composeId: binding.composeId,
+            reactionAdded: true,
+          },
+        },
+        secret,
+        { expiredTimestamp: true },
+      );
+      const response = await POST(request);
+
+      // Then the request should be rejected
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toContain("expired");
+    });
+
+    it("should reject request with missing signature header", async () => {
+      // Given a run ID
+      const runId = "00000000-0000-0000-0000-000000000001";
+
+      // When I send a request without signature header
+      const request = createTestRequest(
+        "http://localhost/api/internal/callbacks/slack",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-VM0-Timestamp": Math.floor(Date.now() / 1000).toString(),
+          },
+          body: JSON.stringify({
+            runId,
+            status: "completed",
+            payload: {
+              workspaceId: "T123",
+              channelId: "C123",
+              threadTs: "1234567890.000000",
+              messageTs: "1234567890.123456",
+              userLinkId: "link-123",
+              agentName: "test-agent",
+              composeId: "compose-123",
+              reactionAdded: false,
+            },
+          }),
+        },
+      );
+      const response = await POST(request);
+
+      // Then the request should be rejected
+      expect(response.status).toBe(404);
+    });
+
+    it("should reject request for non-existent callback", async () => {
+      const runId = "00000000-0000-0000-0000-000000000001";
+
+      // When I send a request for a run with no callback
+      const request = createTestRequest(
+        "http://localhost/api/internal/callbacks/slack",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-VM0-Signature": "any-signature",
+            "X-VM0-Timestamp": Math.floor(Date.now() / 1000).toString(),
+          },
+          body: JSON.stringify({
+            runId,
+            status: "completed",
+            payload: {
+              workspaceId: "T123",
+              channelId: "C123",
+              threadTs: "1234567890.000000",
+              messageTs: "1234567890.123456",
+              userLinkId: "link-123",
+              agentName: "test-agent",
+              composeId: "compose-123",
+              reactionAdded: false,
+            },
+          }),
+        },
+      );
+      const response = await POST(request);
+
+      // Then the request should return 404
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error).toContain("not found");
+    });
+  });
+
+  describe("Successful Callback", () => {
+    it("should post response message to Slack on completed run", async () => {
+      // Given a linked Slack user with an agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { binding } = await givenUserHasAgent(userLink, {
+        agentName: "test-agent",
+      });
+
+      // And a run with a registered callback
+      mockClerk({ userId: userLink.vm0UserId });
+      const { runId } = await createTestRun(binding.composeId, "Test prompt");
+      const channelId = `C-callback-${Date.now()}`;
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/slack",
+        payload: {
+          workspaceId: installation.slackWorkspaceId,
+          channelId,
+          threadTs: "1234567890.000000",
+          messageTs: "1234567890.123456",
+          userLinkId: userLink.id,
+          agentName: "test-agent",
+          composeId: binding.composeId,
+          reactionAdded: true,
+        },
+      });
+
+      // When the callback is invoked with completed status
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "completed",
+          payload: {
+            workspaceId: installation.slackWorkspaceId,
+            channelId,
+            threadTs: "1234567890.000000",
+            messageTs: "1234567890.123456",
+            userLinkId: userLink.id,
+            agentName: "test-agent",
+            composeId: binding.composeId,
+            reactionAdded: true,
+          },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      // Then the request should succeed
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      // And a message should be posted to Slack
+      expect(mockClient.chat.postMessage).toHaveBeenCalledTimes(1);
+      const callArgs = mockClient.chat.postMessage.mock.calls[0]![0] as {
+        channel: string;
+        thread_ts: string;
+      };
+      expect(callArgs.channel).toBe(channelId);
+      expect(callArgs.thread_ts).toBe("1234567890.000000");
+
+      // And the thinking reaction should be removed
+      expect(mockClient.reactions.remove).toHaveBeenCalledTimes(1);
+    });
+
+    it("should post error message on failed run", async () => {
+      // Given a linked Slack user with an agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { binding } = await givenUserHasAgent(userLink, {
+        agentName: "test-agent",
+      });
+
+      // And a run with a registered callback
+      mockClerk({ userId: userLink.vm0UserId });
+      const { runId } = await createTestRun(binding.composeId, "Test prompt");
+      const channelId = `C-fail-${Date.now()}`;
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/slack",
+        payload: {
+          workspaceId: installation.slackWorkspaceId,
+          channelId,
+          threadTs: "1234567890.000000",
+          messageTs: "1234567890.123456",
+          userLinkId: userLink.id,
+          agentName: "test-agent",
+          composeId: binding.composeId,
+          reactionAdded: true,
+        },
+      });
+
+      // When the callback is invoked with failed status
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "failed",
+          error: "Agent crashed unexpectedly",
+          payload: {
+            workspaceId: installation.slackWorkspaceId,
+            channelId,
+            threadTs: "1234567890.000000",
+            messageTs: "1234567890.123456",
+            userLinkId: userLink.id,
+            agentName: "test-agent",
+            composeId: binding.composeId,
+            reactionAdded: true,
+          },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      // Then the request should succeed
+      expect(response.status).toBe(200);
+
+      // And an error message should be posted
+      expect(mockClient.chat.postMessage).toHaveBeenCalledTimes(1);
+      const callArgs = mockClient.chat.postMessage.mock.calls[0]![0] as {
+        text: string;
+      };
+      expect(callArgs.text).toContain("Error");
+      expect(callArgs.text).toContain("Agent crashed unexpectedly");
+    });
+
+    it("should not remove reaction when reactionAdded is false", async () => {
+      // Given a linked Slack user with an agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { binding } = await givenUserHasAgent(userLink, {
+        agentName: "test-agent",
+      });
+
+      // And a run with callback where reactionAdded is false
+      mockClerk({ userId: userLink.vm0UserId });
+      const { runId } = await createTestRun(binding.composeId, "Test prompt");
+      const channelId = `C-noreact-${Date.now()}`;
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/slack",
+        payload: {
+          workspaceId: installation.slackWorkspaceId,
+          channelId,
+          threadTs: "1234567890.000000",
+          messageTs: "1234567890.123456",
+          userLinkId: userLink.id,
+          agentName: "test-agent",
+          composeId: binding.composeId,
+          reactionAdded: false, // No reaction was added
+        },
+      });
+
+      // When the callback is invoked
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "completed",
+          payload: {
+            workspaceId: installation.slackWorkspaceId,
+            channelId,
+            threadTs: "1234567890.000000",
+            messageTs: "1234567890.123456",
+            userLinkId: userLink.id,
+            agentName: "test-agent",
+            composeId: binding.composeId,
+            reactionAdded: false,
+          },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      // Then the request should succeed
+      expect(response.status).toBe(200);
+
+      // And no reaction removal should be attempted
+      expect(mockClient.reactions.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Thread Session", () => {
+    it("should create thread session for new thread on successful completion", async () => {
+      // Given a linked Slack user with an agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { binding } = await givenUserHasAgent(userLink, {
+        agentName: "test-agent",
+      });
+
+      // And a run with callback (no existingSessionId = new thread)
+      mockClerk({ userId: userLink.vm0UserId });
+      const { runId } = await createTestRun(binding.composeId, "Test prompt");
+      const channelId = `C-session-${Date.now()}`;
+      const threadTs = `${Date.now()}.000000`;
+
+      // Create an agent session for the FK constraint
+      await createTestAgentSession(userLink.vm0UserId, binding.composeId);
+
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/slack",
+        payload: {
+          workspaceId: installation.slackWorkspaceId,
+          channelId,
+          threadTs,
+          messageTs: `${Date.now()}.123456`,
+          userLinkId: userLink.id,
+          agentName: "test-agent",
+          composeId: binding.composeId,
+          reactionAdded: true,
+        },
+      });
+
+      // Simulate that findNewSessionId will find this session
+      // by ensuring the agent session was created after the run
+      // (The actual logic queries by composeId and timestamps)
+
+      // When the callback is invoked
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "completed",
+          payload: {
+            workspaceId: installation.slackWorkspaceId,
+            channelId,
+            threadTs,
+            messageTs: `${Date.now()}.123456`,
+            userLinkId: userLink.id,
+            agentName: "test-agent",
+            composeId: binding.composeId,
+            reactionAdded: true,
+          },
+        },
+        secret,
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      // Then a thread session should be created
+      // Note: findNewSessionId may not find the session in this test setup
+      // because the session was created before the run, not after.
+      // This test mainly verifies the callback processes without error.
+    });
+
+    it("should update lastProcessedMessageTs for existing session", async () => {
+      // Given a linked Slack user with an agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { binding } = await givenUserHasAgent(userLink, {
+        agentName: "test-agent",
+      });
+
+      // And a run with callback with an existing session
+      mockClerk({ userId: userLink.vm0UserId });
+      const { runId } = await createTestRun(binding.composeId, "Test prompt");
+      const channelId = `C-existing-${Date.now()}`;
+      const threadTs = `${Date.now()}.000000`;
+      const existingSessionId = "existing-session-id";
+
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/slack",
+        payload: {
+          workspaceId: installation.slackWorkspaceId,
+          channelId,
+          threadTs,
+          messageTs: `${Date.now()}.123456`,
+          userLinkId: userLink.id,
+          agentName: "test-agent",
+          composeId: binding.composeId,
+          existingSessionId, // Existing session
+          reactionAdded: true,
+        },
+      });
+
+      // When the callback is invoked
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "completed",
+          payload: {
+            workspaceId: installation.slackWorkspaceId,
+            channelId,
+            threadTs,
+            messageTs: `${Date.now()}.123456`,
+            userLinkId: userLink.id,
+            agentName: "test-agent",
+            composeId: binding.composeId,
+            existingSessionId,
+            reactionAdded: true,
+          },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      // Then the request should succeed
+      // (actual update depends on having a matching thread session record)
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("Validation", () => {
+    it("should reject request with missing runId", async () => {
+      const request = createTestRequest(
+        "http://localhost/api/internal/callbacks/slack",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-VM0-Signature": "any-signature",
+            "X-VM0-Timestamp": Math.floor(Date.now() / 1000).toString(),
+          },
+          body: JSON.stringify({
+            // runId: missing
+            status: "completed",
+            payload: {
+              workspaceId: "T123",
+              channelId: "C123",
+              threadTs: "1234567890.000000",
+              messageTs: "1234567890.123456",
+              userLinkId: "link-123",
+              agentName: "test-agent",
+              composeId: "compose-123",
+              reactionAdded: false,
+            },
+          }),
+        },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toContain("runId");
+    });
+
+    it("should reject request with invalid payload", async () => {
+      // Given a linked Slack user with an agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { binding } = await givenUserHasAgent(userLink, {
+        agentName: "test-agent",
+      });
+
+      // And a run with a registered callback
+      mockClerk({ userId: userLink.vm0UserId });
+      const { runId } = await createTestRun(binding.composeId, "Test prompt");
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/slack",
+        payload: {
+          workspaceId: installation.slackWorkspaceId,
+          channelId: "C123",
+          threadTs: "1234567890.000000",
+          messageTs: "1234567890.123456",
+          userLinkId: userLink.id,
+          agentName: "test-agent",
+          composeId: binding.composeId,
+          reactionAdded: true,
+        },
+      });
+
+      // When I send a request with incomplete payload
+      const body = JSON.stringify({
+        runId,
+        status: "completed",
+        payload: {
+          workspaceId: installation.slackWorkspaceId,
+          // Missing required fields
+        },
+      });
+      const timestamp = Math.floor(Date.now() / 1000);
+      const signature = computeHmacSignature(body, secret, timestamp);
+
+      const request = createTestRequest(
+        "http://localhost/api/internal/callbacks/slack",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-VM0-Signature": signature,
+            "X-VM0-Timestamp": timestamp.toString(),
+          },
+          body,
+        },
+      );
+      const response = await POST(request);
+
+      // Then the request should be rejected
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toContain("payload");
+    });
+  });
+});

--- a/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
@@ -246,8 +246,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         timestamp: messageTs,
         name: "thought_balloon",
       })
-      .catch(() => {
-        // Ignore errors when removing reaction
+      .catch((err) => {
+        // Non-critical: reaction may already be removed or message deleted
+        log.debug("Failed to remove thinking reaction", { runId, error: err });
       });
   }
 

--- a/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
@@ -1,0 +1,257 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, and, gte, desc } from "drizzle-orm";
+import { initServices } from "../../../../../src/lib/init-services";
+import { verifyCallbackRequest } from "../../../../../src/lib/callback";
+import { decryptCredentialValue } from "../../../../../src/lib/crypto/secrets-encryption";
+import { slackInstallations } from "../../../../../src/db/schema/slack-installation";
+import { slackThreadSessions } from "../../../../../src/db/schema/slack-thread-session";
+import { agentSessions } from "../../../../../src/db/schema/agent-session";
+import { agentRuns } from "../../../../../src/db/schema/agent-run";
+import { agentRunCallbacks } from "../../../../../src/db/schema/agent-run-callback";
+import {
+  createSlackClient,
+  postMessage,
+  buildAgentResponseMessage,
+} from "../../../../../src/lib/slack";
+import { getRunOutput } from "../../../../../src/lib/slack/handlers/run-agent";
+import { buildLogsUrl } from "../../../../../src/lib/slack/handlers/shared";
+import { env } from "../../../../../src/env";
+import { logger } from "../../../../../src/lib/logger";
+
+const log = logger("callback:slack");
+
+interface CallbackPayload {
+  // Slack-specific context
+  workspaceId: string;
+  channelId: string;
+  threadTs: string;
+  messageTs: string;
+  userLinkId: string;
+  agentName: string;
+  composeId: string;
+  existingSessionId?: string;
+  reactionAdded: boolean;
+}
+
+interface CallbackBody {
+  runId: string;
+  status: "completed" | "failed";
+  result?: Record<string, unknown>;
+  error?: string;
+  payload: CallbackPayload;
+}
+
+function parsePayload(body: CallbackBody): CallbackPayload | null {
+  if (!body.payload) return null;
+  const p = body.payload;
+  if (
+    typeof p.workspaceId !== "string" ||
+    typeof p.channelId !== "string" ||
+    typeof p.threadTs !== "string" ||
+    typeof p.messageTs !== "string" ||
+    typeof p.userLinkId !== "string" ||
+    typeof p.agentName !== "string" ||
+    typeof p.composeId !== "string"
+  ) {
+    return null;
+  }
+  return p;
+}
+
+function errorResponse(message: string, status: number): NextResponse {
+  return NextResponse.json({ error: message }, { status });
+}
+
+async function findNewSessionId(
+  userId: string,
+  composeId: string,
+  runCreatedAt: Date,
+): Promise<string | undefined> {
+  const [newSession] = await globalThis.services.db
+    .select({ id: agentSessions.id })
+    .from(agentSessions)
+    .where(
+      and(
+        eq(agentSessions.userId, userId),
+        eq(agentSessions.agentComposeId, composeId),
+        gte(agentSessions.updatedAt, runCreatedAt),
+      ),
+    )
+    .orderBy(desc(agentSessions.updatedAt))
+    .limit(1);
+  return newSession?.id;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  initServices();
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  // Read raw body for signature verification
+  const rawBody = await request.text();
+
+  // Parse body first to get runId for callback lookup
+  let body: CallbackBody;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  const { runId, status, error } = body;
+
+  if (!runId) {
+    return errorResponse("Missing runId", 400);
+  }
+
+  // Query callback record to get the per-callback secret
+  const [callback] = await globalThis.services.db
+    .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
+    .from(agentRunCallbacks)
+    .where(eq(agentRunCallbacks.runId, runId))
+    .limit(1);
+
+  if (!callback) {
+    log.warn("Callback record not found", { runId });
+    return errorResponse("Callback not found", 404);
+  }
+
+  // Decrypt the per-callback secret
+  const callbackSecret = decryptCredentialValue(
+    callback.encryptedSecret,
+    SECRETS_ENCRYPTION_KEY,
+  );
+
+  // Verify signature using the per-callback secret
+  const signature = request.headers.get("X-VM0-Signature");
+  const timestamp = request.headers.get("X-VM0-Timestamp");
+
+  const verification = verifyCallbackRequest(
+    rawBody,
+    callbackSecret,
+    signature,
+    timestamp,
+  );
+
+  if (!verification.valid) {
+    log.warn("Callback signature verification failed", {
+      runId,
+      error: verification.error,
+    });
+    return errorResponse(verification.error ?? "Invalid signature", 401);
+  }
+
+  const payload = parsePayload(body);
+
+  if (!payload) {
+    return errorResponse("Invalid or missing payload", 400);
+  }
+
+  const {
+    workspaceId,
+    channelId,
+    threadTs,
+    messageTs,
+    userLinkId,
+    agentName,
+    composeId,
+    existingSessionId,
+    reactionAdded,
+  } = payload;
+
+  log.debug("Processing Slack callback", { runId, status, channelId });
+
+  // Get Slack installation for bot token
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackInstallations)
+    .where(eq(slackInstallations.slackWorkspaceId, workspaceId))
+    .limit(1);
+
+  if (!installation) {
+    log.error("Slack installation not found", { workspaceId });
+    return errorResponse("Slack installation not found", 404);
+  }
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+
+  // Query Axiom for the agent's output
+  const output = status === "completed" ? await getRunOutput(runId) : undefined;
+
+  // Build response message
+  const responseText =
+    status === "completed"
+      ? (output ?? "Task completed successfully.")
+      : `Error: ${error ?? "Agent execution failed."}`;
+
+  const logsUrl = buildLogsUrl(runId);
+
+  // Post response to Slack
+  await postMessage(client, channelId, responseText, {
+    threadTs,
+    blocks: buildAgentResponseMessage(responseText, agentName, logsUrl),
+  });
+
+  // Get run to find userId for session lookup
+  const [run] = await globalThis.services.db
+    .select({ userId: agentRuns.userId, createdAt: agentRuns.createdAt })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+
+  // Save thread session mapping
+  if (run) {
+    const newSessionId = !existingSessionId
+      ? await findNewSessionId(run.userId, composeId, run.createdAt)
+      : undefined;
+
+    if (!existingSessionId && newSessionId) {
+      // New thread — create mapping
+      await globalThis.services.db
+        .insert(slackThreadSessions)
+        .values({
+          slackUserLinkId: userLinkId,
+          slackChannelId: channelId,
+          slackThreadTs: threadTs,
+          agentSessionId: newSessionId,
+          lastProcessedMessageTs: messageTs,
+        })
+        .onConflictDoNothing();
+    } else if (existingSessionId && status === "completed") {
+      // Existing thread, successful run — update lastProcessedMessageTs
+      await globalThis.services.db
+        .update(slackThreadSessions)
+        .set({
+          lastProcessedMessageTs: messageTs,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(slackThreadSessions.slackUserLinkId, userLinkId),
+            eq(slackThreadSessions.slackChannelId, channelId),
+            eq(slackThreadSessions.slackThreadTs, threadTs),
+          ),
+        );
+    }
+  }
+
+  // Remove thinking reaction
+  if (reactionAdded) {
+    await client.reactions
+      .remove({
+        channel: channelId,
+        timestamp: messageTs,
+        name: "thought_balloon",
+      })
+      .catch(() => {
+        // Ignore errors when removing reaction
+      });
+  }
+
+  log.debug("Slack callback processed successfully", { runId });
+
+  return NextResponse.json({ success: true });
+}

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -624,7 +624,10 @@ describe("POST /api/webhooks/agent/complete", () => {
       const response = await POST(request);
       expect(response.status).toBe(200);
 
-      // Then no Slack DM should be sent (no scheduleId → after() not called)
+      // Then only callback dispatch should be registered (no schedule notification)
+      // Callback dispatch always runs but won't post anything if no callbacks registered
+      expect(afterCallbacks).toHaveLength(1);
+      await flushAfterCallbacks();
       expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
     });
   });

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -626,8 +626,8 @@ describe("POST /api/webhooks/agent/complete", () => {
 
       // Then only callback dispatch should be registered (no schedule notification)
       // Callback dispatch always runs but won't post anything if no callbacks registered
-      expect(afterCallbacks).toHaveLength(1);
-      await flushAfterCallbacks();
+      expect(globalThis.nextAfterCallbacks).toHaveLength(1);
+      await context.mocks.flushAfter();
       expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
     });
   });

--- a/turbo/apps/web/src/db/migrations/0082_add_agent_run_callbacks.sql
+++ b/turbo/apps/web/src/db/migrations/0082_add_agent_run_callbacks.sql
@@ -1,0 +1,17 @@
+-- Agent run callbacks table for webhook notifications on run completion
+CREATE TABLE IF NOT EXISTS "agent_run_callbacks" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "run_id" uuid NOT NULL REFERENCES "agent_runs"("id") ON DELETE CASCADE,
+    "url" text NOT NULL,
+    "encrypted_secret" text NOT NULL,
+    "payload" jsonb,
+    "status" varchar(20) NOT NULL DEFAULT 'pending',
+    "attempts" integer NOT NULL DEFAULT 0,
+    "last_attempt_at" timestamp,
+    "last_error" text,
+    "delivered_at" timestamp,
+    "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "idx_agent_run_callbacks_run_id" ON "agent_run_callbacks" ("run_id");
+CREATE INDEX IF NOT EXISTS "idx_agent_run_callbacks_pending" ON "agent_run_callbacks" ("status") WHERE status = 'pending';

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -575,6 +575,13 @@
       "when": 1770600000000,
       "tag": "0081_add_agent_run_events_local",
       "breakpoints": true
+    },
+    {
+      "idx": 82,
+      "version": "7",
+      "when": 1770700000000,
+      "tag": "0082_add_agent_run_callbacks",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/agent-run-callback.ts
+++ b/turbo/apps/web/src/db/schema/agent-run-callback.ts
@@ -1,0 +1,44 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  varchar,
+  jsonb,
+  timestamp,
+  integer,
+  index,
+} from "drizzle-orm/pg-core";
+import { agentRuns } from "./agent-run";
+
+/**
+ * Agent Run Callbacks table
+ * Stores webhook callbacks to be invoked when an agent run completes.
+ * Used for event-driven notifications (e.g., Slack replies) instead of polling.
+ */
+export const agentRunCallbacks = pgTable(
+  "agent_run_callbacks",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    runId: uuid("run_id")
+      .notNull()
+      .references(() => agentRuns.id, { onDelete: "cascade" }),
+    url: text("url").notNull(),
+    // Secret encrypted with AES-256-GCM for HMAC signature verification
+    encryptedSecret: text("encrypted_secret").notNull(),
+    // Arbitrary JSON payload to include in callback (e.g., Slack context)
+    payload: jsonb("payload"),
+    // pending | delivered | failed
+    status: varchar("status", { length: 20 }).notNull().default("pending"),
+    attempts: integer("attempts").notNull().default(0),
+    lastAttemptAt: timestamp("last_attempt_at"),
+    lastError: text("last_error"),
+    deliveredAt: timestamp("delivered_at"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("idx_agent_run_callbacks_run_id").on(table.runId),
+    index("idx_agent_run_callbacks_pending")
+      .on(table.status)
+      .where("status = 'pending'" as never),
+  ],
+);

--- a/turbo/apps/web/src/lib/callback/dispatcher.ts
+++ b/turbo/apps/web/src/lib/callback/dispatcher.ts
@@ -22,12 +22,15 @@ interface DispatchResult {
 
 /**
  * Get the API base URL for internal callbacks
- * Uses VERCEL_URL in production, localhost in development
+ * Priority: VM0_API_URL > VERCEL_URL > localhost fallback
  */
 export function getApiUrl(): string {
-  const vercelUrl = process.env.VERCEL_URL;
-  if (vercelUrl) {
-    return `https://${vercelUrl}`;
+  const { VM0_API_URL, VERCEL_URL } = env();
+  if (VM0_API_URL) {
+    return VM0_API_URL;
+  }
+  if (VERCEL_URL) {
+    return `https://${VERCEL_URL}`;
   }
   return "http://localhost:3000";
 }

--- a/turbo/apps/web/src/lib/callback/dispatcher.ts
+++ b/turbo/apps/web/src/lib/callback/dispatcher.ts
@@ -1,0 +1,171 @@
+import { eq } from "drizzle-orm";
+import { agentRunCallbacks } from "../../db/schema/agent-run-callback";
+import { decryptCredentialValue } from "../crypto/secrets-encryption";
+import { env } from "../../env";
+import { computeHmacSignature } from "./hmac";
+import { logger } from "../logger";
+
+const log = logger("callback:dispatcher");
+
+interface CallbackRecord {
+  id: string;
+  url: string;
+  encryptedSecret: string;
+  payload: unknown;
+}
+
+interface DispatchResult {
+  callbackId: string;
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Get the API base URL for internal callbacks
+ * Uses VERCEL_URL in production, localhost in development
+ */
+export function getApiUrl(): string {
+  const vercelUrl = process.env.VERCEL_URL;
+  if (vercelUrl) {
+    return `https://${vercelUrl}`;
+  }
+  return "http://localhost:3000";
+}
+
+/**
+ * Dispatch all pending callbacks for a completed run
+ *
+ * This function:
+ * 1. Fetches all pending callbacks for the run
+ * 2. Sends each callback with HMAC signature
+ * 3. Updates callback status based on response
+ *
+ * Called from the agent complete webhook after run status is updated
+ */
+export async function dispatchCallbacks(
+  runId: string,
+  status: "completed" | "failed",
+  result?: Record<string, unknown>,
+  error?: string,
+): Promise<DispatchResult[]> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  // Fetch all pending callbacks for this run
+  const callbacks = await globalThis.services.db
+    .select({
+      id: agentRunCallbacks.id,
+      url: agentRunCallbacks.url,
+      encryptedSecret: agentRunCallbacks.encryptedSecret,
+      payload: agentRunCallbacks.payload,
+    })
+    .from(agentRunCallbacks)
+    .where(eq(agentRunCallbacks.runId, runId));
+
+  if (callbacks.length === 0) {
+    return [];
+  }
+
+  log.debug(`Dispatching ${callbacks.length} callbacks for run ${runId}`);
+
+  const results: DispatchResult[] = [];
+
+  for (const callback of callbacks) {
+    const dispatchResult = await dispatchSingleCallback(
+      callback,
+      runId,
+      status,
+      result,
+      error,
+      SECRETS_ENCRYPTION_KEY,
+    );
+    results.push(dispatchResult);
+  }
+
+  return results;
+}
+
+async function dispatchSingleCallback(
+  callback: CallbackRecord,
+  runId: string,
+  status: "completed" | "failed",
+  result: Record<string, unknown> | undefined,
+  error: string | undefined,
+  encryptionKey: string,
+): Promise<DispatchResult> {
+  const { id, url, encryptedSecret, payload } = callback;
+
+  // Decrypt the callback secret
+  const secret = decryptCredentialValue(encryptedSecret, encryptionKey);
+
+  // Build callback body
+  const body = JSON.stringify({
+    runId,
+    status,
+    result,
+    error,
+    payload,
+  });
+
+  // Generate timestamp and signature
+  const timestamp = Math.floor(Date.now() / 1000);
+  const signature = computeHmacSignature(body, secret, timestamp);
+
+  // Update attempt count
+  await globalThis.services.db
+    .update(agentRunCallbacks)
+    .set({
+      attempts: 1,
+      lastAttemptAt: new Date(),
+    })
+    .where(eq(agentRunCallbacks.id, id));
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-VM0-Signature": signature,
+        "X-VM0-Timestamp": timestamp.toString(),
+      },
+      body,
+    });
+
+    if (response.ok) {
+      // Mark as delivered
+      await globalThis.services.db
+        .update(agentRunCallbacks)
+        .set({
+          status: "delivered",
+          deliveredAt: new Date(),
+        })
+        .where(eq(agentRunCallbacks.id, id));
+
+      log.debug(`Callback ${id} delivered successfully`);
+      return { callbackId: id, success: true };
+    } else {
+      const errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+      await globalThis.services.db
+        .update(agentRunCallbacks)
+        .set({
+          status: "failed",
+          lastError: errorMessage,
+        })
+        .where(eq(agentRunCallbacks.id, id));
+
+      log.warn(`Callback ${id} failed: ${errorMessage}`);
+      return { callbackId: id, success: false, error: errorMessage };
+    }
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : "Unknown error";
+    await globalThis.services.db
+      .update(agentRunCallbacks)
+      .set({
+        status: "failed",
+        lastError: errorMessage,
+      })
+      .where(eq(agentRunCallbacks.id, id));
+
+    log.error(`Callback ${id} failed with exception`, { error: err });
+    return { callbackId: id, success: false, error: errorMessage };
+  }
+}

--- a/turbo/apps/web/src/lib/callback/hmac.ts
+++ b/turbo/apps/web/src/lib/callback/hmac.ts
@@ -1,0 +1,63 @@
+import { createHmac, randomBytes } from "crypto";
+
+/**
+ * Generate a random secret for HMAC signing
+ * Returns a 32-byte hex string (64 characters)
+ */
+export function generateCallbackSecret(): string {
+  return randomBytes(32).toString("hex");
+}
+
+/**
+ * Compute HMAC-SHA256 signature for callback payload
+ *
+ * @param payload - The JSON payload to sign
+ * @param secret - The HMAC secret key
+ * @param timestamp - Unix timestamp in seconds
+ * @returns The hex-encoded HMAC signature
+ */
+export function computeHmacSignature(
+  payload: string,
+  secret: string,
+  timestamp: number,
+): string {
+  const signaturePayload = `${timestamp}.${payload}`;
+  return createHmac("sha256", secret).update(signaturePayload).digest("hex");
+}
+
+/**
+ * Verify HMAC signature matches expected value
+ *
+ * Uses timing-safe comparison to prevent timing attacks
+ */
+export function verifyHmacSignature(
+  payload: string,
+  secret: string,
+  timestamp: number,
+  signature: string,
+): boolean {
+  const expected = computeHmacSignature(payload, secret, timestamp);
+
+  // Timing-safe comparison
+  if (expected.length !== signature.length) {
+    return false;
+  }
+
+  let result = 0;
+  for (let i = 0; i < expected.length; i++) {
+    result |= expected.charCodeAt(i) ^ signature.charCodeAt(i);
+  }
+  return result === 0;
+}
+
+/**
+ * Check if timestamp is within acceptable window (5 minutes)
+ * Prevents replay attacks
+ */
+export function isTimestampValid(
+  timestamp: number,
+  maxAgeSeconds: number = 300,
+): boolean {
+  const now = Math.floor(Date.now() / 1000);
+  return Math.abs(now - timestamp) <= maxAgeSeconds;
+}

--- a/turbo/apps/web/src/lib/callback/index.ts
+++ b/turbo/apps/web/src/lib/callback/index.ts
@@ -1,0 +1,3 @@
+export { generateCallbackSecret } from "./hmac";
+export { dispatchCallbacks, getApiUrl } from "./dispatcher";
+export { verifyCallbackRequest } from "./verify-signature";

--- a/turbo/apps/web/src/lib/callback/verify-signature.ts
+++ b/turbo/apps/web/src/lib/callback/verify-signature.ts
@@ -1,0 +1,47 @@
+import { verifyHmacSignature, isTimestampValid } from "./hmac";
+
+interface VerifyResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * Verify incoming callback request signature
+ *
+ * @param body - Raw request body string
+ * @param secret - The HMAC secret
+ * @param signature - The X-VM0-Signature header value
+ * @param timestamp - The X-VM0-Timestamp header value
+ * @returns Verification result with error message if invalid
+ */
+export function verifyCallbackRequest(
+  body: string,
+  secret: string,
+  signature: string | null,
+  timestamp: string | null,
+): VerifyResult {
+  if (!signature) {
+    return { valid: false, error: "Missing X-VM0-Signature header" };
+  }
+
+  if (!timestamp) {
+    return { valid: false, error: "Missing X-VM0-Timestamp header" };
+  }
+
+  const timestampNum = parseInt(timestamp, 10);
+  if (isNaN(timestampNum)) {
+    return { valid: false, error: "Invalid timestamp format" };
+  }
+
+  // Check timestamp is within acceptable window (5 minutes)
+  if (!isTimestampValid(timestampNum)) {
+    return { valid: false, error: "Timestamp expired" };
+  }
+
+  // Verify HMAC signature
+  if (!verifyHmacSignature(body, secret, timestampNum, signature)) {
+    return { valid: false, error: "Invalid signature" };
+  }
+
+  return { valid: true };
+}

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -8,16 +8,12 @@ import {
   postMessage,
   extractMessageContent,
   buildLoginPromptMessage,
-  buildAgentResponseMessage,
 } from "../index";
 import { runAgentForSlack } from "./run-agent";
 import {
-  removeThinkingReaction,
   fetchConversationContexts,
   lookupThreadSession,
-  saveThreadSession,
   buildLoginUrl,
-  buildLogsUrl,
   getWorkspaceAgent,
 } from "./shared";
 import { logger } from "../../logger";
@@ -44,10 +40,10 @@ interface MentionContext {
  * 5. Add thinking reaction
  * 6. Look up existing thread session
  * 7. Fetch conversation context
- * 8. Execute agent
- * 9. Create/update thread session mapping
- * 10. Post response message
- * 11. Remove thinking reaction
+ * 8. Dispatch agent run with callback
+ *
+ * Note: Response posting is now handled by the callback endpoint
+ * when the agent run completes.
  */
 export async function handleAppMention(context: MentionContext): Promise<void> {
   const { SECRETS_ENCRYPTION_KEY } = env();
@@ -158,67 +154,47 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
     context.messageTs,
   );
 
-  try {
-    // 8. Execute agent with deduplicated context
-    log.debug("Calling runAgentForSlack", { existingSessionId });
-    const {
-      status: runStatus,
-      response: agentResponse,
-      sessionId: newSessionId,
-      runId,
-    } = await runAgentForSlack({
-      composeId: installation.defaultComposeId,
-      agentName: agent.name,
-      sessionId: existingSessionId,
-      prompt: messageContent,
-      threadContext: executionContext,
-      userId: userLink.vm0UserId,
-    });
-
-    // 9. Create or update thread session mapping
-    if (threadTs) {
-      await saveThreadSession({
-        userLinkId: userLink.id,
-        channelId: context.channelId,
-        threadTs,
-        existingSessionId,
-        newSessionId,
-        messageTs: context.messageTs,
-        runStatus,
-      });
-    }
-
-    // 10. Post response message with agent name and logs link
-    const logsUrl = runId ? buildLogsUrl(runId) : undefined;
-    const responseText =
-      runStatus === "timeout"
-        ? `:warning: *Agent timed out*\n${agentResponse}`
-        : agentResponse;
-    await postMessage(client, context.channelId, responseText, {
+  // 8. Dispatch agent run with callback (returns immediately)
+  log.debug("Dispatching agent run", { existingSessionId });
+  const { status, response } = await runAgentForSlack({
+    composeId: installation.defaultComposeId,
+    agentName: agent.name,
+    sessionId: existingSessionId,
+    prompt: messageContent,
+    threadContext: executionContext,
+    userId: userLink.vm0UserId,
+    callbackContext: {
+      workspaceId: context.workspaceId,
+      channelId: context.channelId,
       threadTs,
-      blocks: buildAgentResponseMessage(responseText, agent.name, logsUrl),
-    });
-  } catch (innerError) {
-    // If postMessage or session creation fails, still try to notify the user
-    log.error("Error posting response or creating session", {
-      error: innerError,
-    });
+      messageTs: context.messageTs,
+      userLinkId: userLink.id,
+      agentName: agent.name,
+      composeId: installation.defaultComposeId,
+      existingSessionId,
+      reactionAdded,
+    },
+  });
+
+  // Only handle immediate failures (agent run was not dispatched)
+  if (status === "failed") {
+    log.error("Failed to dispatch agent run", { response });
     await postMessage(
       client,
       context.channelId,
-      "Sorry, an error occurred while sending the response. Please try again.",
+      response ?? "Sorry, an error occurred. Please try again.",
       { threadTs },
-    ).catch(() => {
-      // If even the error message fails, we can't do anything more
-    });
-  } finally {
-    // 11. Remove thinking reaction
+    );
+    // Remove reaction on failure since callback won't be invoked
     if (reactionAdded) {
-      await removeThinkingReaction(
-        client,
-        context.channelId,
-        context.messageTs,
-      );
+      await client.reactions
+        .remove({
+          channel: context.channelId,
+          timestamp: context.messageTs,
+          name: "thought_balloon",
+        })
+        .catch(() => {});
     }
   }
+  // For "dispatched" status, callback will handle response posting and reaction removal
 }


### PR DESCRIPTION
## Summary

Implements a generic webhook callback mechanism for agent runs that replaces the polling-based approach. This fixes the **Slack mention timeout bug** where polling in `after()` exceeds Vercel's `maxDuration` limit (13 min with Fluid Compute on Pro plan).

Closes #2823

## Changes

### New Database Schema
- Added `agent_run_callbacks` table to store callback registrations
- Each callback has its own encrypted secret for HMAC signature verification
- Supports payload storage for context (e.g., Slack channelId, threadTs)

### HMAC Security
- Per-callback HMAC-SHA256 signature verification
- Timestamp validation with 5-minute window to prevent replay attacks
- Secrets encrypted at rest using existing `encryptCredentialValue` pattern

### Slack Integration Refactored
- **Before**: Polling in `after()` waiting for run completion (timeout after ~13 min)
- **After**: Register callback, return immediately, callback endpoint posts response

### New Files
- `src/db/schema/agent-run-callback.ts` - Drizzle schema
- `src/db/migrations/0082_add_agent_run_callbacks.sql` - Migration
- `src/lib/callback/hmac.ts` - HMAC utilities
- `src/lib/callback/dispatcher.ts` - Callback dispatch logic
- `src/lib/callback/verify-signature.ts` - Signature verification
- `app/api/internal/callbacks/slack/route.ts` - Slack callback endpoint

### Modified Files
- `src/lib/slack/handlers/run-agent.ts` - Removed polling, added callback registration
- `src/lib/slack/handlers/mention.ts` - Returns immediately after dispatch
- `src/lib/slack/handlers/direct-message.ts` - Same as mention.ts
- `app/api/webhooks/agent/complete/route.ts` - Dispatches callbacks on completion

## Flow

```
Slack Mention
    ↓
Create run + Register callback (encrypted per-callback secret)
    ↓
Return 200 to Slack immediately (no polling!)
    ↓
Agent completes → /api/webhooks/agent/complete
    ↓
Dispatch callback with HMAC signature
    ↓
/api/internal/callbacks/slack
    - Query callback record for per-callback secret
    - Verify HMAC signature
    - Post Slack reply
    - Save thread session
    - Remove thinking reaction
```

## Test plan

- [x] Lint passes
- [x] Type check passes
- [ ] Existing Slack event tests updated to reflect new behavior
- [ ] HMAC signature verification logic tested
- [ ] Manual test with local dev server and tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)