### PR TITLE
ci(crates): skip ably-subscriber integration test when unchanged

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -19,6 +19,24 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed crates
+        id: detect
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
+          else
+            BASE_REF="HEAD^"
+          fi
+          # scripts/crate-changed.sh: exit 0=changed, 1=not changed, 2+=error
+          check_crate() {
+            ./scripts/crate-changed.sh "$1" "$BASE_REF" && echo "$1-changed=true" >> "$GITHUB_OUTPUT" || {
+              rc=$?; [ $rc -eq 1 ] && echo "$1-changed=false" >> "$GITHUB_OUTPUT" || exit $rc
+            }
+          }
+          check_crate ably-subscriber
 
       - name: Check formatting
         run: |
@@ -36,6 +54,7 @@ jobs:
           cargo test --all-targets
 
       - name: Run ably-subscriber integration test
+        if: steps.detect.outputs.ably-subscriber-changed == 'true'
         env:
           ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
         run: |

--- a/crates/ably-subscriber/src/lib.rs
+++ b/crates/ably-subscriber/src/lib.rs
@@ -1,6 +1,6 @@
 //! Ably Pub/Sub subscribe-only Realtime SDK.
 //!
-//! A minimal implementation of the Ably realtime protocol for
+//! Implements the minimum subset of the Ably realtime protocol needed for
 //! subscribing to channels via WebSocket with MessagePack encoding.
 //!
 //! # Features

--- a/crates/ably-subscriber/src/lib.rs
+++ b/crates/ably-subscriber/src/lib.rs
@@ -1,6 +1,6 @@
 //! Ably Pub/Sub subscribe-only Realtime SDK.
 //!
-//! Implements the minimum subset of the Ably realtime protocol needed for
+//! A minimal implementation of the Ably realtime protocol for
 //! subscribing to channels via WebSocket with MessagePack encoding.
 //!
 //! # Features

--- a/scripts/crate-changed.sh
+++ b/scripts/crate-changed.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Check if a crate or any of its workspace dependencies have changed.
+# Uses cargo metadata to resolve the full internal dependency graph.
+#
+# Usage: crate-changed.sh <crate-name> <base-ref>
+# Exit code: 0 if changed, 1 if not changed, 2 on error
+# Example: crate-changed.sh ably-subscriber origin/main
+
+set -eo pipefail
+
+CRATE_NAME=${1:?Usage: crate-changed.sh <crate-name> <base-ref>}
+BASE_REF=${2:-HEAD^}
+
+# Get all workspace crates and their internal dependencies
+# Must run from crates/ directory where Cargo.toml workspace is defined
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DEPS_JSON=$(cd "$REPO_ROOT/crates" && cargo metadata --no-deps --format-version 1 2>/dev/null | \
+  jq '[.packages[] | {name: .name, deps: [.dependencies[] | select(has("path")) | .name]}]') || {
+  echo "Error: failed to resolve crate dependencies" >&2
+  exit 2
+}
+
+# Resolve transitive internal dependencies using BFS
+AFFECTED_CRATES=$(echo "$DEPS_JSON" | jq -r --arg crate "$CRATE_NAME" '
+  . as $pkgs |
+  {queue: [$crate], visited: [$crate]} |
+  until(.queue | length == 0;
+    .queue[0] as $current |
+    ($pkgs | map(select(.name == $current)) | .[0].deps // []) as $deps |
+    reduce $deps[] as $dep (.;
+      if (.visited | index($dep)) then .
+      else .queue += [$dep] | .visited += [$dep]
+      end
+    ) |
+    .queue = .queue[1:]
+  ) |
+  .visited[]
+')
+
+echo "Crate '$CRATE_NAME' depends on: $AFFECTED_CRATES" >&2
+
+# Workspace-level files affect all crates
+CHANGED_FILES=$(git diff --name-only "$BASE_REF" HEAD -- crates/)
+if echo "$CHANGED_FILES" | grep -qE "^crates/(Cargo\.toml|Cargo\.lock|clippy\.toml)$"; then
+  echo "Workspace-level file changed, all crates affected" >&2
+  exit 0
+fi
+
+# Check if any of the affected crate directories have changes
+for crate in $AFFECTED_CRATES; do
+  if echo "$CHANGED_FILES" | grep -q "^crates/${crate}/"; then
+    echo "Changed: crates/${crate}/" >&2
+    exit 0
+  fi
+done
+
+echo "No changes detected for '$CRATE_NAME' or its dependencies" >&2
+exit 1

--- a/scripts/crate-changed.sh
+++ b/scripts/crate-changed.sh
@@ -42,7 +42,7 @@ AFFECTED_CRATES=$(echo "$DEPS_JSON" | jq -r --arg crate "$CRATE_NAME" '
 echo "Crate '$CRATE_NAME' depends on: $AFFECTED_CRATES" >&2
 
 # Workspace-level files affect all crates
-CHANGED_FILES=$(git diff --name-only "$BASE_REF" HEAD -- crates/)
+CHANGED_FILES=$(git -C "$REPO_ROOT" diff --name-only "$BASE_REF" HEAD -- crates/)
 if echo "$CHANGED_FILES" | grep -qE "^crates/(Cargo\.toml|Cargo\.lock|clippy\.toml)$"; then
   echo "Workspace-level file changed, all crates affected" >&2
   exit 0

--- a/scripts/crate-changed.sh
+++ b/scripts/crate-changed.sh
@@ -16,6 +16,10 @@ BASE_REF=${2:-HEAD^}
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# In CI containers, the repo may be owned by a different user (host vs container).
+# Git 2.35.2+ rejects such repos unless marked as safe.
+git config --global --add safe.directory "$REPO_ROOT" 2>/dev/null || true
+
 DEPS_JSON=$(cd "$REPO_ROOT/crates" && cargo metadata --no-deps --format-version 1 2>/dev/null | \
   jq '[.packages[] | {name: .name, deps: [.dependencies[] | select(has("path")) | .name]}]') || {
   echo "Error: failed to resolve crate dependencies" >&2


### PR DESCRIPTION
## Summary
- Add `scripts/crate-changed.sh` — detects if a crate or its transitive workspace dependencies changed via `cargo metadata` BFS + `git diff`
- Skip `ably-subscriber` integration test in `crates.yml` when the crate hasn't changed
- Handles workspace-level files (`Cargo.toml`, `Cargo.lock`, `clippy.toml`) as affecting all crates

## Test plan
- [ ] PR that only touches `guest-agent` should skip ably-subscriber integration test
- [ ] PR that touches `ably-subscriber` should run the integration test
- [ ] PR that touches `crates/Cargo.toml` should run the integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)