### PR TITLE
feat(storage): add optional volume support for graceful degradation

### DIFF
--- a/e2e/tests/02-parallel/t33-vm0-optional-volume.bats
+++ b/e2e/tests/02-parallel/t33-vm0-optional-volume.bats
@@ -1,0 +1,174 @@
+#!/usr/bin/env bats
+
+# Test VM0 optional volume functionality
+# This test verifies that volumes marked as optional: true can be missing at runtime
+# without causing run failures.
+
+load '../../helpers/setup'
+
+setup_file() {
+    # Unique agent name for this test file
+    export AGENT_NAME="e2e-t33-$(date +%s%3N)-$RANDOM"
+    # Create shared test directory for this file
+    export TEST_DIR="$(mktemp -d)"
+    export TEST_CONFIG="$TEST_DIR/vm0.yaml"
+
+    # Create a claude-files volume that exists (required for claude-code framework)
+    export CLAUDE_VOLUME_NAME="e2e-vol-t33-claude-$(date +%s%3N)-$RANDOM"
+    mkdir -p "$TEST_DIR/$CLAUDE_VOLUME_NAME"
+    cd "$TEST_DIR/$CLAUDE_VOLUME_NAME"
+    cat > CLAUDE.md << 'VOLEOF'
+This is a test file for the volume.
+VOLEOF
+    $CLI_COMMAND volume init --name "$CLAUDE_VOLUME_NAME" >/dev/null
+    $CLI_COMMAND volume push >/dev/null
+    cd - >/dev/null
+
+    # Unique name for the optional volume that will NOT exist
+    export OPTIONAL_VOLUME_NAME="e2e-vol-t33-optional-nonexistent-$(date +%s%3N)-$RANDOM"
+}
+
+teardown_file() {
+    # Clean up shared test directory
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
+}
+
+setup() {
+    # Per-test setup
+    export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
+    export ARTIFACT_NAME="e2e-art-optional-${UNIQUE_ID}"
+}
+
+@test "t33-1: compose succeeds with optional volume that does not exist" {
+    # Create config with optional volume that doesn't exist
+    cat > "$TEST_CONFIG" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_NAME}:
+    description: "Test agent with optional volume"
+    framework: claude-code
+    volumes:
+      - optional-data:/home/user/optional-data
+      - claude-files:/home/user/.config/claude
+volumes:
+  optional-data:
+    name: $OPTIONAL_VOLUME_NAME
+    version: latest
+    optional: true
+  claude-files:
+    name: $CLAUDE_VOLUME_NAME
+    version: latest
+EOF
+
+    run $CLI_COMMAND compose "$TEST_CONFIG"
+    assert_success
+    assert_output --partial "$AGENT_NAME"
+}
+
+@test "t33-2: run succeeds when optional volume does not exist (skip silently)" {
+    # Ensure config is created with optional volume
+    cat > "$TEST_CONFIG" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_NAME}:
+    description: "Test agent with optional volume"
+    framework: claude-code
+    volumes:
+      - optional-data:/home/user/optional-data
+      - claude-files:/home/user/.config/claude
+volumes:
+  optional-data:
+    name: $OPTIONAL_VOLUME_NAME
+    version: latest
+    optional: true
+  claude-files:
+    name: $CLAUDE_VOLUME_NAME
+    version: latest
+EOF
+
+    # Compose the agent
+    $CLI_COMMAND compose "$TEST_CONFIG" >/dev/null
+
+    # Create artifact (required for run)
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME" >/dev/null
+    echo "test" > marker.txt
+    run $CLI_COMMAND artifact push
+    assert_success
+    cd - >/dev/null
+
+    # Run agent - should succeed even though optional volume doesn't exist
+    # The optional volume mount point should simply not exist
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        --verbose \
+        "ls -la /home/user/optional-data 2>&1 || echo 'OPTIONAL_DIR_NOT_MOUNTED'"
+
+    assert_success
+    # The optional directory should not be mounted (volume doesn't exist)
+    assert_output --partial "OPTIONAL_DIR_NOT_MOUNTED"
+}
+
+@test "t33-3: run succeeds with mixed volumes (required exists, optional missing)" {
+    # Create a required volume that DOES exist
+    export REQUIRED_VOLUME_NAME="e2e-vol-t33-required-$(date +%s%3N)-$RANDOM"
+    mkdir -p "$TEST_DIR/$REQUIRED_VOLUME_NAME"
+    cd "$TEST_DIR/$REQUIRED_VOLUME_NAME"
+    echo "required-data-content" > required.txt
+    $CLI_COMMAND volume init --name "$REQUIRED_VOLUME_NAME" >/dev/null
+    $CLI_COMMAND volume push >/dev/null
+    cd - >/dev/null
+
+    # Create config with both required and optional volumes
+    cat > "$TEST_CONFIG" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_NAME}-mixed:
+    description: "Test agent with mixed volumes"
+    framework: claude-code
+    volumes:
+      - required-data:/home/user/required-data
+      - optional-data:/home/user/optional-data
+      - claude-files:/home/user/.config/claude
+volumes:
+  required-data:
+    name: $REQUIRED_VOLUME_NAME
+    version: latest
+  optional-data:
+    name: $OPTIONAL_VOLUME_NAME
+    version: latest
+    optional: true
+  claude-files:
+    name: $CLAUDE_VOLUME_NAME
+    version: latest
+EOF
+
+    # Compose the agent
+    run $CLI_COMMAND compose "$TEST_CONFIG"
+    assert_success
+
+    # Create artifact
+    export ARTIFACT_NAME_MIXED="e2e-art-mixed-${UNIQUE_ID}"
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME_MIXED"
+    cd "$TEST_DIR/$ARTIFACT_NAME_MIXED"
+    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME_MIXED" >/dev/null
+    echo "test" > marker.txt
+    run $CLI_COMMAND artifact push
+    assert_success
+    cd - >/dev/null
+
+    # Run agent - should succeed with required volume mounted, optional skipped
+    run $CLI_COMMAND run "${AGENT_NAME}-mixed" \
+        --artifact-name "$ARTIFACT_NAME_MIXED" \
+        --verbose \
+        "cat /home/user/required-data/required.txt && (ls /home/user/optional-data 2>&1 || echo 'OPTIONAL_NOT_MOUNTED')"
+
+    assert_success
+    # Required volume should be mounted and readable
+    assert_output --partial "required-data-content"
+    # Optional volume should not be mounted
+    assert_output --partial "OPTIONAL_NOT_MOUNTED"
+}

