### PR TITLE
feat(runner): add benchmark subcommand for single-shot vm execution

### DIFF
--- a/crates/runner/src/benchmark.rs
+++ b/crates/runner/src/benchmark.rs
@@ -1,0 +1,148 @@
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::time::{Duration, Instant};
+
+use clap::Args;
+use sandbox::{ExecRequest, ExecResult, SandboxConfig, SandboxFactory};
+use sandbox_fc::FirecrackerFactory;
+use tracing::info;
+use uuid::Uuid;
+
+use crate::config;
+use crate::error::{RunnerError, RunnerResult};
+use crate::executor;
+
+#[derive(Args)]
+pub struct BenchmarkArgs {
+    /// The bash command to execute in the VM
+    prompt: String,
+    /// Path to runner.yaml config file
+    #[arg(long, short)]
+    config: PathBuf,
+    /// Command timeout in seconds
+    #[arg(long, default_value_t = 300)]
+    timeout_secs: u64,
+}
+
+pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
+    let total = Instant::now();
+
+    // 1. Load config, force concurrency=1
+    let mut runner_config = config::load(&args.config).await?;
+    runner_config.sandbox.max_concurrent = 1;
+    let is_snapshot = runner_config.firecracker.snapshot.is_some();
+    let fc_config = runner_config.firecracker_config();
+
+    // 2. Factory init
+    let t = Instant::now();
+    let mut factory = FirecrackerFactory::new(fc_config)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("factory init: {e}")))?;
+    factory
+        .startup()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("factory startup: {e}")))?;
+    let factory_ms = t.elapsed().as_millis();
+    info!(factory_ms, "factory ready");
+
+    // 3. Create + run sandbox — always shutdown factory afterwards
+    let sandbox_config = SandboxConfig {
+        id: Uuid::new_v4(),
+        resources: sandbox::ResourceLimits {
+            cpu_count: runner_config.sandbox.vcpu,
+            memory_mb: runner_config.sandbox.memory_mb,
+        },
+    };
+    let (result, boot_ms, exec_ms) =
+        run_sandbox(&args, &factory, sandbox_config, is_snapshot).await;
+    let total_ms = total.elapsed().as_millis();
+    factory.shutdown().await;
+
+    // 4. Log timing summary (always, even on error)
+    match &result {
+        Ok(exec_result) => {
+            info!(
+                factory_ms,
+                boot_ms,
+                exec_ms,
+                total_ms,
+                exit_code = exec_result.exit_code,
+                "benchmark complete"
+            );
+        }
+        Err(e) => {
+            info!(factory_ms, boot_ms, exec_ms, total_ms, error = %e, "benchmark failed");
+        }
+    }
+
+    let exec_result = result?;
+
+    // 5. Print stdout/stderr directly to terminal
+    let stdout = String::from_utf8_lossy(&exec_result.stdout);
+    let stderr = String::from_utf8_lossy(&exec_result.stderr);
+    if !stdout.is_empty() {
+        print!("{stdout}");
+    }
+    if !stderr.is_empty() {
+        eprint!("{stderr}");
+    }
+
+    // 6. Propagate exit code
+    let code = u8::try_from(exec_result.exit_code).unwrap_or(1);
+    Ok(ExitCode::from(code))
+}
+
+/// Create, start, exec, stop, destroy. Returns (result, boot_ms, exec_ms).
+/// Timing is always returned even on error.
+/// Caller is responsible for `factory.shutdown()`.
+async fn run_sandbox(
+    args: &BenchmarkArgs,
+    factory: &FirecrackerFactory,
+    sandbox_config: SandboxConfig,
+    is_snapshot: bool,
+) -> (RunnerResult<ExecResult>, u128, u128) {
+    let mut sandbox = match factory.create(sandbox_config).await {
+        Ok(s) => s,
+        Err(e) => return (Err(e.into()), 0, 0),
+    };
+
+    let (result, boot_ms, exec_ms) = run_in_sandbox(args, &mut *sandbox, is_snapshot).await;
+
+    if let Err(e) = sandbox.stop().await {
+        info!(error = %e, "sandbox stop failed");
+    }
+    factory.destroy(sandbox).await;
+
+    (result, boot_ms, exec_ms)
+}
+
+/// Start sandbox, fix clock, exec command. Returns result + timing.
+async fn run_in_sandbox(
+    args: &BenchmarkArgs,
+    sandbox: &mut dyn sandbox::Sandbox,
+    is_snapshot: bool,
+) -> (RunnerResult<ExecResult>, u128, u128) {
+    let t = Instant::now();
+    if let Err(e) = sandbox.start().await {
+        return (Err(e.into()), t.elapsed().as_millis(), 0);
+    }
+    let boot_ms = t.elapsed().as_millis();
+    info!(boot_ms, "sandbox started");
+
+    if is_snapshot && let Err(e) = executor::fix_guest_clock(sandbox).await {
+        return (Err(e), boot_ms, 0);
+    }
+
+    let t = Instant::now();
+    let result = sandbox
+        .exec(&ExecRequest {
+            cmd: &args.prompt,
+            timeout: Duration::from_secs(args.timeout_secs),
+            env: &[],
+        })
+        .await
+        .map_err(Into::into);
+    let exec_ms = t.elapsed().as_millis();
+
+    (result, boot_ms, exec_ms)
+}

