### PR TITLE
docs: add glm-5 model and fix model id casing in Z.AI documentation

### DIFF
--- a/turbo/apps/docs/content/docs/model-selection/zai.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/zai.mdx
@@ -21,8 +21,9 @@ Visit the [Z.AI Platform](https://z.ai/model-api) to create and obtain an API ke
 
 | Model | Description |
 |-------|-------------|
-| `GLM-4.7` | Latest GLM model (default) |
-| `GLM-4.5-Air` | Lighter, faster variant |
+| `glm-5` | Latest flagship model with 745B parameters (MoE architecture, 44B active) |
+| `glm-4.7` | GLM 4.7 model (default) |
+| `glm-4.5-air` | Lighter, faster variant |
 
 ## Non-Interactive Setup
 
@@ -31,7 +32,7 @@ Visit the [Z.AI Platform](https://z.ai/model-api) to create and obtain an API ke
 vm0 model-provider setup --type zai-api-key --secret "xxx"
 
 # With specific model
-vm0 model-provider setup --type zai-api-key --secret "xxx" --model "GLM-4.5-Air"
+vm0 model-provider setup --type zai-api-key --secret "xxx" --model "glm-4.5-air"
 ```
 
 ## Run


### PR DESCRIPTION
## Summary

- Add `glm-5` model to Z.AI documentation
- Update model IDs to lowercase format per official Z.AI documentation:
  - `GLM-4.7` -> `glm-4.7`
  - `GLM-4.5-Air` -> `glm-4.5-air`

## Context

GLM-5 is Zhipu AI's (Z.AI) latest flagship model with 745B parameters (MoE architecture, 44B active). According to official Z.AI documentation at [docs.z.ai](https://docs.z.ai/guides/llm/glm-4.7), model IDs should be lowercase.

This documentation update aligns with the model provider changes in #2889.

## Changes

- Updated `turbo/apps/docs/content/docs/model-selection/zai.mdx`:
  - Added glm-5 to available models table with description
  - Changed all model IDs to lowercase format
  - Updated example command to use lowercase model ID

Related to #2889

🤖 Generated with [Claude Code](https://claude.ai/claude-code)