### PR TITLE
fix(runner): make runner sole reporter of job completion

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -153,8 +153,7 @@ async fn execute(
     // Execution phase
     log_info!(LOG_TAG, "▷ Execution");
     let cli_start = Instant::now();
-    let (mut exit_code, error_message) = match cli::execute_cli(masker, heartbeat_handle).await
-    {
+    let (mut exit_code, error_message) = match cli::execute_cli(masker, heartbeat_handle).await {
         Ok((code, stderr_lines)) => {
             if code != 0 {
                 let msg = if stderr_lines.is_empty() {

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -96,7 +96,7 @@ async fn run() -> i32 {
     record_sandbox_op("telemetry_upload_start", t.elapsed(), true, None);
 
     // Execute main logic (init + CLI + checkpoint)
-    let (exit_code, _error_message) = execute(&masker, start, heartbeat_handle).await;
+    let exit_code = execute(&masker, start, heartbeat_handle).await;
 
     // Guaranteed cleanup: final telemetry upload
     log_info!(LOG_TAG, "▷ Cleanup");
@@ -118,12 +118,11 @@ async fn run() -> i32 {
 }
 
 /// Main execution logic: working dir, codex setup, CLI, checkpoint.
-/// Returns `(exit_code, error_message)`.
 async fn execute(
     masker: &masker::SecretMasker,
     start: Instant,
     heartbeat_handle: tokio::task::JoinHandle<Result<(), error::AgentError>>,
-) -> (i32, String) {
+) -> i32 {
     // Working directory setup
     let wd_start = Instant::now();
     if let Err(e) = std::fs::create_dir_all(env::working_dir())
@@ -132,7 +131,7 @@ async fn execute(
         let msg = format!("Working dir setup failed: {e}");
         log_error!(LOG_TAG, "{msg}");
         record_sandbox_op("working_dir_setup", wd_start.elapsed(), false, Some(&msg));
-        return (1, msg);
+        return 1;
     }
     record_sandbox_op("working_dir_setup", wd_start.elapsed(), true, None);
 
@@ -154,7 +153,7 @@ async fn execute(
     // Execution phase
     log_info!(LOG_TAG, "▷ Execution");
     let cli_start = Instant::now();
-    let (mut exit_code, mut error_message) = match cli::execute_cli(masker, heartbeat_handle).await
+    let (mut exit_code, error_message) = match cli::execute_cli(masker, heartbeat_handle).await
     {
         Ok((code, stderr_lines)) => {
             if code != 0 {
@@ -192,10 +191,6 @@ async fn execute(
     if std::path::Path::new(paths::event_error_flag()).exists() {
         log_error!(LOG_TAG, "Some events failed to send, marking run as failed");
         exit_code = 1;
-        // Only override error_message when CLI itself succeeded (matching TS priority)
-        if cli_exit_code == 0 {
-            error_message = "Some events failed to send".to_string();
-        }
     }
 
     if cli_exit_code == 0 && exit_code == 0 {
@@ -226,7 +221,6 @@ async fn execute(
                     cp_start.elapsed().as_secs()
                 );
                 exit_code = 1;
-                error_message = "Checkpoint creation failed".to_string();
             }
         }
     } else if cli_exit_code != 0 {
@@ -237,7 +231,7 @@ async fn execute(
         );
     }
 
-    (exit_code, error_message)
+    exit_code
 }
 
 /// Cleanup that always runs: final telemetry upload.

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -52,7 +52,7 @@ async fn run() -> i32 {
         log_error!(LOG_TAG, "Fatal: VM0_WORKING_DIR is required but not set");
         let masker = masker::SecretMasker::from_env();
         log_info!(LOG_TAG, "▷ Cleanup");
-        cleanup(&masker, 1, "VM0_WORKING_DIR is required but not set").await;
+        cleanup(&masker).await;
         log_info!(LOG_TAG, "Background processes stopped");
         log_info!(LOG_TAG, "✗ Sandbox failed (exit code 1)");
         return 1;
@@ -96,11 +96,11 @@ async fn run() -> i32 {
     record_sandbox_op("telemetry_upload_start", t.elapsed(), true, None);
 
     // Execute main logic (init + CLI + checkpoint)
-    let (exit_code, error_message) = execute(&masker, start, heartbeat_handle).await;
+    let (exit_code, _error_message) = execute(&masker, start, heartbeat_handle).await;
 
-    // Guaranteed cleanup: final telemetry + complete API
+    // Guaranteed cleanup: final telemetry upload
     log_info!(LOG_TAG, "▷ Cleanup");
-    cleanup(&masker, exit_code, &error_message).await;
+    cleanup(&masker).await;
 
     // Stop all background processes (heartbeat, metrics, telemetry)
     shutdown.cancel();
@@ -240,8 +240,9 @@ async fn execute(
     (exit_code, error_message)
 }
 
-/// Cleanup that always runs: final telemetry upload and complete API call.
-async fn cleanup(masker: &masker::SecretMasker, exit_code: i32, error_message: &str) {
+/// Cleanup that always runs: final telemetry upload.
+/// Note: complete API is called by the runner after VM exits, not by guest-agent.
+async fn cleanup(masker: &masker::SecretMasker) {
     // Final telemetry upload
     let telemetry_start = Instant::now();
     let telemetry_ok = telemetry::final_upload(masker).await.is_ok();
@@ -252,39 +253,6 @@ async fn cleanup(masker: &masker::SecretMasker, exit_code: i32, error_message: &
         "final_telemetry_upload",
         telemetry_start.elapsed(),
         telemetry_ok,
-        None,
-    );
-
-    // Complete API call
-    log_info!(LOG_TAG, "Calling complete API with exitCode={exit_code}");
-    let complete_start = Instant::now();
-    let mut payload = serde_json::json!({
-        "runId": env::run_id(),
-        "exitCode": exit_code,
-    });
-    if !error_message.is_empty()
-        && let Some(obj) = payload.as_object_mut()
-    {
-        obj.insert(
-            "error".to_string(),
-            serde_json::Value::String(error_message.to_string()),
-        );
-    }
-    let complete_ok = http::post_json(urls::complete_url(), &payload, constants::HTTP_MAX_RETRIES)
-        .await
-        .is_ok();
-    if complete_ok {
-        log_info!(LOG_TAG, "Complete API called successfully");
-    } else {
-        log_error!(
-            LOG_TAG,
-            "Failed to call complete API (sandbox may not be cleaned up)"
-        );
-    }
-    record_sandbox_op(
-        "complete_api_call",
-        complete_start.elapsed(),
-        complete_ok,
         None,
     );
 }

--- a/crates/guest-agent/src/urls.rs
+++ b/crates/guest-agent/src/urls.rs
@@ -7,8 +7,6 @@ static EVENTS_URL: LazyLock<String> =
     LazyLock::new(|| format!("{}/api/webhooks/agent/events", env::api_url()));
 static CHECKPOINT_URL: LazyLock<String> =
     LazyLock::new(|| format!("{}/api/webhooks/agent/checkpoints", env::api_url()));
-static COMPLETE_URL: LazyLock<String> =
-    LazyLock::new(|| format!("{}/api/webhooks/agent/complete", env::api_url()));
 static HEARTBEAT_URL: LazyLock<String> =
     LazyLock::new(|| format!("{}/api/webhooks/agent/heartbeat", env::api_url()));
 static TELEMETRY_URL: LazyLock<String> =
@@ -23,9 +21,6 @@ pub fn events_url() -> &'static str {
 }
 pub fn checkpoint_url() -> &'static str {
     &CHECKPOINT_URL
-}
-pub fn complete_url() -> &'static str {
-    &COMPLETE_URL
 }
 pub fn heartbeat_url() -> &'static str {
     &HEARTBEAT_URL

--- a/turbo/apps/runner/src/lib/runner/runner.ts
+++ b/turbo/apps/runner/src/lib/runner/runner.ts
@@ -293,8 +293,6 @@ export class Runner {
     const completeResult = await withRunnerTiming("complete", () =>
       completeJob(this.config.server.url, context, exitCode, error),
     );
-    logger.log(
-      `  Job ${context.runId} reported as ${completeResult.status}`,
-    );
+    logger.log(`  Job ${context.runId} reported as ${completeResult.status}`);
   }
 }

--- a/turbo/apps/runner/src/lib/runner/runner.ts
+++ b/turbo/apps/runner/src/lib/runner/runner.ts
@@ -284,18 +284,21 @@ export class Runner {
       logger.error(`  Job ${context.runId} execution failed: ${error}`);
     }
 
-    // Report failure for claimed jobs that didn't complete successfully.
-    // On success, guest-agent already calls the complete API from inside the VM.
-    // On failure, guest-agent may not have started (e.g., storage download error),
-    // so the runner must report it. The API is idempotent, so duplicate calls are safe.
-    if (exitCode !== 0) {
-      const completeResult = await completeJob(
-        this.config.server.url,
-        context,
-        exitCode,
-        error,
+    // Runner is the sole reporter of job completion.
+    // Guest-agent handles telemetry; runner handles the complete API call
+    // after VM exits to ensure it always runs.
+    logger.log(
+      `  Calling complete API for job ${context.runId} with exitCode=${exitCode}`,
+    );
+    try {
+      const completeResult = await withRunnerTiming("complete", () =>
+        completeJob(this.config.server.url, context, exitCode, error),
       );
       logger.log(`  Job ${context.runId} reported as ${completeResult.status}`);
+    } catch (err) {
+      logger.error(
+        `  Failed to call complete API for job ${context.runId}: ${err instanceof Error ? err.message : "Unknown error"}`,
+      );
     }
   }
 }

--- a/turbo/apps/runner/src/lib/runner/runner.ts
+++ b/turbo/apps/runner/src/lib/runner/runner.ts
@@ -284,16 +284,18 @@ export class Runner {
       logger.error(`  Job ${context.runId} execution failed: ${error}`);
     }
 
-    // Always report completion for claimed jobs.
-    // The guest-agent calls complete API on success, but may not run if
-    // the job fails early (e.g., storage download). The API is idempotent,
-    // so duplicate calls are safe.
-    const completeResult = await completeJob(
-      this.config.server.url,
-      context,
-      exitCode,
-      error,
-    );
-    logger.log(`  Job ${context.runId} reported as ${completeResult.status}`);
+    // Report failure for claimed jobs that didn't complete successfully.
+    // On success, guest-agent already calls the complete API from inside the VM.
+    // On failure, guest-agent may not have started (e.g., storage download error),
+    // so the runner must report it. The API is idempotent, so duplicate calls are safe.
+    if (exitCode !== 0) {
+      const completeResult = await completeJob(
+        this.config.server.url,
+        context,
+        exitCode,
+        error,
+      );
+      logger.log(`  Job ${context.runId} reported as ${completeResult.status}`);
+    }
   }
 }

--- a/turbo/apps/runner/src/lib/runner/runner.ts
+++ b/turbo/apps/runner/src/lib/runner/runner.ts
@@ -264,32 +264,36 @@ export class Runner {
     logger.log(`  Prompt: ${context.prompt.substring(0, 100)}...`);
     logger.log(`  Compose version: ${context.agentComposeVersionId}`);
 
+    let exitCode = 1;
+    let error: string | undefined;
+
     try {
       // Execute in Firecracker VM
       const result = await executeJobInVM(context, this.config);
+      exitCode = result.exitCode;
+      error = result.error;
 
       logger.log(
-        `  Job ${context.runId} execution completed with exit code ${result.exitCode}`,
+        `  Job ${context.runId} execution completed with exit code ${exitCode}`,
       );
-
-      // The executor's bootstrap script calls the complete API directly
-      // But if execution fails before that, we need to report it ourselves
-      if (result.exitCode !== 0 && result.error) {
-        logger.error(`  Job ${context.runId} failed: ${result.error}`);
+      if (exitCode !== 0 && error) {
+        logger.error(`  Job ${context.runId} failed: ${error}`);
       }
     } catch (err) {
-      const error =
-        err instanceof Error ? err.message : "Unknown execution error";
+      error = err instanceof Error ? err.message : "Unknown execution error";
       logger.error(`  Job ${context.runId} execution failed: ${error}`);
-
-      // Report failure to server if VM execution failed before bootstrap
-      const result = await completeJob(
-        this.config.server.url,
-        context,
-        1,
-        error,
-      );
-      logger.log(`  Job ${context.runId} reported as ${result.status}`);
     }
+
+    // Always report completion for claimed jobs.
+    // The guest-agent calls complete API on success, but may not run if
+    // the job fails early (e.g., storage download). The API is idempotent,
+    // so duplicate calls are safe.
+    const completeResult = await completeJob(
+      this.config.server.url,
+      context,
+      exitCode,
+      error,
+    );
+    logger.log(`  Job ${context.runId} reported as ${completeResult.status}`);
   }
 }

--- a/turbo/apps/runner/src/lib/runner/runner.ts
+++ b/turbo/apps/runner/src/lib/runner/runner.ts
@@ -290,15 +290,11 @@ export class Runner {
     logger.log(
       `  Calling complete API for job ${context.runId} with exitCode=${exitCode}`,
     );
-    try {
-      const completeResult = await withRunnerTiming("complete", () =>
-        completeJob(this.config.server.url, context, exitCode, error),
-      );
-      logger.log(`  Job ${context.runId} reported as ${completeResult.status}`);
-    } catch (err) {
-      logger.error(
-        `  Failed to call complete API for job ${context.runId}: ${err instanceof Error ? err.message : "Unknown error"}`,
-      );
-    }
+    const completeResult = await withRunnerTiming("complete", () =>
+      completeJob(this.config.server.url, context, exitCode, error),
+    );
+    logger.log(
+      `  Job ${context.runId} reported as ${completeResult.status}`,
+    );
   }
 }


### PR DESCRIPTION
## Summary
- Remove complete API call from guest-agent (E2B uses JS version, Rust guest-agent change is safe)
- Runner now unconditionally calls `completeJob` for all claimed jobs, ensuring backend always gets notified
- Added logging and `withRunnerTiming("complete", ...)` metrics for the complete API call

Fixes #2844

## Test plan
- [ ] Verify runner logs show "Calling complete API" for every job
- [ ] Verify failed jobs (e.g. storage download error) are reported to backend
- [ ] Verify CLI no longer hangs polling for job status on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)