### PR TITLE
feat: owner inline editing for agent instructions

### DIFF
--- a/turbo/apps/platform/src/signals/agent-detail/agent-detail-page.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-detail-page.ts
@@ -2,10 +2,15 @@ import { command } from "ccstate";
 import { createElement } from "react";
 import { AgentDetailPage } from "../../views/agent-detail-page/agent-detail-page.tsx";
 import { updatePage$ } from "../react-router.ts";
-import { fetchAgentDetail$, fetchAgentInstructions$ } from "./agent-detail.ts";
+import {
+  fetchAgentDetail$,
+  fetchAgentInstructions$,
+  initInstructionsViewMode$,
+} from "./agent-detail.ts";
 
 export const setupAgentDetailPage$ = command(async ({ set }) => {
   set(updatePage$, createElement(AgentDetailPage));
+  set(initInstructionsViewMode$);
   await set(fetchAgentDetail$);
   await set(fetchAgentInstructions$);
 });

--- a/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { pathParams$ } from "../route.ts";
 import { fetch$ } from "../fetch.ts";
 import { throwIfAbort } from "../utils.ts";
@@ -231,9 +232,12 @@ export const saveInstructions$ = command(async ({ get, set }) => {
       const data = (await instructionsResponse.json()) as AgentInstructions;
       set(agentInstructionsState$, { instructions: data, loading: false });
     }
+
+    toast.success("Instructions saved");
   } catch (error) {
     throwIfAbort(error);
     L.error("Failed to save instructions:", error);
+    toast.error("Failed to save instructions");
   } finally {
     set(saveInstructionsLoading$, false);
   }

--- a/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
@@ -1,7 +1,6 @@
 import { command, computed, state } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import { pathParams$ } from "../route.ts";
-import { searchParams$, updateSearchParams$ } from "../route.ts";
+import { pathParams$, searchParams$, updateSearchParams$ } from "../route.ts";
 import { fetch$ } from "../fetch.ts";
 import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";

--- a/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
@@ -1,6 +1,7 @@
 import { command, computed, state } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { pathParams$ } from "../route.ts";
+import { searchParams$, updateSearchParams$ } from "../route.ts";
 import { fetch$ } from "../fetch.ts";
 import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
@@ -101,7 +102,7 @@ export const fetchAgentDetail$ = command(async ({ get, set }) => {
 });
 
 // ---------------------------------------------------------------------------
-// Instructions view mode — local UI state for markdown/preview toggle
+// Instructions view mode — synced with ?view= query param
 // ---------------------------------------------------------------------------
 
 type InstructionsViewMode = "markdown" | "preview";
@@ -114,9 +115,25 @@ function isInstructionsViewMode(v: string): v is InstructionsViewMode {
   return v === "markdown" || v === "preview";
 }
 
