### PR TITLE
refactor(runner): split verify logic out of build-rootfs.sh

### DIFF
--- a/crates/runner/build-rootfs.sh
+++ b/crates/runner/build-rootfs.sh
@@ -124,11 +124,6 @@ cleanup() {
   fi
   # Remove temp container
   $DOCKER rm -f "$CONTAINER_NAME" 2>/dev/null || true
-  # Unmount if still mounted
-  if [[ -n "${MOUNT_DIR:-}" ]]; then
-    sudo umount "$MOUNT_DIR" 2>/dev/null || true
-    rmdir "$MOUNT_DIR" 2>/dev/null || true
-  fi
 }
 
 trap cleanup EXIT
@@ -261,103 +256,6 @@ create_squashfs() {
 }
 
 # ---------------------------------------------------------------------------
-# Verification
-# ---------------------------------------------------------------------------
-
-verify_rootfs() {
-  echo "verifying rootfs..."
-
-  # Check file size
-  local size
-  size=$(stat -c%s "$TMP_ROOTFS_PATH")
-  if [[ "$size" -lt 50000000 ]]; then
-    echo "warning: rootfs seems small: ${size} bytes" >&2
-  fi
-
-  # Mount squashfs
-  MOUNT_DIR="$(mktemp -d)"
-  sudo mount -t squashfs -o loop,ro "$TMP_ROOTFS_PATH" "$MOUNT_DIR"
-
-  local errors=()
-
-  # Check python3
-  if [[ -f "${MOUNT_DIR}/usr/bin/python3" ]]; then
-    echo "  python3: found"
-  else
-    errors+=("python3 not found at /usr/bin/python3")
-  fi
-
-  # Check guest binaries
-  local -a dests=(
-    "/usr/local/bin/guest-agent"
-    "/usr/local/bin/guest-download"
-    "/sbin/guest-init"
-    "/usr/local/bin/guest-mock-claude"
-  )
-  for dest in "${dests[@]}"; do
-    local check_path="${MOUNT_DIR}${dest}"
-    if [[ -f "$check_path" ]]; then
-      echo "  ${dest}: found"
-    else
-      errors+=("${dest} not found")
-    fi
-  done
-
-  # Check CLIs
-  if [[ -f "${MOUNT_DIR}/usr/local/bin/codex" ]]; then
-    echo "  codex CLI: found"
-  else
-    errors+=("codex CLI not found at /usr/local/bin/codex")
-  fi
-
-  if [[ -f "${MOUNT_DIR}/usr/bin/gh" ]]; then
-    echo "  gh CLI: found"
-  else
-    errors+=("gh CLI not found at /usr/bin/gh")
-  fi
-
-  # Check proxy CA certificate file
-  local ca_path="${MOUNT_DIR}/${CA_ROOTFS_DEST}"
-  if [[ -f "$ca_path" ]]; then
-    echo "  proxy CA file: found"
-  else
-    errors+=("proxy CA certificate not found")
-  fi
-
-  # Check proxy CA in system bundle
-  local bundle_path="${MOUNT_DIR}/etc/ssl/certs/ca-certificates.crt"
-  if [[ ! -f "$bundle_path" ]]; then
-    errors+=("system CA bundle not found at /etc/ssl/certs/ca-certificates.crt")
-  elif [[ -f "$ca_path" ]]; then
-    # Read second line of CA cert as a unique identifier
-    local ca_line
-    ca_line=$(sed -n '2p' "$ca_path")
-    if [[ -z "$ca_line" ]]; then
-      errors+=("proxy CA cert appears empty or malformed")
-    elif grep -qF "$ca_line" "$bundle_path"; then
-      echo "  proxy CA bundle: updated"
-    else
-      errors+=("proxy CA not found in system CA bundle (update-ca-certificates may have failed)")
-    fi
-  fi
-
-  # Unmount
-  sudo umount "$MOUNT_DIR"
-  rmdir "$MOUNT_DIR"
-  unset MOUNT_DIR
-
-  if [[ ${#errors[@]} -gt 0 ]]; then
-    echo "error: rootfs verification failed:" >&2
-    for err in "${errors[@]}"; do
-      echo "  ${err}" >&2
-    done
-    exit 1
-  fi
-
-  echo "[OK] rootfs verification passed"
-}
-
-# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -371,7 +269,6 @@ extract_and_inject
 sudo rm -f "$TAR_PATH"
 
 create_squashfs
-verify_rootfs
 
 # Move into final place
 mv "$TMP_ROOTFS_PATH" "$ROOTFS_PATH"

--- a/crates/runner/build-rootfs.sh
+++ b/crates/runner/build-rootfs.sh
@@ -89,11 +89,7 @@ check_dependencies() {
   fi
 
   if ! command -v mksquashfs &> /dev/null; then
-    echo "[INSTALL] Installing squashfs-tools..."
-    sudo apt-get update && sudo apt-get install -y squashfs-tools
-    if ! command -v mksquashfs &> /dev/null; then
-      missing+=("mksquashfs")
-    fi
+    missing+=("mksquashfs (apt-get install squashfs-tools)")
   fi
 
   if [[ ${#missing[@]} -gt 0 ]]; then

--- a/crates/runner/build-rootfs.sh
+++ b/crates/runner/build-rootfs.sh
@@ -80,13 +80,11 @@ EXTRACT_DIR=""
 check_dependencies() {
   local missing=()
 
-  if ! command -v docker &> /dev/null; then
-    missing+=("docker")
-  fi
-
-  if ! command -v openssl &> /dev/null; then
-    missing+=("openssl")
-  fi
+  for cmd in docker openssl sudo tar chroot mktemp stat; do
+    if ! command -v "$cmd" &> /dev/null; then
+      missing+=("$cmd")
+    fi
+  done
 
   if ! command -v mksquashfs &> /dev/null; then
     missing+=("mksquashfs (apt-get install squashfs-tools)")

--- a/crates/runner/verify-rootfs.sh
+++ b/crates/runner/verify-rootfs.sh
@@ -50,6 +50,22 @@ cleanup() {
 trap cleanup EXIT
 
 # ---------------------------------------------------------------------------
+# Dependency checks
+# ---------------------------------------------------------------------------
+
+missing=()
+for cmd in sudo mount umount stat mktemp sed grep; do
+  if ! command -v "$cmd" &> /dev/null; then
+    missing+=("$cmd")
+  fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "error: missing required dependencies: ${missing[*]}" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
 # Verification
 # ---------------------------------------------------------------------------
 

--- a/crates/runner/verify-rootfs.sh
+++ b/crates/runner/verify-rootfs.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# verify-rootfs.sh — Verify contents of a built squashfs rootfs.
+#
+# This script is called by the Rust runner binary AFTER build-rootfs.sh.
+# It is NOT included in the build-input hash, so changes here do not
+# invalidate the rootfs cache.
+#
+# Usage:
+#   bash verify-rootfs.sh --rootfs /path/to/rootfs.squashfs
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+ROOTFS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rootfs) ROOTFS="$2"; shift 2 ;;
+    *) echo "error: unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$ROOTFS" ]]; then
+  echo "error: --rootfs is required" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CA_ROOTFS_DEST="usr/local/share/ca-certificates/vm0-proxy-ca.crt"
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+MOUNT_DIR=""
+
+cleanup() {
+  if [[ -n "$MOUNT_DIR" ]]; then
+    sudo umount "$MOUNT_DIR" 2>/dev/null || true
+    rmdir "$MOUNT_DIR" 2>/dev/null || true
+  fi
+}
+
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Verification
+# ---------------------------------------------------------------------------
+
+echo "verifying rootfs..."
+
+# Check file size
+size=$(stat -c%s "$ROOTFS")
+if [[ "$size" -lt 50000000 ]]; then
+  echo "warning: rootfs seems small: ${size} bytes" >&2
+fi
+
+# Mount squashfs
+MOUNT_DIR="$(mktemp -d)"
+sudo mount -t squashfs -o loop,ro "$ROOTFS" "$MOUNT_DIR"
+
+errors=()
+
+# Check python3
+if [[ -f "${MOUNT_DIR}/usr/bin/python3" ]]; then
+  echo "  python3: found"
+else
+  errors+=("python3 not found at /usr/bin/python3")
+fi
+
+# Check guest binaries
+dests=(
+  "/usr/local/bin/guest-agent"
+  "/usr/local/bin/guest-download"
+  "/sbin/guest-init"
+  "/usr/local/bin/guest-mock-claude"
+)
+for dest in "${dests[@]}"; do
+  check_path="${MOUNT_DIR}${dest}"
+  if [[ -f "$check_path" ]]; then
+    echo "  ${dest}: found"
+  else
+    errors+=("${dest} not found")
+  fi
+done
+
+# Check CLIs
+if [[ -f "${MOUNT_DIR}/usr/local/bin/codex" ]]; then
+  echo "  codex CLI: found"
+else
+  errors+=("codex CLI not found at /usr/local/bin/codex")
+fi
+
+if [[ -f "${MOUNT_DIR}/usr/bin/gh" ]]; then
+  echo "  gh CLI: found"
+else
+  errors+=("gh CLI not found at /usr/bin/gh")
+fi
+
+# Check proxy CA certificate file
+ca_path="${MOUNT_DIR}/${CA_ROOTFS_DEST}"
+if [[ -f "$ca_path" ]]; then
+  echo "  proxy CA file: found"
+else
+  errors+=("proxy CA certificate not found")
+fi
+
+# Check proxy CA in system bundle
+bundle_path="${MOUNT_DIR}/etc/ssl/certs/ca-certificates.crt"
+if [[ ! -f "$bundle_path" ]]; then
+  errors+=("system CA bundle not found at /etc/ssl/certs/ca-certificates.crt")
+elif [[ -f "$ca_path" ]]; then
+  # Read second line of CA cert as a unique identifier
+  ca_line=$(sed -n '2p' "$ca_path")
+  if [[ -z "$ca_line" ]]; then
+    errors+=("proxy CA cert appears empty or malformed")
+  elif grep -qF "$ca_line" "$bundle_path"; then
+    echo "  proxy CA bundle: updated"
+  else
+    errors+=("proxy CA not found in system CA bundle (update-ca-certificates may have failed)")
+  fi
+fi
+
+# Unmount
+sudo umount "$MOUNT_DIR"
+rmdir "$MOUNT_DIR"
+MOUNT_DIR=""
+
+if [[ ${#errors[@]} -gt 0 ]]; then
+  echo "error: rootfs verification failed:" >&2
+  for err in "${errors[@]}"; do
+    echo "  ${err}" >&2
+  done
+  exit 1
+fi
+
+echo "[OK] rootfs verification passed"


### PR DESCRIPTION
## Summary
- Move `verify_rootfs()` from `build-rootfs.sh` into a separate `verify-rootfs.sh`
- Only `build-rootfs.sh` participates in `compute_input_hash()` — changes to verification checks no longer invalidate the rootfs cache
- Rust side writes both scripts to temp dir, runs build first then verify separately

## Test plan
- [x] `cargo clippy -p runner` passes
- [ ] `runner build-rootfs` builds and verifies rootfs on target host
- [ ] Changing `verify-rootfs.sh` does not change the input hash

Closes #2887

🤖 Generated with [Claude Code](https://claude.com/claude-code)