### PR TITLE
feat(runner): download and install mitmdump in setup command

### DIFF
--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -55,6 +55,14 @@ impl HomePaths {
         self.firecracker_dir(fc_version).join(kernel_name)
     }
 
+    pub fn mitmproxy_dir(&self, version: &str) -> PathBuf {
+        self.root.join("mitmproxy").join(version)
+    }
+
+    pub fn mitmdump_bin(&self, version: &str) -> PathBuf {
+        self.mitmproxy_dir(version).join("mitmdump")
+    }
+
     pub fn runners_dir(&self) -> PathBuf {
         self.root.join("runners")
     }

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -10,6 +10,7 @@ use crate::paths::HomePaths;
 
 const FIRECRACKER_VERSION: &str = "v1.14.1";
 const KERNEL_VERSION: &str = "6.1.155";
+const MITMPROXY_VERSION: &str = "12.2.1";
 
 // SHA256 checksums for installed artifacts, keyed by arch.
 const FIRECRACKER_SHA256_X86_64: &str =
@@ -20,6 +21,10 @@ const KERNEL_SHA256_X86_64: &str =
     "e41c7048bd2475e7e788153823fcb9166a7e0b78c4c443bd6446d015fa735f53";
 const KERNEL_SHA256_AARCH64: &str =
     "61baeae1ac6197be4fc5c71fa78df266acdc33c54570290d2f611c2b42c105be";
+const MITMDUMP_SHA256_X86_64: &str =
+    "0adfd86a006b593dce745b989f305f14acd94edadf7f998b6985555b44838167";
+const MITMDUMP_SHA256_AARCH64: &str =
+    "48fb2cd30945f03faa5cc2797dd6e5762f09ebe8754da87ac8c372dc82e694df";
 
 /// "v1.14.1" → "v1.14"
 const FIRECRACKER_MINOR: &str = strip_patch(FIRECRACKER_VERSION);
@@ -45,9 +50,10 @@ pub async fn run_setup(strict: bool) -> RunnerResult<()> {
     let (missing_required, missing_optional) = check_system_dependencies();
 
     let paths = HomePaths::new()?;
-    create_directories(&paths, FIRECRACKER_VERSION).await?;
+    create_directories(&paths).await?;
     download_firecracker(&paths, arch).await?;
     download_kernel(&paths, arch).await?;
+    download_mitmdump(&paths, arch).await?;
     check_kvm();
 
     if !missing_required.is_empty() {
@@ -118,16 +124,18 @@ fn check_system_dependencies() -> (Vec<&'static str>, Vec<&'static str>) {
     (missing_required, missing_optional)
 }
 
-async fn create_directories(paths: &HomePaths, fc_version: &str) -> RunnerResult<()> {
-    tokio::fs::create_dir_all(paths.bin_dir())
-        .await
-        .map_err(|e| RunnerError::Internal(format!("create bin dir: {e}")))?;
-    tokio::fs::create_dir_all(paths.firecracker_dir(fc_version))
-        .await
-        .map_err(|e| RunnerError::Internal(format!("create firecracker dir: {e}")))?;
-    tokio::fs::create_dir_all(paths.runners_dir())
-        .await
-        .map_err(|e| RunnerError::Internal(format!("create runners dir: {e}")))?;
+async fn create_directories(paths: &HomePaths) -> RunnerResult<()> {
+    let dirs = [
+        paths.bin_dir(),
+        paths.firecracker_dir(FIRECRACKER_VERSION),
+        paths.mitmproxy_dir(MITMPROXY_VERSION),
+        paths.runners_dir(),
+    ];
+    for dir in &dirs {
+        tokio::fs::create_dir_all(dir)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("create {}: {e}", dir.display())))?;
+    }
     tracing::info!("[OK] directory structure created");
     Ok(())
 }
@@ -241,7 +249,8 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
 
     // Extract the firecracker binary from the tarball on disk
     let tmp_path = bin_path.with_extension(format!("tmp.{}", std::process::id()));
-    let result = extract_firecracker(&tarball_path, &tmp_path, arch).await;
+    let fc_entry_name = format!("firecracker-{FIRECRACKER_VERSION}-{arch}");
+    let result = extract_tar_entry(&tarball_path, &tmp_path, &fc_entry_name).await;
     let _ = tokio::fs::remove_file(&tarball_path).await;
     let sha_hex = match result {
         Ok(sha) => sha,
@@ -279,16 +288,16 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
     }
 }
 
