### PR TITLE
feat(email): add vm0 branding to scheduled run notifications

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
@@ -168,7 +168,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const { messageId } = await sendEmail({
       from: buildFromAddress(composeName),
       to: userEmail,
-      subject: `Scheduled run for "${composeName}" completed`,
+      subject: `VM0 - Scheduled run for "${composeName}" completed`,
       react: ScheduleCompletedEmail({
         agentName: composeName,
         output: truncatedOutput,
@@ -192,7 +192,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     await sendEmail({
       from: buildFromAddress(composeName),
       to: userEmail,
-      subject: `Scheduled run for "${composeName}" failed`,
+      subject: `VM0 - Scheduled run for "${composeName}" failed`,
       react: ScheduleFailedEmail({
         agentName: composeName,
         errorMessage: error ?? "Unknown error",

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -64,7 +64,7 @@ export function buildReplyToAddress(token: string): string {
  * Build the from address for outbound emails.
  */
 export function buildFromAddress(agentName: string): string {
-  return `${agentName} <agent@${getFromDomain()}>`;
+  return `${agentName} from VM0 <agent@${getFromDomain()}>`;
 }
 
 /**

--- a/turbo/apps/web/src/lib/email/templates/schedule-completed.tsx
+++ b/turbo/apps/web/src/lib/email/templates/schedule-completed.tsx
@@ -24,11 +24,13 @@ export function ScheduleCompletedEmail({
   return (
     <Html>
       <Head />
-      <Preview>Scheduled run for &quot;{agentName}&quot; completed</Preview>
+      <Preview>
+        VM0 - Scheduled run for &quot;{agentName}&quot; completed
+      </Preview>
       <Body style={bodyStyle}>
         <Container style={containerStyle}>
           <Text style={headingStyle}>
-            Scheduled run for &quot;{agentName}&quot; completed
+            VM0 - Scheduled run for &quot;{agentName}&quot; completed
           </Text>
           <Section style={outputSectionStyle}>
             <Text style={outputStyle}>{output}</Text>

--- a/turbo/apps/web/src/lib/email/templates/schedule-failed.tsx
+++ b/turbo/apps/web/src/lib/email/templates/schedule-failed.tsx
@@ -24,11 +24,11 @@ export function ScheduleFailedEmail({
   return (
     <Html>
       <Head />
-      <Preview>Scheduled run for &quot;{agentName}&quot; failed</Preview>
+      <Preview>VM0 - Scheduled run for &quot;{agentName}&quot; failed</Preview>
       <Body style={bodyStyle}>
         <Container style={containerStyle}>
           <Text style={headingStyle}>
-            Scheduled run for &quot;{agentName}&quot; failed
+            VM0 - Scheduled run for &quot;{agentName}&quot; failed
           </Text>
           <Section style={errorSectionStyle}>
             <Text style={errorStyle}>{errorMessage}</Text>


### PR DESCRIPTION
## Summary

- Add "VM0 - " prefix to email subjects for scheduled run completion/failure notifications
- Update sender name format from `{agentName}` to `{agentName} from VM0`
- Update email templates (preview text and headings) to match the new subject format

**Example email:**
```
From: my-agent from VM0 <agent@vm7.bot>
Subject: VM0 - Scheduled run for "my-agent" completed
```

## Test plan

- [ ] Verify email subjects include "VM0 - " prefix
- [ ] Verify sender name shows "{agentName} from VM0" format
- [ ] Verify email preview text matches subject in both completed and failed templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)