### PR TITLE
feat(web): add keyword detection for slack agent responses with deep links

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
@@ -12,9 +12,11 @@ import {
   createSlackClient,
   postMessage,
   buildAgentResponseMessage,
+  detectDeepLinks,
 } from "../../../../../src/lib/slack";
 import { getRunOutput } from "../../../../../src/lib/slack/handlers/run-agent";
 import { buildLogsUrl } from "../../../../../src/lib/slack/handlers/shared";
+import { getPlatformUrl } from "../../../../../src/lib/url";
 import { env } from "../../../../../src/env";
 import { logger } from "../../../../../src/lib/logger";
 
@@ -188,11 +190,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       : `Error: ${error ?? "Agent execution failed."}`;
 
   const logsUrl = buildLogsUrl(runId);
+  const deepLinks = detectDeepLinks(responseText, getPlatformUrl());
 
   // Post response to Slack
   await postMessage(client, channelId, responseText, {
     threadTs,
-    blocks: buildAgentResponseMessage(responseText, agentName, logsUrl),
+    blocks: buildAgentResponseMessage(
+      responseText,
+      agentName,
+      logsUrl,
+      deepLinks,
+    ),
   });
 
   // Get run to find userId for session lookup

--- a/turbo/apps/web/src/lib/slack/index.ts
+++ b/turbo/apps/web/src/lib/slack/index.ts
@@ -89,6 +89,7 @@ export {
   buildSuccessMessage,
   buildMarkdownMessage,
   buildAgentResponseMessage,
+  detectDeepLinks,
 } from "./blocks";
 
 // Thread context


### PR DESCRIPTION
## Summary

- Add `detectDeepLinks()` function that scans Slack agent response text for configuration-related keywords
- Extend `buildAgentResponseMessage()` to render matched deep links as context blocks
- Integrate detection in the Slack callback handler so links appear automatically in responses
- 4 keyword categories: model providers, secrets/variables, Slack settings, connectors

Closes #2995

## Test plan

- [x] 8 new tests for `detectDeepLinks` covering all keyword categories, case-insensitivity, deduplication, and multiple matches
- [x] Existing blocks tests pass (13 total)
- [x] Type check passes
- [x] Lint clean
- [x] Knip clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)