### PR TITLE
feat(api): add backend support for agent detail page

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -27,7 +27,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-json-view-lite": "^2.5.0",
-    "signal-timers": "^1.0.4"
+    "signal-timers": "^1.0.4",
+    "yaml": "^2.7.1"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.8",

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { GET } from "../route";
-import * as s3Client from "../../../../../../../src/lib/s3/s3-client";
 import {
   createTestRequest,
   createTestCompose,
@@ -16,10 +15,6 @@ import {
   MOCK_USER_EMAIL,
 } from "../../../../../../../src/__tests__/clerk-mock";
 import { getInstructionsStorageName } from "@vm0/core";
-
-vi.hoisted(() => {
-  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
-});
 
 const context = testContext();
 
@@ -109,22 +104,20 @@ describe("GET /api/agent/composes/:id/instructions", () => {
     const storageName = getInstructionsStorageName(agentName);
     await createTestVolume(storageName);
 
-    // Mock S3 downloads for this test
-    const manifestSpy = vi
-      .spyOn(s3Client, "downloadManifest")
-      .mockResolvedValueOnce({
-        version: "a".repeat(64),
-        createdAt: new Date().toISOString(),
-        totalSize: instructionsContent.length,
-        fileCount: 1,
-        files: [
-          {
-            path: "AGENTS.md",
-            hash: "b".repeat(64),
-            size: instructionsContent.length,
-          },
-        ],
-      });
+    // Configure centralized S3 mocks for this test
+    context.mocks.s3.downloadManifest.mockResolvedValueOnce({
+      version: "a".repeat(64),
+      createdAt: new Date().toISOString(),
+      totalSize: instructionsContent.length,
+      fileCount: 1,
+      files: [
+        {
+          path: "AGENTS.md",
+          hash: "b".repeat(64),
+          size: instructionsContent.length,
+        },
+      ],
+    });
 
     context.mocks.s3.downloadBlob.mockResolvedValueOnce(
       Buffer.from(instructionsContent),
@@ -141,8 +134,6 @@ describe("GET /api/agent/composes/:id/instructions", () => {
     expect(response.status).toBe(200);
     expect(data.content).toBe(instructionsContent);
     expect(data.filename).toBe("AGENTS.md");
-
-    manifestSpy.mockRestore();
   });
 
   it("should allow shared users to read instructions", async () => {
@@ -164,15 +155,13 @@ describe("GET /api/agent/composes/:id/instructions", () => {
     // Switch to the shared user
     mockClerk({ userId: user.userId });
 
-    const manifestSpy = vi
-      .spyOn(s3Client, "downloadManifest")
-      .mockResolvedValueOnce({
-        version: "a".repeat(64),
-        createdAt: new Date().toISOString(),
-        totalSize: 50,
-        fileCount: 1,
-        files: [{ path: "AGENTS.md", hash: "c".repeat(64), size: 50 }],
-      });
+    context.mocks.s3.downloadManifest.mockResolvedValueOnce({
+      version: "a".repeat(64),
+      createdAt: new Date().toISOString(),
+      totalSize: 50,
+      fileCount: 1,
+      files: [{ path: "AGENTS.md", hash: "c".repeat(64), size: 50 }],
+    });
 
     context.mocks.s3.downloadBlob.mockResolvedValueOnce(
       Buffer.from("# Shared Instructions"),
@@ -189,8 +178,6 @@ describe("GET /api/agent/composes/:id/instructions", () => {
     expect(response.status).toBe(200);
     expect(data.content).toBe("# Shared Instructions");
     expect(data.filename).toBe("AGENTS.md");
-
-    manifestSpy.mockRestore();
   });
 
   it("should return 404 for non-shared user", async () => {

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GET } from "../route";
+import * as s3Client from "../../../../../../../src/lib/s3/s3-client";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestVolume,
+  createTestPermission,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../../../src/__tests__/test-helpers";
+import {
+  mockClerk,
+  MOCK_USER_EMAIL,
+} from "../../../../../../../src/__tests__/clerk-mock";
+import { getInstructionsStorageName } from "@vm0/core";
+
+vi.hoisted(() => {
+  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
+});
+
+const context = testContext();
+
+describe("GET /api/agent/composes/:id/instructions", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/composes/some-id/instructions",
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: "some-id" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 404 for non-existent compose", async () => {
+    const fakeId = "00000000-0000-0000-0000-000000000000";
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/composes/${fakeId}/instructions`,
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: fakeId }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return null content when compose has no instructions", async () => {
+    // Create compose without instructions field
+    const { composeId } = await createTestCompose("no-instructions-agent");
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/composes/${composeId}/instructions`,
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: composeId }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.content).toBeNull();
+    expect(data.filename).toBeNull();
+  });
+
+  it("should return null content when instructions volume does not exist", async () => {
+    // Create compose WITH instructions field but no storage volume
+    const { composeId } = await createTestCompose("has-instructions-agent", {
+      overrides: { instructions: "AGENTS.md" },
+    });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/composes/${composeId}/instructions`,
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: composeId }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.content).toBeNull();
+    expect(data.filename).toBe("AGENTS.md");
+  });
+
+  it("should return instructions content when volume exists", async () => {
+    const agentName = "instructions-test-agent";
+    const instructionsContent = "# My Agent\n\nDo the thing.\n";
+
+    // Create compose with instructions field
+    const { composeId } = await createTestCompose(agentName, {
+      overrides: { instructions: "AGENTS.md" },
+    });
+
+    // Create the instructions storage volume
+    const storageName = getInstructionsStorageName(agentName);
+    await createTestVolume(storageName);
+
+    // Mock S3 downloads for this test
+    const manifestSpy = vi
+      .spyOn(s3Client, "downloadManifest")
+      .mockResolvedValueOnce({
+        version: "a".repeat(64),
+        createdAt: new Date().toISOString(),
+        totalSize: instructionsContent.length,
+        fileCount: 1,
+        files: [
+          {
+            path: "AGENTS.md",
+            hash: "b".repeat(64),
+            size: instructionsContent.length,
+          },
+        ],
+      });
+
+    context.mocks.s3.downloadBlob.mockResolvedValueOnce(
+      Buffer.from(instructionsContent),
+    );
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/composes/${composeId}/instructions`,
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: composeId }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.content).toBe(instructionsContent);
+    expect(data.filename).toBe("AGENTS.md");
+
+    manifestSpy.mockRestore();
+  });
+
+  it("should allow shared users to read instructions", async () => {
+    // Owner creates agent with instructions
+    await context.setupUser({ prefix: "owner" });
+    const agentName = "shared-instructions-agent";
+
+    const { composeId } = await createTestCompose(agentName, {
+      overrides: { instructions: "AGENTS.md" },
+    });
+
+    // Share with original user
+    await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
+
+    // Create storage volume
+    const storageName = getInstructionsStorageName(agentName);
+    await createTestVolume(storageName);
+
+    // Switch to the shared user
+    mockClerk({ userId: user.userId });
+
+    const manifestSpy = vi
+      .spyOn(s3Client, "downloadManifest")
+      .mockResolvedValueOnce({
+        version: "a".repeat(64),
+        createdAt: new Date().toISOString(),
+        totalSize: 50,
+        fileCount: 1,
+        files: [{ path: "AGENTS.md", hash: "c".repeat(64), size: 50 }],
+      });
+
+    context.mocks.s3.downloadBlob.mockResolvedValueOnce(
+      Buffer.from("# Shared Instructions"),
+    );
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/composes/${composeId}/instructions`,
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: composeId }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.content).toBe("# Shared Instructions");
+    expect(data.filename).toBe("AGENTS.md");
+
+    manifestSpy.mockRestore();
+  });
+
+  it("should return 404 for non-shared user", async () => {
+    // Owner creates agent
+    await context.setupUser({ prefix: "private-owner" });
+    const { composeId } = await createTestCompose("private-agent", {
+      overrides: { instructions: "AGENTS.md" },
+    });
+
+    // Switch to original user (not shared)
+    mockClerk({ userId: user.userId });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/composes/${composeId}/instructions`,
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: composeId }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -1,0 +1,145 @@
+/**
+ * GET /api/agent/composes/:id/instructions
+ *
+ * Fetch the instructions content for an agent compose.
+ * Instructions are stored as storage volumes (agent-instructions@{agentName})
+ * and this endpoint reads the content from S3.
+ */
+import { NextResponse } from "next/server";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { eq, and } from "drizzle-orm";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../../../src/db/schema/agent-compose";
+import {
+  storages,
+  storageVersions,
+} from "../../../../../../src/db/schema/storage";
+import { getUserId } from "../../../../../../src/lib/auth/get-user-id";
+import { getUserEmail } from "../../../../../../src/lib/auth/get-user-email";
+import { canAccessCompose } from "../../../../../../src/lib/agent/permission-service";
+import {
+  downloadManifest,
+  downloadBlob,
+} from "../../../../../../src/lib/s3/s3-client";
+import { env } from "../../../../../../src/env";
+import { getInstructionsStorageName } from "@vm0/core";
+import type { AgentComposeYaml } from "../../../../../../src/types/agent-compose";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  initServices();
+
+  const authorization = request.headers.get("authorization") ?? undefined;
+  const userId = await getUserId(authorization);
+  if (!userId) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const { id } = await params;
+
+  // Get compose with HEAD version content
+  const [result] = await globalThis.services.db
+    .select({
+      id: agentComposes.id,
+      userId: agentComposes.userId,
+      scopeId: agentComposes.scopeId,
+      name: agentComposes.name,
+      content: agentComposeVersions.content,
+    })
+    .from(agentComposes)
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentComposes.headVersionId, agentComposeVersions.id),
+    )
+    .where(eq(agentComposes.id, id))
+    .limit(1);
+
+  if (!result) {
+    return NextResponse.json(
+      { error: { message: "Agent compose not found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  // Check access (owner or shared via email/public)
+  const userEmail = await getUserEmail(userId);
+  const hasAccess = await canAccessCompose(userId, userEmail, result);
+  if (!hasAccess) {
+    return NextResponse.json(
+      { error: { message: "Agent compose not found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  // Extract instructions filename from compose content
+  const content = result.content as AgentComposeYaml | null;
+  if (!content?.agents) {
+    return NextResponse.json({ content: null, filename: null });
+  }
+
+  const agentKeys = Object.keys(content.agents);
+  const agentDef = agentKeys.length > 0 ? content.agents[agentKeys[0]!] : null;
+  const instructionsFilename = agentDef?.instructions;
+
+  if (!instructionsFilename) {
+    return NextResponse.json({ content: null, filename: null });
+  }
+
+  // Look up the instructions storage volume
+  const storageName = getInstructionsStorageName(result.name);
+  const [storage] = await globalThis.services.db
+    .select()
+    .from(storages)
+    .where(
+      and(
+        eq(storages.scopeId, result.scopeId),
+        eq(storages.name, storageName),
+        eq(storages.type, "volume"),
+      ),
+    )
+    .limit(1);
+
+  if (!storage?.headVersionId) {
+    return NextResponse.json({ content: null, filename: instructionsFilename });
+  }
+
+  // Get the HEAD version to find S3 key
+  const [version] = await globalThis.services.db
+    .select()
+    .from(storageVersions)
+    .where(eq(storageVersions.id, storage.headVersionId))
+    .limit(1);
+
+  if (!version) {
+    return NextResponse.json({ content: null, filename: instructionsFilename });
+  }
+
+  // Download manifest to find instructions file hash
+  const bucket = env().R2_USER_STORAGES_BUCKET_NAME;
+  const manifest = await downloadManifest(bucket, version.s3Key);
+
+  // Find the instructions file in manifest (match by filename)
+  const instructionFile = manifest.files.find(
+    (f) => f.path === instructionsFilename,
+  );
+
+  if (!instructionFile) {
+    return NextResponse.json({ content: null, filename: instructionsFilename });
+  }
+
+  // Download the blob content by hash
+  const blob = await downloadBlob(bucket, instructionFile.hash);
+  const textContent = blob.toString("utf-8");
+
+  return NextResponse.json({
+    content: textContent,
+    filename: instructionsFilename,
+  });
+}

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -105,11 +105,13 @@ const router = tsr.router(composesListContract, {
         name: c.name,
         headVersionId: c.headVersionId,
         updatedAt: c.updatedAt.toISOString(),
+        isOwner: true,
       })),
       ...sharedComposes.map((c) => ({
         name: `${c.scopeSlug}/${c.name}`,
         headVersionId: c.headVersionId,
         updatedAt: c.updatedAt.toISOString(),
+        isOwner: false,
       })),
     ];
 

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -97,6 +97,18 @@ interface S3Mocks {
     (bucket: string, s3Key: string, fileCount: number) => Promise<boolean>
   >;
   downloadBlob: MockInstance<(bucket: string, hash: string) => Promise<Buffer>>;
+  downloadManifest: MockInstance<
+    (
+      bucket: string,
+      s3Key: string,
+    ) => Promise<{
+      version: string;
+      createdAt: string;
+      totalSize: number;
+      fileCount: number;
+      files: Array<{ path: string; hash: string; size: number }>;
+    }>
+  >;
 }
 
 /**
@@ -295,6 +307,15 @@ export function testContext(): TestContext {
         .spyOn(s3Client, "verifyS3FilesExist")
         .mockResolvedValue(true),
       downloadBlob: downloadBlobMock,
+      downloadManifest: vi
+        .spyOn(s3Client, "downloadManifest")
+        .mockResolvedValue({
+          version: "0".repeat(64),
+          createdAt: new Date().toISOString(),
+          totalSize: 0,
+          fileCount: 0,
+          files: [],
+        }),
     };
 
     // Axiom mocks - only set up if Axiom is mocked (vi.mock at module level in test file)

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -331,6 +331,7 @@ const composeListItemSchema = z.object({
   name: z.string(),
   headVersionId: z.string().nullable(),
   updatedAt: z.string(),
+  isOwner: z.boolean(),
 });
 
 /**

--- a/turbo/packages/core/src/contracts/platform.ts
+++ b/turbo/packages/core/src/contracts/platform.ts
@@ -81,6 +81,7 @@ export const platformLogsListContract = c.router({
     path: "/api/platform/logs",
     query: listQuerySchema.extend({
       search: z.string().optional(),
+      agent: z.string().optional(),
     }),
     responses: {
       200: platformLogsListResponseSchema,

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -229,6 +229,9 @@ importers:
       signal-timers:
         specifier: ^1.0.4
         version: 1.0.4
+      yaml:
+        specifier: ^2.7.1
+        version: 2.8.1
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.1.8
@@ -1909,92 +1912,78 @@ packages:
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.0':
     resolution: {integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.0':
     resolution: {integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
     resolution: {integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.3':
     resolution: {integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.3':
     resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.3':
     resolution: {integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.3':
     resolution: {integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.3':
     resolution: {integrity: sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==}
@@ -2249,28 +2238,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.7':
     resolution: {integrity: sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.7':
     resolution: {integrity: sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.7':
     resolution: {integrity: sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.7':
     resolution: {integrity: sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==}
@@ -2562,49 +2547,41 @@ packages:
     resolution: {integrity: sha512-lUmDTmYOGpbIK+FBfZ0ySaQTo7g1Ia/WnDnQR2wi/0AtehZIg/ZZIgiT/fD0iRvKEKma612/0PVo8dXdAKaAGA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.13.2':
     resolution: {integrity: sha512-dkGzOxo+I9lA4Er6qzFgkFevl3JvwyI9i0T/PkOJHva04rb1p9dz8GPogTO9uMK4lrwLWzm/piAu+tHYC7v7+w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.13.2':
     resolution: {integrity: sha512-53kWsjLkVFnoSA7COdps38pBssN48zI8LfsOvupsmQ0/4VeMYb+0Ao9O6r52PtmFZsGB3S1Qjqbjl/Pswj1a3g==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.13.2':
     resolution: {integrity: sha512-MfxN6DMpvmdCbGlheJ+ihy11oTcipqDfcEIQV9ah3FGXBRCZtBOHJpQDk8qI2Y+nCXVr3Nln7OSsOzoC4+rSYQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.13.2':
     resolution: {integrity: sha512-WXrm4YiRU0ijqb72WHSjmfYaQZ7t6/kkQrFc4JtU+pUE4DZA/DEdxOuQEd4Q43VqmLvICTJWSaZMlCGQ4PSRUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.13.2':
     resolution: {integrity: sha512-4pISWIlOFRUhWyvGCB3XUhtcwyvwGGhlXhHz7IXCXuGufaQtvR05trvw8U1ZnaPhsdPBkRhOMIedX11ayi5uXw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.13.2':
     resolution: {integrity: sha512-DVo6jS8n73yNAmCsUOOk2vBeC60j2RauDXQM8p7RDl0afsEaA2le22vD8tky7iNoM5tsxfBmE4sOJXEKgpwWRw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.13.2':
     resolution: {integrity: sha512-6WqrE+hQBFP35KdwQjWcZpldbTq6yJmuTVThISu+rY3+j6MaDp2ciLHTr1X68r2H/7ocOIl4k3NnOVIzeRJE3w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-wasm32-wasi@11.13.2':
     resolution: {integrity: sha512-YpxvQmP2D+mNUkLQZbBjGz20g/pY8XoOBdPPoWMl9X68liFFjXxkPQTrZxWw4zzG/UkTM5z6dPRTyTePRsMcjw==}
@@ -2640,25 +2617,21 @@ packages:
     resolution: {integrity: sha512-ZiVxPZizlXSnAMdkEFWX/mAj7U3bNiku8p6I9UgLrXzgGSSAhFobx8CaFGwVoKyWOd+gQgZ/ogCrunvx2k0CFg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/linux-arm64-musl@1.38.0':
     resolution: {integrity: sha512-ELtlCIGZ72A65ATZZHFxHMFrkRtY+DYDCKiNKg6v7u5PdeOFey+OlqRXgXtXlxWjCL+g7nivwI2FPVsWqf05Qw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/linux-x64-gnu@1.38.0':
     resolution: {integrity: sha512-E1OcDh30qyng1m0EIlsOuapYkqk5QB6o6IMBjvDKqIoo6IrjlVAasoJfS/CmSH998gXRL3BcAJa6Qg9IxPFZnQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/linux-x64-musl@1.38.0':
     resolution: {integrity: sha512-4AfpbM/4sQnr6S1dMijEPfsq4stQbN5vJ2jsahSy/QTcvIVbFkgY+RIhrA5UWlC6eb0rD5CdaPQoKGMJGeXpYw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/win32-arm64@1.38.0':
     resolution: {integrity: sha512-OvUVYdI68OwXh3d1RjH9N/okCxb6PrOGtEtzXyqGA7Gk+IxyZcX0/QCTBwV8FNbSSzDePSSEHOKpoIB+VXdtvg==}
@@ -2699,42 +2672,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -3427,67 +3394,56 @@ packages:
     resolution: {integrity: sha512-OVSQgEZDVLnTbMq5NBs6xkmz3AADByCWI4RdKSFNlDsYXdFtlxS59J+w+LippJe8KcmeSSM3ba+GlsM9+WwC1w==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.49.0':
     resolution: {integrity: sha512-ZnfSFA7fDUHNa4P3VwAcfaBLakCbYaxCk0jUnS3dTou9P95kwoOLAMlT3WmEJDBCSrOEFFV0Y1HXiwfLYJuLlA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.49.0':
     resolution: {integrity: sha512-Z81u+gfrobVK2iV7GqZCBfEB1y6+I61AH466lNK+xy1jfqFLiQ9Qv716WUM5fxFrYxwC7ziVdZRU9qvGHkYIJg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.49.0':
     resolution: {integrity: sha512-zoAwS0KCXSnTp9NH/h9aamBAIve0DXeYpll85shf9NJ0URjSTzzS+Z9evmolN+ICfD3v8skKUPyk2PO0uGdFqg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.49.0':
     resolution: {integrity: sha512-2QyUyQQ1ZtwZGiq0nvODL+vLJBtciItC3/5cYN8ncDQcv5avrt2MbKt1XU/vFAJlLta5KujqyHdYtdag4YEjYQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.49.0':
     resolution: {integrity: sha512-k9aEmOWt+mrMuD3skjVJSSxHckJp+SiFzFG+v8JLXbc/xi9hv2icSkR3U7uQzqy+/QbbYY7iNB9eDTwrELo14g==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.49.0':
     resolution: {integrity: sha512-rDKRFFIWJ/zJn6uk2IdYLc09Z7zkE5IFIOWqpuU0o6ZpHcdniAyWkwSUWE/Z25N/wNDmFHHMzin84qW7Wzkjsw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.49.0':
     resolution: {integrity: sha512-FkkhIY/hYFVnOzz1WeV3S9Bd1h0hda/gRqvZCMpHWDHdiIHn6pqsY3b5eSbvGccWHMQ1uUzgZTKS4oGpykf8Tw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.49.0':
     resolution: {integrity: sha512-gRf5c+A7QiOG3UwLyOOtyJMD31JJhMjBvpfhAitPAoqZFcOeK3Kc1Veg1z/trmt+2P6F/biT02fU19GGTS529A==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.49.0':
     resolution: {integrity: sha512-BR7+blScdLW1h/2hB/2oXM+dhTmpW3rQt1DeSiCP9mc2NMMkqVgjIN3DDsNpKmezffGC9R8XKVOLmBkRUcK/sA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.49.0':
     resolution: {integrity: sha512-hDMOAe+6nX3V5ei1I7Au3wcr9h3ktKzDvF2ne5ovX8RZiAHEtX1A5SNNk4zt1Qt77CmnbqT+upb/umzoPMWiPg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.49.0':
     resolution: {integrity: sha512-wkNRzfiIGaElC9kXUT+HLx17z7D0jl+9tGYRKwd8r7cUqTL7GYAvgUY++U2hK6Ar7z5Z6IRRoWC8kQxpmM7TDA==}
@@ -4042,28 +3998,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.7':
     resolution: {integrity: sha512-/OOp9UZBg4v2q9+x/U21Jtld0Wb8ghzBScwhscI7YvoSh4E8RALaJ1msV8V8AKkBkZH7FUAFB7Vbv0oVzZsezA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.7':
     resolution: {integrity: sha512-VBbs4gtD4XQxrHuQ2/2+TDZpPQQgrOHYRnS6SyJW+dw0Nj/OomRqH+n5Z4e/TgKRRbieufipeIGvADYC/90PYQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.7':
     resolution: {integrity: sha512-kVuy2unodso6p0rMauS2zby8/bhzoGRYxBDyD6i2tls/fEYAE74oP0VPFzxIyHaIjK1SN6u5TgvV9MpyJ5xVug==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.7':
     resolution: {integrity: sha512-uddYoo5Xmo1XKLhAnh4NBIyy5d0xk33x1sX3nIJboFySLNz878ksCFCZ3IBqrt1Za0gaoIWoOSSSk0eNhAc/sw==}
@@ -4188,28 +4140,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -6720,28 +6668,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -13285,7 +13229,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.0.18)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)(yaml@2.8.1)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.0.18)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@4.0.18':
     dependencies:


### PR DESCRIPTION
## Summary

- Add `yaml` dependency to platform app for bidirectional YAML ↔ JSON config sync
- Add `GET /api/agent/composes/:id/instructions` endpoint to fetch instructions content from S3 storage volumes
- Extend `GET /api/platform/logs` with exact `agent` query param (takes precedence over fuzzy `search`)
- Add `isOwner` boolean field to compose list API response items
- Refactor logs route to eliminate duplicated query builder code

Closes #2973

## Test plan

- [x] Instructions API: 7 tests (auth, 404, no instructions, missing volume, content fetch, shared access, non-shared 404)
- [x] Logs agent filter: 4 tests (exact match, empty result, not fuzzy, precedence over search)
- [x] isOwner flag: 1 test (own=true, shared=false)
- [x] All 100 existing tests pass across 10 test files
- [x] Lint, type check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)