### PR TITLE
fix: enable parallel test execution in web app

### DIFF
--- a/turbo/apps/web/vitest.config.ts
+++ b/turbo/apps/web/vitest.config.ts
@@ -7,8 +7,6 @@ export default defineConfig({
     environment: "node",
     setupFiles: "./src/__tests__/setup.ts",
     // Don't override env vars, let them pass through from system
-    // Run tests sequentially to avoid database race conditions
-    fileParallelism: false,
     // Automatically clear mocks before each test (eliminates manual vi.clearAllMocks() calls)
     clearMocks: true,
   },


### PR DESCRIPTION
## Summary
- Remove `fileParallelism: false` from `turbo/apps/web/vitest.config.ts`
- Tests should rely on proper isolation rather than sequential execution to avoid database race conditions

## Test plan
- [ ] Verify all web app tests pass in CI with parallel execution enabled
- [ ] Confirm no flaky tests due to database race conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)