### PR TITLE
feat(runner): add snapshot subcommand with content-addressable caching

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1331,6 +1331,7 @@ dependencies = [
  "nix",
  "sandbox",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/runner/src/error.rs
+++ b/crates/runner/src/error.rs
@@ -15,6 +15,9 @@ pub enum RunnerError {
     #[error("internal error: {0}")]
     Internal(String),
 
+    #[error("snapshot error: {0}")]
+    Snapshot(#[from] sandbox_fc::SnapshotError),
+
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -6,6 +6,7 @@ mod executor;
 mod paths;
 mod runner;
 mod setup;
+mod snapshot;
 mod status;
 mod types;
 
@@ -42,7 +43,9 @@ enum Command {
     Setup,
     /// Build squashfs rootfs for Firecracker VMs
     BuildRootfs(build_rootfs::BuildRootfsArgs),
-    /// Start the runner and poll for jobs
+    /// Create a Firecracker VM snapshot for fast sandbox boot
+    Snapshot(snapshot::SnapshotArgs),
+    /// Start the runner and poll for jobs (must run setup, build-rootfs, snapshot first)
     Start(Box<runner::StartArgs>),
 }
 
@@ -60,9 +63,10 @@ async fn main() -> ExitCode {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Command::Start(args) => runner::run_start(*args).await,
         Command::Setup => setup::run_setup().await,
         Command::BuildRootfs(args) => build_rootfs::run_build_rootfs(args).await,
+        Command::Snapshot(args) => snapshot::run_snapshot(args).await,
+        Command::Start(args) => runner::run_start(*args).await,
     };
 
     if let Err(e) = result {

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::error::{RunnerError, RunnerResult};
 
@@ -67,7 +67,54 @@ impl HomePaths {
         self.root.join("rootfs")
     }
 
+    pub fn snapshots_dir(&self) -> PathBuf {
+        self.root.join("snapshots")
+    }
+
     pub fn runners_dir(&self) -> PathBuf {
         self.root.join("runners")
+    }
+}
+
+/// Paths for a rootfs build output directory (keyed by input hash).
+pub struct RootfsPaths {
+    dir: PathBuf,
+}
+
+impl RootfsPaths {
+    pub fn new(home: &HomePaths, hash: &str) -> Self {
+        Self {
+            dir: home.rootfs_dir().join(hash),
+        }
+    }
+
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    pub fn rootfs(&self) -> PathBuf {
+        self.dir.join("rootfs.squashfs")
+    }
+
+    pub fn ca_cert(&self) -> PathBuf {
+        self.dir.join("mitmproxy-ca-cert.pem")
+    }
+
+    pub fn ca_key(&self) -> PathBuf {
+        self.dir.join("mitmproxy-ca-key.pem")
+    }
+
+    pub fn ca_combined(&self) -> PathBuf {
+        self.dir.join("mitmproxy-ca.pem")
+    }
+
+    /// All files that must exist for the build to be considered complete.
+    pub fn expected_files(&self) -> [PathBuf; 4] {
+        [
+            self.rootfs(),
+            self.ca_cert(),
+            self.ca_key(),
+            self.ca_combined(),
+        ]
     }
 }

--- a/crates/runner/src/snapshot.rs
+++ b/crates/runner/src/snapshot.rs
@@ -36,12 +36,20 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<()> {
     }
 
     // Clean up any partial output from a previous failed attempt.
-    if output_dir.exists() {
-        tokio::fs::remove_dir_all(&output_dir).await?;
+    match tokio::fs::remove_dir_all(&output_dir).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e.into()),
     }
     tokio::fs::create_dir_all(&output_dir).await?;
 
     let rootfs_path = RootfsPaths::new(&paths, &args.rootfs_hash).rootfs();
+    if !tokio::fs::try_exists(&rootfs_path).await.unwrap_or(false) {
+        return Err(RunnerError::Config(format!(
+            "rootfs not found at {}; run `build-rootfs` first",
+            rootfs_path.display()
+        )));
+    }
 
     let config = sandbox_fc::SnapshotCreateConfig {
         binary_path: paths.firecracker_bin(FIRECRACKER_VERSION),

--- a/crates/runner/src/snapshot.rs
+++ b/crates/runner/src/snapshot.rs
@@ -7,7 +7,7 @@ use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::{HomePaths, RootfsPaths};
 
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct SnapshotArgs {
     /// SHA-256 hash of the rootfs inputs (output of `build-rootfs`).
     #[arg(long)]
@@ -44,7 +44,10 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<()> {
     tokio::fs::create_dir_all(&output_dir).await?;
 
     let rootfs_path = RootfsPaths::new(&paths, &args.rootfs_hash).rootfs();
-    if !tokio::fs::try_exists(&rootfs_path).await.unwrap_or(false) {
+    let rootfs_exists = tokio::fs::try_exists(&rootfs_path)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("check rootfs: {e}")))?;
+    if !rootfs_exists {
         return Err(RunnerError::Config(format!(
             "rootfs not found at {}; run `build-rootfs` first",
             rootfs_path.display()
@@ -91,6 +94,8 @@ async fn is_snapshot_complete(output: &SnapshotOutputPaths) -> RunnerResult<bool
 ///   - `rootfs_hash` — rootfs content (from `build-rootfs`)
 ///   - `FIRECRACKER_VERSION` / `KERNEL_VERSION` — binary versions
 ///   - `vcpu` / `memory_mb` — VM resource settings
+///
+/// **Changing this function invalidates all cached snapshots.**
 fn compute_snapshot_hash(args: &SnapshotArgs) -> String {
     let fc_config = sandbox_fc::config_hash();
     let mut hasher = Sha256::new();
@@ -107,4 +112,52 @@ fn compute_snapshot_hash(args: &SnapshotArgs) -> String {
     hasher.update(b"memory_mb:");
     hasher.update(args.memory_mb.to_le_bytes());
     format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_hash_is_stable() {
+        let args = SnapshotArgs {
+            rootfs_hash: "abc123".into(),
+            vcpu: 2,
+            memory_mb: 2048,
+        };
+        let hash = compute_snapshot_hash(&args);
+
+        // Changing this assertion means ALL existing cached snapshots are
+        // invalidated.  Only update deliberately.
+        assert_eq!(
+            hash, "3c68896dabe2536440cc57e8bf7d377c3f0935afd90ca68b189c6e37636fef19",
+            "snapshot hash changed — this invalidates all cached snapshots"
+        );
+    }
+
+    #[test]
+    fn different_inputs_produce_different_hashes() {
+        let base = SnapshotArgs {
+            rootfs_hash: "abc123".into(),
+            vcpu: 2,
+            memory_mb: 2048,
+        };
+        let different_rootfs = SnapshotArgs {
+            rootfs_hash: "def456".into(),
+            ..base.clone()
+        };
+        let different_vcpu = SnapshotArgs {
+            vcpu: 4,
+            ..base.clone()
+        };
+        let different_memory = SnapshotArgs {
+            memory_mb: 4096,
+            ..base.clone()
+        };
+
+        let base_hash = compute_snapshot_hash(&base);
+        assert_ne!(base_hash, compute_snapshot_hash(&different_rootfs));
+        assert_ne!(base_hash, compute_snapshot_hash(&different_vcpu));
+        assert_ne!(base_hash, compute_snapshot_hash(&different_memory));
+    }
 }

--- a/crates/runner/src/snapshot.rs
+++ b/crates/runner/src/snapshot.rs
@@ -1,0 +1,102 @@
+use clap::Args;
+use sha2::{Digest, Sha256};
+
+use sandbox_fc::SnapshotOutputPaths;
+
+use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
+use crate::error::{RunnerError, RunnerResult};
+use crate::paths::{HomePaths, RootfsPaths};
+
+#[derive(Args)]
+pub struct SnapshotArgs {
+    /// SHA-256 hash of the rootfs inputs (output of `build-rootfs`).
+    #[arg(long)]
+    rootfs_hash: String,
+    /// Number of vCPUs for the snapshot VM.
+    #[arg(long, default_value_t = 2)]
+    vcpu: u32,
+    /// Memory size in MiB for the snapshot VM.
+    #[arg(long, default_value_t = 2048)]
+    memory_mb: u32,
+}
+
+pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<()> {
+    let paths = HomePaths::new()?;
+
+    let snapshot_hash = compute_snapshot_hash(&args);
+    tracing::info!("snapshot hash: {snapshot_hash}");
+
+    let output_dir = paths.snapshots_dir().join(&snapshot_hash);
+
+    let output = SnapshotOutputPaths::new(output_dir.clone());
+
+    if is_snapshot_complete(&output).await? {
+        tracing::info!("[OK] snapshot already exists: {}", output_dir.display());
+        return Ok(());
+    }
+
+    // Clean up any partial output from a previous failed attempt.
+    if output_dir.exists() {
+        tokio::fs::remove_dir_all(&output_dir).await?;
+    }
+    tokio::fs::create_dir_all(&output_dir).await?;
+
+    let rootfs_path = RootfsPaths::new(&paths, &args.rootfs_hash).rootfs();
+
+    let config = sandbox_fc::SnapshotCreateConfig {
+        binary_path: paths.firecracker_bin(FIRECRACKER_VERSION),
+        kernel_path: paths.kernel_bin(FIRECRACKER_VERSION, KERNEL_VERSION),
+        rootfs_path,
+        output_dir: output_dir.clone(),
+        vcpu_count: args.vcpu,
+        memory_mb: args.memory_mb,
+    };
+
+    let snapshot_config = sandbox_fc::create_snapshot(config).await?;
+    tracing::info!(
+        snapshot = %snapshot_config.snapshot_path.display(),
+        memory = %snapshot_config.memory_path.display(),
+        overlay = %snapshot_config.overlay_path.display(),
+        "snapshot creation complete"
+    );
+
+    Ok(())
+}
+
+/// Check whether all expected snapshot outputs exist in the directory.
+async fn is_snapshot_complete(output: &SnapshotOutputPaths) -> RunnerResult<bool> {
+    for path in [output.snapshot(), output.memory(), output.overlay()] {
+        let exists = tokio::fs::try_exists(&path)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("check {}: {e}", path.display())))?;
+        if !exists {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// Compute a composite cache key from all inputs that affect the snapshot.
+///
+/// Inputs:
+///   - `sandbox_fc::config_hash()` — boot args, guest network config
+///   - `rootfs_hash` — rootfs content (from `build-rootfs`)
+///   - `FIRECRACKER_VERSION` / `KERNEL_VERSION` — binary versions
+///   - `vcpu` / `memory_mb` — VM resource settings
+fn compute_snapshot_hash(args: &SnapshotArgs) -> String {
+    let fc_config = sandbox_fc::config_hash();
+    let mut hasher = Sha256::new();
+    hasher.update(b"fc_config:");
+    hasher.update(fc_config.as_bytes());
+    hasher.update(b"rootfs:");
+    hasher.update(args.rootfs_hash.as_bytes());
+    hasher.update(b"firecracker:");
+    hasher.update(FIRECRACKER_VERSION.as_bytes());
+    hasher.update(b"kernel:");
+    hasher.update(KERNEL_VERSION.as_bytes());
+    hasher.update(b"vcpu:");
+    hasher.update(args.vcpu.to_le_bytes());
+    hasher.update(b"memory_mb:");
+    hasher.update(args.memory_mb.to_le_bytes());
+    format!("{:x}", hasher.finalize())
+}

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -9,6 +9,7 @@ libc.workspace = true
 nix = { workspace = true, features = ["user", "inotify", "fs"] }
 sandbox.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["process", "fs", "rt", "rt-multi-thread", "macros", "sync", "io-util", "net", "time"] }
 tracing.workspace = true

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -11,7 +11,7 @@ mod sandbox;
 mod snapshot;
 
 pub use config::{FirecrackerConfig, SnapshotConfig};
-pub use factory::FirecrackerFactory;
+pub use factory::{FirecrackerFactory, config_hash};
 pub use paths::{FactoryPaths, SandboxPaths, SnapshotOutputPaths};
 pub use sandbox::FirecrackerSandbox;
 pub use snapshot::{SnapshotCreateConfig, SnapshotError, create_snapshot};

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -7,17 +7,17 @@ use crate::sandbox::Sandbox;
 #[async_trait]
 pub trait SandboxFactory: Send + Sync {
     fn name(&self) -> &str;
-    /// Initialize factory resources (pools, connections, etc.).
-    /// Must be called before `create()` or `destroy()`.
-    async fn startup(&mut self) -> Result<()>;
-    async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>>;
-    async fn destroy(&self, sandbox: Box<dyn Sandbox>);
     /// Content hash of all internal configuration that affects snapshot output.
     ///
     /// Used by the runner to build a composite cache key for pre-warmed
     /// snapshots.  The hash covers boot args, guest network parameters, and
     /// any other factory-specific settings baked into the snapshot.
     fn config_hash(&self) -> String;
+    /// Initialize factory resources (pools, connections, etc.).
+    /// Must be called before `create()` or `destroy()`.
+    async fn startup(&mut self) -> Result<()>;
+    async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>>;
+    async fn destroy(&self, sandbox: Box<dyn Sandbox>);
     /// Release all factory-level resources.
     /// Requires exclusive ownership — callers sharing via `Arc` must
     /// first recover ownership (e.g. `Arc::try_unwrap`) after all

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -12,6 +12,12 @@ pub trait SandboxFactory: Send + Sync {
     async fn startup(&mut self) -> Result<()>;
     async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>>;
     async fn destroy(&self, sandbox: Box<dyn Sandbox>);
+    /// Content hash of all internal configuration that affects snapshot output.
+    ///
+    /// Used by the runner to build a composite cache key for pre-warmed
+    /// snapshots.  The hash covers boot args, guest network parameters, and
+    /// any other factory-specific settings baked into the snapshot.
+    fn config_hash(&self) -> String;
     /// Release all factory-level resources.
     /// Requires exclusive ownership — callers sharing via `Arc` must
     /// first recover ownership (e.g. `Arc::try_unwrap`) after all

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -6,6 +6,7 @@ use crate::sandbox::Sandbox;
 
 #[async_trait]
 pub trait SandboxFactory: Send + Sync {
+    /// Human-readable name for this factory implementation (e.g. "firecracker").
     fn name(&self) -> &str;
     /// Content hash of all internal configuration that affects snapshot output.
     ///
@@ -16,7 +17,9 @@ pub trait SandboxFactory: Send + Sync {
     /// Initialize factory resources (pools, connections, etc.).
     /// Must be called before `create()` or `destroy()`.
     async fn startup(&mut self) -> Result<()>;
+    /// Create a new sandbox instance with the given configuration.
     async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>>;
+    /// Tear down a sandbox, releasing all resources back to the factory pools.
     async fn destroy(&self, sandbox: Box<dyn Sandbox>);
     /// Release all factory-level resources.
     /// Requires exclusive ownership — callers sharing via `Arc` must


### PR DESCRIPTION
## Summary
- Add `runner snapshot` subcommand that creates Firecracker VM snapshots with SHA-256 content-addressable caching
- Add `config_hash()` to `SandboxFactory` trait — each factory exposes a fingerprint of its internal config affecting snapshot output
- Add `RootfsPaths` struct to centralize rootfs file layout, eliminating duplicate file name constants
- Output rootfs hash from `build-rootfs` for downstream `snapshot --rootfs-hash` consumption

Closes #2885

## Test plan
- [ ] `cargo clippy -p sandbox -p sandbox-fc -p runner` passes
- [ ] `runner snapshot --rootfs-hash <hash>` creates snapshot in `~/.vm0-runner/snapshots/<composite-hash>/`
- [ ] Re-running with same args skips creation (cache hit)
- [ ] Changing `--vcpu` or `--memory-mb` produces a different snapshot hash
- [ ] Partial snapshot from failed attempt is cleaned up on retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)