### PR TITLE
refactor: replace dynamic imports with static imports

### DIFF
--- a/turbo/apps/cli/src/commands/info/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/info/__tests__/index.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import chalk from "chalk";
 import * as os from "os";
+import { infoCommand } from "../index";
 
 // Mock os.homedir to point to temp directory for isolated testing
 vi.mock("os", async () => {
@@ -59,11 +60,7 @@ describe("info command", () => {
     writeFileSync(join(configDir, "config.json"), JSON.stringify(content));
   }
 
-  // Need to dynamically import after mocking os.homedir
   async function runInfoCommand(): Promise<void> {
-    // Clear module cache to pick up new homedir mock value
-    vi.resetModules();
-    const { infoCommand } = await import("../index");
     await infoCommand.parseAsync(["node", "cli"]);
   }
 

--- a/turbo/apps/cli/src/commands/info/index.ts
+++ b/turbo/apps/cli/src/commands/info/index.ts
@@ -8,7 +8,9 @@ import { detectPackageManager } from "../../lib/utils/update-checker";
 
 declare const __CLI_VERSION__: string;
 
-const CONFIG_PATH = join(homedir(), ".vm0", "config.json");
+function getConfigPath() {
+  return join(homedir(), ".vm0", "config.json");
+}
 
 export const infoCommand = new Command()
   .name("info")
@@ -32,7 +34,7 @@ export const infoCommand = new Command()
       console.log(`  ${chalk.red("✗")} Not authenticated`);
     }
 
-    const configExists = existsSync(CONFIG_PATH);
+    const configExists = existsSync(getConfigPath());
     const configDisplay = configExists
       ? `~/.vm0/config.json`
       : `~/.vm0/config.json (not found)`;

--- a/turbo/apps/cli/src/commands/onboard/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/onboard/__tests__/index.test.ts
@@ -11,6 +11,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { existsSync, mkdtempSync, rmSync } from "fs";
+import { mkdir } from "fs/promises";
 import * as path from "path";
 import * as os from "os";
 import { http, HttpResponse } from "msw";
@@ -291,7 +292,6 @@ describe("onboard command", () => {
     });
 
     it("should exit with error if directory already exists", async () => {
-      const { mkdir } = await import("fs/promises");
       await mkdir(path.join(tempDir, "my-vm0-agent"));
 
       await expect(

--- a/turbo/apps/platform/src/__tests__/polyfill.test.ts
+++ b/turbo/apps/platform/src/__tests__/polyfill.test.ts
@@ -1,17 +1,12 @@
-import { describe, expect, it, beforeEach, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import "../polyfill.ts";
 
 describe("abortSignal.any polyfill", () => {
-  it("should have AbortSignal.any available", async () => {
-    // Import polyfill to ensure it's loaded
-    await import("../polyfill.ts");
+  it("should have AbortSignal.any available", () => {
     expect(typeof AbortSignal.any).toBe("function");
   });
 
   describe("combining signals", () => {
-    beforeEach(async () => {
-      await import("../polyfill.ts");
-    });
-
     it("should return non-aborted signal when none are aborted", () => {
       const controller1 = new AbortController();
       const controller2 = new AbortController();

--- a/turbo/apps/platform/src/views/slack-connect/__tests__/slack-connect-success-page.test.tsx
+++ b/turbo/apps/platform/src/views/slack-connect/__tests__/slack-connect-success-page.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { setupPage } from "../../../__tests__/page-helper.ts";
+import { mockedClerk } from "../../../__tests__/mock-auth.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { pathname$ } from "../../../signals/route.ts";
 import { screen } from "@testing-library/react";
@@ -51,8 +52,6 @@ describe("slack connect success page", () => {
   });
 
   it("redirects to login when not authenticated", async () => {
-    const { mockedClerk } = await import("../../../__tests__/mock-auth.ts");
-
     await setupPage({
       context,
       path: "/slack/connect/success",

--- a/turbo/apps/runner/src/lib/__tests__/process.test.ts
+++ b/turbo/apps/runner/src/lib/__tests__/process.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { vol } from "memfs";
+import * as fs from "fs";
 import {
   parseFirecrackerCmdline,
   parseMitmproxyCmdline,
@@ -328,8 +329,6 @@ describe("process discovery", () => {
         "/proc/5678/cmdline": "will be mocked to throw",
       });
 
-      // Spy on readFileSync to throw EACCES for specific path
-      const fs = await import("fs");
       const originalReadFileSync = fs.readFileSync;
       vi.spyOn(fs, "readFileSync").mockImplementation((path, options) => {
         if (path === "/proc/5678/cmdline") {

--- a/turbo/apps/web/app/api/agent/schedules/[name]/enable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/enable/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { POST } from "../route";
+import { POST as deployRoute } from "../../../route";
 import {
   createTestRequest,
   createTestCompose,
@@ -125,8 +126,6 @@ describe("POST /api/agent/schedules/:name/enable", () => {
       },
     );
 
-    // Import and call the deploy route directly
-    const { POST: deployRoute } = await import("../../../route");
     await deployRoute(request);
 
     // Try to enable the past schedule

--- a/turbo/apps/web/app/lib/blog/__tests__/data-source.test.ts
+++ b/turbo/apps/web/app/lib/blog/__tests__/data-source.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../../src/mocks/server";
+import { reloadEnv } from "../../../../src/env";
+import { getPosts, getPost, getFeatured, getCategories } from "../data-source";
 
 const STRAPI_URL = "https://test-strapi.example.com";
 
@@ -26,10 +28,9 @@ const mockCategories = [
   { id: 3, name: "Lifestyle", slug: "lifestyle" },
 ];
 
-beforeEach(async () => {
+beforeEach(() => {
   vi.stubEnv("NEXT_PUBLIC_STRAPI_URL", STRAPI_URL);
   vi.stubEnv("NEXT_PUBLIC_DATA_SOURCE", "strapi");
-  const { reloadEnv } = await import("../../../../src/env");
   reloadEnv();
 
   // Register base handlers for Strapi API
@@ -67,7 +68,6 @@ beforeEach(async () => {
 describe("blog/data-source", () => {
   describe("getPosts", () => {
     it("fetches posts from strapi and returns transformed data", async () => {
-      const { getPosts } = await import("../data-source");
       const posts = await getPosts("en");
 
       expect(posts).toHaveLength(1);
@@ -91,7 +91,6 @@ describe("blog/data-source", () => {
         }),
       );
 
-      const { getPosts } = await import("../data-source");
       await getPosts();
 
       expect(capturedLocale).toBe("en");
@@ -104,7 +103,6 @@ describe("blog/data-source", () => {
         }),
       );
 
-      const { getPosts } = await import("../data-source");
       const posts = await getPosts("en");
 
       expect(posts).toEqual([]);
@@ -113,7 +111,6 @@ describe("blog/data-source", () => {
 
   describe("getPost", () => {
     it("fetches single post by slug from strapi", async () => {
-      const { getPost } = await import("../data-source");
       const post = await getPost("test-post", "en");
 
       expect(post).not.toBeNull();
@@ -122,7 +119,6 @@ describe("blog/data-source", () => {
     });
 
     it("returns null when post not found", async () => {
-      const { getPost } = await import("../data-source");
       const post = await getPost("non-existent", "en");
 
       expect(post).toBeNull();
@@ -131,7 +127,6 @@ describe("blog/data-source", () => {
 
   describe("getFeatured", () => {
     it("fetches featured post from strapi and marks it as featured", async () => {
-      const { getFeatured } = await import("../data-source");
       const post = await getFeatured("en");
 
       expect(post).not.toBeNull();
@@ -145,7 +140,6 @@ describe("blog/data-source", () => {
         }),
       );
 
-      const { getFeatured } = await import("../data-source");
       const post = await getFeatured("en");
 
       expect(post).toBeNull();
@@ -154,7 +148,6 @@ describe("blog/data-source", () => {
 
   describe("getCategories", () => {
     it("fetches categories from strapi", async () => {
-      const { getCategories } = await import("../data-source");
       const categories = await getCategories("en");
 
       expect(categories).toEqual(["Technology", "Business", "Lifestyle"]);
@@ -167,7 +160,6 @@ describe("blog/data-source", () => {
         }),
       );
 
-      const { getCategories } = await import("../data-source");
       const categories = await getCategories("en");
 
       expect(categories).toEqual([]);

--- a/turbo/apps/web/app/lib/blog/__tests__/strapi.test.ts
+++ b/turbo/apps/web/app/lib/blog/__tests__/strapi.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../../src/mocks/server";
+import { reloadEnv } from "../../../../src/env";
+import {
+  getPostsFromStrapi,
+  getPostBySlugFromStrapi,
+  getFeaturedPostFromStrapi,
+  getAllCategoriesFromStrapi,
+} from "../strapi";
 
 const STRAPI_URL = "https://test-strapi.example.com";
 
@@ -28,9 +35,8 @@ const mockArticles = [
   },
 ];
 
-beforeEach(async () => {
+beforeEach(() => {
   vi.stubEnv("NEXT_PUBLIC_STRAPI_URL", STRAPI_URL);
-  const { reloadEnv } = await import("../../../../src/env");
   reloadEnv();
 
   // Register base handlers for Strapi API
@@ -82,7 +88,6 @@ beforeEach(async () => {
 describe("blog/strapi", () => {
   describe("getPostsFromStrapi", () => {
     it("fetches posts and transforms them correctly", async () => {
-      const { getPostsFromStrapi } = await import("../strapi");
       const posts = await getPostsFromStrapi("en");
 
       expect(posts).toHaveLength(1);
@@ -108,8 +113,6 @@ describe("blog/strapi", () => {
         }),
       );
 
-      const { getPostsFromStrapi } = await import("../strapi");
-
       await expect(getPostsFromStrapi("en")).rejects.toThrow(
         "Failed to fetch posts: 500 Internal Server Error",
       );
@@ -126,7 +129,6 @@ describe("blog/strapi", () => {
         }),
       );
 
-      const { getPostsFromStrapi } = await import("../strapi");
       await getPostsFromStrapi();
 
       expect(capturedLocale).toBe("en");
@@ -153,7 +155,6 @@ describe("blog/strapi", () => {
         }),
       );
 
-      const { getPostsFromStrapi } = await import("../strapi");
       const posts = await getPostsFromStrapi("en");
 
       expect(posts[0]).toMatchObject({
@@ -167,7 +168,6 @@ describe("blog/strapi", () => {
 
   describe("getPostBySlugFromStrapi", () => {
     it("fetches single post by slug", async () => {
-      const { getPostBySlugFromStrapi } = await import("../strapi");
       const post = await getPostBySlugFromStrapi("test-post", "en");
 
       expect(post).not.toBeNull();
@@ -175,7 +175,6 @@ describe("blog/strapi", () => {
     });
 
     it("returns null when post not found", async () => {
-      const { getPostBySlugFromStrapi } = await import("../strapi");
       const post = await getPostBySlugFromStrapi("non-existent", "en");
 
       expect(post).toBeNull();
@@ -191,8 +190,6 @@ describe("blog/strapi", () => {
         }),
       );
 
-      const { getPostBySlugFromStrapi } = await import("../strapi");
-
       await expect(getPostBySlugFromStrapi("test", "en")).rejects.toThrow(
         "Failed to fetch post by slug: 404 Not Found",
       );
@@ -201,7 +198,6 @@ describe("blog/strapi", () => {
 
   describe("getFeaturedPostFromStrapi", () => {
     it("fetches featured post and marks it as featured", async () => {
-      const { getFeaturedPostFromStrapi } = await import("../strapi");
       const post = await getFeaturedPostFromStrapi("en");
 
       expect(post).not.toBeNull();
@@ -215,7 +211,6 @@ describe("blog/strapi", () => {
         }),
       );
 
-      const { getFeaturedPostFromStrapi } = await import("../strapi");
       const post = await getFeaturedPostFromStrapi("en");
 
       expect(post).toBeNull();
@@ -231,8 +226,6 @@ describe("blog/strapi", () => {
         }),
       );
 
-      const { getFeaturedPostFromStrapi } = await import("../strapi");
-
       await expect(getFeaturedPostFromStrapi("en")).rejects.toThrow(
         "Failed to fetch featured post: 503 Service Unavailable",
       );
@@ -241,7 +234,6 @@ describe("blog/strapi", () => {
 
   describe("getAllCategoriesFromStrapi", () => {
     it("fetches and returns category names", async () => {
-      const { getAllCategoriesFromStrapi } = await import("../strapi");
       const categories = await getAllCategoriesFromStrapi("en");
 
       expect(categories).toEqual(["Technology", "Business", "Lifestyle"]);
@@ -254,7 +246,6 @@ describe("blog/strapi", () => {
         }),
       );
 
-      const { getAllCategoriesFromStrapi } = await import("../strapi");
       const categories = await getAllCategoriesFromStrapi("en");
 
       expect(categories).toEqual([]);
@@ -269,8 +260,6 @@ describe("blog/strapi", () => {
           });
         }),
       );
-
-      const { getAllCategoriesFromStrapi } = await import("../strapi");
 
       await expect(getAllCategoriesFromStrapi("en")).rejects.toThrow(
         "Failed to fetch categories: 500 Internal Server Error",
@@ -301,7 +290,6 @@ describe("blog/strapi", () => {
         }),
       );
 
-      const { getPostsFromStrapi } = await import("../strapi");
       const posts = await getPostsFromStrapi("en");
 
       expect(posts[0]?.cover).toBe(`${STRAPI_URL}/uploads/image.jpg`);
@@ -336,7 +324,6 @@ describe("blog/strapi", () => {
         }),
       );
 
-      const { getPostsFromStrapi } = await import("../strapi");
       const posts = await getPostsFromStrapi("en");
 
       expect(posts[0]?.content).toContain("> **Famous Person**");
@@ -370,7 +357,6 @@ describe("blog/strapi", () => {
         }),
       );
 
-      const { getPostsFromStrapi } = await import("../strapi");
       const posts = await getPostsFromStrapi("en");
 
       expect(posts[0]?.readTime).toBe("2 min read");
@@ -398,7 +384,6 @@ describe("blog/strapi", () => {
         }),
       );
 
-      const { getPostsFromStrapi } = await import("../strapi");
       const posts = await getPostsFromStrapi("en");
 
       expect(posts[0]?.content).toBe("This is the description used as content");

--- a/turbo/apps/web/src/lib/__tests__/url.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/url.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 import { reloadEnv } from "../../env";
+import { getPlatformUrl } from "../url";
 
 describe("getPlatformUrl", () => {
-  it("returns NEXT_PUBLIC_PLATFORM_URL env var", async () => {
+  it("returns NEXT_PUBLIC_PLATFORM_URL env var", () => {
     vi.stubEnv("NEXT_PUBLIC_PLATFORM_URL", "https://platform.vm0.ai");
     reloadEnv();
 
-    const { getPlatformUrl } = await import("../url");
     expect(getPlatformUrl()).toBe("https://platform.vm0.ai");
   });
 });

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   createTestCompose,
   createTestVolume,
+  createTestRequest,
   insertStalePendingRun,
   findTestRunRecord,
   findTestRunCallbacks,
@@ -21,6 +22,8 @@ import {
   type CreateRunResult,
 } from "../run-service";
 import { isConcurrentRunLimit, isForbidden, isBadRequest } from "../../errors";
+import { Sandbox } from "@e2b/code-interpreter";
+import { POST as createComposeRoute } from "../../../../app/api/agent/composes/route";
 
 const context = testContext();
 
@@ -211,7 +214,6 @@ describe("createRun()", () => {
 
   describe("Dispatch Failure", () => {
     it("should mark run as failed when dispatch throws", async () => {
-      const { Sandbox } = await import("@e2b/code-interpreter");
       vi.mocked(Sandbox.create).mockRejectedValueOnce(
         new Error("Sandbox creation failed"),
       );
@@ -276,14 +278,6 @@ describe("createRun()", () => {
         },
         volumes,
       };
-
-      // Use direct DB insert via POST /api/agent/composes
-      const { POST: createComposeRoute } = await import(
-        "../../../../app/api/agent/composes/route"
-      );
-      const { createTestRequest } = await import(
-        "../../../__tests__/api-test-helpers"
-      );
 
       const request = createTestRequest(
         "http://localhost:3000/api/agent/composes",


### PR DESCRIPTION
## Summary

- Replace 38 unnecessary `await import()` occurrences with static imports across 11 files (1 source, 10 test)
- Convert `CONFIG_PATH` module-level constant to lazy `getConfigPath()` function in CLI info command, enabling static imports in tests
- Improves static analysis, tree-shaking, and code readability

## What's excluded

- `i18n.ts` / `layout.tsx` — dynamic locale imports are valid for lazy loading
- `client.ts` / `client.test.ts` — singleton reset requires module-level cache clearing
- `instrumentation.ts` — Next.js framework pattern
- `sandbox-scripts` tests — per user decision

## Test plan

- [x] All 8 affected test files pass (114 tests)
- [x] Type checking passes (pre-existing `.next/types` error unrelated)
- [ ] CI lint, test, and build checks pass

Closes #3005

🤖 Generated with [Claude Code](https://claude.com/claude-code)