### PR TITLE
feat(web): add eslint rule to detect duplicate migration prefixes

### DIFF
--- a/turbo/apps/web/custom-eslint/__tests__/no-duplicate-migration-prefix.test.ts
+++ b/turbo/apps/web/custom-eslint/__tests__/no-duplicate-migration-prefix.test.ts
@@ -1,0 +1,79 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { findDuplicatePrefixes } from "../rules/no-duplicate-migration-prefix.ts";
+
+describe("findDuplicatePrefixes", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "migrations-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("should return empty array when no duplicates exist", () => {
+    fs.writeFileSync(path.join(tempDir, "0001_first.sql"), "");
+    fs.writeFileSync(path.join(tempDir, "0002_second.sql"), "");
+    fs.writeFileSync(path.join(tempDir, "0003_third.sql"), "");
+
+    const result = findDuplicatePrefixes(tempDir);
+    expect(result).toEqual([]);
+  });
+
+  it("should detect duplicate prefixes", () => {
+    fs.writeFileSync(path.join(tempDir, "0001_first.sql"), "");
+    fs.writeFileSync(path.join(tempDir, "0001_duplicate.sql"), "");
+    fs.writeFileSync(path.join(tempDir, "0002_second.sql"), "");
+
+    const result = findDuplicatePrefixes(tempDir);
+    expect(result).toEqual([
+      { prefix: "0001", files: ["0001_duplicate.sql", "0001_first.sql"] },
+    ]);
+  });
+
+  it("should detect multiple duplicate prefixes", () => {
+    fs.writeFileSync(path.join(tempDir, "0001_a.sql"), "");
+    fs.writeFileSync(path.join(tempDir, "0001_b.sql"), "");
+    fs.writeFileSync(path.join(tempDir, "0002_a.sql"), "");
+    fs.writeFileSync(path.join(tempDir, "0002_b.sql"), "");
+
+    const result = findDuplicatePrefixes(tempDir);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({
+      prefix: "0001",
+      files: ["0001_a.sql", "0001_b.sql"],
+    });
+    expect(result).toContainEqual({
+      prefix: "0002",
+      files: ["0002_a.sql", "0002_b.sql"],
+    });
+  });
+
+  it("should return empty array for non-existent directory", () => {
+    const result = findDuplicatePrefixes("/non/existent/path");
+    expect(result).toEqual([]);
+  });
+
+  it("should ignore non-migration files", () => {
+    fs.writeFileSync(path.join(tempDir, "0001_first.sql"), "");
+    fs.writeFileSync(path.join(tempDir, "_journal.json"), "{}");
+    fs.writeFileSync(path.join(tempDir, "README.md"), "");
+    fs.writeFileSync(path.join(tempDir, "0001.sql"), ""); // Missing underscore
+
+    const result = findDuplicatePrefixes(tempDir);
+    expect(result).toEqual([]);
+  });
+
+  it("should handle files with similar but different prefixes", () => {
+    fs.writeFileSync(path.join(tempDir, "0001_first.sql"), "");
+    fs.writeFileSync(path.join(tempDir, "0010_tenth.sql"), "");
+    fs.writeFileSync(path.join(tempDir, "0100_hundredth.sql"), "");
+
+    const result = findDuplicatePrefixes(tempDir);
+    expect(result).toEqual([]);
+  });
+});

--- a/turbo/apps/web/custom-eslint/index.ts
+++ b/turbo/apps/web/custom-eslint/index.ts
@@ -1,12 +1,14 @@
 /**
- * Custom ESLint plugin for web app testing patterns.
+ * Custom ESLint plugin for web app patterns.
  *
- * Enforces testing best practices:
+ * Enforces best practices:
  * - no-direct-db-in-tests: Don't access database directly in test files
  * - no-relative-vi-mock: Don't use relative paths in vi.mock()
+ * - no-duplicate-migration-prefix: Prevent duplicate migration file prefixes
  */
 
 import noDirectDbInTests from "./rules/no-direct-db-in-tests.ts";
+import noDuplicateMigrationPrefix from "./rules/no-duplicate-migration-prefix.ts";
 import noRelativeViMock from "./rules/no-relative-vi-mock.ts";
 
 const plugin = {
@@ -16,6 +18,7 @@ const plugin = {
   },
   rules: {
     "no-direct-db-in-tests": noDirectDbInTests,
+    "no-duplicate-migration-prefix": noDuplicateMigrationPrefix,
     "no-relative-vi-mock": noRelativeViMock,
   },
 };

