### PR TITLE
fix(slack): use most recent workspace link for settings api

### DIFF
--- a/turbo/apps/web/app/api/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import {
   extractVariableReferences,
   groupVariablesBySource,
@@ -49,11 +49,12 @@ export async function GET(request: Request) {
 
   const db = globalThis.services.db;
 
-  // Find user's Slack link
+  // Find user's most recent Slack link
   const [userLink] = await db
     .select()
     .from(slackUserLinks)
     .where(eq(slackUserLinks.vm0UserId, userId))
+    .orderBy(desc(slackUserLinks.createdAt))
     .limit(1);
 
   if (!userLink) {
@@ -179,11 +180,12 @@ export async function DELETE(request: Request) {
   const { SECRETS_ENCRYPTION_KEY } = env();
   const db = globalThis.services.db;
 
-  // Find user's Slack link
+  // Find user's most recent Slack link
   const [userLink] = await db
     .select()
     .from(slackUserLinks)
     .where(eq(slackUserLinks.vm0UserId, userId))
+    .orderBy(desc(slackUserLinks.createdAt))
     .limit(1);
 
   if (!userLink) {
@@ -255,11 +257,12 @@ export async function PATCH(request: Request) {
 
   const db = globalThis.services.db;
 
-  // Find user's Slack link
+  // Find user's most recent Slack link
   const [userLink] = await db
     .select()
     .from(slackUserLinks)
     .where(eq(slackUserLinks.vm0UserId, userId))
+    .orderBy(desc(slackUserLinks.createdAt))
     .limit(1);
 
   if (!userLink) {


### PR DESCRIPTION
## Summary
- Add `orderBy(desc(slackUserLinks.createdAt))` to all three Slack user link queries (GET, DELETE, PATCH) in `/api/integrations/slack`
- When a user is connected to multiple Slack workspaces, the settings API now consistently returns the most recently connected workspace instead of an arbitrary one

## Test plan
- [ ] Connect a VM0 account to two different Slack workspaces
- [ ] Verify `/settings/slack` shows the most recently connected workspace
- [ ] Verify disconnect removes the most recent link
- [ ] Verify agent update targets the most recent workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)