### PR TITLE
feat(runner): add build command combining rootfs + snapshot

### DIFF
--- a/crates/runner/src/build.rs
+++ b/crates/runner/src/build.rs
@@ -1,0 +1,27 @@
+use clap::Args;
+
+use crate::error::RunnerResult;
+use crate::rootfs::RootfsArgs;
+use crate::snapshot::SnapshotArgs;
+
+#[derive(Args)]
+pub struct BuildArgs {
+    #[command(flatten)]
+    rootfs: RootfsArgs,
+    /// Number of vCPUs for the snapshot VM.
+    #[arg(long, default_value_t = 2)]
+    vcpu: u32,
+    /// Memory size in MiB for the snapshot VM.
+    #[arg(long, default_value_t = 2048)]
+    memory_mb: u32,
+}
+
+pub async fn run_build(args: BuildArgs) -> RunnerResult<()> {
+    let rootfs_hash = crate::rootfs::run_rootfs(args.rootfs).await?;
+    let snapshot_args = SnapshotArgs {
+        rootfs_hash,
+        vcpu: args.vcpu,
+        memory_mb: args.memory_mb,
+    };
+    crate::snapshot::run_snapshot(snapshot_args).await
+}

--- a/crates/runner/src/build.rs
+++ b/crates/runner/src/build.rs
@@ -2,17 +2,17 @@ use clap::Args;
 
 use crate::error::RunnerResult;
 use crate::rootfs::RootfsArgs;
-use crate::snapshot::SnapshotArgs;
+use crate::snapshot::{DEFAULT_MEMORY_MB, DEFAULT_VCPU, SnapshotArgs};
 
 #[derive(Args)]
 pub struct BuildArgs {
     #[command(flatten)]
     rootfs: RootfsArgs,
     /// Number of vCPUs for the snapshot VM.
-    #[arg(long, default_value_t = 2)]
+    #[arg(long, default_value_t = DEFAULT_VCPU)]
     vcpu: u32,
     /// Memory size in MiB for the snapshot VM.
-    #[arg(long, default_value_t = 2048)]
+    #[arg(long, default_value_t = DEFAULT_MEMORY_MB)]
     memory_mb: u32,
 }
 

--- a/crates/runner/src/setup.rs
+++ b/crates/runner/src/setup.rs
@@ -54,7 +54,7 @@ fn check_architecture() -> RunnerResult<&'static str> {
 fn check_system_dependencies() -> Vec<&'static str> {
     // Required by `runner start` (sandbox networking)
     let required = ["ip", "iptables", "iptables-save", "sysctl"];
-    // Only needed by specific commands (build-rootfs, etc.)
+    // Only needed by specific commands (rootfs, build, etc.)
     let optional = ["pgrep", "mkfs.ext4", "mksquashfs", "docker"];
 
     let missing_required: Vec<&str> = required

--- a/crates/runner/src/snapshot.rs
+++ b/crates/runner/src/snapshot.rs
@@ -7,16 +7,19 @@ use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::{HomePaths, RootfsPaths};
 
+pub const DEFAULT_VCPU: u32 = 2;
+pub const DEFAULT_MEMORY_MB: u32 = 2048;
+
 #[derive(Args, Clone)]
 pub struct SnapshotArgs {
     /// SHA-256 hash of the rootfs inputs (output of `rootfs`).
     #[arg(long)]
     pub rootfs_hash: String,
     /// Number of vCPUs for the snapshot VM.
-    #[arg(long, default_value_t = 2)]
+    #[arg(long, default_value_t = DEFAULT_VCPU)]
     pub vcpu: u32,
     /// Memory size in MiB for the snapshot VM.
-    #[arg(long, default_value_t = 2048)]
+    #[arg(long, default_value_t = DEFAULT_MEMORY_MB)]
     pub memory_mb: u32,
 }
 

--- a/crates/runner/src/snapshot.rs
+++ b/crates/runner/src/snapshot.rs
@@ -9,7 +9,7 @@ use crate::paths::{HomePaths, RootfsPaths};
 
 #[derive(Args, Clone)]
 pub struct SnapshotArgs {
-    /// SHA-256 hash of the rootfs inputs (output of `build-rootfs`).
+    /// SHA-256 hash of the rootfs inputs (output of `rootfs`).
     #[arg(long)]
     pub rootfs_hash: String,
     /// Number of vCPUs for the snapshot VM.
@@ -49,7 +49,7 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<()> {
         .map_err(|e| RunnerError::Internal(format!("check rootfs: {e}")))?;
     if !rootfs_exists {
         return Err(RunnerError::Config(format!(
-            "rootfs not found at {}; run `build-rootfs` first",
+            "rootfs not found at {}; run `build` or `rootfs` first",
             rootfs_path.display()
         )));
     }
@@ -91,7 +91,7 @@ async fn is_snapshot_complete(output: &SnapshotOutputPaths) -> RunnerResult<bool
 ///
 /// Inputs:
 ///   - `sandbox_fc::config_hash()` — boot args, guest network config
-///   - `rootfs_hash` — rootfs content (from `build-rootfs`)
+///   - `rootfs_hash` — rootfs content (from `rootfs`)
 ///   - `FIRECRACKER_VERSION` / `KERNEL_VERSION` — binary versions
 ///   - `vcpu` / `memory_mb` — VM resource settings
 ///

--- a/crates/runner/src/snapshot.rs
+++ b/crates/runner/src/snapshot.rs
@@ -11,13 +11,13 @@ use crate::paths::{HomePaths, RootfsPaths};
 pub struct SnapshotArgs {
     /// SHA-256 hash of the rootfs inputs (output of `build-rootfs`).
     #[arg(long)]
-    rootfs_hash: String,
+    pub rootfs_hash: String,
     /// Number of vCPUs for the snapshot VM.
     #[arg(long, default_value_t = 2)]
-    vcpu: u32,
+    pub vcpu: u32,
     /// Memory size in MiB for the snapshot VM.
     #[arg(long, default_value_t = 2048)]
-    memory_mb: u32,
+    pub memory_mb: u32,
 }
 
 pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<()> {


### PR DESCRIPTION
## Summary
- Add `runner build` command that runs rootfs build + snapshot creation in one step, automatically passing the rootfs hash between stages
- Rename `build-rootfs` subcommand to `rootfs` for consistency
- CLI workflow: `setup` → `build` → `start` (with `rootfs` and `snapshot` as lower-level primitives)

## Test plan
- [ ] `cargo clippy -p runner` passes
- [ ] `runner build --guest-init ... --guest-agent ... --vcpu 2 --memory-mb 2048` runs rootfs + snapshot sequentially
- [ ] `runner rootfs` still works standalone
- [ ] `runner snapshot --rootfs-hash <hash>` still works standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)