### PR TITLE
feat(ably-subscriber): add dropped message counter for backpressure observability

### DIFF
--- a/crates/ably-subscriber/src/subscribe.rs
+++ b/crates/ably-subscriber/src/subscribe.rs
@@ -107,6 +107,7 @@ pub async fn subscribe(config: SubscribeConfig) -> Result<Subscription, Error> {
             http,
             get_token: config.get_token,
             token_renewal_failures: 0,
+            dropped_messages: 0,
         },
         close_rx,
     ));


### PR DESCRIPTION
## Summary

- Add `dropped_messages` counter to `EventLoopState`
- Include `total_dropped` in the warning log when event channel is full
- Provides visibility into cumulative message loss under backpressure

Closes #2909

🤖 Generated with [Claude Code](https://claude.com/claude-code)