### PR TITLE
fix(platform): persist model selection for providers with predefined models

### DIFF
--- a/turbo/apps/platform/src/signals/onboarding.ts
+++ b/turbo/apps/platform/src/signals/onboarding.ts
@@ -141,7 +141,11 @@ export const setOnboardingSecret$ = command(({ set }, value: string) => {
 });
 
 export const setOnboardingModel$ = command(({ set }, value: string) => {
-  set(internalFormValues$, (prev) => ({ ...prev, selectedModel: value }));
+  set(internalFormValues$, (prev) => ({
+    ...prev,
+    selectedModel: value,
+    useDefaultModel: false,
+  }));
 });
 
 export const setOnboardingUseDefaultModel$ = command(

--- a/turbo/apps/platform/src/signals/settings-page/model-providers.ts
+++ b/turbo/apps/platform/src/signals/settings-page/model-providers.ts
@@ -188,7 +188,11 @@ export const updateFormSecret$ = command(({ set }, value: string) => {
 });
 
 export const updateFormModel$ = command(({ set }, value: string) => {
-  set(internalFormValues$, (prev) => ({ ...prev, selectedModel: value }));
+  set(internalFormValues$, (prev) => ({
+    ...prev,
+    selectedModel: value,
+    useDefaultModel: false,
+  }));
 });
 
 export const updateFormUseDefaultModel$ = command(({ set }, value: boolean) => {


### PR DESCRIPTION
## Summary
- Fix model selection not persisting when adding providers with predefined models (e.g., Z.AI GLM)
- Root cause: `updateFormModel$` only updated `selectedModel` but left `useDefaultModel: true`, so `selectedModel` was never included in the PUT request
- Fix both settings page and onboarding modal signals to set `useDefaultModel: false` when a model is explicitly selected

## Test plan
- [x] Added integration test verifying `selectedModel` is sent in the request when selecting glm-5 for Z.AI provider
- [x] All 347 platform tests pass
- [x] Lint and type checks pass
- [x] Knip clean

Closes #2923

🤖 Generated with [Claude Code](https://claude.com/claude-code)