--- a/turbo/apps/cli/src/lib/domain/compose-types.ts
+++ b/turbo/apps/cli/src/lib/domain/compose-types.ts
@@ -32,6 +32,8 @@ export interface AgentDefinition {
 export interface VolumeConfig {
   name: string;
   version: string;
+  /** When true, skip mounting without error if volume doesn't exist */
+  optional?: boolean;
 }
 
 /**

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -402,5 +402,66 @@ describe("createRun()", () => {
       // because the checkpoint resume should skip this optional volume
       expect(result.status).toBe("running");
     });
+
+    it("should mount optional volume in session/continue when it now exists (no volumeVersions)", async () => {
+      const volumeName = uniqueId("vol");
+      // Create the volume first
+      await createTestVolume(volumeName);
+
+      // Create compose with optional volume
+      const compose = await createComposeWithVolumes(
+        uniqueId("agent"),
+        {
+          mydata: {
+            name: volumeName,
+            version: "latest",
+            optional: true,
+          },
+        },
+        ["mydata:/data"],
+      );
+
+      // Session/Continue scenario: volumeVersions is NOT provided (undefined)
+      // This means we should use current config and mount if volume exists
+      const result = await createRun(
+        baseParams({
+          agentComposeVersionId: compose.versionId,
+          // No volumeVersions - use latest state
+        }),
+      );
+
+      expect(result.status).toBe("running");
+    });
+
+    it("should succeed with mixed volumes (required exists, optional missing)", async () => {
+      const requiredVolumeName = uniqueId("required-vol");
+      // Create only the required volume
+      await createTestVolume(requiredVolumeName);
+
+      // Create compose with both required and optional volumes
+      const compose = await createComposeWithVolumes(
+        uniqueId("agent"),
+        {
+          requiredData: {
+            name: requiredVolumeName,
+            version: "latest",
+            // optional defaults to false (required)
+          },
+          optionalData: {
+            name: "nonexistent-optional-volume",
+            version: "latest",
+            optional: true,
+          },
+        },
+        ["requiredData:/required", "optionalData:/optional"],
+      );
+
+      // Should succeed - required volume exists, optional is skipped
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: compose.versionId }),
+      );
+
+      expect(result.status).toBe("running");
+    });
   });
 });

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -6,11 +6,13 @@ import {
 } from "../../../__tests__/test-helpers";
 import {
   createTestCompose,
+  createTestVolume,
   insertStalePendingRun,
   findTestRunRecord,
   findTestRunCallbacks,
   findTestRunByStatus,
 } from "../../../__tests__/api-test-helpers";
+import type { AgentComposeYaml } from "../../../types/agent-compose";
 import { addPermission } from "../../agent/permission-service";
 import { reloadEnv } from "../../../env";
 import {
@@ -247,6 +249,158 @@ describe("createRun()", () => {
         channel: "C123",
         threadTs: "1234.5678",
       });
+    });
+  });
+
+  describe("Optional Volumes", () => {
+    /**
+     * Helper to create a compose with volume configuration
+     */
+    async function createComposeWithVolumes(
+      agentName: string,
+      volumes: AgentComposeYaml["volumes"],
+      agentVolumes: string[],
+    ) {
+      const config: AgentComposeYaml = {
+        version: "1.0",
+        agents: {
+          [agentName]: {
+            image: "vm0/claude-code:latest",
+            framework: "claude-code",
+            working_dir: "/home/user/workspace",
+            environment: { ANTHROPIC_API_KEY: "test-api-key" },
+            volumes: agentVolumes,
+          },
+        },
+        volumes,
+      };
+
+      // Use direct DB insert via POST /api/agent/composes
+      const { POST: createComposeRoute } = await import(
+        "../../../../app/api/agent/composes/route"
+      );
+      const { createTestRequest } = await import(
+        "../../../__tests__/api-test-helpers"
+      );
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/composes",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: config }),
+        },
+      );
+      const response = await createComposeRoute(request);
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(
+          `Failed to create compose: ${error.error?.message || response.status}`,
+        );
+      }
+      return response.json() as Promise<{
+        composeId: string;
+        versionId: string;
+      }>;
+    }
+
+    it("should succeed when optional volume exists", async () => {
+      const volumeName = uniqueId("vol");
+      // Create the volume first
+      await createTestVolume(volumeName);
+
+      // Create compose with optional volume
+      const compose = await createComposeWithVolumes(
+        uniqueId("agent"),
+        {
+          mydata: {
+            name: volumeName,
+            version: "latest",
+            optional: true,
+          },
+        },
+        ["mydata:/data"],
+      );
+
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: compose.versionId }),
+      );
+
+      expect(result.status).toBe("running");
+    });
+
+    it("should succeed when optional volume does not exist (skip silently)", async () => {
+      // Create compose with optional volume that doesn't exist
+      const compose = await createComposeWithVolumes(
+        uniqueId("agent"),
+        {
+          mydata: {
+            name: "nonexistent-volume",
+            version: "latest",
+            optional: true,
+          },
+        },
+        ["mydata:/data"],
+      );
+
+      // Should succeed - optional volume is silently skipped
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: compose.versionId }),
+      );
+
+      expect(result.status).toBe("running");
+    });
+
+    it("should fail when required volume does not exist", async () => {
+      // Create compose with required volume (optional: false or not specified)
+      const compose = await createComposeWithVolumes(
+        uniqueId("agent"),
+        {
+          mydata: {
+            name: "nonexistent-volume",
+            version: "latest",
+            // optional defaults to false
+          },
+        },
+        ["mydata:/data"],
+      );
+
+      // Should fail - required volume doesn't exist
+      await expect(
+        createRun(baseParams({ agentComposeVersionId: compose.versionId })),
+      ).rejects.toThrow(/not found/);
+    });
+
+    it("should skip optional volume during checkpoint resume when it was skipped originally", async () => {
+      const volumeName = uniqueId("vol");
+
+      // Create compose with optional volume
+      const compose = await createComposeWithVolumes(
+        uniqueId("agent"),
+        {
+          mydata: {
+            name: volumeName,
+            version: "latest",
+            optional: true,
+          },
+        },
+        ["mydata:/data"],
+      );
+
+      // Simulate checkpoint resume scenario:
+      // volumeVersions is provided but does NOT include the optional volume
+      // (meaning it was skipped at checkpoint time)
+      const result = await createRun(
+        baseParams({
+          agentComposeVersionId: compose.versionId,
+          // Empty volumeVersions means no volumes were mounted at checkpoint
+          volumeVersions: {},
+        }),
+      );
+
+      // Even if we now create the volume, it should still succeed
+      // because the checkpoint resume should skip this optional volume
+      expect(result.status).toBe("running");
     });
   });
 });

