### PR TITLE
fix(web): make vars validation respect checkenv flag

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -270,7 +270,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(data.status).toBe("running");
     });
 
-    it("should fail run when only some vars are provided with checkEnv", async () => {
+    it("should reject run when only some vars are provided with checkEnv", async () => {
       // Create compose that requires multiple vars
       const { composeId: multiVarsComposeId } = await createTestCompose(
         `multi-vars-${Date.now()}`,
@@ -287,20 +287,28 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
       // Try to create run with only one var AND checkEnv: true
       // Vars validation only happens when checkEnv is enabled
-      const data = await createTestRun(
-        multiVarsComposeId,
-        "Test with partial vars",
-        { vars: { VAR_A: "value-a" }, checkEnv: true }, // Missing VAR_B
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentComposeId: multiVarsComposeId,
+            prompt: "Test with partial vars",
+            vars: { VAR_A: "value-a" }, // Missing VAR_B
+            checkEnv: true,
+          }),
+        },
       );
 
-      expect(data.status).toBe("failed");
+      const response = await POST(request);
+      const data = await response.json();
 
-      // Verify error via API
-      const run = await getTestRun(data.runId);
-      expect(run.error).toMatch(/Missing required template variables/i);
-      expect(run.error).toContain("VAR_B");
+      // API validates template variables when checkEnv is true
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain("VAR_B");
       // VAR_A should NOT be in the error (it was provided)
-      expect(run.error).not.toContain("VAR_A");
+      expect(data.error.message).not.toContain("VAR_A");
     });
 
     it("should succeed when all required vars are provided", async () => {
@@ -1140,7 +1148,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(run.error).toContain("not found");
     });
 
-    it("should reject request when volume has missing template variable", async () => {
+    it("should reject request when volume has missing template variable with checkEnv", async () => {
       // Create compose with volume that uses a template variable
       const composeRequest = createTestRequest(
         "http://localhost:3000/api/agent/composes",
@@ -1172,8 +1180,8 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       const composeResponse = await createComposeRoute(composeRequest);
       const compose = await composeResponse.json();
 
-      // Create run WITHOUT providing required vars
-      // This should return 400 because template vars are validated before run creation
+      // Create run WITHOUT providing required vars but WITH checkEnv: true
+      // Vars validation only happens when checkEnv is enabled
       const runRequest = createTestRequest(
         "http://localhost:3000/api/agent/runs",
         {
@@ -1182,6 +1190,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
           body: JSON.stringify({
             agentComposeId: compose.composeId,
             prompt: "Test missing var",
+            checkEnv: true,
           }),
         },
       );
@@ -1189,7 +1198,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       const response = await POST(runRequest);
       const data = await response.json();
 
-      // API validates template variables before creating run
+      // API validates template variables when checkEnv is true
       expect(response.status).toBe(400);
       expect(data.error.message).toContain("userId");
     });
@@ -1308,7 +1317,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(envs?.MY_VAR).toBe("cli-value");
     });
 
-    it("should still fail when required var is neither on server nor CLI", async () => {
+    it("should still fail when required var is neither on server nor CLI with checkEnv", async () => {
       // Create compose that requires a variable that doesn't exist
       const { composeId } = await createTestCompose(uniqueId("missing-var"), {
         overrides: {
@@ -1319,7 +1328,8 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
         },
       });
 
-      // Try to create run without providing the variable
+      // Try to create run without providing the variable but WITH checkEnv: true
+      // Vars validation only happens when checkEnv is enabled
       const request = createTestRequest(
         "http://localhost:3000/api/agent/runs",
         {
@@ -1328,6 +1338,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
           body: JSON.stringify({
             agentComposeId: composeId,
             prompt: "Test without var",
+            checkEnv: true,
           }),
         },
       );
@@ -1363,7 +1374,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(data.status).toBe("running");
     });
 
-    it("should fail run with missing vars when checkEnv is true", async () => {
+    it("should reject run with missing vars when checkEnv is true", async () => {
       // Create compose that requires vars
       const { composeId } = await createTestCompose(
         `vars-check-${Date.now()}`,
@@ -1378,16 +1389,28 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       );
 
       // Create run WITHOUT providing vars but WITH checkEnv: true
-      const data = await createTestRun(composeId, "Test with checkEnv", {
-        checkEnv: true,
-      });
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentComposeId: composeId,
+            prompt: "Test with checkEnv",
+            checkEnv: true,
+          }),
+        },
+      );
 
-      expect(data.status).toBe("failed");
+      const response = await POST(request);
+      const data = await response.json();
 
-      // Verify error message
-      const run = await getTestRun(data.runId);
-      expect(run.error).toMatch(/Missing required template variables/i);
-      expect(run.error).toContain("MY_VAR");
+      // API validates template variables when checkEnv is true
+      expect(response.status).toBe(400);
+      expect(data.error.message).toMatch(
+        /Missing required template variables/i,
+      );
+      expect(data.error.message).toContain("MY_VAR");
     });
 
     it("should succeed with checkEnv when all vars are provided", async () => {

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -270,7 +270,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(data.status).toBe("running");
     });
 
-    it("should reject request when only some vars are provided", async () => {
+    it("should fail run when only some vars are provided with checkEnv", async () => {
       // Create compose that requires multiple vars
       const { composeId: multiVarsComposeId } = await createTestCompose(
         `multi-vars-${Date.now()}`,
@@ -285,28 +285,22 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
         },
       );
 
-      // Try to create run with only one var
-      // Template vars are validated at route level BEFORE run creation
-      const request = createTestRequest(
-        "http://localhost:3000/api/agent/runs",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentComposeId: multiVarsComposeId,
-            prompt: "Test with partial vars",
-            vars: { VAR_A: "value-a" }, // Missing VAR_B
-          }),
-        },
+      // Try to create run with only one var AND checkEnv: true
+      // Vars validation only happens when checkEnv is enabled
+      const data = await createTestRun(
+        multiVarsComposeId,
+        "Test with partial vars",
+        { vars: { VAR_A: "value-a" }, checkEnv: true }, // Missing VAR_B
       );
 
-      const response = await POST(request);
-      const data = await response.json();
+      expect(data.status).toBe("failed");
 
-      expect(response.status).toBe(400);
-      expect(data.error.message).toContain("VAR_B");
+      // Verify error via API
+      const run = await getTestRun(data.runId);
+      expect(run.error).toMatch(/Missing required template variables/i);
+      expect(run.error).toContain("VAR_B");
       // VAR_A should NOT be in the error (it was provided)
-      expect(data.error.message).not.toContain("VAR_A");
+      expect(run.error).not.toContain("VAR_A");
     });
 
     it("should succeed when all required vars are provided", async () => {
@@ -1343,6 +1337,84 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
       expect(response.status).toBe(400);
       expect(data.error.message).toContain("MISSING_VAR");
+    });
+  });
+
+  describe("checkEnv flag behavior for vars", () => {
+    it("should allow run with missing vars when checkEnv is not set (default)", async () => {
+      // Create compose that requires vars
+      const { composeId } = await createTestCompose(
+        `vars-no-check-${Date.now()}`,
+        {
+          overrides: {
+            environment: {
+              ANTHROPIC_API_KEY: "test-key",
+              MY_VAR: "${{ vars.MY_VAR }}",
+            },
+          },
+        },
+      );
+
+      // Create run WITHOUT providing vars and WITHOUT checkEnv
+      // This should succeed because validation is opt-in
+      const data = await createTestRun(composeId, "Test without vars");
+
+      // Should succeed (running, not failed) - validation is skipped
+      expect(data.status).toBe("running");
+    });
+
+    it("should fail run with missing vars when checkEnv is true", async () => {
+      // Create compose that requires vars
+      const { composeId } = await createTestCompose(
+        `vars-check-${Date.now()}`,
+        {
+          overrides: {
+            environment: {
+              ANTHROPIC_API_KEY: "test-key",
+              MY_VAR: "${{ vars.MY_VAR }}",
+            },
+          },
+        },
+      );
+
+      // Create run WITHOUT providing vars but WITH checkEnv: true
+      const data = await createTestRun(composeId, "Test with checkEnv", {
+        checkEnv: true,
+      });
+
+      expect(data.status).toBe("failed");
+
+      // Verify error message
+      const run = await getTestRun(data.runId);
+      expect(run.error).toMatch(/Missing required template variables/i);
+      expect(run.error).toContain("MY_VAR");
+    });
+
+    it("should succeed with checkEnv when all vars are provided", async () => {
+      // Create compose that requires vars
+      const { composeId } = await createTestCompose(
+        `vars-check-ok-${Date.now()}`,
+        {
+          overrides: {
+            environment: {
+              ANTHROPIC_API_KEY: "test-key",
+              MY_VAR: "${{ vars.MY_VAR }}",
+            },
+          },
+        },
+      );
+
+      // Create run WITH vars AND checkEnv: true
+      const data = await createTestRun(
+        composeId,
+        "Test with vars and checkEnv",
+        {
+          vars: { MY_VAR: "value" },
+          checkEnv: true,
+        },
+      );
+
+      expect(data.status).toBe("running");
     });
   });
 });

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -185,7 +185,7 @@ describe("createRun()", () => {
       ).rejects.toSatisfy(isBadRequest);
     });
 
