### PR TITLE
perf(sandbox-fc): include prewarm script in snapshot hash computation

### DIFF
--- a/crates/runner/src/snapshot.rs
+++ b/crates/runner/src/snapshot.rs
@@ -188,7 +188,7 @@ mod tests {
         // Changing this assertion means ALL existing cached snapshots are
         // invalidated.  Only update deliberately.
         assert_eq!(
-            hash, "3c68896dabe2536440cc57e8bf7d377c3f0935afd90ca68b189c6e37636fef19",
+            hash, "56c7e2d80112e9bbcaf6de63a8fbe90237f811bb3a144798dc47a633861b2c11",
             "snapshot hash changed — this invalidates all cached snapshots"
         );
     }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -11,8 +11,12 @@ use crate::overlay::{
 use crate::paths::{FactoryPaths, RuntimePaths, SandboxPaths, SockPaths};
 use crate::sandbox::FirecrackerSandbox;
 
+/// Shell command executed during snapshot creation to pre-warm guest caches.
+/// Changing this invalidates all cached snapshots (included in [`config_hash`]).
+pub const PREWARM_SCRIPT: &str = "su - user -c true";
+
 /// SHA-256 fingerprint of all sandbox-fc internal configuration that affects
-/// snapshot output (boot args, guest network, etc.).
+/// snapshot output (boot args, guest network, pre-warm script, etc.).
 ///
 /// This is the backing implementation for [`SandboxFactory::config_hash`].
 /// It is also available as a free function so callers that don't have a
@@ -29,6 +33,8 @@ pub fn config_hash() -> String {
     hasher.update(GUEST_NETWORK.guest_mac.as_bytes());
     hasher.update(b"tap_name:");
     hasher.update(GUEST_NETWORK.tap_name.as_bytes());
+    hasher.update(b"prewarm:");
+    hasher.update(PREWARM_SCRIPT.as_bytes());
     format!("{:x}", hasher.finalize())
 }
 

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -11,7 +11,7 @@ mod sandbox;
 mod snapshot;
 
 pub use config::{FirecrackerConfig, SnapshotConfig};
-pub use factory::{FirecrackerFactory, config_hash};
+pub use factory::{FirecrackerFactory, PREWARM_SCRIPT, config_hash};
 pub use paths::{
     FactoryPaths, LockPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths,
 };

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -286,7 +286,10 @@ async fn run_with_firecracker(
 
     // 9.5. Pre-warm PAM/nsswitch caches so post-restore `su` calls are fast.
     //      The snapshot captures memory state, so caches populated here persist.
-    match guest.exec("su - user -c true", 5000, &[], false).await {
+    match guest
+        .exec(crate::factory::PREWARM_SCRIPT, 5000, &[], false)
+        .await
+    {
         Ok(result) => info!(exit_code = result.exit_code, "pre-warm: su cache"),
         Err(e) => tracing::warn!(error = %e, "pre-warm: su cache failed (non-fatal)"),
     }


### PR DESCRIPTION
## Summary
- Extract pre-warm command to `PREWARM_SCRIPT` constant in `sandbox-fc`
- Include it in `config_hash()` so changing pre-warm commands automatically invalidates cached snapshots
- No manual snapshot deletion or version bumping needed

Closes #3002

## Test plan
- [x] `snapshot_hash_is_stable` test updated with new hash value
- [x] Clippy + all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)