### PR TITLE
feat(api): include email-shared agents in agent list endpoints

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { GET } from "../route";
 import {
   createTestRequest,
   createTestCompose,
+  createTestPermission,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -36,9 +37,13 @@ describe("GET /api/agent/composes/list", () => {
     expect(data.error.message).toBe("Not authenticated");
   });
 
-  it("should return empty array when no composes exist", async () => {
+  it("should return no own composes when none exist in scope", async () => {
+    // Use explicit scope param to only get own agents (excludes shared)
+    const uniqueSuffix = user.userId.replace("test-user-", "");
+    const scopeSlug = `scope-${uniqueSuffix}`;
+
     const request = createTestRequest(
-      "http://localhost:3000/api/agent/composes/list",
+      `http://localhost:3000/api/agent/composes/list?scope=${scopeSlug}`,
     );
     const response = await GET(request);
     const data = await response.json();
@@ -55,9 +60,12 @@ describe("GET /api/agent/composes/list", () => {
     await createTestCompose(agentName1);
     await createTestCompose(agentName2);
 
-    // List composes
+    // Use explicit scope param to get only own agents
+    const uniqueSuffix = user.userId.replace("test-user-", "");
+    const scopeSlug = `scope-${uniqueSuffix}`;
+
     const request = createTestRequest(
-      "http://localhost:3000/api/agent/composes/list",
+      `http://localhost:3000/api/agent/composes/list?scope=${scopeSlug}`,
     );
     const response = await GET(request);
     const data = await response.json();
@@ -176,5 +184,129 @@ describe("GET /api/agent/composes/list", () => {
     expect(response.status).toBe(200);
     const names = data.composes.map((c: { name: string }) => c.name);
     expect(names).toContain(agentName);
+  });
+
+  describe("email-shared agents", () => {
+    it("should show shared agent with scope/name format", async () => {
+      // User A (owner) creates an agent and shares it
+      const owner = await context.setupUser({ prefix: "owner" });
+      const agentName = uniqueId("shared-agent");
+      const { composeId } = await createTestCompose(agentName);
+      await createTestPermission(composeId, "email", "test@example.com");
+
+      // Derive owner's scope slug
+      const ownerSuffix = owner.userId.replace("owner-", "");
+      const ownerScopeSlug = `scope-${ownerSuffix}`;
+
+      // Switch to recipient (original user) and list
+      mockClerk({ userId: user.userId });
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/composes/list",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      const names = data.composes.map((c: { name: string }) => c.name);
+      expect(names).toContain(`${ownerScopeSlug}/${agentName}`);
+    });
+
+    it("should not show unshared agents from other users", async () => {
+      // User A creates an agent but does NOT share it
+      await context.setupUser({ prefix: "private-owner" });
+      const agentName = uniqueId("private-agent");
+      await createTestCompose(agentName);
+
+      // Switch to original user and list
+      mockClerk({ userId: user.userId });
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/composes/list",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      const names = data.composes.map((c: { name: string }) => c.name);
+      // Should not contain the private agent in any form
+      expect(names.some((n: string) => n.includes(agentName))).toBe(false);
+    });
+
+    it("should combine own and shared agents in default list", async () => {
+      // Create own agent
+      const ownAgentName = uniqueId("own-agent");
+      await createTestCompose(ownAgentName);
+
+      // Create shared agent from another user
+      const owner = await context.setupUser({ prefix: "combo-owner" });
+      const sharedAgentName = uniqueId("combo-shared");
+      const { composeId } = await createTestCompose(sharedAgentName);
+      await createTestPermission(composeId, "email", "test@example.com");
+
+      const ownerSuffix = owner.userId.replace("combo-owner-", "");
+      const ownerScopeSlug = `scope-${ownerSuffix}`;
+
+      // Switch back to original user
+      mockClerk({ userId: user.userId });
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/composes/list",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      const names = data.composes.map((c: { name: string }) => c.name);
+      // Own agent has plain name
+      expect(names).toContain(ownAgentName);
+      // Shared agent has scope/name format
+      expect(names).toContain(`${ownerScopeSlug}/${sharedAgentName}`);
+    });
+
+    it("should not include shared agents when scope param is provided", async () => {
+      // Create shared agent from another user
+      await context.setupUser({ prefix: "scope-owner" });
+      const sharedAgentName = uniqueId("scope-shared");
+      const { composeId } = await createTestCompose(sharedAgentName);
+      await createTestPermission(composeId, "email", "test@example.com");
+
+      // Switch back to original user, list with explicit scope
+      mockClerk({ userId: user.userId });
+      const uniqueSuffix = user.userId.replace("test-user-", "");
+      const scopeSlug = `scope-${uniqueSuffix}`;
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/list?scope=${scopeSlug}`,
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      const names = data.composes.map((c: { name: string }) => c.name);
+      // Shared agent should NOT appear when using scope param
+      expect(names.some((n: string) => n.includes(sharedAgentName))).toBe(
+        false,
+      );
+    });
+
+    it("should not duplicate agent when owner shares with own email", async () => {
+      // Current user creates agent and shares with own email
+      const agentName = uniqueId("self-shared");
+      const { composeId } = await createTestCompose(agentName);
+      await createTestPermission(composeId, "email", "test@example.com");
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/composes/list",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      const matches = data.composes.filter(
+        (c: { name: string }) =>
+          c.name === agentName || c.name.endsWith(`/${agentName}`),
+      );
+      // Should appear exactly once (as own agent), not duplicated as shared
+      expect(matches).toHaveLength(1);
+      expect(matches[0].name).toBe(agentName);
+    });
   });
 });

--- a/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
@@ -10,7 +10,10 @@ import {
   uniqueId,
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
-import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import {
+  mockClerk,
+  MOCK_USER_EMAIL,
+} from "../../../../../../src/__tests__/clerk-mock";
 
 // Only mock external services
 
@@ -192,7 +195,7 @@ describe("GET /api/agent/composes/list", () => {
       const owner = await context.setupUser({ prefix: "owner" });
       const agentName = uniqueId("shared-agent");
       const { composeId } = await createTestCompose(agentName);
-      await createTestPermission(composeId, "email", "test@example.com");
+      await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
 
       // Derive owner's scope slug
       const ownerSuffix = owner.userId.replace("owner-", "");
@@ -240,7 +243,7 @@ describe("GET /api/agent/composes/list", () => {
       const owner = await context.setupUser({ prefix: "combo-owner" });
       const sharedAgentName = uniqueId("combo-shared");
       const { composeId } = await createTestCompose(sharedAgentName);
-      await createTestPermission(composeId, "email", "test@example.com");
+      await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
 
       const ownerSuffix = owner.userId.replace("combo-owner-", "");
       const ownerScopeSlug = `scope-${ownerSuffix}`;
@@ -266,7 +269,7 @@ describe("GET /api/agent/composes/list", () => {
       await context.setupUser({ prefix: "scope-owner" });
       const sharedAgentName = uniqueId("scope-shared");
       const { composeId } = await createTestCompose(sharedAgentName);
-      await createTestPermission(composeId, "email", "test@example.com");
+      await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
 
       // Switch back to original user, list with explicit scope
       mockClerk({ userId: user.userId });
@@ -291,7 +294,7 @@ describe("GET /api/agent/composes/list", () => {
       // Current user creates agent and shares with own email
       const agentName = uniqueId("self-shared");
       const { composeId } = await createTestCompose(agentName);
-      await createTestPermission(composeId, "email", "test@example.com");
+      await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
 
       const request = createTestRequest(
         "http://localhost:3000/api/agent/composes/list",

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -2,16 +2,15 @@ import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { composesListContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { agentComposes } from "../../../../../src/db/schema/agent-compose";
-import { agentPermissions } from "../../../../../src/db/schema/agent-permission";
-import { scopes } from "../../../../../src/db/schema/scope";
 import { getUserId } from "../../../../../src/lib/auth/get-user-id";
 import { getUserEmail } from "../../../../../src/lib/auth/get-user-email";
-import { eq, and, desc, ne } from "drizzle-orm";
+import { eq, desc } from "drizzle-orm";
 import {
   getUserScopeByClerkId,
   getScopeBySlug,
   canAccessScope,
 } from "../../../../../src/lib/scope/scope-service";
+import { getEmailSharedAgents } from "../../../../../src/lib/agent/permission-service";
 
 const router = tsr.router(composesListContract, {
   list: async ({ query, headers }) => {
@@ -96,29 +95,8 @@ const router = tsr.router(composesListContract, {
 
     if (!query.scope) {
       const userEmail = await getUserEmail(userId);
-      if (userEmail) {
-        sharedComposes = await globalThis.services.db
-          .select({
-            name: agentComposes.name,
-            headVersionId: agentComposes.headVersionId,
-            updatedAt: agentComposes.updatedAt,
-            scopeSlug: scopes.slug,
-          })
-          .from(agentPermissions)
-          .innerJoin(
-            agentComposes,
-            eq(agentPermissions.agentComposeId, agentComposes.id),
-          )
-          .innerJoin(scopes, eq(agentComposes.scopeId, scopes.id))
-          .where(
-            and(
-              eq(agentPermissions.granteeType, "email"),
-              eq(agentPermissions.granteeEmail, userEmail),
-              ne(agentComposes.userId, userId),
-            ),
-          )
-          .orderBy(desc(agentComposes.updatedAt));
-      }
+      const shared = await getEmailSharedAgents(userId, userEmail);
+      sharedComposes = shared;
     }
 
     // Combine: own agents first, then shared agents with scope/name format

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -2,8 +2,11 @@ import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { composesListContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { agentComposes } from "../../../../../src/db/schema/agent-compose";
+import { agentPermissions } from "../../../../../src/db/schema/agent-permission";
+import { scopes } from "../../../../../src/db/schema/scope";
 import { getUserId } from "../../../../../src/lib/auth/get-user-id";
-import { eq, desc } from "drizzle-orm";
+import { getUserEmail } from "../../../../../src/lib/auth/get-user-email";
+import { eq, and, desc, ne } from "drizzle-orm";
 import {
   getUserScopeByClerkId,
   getScopeBySlug,
@@ -72,8 +75,8 @@ const router = tsr.router(composesListContract, {
       scopeId = userScope.id;
     }
 
-    // Query all composes for this scope
-    const composes = await globalThis.services.db
+    // Query own composes for this scope
+    const ownComposes = await globalThis.services.db
       .select({
         name: agentComposes.name,
         headVersionId: agentComposes.headVersionId,
@@ -83,14 +86,59 @@ const router = tsr.router(composesListContract, {
       .where(eq(agentComposes.scopeId, scopeId))
       .orderBy(desc(agentComposes.updatedAt));
 
+    // When using default scope (no ?scope= param), also include email-shared agents
+    let sharedComposes: {
+      name: string;
+      headVersionId: string | null;
+      updatedAt: Date;
+      scopeSlug: string;
+    }[] = [];
+
+    if (!query.scope) {
+      const userEmail = await getUserEmail(userId);
+      if (userEmail) {
+        sharedComposes = await globalThis.services.db
+          .select({
+            name: agentComposes.name,
+            headVersionId: agentComposes.headVersionId,
+            updatedAt: agentComposes.updatedAt,
+            scopeSlug: scopes.slug,
+          })
+          .from(agentPermissions)
+          .innerJoin(
+            agentComposes,
+            eq(agentPermissions.agentComposeId, agentComposes.id),
+          )
+          .innerJoin(scopes, eq(agentComposes.scopeId, scopes.id))
+          .where(
+            and(
+              eq(agentPermissions.granteeType, "email"),
+              eq(agentPermissions.granteeEmail, userEmail),
+              ne(agentComposes.userId, userId),
+            ),
+          )
+          .orderBy(desc(agentComposes.updatedAt));
+      }
+    }
+
+    // Combine: own agents first, then shared agents with scope/name format
+    const allComposes = [
+      ...ownComposes.map((c) => ({
+        name: c.name,
+        headVersionId: c.headVersionId,
+        updatedAt: c.updatedAt.toISOString(),
+      })),
+      ...sharedComposes.map((c) => ({
+        name: `${c.scopeSlug}/${c.name}`,
+        headVersionId: c.headVersionId,
+        updatedAt: c.updatedAt.toISOString(),
+      })),
+    ];
+
     return {
       status: 200 as const,
       body: {
-        composes: composes.map((compose) => ({
-          name: compose.name,
-          headVersionId: compose.headVersionId,
-          updatedAt: compose.updatedAt.toISOString(),
-        })),
+        composes: allComposes,
       },
     };
   },

--- a/turbo/apps/web/app/api/agent/required-env/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/required-env/__tests__/route.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestPermission,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
+import {
+  mockClerk,
+  MOCK_USER_EMAIL,
+} from "../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+describe("GET /api/agent/required-env", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/required-env",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return required secrets for own agent", async () => {
+    const agentName = uniqueId("env-agent");
+    await createTestCompose(agentName, {
+      overrides: {
+        environment: {
+          MY_KEY: "${{ secrets.MY_KEY }}",
+          SOME_VAR: "${{ vars.SOME_VAR }}",
+        },
+      },
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/required-env",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const agent = data.agents.find(
+      (a: { agentName: string }) => a.agentName === agentName,
+    );
+    expect(agent).toBeDefined();
+    expect(agent.requiredSecrets).toContain("MY_KEY");
+    expect(agent.requiredVariables).toContain("SOME_VAR");
+  });
+
+  it("should return required secrets for email-shared agent", async () => {
+    // Owner creates agent with secret refs and shares it
+    const owner = await context.setupUser({ prefix: "env-owner" });
+    const agentName = uniqueId("shared-env");
+    const { composeId } = await createTestCompose(agentName, {
+      overrides: {
+        environment: {
+          SHARED_SECRET: "${{ secrets.SHARED_SECRET }}",
+        },
+      },
+    });
+    await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
+
+    const ownerSuffix = owner.userId.replace("env-owner-", "");
+    const ownerScopeSlug = `scope-${ownerSuffix}`;
+
+    // Switch to recipient and fetch required env
+    mockClerk({ userId: user.userId });
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/required-env",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const agent = data.agents.find(
+      (a: { agentName: string }) =>
+        a.agentName === `${ownerScopeSlug}/${agentName}`,
+    );
+    expect(agent).toBeDefined();
+    expect(agent.requiredSecrets).toContain("SHARED_SECRET");
+  });
+
+  it("should skip agents with no environment block", async () => {
+    const agentName = uniqueId("no-env");
+    await createTestCompose(agentName, { noEnvironmentBlock: true });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/required-env",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const agent = data.agents.find(
+      (a: { agentName: string }) => a.agentName === agentName,
+    );
+    expect(agent).toBeUndefined();
+  });
+});

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/__tests__/route.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestPermission,
+  createTestSecret,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../src/__tests__/test-helpers";
+import {
+  mockClerk,
+  MOCK_USER_EMAIL,
+} from "../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+describe("GET /api/agent/schedules/missing-secrets", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/schedules/missing-secrets",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should report missing secrets for own agent", async () => {
+    const agentName = uniqueId("missing-agent");
+    await createTestCompose(agentName, {
+      overrides: {
+        environment: {
+          MY_SECRET: "${{ secrets.MY_SECRET }}",
+        },
+      },
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/schedules/missing-secrets",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const agent = data.agents.find(
+      (a: { agentName: string }) => a.agentName === agentName,
+    );
+    expect(agent).toBeDefined();
+    expect(agent.missingSecrets).toContain("MY_SECRET");
+  });
+
+  it("should not report configured secrets as missing", async () => {
+    const secretName = `TEST_SECRET_${Date.now()}`;
+    const agentName = uniqueId("configured-agent");
+    await createTestCompose(agentName, {
+      overrides: {
+        environment: {
+          [secretName]: `\${{ secrets.${secretName} }}`,
+        },
+      },
+    });
+
+    // Configure the secret
+    await createTestSecret(secretName, "secret-value");
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/schedules/missing-secrets",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const agent = data.agents.find(
+      (a: { agentName: string }) => a.agentName === agentName,
+    );
+    // Agent should not appear since its only secret is configured
+    expect(agent).toBeUndefined();
+  });
+
+  it("should report missing secrets for email-shared agent", async () => {
+    // Owner creates agent with secret refs and shares it
+    const owner = await context.setupUser({ prefix: "ms-owner" });
+    const agentName = uniqueId("shared-missing");
+    const { composeId } = await createTestCompose(agentName, {
+      overrides: {
+        environment: {
+          SHARED_KEY: "${{ secrets.SHARED_KEY }}",
+        },
+      },
+    });
+    await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
+
+    const ownerSuffix = owner.userId.replace("ms-owner-", "");
+    const ownerScopeSlug = `scope-${ownerSuffix}`;
+
+    // Switch to recipient — they don't have SHARED_KEY configured
+    mockClerk({ userId: user.userId });
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/schedules/missing-secrets",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const agent = data.agents.find(
+      (a: { agentName: string }) =>
+        a.agentName === `${ownerScopeSlug}/${agentName}`,
+    );
+    expect(agent).toBeDefined();
+    expect(agent.missingSecrets).toContain("SHARED_KEY");
+  });
+});

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
@@ -3,11 +3,13 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { getUserId } from "../../../../../src/lib/auth/get-user-id";
 import { logger } from "../../../../../src/lib/logger";
 import { eq } from "drizzle-orm";
-import { agentComposes } from "../../../../../src/db/schema/agent-compose";
-import { agentComposeVersions } from "../../../../../src/db/schema/agent-compose";
 import { secrets } from "../../../../../src/db/schema/secret";
 import { extractVariableReferences, groupVariablesBySource } from "@vm0/core";
-import type { AgentComposeYaml } from "../../../../../src/types/agent-compose";
+import {
+  getUserAgents,
+  batchFetchVersionContents,
+} from "../../../../../src/lib/agent/get-user-agents";
+import { getUserScopeByClerkId } from "../../../../../src/lib/scope/scope-service";
 
 const log = logger("api:agents:missing-secrets");
 
@@ -42,66 +44,53 @@ export async function GET(request: Request) {
 
   const db = globalThis.services.db;
 
-  // Get all user's agents
-  const agents = await db
-    .select({
-      composeId: agentComposes.id,
-      agentName: agentComposes.name,
-      scopeId: agentComposes.scopeId,
-      headVersionId: agentComposes.headVersionId,
-    })
-    .from(agentComposes)
-    .where(eq(agentComposes.userId, userId));
+  const agents = await getUserAgents(userId);
 
   if (agents.length === 0) {
     return NextResponse.json({ agents: [] });
   }
 
-  // Get user's scope ID from first agent (all agents belong to same user scope)
-  const userScopeId = agents[0]!.scopeId;
+  // Get user's scope to query configured secrets
+  const userScope = await getUserScopeByClerkId(userId);
+  if (!userScope) {
+    return NextResponse.json({ agents: [] });
+  }
 
   // Get all user's configured secrets (only names, not values)
   const userSecrets = await db
     .select({ name: secrets.name })
     .from(secrets)
-    .where(eq(secrets.scopeId, userScopeId));
+    .where(eq(secrets.scopeId, userScope.id));
 
   const configuredSecretNames = new Set(userSecrets.map((s) => s.name));
+
+  // Batch-fetch all versions in a single query
+  const versionIds = agents
+    .map((a) => a.headVersionId)
+    .filter((id): id is string => id !== null);
+
+  const versionContents = await batchFetchVersionContents(versionIds);
 
   const result: AgentMissingSecrets[] = [];
 
   for (const agent of agents) {
     if (!agent.headVersionId) {
-      log.debug(`Agent ${agent.agentName} has no head version, skipping`);
       continue;
     }
 
-    // Get compose content from version
-    const [version] = await db
-      .select({ content: agentComposeVersions.content })
-      .from(agentComposeVersions)
-      .where(eq(agentComposeVersions.id, agent.headVersionId))
-      .limit(1);
-
-    if (!version) {
-      log.warn(
-        `Version ${agent.headVersionId} not found for agent ${agent.agentName}`,
-      );
+    const composeYaml = versionContents.get(agent.headVersionId);
+    if (!composeYaml) {
       continue;
     }
-
-    const composeYaml = version.content as AgentComposeYaml;
 
     // Extract required secrets from compose environment
     const agentDefs = Object.values(composeYaml.agents || {});
     const firstAgent = agentDefs[0];
 
     if (!firstAgent?.environment) {
-      // No environment variables means no secrets required
       continue;
     }
 
-    // Extract all variable references from environment
     const refs = extractVariableReferences(firstAgent.environment);
     const grouped = groupVariablesBySource(refs);
 
@@ -112,7 +101,6 @@ export async function GET(request: Request) {
     ];
 
     if (requiredSecrets.length === 0) {
-      // No secrets required
       continue;
     }
 

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
@@ -56,7 +56,8 @@ export async function GET(request: Request) {
     return NextResponse.json({ agents: [] });
   }
 
-  // Get all user's configured secrets (only names, not values)
+  // Check the recipient's own secrets — shared agents run with the
+  // recipient's secrets, so missing ones need to be configured by them.
   const userSecrets = await db
     .select({ name: secrets.name })
     .from(secrets)

--- a/turbo/apps/web/app/v1/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/v1/agents/__tests__/route.test.ts
@@ -8,7 +8,10 @@ import {
   createTestPermission,
 } from "../../../../src/__tests__/api-test-helpers";
 import { testContext, uniqueId } from "../../../../src/__tests__/test-helpers";
-import { mockClerk } from "../../../../src/__tests__/clerk-mock";
+import {
+  mockClerk,
+  MOCK_USER_EMAIL,
+} from "../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
 
 const context = testContext();
@@ -28,15 +31,19 @@ describe("Public API v1 - Agents Endpoints", () => {
 
   describe("GET /v1/agents - List Agents", () => {
     it("should list agents with pagination", async () => {
-      const request = createTestRequest("http://localhost:3000/v1/agents");
+      // Use name filter for deterministic results (avoids shared agent interference)
+      const request = createTestRequest(
+        `http://localhost:3000/v1/agents?name=${testAgentName}`,
+      );
 
       const response = await listAgents(request);
       const data = await response.json();
 
       expect(response.status).toBe(200);
       expect(data.data).toBeInstanceOf(Array);
-      expect(data.data.length).toBeGreaterThanOrEqual(1);
+      expect(data.data.length).toBe(1);
       expect(data.pagination).toBeDefined();
+      expect(data.pagination.hasMore).toBe(false);
     });
 
     it("should support limit parameter", async () => {
@@ -197,7 +204,7 @@ describe("Public API v1 - Agents Endpoints", () => {
       const owner = await context.setupUser({ prefix: "v1-owner" });
       const sharedAgentName = uniqueId("v1-shared");
       const { composeId } = await createTestCompose(sharedAgentName);
-      await createTestPermission(composeId, "email", "test@example.com");
+      await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
 
       const ownerSuffix = owner.userId.replace("v1-owner-", "");
       const ownerScopeSlug = `scope-${ownerSuffix}`;

--- a/turbo/apps/web/app/v1/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/v1/agents/__tests__/route.test.ts
@@ -5,8 +5,9 @@ import { GET as listVersions } from "../[id]/versions/route";
 import {
   createTestRequest,
   createTestCompose,
+  createTestPermission,
 } from "../../../../src/__tests__/api-test-helpers";
-import { testContext } from "../../../../src/__tests__/test-helpers";
+import { testContext, uniqueId } from "../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
 
@@ -34,8 +35,8 @@ describe("Public API v1 - Agents Endpoints", () => {
 
       expect(response.status).toBe(200);
       expect(data.data).toBeInstanceOf(Array);
+      expect(data.data.length).toBeGreaterThanOrEqual(1);
       expect(data.pagination).toBeDefined();
-      expect(data.pagination.hasMore).toBe(false);
     });
 
     it("should support limit parameter", async () => {
@@ -187,6 +188,51 @@ describe("Public API v1 - Agents Endpoints", () => {
 
       expect(response.status).toBe(404);
       expect(data.error.type).toBe("not_found_error");
+    });
+  });
+
+  describe("Email-shared agents", () => {
+    it("should include shared agent with scope/name format", async () => {
+      // Owner creates and shares an agent
+      const owner = await context.setupUser({ prefix: "v1-owner" });
+      const sharedAgentName = uniqueId("v1-shared");
+      const { composeId } = await createTestCompose(sharedAgentName);
+      await createTestPermission(composeId, "email", "test@example.com");
+
+      const ownerSuffix = owner.userId.replace("v1-owner-", "");
+      const ownerScopeSlug = `scope-${ownerSuffix}`;
+
+      // Switch to a different user (recipient)
+      await context.setupUser({ prefix: "v1-recipient" });
+
+      const request = createTestRequest(
+        `http://localhost:3000/v1/agents?name=${sharedAgentName}`,
+      );
+      const response = await listAgents(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data.length).toBe(1);
+      expect(data.data[0].name).toBe(`${ownerScopeSlug}/${sharedAgentName}`);
+    });
+
+    it("should not show unshared agents from other users", async () => {
+      // Owner creates an agent but does NOT share
+      await context.setupUser({ prefix: "v1-private" });
+      const privateAgentName = uniqueId("v1-private-agent");
+      await createTestCompose(privateAgentName);
+
+      // Switch to recipient
+      await context.setupUser({ prefix: "v1-viewer" });
+
+      const request = createTestRequest(
+        `http://localhost:3000/v1/agents?name=${privateAgentName}`,
+      );
+      const response = await listAgents(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data.length).toBe(0);
     });
   });
 

--- a/turbo/apps/web/app/v1/agents/route.ts
+++ b/turbo/apps/web/app/v1/agents/route.ts
@@ -14,8 +14,11 @@ import {
   isAuthSuccess,
 } from "../../../src/lib/public-api/auth";
 import { getUserScopeByClerkId } from "../../../src/lib/scope/scope-service";
+import { getUserEmail } from "../../../src/lib/auth/get-user-email";
 import { agentComposes } from "../../../src/db/schema/agent-compose";
-import { eq, and, desc, gt } from "drizzle-orm";
+import { agentPermissions } from "../../../src/db/schema/agent-permission";
+import { scopes } from "../../../src/db/schema/scope";
+import { eq, and, desc, gt, ne } from "drizzle-orm";
 
 const router = tsr.router(publicAgentsListContract, {
   list: async ({ query, headers }) => {
@@ -51,32 +54,97 @@ const router = tsr.router(publicAgentsListContract, {
       };
     }
 
-    // Build query conditions
-    const conditions = [eq(agentComposes.scopeId, userScope.id)];
+    // Build query conditions for own agents
+    const ownConditions = [eq(agentComposes.scopeId, userScope.id)];
 
     // Filter by name if provided (case-insensitive - normalize to lowercase)
-    if (query.name) {
-      conditions.push(eq(agentComposes.name, query.name.toLowerCase()));
+    const nameFilter = query.name?.toLowerCase();
+    if (nameFilter) {
+      ownConditions.push(eq(agentComposes.name, nameFilter));
     }
 
     // Handle cursor-based pagination
     if (query.cursor) {
-      conditions.push(gt(agentComposes.id, query.cursor));
+      ownConditions.push(gt(agentComposes.id, query.cursor));
     }
 
     const limit = query.limit ?? 20;
 
-    // Fetch agents
-    const agents = await globalThis.services.db
+    // Fetch own agents
+    const ownAgents = await globalThis.services.db
       .select()
       .from(agentComposes)
-      .where(and(...conditions))
+      .where(and(...ownConditions))
       .orderBy(desc(agentComposes.createdAt))
-      .limit(limit + 1); // Fetch one extra to check has_more
+      .limit(limit + 1);
 
-    // Determine pagination info
-    const hasMore = agents.length > limit;
-    const data = hasMore ? agents.slice(0, limit) : agents;
+    // Fetch email-shared agents
+    const userEmail = await getUserEmail(auth.userId);
+    let sharedAgents: {
+      id: string;
+      name: string;
+      headVersionId: string | null;
+      createdAt: Date;
+      updatedAt: Date;
+      scopeSlug: string;
+    }[] = [];
+
+    if (userEmail) {
+      const sharedConditions = [
+        eq(agentPermissions.granteeType, "email"),
+        eq(agentPermissions.granteeEmail, userEmail),
+        ne(agentComposes.userId, auth.userId),
+      ];
+
+      if (nameFilter) {
+        sharedConditions.push(eq(agentComposes.name, nameFilter));
+      }
+
+      if (query.cursor) {
+        sharedConditions.push(gt(agentComposes.id, query.cursor));
+      }
+
+      sharedAgents = await globalThis.services.db
+        .select({
+          id: agentComposes.id,
+          name: agentComposes.name,
+          headVersionId: agentComposes.headVersionId,
+          createdAt: agentComposes.createdAt,
+          updatedAt: agentComposes.updatedAt,
+          scopeSlug: scopes.slug,
+        })
+        .from(agentPermissions)
+        .innerJoin(
+          agentComposes,
+          eq(agentPermissions.agentComposeId, agentComposes.id),
+        )
+        .innerJoin(scopes, eq(agentComposes.scopeId, scopes.id))
+        .where(and(...sharedConditions))
+        .orderBy(desc(agentComposes.createdAt))
+        .limit(limit + 1);
+    }
+
+    // Combine own + shared, sort by createdAt desc, apply pagination
+    const combined = [
+      ...ownAgents.map((agent) => ({
+        id: agent.id,
+        name: agent.name,
+        currentVersionId: agent.headVersionId,
+        createdAt: agent.createdAt,
+        updatedAt: agent.updatedAt,
+      })),
+      ...sharedAgents.map((agent) => ({
+        id: agent.id,
+        name: `${agent.scopeSlug}/${agent.name}`,
+        currentVersionId: agent.headVersionId,
+        createdAt: agent.createdAt,
+        updatedAt: agent.updatedAt,
+      })),
+    ].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+
+    // Apply limit + 1 pagination
+    const hasMore = combined.length > limit;
+    const data = hasMore ? combined.slice(0, limit) : combined;
     const nextCursor =
       hasMore && data.length > 0 ? data[data.length - 1]!.id : null;
 
@@ -86,7 +154,7 @@ const router = tsr.router(publicAgentsListContract, {
         data: data.map((agent) => ({
           id: agent.id,
           name: agent.name,
-          currentVersionId: agent.headVersionId,
+          currentVersionId: agent.currentVersionId,
           createdAt: agent.createdAt.toISOString(),
           updatedAt: agent.updatedAt.toISOString(),
         })),

--- a/turbo/apps/web/app/v1/agents/route.ts
+++ b/turbo/apps/web/app/v1/agents/route.ts
@@ -15,10 +15,9 @@ import {
 } from "../../../src/lib/public-api/auth";
 import { getUserScopeByClerkId } from "../../../src/lib/scope/scope-service";
 import { getUserEmail } from "../../../src/lib/auth/get-user-email";
+import { getEmailSharedAgents } from "../../../src/lib/agent/permission-service";
 import { agentComposes } from "../../../src/db/schema/agent-compose";
-import { agentPermissions } from "../../../src/db/schema/agent-permission";
-import { scopes } from "../../../src/db/schema/scope";
-import { eq, and, desc, gt, ne } from "drizzle-orm";
+import { eq, and, desc, gt } from "drizzle-orm";
 
 const router = tsr.router(publicAgentsListContract, {
   list: async ({ query, headers }) => {
@@ -78,53 +77,15 @@ const router = tsr.router(publicAgentsListContract, {
       .orderBy(desc(agentComposes.createdAt))
       .limit(limit + 1);
 
-    // Fetch email-shared agents
+    // Fetch email-shared agents (small set, no cursor/limit needed)
     const userEmail = await getUserEmail(auth.userId);
-    let sharedAgents: {
-      id: string;
-      name: string;
-      headVersionId: string | null;
-      createdAt: Date;
-      updatedAt: Date;
-      scopeSlug: string;
-    }[] = [];
+    const sharedAgents = await getEmailSharedAgents(
+      auth.userId,
+      userEmail,
+      nameFilter ? { nameFilter } : undefined,
+    );
 
-    if (userEmail) {
-      const sharedConditions = [
-        eq(agentPermissions.granteeType, "email"),
-        eq(agentPermissions.granteeEmail, userEmail),
-        ne(agentComposes.userId, auth.userId),
-      ];
-
-      if (nameFilter) {
-        sharedConditions.push(eq(agentComposes.name, nameFilter));
-      }
-
-      if (query.cursor) {
-        sharedConditions.push(gt(agentComposes.id, query.cursor));
-      }
-
-      sharedAgents = await globalThis.services.db
-        .select({
-          id: agentComposes.id,
-          name: agentComposes.name,
-          headVersionId: agentComposes.headVersionId,
-          createdAt: agentComposes.createdAt,
-          updatedAt: agentComposes.updatedAt,
-          scopeSlug: scopes.slug,
-        })
-        .from(agentPermissions)
-        .innerJoin(
-          agentComposes,
-          eq(agentPermissions.agentComposeId, agentComposes.id),
-        )
-        .innerJoin(scopes, eq(agentComposes.scopeId, scopes.id))
-        .where(and(...sharedConditions))
-        .orderBy(desc(agentComposes.createdAt))
-        .limit(limit + 1);
-    }
-
-    // Combine own + shared, sort by createdAt desc, apply pagination
+    // Combine own + shared, sort by createdAt desc
     const combined = [
       ...ownAgents.map((agent) => ({
         id: agent.id,
@@ -142,9 +103,14 @@ const router = tsr.router(publicAgentsListContract, {
       })),
     ].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
 
+    // Apply cursor filter in app code (shared agents weren't DB-filtered by cursor)
+    const afterCursor = query.cursor
+      ? combined.filter((agent) => agent.id > query.cursor!)
+      : combined;
+
     // Apply limit + 1 pagination
-    const hasMore = combined.length > limit;
-    const data = hasMore ? combined.slice(0, limit) : combined;
+    const hasMore = afterCursor.length > limit;
+    const data = hasMore ? afterCursor.slice(0, limit) : afterCursor;
     const nextCursor =
       hasMore && data.length > 0 ? data[data.length - 1]!.id : null;
 

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -23,6 +23,9 @@ import { auth, clerkClient } from "@clerk/nextjs/server";
  * ```
  */
 
+/** The email address returned by the Clerk mock for all test users */
+export const MOCK_USER_EMAIL = "test@example.com";
+
 const mockAuth = vi.mocked(auth);
 const mockClerkClient = vi.mocked(clerkClient);
 
@@ -40,7 +43,7 @@ export function mockClerk(options: { userId: string | null }) {
   mockClerkClient.mockResolvedValue({
     users: {
       getUser: vi.fn().mockResolvedValue({
-        emailAddresses: [{ id: "email_1", emailAddress: "test@example.com" }],
+        emailAddresses: [{ id: "email_1", emailAddress: MOCK_USER_EMAIL }],
         primaryEmailAddressId: "email_1",
       }),
     },

--- a/turbo/apps/web/src/lib/agent/get-user-agents.ts
+++ b/turbo/apps/web/src/lib/agent/get-user-agents.ts
@@ -1,0 +1,69 @@
+import { eq, inArray } from "drizzle-orm";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../db/schema/agent-compose";
+import { getUserEmail } from "../auth/get-user-email";
+import { getEmailSharedAgents } from "./permission-service";
+import type { AgentComposeYaml } from "../../types/agent-compose";
+
+interface UserAgent {
+  composeId: string;
+  agentName: string;
+  headVersionId: string | null;
+}
+
+/**
+ * Fetch all agents accessible to a user (own + email-shared).
+ * Shared agents are returned with `scopeSlug/name` format for agentName.
+ */
+export async function getUserAgents(userId: string): Promise<UserAgent[]> {
+  const db = globalThis.services.db;
+
+  const ownAgents = await db
+    .select({
+      composeId: agentComposes.id,
+      agentName: agentComposes.name,
+      headVersionId: agentComposes.headVersionId,
+    })
+    .from(agentComposes)
+    .where(eq(agentComposes.userId, userId));
+
+  const userEmail = await getUserEmail(userId);
+  const sharedAgents = await getEmailSharedAgents(userId, userEmail);
+
+  return [
+    ...ownAgents,
+    ...sharedAgents.map((a) => ({
+      composeId: a.id,
+      agentName: `${a.scopeSlug}/${a.name}`,
+      headVersionId: a.headVersionId,
+    })),
+  ];
+}
+
+/**
+ * Batch-fetch compose version contents by their IDs.
+ * Returns a Map from versionId to parsed compose YAML.
+ */
+export async function batchFetchVersionContents(
+  versionIds: string[],
+): Promise<Map<string, AgentComposeYaml>> {
+  const contents = new Map<string, AgentComposeYaml>();
+  if (versionIds.length === 0) return contents;
+
+  const db = globalThis.services.db;
+  const versions = await db
+    .select({
+      id: agentComposeVersions.id,
+      content: agentComposeVersions.content,
+    })
+    .from(agentComposeVersions)
+    .where(inArray(agentComposeVersions.id, versionIds));
+
+  for (const v of versions) {
+    contents.set(v.id, v.content as AgentComposeYaml);
+  }
+
+  return contents;
+}

--- a/turbo/apps/web/src/lib/agent/get-user-agents.ts
+++ b/turbo/apps/web/src/lib/agent/get-user-agents.ts
@@ -16,6 +16,11 @@ interface UserAgent {
 /**
  * Fetch all agents accessible to a user (own + email-shared).
  * Shared agents are returned with `scopeSlug/name` format for agentName.
+ *
+ * Note: This always includes shared agents, unlike `composes/list` which
+ * only includes them when no `?scope=` param is provided. This is intentional
+ * — routes like `required-env` and `missing-secrets` need the full picture
+ * regardless of scope filtering.
  */
 export async function getUserAgents(userId: string): Promise<UserAgent[]> {
   const db = globalThis.services.db;


### PR DESCRIPTION
## Summary

- Both internal API (`GET /api/agent/composes/list`) and public API v1 (`GET /v1/agents`) now return email-shared agents alongside the user's own agents
- Shared agents appear with `scope/name` format (e.g., `owner-scope/my-agent`) to distinguish from own agents
- When `?scope=` param is provided, only agents from that scope are returned (no shared agents mixed in)
- Self-sharing is handled: if an owner shares an agent with their own email, it only appears once (as own agent)

## Test plan

- [x] Shared agent appears in list with `scope/name` format
- [x] Unshared agents from other users do not appear
- [x] Own and shared agents combined in default list
- [x] `?scope=` param excludes shared agents
- [x] No self-duplicates when owner shares with own email
- [x] v1 API: shared agent visible with name filter
- [x] v1 API: unshared agents not visible
- [x] All existing tests still pass (26 total)
- [x] Lint, type-check, and knip pass

Closes #2939

🤖 Generated with [Claude Code](https://claude.com/claude-code)