### PR TITLE
feat: add markdown preview for prompts, slack image hints, and platform tests

### DIFF
--- a/turbo/apps/platform/src/signals/settings-page/__tests__/secrets-and-variables.test.ts
+++ b/turbo/apps/platform/src/signals/settings-page/__tests__/secrets-and-variables.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { mergedItems$ } from "../secrets-and-variables.ts";
+
+const context = testContext();
+
+describe("mergedItems$", () => {
+  it("should return configured secrets and variables", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/secrets", () => {
+        return HttpResponse.json({
+          secrets: [
+            {
+              id: "s1",
+              name: "API_KEY",
+              description: "key",
+              type: "user",
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+          ],
+        });
+      }),
+      http.get("http://localhost:3000/api/variables", () => {
+        return HttpResponse.json({
+          variables: [
+            {
+              id: "v1",
+              name: "MY_VAR",
+              value: "val",
+              description: null,
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+          ],
+        });
+      }),
+      http.get("http://localhost:3000/api/agent/required-env", () => {
+        return HttpResponse.json({ agents: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    const items = await context.store.get(mergedItems$);
+
+    expect(items).toHaveLength(2);
+
+    const secret = items.find(
+      (i) => i.kind === "secret" && i.name === "API_KEY",
+    );
+    expect(secret).toBeDefined();
+    expect(secret!.data).not.toBeNull();
+    expect(secret!.agentRequired).toBeFalsy();
+
+    const variable = items.find(
+      (i) => i.kind === "variable" && i.name === "MY_VAR",
+    );
+    expect(variable).toBeDefined();
+    expect(variable!.data).not.toBeNull();
+    expect(variable!.agentRequired).toBeFalsy();
+  });
+
+  it("should include missing required secrets as placeholder items", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/secrets", () => {
+        return HttpResponse.json({ secrets: [] });
+      }),
+      http.get("http://localhost:3000/api/variables", () => {
+        return HttpResponse.json({ variables: [] });
+      }),
+      http.get("http://localhost:3000/api/agent/required-env", () => {
+        return HttpResponse.json({
+          agents: [
+            {
+              composeId: "c1",
+              agentName: "agent-1",
+              requiredSecrets: ["MISSING_KEY"],
+              requiredVariables: ["MISSING_VAR"],
+            },
+          ],
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    const items = await context.store.get(mergedItems$);
+
+    const missingSecret = items.find(
+      (i) => i.kind === "secret" && i.name === "MISSING_KEY",
+    );
+    expect(missingSecret).toBeDefined();
+    expect(missingSecret!.data).toBeNull();
+    expect(missingSecret!.agentRequired).toBeTruthy();
+
+    const missingVar = items.find(
+      (i) => i.kind === "variable" && i.name === "MISSING_VAR",
+    );
+    expect(missingVar).toBeDefined();
+    expect(missingVar!.data).toBeNull();
+    expect(missingVar!.agentRequired).toBeTruthy();
+  });
+
+  it("should hide connector-resolvable missing secrets", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/secrets", () => {
+        return HttpResponse.json({ secrets: [] });
+      }),
+      http.get("http://localhost:3000/api/variables", () => {
+        return HttpResponse.json({ variables: [] });
+      }),
+      http.get("http://localhost:3000/api/agent/required-env", () => {
+        return HttpResponse.json({
+          agents: [
+            {
+              composeId: "c1",
+              agentName: "agent-1",
+              // GH_TOKEN is resolvable by the GitHub connector
+              requiredSecrets: ["GH_TOKEN", "CUSTOM_KEY"],
+              requiredVariables: [],
+            },
+          ],
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    const items = await context.store.get(mergedItems$);
+
+    // GH_TOKEN should not appear as a missing item (connector-resolvable)
+    const ghToken = items.find((i) => i.name === "GH_TOKEN");
+    expect(ghToken).toBeUndefined();
+
+    // CUSTOM_KEY should appear as a missing placeholder
+    const customKey = items.find((i) => i.name === "CUSTOM_KEY");
+    expect(customKey).toBeDefined();
+    expect(customKey!.data).toBeNull();
+    expect(customKey!.agentRequired).toBeTruthy();
+  });
+
+  it("should mark configured agent-required secrets as agentRequired", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/secrets", () => {
+        return HttpResponse.json({
+          secrets: [
+            {
+              id: "s1",
+              name: "API_KEY",
+              description: null,
+              type: "user",
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+          ],
+        });
+      }),
+      http.get("http://localhost:3000/api/variables", () => {
+        return HttpResponse.json({ variables: [] });
+      }),
+      http.get("http://localhost:3000/api/agent/required-env", () => {
+        return HttpResponse.json({
+          agents: [
+            {
+              composeId: "c1",
+              agentName: "agent-1",
+              requiredSecrets: ["API_KEY"],
+              requiredVariables: [],
+            },
+          ],
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    const items = await context.store.get(mergedItems$);
+
+    const secret = items.find(
+      (i) => i.kind === "secret" && i.name === "API_KEY",
+    );
+    expect(secret).toBeDefined();
+    expect(secret!.data).not.toBeNull();
+    expect(secret!.agentRequired).toBeTruthy();
+  });
+
+  it("should mark connector-resolvable configured secret as not agentRequired even if required", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/secrets", () => {
+        return HttpResponse.json({
+          secrets: [
+            {
+              id: "s1",
+              name: "GH_TOKEN",
+              description: null,
+              type: "user",
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+          ],
+        });
+      }),
+      http.get("http://localhost:3000/api/variables", () => {
+        return HttpResponse.json({ variables: [] });
+      }),
+      http.get("http://localhost:3000/api/agent/required-env", () => {
+        return HttpResponse.json({
+          agents: [
+            {
+              composeId: "c1",
+              agentName: "agent-1",
+              requiredSecrets: ["GH_TOKEN"],
+              requiredVariables: [],
+            },
+          ],
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    const items = await context.store.get(mergedItems$);
+
+    const ghToken = items.find(
+      (i) => i.kind === "secret" && i.name === "GH_TOKEN",
+    );
+    expect(ghToken).toBeDefined();
+    expect(ghToken!.data).not.toBeNull();
+    // Connector-resolvable → deletable → not agentRequired
+    expect(ghToken!.agentRequired).toBeFalsy();
+  });
+
+  it("should mark configured agent-required variables as agentRequired", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/secrets", () => {
+        return HttpResponse.json({ secrets: [] });
+      }),
+      http.get("http://localhost:3000/api/variables", () => {
+        return HttpResponse.json({
+          variables: [
+            {
+              id: "v1",
+              name: "MY_VAR",
+              value: "val",
+              description: null,
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+          ],
+        });
+      }),
+      http.get("http://localhost:3000/api/agent/required-env", () => {
+        return HttpResponse.json({
+          agents: [
+            {
+              composeId: "c1",
+              agentName: "agent-1",
+              requiredSecrets: [],
+              requiredVariables: ["MY_VAR"],
+            },
+          ],
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    const items = await context.store.get(mergedItems$);
+
+    const variable = items.find(
+      (i) => i.kind === "variable" && i.name === "MY_VAR",
+    );
+    expect(variable).toBeDefined();
+    expect(variable!.data).not.toBeNull();
+    expect(variable!.agentRequired).toBeTruthy();
+  });
+
+  it("should deduplicate required secrets from multiple agents", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/secrets", () => {
+        return HttpResponse.json({ secrets: [] });
+      }),
+      http.get("http://localhost:3000/api/variables", () => {
+        return HttpResponse.json({ variables: [] });
+      }),
+      http.get("http://localhost:3000/api/agent/required-env", () => {
+        return HttpResponse.json({
+          agents: [
+            {
+              composeId: "c1",
+              agentName: "agent-1",
+              requiredSecrets: ["SHARED_KEY"],
+              requiredVariables: ["SHARED_VAR"],
+            },
+            {
+              composeId: "c2",
+              agentName: "agent-2",
+              requiredSecrets: ["SHARED_KEY"],
+              requiredVariables: ["SHARED_VAR"],
+            },
+          ],
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    const items = await context.store.get(mergedItems$);
+
+    // SHARED_KEY and SHARED_VAR should appear only once each
+    const secretItems = items.filter(
+      (i) => i.kind === "secret" && i.name === "SHARED_KEY",
+    );
+    expect(secretItems).toHaveLength(1);
+
+    const varItems = items.filter(
+      (i) => i.kind === "variable" && i.name === "SHARED_VAR",
+    );
+    expect(varItems).toHaveLength(1);
+  });
+
+  it("should not include missing placeholder for already-configured items", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/secrets", () => {
+        return HttpResponse.json({
+          secrets: [
+            {
+              id: "s1",
+              name: "API_KEY",
+              description: null,
+              type: "user",
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+          ],
+        });
+      }),
+      http.get("http://localhost:3000/api/variables", () => {
+        return HttpResponse.json({
+          variables: [
+            {
+              id: "v1",
+              name: "MY_VAR",
+              value: "val",
+              description: null,
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+          ],
+        });
+      }),
+      http.get("http://localhost:3000/api/agent/required-env", () => {
+        return HttpResponse.json({
+          agents: [
+            {
+              composeId: "c1",
+              agentName: "agent-1",
+              requiredSecrets: ["API_KEY"],
+              requiredVariables: ["MY_VAR"],
+            },
+          ],
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    const items = await context.store.get(mergedItems$);
+
+    // Should have exactly 2 items (both configured), no missing placeholders
+    expect(items).toHaveLength(2);
+
+    const missingItems = items.filter((i) => i.data === null);
+    expect(missingItems).toHaveLength(0);
+  });
+});

--- a/turbo/apps/platform/src/views/agents-page/__tests__/agents-page.test.tsx
+++ b/turbo/apps/platform/src/views/agents-page/__tests__/agents-page.test.tsx
@@ -1,0 +1,358 @@
+import { describe, expect, it, vi } from "vitest";
+import { server } from "../../../mocks/server.ts";
+import { http, HttpResponse } from "msw";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { screen, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+
+const context = testContext();
+const user = userEvent.setup();
+
+describe("agents page", () => {
+  it("shows agents table with agent names", async () => {
+    server.use(
+      http.get("/api/agent/composes/list", () => {
+        return HttpResponse.json({
+          composes: [
+            {
+              name: "my-agent",
+              headVersionId: "v1",
+              updatedAt: "2024-06-15T10:00:00Z",
+            },
+          ],
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/agents" });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("my-agent")).toBeInTheDocument();
+    });
+    // Table header "Your agents" should be present
+    expect(screen.getByText("Model provider")).toBeInTheDocument();
+    expect(screen.getByText("Schedule status")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no agents exist", async () => {
+    server.use(
+      http.get("/api/agent/composes/list", () => {
+        return HttpResponse.json({ composes: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/agents" });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByText("No agents yet. Time to create your first one."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows error state when agents API fails", async () => {
+    server.use(
+      http.get("/api/agent/composes/list", () => {
+        return HttpResponse.json(
+          { error: "Unauthorized" },
+          { status: 401, statusText: "Unauthorized" },
+        );
+      }),
+    );
+
+    await setupPage({ context, path: "/agents" });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/Whoops!/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows missing environment variables count for agent with missing items", async () => {
+    server.use(
+      http.get("/api/agent/composes/list", () => {
+        return HttpResponse.json({
+          composes: [
+            {
+              name: "my-agent",
+              headVersionId: "v1",
+              updatedAt: "2024-06-15T10:00:00Z",
+            },
+          ],
+        });
+      }),
+      http.get("/api/agent/required-env", () => {
+        return HttpResponse.json({
+          agents: [
+            {
+              composeId: "c1",
+              agentName: "my-agent",
+              requiredSecrets: ["API_KEY", "OTHER_KEY"],
+              requiredVariables: ["MY_VAR"],
+            },
+          ],
+        });
+      }),
+      http.get("/api/secrets", () => {
+        return HttpResponse.json({ secrets: [] });
+      }),
+      http.get("/api/variables", () => {
+        return HttpResponse.json({ variables: [] });
+      }),
+      http.get("/api/connectors", () => {
+        return HttpResponse.json({ connectors: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/agents" });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("my-agent")).toBeInTheDocument();
+    });
+
+    // Should display "Missing 3 environment variables" (2 secrets + 1 variable)
+    await vi.waitFor(() => {
+      expect(
+        screen.getByText("Missing 3 environment variables"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows singular label for one missing environment variable", async () => {
+    server.use(
+      http.get("/api/agent/composes/list", () => {
+        return HttpResponse.json({
+          composes: [
+            {
+              name: "my-agent",
+              headVersionId: "v1",
+              updatedAt: "2024-06-15T10:00:00Z",
+            },
+          ],
+        });
+      }),
+      http.get("/api/agent/required-env", () => {
+        return HttpResponse.json({
+          agents: [
+            {
+              composeId: "c1",
+              agentName: "my-agent",
+              requiredSecrets: ["API_KEY"],
+              requiredVariables: [],
+            },
+          ],
+        });
+      }),
+      http.get("/api/secrets", () => {
+        return HttpResponse.json({ secrets: [] });
+      }),
+      http.get("/api/variables", () => {
+        return HttpResponse.json({ variables: [] });
+      }),
+      http.get("/api/connectors", () => {
+        return HttpResponse.json({ connectors: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/agents" });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByText("Missing 1 environment variable"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows missing env banner in agent dialog with secrets/variables link", async () => {
+    server.use(
+      http.get("/api/agent/composes/list", () => {
+        return HttpResponse.json({
+          composes: [
+            {
+              name: "my-agent",
+              headVersionId: "v1",
+              updatedAt: "2024-06-15T10:00:00Z",
+            },
+          ],
+        });
+      }),
+      http.get("/api/agent/required-env", () => {
+        return HttpResponse.json({
+          agents: [
+            {
+              composeId: "c1",
+              agentName: "my-agent",
+              requiredSecrets: ["CUSTOM_KEY"],
+              requiredVariables: ["MY_VAR"],
+            },
+          ],
+        });
+      }),
+      http.get("/api/secrets", () => {
+        return HttpResponse.json({ secrets: [] });
+      }),
+      http.get("/api/variables", () => {
+        return HttpResponse.json({ variables: [] });
+      }),
+      http.get("/api/connectors", () => {
+        return HttpResponse.json({ connectors: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/agents" });
+
+    // Wait for the missing items to load
+    await vi.waitFor(() => {
+      expect(
+        screen.getByText(/Missing \d+ environment variable/),
+      ).toBeInTheDocument();
+    });
+
+    // Click on the agent row to open the dialog
+    await user.click(screen.getByText("my-agent"));
+
+    // Dialog should open
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Manage my-agent")).toBeInTheDocument();
+
+    // Should show the missing env banner
+    expect(within(dialog).getByText(/missing some/)).toBeInTheDocument();
+
+    // Should show a link to secrets or variables
+    expect(
+      within(dialog).getByRole("button", {
+        name: /secrets or variables/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows connectors link in banner when missing connector-resolvable secrets", async () => {
+    server.use(
+      http.get("/api/agent/composes/list", () => {
+        return HttpResponse.json({
+          composes: [
+            {
+              name: "my-agent",
+              headVersionId: "v1",
+              updatedAt: "2024-06-15T10:00:00Z",
+            },
+          ],
+        });
+      }),
+      http.get("/api/agent/required-env", () => {
+        return HttpResponse.json({
+          agents: [
+            {
+              composeId: "c1",
+              agentName: "my-agent",
+              // GH_TOKEN is resolvable by the GitHub connector
+              requiredSecrets: ["GH_TOKEN"],
+              requiredVariables: [],
+            },
+          ],
+        });
+      }),
+      http.get("/api/secrets", () => {
+        return HttpResponse.json({ secrets: [] });
+      }),
+      http.get("/api/variables", () => {
+        return HttpResponse.json({ variables: [] });
+      }),
+      http.get("/api/connectors", () => {
+        return HttpResponse.json({ connectors: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/agents" });
+
+    // Wait for missing items to compute
+    await vi.waitFor(() => {
+      expect(
+        screen.getByText(/Missing \d+ environment variable/),
+      ).toBeInTheDocument();
+    });
+
+    // Open the agent dialog
+    await user.click(screen.getByText("my-agent"));
+
+    const dialog = await screen.findByRole("dialog");
+
+    // Should show the connectors link
+    expect(
+      within(dialog).getByRole("button", { name: /connectors/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show missing env count when all items are provided", async () => {
+    server.use(
+      http.get("/api/agent/composes/list", () => {
+        return HttpResponse.json({
+          composes: [
+            {
+              name: "my-agent",
+              headVersionId: "v1",
+              updatedAt: "2024-06-15T10:00:00Z",
+            },
+          ],
+        });
+      }),
+      http.get("/api/agent/required-env", () => {
+        return HttpResponse.json({
+          agents: [
+            {
+              composeId: "c1",
+              agentName: "my-agent",
+              requiredSecrets: ["API_KEY"],
+              requiredVariables: ["MY_VAR"],
+            },
+          ],
+        });
+      }),
+      http.get("/api/secrets", () => {
+        return HttpResponse.json({
+          secrets: [
+            {
+              id: "s1",
+              name: "API_KEY",
+              type: "user",
+              description: null,
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+          ],
+        });
+      }),
+      http.get("/api/variables", () => {
+        return HttpResponse.json({
+          variables: [
+            {
+              id: "v1",
+              name: "MY_VAR",
+              value: "val",
+              description: null,
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+          ],
+        });
+      }),
+      http.get("/api/connectors", () => {
+        return HttpResponse.json({ connectors: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/agents" });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("my-agent")).toBeInTheDocument();
+    });
+
+    // Give time for async missing items to resolve, then verify no warning
+    // Wait a tick for any pending updates
+    await vi.waitFor(() => {
+      expect(
+        screen.queryByText(/Missing \d+ environment variable/),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
@@ -1,5 +1,6 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import { IconSearch, IconLoader2 } from "@tabler/icons-react";
+import MarkdownPreview from "@uiw/react-markdown-preview";
 import { Input } from "@vm0/ui";
 import { StatusDot } from "../../components/status-dot.tsx";
 import {
@@ -256,9 +257,18 @@ function PromptCard({
           </div>
         </summary>
         <div className="absolute left-[2px] top-[2.25rem] bottom-0 w-[1px] bg-border/70 group-open:block hidden" />
-        <p className="ml-[18px] mt-2 text-sm text-foreground whitespace-pre-wrap break-words">
-          {prompt}
-        </p>
+        <div className="ml-[18px] mt-2">
+          <MarkdownPreview
+            source={prompt}
+            className="!bg-transparent !text-foreground text-sm"
+            style={{
+              backgroundColor: "transparent",
+              fontSize: "0.875rem",
+              lineHeight: "1.5",
+              fontFamily: "var(--font-family-sans)",
+            }}
+          />
+        </div>
       </details>
     </div>
   );

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -268,6 +268,9 @@ async function formatFileInfoWithImage(
     );
     if (presignedUrl) {
       parts.push(`   Image URL: ${presignedUrl}`);
+      parts.push(
+        `   To view this image, download it with: curl -sS -o /tmp/${file.id || "image"}.${file.filetype || "png"} "${presignedUrl}" && read the downloaded file`,
+      );
       return parts.join("\n");
     }
   }
@@ -303,6 +306,9 @@ function formatAttachmentImage(attachment: SlackAttachment): string | null {
   const url = attachment.image_url || attachment.thumb_url;
   if (url) {
     parts.push(`   URL: ${url}`);
+    parts.push(
+      `   To view this image, download it with: curl -sS -o /tmp/attachment_image.jpg "${url}" && read the downloaded file`,
+    );
   }
 
   return parts.join("\n");


### PR DESCRIPTION
## Summary
- **Markdown prompt rendering**: Replace plain-text `<p>` with `@uiw/react-markdown-preview` in the agent events card so prompts with formatting (headers, lists, code blocks) render properly.
- **Slack image download hints**: Add `curl` download instructions alongside image URLs in Slack context formatting, so agents can actually retrieve and view shared images.
- **Secrets & variables signal tests**: Add 8 integration tests for `mergedItems$` covering configured items, missing placeholders, connector-resolvable secrets, deduplication, and agent-required flags.
- **Agents page UI tests**: Add 8 integration tests for the agents page covering table rendering, empty/error states, missing env variable counts, dialog banners with secrets/variables and connectors links.

## Test plan
- [x] All 16 new tests pass (`pnpm vitest run` on the specific files)
- [x] All 37 platform test files pass (370 tests total)
- [x] Lint passes across all packages
- [x] TypeScript type-check passes
- [x] Knip reports no unused code issues
- [x] Prettier formatting is clean
- [x] All lefthook pre-commit hooks pass (check-file-size, prettier, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)