### PR TITLE
fix(slack): use session's compose when continuing conversation

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -60,6 +60,12 @@ import { secrets } from "../db/schema/secret";
 import { encryptCredentialValue } from "../lib/crypto/secrets-encryption";
 import type { ConnectorType } from "@vm0/core";
 import { agentSessions } from "../db/schema/agent-session";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../db/schema/agent-compose";
+import { conversations } from "../db/schema/conversation";
+import { uniqueId } from "./test-helpers";
 
 /**
  * Helper to create a NextRequest for testing.
@@ -422,6 +428,93 @@ export async function createTestAgentSession(
   const [session] = await globalThis.services.db
     .insert(agentSessions)
     .values({ userId, agentComposeId })
+    .returning({ id: agentSessions.id });
+  return session!;
+}
+
+/**
+ * Create a compose version for a compose.
+ * Internal helper for createTestSessionWithConversation.
+ */
+async function createTestComposeVersion(
+  composeId: string,
+  userId: string,
+): Promise<string> {
+  const versionId = uniqueId("version");
+  await globalThis.services.db.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId,
+    content: { name: "test-agent", model: "claude-3-5-sonnet-20241022" },
+    createdBy: userId,
+  });
+  // Update compose to point to this version
+  await globalThis.services.db
+    .update(agentComposes)
+    .set({ headVersionId: versionId })
+    .where(eq(agentComposes.id, composeId));
+  return versionId;
+}
+
+/**
+ * Create a run record directly in the database.
+ * Internal helper for createTestSessionWithConversation.
+ */
+async function createTestRunRecord(
+  userId: string,
+  versionId: string,
+): Promise<{ id: string }> {
+  const [run] = await globalThis.services.db
+    .insert(agentRuns)
+    .values({
+      userId,
+      agentComposeVersionId: versionId,
+      status: "completed",
+      prompt: "test prompt",
+    })
+    .returning({ id: agentRuns.id });
+  return run!;
+}
+
+/**
+ * Create a conversation record for a run.
+ * Internal helper for createTestSessionWithConversation.
+ */
+async function createTestConversation(runId: string): Promise<{ id: string }> {
+  const [conversation] = await globalThis.services.db
+    .insert(conversations)
+    .values({
+      runId,
+      cliAgentType: "claude",
+      cliAgentSessionId: uniqueId("cli-session"),
+      cliAgentSessionHistory: "[]",
+    })
+    .returning({ id: conversations.id });
+  return conversation!;
+}
+
+/**
+ * Create an agent session with a linked conversation.
+ * This creates the full data chain required by validateAgentSession:
+ * compose version -> run -> conversation -> session
+ */
+export async function createTestSessionWithConversation(
+  userId: string,
+  agentComposeId: string,
+): Promise<{ id: string }> {
+  // Create compose version
+  const versionId = await createTestComposeVersion(agentComposeId, userId);
+  // Create run
+  const run = await createTestRunRecord(userId, versionId);
+  // Create conversation
+  const conversation = await createTestConversation(run.id);
+  // Create session with conversation
+  const [session] = await globalThis.services.db
+    .insert(agentSessions)
+    .values({
+      userId,
+      agentComposeId,
+      conversationId: conversation.id,
+    })
     .returning({ id: agentSessions.id });
   return session!;
 }