--- a/crates/runner/src/benchmark.rs
+++ b/crates/runner/src/benchmark.rs
@@ -9,13 +9,13 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::config;
-use crate::error::{RunnerError, RunnerResult};
+use crate::error::RunnerResult;
 use crate::executor;
 
 #[derive(Args)]
 pub struct BenchmarkArgs {
     /// The bash command to execute in the VM
-    prompt: String,
+    command: String,
     /// Path to runner.yaml config file
     #[arg(long, short)]
     config: PathBuf,
@@ -35,13 +35,8 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
 
     // 2. Factory init
     let t = Instant::now();
-    let mut factory = FirecrackerFactory::new(fc_config)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("factory init: {e}")))?;
-    factory
-        .startup()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("factory startup: {e}")))?;
+    let mut factory = FirecrackerFactory::new(fc_config).await?;
+    factory.startup().await?;
     let factory_ms = t.elapsed().as_millis();
     info!(factory_ms, "factory ready");
 
@@ -115,7 +110,7 @@ async fn run_sandbox(
         Err(e) => return (Err(e.into()), 0, 0),
     };
 
-    let (result, boot_ms, exec_ms) = run_in_sandbox(args, &mut *sandbox, is_snapshot).await;
+    let (result, boot_ms, exec_ms) = run_in_sandbox(args, sandbox.as_mut(), is_snapshot).await;
 
     if let Err(e) = sandbox.stop().await {
         warn!(error = %e, "sandbox stop failed");
@@ -145,7 +140,7 @@ async fn run_in_sandbox(
     let t = Instant::now();
     let result = sandbox
         .exec(&ExecRequest {
-            cmd: &args.prompt,
+            cmd: &args.command,
             timeout: Duration::from_secs(args.timeout_secs),
             env: &[],
         })

--- a/crates/runner/src/benchmark.rs
+++ b/crates/runner/src/benchmark.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use clap::Args;
 use sandbox::{ExecRequest, ExecResult, SandboxConfig, SandboxFactory};
 use sandbox_fc::FirecrackerFactory;
-use tracing::info;
+use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::config;
@@ -88,7 +88,16 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     }
 
     // 6. Propagate exit code
-    let code = u8::try_from(exec_result.exit_code).unwrap_or(1);
+    let code = match u8::try_from(exec_result.exit_code) {
+        Ok(c) => c,
+        Err(_) => {
+            warn!(
+                exit_code = exec_result.exit_code,
+                "exit code out of u8 range, using 1"
+            );
+            1
+        }
+    };
     Ok(ExitCode::from(code))
 }
 
@@ -109,7 +118,7 @@ async fn run_sandbox(
     let (result, boot_ms, exec_ms) = run_in_sandbox(args, &mut *sandbox, is_snapshot).await;
 
     if let Err(e) = sandbox.stop().await {
-        info!(error = %e, "sandbox stop failed");
+        warn!(error = %e, "sandbox stop failed");
     }
     factory.destroy(sandbox).await;
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -162,7 +162,7 @@ async fn run_in_sandbox(
 /// Sync guest clock to host time after snapshot restore.
 ///
 /// Must run before any HTTPS calls — stale clock breaks TLS cert validation.
-async fn fix_guest_clock(sandbox: &dyn Sandbox) -> RunnerResult<()> {
+pub(crate) async fn fix_guest_clock(sandbox: &dyn Sandbox) -> RunnerResult<()> {
     let timestamp = format!(
         "{:.3}",
         std::time::SystemTime::now()

--- a/crates/runner/src/runner.rs
+++ b/crates/runner/src/runner.rs
@@ -118,13 +118,8 @@ struct RunConfig {
 }
 
 async fn run(config: RunConfig) -> RunnerResult<()> {
-    let mut factory = FirecrackerFactory::new(config.fc_config.clone())
-        .await
-        .map_err(|e| RunnerError::Internal(format!("factory init: {e}")))?;
-    factory
-        .startup()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("factory startup: {e}")))?;
+    let mut factory = FirecrackerFactory::new(config.fc_config.clone()).await?;
+    factory.startup().await?;
     let factory = Arc::new(factory);
 
     let api = ApiClient::new(config.api_url.clone(), config.token.clone())?;


### PR DESCRIPTION
## Summary
- Add `runner benchmark` subcommand that executes a single bash command in a Firecracker VM for performance testing and environment validation
- Reuse `runner.yaml` config via `--config` flag, with `--timeout-secs` for command timeout
- Propagate VM command exit code through `ExitCode` for scripting integration

Closes #2919

## Changes
- **`benchmark.rs`** (new): `BenchmarkArgs` + `run_benchmark()` with three-layer cleanup (sandbox → factory → process)
- **`main.rs`**: Add `Benchmark` variant, unify match arms to return `RunnerResult<ExitCode>`
- **`executor.rs`**: Change `fix_guest_clock` to `pub(crate)` for reuse

## Test plan
- [ ] `cargo clippy -p runner` — zero warnings
- [ ] `cargo test -p runner` — 29 tests pass
- [ ] E2E on dev-2: `runner benchmark -c runner.yaml "echo hello && date"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)