### PR TITLE
fix(runner): add flock to prevent concurrent rootfs/snapshot builds

### DIFF
--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -10,7 +10,7 @@ sandbox-fc = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true, features = ["serde", "now"] }
 clap = { workspace = true, features = ["derive", "env"] }
-nix = { workspace = true, features = ["user", "signal"] }
+nix = { workspace = true, features = ["user", "signal", "fs"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }

--- a/crates/runner/src/lock.rs
+++ b/crates/runner/src/lock.rs
@@ -1,0 +1,24 @@
+use std::path::PathBuf;
+
+use nix::fcntl::{Flock, FlockArg};
+
+use crate::error::{RunnerError, RunnerResult};
+
+/// Acquire an exclusive flock on the given path, blocking until available.
+///
+/// The returned guard holds the lock until dropped.
+pub async fn acquire(path: PathBuf) -> RunnerResult<Flock<std::fs::File>> {
+    tokio::task::spawn_blocking(move || {
+        let file = std::fs::File::options()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .map_err(|e| RunnerError::Internal(format!("open lock {}: {e}", path.display())))?;
+        Flock::lock(file, FlockArg::LockExclusive)
+            .map_err(|(_file, e)| RunnerError::Internal(format!("flock {}: {e}", path.display())))
+    })
+    .await
+    .map_err(|e| RunnerError::Internal(format!("lock task: {e}")))?
+}

--- a/crates/runner/src/lock.rs
+++ b/crates/runner/src/lock.rs
@@ -22,3 +22,60 @@ pub async fn acquire(path: PathBuf) -> RunnerResult<Flock<std::fs::File>> {
     .await
     .map_err(|e| RunnerError::Internal(format!("lock task: {e}")))?
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn acquire_creates_lock_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+
+        let guard = acquire(path.clone()).await.unwrap();
+        assert!(path.exists());
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn held_lock_blocks_nonblocking_attempt() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+
+        // Hold the lock via acquire().
+        let _guard = acquire(path.clone()).await.unwrap();
+
+        // A non-blocking attempt on the same file must fail with EWOULDBLOCK.
+        let file = std::fs::File::options()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        let err = Flock::lock(file, FlockArg::LockExclusiveNonblock).unwrap_err();
+        assert_eq!(err.1, nix::errno::Errno::EWOULDBLOCK);
+    }
+
+    #[tokio::test]
+    async fn lock_released_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+
+        let guard = acquire(path.clone()).await.unwrap();
+        drop(guard);
+
+        // After drop, a non-blocking lock should succeed.
+        let file = std::fs::File::options()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        let _lock = Flock::lock(file, FlockArg::LockExclusiveNonblock).unwrap();
+    }
+
+    #[tokio::test]
+    async fn invalid_path_returns_error() {
+        let path = PathBuf::from("/nonexistent/dir/test.lock");
+        let result = acquire(path).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod deps;
 mod error;
 mod executor;
+mod lock;
 mod paths;
 mod rootfs;
 mod runner;

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -76,6 +76,35 @@ impl HomePaths {
     }
 }
 