-/// Extract the firecracker binary from a tarball, writing to tmp_path.
-/// Returns the SHA256 hex digest of the extracted binary.
-async fn extract_firecracker(
+/// Extract a named entry from a gzipped tarball, writing to tmp_path.
+/// Matches by file_name (last path component). Returns the SHA256 hex digest.
+async fn extract_tar_entry(
     tarball_path: &Path,
     tmp_path: &Path,
-    arch: &str,
+    entry_name: &str,
 ) -> RunnerResult<String> {
     let tarball = tarball_path.to_owned();
     let tmp = tmp_path.to_owned();
-    let arch = arch.to_owned();
+    let entry_name = entry_name.to_owned();
 
     // Sync I/O on local files — fine for a setup command
     tokio::task::spawn_blocking(move || {
@@ -296,8 +305,6 @@ async fn extract_firecracker(
             .map_err(|e| RunnerError::Internal(format!("open tarball: {e}")))?;
         let decoder = flate2::read::GzDecoder::new(file);
         let mut archive = tar::Archive::new(decoder);
-
-        let expected_name = format!("firecracker-{FIRECRACKER_VERSION}-{arch}");
 
         let entries = archive
             .entries()
@@ -316,7 +323,7 @@ async fn extract_firecracker(
                 .and_then(|n| n.to_str())
                 .unwrap_or_default();
 
-            if file_name == expected_name {
+            if file_name == entry_name {
                 let mut out = std::fs::File::create(&tmp)
                     .map_err(|e| RunnerError::Internal(format!("create temp binary: {e}")))?;
                 let mut hasher = Sha256::new();
@@ -340,7 +347,7 @@ async fn extract_firecracker(
         }
 
         Err(RunnerError::Internal(format!(
-            "firecracker binary '{expected_name}' not found in tarball"
+            "'{entry_name}' not found in tarball"
         )))
     })
     .await
@@ -400,6 +407,90 @@ async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
         Err(e) => {
             if tokio::fs::try_exists(&kernel_path).await.unwrap_or(false) {
                 tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} installed by another process");
+                return Ok(());
+            }
+            Err(e)
+        }
+    }
+}
+
+async fn is_mitmdump_installed(bin_path: &Path) -> bool {
+    if !tokio::fs::try_exists(bin_path).await.unwrap_or(false) {
+        return false;
+    }
+    let Ok(output) = tokio::process::Command::new(bin_path)
+        .arg("--version")
+        .output()
+        .await
+    else {
+        return false;
+    };
+    let version_str = String::from_utf8_lossy(&output.stdout);
+    version_str.contains(MITMPROXY_VERSION)
+}
+
+async fn download_mitmdump(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
+    let bin_path = paths.mitmdump_bin(MITMPROXY_VERSION);
+
+    if is_mitmdump_installed(&bin_path).await {
+        tracing::info!("[OK] mitmdump {MITMPROXY_VERSION} already installed, skipping download");
+        return Ok(());
+    }
+
+    let url = format!(
+        "https://downloads.mitmproxy.org/{MITMPROXY_VERSION}/mitmproxy-{MITMPROXY_VERSION}-linux-{arch}.tar.gz"
+    );
+    tracing::info!("downloading mitmdump from {url}");
+
+    let response = reqwest::get(&url)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("download mitmdump: {e}")))?;
+
+    if !response.status().is_success() {
+        return Err(RunnerError::Internal(format!(
+            "download mitmdump: HTTP {}",
+            response.status()
+        )));
+    }
+
+    // Stream tarball to a temp file
+    let tarball_path = bin_path.with_extension(format!("tgz.{}", std::process::id()));
+    if let Err(e) = stream_to_file(response, &tarball_path).await {
+        let _ = tokio::fs::remove_file(&tarball_path).await;
+        return Err(e);
+    }
+
+    // Extract mitmdump binary from the tarball
+    let tmp_path = bin_path.with_extension(format!("tmp.{}", std::process::id()));
+    let result = extract_tar_entry(&tarball_path, &tmp_path, "mitmdump").await;
+    let _ = tokio::fs::remove_file(&tarball_path).await;
+    let sha_hex = match result {
+        Ok(sha) => sha,
+        Err(e) => {
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            return Err(e);
+        }
+    };
+
+    #[allow(clippy::unreachable)] // arch validated by check_architecture
+    let expected_sha = match arch {
+        "x86_64" => MITMDUMP_SHA256_X86_64,
+        "aarch64" => MITMDUMP_SHA256_AARCH64,
+        _ => unreachable!(),
+    };
+    if let Err(e) = verify_sha256(&sha_hex, expected_sha, "mitmdump") {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(e);
+    }
+
+    match atomic_rename(&tmp_path, &bin_path, Some(0o755)).await {
+        Ok(()) => {
+            tracing::info!("[OK] mitmdump {MITMPROXY_VERSION} installed");
+            Ok(())
+        }
+        Err(e) => {
+            if is_mitmdump_installed(&bin_path).await {
+                tracing::info!("[OK] mitmdump {MITMPROXY_VERSION} installed by another process");
                 return Ok(());
             }
             Err(e)

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -140,6 +140,10 @@ async fn create_directories(paths: &HomePaths) -> RunnerResult<()> {
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Shared download helpers
+// ---------------------------------------------------------------------------
+
 /// Stream an HTTP response to a file, computing SHA256 incrementally.
 /// Returns the hex-encoded digest.
 async fn stream_to_file(mut response: reqwest::Response, path: &Path) -> RunnerResult<String> {
@@ -166,123 +170,45 @@ async fn stream_to_file(mut response: reqwest::Response, path: &Path) -> RunnerR
     Ok(format!("{:x}", hasher.finalize()))
 }
 
-/// Set permissions then atomically rename to target. Cleans up temp on failure.
-async fn atomic_rename(tmp_path: &Path, target: &Path, mode: Option<u32>) -> RunnerResult<()> {
-    let result = async {
-        if let Some(mode) = mode {
-            tokio::fs::set_permissions(tmp_path, std::fs::Permissions::from_mode(mode))
-                .await
-                .map_err(|e| RunnerError::Internal(format!("chmod {}: {e}", target.display())))?;
-        }
-        tokio::fs::rename(tmp_path, target)
-            .await
-            .map_err(|e| RunnerError::Internal(format!("rename to {}: {e}", target.display())))
-    }
-    .await;
-
-    if result.is_err() {
-        let _ = tokio::fs::remove_file(tmp_path).await;
-    }
-    result
-}
-
-fn verify_sha256(actual_hex: &str, expected_hex: &str, label: &str) -> RunnerResult<()> {
-    if actual_hex != expected_hex {
-        return Err(RunnerError::Internal(format!(
-            "{label} SHA256 mismatch: expected {expected_hex}, got {actual_hex}"
-        )));
-    }
-    tracing::info!("[OK] {label} SHA256 verified");
-    Ok(())
-}
-
-async fn is_firecracker_installed(bin_path: &Path) -> bool {
-    if !tokio::fs::try_exists(bin_path).await.unwrap_or(false) {
-        return false;
-    }
-    let Ok(output) = tokio::process::Command::new(bin_path)
-        .arg("--version")
-        .output()
+/// Download a URL to a temp file. Cleans up on failure. Returns hex SHA256.
+async fn download_to_temp(url: &str, tmp_path: &Path, label: &str) -> RunnerResult<String> {
+    let response = reqwest::get(url)
         .await
-    else {
-        return false;
-    };
-    let version_str = String::from_utf8_lossy(&output.stdout);
-    let version_no_prefix = FIRECRACKER_VERSION
-        .strip_prefix('v')
-        .unwrap_or(FIRECRACKER_VERSION);
-    version_str.contains(version_no_prefix)
-}
-
-async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
-    let bin_path = paths.firecracker_bin(FIRECRACKER_VERSION);
-
-    if is_firecracker_installed(&bin_path).await {
-        tracing::info!(
-            "[OK] firecracker {FIRECRACKER_VERSION} already installed, skipping download"
-        );
-        return Ok(());
-    }
-
-    let url = format!(
-        "https://github.com/firecracker-microvm/firecracker/releases/download/{FIRECRACKER_VERSION}/firecracker-{FIRECRACKER_VERSION}-{arch}.tgz"
-    );
-    tracing::info!("downloading firecracker from {url}");
-
-    let response = reqwest::get(&url)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("download firecracker: {e}")))?;
+        .map_err(|e| RunnerError::Internal(format!("download {label}: {e}")))?;
 
     if !response.status().is_success() {
         return Err(RunnerError::Internal(format!(
-            "download firecracker: HTTP {}",
+            "download {label}: HTTP {}",
             response.status()
         )));
     }
 
-    // Stream tarball to a temp file
-    let tarball_path = bin_path.with_extension(format!("tgz.{}", std::process::id()));
-    if let Err(e) = stream_to_file(response, &tarball_path).await {
-        let _ = tokio::fs::remove_file(&tarball_path).await;
-        return Err(e);
-    }
-
-    // Extract the firecracker binary from the tarball on disk
-    let tmp_path = bin_path.with_extension(format!("tmp.{}", std::process::id()));
-    let fc_entry_name = format!("firecracker-{FIRECRACKER_VERSION}-{arch}");
-    let result = extract_tar_entry(&tarball_path, &tmp_path, &fc_entry_name).await;
-    let _ = tokio::fs::remove_file(&tarball_path).await;
-    let sha_hex = match result {
-        Ok(sha) => sha,
+    match stream_to_file(response, tmp_path).await {
+        Ok(sha) => Ok(sha),
         Err(e) => {
-            let _ = tokio::fs::remove_file(&tmp_path).await;
-            return Err(e);
+            let _ = tokio::fs::remove_file(tmp_path).await;
+            Err(e)
         }
-    };
-
-    #[allow(clippy::unreachable)] // arch validated by check_architecture
-    let expected_sha = match arch {
-        "x86_64" => FIRECRACKER_SHA256_X86_64,
-        "aarch64" => FIRECRACKER_SHA256_AARCH64,
-        _ => unreachable!(),
-    };
-    if let Err(e) = verify_sha256(&sha_hex, expected_sha, "firecracker binary") {
-        let _ = tokio::fs::remove_file(&tmp_path).await;
-        return Err(e);
     }
+}
 
-    match atomic_rename(&tmp_path, &bin_path, Some(0o755)).await {
-        Ok(()) => {
-            tracing::info!("[OK] firecracker {FIRECRACKER_VERSION} installed");
-            Ok(())
-        }
+/// Download a tarball, extract a named entry. Cleans up tarball after extraction.
+/// Returns hex SHA256 of the extracted entry. Cleans up tmp_path on failure.
+async fn download_and_extract(
+    url: &str,
+    label: &str,
+    entry_name: &str,
+    tarball_path: &Path,
+    tmp_path: &Path,
+) -> RunnerResult<String> {
+    download_to_temp(url, tarball_path, label).await?;
+
+    let result = extract_tar_entry(tarball_path, tmp_path, entry_name).await;
+    let _ = tokio::fs::remove_file(tarball_path).await;
+    match result {
+        Ok(sha) => Ok(sha),
         Err(e) => {
-            if is_firecracker_installed(&bin_path).await {
-                tracing::info!(
-                    "[OK] firecracker {FIRECRACKER_VERSION} installed by another process"
-                );
-                return Ok(());
-            }
+            let _ = tokio::fs::remove_file(tmp_path).await;
             Err(e)
         }
     }
@@ -299,7 +225,6 @@ async fn extract_tar_entry(
     let tmp = tmp_path.to_owned();
     let entry_name = entry_name.to_owned();
 
-    // Sync I/O on local files — fine for a setup command
     tokio::task::spawn_blocking(move || {
         let file = std::fs::File::open(&tarball)
             .map_err(|e| RunnerError::Internal(format!("open tarball: {e}")))?;
@@ -354,6 +279,126 @@ async fn extract_tar_entry(
     .map_err(|e| RunnerError::Internal(format!("extract task failed: {e}")))?
 }
 
+/// Verify SHA256, set permissions, atomically rename to target.
+/// If rename fails but target already exists, assumes another process installed it.
+async fn verify_and_install(
+    sha_hex: &str,
+    expected_sha: &str,
+    label: &str,
+    tmp_path: &Path,
+    target: &Path,
+    mode: Option<u32>,
+) -> RunnerResult<()> {
+    if let Err(e) = verify_sha256(sha_hex, expected_sha, label) {
+        let _ = tokio::fs::remove_file(tmp_path).await;
+        return Err(e);
+    }
+
+    match atomic_rename(tmp_path, target, mode).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            if tokio::fs::try_exists(target).await.unwrap_or(false) {
+                tracing::info!("[OK] {label} installed by another process");
+                Ok(())
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+/// Set permissions then atomically rename. Cleans up temp on failure.
+async fn atomic_rename(tmp_path: &Path, target: &Path, mode: Option<u32>) -> RunnerResult<()> {
+    let result = async {
+        if let Some(mode) = mode {
+            tokio::fs::set_permissions(tmp_path, std::fs::Permissions::from_mode(mode))
+                .await
+                .map_err(|e| RunnerError::Internal(format!("chmod {}: {e}", target.display())))?;
+        }
+        tokio::fs::rename(tmp_path, target)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("rename to {}: {e}", target.display())))
+    }
+    .await;
+
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(tmp_path).await;
+    }
+    result
+}
+
+fn verify_sha256(actual_hex: &str, expected_hex: &str, label: &str) -> RunnerResult<()> {
+    if actual_hex != expected_hex {
+        return Err(RunnerError::Internal(format!(
+            "{label} SHA256 mismatch: expected {expected_hex}, got {actual_hex}"
+        )));
+    }
+    tracing::info!("[OK] {label} SHA256 verified");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Artifact downloads
+// ---------------------------------------------------------------------------
+
+async fn is_firecracker_installed(bin_path: &Path) -> bool {
+    if !tokio::fs::try_exists(bin_path).await.unwrap_or(false) {
+        return false;
+    }
+    let Ok(output) = tokio::process::Command::new(bin_path)
+        .arg("--version")
+        .output()
+        .await
+    else {
+        return false;
+    };
+    let version_str = String::from_utf8_lossy(&output.stdout);
+    let version_no_prefix = FIRECRACKER_VERSION
+        .strip_prefix('v')
+        .unwrap_or(FIRECRACKER_VERSION);
+    version_str.contains(version_no_prefix)
+}
+
+async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
+    let bin_path = paths.firecracker_bin(FIRECRACKER_VERSION);
+
+    if is_firecracker_installed(&bin_path).await {
+        tracing::info!(
+            "[OK] firecracker {FIRECRACKER_VERSION} already installed, skipping download"
+        );
+        return Ok(());
+    }
+
+    let url = format!(
+        "https://github.com/firecracker-microvm/firecracker/releases/download/{FIRECRACKER_VERSION}/firecracker-{FIRECRACKER_VERSION}-{arch}.tgz"
+    );
+    tracing::info!("downloading firecracker from {url}");
+
+    let tarball_path = bin_path.with_extension(format!("tgz.{}", std::process::id()));
+    let tmp_path = bin_path.with_extension(format!("tmp.{}", std::process::id()));
+    let fc_entry = format!("firecracker-{FIRECRACKER_VERSION}-{arch}");
+    let sha_hex =
+        download_and_extract(&url, "firecracker", &fc_entry, &tarball_path, &tmp_path).await?;
+
+    #[allow(clippy::unreachable)] // arch validated by check_architecture
+    let expected_sha = match arch {
+        "x86_64" => FIRECRACKER_SHA256_X86_64,
+        "aarch64" => FIRECRACKER_SHA256_AARCH64,
+        _ => unreachable!(),
+    };
+    verify_and_install(
+        &sha_hex,
+        expected_sha,
+        "firecracker",
+        &tmp_path,
+        &bin_path,
+        Some(0o755),
+    )
+    .await?;
+    tracing::info!("[OK] firecracker {FIRECRACKER_VERSION} installed");
+    Ok(())
+}
+
 async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let kernel_path = paths.kernel_bin(FIRECRACKER_VERSION, KERNEL_VERSION);
 
@@ -367,26 +412,8 @@ async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     );
     tracing::info!("downloading kernel from {url}");
 
-    let response = reqwest::get(&url)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("download kernel: {e}")))?;
-
-    if !response.status().is_success() {
-        return Err(RunnerError::Internal(format!(
-            "download kernel: HTTP {}",
-            response.status()
-        )));
-    }
-
-    // Stream directly to temp file, computing SHA256 incrementally
     let tmp_path = kernel_path.with_extension(format!("tmp.{}", std::process::id()));
-    let sha_hex = match stream_to_file(response, &tmp_path).await {
-        Ok(sha) => sha,
-        Err(e) => {
-            let _ = tokio::fs::remove_file(&tmp_path).await;
-            return Err(e);
-        }
-    };
+    let sha_hex = download_to_temp(&url, &tmp_path, "kernel").await?;
 
     #[allow(clippy::unreachable)] // arch validated by check_architecture
     let expected_sha = match arch {
@@ -394,24 +421,17 @@ async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
         "aarch64" => KERNEL_SHA256_AARCH64,
         _ => unreachable!(),
     };
-    if let Err(e) = verify_sha256(&sha_hex, expected_sha, "kernel") {
-        let _ = tokio::fs::remove_file(&tmp_path).await;
-        return Err(e);
-    }
-
-    match atomic_rename(&tmp_path, &kernel_path, None).await {
-        Ok(()) => {
-            tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} installed");
-            Ok(())
-        }
-        Err(e) => {
-            if tokio::fs::try_exists(&kernel_path).await.unwrap_or(false) {
-                tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} installed by another process");
-                return Ok(());
-            }
-            Err(e)
-        }
-    }
+    verify_and_install(
+        &sha_hex,
+        expected_sha,
+        "kernel",
+        &tmp_path,
+        &kernel_path,
+        None,
+    )
+    .await?;
+    tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} installed");
+    Ok(())
 }
 
 async fn is_mitmdump_installed(bin_path: &Path) -> bool {
@@ -442,35 +462,10 @@ async fn download_mitmdump(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     );
     tracing::info!("downloading mitmdump from {url}");
 
-    let response = reqwest::get(&url)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("download mitmdump: {e}")))?;
-
-    if !response.status().is_success() {
-        return Err(RunnerError::Internal(format!(
-            "download mitmdump: HTTP {}",
-            response.status()
-        )));
-    }
-
-    // Stream tarball to a temp file
     let tarball_path = bin_path.with_extension(format!("tgz.{}", std::process::id()));
