### PR TITLE
fix(platform): show workspace agent in slack settings when not owned by user

### DIFF
--- a/turbo/apps/platform/src/signals/integrations-page/slack-integration.ts
+++ b/turbo/apps/platform/src/signals/integrations-page/slack-integration.ts
@@ -115,7 +115,9 @@ export const updateSlackDefaultAgent$ = command(
   async ({ get, set }, agentName: string) => {
     // Optimistically update agent name so the UI doesn't flash a loading state
     set(slackIntegrationState$, (prev) => {
-      if (!prev.data) return prev;
+      if (!prev.data) {
+        return prev;
+      }
       return {
         ...prev,
         data: {

--- a/turbo/apps/platform/src/signals/integrations-page/slack-integration.ts
+++ b/turbo/apps/platform/src/signals/integrations-page/slack-integration.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { fetch$ } from "../fetch.ts";
 import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
@@ -112,6 +113,20 @@ export const closeSlackDisconnectDialog$ = command(({ set }) => {
 
 export const updateSlackDefaultAgent$ = command(
   async ({ get, set }, agentName: string) => {
+    // Optimistically update agent name so the UI doesn't flash a loading state
+    set(slackIntegrationState$, (prev) => {
+      if (!prev.data) return prev;
+      return {
+        ...prev,
+        data: {
+          ...prev.data,
+          agent: prev.data.agent
+            ? { ...prev.data.agent, name: agentName }
+            : { id: "", name: agentName },
+        },
+      };
+    });
+
     const fetchFn = get(fetch$);
     const response = await fetchFn("/api/integrations/slack", {
       method: "PATCH",
@@ -120,11 +135,28 @@ export const updateSlackDefaultAgent$ = command(
     });
 
     if (!response.ok) {
-      throw new Error("Failed to update default agent");
+      toast.error("Failed to update default agent");
+      // Re-fetch to revert optimistic update
+      await set(fetchSlackIntegration$);
+      return;
     }
 
-    // Re-fetch to get updated agent info and environment status
-    await set(fetchSlackIntegration$);
+    toast.success(`Default agent updated to ${agentName}`);
+
+    // Silently refresh to pick up updated environment status without loading spinner
+    try {
+      const refreshResponse = await fetchFn("/api/integrations/slack");
+      if (refreshResponse.ok) {
+        const data = (await refreshResponse.json()) as SlackIntegrationData;
+        set(slackIntegrationState$, (prev) => ({
+          ...prev,
+          data,
+        }));
+      }
+    } catch (error) {
+      throwIfAbort(error);
+      L.error("Failed to refresh after agent update:", error);
+    }
   },
 );
 

--- a/turbo/apps/platform/src/views/integrations-page/__tests__/slack-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/__tests__/slack-settings-page.test.tsx
@@ -129,6 +129,40 @@ describe("slack settings page", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows workspace agent even when not in user's agents list", async () => {
+    server.use(
+      http.get("/api/integrations/slack", () => {
+        return HttpResponse.json({
+          workspace: { id: "T123", name: "Test Workspace" },
+          agent: { id: "other_compose", name: "shared-agent" },
+          isAdmin: true,
+          environment: {
+            requiredSecrets: [],
+            requiredVars: [],
+            missingSecrets: [],
+            missingVars: [],
+          },
+        });
+      }),
+      http.get("/api/agent/composes/list", () => {
+        return HttpResponse.json({
+          composes: [
+            {
+              name: "my-agent",
+              headVersionId: "v1",
+              updatedAt: "2024-01-01T00:00:00Z",
+            },
+          ],
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/settings/slack" });
+
+    // The workspace default agent should be visible in the select
+    expect(screen.getByText("shared-agent")).toBeInTheDocument();
+  });
+
   it("closes disconnect dialog on cancel", async () => {
     await setupPage({ context, path: "/settings/slack" });
 

--- a/turbo/apps/platform/src/views/integrations-page/slack-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/slack-settings-page.tsx
@@ -42,6 +42,18 @@ export function SlackSettingsPage() {
   const openConfirm = useSet(openSlackDisconnectDialog$);
   const closeConfirm = useSet(closeSlackDisconnectDialog$);
 
+  // Ensure the current workspace agent appears in the dropdown even if
+  // it isn't in the user's own agents list (e.g. shared by another user).
+  const agentOptions = (() => {
+    if (!data?.agent) return agents;
+    const hasCurrentAgent = agents.some((a) => a.name === data.agent?.name);
+    if (hasCurrentAgent) return agents;
+    return [
+      { name: data.agent.name, headVersionId: null, updatedAt: "" },
+      ...agents,
+    ];
+  })();
+
   const handleDisconnect = () => {
     detach(
       (async () => {
@@ -148,7 +160,7 @@ export function SlackSettingsPage() {
                       <SelectValue placeholder="Select an agent" />
                     </SelectTrigger>
                     <SelectContent>
-                      {agents.map((agent) => (
+                      {agentOptions.map((agent) => (
                         <SelectItem key={agent.name} value={agent.name}>
                           {agent.name}
                         </SelectItem>

--- a/turbo/apps/platform/src/views/integrations-page/slack-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/slack-settings-page.tsx
@@ -45,9 +45,13 @@ export function SlackSettingsPage() {
   // Ensure the current workspace agent appears in the dropdown even if
   // it isn't in the user's own agents list (e.g. shared by another user).
   const agentOptions = (() => {
-    if (!data?.agent) return agents;
+    if (!data?.agent) {
+      return agents;
+    }
     const hasCurrentAgent = agents.some((a) => a.name === data.agent?.name);
-    if (hasCurrentAgent) return agents;
+    if (hasCurrentAgent) {
+      return agents;
+    }
     return [
       { name: data.agent.name, headVersionId: null, updatedAt: "" },
       ...agents,

--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -1,6 +1,7 @@
 import type { Store } from "ccstate";
 import { StoreProvider } from "ccstate-react";
 import { StrictMode } from "react";
+import { Toaster } from "@vm0/ui/components/ui/sonner";
 import { ErrorBoundary } from "./error-boundary.tsx";
 import { Router } from "./router.tsx";
 import "./css/index.css";
@@ -17,6 +18,7 @@ export const setupRouter = (
         <ErrorBoundary>
           <Router />
         </ErrorBoundary>
+        <Toaster position="top-center" />
       </StoreProvider>
     </StrictMode>,
   );

--- a/turbo/apps/platform/src/views/settings-page/provider-list.tsx
+++ b/turbo/apps/platform/src/views/settings-page/provider-list.tsx
@@ -1,4 +1,5 @@
 import { useLastResolved } from "ccstate-react";
+import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import { configuredProviders$ } from "../../signals/settings-page/model-providers.ts";
 import { ProviderRow } from "./provider-row.tsx";
 import { AddProviderMenu } from "./add-provider-menu.tsx";
@@ -8,20 +9,31 @@ export function ProviderList() {
 
   return (
     <div className="flex flex-col gap-4">
-      <h3 className="text-base font-medium text-foreground">
-        Configured model providers
-      </h3>
-      <div className="flex flex-col">
-        {providers &&
-          providers.map((provider, index) => (
-            <ProviderRow
-              key={provider.type}
-              provider={provider}
-              isFirst={index === 0}
-            />
-          ))}
-        <AddProviderMenu isFirst={!providers || providers.length === 0} />
-      </div>
+      {providers === undefined ? (
+        <>
+          <Skeleton className="h-5 w-52 rounded" />
+          <div className="flex flex-col">
+            <Skeleton className="h-[68px] w-full rounded-t-xl rounded-b-none" />
+            <Skeleton className="h-[68px] w-full rounded-t-none rounded-b-xl border-t border-background" />
+          </div>
+        </>
+      ) : (
+        <>
+          <h3 className="text-base font-medium text-foreground">
+            Configured model providers
+          </h3>
+          <div className="flex flex-col">
+            {providers.map((provider, index) => (
+              <ProviderRow
+                key={provider.type}
+                provider={provider}
+                isFirst={index === 0}
+              />
+            ))}
+            <AddProviderMenu isFirst={providers.length === 0} />
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/turbo/packages/ui/package.json
+++ b/turbo/packages/ui/package.json
@@ -48,6 +48,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "react": "^19.1.2",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.0.2"
   }
 }

--- a/turbo/packages/ui/src/components/ui/sonner.tsx
+++ b/turbo/packages/ui/src/components/ui/sonner.tsx
@@ -1,0 +1,25 @@
+import { Toaster as Sonner, toast } from "sonner";
+
+type ToasterProps = React.ComponentProps<typeof Sonner>;
+
+function Toaster({ ...props }: ToasterProps) {
+  return (
+    <Sonner
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            "group toast group-[.toaster]:bg-popover group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg [&_[data-icon]]:text-primary",
+          description: "group-[.toast]:text-muted-foreground",
+          actionButton:
+            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+          cancelButton:
+            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+        },
+      }}
+      {...props}
+    />
+  );
+}
+
+export { Toaster, toast };

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -666,6 +666,9 @@ importers:
       react:
         specifier: ^19.1.2
         version: 19.2.1
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       tailwind-merge:
         specifier: ^3.0.2
         version: 3.3.1
@@ -7705,6 +7708,12 @@ packages:
   smol-toml@1.5.2:
     resolution: {integrity: sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==}
     engines: {node: '>= 18'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -16813,6 +16822,11 @@ snapshots:
   sisteransi@1.0.5: {}
 
   smol-toml@1.5.2: {}
+
+  sonner@2.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary
- Fix blank default agent in Slack settings when the workspace agent isn't owned by the current user — prepend it to the select options
- Optimistic update when switching default agent so the page doesn't flash a full loading state
- Add sonner-based toast notifications (`@vm0/ui/components/ui/sonner`) — show success/error after agent switch
- Add skeleton loading state for model providers list to avoid showing bare text before data loads

## Test plan
- [x] Added test: "shows workspace agent even when not in user's agents list"
- [x] Existing tests pass (8/8)
- [x] Type check passes

Closes #2880

🤖 Generated with [Claude Code](https://claude.com/claude-code)