--- a/turbo/apps/web/custom-eslint/rules/no-duplicate-migration-prefix.ts
+++ b/turbo/apps/web/custom-eslint/rules/no-duplicate-migration-prefix.ts
@@ -1,0 +1,120 @@
+/**
+ * ESLint rule: no-duplicate-migration-prefix
+ *
+ * Detects duplicate numeric prefixes in database migration files.
+ * Migration files follow the pattern: {4-digit}_{name}.sql
+ *
+ * This rule scans the migrations directory once per lint process
+ * (using module-level caching) and reports any duplicate prefixes.
+ *
+ * Good:
+ *   0065_add_variables.sql
+ *   0066_add_permissions.sql
+ *
+ * Bad:
+ *   0065_add_variables.sql
+ *   0065_add_permissions.sql  // Duplicate prefix!
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRule } from "../utils.ts";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Module-level cache to ensure we only check and report once per ESLint process
+let hasChecked = false;
+let hasReported = false;
+let cachedError: { prefix: string; files: string[] }[] | null = null;
+
+const MIGRATION_PREFIX_PATTERN = /^(\d{4})_.*\.sql$/;
+
+export function findDuplicatePrefixes(
+  migrationsDir: string,
+): { prefix: string; files: string[] }[] {
+  if (!fs.existsSync(migrationsDir)) {
+    return [];
+  }
+
+  const files = fs.readdirSync(migrationsDir);
+  const prefixMap = new Map<string, string[]>();
+
+  for (const file of files) {
+    const match = MIGRATION_PREFIX_PATTERN.exec(file);
+    if (match && match[1]) {
+      const prefix = match[1];
+      const existing = prefixMap.get(prefix) ?? [];
+      existing.push(file);
+      prefixMap.set(prefix, existing);
+    }
+  }
+
+  const duplicates: { prefix: string; files: string[] }[] = [];
+  for (const [prefix, fileList] of prefixMap) {
+    if (fileList.length > 1) {
+      duplicates.push({ prefix, files: fileList.sort() });
+    }
+  }
+
+  return duplicates;
+}
+
+export default createRule({
+  name: "no-duplicate-migration-prefix",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow duplicate numeric prefixes in database migration files.",
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      duplicatePrefix:
+        'Duplicate migration prefix "{{prefix}}" found in: {{files}}. Each migration must have a unique numeric prefix.',
+    },
+  },
+  create(context) {
+    return {
+      Program(node) {
+        // Only check and report once per ESLint process
+        if (hasReported) {
+          return;
+        }
+
+        if (!hasChecked) {
+          hasChecked = true;
+
+          // Resolve migrations directory relative to this rule file
+          const migrationsDir = path.resolve(
+            __dirname,
+            "../../src/db/migrations",
+          );
+
+          const duplicates = findDuplicatePrefixes(migrationsDir);
+          if (duplicates.length > 0) {
+            cachedError = duplicates;
+          }
+        }
+
+        // Report errors only once
+        if (cachedError) {
+          hasReported = true;
+          for (const dup of cachedError) {
+            context.report({
+              node,
+              messageId: "duplicatePrefix",
+              data: {
+                prefix: dup.prefix,
+                files: dup.files.join(", "),
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/web/eslint.config.js
+++ b/turbo/apps/web/eslint.config.js
@@ -22,6 +22,16 @@ export default [
     },
   },
   {
+    files: ["**/*.ts", "**/*.tsx"],
+    plugins: {
+      web: webPlugin,
+    },
+    rules: {
+      // Check for duplicate migration prefixes (runs once per lint process)
+      "web/no-duplicate-migration-prefix": "error",
+    },
+  },
+  {
     files: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
     plugins: {
       web: webPlugin,


### PR DESCRIPTION
## Summary

- Add a custom ESLint rule `no-duplicate-migration-prefix` that detects when multiple migration files share the same numeric prefix
- Prevents migration ordering conflicts that can occur when multiple developers create migrations with the same sequence number
- Integrates with existing `pnpm lint` workflow and CI pipeline

## Changes

- **New rule**: `turbo/apps/web/custom-eslint/rules/no-duplicate-migration-prefix.ts`
  - Scans `src/db/migrations/` for `.sql` files matching `{4-digit}_{name}.sql` pattern
  - Uses module-level caching to run only once per lint process
  - Reports all duplicate prefixes with conflicting filenames

- **Plugin registration**: Updated `custom-eslint/index.ts` to include the new rule

- **ESLint config**: Enabled rule for all `.ts/.tsx` files in `eslint.config.js`

- **Tests**: Added comprehensive tests for the core detection logic

## Example Error

```
Duplicate migration prefix "0065" found in: 0065_add_variables.sql, 0065_duplicate_test.sql.
Each migration must have a unique numeric prefix.
```

## Test plan

- [x] Run `pnpm lint` with no duplicate migrations - passes
- [x] Create a duplicate migration file - lint fails with descriptive error
- [x] Run unit tests - all 6 tests pass
- [x] Verify TypeScript types - no errors

🤖 Generated with [Claude Code](https://claude.ai/code)