### PR TITLE
fix(email): align reply subject with schedule notification for threading

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
@@ -198,7 +198,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const { messageId } = await sendEmail({
     from: buildFromAddress(compose.name),
     to: userEmail,
-    subject: `Re: Reply from "${compose.name}"`,
+    subject: `Re: VM0 - Scheduled run for "${compose.name}" completed`,
     react: AgentReplyEmail({
       agentName: compose.name,
       output,


### PR DESCRIPTION
## Summary

- Align email reply subject format with schedule notification subject
- Enables Gmail to properly thread email conversations when users reply to scheduled run notifications

**Before:**
```
Subject: Re: Reply from "my-agent"
```

**After:**
```
Subject: Re: VM0 - Scheduled run for "my-agent" completed
```

This matches the schedule notification subject introduced in #2949, allowing email clients to recognize these as part of the same conversation thread.

## Test plan

- [ ] Reply to a scheduled run notification email
- [ ] Verify the agent's response appears in the same email thread (not a new conversation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)