### PR TITLE
refactor: decompose complex functions to remove eslint-disable comments

### DIFF
--- a/turbo/packages/sandbox-scripts/src/scripts/lib/direct-upload.ts
+++ b/turbo/packages/sandbox-scripts/src/scripts/lib/direct-upload.ts
@@ -127,6 +127,32 @@ interface Manifest {
 }
 
 /**
+ * Build a commit payload with optional runId and message fields.
+ */
+function buildCommitPayload(
+  storageName: string,
+  storageType: string,
+  versionId: string,
+  files: FileEntry[],
+  runId?: string,
+  message?: string,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    storageName,
+    storageType,
+    versionId,
+    files,
+  };
+  if (runId) {
+    payload.runId = runId;
+  }
+  if (message) {
+    payload.message = message;
+  }
+  return payload;
+}
+
+/**
  * Create manifest JSON file.
  *
  * @param files - List of file entries
@@ -162,7 +188,6 @@ export function createManifest(
  * @param message - Optional commit message
  * @returns Object with versionId on success, null on failure
  */
-// eslint-disable-next-line complexity -- TODO: refactor complex function
 export async function createDirectUploadSnapshot(
   mountPath: string,
   storageName: string,
@@ -221,15 +246,13 @@ export async function createDirectUploadSnapshot(
     logInfo(`Version already exists (deduplicated): ${versionId.slice(0, 8)}`);
     logInfo("Updating HEAD pointer...");
 
-    const commitPayload: Record<string, unknown> = {
+    const commitPayload = buildCommitPayload(
       storageName,
       storageType,
       versionId,
       files,
-    };
-    if (runId) {
-      commitPayload.runId = runId;
-    }
+      runId,
+    );
 
     const commitResponse = (await httpPostJson(
       STORAGE_COMMIT_URL,
@@ -318,18 +341,14 @@ export async function createDirectUploadSnapshot(
     // Step 6: Call commit endpoint
     logInfo("Calling commit endpoint...");
     const commitStart = Date.now();
-    const commitPayload: Record<string, unknown> = {
+    const commitPayload = buildCommitPayload(
       storageName,
       storageType,
       versionId,
       files,
-    };
-    if (runId) {
-      commitPayload.runId = runId;
-    }
-    if (message) {
-      commitPayload.message = message;
-    }
+      runId,
+      message,
+    );
 
     const commitResponse = (await httpPostJson(
       STORAGE_COMMIT_URL,


### PR DESCRIPTION
## Summary
- Split `formatNetworkLog` in CLI logs into `formatSniLog` and `formatMitmLog` for clearer separation of concerns
- Decompose `isPrivateOrInternalHost` in proxy service into five focused helpers: `isLoopbackHost`, `isCloudMetadataHost`, `isInternalServiceHost`, `isPrivateIPv4`, `isPrivateIPv6`
- Remove `eslint-disable complexity` comments by reducing cyclomatic complexity through extraction

## Test plan
- [x] All 41 CLI logs tests pass (`apps/cli/src/commands/logs/__tests__/index.test.ts`)
- [x] All 19 proxy tests pass (`apps/web/src/lib/proxy/__tests__/token-service.test.ts`)
- [x] Lint passes with no new warnings
- [x] Knip reports no unused exports or files
- [x] All pre-commit hooks (prettier, knip, commitlint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)