### PR TITLE
feat(settings): improve ui consistency and add success notifications

### DIFF
--- a/turbo/apps/platform/src/signals/settings-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/settings-page/connectors.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   CONNECTOR_TYPES,
   type ConnectorType,
@@ -88,6 +89,9 @@ export const connectConnector$ = command(
         window.clearInterval(interval);
         window.clearTimeout(timeout);
         set(internalPollingType$, null);
+
+        const connectorLabel = CONNECTOR_TYPES[type]?.label ?? type;
+        toast.success(`${connectorLabel} connected successfully`);
       }
     };
 
@@ -154,9 +158,14 @@ export const confirmDisconnect$ = command(
       return;
     }
 
+    const connectorLabel =
+      CONNECTOR_TYPES[dialogState.connectorType]?.label ??
+      dialogState.connectorType;
+
     const promise = (async () => {
       await set(deleteConnector$, dialogState.connectorType as string);
       signal.throwIfAborted();
+      toast.success(`${connectorLabel} disconnected successfully`);
       set(internalDisconnectDialogState$, {
         open: false,
         connectorType: null,

--- a/turbo/apps/platform/src/signals/settings-page/model-providers.ts
+++ b/turbo/apps/platform/src/signals/settings-page/model-providers.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   MODEL_PROVIDER_TYPES,
   getDefaultAuthMethod,
@@ -297,6 +298,13 @@ export const submitDialog$ = command(
         request as Parameters<typeof createModelProvider$.write>[1],
       );
       signal.throwIfAborted();
+
+      const providerLabel =
+        MODEL_PROVIDER_TYPES[providerType]?.label ?? providerType;
+      toast.success(
+        `${providerLabel} ${dialogState.mode === "add" ? "added" : "updated"} successfully`,
+      );
+
       set(internalDialogState$, {
         open: false,
         mode: "add",
@@ -343,9 +351,14 @@ export const confirmDelete$ = command(
       return;
     }
 
+    const providerLabel =
+      MODEL_PROVIDER_TYPES[deleteState.providerType]?.label ??
+      deleteState.providerType;
+
     const promise = (async () => {
       await set(deleteModelProvider$, deleteState.providerType as string);
       signal.throwIfAborted();
+      toast.success(`${providerLabel} removed successfully`);
       set(internalDeleteDialogState$, { open: false, providerType: null });
     })();
 
@@ -365,7 +378,14 @@ export const confirmDelete$ = command(
 
 export const setDefaultProvider$ = command(
   async ({ set }, type: ModelProviderType, signal: AbortSignal) => {
-    const promise = set(setDefaultModelProvider$, type);
+    const providerLabel = MODEL_PROVIDER_TYPES[type]?.label ?? type;
+
+    const promise = (async () => {
+      await set(setDefaultModelProvider$, type);
+      signal.throwIfAborted();
+      toast.success(`${providerLabel} set as default`);
+    })();
+
     set(internalActionPromise$, promise);
     signal.addEventListener("abort", () => {
       set(internalActionPromise$, null);

--- a/turbo/apps/platform/src/signals/settings-page/secrets.ts
+++ b/turbo/apps/platform/src/signals/settings-page/secrets.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import type {
   SecretListResponse,
   SecretResponse,
@@ -239,6 +240,9 @@ export const submitSecretDialog$ = command(
       }
 
       signal.throwIfAborted();
+      toast.success(
+        `Secret ${dialogState.mode === "add" ? "added" : "updated"} successfully`,
+      );
       set(internalReloadSecrets$, (x) => x + 1);
       set(internalDialogState$, {
         open: false,
@@ -292,6 +296,7 @@ export const confirmDeleteSecret$ = command(
       }
 
       signal.throwIfAborted();
+      toast.success("Secret deleted successfully");
       set(internalReloadSecrets$, (x) => x + 1);
       set(internalDeleteDialogState$, { open: false, secretName: null });
     })();

--- a/turbo/apps/platform/src/signals/settings-page/variables.ts
+++ b/turbo/apps/platform/src/signals/settings-page/variables.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import type {
   VariableListResponse,
   VariableResponse,
@@ -241,6 +242,9 @@ export const submitVariableDialog$ = command(
       }
 
       signal.throwIfAborted();
+      toast.success(
+        `Variable ${dialogState.mode === "add" ? "added" : "updated"} successfully`,
+      );
       set(internalReloadVariables$, (x) => x + 1);
       set(internalDialogState$, {
         open: false,
@@ -294,6 +298,7 @@ export const confirmDeleteVariable$ = command(
       }
 
       signal.throwIfAborted();
+      toast.success("Variable deleted successfully");
       set(internalReloadVariables$, (x) => x + 1);
       set(internalDeleteDialogState$, { open: false, variableName: null });
     })();

--- a/turbo/apps/platform/src/views/integrations-page/__tests__/slack-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/__tests__/slack-settings-page.test.tsx
@@ -194,10 +194,10 @@ describe("settings integrations tab", () => {
     expect(screen.getByText("Use your VM0 agent in Slack")).toBeInTheDocument();
 
     // Should show a Settings button inside the Slack card (not the nav "Settings")
-    // The Slack card has an outline variant Settings button
+    // The Slack card now uses rounded-xl instead of rounded-lg
     const slackCard = screen
       .getByText("Use your VM0 agent in Slack")
-      .closest("div.rounded-lg") as HTMLElement;
+      .closest("div.rounded-xl") as HTMLElement;
     expect(
       within(slackCard).getByRole("button", { name: /settings/i }),
     ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/integrations-page/integrations-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/integrations-page.tsx
@@ -16,33 +16,31 @@ export function SlackIntegrationCard() {
 
   if (loading) {
     return (
-      <div className="rounded-lg border border-border">
-        <div className="flex items-center justify-between px-5 py-4">
-          <div className="flex items-center gap-3">
-            <Skeleton className="h-9 w-9 rounded" />
-            <div>
-              <Skeleton className="h-4 w-24 mb-1.5" />
-              <Skeleton className="h-3 w-40" />
-            </div>
-          </div>
-          <Skeleton className="h-8 w-16" />
+      <div className="flex items-center gap-4 rounded-xl border border-border bg-card p-4">
+        <div className="shrink-0">
+          <Skeleton className="h-7 w-7 rounded" />
         </div>
+        <div className="flex flex-1 flex-col gap-2 min-w-0">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-3 w-48" />
+        </div>
+        <Skeleton className="h-8 w-16 shrink-0" />
       </div>
     );
   }
 
   return (
-    <div className="rounded-lg border border-border">
-      <div className="flex items-center justify-between px-5 py-4">
-        <div className="flex items-center gap-3">
-          <img src="/slack-icon.svg" alt="Slack" className="h-9 w-9" />
-          <div>
-            <p className="text-sm font-medium">VM0 in Slack</p>
-            <p className="text-sm text-muted-foreground">
-              Use your VM0 agent in Slack
-            </p>
-          </div>
+    <div className="flex items-center gap-4 rounded-xl border border-border bg-card p-4">
+      <div className="shrink-0">
+        <img src="/slack-icon.svg" alt="Slack" className="h-7 w-7" />
+      </div>
+      <div className="flex flex-1 flex-col gap-1 min-w-0">
+        <div className="text-sm font-medium text-foreground">VM0 in Slack</div>
+        <div className="text-sm text-muted-foreground">
+          Use your VM0 agent in Slack
         </div>
+      </div>
+      <div className="shrink-0">
         {notLinked ? (
           installUrl ? (
             <Button variant="outline" size="sm" asChild>

--- a/turbo/apps/platform/src/views/settings-page/__tests__/connectors.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/connectors.test.tsx
@@ -49,7 +49,7 @@ describe("connectors tab", () => {
 
     // Notion should still show Connect button
     expect(screen.getByText("Connect")).toBeInTheDocument();
-    expect(screen.getByText("Not connected")).toBeInTheDocument();
+    // "Not connected" status has been removed from the UI
   });
 
   it("can disconnect a connector via kebab menu", async () => {

--- a/turbo/apps/platform/src/views/settings-page/connector-list.tsx
+++ b/turbo/apps/platform/src/views/settings-page/connector-list.tsx
@@ -1,5 +1,9 @@
 import { useLastResolved, useGet, useSet } from "ccstate-react";
-import { IconDotsVertical } from "@tabler/icons-react";
+import {
+  IconDotsVertical,
+  IconCircleCheck,
+  IconLoader,
+} from "@tabler/icons-react";
 import {
   Popover,
   PopoverContent,
@@ -47,22 +51,22 @@ function ConnectorRow({
       {/* Status */}
       <div className="shrink-0">
         {item.connected && item.connector?.externalUsername && (
-          <span className="text-xs px-2 py-1 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
+          <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
+            <IconCircleCheck className="h-3 w-3 text-green-600" />
             Connected as {item.connector.externalUsername}
           </span>
         )}
         {item.connected && !item.connector?.externalUsername && (
-          <span className="text-xs px-2 py-1 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
+          <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
+            <IconCircleCheck className="h-3 w-3 text-green-600" />
             Connected
           </span>
         )}
         {!item.connected && isPolling && (
-          <span className="text-xs px-2 py-1 rounded-full bg-yellow-500/10 text-yellow-600 dark:text-yellow-400">
+          <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
+            <IconLoader className="h-3 w-3 text-yellow-600 animate-spin" />
             Connecting...
           </span>
-        )}
-        {!item.connected && !isPolling && (
-          <span className="text-xs text-muted-foreground">Not connected</span>
         )}
       </div>
 

--- a/turbo/packages/ui/src/components/ui/sonner.tsx
+++ b/turbo/packages/ui/src/components/ui/sonner.tsx
@@ -5,16 +5,21 @@ type ToasterProps = React.ComponentProps<typeof Sonner>;
 function Toaster({ ...props }: ToasterProps) {
   return (
     <Sonner
-      className="toaster group"
+      className="toaster group !flex !flex-col !items-center"
+      duration={3000}
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-popover group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg [&_[data-icon]]:text-primary",
+            "group toast group-[.toaster]:bg-popover group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg group-[.toaster]:!rounded-[10px] group-[.toaster]:!text-sm group-[.toaster]:!font-medium group-[.toaster]:!w-auto group-[.toaster]:!whitespace-nowrap group-[.toaster]:!left-auto group-[.toaster]:!top-auto group-[.toaster]:!relative [&_[data-icon]]:text-green-600",
           description: "group-[.toast]:text-muted-foreground",
           actionButton:
             "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
           cancelButton:
             "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+        },
+        style: {
+          fontFamily:
+            '"Noto Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
         },
       }}
       {...props}


### PR DESCRIPTION
## Summary
- Improve UI consistency across settings page components
- Add success toast notifications for all settings operations
- Update connector status badges to match table design system
- Unify integration card styling with connector list

## Changes

### UI Consistency
- **Connector status badges**: Updated to match logs table status badge style with icons and colors
  - Connected: Green check icon (`IconCircleCheck`)
  - Connecting: Yellow spinner icon (`IconLoader`) with animation
  - Removed "Not connected" label for cleaner UI
- **Integration card**: Unified styling with connector list (rounded-xl, bg-card, consistent padding)

### Success Notifications
Added toast notifications for all settings operations:
- **Model Providers**: Add/update, delete, set as default
- **Connectors**: Connect success, disconnect
- **Secrets**: Add/update, delete
- **Variables**: Add/update, delete

### Toast Customization
- Font: Noto Sans (consistent with app)
- Border radius: 10px
- Width: Auto-width with content wrapping (no fixed width)
- Duration: 3 seconds auto-dismiss
- Position: Top center
- Icon color: Green for success states

## Test Plan
- [ ] Test connector status display (connected, connecting, not connected states)
- [ ] Test all settings operations show success notifications
- [ ] Verify toast styling matches design (font, border radius, width)
- [ ] Confirm toast auto-dismisses after 3 seconds
- [ ] Check integration card matches connector list styling
- [ ] Verify responsive behavior on different screen sizes


Made with [Cursor](https://cursor.com)