### PR TITLE
ci(crates): add runner metal test for setup, build, and benchmark

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -99,9 +99,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
-    defaults:
-      run:
-        shell: bash
     needs: [detect]
     if: |
       needs.detect.outputs.workflow-changed == 'true' ||
@@ -134,11 +131,10 @@ jobs:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           JOB_REF: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main' }}
         run: |
-          IFS=',' read -ra HOSTS <<< "$METAL_HOSTS"
-          NUM_HOSTS=${#HOSTS[@]}
+          NUM_HOSTS=$(echo "$METAL_HOSTS" | tr ',' '\n' | wc -l)
           HASH=$(echo -n "$JOB_REF" | md5sum | cut -c1-8)
-          HOST_INDEX=$((16#$HASH % NUM_HOSTS))
-          HOST="${HOSTS[$HOST_INDEX]}"
+          HOST_INDEX=$(( 0x$HASH % NUM_HOSTS ))
+          HOST=$(echo "$METAL_HOSTS" | tr ',' '\n' | sed -n "$((HOST_INDEX + 1))p")
           echo "host=${HOST}" >> "$GITHUB_OUTPUT"
           echo "job-ref=${JOB_REF}" >> "$GITHUB_OUTPUT"
           echo "Selected metal host: ${HOST} (index ${HOST_INDEX}/${NUM_HOSTS})"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -99,6 +99,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
+    defaults:
+      run:
+        shell: bash
     needs: [detect]
     if: |
       needs.detect.outputs.workflow-changed == 'true' ||

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -151,9 +151,9 @@ jobs:
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
           TARGET_DIR="crates/target/aarch64-unknown-linux-musl/release"
 
-          # Upload binaries
+          # Upload binaries (rm first to avoid "Text file busy" if a stale process holds the old binary)
           echo "=== Deploying binaries to ${HOST}:${BIN_DIR} ==="
-          ssh $SSH_OPTS $REMOTE "mkdir -p ${BIN_DIR}"
+          ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} && mkdir -p ${BIN_DIR}"
           for bin in runner guest-init guest-download guest-agent guest-mock-claude; do
             scp $SSH_OPTS "${TARGET_DIR}/${bin}" "${REMOTE}:${BIN_DIR}/"
           done

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -149,11 +149,12 @@ jobs:
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
           REMOTE="${METAL_USER}@${HOST}"
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
+          RUNNER_DIR="~/.vm0-runner/runners/${JOB_REF}"
           TARGET_DIR="crates/target/aarch64-unknown-linux-musl/release"
 
-          # Upload binaries (rm first to avoid "Text file busy" if a stale process holds the old binary)
+          # Clean previous run artifacts and upload binaries
           echo "=== Deploying binaries to ${HOST}:${BIN_DIR} ==="
-          ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} && mkdir -p ${BIN_DIR}"
+          ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} ${RUNNER_DIR} && mkdir -p ${BIN_DIR}"
           for bin in runner guest-init guest-download guest-agent guest-mock-claude; do
             scp $SSH_OPTS "${TARGET_DIR}/${bin}" "${REMOTE}:${BIN_DIR}/"
           done
@@ -178,7 +179,7 @@ jobs:
           # Run benchmark (boot VM from snapshot, exec command, verify output)
           echo "=== Running benchmark ==="
           ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner benchmark \
-            --config ~/.vm0-runner/runners/${JOB_REF}/runner.yaml \
+            --config ${RUNNER_DIR}/runner.yaml \
             'echo hello-from-vm'"
 
       - name: Cleanup
@@ -190,5 +191,7 @@ jobs:
         run: |
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
           REMOTE="${METAL_USER}@${HOST}"
+          BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
+          RUNNER_DIR="~/.vm0-runner/runners/${JOB_REF}"
           echo "Cleaning up ${JOB_REF} on ${HOST}"
