### PR TITLE
refactor(guest-agent): align log file names with code conventions

### DIFF
--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -1,4 +1,10 @@
 //! Derived temp-file paths — all scoped to the current run ID.
+//!
+//! Naming conventions:
+//! - "system log" = guest-agent's own stderr (matches TS `SYSTEM_LOG_FILE` and API `systemLog`)
+//! - "agent log" = AI agent (Claude Code / Codex) stdout output
+//! - "metrics" = periodic CPU/memory/disk snapshots
+//! - "sandbox ops" = operation timing records (defined in guest-common, re-exported here)
 
 use crate::env;
 use std::sync::LazyLock;
@@ -26,7 +32,7 @@ pub fn session_history_path_file() -> &'static str {
 static EVENT_ERROR_FLAG: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-event-error-{}", env::run_id()));
 static SYSTEM_LOG_FILE: LazyLock<String> =
-    LazyLock::new(|| format!("/tmp/vm0-main-{}.log", env::run_id()));
+    LazyLock::new(|| format!("/tmp/vm0-system-{}.log", env::run_id()));
 static AGENT_LOG_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-agent-{}.log", env::run_id()));
 static METRICS_LOG_FILE: LazyLock<String> =
@@ -45,19 +51,24 @@ pub fn metrics_log_file() -> &'static str {
     &METRICS_LOG_FILE
 }
 
+/// Re-export sandbox ops log path from guest-common for consistent access.
+pub fn sandbox_ops_file() -> &'static str {
+    guest_common::telemetry::sandbox_ops_log()
+}
+
 // ---------------------------------------------------------------------------
 // Telemetry position tracking
 // ---------------------------------------------------------------------------
 
-static TELEMETRY_LOG_POS_FILE: LazyLock<String> =
-    LazyLock::new(|| format!("/tmp/vm0-telemetry-log-pos-{}.txt", env::run_id()));
+static TELEMETRY_SYSTEM_LOG_POS_FILE: LazyLock<String> =
+    LazyLock::new(|| format!("/tmp/vm0-telemetry-system-log-pos-{}.txt", env::run_id()));
 static TELEMETRY_METRICS_POS_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-telemetry-metrics-pos-{}.txt", env::run_id()));
 static TELEMETRY_SANDBOX_OPS_POS_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-telemetry-sandbox-ops-pos-{}.txt", env::run_id()));
 
