### PR TITLE
chore: remove .docker from workspace folders

### DIFF
--- a/vm0.code-workspace
+++ b/vm0.code-workspace
@@ -22,9 +22,6 @@
       "path": ".devcontainer"
     },
     {
-      "path": ".docker"
-    },
-    {
       "path": "scripts"
     },
     {


### PR DESCRIPTION
## Summary

- Remove `.docker` folder from `vm0.code-workspace` as it no longer exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)