-export const setInstructionsViewMode$ = command(({ set }, v: string) => {
+export const initInstructionsViewMode$ = command(({ get, set }) => {
+  const params = get(searchParams$);
+  const view = params.get("view");
+  if (view && isInstructionsViewMode(view)) {
+    set(internalInstructionsViewMode$, view);
+  }
+});
+
+export const setInstructionsViewMode$ = command(({ get, set }, v: string) => {
   if (isInstructionsViewMode(v)) {
     set(internalInstructionsViewMode$, v);
+
+    const params = new URLSearchParams(get(searchParams$));
+    if (v === "preview") {
+      params.delete("view");
+    } else {
+      params.set("view", v);
+    }
+    set(updateSearchParams$, params);
   }
 });
 

--- a/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
@@ -166,3 +166,75 @@ export const fetchAgentInstructions$ = command(async ({ get, set }) => {
     set(agentInstructionsState$, { instructions: null, loading: false });
   }
 });
+
+// ---------------------------------------------------------------------------
+// Instructions editing — owner inline editing state
+// ---------------------------------------------------------------------------
+
+const editedInstructionsContent$ = state<string | null>(null);
+
+export const editedContent$ = computed((get) =>
+  get(editedInstructionsContent$),
+);
+
+export const isInstructionsDirty$ = computed((get) => {
+  const edited = get(editedInstructionsContent$);
+  const instructions = get(agentInstructions$);
+  return edited !== null && edited !== (instructions?.content ?? "");
+});
+
+export const setEditedContent$ = command(({ set }, value: string) => {
+  set(editedInstructionsContent$, value);
+});
+
+export const cancelEditInstructions$ = command(({ set }) => {
+  set(editedInstructionsContent$, null);
+});
+
+const saveInstructionsLoading$ = state(false);
+export const isSavingInstructions$ = computed((get) =>
+  get(saveInstructionsLoading$),
+);
+
+export const saveInstructions$ = command(async ({ get, set }) => {
+  const detail = get(agentDetail$);
+  const edited = get(editedInstructionsContent$);
+  if (!detail || edited === null) {
+    return;
+  }
+
+  set(saveInstructionsLoading$, true);
+
+  try {
+    const fetchFn = get(fetch$);
+    const response = await fetchFn(
+      `/api/agent/composes/${detail.id}/instructions`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: edited }),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to save instructions: ${response.statusText}`);
+    }
+
+    // Clear editing state
+    set(editedInstructionsContent$, null);
+
+    // Re-fetch instructions to show the persisted content
+    const instructionsResponse = await fetchFn(
+      `/api/agent/composes/${detail.id}/instructions`,
+    );
+    if (instructionsResponse.ok) {
+      const data = (await instructionsResponse.json()) as AgentInstructions;
+      set(agentInstructionsState$, { instructions: data, loading: false });
+    }
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to save instructions:", error);
+  } finally {
+    set(saveInstructionsLoading$, false);
+  }
+});

--- a/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
@@ -238,17 +238,19 @@ export const saveInstructions$ = command(async ({ get, set }) => {
       throw new Error(`Failed to save instructions: ${response.statusText}`);
     }
 
+    // Optimistically update the instructions state with the saved content
+    // so the UI reflects the change immediately without a re-fetch.
+    const current = get(agentInstructions$);
+    set(agentInstructionsState$, {
+      instructions: {
+        content: edited,
+        filename: current?.filename ?? null,
+      },
+      loading: false,
+    });
+
     // Clear editing state
     set(editedInstructionsContent$, null);
-
-    // Re-fetch instructions to show the persisted content
-    const instructionsResponse = await fetchFn(
-      `/api/agent/composes/${detail.id}/instructions`,
-    );
-    if (instructionsResponse.ok) {
-      const data = (await instructionsResponse.json()) as AgentInstructions;
-      set(agentInstructionsState$, { instructions: data, loading: false });
-    }
 
     toast.success("Instructions saved");
   } catch (error) {

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-detail-page.test.tsx
@@ -189,7 +189,7 @@ describe("agent detail page", () => {
     expect(textarea).toHaveValue("# Editable");
   });
 
-  it("should show Save/Cancel when content is edited", async () => {
+  it("should show Save/Discard when content is edited", async () => {
     mockAgentDetailAPI({
       instructions: {
         content: "# Original",
@@ -212,16 +212,16 @@ describe("agent detail page", () => {
     const textarea = screen.getByRole("textbox");
     fireEvent.change(textarea, { target: { value: "# Modified" } });
 
-    // Save and Cancel buttons should appear
+    // Save and Discard buttons should appear
     await vi.waitFor(() => {
       expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: "Cancel" }),
+        screen.getByRole("button", { name: "Discard" }),
       ).toBeInTheDocument();
     });
   });
 
-  it("should discard edits on Cancel", async () => {
+  it("should discard edits on Discard", async () => {
     mockAgentDetailAPI({
       instructions: {
         content: "# Original",
@@ -239,25 +239,25 @@ describe("agent detail page", () => {
       expect(screen.getByText("Agent instructions")).toBeInTheDocument();
     });
 
-    // Switch to markdown mode, edit, then cancel
+    // Switch to markdown mode, edit, then discard
     fireEvent.click(screen.getByRole("tab", { name: "Markdown" }));
     const textarea = screen.getByRole("textbox");
     fireEvent.change(textarea, { target: { value: "# Modified" } });
 
     await vi.waitFor(() => {
       expect(
-        screen.getByRole("button", { name: "Cancel" }),
+        screen.getByRole("button", { name: "Discard" }),
       ).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
 
     // Should revert to original
     await vi.waitFor(() => {
       expect(screen.getByRole("textbox")).toHaveValue("# Original");
     });
 
-    // Save/Cancel should disappear
+    // Save/Discard should disappear
     expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
   });
 

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-detail-page.test.tsx
@@ -261,6 +261,28 @@ describe("agent detail page", () => {
     expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
   });
 
+  it("should initialize view mode from query param", async () => {
+    mockAgentDetailAPI({
+      instructions: {
+        content: "# From URL",
+        filename: "instructions.md",
+      },
+    });
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent?view=markdown",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Agent instructions")).toBeInTheDocument();
+    });
+
+    // Should start in markdown mode (from ?view=markdown), showing textarea
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
   it("should show read-only pre for shared (non-owner) agents", async () => {
     // Shared agent path has scope/name format
     server.use(

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-detail-page.test.tsx
@@ -161,4 +161,153 @@ describe("agent detail page", () => {
     const nav = screen.getByRole("navigation");
     expect(within(nav).getByText("Agents")).toBeInTheDocument();
   });
+
+  it("should show textarea for owner in markdown mode", async () => {
+    mockAgentDetailAPI({
+      instructions: {
+        content: "# Editable",
+        filename: "instructions.md",
+      },
+    });
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Agent instructions")).toBeInTheDocument();
+    });
+
+    // Switch to markdown mode
+    fireEvent.click(screen.getByRole("tab", { name: "Markdown" }));
+
+    // Owner should see a textarea
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toBeInTheDocument();
+    expect(textarea).toHaveValue("# Editable");
+  });
+
+  it("should show Save/Cancel when content is edited", async () => {
+    mockAgentDetailAPI({
+      instructions: {
+        content: "# Original",
+        filename: "instructions.md",
+      },
+    });
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Agent instructions")).toBeInTheDocument();
+    });
+
+    // Switch to markdown mode and edit
+    fireEvent.click(screen.getByRole("tab", { name: "Markdown" }));
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "# Modified" } });
+
+    // Save and Cancel buttons should appear
+    await vi.waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Cancel" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should discard edits on Cancel", async () => {
+    mockAgentDetailAPI({
+      instructions: {
+        content: "# Original",
+        filename: "instructions.md",
+      },
+    });
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Agent instructions")).toBeInTheDocument();
+    });
+
+    // Switch to markdown mode, edit, then cancel
+    fireEvent.click(screen.getByRole("tab", { name: "Markdown" }));
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "# Modified" } });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Cancel" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    // Should revert to original
+    await vi.waitFor(() => {
+      expect(screen.getByRole("textbox")).toHaveValue("# Original");
+    });
+
+    // Save/Cancel should disappear
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+  });
+
+  it("should show read-only pre for shared (non-owner) agents", async () => {
+    // Shared agent path has scope/name format
+    server.use(
+      http.get("/api/agent/composes", ({ request }) => {
+        const url = new URL(request.url);
+        const queryName = url.searchParams.get("name");
+        if (queryName !== "shared-agent") {
+          return new HttpResponse(null, { status: 404 });
+        }
+        return HttpResponse.json({
+          id: "compose_2",
+          name: "shared-agent",
+          headVersionId: "version_1",
+          content: {
+            version: "1",
+            agents: {
+              "shared-agent": {
+                description: "A shared agent",
+                framework: "claude-code",
+              },
+            },
+          },
+          createdAt: "2024-01-01T00:00:00Z",
+          updatedAt: "2024-01-01T00:00:00Z",
+        });
+      }),
+      http.get("/api/agent/composes/:id/instructions", () => {
+        return HttpResponse.json({
+          content: "# Shared Content",
+          filename: "instructions.md",
+        });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: `/agents/${encodeURIComponent("other-scope/shared-agent")}`,
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Agent instructions")).toBeInTheDocument();
+    });
+
+    // Switch to markdown mode — should be read-only (pre, not textarea)
+    fireEvent.click(screen.getByRole("tab", { name: "Markdown" }));
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(screen.getByText("# Shared Content")).toBeInTheDocument();
+  });
 });

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-detail-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-detail-page.tsx
@@ -42,6 +42,7 @@ export function AgentDetailPage() {
             <AgentInstructions
               instructions={instructions}
               loading={instructionsLoading}
+              isOwner={isOwner}
             />
           </>
         ) : (

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
@@ -101,6 +101,7 @@ export function AgentInstructions({
         {viewMode === "markdown" ? (
           isOwner ? (
             <textarea
+              aria-label="Agent instructions editor"
               className="px-1 text-sm font-mono text-foreground w-full flex-1 bg-transparent border-none outline-none resize-none whitespace-pre-wrap"
               value={displayContent}
               onChange={(e) => setEdited(e.target.value)}

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
@@ -97,11 +97,11 @@ export function AgentInstructions({
         </Tabs>
       </div>
 
-      <div className="mt-6 flex-1 overflow-y-auto min-h-0">
+      <div className="mt-6 flex-1 overflow-y-auto min-h-0 flex flex-col">
         {viewMode === "markdown" ? (
           isOwner ? (
             <textarea
-              className="px-1 text-sm font-mono text-foreground w-full h-full bg-transparent border-none outline-none resize-none whitespace-pre-wrap"
+              className="px-1 text-sm font-mono text-foreground w-full flex-1 bg-transparent border-none outline-none resize-none whitespace-pre-wrap"
               value={displayContent}
               onChange={(e) => setEdited(e.target.value)}
             />

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
@@ -1,24 +1,41 @@
 import { useGet, useSet } from "ccstate-react";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
+import { Button } from "@vm0/ui/components/ui/button";
 import MarkdownPreview from "@uiw/react-markdown-preview";
 import {
   instructionsViewMode$,
   setInstructionsViewMode$,
+  editedContent$,
+  isInstructionsDirty$,
+  setEditedContent$,
+  cancelEditInstructions$,
+  saveInstructions$,
+  isSavingInstructions$,
 } from "../../signals/agent-detail/agent-detail.ts";
 import type { AgentInstructions as AgentInstructionsType } from "../../signals/agent-detail/types.ts";
 
 interface AgentInstructionsProps {
   instructions: AgentInstructionsType | null;
   loading: boolean;
+  isOwner: boolean;
 }
 
 export function AgentInstructions({
   instructions,
   loading,
+  isOwner,
 }: AgentInstructionsProps) {
   const viewMode = useGet(instructionsViewMode$);
   const setViewMode = useSet(setInstructionsViewMode$);
+  const edited = useGet(editedContent$);
+  const isDirty = useGet(isInstructionsDirty$);
+  const setEdited = useSet(setEditedContent$);
+  const cancel = useSet(cancelEditInstructions$);
+  const save = useSet(saveInstructions$);
+  const isSaving = useGet(isSavingInstructions$);
+
+  const displayContent = edited ?? instructions?.content ?? "";
 
   if (loading) {
     return (
@@ -29,7 +46,7 @@ export function AgentInstructions({
     );
   }
 
-  if (!instructions?.content) {
+  if (!instructions?.content && !isOwner) {
     return (
       <div className="flex-1 rounded-lg border border-border p-4">
         <h2 className="text-base font-medium text-foreground">
@@ -58,13 +75,21 @@ export function AgentInstructions({
 
       <div className="mt-6 flex-1 overflow-y-auto">
         {viewMode === "markdown" ? (
-          <pre className="px-1 text-sm font-mono text-foreground overflow-x-auto whitespace-pre-wrap">
-            {instructions.content}
-          </pre>
+          isOwner ? (
+            <textarea
+              className="px-1 text-sm font-mono text-foreground w-full min-h-[400px] bg-transparent border-none outline-none resize-none whitespace-pre-wrap"
+              value={displayContent}
+              onChange={(e) => setEdited(e.target.value)}
+            />
+          ) : (
+            <pre className="px-1 text-sm font-mono text-foreground overflow-x-auto whitespace-pre-wrap">
+              {instructions?.content}
+            </pre>
+          )
         ) : (
           <div className="px-1">
             <MarkdownPreview
-              source={instructions.content}
+              source={displayContent}
               className="!bg-transparent !text-foreground text-sm"
               style={{
                 backgroundColor: "transparent",
@@ -75,6 +100,21 @@ export function AgentInstructions({
           </div>
         )}
       </div>
+
+      {isDirty && (
+        <div className="border-t border-border pt-4 mt-4 flex justify-center gap-3">
+          <Button
+            variant="outline"
+            onClick={() => cancel()}
+            disabled={isSaving}
+          >
+            Cancel
+          </Button>
+          <Button onClick={() => void save()} disabled={isSaving}>
+            {isSaving ? "Saving..." : "Save"}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
@@ -97,7 +97,7 @@ export function AgentInstructions({
         </div>
       </div>
 
-      <div className="mt-6 flex-1 overflow-y-auto min-h-0 flex flex-col">
+      <div className="instructions-content mt-6 flex-1 overflow-y-auto min-h-0 flex flex-col">
         {viewMode === "markdown" ? (
           isOwner ? (
             <textarea

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
@@ -60,11 +60,35 @@ export function AgentInstructions({
   }
 
   return (
-    <div className="flex-1 rounded-lg border border-border p-4 flex flex-col">
+    <div className="flex-1 rounded-lg border border-border p-4 flex flex-col min-h-0">
       <div className="flex items-start justify-between gap-4">
-        <h2 className="text-base font-medium text-foreground">
-          Agent instructions
-        </h2>
+        <div className="flex items-center gap-3">
+          <h2 className="text-base font-medium text-foreground">
+            Agent instructions
+          </h2>
+          {isDirty && (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted-foreground">Unsaved</span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 text-xs"
+                onClick={() => cancel()}
+                disabled={isSaving}
+              >
+                Discard
+              </Button>
+              <Button
+                size="sm"
+                className="h-7 text-xs"
+                onClick={() => void save()}
+                disabled={isSaving}
+              >
+                {isSaving ? "Saving..." : "Save"}
+              </Button>
+            </div>
+          )}
+        </div>
         <Tabs value={viewMode} onValueChange={(v) => setViewMode(v)}>
           <TabsList>
             <TabsTrigger value="markdown">Markdown</TabsTrigger>
@@ -73,11 +97,11 @@ export function AgentInstructions({
         </Tabs>
       </div>
 
-      <div className="mt-6 flex-1 overflow-y-auto">
+      <div className="mt-6 flex-1 overflow-y-auto min-h-0">
         {viewMode === "markdown" ? (
           isOwner ? (
             <textarea
-              className="px-1 text-sm font-mono text-foreground w-full min-h-[400px] bg-transparent border-none outline-none resize-none whitespace-pre-wrap"
+              className="px-1 text-sm font-mono text-foreground w-full h-full bg-transparent border-none outline-none resize-none whitespace-pre-wrap"
               value={displayContent}
               onChange={(e) => setEdited(e.target.value)}
             />
@@ -100,21 +124,6 @@ export function AgentInstructions({
           </div>
         )}
       </div>
-
-      {isDirty && (
-        <div className="border-t border-border pt-4 mt-4 flex justify-center gap-3">
-          <Button
-            variant="outline"
-            onClick={() => cancel()}
-            disabled={isSaving}
-          >
-            Cancel
-          </Button>
-          <Button onClick={() => void save()} disabled={isSaving}>
-            {isSaving ? "Saving..." : "Save"}
-          </Button>
-        </div>
-      )}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
@@ -61,13 +61,13 @@ export function AgentInstructions({
 
   return (
     <div className="flex-1 rounded-lg border border-border p-4 flex flex-col min-h-0">
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex items-center gap-3">
-          <h2 className="text-base font-medium text-foreground">
-            Agent instructions
-          </h2>
+      <div className="flex items-center justify-between gap-4">
+        <h2 className="text-base font-medium text-foreground">
+          Agent instructions
+        </h2>
+        <div className="flex items-center gap-2">
           {isDirty && (
-            <div className="flex items-center gap-2">
+            <>
               <span className="text-xs text-muted-foreground">Unsaved</span>
               <Button
                 variant="ghost"
@@ -86,15 +86,15 @@ export function AgentInstructions({
               >
                 {isSaving ? "Saving..." : "Save"}
               </Button>
-            </div>
+            </>
           )}
+          <Tabs value={viewMode} onValueChange={(v) => setViewMode(v)}>
+            <TabsList>
+              <TabsTrigger value="markdown">Markdown</TabsTrigger>
+              <TabsTrigger value="preview">Preview</TabsTrigger>
+            </TabsList>
+          </Tabs>
         </div>
-        <Tabs value={viewMode} onValueChange={(v) => setViewMode(v)}>
-          <TabsList>
-            <TabsTrigger value="markdown">Markdown</TabsTrigger>
-            <TabsTrigger value="preview">Preview</TabsTrigger>
-          </TabsList>
-        </Tabs>
       </div>
 
       <div className="mt-6 flex-1 overflow-y-auto min-h-0 flex flex-col">
@@ -111,7 +111,7 @@ export function AgentInstructions({
             </pre>
           )
         ) : (
-          <div className="px-1">
+          <div className="px-1 flex-1">
             <MarkdownPreview
               source={displayContent}
               className="!bg-transparent !text-foreground text-sm"

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -83,6 +83,12 @@
   }
 }
 
+/* Selection color for instructions editor/viewer */
+.instructions-content ::selection {
+  background-color: hsl(var(--primary-200));
+  color: hsl(var(--foreground));
+}
+
 /* Markdown preview spacing overrides - outside @layer for higher specificity */
 
 /* Unified spacing for all elements */

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { gzipSync } from "node:zlib";
-import { GET } from "../route";
+import { GET, PUT } from "../route";
 import {
   createTestRequest,
   createTestCompose,
@@ -250,5 +250,127 @@ describe("GET /api/agent/composes/:id/instructions", () => {
 
     expect(response.status).toBe(404);
     expect(data.error.code).toBe("NOT_FOUND");
+  });
+});
+
+describe("PUT /api/agent/composes/:id/instructions", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/composes/some-id/instructions",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: "new content" }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: "some-id" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 403 for non-owner", async () => {
+    // Owner creates agent
+    await context.setupUser({ prefix: "owner" });
+    const { composeId } = await createTestCompose("owned-agent", {
+      overrides: { instructions: "AGENTS.md" },
+    });
+
+    // Share with original user
+    await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
+
+    // Switch to the shared (non-owner) user
+    mockClerk({ userId: user.userId });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/composes/${composeId}/instructions`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: "hacked" }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: composeId }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error.code).toBe("FORBIDDEN");
+  });
+
+  it("should save instructions and create storage version", async () => {
+    const agentName = "editable-agent";
+    const { composeId } = await createTestCompose(agentName, {
+      overrides: { instructions: "AGENTS.md" },
+    });
+
+    const newContent = "# Updated Instructions\n\nNew content here.\n";
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/composes/${composeId}/instructions`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: newContent }),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: composeId }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+
+    // Verify S3 uploads were called (manifest + archive)
+    expect(context.mocks.s3.putS3Object).toHaveBeenCalledTimes(2);
+
+    // Verify manifest upload
+    const manifestCall = context.mocks.s3.putS3Object.mock.calls.find(
+      (call) =>
+        typeof call[1] === "string" && call[1].endsWith("/manifest.json"),
+    );
+    expect(manifestCall).toBeDefined();
+
+    // Verify archive upload
+    const archiveCall = context.mocks.s3.putS3Object.mock.calls.find(
+      (call) =>
+        typeof call[1] === "string" && call[1].endsWith("/archive.tar.gz"),
+    );
+    expect(archiveCall).toBeDefined();
+  });
+
+  it("should return 400 when content is missing", async () => {
+    const { composeId } = await createTestCompose("bad-request-agent", {
+      overrides: { instructions: "AGENTS.md" },
+    });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/composes/${composeId}/instructions`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      },
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: composeId }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.code).toBe("BAD_REQUEST");
   });
 });

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
@@ -16,52 +16,10 @@ import {
   MOCK_USER_EMAIL,
 } from "../../../../../../../src/__tests__/clerk-mock";
 import { getInstructionsStorageName } from "@vm0/core";
