### PR TITLE
refactor(sandbox): add startup/shutdown lifecycle to factory trait

### DIFF
--- a/crates/sandbox-fc/examples/sandbox-fc.rs
+++ b/crates/sandbox-fc/examples/sandbox-fc.rs
@@ -213,7 +213,8 @@ async fn run_exec(
         snapshot,
     };
 
-    let factory = sandbox_fc::FirecrackerFactory::new(config).await?;
+    let mut factory = sandbox_fc::FirecrackerFactory::new(config).await?;
+    factory.startup().await?;
 
     let sandbox_config = SandboxConfig {
         id: Uuid::new_v4(),
@@ -240,7 +241,7 @@ async fn run_exec(
 
     sandbox.stop().await?;
     factory.destroy(sandbox).await;
-    factory.cleanup().await;
+    factory.shutdown().await;
 
     Ok(())
 }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -19,7 +19,7 @@ pub struct FirecrackerFactory {
 
 impl FirecrackerFactory {
     /// Create a new factory without allocating system resources.
-    /// Call `start()` to initialize pools before use.
+    /// Call `startup()` to initialize pools before use.
     pub async fn new(config: FirecrackerConfig) -> Result<Self, SandboxError> {
         crate::prerequisites::check_prerequisites(&config).await?;
 
@@ -33,11 +33,15 @@ impl FirecrackerFactory {
         })
     }
 
+    /// # Panics
+    /// Panics if called before `startup()` — this is a programming error.
     #[allow(clippy::expect_used)]
     fn netns_pool(&self) -> &tokio::sync::Mutex<NetnsPool> {
         self.netns_pool.as_ref().expect("factory not started")
     }
 
+    /// # Panics
+    /// Panics if called before `startup()` — this is a programming error.
     #[allow(clippy::expect_used)]
     fn overlay_pool(&self) -> &tokio::sync::Mutex<OverlayPool> {
         self.overlay_pool.as_ref().expect("factory not started")
@@ -51,6 +55,12 @@ impl SandboxFactory for FirecrackerFactory {
     }
 
     async fn startup(&mut self) -> sandbox::Result<()> {
+        if self.netns_pool.is_some() {
+            return Err(SandboxError::CreationFailed(
+                "factory already started".into(),
+            ));
+        }
+
         let concurrency = self.config.concurrency.max(1);
 
         let mut netns_pool = NetnsPool::create(NetnsPoolConfig {

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -55,6 +55,7 @@ impl SandboxFactory for FirecrackerFactory {
     }
 
     async fn startup(&mut self) -> sandbox::Result<()> {
+        // Both pools are always set together, so checking one is sufficient.
         if self.netns_pool.is_some() {
             return Err(SandboxError::CreationFailed(
                 "factory already started".into(),

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -13,26 +13,54 @@ use crate::sandbox::FirecrackerSandbox;
 pub struct FirecrackerFactory {
     config: FirecrackerConfig,
     paths: FactoryPaths,
-    netns_pool: tokio::sync::Mutex<NetnsPool>,
-    overlay_pool: tokio::sync::Mutex<OverlayPool>,
+    netns_pool: Option<tokio::sync::Mutex<NetnsPool>>,
+    overlay_pool: Option<tokio::sync::Mutex<OverlayPool>>,
 }
 
 impl FirecrackerFactory {
-    /// Create a new factory, pre-warming the network namespace and overlay pools.
+    /// Create a new factory without allocating system resources.
+    /// Call `start()` to initialize pools before use.
     pub async fn new(config: FirecrackerConfig) -> Result<Self, SandboxError> {
         crate::prerequisites::check_prerequisites(&config).await?;
 
-        let concurrency = config.concurrency.max(1);
         let paths = FactoryPaths::new(config.base_dir.clone());
+
+        Ok(Self {
+            config,
+            paths,
+            netns_pool: None,
+            overlay_pool: None,
+        })
+    }
+
+    #[allow(clippy::expect_used)]
+    fn netns_pool(&self) -> &tokio::sync::Mutex<NetnsPool> {
+        self.netns_pool.as_ref().expect("factory not started")
+    }
+
+    #[allow(clippy::expect_used)]
+    fn overlay_pool(&self) -> &tokio::sync::Mutex<OverlayPool> {
+        self.overlay_pool.as_ref().expect("factory not started")
+    }
+}
+
+#[async_trait]
+impl SandboxFactory for FirecrackerFactory {
+    fn name(&self) -> &str {
+        "firecracker"
+    }
+
+    async fn startup(&mut self) -> sandbox::Result<()> {
+        let concurrency = self.config.concurrency.max(1);
 
         let mut netns_pool = NetnsPool::create(NetnsPoolConfig {
             size: concurrency,
-            proxy_port: config.proxy_port,
+            proxy_port: self.config.proxy_port,
         })
         .await
         .map_err(|e| SandboxError::CreationFailed(format!("netns pool: {e}")))?;
 
-        let overlay_creator: Box<dyn OverlayCreator> = match &config.snapshot {
+        let overlay_creator: Box<dyn OverlayCreator> = match &self.config.snapshot {
             Some(snapshot) => Box::new(SnapshotCopyCreator::new(snapshot.overlay_path.clone())),
             None => Box::new(Ext4Creator),
         };
@@ -40,7 +68,7 @@ impl FirecrackerFactory {
         let overlay_pool = match OverlayPool::create(OverlayPoolConfig {
             size: concurrency,
             replenish_threshold: (concurrency / 2).max(1),
-            pool_dir: paths.overlays(),
+            pool_dir: self.paths.overlays(),
             creator: overlay_creator,
         })
         .await
@@ -54,41 +82,17 @@ impl FirecrackerFactory {
             }
         };
 
-        let mode = if config.snapshot.is_some() {
+        self.netns_pool = Some(tokio::sync::Mutex::new(netns_pool));
+        self.overlay_pool = Some(tokio::sync::Mutex::new(overlay_pool));
+
+        let mode = if self.config.snapshot.is_some() {
             "snapshot"
         } else {
             "fresh"
         };
-        info!(concurrency, mode, "factory initialized");
+        info!(concurrency, mode, "factory started");
 
-        Ok(Self {
-            config,
-            paths,
-            netns_pool: tokio::sync::Mutex::new(netns_pool),
-            overlay_pool: tokio::sync::Mutex::new(overlay_pool),
-        })
-    }
-
-    /// Clean up all factory-level resources (pools).
-    pub async fn cleanup(&self) {
-        let mut netns_pool = self.netns_pool.lock().await;
-        if let Err(e) = netns_pool.cleanup().await {
-            warn!(error = %e, "failed to cleanup netns pool");
-        }
-        drop(netns_pool);
-
-        let mut overlay_pool = self.overlay_pool.lock().await;
-        overlay_pool.cleanup().await;
-        drop(overlay_pool);
-
-        info!("factory cleanup complete");
-    }
-}
-
-#[async_trait]
-impl SandboxFactory for FirecrackerFactory {
-    fn name(&self) -> &str {
-        "firecracker"
+        Ok(())
     }
 
     async fn create(&self, config: SandboxConfig) -> sandbox::Result<Box<dyn Sandbox>> {
@@ -102,7 +106,7 @@ impl SandboxFactory for FirecrackerFactory {
 
         // Acquire a network namespace from the pool.
         let network = self
-            .netns_pool
+            .netns_pool()
             .lock()
             .await
             .acquire()
@@ -110,11 +114,11 @@ impl SandboxFactory for FirecrackerFactory {
             .map_err(|e| SandboxError::CreationFailed(format!("acquire netns: {e}")))?;
 
         // Acquire an overlay file from the pool.
-        let overlay = match self.overlay_pool.lock().await.acquire().await {
+        let overlay = match self.overlay_pool().lock().await.acquire().await {
             Ok(overlay) => overlay,
             Err(e) => {
                 // Roll back: return netns to pool before propagating error.
-                let mut netns_pool = self.netns_pool.lock().await;
+                let mut netns_pool = self.netns_pool().lock().await;
                 if let Err(rel_err) = netns_pool.release(network).await {
                     warn!(error = %rel_err, "failed to release netns during rollback");
                 }
@@ -148,14 +152,14 @@ impl SandboxFactory for FirecrackerFactory {
         let sandbox_id = sandbox.id;
 
         // Return the network namespace to the pool.
-        let mut netns_pool = self.netns_pool.lock().await;
+        let mut netns_pool = self.netns_pool().lock().await;
         if let Err(e) = netns_pool.release(sandbox.network).await {
             warn!(id = %sandbox_id, error = %e, "failed to release netns");
         }
         drop(netns_pool);
 
         // Delete the overlay file.
-        let mut overlay_pool = self.overlay_pool.lock().await;
+        let mut overlay_pool = self.overlay_pool().lock().await;
         overlay_pool.release(sandbox.overlay).await;
         drop(overlay_pool);
 
@@ -165,5 +169,21 @@ impl SandboxFactory for FirecrackerFactory {
         }
 
         info!(id = %sandbox_id, "sandbox destroyed");
+    }
+
+    async fn shutdown(&mut self) {
+        if let Some(netns_pool) = self.netns_pool.take() {
+            let mut pool = netns_pool.into_inner();
+            if let Err(e) = pool.cleanup().await {
+                warn!(error = %e, "failed to cleanup netns pool");
+            }
+        }
+
+        if let Some(overlay_pool) = self.overlay_pool.take() {
+            let mut pool = overlay_pool.into_inner();
+            pool.cleanup().await;
+        }
+
+        info!("factory shutdown complete");
     }
 }

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -13,5 +13,8 @@ pub trait SandboxFactory: Send + Sync {
     async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>>;
     async fn destroy(&self, sandbox: Box<dyn Sandbox>);
     /// Release all factory-level resources.
+    /// Requires exclusive ownership — callers sharing via `Arc` must
+    /// first recover ownership (e.g. `Arc::try_unwrap`) after all
+    /// concurrent users have been dropped.
     async fn shutdown(&mut self);
 }

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -7,6 +7,11 @@ use crate::sandbox::Sandbox;
 #[async_trait]
 pub trait SandboxFactory: Send + Sync {
     fn name(&self) -> &str;
+    /// Initialize factory resources (pools, connections, etc.).
+    /// Must be called before `create()` or `destroy()`.
+    async fn startup(&mut self) -> Result<()>;
     async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>>;
     async fn destroy(&self, sandbox: Box<dyn Sandbox>);
+    /// Release all factory-level resources.
+    async fn shutdown(&mut self);
 }


### PR DESCRIPTION
## Summary

Add `startup(&mut self)` / `shutdown(&mut self)` lifecycle to `SandboxFactory` trait, so factory doesn't occupy system resources before explicit initialization.

**Before:** `FirecrackerFactory::new()` eagerly creates netns pool + overlay pool. `cleanup()` is an inherent method, not on trait.

**After:** `new()` is lightweight (config + prerequisites only). `startup()` allocates pools. `shutdown()` releases them via `take()` + `into_inner()`. Both are trait methods with `&mut self`.

## Changes

- **`sandbox`**: add `startup`/`shutdown` to `SandboxFactory` trait
- **`sandbox-fc`**: split `new()` into lightweight constructor + `startup()`; `shutdown()` replaces `cleanup()` with lock-free teardown
- **`runner`**: `new()` → `startup()` → `Arc::new()` → ... → `Arc::try_unwrap()` → `shutdown()`
- Double `startup()` guard to prevent resource leak
- `# Panics` doc on `expect_used` helpers (invariant: only called after `startup()`)

## Test plan

- [x] `cargo clippy --all-targets --all-features` passes
- [x] `cargo test --all-targets` passes (236 tests)
- [ ] CI passes

Closes #2896

🤖 Generated with [Claude Code](https://claude.com/claude-code)