### PR TITLE
refactor(runner): slim down main.rs to thin CLI dispatch

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -9,18 +9,11 @@ mod status;
 mod types;
 
 use std::fmt;
-use std::path::PathBuf;
 use std::process::ExitCode;
-use std::sync::Arc;
 use std::time::Instant;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use tracing_subscriber::fmt::time::FormatTime;
-
-use crate::error::{RunnerError, RunnerResult};
-use crate::paths::RunnerPaths;
-use crate::runner::RunConfig;
-use crate::status::StatusTracker;
 
 struct Elapsed(Instant);
 
@@ -45,58 +38,11 @@ struct Cli {
 #[derive(Subcommand)]
 enum Command {
     /// Start the runner and poll for jobs
-    Start(Box<StartArgs>),
+    Start(Box<runner::StartArgs>),
     /// Download Firecracker, kernel, and verify host prerequisites
-    Setup(SetupArgs),
+    Setup,
     /// Build squashfs rootfs for Firecracker VMs
     BuildRootfs(build_rootfs::BuildRootfsArgs),
-}
-
-#[derive(Args)]
-struct StartArgs {
-    /// Path to the Firecracker binary
-    #[arg(long)]
-    firecracker: PathBuf,
-    /// Path to the guest kernel image
-    #[arg(long)]
-    kernel: PathBuf,
-    /// Path to the root filesystem image
-    #[arg(long)]
-    rootfs: PathBuf,
-    /// vm0 API URL
-    #[arg(long, env = "VM0_API_URL")]
-    api_url: String,
-    /// Runner authentication token
-    #[arg(long, env = "VM0_RUNNER_TOKEN")]
-    token: String,
-    /// Runner group in scope/name format (e.g. "acme/production")
-    #[arg(long)]
-    group: String,
-    /// Base directory for runtime data
-    #[arg(long)]
-    base_dir: PathBuf,
-    /// Snapshot directory to restore from
-    #[arg(long)]
-    snapshot_dir: Option<PathBuf>,
-    /// Maximum concurrent job executions
-    #[arg(long, default_value_t = 4)]
-    max_concurrent: usize,
-    /// vCPUs per sandbox
-    #[arg(long, default_value_t = 2)]
-    vcpu: u32,
-    /// Memory (MiB) per sandbox
-    #[arg(long, default_value_t = 2048)]
-    memory_mb: u32,
-    /// HTTP/HTTPS proxy port for network security
-    #[arg(long)]
-    proxy_port: Option<u16>,
-}
-
-#[derive(Args)]
-struct SetupArgs {
-    /// Fail on missing optional dependencies (for CI)
-    #[arg(long)]
-    strict: bool,
 }
 
 #[tokio::main]
@@ -113,8 +59,8 @@ async fn main() -> ExitCode {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Command::Start(args) => run_start(*args).await,
-        Command::Setup(args) => setup::run_setup(args.strict).await,
+        Command::Start(args) => runner::run_start(*args).await,
+        Command::Setup => setup::run_setup().await,
         Command::BuildRootfs(args) => build_rootfs::run_build_rootfs(args).await,
     };
 
@@ -124,68 +70,4 @@ async fn main() -> ExitCode {
     }
 
     ExitCode::SUCCESS
-}
-
-async fn run_start(args: StartArgs) -> RunnerResult<()> {
-    let firecracker = resolve_path(args.firecracker).await?;
-    let kernel = resolve_path(args.kernel).await?;
-    let rootfs = resolve_path(args.rootfs).await?;
-    let base_dir = resolve_or_create(args.base_dir).await?;
-
-    let snapshot = match args.snapshot_dir {
-        Some(dir) => {
-            let dir = resolve_path(dir).await?;
-            let output = sandbox_fc::SnapshotOutputPaths::new(dir.clone());
-            let work = sandbox_fc::SandboxPaths::new(dir.join("work"));
-            Some(sandbox_fc::SnapshotConfig {
-                snapshot_path: output.snapshot(),
-                memory_path: output.memory(),
-                overlay_path: output.overlay(),
-                overlay_bind_path: work.overlay(),
-                vsock_bind_dir: work.vsock_dir(),
-            })
-        }
-        None => None,
-    };
-
-    let fc_config = sandbox_fc::FirecrackerConfig {
-        binary_path: firecracker,
-        kernel_path: kernel,
-        rootfs_path: rootfs,
-        base_dir: base_dir.clone(),
-        concurrency: args.max_concurrent,
-        proxy_port: args.proxy_port,
-        snapshot,
-    };
-
-    let paths = RunnerPaths::new(base_dir);
-    let status = Arc::new(StatusTracker::new(paths.status()));
-
-    let config = RunConfig {
-        api_url: args.api_url,
-        token: args.token,
-        group: args.group,
-        fc_config,
-        max_concurrent: args.max_concurrent,
-        vcpu: args.vcpu,
-        memory_mb: args.memory_mb,
-        status,
-    };
-
-    runner::run(config).await?;
-
-    Ok(())
-}
-
-async fn resolve_path(path: PathBuf) -> RunnerResult<PathBuf> {
-    tokio::fs::canonicalize(&path)
-        .await
-        .map_err(|e| RunnerError::Config(format!("resolve path {}: {e}", path.display())))
-}
-
-async fn resolve_or_create(path: PathBuf) -> RunnerResult<PathBuf> {
-    tokio::fs::create_dir_all(&path)
-        .await
-        .map_err(|e| RunnerError::Config(format!("create dir {}: {e}", path.display())))?;
-    resolve_path(path).await
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -37,12 +37,12 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
-    /// Start the runner and poll for jobs
-    Start(Box<runner::StartArgs>),
     /// Download Firecracker, kernel, and verify host prerequisites
     Setup,
     /// Build squashfs rootfs for Firecracker VMs
     BuildRootfs(build_rootfs::BuildRootfsArgs),
+    /// Start the runner and poll for jobs
+    Start(Box<runner::StartArgs>),
 }
 
 #[tokio::main]

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -47,7 +47,7 @@ const fn strip_patch(version: &str) -> &str {
 
 pub async fn run_setup() -> RunnerResult<()> {
     let arch = check_architecture()?;
-    let (missing_required, _missing_optional) = check_system_dependencies();
+    let missing_required = check_system_dependencies();
 
     let paths = HomePaths::new()?;
     create_directories(&paths).await?;
@@ -81,8 +81,8 @@ fn check_architecture() -> RunnerResult<&'static str> {
     Ok(arch)
 }
 
-/// Returns (missing_required, missing_optional) dependency names.
-fn check_system_dependencies() -> (Vec<&'static str>, Vec<&'static str>) {
+/// Returns names of missing required dependencies.
+fn check_system_dependencies() -> Vec<&'static str> {
     // Required by `runner start` (sandbox networking)
     let required = ["ip", "iptables", "iptables-save", "sysctl"];
     // Only needed by specific commands (build-rootfs, etc.)
@@ -115,7 +115,7 @@ fn check_system_dependencies() -> (Vec<&'static str>, Vec<&'static str>) {
         );
     }
 
-    (missing_required, missing_optional)
+    missing_required
 }
 
 async fn create_directories(paths: &HomePaths) -> RunnerResult<()> {

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -45,9 +45,9 @@ const fn strip_patch(version: &str) -> &str {
     panic!("FIRECRACKER_VERSION must be in vMAJOR.MINOR.PATCH format")
 }
 
-pub async fn run_setup(strict: bool) -> RunnerResult<()> {
+pub async fn run_setup() -> RunnerResult<()> {
     let arch = check_architecture()?;
-    let (missing_required, missing_optional) = check_system_dependencies();
+    let (missing_required, _missing_optional) = check_system_dependencies();
 
     let paths = HomePaths::new()?;
     create_directories(&paths).await?;
@@ -60,12 +60,6 @@ pub async fn run_setup(strict: bool) -> RunnerResult<()> {
         return Err(RunnerError::Config(format!(
             "missing required dependencies: {}",
             missing_required.join(", ")
-        )));
-    }
-    if strict && !missing_optional.is_empty() {
-        return Err(RunnerError::Config(format!(
-            "missing optional dependencies (strict mode): {}",
-            missing_optional.join(", ")
         )));
     }
 


### PR DESCRIPTION
## Summary
- Move `StartArgs`, `run_start`, `resolve_path`, `resolve_or_create` from `main.rs` to `runner.rs` — `RunConfig` becomes module-private
- Remove unused `--strict` flag from `setup` subcommand
- Reorder subcommands to match usage flow: `setup` → `build-rootfs` → `start`

## Test plan
- [x] `cargo clippy -p runner` passes with no warnings
- [ ] `runner setup` works as before (no `--strict` flag)
- [ ] `runner start --help` shows all args unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)