+import { createSingleFileTar } from "../../../../../../../src/lib/tar";
 
-/**
- * Build a gzipped tar archive containing a single file.
- * The route downloads archive.tar.gz, decompresses, and extracts from tar.
- */
 function buildTarGz(filename: string, content: string): Buffer {
-  const contentBuf = Buffer.from(content, "utf-8");
-
-  // Tar header: 512 bytes
-  const header = Buffer.alloc(512);
-  // File name at offset 0 (up to 100 bytes)
-  header.write(filename, 0, Math.min(filename.length, 100), "utf-8");
-  // File mode at offset 100 (8 bytes, octal)
-  header.write("0000644\0", 100, 8, "utf-8");
-  // Owner/group IDs at offsets 108, 116 (8 bytes each, octal)
-  header.write("0000000\0", 108, 8, "utf-8");
-  header.write("0000000\0", 116, 8, "utf-8");
-  // File size at offset 124 (12 bytes, octal, null-terminated)
-  const sizeOctal = contentBuf.length.toString(8).padStart(11, "0");
-  header.write(sizeOctal + "\0", 124, 12, "utf-8");
-  // Modification time at offset 136 (12 bytes, octal)
-  const mtime = Math.floor(Date.now() / 1000)
-    .toString(8)
-    .padStart(11, "0");
-  header.write(mtime + "\0", 136, 12, "utf-8");
-  // Type flag at offset 156: '0' = regular file
-  header.write("0", 156, 1, "utf-8");
-
-  // Compute checksum: fill checksum field (offset 148, 8 bytes) with spaces first
-  header.write("        ", 148, 8, "utf-8");
-  let checksum = 0;
-  for (let i = 0; i < 512; i++) {
-    checksum += header[i] ?? 0;
-  }
-  // Write checksum as 6-digit octal, null-terminated, space-padded
-  header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148, 8, "utf-8");
-
-  // Pad content to 512-byte boundary
-  const paddingSize = (512 - (contentBuf.length % 512)) % 512;
-  const padding = Buffer.alloc(paddingSize);
-
-  // End-of-archive marker: two 512-byte zero blocks
-  const endMarker = Buffer.alloc(1024);
-
-  const tar = Buffer.concat([header, contentBuf, padding, endMarker]);
-  return gzipSync(tar);
+  return gzipSync(createSingleFileTar(filename, Buffer.from(content, "utf-8")));
 }
 
 const context = testContext();

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -173,11 +173,14 @@ export async function GET(
   // Download manifest to find the actual filename in storage
   const manifest = await downloadManifest(bucket, version.s3Key);
 
-  // Find the instructions file in manifest, normalizing ./ prefix
+  // Find the instructions file in manifest, normalizing ./ prefix.
+  // Temporary fallback: if the configured filename isn't found, try CLAUDE.md
+  // (some volumes were created with CLAUDE.md before the rename to AGENTS.md).
   const normalize = (p: string) => (p.startsWith("./") ? p.slice(2) : p);
-  const instructionFile = manifest.files.find(
-    (f) => normalize(f.path) === normalize(instructionsFilename),
-  );
+  const instructionFile =
+    manifest.files.find(
+      (f) => normalize(f.path) === normalize(instructionsFilename),
+    ) ?? manifest.files.find((f) => normalize(f.path) === "CLAUDE.md");
 
   if (!instructionFile) {
     return NextResponse.json({ content: null, filename: instructionsFilename });

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -173,9 +173,10 @@ export async function GET(
   // Download manifest to find the actual filename in storage
   const manifest = await downloadManifest(bucket, version.s3Key);
 
-  // Find the instructions file in manifest by exact path match
+  // Find the instructions file in manifest, normalizing ./ prefix
+  const normalize = (p: string) => (p.startsWith("./") ? p.slice(2) : p);
   const instructionFile = manifest.files.find(
-    (f) => f.path === instructionsFilename,
+    (f) => normalize(f.path) === normalize(instructionsFilename),
   );
 
   if (!instructionFile) {

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -1,12 +1,13 @@
 /**
  * GET /api/agent/composes/:id/instructions
+ * PUT /api/agent/composes/:id/instructions
  *
- * Fetch the instructions content for an agent compose.
+ * Fetch or update the instructions content for an agent compose.
  * Instructions are stored as storage volumes (agent-instructions@{agentName})
- * and this endpoint reads the content from S3.
+ * and this endpoint reads/writes the content from/to S3.
  */
 import { NextResponse } from "next/server";
-import { gunzipSync } from "node:zlib";
+import { gunzipSync, gzipSync } from "node:zlib";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { eq, and } from "drizzle-orm";
 import {
@@ -17,16 +18,23 @@ import {
   storages,
   storageVersions,
 } from "../../../../../../src/db/schema/storage";
+import { scopes } from "../../../../../../src/db/schema/scope";
 import { getUserId } from "../../../../../../src/lib/auth/get-user-id";
 import { getUserEmail } from "../../../../../../src/lib/auth/get-user-email";
 import { canAccessCompose } from "../../../../../../src/lib/agent/permission-service";
 import {
   downloadManifest,
   downloadS3Buffer,
+  putS3Object,
 } from "../../../../../../src/lib/s3/s3-client";
+import type { S3StorageManifest } from "../../../../../../src/lib/s3/types";
 import { env } from "../../../../../../src/env";
 import { getInstructionsStorageName } from "@vm0/core";
 import type { AgentComposeYaml } from "../../../../../../src/types/agent-compose";
+import {
+  hashFileContent,
+  computeContentHashFromHashes,
+} from "../../../../../../src/lib/storage/content-hash";
 
 /**
  * Extract a single file from a tar archive buffer.
@@ -191,4 +199,276 @@ export async function GET(
     content: fileContent.toString("utf-8"),
     filename: instructionsFilename,
   });
+}
+
+/**
+ * Create a tar archive containing a single file.
+ */
+function createSingleFileTar(filename: string, content: Buffer): Buffer {
+  const header = Buffer.alloc(512);
+
+  // File name (bytes 0-99)
+  header.write(filename, 0, Math.min(filename.length, 100), "utf-8");
+
+  // File mode (bytes 100-107): 0644
+  header.write("0000644\0", 100, 8, "utf-8");
+
+  // UID/GID (bytes 108-123): 0
+  header.write("0000000\0", 108, 8, "utf-8");
+  header.write("0000000\0", 116, 8, "utf-8");
+
+  // File size (bytes 124-135): octal
+  header.write(
+    content.length.toString(8).padStart(11, "0") + "\0",
+    124,
+    12,
+    "utf-8",
+  );
+
+  // Mtime (bytes 136-147)
+  const mtime = Math.floor(Date.now() / 1000)
+    .toString(8)
+    .padStart(11, "0");
+  header.write(mtime + "\0", 136, 12, "utf-8");
+
+  // Type flag (byte 156): '0' = regular file
+  header.write("0", 156, 1, "utf-8");
+
+  // Compute checksum: fill checksum field with spaces first
+  header.write("        ", 148, 8, "utf-8");
+  let checksum = 0;
+  for (let i = 0; i < 512; i++) {
+    checksum += header[i] ?? 0;
+  }
+  header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148, 8, "utf-8");
+
+  // Pad content to 512-byte boundary
+  const paddingSize = (512 - (content.length % 512)) % 512;
+  const padding = Buffer.alloc(paddingSize);
+
+  // End-of-archive marker: two 512-byte zero blocks
+  const endMarker = Buffer.alloc(1024);
+
+  return Buffer.concat([header, content, padding, endMarker]);
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  initServices();
+
+  const authorization = request.headers.get("authorization") ?? undefined;
+  const userId = await getUserId(authorization);
+  if (!userId) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const { id } = await params;
+
+  // Get compose with HEAD version content
+  const [result] = await globalThis.services.db
+    .select({
+      id: agentComposes.id,
+      userId: agentComposes.userId,
+      scopeId: agentComposes.scopeId,
+      name: agentComposes.name,
+      content: agentComposeVersions.content,
+    })
+    .from(agentComposes)
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentComposes.headVersionId, agentComposeVersions.id),
+    )
+    .where(eq(agentComposes.id, id))
+    .limit(1);
+
+  if (!result) {
+    return NextResponse.json(
+      { error: { message: "Agent compose not found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  // Ownership check — only the owner can edit instructions
+  if (result.userId !== userId) {
+    return NextResponse.json(
+      { error: { message: "Forbidden", code: "FORBIDDEN" } },
+      { status: 403 },
+    );
+  }
+
+  // Parse request body
+  const body = (await request.json()) as { content?: string };
+  if (typeof body.content !== "string") {
+    return NextResponse.json(
+      { error: { message: "content is required", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+
+  // Extract instructions filename from compose content
+  const composeContent = result.content as AgentComposeYaml | null;
+  if (!composeContent?.agents) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "No agents configured in compose",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const agentKeys = Object.keys(composeContent.agents);
+  const firstKey = agentKeys[0];
+  const agentDef = firstKey ? composeContent.agents[firstKey] : null;
+  const instructionsFilename = agentDef?.instructions;
+
+  if (!instructionsFilename) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "No instructions file configured",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  // Get scope slug for S3 key construction
+  const [scope] = await globalThis.services.db
+    .select({ slug: scopes.slug })
+    .from(scopes)
+    .where(eq(scopes.id, result.scopeId))
+    .limit(1);
+
+  if (!scope) {
+    return NextResponse.json(
+      { error: { message: "Scope not found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  // Find or create the instructions storage volume
+  const storageName = getInstructionsStorageName(result.name);
+  let [storage] = await globalThis.services.db
+    .select()
+    .from(storages)
+    .where(
+      and(
+        eq(storages.scopeId, result.scopeId),
+        eq(storages.name, storageName),
+        eq(storages.type, "volume"),
+      ),
+    )
+    .limit(1);
+
+  if (!storage) {
+    const [newStorage] = await globalThis.services.db
+      .insert(storages)
+      .values({
+        userId,
+        scopeId: result.scopeId,
+        name: storageName,
+        type: "volume",
+        s3Prefix: `${scope.slug}/volume/${storageName}`,
+        size: 0,
+        fileCount: 0,
+      })
+      .returning();
+    storage = newStorage;
+  }
+
+  if (!storage) {
+    return NextResponse.json(
+      { error: { message: "Failed to create storage", code: "INTERNAL" } },
+      { status: 500 },
+    );
+  }
+
+  // Compute content hash and version ID
+  const contentBuffer = Buffer.from(body.content, "utf-8");
+  const contentHash = hashFileContent(contentBuffer);
+  const files = [
+    {
+      path: instructionsFilename,
+      hash: contentHash,
+      size: contentBuffer.length,
+    },
+  ];
+  const versionId = computeContentHashFromHashes(storage.id, files);
+
+  // Build S3 key and upload archive + manifest
+  const s3Key = `${scope.slug}/volume/${storageName}/${versionId}`;
+  const bucket = env().R2_USER_STORAGES_BUCKET_NAME;
+
+  const manifest: S3StorageManifest = {
+    version: versionId,
+    createdAt: new Date().toISOString(),
+    totalSize: contentBuffer.length,
+    fileCount: 1,
+    files,
+  };
+
+  const tarBuffer = createSingleFileTar(instructionsFilename, contentBuffer);
+  const archiveBuffer = gzipSync(tarBuffer);
+
+  await Promise.all([
+    putS3Object(
+      bucket,
+      `${s3Key}/manifest.json`,
+      JSON.stringify(manifest),
+      "application/json",
+    ),
+    putS3Object(
+      bucket,
+      `${s3Key}/archive.tar.gz`,
+      archiveBuffer,
+      "application/gzip",
+    ),
+  ]);
+
+  // DB transaction: create version + update HEAD pointer
+  await globalThis.services.db.transaction(async (tx) => {
+    await tx
+      .insert(storageVersions)
+      .values({
+        id: versionId,
+        storageId: storage.id,
+        s3Key,
+        size: contentBuffer.length,
+        fileCount: 1,
+        message: null,
+        createdBy: "user",
+      })
+      .onConflictDoNothing();
+
+    const [version] = await tx
+      .select({ id: storageVersions.id })
+      .from(storageVersions)
+      .where(eq(storageVersions.id, versionId))
+      .limit(1);
+
+    if (!version) {
+      throw new Error(`Version ${versionId} not found after insert`);
+    }
+
+    await tx
+      .update(storages)
+      .set({
+        headVersionId: versionId,
+        size: contentBuffer.length,
+        fileCount: 1,
+        updatedAt: new Date(),
+      })
+      .where(eq(storages.id, storage.id));
+  });
+
+  return NextResponse.json({ success: true });
 }

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -35,43 +35,10 @@ import {
   hashFileContent,
   computeContentHashFromHashes,
 } from "../../../../../../src/lib/storage/content-hash";
-
-/**
- * Extract a single file from a tar archive buffer.
- * Tar format: 512-byte header + file data (padded to 512-byte blocks).
- */
-function extractFileFromTar(
-  tarBuffer: Buffer,
-  targetPath: string,
-): Buffer | null {
-  let offset = 0;
-  while (offset + 512 <= tarBuffer.length) {
-    const header = tarBuffer.subarray(offset, offset + 512);
-
-    // End of archive: two consecutive zero blocks
-    if (header.every((b) => b === 0)) break;
-
-    // File name: bytes 0-99, null-terminated
-    const nameEnd = header.indexOf(0);
-    const name = header
-      .subarray(0, nameEnd > 0 && nameEnd < 100 ? nameEnd : 100)
-      .toString("utf-8");
-
-    // File size: bytes 124-135, octal string
-    const sizeStr = header.subarray(124, 136).toString("utf-8").trim();
-    const size = parseInt(sizeStr, 8) || 0;
-
-    offset += 512; // Move past header
-
-    if (name === targetPath || name === `./${targetPath}`) {
-      return tarBuffer.subarray(offset, offset + size);
-    }
-
-    // Skip file data (padded to 512-byte boundary)
-    offset += Math.ceil(size / 512) * 512;
-  }
-  return null;
-}
+import {
+  createSingleFileTar,
+  extractFileFromTar,
+} from "../../../../../../src/lib/tar";
 
 export async function GET(
   request: Request,
@@ -205,57 +172,6 @@ export async function GET(
   });
 }
 
-/**
- * Create a tar archive containing a single file.
- */
-function createSingleFileTar(filename: string, content: Buffer): Buffer {
-  const header = Buffer.alloc(512);
-
-  // File name (bytes 0-99)
-  header.write(filename, 0, Math.min(filename.length, 100), "utf-8");
-
-  // File mode (bytes 100-107): 0644
-  header.write("0000644\0", 100, 8, "utf-8");
-
-  // UID/GID (bytes 108-123): 0
-  header.write("0000000\0", 108, 8, "utf-8");
-  header.write("0000000\0", 116, 8, "utf-8");
-
-  // File size (bytes 124-135): octal
-  header.write(
-    content.length.toString(8).padStart(11, "0") + "\0",
-    124,
-    12,
-    "utf-8",
-  );
-
-  // Mtime (bytes 136-147)
-  const mtime = Math.floor(Date.now() / 1000)
-    .toString(8)
-    .padStart(11, "0");
-  header.write(mtime + "\0", 136, 12, "utf-8");
-
-  // Type flag (byte 156): '0' = regular file
-  header.write("0", 156, 1, "utf-8");
-
-  // Compute checksum: fill checksum field with spaces first
-  header.write("        ", 148, 8, "utf-8");
-  let checksum = 0;
-  for (let i = 0; i < 512; i++) {
-    checksum += header[i] ?? 0;
-  }
-  header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148, 8, "utf-8");
-
-  // Pad content to 512-byte boundary
-  const paddingSize = (512 - (content.length % 512)) % 512;
-  const padding = Buffer.alloc(paddingSize);
-
-  // End-of-archive marker: two 512-byte zero blocks
-  const endMarker = Buffer.alloc(1024);
-
-  return Buffer.concat([header, content, padding, endMarker]);
-}
-
 export async function PUT(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
@@ -311,6 +227,19 @@ export async function PUT(
     return NextResponse.json(
       { error: { message: "content is required", code: "BAD_REQUEST" } },
       { status: 400 },
+    );
+  }
+
+  const MAX_CONTENT_SIZE = 1024 * 1024; // 1 MB
+  if (Buffer.byteLength(body.content, "utf-8") > MAX_CONTENT_SIZE) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Content too large (max 1 MB)",
+          code: "PAYLOAD_TOO_LARGE",
+        },
+      },
+      { status: 413 },
     );
   }
 
@@ -423,6 +352,10 @@ export async function PUT(
   const tarBuffer = createSingleFileTar(instructionsFilename, contentBuffer);
   const archiveBuffer = gzipSync(tarBuffer);
 
+  // Upload to S3 before the DB transaction. If the DB transaction fails,
+  // orphaned S3 objects are benign because keys are content-addressable —
+  // the version ID won't be referenced, and re-uploading the same content
+  // produces the same key (idempotent).
   await Promise.all([
     putS3Object(
       bucket,

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -112,6 +112,14 @@ interface S3Mocks {
       files: Array<{ path: string; hash: string; size: number }>;
     }>
   >;
+  putS3Object: MockInstance<
+    (
+      bucket: string,
+      key: string,
+      body: string | Buffer,
+      contentType: string,
+    ) => Promise<void>
+  >;
 }
 
 /**
@@ -322,6 +330,9 @@ export function testContext(): TestContext {
           fileCount: 0,
           files: [],
         }),
+      putS3Object: vi
+        .spyOn(s3Client, "putS3Object")
+        .mockResolvedValue(undefined),
     };
 
     // Axiom mocks - only set up if Axiom is mocked (vi.mock at module level in test file)

--- a/turbo/apps/web/src/lib/tar.ts
+++ b/turbo/apps/web/src/lib/tar.ts
@@ -1,0 +1,100 @@
+/**
+ * Minimal tar archive utilities for single-file archives.
+ *
+ * Used by:
+ *  - Instructions route (create + extract)
+ *  - Docker sandbox (create)
+ */
+
+const BLOCK_SIZE = 512;
+
+/**
+ * Create a tar archive containing a single file.
+ * Produces a valid POSIX (ustar) tar with checksum, end-of-archive markers,
+ * and 512-byte block alignment.
+ */
+export function createSingleFileTar(filename: string, content: Buffer): Buffer {
+  const blocks: Buffer[] = [];
+
+  const header = Buffer.alloc(BLOCK_SIZE, 0);
+  // File name (bytes 0-99)
+  header.write(filename, 0, Math.min(filename.length, 100), "utf-8");
+  // File mode (bytes 100-107): 0644
+  header.write("0000644\0", 100, 8, "utf-8");
+  // UID/GID (bytes 108-123): 0
+  header.write("0000000\0", 108, 8, "utf-8");
+  header.write("0000000\0", 116, 8, "utf-8");
+  // File size (bytes 124-135): octal
+  const sizeOctal = content.length.toString(8).padStart(11, "0");
+  header.write(sizeOctal + "\0", 124, 12, "utf-8");
+  // Mtime (bytes 136-147)
+  const mtime = Math.floor(Date.now() / 1000)
+    .toString(8)
+    .padStart(11, "0");
+  header.write(mtime + "\0", 136, 12, "utf-8");
+  // Checksum placeholder (bytes 148-155): spaces for initial calculation
+  header.write("        ", 148, 8, "utf-8");
+  // Type flag (byte 156): '0' = regular file
+  header.write("0", 156, 1, "utf-8");
+  // ustar magic (bytes 257-264)
+  header.write("ustar\0", 257, 6, "utf-8");
+  header.write("00", 263, 2, "utf-8");
+
+  // Compute and write checksum
+  let checksum = 0;
+  for (let i = 0; i < BLOCK_SIZE; i++) {
+    checksum += header.readUInt8(i);
+  }
+  header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148, 8, "utf-8");
+
+  blocks.push(header);
+  blocks.push(content);
+
+  // Pad content to 512-byte boundary
+  const padding = BLOCK_SIZE - (content.length % BLOCK_SIZE);
+  if (padding < BLOCK_SIZE) {
+    blocks.push(Buffer.alloc(padding, 0));
+  }
+
+  // End-of-archive marker: two 512-byte zero blocks
+  blocks.push(Buffer.alloc(BLOCK_SIZE * 2, 0));
+
+  return Buffer.concat(blocks);
+}
+
+/**
+ * Extract a single file from a tar archive buffer.
+ * Tar format: 512-byte header + file data (padded to 512-byte blocks).
+ */
+export function extractFileFromTar(
+  tarBuffer: Buffer,
+  targetPath: string,
+): Buffer | null {
+  let offset = 0;
+  while (offset + BLOCK_SIZE <= tarBuffer.length) {
+    const header = tarBuffer.subarray(offset, offset + BLOCK_SIZE);
+
+    // End of archive: two consecutive zero blocks
+    if (header.every((b) => b === 0)) break;
+
+    // File name: bytes 0-99, null-terminated
+    const nameEnd = header.indexOf(0);
+    const name = header
+      .subarray(0, nameEnd > 0 && nameEnd < 100 ? nameEnd : 100)
+      .toString("utf-8");
+
+    // File size: bytes 124-135, octal string
+    const sizeStr = header.subarray(124, 136).toString("utf-8").trim();
+    const size = parseInt(sizeStr, 8) || 0;
+
+    offset += BLOCK_SIZE; // Move past header
+
+    if (name === targetPath || name === `./${targetPath}`) {
+      return tarBuffer.subarray(offset, offset + size);
+    }
+
+    // Skip file data (padded to 512-byte boundary)
+    offset += Math.ceil(size / BLOCK_SIZE) * BLOCK_SIZE;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Closes #3010

- Add `PUT /api/agent/composes/:id/instructions` endpoint for saving edited instructions to S3
  - Ownership check (403 for non-owners)
  - Creates tar.gz archive + manifest.json, uploads to S3
  - DB transaction to create storage version and update HEAD pointer
- Add editing signals (`editedContent$`, `isInstructionsDirty$`, `saveInstructions$`, etc.)
- Owner sees editable `<textarea>` in Markdown mode; non-owners see read-only `<pre>`
- Save/Cancel bar appears when content is modified
- Preview tab reflects live edits before saving

## Test plan

- [x] PUT endpoint tests: auth (401), ownership (403), success (200 + S3 uploads), bad request (400)
- [x] Platform UI tests: textarea for owner, Save/Cancel on edit, Cancel discards, read-only for shared
- [x] All 21 tests pass (11 web + 10 platform)
- [ ] Manual: edit instructions on owned agent, verify Save persists and Cancel reverts
- [ ] Manual: shared agent detail page shows read-only view

🤖 Generated with [Claude Code](https://claude.com/claude-code)