-pub fn telemetry_log_pos_file() -> &'static str {
-    &TELEMETRY_LOG_POS_FILE
+pub fn telemetry_system_log_pos_file() -> &'static str {
+    &TELEMETRY_SYSTEM_LOG_POS_FILE
 }
 pub fn telemetry_metrics_pos_file() -> &'static str {
     &TELEMETRY_METRICS_POS_FILE

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -74,14 +74,16 @@ fn save_position(pos_path: &str, pos: u64) {
 /// Perform one telemetry upload cycle.
 async fn upload_telemetry(masker: &SecretMasker) -> Result<(), AgentError> {
     // Read deltas
-    let (system_log, log_pos) =
-        read_file_delta(paths::system_log_file(), paths::telemetry_log_pos_file());
+    let (system_log, log_pos) = read_file_delta(
+        paths::system_log_file(),
+        paths::telemetry_system_log_pos_file(),
+    );
     let (metrics, metrics_pos) = read_jsonl_delta(
         paths::metrics_log_file(),
         paths::telemetry_metrics_pos_file(),
     );
     let (sandbox_ops, sandbox_ops_pos) = read_jsonl_delta(
-        guest_common::telemetry::sandbox_ops_log(),
+        paths::sandbox_ops_file(),
         paths::telemetry_sandbox_ops_pos_file(),
     );
 
@@ -107,7 +109,7 @@ async fn upload_telemetry(masker: &SecretMasker) -> Result<(), AgentError> {
     // Use 1 attempt for telemetry (non-critical, best-effort)
     match http::post_json(urls::telemetry_url(), &payload, 1).await {
         Ok(_) => {
-            save_position(paths::telemetry_log_pos_file(), log_pos);
+            save_position(paths::telemetry_system_log_pos_file(), log_pos);
             save_position(paths::telemetry_metrics_pos_file(), metrics_pos);
             save_position(paths::telemetry_sandbox_ops_pos_file(), sandbox_ops_pos);
             Ok(())

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -124,8 +124,9 @@ async fn run_in_sandbox(
         .collect();
     info!(run_id = %context.run_id, count = env_refs.len(), "passing env vars via vsock");
 
-    // 5. Spawn agent
-    let log_file = format!("/tmp/vm0-main-{}.log", context.run_id);
+    // 5. Spawn agent — redirect stdout+stderr to system log file
+    //    (guest-agent reads this back via telemetry for incremental upload)
+    let log_file = format!("/tmp/vm0-system-{}.log", context.run_id);
     let agent_cmd = format!("{} > {log_file} 2>&1", guest::RUN_AGENT);
     info!(run_id = %context.run_id, "spawning agent");
 

--- a/turbo/apps/runner/src/lib/executor/index.ts
+++ b/turbo/apps/runner/src/lib/executor/index.ts
@@ -201,7 +201,7 @@ export async function executeJob(
     // Execute agent or direct command using event-driven mode
     // Note: Network connectivity is validated by agent's first heartbeat (fail-fast)
     // The agent spawns in background, and we wait for exit notification (no polling)
-    const systemLogFile = `/tmp/vm0-main-${context.runId}.log`;
+    const systemLogFile = `/tmp/vm0-system-${context.runId}.log`;
     const startTime = Date.now();
     const maxWaitMs = 2 * 60 * 60 * 1000; // 2 hours max (same as E2B sandbox timeout)
 

--- a/turbo/apps/web/src/lib/run/executors/docker-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/docker-executor.ts
@@ -447,7 +447,7 @@ async function startAgentExecution(
   sandbox: SandboxLike,
   runId: string,
 ): Promise<void> {
-  const cmd = `nohup node ${SCRIPT_PATHS.runAgent} > /tmp/vm0-main-${runId}.log 2>&1 &`;
+  const cmd = `nohup node ${SCRIPT_PATHS.runAgent} > /tmp/vm0-system-${runId}.log 2>&1 &`;
   await sandbox.commands.run(cmd);
 }
 

--- a/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
@@ -444,7 +444,7 @@ async function startAgentExecution(
   sandbox: Sandbox,
   runId: string,
 ): Promise<void> {
-  const cmd = `nohup node ${SCRIPT_PATHS.runAgent} > /tmp/vm0-main-${runId}.log 2>&1 &`;
+  const cmd = `nohup node ${SCRIPT_PATHS.runAgent} > /tmp/vm0-system-${runId}.log 2>&1 &`;
   await sandbox.commands.run(cmd);
 }
 

--- a/turbo/packages/sandbox-scripts/src/__tests__/common.test.ts
+++ b/turbo/packages/sandbox-scripts/src/__tests__/common.test.ts
@@ -270,7 +270,7 @@ describe("common", () => {
 
         expect(SESSION_ID_FILE).toBe("/tmp/vm0-session-unique-run-456.txt");
         expect(EVENT_ERROR_FLAG).toBe("/tmp/vm0-event-error-unique-run-456");
-        expect(SYSTEM_LOG_FILE).toBe("/tmp/vm0-main-unique-run-456.log");
+        expect(SYSTEM_LOG_FILE).toBe("/tmp/vm0-system-unique-run-456.log");
         expect(AGENT_LOG_FILE).toBe("/tmp/vm0-agent-unique-run-456.log");
         expect(METRICS_LOG_FILE).toBe("/tmp/vm0-metrics-unique-run-456.jsonl");
       } finally {

--- a/turbo/packages/sandbox-scripts/src/scripts/lib/common.ts
+++ b/turbo/packages/sandbox-scripts/src/scripts/lib/common.ts
@@ -62,14 +62,14 @@ export const SESSION_HISTORY_PATH_FILE = `/tmp/vm0-session-history-${RUN_ID}.txt
 export const EVENT_ERROR_FLAG = `/tmp/vm0-event-error-${RUN_ID}`;
 
 // Log file for persistent logging (directly in /tmp with vm0- prefix)
-export const SYSTEM_LOG_FILE = `/tmp/vm0-main-${RUN_ID}.log`;
+export const SYSTEM_LOG_FILE = `/tmp/vm0-system-${RUN_ID}.log`;
 export const AGENT_LOG_FILE = `/tmp/vm0-agent-${RUN_ID}.log`;
 
 // Metrics log file for system resource metrics (JSONL format)
 export const METRICS_LOG_FILE = `/tmp/vm0-metrics-${RUN_ID}.jsonl`;
 
 // Telemetry position tracking files (to avoid duplicate uploads)
-export const TELEMETRY_LOG_POS_FILE = `/tmp/vm0-telemetry-log-pos-${RUN_ID}.txt`;
+export const TELEMETRY_SYSTEM_LOG_POS_FILE = `/tmp/vm0-telemetry-system-log-pos-${RUN_ID}.txt`;
 export const TELEMETRY_METRICS_POS_FILE = `/tmp/vm0-telemetry-metrics-pos-${RUN_ID}.txt`;
 export const TELEMETRY_SANDBOX_OPS_POS_FILE = `/tmp/vm0-telemetry-sandbox-ops-pos-${RUN_ID}.txt`;
 

--- a/turbo/packages/sandbox-scripts/src/scripts/lib/upload-telemetry.ts
+++ b/turbo/packages/sandbox-scripts/src/scripts/lib/upload-telemetry.ts
@@ -11,7 +11,7 @@ import {
   SYSTEM_LOG_FILE,
   METRICS_LOG_FILE,
   SANDBOX_OPS_LOG_FILE,
-  TELEMETRY_LOG_POS_FILE,
+  TELEMETRY_SYSTEM_LOG_POS_FILE,
   TELEMETRY_METRICS_POS_FILE,
   TELEMETRY_SANDBOX_OPS_POS_FILE,
 } from "./common.js";
@@ -140,7 +140,7 @@ async function uploadTelemetry(): Promise<boolean> {
   // Read new system log content
   const [systemLog, logPos] = readFileFromPosition(
     SYSTEM_LOG_FILE,
-    TELEMETRY_LOG_POS_FILE,
+    TELEMETRY_SYSTEM_LOG_POS_FILE,
   );
 
   // Read new metrics
@@ -178,7 +178,7 @@ async function uploadTelemetry(): Promise<boolean> {
 
   if (result) {
     // Save positions only on successful upload
-    savePosition(TELEMETRY_LOG_POS_FILE, logPos);
+    savePosition(TELEMETRY_SYSTEM_LOG_POS_FILE, logPos);
     savePosition(TELEMETRY_METRICS_POS_FILE, metricsPos);
     savePosition(TELEMETRY_SANDBOX_OPS_POS_FILE, sandboxOpsPos);
     logDebug(


### PR DESCRIPTION
Closes #2926

## Summary
- Rename `vm0-main-*` → `vm0-system-*` across Rust and TS to match function names (`system_log_file` / `SYSTEM_LOG_FILE` / `systemLog`)
- Rename `telemetry_log_pos_file()` → `telemetry_system_log_pos_file()` to clarify which log the position tracks
- Add `sandbox_ops_file()` re-export in `paths.rs` so all path lookups go through a single module
- Add naming conventions doc comment to `paths.rs`

## Test plan
- [x] `cargo clippy` passes
- [x] `cargo test -p guest-agent` — 17 tests pass
- [x] `cargo test -p runner` — 18 tests pass
- [x] All pre-commit hooks pass (fmt, clippy, prettier, knip, commitlint)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)