### PR TITLE
feat: add notify-slack preference to gate slack schedule notifications

### DIFF
--- a/turbo/apps/cli/src/lib/api/domains/user-preferences.ts
+++ b/turbo/apps/cli/src/lib/api/domains/user-preferences.ts
@@ -27,6 +27,7 @@ export async function getUserPreferences(): Promise<UserPreferencesResponse> {
 export async function updateUserPreferences(body: {
   timezone?: string;
   notifyEmail?: boolean;
+  notifySlack?: boolean;
 }): Promise<UserPreferencesResponse> {
   const config = await getClientConfig();
   const client = initClient(userPreferencesContract, config);

--- a/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
@@ -38,6 +38,7 @@ describe("GET /api/user/preferences", () => {
     expect(response.status).toBe(200);
     expect(data.timezone).toBeNull();
     expect(data.notifyEmail).toBe(false);
+    expect(data.notifySlack).toBe(true);
   });
 
   it("should return saved timezone after update", async () => {
@@ -241,6 +242,56 @@ describe("PUT /api/user/preferences", () => {
     expect(response.status).toBe(200);
     expect(data.timezone).toBe("Europe/Berlin");
     expect(data.notifyEmail).toBe(true);
+  });
+
+  it("should update notifySlack to false", async () => {
+    await context.setupUser();
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/user/preferences",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notifySlack: false }),
+      },
+    );
+    const response = await PUT(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.notifySlack).toBe(false);
+  });
+
+  it("should update notifySlack independently without affecting other preferences", async () => {
+    await context.setupUser();
+
+    // Set timezone and notifyEmail first
+    const setup = createTestRequest(
+      "http://localhost:3000/api/user/preferences",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ timezone: "Europe/Berlin", notifyEmail: true }),
+      },
+    );
+    await PUT(setup);
+
+    // Update only notifySlack
+    const request = createTestRequest(
+      "http://localhost:3000/api/user/preferences",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notifySlack: false }),
+      },
+    );
+    const response = await PUT(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.timezone).toBe("Europe/Berlin");
+    expect(data.notifyEmail).toBe(true);
+    expect(data.notifySlack).toBe(false);
   });
 
   it("should reject request with no preferences", async () => {

--- a/turbo/apps/web/app/api/user/preferences/route.ts
+++ b/turbo/apps/web/app/api/user/preferences/route.ts
@@ -27,6 +27,7 @@ const router = tsr.router(userPreferencesContract, {
       body: {
         timezone: prefs.timezone,
         notifyEmail: prefs.notifyEmail,
+        notifySlack: prefs.notifySlack,
       },
     };
   },
@@ -46,6 +47,7 @@ const router = tsr.router(userPreferencesContract, {
       const prefs = await updateUserPreferences(userId, {
         timezone: body.timezone,
         notifyEmail: body.notifyEmail,
+        notifySlack: body.notifySlack,
       });
 
       return {
@@ -53,6 +55,7 @@ const router = tsr.router(userPreferencesContract, {
         body: {
           timezone: prefs.timezone,
           notifyEmail: prefs.notifyEmail,
+          notifySlack: prefs.notifySlack,
         },
       };
     } catch (error) {

--- a/turbo/apps/web/src/db/migrations/0087_add_notify_slack.sql
+++ b/turbo/apps/web/src/db/migrations/0087_add_notify_slack.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "scopes" ADD COLUMN "notify_slack" boolean DEFAULT true NOT NULL;

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -610,6 +610,13 @@
       "when": 1771100000000,
       "tag": "0086_add_notify_email",
       "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "7",
+      "when": 1771200000000,
+      "tag": "0087_add_notify_slack",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/scope.ts
+++ b/turbo/apps/web/src/db/schema/scope.ts
@@ -36,6 +36,7 @@ export const scopes = pgTable(
     ownerId: text("owner_id"), // Clerk user ID, null for system scopes
     timezone: varchar("timezone", { length: 50 }), // IANA timezone (e.g., "Asia/Shanghai")
     notifyEmail: boolean("notify_email").default(false).notNull(),
+    notifySlack: boolean("notify_slack").default(true).notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -885,24 +885,25 @@ async function executeSchedule(
     userId: compose.userId,
   };
 
+  const prefs = await getUserPreferences(compose.userId);
+
   // Email schedule notification callback (only if Resend is configured AND user opted in)
-  if (globalThis.services.env.RESEND_API_KEY) {
-    const prefs = await getUserPreferences(compose.userId);
-    if (prefs.notifyEmail) {
-      callbacks.push({
-        url: `${getApiUrl()}/api/internal/callbacks/email/schedule`,
-        secret: generateCallbackSecret(),
-        payload: callbackPayload,
-      });
-    }
+  if (globalThis.services.env.RESEND_API_KEY && prefs.notifyEmail) {
+    callbacks.push({
+      url: `${getApiUrl()}/api/internal/callbacks/email/schedule`,
+      secret: generateCallbackSecret(),
+      payload: callbackPayload,
+    });
   }
 
-  // Slack schedule DM notification callback
-  callbacks.push({
-    url: `${getApiUrl()}/api/internal/callbacks/slack/schedule`,
-    secret: generateCallbackSecret(),
-    payload: callbackPayload,
-  });
+  // Slack schedule DM notification callback (only if user opted in)
+  if (prefs.notifySlack) {
+    callbacks.push({
+      url: `${getApiUrl()}/api/internal/callbacks/slack/schedule`,
+      secret: generateCallbackSecret(),
+      payload: callbackPayload,
+    });
+  }
 
   // Delegate run creation, validation, and dispatch to createRun()
   let runId: string;

--- a/turbo/packages/core/src/contracts/user-preferences.ts
+++ b/turbo/packages/core/src/contracts/user-preferences.ts
@@ -10,6 +10,7 @@ const c = initContract();
 export const userPreferencesResponseSchema = z.object({
   timezone: z.string().nullable(),
   notifyEmail: z.boolean(),
+  notifySlack: z.boolean(),
 });
 
 export type UserPreferencesResponse = z.infer<
@@ -23,9 +24,13 @@ export const updateUserPreferencesRequestSchema = z
   .object({
     timezone: z.string().min(1).optional(),
     notifyEmail: z.boolean().optional(),
+    notifySlack: z.boolean().optional(),
   })
   .refine(
-    (data) => data.timezone !== undefined || data.notifyEmail !== undefined,
+    (data) =>
+      data.timezone !== undefined ||
+      data.notifyEmail !== undefined ||
+      data.notifySlack !== undefined,
     {
       message: "At least one preference must be provided",
     },


### PR DESCRIPTION
## Summary

- Add `notifySlack` boolean preference (default `true`) mirroring the existing `notifyEmail` pattern
- Gate Slack schedule notification callbacks on user preference, allowing opt-out via CLI (`--notify-slack off`) or API
- Refactor CLI preference command to reduce complexity (extract `buildUpdates`, `printUpdateResult`, `interactiveSetup` helpers)

## Test plan

- [x] `pnpm vitest run apps/web/app/api/user/preferences` — 14 tests pass (including new notifySlack tests)
- [x] `pnpm vitest run apps/web/app/api/internal/callbacks` — 22 tests pass
- [x] `pnpm check-types` — no type errors
- [x] `pnpm turbo run lint` — no lint errors
- [x] `pnpm knip` — no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)