### PR TITLE
fix(sandbox-fc): add prerequisite checks to create_snapshot

### DIFF
--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -44,7 +44,13 @@ impl FirecrackerFactory {
     /// Create a new factory without allocating system resources.
     /// Call `startup()` to initialize pools before use.
     pub async fn new(config: FirecrackerConfig) -> Result<Self, SandboxError> {
-        crate::prerequisites::check_prerequisites(&config).await?;
+        crate::prerequisites::check_prerequisites(&crate::prerequisites::PrerequisiteConfig {
+            binary_path: &config.binary_path,
+            kernel_path: &config.kernel_path,
+            rootfs_path: &config.rootfs_path,
+            snapshot: config.snapshot.as_ref(),
+        })
+        .await?;
 
         let factory_paths = FactoryPaths::new(config.base_dir.clone());
         let runtime_paths = RuntimePaths::new();


### PR DESCRIPTION
## Summary
- Extract `PrerequisiteConfig` parameter type so `check_prerequisites` can be shared between `FirecrackerFactory::new()` and `create_snapshot()`
- `create_snapshot` now runs full prerequisite validation (kvm, sudo, runtime dir, required commands) instead of inline sudo commands
- Fix missing `create_dir_all(sock_paths.dir())` before Firecracker spawn in snapshot workflow

Fixes #2951 (follow-up)

## Test plan
- [x] `cargo clippy -p sandbox-fc` — clean
- [x] `cargo test -p sandbox-fc` — 70 tests pass
- [x] E2E `runner build` on dev-2 (aarch64) — snapshot creation succeeds with socket paths under `/run/vm0/sock/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)