### PR TITLE
fix(telemetry): await db fallback instead of fire-and-forget

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
@@ -177,9 +177,7 @@ const router = tsr.router(webhookTelemetryContract, {
 
     // DB fallback: store telemetry locally when Axiom is not configured
     if (!axiomIngested) {
-      storeTelemetryFallback(body).catch((err: unknown) => {
-        log.error("DB telemetry store failed:", err);
-      });
+      await storeTelemetryFallback(body);
     }
 
     // Record sandbox internal operations as OpenTelemetry metrics (to sandbox-metric-{env} dataset)

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -40,6 +40,7 @@ vi.hoisted(() => {
   vi.stubEnv("SLACK_REDIRECT_BASE_URL", "https://test.example.com");
   // API URL for compose job webhooks
   vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+  vi.stubEnv("PLATFORM_URL", "http://localhost:3000");
   // Initialize Next.js after() callback queue (shared with test-helpers.ts flushAfter)
   globalThis.nextAfterCallbacks = [];
 });


### PR DESCRIPTION
## Summary

- **Await `storeTelemetryFallback`** in the telemetry webhook route instead of using fire-and-forget `.catch()` pattern. This ensures errors propagate properly and are not silently swallowed, aligning with the project's "avoid defensive programming" principle.
- **Add missing `PLATFORM_URL` env stub** in test setup to prevent test failures when the env variable is required.

## Test plan

- [x] All 236 test files pass (2866 tests)
- [x] TypeScript type check passes
- [x] Lint passes
- [x] Knip passes (no unused code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)