### PR TITLE
fix(runner): switch cache keys from sha-256 to xxh64

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1446,6 +1446,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "which",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -2742,6 +2743,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -59,6 +59,7 @@ rmp-serde = "1"
 rmpv = "1"
 futures-util = "0.3"
 url = "2"
+xxhash-rust = "0.8"
 
 [profile.release]
 lto = true

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -25,6 +25,7 @@ tar = { workspace = true }
 tempfile = { workspace = true }
 uuid = { workspace = true, features = ["v4", "serde"] }
 which = { workspace = true }
+xxhash-rust = { workspace = true, features = ["xxh64"] }
 
 [lints]
 workspace = true

--- a/crates/runner/src/rootfs.rs
+++ b/crates/runner/src/rootfs.rs
@@ -1,7 +1,8 @@
+use std::hash::Hasher;
 use std::path::{Path, PathBuf};
 
 use clap::Args;
-use sha2::{Digest, Sha256};
+use xxhash_rust::xxh64::Xxh64;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::{HomePaths, RootfsPaths};
@@ -40,7 +41,7 @@ impl RootfsArgs {
     }
 }
 
-/// Build rootfs and return the content hash of the inputs.
+/// Build rootfs and return the cache key (xxh64 of inputs).
 pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
     let guest_bins = args.guest_bins();
     let paths = HomePaths::new()?;
@@ -151,16 +152,25 @@ async fn is_build_complete(rootfs: &RootfsPaths) -> RunnerResult<bool> {
 }
 
 /// Hash all deterministic inputs: build script, Dockerfile, and guest binaries.
+///
+/// We use xxh64 (64-bit, 16 hex chars) instead of SHA-256 (64 hex chars) because
+/// the hash becomes a directory name in the rootfs/snapshot path. Firecracker binds
+/// Unix sockets inside that directory, and `sun_path` is limited to 108 bytes on
+/// Linux. SHA-256 pushed paths to ~113 bytes, exceeding the limit.
+///
+/// Collision risk is negligible: a single machine has at most tens of cached builds,
+/// and 64 bits gives ~50% collision probability only at ~5 billion entries (birthday
+/// bound). This is purely a local cache key — not used for integrity verification.
 async fn compute_input_hash(guest_bins: &[(&Path, &str)]) -> RunnerResult<String> {
-    let mut hasher = Sha256::new();
+    let mut hasher = Xxh64::default();
 
     // Hash build script content (includes resolv.conf, constants, all logic)
-    hasher.update(b"script:");
-    hasher.update(BUILD_SCRIPT.as_bytes());
+    hasher.write(b"script:");
+    hasher.write(BUILD_SCRIPT.as_bytes());
 
     // Hash Dockerfile content
-    hasher.update(b"dockerfile:");
-    hasher.update(EMBEDDED_DOCKERFILE.as_bytes());
+    hasher.write(b"dockerfile:");
+    hasher.write(EMBEDDED_DOCKERFILE.as_bytes());
 
     // Hash guest binaries (already sorted by name via guest_bins())
     for (src, dest) in guest_bins {
@@ -168,9 +178,9 @@ async fn compute_input_hash(guest_bins: &[(&Path, &str)]) -> RunnerResult<String
             .await
             .map_err(|e| RunnerError::Internal(format!("read {}: {e}", src.display())))?;
         let tag = format!("bin:{dest}:");
-        hasher.update(tag.as_bytes());
-        hasher.update(&content);
+        hasher.write(tag.as_bytes());
+        hasher.write(&content);
     }
 
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(format!("{:016x}", hasher.finish()))
 }

--- a/crates/runner/src/snapshot.rs
+++ b/crates/runner/src/snapshot.rs
@@ -1,5 +1,7 @@
+use std::hash::Hasher;
+
 use clap::Args;
-use sha2::{Digest, Sha256};
+use xxhash_rust::xxh64::Xxh64;
 
 use sandbox_fc::SnapshotOutputPaths;
 
