### PR TITLE
fix(web): make platform url available to client-side code

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -185,7 +185,7 @@ jobs:
             GH_OAUTH_CLIENT_SECRET=${{ secrets.GH_OAUTH_CLIENT_SECRET }}
             NOTION_OAUTH_CLIENT_ID=${{ vars.NOTION_OAUTH_CLIENT_ID }}
             NOTION_OAUTH_CLIENT_SECRET=${{ secrets.NOTION_OAUTH_CLIENT_SECRET }}
-            PLATFORM_URL=${{ vars.PLATFORM_URL }}
+            NEXT_PUBLIC_PLATFORM_URL=${{ vars.PLATFORM_URL }}
 
       - name: Notify Slack - Success
         if: ${{ success() && steps.slack-start.outputs.ts }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -375,7 +375,7 @@ jobs:
         working-directory: turbo
         env:
           DATABASE_URL: postgresql://postgres@postgres:5432/postgres
-          PLATFORM_URL: https://platform.test.local
+          NEXT_PUBLIC_PLATFORM_URL: https://platform.test.local
         run: pnpm vitest run --project=web
 
   test-cli:
@@ -503,7 +503,7 @@ jobs:
             GH_OAUTH_CLIENT_SECRET=${{ secrets.GH_OAUTH_CLIENT_SECRET }}
             NOTION_OAUTH_CLIENT_ID=${{ vars.NOTION_OAUTH_CLIENT_ID }}
             NOTION_OAUTH_CLIENT_SECRET=${{ secrets.NOTION_OAUTH_CLIENT_SECRET }}
-            PLATFORM_URL=${{ needs.prepare.outputs.platform-preview-url }}
+            NEXT_PUBLIC_PLATFORM_URL=${{ needs.prepare.outputs.platform-preview-url }}
             NEXT_PUBLIC_STRAPI_URL=${{ vars.NEXT_PUBLIC_STRAPI_URL }}
           meta-branch: ${{ github.head_ref || github.ref_name }}
           meta-pr: ${{ needs.prepare.outputs.job-ref }}

--- a/docker/docker-compose.web-base.yml
+++ b/docker/docker-compose.web-base.yml
@@ -50,7 +50,7 @@ services:
       CLAUDE_CODE_VERSION_URL: ${CLAUDE_CODE_VERSION_URL:-https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/latest}
       # Platform console
       PLATFORM_PORT: ${PLATFORM_PORT:-3001}
-      PLATFORM_URL: http://${DOMAIN:-localhost}:${PLATFORM_PORT:-3001}
+      NEXT_PUBLIC_PLATFORM_URL: http://${DOMAIN:-localhost}:${PLATFORM_PORT:-3001}
     volumes:
       - web_data:/app/data
       # Docker socket for creating sandbox containers (Docker Sandbox executor)

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -6,8 +6,8 @@ import { server } from "../mocks/server";
 // Using vi.hoisted() ensures stubs run before module imports.
 //
 // All env vars are explicitly stubbed here for deterministic test behavior.
-// Note: DATABASE_URL and PLATFORM_URL are NOT stubbed because they differ
-// between environments (local dev vs CI) and come from .env / .env.local.
+// Note: DATABASE_URL is NOT stubbed because it differs between environments
+// (local dev vs CI) and comes from .env / .env.local.
 //
 // resetEnv() is called in vi.hoisted() for initial import-time validation AND
 // in beforeEach to re-apply defaults after Vitest's unstubEnvs auto-cleanup.
@@ -43,8 +43,8 @@ const resetEnv = vi.hoisted(() => {
     vi.stubEnv("SLACK_REDIRECT_BASE_URL", "https://test.example.com");
     // API URL for compose job webhooks
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
-    // Platform URL for settings page links
-    vi.stubEnv("PLATFORM_URL", "http://localhost:3001");
+    // Platform UI URL
+    vi.stubEnv("NEXT_PUBLIC_PLATFORM_URL", "http://localhost:3001");
     // Initialize Next.js after() callback queue (shared with test-helpers.ts flushAfter)
     globalThis.nextAfterCallbacks = [];
   };

--- a/turbo/apps/web/src/env.ts
+++ b/turbo/apps/web/src/env.ts
@@ -77,8 +77,6 @@ function initEnv() {
       // Notion OAuth (for connector)
       NOTION_OAUTH_CLIENT_ID: z.string().min(1).optional(),
       NOTION_OAUTH_CLIENT_SECRET: z.string().min(1).optional(),
-      // Platform UI URL (for settings page links in error messages)
-      PLATFORM_URL: z.string().url(),
       // Sentry
       SENTRY_DSN: z.string().url().optional(),
       SENTRY_AUTH_TOKEN: z.string().min(1).optional(),
@@ -111,6 +109,8 @@ function initEnv() {
       NEXT_PUBLIC_BASE_URL: z.string().url().optional(),
       NEXT_PUBLIC_DATA_SOURCE: z.string().optional(),
       NEXT_PUBLIC_STRAPI_URL: z.string().url().optional(),
+      // Platform UI URL (for settings page links, Navbar, LandingPage)
+      NEXT_PUBLIC_PLATFORM_URL: z.string().url(),
     },
     runtimeEnv: {
       DATABASE_URL: process.env.DATABASE_URL,
@@ -150,7 +150,7 @@ function initEnv() {
       GH_OAUTH_CLIENT_SECRET: process.env.GH_OAUTH_CLIENT_SECRET,
       NOTION_OAUTH_CLIENT_ID: process.env.NOTION_OAUTH_CLIENT_ID,
       NOTION_OAUTH_CLIENT_SECRET: process.env.NOTION_OAUTH_CLIENT_SECRET,
-      PLATFORM_URL: process.env.PLATFORM_URL,
+      NEXT_PUBLIC_PLATFORM_URL: process.env.NEXT_PUBLIC_PLATFORM_URL,
       SENTRY_DSN: process.env.SENTRY_DSN,
       SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
       SENTRY_ORG: process.env.SENTRY_ORG,

--- a/turbo/apps/web/src/lib/__tests__/url.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/url.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi } from "vitest";
 import { reloadEnv } from "../../env";
 
 describe("getPlatformUrl", () => {
-  it("returns PLATFORM_URL env var", async () => {
-    vi.stubEnv("PLATFORM_URL", "https://platform.vm0.ai");
+  it("returns NEXT_PUBLIC_PLATFORM_URL env var", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PLATFORM_URL", "https://platform.vm0.ai");
     reloadEnv();
 
     const { getPlatformUrl } = await import("../url");

--- a/turbo/apps/web/src/lib/run/environment/expand-environment.ts
+++ b/turbo/apps/web/src/lib/run/environment/expand-environment.ts
@@ -130,7 +130,7 @@ export function expandEnvironmentFromCompose(
         (name) => !credentials || !credentials[name],
       );
       if (missingCredentials.length > 0) {
-        const platformUrl = env().PLATFORM_URL;
+        const platformUrl = env().NEXT_PUBLIC_PLATFORM_URL;
         const settingsUrl = `${platformUrl}/settings?tab=secrets&required=${missingCredentials.join(",")}`;
         throw badRequest(
           `Missing required secrets: ${missingCredentials.join(", ")}. Use 'vm0 secret set ${missingCredentials[0]} <value>' or add them at: ${settingsUrl}`,

--- a/turbo/apps/web/src/lib/url.ts
+++ b/turbo/apps/web/src/lib/url.ts
@@ -4,5 +4,5 @@ import { env } from "../env";
  * Returns the Platform URL from the PLATFORM_URL environment variable.
  */
 export function getPlatformUrl(): string {
-  return env().PLATFORM_URL;
+  return env().NEXT_PUBLIC_PLATFORM_URL;
 }


### PR DESCRIPTION
## Summary

- Rename `PLATFORM_URL` to `NEXT_PUBLIC_PLATFORM_URL` across the entire codebase so the platform URL is exposed to client-side Next.js code via the `NEXT_PUBLIC_` prefix convention
- Updates CI workflows (`release-please.yml`, `turbo.yml`), docker compose config, env validation schema, test setup, and all application references
- No functional change -- same URL value, just a different env var name

## Files Changed

- `.github/workflows/release-please.yml` - CI build arg rename
- `.github/workflows/turbo.yml` - CI test env and deploy build arg rename
- `docker/docker-compose.web-base.yml` - Docker compose env rename
- `turbo/apps/web/src/env.ts` - Zod schema: move from server to client section
- `turbo/apps/web/src/__tests__/setup.ts` - Test env stub rename
- `turbo/apps/web/src/lib/__tests__/url.test.ts` - Test assertion update
- `turbo/apps/web/src/lib/url.ts` - Runtime reference update
- `turbo/apps/web/src/lib/run/environment/expand-environment.ts` - Runtime reference update

## Test plan

- [ ] CI passes (lint, type-check, tests, knip)
- [ ] Verify `getPlatformUrl()` returns the correct value in tests
- [ ] Confirm docker compose picks up the renamed env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)