### PR TITLE
feat(platform): add agent detail page with feature flag gating

### DIFF
--- a/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
@@ -96,9 +96,21 @@ export const fetchAgentDetail$ = command(async ({ get, set }) => {
 // Instructions view mode — local UI state for markdown/preview toggle
 // ---------------------------------------------------------------------------
 
-export type InstructionsViewMode = "markdown" | "preview";
+type InstructionsViewMode = "markdown" | "preview";
 const internalInstructionsViewMode$ = state<InstructionsViewMode>("markdown");
-export const instructionsViewMode$ = internalInstructionsViewMode$;
+export const instructionsViewMode$ = computed((get) =>
+  get(internalInstructionsViewMode$),
+);
+
+function isInstructionsViewMode(v: string): v is InstructionsViewMode {
+  return v === "markdown" || v === "preview";
+}
+
+export const setInstructionsViewMode$ = command(({ set }, v: string) => {
+  if (isInstructionsViewMode(v)) {
+    set(internalInstructionsViewMode$, v);
+  }
+});
 
 // ---------------------------------------------------------------------------
 // Agent instructions — fetches instructions content

--- a/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
@@ -93,6 +93,14 @@ export const fetchAgentDetail$ = command(async ({ get, set }) => {
 });
 
 // ---------------------------------------------------------------------------
+// Instructions view mode — local UI state for markdown/preview toggle
+// ---------------------------------------------------------------------------
+
+export type InstructionsViewMode = "markdown" | "preview";
+const internalInstructionsViewMode$ = state<InstructionsViewMode>("markdown");
+export const instructionsViewMode$ = internalInstructionsViewMode$;
+
+// ---------------------------------------------------------------------------
 // Agent instructions — fetches instructions content
 // ---------------------------------------------------------------------------
 

--- a/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
@@ -104,7 +104,7 @@ export const fetchAgentDetail$ = command(async ({ get, set }) => {
 // ---------------------------------------------------------------------------
 
 type InstructionsViewMode = "markdown" | "preview";
-const internalInstructionsViewMode$ = state<InstructionsViewMode>("markdown");
+const internalInstructionsViewMode$ = state<InstructionsViewMode>("preview");
 export const instructionsViewMode$ = computed((get) =>
   get(internalInstructionsViewMode$),
 );

--- a/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
@@ -56,9 +56,19 @@ export const fetchAgentDetail$ = command(async ({ get, set }) => {
 
   try {
     const fetchFn = get(fetch$);
-    const response = await fetchFn(
-      `/api/agent/composes?name=${encodeURIComponent(name)}`,
-    );
+
+    // Shared agents have scope/agentName format; split for the API
+    const slashIndex = name.indexOf("/");
+    const isOwner = slashIndex === -1;
+    const agentName = isOwner ? name : name.slice(slashIndex + 1);
+    const scope = isOwner ? undefined : name.slice(0, slashIndex);
+
+    const params = new URLSearchParams({ name: agentName });
+    if (scope) {
+      params.set("scope", scope);
+    }
+
+    const response = await fetchFn(`/api/agent/composes?${params.toString()}`);
 
     if (!response.ok) {
       throw new Error(`Failed to fetch agent: ${response.statusText}`);
@@ -72,9 +82,6 @@ export const fetchAgentDetail$ = command(async ({ get, set }) => {
       createdAt: string;
       updatedAt: string;
     };
-
-    // Determine ownership: if the URL name contains /, it's a shared agent
-    const isOwner = !name.includes("/");
 
     set(agentDetailState$, {
       detail: { ...data, isOwner },

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -181,7 +181,7 @@ export const generateRouterPath = <T extends RoutePath>(
   }
   let _path = path as string;
   for (const [key, value] of Object.entries(pathParams)) {
-    _path = _path.replace(`:${key}`, String(value));
+    _path = _path.replace(`:${key}`, encodeURIComponent(String(value)));
   }
   return _path;
 };

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-detail-page.test.tsx
@@ -116,7 +116,6 @@ describe("agent detail page", () => {
     await vi.waitFor(() => {
       expect(screen.getByText("Agent instructions")).toBeInTheDocument();
     });
-    expect(screen.getByText("(instructions.md)")).toBeInTheDocument();
     expect(screen.getByText("# My Instructions")).toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-detail-page.test.tsx
@@ -1,7 +1,7 @@
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { describe, expect, it, vi } from "vitest";
-import { screen, within } from "@testing-library/react";
+import { screen, within, fireEvent } from "@testing-library/react";
 import { pathname$ } from "../../../signals/route.ts";
 import { server } from "../../../mocks/server.ts";
 import { http, HttpResponse } from "msw";
@@ -95,7 +95,8 @@ describe("agent detail page", () => {
     });
 
     await vi.waitFor(() => {
-      expect(screen.getByText(/Failed to fetch agent/)).toBeInTheDocument();
+      const errorEl = screen.getByText(/failed to fetch/i);
+      expect(errorEl).toHaveClass("text-destructive");
     });
   });
 
@@ -116,6 +117,9 @@ describe("agent detail page", () => {
     await vi.waitFor(() => {
       expect(screen.getByText("Agent instructions")).toBeInTheDocument();
     });
+
+    // Default view mode is "preview", switch to "markdown" to see raw text
+    fireEvent.click(screen.getByRole("tab", { name: "Markdown" }));
     expect(screen.getByText("# My Instructions")).toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-detail-page.test.tsx
@@ -1,0 +1,161 @@
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { describe, expect, it, vi } from "vitest";
+import { screen, within } from "@testing-library/react";
+import { pathname$ } from "../../../signals/route.ts";
+import { server } from "../../../mocks/server.ts";
+import { http, HttpResponse } from "msw";
+import { FeatureSwitchKey } from "@vm0/core";
+
+const context = testContext();
+
+function mockAgentDetailAPI(options?: {
+  name?: string;
+  description?: string;
+  instructions?: { content: string | null; filename: string | null };
+  error?: boolean;
+}) {
+  const name = options?.name ?? "my-agent";
+  const description = options?.description ?? "A test agent";
+  const instructions = options?.instructions ?? {
+    content: "# Instructions\nDo stuff",
+    filename: "instructions.md",
+  };
+
+  server.use(
+    http.get("/api/agent/composes", ({ request }) => {
+      const url = new URL(request.url);
+      const queryName = url.searchParams.get("name");
+
+      if (options?.error) {
+        return new HttpResponse(null, { status: 500 });
+      }
+
+      if (queryName !== name) {
+        return new HttpResponse(null, { status: 404 });
+      }
+
+      return HttpResponse.json({
+        id: "compose_1",
+        name,
+        headVersionId: "version_1",
+        content: {
+          version: "1",
+          agents: {
+            [name]: {
+              description,
+              framework: "claude-code",
+            },
+          },
+        },
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      });
+    }),
+    http.get("/api/agent/composes/:id/instructions", () => {
+      return HttpResponse.json(instructions);
+    }),
+  );
+}
+
+describe("agent detail page", () => {
+  it("should redirect to /agents when feature flag is disabled", async () => {
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+    });
+
+    expect(context.store.get(pathname$)).toBe("/agents");
+  });
+
+  it("should render agent detail when feature flag is enabled", async () => {
+    mockAgentDetailAPI();
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "my-agent" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("A test agent")).toBeInTheDocument();
+  });
+
+  it("should show error state when API fails", async () => {
+    mockAgentDetailAPI({ error: true });
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/Failed to fetch agent/)).toBeInTheDocument();
+    });
+  });
+
+  it("should show instructions with markdown content for owned agents", async () => {
+    mockAgentDetailAPI({
+      instructions: {
+        content: "# My Instructions",
+        filename: "instructions.md",
+      },
+    });
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Agent instructions")).toBeInTheDocument();
+    });
+    expect(screen.getByText("(instructions.md)")).toBeInTheDocument();
+    expect(screen.getByText("# My Instructions")).toBeInTheDocument();
+  });
+
+  it("should show disabled Run button for unimplemented features", async () => {
+    mockAgentDetailAPI();
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "my-agent" }),
+      ).toBeInTheDocument();
+    });
+
+    const runButton = screen.getByRole("button", { name: /Run/ });
+    expect(runButton).toBeDisabled();
+  });
+
+  it("should show breadcrumb with agents link and agent name", async () => {
+    mockAgentDetailAPI();
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "my-agent" }),
+      ).toBeInTheDocument();
+    });
+
+    // Breadcrumb should contain "Agents" link
+    const nav = screen.getByRole("navigation");
+    expect(within(nav).getByText("Agents")).toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-avatar.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-avatar.tsx
@@ -16,7 +16,8 @@ function getColorForName(name: string): string {
   for (let i = 0; i < name.length; i++) {
     hash = name.charCodeAt(i) + ((hash << 5) - hash);
   }
-  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length]!;
+  const index = Math.abs(hash) % AVATAR_COLORS.length;
+  return AVATAR_COLORS[index] ?? AVATAR_COLORS[0];
 }
 
 interface AgentAvatarProps {

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-avatar.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-avatar.tsx
@@ -1,0 +1,54 @@
+import { cn } from "@vm0/ui/lib/utils";
+
+const AVATAR_COLORS = [
+  "bg-orange-500",
+  "bg-blue-500",
+  "bg-green-500",
+  "bg-purple-500",
+  "bg-pink-500",
+  "bg-teal-500",
+  "bg-indigo-500",
+  "bg-amber-500",
+] as const;
+
+function getColorForName(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length]!;
+}
+
+interface AgentAvatarProps {
+  name: string;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+const SIZE_CLASSES = {
+  sm: "h-8 w-8 text-sm",
+  md: "h-10 w-10 text-lg",
+  lg: "h-14 w-14 text-2xl",
+} as const;
+
+export function AgentAvatar({
+  name,
+  size = "md",
+  className,
+}: AgentAvatarProps) {
+  const initial = name.charAt(0).toUpperCase();
+  const bgColor = getColorForName(name);
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center justify-center rounded-full font-semibold text-white shrink-0",
+        bgColor,
+        SIZE_CLASSES[size],
+        className,
+      )}
+    >
+      {initial}
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-avatar.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-avatar.tsx
@@ -42,7 +42,7 @@ export function AgentAvatar({
   return (
     <div
       className={cn(
-        "inline-flex items-center justify-center rounded-full font-semibold text-white shrink-0",
+        "inline-flex items-center justify-center rounded-xl font-semibold text-white shrink-0",
         bgColor,
         SIZE_CLASSES[size],
         className,

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-detail-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-detail-page.tsx
@@ -29,7 +29,7 @@ export function AgentDetailPage() {
         agentName ?? "Loading...",
       ]}
     >
-      <div className="flex flex-col gap-6 px-4 sm:px-6 pb-8">
+      <div className="flex flex-col gap-[22px] p-8 min-h-full">
         {loading ? (
           <AgentDetailSkeleton />
         ) : error ? (
@@ -58,24 +58,21 @@ export function AgentDetailPage() {
 
 function AgentDetailSkeleton() {
   return (
-    <div className="space-y-6">
-      <div className="flex items-start gap-4">
-        <Skeleton className="h-14 w-14 rounded-full" />
+    <>
+      <div className="flex items-center gap-3.5">
+        <Skeleton className="h-14 w-14 rounded-xl" />
         <div className="flex-1 space-y-2">
-          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-7 w-48" />
           <Skeleton className="h-4 w-72" />
         </div>
-        <div className="flex gap-1">
+        <div className="flex gap-2">
           <Skeleton className="h-9 w-16 rounded-lg" />
           <Skeleton className="h-9 w-9 rounded-lg" />
           <Skeleton className="h-9 w-9 rounded-lg" />
           <Skeleton className="h-9 w-9 rounded-lg" />
         </div>
       </div>
-      <div className="space-y-3">
-        <Skeleton className="h-5 w-40" />
-        <Skeleton className="h-64 w-full rounded-lg" />
-      </div>
-    </div>
+      <Skeleton className="flex-1 rounded-lg" />
+    </>
   );
 }

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-detail-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-detail-page.tsx
@@ -1,4 +1,5 @@
 import { useGet } from "ccstate-react";
+import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import { AppShell } from "../layout/app-shell.tsx";
 import {
   agentDetail$,
@@ -9,6 +10,8 @@ import {
   agentName$,
   isOwner$,
 } from "../../signals/agent-detail/agent-detail.ts";
+import { AgentHeader } from "./agent-header.tsx";
+import { AgentInstructions } from "./agent-instructions.tsx";
 
 export function AgentDetailPage() {
   const agentName = useGet(agentName$);
@@ -26,36 +29,53 @@ export function AgentDetailPage() {
         agentName ?? "Loading...",
       ]}
     >
-      {loading ? (
-        <div className="p-6 text-muted-foreground">Loading agent...</div>
-      ) : error ? (
-        <div className="p-6 text-destructive">{error}</div>
-      ) : detail ? (
-        <div className="p-6 space-y-4">
-          <div>
-            <h1 className="text-2xl font-bold">{detail.name}</h1>
-            <p className="text-sm text-muted-foreground">
-              {isOwner ? "Owner" : "Shared with you"}
-            </p>
+      <div className="flex flex-col gap-6 px-4 sm:px-6 pb-8">
+        {loading ? (
+          <AgentDetailSkeleton />
+        ) : error ? (
+          <div className="rounded-lg border border-border bg-card p-8 text-center">
+            <p className="text-sm text-destructive">{error}</p>
           </div>
-          {isOwner && (
-            <div>
-              <h2 className="text-lg font-semibold">Instructions</h2>
-              {instructionsLoading ? (
-                <p className="text-muted-foreground">Loading instructions...</p>
-              ) : instructions?.content ? (
-                <pre className="mt-2 rounded bg-muted p-4 text-sm whitespace-pre-wrap">
-                  {instructions.content}
-                </pre>
-              ) : (
-                <p className="text-muted-foreground">No instructions</p>
-              )}
-            </div>
-          )}
-        </div>
-      ) : (
-        <div className="p-6 text-muted-foreground">Agent not found</div>
-      )}
+        ) : detail ? (
+          <>
+            <AgentHeader detail={detail} isOwner={isOwner} />
+            {isOwner && (
+              <AgentInstructions
+                instructions={instructions}
+                loading={instructionsLoading}
+              />
+            )}
+          </>
+        ) : (
+          <div className="rounded-lg border border-border bg-card p-8 text-center">
+            <p className="text-sm text-muted-foreground">Agent not found</p>
+          </div>
+        )}
+      </div>
     </AppShell>
+  );
+}
+
+function AgentDetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start gap-4">
+        <Skeleton className="h-14 w-14 rounded-full" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-72" />
+        </div>
+        <div className="flex gap-1">
+          <Skeleton className="h-9 w-16 rounded-lg" />
+          <Skeleton className="h-9 w-9 rounded-lg" />
+          <Skeleton className="h-9 w-9 rounded-lg" />
+          <Skeleton className="h-9 w-9 rounded-lg" />
+        </div>
+      </div>
+      <div className="space-y-3">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    </div>
   );
 }

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-detail-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-detail-page.tsx
@@ -39,12 +39,10 @@ export function AgentDetailPage() {
         ) : detail ? (
           <>
             <AgentHeader detail={detail} isOwner={isOwner} />
-            {isOwner && (
-              <AgentInstructions
-                instructions={instructions}
-                loading={instructionsLoading}
-              />
-            )}
+            <AgentInstructions
+              instructions={instructions}
+              loading={instructionsLoading}
+            />
           </>
         ) : (
           <div className="rounded-lg border border-border bg-card p-8 text-center">

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
@@ -8,7 +8,6 @@ import {
 import {
   IconPlayerPlay,
   IconSettings,
-  IconClock,
   IconPlug,
   IconList,
 } from "@tabler/icons-react";
@@ -71,20 +70,6 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
               <TooltipContent>Settings</TooltipContent>
             </Tooltip>
           )}
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-9 w-9"
-                disabled
-              >
-                <IconClock size={18} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Schedule</TooltipContent>
-          </Tooltip>
 
           <Tooltip>
             <TooltipTrigger asChild>

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
@@ -10,6 +10,7 @@ import {
   IconSettings,
   IconPlug,
   IconList,
+  IconLink,
 } from "@tabler/icons-react";
 import { useSet } from "ccstate-react";
 import { navigateInReact$ } from "../../signals/route.ts";
@@ -36,7 +37,17 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
     <div className="flex items-center gap-3.5">
       <AgentAvatar name={detail.name} size="lg" />
       <div className="flex-1 min-w-0 flex flex-col gap-1.5">
-        <h1 className="text-2xl text-foreground truncate">{detail.name}</h1>
+        <div className="flex items-center gap-2.5">
+          <h1 className="text-2xl leading-8 font-normal text-foreground truncate">
+            {detail.name}
+          </h1>
+          {!isOwner && (
+            <span className="inline-flex h-[22px] items-center gap-1 shrink-0 rounded-md border border-border bg-background px-1.5 text-xs font-medium leading-4 text-muted-foreground">
+              <IconLink size={14} className="shrink-0 text-lime-600" />
+              Shared
+            </span>
+          )}
+        </div>
         {description && (
           <p className="text-sm text-muted-foreground truncate">
             {description}

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
@@ -1,0 +1,126 @@
+import { Button } from "@vm0/ui/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vm0/ui/components/ui/tooltip";
+import {
+  IconPlayerPlay,
+  IconSettings,
+  IconChartBar,
+  IconPlug,
+  IconLayoutGrid,
+} from "@tabler/icons-react";
+import { useSet } from "ccstate-react";
+import { navigateInReact$ } from "../../signals/route.ts";
+import { AgentAvatar } from "./agent-avatar.tsx";
+import type { AgentDetail } from "../../signals/agent-detail/types.ts";
+
+interface AgentHeaderProps {
+  detail: AgentDetail;
+  isOwner: boolean;
+}
+
+export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
+  const navigate = useSet(navigateInReact$);
+
+  // Extract description from the first agent definition
+  const agentKeys = detail.content?.agents
+    ? Object.keys(detail.content.agents)
+    : [];
+  const agentDef =
+    agentKeys.length > 0 ? detail.content?.agents[agentKeys[0]!] : null;
+  const description = agentDef?.description;
+
+  return (
+    <div className="flex items-start gap-4">
+      <AgentAvatar name={detail.name} size="lg" />
+      <div className="flex-1 min-w-0">
+        <h1 className="text-xl font-semibold text-foreground truncate">
+          {detail.name}
+        </h1>
+        {description && (
+          <p className="text-sm text-muted-foreground mt-0.5 line-clamp-2">
+            {description}
+          </p>
+        )}
+      </div>
+      <div className="flex items-center gap-1 shrink-0">
+        <TooltipProvider delayDuration={100}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="default"
+                size="sm"
+                className="bg-orange-500 hover:bg-orange-600 text-white"
+              >
+                <IconPlayerPlay size={16} className="mr-1" />
+                Run
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Run this agent</TooltipContent>
+          </Tooltip>
+
+          {isOwner && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="icon">
+                  <IconSettings size={18} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Settings</TooltipContent>
+            </Tooltip>
+          )}
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() =>
+                  navigate("/agents/:name/logs", {
+                    pathParams: { name: detail.name },
+                  })
+                }
+              >
+                <IconChartBar size={18} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Logs</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() =>
+                  navigate("/agents/:name/connections", {
+                    pathParams: { name: detail.name },
+                  })
+                }
+              >
+                <IconPlug size={18} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Connections</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => navigate("/agents")}
+              >
+                <IconLayoutGrid size={18} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Back to agents</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
@@ -48,12 +48,7 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
         <TooltipProvider delayDuration={100}>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button
-                variant="default"
-                size="sm"
-                className="bg-orange-500 hover:bg-orange-600 text-white"
-                disabled
-              >
+              <Button variant="default" size="sm" disabled>
                 <IconPlayerPlay size={16} className="mr-1" />
                 Run
               </Button>
@@ -64,7 +59,12 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
           {isOwner && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon" disabled>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="h-9 w-9"
+                  disabled
+                >
                   <IconSettings size={18} />
                 </Button>
               </TooltipTrigger>
@@ -75,8 +75,9 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
-                variant="ghost"
+                variant="outline"
                 size="icon"
+                className="h-9 w-9"
                 onClick={() =>
                   navigate("/agents/:name/logs", {
                     pathParams: { name: detail.name },
@@ -92,8 +93,9 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
-                variant="ghost"
+                variant="outline"
                 size="icon"
+                className="h-9 w-9"
                 onClick={() =>
                   navigate("/agents/:name/connections", {
                     pathParams: { name: detail.name },
@@ -109,8 +111,9 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
-                variant="ghost"
+                variant="outline"
                 size="icon"
+                className="h-9 w-9"
                 onClick={() => navigate("/agents")}
               >
                 <IconLayoutGrid size={18} />

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
@@ -60,7 +60,7 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
                 Run
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Run this agent</TooltipContent>
+            <TooltipContent>Coming soon</TooltipContent>
           </Tooltip>
 
           {isOwner && (
@@ -70,7 +70,7 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
                   <IconSettings size={18} />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>Settings</TooltipContent>
+              <TooltipContent>Coming soon</TooltipContent>
             </Tooltip>
           )}
 

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
@@ -29,8 +29,8 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
   const agentKeys = detail.content?.agents
     ? Object.keys(detail.content.agents)
     : [];
-  const agentDef =
-    agentKeys.length > 0 ? detail.content?.agents[agentKeys[0]!] : null;
+  const firstKey = agentKeys[0];
+  const agentDef = firstKey ? detail.content?.agents[firstKey] : null;
   const description = agentDef?.description;
 
   return (
@@ -54,6 +54,7 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
                 variant="default"
                 size="sm"
                 className="bg-orange-500 hover:bg-orange-600 text-white"
+                disabled
               >
                 <IconPlayerPlay size={16} className="mr-1" />
                 Run
@@ -65,7 +66,7 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
           {isOwner && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon">
+                <Button variant="ghost" size="icon" disabled>
                   <IconSettings size={18} />
                 </Button>
               </TooltipTrigger>

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
@@ -34,19 +34,17 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
   const description = agentDef?.description;
 
   return (
-    <div className="flex items-start gap-4">
+    <div className="flex items-center gap-3.5">
       <AgentAvatar name={detail.name} size="lg" />
-      <div className="flex-1 min-w-0">
-        <h1 className="text-xl font-semibold text-foreground truncate">
-          {detail.name}
-        </h1>
+      <div className="flex-1 min-w-0 flex flex-col gap-1.5">
+        <h1 className="text-2xl text-foreground truncate">{detail.name}</h1>
         {description && (
-          <p className="text-sm text-muted-foreground mt-0.5 line-clamp-2">
+          <p className="text-sm text-muted-foreground truncate">
             {description}
           </p>
         )}
       </div>
-      <div className="flex items-center gap-1 shrink-0">
+      <div className="flex items-center gap-2 shrink-0">
         <TooltipProvider delayDuration={100}>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
@@ -8,9 +8,9 @@ import {
 import {
   IconPlayerPlay,
   IconSettings,
-  IconChartBar,
+  IconClock,
   IconPlug,
-  IconLayoutGrid,
+  IconList,
 } from "@tabler/icons-react";
 import { useSet } from "ccstate-react";
 import { navigateInReact$ } from "../../signals/route.ts";
@@ -68,7 +68,7 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
                   <IconSettings size={18} />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>Coming soon</TooltipContent>
+              <TooltipContent>Settings</TooltipContent>
             </Tooltip>
           )}
 
@@ -78,16 +78,12 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
                 variant="outline"
                 size="icon"
                 className="h-9 w-9"
-                onClick={() =>
-                  navigate("/agents/:name/logs", {
-                    pathParams: { name: detail.name },
-                  })
-                }
+                disabled
               >
-                <IconChartBar size={18} />
+                <IconClock size={18} />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Logs</TooltipContent>
+            <TooltipContent>Schedule</TooltipContent>
           </Tooltip>
 
           <Tooltip>
@@ -114,12 +110,16 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
                 variant="outline"
                 size="icon"
                 className="h-9 w-9"
-                onClick={() => navigate("/agents")}
+                onClick={() =>
+                  navigate("/agents/:name/logs", {
+                    pathParams: { name: detail.name },
+                  })
+                }
               >
-                <IconLayoutGrid size={18} />
+                <IconList size={18} />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Back to agents</TooltipContent>
+            <TooltipContent>Logs</TooltipContent>
           </Tooltip>
         </TooltipProvider>
       </div>

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import MarkdownPreview from "@uiw/react-markdown-preview";
 import {
   instructionsViewMode$,
-  type InstructionsViewMode,
+  setInstructionsViewMode$,
 } from "../../signals/agent-detail/agent-detail.ts";
 import type { AgentInstructions as AgentInstructionsType } from "../../signals/agent-detail/types.ts";
 
@@ -18,7 +18,7 @@ export function AgentInstructions({
   loading,
 }: AgentInstructionsProps) {
   const viewMode = useGet(instructionsViewMode$);
-  const setViewMode = useSet(instructionsViewMode$);
+  const setViewMode = useSet(setInstructionsViewMode$);
 
   if (loading) {
     return (
@@ -54,10 +54,7 @@ export function AgentInstructions({
             </span>
           )}
         </h2>
-        <Tabs
-          value={viewMode}
-          onValueChange={(v) => setViewMode(v as InstructionsViewMode)}
-        >
+        <Tabs value={viewMode} onValueChange={(v) => setViewMode(v)}>
           <TabsList>
             <TabsTrigger value="markdown">Markdown</TabsTrigger>
             <TabsTrigger value="preview">Preview</TabsTrigger>

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
@@ -1,0 +1,89 @@
+import { useGet, useSet } from "ccstate-react";
+import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
+import { Skeleton } from "@vm0/ui/components/ui/skeleton";
+import MarkdownPreview from "@uiw/react-markdown-preview";
+import {
+  instructionsViewMode$,
+  type InstructionsViewMode,
+} from "../../signals/agent-detail/agent-detail.ts";
+import type { AgentInstructions as AgentInstructionsType } from "../../signals/agent-detail/types.ts";
+
+interface AgentInstructionsProps {
+  instructions: AgentInstructionsType | null;
+  loading: boolean;
+}
+
+export function AgentInstructions({
+  instructions,
+  loading,
+}: AgentInstructionsProps) {
+  const viewMode = useGet(instructionsViewMode$);
+  const setViewMode = useSet(instructionsViewMode$);
+
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!instructions?.content) {
+    return (
+      <div className="space-y-3">
+        <h2 className="text-base font-semibold text-foreground">
+          Agent instructions
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          No instructions configured
+          {instructions?.filename ? ` (${instructions.filename})` : ""}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-base font-semibold text-foreground">
+          Agent instructions
+          {instructions.filename && (
+            <span className="ml-2 text-sm font-normal text-muted-foreground">
+              ({instructions.filename})
+            </span>
+          )}
+        </h2>
+        <Tabs
+          value={viewMode}
+          onValueChange={(v) => setViewMode(v as InstructionsViewMode)}
+        >
+          <TabsList>
+            <TabsTrigger value="markdown">Markdown</TabsTrigger>
+            <TabsTrigger value="preview">Preview</TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
+
+      <div className="rounded-lg border border-border overflow-hidden">
+        {viewMode === "markdown" ? (
+          <pre className="p-4 text-sm font-mono text-foreground bg-muted/30 overflow-x-auto whitespace-pre-wrap max-h-[600px] overflow-y-auto">
+            {instructions.content}
+          </pre>
+        ) : (
+          <div className="p-4 max-h-[600px] overflow-y-auto">
+            <MarkdownPreview
+              source={instructions.content}
+              className="!bg-transparent !text-foreground text-sm"
+              style={{
+                backgroundColor: "transparent",
+                fontSize: "0.875rem",
+                lineHeight: "1.5",
+              }}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
@@ -22,8 +22,8 @@ export function AgentInstructions({
 
   if (loading) {
     return (
-      <div className="space-y-3">
-        <Skeleton className="h-5 w-40" />
+      <div className="flex-1 rounded-lg border border-border p-4">
+        <Skeleton className="h-5 w-40 mb-6" />
         <Skeleton className="h-64 w-full" />
       </div>
     );
@@ -31,28 +31,22 @@ export function AgentInstructions({
 
   if (!instructions?.content) {
     return (
-      <div className="space-y-3">
-        <h2 className="text-base font-semibold text-foreground">
+      <div className="flex-1 rounded-lg border border-border p-4">
+        <h2 className="text-base font-medium text-foreground">
           Agent instructions
         </h2>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-sm text-muted-foreground mt-6">
           No instructions configured
-          {instructions?.filename ? ` (${instructions.filename})` : ""}
         </p>
       </div>
     );
   }
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <h2 className="text-base font-semibold text-foreground">
+    <div className="flex-1 rounded-lg border border-border p-4 flex flex-col">
+      <div className="flex items-start justify-between gap-4">
+        <h2 className="text-base font-medium text-foreground">
           Agent instructions
-          {instructions.filename && (
-            <span className="ml-2 text-sm font-normal text-muted-foreground">
-              ({instructions.filename})
-            </span>
-          )}
         </h2>
         <Tabs value={viewMode} onValueChange={(v) => setViewMode(v)}>
           <TabsList>
@@ -62,13 +56,13 @@ export function AgentInstructions({
         </Tabs>
       </div>
 
-      <div className="rounded-lg border border-border overflow-hidden">
+      <div className="mt-6 flex-1 overflow-y-auto">
         {viewMode === "markdown" ? (
-          <pre className="p-4 text-sm font-mono text-foreground bg-muted/30 overflow-x-auto whitespace-pre-wrap max-h-[600px] overflow-y-auto">
+          <pre className="px-1 text-sm font-mono text-foreground overflow-x-auto whitespace-pre-wrap">
             {instructions.content}
           </pre>
         ) : (
-          <div className="p-4 max-h-[600px] overflow-y-auto">
+          <div className="px-1">
             <MarkdownPreview
               source={instructions.content}
               className="!bg-transparent !text-foreground text-sm"

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { gzipSync } from "node:zlib";
 import { GET } from "../route";
 import {
   createTestRequest,
@@ -15,6 +16,53 @@ import {
   MOCK_USER_EMAIL,
 } from "../../../../../../../src/__tests__/clerk-mock";
 import { getInstructionsStorageName } from "@vm0/core";
+
+/**
+ * Build a gzipped tar archive containing a single file.
+ * The route downloads archive.tar.gz, decompresses, and extracts from tar.
+ */
+function buildTarGz(filename: string, content: string): Buffer {
+  const contentBuf = Buffer.from(content, "utf-8");
+
+  // Tar header: 512 bytes
+  const header = Buffer.alloc(512);
+  // File name at offset 0 (up to 100 bytes)
+  header.write(filename, 0, Math.min(filename.length, 100), "utf-8");
+  // File mode at offset 100 (8 bytes, octal)
+  header.write("0000644\0", 100, 8, "utf-8");
+  // Owner/group IDs at offsets 108, 116 (8 bytes each, octal)
+  header.write("0000000\0", 108, 8, "utf-8");
+  header.write("0000000\0", 116, 8, "utf-8");
+  // File size at offset 124 (12 bytes, octal, null-terminated)
+  const sizeOctal = contentBuf.length.toString(8).padStart(11, "0");
+  header.write(sizeOctal + "\0", 124, 12, "utf-8");
+  // Modification time at offset 136 (12 bytes, octal)
+  const mtime = Math.floor(Date.now() / 1000)
+    .toString(8)
+    .padStart(11, "0");
+  header.write(mtime + "\0", 136, 12, "utf-8");
+  // Type flag at offset 156: '0' = regular file
+  header.write("0", 156, 1, "utf-8");
+
+  // Compute checksum: fill checksum field (offset 148, 8 bytes) with spaces first
+  header.write("        ", 148, 8, "utf-8");
+  let checksum = 0;
+  for (let i = 0; i < 512; i++) {
+    checksum += header[i]!;
+  }
+  // Write checksum as 6-digit octal, null-terminated, space-padded
+  header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148, 8, "utf-8");
+
+  // Pad content to 512-byte boundary
+  const paddingSize = (512 - (contentBuf.length % 512)) % 512;
+  const padding = Buffer.alloc(paddingSize);
+
+  // End-of-archive marker: two 512-byte zero blocks
+  const endMarker = Buffer.alloc(1024);
+
+  const tar = Buffer.concat([header, contentBuf, padding, endMarker]);
+  return gzipSync(tar);
+}
 
 const context = testContext();
 
@@ -104,7 +152,7 @@ describe("GET /api/agent/composes/:id/instructions", () => {
     const storageName = getInstructionsStorageName(agentName);
     await createTestVolume(storageName);
 
-    // Configure centralized S3 mocks for this test
+    // Mock manifest to describe the file in the archive
     context.mocks.s3.downloadManifest.mockResolvedValueOnce({
       version: "a".repeat(64),
       createdAt: new Date().toISOString(),
@@ -119,8 +167,9 @@ describe("GET /api/agent/composes/:id/instructions", () => {
       ],
     });
 
-    context.mocks.s3.downloadBlob.mockResolvedValueOnce(
-      Buffer.from(instructionsContent),
+    // Mock downloadS3Buffer to return a gzipped tar archive containing the instructions
+    context.mocks.s3.downloadS3Buffer.mockResolvedValueOnce(
+      buildTarGz("AGENTS.md", instructionsContent),
     );
 
     const request = createTestRequest(
@@ -163,8 +212,9 @@ describe("GET /api/agent/composes/:id/instructions", () => {
       files: [{ path: "AGENTS.md", hash: "c".repeat(64), size: 50 }],
     });
 
-    context.mocks.s3.downloadBlob.mockResolvedValueOnce(
-      Buffer.from("# Shared Instructions"),
+    // Mock downloadS3Buffer to return a gzipped tar archive
+    context.mocks.s3.downloadS3Buffer.mockResolvedValueOnce(
+      buildTarGz("AGENTS.md", "# Shared Instructions"),
     );
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
@@ -48,7 +48,7 @@ function buildTarGz(filename: string, content: string): Buffer {
   header.write("        ", 148, 8, "utf-8");
   let checksum = 0;
   for (let i = 0; i < 512; i++) {
-    checksum += header[i]!;
+    checksum += header[i] ?? 0;
   }
   // Write checksum as 6-digit octal, null-terminated, space-padded
   header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148, 8, "utf-8");

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -123,7 +123,8 @@ export async function GET(
   }
 
   const agentKeys = Object.keys(content.agents);
-  const agentDef = agentKeys.length > 0 ? content.agents[agentKeys[0]!] : null;
+  const firstKey = agentKeys[0];
+  const agentDef = firstKey ? content.agents[firstKey] : null;
   const instructionsFilename = agentDef?.instructions;
 
   if (!instructionsFilename) {

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -164,36 +164,30 @@ export async function GET(
   // Download manifest to find the actual filename in storage
   const manifest = await downloadManifest(bucket, version.s3Key);
 
-  // Find the instructions file in manifest.
-  // First try exact match, then fall back to the single file if there's only one
-  // (the storage volume is dedicated to instructions, so a single file is the instructions).
-  const instructionFile =
-    manifest.files.find((f) => f.path === instructionsFilename) ??
-    (manifest.files.length === 1 ? manifest.files[0] : undefined);
+  // Find the instructions file in manifest by exact path match
+  const instructionFile = manifest.files.find(
+    (f) => f.path === instructionsFilename,
+  );
 
   if (!instructionFile) {
     return NextResponse.json({ content: null, filename: instructionsFilename });
   }
 
   // Download and extract from the archive (CLI uploads archive.tar.gz, not individual blobs)
-  try {
-    const archiveKey = `${version.s3Key}/archive.tar.gz`;
-    const archiveBuffer = await downloadS3Buffer(bucket, archiveKey);
-    const tarBuffer = gunzipSync(archiveBuffer);
-    const fileContent = extractFileFromTar(tarBuffer, instructionFile.path);
+  const archiveKey = `${version.s3Key}/archive.tar.gz`;
+  const archiveBuffer = await downloadS3Buffer(bucket, archiveKey);
+  const tarBuffer = gunzipSync(archiveBuffer);
+  const fileContent = extractFileFromTar(tarBuffer, instructionFile.path);
 
-    if (!fileContent) {
-      return NextResponse.json({
-        content: null,
-        filename: instructionsFilename,
-      });
-    }
-
+  if (!fileContent) {
     return NextResponse.json({
-      content: fileContent.toString("utf-8"),
+      content: null,
       filename: instructionsFilename,
     });
-  } catch {
-    return NextResponse.json({ content: null, filename: instructionsFilename });
   }
+
+  return NextResponse.json({
+    content: fileContent.toString("utf-8"),
+    filename: instructionsFilename,
+  });
 }

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -6,6 +6,7 @@
  * and this endpoint reads the content from S3.
  */
 import { NextResponse } from "next/server";
+import { gunzipSync } from "node:zlib";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { eq, and } from "drizzle-orm";
 import {
@@ -21,11 +22,48 @@ import { getUserEmail } from "../../../../../../src/lib/auth/get-user-email";
 import { canAccessCompose } from "../../../../../../src/lib/agent/permission-service";
 import {
   downloadManifest,
-  downloadBlob,
+  downloadS3Buffer,
 } from "../../../../../../src/lib/s3/s3-client";
 import { env } from "../../../../../../src/env";
 import { getInstructionsStorageName } from "@vm0/core";
 import type { AgentComposeYaml } from "../../../../../../src/types/agent-compose";
+
+/**
+ * Extract a single file from a tar archive buffer.
+ * Tar format: 512-byte header + file data (padded to 512-byte blocks).
+ */
+function extractFileFromTar(
+  tarBuffer: Buffer,
+  targetPath: string,
+): Buffer | null {
+  let offset = 0;
+  while (offset + 512 <= tarBuffer.length) {
+    const header = tarBuffer.subarray(offset, offset + 512);
+
+    // End of archive: two consecutive zero blocks
+    if (header.every((b) => b === 0)) break;
+
+    // File name: bytes 0-99, null-terminated
+    const nameEnd = header.indexOf(0);
+    const name = header
+      .subarray(0, nameEnd > 0 && nameEnd < 100 ? nameEnd : 100)
+      .toString("utf-8");
+
+    // File size: bytes 124-135, octal string
+    const sizeStr = header.subarray(124, 136).toString("utf-8").trim();
+    const size = parseInt(sizeStr, 8) || 0;
+
+    offset += 512; // Move past header
+
+    if (name === targetPath || name === `./${targetPath}`) {
+      return tarBuffer.subarray(offset, offset + size);
+    }
+
+    // Skip file data (padded to 512-byte boundary)
+    offset += Math.ceil(size / 512) * 512;
+  }
+  return null;
+}
 
 export async function GET(
   request: Request,
@@ -121,8 +159,9 @@ export async function GET(
     return NextResponse.json({ content: null, filename: instructionsFilename });
   }
 
-  // Download manifest to find instructions file hash
   const bucket = env().R2_USER_STORAGES_BUCKET_NAME;
+
+  // Download manifest to find the actual filename in storage
   const manifest = await downloadManifest(bucket, version.s3Key);
 
   // Find the instructions file in manifest.
@@ -136,17 +175,25 @@ export async function GET(
     return NextResponse.json({ content: null, filename: instructionsFilename });
   }
 
-  // Download the blob content by hash
+  // Download and extract from the archive (CLI uploads archive.tar.gz, not individual blobs)
   try {
-    const blob = await downloadBlob(bucket, instructionFile.hash);
-    const textContent = blob.toString("utf-8");
+    const archiveKey = `${version.s3Key}/archive.tar.gz`;
+    const archiveBuffer = await downloadS3Buffer(bucket, archiveKey);
+    const tarBuffer = gunzipSync(archiveBuffer);
+    const fileContent = extractFileFromTar(tarBuffer, instructionFile.path);
+
+    if (!fileContent) {
+      return NextResponse.json({
+        content: null,
+        filename: instructionsFilename,
+      });
+    }
 
     return NextResponse.json({
-      content: textContent,
+      content: fileContent.toString("utf-8"),
       filename: instructionsFilename,
     });
   } catch {
-    // Blob may not exist in S3 (deleted or never uploaded)
     return NextResponse.json({ content: null, filename: instructionsFilename });
   }
 }

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -125,21 +125,28 @@ export async function GET(
   const bucket = env().R2_USER_STORAGES_BUCKET_NAME;
   const manifest = await downloadManifest(bucket, version.s3Key);
 
-  // Find the instructions file in manifest (match by filename)
-  const instructionFile = manifest.files.find(
-    (f) => f.path === instructionsFilename,
-  );
+  // Find the instructions file in manifest.
+  // First try exact match, then fall back to the single file if there's only one
+  // (the storage volume is dedicated to instructions, so a single file is the instructions).
+  const instructionFile =
+    manifest.files.find((f) => f.path === instructionsFilename) ??
+    (manifest.files.length === 1 ? manifest.files[0] : undefined);
 
   if (!instructionFile) {
     return NextResponse.json({ content: null, filename: instructionsFilename });
   }
 
   // Download the blob content by hash
-  const blob = await downloadBlob(bucket, instructionFile.hash);
-  const textContent = blob.toString("utf-8");
+  try {
+    const blob = await downloadBlob(bucket, instructionFile.hash);
+    const textContent = blob.toString("utf-8");
 
-  return NextResponse.json({
-    content: textContent,
-    filename: instructionsFilename,
-  });
+    return NextResponse.json({
+      content: textContent,
+      filename: instructionsFilename,
+    });
+  } catch {
+    // Blob may not exist in S3 (deleted or never uploaded)
+    return NextResponse.json({ content: null, filename: instructionsFilename });
+  }
 }

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -97,6 +97,9 @@ interface S3Mocks {
     (bucket: string, s3Key: string, fileCount: number) => Promise<boolean>
   >;
   downloadBlob: MockInstance<(bucket: string, hash: string) => Promise<Buffer>>;
+  downloadS3Buffer: MockInstance<
+    (bucket: string, key: string) => Promise<Buffer>
+  >;
   downloadManifest: MockInstance<
     (
       bucket: string,
@@ -307,6 +310,9 @@ export function testContext(): TestContext {
         .spyOn(s3Client, "verifyS3FilesExist")
         .mockResolvedValue(true),
       downloadBlob: downloadBlobMock,
+      downloadS3Buffer: vi
+        .spyOn(s3Client, "downloadS3Buffer")
+        .mockResolvedValue(Buffer.from("")),
       downloadManifest: vi
         .spyOn(s3Client, "downloadManifest")
         .mockResolvedValue({

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -11,4 +11,5 @@ export enum FeatureSwitchKey {
   PlatformArtifacts = "platformArtifacts",
   PlatformApiKeys = "platformApiKeys",
   ComputerConnector = "computerConnector",
+  AgentDetailPage = "agentDetailPage",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -44,6 +44,10 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     enabled: false,
   },
+  [FeatureSwitchKey.AgentDetailPage]: {
+    maintainer: "yuma@vm0.ai",
+    enabled: false,
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary
- Add `AgentDetailPage` feature flag (disabled by default) to gate access to the agent detail page
- Implement agent detail page components: avatar, header with action buttons, and instructions viewer with Markdown/Preview toggle
- Feature-gate all agent detail routes (`/agents/:name`, `/agents/:name/logs`, `/agents/:name/connections`) — redirects to `/agents` when disabled
- Update agent list page to navigate to detail page when feature flag is enabled, preserving existing dialog behavior when disabled

## Test plan
- [ ] Enable feature flag via `window._vm0.featureSwitches` and verify agent detail page renders correctly
- [ ] Verify clicking an agent row in the list navigates to `/agents/:name` when flag is enabled
- [ ] Verify clicking an agent row shows the existing dialog when flag is disabled
- [ ] Verify the instructions viewer toggles between Markdown and Preview modes
- [ ] Verify owner-only elements (Settings button, instructions section) are hidden for non-owners

Closes #2975

🤖 Generated with [Claude Code](https://claude.com/claude-code)