+/// Lock file paths under `/var/lock` for coordinating concurrent builds.
+///
+/// `/var/lock` is FHS-standard (mode 1777), same as the netns pool locks.
+pub struct LockPaths {
+    base_dir: PathBuf,
+}
+
+impl Default for LockPaths {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LockPaths {
+    pub fn new() -> Self {
+        Self {
+            base_dir: PathBuf::from("/var/lock"),
+        }
+    }
+
+    pub fn rootfs(&self, hash: &str) -> PathBuf {
+        self.base_dir.join(format!("vm0-rootfs-{hash}.lock"))
+    }
+
+    pub fn snapshot(&self, hash: &str) -> PathBuf {
+        self.base_dir.join(format!("vm0-snapshot-{hash}.lock"))
+    }
+}
+
 /// Paths for a rootfs build output directory (keyed by input hash).
 pub struct RootfsPaths {
     dir: PathBuf,

--- a/crates/runner/src/snapshot.rs
+++ b/crates/runner/src/snapshot.rs
@@ -6,7 +6,7 @@ use sandbox_fc::SnapshotOutputPaths;
 use crate::config::{DEFAULT_MEMORY_MB, DEFAULT_VCPU, SnapshotConfig};
 use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
 use crate::error::{RunnerError, RunnerResult};
-use crate::paths::{HomePaths, RootfsPaths};
+use crate::paths::{HomePaths, LockPaths, RootfsPaths};
 
 #[derive(Args, Clone)]
 pub struct SnapshotArgs {
@@ -31,6 +31,16 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<SnapshotConfig> {
     let output_dir = paths.snapshots_dir().join(&snapshot_hash);
     let output = SnapshotOutputPaths::new(output_dir.clone());
 
+    if is_snapshot_complete(&output).await? {
+        tracing::info!("[OK] snapshot already exists: {}", output_dir.display());
+        return Ok(output.snapshot_config(&snapshot_hash).into());
+    }
+
+    // Acquire exclusive lock to prevent concurrent builds with the same hash.
+    let locks = LockPaths::new();
+    let _lock = crate::lock::acquire(locks.snapshot(&snapshot_hash)).await?;
+
+    // Re-check after acquiring lock — another process may have completed the build.
     if is_snapshot_complete(&output).await? {
         tracing::info!("[OK] snapshot already exists: {}", output_dir.display());
         return Ok(output.snapshot_config(&snapshot_hash).into());

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -12,6 +12,8 @@ mod snapshot;
 
 pub use config::{FirecrackerConfig, SnapshotConfig};
 pub use factory::{FirecrackerFactory, config_hash};
-pub use paths::{FactoryPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
+pub use paths::{
+    FactoryPaths, LockPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths,
+};
 pub use sandbox::FirecrackerSandbox;
 pub use snapshot::{SnapshotCreateConfig, SnapshotError, create_snapshot};

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -1,9 +1,5 @@
 use std::path::{Path, PathBuf};
 
-/// Directory for flock-based pool index allocation.
-/// `/var/lock` is the FHS-standard location for lock files (mode 1777).
-pub const LOCK_DIR: &str = "/var/lock";
-
 /// Base directory for runtime sockets under `/run`.
 /// Created with mode 1777 (world-writable + sticky bit) by `prerequisites.rs`.
 pub const RUNTIME_DIR: &str = "/run/vm0";
@@ -29,6 +25,37 @@ impl RuntimePaths {
     /// Socket directory: `/run/vm0/sock/<id>/`.
     pub fn sock_dir(&self, id: &str) -> PathBuf {
         self.base_dir.join("sock").join(id)
+    }
+}
+
+/// Lock file paths under `/var/lock` for flock-based coordination.
+///
+/// `/var/lock` is the FHS-standard location for lock files (mode 1777).
+pub struct LockPaths {
+    base_dir: PathBuf,
+}
+
+impl Default for LockPaths {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LockPaths {
+    pub fn new() -> Self {
+        Self {
+            base_dir: PathBuf::from("/var/lock"),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_dir(base_dir: PathBuf) -> Self {
+        Self { base_dir }
+    }
+
+    /// Lock file for netns pool index allocation.
+    pub fn netns_pool(&self, index: u32) -> PathBuf {
+        self.base_dir.join(format!("vm0-netns-pool-{index}.lock"))
     }
 }
 


### PR DESCRIPTION
## Summary
- Add exclusive flock on `/var/lock/vm0-{rootfs,snapshot}-<hash>.lock` with double-checked locking to serialize concurrent `runner build` processes with the same inputs
- Introduce `LockPaths` struct in `sandbox-fc` to centralize lock file path management, replacing the raw `LOCK_DIR` constant
- New `lock.rs` module in runner for async flock acquisition via `spawn_blocking`

## Test plan
- [x] `cargo clippy -p sandbox-fc -p runner` — clean
- [x] `cargo test -p sandbox-fc` — 70 tests pass
- [x] `cargo test -p runner` — 25 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)