### PR TITLE
fix(platform): show skeleton loading state in secrets/vars lists

### DIFF
--- a/turbo/apps/platform/src/views/settings-page/__tests__/secrets.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/secrets.test.tsx
@@ -47,6 +47,26 @@ describe("secrets tab", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not flash empty state while loading", async () => {
+    server.use(
+      http.get("/api/secrets", () => {
+        return HttpResponse.json({ secrets: mockSecrets() });
+      }),
+    );
+
+    await setupPage({ context, path: "/settings?tab=secrets" });
+
+    // Should not show empty state while data is loading
+    expect(
+      screen.queryByText("No secrets configured yet"),
+    ).not.toBeInTheDocument();
+
+    // Wait for data to load
+    await vi.waitFor(() => {
+      expect(screen.getByText("API_KEY")).toBeInTheDocument();
+    });
+  });
+
   it("shows empty state when no secrets configured", async () => {
     server.use(
       http.get("/api/secrets", () => {
@@ -56,7 +76,9 @@ describe("secrets tab", () => {
 
     await setupPage({ context, path: "/settings?tab=secrets" });
 
-    expect(screen.getByText("No secrets configured yet")).toBeInTheDocument();
+    await vi.waitFor(() => {
+      expect(screen.getByText("No secrets configured yet")).toBeInTheDocument();
+    });
     expect(screen.getByText("Add secret")).toBeInTheDocument();
   });
 
@@ -100,6 +122,11 @@ describe("secrets tab", () => {
     );
 
     await setupPage({ context, path: "/settings?tab=secrets" });
+
+    // Wait for data to resolve before "Add secret" button appears
+    await vi.waitFor(() => {
+      expect(screen.getByText("Add secret")).toBeInTheDocument();
+    });
 
     // Click "Add secret"
     await user.click(screen.getByText("Add secret"));
@@ -218,6 +245,11 @@ describe("secrets tab", () => {
     );
 
     await setupPage({ context, path: "/settings?tab=secrets" });
+
+    // Wait for data to resolve before "Add secret" button appears
+    await vi.waitFor(() => {
+      expect(screen.getByText("Add secret")).toBeInTheDocument();
+    });
 
     await user.click(screen.getByText("Add secret"));
 

--- a/turbo/apps/platform/src/views/settings-page/__tests__/variables.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/variables.test.tsx
@@ -51,6 +51,26 @@ describe("variables tab", () => {
     expect(screen.getByText("Backend API URL")).toBeInTheDocument();
   });
 
+  it("does not flash empty state while loading", async () => {
+    server.use(
+      http.get("/api/variables", () => {
+        return HttpResponse.json({ variables: mockVariables() });
+      }),
+    );
+
+    await setupPage({ context, path: "/settings?tab=variables" });
+
+    // Should not show empty state while data is loading
+    expect(
+      screen.queryByText("No variables configured yet"),
+    ).not.toBeInTheDocument();
+
+    // Wait for data to load
+    await vi.waitFor(() => {
+      expect(screen.getByText("API_URL")).toBeInTheDocument();
+    });
+  });
+
   it("can add a new variable via dialog", async () => {
     let capturedBody: Record<string, unknown> | null = null;
 
@@ -75,6 +95,11 @@ describe("variables tab", () => {
     );
 
     await setupPage({ context, path: "/settings?tab=variables" });
+
+    // Wait for data to resolve before "Add variable" button appears
+    await vi.waitFor(() => {
+      expect(screen.getByText("Add variable")).toBeInTheDocument();
+    });
 
     // Click "Add variable"
     await user.click(screen.getByText("Add variable"));
@@ -140,7 +165,11 @@ describe("variables tab", () => {
 
     await setupPage({ context, path: "/settings?tab=variables" });
 
-    expect(screen.getByText("No variables configured yet")).toBeInTheDocument();
+    await vi.waitFor(() => {
+      expect(
+        screen.getByText("No variables configured yet"),
+      ).toBeInTheDocument();
+    });
     expect(screen.getByText("Add variable")).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/settings-page/secret-list.tsx
+++ b/turbo/apps/platform/src/views/settings-page/secret-list.tsx
@@ -129,40 +129,58 @@ export function SecretList() {
       )}
 
       <div className="flex flex-col">
-        {secretsList &&
-          secretsList.map((secret, index) => (
-            <SecretRow key={secret.id} secret={secret} isFirst={index === 0} />
-          ))}
+        {!secretsList
+          ? ["s1", "s2", "s3"].map((id, i) => (
+              <div
+                key={id}
+                className={`flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 animate-pulse ${i === 0 ? "rounded-t-xl" : ""} ${i === 2 ? "rounded-b-xl border-b" : ""}`}
+              >
+                <div className="flex flex-1 flex-col gap-2">
+                  <div className="h-4 w-32 rounded bg-muted" />
+                  <div className="h-3 w-48 rounded bg-muted" />
+                </div>
+                <div className="h-3 w-16 rounded bg-muted" />
+              </div>
+            ))
+          : secretsList.map((secret, index) => (
+              <SecretRow
+                key={secret.id}
+                secret={secret}
+                isFirst={index === 0}
+              />
+            ))}
 
-        <div
-          className={`flex flex-col gap-4 border border-border bg-card p-4 rounded-b-xl sm:flex-row sm:items-center ${!secretsList || secretsList.length === 0 ? "rounded-t-xl" : ""}`}
-        >
-          <div className="flex flex-1 items-center gap-4 min-w-0">
-            <div className="flex shrink-0 items-center justify-center size-[28px]">
-              <IconPlus size={24} stroke={1.5} className="text-foreground" />
-            </div>
-            <div className="flex flex-1 flex-col gap-1 min-w-0">
-              <div className="text-sm font-medium text-foreground">
-                {!secretsList || secretsList.length === 0
-                  ? "No secrets configured yet"
-                  : "New secret"}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                {!secretsList || secretsList.length === 0
-                  ? "Add your first encrypted credential"
-                  : "Add a new encrypted credential for your agents"}
-              </div>
-            </div>
-          </div>
-          <button
-            onClick={() => openAdd()}
-            className="flex items-center self-start shrink-0 rounded-lg border border-border bg-background overflow-hidden hover:bg-muted transition-colors"
+        {secretsList && (
+          <div
+            className={`flex flex-col gap-4 border border-border bg-card p-4 rounded-b-xl sm:flex-row sm:items-center ${secretsList.length === 0 ? "rounded-t-xl" : ""}`}
           >
-            <span className="px-4 py-2 text-sm font-medium text-foreground">
-              Add secret
-            </span>
-          </button>
-        </div>
+            <div className="flex flex-1 items-center gap-4 min-w-0">
+              <div className="flex shrink-0 items-center justify-center size-[28px]">
+                <IconPlus size={24} stroke={1.5} className="text-foreground" />
+              </div>
+              <div className="flex flex-1 flex-col gap-1 min-w-0">
+                <div className="text-sm font-medium text-foreground">
+                  {secretsList.length === 0
+                    ? "No secrets configured yet"
+                    : "New secret"}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  {secretsList.length === 0
+                    ? "Add your first encrypted credential"
+                    : "Add a new encrypted credential for your agents"}
+                </div>
+              </div>
+            </div>
+            <button
+              onClick={() => openAdd()}
+              className="flex items-center self-start shrink-0 rounded-lg border border-border bg-background overflow-hidden hover:bg-muted transition-colors"
+            >
+              <span className="px-4 py-2 text-sm font-medium text-foreground">
+                Add secret
+              </span>
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/turbo/apps/platform/src/views/settings-page/variable-list.tsx
+++ b/turbo/apps/platform/src/views/settings-page/variable-list.tsx
@@ -141,44 +141,58 @@ export function VariableList() {
       )}
 
       <div className="flex flex-col">
-        {variablesList &&
-          variablesList.map((variable, index) => (
-            <VariableRow
-              key={variable.id}
-              variable={variable}
-              isFirst={index === 0}
-            />
-          ))}
+        {!variablesList
+          ? ["v1", "v2", "v3"].map((id, i) => (
+              <div
+                key={id}
+                className={`flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 animate-pulse ${i === 0 ? "rounded-t-xl" : ""} ${i === 2 ? "rounded-b-xl border-b" : ""}`}
+              >
+                <div className="flex flex-1 flex-col gap-2">
+                  <div className="h-4 w-32 rounded bg-muted" />
+                  <div className="h-3 w-48 rounded bg-muted" />
+                </div>
+                <div className="h-3 w-16 rounded bg-muted" />
+              </div>
+            ))
+          : variablesList.map((variable, index) => (
+              <VariableRow
+                key={variable.id}
+                variable={variable}
+                isFirst={index === 0}
+              />
+            ))}
 
-        <div
-          className={`flex flex-col gap-4 border border-border bg-card p-4 rounded-b-xl sm:flex-row sm:items-center ${!variablesList || variablesList.length === 0 ? "rounded-t-xl" : ""}`}
-        >
-          <div className="flex flex-1 items-center gap-4 min-w-0">
-            <div className="flex shrink-0 items-center justify-center size-[28px]">
-              <IconPlus size={24} stroke={1.5} className="text-foreground" />
-            </div>
-            <div className="flex flex-1 flex-col gap-1 min-w-0">
-              <div className="text-sm font-medium text-foreground">
-                {!variablesList || variablesList.length === 0
-                  ? "No variables configured yet"
-                  : "New variable"}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                {!variablesList || variablesList.length === 0
-                  ? "Add your first configuration value"
-                  : "Add a new configuration value for your agents"}
-              </div>
-            </div>
-          </div>
-          <button
-            onClick={() => openAdd()}
-            className="flex items-center self-start shrink-0 rounded-lg border border-border bg-background overflow-hidden hover:bg-muted transition-colors"
+        {variablesList && (
+          <div
+            className={`flex flex-col gap-4 border border-border bg-card p-4 rounded-b-xl sm:flex-row sm:items-center ${variablesList.length === 0 ? "rounded-t-xl" : ""}`}
           >
-            <span className="px-4 py-2 text-sm font-medium text-foreground">
-              Add variable
-            </span>
-          </button>
-        </div>
+            <div className="flex flex-1 items-center gap-4 min-w-0">
+              <div className="flex shrink-0 items-center justify-center size-[28px]">
+                <IconPlus size={24} stroke={1.5} className="text-foreground" />
+              </div>
+              <div className="flex flex-1 flex-col gap-1 min-w-0">
+                <div className="text-sm font-medium text-foreground">
+                  {variablesList.length === 0
+                    ? "No variables configured yet"
+                    : "New variable"}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  {variablesList.length === 0
+                    ? "Add your first configuration value"
+                    : "Add a new configuration value for your agents"}
+                </div>
+              </div>
+            </div>
+            <button
+              onClick={() => openAdd()}
+              className="flex items-center self-start shrink-0 rounded-lg border border-border bg-background overflow-hidden hover:bg-muted transition-colors"
+            >
+              <span className="px-4 py-2 text-sm font-medium text-foreground">
+                Add variable
+              </span>
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace the empty state flash ("No secrets/vars configured yet") with animated skeleton placeholders while data is loading
- The empty state now only appears after data has confirmed to be empty (`useLastResolved()` returns an empty array, not `undefined`)
- Matches the existing `connector-list.tsx` skeleton loading pattern

## Test plan
- [x] Added "does not flash empty state while loading" tests for both secrets and variables
- [x] Updated empty state tests to use `vi.waitFor` since empty state now only appears after data resolves
- [x] All 13 existing tests pass (secrets + variables)
- [x] Lint, type-check, format, knip all pass

Closes #2658

🤖 Generated with [Claude Code](https://claude.com/claude-code)