--- a/turbo/apps/web/src/lib/slack/handlers/__tests__/session-resolution.test.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/__tests__/session-resolution.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
+import { resolveSessionCompose, getWorkspaceAgent } from "../shared";
+import { agentSessions } from "../../../../db/schema/agent-session";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../db/schema/agent-compose";
+import { agentRuns } from "../../../../db/schema/agent-run";
+import { conversations } from "../../../../db/schema/conversation";
+import { scopes } from "../../../../db/schema/scope";
+import { eq } from "drizzle-orm";
+import { initServices } from "../../../init-services";
+
+const context = testContext();
+
+describe("resolveSessionCompose", () => {
+  beforeEach(() => {
+    context.setupMocks();
+    initServices();
+  });
+
+  async function createTestScope(userId: string) {
+    const [scope] = await globalThis.services.db
+      .insert(scopes)
+      .values({
+        slug: uniqueId("scope"),
+        type: "personal",
+        ownerId: userId,
+      })
+      .returning();
+    return scope!;
+  }
+
+  async function createTestCompose(
+    userId: string,
+    scopeId: string,
+    name: string,
+  ) {
+    const [compose] = await globalThis.services.db
+      .insert(agentComposes)
+      .values({
+        userId,
+        scopeId,
+        name,
+      })
+      .returning();
+    return compose!;
+  }
+
+  async function createTestComposeVersion(composeId: string, userId: string) {
+    const versionId = uniqueId("version");
+    await globalThis.services.db.insert(agentComposeVersions).values({
+      id: versionId,
+      composeId,
+      content: { name: "test-agent", model: "claude-3-5-sonnet-20241022" },
+      createdBy: userId,
+    });
+    // Update compose to point to this version
+    await globalThis.services.db
+      .update(agentComposes)
+      .set({ headVersionId: versionId })
+      .where(eq(agentComposes.id, composeId));
+    return versionId;
+  }
+
+  async function createTestRun(userId: string, versionId: string) {
+    const [run] = await globalThis.services.db
+      .insert(agentRuns)
+      .values({
+        userId,
+        agentComposeVersionId: versionId,
+        status: "completed",
+        prompt: "test prompt",
+      })
+      .returning({ id: agentRuns.id });
+    return run!;
+  }
+
+  async function createTestConversation(runId: string) {
+    const [conversation] = await globalThis.services.db
+      .insert(conversations)
+      .values({
+        runId,
+        cliAgentType: "claude",
+        cliAgentSessionId: uniqueId("cli-session"),
+        cliAgentSessionHistory: "[]",
+      })
+      .returning({ id: conversations.id });
+    return conversation!;
+  }
+
+  async function createTestSession(userId: string, agentComposeId: string) {
+    const [session] = await globalThis.services.db
+      .insert(agentSessions)
+      .values({ userId, agentComposeId })
+      .returning({ id: agentSessions.id });
+    return session!;
+  }
+
+  async function createTestSessionWithConversation(
+    userId: string,
+    agentComposeId: string,
+  ) {
+    // Create compose version
+    const versionId = await createTestComposeVersion(agentComposeId, userId);
+    // Create run
+    const run = await createTestRun(userId, versionId);
+    // Create conversation
+    const conversation = await createTestConversation(run.id);
+    // Create session with conversation
+    const [session] = await globalThis.services.db
+      .insert(agentSessions)
+      .values({
+        userId,
+        agentComposeId,
+        conversationId: conversation.id,
+      })
+      .returning({ id: agentSessions.id });
+    return session!;
+  }
+
+  describe("when session exists and belongs to user", () => {
+    it("should return compose info from session", async () => {
+      const userId = uniqueId("test-user");
+
+      // Create scope and compose
+      const scope = await createTestScope(userId);
+      const compose = await createTestCompose(
+        userId,
+        scope.id,
+        "session-agent",
+      );
+
+      // Create an agent session with conversation (required by validateAgentSession)
+      const session = await createTestSessionWithConversation(
+        userId,
+        compose.id,
+      );
+
+      // Resolve session compose
+      const result = await resolveSessionCompose(session.id, userId);
+
+      expect(result).toBeDefined();
+      expect(result!.composeId).toBe(compose.id);
+      expect(result!.agentName).toBe("session-agent");
+    });
+  });
+
+  describe("when session does not exist", () => {
+    it("should return undefined", async () => {
+      const userId = uniqueId("test-user");
+
+      const result = await resolveSessionCompose(
+        "non-existent-session-id",
+        userId,
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("when session belongs to different user", () => {
+    it("should return undefined", async () => {
+      const ownerUserId = uniqueId("owner-user");
+      const otherUserId = uniqueId("other-user");
+
+      // Create scope and compose for owner
+      const scope = await createTestScope(ownerUserId);
+      const compose = await createTestCompose(
+        ownerUserId,
+        scope.id,
+        "owner-agent",
+      );
+
+      // Create a session owned by the owner
+      const session = await createTestSession(ownerUserId, compose.id);
+
+      // Try to resolve with other user - should fail authorization
+      const result = await resolveSessionCompose(session.id, otherUserId);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("when session compose is deleted", () => {
+    it("should return undefined if compose no longer exists", async () => {
+      const userId = uniqueId("test-user");
+
+      // Create scope and compose
+      const scope = await createTestScope(userId);
+      const compose = await createTestCompose(
+        userId,
+        scope.id,
+        "deleted-agent",
+      );
+
+      // Create a session
+      const session = await createTestSession(userId, compose.id);
+
+      // Delete the compose (simulate orphaned session)
+      await globalThis.services.db
+        .delete(agentComposes)
+        .where(eq(agentComposes.id, compose.id));
+
+      // Resolve should return undefined since compose doesn't exist
+      const result = await resolveSessionCompose(session.id, userId);
+
+      expect(result).toBeUndefined();
+    });
+  });
+});
+
+describe("getWorkspaceAgent", () => {
+  beforeEach(() => {
+    context.setupMocks();
+    initServices();
+  });
+
+  it("should return agent info for valid composeId", async () => {
+    const userId = uniqueId("test-user");
+
+    // Create scope and compose directly
+    const [scope] = await globalThis.services.db
+      .insert(scopes)
+      .values({
+        slug: uniqueId("scope"),
+        type: "personal",
+        ownerId: userId,
+      })
+      .returning();
+
+    const [compose] = await globalThis.services.db
+      .insert(agentComposes)
+      .values({
+        userId,
+        scopeId: scope!.id,
+        name: "test-agent",
+      })
+      .returning();
+
+    const result = await getWorkspaceAgent(compose!.id);
+
+    expect(result).toBeDefined();
+    expect(result!.id).toBe(compose!.id);
+    expect(result!.name).toBe("test-agent");
+  });
+
+  it("should return undefined for non-existent composeId", async () => {
+    // Use valid UUID format that doesn't exist in database
+    const result = await getWorkspaceAgent(
+      "00000000-0000-0000-0000-000000000000",
+    );
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/turbo/apps/web/src/lib/slack/handlers/__tests__/session-resolution.test.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/__tests__/session-resolution.test.ts
@@ -1,136 +1,26 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
-import { resolveSessionCompose, getWorkspaceAgent } from "../shared";
-import { agentSessions } from "../../../../db/schema/agent-session";
 import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../../../db/schema/agent-compose";
-import { agentRuns } from "../../../../db/schema/agent-run";
-import { conversations } from "../../../../db/schema/conversation";
-import { scopes } from "../../../../db/schema/scope";
-import { eq } from "drizzle-orm";
-import { initServices } from "../../../init-services";
+  createTestAgentSession,
+  createTestSessionWithConversation,
+} from "../../../../__tests__/api-test-helpers";
+import { resolveSessionCompose, getWorkspaceAgent } from "../shared";
 
 const context = testContext();
 
 describe("resolveSessionCompose", () => {
   beforeEach(() => {
     context.setupMocks();
-    initServices();
   });
-
-  async function createTestScope(userId: string) {
-    const [scope] = await globalThis.services.db
-      .insert(scopes)
-      .values({
-        slug: uniqueId("scope"),
-        type: "personal",
-        ownerId: userId,
-      })
-      .returning();
-    return scope!;
-  }
-
-  async function createTestCompose(
-    userId: string,
-    scopeId: string,
-    name: string,
-  ) {
-    const [compose] = await globalThis.services.db
-      .insert(agentComposes)
-      .values({
-        userId,
-        scopeId,
-        name,
-      })
-      .returning();
-    return compose!;
-  }
-
-  async function createTestComposeVersion(composeId: string, userId: string) {
-    const versionId = uniqueId("version");
-    await globalThis.services.db.insert(agentComposeVersions).values({
-      id: versionId,
-      composeId,
-      content: { name: "test-agent", model: "claude-3-5-sonnet-20241022" },
-      createdBy: userId,
-    });
-    // Update compose to point to this version
-    await globalThis.services.db
-      .update(agentComposes)
-      .set({ headVersionId: versionId })
-      .where(eq(agentComposes.id, composeId));
-    return versionId;
-  }
-
-  async function createTestRun(userId: string, versionId: string) {
-    const [run] = await globalThis.services.db
-      .insert(agentRuns)
-      .values({
-        userId,
-        agentComposeVersionId: versionId,
-        status: "completed",
-        prompt: "test prompt",
-      })
-      .returning({ id: agentRuns.id });
-    return run!;
-  }
-
-  async function createTestConversation(runId: string) {
-    const [conversation] = await globalThis.services.db
-      .insert(conversations)
-      .values({
-        runId,
-        cliAgentType: "claude",
-        cliAgentSessionId: uniqueId("cli-session"),
-        cliAgentSessionHistory: "[]",
-      })
-      .returning({ id: conversations.id });
-    return conversation!;
-  }
-
-  async function createTestSession(userId: string, agentComposeId: string) {
-    const [session] = await globalThis.services.db
-      .insert(agentSessions)
-      .values({ userId, agentComposeId })
-      .returning({ id: agentSessions.id });
-    return session!;
-  }
-
-  async function createTestSessionWithConversation(
-    userId: string,
-    agentComposeId: string,
-  ) {
-    // Create compose version
-    const versionId = await createTestComposeVersion(agentComposeId, userId);
-    // Create run
-    const run = await createTestRun(userId, versionId);
-    // Create conversation
-    const conversation = await createTestConversation(run.id);
-    // Create session with conversation
-    const [session] = await globalThis.services.db
-      .insert(agentSessions)
-      .values({
-        userId,
-        agentComposeId,
-        conversationId: conversation.id,
-      })
-      .returning({ id: agentSessions.id });
-    return session!;
-  }
 
   describe("when session exists and belongs to user", () => {
     it("should return compose info from session", async () => {
       const userId = uniqueId("test-user");
 
-      // Create scope and compose
-      const scope = await createTestScope(userId);
-      const compose = await createTestCompose(
-        userId,
-        scope.id,
-        "session-agent",
-      );
+      // Create compose using testContext helper
+      const compose = await context.createAgentCompose(userId, {
+        name: "session-agent",
+      });
 
       // Create an agent session with conversation (required by validateAgentSession)
       const session = await createTestSessionWithConversation(
@@ -165,16 +55,13 @@ describe("resolveSessionCompose", () => {
       const ownerUserId = uniqueId("owner-user");
       const otherUserId = uniqueId("other-user");
 
-      // Create scope and compose for owner
-      const scope = await createTestScope(ownerUserId);
-      const compose = await createTestCompose(
-        ownerUserId,
-        scope.id,
-        "owner-agent",
-      );
+      // Create compose for owner
+      const compose = await context.createAgentCompose(ownerUserId, {
+        name: "owner-agent",
+      });
 
-      // Create a session owned by the owner
-      const session = await createTestSession(ownerUserId, compose.id);
+      // Create a session owned by the owner (without conversation - auth check happens first)
+      const session = await createTestAgentSession(ownerUserId, compose.id);
 
       // Try to resolve with other user - should fail authorization
       const result = await resolveSessionCompose(session.id, otherUserId);
@@ -183,27 +70,19 @@ describe("resolveSessionCompose", () => {
     });
   });
 
-  describe("when session compose is deleted", () => {
-    it("should return undefined if compose no longer exists", async () => {
+  describe("when session has no conversation", () => {
+    it("should return undefined", async () => {
       const userId = uniqueId("test-user");
 
-      // Create scope and compose
-      const scope = await createTestScope(userId);
-      const compose = await createTestCompose(
-        userId,
-        scope.id,
-        "deleted-agent",
-      );
+      // Create compose
+      const compose = await context.createAgentCompose(userId, {
+        name: "test-agent",
+      });
 
-      // Create a session
-      const session = await createTestSession(userId, compose.id);
+      // Create a session without conversation
+      const session = await createTestAgentSession(userId, compose.id);
 
-      // Delete the compose (simulate orphaned session)
-      await globalThis.services.db
-        .delete(agentComposes)
-        .where(eq(agentComposes.id, compose.id));
-
-      // Resolve should return undefined since compose doesn't exist
+      // Resolve should return undefined since session has no conversation
       const result = await resolveSessionCompose(session.id, userId);
 
       expect(result).toBeUndefined();
@@ -214,35 +93,20 @@ describe("resolveSessionCompose", () => {
 describe("getWorkspaceAgent", () => {
   beforeEach(() => {
     context.setupMocks();
-    initServices();
   });
 
   it("should return agent info for valid composeId", async () => {
     const userId = uniqueId("test-user");
 
-    // Create scope and compose directly
-    const [scope] = await globalThis.services.db
-      .insert(scopes)
-      .values({
-        slug: uniqueId("scope"),
-        type: "personal",
-        ownerId: userId,
-      })
-      .returning();
+    // Create compose using testContext helper
+    const compose = await context.createAgentCompose(userId, {
+      name: "test-agent",
+    });
 
-    const [compose] = await globalThis.services.db
-      .insert(agentComposes)
-      .values({
-        userId,
-        scopeId: scope!.id,
-        name: "test-agent",
-      })
-      .returning();
-
-    const result = await getWorkspaceAgent(compose!.id);
+    const result = await getWorkspaceAgent(compose.id);
 
     expect(result).toBeDefined();
-    expect(result!.id).toBe(compose!.id);
+    expect(result!.id).toBe(compose.id);
     expect(result!.name).toBe("test-agent");
   });
 

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -15,6 +15,7 @@ import {
   createUserScope,
   generateDefaultScopeSlug,
 } from "../../scope/scope-service";
+import { validateAgentSession } from "../../run";
 import { computeContentHashFromHashes } from "../../storage/content-hash";
 import { putS3Object } from "../../s3/s3-client";
 import { env } from "../../../env";
@@ -354,4 +355,28 @@ export async function getWorkspaceAgent(
     .where(eq(agentComposes.id, composeId))
     .limit(1);
   return compose ?? undefined;
+}
+
+/**
+ * Resolve compose info from an existing session.
+ * Used when continuing a conversation to ensure we use the session's agent,
+ * not the workspace default.
+ */
+export async function resolveSessionCompose(
+  sessionId: string,
+  userId: string,
+): Promise<{ composeId: string; agentName: string } | undefined> {
+  try {
+    const sessionData = await validateAgentSession(sessionId, userId);
+    const agent = await getWorkspaceAgent(sessionData.agentComposeId);
+    if (agent) {
+      return {
+        composeId: sessionData.agentComposeId,
+        agentName: agent.name,
+      };
+    }
+  } catch {
+    // Session validation failed - fall back to workspace default
+  }
+  return undefined;
 }

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -375,8 +375,11 @@ export async function resolveSessionCompose(
         agentName: agent.name,
       };
     }
-  } catch {
-    // Session validation failed - fall back to workspace default
+  } catch (error) {
+    log.warn("Failed to resolve session compose, using workspace default", {
+      sessionId,
+      error,
+    });
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

- Fixed bug where Slack DM and mention replies use wrong agent when continuing a session
- Added `resolveSessionCompose` helper to resolve compose info from existing session
- Updated `handleDirectMessage` and `handleAppMention` to use session's compose instead of workspace default

## Problem

When replying to a Slack DM notification from a scheduled run (e.g., agent "temp"), the system incorrectly used the workspace default agent instead of the session's original agent. This caused `Storage "agent-instructions@{agent}" not found in database` errors.

## Solution

Follow the same pattern as API routes (`/api/agent/runs`, `/v1/runs`): when `existingSessionId` is found, resolve `composeId` and `agentName` from the session before calling `runAgentForSlack`.

## Test plan

- [ ] Reply to a Slack DM notification from a scheduled run with a non-default agent
- [ ] Verify the reply uses the correct agent (no storage not found error)
- [ ] New conversation in DM still uses workspace default agent
- [ ] @mention in thread with existing session uses session's agent

Closes #2927

🤖 Generated with [Claude Code](https://claude.com/claude-code)