### PR TITLE
feat(runner): add runner.yaml config file generated by build

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1436,7 +1436,7 @@ dependencies = [
  "sandbox-fc",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "sha2",
  "tar",
  "tempfile",
@@ -1691,10 +1691,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1436,6 +1436,7 @@ dependencies = [
  "sandbox-fc",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "tar",
  "tempfile",
@@ -1687,6 +1688,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2143,6 +2157,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -40,7 +40,7 @@ libc = "0.2"
 nix = { version = "0.31", default-features = false }
 serde = "1"
 serde_json = "1"
-serde_yaml = "0.9"
+serde_yaml_ng = "0.10"
 tar = "0.4"
 thiserror = "2"
 tempfile = "3"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -40,6 +40,7 @@ libc = "0.2"
 nix = { version = "0.31", default-features = false }
 serde = "1"
 serde_json = "1"
+serde_yaml = "0.9"
 tar = "0.4"
 thiserror = "2"
 tempfile = "3"

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -13,7 +13,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 nix = { workspace = true, features = ["user", "signal"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
+serde_yaml_ng = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "signal", "time", "fs"] }
 tracing = { workspace = true }

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -13,6 +13,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 nix = { workspace = true, features = ["user", "signal"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "signal", "time", "fs"] }
 tracing = { workspace = true }

--- a/crates/runner/src/build.rs
+++ b/crates/runner/src/build.rs
@@ -1,27 +1,86 @@
 use clap::Args;
 
+use crate::config::{
+    self, DEFAULT_MAX_CONCURRENT, DEFAULT_MEMORY_MB, DEFAULT_VCPU, FirecrackerConfig, RunnerConfig,
+    SandboxConfig, ServerConfig,
+};
+use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
 use crate::error::RunnerResult;
+use crate::paths::{HomePaths, RootfsPaths};
 use crate::rootfs::RootfsArgs;
-use crate::snapshot::{DEFAULT_MEMORY_MB, DEFAULT_VCPU, SnapshotArgs};
+use crate::snapshot::SnapshotArgs;
 
 #[derive(Args)]
 pub struct BuildArgs {
+    /// Runner logical name
+    #[arg(long)]
+    name: String,
+    /// Runner group in scope/name format (e.g. "acme/production")
+    #[arg(long)]
+    group: String,
+    /// Runner directory name (under ~/.vm0-runner/runners/)
+    #[arg(long)]
+    runner_dirname: String,
+
     #[command(flatten)]
     rootfs: RootfsArgs,
-    /// Number of vCPUs for the snapshot VM.
+    /// Number of vCPUs for the snapshot VM
     #[arg(long, default_value_t = DEFAULT_VCPU)]
     vcpu: u32,
-    /// Memory size in MiB for the snapshot VM.
+    /// Memory size in MiB for the snapshot VM
     #[arg(long, default_value_t = DEFAULT_MEMORY_MB)]
     memory_mb: u32,
+
+    /// Maximum concurrent job executions
+    #[arg(long, default_value_t = DEFAULT_MAX_CONCURRENT)]
+    max_concurrent: usize,
+
+    /// vm0 API URL
+    #[arg(long, env = "VM0_API_URL")]
+    api_url: String,
+    /// Runner authentication token
+    #[arg(long, env = "VM0_RUNNER_TOKEN")]
+    token: String,
 }
 
 pub async fn run_build(args: BuildArgs) -> RunnerResult<()> {
     let rootfs_hash = crate::rootfs::run_rootfs(args.rootfs).await?;
-    let snapshot_args = SnapshotArgs {
-        rootfs_hash,
+    let snapshot_paths = crate::snapshot::run_snapshot(SnapshotArgs {
+        rootfs_hash: rootfs_hash.clone(),
         vcpu: args.vcpu,
         memory_mb: args.memory_mb,
+    })
+    .await?;
+
+    // Generate runner.yaml
+    let paths = HomePaths::new()?;
+    let rootfs_paths = RootfsPaths::new(&paths, &rootfs_hash);
+    let runner_dir = paths.runners_dir().join(&args.runner_dirname);
+
+    let runner_config = RunnerConfig {
+        name: args.name,
+        group: args.group,
+        base_dir: runner_dir.clone(),
+        firecracker: FirecrackerConfig {
+            binary: paths.firecracker_bin(FIRECRACKER_VERSION),
+            kernel: paths.kernel_bin(FIRECRACKER_VERSION, KERNEL_VERSION),
+            rootfs: rootfs_paths.rootfs(),
+            snapshot: Some(snapshot_paths),
+        },
+        sandbox: SandboxConfig {
+            vcpu: args.vcpu,
+            memory_mb: args.memory_mb,
+            max_concurrent: args.max_concurrent,
+        },
+        server: Some(ServerConfig {
+            url: args.api_url,
+            token: args.token,
+        }),
     };
-    crate::snapshot::run_snapshot(snapshot_args).await
+
+    config::generate(&runner_config).await?;
+    let config_path = runner_dir.join("runner.yaml");
+    tracing::info!("config written to {}", config_path.display());
+
+    Ok(())
 }

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -381,19 +381,47 @@ firecracker:
         generate(&config).await.unwrap();
 
         let loaded = load(&runner_dir.join("runner.yaml")).await.unwrap();
-        assert_eq!(loaded.name, "test-runner");
-        assert_eq!(loaded.group, "acme/prod");
-        assert_eq!(loaded.base_dir, runner_dir);
-        assert_eq!(loaded.firecracker.binary, fc);
-        assert_eq!(loaded.firecracker.kernel, kernel);
-        assert_eq!(loaded.firecracker.rootfs, rootfs);
-        assert!(loaded.firecracker.snapshot.is_none());
-        assert_eq!(loaded.sandbox.vcpu, 4);
-        assert_eq!(loaded.sandbox.memory_mb, 4096);
-        assert_eq!(loaded.sandbox.max_concurrent, 8);
-        let server = loaded.server.unwrap();
-        assert_eq!(server.url, "https://api.example.com");
-        assert_eq!(server.token, "secret");
+        assert_eq!(loaded, config);
+    }
+
+    #[tokio::test]
+    async fn generate_then_load_round_trip_with_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        let rootfs = dir.path().join("rootfs.squashfs");
+        let snap = dir.path().join("snapshot.bin");
+        let mem = dir.path().join("memory.bin");
+        let overlay = dir.path().join("overlay.ext4");
+        for f in [&fc, &kernel, &rootfs, &snap, &mem, &overlay] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+
+        let runner_dir = dir.path().join("my-runner");
+        let config = RunnerConfig {
+            name: "snap-runner".into(),
+            group: "acme/staging".into(),
+            base_dir: runner_dir.clone(),
+            firecracker: FirecrackerConfig {
+                binary: fc,
+                kernel,
+                rootfs,
+                snapshot: Some(SnapshotConfig {
+                    snapshot_path: snap,
+                    memory_path: mem,
+                    overlay_path: overlay,
+                    overlay_bind_path: dir.path().join("work/overlay.ext4"),
+                    vsock_bind_dir: dir.path().join("work/vsock"),
+                }),
+            },
+            sandbox: SandboxConfig::default(),
+            server: None,
+        };
+
+        generate(&config).await.unwrap();
+
+        let loaded = load(&runner_dir.join("runner.yaml")).await.unwrap();
+        assert_eq!(loaded, config);
     }
 
     #[tokio::test]

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -8,7 +8,7 @@ pub(crate) const DEFAULT_VCPU: u32 = 2;
 pub(crate) const DEFAULT_MEMORY_MB: u32 = 2048;
 pub(crate) const DEFAULT_MAX_CONCURRENT: usize = 4;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct RunnerConfig {
     pub name: String,
     pub group: String,
@@ -19,7 +19,7 @@ pub struct RunnerConfig {
     pub server: Option<ServerConfig>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct FirecrackerConfig {
     pub binary: PathBuf,
     pub kernel: PathBuf,
@@ -27,7 +27,7 @@ pub struct FirecrackerConfig {
     pub snapshot: Option<SnapshotConfig>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct SnapshotConfig {
     pub snapshot_path: PathBuf,
     pub memory_path: PathBuf,
@@ -48,7 +48,7 @@ impl From<sandbox_fc::SnapshotConfig> for SnapshotConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct SandboxConfig {
     pub vcpu: u32,
@@ -66,7 +66,7 @@ impl Default for SandboxConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ServerConfig {
     pub url: String,
     pub token: String,
@@ -79,7 +79,7 @@ pub async fn load(path: &Path) -> RunnerResult<RunnerConfig> {
     let content = tokio::fs::read_to_string(path)
         .await
         .map_err(|e| RunnerError::Config(format!("read {}: {e}", path.display())))?;
-    let mut config: RunnerConfig = serde_yaml::from_str(&content)
+    let mut config: RunnerConfig = serde_yaml_ng::from_str(&content)
         .map_err(|e| RunnerError::Config(format!("parse {}: {e}", path.display())))?;
     if let Some(config_dir) = path.parent() {
         config.resolve_relative_paths(config_dir);
@@ -95,7 +95,7 @@ pub async fn generate(config: &RunnerConfig) -> RunnerResult<()> {
         .await
         .map_err(|e| RunnerError::Config(format!("create {}: {e}", runner_dir.display())))?;
 
-    let content = serde_yaml::to_string(config)
+    let content = serde_yaml_ng::to_string(config)
         .map_err(|e| RunnerError::Config(format!("serialize config: {e}")))?;
 
     let config_path = runner_dir.join("runner.yaml");
@@ -394,5 +394,40 @@ firecracker:
         let server = loaded.server.unwrap();
         assert_eq!(server.url, "https://api.example.com");
         assert_eq!(server.token, "secret");
+    }
+
+    #[tokio::test]
+    async fn load_resolves_relative_paths() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Create files in a subdirectory
+        let sub = dir.path().join("artifacts");
+        tokio::fs::create_dir_all(&sub).await.unwrap();
+        for name in ["firecracker", "vmlinux", "rootfs.squashfs"] {
+            tokio::fs::write(sub.join(name), b"").await.unwrap();
+        }
+
+        // YAML uses relative paths (relative to config file location)
+        let yaml = r#"
+name: test
+group: test/group
+base_dir: my-runner
+firecracker:
+  binary: artifacts/firecracker
+  kernel: artifacts/vmlinux
+  rootfs: artifacts/rootfs.squashfs
+"#;
+
+        let config_path = dir.path().join("runner.yaml");
+        tokio::fs::write(&config_path, yaml).await.unwrap();
+
+        let config = load(&config_path).await.unwrap();
+
+        // All paths should be resolved to absolute paths under dir
+        assert!(config.base_dir.is_absolute());
+        assert_eq!(config.base_dir, dir.path().join("my-runner"));
+        assert_eq!(config.firecracker.binary, sub.join("firecracker"));
+        assert_eq!(config.firecracker.kernel, sub.join("vmlinux"));
+        assert_eq!(config.firecracker.rootfs, sub.join("rootfs.squashfs"));
     }
 }

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -1,0 +1,398 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{RunnerError, RunnerResult};
+
+pub(crate) const DEFAULT_VCPU: u32 = 2;
+pub(crate) const DEFAULT_MEMORY_MB: u32 = 2048;
+pub(crate) const DEFAULT_MAX_CONCURRENT: usize = 4;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RunnerConfig {
+    pub name: String,
+    pub group: String,
+    pub base_dir: PathBuf,
+    pub firecracker: FirecrackerConfig,
+    #[serde(default)]
+    pub sandbox: SandboxConfig,
+    pub server: Option<ServerConfig>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FirecrackerConfig {
+    pub binary: PathBuf,
+    pub kernel: PathBuf,
+    pub rootfs: PathBuf,
+    pub snapshot: Option<SnapshotConfig>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SnapshotConfig {
+    pub snapshot_path: PathBuf,
+    pub memory_path: PathBuf,
+    pub overlay_path: PathBuf,
+    pub overlay_bind_path: PathBuf,
+    pub vsock_bind_dir: PathBuf,
+}
+
+impl From<sandbox_fc::SnapshotConfig> for SnapshotConfig {
+    fn from(sc: sandbox_fc::SnapshotConfig) -> Self {
+        Self {
+            snapshot_path: sc.snapshot_path,
+            memory_path: sc.memory_path,
+            overlay_path: sc.overlay_path,
+            overlay_bind_path: sc.overlay_bind_path,
+            vsock_bind_dir: sc.vsock_bind_dir,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SandboxConfig {
+    pub vcpu: u32,
+    pub memory_mb: u32,
+    pub max_concurrent: usize,
+}
+
+impl Default for SandboxConfig {
+    fn default() -> Self {
+        Self {
+            vcpu: DEFAULT_VCPU,
+            memory_mb: DEFAULT_MEMORY_MB,
+            max_concurrent: DEFAULT_MAX_CONCURRENT,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ServerConfig {
+    pub url: String,
+    pub token: String,
+}
+
+/// Load and validate a runner config from a YAML file.
+///
+/// Relative paths in the config are resolved against the config file's parent directory.
+pub async fn load(path: &Path) -> RunnerResult<RunnerConfig> {
+    let content = tokio::fs::read_to_string(path)
+        .await
+        .map_err(|e| RunnerError::Config(format!("read {}: {e}", path.display())))?;
+    let mut config: RunnerConfig = serde_yaml::from_str(&content)
+        .map_err(|e| RunnerError::Config(format!("parse {}: {e}", path.display())))?;
+    if let Some(config_dir) = path.parent() {
+        config.resolve_relative_paths(config_dir);
+    }
+    validate_paths(&config).await?;
+    Ok(config)
+}
+
+/// Generate a runner.yaml config file from a `RunnerConfig`.
+pub async fn generate(config: &RunnerConfig) -> RunnerResult<()> {
+    let runner_dir = &config.base_dir;
+    tokio::fs::create_dir_all(runner_dir)
+        .await
+        .map_err(|e| RunnerError::Config(format!("create {}: {e}", runner_dir.display())))?;
+
+    let content = serde_yaml::to_string(config)
+        .map_err(|e| RunnerError::Config(format!("serialize config: {e}")))?;
+
+    let config_path = runner_dir.join("runner.yaml");
+    tokio::fs::write(&config_path, content)
+        .await
+        .map_err(|e| RunnerError::Config(format!("write {}: {e}", config_path.display())))?;
+    Ok(())
+}
+
+async fn check_path_exists(path: &Path, label: &str) -> RunnerResult<()> {
+    let exists = tokio::fs::try_exists(path)
+        .await
+        .map_err(|e| RunnerError::Config(format!("check {label}: {e}")))?;
+    if !exists {
+        return Err(RunnerError::Config(format!(
+            "{label} not found: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+async fn validate_paths(config: &RunnerConfig) -> RunnerResult<()> {
+    check_path_exists(&config.firecracker.binary, "firecracker binary").await?;
+    check_path_exists(&config.firecracker.kernel, "kernel").await?;
+    check_path_exists(&config.firecracker.rootfs, "rootfs").await?;
+
+    if let Some(snap) = &config.firecracker.snapshot {
+        check_path_exists(&snap.snapshot_path, "snapshot state").await?;
+        check_path_exists(&snap.memory_path, "snapshot memory").await?;
+        check_path_exists(&snap.overlay_path, "snapshot overlay").await?;
+        // overlay_bind_path and vsock_bind_dir are created at sandbox runtime
+    }
+
+    Ok(())
+}
+
+impl RunnerConfig {
+    /// Resolve relative paths against `config_dir` (the directory containing the YAML file).
+    fn resolve_relative_paths(&mut self, config_dir: &Path) {
+        let resolve = |p: &mut PathBuf| {
+            if p.is_relative() {
+                *p = config_dir.join(&*p);
+            }
+        };
+        resolve(&mut self.base_dir);
+        resolve(&mut self.firecracker.binary);
+        resolve(&mut self.firecracker.kernel);
+        resolve(&mut self.firecracker.rootfs);
+        if let Some(snap) = &mut self.firecracker.snapshot {
+            resolve(&mut snap.snapshot_path);
+            resolve(&mut snap.memory_path);
+            resolve(&mut snap.overlay_path);
+            resolve(&mut snap.overlay_bind_path);
+            resolve(&mut snap.vsock_bind_dir);
+        }
+    }
+
+    /// Build a `sandbox_fc::SnapshotConfig` from the config's snapshot paths.
+    pub fn snapshot_config(&self) -> Option<sandbox_fc::SnapshotConfig> {
+        self.firecracker
+            .snapshot
+            .as_ref()
+            .map(|s| sandbox_fc::SnapshotConfig {
+                snapshot_path: s.snapshot_path.clone(),
+                memory_path: s.memory_path.clone(),
+                overlay_path: s.overlay_path.clone(),
+                overlay_bind_path: s.overlay_bind_path.clone(),
+                vsock_bind_dir: s.vsock_bind_dir.clone(),
+            })
+    }
+
+    /// Build a `sandbox_fc::FirecrackerConfig` from this runner config.
+    pub fn firecracker_config(&self) -> sandbox_fc::FirecrackerConfig {
+        sandbox_fc::FirecrackerConfig {
+            binary_path: self.firecracker.binary.clone(),
+            kernel_path: self.firecracker.kernel.clone(),
+            rootfs_path: self.firecracker.rootfs.clone(),
+            base_dir: self.base_dir.clone(),
+            concurrency: self.sandbox.max_concurrent,
+            proxy_port: None,
+            snapshot: self.snapshot_config(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn load_full_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        let rootfs = dir.path().join("rootfs.squashfs");
+        for f in [&fc, &kernel, &rootfs] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+
+        let yaml = format!(
+            r#"
+name: test-runner
+group: acme/prod
+base_dir: {base_dir}
+firecracker:
+  binary: {fc}
+  kernel: {kernel}
+  rootfs: {rootfs}
+sandbox:
+  vcpu: 4
+  memory_mb: 4096
+  max_concurrent: 8
+server:
+  url: https://api.example.com
+  token: secret
+"#,
+            base_dir = dir.path().display(),
+            fc = fc.display(),
+            kernel = kernel.display(),
+            rootfs = rootfs.display(),
+        );
+
+        let config_path = dir.path().join("runner.yaml");
+        tokio::fs::write(&config_path, &yaml).await.unwrap();
+
+        let config = load(&config_path).await.unwrap();
+        assert_eq!(config.name, "test-runner");
+        assert_eq!(config.group, "acme/prod");
+        assert_eq!(config.sandbox.vcpu, 4);
+        assert_eq!(config.sandbox.memory_mb, 4096);
+        assert_eq!(config.sandbox.max_concurrent, 8);
+        let server = config.server.unwrap();
+        assert_eq!(server.url, "https://api.example.com");
+        assert_eq!(server.token, "secret");
+    }
+
+    #[tokio::test]
+    async fn load_defaults_for_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        let rootfs = dir.path().join("rootfs.squashfs");
+        for f in [&fc, &kernel, &rootfs] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+
+        let yaml = format!(
+            r#"
+name: test
+group: test/group
+base_dir: {base_dir}
+firecracker:
+  binary: {fc}
+  kernel: {kernel}
+  rootfs: {rootfs}
+"#,
+            base_dir = dir.path().display(),
+            fc = fc.display(),
+            kernel = kernel.display(),
+            rootfs = rootfs.display(),
+        );
+
+        let config_path = dir.path().join("runner.yaml");
+        tokio::fs::write(&config_path, &yaml).await.unwrap();
+
+        let config = load(&config_path).await.unwrap();
+        assert_eq!(config.sandbox.vcpu, DEFAULT_VCPU);
+        assert_eq!(config.sandbox.memory_mb, DEFAULT_MEMORY_MB);
+        assert_eq!(config.sandbox.max_concurrent, DEFAULT_MAX_CONCURRENT);
+        assert!(config.server.is_none());
+    }
+
+    #[tokio::test]
+    async fn load_fails_on_missing_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = format!(
+            r#"
+name: test
+group: test/group
+base_dir: {base_dir}
+firecracker:
+  binary: /nonexistent/firecracker
+  kernel: /nonexistent/kernel
+  rootfs: /nonexistent/rootfs
+"#,
+            base_dir = dir.path().display(),
+        );
+
+        let config_path = dir.path().join("runner.yaml");
+        tokio::fs::write(&config_path, &yaml).await.unwrap();
+
+        let err = load(&config_path).await.unwrap_err();
+        assert!(err.to_string().contains("not found"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn load_with_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        let rootfs = dir.path().join("rootfs.squashfs");
+        let snap = dir.path().join("snapshot.bin");
+        let mem = dir.path().join("memory.bin");
+        let overlay = dir.path().join("overlay.ext4");
+        let overlay_bind = dir.path().join("overlay_bind.ext4");
+        let vsock_dir = dir.path().join("vsock");
+        for f in [&fc, &kernel, &rootfs, &snap, &mem, &overlay] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+
+        let yaml = format!(
+            r#"
+name: test
+group: test/group
+base_dir: {base_dir}
+firecracker:
+  binary: {fc}
+  kernel: {kernel}
+  rootfs: {rootfs}
+  snapshot:
+    snapshot_path: {snap}
+    memory_path: {mem}
+    overlay_path: {overlay}
+    overlay_bind_path: {overlay_bind}
+    vsock_bind_dir: {vsock_dir}
+"#,
+            base_dir = dir.path().display(),
+            fc = fc.display(),
+            kernel = kernel.display(),
+            rootfs = rootfs.display(),
+            snap = snap.display(),
+            mem = mem.display(),
+            overlay = overlay.display(),
+            overlay_bind = overlay_bind.display(),
+            vsock_dir = vsock_dir.display(),
+        );
+
+        let config_path = dir.path().join("runner.yaml");
+        tokio::fs::write(&config_path, &yaml).await.unwrap();
+
+        let config = load(&config_path).await.unwrap();
+        let snap_config = config.snapshot_config().unwrap();
+        assert_eq!(snap_config.snapshot_path, snap);
+        assert_eq!(snap_config.memory_path, mem);
+        assert_eq!(snap_config.overlay_path, overlay);
+        assert_eq!(snap_config.overlay_bind_path, overlay_bind);
+        assert_eq!(snap_config.vsock_bind_dir, vsock_dir);
+    }
+
+    #[tokio::test]
+    async fn generate_then_load_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        let rootfs = dir.path().join("rootfs.squashfs");
+        for f in [&fc, &kernel, &rootfs] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+
+        let runner_dir = dir.path().join("my-runner");
+        let config = RunnerConfig {
+            name: "test-runner".into(),
+            group: "acme/prod".into(),
+            base_dir: runner_dir.clone(),
+            firecracker: FirecrackerConfig {
+                binary: fc.clone(),
+                kernel: kernel.clone(),
+                rootfs: rootfs.clone(),
+                snapshot: None,
+            },
+            sandbox: SandboxConfig {
+                vcpu: 4,
+                memory_mb: 4096,
+                max_concurrent: 8,
+            },
+            server: Some(ServerConfig {
+                url: "https://api.example.com".into(),
+                token: "secret".into(),
+            }),
+        };
+
+        generate(&config).await.unwrap();
+
+        let loaded = load(&runner_dir.join("runner.yaml")).await.unwrap();
+        assert_eq!(loaded.name, "test-runner");
+        assert_eq!(loaded.group, "acme/prod");
+        assert_eq!(loaded.base_dir, runner_dir);
+        assert_eq!(loaded.firecracker.binary, fc);
+        assert_eq!(loaded.firecracker.kernel, kernel);
+        assert_eq!(loaded.firecracker.rootfs, rootfs);
+        assert!(loaded.firecracker.snapshot.is_none());
+        assert_eq!(loaded.sandbox.vcpu, 4);
+        assert_eq!(loaded.sandbox.memory_mb, 4096);
+        assert_eq!(loaded.sandbox.max_concurrent, 8);
+        let server = loaded.server.unwrap();
+        assert_eq!(server.url, "https://api.example.com");
+        assert_eq!(server.token, "secret");
+    }
+}

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1,5 +1,6 @@
 mod api;
 mod build;
+mod config;
 mod deps;
 mod error;
 mod executor;
@@ -69,7 +70,7 @@ async fn main() -> ExitCode {
         Command::Setup => setup::run_setup().await,
         Command::Build(args) => build::run_build(args).await,
         Command::Rootfs(args) => rootfs::run_rootfs(args).await.map(drop),
-        Command::Snapshot(args) => snapshot::run_snapshot(args).await,
+        Command::Snapshot(args) => snapshot::run_snapshot(args).await.map(drop),
         Command::Start(args) => runner::run_start(*args).await,
     };
 

--- a/crates/runner/src/runner.rs
+++ b/crates/runner/src/runner.rs
@@ -70,7 +70,14 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
     let vcpu = runner_config.sandbox.vcpu;
     let memory_mb = runner_config.sandbox.memory_mb;
 
-    runner_config.base_dir = resolve_or_create(runner_config.base_dir.clone()).await?;
+    tokio::fs::create_dir_all(&runner_config.base_dir)
+        .await
+        .map_err(|e| {
+            RunnerError::Config(format!(
+                "create base_dir {}: {e}",
+                runner_config.base_dir.display()
+            ))
+        })?;
     let fc_config = runner_config.firecracker_config();
     let base_dir = runner_config.base_dir.clone();
 
@@ -310,17 +317,4 @@ async fn recv_signal(sig: &mut Option<tokio::signal::unix::Signal>) {
         }
         None => std::future::pending().await,
     }
-}
-
-async fn resolve_path(path: PathBuf) -> RunnerResult<PathBuf> {
-    tokio::fs::canonicalize(&path)
-        .await
-        .map_err(|e| RunnerError::Config(format!("resolve path {}: {e}", path.display())))
-}
-
-async fn resolve_or_create(path: PathBuf) -> RunnerResult<PathBuf> {
-    tokio::fs::create_dir_all(&path)
-        .await
-        .map_err(|e| RunnerError::Config(format!("create dir {}: {e}", path.display())))?;
-    resolve_path(path).await
 }

--- a/crates/runner/src/runner.rs
+++ b/crates/runner/src/runner.rs
@@ -10,6 +10,7 @@ use tokio::task::JoinSet;
 use tracing::{error, info};
 
 use crate::api::ApiClient;
+use crate::config;
 use crate::error::{RunnerError, RunnerResult};
 use crate::executor::{self, ExecutorConfig};
 use crate::paths::RunnerPaths;
@@ -19,88 +20,72 @@ const POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Args)]
 pub struct StartArgs {
-    /// Path to the Firecracker binary
-    #[arg(long)]
-    firecracker: PathBuf,
-    /// Path to the guest kernel image
-    #[arg(long)]
-    kernel: PathBuf,
-    /// Path to the root filesystem image
-    #[arg(long)]
-    rootfs: PathBuf,
-    /// vm0 API URL
+    /// Path to runner.yaml config file
+    #[arg(long, short)]
+    config: PathBuf,
+    /// vm0 API URL (overrides config)
     #[arg(long, env = "VM0_API_URL")]
-    api_url: String,
-    /// Runner authentication token
+    api_url: Option<String>,
+    /// Runner authentication token (overrides config)
     #[arg(long, env = "VM0_RUNNER_TOKEN")]
-    token: String,
-    /// Runner group in scope/name format (e.g. "acme/production")
-    #[arg(long)]
-    group: String,
-    /// Base directory for runtime data
-    #[arg(long)]
-    base_dir: PathBuf,
-    /// Snapshot directory to restore from
-    #[arg(long)]
-    snapshot_dir: Option<PathBuf>,
-    /// Maximum concurrent job executions
-    #[arg(long, default_value_t = 4)]
-    max_concurrent: usize,
-    /// vCPUs per sandbox
-    #[arg(long, default_value_t = 2)]
-    vcpu: u32,
-    /// Memory (MiB) per sandbox
-    #[arg(long, default_value_t = 2048)]
-    memory_mb: u32,
-    /// HTTP/HTTPS proxy port for network security
-    #[arg(long)]
-    proxy_port: Option<u16>,
+    token: Option<String>,
 }
 
-/// Build config from CLI args and run the main poll loop.
+/// Load config and run the main poll loop.
 pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
-    let firecracker = resolve_path(args.firecracker).await?;
-    let kernel = resolve_path(args.kernel).await?;
-    let rootfs = resolve_path(args.rootfs).await?;
-    let base_dir = resolve_or_create(args.base_dir).await?;
+    let mut runner_config = config::load(&args.config).await?;
 
-    let snapshot = match args.snapshot_dir {
-        Some(dir) => {
-            let dir = resolve_path(dir).await?;
-            let output = sandbox_fc::SnapshotOutputPaths::new(dir.clone());
-            let work = sandbox_fc::SandboxPaths::new(dir.join("work"));
-            Some(sandbox_fc::SnapshotConfig {
-                snapshot_path: output.snapshot(),
-                memory_path: output.memory(),
-                overlay_path: output.overlay(),
-                overlay_bind_path: work.overlay(),
-                vsock_bind_dir: work.vsock_dir(),
-            })
-        }
-        None => None,
-    };
+    // CLI / env overrides
+    let server = runner_config
+        .server
+        .get_or_insert_with(|| crate::config::ServerConfig {
+            url: String::new(),
+            token: String::new(),
+        });
+    if let Some(url) = args.api_url {
+        server.url = url;
+    }
+    if let Some(token) = args.token {
+        server.token = token;
+    }
 
-    let fc_config = sandbox_fc::FirecrackerConfig {
-        binary_path: firecracker,
-        kernel_path: kernel,
-        rootfs_path: rootfs,
-        base_dir: base_dir.clone(),
-        concurrency: args.max_concurrent,
-        proxy_port: args.proxy_port,
-        snapshot,
-    };
+    // Validate required server fields
+    if server.url.is_empty() {
+        return Err(RunnerError::Config(
+            "server.url is required (set in config or via --api-url / VM0_API_URL)".into(),
+        ));
+    }
+    if server.token.is_empty() {
+        return Err(RunnerError::Config(
+            "server.token is required (set in config or via --token / VM0_RUNNER_TOKEN)".into(),
+        ));
+    }
+
+    // Extract values before borrowing runner_config immutably
+    let api_url = server.url.clone();
+    let token = server.token.clone();
+    let name = runner_config.name.clone();
+    let group = runner_config.group.clone();
+    let max_concurrent = runner_config.sandbox.max_concurrent;
+    let vcpu = runner_config.sandbox.vcpu;
+    let memory_mb = runner_config.sandbox.memory_mb;
+
+    runner_config.base_dir = resolve_or_create(runner_config.base_dir.clone()).await?;
+    let fc_config = runner_config.firecracker_config();
+    let base_dir = runner_config.base_dir.clone();
 
     let paths = RunnerPaths::new(base_dir);
     let status = Arc::new(StatusTracker::new(paths.status()));
 
     let config = RunConfig {
-        api_url: args.api_url,
-        token: args.token,
-        group: args.group,
+        name,
+        api_url,
+        token,
+        group,
         fc_config,
-        max_concurrent: args.max_concurrent,
-        vcpu: args.vcpu,
-        memory_mb: args.memory_mb,
+        max_concurrent,
+        vcpu,
+        memory_mb,
         status,
     };
 
@@ -108,6 +93,7 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
 }
 
 struct RunConfig {
+    name: String,
     api_url: String,
     token: String,
     group: String,
@@ -142,6 +128,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 
     config.status.write_initial().await;
     info!(
+        name = %config.name,
         group = %config.group,
         max_concurrent = config.max_concurrent,
         "runner started, polling for jobs"

--- a/crates/runner/src/runner.rs
+++ b/crates/runner/src/runner.rs
@@ -35,13 +35,11 @@ pub struct StartArgs {
 pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
     let mut runner_config = config::load(&args.config).await?;
 
-    // CLI / env overrides
-    let server = runner_config
-        .server
-        .get_or_insert_with(|| crate::config::ServerConfig {
-            url: String::new(),
-            token: String::new(),
-        });
+    // CLI / env overrides — take server out so we can mutate independently
+    let mut server = runner_config.server.take().unwrap_or(config::ServerConfig {
+        url: String::new(),
+        token: String::new(),
+    });
     if let Some(url) = args.api_url {
         server.url = url;
     }
@@ -61,15 +59,6 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         ));
     }
 
-    // Extract values before borrowing runner_config immutably
-    let api_url = server.url.clone();
-    let token = server.token.clone();
-    let name = runner_config.name.clone();
-    let group = runner_config.group.clone();
-    let max_concurrent = runner_config.sandbox.max_concurrent;
-    let vcpu = runner_config.sandbox.vcpu;
-    let memory_mb = runner_config.sandbox.memory_mb;
-
     tokio::fs::create_dir_all(&runner_config.base_dir)
         .await
         .map_err(|e| {
@@ -79,7 +68,24 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
             ))
         })?;
     let fc_config = runner_config.firecracker_config();
-    let base_dir = runner_config.base_dir.clone();
+
+    // Destructure — no clones needed
+    let config::RunnerConfig {
+        name,
+        group,
+        base_dir,
+        sandbox,
+        ..
+    } = runner_config;
+    let config::SandboxConfig {
+        max_concurrent,
+        vcpu,
+        memory_mb,
+    } = sandbox;
+    let config::ServerConfig {
+        url: api_url,
+        token,
+    } = server;
 
     let paths = RunnerPaths::new(base_dir);
     let status = Arc::new(StatusTracker::new(paths.status()));

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -83,4 +83,23 @@ impl SnapshotOutputPaths {
     pub fn overlay(&self) -> PathBuf {
         self.output_dir.join("overlay.ext4")
     }
+
+    /// Work directory used during snapshot creation.
+    /// Its layout is preserved as bind-mount targets during restore.
+    pub fn work_dir(&self) -> PathBuf {
+        self.output_dir.join("work")
+    }
+
+    /// Build a [`SnapshotConfig`] combining the output artifacts with
+    /// the work directory paths recorded during snapshot creation.
+    pub fn snapshot_config(&self) -> crate::SnapshotConfig {
+        let work = SandboxPaths::new(self.work_dir());
+        crate::SnapshotConfig {
+            snapshot_path: self.snapshot(),
+            memory_path: self.memory(),
+            overlay_path: self.overlay(),
+            overlay_bind_path: work.overlay(),
+            vsock_bind_dir: work.vsock_dir(),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add `config` module with serde-based YAML config for runner (`RunnerConfig`, `FirecrackerConfig`, `SnapshotConfig`, `SandboxConfig`, `ServerConfig`)
- `build` command takes all runner parameters (name, group, dirname, server credentials) and generates a complete `runner.yaml` under `~/.vm0-runner/runners/{dirname}/`
- `start` command reads from `--config` with optional `--api-url`/`--token` CLI overrides, replacing individual path arguments
- Add `SnapshotOutputPaths::work_dir()` and `snapshot_config()` to `sandbox-fc` to eliminate hardcoded "work" directory convention
- `run_snapshot` returns full `SnapshotConfig` instead of raw `PathBuf`
- Relative paths in config resolved against config file directory
- Move `DEFAULT_VCPU`/`DEFAULT_MEMORY_MB`/`DEFAULT_MAX_CONCURRENT` constants to config module as single source of truth

## Test plan
- [x] 23 runner tests pass (including generate→load round-trip)
- [x] 68 sandbox-fc tests pass
- [x] clippy clean, pre-commit hooks pass

Closes #2924

🤖 Generated with [Claude Code](https://claude.com/claude-code)