### PR TITLE
fix(platform): connector setup improvements and trailing ? fix

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/route.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/route.test.ts
@@ -152,6 +152,39 @@ describe("route", () => {
       );
       expect(mockSetup).toHaveBeenCalledWith();
     });
+
+    it("should not append trailing question mark when searchParams is empty", async () => {
+      const { store, signal } = context;
+      const pushStateMock = createPushStateMock(signal);
+
+      mockLocation({ pathname: "/", search: "" }, signal);
+
+      await store.set(
+        initRoutes$,
+        [
+          {
+            path: "/",
+            setup: command(() => void 0),
+          },
+          {
+            path: "/home",
+            setup: command(() => void 0),
+          },
+        ],
+        signal,
+      );
+
+      // Navigate with empty URLSearchParams
+      await store.set(
+        navigate$,
+        "/home",
+        { searchParams: new URLSearchParams() },
+        signal,
+      );
+
+      expect(pushStateMock).toHaveBeenCalledWith({}, "", "/home");
+      expect(store.get(pathname$)).toBe("/home");
+    });
   });
 
   describe("initRoutes$", () => {

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -127,10 +127,8 @@ export const navigate$ = command(
     options: NavigateOptions,
     signal: AbortSignal,
   ) => {
-    const searchParams = options.searchParams
-      ? `?${options.searchParams.toString()}`
-      : "";
-    const newPath = `${pathname}${searchParams}`;
+    const searchStr = options.searchParams?.toString();
+    const newPath = `${pathname}${searchStr ? `?${searchStr}` : ""}`;
     L.debug("navigating to", newPath);
     pushState({}, "", newPath);
     set(reloadPathname$, (x) => x + 1);

--- a/turbo/apps/platform/src/views/environment-variables-setup/environment-variables-setup-page.tsx
+++ b/turbo/apps/platform/src/views/environment-variables-setup/environment-variables-setup-page.tsx
@@ -196,10 +196,6 @@ function FormState() {
           </div>
 
           <div className="flex flex-col gap-5 w-full">
-            {connectors.map((item) => (
-              <ConnectorCard key={item.connectorType} item={item} />
-            ))}
-
             {manualItems.map((item) => (
               <div key={item.name} className="flex flex-col gap-2 w-full">
                 <label className="text-sm font-medium leading-5 text-foreground px-1">
@@ -228,6 +224,10 @@ function FormState() {
                   </p>
                 )}
               </div>
+            ))}
+
+            {connectors.map((item) => (
+              <ConnectorCard key={item.connectorType} item={item} />
             ))}
           </div>
 

--- a/turbo/apps/platform/src/views/environment-variables-setup/environment-variables-setup-page.tsx
+++ b/turbo/apps/platform/src/views/environment-variables-setup/environment-variables-setup-page.tsx
@@ -22,6 +22,7 @@ import {
   connectConnector$,
   pollingConnectorType$,
 } from "../../signals/settings-page/connectors.ts";
+import { deleteConnector$ } from "../../signals/external/connectors.ts";
 import { ConnectorIcon } from "../settings-page/connector-icons.tsx";
 
 function LogoHeader() {
@@ -113,6 +114,7 @@ function SuccessState() {
 function ConnectorCard({ item }: { item: ConnectorItem }) {
   const pollingType = useGet(pollingConnectorType$);
   const connect = useSet(connectConnector$);
+  const disconnect = useSet(deleteConnector$);
   const pageSignal = useGet(pageSignal$);
 
   const isPolling = pollingType === item.connectorType;
@@ -127,9 +129,22 @@ function ConnectorCard({ item }: { item: ConnectorItem }) {
         <span className="text-xs text-muted-foreground">{item.helpText}</span>
       </div>
       {item.connected ? (
-        <span className="text-xs px-2 py-1 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 shrink-0">
-          Connected
-        </span>
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-xs px-2 py-1 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
+            Connected
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              detach(disconnect(item.connectorType), Reason.DomCallback);
+            }}
+            className="text-xs text-muted-foreground h-auto px-1 py-0.5"
+          >
+            Disconnect
+          </Button>
+        </div>
       ) : (
         <Button
           type="button"


### PR DESCRIPTION
## Summary
- Move connector cards below manual input fields in the environment variables setup page
- Add "Disconnect" button to connector cards when already connected
- Fix trailing `?` in URL when navigating with empty search params (e.g., clicking sidebar tabs from a page with query params)

## Test plan
- [x] Lint and type checks pass
- [x] Existing tests pass (28 tests in environment-variables-setup)
- [ ] Open setup page with `?secrets=GH_TOKEN&vars=MY_VAR` — manual inputs appear above connector cards
- [ ] Connected connector shows "Connected" badge + "Disconnect" button
- [ ] Click "Disconnect" reverts card to "Connect" state
- [ ] Navigate between sidebar tabs from a page with query params — no trailing `?` in URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)