### PR TITLE
feat(core): add glm-5 model and fix model id casing

### DIFF
--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -157,8 +157,8 @@ export const MODEL_PROVIDER_TYPES = {
       CLAUDE_CODE_SUBAGENT_MODEL: "$model",
       API_TIMEOUT_MS: "3000000",
     } as Record<string, string>,
-    models: ["GLM-4.7", "GLM-4.5-Air"] as string[],
-    defaultModel: "GLM-4.7",
+    models: ["glm-5", "glm-4.7", "glm-4.5-air"] as string[],
+    defaultModel: "glm-4.7",
   },
   "azure-foundry": {
     framework: "claude-code" as const,


### PR DESCRIPTION
## Summary

- Add `glm-5` to Z.AI (GLM) provider model list
- Fix model IDs to use lowercase format per official Z.AI documentation:
  - `GLM-4.7` -> `glm-4.7`
  - `GLM-4.5-Air` -> `glm-4.5-air`

## Context

GLM-5 is Zhipu AI's (Z.AI) latest flagship model with 745B parameters (MoE architecture, 44B active). According to official Z.AI documentation at [docs.z.ai](https://docs.z.ai/guides/llm/glm-4.7), model IDs should be lowercase.

## Test plan

- [ ] Verify GLM models appear correctly in provider dropdown
- [ ] Test API calls work with lowercase model IDs

Closes #2883

🤖 Generated with [Claude Code](https://claude.ai/code)