### PR TITLE
fix: ensure after() awaits callback dispatch promise

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -198,15 +198,19 @@ const router = tsr.router(webhookCompleteContract, {
 
     // Dispatch registered callbacks (non-blocking)
     // This handles Slack mentions and other webhook integrations
-    after(() => {
-      const errorMsg =
-        finalStatus === "failed"
-          ? (body.error ?? `Agent exited with code ${body.exitCode}`)
-          : undefined;
-      dispatchCallbacks(body.runId, finalStatus, undefined, errorMsg).catch(
-        (err) => log.error("Failed to dispatch callbacks", { err }),
-      );
-    });
+    // Note: Must return the promise so after() waits for completion
+    const callbackErrorMsg =
+      finalStatus === "failed"
+        ? (body.error ?? `Agent exited with code ${body.exitCode}`)
+        : undefined;
+    after(
+      dispatchCallbacks(
+        body.runId,
+        finalStatus,
+        undefined,
+        callbackErrorMsg,
+      ).catch((err) => log.error("Failed to dispatch callbacks", { err })),
+    );
 
     // Kill sandbox (wait for completion to ensure cleanup before response)
     if (sandboxId) {

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -183,13 +183,15 @@ const router = tsr.router(webhookCompleteContract, {
       await publishStatus(body.runId, "failed", undefined, errorMessage);
     }
 
+    // Error message for notifications (only set on failure)
+    const errorMsg =
+      finalStatus === "failed"
+        ? (body.error ?? `Agent exited with code ${body.exitCode}`)
+        : undefined;
+
     // Send Slack DM notification for scheduled runs (non-blocking)
     if (run.scheduleId) {
-      const errorMsg =
-        finalStatus === "failed"
-          ? (body.error ?? `Agent exited with code ${body.exitCode}`)
-          : undefined;
-      after(() =>
+      after(
         notifyScheduleRunComplete(body.runId, finalStatus, errorMsg).catch(
           (err) => log.error("Failed to send schedule notification", { err }),
         ),
@@ -198,18 +200,10 @@ const router = tsr.router(webhookCompleteContract, {
 
     // Dispatch registered callbacks (non-blocking)
     // This handles Slack mentions and other webhook integrations
-    // Note: Must return the promise so after() waits for completion
-    const callbackErrorMsg =
-      finalStatus === "failed"
-        ? (body.error ?? `Agent exited with code ${body.exitCode}`)
-        : undefined;
     after(
-      dispatchCallbacks(
-        body.runId,
-        finalStatus,
-        undefined,
-        callbackErrorMsg,
-      ).catch((err) => log.error("Failed to dispatch callbacks", { err })),
+      dispatchCallbacks(body.runId, finalStatus, undefined, errorMsg).catch(
+        (err) => log.error("Failed to dispatch callbacks", { err }),
+      ),
     );
 
     // Kill sandbox (wait for completion to ensure cleanup before response)


### PR DESCRIPTION
## Summary

- Fix Slack callback not responding after agent completion by ensuring `after()` properly awaits the callback dispatch promise
- Root cause: The callback dispatch was wrapped in a function that didn't return the promise, causing Next.js `after()` to not wait for completion

## Root Cause Analysis

The issue was in how `dispatchCallbacks` was passed to `after()`:

**Before (buggy):**
```typescript
after(() => {
  dispatchCallbacks(...).catch(...);  // No return! Function returns undefined
});
```

**After (fixed):**
```typescript
after(
  dispatchCallbacks(...).catch(...)  // Promise passed directly
);
```

When `after()` receives a function that returns `undefined`, it immediately considers the task complete. The serverless function could be frozen before callbacks were actually delivered.

This matches the pattern used in `slack/events/route.ts` which correctly passes the promise directly to `after()`.

## Test plan

- [ ] Deploy to preview environment
- [ ] Trigger agent via Slack mention
- [ ] Verify response is posted back to Slack thread after completion

Closes #2898

🤖 Generated with [Claude Code](https://claude.com/claude-code)