--- a/turbo/apps/web/src/lib/storage/storage-resolver.ts
+++ b/turbo/apps/web/src/lib/storage/storage-resolver.ts
@@ -141,6 +141,7 @@ function resolveVasVolume(
       mountPath,
       vasStorageName: storageName,
       vasVersion: version,
+      optional: volumeConfig.optional,
     },
     error: null,
   };

--- a/turbo/apps/web/src/lib/storage/types.ts
+++ b/turbo/apps/web/src/lib/storage/types.ts
@@ -18,6 +18,8 @@ export interface ResolvedVolume {
   mountPath: string;
   vasStorageName: string;
   vasVersion: string; // Version hash or "latest"
+  /** When true, skip mounting without error if volume doesn't exist */
+  optional?: boolean;
 }
 
 /**

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -9,6 +9,8 @@
 export interface VolumeConfig {
   name: string; // Required: actual storage name
   version: string; // Required: version hash or "latest"
+  /** When true, skip mounting without error if volume doesn't exist */
+  optional?: boolean;
 }
 
 /**

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -39,6 +39,8 @@ const agentNameSchema = z
 const volumeConfigSchema = z.object({
   name: z.string().min(1, "Volume name is required"),
   version: z.string().min(1, "Volume version is required"),
+  /** When true, skip mounting without error if volume doesn't exist */
+  optional: z.boolean().optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary
- Add `optional` field to VolumeConfig schema allowing volumes to be marked as optional
- When an optional volume doesn't exist in storage, it's silently skipped instead of failing the run
- Preserves checkpoint/resume behavior correctly (optional volumes not in snapshot are skipped)

## Changes
- **Schema**: Added `optional?: boolean` to VolumeConfig in core contracts and TypeScript interfaces
- **Resolution**: Pass optional flag through storage resolution chain
- **Service**: Handle optional volumes in `prepareStorageManifest()` with two skip conditions:
  1. Checkpoint resume: skip if `volumeVersionOverrides` provided but volume not in overrides
  2. Runtime: skip if volume not found in storage (error contains "not found")
- **Tests**: Added integration tests covering all optional volume scenarios

## Test plan
- [x] Optional volume exists → mounts successfully
- [x] Optional volume doesn't exist → skips silently, run succeeds
- [x] Required volume doesn't exist → throws error (unchanged behavior)
- [x] Checkpoint resume with optional volume skipped → respects snapshot state

Closes #2920

🤖 Generated with [Claude Code](https://claude.com/claude-code)