-          ssh $SSH_OPTS $REMOTE "rm -rf ~/.vm0-runner/bin/${JOB_REF} ~/.vm0-runner/runners/${JOB_REF}" || true
+          ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} ${RUNNER_DIR}" || true

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -13,12 +13,13 @@ on:
       - '.github/workflows/crates.yml'
 
 jobs:
-  check:
+  detect:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
     outputs:
       workflow-changed: ${{ steps.detect.outputs.workflow-changed }}
+      ably-subscriber-changed: ${{ steps.detect.outputs.ably-subscriber-changed }}
       runner-changed: ${{ steps.detect.outputs.runner-changed }}
       guest-init-changed: ${{ steps.detect.outputs.guest-init-changed }}
       guest-download-changed: ${{ steps.detect.outputs.guest-download-changed }}
@@ -41,12 +42,6 @@ jobs:
           # Git 2.35.2+ rejects such repos unless marked as safe.
           git config --global --add safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
 
-          # scripts/crate-changed.sh: exit 0=changed, 1=not changed, 2+=error
-          check_crate() {
-            ./scripts/crate-changed.sh "$1" "$BASE_REF" && echo "$1-changed=true" >> "$GITHUB_OUTPUT" || {
-              rc=$?; [ $rc -eq 1 ] && echo "$1-changed=false" >> "$GITHUB_OUTPUT" || exit $rc
-            }
-          }
           # Check if the workflow file itself changed
           if git diff --name-only "$BASE_REF" HEAD | grep -q "^\.github/workflows/crates\.yml$"; then
             echo "workflow-changed=true" >> "$GITHUB_OUTPUT"
@@ -54,12 +49,26 @@ jobs:
             echo "workflow-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
+          # scripts/crate-changed.sh: exit 0=changed, 1=not changed, 2+=error
+          check_crate() {
+            ./scripts/crate-changed.sh "$1" "$BASE_REF" && echo "$1-changed=true" >> "$GITHUB_OUTPUT" || {
+              rc=$?; [ $rc -eq 1 ] && echo "$1-changed=false" >> "$GITHUB_OUTPUT" || exit $rc
+            }
+          }
           check_crate ably-subscriber
           check_crate runner
           check_crate guest-init
           check_crate guest-download
           check_crate guest-agent
           check_crate guest-mock-claude
+
+  check:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
+    needs: [detect]
+    steps:
+      - uses: actions/checkout@v6
 
       - name: Check formatting
         run: |
@@ -78,8 +87,8 @@ jobs:
 
       - name: Run ably-subscriber smoke test
         if: |
-          steps.detect.outputs.ably-subscriber-changed == 'true' ||
-          steps.detect.outputs.workflow-changed == 'true'
+          needs.detect.outputs.ably-subscriber-changed == 'true' ||
+          needs.detect.outputs.workflow-changed == 'true'
         env:
           ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
         run: |
@@ -90,14 +99,14 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
-    needs: [check]
+    needs: [detect]
     if: |
-      needs.check.outputs.workflow-changed == 'true' ||
-      needs.check.outputs.runner-changed == 'true' ||
-      needs.check.outputs.guest-init-changed == 'true' ||
-      needs.check.outputs.guest-download-changed == 'true' ||
-      needs.check.outputs.guest-agent-changed == 'true' ||
-      needs.check.outputs.guest-mock-claude-changed == 'true'
+      needs.detect.outputs.workflow-changed == 'true' ||
+      needs.detect.outputs.runner-changed == 'true' ||
+      needs.detect.outputs.guest-init-changed == 'true' ||
+      needs.detect.outputs.guest-download-changed == 'true' ||
+      needs.detect.outputs.guest-agent-changed == 'true' ||
+      needs.detect.outputs.guest-mock-claude-changed == 'true'
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
+    outputs:
+      workflow-changed: ${{ steps.detect.outputs.workflow-changed }}
+      runner-changed: ${{ steps.detect.outputs.runner-changed }}
+      guest-init-changed: ${{ steps.detect.outputs.guest-init-changed }}
+      guest-download-changed: ${{ steps.detect.outputs.guest-download-changed }}
+      guest-agent-changed: ${{ steps.detect.outputs.guest-agent-changed }}
+      guest-mock-claude-changed: ${{ steps.detect.outputs.guest-mock-claude-changed }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -36,7 +43,19 @@ jobs:
               rc=$?; [ $rc -eq 1 ] && echo "$1-changed=false" >> "$GITHUB_OUTPUT" || exit $rc
             }
           }
