### PR TITLE
fix(guest-download): skip retry on 4xx errors and log failed url

### DIFF
--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -227,6 +227,17 @@ fn download_storages_parallel(storages: &[Storage]) -> bool {
     all_success
 }
 
+struct DownloadError {
+    message: String,
+    retriable: bool,
+}
+
+impl std::fmt::Display for DownloadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
 fn download_with_retry(url: &str, target_path: &str) -> Result<(), String> {
     let mut last_error = String::new();
 
@@ -235,7 +246,10 @@ fn download_with_retry(url: &str, target_path: &str) -> Result<(), String> {
             Ok(()) => return Ok(()),
             Err(e) => {
                 log_warn!(LOG_TAG, "Attempt {attempt}/{MAX_RETRIES} failed: {e}");
-                last_error = e;
+                last_error = e.message.clone();
+                if !e.retriable {
+                    break;
+                }
                 if attempt < MAX_RETRIES {
                     thread::sleep(RETRY_DELAY);
                 }
@@ -246,16 +260,21 @@ fn download_with_retry(url: &str, target_path: &str) -> Result<(), String> {
     Err(last_error)
 }
 
-fn download_and_extract(url: &str, target_path: &str) -> Result<(), String> {
+fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadError> {
     // Create target directory
-    fs::create_dir_all(target_path)
-        .map_err(|e| format!("Failed to create directory {target_path}: {e}"))?;
+    fs::create_dir_all(target_path).map_err(|e| DownloadError {
+        message: format!("Failed to create directory {target_path}: {e}"),
+        retriable: false,
+    })?;
 
     // Make HTTP request using global agent
-    let response = HTTP_AGENT
-        .get(url)
-        .call()
-        .map_err(|e| format!("HTTP request failed: {e}"))?;
+    let response = HTTP_AGENT.get(url).call().map_err(|e| {
+        let retriable = matches!(&e, ureq::Error::StatusCode(code) if *code >= 500);
+        DownloadError {
+            message: format!("HTTP {e} url={url}"),
+            retriable,
+        }
+    })?;
 
     // Stream: HTTP response -> GzDecoder -> tar::Archive
     let reader = response.into_body().into_reader();
@@ -264,9 +283,10 @@ fn download_and_extract(url: &str, target_path: &str) -> Result<(), String> {
 
     // Extract to target path
     // Note: tar crate handles empty archives gracefully (returns Ok with 0 entries)
-    archive
-        .unpack(target_path)
-        .map_err(|e| format!("Failed to extract archive: {e}"))?;
+    archive.unpack(target_path).map_err(|e| DownloadError {
+        message: format!("Failed to extract archive: {e}"),
+        retriable: false,
+    })?;
 
     Ok(())
 }

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -269,7 +269,10 @@ fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadErro
 
     // Make HTTP request using global agent
     let response = HTTP_AGENT.get(url).call().map_err(|e| {
-        let retriable = matches!(&e, ureq::Error::StatusCode(code) if *code >= 500);
+        let retriable = match &e {
+            ureq::Error::StatusCode(code) => *code >= 500,
+            _ => true, // network/timeout errors are retriable
+        };
         DownloadError {
             message: format!("HTTP {e} url={url}"),
             retriable,


### PR DESCRIPTION
## Summary

- **Skip retry on 4xx errors**: HTTP client errors (like 404 Not Found) are not retriable — the resource doesn't exist, retrying won't help. Only retry on 5xx server errors and network/timeout errors.
- **Log the failed URL**: Previously only logged `HTTP request failed: http status: 404` with no URL. Now logs the full URL so 404 errors are debuggable.
- **Structured error type**: Replaced string-based error with `DownloadError` struct carrying a `retriable` flag.

Discovered during PR #2837 CI investigation — 3 jobs failed with artifact download 404, each wasting ~3s on pointless retries with no URL in logs.

## Test plan

- [x] `cargo build -p guest-download` passes
- [x] `cargo test -p guest-download` passes (8 tests)
- [ ] Verify in CI that 404 errors now show the URL and fail immediately without retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)