### PR TITLE
refactor: unify agent run creation pipeline

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../__tests__/test-helpers";
+import {
+  createTestCompose,
+  insertStalePendingRun,
+} from "../../../__tests__/api-test-helpers";
+import { addPermission } from "../../agent/permission-service";
+import { reloadEnv } from "../../../env";
+import {
+  createRun,
+  type CreateRunParams,
+  type CreateRunResult,
+} from "../run-service";
+import { agentRuns } from "../../../db/schema/agent-run";
+import { agentRunCallbacks } from "../../../db/schema/agent-run-callback";
+import { isConcurrentRunLimit, isForbidden, isBadRequest } from "../../errors";
+
+const context = testContext();
+
+describe("createRun()", () => {
+  let user: UserContext;
+  let composeId: string;
+  let versionId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    const compose = await createTestCompose(uniqueId("agent"));
+    composeId = compose.composeId;
+    versionId = compose.versionId;
+  });
+
+  function baseParams(overrides?: Partial<CreateRunParams>): CreateRunParams {
+    return {
+      userId: user.userId,
+      agentComposeVersionId: versionId,
+      prompt: "Hello, world!",
+      ...overrides,
+    };
+  }
+
+  describe("Happy Path", () => {
+    it("should create and dispatch a run successfully", async () => {
+      const result: CreateRunResult = await createRun(baseParams());
+
+      expect(result.runId).toBeDefined();
+      expect(result.status).toBe("running");
+      expect(result.sandboxId).toBeDefined();
+      expect(result.createdAt).toBeInstanceOf(Date);
+
+      // Verify run record in DB
+      const [run] = await globalThis.services.db
+        .select()
+        .from(agentRuns)
+        .where(eq(agentRuns.id, result.runId))
+        .limit(1);
+
+      expect(run).toBeDefined();
+      expect(run!.status).toBe("running");
+      expect(run!.userId).toBe(user.userId);
+      expect(run!.prompt).toBe("Hello, world!");
+      expect(run!.lastHeartbeatAt).toBeDefined();
+    });
+
+    it("should always set lastHeartbeatAt", async () => {
+      const result = await createRun(baseParams());
+
+      const [run] = await globalThis.services.db
+        .select()
+        .from(agentRuns)
+        .where(eq(agentRuns.id, result.runId))
+        .limit(1);
+
+      expect(run!.lastHeartbeatAt).not.toBeNull();
+    });
+
+    it("should store vars when provided", async () => {
+      const vars = { MY_VAR: "value1", OTHER_VAR: "value2" };
+      const result = await createRun(baseParams({ vars }));
+
+      const [run] = await globalThis.services.db
+        .select()
+        .from(agentRuns)
+        .where(eq(agentRuns.id, result.runId))
+        .limit(1);
+
+      expect(run!.vars).toEqual(vars);
+    });
+
+    it("should store secretNames when secrets provided", async () => {
+      const secrets = { API_KEY: "sk-123", DB_PASS: "pw" };
+      const result = await createRun(baseParams({ secrets }));
+
+      const [run] = await globalThis.services.db
+        .select()
+        .from(agentRuns)
+        .where(eq(agentRuns.id, result.runId))
+        .limit(1);
+
+      expect(run!.secretNames).toEqual(["API_KEY", "DB_PASS"]);
+    });
+
+    it("should set null scheduleId when not provided", async () => {
+      const result = await createRun(baseParams());
+
+      const [run] = await globalThis.services.db
+        .select()
+        .from(agentRuns)
+        .where(eq(agentRuns.id, result.runId))
+        .limit(1);
+
+      expect(run!.scheduleId).toBeNull();
+    });
+  });
+
+  describe("Concurrent Run Limit", () => {
+    it("should throw ConcurrentRunLimitError when limit reached", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT", "1");
+      reloadEnv();
+
+      // Create first run
+      await createRun(baseParams({ prompt: "First run" }));
+
+      // Second run should fail
+      await expect(
+        createRun(baseParams({ prompt: "Second run" })),
+      ).rejects.toSatisfy(isConcurrentRunLimit);
+    });
+
+    it("should allow unlimited runs when limit is 0", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT", "0");
+      reloadEnv();
+
+      const run1 = await createRun(baseParams({ prompt: "Run 1" }));
+      const run2 = await createRun(baseParams({ prompt: "Run 2" }));
+
+      expect(run1.status).toBe("running");
+      expect(run2.status).toBe("running");
+    });
+
+    it("should not count stale pending runs", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT", "1");
+      reloadEnv();
+
+      // Insert a stale pending run (20 minutes old, beyond 15-min TTL)
+      await insertStalePendingRun(user.userId, versionId);
+
+      // New run should succeed
+      const result = await createRun(baseParams());
+      expect(result.status).toBe("running");
+    });
+  });
+
+  describe("Permission Check", () => {
+    it("should allow owner to access their own compose", async () => {
+      // Default test compose is owned by the test user
+      const result = await createRun(baseParams());
+      expect(result.runId).toBeDefined();
+    });
+
+    it("should deny access for non-owner without permission", async () => {
+      // Create a second user
+      const otherUser = await context.setupUser({ prefix: "other-user" });
+
+      await expect(
+        createRun(
+          baseParams({
+            userId: otherUser.userId,
+          }),
+        ),
+      ).rejects.toSatisfy(isForbidden);
+    });
+
+    it("should allow access for non-owner with public permission", async () => {
+      const otherUser = await context.setupUser({ prefix: "perm-user" });
+
+      // Grant public access directly via service (avoids API route auth check)
+      await addPermission(composeId, "public", user.userId);
+
+      const result = await createRun(
+        baseParams({
+          userId: otherUser.userId,
+        }),
+      );
+      expect(result.runId).toBeDefined();
+    });
+  });
+
+  describe("Validation", () => {
+    it("should reject mutually exclusive checkpointId and sessionId", async () => {
+      await expect(
+        createRun(
+          baseParams({
+            checkpointId: "some-checkpoint",
+            sessionId: "some-session",
+          }),
+        ),
+      ).rejects.toSatisfy(isBadRequest);
+    });
+
+    it("should reject missing required template variables", async () => {
+      // Create a compose with template variables
+      const compose = await createTestCompose(uniqueId("var-agent"), {
+        overrides: {
+          environment: {
+            MY_KEY: "${{ vars.REQUIRED_VAR }}",
+            ANTHROPIC_API_KEY: "test-key",
+          },
+        },
+      });
+
+      await expect(
+        createRun(
+          baseParams({
+            agentComposeVersionId: compose.versionId,
+            // No vars provided — should fail
+          }),
+        ),
+      ).rejects.toSatisfy(isBadRequest);
+    });
+  });
+
+  describe("Dispatch Failure", () => {
+    it("should mark run as failed when dispatch throws", async () => {
+      const { Sandbox } = await import("@e2b/code-interpreter");
+      vi.mocked(Sandbox.create).mockRejectedValueOnce(
+        new Error("Sandbox creation failed"),
+      );
+
+      await expect(createRun(baseParams())).rejects.toThrow(
+        "Sandbox creation failed",
+      );
+
+      // Verify run is marked as failed in DB
+      const [run] = await globalThis.services.db
+        .select()
+        .from(agentRuns)
+        .where(eq(agentRuns.status, "failed"))
+        .limit(1);
+
+      expect(run).toBeDefined();
+      expect(run!.error).toContain("Sandbox creation failed");
+      expect(run!.completedAt).toBeDefined();
+    });
+  });
+
+  describe("Callback Registration", () => {
+    it("should register callbacks when provided", async () => {
+      const callbacks = [
+        {
+          url: "https://example.com/callback",
+          secret: "test-secret-123",
+          payload: { channel: "C123", threadTs: "1234.5678" },
+        },
+      ];
+
+      const result = await createRun(baseParams({ callbacks }));
+
+      // Verify callback record in DB
+      const callbackRecords = await globalThis.services.db
+        .select()
+        .from(agentRunCallbacks)
+        .where(eq(agentRunCallbacks.runId, result.runId));
+
+      expect(callbackRecords).toHaveLength(1);
+      expect(callbackRecords[0]!.url).toBe("https://example.com/callback");
+      expect(callbackRecords[0]!.encryptedSecret).toBeDefined();
+      expect(callbackRecords[0]!.payload).toEqual({
+        channel: "C123",
+        threadTs: "1234.5678",
+      });
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { eq } from "drizzle-orm";
 import {
   testContext,
   uniqueId,
@@ -8,6 +7,9 @@ import {
 import {
   createTestCompose,
   insertStalePendingRun,
+  findTestRunRecord,
+  findTestRunCallbacks,
+  findTestRunByStatus,
 } from "../../../__tests__/api-test-helpers";
 import { addPermission } from "../../agent/permission-service";
 import { reloadEnv } from "../../../env";
@@ -16,8 +18,6 @@ import {
   type CreateRunParams,
   type CreateRunResult,
 } from "../run-service";
-import { agentRuns } from "../../../db/schema/agent-run";
-import { agentRunCallbacks } from "../../../db/schema/agent-run-callback";
 import { isConcurrentRunLimit, isForbidden, isBadRequest } from "../../errors";
 
 const context = testContext();
@@ -54,11 +54,7 @@ describe("createRun()", () => {
       expect(result.createdAt).toBeInstanceOf(Date);
 
       // Verify run record in DB
-      const [run] = await globalThis.services.db
-        .select()
-        .from(agentRuns)
-        .where(eq(agentRuns.id, result.runId))
-        .limit(1);
+      const run = await findTestRunRecord(result.runId);
 
       expect(run).toBeDefined();
       expect(run!.status).toBe("running");
@@ -70,11 +66,7 @@ describe("createRun()", () => {
     it("should always set lastHeartbeatAt", async () => {
       const result = await createRun(baseParams());
 
-      const [run] = await globalThis.services.db
-        .select()
-        .from(agentRuns)
-        .where(eq(agentRuns.id, result.runId))
-        .limit(1);
+      const run = await findTestRunRecord(result.runId);
 
       expect(run!.lastHeartbeatAt).not.toBeNull();
     });
@@ -83,11 +75,7 @@ describe("createRun()", () => {
       const vars = { MY_VAR: "value1", OTHER_VAR: "value2" };
       const result = await createRun(baseParams({ vars }));
 
-      const [run] = await globalThis.services.db
-        .select()
-        .from(agentRuns)
-        .where(eq(agentRuns.id, result.runId))
-        .limit(1);
+      const run = await findTestRunRecord(result.runId);
 
       expect(run!.vars).toEqual(vars);
     });
@@ -96,11 +84,7 @@ describe("createRun()", () => {
       const secrets = { API_KEY: "sk-123", DB_PASS: "pw" };
       const result = await createRun(baseParams({ secrets }));
 
-      const [run] = await globalThis.services.db
-        .select()
-        .from(agentRuns)
-        .where(eq(agentRuns.id, result.runId))
-        .limit(1);
+      const run = await findTestRunRecord(result.runId);
 
       expect(run!.secretNames).toEqual(["API_KEY", "DB_PASS"]);
     });
@@ -108,11 +92,7 @@ describe("createRun()", () => {
     it("should set null scheduleId when not provided", async () => {
       const result = await createRun(baseParams());
 
-      const [run] = await globalThis.services.db
-        .select()
-        .from(agentRuns)
-        .where(eq(agentRuns.id, result.runId))
-        .limit(1);
+      const run = await findTestRunRecord(result.runId);
 
       expect(run!.scheduleId).toBeNull();
     });
@@ -237,11 +217,7 @@ describe("createRun()", () => {
       );
 
       // Verify run is marked as failed in DB
-      const [run] = await globalThis.services.db
-        .select()
-        .from(agentRuns)
-        .where(eq(agentRuns.status, "failed"))
-        .limit(1);
+      const run = await findTestRunByStatus("failed");
 
       expect(run).toBeDefined();
       expect(run!.error).toContain("Sandbox creation failed");
@@ -262,10 +238,7 @@ describe("createRun()", () => {
       const result = await createRun(baseParams({ callbacks }));
 
       // Verify callback record in DB
-      const callbackRecords = await globalThis.services.db
-        .select()
-        .from(agentRunCallbacks)
-        .where(eq(agentRunCallbacks.runId, result.runId));
+      const callbackRecords = await findTestRunCallbacks(result.runId);
 
       expect(callbackRecords).toHaveLength(1);
       expect(callbackRecords[0]!.url).toBe("https://example.com/callback");

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -638,6 +638,8 @@ export interface BuildContextParams {
   vars?: Record<string, string>;
   secrets?: Record<string, string>;
   volumeVersions?: Record<string, string>;
+  // Pre-loaded compose content — skips DB lookup in new-run path if provided
+  agentCompose?: unknown;
   // Required
   prompt: string;
   runId: string;
@@ -869,9 +871,11 @@ export async function buildExecutionContext(
       `Resolution applied: artifact=${artifactName}@${artifactVersion}`,
     );
   }
-  // Step 3: New run - load agent compose version if agentComposeVersionId provided (no conversation)
+  // Step 3: New run - use pre-loaded compose or load from DB
   else if (agentComposeVersionId) {
-    agentCompose = await loadAgentComposeForNewRun(agentComposeVersionId);
+    agentCompose =
+      params.agentCompose ??
+      (await loadAgentComposeForNewRun(agentComposeVersionId));
 
     // For new runs, derive secretNames from provided secrets
     if (secrets) {

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -626,7 +626,7 @@ async function fetchAndMergeVariables(
 /**
  * Parameters for building execution context
  */
-export interface BuildContextParams {
+interface BuildContextParams {
   // Shortcuts (mutually exclusive)
   checkpointId?: string;
   sessionId?: string;

--- a/turbo/apps/web/src/lib/run/index.ts
+++ b/turbo/apps/web/src/lib/run/index.ts
@@ -4,9 +4,8 @@
  */
 
 export {
-  checkRunConcurrencyLimit,
   validateCheckpoint,
   validateAgentSession,
-  buildExecutionContext,
-  prepareAndDispatchRun,
+  createRun,
+  type RunDispatchError,
 } from "./run-service";

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -313,6 +313,155 @@ export interface CreateRunResult {
 }
 
 /**
+ * Load compose version and compose metadata, then verify access.
+ *
+ * @returns composeContent and compose record
+ * @throws NotFoundError - version or compose not found
+ * @throws ForbiddenError - user cannot access compose
+ */
+async function loadAndAuthorizeCompose(
+  userId: string,
+  agentComposeVersionId: string,
+  callerComposeId?: string,
+): Promise<{
+  composeContent: AgentComposeYaml;
+  compose: { id: string; userId: string; scopeId: string | null };
+}> {
+  const [version] = await globalThis.services.db
+    .select({
+      id: agentComposeVersions.id,
+      content: agentComposeVersions.content,
+      composeId: agentComposeVersions.composeId,
+    })
+    .from(agentComposeVersions)
+    .where(eq(agentComposeVersions.id, agentComposeVersionId))
+    .limit(1);
+
+  if (!version) {
+    throw notFound("Agent compose version not found");
+  }
+
+  const composeContent = version.content as AgentComposeYaml;
+
+  // Use caller-provided composeId when available to avoid content-addressed
+  // version collisions (version.composeId may point to a different user's compose)
+  const resolvedComposeId = callerComposeId ?? version.composeId;
+
+  const [compose] = await globalThis.services.db
+    .select({
+      id: agentComposes.id,
+      userId: agentComposes.userId,
+      scopeId: agentComposes.scopeId,
+    })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, resolvedComposeId))
+    .limit(1);
+
+  if (!compose) {
+    throw notFound("Agent compose not found");
+  }
+
+  const userEmail = await getUserEmail(userId);
+  const hasAccess = await canAccessCompose(userId, userEmail, compose);
+  if (!hasAccess) {
+    throw forbidden("You do not have permission to access this agent");
+  }
+
+  return { composeContent, compose };
+}
+
+/**
+ * Validate template vars availability and image access for new runs.
+ *
+ * Skipped when resuming from checkpoint or continuing a session.
+ *
+ * @throws BadRequestError - missing required template variables
+ */
+async function validateComposeRequirements(
+  userId: string,
+  composeContent: AgentComposeYaml,
+  vars?: Record<string, string>,
+): Promise<void> {
+  if (!composeContent?.agents) {
+    return;
+  }
+
+  const requiredVars = extractTemplateVars(composeContent);
+  if (requiredVars.length > 0) {
+    const scope = await getUserScopeByClerkId(userId);
+    const storedVars = scope ? await getVariableValues(scope.id) : {};
+    const allVars = { ...storedVars, ...vars };
+    const missingVars = requiredVars.filter(
+      (varName) => allVars[varName] === undefined,
+    );
+    if (missingVars.length > 0) {
+      throw badRequest(
+        `Missing required template variables: ${missingVars.join(", ")}`,
+      );
+    }
+  }
+
+  const agentKeys = Object.keys(composeContent.agents);
+  const firstAgentKey = agentKeys[0];
+  const agent = firstAgentKey
+    ? composeContent.agents[firstAgentKey]
+    : undefined;
+  if (agent?.image) {
+    await assertImageAccess(userId, agent.image);
+  }
+}
+
+/**
+ * Register run callbacks with encrypted secrets.
+ */
+async function registerCallbacks(
+  runId: string,
+  callbacks: Array<{ url: string; secret: string; payload: unknown }>,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  for (const callback of callbacks) {
+    const encryptedSecret = encryptCredentialValue(
+      callback.secret,
+      SECRETS_ENCRYPTION_KEY,
+    );
+    await globalThis.services.db.insert(agentRunCallbacks).values({
+      runId,
+      url: callback.url,
+      encryptedSecret,
+      payload: callback.payload,
+    });
+  }
+  log.debug(`Registered ${callbacks.length} callback(s) for run ${runId}`);
+}
+
+/**
+ * Mark a run as failed and attach run metadata to the error for callers.
+ */
+async function markRunFailed(
+  runId: string,
+  createdAt: Date,
+  error: unknown,
+): Promise<void> {
+  const errorMessage = error instanceof Error ? error.message : "Unknown error";
+  log.error(`Run ${runId} failed: ${errorMessage}`);
+
+  await globalThis.services.db
+    .update(agentRuns)
+    .set({
+      status: "failed",
+      error: errorMessage,
+      completedAt: new Date(),
+    })
+    .where(eq(agentRuns.id, runId));
+
+  // Attach run metadata so callers can return partial results
+  if (error instanceof Error) {
+    (error as RunDispatchError).runId = runId;
+    (error as RunDispatchError).createdAt = createdAt;
+  }
+}
+
+/**
  * Unified run creation pipeline
  *
  * Validates, creates, and dispatches a run in a single call.
@@ -344,75 +493,16 @@ export async function createRun(
   // Step 1: Check concurrent run limit
   await checkRunConcurrencyLimit(userId);
 
-  // Step 2: Load compose version content and compose metadata
-  const [version] = await globalThis.services.db
-    .select({
-      id: agentComposeVersions.id,
-      content: agentComposeVersions.content,
-      composeId: agentComposeVersions.composeId,
-    })
-    .from(agentComposeVersions)
-    .where(eq(agentComposeVersions.id, agentComposeVersionId))
-    .limit(1);
+  // Steps 2-3: Load compose version/metadata and verify access
+  const { composeContent } = await loadAndAuthorizeCompose(
+    userId,
+    agentComposeVersionId,
+    params.composeId,
+  );
 
-  if (!version) {
-    throw notFound("Agent compose version not found");
-  }
-
-  const composeContent = version.content as AgentComposeYaml;
-
-  // Use caller-provided composeId when available to avoid content-addressed
-  // version collisions (version.composeId may point to a different user's compose)
-  const resolvedComposeId = params.composeId ?? version.composeId;
-
-  const [compose] = await globalThis.services.db
-    .select({
-      id: agentComposes.id,
-      userId: agentComposes.userId,
-      scopeId: agentComposes.scopeId,
-    })
-    .from(agentComposes)
-    .where(eq(agentComposes.id, resolvedComposeId))
-    .limit(1);
-
-  if (!compose) {
-    throw notFound("Agent compose not found");
-  }
-
-  // Step 3: Permission check
-  const userEmail = await getUserEmail(userId);
-  const hasAccess = await canAccessCompose(userId, userEmail, compose);
-  if (!hasAccess) {
-    throw forbidden("You do not have permission to access this agent");
-  }
-
-  // Step 4: Validate template vars and image access (for new runs with compose content)
-  if (composeContent?.agents && !params.checkpointId && !params.sessionId) {
-    const requiredVars = extractTemplateVars(composeContent);
-    if (requiredVars.length > 0) {
-      // Fetch stored vars and merge with provided vars
-      const scope = await getUserScopeByClerkId(userId);
-      const storedVars = scope ? await getVariableValues(scope.id) : {};
-      const allVars = { ...storedVars, ...(params.vars ?? {}) };
-      const missingVars = requiredVars.filter(
-        (varName) => allVars[varName] === undefined,
-      );
-      if (missingVars.length > 0) {
-        throw badRequest(
-          `Missing required template variables: ${missingVars.join(", ")}`,
-        );
-      }
-    }
-
-    // Image access check
-    const agentKeys = Object.keys(composeContent.agents);
-    const firstAgentKey = agentKeys[0];
-    const agent = firstAgentKey
-      ? composeContent.agents[firstAgentKey]
-      : undefined;
-    if (agent?.image) {
-      await assertImageAccess(userId, agent.image);
-    }
+  // Step 4: Validate template vars and image access (for new runs only)
+  if (!params.checkpointId && !params.sessionId) {
+    await validateComposeRequirements(userId, composeContent, params.vars);
   }
 
   // Step 5: Validate mutual exclusivity
@@ -448,22 +538,7 @@ export async function createRun(
   try {
     // Step 7: Register callbacks (if any)
     if (params.callbacks && params.callbacks.length > 0) {
-      const { SECRETS_ENCRYPTION_KEY } = env();
-      for (const callback of params.callbacks) {
-        const encryptedSecret = encryptCredentialValue(
-          callback.secret,
-          SECRETS_ENCRYPTION_KEY,
-        );
-        await globalThis.services.db.insert(agentRunCallbacks).values({
-          runId: run.id,
-          url: callback.url,
-          encryptedSecret,
-          payload: callback.payload,
-        });
-      }
-      log.debug(
-        `Registered ${params.callbacks.length} callback(s) for run ${run.id}`,
-      );
+      await registerCallbacks(run.id, params.callbacks);
     }
 
     // Step 8: Generate sandbox token
@@ -506,26 +581,7 @@ export async function createRun(
       createdAt: run.createdAt,
     };
   } catch (error) {
-    // Mark run as failed on any post-INSERT error
-    const errorMessage =
-      error instanceof Error ? error.message : "Unknown error";
-    log.error(`Run ${run.id} failed: ${errorMessage}`);
-
-    await globalThis.services.db
-      .update(agentRuns)
-      .set({
-        status: "failed",
-        error: errorMessage,
-        completedAt: new Date(),
-      })
-      .where(eq(agentRuns.id, run.id));
-
-    // Attach run metadata so callers can return partial results
-    if (error instanceof Error) {
-      (error as RunDispatchError).runId = run.id;
-      (error as RunDispatchError).createdAt = run.createdAt;
-    }
-
+    await markRunFailed(run.id, run.createdAt, error);
     throw error;
   }
 }

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -24,10 +24,7 @@ import { executeE2bRun } from "./executors/e2b-executor";
 import { executeRunnerJob } from "./executors/runner-executor";
 import { executeDockerRun } from "./executors/docker-executor";
 import type { ExecutorResult, PreparedContext } from "./executors/types";
-import {
-  buildExecutionContext as buildContext,
-  type BuildContextParams,
-} from "./build-context";
+import { buildExecutionContext as buildContext } from "./build-context";
 import { generateSandboxToken } from "../auth/sandbox-token";
 import { canAccessCompose } from "../agent/permission-service";
 import { getUserEmail } from "../auth/get-user-email";
@@ -54,7 +51,7 @@ export { calculateSessionHistoryPath } from "./utils/session-history-path";
  * @param limit Maximum allowed concurrent runs (default: 1, or CONCURRENT_RUN_LIMIT env var, 0 = no limit)
  * @throws ConcurrentRunLimitError if limit exceeded
  */
-export async function checkRunConcurrencyLimit(
+async function checkRunConcurrencyLimit(
   userId: string,
   limit?: number,
 ): Promise<void> {
@@ -218,19 +215,6 @@ export async function validateAgentSession(
 }
 
 /**
- * Build unified execution context from various parameter sources
- * Supports: new run, checkpoint resume, session continue
- *
- * @param params Unified run parameters
- * @returns Execution context for executors
- */
-export async function buildExecutionContext(
-  params: BuildContextParams,
-): Promise<ExecutionContext> {
-  return buildContext(params);
-}
-
-/**
  * Prepare execution context and dispatch to appropriate executor
  *
  * This is the unified entry point that handles both E2B and runner paths:
@@ -240,7 +224,7 @@ export async function buildExecutionContext(
  * @param context ExecutionContext built by buildExecutionContext()
  * @returns ExecutorResult with status and optional sandboxId
  */
-export async function prepareAndDispatchRun(
+async function prepareAndDispatchRun(
   context: ExecutionContext,
 ): Promise<ExecutorResult> {
   log.debug(`Preparing and dispatching run ${context.runId}...`);
@@ -279,11 +263,28 @@ async function dispatchRun(context: PreparedContext): Promise<ExecutorResult> {
 // Unified Run Creation
 // ============================================================================
 
+/**
+ * Extended error type for dispatch failures that includes run metadata.
+ * When createRun() fails after the run record is created (post-INSERT),
+ * the error is augmented with runId and createdAt so callers can
+ * return partial results if needed.
+ */
+export interface RunDispatchError extends Error {
+  runId?: string;
+  createdAt?: Date;
+}
+
 export interface CreateRunParams {
   // Required — every caller must provide
   userId: string;
   agentComposeVersionId: string;
   prompt: string;
+
+  // Optional — caller-resolved compose ID
+  // When provided, createRun() uses this to load the compose instead of
+  // resolving via version.composeId. This avoids content-addressed version
+  // collisions where version.composeId may point to a different user's compose.
+  composeId?: string;
 
   // Optional — caller-specific
   sessionId?: string;
@@ -360,6 +361,10 @@ export async function createRun(
 
   const composeContent = version.content as AgentComposeYaml;
 
+  // Use caller-provided composeId when available to avoid content-addressed
+  // version collisions (version.composeId may point to a different user's compose)
+  const resolvedComposeId = params.composeId ?? version.composeId;
+
   const [compose] = await globalThis.services.db
     .select({
       id: agentComposes.id,
@@ -367,7 +372,7 @@ export async function createRun(
       scopeId: agentComposes.scopeId,
     })
     .from(agentComposes)
-    .where(eq(agentComposes.id, version.composeId))
+    .where(eq(agentComposes.id, resolvedComposeId))
     .limit(1);
 
   if (!compose) {
@@ -514,6 +519,12 @@ export async function createRun(
         completedAt: new Date(),
       })
       .where(eq(agentRuns.id, run.id));
+
+    // Attach run metadata so callers can return partial results
+    if (error instanceof Error) {
+      (error as RunDispatchError).runId = run.id;
+      (error as RunDispatchError).createdAt = run.createdAt;
+    }
 
     throw error;
   }

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -3,14 +3,21 @@ import { env, isSelfHosted } from "../../env";
 import { checkpoints } from "../../db/schema/checkpoint";
 import { agentRuns } from "../../db/schema/agent-run";
 import {
+  agentComposeVersions,
+  agentComposes,
+} from "../../db/schema/agent-compose";
+import { agentRunCallbacks } from "../../db/schema/agent-run-callback";
+import {
   notFound,
   unauthorized,
   badRequest,
+  forbidden,
   concurrentRunLimit,
 } from "../errors";
 import { logger } from "../logger";
 import type { ExecutionContext } from "./types";
 import type { AgentComposeSnapshot } from "../checkpoint/types";
+import type { AgentComposeYaml } from "../../types/agent-compose";
 import { getAgentSessionWithConversation } from "../agent-session";
 import { prepareForExecution } from "./context/execution-preparer";
 import { executeE2bRun } from "./executors/e2b-executor";
@@ -21,6 +28,14 @@ import {
   buildExecutionContext as buildContext,
   type BuildContextParams,
 } from "./build-context";
+import { generateSandboxToken } from "../auth/sandbox-token";
+import { canAccessCompose } from "../agent/permission-service";
+import { getUserEmail } from "../auth/get-user-email";
+import { extractTemplateVars } from "../config-validator";
+import { assertImageAccess } from "../image/image-service";
+import { getUserScopeByClerkId } from "../scope/scope-service";
+import { getVariableValues } from "../variable/variable-service";
+import { encryptCredentialValue } from "../crypto/secrets-encryption";
 
 const log = logger("service:run");
 
@@ -257,5 +272,249 @@ async function dispatchRun(context: PreparedContext): Promise<ExecutorResult> {
   } else {
     log.debug(`Dispatching run ${context.runId} to E2B executor`);
     return await executeE2bRun(context);
+  }
+}
+
+// ============================================================================
+// Unified Run Creation
+// ============================================================================
+
+export interface CreateRunParams {
+  // Required — every caller must provide
+  userId: string;
+  agentComposeVersionId: string;
+  prompt: string;
+
+  // Optional — caller-specific
+  sessionId?: string;
+  checkpointId?: string;
+  conversationId?: string;
+  vars?: Record<string, string>;
+  secrets?: Record<string, string>;
+  artifactName?: string;
+  artifactVersion?: string;
+  volumeVersions?: Record<string, string>;
+  scheduleId?: string;
+  callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
+  resumedFromCheckpointId?: string;
+  agentName?: string;
+  modelProvider?: string;
+  debugNoMockClaude?: boolean;
+  checkEnv?: boolean;
+  apiStartTime?: number;
+}
+
+export interface CreateRunResult {
+  runId: string;
+  status: string;
+  sandboxId?: string;
+  createdAt: Date;
+}
+
+/**
+ * Unified run creation pipeline
+ *
+ * Validates, creates, and dispatches a run in a single call.
+ * All callers (API Route, Public API, Schedule, Slack) should use this.
+ *
+ * Pipeline:
+ * 1. Check concurrent run limit
+ * 2. Load compose version content + compose metadata
+ * 3. Permission check (canAccessCompose)
+ * 4. Validate template vars and image access
+ * 5. Validate mutual exclusivity (checkpointId vs sessionId)
+ * 6. INSERT agentRuns
+ * 7. Register callbacks (if any)
+ * 8. Generate sandbox token
+ * 9. Build execution context
+ * 10. Dispatch to executor
+ *
+ * @throws ConcurrentRunLimitError - concurrent run limit reached
+ * @throws ForbiddenError - user cannot access compose
+ * @throws BadRequestError - validation failure (missing vars, mutual exclusivity)
+ * @throws NotFoundError - compose version not found
+ * @throws Error - dispatch failure (run already marked as "failed")
+ */
+export async function createRun(
+  params: CreateRunParams,
+): Promise<CreateRunResult> {
+  const { userId, agentComposeVersionId, prompt } = params;
+
+  // Step 1: Check concurrent run limit
+  await checkRunConcurrencyLimit(userId);
+
+  // Step 2: Load compose version content and compose metadata
+  const [version] = await globalThis.services.db
+    .select({
+      id: agentComposeVersions.id,
+      content: agentComposeVersions.content,
+      composeId: agentComposeVersions.composeId,
+    })
+    .from(agentComposeVersions)
+    .where(eq(agentComposeVersions.id, agentComposeVersionId))
+    .limit(1);
+
+  if (!version) {
+    throw notFound("Agent compose version not found");
+  }
+
+  const composeContent = version.content as AgentComposeYaml;
+
+  const [compose] = await globalThis.services.db
+    .select({
+      id: agentComposes.id,
+      userId: agentComposes.userId,
+      scopeId: agentComposes.scopeId,
+    })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, version.composeId))
+    .limit(1);
+
+  if (!compose) {
+    throw notFound("Agent compose not found");
+  }
+
+  // Step 3: Permission check
+  const userEmail = await getUserEmail(userId);
+  const hasAccess = await canAccessCompose(userId, userEmail, compose);
+  if (!hasAccess) {
+    throw forbidden("You do not have permission to access this agent");
+  }
+
+  // Step 4: Validate template vars and image access (for new runs with compose content)
+  if (composeContent?.agents && !params.checkpointId && !params.sessionId) {
+    const requiredVars = extractTemplateVars(composeContent);
+    if (requiredVars.length > 0) {
+      // Fetch stored vars and merge with provided vars
+      const scope = await getUserScopeByClerkId(userId);
+      const storedVars = scope ? await getVariableValues(scope.id) : {};
+      const allVars = { ...storedVars, ...(params.vars ?? {}) };
+      const missingVars = requiredVars.filter(
+        (varName) => allVars[varName] === undefined,
+      );
+      if (missingVars.length > 0) {
+        throw badRequest(
+          `Missing required template variables: ${missingVars.join(", ")}`,
+        );
+      }
+    }
+
+    // Image access check
+    const agentKeys = Object.keys(composeContent.agents);
+    const firstAgentKey = agentKeys[0];
+    const agent = firstAgentKey
+      ? composeContent.agents[firstAgentKey]
+      : undefined;
+    if (agent?.image) {
+      await assertImageAccess(userId, agent.image);
+    }
+  }
+
+  // Step 5: Validate mutual exclusivity
+  if (params.checkpointId && params.sessionId) {
+    throw badRequest(
+      "Cannot specify both checkpointId and sessionId. Use checkpointId to resume from a checkpoint, or sessionId to continue a session.",
+    );
+  }
+
+  // Step 6: INSERT agentRuns
+  const [run] = await globalThis.services.db
+    .insert(agentRuns)
+    .values({
+      userId,
+      agentComposeVersionId,
+      status: "pending",
+      prompt,
+      vars: params.vars ?? null,
+      secretNames: params.secrets ? Object.keys(params.secrets) : null,
+      resumedFromCheckpointId: params.resumedFromCheckpointId ?? null,
+      scheduleId: params.scheduleId ?? null,
+      lastHeartbeatAt: new Date(),
+    })
+    .returning();
+
+  if (!run) {
+    throw new Error("Failed to create run record");
+  }
+
+  log.debug(`Created run ${run.id} for user ${userId}`);
+
+  // From this point on, errors must mark the run as "failed"
+  try {
+    // Step 7: Register callbacks (if any)
+    if (params.callbacks && params.callbacks.length > 0) {
+      const { SECRETS_ENCRYPTION_KEY } = env();
+      for (const callback of params.callbacks) {
+        const encryptedSecret = encryptCredentialValue(
+          callback.secret,
+          SECRETS_ENCRYPTION_KEY,
+        );
+        await globalThis.services.db.insert(agentRunCallbacks).values({
+          runId: run.id,
+          url: callback.url,
+          encryptedSecret,
+          payload: callback.payload,
+        });
+      }
+      log.debug(
+        `Registered ${params.callbacks.length} callback(s) for run ${run.id}`,
+      );
+    }
+
+    // Step 8: Generate sandbox token
+    const sandboxToken = await generateSandboxToken(userId, run.id);
+
+    // Step 9: Build execution context (pass pre-loaded compose to avoid double fetch)
+    const context = await buildContext({
+      checkpointId: params.checkpointId,
+      sessionId: params.sessionId,
+      conversationId: params.conversationId,
+      agentComposeVersionId,
+      artifactName: params.artifactName,
+      artifactVersion: params.artifactVersion,
+      vars: params.vars,
+      secrets: params.secrets,
+      volumeVersions: params.volumeVersions,
+      agentCompose: composeContent,
+      prompt,
+      runId: run.id,
+      sandboxToken,
+      userId,
+      agentName: params.agentName,
+      resumedFromCheckpointId: params.resumedFromCheckpointId,
+      continuedFromSessionId: params.sessionId,
+      debugNoMockClaude: params.debugNoMockClaude,
+      modelProvider: params.modelProvider,
+      checkEnv: params.checkEnv,
+      apiStartTime: params.apiStartTime,
+    });
+
+    // Step 10: Dispatch to executor
+    const result = await prepareAndDispatchRun(context);
+
+    log.debug(`Run ${run.id} dispatched with status: ${result.status}`);
+
+    return {
+      runId: run.id,
+      status: result.status,
+      sandboxId: result.sandboxId,
+      createdAt: run.createdAt,
+    };
+  } catch (error) {
+    // Mark run as failed on any post-INSERT error
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    log.error(`Run ${run.id} failed: ${errorMessage}`);
+
+    await globalThis.services.db
+      .update(agentRuns)
+      .set({
+        status: "failed",
+        error: errorMessage,
+        completedAt: new Date(),
+      })
+      .where(eq(agentRuns.id, run.id));
+
+    throw error;
   }
 }

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -17,12 +17,7 @@ import {
   type ConcurrentRunLimitError,
 } from "../errors";
 import { logger } from "../logger";
-import {
-  checkRunConcurrencyLimit,
-  buildExecutionContext,
-  prepareAndDispatchRun,
-} from "../run/run-service";
-import { generateSandboxToken } from "../auth/sandbox-token";
+import { createRun } from "../run/run-service";
 import { getUserScopeByClerkId } from "../scope/scope-service";
 import { getSecretValues } from "../secret/secret-service";
 import { getVariableValues } from "../variable/variable-service";
@@ -878,9 +873,21 @@ async function executeSchedule(
     return;
   }
 
-  // Check concurrent run limit before creating run
+  // Delegate run creation, validation, and dispatch to createRun()
+  let runId: string;
   try {
-    await checkRunConcurrencyLimit(compose.userId);
+    const result = await createRun({
+      userId: compose.userId,
+      agentComposeVersionId: compose.headVersionId,
+      prompt: schedule.prompt,
+      composeId: compose.id,
+      scheduleId: schedule.id,
+      artifactName: schedule.artifactName ?? undefined,
+      artifactVersion: schedule.artifactVersion ?? undefined,
+      volumeVersions: schedule.volumeVersions ?? undefined,
+      agentName: compose.name,
+    });
+    runId = result.runId;
   } catch (error) {
     if (isConcurrentRunLimit(error)) {
       log.debug(`Schedule ${schedule.name} blocked by concurrent run limit`);
@@ -895,78 +902,9 @@ async function executeSchedule(
         return; // Retry scheduled, don't continue
       }
       // Retry window expired, re-throw to advance to next occurrence
-      throw error;
     }
-    throw error;
-  }
 
-  // Note: vars and secrets are no longer stored in schedule table
-  // They are fetched from platform tables by buildExecutionContext
-
-  // Create run record first
-  const [run] = await globalThis.services.db
-    .insert(agentRuns)
-    .values({
-      userId: compose.userId,
-      agentComposeVersionId: compose.headVersionId,
-      scheduleId: schedule.id,
-      status: "pending",
-      prompt: schedule.prompt,
-      vars: null, // Vars come from platform tables
-      secretNames: null, // Secret names come from platform tables
-      createdAt: new Date(Date.now()),
-    })
-    .returning();
-
-  if (!run) {
-    log.error(`Failed to create run for schedule ${schedule.name}`);
-    return;
-  }
-
-  // Update lastRunId immediately to prevent duplicate runs
-  // This ensures skip-if-active check works even if subsequent steps fail
-  await globalThis.services.db
-    .update(agentSchedules)
-    .set({ lastRunId: run.id })
-    .where(eq(agentSchedules.id, schedule.id));
-
-  try {
-    // Generate sandbox token with the run ID
-    const sandboxToken = await generateSandboxToken(compose.userId, run.id);
-
-    // Build execution context and dispatch
-    // Note: vars and secrets are fetched from platform tables by buildExecutionContext
-    const context = await buildExecutionContext({
-      runId: run.id,
-      agentComposeVersionId: compose.headVersionId,
-      prompt: schedule.prompt,
-      sandboxToken,
-      userId: compose.userId,
-      // vars: undefined - fetched from platform tables by buildExecutionContext
-      // secrets: undefined - fetched from platform tables by buildExecutionContext
-      artifactName: schedule.artifactName ?? undefined,
-      artifactVersion: schedule.artifactVersion ?? undefined,
-      volumeVersions: schedule.volumeVersions ?? undefined,
-      agentName: compose.name,
-    });
-
-    await prepareAndDispatchRun(context);
-  } catch (error) {
-    // Mark run as failed with error message
-    const errorMessage =
-      error instanceof Error ? error.message : "Unknown error";
-    log.error(`Run ${run.id} failed during preparation: ${errorMessage}`);
-
-    await globalThis.services.db
-      .update(agentRuns)
-      .set({
-        status: "failed",
-        completedAt: new Date(Date.now()),
-        error: errorMessage,
-      })
-      .where(eq(agentRuns.id, run.id));
-
-    // Update schedule state (disable one-time, advance cron)
+    // Non-concurrency failure: update schedule state (disable one-time, advance cron)
     if (schedule.cronExpression) {
       const nextRunAt = calculateNextRun(
         schedule.cronExpression,
@@ -977,21 +915,20 @@ async function executeSchedule(
         .set({
           lastRunAt: new Date(Date.now()),
           nextRunAt,
-          retryStartedAt: null, // Clear retry state on non-concurrency failure
+          retryStartedAt: null,
         })
         .where(eq(agentSchedules.id, schedule.id));
       log.debug(
         `Cron schedule ${schedule.name} failed, next run at ${nextRunAt?.toISOString()}`,
       );
     } else {
-      // One-time schedule: disable after failed execution (non-concurrency errors)
       await globalThis.services.db
         .update(agentSchedules)
         .set({
           enabled: false,
           lastRunAt: new Date(Date.now()),
           nextRunAt: null,
-          retryStartedAt: null, // Clear retry state
+          retryStartedAt: null,
         })
         .where(eq(agentSchedules.id, schedule.id));
       log.debug(`One-time schedule ${schedule.name} failed and disabled`);
@@ -999,6 +936,12 @@ async function executeSchedule(
 
     throw error; // Re-throw so executeDueSchedules counts it as skipped
   }
+
+  // Update lastRunId after successful creation
+  await globalThis.services.db
+    .update(agentSchedules)
+    .set({ lastRunId: runId })
+    .where(eq(agentSchedules.id, schedule.id));
 
   // Calculate next run time for success path
   let nextRunAt: Date | null = null;
@@ -1012,20 +955,20 @@ async function executeSchedule(
         enabled: false,
         lastRunAt: new Date(Date.now()),
         nextRunAt: null,
-        retryStartedAt: null, // Clear retry state
+        retryStartedAt: null,
       })
       .where(eq(agentSchedules.id, schedule.id));
     log.debug(`One-time schedule ${schedule.name} executed and disabled`);
     return;
   }
 
-  // Update schedule with next run time (lastRunId already set above)
+  // Update schedule with next run time
   await globalThis.services.db
     .update(agentSchedules)
     .set({
       lastRunAt: new Date(Date.now()),
       nextRunAt,
-      retryStartedAt: null, // Clear retry state on success
+      retryStartedAt: null,
     })
     .where(eq(agentSchedules.id, schedule.id));
 

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -901,10 +901,10 @@ async function executeSchedule(
       if (retryScheduled) {
         return; // Retry scheduled, don't continue
       }
-      // Retry window expired, re-throw to advance to next occurrence
+      // Retry window expired — fall through to advance schedule to next occurrence
     }
 
-    // Non-concurrency failure: update schedule state (disable one-time, advance cron)
+    // Any failure (concurrency-expired or other): update schedule state (disable one-time, advance cron)
     if (schedule.cronExpression) {
       const nextRunAt = calculateNextRun(
         schedule.cronExpression,


### PR DESCRIPTION
## Summary

- Unify agent run creation across all 4 entry points (API Route, Public API, Schedule, Slack) into a single `createRun()` function in `run-service.ts`
- Add `composeId` parameter to `CreateRunParams` to prevent content-addressed version ID collisions where `version.composeId` may resolve to a different user's compose
- Extract helper functions in route handlers to reduce cyclomatic complexity and improve readability

## Changes

### Core (`run-service.ts`)
- Add `composeId` optional parameter — callers pass the already-resolved compose ID so `createRun()` uses it instead of resolving via `version.composeId`
- Make internal functions (`checkRunConcurrencyLimit`, `prepareAndDispatchRun`) non-exported since they're only used within `createRun()`
- Remove redundant `buildExecutionContext` wrapper and unused `BuildContextParams` export
- Clean up barrel exports in `index.ts`

### API Route (`app/api/agent/runs/route.ts`)
- Extract `resolveComposeVersion()`, `resolveNewRun()`, `resolveCheckpointResume()`, `resolveSessionContinue()` for compose resolution
- Extract `handleCreateRunError()` for error translation
- Pass `composeId` to `createRun()`

### Public API (`app/v1/runs/route.ts`)
- Extract `resolveAgent()`, `resolveFromSession()`, `resolveFromAgentId()`, `resolveFromAgentName()` for agent resolution
- Extract `handlePublicApiError()` for error translation
- Use `PublicApiErrorType` from `@vm0/core` for type-safe error responses
- Pass `composeId` to `createRun()`

### Schedule (`schedule-service.ts`)
- Pass `composeId` to `createRun()` — eliminates duplicated orchestration logic

### Slack (`run-agent.ts`)
- Pass `composeId` to `createRun()` — eliminates duplicated orchestration logic

## Net result
- **-140 lines** (944 added, 1084 removed)
- All 192 related tests pass
- Lint errors unchanged from main (8 pre-existing)
- No new type errors
- Knip clean

Closes #2892

## Test plan

- [x] All 49 API Route tests pass
- [x] All 24 Public API v1 tests pass
- [x] All 15 create-run unit tests pass
- [x] All 104 other related test suites pass (cancel, events, telemetry, etc.)
- [x] Type check passes (no new errors)
- [x] Lint check matches main branch (8 pre-existing errors)
- [x] Knip clean (no unused exports)
- [x] Format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)