+          # Check if the workflow file itself changed
+          if git diff --name-only "$BASE_REF" HEAD | grep -q "^\.github/workflows/crates\.yml$"; then
+            echo "workflow-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "workflow-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
           check_crate ably-subscriber
+          check_crate runner
+          check_crate guest-init
+          check_crate guest-download
+          check_crate guest-agent
+          check_crate guest-mock-claude
 
       - name: Check formatting
         run: |
@@ -54,9 +73,110 @@ jobs:
           cargo test --all-targets
 
       - name: Run ably-subscriber smoke test
-        if: steps.detect.outputs.ably-subscriber-changed == 'true'
+        if: |
+          steps.detect.outputs.ably-subscriber-changed == 'true' ||
+          steps.detect.outputs.workflow-changed == 'true'
         env:
           ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
         run: |
           cd crates
           cargo run -p ably-subscriber --example smoke_test
+
+  runner-metal-test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
+    needs: [check]
+    if: |
+      needs.check.outputs.workflow-changed == 'true' ||
+      needs.check.outputs.runner-changed == 'true' ||
+      needs.check.outputs.guest-init-changed == 'true' ||
+      needs.check.outputs.guest-download-changed == 'true' ||
+      needs.check.outputs.guest-agent-changed == 'true' ||
+      needs.check.outputs.guest-mock-claude-changed == 'true'
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cross-compile runner and guest binaries for ARM64
+        run: |
+          cd crates
+          cargo build --release --target aarch64-unknown-linux-musl \
+            -p runner -p guest-init -p guest-download -p guest-agent -p guest-mock-claude
+
+      - name: Setup SSH
+        env:
+          SSH_KEY: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+        run: |
+          mkdir -p "$HOME/.ssh"
+          echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
+          chmod 600 "$HOME/.ssh/runner.pem"
+
+      - name: Select metal host
+        id: host
+        env:
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          JOB_REF: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main' }}
+        run: |
+          IFS=',' read -ra HOSTS <<< "$METAL_HOSTS"
+          NUM_HOSTS=${#HOSTS[@]}
+          HASH=$(echo -n "$JOB_REF" | md5sum | cut -c1-8)
+          HOST_INDEX=$((16#$HASH % NUM_HOSTS))
+          HOST="${HOSTS[$HOST_INDEX]}"
+          echo "host=${HOST}" >> "$GITHUB_OUTPUT"
+          echo "job-ref=${JOB_REF}" >> "$GITHUB_OUTPUT"
+          echo "Selected metal host: ${HOST} (index ${HOST_INDEX}/${NUM_HOSTS})"
+
+      - name: Deploy and test on metal host
+        env:
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+          HOST: ${{ steps.host.outputs.host }}
+          JOB_REF: ${{ steps.host.outputs.job-ref }}
+        run: |
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
+          REMOTE="${METAL_USER}@${HOST}"
+          BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
+          TARGET_DIR="crates/target/aarch64-unknown-linux-musl/release"
+
+          # Upload binaries
+          echo "=== Deploying binaries to ${HOST}:${BIN_DIR} ==="
+          ssh $SSH_OPTS $REMOTE "mkdir -p ${BIN_DIR}"
+          for bin in runner guest-init guest-download guest-agent guest-mock-claude; do
+            scp $SSH_OPTS "${TARGET_DIR}/${bin}" "${REMOTE}:${BIN_DIR}/"
+          done
+
+          # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
+          echo "=== Running setup ==="
+          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner setup"
+
+          # Run build (rootfs via Docker + snapshot via Firecracker, generates runner.yaml)
+          echo "=== Running build ==="
+          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner build \
+            --name ${JOB_REF} \
+            --group vm0/development-${JOB_REF} \
+            --runner-dirname ${JOB_REF} \
+            --guest-init ${BIN_DIR}/guest-init \
+            --guest-download ${BIN_DIR}/guest-download \
+            --guest-agent ${BIN_DIR}/guest-agent \
+            --guest-mock-claude ${BIN_DIR}/guest-mock-claude \
+            --api-url https://localhost \
+            --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
+
+          # Run benchmark (boot VM from snapshot, exec command, verify output)
+          echo "=== Running benchmark ==="
+          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner benchmark \
+            --config ~/.vm0-runner/runners/${JOB_REF}/runner.yaml \
+            'echo hello-from-vm'"
+
+      - name: Cleanup
+        if: always()
+        env:
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          HOST: ${{ steps.host.outputs.host }}
+          JOB_REF: ${{ steps.host.outputs.job-ref }}
+        run: |
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
+          REMOTE="${METAL_USER}@${HOST}"
+          echo "Cleaning up ${JOB_REF} on ${HOST}"
+          ssh $SSH_OPTS $REMOTE "rm -rf ~/.vm0-runner/bin/${JOB_REF} ~/.vm0-runner/runners/${JOB_REF}" || true

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -37,6 +37,10 @@ jobs:
           else
             BASE_REF="HEAD^"
           fi
+          # In CI containers, the repo may be owned by a different user (host vs container).
+          # Git 2.35.2+ rejects such repos unless marked as safe.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
+
           # scripts/crate-changed.sh: exit 0=changed, 1=not changed, 2+=error
           check_crate() {
             ./scripts/crate-changed.sh "$1" "$BASE_REF" && echo "$1-changed=true" >> "$GITHUB_OUTPUT" || {

--- a/crates/runner/src/benchmark.rs
+++ b/crates/runner/src/benchmark.rs
@@ -48,7 +48,7 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
             memory_mb: runner_config.sandbox.memory_mb,
         },
     };
-    let (result, boot_ms, exec_ms) =
+    let (result, boot_ms, clock_ms, exec_ms) =
         run_sandbox(&args, &factory, sandbox_config, is_snapshot).await;
     let total_ms = total.elapsed().as_millis();
     factory.shutdown().await;
@@ -59,6 +59,7 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
             info!(
                 factory_ms,
                 boot_ms,
+                clock_ms,
                 exec_ms,
                 total_ms,
                 exit_code = exec_result.exit_code,
@@ -66,7 +67,7 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
             );
         }
         Err(e) => {
-            info!(factory_ms, boot_ms, exec_ms, total_ms, error = %e, "benchmark failed");
+            info!(factory_ms, boot_ms, clock_ms, exec_ms, total_ms, error = %e, "benchmark failed");
         }
     }
 
@@ -96,7 +97,7 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     Ok(ExitCode::from(code))
 }
 
