### PR TITLE
feat(ably-subscriber): extract timing constants into configurable struct

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "base64",
  "futures-util",
  "hmac",
+ "httpmock",
  "reqwest",
  "rmp-serde",
  "rmpv",

--- a/crates/ably-subscriber/Cargo.toml
+++ b/crates/ably-subscriber/Cargo.toml
@@ -19,8 +19,9 @@ url = { workspace = true }
 
 [dev-dependencies]
 hmac = { workspace = true }
+httpmock = { workspace = true }
 sha2 = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util", "net"] }
 tracing-subscriber = { workspace = true }
 
 [lints]

--- a/crates/ably-subscriber/examples/integration_test.rs
+++ b/crates/ably-subscriber/examples/integration_test.rs
@@ -323,6 +323,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         channel_params: None,
         host: None,
         rest_host: None,
+        timing: None,
     })
     .await?;
 
@@ -425,6 +426,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         channel_params: None,
         host: None,
         rest_host: None,
+        timing: None,
     })
     .await?;
 

--- a/crates/ably-subscriber/examples/integration_test.rs
+++ b/crates/ably-subscriber/examples/integration_test.rs
@@ -313,18 +313,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let kn = key_name.to_string();
     let ks = key_secret.to_string();
 
-    let mut sub = subscribe(SubscribeConfig {
-        get_token: Box::new(move || {
+    let mut sub = subscribe(SubscribeConfig::new(
+        Box::new(move || {
             let kn = kn.clone();
             let ks = ks.clone();
             Box::pin(async move { create_token_request(&kn, &ks, 3_600_000) })
         }),
-        channel: channel.clone(),
-        channel_params: None,
-        host: None,
-        rest_host: None,
-        timing: None,
-    })
+        channel.clone(),
+    ))
     .await?;
 
     eprintln!("waiting for connection...");
@@ -409,8 +405,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let ks = key_secret.to_string();
     let call_count = Arc::new(AtomicU32::new(0));
 
-    let mut renewal_sub = subscribe(SubscribeConfig {
-        get_token: Box::new(move || {
+    let mut renewal_sub = subscribe(SubscribeConfig::new(
+        Box::new(move || {
             let kn = kn.clone();
             let ks = ks.clone();
             let cc = call_count.clone();
@@ -422,12 +418,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 create_token_request(&kn, &ks, ttl)
             })
         }),
-        channel: renewal_channel.clone(),
-        channel_params: None,
-        host: None,
-        rest_host: None,
-        timing: None,
-    })
+        renewal_channel.clone(),
+    ))
     .await?;
 
     wait_for_connected(&mut renewal_sub).await?;

--- a/crates/ably-subscriber/examples/subscribe.rs
+++ b/crates/ably-subscriber/examples/subscribe.rs
@@ -84,19 +84,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     eprintln!("subscribing to '{channel}' ...");
 
-    let mut sub = subscribe(SubscribeConfig {
-        get_token: Box::new(move || {
+    let mut config = SubscribeConfig::new(
+        Box::new(move || {
             let kn = key_name.clone();
             let ks = key_secret.clone();
             Box::pin(async move { create_token_request(&kn, &ks) })
         }),
-        channel: channel.to_string(),
-        channel_params: None,
-        host,
-        rest_host: None,
-        timing: None,
-    })
-    .await?;
+        channel.to_string(),
+    );
+    config.host = host;
+    let mut sub = subscribe(config).await?;
 
     while let Some(event) = sub.next().await {
         match &event {

--- a/crates/ably-subscriber/examples/subscribe.rs
+++ b/crates/ably-subscriber/examples/subscribe.rs
@@ -94,6 +94,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         channel_params: None,
         host,
         rest_host: None,
+        timing: None,
     })
     .await?;
 

--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -24,6 +24,10 @@ pub(crate) const DEFAULT_REALTIME_HOST: &str = "realtime.ably.io";
 const PROTOCOL_VERSION: &str = "5";
 const AGENT_STRING: &str = "ably-subscriber-rs/0.1";
 
+fn is_localhost(host: &str) -> bool {
+    host.starts_with("127.0.0.1") || host.starts_with("localhost")
+}
+
 fn error_or_unknown(error: Option<crate::protocol::ErrorInfo>) -> crate::protocol::ErrorInfo {
     error.unwrap_or_else(|| crate::protocol::ErrorInfo {
         code: error_code::FAILED,
@@ -61,11 +65,7 @@ pub(crate) async fn exchange_token(
     token_request: &crate::TokenRequest,
     host: &str,
 ) -> Result<TokenDetails, Error> {
-    let scheme = if host.starts_with("127.0.0.1") || host.starts_with("localhost") {
-        "http"
-    } else {
-        "https"
-    };
+    let scheme = if is_localhost(host) { "http" } else { "https" };
     let url = format!(
         "{scheme}://{host}/keys/{}/requestToken",
         token_request.key_name
@@ -87,11 +87,7 @@ pub(crate) async fn exchange_token(
 // ---------------------------------------------------------------------------
 
 fn build_ws_url(host: &str, token: &str, resume: Option<&str>) -> Result<String, Error> {
-    let scheme = if host.starts_with("127.0.0.1") || host.starts_with("localhost") {
-        "ws"
-    } else {
-        "wss"
-    };
+    let scheme = if is_localhost(host) { "ws" } else { "wss" };
     let mut u = url::Url::parse(&format!("{scheme}://{host}/"))?;
     {
         let mut q = u.query_pairs_mut();

--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -14,28 +14,15 @@ use crate::protocol::{
     AuthDetails, ProtocolMessage, action, build_attach_msg, decode_msg, encode_msg, error_code,
     flags,
 };
-use crate::types::{Event, Message, TokenDetails, TokenFuture};
+use crate::types::{Event, Message, TimingConfig, TokenDetails, TokenFuture};
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 pub(crate) const DEFAULT_REALTIME_HOST: &str = "realtime.ably.io";
-pub(crate) const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 const PROTOCOL_VERSION: &str = "5";
 const AGENT_STRING: &str = "ably-subscriber-rs/0.1";
-const HEARTBEAT_MARGIN: Duration = Duration::from_secs(10);
-const DEFAULT_MAX_IDLE_INTERVAL: Duration = Duration::from_secs(15);
-const DEFAULT_CONNECTION_STATE_TTL: Duration = Duration::from_secs(120);
-const INITIAL_RETRY_INTERVAL: Duration = Duration::from_secs(1);
-const MAX_RETRY_INTERVAL: Duration = Duration::from_secs(15);
-const RECONNECT_TIMEOUT: Duration = Duration::from_secs(60);
-const CHANNEL_RETRY_TIMEOUT: Duration = Duration::from_secs(15);
-const MAX_RETRY_ATTEMPTS: u32 = 40; // ~10 min (fast fail) to ~50 min (all timeouts)
-const TOKEN_RENEWAL_MARGIN: Duration = Duration::from_secs(300); // 5 minutes
-const TOKEN_RENEWAL_RETRY_DELAY: Duration = Duration::from_secs(30);
-const MAX_TOKEN_RENEWAL_FAILURES: u32 = 3;
-pub(crate) const EVENT_CHANNEL_CAPACITY: usize = 64;
 
 fn error_or_unknown(error: Option<crate::protocol::ErrorInfo>) -> crate::protocol::ErrorInfo {
     error.unwrap_or_else(|| crate::protocol::ErrorInfo {
@@ -74,8 +61,13 @@ pub(crate) async fn exchange_token(
     token_request: &crate::TokenRequest,
     host: &str,
 ) -> Result<TokenDetails, Error> {
+    let scheme = if host.starts_with("127.0.0.1") || host.starts_with("localhost") {
+        "http"
+    } else {
+        "https"
+    };
     let url = format!(
-        "https://{host}/keys/{}/requestToken",
+        "{scheme}://{host}/keys/{}/requestToken",
         token_request.key_name
     );
     let resp = client
@@ -95,7 +87,12 @@ pub(crate) async fn exchange_token(
 // ---------------------------------------------------------------------------
 
 fn build_ws_url(host: &str, token: &str, resume: Option<&str>) -> Result<String, Error> {
-    let mut u = url::Url::parse(&format!("wss://{host}/"))?;
+    let scheme = if host.starts_with("127.0.0.1") || host.starts_with("localhost") {
+        "ws"
+    } else {
+        "wss"
+    };
+    let mut u = url::Url::parse(&format!("{scheme}://{host}/"))?;
     {
         let mut q = u.query_pairs_mut();
         q.append_pair("access_token", token);
@@ -199,11 +196,12 @@ pub(crate) async fn connect_and_attach(
     token: TokenDetails,
     channel: &str,
     channel_params: Option<&HashMap<String, String>>,
+    timing: &TimingConfig,
 ) -> Result<(WsWrite, WsRead, ConnState), Error> {
     let ws_url = build_ws_url(realtime_host, &token.token, None)?;
     let (mut ws_write, mut ws_read) = connect_and_split(&ws_url).await?;
     let connected_msg = wait_for_connected(&mut ws_read).await?;
-    let mut conn_state = ConnState::from_connected(&connected_msg, token);
+    let mut conn_state = ConnState::from_connected(&connected_msg, token, timing);
     let attach = build_attach_msg(channel, channel_params, None);
     let encoded = encode_msg(&attach)?;
     ws_write
@@ -231,16 +229,16 @@ pub(crate) struct ConnState {
 }
 
 impl ConnState {
-    fn from_connected(msg: &ProtocolMessage, token: TokenDetails) -> Self {
+    fn from_connected(msg: &ProtocolMessage, token: TokenDetails, timing: &TimingConfig) -> Self {
         let mut state = ConnState {
             connection_id: None,
             connection_key: None,
             channel_serial: None,
-            connection_state_ttl: DEFAULT_CONNECTION_STATE_TTL,
-            max_idle_interval: DEFAULT_MAX_IDLE_INTERVAL,
+            connection_state_ttl: timing.default_connection_state_ttl,
+            max_idle_interval: timing.default_max_idle_interval,
             disconnected_at: None,
             last_reattach_at: None,
-            token_renewal_at: Self::compute_renewal_at(&token),
+            token_renewal_at: Self::compute_renewal_at(&token, timing.token_renewal_margin),
             token,
         };
         state.update_from_connected(msg);
@@ -266,13 +264,13 @@ impl ConnState {
         }
     }
 
-    fn compute_renewal_at(token: &TokenDetails) -> Instant {
+    fn compute_renewal_at(token: &TokenDetails, margin: Duration) -> Instant {
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as i64;
         let remaining_ms = (token.expires - now_ms).max(0) as u64;
-        let margin_ms = TOKEN_RENEWAL_MARGIN.as_millis() as u64;
+        let margin_ms = margin.as_millis() as u64;
         let renew_in = Duration::from_millis(remaining_ms.saturating_sub(margin_ms));
         Instant::now() + renew_in
     }
@@ -301,6 +299,7 @@ pub(crate) struct EventLoopState {
     pub rest_host: String,
     pub http: reqwest::Client,
     pub get_token: Box<dyn Fn() -> TokenFuture + Send + Sync>,
+    pub timing: TimingConfig,
     pub token_renewal_failures: u32,
     pub dropped_messages: u64,
 }
@@ -312,7 +311,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
         let mut disconnected_sent = false;
         // Main message processing loop
         loop {
-            let idle_timeout = p.conn_state.max_idle_interval + HEARTBEAT_MARGIN;
+            let idle_timeout = p.conn_state.max_idle_interval + p.timing.heartbeat_margin;
             let idle_deadline = Instant::now() + idle_timeout;
 
             tokio::select! {
@@ -356,7 +355,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                 }
 
                 _ = tokio::time::sleep_until(p.conn_state.token_renewal_at) => {
-                    let result = tokio::time::timeout(CONNECT_TIMEOUT, renew_token(&mut p)).await;
+                    let result = tokio::time::timeout(p.timing.connect_timeout, renew_token(&mut p)).await;
                     if handle_renewal_result(&mut p, result).await {
                         return;
                     }
@@ -384,12 +383,15 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
 
         loop {
             retry_count += 1;
-            if retry_count > MAX_RETRY_ATTEMPTS {
+            if retry_count > p.timing.max_retry_attempts {
                 let _ = p
                     .event_tx
                     .send(Event::Error {
                         code: error_code::FAILED,
-                        message: format!("Connection failed after {MAX_RETRY_ATTEMPTS} attempts"),
+                        message: format!(
+                            "Connection failed after {} attempts",
+                            p.timing.max_retry_attempts
+                        ),
                     })
                     .await;
                 return;
@@ -397,9 +399,11 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
 
             // Exponential backoff: 1s, 2s, 4s, 8s, 15s, 15s, ...
             let exp = retry_count.saturating_sub(1).min(30);
-            let backoff = INITIAL_RETRY_INTERVAL
+            let backoff = p
+                .timing
+                .initial_retry_interval
                 .saturating_mul(1u32 << exp)
-                .min(MAX_RETRY_INTERVAL);
+                .min(p.timing.max_retry_interval);
             // Use subsecond nanos from wall clock for non-deterministic jitter
             let nanos = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -414,7 +418,8 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                 }
             }
 
-            match tokio::time::timeout(RECONNECT_TIMEOUT, attempt_reconnect(&mut p)).await {
+            match tokio::time::timeout(p.timing.reconnect_timeout, attempt_reconnect(&mut p)).await
+            {
                 Ok(Ok(())) => {
                     retry_count = 0;
                     p.token_renewal_failures = 0;
@@ -605,7 +610,7 @@ async fn handle_message(p: &mut EventLoopState, msg: ProtocolMessage) -> LoopAct
             }
             if p.conn_state
                 .last_reattach_at
-                .is_some_and(|t| t.elapsed() < CHANNEL_RETRY_TIMEOUT)
+                .is_some_and(|t| t.elapsed() < p.timing.reattach_window)
             {
                 tracing::warn!("Channel detached again within retry window, reconnecting");
                 return LoopAction::Reconnect;
@@ -660,7 +665,7 @@ async fn handle_message(p: &mut EventLoopState, msg: ProtocolMessage) -> LoopAct
         }
         action::AUTH => {
             tracing::info!("Server requested reauthentication");
-            let result = tokio::time::timeout(CONNECT_TIMEOUT, renew_token(p)).await;
+            let result = tokio::time::timeout(p.timing.connect_timeout, renew_token(p)).await;
             if handle_renewal_result(p, result).await {
                 return LoopAction::Stop;
             }
@@ -695,28 +700,29 @@ async fn handle_renewal_result(
     tracing::error!(
         "{failure_reason} ({}/{})",
         p.token_renewal_failures,
-        MAX_TOKEN_RENEWAL_FAILURES,
+        p.timing.max_token_renewal_failures,
     );
 
-    if p.token_renewal_failures >= MAX_TOKEN_RENEWAL_FAILURES {
+    if p.token_renewal_failures >= p.timing.max_token_renewal_failures {
         let _ = p
             .event_tx
             .send(Event::Error {
                 code: error_code::FAILED,
                 message: format!(
-                    "Token renewal failed {MAX_TOKEN_RENEWAL_FAILURES} consecutive times"
+                    "Token renewal failed {} consecutive times",
+                    p.timing.max_token_renewal_failures
                 ),
             })
             .await;
         return true;
     }
 
-    p.conn_state.token_renewal_at = Instant::now() + TOKEN_RENEWAL_RETRY_DELAY;
+    p.conn_state.token_renewal_at = Instant::now() + p.timing.token_renewal_retry_delay;
     false
 }
 
 /// Renew the token and send an AUTH message. Callers are responsible for
-/// applying an outer timeout (e.g. `CONNECT_TIMEOUT`).
+/// applying an outer timeout (e.g. `timing.connect_timeout`).
 async fn renew_token(p: &mut EventLoopState) -> Result<(), Error> {
     tracing::info!("Renewing token");
     let token_request = (p.get_token)().await.map_err(Error::TokenFetch)?;
@@ -735,7 +741,8 @@ async fn renew_token(p: &mut EventLoopState) -> Result<(), Error> {
         .await?;
 
     p.conn_state.token = new_token;
-    p.conn_state.token_renewal_at = ConnState::compute_renewal_at(&p.conn_state.token);
+    p.conn_state.token_renewal_at =
+        ConnState::compute_renewal_at(&p.conn_state.token, p.timing.token_renewal_margin);
     tracing::info!("Token renewed successfully");
     Ok(())
 }
@@ -745,7 +752,7 @@ async fn renew_token(p: &mut EventLoopState) -> Result<(), Error> {
 // ---------------------------------------------------------------------------
 
 /// Attempt a single reconnect (resume or fresh). Callers are responsible for
-/// applying an outer timeout (e.g. `RECONNECT_TIMEOUT`).
+/// applying an outer timeout (e.g. `timing.reconnect_timeout`).
 ///
 /// All mutations to `p` are deferred until every step (connect, handshake,
 /// channel attach) has succeeded. This prevents a partial reconnect from
@@ -806,7 +813,8 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<(), Error> {
     }
     if let Some(token) = new_token {
         p.conn_state.token = token;
-        p.conn_state.token_renewal_at = ConnState::compute_renewal_at(&p.conn_state.token);
+        p.conn_state.token_renewal_at =
+            ConnState::compute_renewal_at(&p.conn_state.token, p.timing.token_renewal_margin);
     }
     p.ws_read = ws_read;
     p.ws_write = ws_write;
@@ -883,7 +891,8 @@ mod tests {
             capability: None,
             client_id: None,
         };
-        let state = ConnState::from_connected(&msg, token);
+        let timing = TimingConfig::default();
+        let state = ConnState::from_connected(&msg, token, &timing);
         assert_eq!(state.connection_id.as_deref(), Some("conn-1"));
         assert_eq!(state.connection_key.as_deref(), Some("conn-1!key"));
         assert_eq!(state.connection_state_ttl, Duration::from_millis(60000));
@@ -1020,5 +1029,14 @@ mod tests {
             message: String::new(),
         };
         assert!(!is_retriable(&err));
+    }
+
+    #[test]
+    fn build_ws_url_localhost_uses_ws() {
+        let url = build_ws_url("127.0.0.1:9000", "tok", None).unwrap();
+        assert!(url.starts_with("ws://127.0.0.1:9000/"));
+
+        let url = build_ws_url("localhost:9000", "tok", None).unwrap();
+        assert!(url.starts_with("ws://localhost:9000/"));
     }
 }

--- a/crates/ably-subscriber/src/lib.rs
+++ b/crates/ably-subscriber/src/lib.rs
@@ -21,6 +21,7 @@
 //!     channel_params: None,
 //!     host: None,
 //!     rest_host: None,
+//!     timing: None,
 //! };
 //!
 //! let mut sub = ably_subscriber::subscribe(config).await?;
@@ -36,11 +37,12 @@
 //! ```
 
 mod connection;
-mod protocol;
+pub mod protocol;
 mod subscribe;
 mod types;
 
 pub use subscribe::{Subscription, subscribe};
 pub use types::{
-    BoxError, Error, Event, Message, SubscribeConfig, TokenDetails, TokenFuture, TokenRequest,
+    BoxError, Error, Event, Message, SubscribeConfig, TimingConfig, TokenDetails, TokenFuture,
+    TokenRequest,
 };

--- a/crates/ably-subscriber/src/lib.rs
+++ b/crates/ably-subscriber/src/lib.rs
@@ -37,6 +37,7 @@
 //! ```
 
 mod connection;
+#[doc(hidden)]
 pub mod protocol;
 mod subscribe;
 mod types;

--- a/crates/ably-subscriber/src/lib.rs
+++ b/crates/ably-subscriber/src/lib.rs
@@ -15,14 +15,10 @@
 //! # async fn example() -> Result<(), ably_subscriber::Error> {
 //! use ably_subscriber::{SubscribeConfig, Event};
 //!
-//! let config = ably_subscriber::SubscribeConfig {
-//!     get_token: Box::new(|| Box::pin(async { todo!() })),
-//!     channel: "my-channel".to_string(),
-//!     channel_params: None,
-//!     host: None,
-//!     rest_host: None,
-//!     timing: None,
-//! };
+//! let config = ably_subscriber::SubscribeConfig::new(
+//!     Box::new(|| Box::pin(async { todo!() })),
+//!     "my-channel",
+//! );
 //!
 //! let mut sub = ably_subscriber::subscribe(config).await?;
 //! while let Some(event) = sub.next().await {

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -81,6 +81,7 @@ pub enum Event {
 /// constants they replace, so `TimingConfig::default()` preserves existing
 /// production behavior.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct TimingConfig {
     // -- Connection ----------------------------------------------------------
     /// Timeout for WebSocket connect, HTTP requests, and token operations.

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -150,6 +150,7 @@ impl Default for TimingConfig {
 }
 
 /// Configuration for [`subscribe`](crate::subscribe).
+#[non_exhaustive]
 pub struct SubscribeConfig {
     /// Callback that returns a fresh [`TokenRequest`] from your server.
     pub get_token: Box<dyn Fn() -> TokenFuture + Send + Sync>,
@@ -164,6 +165,26 @@ pub struct SubscribeConfig {
     pub rest_host: Option<String>,
     /// Override timing parameters. `None` uses [`TimingConfig::default()`].
     pub timing: Option<TimingConfig>,
+}
+
+impl SubscribeConfig {
+    /// Create a new configuration with the required fields.
+    ///
+    /// Optional fields (`channel_params`, `host`, `rest_host`, `timing`) default
+    /// to `None` and can be set directly after construction.
+    pub fn new(
+        get_token: Box<dyn Fn() -> TokenFuture + Send + Sync>,
+        channel: impl Into<String>,
+    ) -> Self {
+        Self {
+            get_token,
+            channel: channel.into(),
+            channel_params: None,
+            host: None,
+            rest_host: None,
+            timing: None,
+        }
+    }
 }
 
 /// Errors returned by this crate.

--- a/crates/ably-subscriber/src/types.rs
+++ b/crates/ably-subscriber/src/types.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tokio_tungstenite::tungstenite;
@@ -75,6 +76,78 @@ pub enum Event {
     Error { code: i32, message: String },
 }
 
+/// Timing parameters that control reconnection, heartbeat, token renewal, and
+/// backpressure behavior. All fields use the same defaults as the hardcoded
+/// constants they replace, so `TimingConfig::default()` preserves existing
+/// production behavior.
+#[derive(Debug, Clone)]
+pub struct TimingConfig {
+    // -- Connection ----------------------------------------------------------
+    /// Timeout for WebSocket connect, HTTP requests, and token operations.
+    pub connect_timeout: Duration,
+    /// Timeout wrapping each individual reconnect attempt.
+    pub reconnect_timeout: Duration,
+    /// Default `max_idle_interval` when the server doesn't specify one.
+    pub default_max_idle_interval: Duration,
+    /// Default `connection_state_ttl` when the server doesn't specify one.
+    pub default_connection_state_ttl: Duration,
+
+    // -- Heartbeat -----------------------------------------------------------
+    /// Extra margin added to `max_idle_interval` for heartbeat timeout.
+    pub heartbeat_margin: Duration,
+
+    // -- Reconnection retry --------------------------------------------------
+    /// Base interval for the first retry attempt.
+    pub initial_retry_interval: Duration,
+    /// Cap on exponential backoff between retries.
+    pub max_retry_interval: Duration,
+    /// Maximum number of consecutive reconnection attempts before giving up.
+    pub max_retry_attempts: u32,
+
+    // -- Channel re-attach ---------------------------------------------------
+    /// If a channel is DETACHED again within this window after a re-attach,
+    /// a full reconnect is triggered instead.
+    pub reattach_window: Duration,
+
+    // -- Token renewal -------------------------------------------------------
+    /// How early before token expiry to start proactive renewal.
+    pub token_renewal_margin: Duration,
+    /// Delay before retrying a failed token renewal.
+    pub token_renewal_retry_delay: Duration,
+    /// Number of consecutive token renewal failures before emitting a fatal error.
+    pub max_token_renewal_failures: u32,
+
+    // -- Backpressure --------------------------------------------------------
+    /// Bounded capacity of the internal event channel (mpsc).
+    pub event_channel_capacity: usize,
+}
+
+impl Default for TimingConfig {
+    fn default() -> Self {
+        Self {
+            // Connection
+            connect_timeout: Duration::from_secs(30),
+            reconnect_timeout: Duration::from_secs(60),
+            default_max_idle_interval: Duration::from_secs(15),
+            default_connection_state_ttl: Duration::from_secs(120),
+            // Heartbeat
+            heartbeat_margin: Duration::from_secs(10),
+            // Reconnection retry
+            initial_retry_interval: Duration::from_secs(1),
+            max_retry_interval: Duration::from_secs(15),
+            max_retry_attempts: 40,
+            // Channel re-attach
+            reattach_window: Duration::from_secs(15),
+            // Token renewal
+            token_renewal_margin: Duration::from_secs(300),
+            token_renewal_retry_delay: Duration::from_secs(30),
+            max_token_renewal_failures: 3,
+            // Backpressure
+            event_channel_capacity: 64,
+        }
+    }
+}
+
 /// Configuration for [`subscribe`](crate::subscribe).
 pub struct SubscribeConfig {
     /// Callback that returns a fresh [`TokenRequest`] from your server.
@@ -88,6 +161,8 @@ pub struct SubscribeConfig {
     /// Ably REST host for token exchange. Defaults to `"rest.ably.io"` when
     /// `host` is the default, otherwise falls back to the realtime host value.
     pub rest_host: Option<String>,
+    /// Override timing parameters. `None` uses [`TimingConfig::default()`].
+    pub timing: Option<TimingConfig>,
 }
 
 /// Errors returned by this crate.

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -1,0 +1,1714 @@
+use std::time::Duration;
+
+use ably_subscriber::protocol::{
+    AblyMessage, ConnectionDetails, ErrorInfo, ProtocolMessage, action, decode_msg, encode_msg,
+    error_code,
+};
+use ably_subscriber::{Event, SubscribeConfig, TimingConfig, subscribe};
+use futures_util::{SinkExt, StreamExt};
+use httpmock::prelude::*;
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+struct MockAblyServer {
+    listener: TcpListener,
+    port: u16,
+}
+
+type WsStream = tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>;
+
+impl MockAblyServer {
+    async fn start() -> std::io::Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let port = listener.local_addr()?.port();
+        Ok(Self { listener, port })
+    }
+
+    /// Accept one TCP connection and perform the Ably handshake (CONNECTED + ATTACH/ATTACHED).
+    ///
+    /// `conn_id` controls the connection identity. Use different IDs across
+    /// reconnect attempts so the client knows it's a fresh connect (not a
+    /// resume) and sends ATTACH.
+    async fn accept_and_handshake(
+        &self,
+        channel: &str,
+        conn_id: &str,
+    ) -> Result<WsStream, Box<dyn std::error::Error>> {
+        let (tcp, _) = self.listener.accept().await?;
+        let mut ws = tokio_tungstenite::accept_async(tcp).await?;
+
+        let conn_key = format!("{conn_id}!key");
+
+        // Send CONNECTED
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some(conn_id.into()),
+            connection_key: Some(conn_key.clone()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some(conn_key),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        ws.send(tungstenite::Message::Binary(encode_msg(&connected)?.into()))
+            .await?;
+
+        // Read ATTACH
+        let msg = read_protocol_msg(&mut ws).await?;
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some(channel));
+
+        // Send ATTACHED
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some(channel.into()),
+            channel_serial: Some("serial-0".into()),
+            ..Default::default()
+        };
+        ws.send(tungstenite::Message::Binary(encode_msg(&attached)?.into()))
+            .await?;
+
+        Ok(ws)
+    }
+
+    /// Like `accept_and_handshake` but allows overriding `connection_state_ttl`.
+    async fn accept_and_handshake_with_ttl(
+        &self,
+        channel: &str,
+        conn_id: &str,
+        connection_state_ttl_ms: i64,
+    ) -> Result<WsStream, Box<dyn std::error::Error>> {
+        let (tcp, _) = self.listener.accept().await?;
+        let mut ws = tokio_tungstenite::accept_async(tcp).await?;
+
+        let conn_key = format!("{conn_id}!key");
+
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some(conn_id.into()),
+            connection_key: Some(conn_key.clone()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some(conn_key),
+                connection_state_ttl: Some(connection_state_ttl_ms),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        ws.send(tungstenite::Message::Binary(encode_msg(&connected)?.into()))
+            .await?;
+
+        let msg = read_protocol_msg(&mut ws).await?;
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some(channel));
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some(channel.into()),
+            channel_serial: Some("serial-0".into()),
+            ..Default::default()
+        };
+        ws.send(tungstenite::Message::Binary(encode_msg(&attached)?.into()))
+            .await?;
+
+        Ok(ws)
+    }
+
+    /// Like `accept_and_handshake` but allows overriding `max_idle_interval`.
+    async fn accept_and_handshake_with_idle(
+        &self,
+        channel: &str,
+        conn_id: &str,
+        max_idle_interval_ms: i64,
+    ) -> Result<WsStream, Box<dyn std::error::Error>> {
+        let (tcp, _) = self.listener.accept().await?;
+        let mut ws = tokio_tungstenite::accept_async(tcp).await?;
+
+        let conn_key = format!("{conn_id}!key");
+
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some(conn_id.into()),
+            connection_key: Some(conn_key.clone()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some(conn_key),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(max_idle_interval_ms),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        ws.send(tungstenite::Message::Binary(encode_msg(&connected)?.into()))
+            .await?;
+
+        let msg = read_protocol_msg(&mut ws).await?;
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some(channel));
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some(channel.into()),
+            channel_serial: Some("serial-0".into()),
+            ..Default::default()
+        };
+        ws.send(tungstenite::Message::Binary(encode_msg(&attached)?.into()))
+            .await?;
+
+        Ok(ws)
+    }
+
+    /// Accept one TCP connection and return the raw WebSocket (no handshake).
+    async fn accept_raw(&self) -> Result<WsStream, Box<dyn std::error::Error>> {
+        let (tcp, _) = self.listener.accept().await?;
+        let ws = tokio_tungstenite::accept_async(tcp).await?;
+        Ok(ws)
+    }
+}
+
+async fn read_protocol_msg(
+    ws: &mut WsStream,
+) -> Result<ProtocolMessage, Box<dyn std::error::Error>> {
+    loop {
+        let frame = ws.next().await.ok_or("WebSocket closed unexpectedly")??;
+        if let tungstenite::Message::Binary(data) = frame {
+            return Ok(decode_msg(&data)?);
+        }
+    }
+}
+
+async fn send_message(
+    ws: &mut WsStream,
+    channel: &str,
+    name: &str,
+    data: serde_json::Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let msg = ProtocolMessage {
+        action: action::MESSAGE,
+        channel: Some(channel.into()),
+        channel_serial: Some("serial-1".into()),
+        messages: Some(vec![AblyMessage {
+            id: Some("msg-1".into()),
+            name: Some(name.into()),
+            data: Some(data),
+            timestamp: Some(now_ms()),
+            ..Default::default()
+        }]),
+        ..Default::default()
+    };
+    ws.send(tungstenite::Message::Binary(encode_msg(&msg)?.into()))
+        .await?;
+    Ok(())
+}
+
+fn mock_token_endpoint(server: &MockServer, key_name: &str) {
+    let path = format!("/keys/{key_name}/requestToken");
+    let now = now_ms();
+    let body = serde_json::json!({
+        "token": "mock-token-abc",
+        "expires": now + 3_600_000,
+        "issued": now,
+        "capability": "{\"*\":[\"*\"]}",
+    });
+    server.mock(|when, then| {
+        when.method(POST).path(path);
+        then.status(201)
+            .header("content-type", "application/json")
+            .json_body(body);
+    });
+}
+
+fn test_config(ws_port: u16, http_port: u16, channel: &str) -> SubscribeConfig {
+    let host = format!("127.0.0.1:{ws_port}");
+    let rest_host = format!("127.0.0.1:{http_port}");
+    let channel = channel.to_string();
+    SubscribeConfig {
+        get_token: Box::new(move || {
+            Box::pin(async {
+                Ok(ably_subscriber::TokenRequest {
+                    key_name: "testKey.testId".into(),
+                    timestamp: now_ms(),
+                    nonce: "nonce-1".into(),
+                    mac: "fake-mac".into(),
+                    capability: r#"{"*":["subscribe"]}"#.into(),
+                    ttl: None,
+                    client_id: None,
+                })
+            })
+        }),
+        channel,
+        channel_params: None,
+        host: Some(host),
+        rest_host: Some(rest_host),
+        timing: None,
+    }
+}
+
+fn test_config_with_timing(
+    ws_port: u16,
+    http_port: u16,
+    channel: &str,
+    timing: TimingConfig,
+) -> SubscribeConfig {
+    let mut config = test_config(ws_port, http_port, channel);
+    config.timing = Some(timing);
+    config
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: connect and receive a single message
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn connect_and_receive_message() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("test-ch", "conn-1").await.unwrap();
+        send_message(
+            &mut conn,
+            "test-ch",
+            "greeting",
+            serde_json::json!({"hello": "world"}),
+        )
+        .await
+        .unwrap();
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "test-ch"))
+        .await
+        .unwrap();
+
+    let event = sub.next().await.unwrap();
+    assert!(matches!(event, Event::Connected));
+
+    let event = sub.next().await.unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("greeting"));
+            assert_eq!(msg.data, serde_json::json!({"hello": "world"}));
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: multiple messages received in order
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn multiple_messages() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        for i in 0..3 {
+            send_message(&mut conn, "ch", &format!("evt-{i}"), serde_json::json!(i))
+                .await
+                .unwrap();
+        }
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    for i in 0..3 {
+        match sub.next().await.unwrap() {
+            Event::Message(msg) => {
+                assert_eq!(msg.name.as_deref(), Some(format!("evt-{i}").as_str()));
+            }
+            other => panic!("expected Message, got {other:?}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: batched messages in a single frame
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn batched_messages_in_single_frame() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        let msg = ProtocolMessage {
+            action: action::MESSAGE,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-1".into()),
+            messages: Some(vec![
+                AblyMessage {
+                    name: Some("a".into()),
+                    data: Some(serde_json::json!(1)),
+                    ..Default::default()
+                },
+                AblyMessage {
+                    name: Some("b".into()),
+                    data: Some(serde_json::json!(2)),
+                    ..Default::default()
+                },
+                AblyMessage {
+                    name: Some("c".into()),
+                    data: Some(serde_json::json!(3)),
+                    ..Default::default()
+                },
+            ]),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&msg).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let names: Vec<String> = futures_util::stream::unfold(&mut sub, |sub| async {
+        match sub.next().await {
+            Some(Event::Message(m)) => Some((m.name.unwrap_or_default(), sub)),
+            _ => None,
+        }
+    })
+    .take(3)
+    .collect()
+    .await;
+
+    assert_eq!(names, vec!["a", "b", "c"]);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: message with json encoding
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn message_with_json_encoding() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        let msg = ProtocolMessage {
+            action: action::MESSAGE,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-1".into()),
+            messages: Some(vec![AblyMessage {
+                name: Some("evt".into()),
+                data: Some(serde_json::json!(r#"{"runId":"uuid-123"}"#)),
+                encoding: Some("json".into()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&msg).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    match sub.next().await.unwrap() {
+        Event::Message(msg) => {
+            assert_eq!(msg.data, serde_json::json!({"runId": "uuid-123"}));
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: server error during handshake
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn server_error_during_handshake() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let mut conn = ws.accept_raw().await.unwrap();
+        let error_msg = ProtocolMessage {
+            action: action::ERROR,
+            error: Some(ErrorInfo {
+                code: error_code::FAILED,
+                status_code: Some(401),
+                message: "Unauthorized".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&error_msg).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+    });
+
+    let result = subscribe(test_config(ws_port, http.port(), "ch")).await;
+    match result {
+        Err(ably_subscriber::Error::Protocol { .. }) => {}
+        Err(other) => panic!("expected Protocol error, got {other:?}"),
+        Ok(_) => panic!("expected error, got Ok"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: connection closed before CONNECTED
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn connection_closed_before_connected() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let conn = ws.accept_raw().await.unwrap();
+        drop(conn);
+    });
+
+    let result = subscribe(test_config(ws_port, http.port(), "ch")).await;
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: HTTP token exchange error (500)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn http_token_exchange_error() {
+    let http = MockServer::start();
+    // No WS server needed — we fail before connecting
+    let path = "/keys/testKey.testId/requestToken";
+    http.mock(|when, then| {
+        when.method(POST).path(path);
+        then.status(500).body("Internal Server Error");
+    });
+
+    let result = subscribe(test_config(19999, http.port(), "ch")).await;
+    match result {
+        Err(ably_subscriber::Error::Http(_)) => {}
+        Err(other) => panic!("expected Http error, got {other:?}"),
+        Ok(_) => panic!("expected error, got Ok"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: token renewal — server receives AUTH after short-TTL token
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn token_renewal() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+
+    let now = now_ms();
+    // First token: expires in 1 second (token renewal margin is 300s, so
+    // renewal fires almost immediately)
+    let short_token_body = serde_json::json!({
+        "token": "short-lived-token",
+        "expires": now + 1_000,
+        "issued": now,
+    });
+    let renewed_token_body = serde_json::json!({
+        "token": "renewed-token",
+        "expires": now + 3_600_000,
+        "issued": now,
+    });
+    // httpmock serves first call then second call
+    let path = "/keys/testKey.testId/requestToken";
+    http.mock(|when, then| {
+        when.method(POST).path(path);
+        then.status(201)
+            .header("content-type", "application/json")
+            .json_body(short_token_body);
+    });
+    // Second mock for renewal exchange
+    http.mock(|when, then| {
+        when.method(POST).path(path);
+        then.status(201)
+            .header("content-type", "application/json")
+            .json_body(renewed_token_body);
+    });
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        // Wait for AUTH message from client
+        let auth_msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for AUTH")
+            .unwrap();
+        assert_eq!(auth_msg.action, action::AUTH);
+
+        // Send a message after renewal
+        send_message(&mut conn, "ch", "after-renewal", serde_json::json!("ok"))
+            .await
+            .unwrap();
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    // Should receive the message sent after token renewal
+    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
+        .await
+        .expect("timed out waiting for message after renewal")
+        .unwrap();
+
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("after-renewal"));
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: reconnect after server drops connection
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn reconnect_after_server_drop() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+    // Need a second mock for the token exchange on reconnect
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        // First connection
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        send_message(&mut conn, "ch", "before-drop", serde_json::json!(1))
+            .await
+            .unwrap();
+        // Give client time to receive the message
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        drop(conn);
+
+        // Second connection (after reconnect)
+        let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
+        send_message(&mut conn2, "ch", "after-reconnect", serde_json::json!(2))
+            .await
+            .unwrap();
+        // Keep alive long enough for client to read
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    // First message
+    match sub.next().await.unwrap() {
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("before-drop")),
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    // Disconnected event
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    // Reconnected
+    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
+        .await
+        .expect("timed out waiting for Connected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected, got {event:?}"
+    );
+
+    // Message after reconnect
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after reconnect")
+        .unwrap();
+    match event {
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-reconnect")),
+        other => panic!("expected Message, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: server sends DISCONNECTED, client reconnects
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn server_sends_disconnected() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        // Send DISCONNECTED (retriable)
+        let disconnected = ProtocolMessage {
+            action: action::DISCONNECTED,
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "server going away".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&disconnected).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        // Second connection
+        let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
+        send_message(&mut conn2, "ch", "reconnected", serde_json::json!("ok"))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    // Disconnected
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    // Reconnected
+    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
+        .await
+        .expect("timed out")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected, got {event:?}"
+    );
+
+    // Message
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out")
+        .unwrap();
+    match event {
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("reconnected")),
+        other => panic!("expected Message, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: server sends DETACHED, client re-attaches
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn server_sends_detached_reattach() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        // Send DETACHED (retriable — server error)
+        let detached = ProtocolMessage {
+            action: action::DETACHED,
+            channel: Some("ch".into()),
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "channel detached".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&detached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        // Expect re-ATTACH from client
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+
+        // Send ATTACHED
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-2".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&attached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        // Send message after reattach
+        send_message(&mut conn, "ch", "after-reattach", serde_json::json!("ok"))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    // Message after reattach
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after reattach")
+        .unwrap();
+    match event {
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-reattach")),
+        other => panic!("expected Message, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 12: close subscription sends CLOSE to server
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn close_subscription() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (close_tx, close_rx) = tokio::sync::oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        // Wait for CLOSE from client
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for CLOSE")
+            .unwrap();
+        assert_eq!(msg.action, action::CLOSE);
+        close_tx.send(()).unwrap();
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    sub.close();
+
+    // Server task confirms it received CLOSE
+    tokio::time::timeout(Duration::from_secs(5), close_rx)
+        .await
+        .expect("timed out waiting for server to confirm CLOSE")
+        .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Test 13: non-retriable DISCONNECTED → Event::Error (not reconnect)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn non_retriable_disconnected_emits_error() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        // Send DISCONNECTED with a non-retriable error (401 + non-connection code)
+        let disconnected = ProtocolMessage {
+            action: action::DISCONNECTED,
+            error: Some(ErrorInfo {
+                code: 40142,
+                status_code: Some(401),
+                message: "Token expired".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&disconnected).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out")
+        .unwrap();
+    match event {
+        Event::Error { code, .. } => assert_eq!(code, 40142),
+        other => panic!("expected Error, got {other:?}"),
+    }
+
+    // Stream should end (loop stopped)
+    assert!(sub.next().await.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Test 14: ERROR during event loop → Event::Error + stop
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn error_during_event_loop() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        let error_msg = ProtocolMessage {
+            action: action::ERROR,
+            error: Some(ErrorInfo {
+                code: 40000,
+                status_code: Some(400),
+                message: "Bad request".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&error_msg).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out")
+        .unwrap();
+    match event {
+        Event::Error { code, .. } => assert_eq!(code, 40000),
+        other => panic!("expected Error, got {other:?}"),
+    }
+
+    assert!(sub.next().await.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Test 15: non-retriable DETACHED → Event::Error (not re-attach)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn non_retriable_detached_emits_error() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        // DETACHED with non-retriable error (401 + non-connection code)
+        let detached = ProtocolMessage {
+            action: action::DETACHED,
+            channel: Some("ch".into()),
+            error: Some(ErrorInfo {
+                code: 40160,
+                status_code: Some(401),
+                message: "Channel denied".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&detached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out")
+        .unwrap();
+    match event {
+        Event::Error { code, message } => {
+            assert_eq!(code, 40160);
+            assert!(message.contains("Channel detached"), "got: {message}");
+        }
+        other => panic!("expected Error, got {other:?}"),
+    }
+
+    assert!(sub.next().await.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Test 16: server sends CLOSED → event loop stops
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn server_sends_closed() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        let closed = ProtocolMessage {
+            action: action::CLOSED,
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&closed).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    // Stream should end (CLOSED → LoopAction::Stop)
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out");
+    assert!(event.is_none(), "expected None after CLOSED, got {event:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Test 17: server-initiated AUTH (action 17) → client renews token
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn server_initiated_auth() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+    // Second mock for the renewal exchange triggered by server AUTH
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        // Server sends AUTH to request reauthentication
+        let auth_request = ProtocolMessage {
+            action: action::AUTH,
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&auth_request).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        // Client should respond with AUTH containing new token
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for client AUTH response")
+            .unwrap();
+        assert_eq!(msg.action, action::AUTH);
+        assert!(
+            msg.auth.is_some(),
+            "AUTH message should contain auth details"
+        );
+
+        // Send a message to confirm the connection is still alive
+        send_message(
+            &mut conn,
+            "ch",
+            "after-server-auth",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after server AUTH")
+        .unwrap();
+    match event {
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-server-auth")),
+        other => panic!("expected Message, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 18: get_token callback returns error → subscribe fails
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_token_callback_error() {
+    let config = SubscribeConfig {
+        get_token: Box::new(|| Box::pin(async { Err("token fetch failed".into()) })),
+        channel: "ch".into(),
+        channel_params: None,
+        host: Some("127.0.0.1:19999".into()),
+        rest_host: Some("127.0.0.1:19999".into()),
+        timing: None,
+    };
+
+    let result = subscribe(config).await;
+    match result {
+        Err(ably_subscriber::Error::TokenFetch(_)) => {}
+        Err(other) => panic!("expected TokenFetch error, got {other:?}"),
+        Ok(_) => panic!("expected error, got Ok"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 19: heartbeat timeout triggers reconnect (fast with TimingConfig)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn heartbeat_timeout_triggers_reconnect() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        // First connection: tiny max_idle_interval, then silence (no heartbeats)
+        let _conn = ws
+            .accept_and_handshake_with_idle("ch", "conn-1", 50)
+            .await
+            .unwrap();
+        // Don't send anything — let the heartbeat timeout fire
+
+        // Second connection after reconnect
+        let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
+        send_message(
+            &mut conn2,
+            "ch",
+            "after-hb-timeout",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    let timing = TimingConfig {
+        heartbeat_margin: Duration::from_millis(50),
+        initial_retry_interval: Duration::from_millis(10),
+        max_retry_interval: Duration::from_millis(50),
+        ..TimingConfig::default()
+    };
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    // Disconnected from heartbeat timeout
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    // Reconnected
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Connected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected, got {event:?}"
+    );
+
+    // Message after reconnect
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message")
+        .unwrap();
+    match event {
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-hb-timeout")),
+        other => panic!("expected Message, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 20: retry exhaustion emits error (fast with TimingConfig)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn retry_exhaustion_emits_error() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+    // Extra token mocks for the retry attempts (each fresh connect needs a token)
+    mock_token_endpoint(&http, "testKey.testId");
+    mock_token_endpoint(&http, "testKey.testId");
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        // First connection: handshake then drop
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        drop(conn);
+        // Drop the server so the port is unbound — reconnects fail with
+        // "connection refused" immediately instead of hanging on the listener.
+        drop(ws);
+        tokio::time::sleep(Duration::from_secs(30)).await;
+    });
+
+    let timing = TimingConfig {
+        max_retry_attempts: 2,
+        initial_retry_interval: Duration::from_millis(10),
+        max_retry_interval: Duration::from_millis(10),
+        ..TimingConfig::default()
+    };
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    // Disconnected
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    // Error after exhausting retries
+    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
+        .await
+        .expect("timed out waiting for Error")
+        .unwrap();
+    match event {
+        Event::Error { message, .. } => {
+            assert!(
+                message.contains("failed after 2 attempts"),
+                "unexpected message: {message}"
+            );
+        }
+        other => panic!("expected Error, got {other:?}"),
+    }
+
+    assert!(sub.next().await.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Test 21: token renewal failures become fatal (fast with TimingConfig)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn token_renewal_failures_fatal() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+
+    // Return a short-lived token so renewal fires immediately.
+    // TOKEN_RENEWAL_MARGIN is 300s, so a 1s token means renew_in = 0.
+    let now = now_ms();
+    let short_token = serde_json::json!({
+        "token": "short-lived-token",
+        "expires": now + 1_000,
+        "issued": now,
+    });
+    let path = "/keys/testKey.testId/requestToken";
+    http.mock(|when, then| {
+        when.method(POST).path(path);
+        then.status(201)
+            .header("content-type", "application/json")
+            .json_body(short_token);
+    });
+
+    let ws_port = ws.port;
+    let host = format!("127.0.0.1:{ws_port}");
+    let rest_host = format!("127.0.0.1:{}", http.port());
+
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        // Keep the connection alive while renewal attempts happen
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        let _ = conn.close(None).await;
+    });
+
+    // Use an atomic counter so get_token succeeds for the initial exchange
+    // but fails for all subsequent renewal attempts.
+    let call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let cc = call_count.clone();
+    let config = SubscribeConfig {
+        get_token: Box::new(move || {
+            let n = cc.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Box::pin(async move {
+                if n > 0 {
+                    return Err("simulated token fetch failure".into());
+                }
+                Ok(ably_subscriber::TokenRequest {
+                    key_name: "testKey.testId".into(),
+                    timestamp: now_ms(),
+                    nonce: "nonce-1".into(),
+                    mac: "fake-mac".into(),
+                    capability: r#"{"*":["subscribe"]}"#.into(),
+                    ttl: None,
+                    client_id: None,
+                })
+            })
+        }),
+        channel: "ch".into(),
+        channel_params: None,
+        host: Some(host),
+        rest_host: Some(rest_host),
+        timing: Some(TimingConfig {
+            token_renewal_retry_delay: Duration::from_millis(10),
+            ..TimingConfig::default()
+        }),
+    };
+    let mut sub = subscribe(config).await.unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    // Should eventually get a fatal error after 3 consecutive renewal failures
+    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
+        .await
+        .expect("timed out waiting for Error")
+        .unwrap();
+    match event {
+        Event::Error { message, .. } => {
+            assert!(
+                message.contains("renewal failed 3 consecutive"),
+                "unexpected message: {message}"
+            );
+        }
+        other => panic!("expected Error, got {other:?}"),
+    }
+
+    assert!(sub.next().await.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Test 22: backpressure drops messages when channel is full
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn backpressure_drops_messages() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        // Send 10 messages rapidly (channel capacity = 2, plus 1 Connected event)
+        for i in 0..10 {
+            send_message(&mut conn, "ch", &format!("msg-{i}"), serde_json::json!(i))
+                .await
+                .unwrap();
+        }
+        // Keep connection alive
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    let timing = TimingConfig {
+        event_channel_capacity: 2,
+        ..TimingConfig::default()
+    };
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    // Drain some messages — we may not get all 10 due to backpressure drops,
+    // but we should get at least 1 and the stream should still work
+    let mut received = 0;
+    while let Ok(Some(Event::Message(_))) =
+        tokio::time::timeout(Duration::from_secs(2), sub.next()).await
+    {
+        received += 1;
+    }
+    assert!(
+        (1..10).contains(&received),
+        "expected some messages dropped, got {received}/10"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 23: detached within retry window triggers full reconnect
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn detached_within_retry_window_triggers_reconnect() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        let detached = ProtocolMessage {
+            action: action::DETACHED,
+            channel: Some("ch".into()),
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "channel detached".into(),
+            }),
+            ..Default::default()
+        };
+
+        // First DETACHED (retriable) → client sets last_reattach_at and sends ATTACH
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&detached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        // Wait for re-ATTACH
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+
+        // Send second DETACHED *before* ATTACHED — while last_reattach_at is
+        // still set. This is within the retry window → triggers full reconnect.
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&detached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        // Client should do a full reconnect
+        let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
+        send_message(
+            &mut conn2,
+            "ch",
+            "after-full-reconnect",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    let timing = TimingConfig {
+        reattach_window: Duration::from_secs(60),
+        initial_retry_interval: Duration::from_millis(10),
+        max_retry_interval: Duration::from_millis(50),
+        ..TimingConfig::default()
+    };
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    // The DETACHED→Reconnect code path does NOT emit a Disconnected event
+    // (unlike the DISCONNECTED action handler which does). So we expect
+    // Connected directly after the full reconnect completes.
+    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
+        .await
+        .expect("timed out waiting for Connected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected, got {event:?}"
+    );
+
+    // Message after full reconnect
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message")
+        .unwrap();
+    match event {
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-full-reconnect")),
+        other => panic!("expected Message, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 24: connect_timeout fires when server hangs during handshake
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn connect_timeout_fires() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        // Accept TCP but never complete the WebSocket handshake — just sleep
+        let (tcp, _) = ws.listener.accept().await.unwrap();
+        let _hold = tcp; // keep socket open
+        tokio::time::sleep(Duration::from_secs(30)).await;
+    });
+
+    let timing = TimingConfig {
+        connect_timeout: Duration::from_millis(100),
+        ..TimingConfig::default()
+    };
+    let result = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing)).await;
+    match result {
+        Err(ably_subscriber::Error::Protocol { code, message }) => {
+            assert_eq!(code, ably_subscriber::protocol::error_code::TIMEOUT);
+            assert!(
+                message.contains("timed out"),
+                "unexpected message: {message}"
+            );
+        }
+        Err(other) => panic!("expected Protocol/TIMEOUT error, got {other:?}"),
+        Ok(_) => panic!("expected error, got Ok"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 25: reconnect_timeout fires when reconnect attempt hangs
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn reconnect_timeout_fires() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    tokio::spawn(async move {
+        // First connection succeeds, then drop
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        drop(conn);
+
+        // For reconnect attempts: accept TCP but never complete WebSocket
+        // handshake — forces reconnect_timeout to fire (not "connection refused").
+        while let Ok((tcp, _)) = ws.listener.accept().await {
+            let _hold = tcp;
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        }
+    });
+
+    let timing = TimingConfig {
+        reconnect_timeout: Duration::from_millis(100),
+        max_retry_attempts: 2,
+        initial_retry_interval: Duration::from_millis(10),
+        max_retry_interval: Duration::from_millis(10),
+        ..TimingConfig::default()
+    };
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    // Disconnected
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    // Each reconnect attempt hangs → reconnect_timeout fires → retry.
+    // After max_retry_attempts, we get a fatal error.
+    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
+        .await
+        .expect("timed out waiting for Error")
+        .unwrap();
+    match event {
+        Event::Error { message, .. } => {
+            assert!(
+                message.contains("failed after 2 attempts"),
+                "unexpected message: {message}"
+            );
+        }
+        other => panic!("expected Error, got {other:?}"),
+    }
+
+    assert!(sub.next().await.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Test 26: expired connection_state_ttl skips resume (fresh connect)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn expired_ttl_skips_resume() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (resume_tx, resume_rx) = tokio::sync::oneshot::channel::<bool>();
+
+    tokio::spawn(async move {
+        // First connection with a tiny connection_state_ttl (1ms).
+        // The server-provided TTL overrides the TimingConfig default, so we
+        // set it here to ensure can_resume() sees a short TTL.
+        let conn = ws
+            .accept_and_handshake_with_ttl("ch", "conn-1", 1)
+            .await
+            .unwrap();
+        // Small delay so the 1ms TTL expires before the reconnect attempt.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        drop(conn);
+
+        // Second connection — send CONNECTED with the *same* conn_id.
+        // If client tried resume and got the same ID, it would skip ATTACH.
+        // But since TTL expired, can_resume()=false → fresh connect → ATTACH.
+        let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
+
+        // The fact that accept_and_handshake succeeded (it reads ATTACH and
+        // sends ATTACHED) proves the client sent ATTACH, i.e. did NOT resume.
+        let _ = resume_tx.send(true);
+
+        send_message(
+            &mut conn2,
+            "ch",
+            "after-fresh-connect",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    let timing = TimingConfig {
+        initial_retry_interval: Duration::from_millis(10),
+        max_retry_interval: Duration::from_millis(50),
+        ..TimingConfig::default()
+    };
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    // Wait for reconnection
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(matches!(event, Event::Disconnected { .. }));
+
+    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
+        .await
+        .expect("timed out waiting for Connected")
+        .unwrap();
+    assert!(matches!(event, Event::Connected));
+
+    // Message after fresh connect
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message")
+        .unwrap();
+    match event {
+        Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-fresh-connect")),
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    // Verify server saw ATTACH (meaning client did NOT resume)
+    let did_attach = resume_rx.await.expect("server task panicked");
+    assert!(did_attach, "client should have sent ATTACH (no resume)");
+}

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -173,8 +173,8 @@ fn test_config(ws_port: u16, http_port: u16, channel: &str) -> SubscribeConfig {
     let host = format!("127.0.0.1:{ws_port}");
     let rest_host = format!("127.0.0.1:{http_port}");
     let channel = channel.to_string();
-    SubscribeConfig {
-        get_token: Box::new(move || {
+    let mut config = SubscribeConfig::new(
+        Box::new(move || {
             Box::pin(async {
                 Ok(ably_subscriber::TokenRequest {
                     key_name: "testKey.testId".into(),
@@ -188,11 +188,10 @@ fn test_config(ws_port: u16, http_port: u16, channel: &str) -> SubscribeConfig {
             })
         }),
         channel,
-        channel_params: None,
-        host: Some(host),
-        rest_host: Some(rest_host),
-        timing: None,
-    }
+    );
+    config.host = Some(host);
+    config.rest_host = Some(rest_host);
+    config
 }
 
 fn test_config_with_timing(
@@ -1075,14 +1074,12 @@ async fn server_initiated_auth() {
 
 #[tokio::test]
 async fn get_token_callback_error() {
-    let config = SubscribeConfig {
-        get_token: Box::new(|| Box::pin(async { Err("token fetch failed".into()) })),
-        channel: "ch".into(),
-        channel_params: None,
-        host: Some("127.0.0.1:19999".into()),
-        rest_host: Some("127.0.0.1:19999".into()),
-        timing: None,
-    };
+    let mut config = SubscribeConfig::new(
+        Box::new(|| Box::pin(async { Err("token fetch failed".into()) })),
+        "ch",
+    );
+    config.host = Some("127.0.0.1:19999".into());
+    config.rest_host = Some("127.0.0.1:19999".into());
 
     let result = subscribe(config).await;
     match result {
@@ -1276,8 +1273,8 @@ async fn token_renewal_failures_fatal() {
     // but fails for all subsequent renewal attempts.
     let call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
     let cc = call_count.clone();
-    let config = SubscribeConfig {
-        get_token: Box::new(move || {
+    let mut config = SubscribeConfig::new(
+        Box::new(move || {
             let n = cc.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             Box::pin(async move {
                 if n > 0 {
@@ -1294,16 +1291,15 @@ async fn token_renewal_failures_fatal() {
                 })
             })
         }),
-        channel: "ch".into(),
-        channel_params: None,
-        host: Some(host),
-        rest_host: Some(rest_host),
-        timing: Some({
-            let mut t = TimingConfig::default();
-            t.token_renewal_retry_delay = Duration::from_millis(10);
-            t
-        }),
-    };
+        "ch",
+    );
+    config.host = Some(host);
+    config.rest_host = Some(rest_host);
+    config.timing = Some({
+        let mut t = TimingConfig::default();
+        t.token_renewal_retry_delay = Duration::from_millis(10);
+        t
+    });
     let mut sub = subscribe(config).await.unwrap();
 
     assert!(matches!(sub.next().await.unwrap(), Event::Connected));

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -28,6 +28,20 @@ struct MockAblyServer {
 
 type WsStream = tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>;
 
+struct HandshakeOptions {
+    max_idle_interval_ms: i64,
+    connection_state_ttl_ms: i64,
+}
+
+impl Default for HandshakeOptions {
+    fn default() -> Self {
+        Self {
+            max_idle_interval_ms: 15_000,
+            connection_state_ttl_ms: 120_000,
+        }
+    }
+}
+
 impl MockAblyServer {
     async fn start() -> std::io::Result<Self> {
         let listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -45,6 +59,17 @@ impl MockAblyServer {
         channel: &str,
         conn_id: &str,
     ) -> Result<WsStream, Box<dyn std::error::Error>> {
+        self.accept_and_handshake_with_opts(channel, conn_id, HandshakeOptions::default())
+            .await
+    }
+
+    /// Accept one TCP connection and perform the Ably handshake with custom options.
+    async fn accept_and_handshake_with_opts(
+        &self,
+        channel: &str,
+        conn_id: &str,
+        opts: HandshakeOptions,
+    ) -> Result<WsStream, Box<dyn std::error::Error>> {
         let (tcp, _) = self.listener.accept().await?;
         let mut ws = tokio_tungstenite::accept_async(tcp).await?;
 
@@ -57,8 +82,8 @@ impl MockAblyServer {
             connection_key: Some(conn_key.clone()),
             connection_details: Some(ConnectionDetails {
                 connection_key: Some(conn_key),
-                connection_state_ttl: Some(120_000),
-                max_idle_interval: Some(15_000),
+                connection_state_ttl: Some(opts.connection_state_ttl_ms),
+                max_idle_interval: Some(opts.max_idle_interval_ms),
                 ..Default::default()
             }),
             ..Default::default()
@@ -72,92 +97,6 @@ impl MockAblyServer {
         assert_eq!(msg.channel.as_deref(), Some(channel));
 
         // Send ATTACHED
-        let attached = ProtocolMessage {
-            action: action::ATTACHED,
-            channel: Some(channel.into()),
-            channel_serial: Some("serial-0".into()),
-            ..Default::default()
-        };
-        ws.send(tungstenite::Message::Binary(encode_msg(&attached)?.into()))
-            .await?;
-
-        Ok(ws)
-    }
-
-    /// Like `accept_and_handshake` but allows overriding `connection_state_ttl`.
-    async fn accept_and_handshake_with_ttl(
-        &self,
-        channel: &str,
-        conn_id: &str,
-        connection_state_ttl_ms: i64,
-    ) -> Result<WsStream, Box<dyn std::error::Error>> {
-        let (tcp, _) = self.listener.accept().await?;
-        let mut ws = tokio_tungstenite::accept_async(tcp).await?;
-
-        let conn_key = format!("{conn_id}!key");
-
-        let connected = ProtocolMessage {
-            action: action::CONNECTED,
-            connection_id: Some(conn_id.into()),
-            connection_key: Some(conn_key.clone()),
-            connection_details: Some(ConnectionDetails {
-                connection_key: Some(conn_key),
-                connection_state_ttl: Some(connection_state_ttl_ms),
-                max_idle_interval: Some(15_000),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        ws.send(tungstenite::Message::Binary(encode_msg(&connected)?.into()))
-            .await?;
-
-        let msg = read_protocol_msg(&mut ws).await?;
-        assert_eq!(msg.action, action::ATTACH);
-        assert_eq!(msg.channel.as_deref(), Some(channel));
-
-        let attached = ProtocolMessage {
-            action: action::ATTACHED,
-            channel: Some(channel.into()),
-            channel_serial: Some("serial-0".into()),
-            ..Default::default()
-        };
-        ws.send(tungstenite::Message::Binary(encode_msg(&attached)?.into()))
-            .await?;
-
-        Ok(ws)
-    }
-
-    /// Like `accept_and_handshake` but allows overriding `max_idle_interval`.
-    async fn accept_and_handshake_with_idle(
-        &self,
-        channel: &str,
-        conn_id: &str,
-        max_idle_interval_ms: i64,
-    ) -> Result<WsStream, Box<dyn std::error::Error>> {
-        let (tcp, _) = self.listener.accept().await?;
-        let mut ws = tokio_tungstenite::accept_async(tcp).await?;
-
-        let conn_key = format!("{conn_id}!key");
-
-        let connected = ProtocolMessage {
-            action: action::CONNECTED,
-            connection_id: Some(conn_id.into()),
-            connection_key: Some(conn_key.clone()),
-            connection_details: Some(ConnectionDetails {
-                connection_key: Some(conn_key),
-                connection_state_ttl: Some(120_000),
-                max_idle_interval: Some(max_idle_interval_ms),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        ws.send(tungstenite::Message::Binary(encode_msg(&connected)?.into()))
-            .await?;
-
-        let msg = read_protocol_msg(&mut ws).await?;
-        assert_eq!(msg.action, action::ATTACH);
-        assert_eq!(msg.channel.as_deref(), Some(channel));
-
         let attached = ProtocolMessage {
             action: action::ATTACHED,
             channel: Some(channel.into()),
@@ -1168,7 +1107,14 @@ async fn heartbeat_timeout_triggers_reconnect() {
     tokio::spawn(async move {
         // First connection: tiny max_idle_interval, then silence (no heartbeats)
         let _conn = ws
-            .accept_and_handshake_with_idle("ch", "conn-1", 50)
+            .accept_and_handshake_with_opts(
+                "ch",
+                "conn-1",
+                HandshakeOptions {
+                    max_idle_interval_ms: 50,
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
         // Don't send anything — let the heartbeat timeout fire
@@ -1186,12 +1132,10 @@ async fn heartbeat_timeout_triggers_reconnect() {
         tokio::time::sleep(Duration::from_secs(5)).await;
     });
 
-    let timing = TimingConfig {
-        heartbeat_margin: Duration::from_millis(50),
-        initial_retry_interval: Duration::from_millis(10),
-        max_retry_interval: Duration::from_millis(50),
-        ..TimingConfig::default()
-    };
+    let mut timing = TimingConfig::default();
+    timing.heartbeat_margin = Duration::from_millis(50);
+    timing.initial_retry_interval = Duration::from_millis(10);
+    timing.max_retry_interval = Duration::from_millis(50);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -1254,12 +1198,10 @@ async fn retry_exhaustion_emits_error() {
         tokio::time::sleep(Duration::from_secs(30)).await;
     });
 
-    let timing = TimingConfig {
-        max_retry_attempts: 2,
-        initial_retry_interval: Duration::from_millis(10),
-        max_retry_interval: Duration::from_millis(10),
-        ..TimingConfig::default()
-    };
+    let mut timing = TimingConfig::default();
+    timing.max_retry_attempts = 2;
+    timing.initial_retry_interval = Duration::from_millis(10);
+    timing.max_retry_interval = Duration::from_millis(10);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -1356,9 +1298,10 @@ async fn token_renewal_failures_fatal() {
         channel_params: None,
         host: Some(host),
         rest_host: Some(rest_host),
-        timing: Some(TimingConfig {
-            token_renewal_retry_delay: Duration::from_millis(10),
-            ..TimingConfig::default()
+        timing: Some({
+            let mut t = TimingConfig::default();
+            t.token_renewal_retry_delay = Duration::from_millis(10);
+            t
         }),
     };
     let mut sub = subscribe(config).await.unwrap();
@@ -1406,10 +1349,8 @@ async fn backpressure_drops_messages() {
         tokio::time::sleep(Duration::from_secs(5)).await;
     });
 
-    let timing = TimingConfig {
-        event_channel_capacity: 2,
-        ..TimingConfig::default()
-    };
+    let mut timing = TimingConfig::default();
+    timing.event_channel_capacity = 2;
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -1491,12 +1432,10 @@ async fn detached_within_retry_window_triggers_reconnect() {
         tokio::time::sleep(Duration::from_secs(5)).await;
     });
 
-    let timing = TimingConfig {
-        reattach_window: Duration::from_secs(60),
-        initial_retry_interval: Duration::from_millis(10),
-        max_retry_interval: Duration::from_millis(50),
-        ..TimingConfig::default()
-    };
+    let mut timing = TimingConfig::default();
+    timing.reattach_window = Duration::from_secs(60);
+    timing.initial_retry_interval = Duration::from_millis(10);
+    timing.max_retry_interval = Duration::from_millis(50);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -1544,10 +1483,8 @@ async fn connect_timeout_fires() {
         tokio::time::sleep(Duration::from_secs(30)).await;
     });
 
-    let timing = TimingConfig {
-        connect_timeout: Duration::from_millis(100),
-        ..TimingConfig::default()
-    };
+    let mut timing = TimingConfig::default();
+    timing.connect_timeout = Duration::from_millis(100);
     let result = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing)).await;
     match result {
         Err(ably_subscriber::Error::Protocol { code, message }) => {
@@ -1586,13 +1523,11 @@ async fn reconnect_timeout_fires() {
         }
     });
 
-    let timing = TimingConfig {
-        reconnect_timeout: Duration::from_millis(100),
-        max_retry_attempts: 2,
-        initial_retry_interval: Duration::from_millis(10),
-        max_retry_interval: Duration::from_millis(10),
-        ..TimingConfig::default()
-    };
+    let mut timing = TimingConfig::default();
+    timing.reconnect_timeout = Duration::from_millis(100);
+    timing.max_retry_attempts = 2;
+    timing.initial_retry_interval = Duration::from_millis(10);
+    timing.max_retry_interval = Duration::from_millis(10);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -1647,7 +1582,14 @@ async fn expired_ttl_skips_resume() {
         // The server-provided TTL overrides the TimingConfig default, so we
         // set it here to ensure can_resume() sees a short TTL.
         let conn = ws
-            .accept_and_handshake_with_ttl("ch", "conn-1", 1)
+            .accept_and_handshake_with_opts(
+                "ch",
+                "conn-1",
+                HandshakeOptions {
+                    connection_state_ttl_ms: 1,
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
         // Small delay so the 1ms TTL expires before the reconnect attempt.
@@ -1674,11 +1616,9 @@ async fn expired_ttl_skips_resume() {
         tokio::time::sleep(Duration::from_secs(5)).await;
     });
 
-    let timing = TimingConfig {
-        initial_retry_interval: Duration::from_millis(10),
-        max_retry_interval: Duration::from_millis(50),
-        ..TimingConfig::default()
-    };
+    let mut timing = TimingConfig::default();
+    timing.initial_retry_interval = Duration::from_millis(10);
+    timing.max_retry_interval = Duration::from_millis(50);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();


### PR DESCRIPTION
## Summary
- Extract all 13 hardcoded timing/capacity constants from `connection.rs` into a new `TimingConfig` struct in `types.rs`, configurable via `SubscribeConfig::timing`
- `TimingConfig::default()` preserves all existing production defaults — zero behavior change for existing consumers
- Add 8 new integration tests (T19-T26) that override timing values to exercise slow paths in milliseconds instead of 10-90+ seconds

## TimingConfig fields (grouped by concern)

| Group | Fields |
|---|---|
| Connection | `connect_timeout`, `reconnect_timeout`, `default_max_idle_interval`, `default_connection_state_ttl` |
| Heartbeat | `heartbeat_margin` |
| Reconnection retry | `initial_retry_interval`, `max_retry_interval`, `max_retry_attempts` |
| Channel re-attach | `reattach_window` |
| Token renewal | `token_renewal_margin`, `token_renewal_retry_delay`, `max_token_renewal_failures` |
| Backpressure | `event_channel_capacity` |

## New integration tests

| # | Test | Key overrides |
|---|------|---|
| 19 | `heartbeat_timeout_triggers_reconnect` | `heartbeat_margin: 50ms`, mock `max_idle_interval: 50ms` |
| 20 | `retry_exhaustion_emits_error` | `max_retry_attempts: 2`, `initial/max_retry_interval: 10ms` |
| 21 | `token_renewal_failures_fatal` | `token_renewal_retry_delay: 10ms` |
| 22 | `backpressure_drops_messages` | `event_channel_capacity: 2` |
| 23 | `detached_within_retry_window_triggers_reconnect` | `reattach_window: 60s` |
| 24 | `connect_timeout_fires` | `connect_timeout: 100ms` |
| 25 | `reconnect_timeout_fires` | `reconnect_timeout: 100ms`, `max_retry_attempts: 2` |
| 26 | `expired_ttl_skips_resume` | server sends `connection_state_ttl: 1ms` |

## Test plan
- [x] `cargo clippy -p ably-subscriber --tests` — zero warnings
- [x] `cargo test -p ably-subscriber` — 37 unit + 26 integration + 1 doctest pass
- [x] All pre-commit hooks (fmt, clippy, commitlint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)