-    if let Err(e) = stream_to_file(response, &tarball_path).await {
-        let _ = tokio::fs::remove_file(&tarball_path).await;
-        return Err(e);
-    }
-
-    // Extract mitmdump binary from the tarball
     let tmp_path = bin_path.with_extension(format!("tmp.{}", std::process::id()));
-    let result = extract_tar_entry(&tarball_path, &tmp_path, "mitmdump").await;
-    let _ = tokio::fs::remove_file(&tarball_path).await;
-    let sha_hex = match result {
-        Ok(sha) => sha,
-        Err(e) => {
-            let _ = tokio::fs::remove_file(&tmp_path).await;
-            return Err(e);
-        }
-    };
+    let sha_hex =
+        download_and_extract(&url, "mitmdump", "mitmdump", &tarball_path, &tmp_path).await?;
 
     #[allow(clippy::unreachable)] // arch validated by check_architecture
     let expected_sha = match arch {
@@ -478,25 +473,22 @@ async fn download_mitmdump(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
         "aarch64" => MITMDUMP_SHA256_AARCH64,
         _ => unreachable!(),
     };
-    if let Err(e) = verify_sha256(&sha_hex, expected_sha, "mitmdump") {
-        let _ = tokio::fs::remove_file(&tmp_path).await;
-        return Err(e);
-    }
-
-    match atomic_rename(&tmp_path, &bin_path, Some(0o755)).await {
-        Ok(()) => {
-            tracing::info!("[OK] mitmdump {MITMPROXY_VERSION} installed");
-            Ok(())
-        }
-        Err(e) => {
-            if is_mitmdump_installed(&bin_path).await {
-                tracing::info!("[OK] mitmdump {MITMPROXY_VERSION} installed by another process");
-                return Ok(());
-            }
-            Err(e)
-        }
-    }
+    verify_and_install(
+        &sha_hex,
+        expected_sha,
+        "mitmdump",
+        &tmp_path,
+        &bin_path,
+        Some(0o755),
+    )
+    .await?;
+    tracing::info!("[OK] mitmdump {MITMPROXY_VERSION} installed");
+    Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Host checks
+// ---------------------------------------------------------------------------
 
 fn check_kvm() {
     use std::fs::File;

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -350,28 +350,48 @@ fn verify_sha256(actual_hex: &str, expected_hex: &str, label: &str) -> RunnerRes
 // Artifact downloads
 // ---------------------------------------------------------------------------
 
-async fn is_firecracker_installed(bin_path: &Path) -> bool {
-    if !tokio::fs::try_exists(bin_path).await.unwrap_or(false) {
+/// Compute SHA256 of an existing file. Returns hex digest.
+async fn file_sha256(path: &Path) -> RunnerResult<String> {
+    let path = path.to_owned();
+    tokio::task::spawn_blocking(move || {
+        let mut file = std::fs::File::open(&path)
+            .map_err(|e| RunnerError::Internal(format!("open {}: {e}", path.display())))?;
+        let mut hasher = Sha256::new();
+        let mut buf = [0u8; 64 * 1024];
+        loop {
+            let n = file
+                .read(&mut buf)
+                .map_err(|e| RunnerError::Internal(format!("read {}: {e}", path.display())))?;
+            if n == 0 {
+                break;
+            }
+            let chunk = buf
+                .get(..n)
+                .ok_or_else(|| RunnerError::Internal("read returned invalid length".into()))?;
+            hasher.update(chunk);
+        }
+        Ok(format!("{:x}", hasher.finalize()))
+    })
+    .await
+    .map_err(|e| RunnerError::Internal(format!("sha256 task failed: {e}")))?
+}
+
+/// Check if an artifact is already installed with the expected SHA256.
+async fn is_already_installed(path: &Path, expected_sha: &str) -> bool {
+    if !tokio::fs::try_exists(path).await.unwrap_or(false) {
         return false;
     }
-    let Ok(output) = tokio::process::Command::new(bin_path)
-        .arg("--version")
-        .output()
-        .await
-    else {
+    let Ok(sha) = file_sha256(path).await else {
         return false;
     };
-    let version_str = String::from_utf8_lossy(&output.stdout);
-    let version_no_prefix = FIRECRACKER_VERSION
-        .strip_prefix('v')
-        .unwrap_or(FIRECRACKER_VERSION);
-    version_str.contains(version_no_prefix)
+    sha == expected_sha
 }
 
 async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let bin_path = paths.firecracker_bin(FIRECRACKER_VERSION);
+    let expected_sha = select_sha(arch, FIRECRACKER_SHA256_X86_64, FIRECRACKER_SHA256_AARCH64);
 
-    if is_firecracker_installed(&bin_path).await {
+    if is_already_installed(&bin_path, expected_sha).await {
         tracing::info!(
             "[OK] firecracker {FIRECRACKER_VERSION} already installed, skipping download"
         );
@@ -389,7 +409,6 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
     let sha_hex =
         download_and_extract(&url, "firecracker", &fc_entry, &tarball_path, &tmp_path).await?;
 
-    let expected_sha = select_sha(arch, FIRECRACKER_SHA256_X86_64, FIRECRACKER_SHA256_AARCH64);
     verify_and_install(
         &sha_hex,
         expected_sha,
@@ -405,9 +424,10 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
 
 async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let kernel_path = paths.kernel_bin(FIRECRACKER_VERSION, KERNEL_VERSION);
+    let expected_sha = select_sha(arch, KERNEL_SHA256_X86_64, KERNEL_SHA256_AARCH64);
 
-    if tokio::fs::try_exists(&kernel_path).await.unwrap_or(false) {
-        tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} already present, skipping download");
+    if is_already_installed(&kernel_path, expected_sha).await {
+        tracing::info!("[OK] kernel vmlinux-{KERNEL_VERSION} already installed, skipping download");
         return Ok(());
     }
 
@@ -419,7 +439,6 @@ async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let tmp_path = kernel_path.with_extension(format!("tmp.{}", std::process::id()));
     let sha_hex = download_to_temp(&url, &tmp_path, "kernel").await?;
 
-    let expected_sha = select_sha(arch, KERNEL_SHA256_X86_64, KERNEL_SHA256_AARCH64);
     verify_and_install(
         &sha_hex,
         expected_sha,
@@ -433,25 +452,11 @@ async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     Ok(())
 }
 
-async fn is_mitmdump_installed(bin_path: &Path) -> bool {
-    if !tokio::fs::try_exists(bin_path).await.unwrap_or(false) {
-        return false;
-    }
-    let Ok(output) = tokio::process::Command::new(bin_path)
-        .arg("--version")
-        .output()
-        .await
-    else {
-        return false;
-    };
-    let version_str = String::from_utf8_lossy(&output.stdout);
-    version_str.contains(MITMPROXY_VERSION)
-}
-
 async fn download_mitmdump(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let bin_path = paths.mitmdump_bin(MITMPROXY_VERSION);
+    let expected_sha = select_sha(arch, MITMDUMP_SHA256_X86_64, MITMDUMP_SHA256_AARCH64);
 
-    if is_mitmdump_installed(&bin_path).await {
+    if is_already_installed(&bin_path, expected_sha).await {
         tracing::info!("[OK] mitmdump {MITMPROXY_VERSION} already installed, skipping download");
         return Ok(());
     }
@@ -466,7 +471,6 @@ async fn download_mitmdump(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let sha_hex =
         download_and_extract(&url, "mitmdump", "mitmdump", &tarball_path, &tmp_path).await?;
 
-    let expected_sha = select_sha(arch, MITMDUMP_SHA256_X86_64, MITMDUMP_SHA256_AARCH64);
     verify_and_install(
         &sha_hex,
         expected_sha,

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -327,6 +327,15 @@ async fn atomic_rename(tmp_path: &Path, target: &Path, mode: Option<u32>) -> Run
     result
 }
 
+#[allow(clippy::unreachable)] // arch validated by check_architecture
+fn select_sha<'a>(arch: &str, x86_64: &'a str, aarch64: &'a str) -> &'a str {
+    match arch {
+        "x86_64" => x86_64,
+        "aarch64" => aarch64,
+        _ => unreachable!(),
+    }
+}
+
 fn verify_sha256(actual_hex: &str, expected_hex: &str, label: &str) -> RunnerResult<()> {
     if actual_hex != expected_hex {
         return Err(RunnerError::Internal(format!(
@@ -380,12 +389,7 @@ async fn download_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()>
     let sha_hex =
         download_and_extract(&url, "firecracker", &fc_entry, &tarball_path, &tmp_path).await?;
 
-    #[allow(clippy::unreachable)] // arch validated by check_architecture
-    let expected_sha = match arch {
-        "x86_64" => FIRECRACKER_SHA256_X86_64,
-        "aarch64" => FIRECRACKER_SHA256_AARCH64,
-        _ => unreachable!(),
-    };
+    let expected_sha = select_sha(arch, FIRECRACKER_SHA256_X86_64, FIRECRACKER_SHA256_AARCH64);
     verify_and_install(
         &sha_hex,
         expected_sha,
@@ -415,12 +419,7 @@ async fn download_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let tmp_path = kernel_path.with_extension(format!("tmp.{}", std::process::id()));
     let sha_hex = download_to_temp(&url, &tmp_path, "kernel").await?;
 
-    #[allow(clippy::unreachable)] // arch validated by check_architecture
-    let expected_sha = match arch {
-        "x86_64" => KERNEL_SHA256_X86_64,
-        "aarch64" => KERNEL_SHA256_AARCH64,
-        _ => unreachable!(),
-    };
+    let expected_sha = select_sha(arch, KERNEL_SHA256_X86_64, KERNEL_SHA256_AARCH64);
     verify_and_install(
         &sha_hex,
         expected_sha,
@@ -467,12 +466,7 @@ async fn download_mitmdump(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
     let sha_hex =
         download_and_extract(&url, "mitmdump", "mitmdump", &tarball_path, &tmp_path).await?;
 
-    #[allow(clippy::unreachable)] // arch validated by check_architecture
-    let expected_sha = match arch {
-        "x86_64" => MITMDUMP_SHA256_X86_64,
-        "aarch64" => MITMDUMP_SHA256_AARCH64,
-        _ => unreachable!(),
-    };
+    let expected_sha = select_sha(arch, MITMDUMP_SHA256_X86_64, MITMDUMP_SHA256_AARCH64);
     verify_and_install(
         &sha_hex,
         expected_sha,

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -201,6 +201,7 @@ async fn download_and_extract(
     tarball_path: &Path,
     tmp_path: &Path,
 ) -> RunnerResult<String> {
+    // Tarball SHA is intentionally discarded — we verify the extracted binary's SHA instead.
     download_to_temp(url, tarball_path, label).await?;
 
     let result = extract_tar_entry(tarball_path, tmp_path, entry_name).await;


### PR DESCRIPTION
## Summary
- Add mitmdump (mitmproxy standalone) download to `runner setup`, installing to `~/.vm0-runner/mitmproxy/<version>/mitmdump`
- Add SHA256 verification for mitmdump binaries (both x86_64 and aarch64)
- Refactor download logic: extract `download_to_temp`, `download_and_extract`, `verify_and_install`, and `select_sha` shared helpers to eliminate duplication across firecracker/kernel/mitmdump downloads
- Add `mitmproxy_dir()` and `mitmdump_bin()` path methods to `HomePaths`

Closes #2834

## Test plan
- [ ] `cargo clippy -p runner` passes with no warnings
- [ ] `runner setup` downloads and installs mitmdump on first run
- [ ] `runner setup` skips mitmdump on second run (version check)
- [ ] Existing firecracker and kernel downloads still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)