-/// Create, start, exec, stop, destroy. Returns (result, boot_ms, exec_ms).
+/// Create, start, exec, stop, destroy. Returns (result, boot_ms, clock_ms, exec_ms).
 /// Timing is always returned even on error.
 /// Caller is responsible for `factory.shutdown()`.
 async fn run_sandbox(
@@ -104,20 +105,21 @@ async fn run_sandbox(
     factory: &FirecrackerFactory,
     sandbox_config: SandboxConfig,
     is_snapshot: bool,
-) -> (RunnerResult<ExecResult>, u128, u128) {
+) -> (RunnerResult<ExecResult>, u128, u128, u128) {
     let mut sandbox = match factory.create(sandbox_config).await {
         Ok(s) => s,
-        Err(e) => return (Err(e.into()), 0, 0),
+        Err(e) => return (Err(e.into()), 0, 0, 0),
     };
 
-    let (result, boot_ms, exec_ms) = run_in_sandbox(args, sandbox.as_mut(), is_snapshot).await;
+    let (result, boot_ms, clock_ms, exec_ms) =
+        run_in_sandbox(args, sandbox.as_mut(), is_snapshot).await;
 
     if let Err(e) = sandbox.stop().await {
         warn!(error = %e, "sandbox stop failed");
     }
     factory.destroy(sandbox).await;
 
-    (result, boot_ms, exec_ms)
+    (result, boot_ms, clock_ms, exec_ms)
 }
 
 /// Start sandbox, fix clock, exec command. Returns result + timing.
@@ -125,17 +127,19 @@ async fn run_in_sandbox(
     args: &BenchmarkArgs,
     sandbox: &mut dyn sandbox::Sandbox,
     is_snapshot: bool,
-) -> (RunnerResult<ExecResult>, u128, u128) {
+) -> (RunnerResult<ExecResult>, u128, u128, u128) {
     let t = Instant::now();
     if let Err(e) = sandbox.start().await {
-        return (Err(e.into()), t.elapsed().as_millis(), 0);
+        return (Err(e.into()), t.elapsed().as_millis(), 0, 0);
     }
     let boot_ms = t.elapsed().as_millis();
     info!(boot_ms, "sandbox started");
 
+    let t = Instant::now();
     if is_snapshot && let Err(e) = executor::fix_guest_clock(sandbox).await {
-        return (Err(e), boot_ms, 0);
+        return (Err(e), boot_ms, t.elapsed().as_millis(), 0);
     }
+    let clock_ms = t.elapsed().as_millis();
 
     let t = Instant::now();
     let result = sandbox
@@ -148,5 +152,5 @@ async fn run_in_sandbox(
         .map_err(Into::into);
     let exec_ms = t.elapsed().as_millis();
 
-    (result, boot_ms, exec_ms)
+    (result, boot_ms, clock_ms, exec_ms)
 }

--- a/crates/runner/src/benchmark.rs
+++ b/crates/runner/src/benchmark.rs
@@ -12,6 +12,12 @@ use crate::config;
 use crate::error::RunnerResult;
 use crate::executor;
 
+struct Timing {
+    boot_ms: u128,
+    clock_ms: u128,
+    exec_ms: u128,
+}
+
 #[derive(Args)]
 pub struct BenchmarkArgs {
     /// The bash command to execute in the VM
@@ -48,12 +54,16 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
             memory_mb: runner_config.sandbox.memory_mb,
         },
     };
-    let (result, boot_ms, clock_ms, exec_ms) =
-        run_sandbox(&args, &factory, sandbox_config, is_snapshot).await;
+    let (result, timing) = run_sandbox(&args, &factory, sandbox_config, is_snapshot).await;
     let total_ms = total.elapsed().as_millis();
     factory.shutdown().await;
 
     // 4. Log timing summary (always, even on error)
+    let Timing {
+        boot_ms,
+        clock_ms,
+        exec_ms,
+    } = timing;
     match &result {
         Ok(exec_result) => {
             info!(
@@ -97,7 +107,7 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     Ok(ExitCode::from(code))
 }
 
-/// Create, start, exec, stop, destroy. Returns (result, boot_ms, clock_ms, exec_ms).
+/// Create, start, exec, stop, destroy.
 /// Timing is always returned even on error.
 /// Caller is responsible for `factory.shutdown()`.
 async fn run_sandbox(
@@ -105,21 +115,25 @@ async fn run_sandbox(
     factory: &FirecrackerFactory,
     sandbox_config: SandboxConfig,
     is_snapshot: bool,
-) -> (RunnerResult<ExecResult>, u128, u128, u128) {
+) -> (RunnerResult<ExecResult>, Timing) {
+    let zero = Timing {
+        boot_ms: 0,
+        clock_ms: 0,
+        exec_ms: 0,
+    };
     let mut sandbox = match factory.create(sandbox_config).await {
         Ok(s) => s,
-        Err(e) => return (Err(e.into()), 0, 0, 0),
+        Err(e) => return (Err(e.into()), zero),
     };
 
-    let (result, boot_ms, clock_ms, exec_ms) =
-        run_in_sandbox(args, sandbox.as_mut(), is_snapshot).await;
+    let (result, timing) = run_in_sandbox(args, sandbox.as_mut(), is_snapshot).await;
 
     if let Err(e) = sandbox.stop().await {
         warn!(error = %e, "sandbox stop failed");
     }
     factory.destroy(sandbox).await;
 
-    (result, boot_ms, clock_ms, exec_ms)
+    (result, timing)
 }
 
 /// Start sandbox, fix clock, exec command. Returns result + timing.
@@ -127,17 +141,27 @@ async fn run_in_sandbox(
     args: &BenchmarkArgs,
     sandbox: &mut dyn sandbox::Sandbox,
     is_snapshot: bool,
-) -> (RunnerResult<ExecResult>, u128, u128, u128) {
+) -> (RunnerResult<ExecResult>, Timing) {
     let t = Instant::now();
     if let Err(e) = sandbox.start().await {
-        return (Err(e.into()), t.elapsed().as_millis(), 0, 0);
+        let timing = Timing {
+            boot_ms: t.elapsed().as_millis(),
+            clock_ms: 0,
+            exec_ms: 0,
+        };
+        return (Err(e.into()), timing);
     }
     let boot_ms = t.elapsed().as_millis();
     info!(boot_ms, "sandbox started");
 
     let t = Instant::now();
     if is_snapshot && let Err(e) = executor::fix_guest_clock(sandbox).await {
-        return (Err(e), boot_ms, t.elapsed().as_millis(), 0);
+        let timing = Timing {
+            boot_ms,
+            clock_ms: t.elapsed().as_millis(),
+            exec_ms: 0,
+        };
+        return (Err(e), timing);
     }
     let clock_ms = t.elapsed().as_millis();
 
@@ -152,5 +176,10 @@ async fn run_in_sandbox(
         .map_err(Into::into);
     let exec_ms = t.elapsed().as_millis();
 
-    (result, boot_ms, clock_ms, exec_ms)
+    let timing = Timing {
+        boot_ms,
+        clock_ms,
+        exec_ms,
+    };
+    (result, timing)
 }

--- a/scripts/crate-changed.sh
+++ b/scripts/crate-changed.sh
@@ -16,10 +16,6 @@ BASE_REF=${2:-HEAD^}
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# In CI containers, the repo may be owned by a different user (host vs container).
-# Git 2.35.2+ rejects such repos unless marked as safe.
-git config --global --add safe.directory "$REPO_ROOT" 2>/dev/null || true
-
 DEPS_JSON=$(cd "$REPO_ROOT/crates" && cargo metadata --no-deps --format-version 1 2>/dev/null | \
   jq '[.packages[] | {name: .name, deps: [.dependencies[] | select(has("path")) | .name]}]') || {
   echo "Error: failed to resolve crate dependencies" >&2


### PR DESCRIPTION
## Summary
- Add `runner-metal-test` job to `crates.yml` that cross-compiles runner + guest binaries for ARM64, deploys to a metal host via SSH, and runs `setup` → `build` → `benchmark` end-to-end
- Add change detection for runner, guest-init, guest-download, guest-agent, guest-mock-claude crates
- Add workflow-changed detection so all conditional tests run when `crates.yml` itself is modified

## Test plan
- [ ] Verify `check` job detects crate changes correctly
- [ ] Verify `runner-metal-test` triggers when any of the 5 crates or the workflow file changes
- [ ] Verify cross-compilation, SSH deploy, setup, build, benchmark succeed on metal host
- [ ] Verify cleanup runs even on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)