### PR TITLE
test(platform): replace user.type with user.paste and merge waitfor blocks

### DIFF
--- a/turbo/apps/platform/src/views/home/__tests__/home-page.test.tsx
+++ b/turbo/apps/platform/src/views/home/__tests__/home-page.test.tsx
@@ -57,7 +57,8 @@ describe("home page", () => {
 
     // Type a token value (default provider is claude-code-oauth-token)
     const tokenInput = screen.getByPlaceholderText("sk-ant-oat...");
-    await user.type(tokenInput, "sk-ant-oat-test-token");
+    await user.click(tokenInput);
+    await user.paste("sk-ant-oat-test-token");
 
     // Save button should now be enabled
     expect(saveButton).toBeEnabled();
@@ -138,7 +139,8 @@ describe("home page", () => {
 
     // Type a token value
     const tokenInput = screen.getByPlaceholderText("sk-ant-oat...");
-    await user.type(tokenInput, "sk-ant-oat-test-token");
+    await user.click(tokenInput);
+    await user.paste("sk-ant-oat-test-token");
 
     // Click Save
     await user.click(screen.getByRole("button", { name: "Save" }));
@@ -194,7 +196,8 @@ describe("home page", () => {
     });
 
     const tokenInput = screen.getByPlaceholderText("sk-ant-oat...");
-    await user.type(tokenInput, "sk-ant-oat-test-token");
+    await user.click(tokenInput);
+    await user.paste("sk-ant-oat-test-token");
 
     const saveButton = screen.getByRole("button", { name: "Save" });
     expect(saveButton).toBeEnabled();

--- a/turbo/apps/platform/src/views/logs-page/__tests__/log-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/logs-page/__tests__/log-detail-page.test.tsx
@@ -342,12 +342,9 @@ describe("log detail page", () => {
       path: "/logs/run-raw-data",
     });
 
-    await waitFor(() => {
-      expect(screen.getByText("Agent events")).toBeInTheDocument();
-    });
-
     // Verify the events are rendered (in formatted view)
     await waitFor(() => {
+      expect(screen.getByText("Agent events")).toBeInTheDocument();
       expect(screen.getByText(/Starting task/)).toBeInTheDocument();
     });
   });
@@ -612,9 +609,7 @@ describe("log detail page", () => {
         path: "/logs/run-search-test",
       });
 
-      await waitFor(() => {
-        expect(screen.getByPlaceholderText("Search logs")).toBeInTheDocument();
-      });
+      expect(screen.getByPlaceholderText("Search logs")).toBeInTheDocument();
     });
 
     it("should filter events when searching", async () => {
@@ -634,7 +629,8 @@ describe("log detail page", () => {
 
       // Type a search term that matches one message
       const searchInput = screen.getByPlaceholderText("Search logs");
-      await user.type(searchInput, "Third");
+      await user.click(searchInput);
+      await user.paste("Third");
 
       // Should show matching count in header (1 message matches out of 3)
       await waitFor(() => {
@@ -659,7 +655,8 @@ describe("log detail page", () => {
 
       // Type a search term that matches multiple times
       const searchInput = screen.getByPlaceholderText("Search logs");
-      await user.type(searchInput, "world");
+      await user.click(searchInput);
+      await user.paste("world");
 
       // Should show match counter
       await waitFor(() => {
@@ -691,7 +688,8 @@ describe("log detail page", () => {
 
       // Type a search term
       const searchInput = screen.getByPlaceholderText("Search logs");
-      await user.type(searchInput, "world");
+      await user.click(searchInput);
+      await user.paste("world");
 
       // Wait for match counter to appear
       await waitFor(() => {
@@ -724,7 +722,8 @@ describe("log detail page", () => {
 
       // Type a search term
       const searchInput = screen.getByPlaceholderText("Search logs");
-      await user.type(searchInput, "world");
+      await user.click(searchInput);
+      await user.paste("world");
 
       // Wait for match counter to appear
       await waitFor(() => {
@@ -757,7 +756,8 @@ describe("log detail page", () => {
 
       // Type a search term
       const searchInput = screen.getByPlaceholderText("Search logs");
-      await user.type(searchInput, "world");
+      await user.click(searchInput);
+      await user.paste("world");
 
       // Wait for match counter to appear
       await waitFor(() => {
@@ -798,7 +798,8 @@ describe("log detail page", () => {
 
       // Type a search term
       const searchInput = screen.getByPlaceholderText("Search logs");
-      await user.type(searchInput, "world");
+      await user.click(searchInput);
+      await user.paste("world");
 
       // Wait and navigate to a different match
       await waitFor(() => {
@@ -812,7 +813,8 @@ describe("log detail page", () => {
 
       // Change search term - "message" appears in 2 assistant messages
       await user.clear(searchInput);
-      await user.type(searchInput, "message");
+      await user.click(searchInput);
+      await user.paste("message");
 
       // Should reset to first match (2 matches for "message")
       await waitFor(() => {
@@ -837,7 +839,8 @@ describe("log detail page", () => {
 
       // Type a search term with no matches
       const searchInput = screen.getByPlaceholderText("Search logs");
-      await user.type(searchInput, "nonexistent");
+      await user.click(searchInput);
+      await user.paste("nonexistent");
 
       // Should show 0/0
       await waitFor(() => {
@@ -1004,13 +1007,9 @@ describe("log detail page", () => {
         path: "/logs/run-collapsed-tools",
       });
 
-      // Wait for assistant text to render
+      // Wait for events and collapsed tool groups to render
       await waitFor(() => {
         expect(screen.getByText(/Let me read those files/)).toBeInTheDocument();
-      });
-
-      // The 3 Read operations should be collapsed into a group with "3 files" badge
-      await waitFor(() => {
         expect(screen.getByText("3 files")).toBeInTheDocument();
       });
     });

--- a/turbo/apps/platform/src/views/logs-page/__tests__/logs-page.test.tsx
+++ b/turbo/apps/platform/src/views/logs-page/__tests__/logs-page.test.tsx
@@ -27,9 +27,7 @@ describe("logs page", () => {
       path: "/logs",
     });
 
-    await waitFor(() => {
-      expect(screen.getByText("Run ID")).toBeInTheDocument();
-    });
+    expect(screen.getByText("Run ID")).toBeInTheDocument();
     expect(screen.getByText("Session ID")).toBeInTheDocument();
     expect(screen.getByText("Agent")).toBeInTheDocument();
     expect(screen.getByText("Framework")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/settings-page/__tests__/connectors.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/connectors.test.tsx
@@ -86,12 +86,9 @@ describe("connectors tab", () => {
     });
     await user.click(confirmButton);
 
-    // Verify delete API was called
+    // Verify delete API was called and dialog closed
     await vi.waitFor(() => {
       expect(deletedType).toBe("github");
-    });
-
-    await vi.waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/settings-page/__tests__/secrets.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/secrets.test.tsx
@@ -142,12 +142,12 @@ describe("secrets tab", () => {
     // Fill in the form
     const nameInput = within(dialog).getByPlaceholderText("MY_API_KEY");
     await user.click(nameInput);
-    await user.keyboard("NEW_SECRET");
+    await user.paste("NEW_SECRET");
 
     const valueInput =
       within(dialog).getByPlaceholderText("Enter secret value");
     await user.click(valueInput);
-    await user.keyboard("super-secret-value");
+    await user.paste("super-secret-value");
 
     // Submit
     const submitButton = within(dialog).getByRole("button", {
@@ -155,16 +155,13 @@ describe("secrets tab", () => {
     });
     await user.click(submitButton);
 
-    // Verify request
+    // Verify request and dialog closed
     await vi.waitFor(() => {
       expect(capturedBody).toBeTruthy();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
     expect(capturedBody!.name).toBe("NEW_SECRET");
     expect(capturedBody!.value).toBe("super-secret-value");
-
-    await vi.waitFor(() => {
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    });
   });
 
   it("can delete a secret via kebab menu", async () => {
@@ -207,9 +204,6 @@ describe("secrets tab", () => {
 
     await vi.waitFor(() => {
       expect(deletedName).toBe("API_KEY");
-    });
-
-    await vi.waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/settings-page/__tests__/settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/settings-page.test.tsx
@@ -99,7 +99,7 @@ describe("settings page", () => {
     // Fill in the API key
     const input = within(dialog).getByPlaceholderText("Enter your API key");
     await user.click(input);
-    await user.keyboard("sk-ant-api-key-12345");
+    await user.paste("sk-ant-api-key-12345");
 
     // Submit
     const addProviderButton = within(dialog).getByRole("button", {
@@ -110,13 +110,10 @@ describe("settings page", () => {
     // Verify request was sent with correct data and dialog closed
     await vi.waitFor(() => {
       expect(capturedBody).toBeTruthy();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
     expect(capturedBody!.type).toBe("anthropic-api-key");
     expect(capturedBody!.secret).toBe("sk-ant-api-key-12345");
-
-    await vi.waitFor(() => {
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    });
   });
 
   it("can delete a provider via kebab menu", async () => {
@@ -153,9 +150,6 @@ describe("settings page", () => {
     // Verify delete API was called with correct provider type and dialog closed
     await vi.waitFor(() => {
       expect(deletedType).toBe("claude-code-oauth-token");
-    });
-
-    await vi.waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/settings-page/__tests__/variables.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/variables.test.tsx
@@ -110,13 +110,13 @@ describe("variables tab", () => {
     // Fill in the form
     const nameInput = within(dialog).getByPlaceholderText("MY_VARIABLE");
     await user.click(nameInput);
-    await user.keyboard("MY_VAR");
+    await user.paste("MY_VAR");
 
     const valueInput = within(dialog).getByPlaceholderText(
       "Enter variable value",
     );
     await user.click(valueInput);
-    await user.keyboard("some-value");
+    await user.paste("some-value");
 
     // Submit
     const submitButton = within(dialog).getByRole("button", {
@@ -126,13 +126,10 @@ describe("variables tab", () => {
 
     await vi.waitFor(() => {
       expect(capturedBody).toBeTruthy();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
     expect(capturedBody!.name).toBe("MY_VAR");
     expect(capturedBody!.value).toBe("some-value");
-
-    await vi.waitFor(() => {
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    });
   });
 
   it("shows missing variables banner from URL required param", async () => {


### PR DESCRIPTION
## Summary
- Replace `user.type()` and `user.keyboard()` with `user.click()` + `user.paste()` across platform test files for faster input simulation (avoids per-keystroke event firing)
- Merge consecutive `waitFor` blocks that assert on the same async state into single blocks, reducing redundant async waits
- Remove unnecessary `waitFor` wrappers around assertions for elements that are already rendered synchronously

## Test plan
- [x] All 299 platform tests pass locally
- [x] Lint, type check, format, and knip checks all pass
- [ ] CI pipeline passes on PR

Generated with [Claude Code](https://claude.com/claude-code)