-    it("should reject missing required template variables", async () => {
+    it("should reject missing required template variables with checkEnv", async () => {
       // Create a compose with template variables
       const compose = await createTestCompose(uniqueId("var-agent"), {
         overrides: {
@@ -196,10 +196,12 @@ describe("createRun()", () => {
         },
       });
 
+      // Vars validation only happens when checkEnv is enabled
       await expect(
         createRun(
           baseParams({
             agentComposeVersionId: compose.versionId,
+            checkEnv: true, // Enable vars validation
             // No vars provided — should fail
           }),
         ),


### PR DESCRIPTION
## Summary

- Fix `validateComposeRequirements()` to accept `checkEnv` parameter and only validate template variables when the flag is true
- This aligns vars validation behavior with secrets validation in `expand-environment.ts`
- Unblocks Slack runs, scheduled runs, and email inbound runs that don't pre-configure vars in scope

## Background

The `--check-env` flag (PR #2760) was designed to make environment validation opt-in. However, while secrets validation was correctly made conditional, vars validation in `validateComposeRequirements()` remained unconditional.

This caused Slack app mention runs to fail with "Missing required template variables" even when the user hadn't configured vars in their scope - because Slack integration doesn't pass `checkEnv: true`.

## Changes

1. **`run-service.ts`**: Add `checkEnv` parameter to `validateComposeRequirements()` and wrap vars validation in conditional
2. **`route.test.ts`**: Update existing test to use `checkEnv: true` and add new tests for the checkEnv flag behavior

## Test plan

- [x] Add test: should allow run with missing vars when checkEnv is not set
- [x] Add test: should fail run with missing vars when checkEnv is true
- [x] Add test: should succeed with checkEnv when all vars are provided
- [x] Update existing test to require checkEnv for vars validation

Closes #2956

🤖 Generated with [Claude Code](https://claude.com/claude-code)