### PR TITLE
ci: remove redundant platform-url env from web test job

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -375,7 +375,6 @@ jobs:
         working-directory: turbo
         env:
           DATABASE_URL: postgresql://postgres@postgres:5432/postgres
-          PLATFORM_URL: https://platform.test.local
         run: pnpm vitest run --project=web
 
   test-cli:


### PR DESCRIPTION
## Summary
- Removes the `PLATFORM_URL` environment variable from the `test-web` CI job in `turbo.yml`
- The test setup (`src/__tests__/setup.ts`) already stubs `PLATFORM_URL` via `vi.stubEnv("PLATFORM_URL", "http://localhost:3001")`, making the CI-level env var redundant
- Aligns with the recent `refactor(web): converge env patterns to unified env() access` (#2860)

## Test plan
- [x] Verified web tests produce identical results with and without `PLATFORM_URL` set as a CI env var (test setup stubs it regardless)
- [ ] CI `test-web` job passes without the env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)