@@ -10,7 +12,7 @@ use crate::paths::{HomePaths, RootfsPaths};
 
 #[derive(Args, Clone)]
 pub struct SnapshotArgs {
-    /// SHA-256 hash of the rootfs inputs (output of `rootfs`).
+    /// Cache key of the rootfs inputs (xxh64, output of `rootfs`).
     #[arg(long)]
     pub rootfs_hash: String,
     /// Number of vCPUs for the snapshot VM.
@@ -90,6 +92,10 @@ async fn is_snapshot_complete(output: &SnapshotOutputPaths) -> RunnerResult<bool
 
 /// Compute a composite cache key from all inputs that affect the snapshot.
 ///
+/// Uses xxh64 (64-bit) for the same reason as rootfs `compute_input_hash`:
+/// SHA-256's 64 hex chars exceed the 108-byte Unix socket `sun_path` limit
+/// when used as a directory name. See that function's doc comment for details.
+///
 /// Inputs:
 ///   - `sandbox_fc::config_hash()` — boot args, guest network config
 ///   - `rootfs_hash` — rootfs content (from `rootfs`)
@@ -99,20 +105,20 @@ async fn is_snapshot_complete(output: &SnapshotOutputPaths) -> RunnerResult<bool
 /// **Changing this function invalidates all cached snapshots.**
 pub(crate) fn compute_snapshot_hash(args: &SnapshotArgs) -> String {
     let fc_config = sandbox_fc::config_hash();
-    let mut hasher = Sha256::new();
-    hasher.update(b"fc_config:");
-    hasher.update(fc_config.as_bytes());
-    hasher.update(b"rootfs:");
-    hasher.update(args.rootfs_hash.as_bytes());
-    hasher.update(b"firecracker:");
-    hasher.update(FIRECRACKER_VERSION.as_bytes());
-    hasher.update(b"kernel:");
-    hasher.update(KERNEL_VERSION.as_bytes());
-    hasher.update(b"vcpu:");
-    hasher.update(args.vcpu.to_le_bytes());
-    hasher.update(b"memory_mb:");
-    hasher.update(args.memory_mb.to_le_bytes());
-    format!("{:x}", hasher.finalize())
+    let mut hasher = Xxh64::default();
+    hasher.write(b"fc_config:");
+    hasher.write(fc_config.as_bytes());
+    hasher.write(b"rootfs:");
+    hasher.write(args.rootfs_hash.as_bytes());
+    hasher.write(b"firecracker:");
+    hasher.write(FIRECRACKER_VERSION.as_bytes());
+    hasher.write(b"kernel:");
+    hasher.write(KERNEL_VERSION.as_bytes());
+    hasher.write(b"vcpu:");
+    hasher.write(&args.vcpu.to_le_bytes());
+    hasher.write(b"memory_mb:");
+    hasher.write(&args.memory_mb.to_le_bytes());
+    format!("{:016x}", hasher.finish())
 }
 
 #[cfg(test)]
@@ -131,7 +137,7 @@ mod tests {
         // Changing this assertion means ALL existing cached snapshots are
         // invalidated.  Only update deliberately.
         assert_eq!(
-            hash, "3c68896dabe2536440cc57e8bf7d377c3f0935afd90ca68b189c6e37636fef19",
+            hash, "9393ede23e670df9",
             "snapshot hash changed — this invalidates all cached snapshots"
         );
     }


### PR DESCRIPTION
## Summary

- Switch rootfs and snapshot cache key hashing from SHA-256 to xxh64 (64-bit native output, 16 hex chars)
- SHA-256 produced 64 hex chars in directory names, pushing Firecracker Unix socket paths over the 108-byte `sun_path` limit (113 bytes on `dev-2.aws.vm3.ai`)
- xxh64 produces 16 hex chars natively — socket paths now 75 bytes, well within the limit
- `sha2` remains in runner for file integrity verification in `setup.rs`

**Tested on dev-2.aws.vm3.ai** — full `runner build` (rootfs + snapshot) completes successfully.

Closes #2944

## Test plan

- [x] `snapshot_hash_is_stable` test updated with new expected value
- [x] `different_inputs_produce_different_hashes` passes
- [x] All 25 runner tests pass
- [x] Clippy clean
- [x] End-to-end `runner build` on aarch64 metal (dev-2.aws.vm3.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)