### PR TITLE
feat(email): add email-triggered agent runs

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import { Resend } from "resend";
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import {
+  createTestCompose,
+  createTestRun,
+  createTestCallback,
+  createTestRequest,
+  completeTestRun,
+  findTestEmailThreadSession,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import { computeHmacSignature } from "../../../../../../../src/lib/callback/hmac";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { generateReplyToken } from "../../../../../../../src/lib/email/handlers/shared";
+
+const context = testContext();
+const mockResend = vi.mocked(new Resend(""), true);
+
+interface TriggerCallbackPayload {
+  senderEmail: string;
+  composeId: string;
+  userId: string;
+  inboundEmailId: string;
+  replyToken: string;
+}
+
+function createCallbackRequest(
+  body: {
+    runId: string;
+    status: "completed" | "failed";
+    error?: string;
+    payload: TriggerCallbackPayload;
+  },
+  secret: string,
+  options?: { invalidSignature?: boolean; expiredTimestamp?: boolean },
+): NextRequest {
+  const bodyString = JSON.stringify(body);
+  const timestamp = options?.expiredTimestamp
+    ? Math.floor(Date.now() / 1000) - 600
+    : Math.floor(Date.now() / 1000);
+
+  const signature = options?.invalidSignature
+    ? "invalid-signature"
+    : computeHmacSignature(bodyString, secret, timestamp);
+
+  return createTestRequest(
+    "http://localhost/api/internal/callbacks/email/trigger",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-VM0-Signature": signature,
+        "X-VM0-Timestamp": timestamp.toString(),
+      },
+      body: bodyString,
+    },
+  );
+}
+
+describe("POST /api/internal/callbacks/email/trigger", () => {
+  beforeEach(() => {
+    context.setupMocks();
+    mockResend.emails.send.mockClear();
+  });
+
+  describe("Signature Verification", () => {
+    it("should reject request with invalid signature", async () => {
+      const user = await context.setupUser({ prefix: "trigger-sig" });
+      mockClerk({ userId: user.userId });
+      const { composeId } = await createTestCompose(uniqueId("trigger-agent"));
+      const { runId } = await createTestRun(composeId, "Test prompt");
+
+      const replyToken = generateReplyToken(crypto.randomUUID());
+      const payload: TriggerCallbackPayload = {
+        senderEmail: "sender@example.com",
+        composeId,
+        userId: user.userId,
+        inboundEmailId: "email-123",
+        replyToken,
+      };
+
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/email/trigger",
+        payload: { ...payload },
+      });
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+        { invalidSignature: true },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should reject request with expired timestamp", async () => {
+      const user = await context.setupUser({ prefix: "trigger-exp" });
+      mockClerk({ userId: user.userId });
+      const { composeId } = await createTestCompose(uniqueId("trigger-agent"));
+      const { runId } = await createTestRun(composeId, "Test prompt");
+
+      const replyToken = generateReplyToken(crypto.randomUUID());
+      const payload: TriggerCallbackPayload = {
+        senderEmail: "sender@example.com",
+        composeId,
+        userId: user.userId,
+        inboundEmailId: "email-123",
+        replyToken,
+      };
+
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/email/trigger",
+        payload: { ...payload },
+      });
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+        { expiredTimestamp: true },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("Email Sending", () => {
+    it("should send response email for completed trigger run", async () => {
+      const user = await context.setupUser({ prefix: "trigger-ok" });
+      mockClerk({ userId: user.userId });
+      const agentName = uniqueId("trigger-agent");
+      const { composeId } = await createTestCompose(agentName);
+      const { runId } = await createTestRun(composeId, "Test prompt");
+      await completeTestRun(user.userId, runId);
+
+      const replyToken = generateReplyToken(crypto.randomUUID());
+      const senderEmail = "sender@example.com";
+      const payload: TriggerCallbackPayload = {
+        senderEmail,
+        composeId,
+        userId: user.userId,
+        inboundEmailId: "email-123",
+        replyToken,
+      };
+
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/email/trigger",
+        payload: { ...payload },
+      });
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
+      const sendArgs = mockResend.emails.send.mock.calls[0]![0] as {
+        from: string;
+        to: string;
+        subject: string;
+        replyTo: string;
+      };
+      expect(sendArgs.to).toBe(senderEmail);
+      expect(sendArgs.subject).toContain("Re:");
+      expect(sendArgs.replyTo).toContain("reply+");
+    });
+
+    it("should send error email for failed trigger run", async () => {
+      const user = await context.setupUser({ prefix: "trigger-fail" });
+      mockClerk({ userId: user.userId });
+      const agentName = uniqueId("fail-agent");
+      const { composeId } = await createTestCompose(agentName);
+      const { runId } = await createTestRun(composeId, "Test prompt");
+
+      const replyToken = generateReplyToken(crypto.randomUUID());
+      const senderEmail = "sender@example.com";
+      const payload: TriggerCallbackPayload = {
+        senderEmail,
+        composeId,
+        userId: user.userId,
+        inboundEmailId: "email-123",
+        replyToken,
+      };
+
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/email/trigger",
+        payload: { ...payload },
+      });
+
+      const request = createCallbackRequest(
+        { runId, status: "failed", error: "Agent crashed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
+      const sendArgs = mockResend.emails.send.mock.calls[0]![0] as {
+        to: string;
+      };
+      expect(sendArgs.to).toBe(senderEmail);
+    });
+  });
+
+  describe("Session Creation", () => {
+    it("should create email thread session for reply continuity", async () => {
+      const user = await context.setupUser({ prefix: "trigger-session" });
+      mockClerk({ userId: user.userId });
+      const agentName = uniqueId("session-agent");
+      const { composeId } = await createTestCompose(agentName);
+      const { runId } = await createTestRun(composeId, "Test prompt");
+      await completeTestRun(user.userId, runId);
+
+      const replyToken = generateReplyToken(crypto.randomUUID());
+      const senderEmail = "sender@example.com";
+      const payload: TriggerCallbackPayload = {
+        senderEmail,
+        composeId,
+        userId: user.userId,
+        inboundEmailId: "email-123",
+        replyToken,
+      };
+
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/email/trigger",
+        payload: { ...payload },
+      });
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      // Verify email thread session was created
+      const session = await findTestEmailThreadSession(replyToken);
+      expect(session).toBeDefined();
+      expect(session!.userId).toBe(user.userId);
+      expect(session!.composeId).toBe(composeId);
+      expect(session!.replyToToken).toBe(replyToken);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
@@ -1,0 +1,213 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { verifyCallbackRequest } from "../../../../../../src/lib/callback";
+import { decryptCredentialValue } from "../../../../../../src/lib/crypto/secrets-encryption";
+import { agentRunCallbacks } from "../../../../../../src/db/schema/agent-run-callback";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import { agentComposes } from "../../../../../../src/db/schema/agent-compose";
+import { getRunOutput } from "../../../../../../src/lib/slack/handlers/run-agent";
+import { sendEmail } from "../../../../../../src/lib/email/client";
+import {
+  saveEmailThreadSession,
+  buildReplyToAddress,
+  buildFromAddress,
+  buildLogsUrl,
+} from "../../../../../../src/lib/email/handlers/shared";
+import { AgentReplyEmail } from "../../../../../../src/lib/email/templates/agent-reply";
+import { env } from "../../../../../../src/env";
+import { logger } from "../../../../../../src/lib/logger";
+
+const log = logger("callback:email:trigger");
+
+interface CallbackPayload {
+  senderEmail: string;
+  composeId: string;
+  userId: string;
+  inboundEmailId: string;
+  replyToken: string;
+}
+
+interface CallbackBody {
+  runId: string;
+  status: "completed" | "failed";
+  result?: Record<string, unknown>;
+  error?: string;
+  payload: CallbackPayload;
+}
+
+function parsePayload(body: CallbackBody): CallbackPayload | null {
+  const p = body.payload;
+  if (!p) return null;
+  if (
+    typeof p.senderEmail !== "string" ||
+    typeof p.composeId !== "string" ||
+    typeof p.userId !== "string" ||
+    typeof p.inboundEmailId !== "string" ||
+    typeof p.replyToken !== "string"
+  ) {
+    return null;
+  }
+  return p;
+}
+
+function errorResponse(message: string, status: number): NextResponse {
+  return NextResponse.json({ error: message }, { status });
+}
+
+function extractAgentSessionId(result: unknown): string | undefined {
+  if (
+    result &&
+    typeof result === "object" &&
+    "agentSessionId" in result &&
+    typeof result.agentSessionId === "string"
+  ) {
+    return result.agentSessionId;
+  }
+  return undefined;
+}
+
+/**
+ * Email Trigger Callback Handler
+ *
+ * POST /api/internal/callbacks/email/trigger
+ *
+ * Called when an agent run (triggered by email) completes.
+ * Sends the response email to the original sender and creates
+ * an email thread session for conversation continuity.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  initServices();
+
+  // Skip if Resend is not configured
+  if (!env().RESEND_API_KEY) {
+    return NextResponse.json({ success: true, skipped: true });
+  }
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  const rawBody = await request.text();
+
+  let body: CallbackBody;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  const { runId, status, error } = body;
+
+  if (!runId) {
+    return errorResponse("Missing runId", 400);
+  }
+
+  // Verify callback signature
+  const [callback] = await globalThis.services.db
+    .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
+    .from(agentRunCallbacks)
+    .where(eq(agentRunCallbacks.runId, runId))
+    .limit(1);
+
+  if (!callback) {
+    log.warn("Callback record not found", { runId });
+    return errorResponse("Callback not found", 404);
+  }
+
+  const callbackSecret = decryptCredentialValue(
+    callback.encryptedSecret,
+    SECRETS_ENCRYPTION_KEY,
+  );
+
+  const signature = request.headers.get("X-VM0-Signature");
+  const timestamp = request.headers.get("X-VM0-Timestamp");
+
+  const verification = verifyCallbackRequest(
+    rawBody,
+    callbackSecret,
+    signature,
+    timestamp,
+  );
+
+  if (!verification.valid) {
+    log.warn("Callback signature verification failed", {
+      runId,
+      error: verification.error,
+    });
+    return errorResponse(verification.error ?? "Invalid signature", 401);
+  }
+
+  const payload = parsePayload(body);
+  if (!payload) {
+    return errorResponse("Invalid or missing payload", 400);
+  }
+
+  const { senderEmail, composeId, userId, replyToken } = payload;
+
+  log.debug("Processing email trigger callback", { runId, status });
+
+  // Get compose name
+  const [compose] = await globalThis.services.db
+    .select({ name: agentComposes.name })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+
+  if (!compose) {
+    return errorResponse("Compose not found", 404);
+  }
+
+  // Get run output and session ID
+  const logsUrl = buildLogsUrl(runId);
+  const rawOutput = status === "completed" ? await getRunOutput(runId) : null;
+
+  const output =
+    status === "completed"
+      ? rawOutput
+        ? rawOutput.length > 2000
+          ? `${rawOutput.slice(0, 2000)}…`
+          : rawOutput
+        : "Task completed successfully."
+      : (error ?? "The agent run failed.");
+
+  const [run] = await globalThis.services.db
+    .select({ result: agentRuns.result })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+
+  const agentSessionId = extractAgentSessionId(run?.result);
+
+  // Send response email
+  const replyToAddress = buildReplyToAddress(replyToken);
+
+  const { messageId } = await sendEmail({
+    from: buildFromAddress(compose.name),
+    to: senderEmail,
+    subject: `Re: ${compose.name}`,
+    react: AgentReplyEmail({
+      agentName: compose.name,
+      output,
+      logsUrl,
+    }),
+    replyTo: replyToAddress,
+  });
+
+  // Save email thread session for reply continuity
+  if (agentSessionId) {
+    await saveEmailThreadSession({
+      userId,
+      composeId,
+      agentSessionId,
+      lastEmailMessageId: messageId,
+      replyToToken: replyToken,
+    });
+  }
+
+  log.info("Sent email trigger response", {
+    runId,
+    status,
+    agentName: compose.name,
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
@@ -177,9 +177,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const agentSessionId = extractAgentSessionId(run?.result);
 
-  // Send response email
-  const replyToAddress = buildReplyToAddress(replyToken);
+  // Only enable reply continuity when we have a session to resume
+  const replyToAddress = agentSessionId
+    ? buildReplyToAddress(replyToken)
+    : undefined;
 
+  // Send response email
   const { messageId } = await sendEmail({
     from: buildFromAddress(compose.name),
     to: senderEmail,

--- a/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
@@ -15,9 +15,6 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { generateReplyToken } from "../../../../../../src/lib/email/handlers/shared";
-import { agentComposes } from "../../../../../../src/db/schema/agent-compose";
-import { scopes } from "../../../../../../src/db/schema/scope";
-import { eq } from "drizzle-orm";
 
 const context = testContext();
 const mockResend = vi.mocked(new Resend(""), true);
@@ -257,31 +254,18 @@ describe("POST /api/webhooks/email/inbound", () => {
   describe("Email Trigger (scope+agent@domain)", () => {
     it("should dispatch agent run for valid trigger email", async () => {
       // Given a user with a scope and compose
+      // setupUser creates a user with userId = "trigger-user-{suffix}" and
+      // scope slug = "scope-{suffix}" using the same suffix
       const user = await context.setupUser({ prefix: "trigger-user" });
-      const scopeSlug = uniqueId("trigger-scope");
+
+      // Extract suffix from userId to derive scope slug
+      // userId format: "{prefix}-{suffix}" where suffix is an 8-char UUID
+      const suffix = user.userId.slice("trigger-user-".length);
+      const scopeSlug = `scope-${suffix}`;
       const agentName = uniqueId("trigger-agent");
 
-      // Get the user's existing scope (created by setupUser)
-      const [userScope] = await globalThis.services.db
-        .select()
-        .from(scopes)
-        .where(eq(scopes.ownerId, user.userId))
-        .limit(1);
-
-      // Update scope slug to our test slug
-      await globalThis.services.db
-        .update(scopes)
-        .set({ slug: scopeSlug })
-        .where(eq(scopes.id, userScope!.id));
-
-      // Create compose under that scope
+      // Create compose (automatically associates with user's scope)
       const { composeId } = await createTestCompose(agentName);
-
-      // Update compose to use the user's scope
-      await globalThis.services.db
-        .update(agentComposes)
-        .set({ scopeId: userScope!.id })
-        .where(eq(agentComposes.id, composeId));
 
       // Mock Clerk to return the user when looking up by email
       const senderEmail = "sender@example.com";

--- a/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
@@ -15,6 +15,9 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { generateReplyToken } from "../../../../../../src/lib/email/handlers/shared";
+import { agentComposes } from "../../../../../../src/db/schema/agent-compose";
+import { scopes } from "../../../../../../src/db/schema/scope";
+import { eq } from "drizzle-orm";
 
 const context = testContext();
 const mockResend = vi.mocked(new Resend(""), true);
@@ -249,5 +252,143 @@ describe("POST /api/webhooks/email/inbound", () => {
 
     // The handler should have returned early — Resend receiving.get not called
     expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
+  });
+
+  describe("Email Trigger (scope+agent@domain)", () => {
+    it("should dispatch agent run for valid trigger email", async () => {
+      // Given a user with a scope and compose
+      const user = await context.setupUser({ prefix: "trigger-user" });
+      const scopeSlug = uniqueId("trigger-scope");
+      const agentName = uniqueId("trigger-agent");
+
+      // Get the user's existing scope (created by setupUser)
+      const [userScope] = await globalThis.services.db
+        .select()
+        .from(scopes)
+        .where(eq(scopes.ownerId, user.userId))
+        .limit(1);
+
+      // Update scope slug to our test slug
+      await globalThis.services.db
+        .update(scopes)
+        .set({ slug: scopeSlug })
+        .where(eq(scopes.id, userScope!.id));
+
+      // Create compose under that scope
+      const { composeId } = await createTestCompose(agentName);
+
+      // Update compose to use the user's scope
+      await globalThis.services.db
+        .update(agentComposes)
+        .set({ scopeId: userScope!.id })
+        .where(eq(agentComposes.id, composeId));
+
+      // Mock Clerk to return the user when looking up by email
+      const senderEmail = "sender@example.com";
+      mockClerk({ userId: user.userId, email: senderEmail });
+
+      // Build inbound email webhook payload with scope+agent format
+      const payload = JSON.stringify({
+        type: "email.received",
+        data: {
+          email_id: "trigger-email-123",
+          to: [`${scopeSlug}+${agentName}@vm7.bot`],
+          from: senderEmail,
+          subject: "Test Subject",
+          created_at: new Date().toISOString(),
+        },
+      });
+
+      const request = createWebhookRequest(payload);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ received: true });
+
+      // Flush the after() callback
+      await context.mocks.flushAfter();
+
+      // Verify: agent run was created with subject + body as prompt
+      const runs = await findTestRunsByUserAndPrompt(
+        user.userId,
+        "Test Subject\n\nHello from email",
+      );
+
+      expect(runs).toHaveLength(1);
+      const run = runs[0]!;
+      expect(run.status).toBeDefined();
+
+      // Verify: trigger callback was registered
+      const callbacks = await findTestCallbacksByRunId(run.id);
+      expect(callbacks.length).toBeGreaterThanOrEqual(1);
+
+      const triggerCallback = callbacks.find((c) =>
+        c.url.includes("/callbacks/email/trigger"),
+      );
+      expect(triggerCallback).toBeDefined();
+      expect(triggerCallback!.payload).toMatchObject({
+        senderEmail,
+        composeId,
+        userId: user.userId,
+        inboundEmailId: "trigger-email-123",
+        replyToken: expect.any(String),
+      });
+    });
+
+    it("should ignore trigger email from unregistered sender", async () => {
+      mockResend.emails.receiving.get.mockClear();
+
+      // Mock Clerk to return user only for registered email
+      mockClerk({ userId: "some-user-id", email: "registered@example.com" });
+
+      // Send email from unregistered address
+      const payload = JSON.stringify({
+        type: "email.received",
+        data: {
+          email_id: "unreg-email",
+          to: ["somescope+someagent@vm7.bot"],
+          from: "unregistered@example.com",
+          subject: "Test",
+          created_at: new Date().toISOString(),
+        },
+      });
+
+      const request = createWebhookRequest(payload);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      // No email should have been fetched (early return)
+      expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
+    });
+
+    it("should ignore trigger email for non-existent agent", async () => {
+      mockResend.emails.receiving.get.mockClear();
+
+      const senderEmail = "sender@example.com";
+      mockClerk({ userId: "some-user-id", email: senderEmail });
+
+      // Send email to non-existent scope/agent
+      const payload = JSON.stringify({
+        type: "email.received",
+        data: {
+          email_id: "no-agent-email",
+          to: ["nonexistent+fakeagent@vm7.bot"],
+          from: senderEmail,
+          subject: "Test",
+          created_at: new Date().toISOString(),
+        },
+      });
+
+      const request = createWebhookRequest(payload);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      // Resend should not have been called (early return after agent lookup failed)
+      expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
+    });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/email/inbound/route.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/route.ts
@@ -5,6 +5,8 @@ import {
   getSvixHeaders,
 } from "../../../../../src/lib/email/verify";
 import { handleInboundEmailReply } from "../../../../../src/lib/email/handlers/inbound-reply";
+import { handleInboundEmailTrigger } from "../../../../../src/lib/email/handlers/inbound-trigger";
+import { isReplyAddress } from "../../../../../src/lib/email/handlers/shared";
 import { logger } from "../../../../../src/lib/logger";
 
 const log = logger("webhook:email:inbound");
@@ -15,6 +17,10 @@ const log = logger("webhook:email:inbound");
  * POST /api/webhooks/email/inbound
  *
  * Receives inbound email events from Resend via Svix.
+ * Routes to appropriate handler based on email address type:
+ * - reply+{token}@domain → handleInboundEmailReply (continue conversation)
+ * - {scope}+{agent}@domain → handleInboundEmailTrigger (new agent run)
+ *
  * Verifies the webhook signature and dispatches handling in the background.
  * Returns 200 immediately to acknowledge receipt.
  */
@@ -42,20 +48,33 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   // 3. Check event type
-  const event = payload as { type?: string; data?: Record<string, unknown> };
+  const event = payload as { type?: string; data?: { to?: string[] } };
   if (event.type !== "email.received") {
     // Acknowledge non-inbound events silently
     return NextResponse.json({ received: true });
   }
 
-  // 4. Dispatch handling in the background (fire-and-forget)
-  after(() =>
-    handleInboundEmailReply(
-      event as Parameters<typeof handleInboundEmailReply>[0],
-    ).catch((err) =>
-      log.error("Failed to handle inbound email reply", { err }),
-    ),
-  );
+  // 4. Route to appropriate handler based on address type
+  const toAddresses = event.data?.to ?? [];
+  const hasReplyAddress = toAddresses.some(isReplyAddress);
+
+  // 5. Dispatch handling in the background (fire-and-forget)
+  after(() => {
+    const handler = hasReplyAddress
+      ? handleInboundEmailReply(
+          event as Parameters<typeof handleInboundEmailReply>[0],
+        )
+      : handleInboundEmailTrigger(
+          event as Parameters<typeof handleInboundEmailTrigger>[0],
+        );
+
+    return handler.catch((err) =>
+      log.error("Failed to handle inbound email", {
+        err,
+        type: hasReplyAddress ? "reply" : "trigger",
+      }),
+    );
+  });
 
   return NextResponse.json({ received: true });
 }

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -33,8 +33,11 @@ const mockClerkClient = vi.mocked(clerkClient);
  * Configure Clerk auth mock
  * @param options - Auth configuration
  * @param options.userId - User ID to return, or null for unauthenticated
+ * @param options.email - Email address for the user (default: "test@example.com")
  */
-export function mockClerk(options: { userId: string | null }) {
+export function mockClerk(options: { userId: string | null; email?: string }) {
+  const email = options.email ?? "test@example.com";
+
   mockAuth.mockResolvedValue({
     userId: options.userId,
   } as Awaited<ReturnType<typeof auth>>);
@@ -43,8 +46,18 @@ export function mockClerk(options: { userId: string | null }) {
   mockClerkClient.mockResolvedValue({
     users: {
       getUser: vi.fn().mockResolvedValue({
-        emailAddresses: [{ id: "email_1", emailAddress: MOCK_USER_EMAIL }],
+        emailAddresses: [{ id: "email_1", emailAddress: email }],
         primaryEmailAddressId: "email_1",
+      }),
+      getUserList: vi.fn().mockImplementation(({ emailAddress }) => {
+        // Return user if email matches, empty array otherwise
+        const queryEmail = emailAddress?.[0];
+        if (queryEmail === email && options.userId) {
+          return Promise.resolve({
+            data: [{ id: options.userId }],
+          });
+        }
+        return Promise.resolve({ data: [] });
       }),
     },
   } as unknown as Awaited<ReturnType<typeof clerkClient>>);

--- a/turbo/apps/web/src/lib/auth/auth-provider.ts
+++ b/turbo/apps/web/src/lib/auth/auth-provider.ts
@@ -13,6 +13,7 @@ export { SELF_HOSTED_USER_ID } from "./constants";
 interface AuthProvider {
   getUserId(): Promise<string | null>;
   getUserEmail(userId: string): Promise<string>;
+  getUserIdByEmail(email: string): Promise<string | null>;
 }
 
 /**
@@ -33,6 +34,13 @@ function createClerkAuthProvider(): AuthProvider {
       )?.emailAddress;
       return email || "";
     },
+
+    async getUserIdByEmail(email: string) {
+      const client = await clerkClient();
+      const users = await client.users.getUserList({ emailAddress: [email] });
+      const user = users.data[0];
+      return user?.id ?? null;
+    },
   };
 }
 
@@ -47,6 +55,14 @@ function createLocalAuthProvider(): AuthProvider {
 
     async getUserEmail() {
       return SELF_HOSTED_USER_EMAIL;
+    },
+
+    async getUserIdByEmail(email: string) {
+      // In self-hosted mode, if the email matches the default user's email, return the default user ID
+      if (email.toLowerCase() === SELF_HOSTED_USER_EMAIL.toLowerCase()) {
+        return SELF_HOSTED_USER_ID;
+      }
+      return null;
     },
   };
 }

--- a/turbo/apps/web/src/lib/auth/get-user-id-by-email.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-id-by-email.ts
@@ -1,0 +1,12 @@
+import { getAuthProvider } from "./auth-provider";
+
+/**
+ * Look up a user ID by their email address.
+ *
+ * @param email - The email address to look up
+ * @returns The user ID if found, null otherwise
+ */
+export async function getUserIdByEmail(email: string): Promise<string | null> {
+  const provider = getAuthProvider();
+  return provider.getUserIdByEmail(email);
+}

--- a/turbo/apps/web/src/lib/email/handlers/__tests__/shared.test.ts
+++ b/turbo/apps/web/src/lib/email/handlers/__tests__/shared.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { parseEmailTriggerAddress, isReplyAddress } from "../shared";
+
+describe("parseEmailTriggerAddress", () => {
+  it("should parse valid scope+agent address", () => {
+    const result = parseEmailTriggerAddress("lancy+my-agent@vm0.bot");
+    expect(result).toEqual({ scope: "lancy", agent: "my-agent" });
+  });
+
+  it("should normalize to lowercase", () => {
+    const result = parseEmailTriggerAddress("LANCY+MY-AGENT@vm0.bot");
+    expect(result).toEqual({ scope: "lancy", agent: "my-agent" });
+  });
+
+  it("should handle scope and agent with numbers", () => {
+    const result = parseEmailTriggerAddress("user123+agent456@vm0.bot");
+    expect(result).toEqual({ scope: "user123", agent: "agent456" });
+  });
+
+  it("should handle scope and agent with hyphens", () => {
+    const result = parseEmailTriggerAddress("my-scope+my-agent@vm0.bot");
+    expect(result).toEqual({ scope: "my-scope", agent: "my-agent" });
+  });
+
+  it("should return null for reply address", () => {
+    const result = parseEmailTriggerAddress("reply+token123@vm0.bot");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for address without plus sign", () => {
+    const result = parseEmailTriggerAddress("invalid@vm0.bot");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for address with only scope", () => {
+    const result = parseEmailTriggerAddress("scope+@vm0.bot");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for address with only agent", () => {
+    const result = parseEmailTriggerAddress("+agent@vm0.bot");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for scope starting with hyphen", () => {
+    const result = parseEmailTriggerAddress("-invalid+agent@vm0.bot");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for agent starting with hyphen", () => {
+    const result = parseEmailTriggerAddress("scope+-agent@vm0.bot");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for empty string", () => {
+    const result = parseEmailTriggerAddress("");
+    expect(result).toBeNull();
+  });
+});
+
+describe("isReplyAddress", () => {
+  it("should return true for reply address", () => {
+    expect(isReplyAddress("reply+token123@vm0.bot")).toBe(true);
+  });
+
+  it("should return true for reply address with any case", () => {
+    expect(isReplyAddress("REPLY+token123@vm0.bot")).toBe(true);
+    expect(isReplyAddress("Reply+token123@vm0.bot")).toBe(true);
+  });
+
+  it("should return false for trigger address", () => {
+    expect(isReplyAddress("lancy+my-agent@vm0.bot")).toBe(false);
+  });
+
+  it("should return false for regular address", () => {
+    expect(isReplyAddress("user@vm0.bot")).toBe(false);
+  });
+});

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -137,7 +137,7 @@ export async function handleInboundEmailTrigger(
   // 8. Create and dispatch run
   const result = await createRun({
     userId,
-    agentComposeVersionId: compose.headVersionId ?? "",
+    agentComposeVersionId: compose.headVersionId,
     prompt,
     composeId: compose.composeId,
     agentName: triggerAddress.agent,

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -1,0 +1,154 @@
+import { getReceivedEmail } from "../client";
+import { stripQuotedReply } from "../quote-strip";
+import {
+  parseEmailTriggerAddress,
+  resolveAgentByAddress,
+  generateReplyToken,
+} from "./shared";
+import { createRun } from "../../run";
+import { generateCallbackSecret, getApiUrl } from "../../callback";
+import { getUserIdByEmail } from "../../auth/get-user-id-by-email";
+import { canAccessCompose } from "../../agent/permission-service";
+import { getUserEmail } from "../../auth/get-user-email";
+import { logger } from "../../logger";
+
+const log = logger("email:inbound-trigger");
+
+interface InboundEmailEvent {
+  type: string;
+  data: {
+    email_id: string;
+    to: string[];
+    from: string;
+    subject: string;
+    created_at: string;
+  };
+}
+
+/**
+ * Handle an inbound email that triggers an agent run.
+ * This is for direct emails to scope+agent@domain addresses.
+ *
+ * Flow:
+ * 1. Parse scope+agent from recipient address
+ * 2. Look up sender email in Clerk to get user ID
+ * 3. Resolve agent by scope slug + agent name
+ * 4. Check if user has permission to access the agent
+ * 5. Create agent run with callback for response delivery
+ *
+ * All failures are silent (no response email) to prevent information leakage.
+ */
+export async function handleInboundEmailTrigger(
+  event: InboundEmailEvent,
+): Promise<void> {
+  const { email_id: emailId, to, from: senderEmail, subject } = event.data;
+
+  // 1. Find trigger address in recipients
+  let triggerAddress: { scope: string; agent: string } | null = null;
+
+  for (const addr of to) {
+    const parsed = parseEmailTriggerAddress(addr);
+    if (parsed) {
+      triggerAddress = parsed;
+      break;
+    }
+  }
+
+  if (!triggerAddress) {
+    log.debug("No trigger address found in recipients", { to });
+    return;
+  }
+
+  log.debug("Processing email trigger", {
+    scope: triggerAddress.scope,
+    agent: triggerAddress.agent,
+    from: senderEmail,
+  });
+
+  // 2. Look up sender in Clerk
+  const userId = await getUserIdByEmail(senderEmail);
+  if (!userId) {
+    log.debug("Sender email not registered", { from: senderEmail });
+    return;
+  }
+
+  // 3. Resolve agent
+  const compose = await resolveAgentByAddress(
+    triggerAddress.scope,
+    triggerAddress.agent,
+  );
+  if (!compose) {
+    log.debug("Agent not found", {
+      scope: triggerAddress.scope,
+      agent: triggerAddress.agent,
+    });
+    return;
+  }
+
+  // 4. Check permission
+  const userEmail = await getUserEmail(userId);
+  const hasAccess = await canAccessCompose(userId, userEmail, {
+    id: compose.composeId,
+    userId: compose.userId,
+    scopeId: compose.scopeId,
+  });
+
+  if (!hasAccess) {
+    log.debug("User does not have access to agent", {
+      userId,
+      composeId: compose.composeId,
+    });
+    return;
+  }
+
+  // 5. Fetch full email and build prompt
+  const email = await getReceivedEmail(emailId);
+  const bodyContent = stripQuotedReply(email.text);
+
+  // Combine subject + body as prompt
+  const prompt = subject
+    ? `${subject}\n\n${bodyContent}`.trim()
+    : bodyContent.trim();
+
+  if (!prompt) {
+    log.debug("Empty prompt after processing", { emailId });
+    return;
+  }
+
+  // 6. Generate reply token for conversation continuity
+  const sessionPlaceholderId = crypto.randomUUID();
+  const replyToken = generateReplyToken(sessionPlaceholderId);
+
+  // 7. Build callback
+  const callbacks = [
+    {
+      url: `${getApiUrl()}/api/internal/callbacks/email/trigger`,
+      secret: generateCallbackSecret(),
+      payload: {
+        senderEmail,
+        composeId: compose.composeId,
+        userId,
+        inboundEmailId: emailId,
+        replyToken,
+      },
+    },
+  ];
+
+  // 8. Create and dispatch run
+  const result = await createRun({
+    userId,
+    agentComposeVersionId: compose.headVersionId ?? "",
+    prompt,
+    composeId: compose.composeId,
+    agentName: triggerAddress.agent,
+    artifactName: "artifact",
+    callbacks,
+  });
+
+  log.info("Dispatched agent run from email trigger", {
+    runId: result.runId,
+    emailId,
+    scope: triggerAddress.scope,
+    agent: triggerAddress.agent,
+  });
+}

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -58,7 +58,7 @@ interface ResolvedAgent {
   composeId: string;
   userId: string;
   scopeId: string;
-  headVersionId: string | null;
+  headVersionId: string;
 }
 
 /**
@@ -96,6 +96,9 @@ export async function resolveAgentByAddress(
     .limit(1);
 
   if (!compose) return null;
+
+  // Compose must have a published version to be triggerable
+  if (!compose.headVersionId) return null;
 
   return {
     composeId: compose.id,

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -1,8 +1,113 @@
 import crypto from "crypto";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { emailThreadSessions } from "../../../db/schema/email-thread-session";
+import { agentComposes } from "../../../db/schema/agent-compose";
+import { scopes } from "../../../db/schema/scope";
 import { env } from "../../../env";
 import { getPlatformUrl } from "../../url";
+
+// ============================================================================
+// Email Address Parsing
+// ============================================================================
+
+interface EmailTriggerAddress {
+  scope: string;
+  agent: string;
+}
+
+/**
+ * Parse a trigger email address in the format: scope+agent@domain
+ * Returns null if the address doesn't match the expected format.
+ *
+ * Examples:
+ * - "lancy+my-agent@vm0.bot" → { scope: "lancy", agent: "my-agent" }
+ * - "reply+token@vm0.bot" → null (reply address, not trigger)
+ * - "invalid@vm0.bot" → null (no plus sign)
+ */
+export function parseEmailTriggerAddress(
+  toAddress: string,
+): EmailTriggerAddress | null {
+  // Match: scope+agent@domain (case-insensitive)
+  // Scope and agent must start with alphanumeric, can contain hyphens
+  const match = toAddress.match(
+    /^([a-z0-9][a-z0-9-]*)\+([a-z0-9][a-z0-9-]*)@/i,
+  );
+  if (!match || !match[1] || !match[2]) return null;
+
+  const scope = match[1].toLowerCase();
+  const agent = match[2].toLowerCase();
+
+  // Exclude reply addresses (reply+token@domain)
+  if (scope === "reply") return null;
+
+  return { scope, agent };
+}
+
+/**
+ * Check if an email address is a reply address (reply+token@domain)
+ */
+export function isReplyAddress(toAddress: string): boolean {
+  return toAddress.toLowerCase().startsWith("reply+");
+}
+
+// ============================================================================
+// Agent Resolution
+// ============================================================================
+
+interface ResolvedAgent {
+  composeId: string;
+  userId: string;
+  scopeId: string;
+  headVersionId: string | null;
+}
+
+/**
+ * Resolve an agent compose by scope slug and agent name.
+ * Returns compose details if found, null otherwise.
+ */
+export async function resolveAgentByAddress(
+  scopeSlug: string,
+  agentName: string,
+): Promise<ResolvedAgent | null> {
+  // 1. Find scope by slug
+  const [scope] = await globalThis.services.db
+    .select({ id: scopes.id })
+    .from(scopes)
+    .where(eq(scopes.slug, scopeSlug))
+    .limit(1);
+
+  if (!scope) return null;
+
+  // 2. Find compose by scopeId + name
+  const [compose] = await globalThis.services.db
+    .select({
+      id: agentComposes.id,
+      userId: agentComposes.userId,
+      scopeId: agentComposes.scopeId,
+      headVersionId: agentComposes.headVersionId,
+    })
+    .from(agentComposes)
+    .where(
+      and(
+        eq(agentComposes.scopeId, scope.id),
+        eq(agentComposes.name, agentName),
+      ),
+    )
+    .limit(1);
+
+  if (!compose) return null;
+
+  return {
+    composeId: compose.id,
+    userId: compose.userId,
+    scopeId: compose.scopeId,
+    headVersionId: compose.headVersionId,
+  };
+}
+
+// ============================================================================
+// Reply Token Management
+// ============================================================================
 
 /**
  * Generate an HMAC-signed reply token for plus addressing.


### PR DESCRIPTION
## Summary

- Allow users to trigger agent runs by sending emails to `scope+agentName@vm0.bot`
- System verifies sender is a registered VM0 user via Clerk
- Resolves agent by scope slug + agent name
- Checks user permission to access the agent
- Creates agent run with callback for response delivery
- Response email enables conversation continuity via reply

## Key Changes

### Auth Layer
- Add `getUserIdByEmail()` to auth-provider for reverse email lookup
- Create `get-user-id-by-email.ts` convenience function

### Email Handlers
- Add `parseEmailTriggerAddress()` to parse `scope+agent` format from email address
- Add `isReplyAddress()` to distinguish reply vs trigger addresses
- Add `resolveAgentByAddress()` to find agent by scope slug + name
- Create `inbound-trigger.ts` handler for new trigger emails

### API Routes
- Add `/api/internal/callbacks/email/trigger` callback endpoint
- Update `/api/webhooks/email/inbound` to route between reply and trigger handlers

### Tests
- Add unit tests for email address parsing edge cases

## Test plan

- [ ] Verify type check passes: `pnpm check-types`
- [ ] Verify lint passes: `pnpm turbo run lint`
- [ ] Verify unit tests pass: `pnpm vitest run src/lib/email`
- [ ] Manual test: Send email to `scope+agent@vm0.bot`, verify run is created
- [ ] Manual test: Verify response email is received with logs link
- [ ] Manual test: Reply to response email, verify conversation continues

Closes #2957

🤖 Generated with [Claude Code](https://claude.com/claude-code)