### PR TITLE
fix(web): ensure platform url is available in client components

### DIFF
--- a/turbo/apps/web/src/lib/url.ts
+++ b/turbo/apps/web/src/lib/url.ts
@@ -1,8 +1,5 @@
 import { env } from "../env";
 
-/**
- * Returns the Platform URL from the PLATFORM_URL environment variable.
- */
 export function getPlatformUrl(): string {
   return env().NEXT_PUBLIC_PLATFORM_URL;
 }


### PR DESCRIPTION
## Summary
- Remove redundant JSDoc comment from url.ts to trigger a web release

## Context
The previous PR (#2870) that renamed `PLATFORM_URL` → `NEXT_PUBLIC_PLATFORM_URL` used `refactor:` type which doesn't trigger release-please. This fix commit triggers a web release so the platform link fix reaches production.

## Test plan
- [ ] Verify production deployment has `NEXT_PUBLIC_PLATFORM_URL` set
- [ ] Verify Navbar "Platform" link has correct `href` on https://www.vm0.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)