### PR TITLE
feat(platform): add agent logs and connections pages

### DIFF
--- a/turbo/apps/platform/src/signals/agent-detail/agent-logs-page.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-logs-page.ts
@@ -3,8 +3,10 @@ import { createElement } from "react";
 import { AgentLogsPage } from "../../views/agent-detail-page/agent-logs-page.tsx";
 import { updatePage$ } from "../react-router.ts";
 import { fetchAgentDetail$ } from "./agent-detail.ts";
+import { seedAgentLogsCursorHistory$ } from "./agent-logs.ts";
 
 export const setupAgentLogsPage$ = command(async ({ set }) => {
   set(updatePage$, createElement(AgentLogsPage));
+  set(seedAgentLogsCursorHistory$);
   await set(fetchAgentDetail$);
 });

--- a/turbo/apps/platform/src/signals/agent-detail/agent-logs.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-logs.ts
@@ -1,0 +1,236 @@
+import { state, computed, command } from "ccstate";
+import type { LogsListResponse } from "../logs-page/types.ts";
+import { fetch$ } from "../fetch.ts";
+import { searchParams$, updateSearchParams$ } from "../route.ts";
+import { agentName$ } from "./agent-detail.ts";
+
+const DEFAULT_LIMIT = 10;
+const VALID_LIMITS = [10, 20, 50, 100] as const;
+
+// ---------------------------------------------------------------------------
+// URL-derived computeds
+// ---------------------------------------------------------------------------
+
+export const agentLogsLimit$ = computed((get) => {
+  const raw = get(searchParams$).get("limit");
+  if (!raw) {
+    return DEFAULT_LIMIT;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return VALID_LIMITS.includes(parsed as (typeof VALID_LIMITS)[number])
+    ? parsed
+    : DEFAULT_LIMIT;
+});
+
+const agentLogsCursor$ = computed((get) => {
+  return get(searchParams$).get("cursor") ?? null;
+});
+
+// ---------------------------------------------------------------------------
+// Data fetching — single async computed
+// ---------------------------------------------------------------------------
+
+export const currentAgentLogs$ = computed(async (get) => {
+  const fetchFn = get(fetch$);
+  const limit = get(agentLogsLimit$);
+  const cursor = get(agentLogsCursor$);
+  const agentName = get(agentName$);
+
+  if (!agentName) {
+    return {
+      data: [],
+      pagination: { hasMore: false, nextCursor: null, totalPages: 1 },
+    } satisfies LogsListResponse;
+  }
+
+  const params = new URLSearchParams({
+    limit: String(limit),
+    agent: agentName,
+  });
+  if (cursor) {
+    params.set("cursor", cursor);
+  }
+
+  const response = await fetchFn(`/api/platform/logs?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch agent logs: ${response.statusText}`);
+  }
+  return (await response.json()) as LogsListResponse;
+});
+
+// ---------------------------------------------------------------------------
+// Cursor history — the only runtime state
+// ---------------------------------------------------------------------------
+
+const cursorHistory$ = state<(string | null)[]>([null]);
+
+export const seedAgentLogsCursorHistory$ = command(({ get, set }) => {
+  const cursor = get(agentLogsCursor$);
+  if (cursor) {
+    set(cursorHistory$, [null, cursor]);
+  } else {
+    set(cursorHistory$, [null]);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Derived pagination computeds
+// ---------------------------------------------------------------------------
+
+export const agentLogsHasPrev$ = computed(
+  (get) => get(agentLogsCursor$) !== null,
+);
+
+export const agentLogsCurrentPage$ = computed((get) => {
+  const cursor = get(agentLogsCursor$);
+  const history = get(cursorHistory$);
+  const idx = history.indexOf(cursor);
+  return idx === -1 ? 1 : idx + 1;
+});
+
+// ---------------------------------------------------------------------------
+// Internal command: write URL params
+// ---------------------------------------------------------------------------
+
+interface UrlParamOverrides {
+  cursor?: string | null;
+  limit?: number;
+}
+
+const writeUrlParams$ = command(
+  ({ get, set }, overrides: UrlParamOverrides) => {
+    const params = new URLSearchParams();
+    const limit =
+      overrides.limit !== undefined ? overrides.limit : get(agentLogsLimit$);
+    const cursor =
+      overrides.cursor !== undefined ? overrides.cursor : get(agentLogsCursor$);
+
+    if (limit !== DEFAULT_LIMIT) {
+      params.set("limit", String(limit));
+    }
+    if (cursor) {
+      params.set("cursor", cursor);
+    }
+
+    set(updateSearchParams$, params);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Navigation commands — URL writers only
+// ---------------------------------------------------------------------------
+
+export const goToNextAgentLogsPage$ = command(async ({ get, set }) => {
+  const response = await get(currentAgentLogs$);
+  if (!response.pagination.hasMore) {
+    return;
+  }
+
+  const nextCursor = response.pagination.nextCursor;
+  const cursor = get(agentLogsCursor$);
+  const history = get(cursorHistory$);
+  const currentIdx = Math.max(0, history.indexOf(cursor));
+
+  set(cursorHistory$, (prev) => {
+    const next = [...prev];
+    if (next.length <= currentIdx + 1) {
+      next.push(nextCursor);
+    } else {
+      next[currentIdx + 1] = nextCursor;
+    }
+    return next;
+  });
+
+  set(writeUrlParams$, { cursor: nextCursor });
+});
+
+export const goToPrevAgentLogsPage$ = command(({ get, set }) => {
+  const cursor = get(agentLogsCursor$);
+  const history = get(cursorHistory$);
+  const currentIdx = history.indexOf(cursor);
+  if (currentIdx <= 0) {
+    return;
+  }
+
+  const prevCursor = history[currentIdx - 1] ?? null;
+  set(writeUrlParams$, { cursor: prevCursor });
+});
+
+export const goForwardTwoAgentLogsPages$ = command(async ({ get, set }) => {
+  const response1 = await get(currentAgentLogs$);
+  if (!response1.pagination.hasMore) {
+    return;
+  }
+
+  const cursor1 = response1.pagination.nextCursor;
+  if (!cursor1) {
+    return;
+  }
+
+  const currentCursor = get(agentLogsCursor$);
+  const history = get(cursorHistory$);
+  const idx = Math.max(0, history.indexOf(currentCursor));
+
+  set(cursorHistory$, (prev) => {
+    const next = [...prev];
+    if (next.length <= idx + 1) {
+      next.push(cursor1);
+    } else {
+      next[idx + 1] = cursor1;
+    }
+    return next;
+  });
+
+  // Fetch intermediate page to get second cursor
+  const limit = get(agentLogsLimit$);
+  const agentName = get(agentName$);
+  const params = new URLSearchParams({ limit: String(limit) });
+  params.set("cursor", cursor1);
+  if (agentName) {
+    params.set("agent", agentName);
+  }
+  const fetchFn = get(fetch$);
+  const resp2 = await fetchFn(`/api/platform/logs?${params.toString()}`);
+
+  if (!resp2.ok) {
+    set(writeUrlParams$, { cursor: cursor1 });
+    return;
+  }
+
+  const response2 = (await resp2.json()) as LogsListResponse;
+  if (!response2.pagination.hasMore) {
+    set(writeUrlParams$, { cursor: cursor1 });
+    return;
+  }
+
+  const cursor2 = response2.pagination.nextCursor;
+  set(cursorHistory$, (prev) => {
+    const next = [...prev];
+    if (next.length <= idx + 2) {
+      next.push(cursor2);
+    } else {
+      next[idx + 2] = cursor2;
+    }
+    return next;
+  });
+
+  set(writeUrlParams$, { cursor: cursor2 });
+});
+
+export const goBackTwoAgentLogsPages$ = command(({ get, set }) => {
+  const cursor = get(agentLogsCursor$);
+  const history = get(cursorHistory$);
+  const currentIdx = history.indexOf(cursor);
+  if (currentIdx <= 0) {
+    return;
+  }
+
+  const targetIdx = Math.max(0, currentIdx - 2);
+  const targetCursor = history[targetIdx] ?? null;
+  set(writeUrlParams$, { cursor: targetCursor });
+});
+
+export const setAgentLogsRowsPerPage$ = command(({ set }, limit: number) => {
+  set(cursorHistory$, [null]);
+  set(writeUrlParams$, { cursor: null, limit });
+});

--- a/turbo/apps/platform/src/signals/agent-detail/agent-logs.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-logs.ts
@@ -1,236 +1,35 @@
-import { state, computed, command } from "ccstate";
-import type { LogsListResponse } from "../logs-page/types.ts";
-import { fetch$ } from "../fetch.ts";
-import { searchParams$, updateSearchParams$ } from "../route.ts";
+import { createCursorPagination } from "../cursor-pagination.ts";
 import { agentName$ } from "./agent-detail.ts";
 
-const DEFAULT_LIMIT = 10;
-const VALID_LIMITS = [10, 20, 50, 100] as const;
-
 // ---------------------------------------------------------------------------
-// URL-derived computeds
+// Pagination — shared cursor machinery with agent filter
 // ---------------------------------------------------------------------------
 
-export const agentLogsLimit$ = computed((get) => {
-  const raw = get(searchParams$).get("limit");
-  if (!raw) {
-    return DEFAULT_LIMIT;
-  }
-  const parsed = Number.parseInt(raw, 10);
-  return VALID_LIMITS.includes(parsed as (typeof VALID_LIMITS)[number])
-    ? parsed
-    : DEFAULT_LIMIT;
-});
-
-const agentLogsCursor$ = computed((get) => {
-  return get(searchParams$).get("cursor") ?? null;
-});
-
-// ---------------------------------------------------------------------------
-// Data fetching — single async computed
-// ---------------------------------------------------------------------------
-
-export const currentAgentLogs$ = computed(async (get) => {
-  const fetchFn = get(fetch$);
-  const limit = get(agentLogsLimit$);
-  const cursor = get(agentLogsCursor$);
-  const agentName = get(agentName$);
-
-  if (!agentName) {
-    return {
-      data: [],
-      pagination: { hasMore: false, nextCursor: null, totalPages: 1 },
-    } satisfies LogsListResponse;
-  }
-
-  const params = new URLSearchParams({
-    limit: String(limit),
-    agent: agentName,
-  });
-  if (cursor) {
-    params.set("cursor", cursor);
-  }
-
-  const response = await fetchFn(`/api/platform/logs?${params.toString()}`);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch agent logs: ${response.statusText}`);
-  }
-  return (await response.json()) as LogsListResponse;
-});
-
-// ---------------------------------------------------------------------------
-// Cursor history — the only runtime state
-// ---------------------------------------------------------------------------
-
-const cursorHistory$ = state<(string | null)[]>([null]);
-
-export const seedAgentLogsCursorHistory$ = command(({ get, set }) => {
-  const cursor = get(agentLogsCursor$);
-  if (cursor) {
-    set(cursorHistory$, [null, cursor]);
-  } else {
-    set(cursorHistory$, [null]);
-  }
-});
-
-// ---------------------------------------------------------------------------
-// Derived pagination computeds
-// ---------------------------------------------------------------------------
-
-export const agentLogsHasPrev$ = computed(
-  (get) => get(agentLogsCursor$) !== null,
-);
-
-export const agentLogsCurrentPage$ = computed((get) => {
-  const cursor = get(agentLogsCursor$);
-  const history = get(cursorHistory$);
-  const idx = history.indexOf(cursor);
-  return idx === -1 ? 1 : idx + 1;
-});
-
-// ---------------------------------------------------------------------------
-// Internal command: write URL params
-// ---------------------------------------------------------------------------
-
-interface UrlParamOverrides {
-  cursor?: string | null;
-  limit?: number;
-}
-
-const writeUrlParams$ = command(
-  ({ get, set }, overrides: UrlParamOverrides) => {
-    const params = new URLSearchParams();
-    const limit =
-      overrides.limit !== undefined ? overrides.limit : get(agentLogsLimit$);
-    const cursor =
-      overrides.cursor !== undefined ? overrides.cursor : get(agentLogsCursor$);
-
-    if (limit !== DEFAULT_LIMIT) {
-      params.set("limit", String(limit));
+export const {
+  limit$: agentLogsLimit$,
+  data$: currentAgentLogs$,
+  seedCursorHistory$: seedAgentLogsCursorHistory$,
+  hasPrev$: agentLogsHasPrev$,
+  currentPage$: agentLogsCurrentPage$,
+  goToNextPage$: goToNextAgentLogsPage$,
+  goToPrevPage$: goToPrevAgentLogsPage$,
+  goForwardTwoPages$: goForwardTwoAgentLogsPages$,
+  goBackTwoPages$: goBackTwoAgentLogsPages$,
+  setRowsPerPage$: setAgentLogsRowsPerPage$,
+} = createCursorPagination({
+  buildFetchParams: (limit, cursor, get) => {
+    const agentName = get(agentName$);
+    if (!agentName) {
+      return null;
     }
+
+    const params = new URLSearchParams({
+      limit: String(limit),
+      agent: agentName,
+    });
     if (cursor) {
       params.set("cursor", cursor);
     }
-
-    set(updateSearchParams$, params);
+    return params;
   },
-);
-
-// ---------------------------------------------------------------------------
-// Navigation commands — URL writers only
-// ---------------------------------------------------------------------------
-
-export const goToNextAgentLogsPage$ = command(async ({ get, set }) => {
-  const response = await get(currentAgentLogs$);
-  if (!response.pagination.hasMore) {
-    return;
-  }
-
-  const nextCursor = response.pagination.nextCursor;
-  const cursor = get(agentLogsCursor$);
-  const history = get(cursorHistory$);
-  const currentIdx = Math.max(0, history.indexOf(cursor));
-
-  set(cursorHistory$, (prev) => {
-    const next = [...prev];
-    if (next.length <= currentIdx + 1) {
-      next.push(nextCursor);
-    } else {
-      next[currentIdx + 1] = nextCursor;
-    }
-    return next;
-  });
-
-  set(writeUrlParams$, { cursor: nextCursor });
-});
-
-export const goToPrevAgentLogsPage$ = command(({ get, set }) => {
-  const cursor = get(agentLogsCursor$);
-  const history = get(cursorHistory$);
-  const currentIdx = history.indexOf(cursor);
-  if (currentIdx <= 0) {
-    return;
-  }
-
-  const prevCursor = history[currentIdx - 1] ?? null;
-  set(writeUrlParams$, { cursor: prevCursor });
-});
-
-export const goForwardTwoAgentLogsPages$ = command(async ({ get, set }) => {
-  const response1 = await get(currentAgentLogs$);
-  if (!response1.pagination.hasMore) {
-    return;
-  }
-
-  const cursor1 = response1.pagination.nextCursor;
-  if (!cursor1) {
-    return;
-  }
-
-  const currentCursor = get(agentLogsCursor$);
-  const history = get(cursorHistory$);
-  const idx = Math.max(0, history.indexOf(currentCursor));
-
-  set(cursorHistory$, (prev) => {
-    const next = [...prev];
-    if (next.length <= idx + 1) {
-      next.push(cursor1);
-    } else {
-      next[idx + 1] = cursor1;
-    }
-    return next;
-  });
-
-  // Fetch intermediate page to get second cursor
-  const limit = get(agentLogsLimit$);
-  const agentName = get(agentName$);
-  const params = new URLSearchParams({ limit: String(limit) });
-  params.set("cursor", cursor1);
-  if (agentName) {
-    params.set("agent", agentName);
-  }
-  const fetchFn = get(fetch$);
-  const resp2 = await fetchFn(`/api/platform/logs?${params.toString()}`);
-
-  if (!resp2.ok) {
-    set(writeUrlParams$, { cursor: cursor1 });
-    return;
-  }
-
-  const response2 = (await resp2.json()) as LogsListResponse;
-  if (!response2.pagination.hasMore) {
-    set(writeUrlParams$, { cursor: cursor1 });
-    return;
-  }
-
-  const cursor2 = response2.pagination.nextCursor;
-  set(cursorHistory$, (prev) => {
-    const next = [...prev];
-    if (next.length <= idx + 2) {
-      next.push(cursor2);
-    } else {
-      next[idx + 2] = cursor2;
-    }
-    return next;
-  });
-
-  set(writeUrlParams$, { cursor: cursor2 });
-});
-
-export const goBackTwoAgentLogsPages$ = command(({ get, set }) => {
-  const cursor = get(agentLogsCursor$);
-  const history = get(cursorHistory$);
-  const currentIdx = history.indexOf(cursor);
-  if (currentIdx <= 0) {
-    return;
-  }
-
-  const targetIdx = Math.max(0, currentIdx - 2);
-  const targetCursor = history[targetIdx] ?? null;
-  set(writeUrlParams$, { cursor: targetCursor });
-});
-
-export const setAgentLogsRowsPerPage$ = command(({ set }, limit: number) => {
-  set(cursorHistory$, [null]);
-  set(writeUrlParams$, { cursor: null, limit });
 });

--- a/turbo/apps/platform/src/signals/agent-detail/connections.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/connections.ts
@@ -1,0 +1,143 @@
+import { computed, state, command } from "ccstate";
+import {
+  extractVariableReferences,
+  groupVariablesBySource,
+  getConnectorProvidedSecretNames,
+  CONNECTOR_TYPES,
+  type ConnectorType,
+} from "@vm0/core";
+import { agentDetail$ } from "./agent-detail.ts";
+import { connectors$ } from "../external/connectors.ts";
+import { secrets$ } from "../settings-page/secrets.ts";
+
+// ---------------------------------------------------------------------------
+// Agent required env — derived from compose content
+// ---------------------------------------------------------------------------
+
+interface AgentRequiredEnv {
+  requiredSecrets: string[];
+  requiredVariables: string[];
+}
+
+const agentRequiredEnv$ = computed((get): AgentRequiredEnv => {
+  const detail = get(agentDetail$);
+  if (!detail?.content?.agents) {
+    return { requiredSecrets: [], requiredVariables: [] };
+  }
+
+  const agentDefs = Object.values(detail.content.agents);
+  const firstAgent = agentDefs[0];
+
+  if (!firstAgent?.environment) {
+    return { requiredSecrets: [], requiredVariables: [] };
+  }
+
+  const refs = extractVariableReferences(firstAgent.environment);
+  const grouped = groupVariablesBySource(refs);
+
+  return {
+    requiredSecrets: [
+      ...grouped.secrets.map((r) => r.name),
+      ...grouped.credentials.map((r) => r.name),
+    ],
+    requiredVariables: grouped.vars.map((r) => r.name),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Connector status — which connectors the agent needs
+// ---------------------------------------------------------------------------
+
+export interface AgentConnectorStatus {
+  type: ConnectorType;
+  label: string;
+  helpText: string;
+  connected: boolean;
+  externalUsername: string | null;
+}
+
+export const agentConnectorStatus$ = computed(async (get) => {
+  const { connectors } = await get(connectors$);
+  const connectorMap = new Map(connectors.map((c) => [c.type, c]));
+
+  return (Object.keys(CONNECTOR_TYPES) as ConnectorType[])
+    .filter((type) => type !== "computer")
+    .map((type) => {
+      const config = CONNECTOR_TYPES[type];
+      const connector = connectorMap.get(type);
+      return {
+        type,
+        label: config.label,
+        helpText: config.helpText,
+        connected: connector !== undefined,
+        externalUsername: connector?.externalUsername ?? null,
+      };
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Secret status — which secrets the agent needs
+// ---------------------------------------------------------------------------
+
+export interface AgentSecretStatus {
+  name: string;
+  configured: boolean;
+}
+
+export const agentSecretStatus$ = computed(async (get) => {
+  const { requiredSecrets } = get(agentRequiredEnv$);
+  const configuredSecrets = await get(secrets$);
+  const configuredNames = new Set(configuredSecrets.map((s) => s.name));
+
+  // Hide secrets that connectors can provide
+  const connectorEnvVars = getConnectorProvidedSecretNames(
+    Object.keys(CONNECTOR_TYPES) as ConnectorType[],
+  );
+
+  return requiredSecrets
+    .filter((name) => !connectorEnvVars.has(name))
+    .map((name) => ({
+      name,
+      configured: configuredNames.has(name),
+    }));
+});
+
+// ---------------------------------------------------------------------------
+// Variable status — which variables the agent needs
+// ---------------------------------------------------------------------------
+
+export interface AgentVariableStatus {
+  name: string;
+  configured: boolean;
+}
+
+export const agentVariableStatus$ = computed((get) => {
+  const { requiredVariables } = get(agentRequiredEnv$);
+
+  // Variables are always "configured" since they're resolved from CLI --vars at runtime.
+  // We show them for informational purposes.
+  return requiredVariables.map((name) => ({
+    name,
+    configured: false,
+  }));
+});
+
+// ---------------------------------------------------------------------------
+// Active tab state
+// ---------------------------------------------------------------------------
+
+type ConnectionsTab = "connectors" | "secrets";
+
+const internalActiveTab$ = state<ConnectionsTab>("connectors");
+
+export const connectionsActiveTab$ = computed((get) => get(internalActiveTab$));
+
+function isConnectionsTab(v: string): v is ConnectionsTab {
+  return v === "connectors" || v === "secrets";
+}
+
+export const setConnectionsActiveTab$ = command(({ set }, v: string) => {
+  if (isConnectionsTab(v)) {
+    set(internalActiveTab$, v);
+  }
+});

--- a/turbo/apps/platform/src/signals/agent-detail/connections.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/connections.ts
@@ -9,6 +9,8 @@ import {
 import { agentDetail$ } from "./agent-detail.ts";
 import { connectors$ } from "../external/connectors.ts";
 import { secrets$ } from "../settings-page/secrets.ts";
+import { variables$ } from "../settings-page/variables.ts";
+import type { MergedItem } from "../settings-page/secrets-and-variables.ts";
 
 // ---------------------------------------------------------------------------
 // Agent required env — derived from compose content
@@ -76,50 +78,68 @@ export const agentConnectorStatus$ = computed(async (get) => {
 });
 
 // ---------------------------------------------------------------------------
-// Secret status — which secrets the agent needs
+// Merged items — secrets & variables scoped to the current agent
 // ---------------------------------------------------------------------------
 
-export interface AgentSecretStatus {
-  name: string;
-  configured: boolean;
-}
+export const agentMergedItems$ = computed(async (get) => {
+  const { requiredSecrets, requiredVariables } = get(agentRequiredEnv$);
+  const [secretsList, variablesList] = await Promise.all([
+    get(secrets$),
+    get(variables$),
+  ]);
 
-export const agentSecretStatus$ = computed(async (get) => {
-  const { requiredSecrets } = get(agentRequiredEnv$);
-  const configuredSecrets = await get(secrets$);
-  const configuredNames = new Set(configuredSecrets.map((s) => s.name));
-
-  // Hide secrets that connectors can provide
-  const connectorEnvVars = getConnectorProvidedSecretNames(
+  const allConnectorEnvVars = getConnectorProvidedSecretNames(
     Object.keys(CONNECTOR_TYPES) as ConnectorType[],
   );
 
-  return requiredSecrets
-    .filter((name) => !connectorEnvVars.has(name))
-    .map((name) => ({
-      name,
-      configured: configuredNames.has(name),
-    }));
-});
+  const items: MergedItem[] = [];
 
-// ---------------------------------------------------------------------------
-// Variable status — which variables the agent needs
-// ---------------------------------------------------------------------------
+  const configuredSecretNames = new Set(secretsList.map((s) => s.name));
+  const configuredVariableNames = new Set(variablesList.map((v) => v.name));
+  const requiredSecretSet = new Set(requiredSecrets);
+  const requiredVariableSet = new Set(requiredVariables);
 
-export interface AgentVariableStatus {
-  name: string;
-  configured: boolean;
-}
+  // Missing required secrets (not yet configured, not resolvable by any connector)
+  for (const name of requiredSecrets) {
+    if (!configuredSecretNames.has(name) && !allConnectorEnvVars.has(name)) {
+      items.push({ kind: "secret", name, data: null, agentRequired: true });
+    }
+  }
 
-export const agentVariableStatus$ = computed((get) => {
-  const { requiredVariables } = get(agentRequiredEnv$);
+  // Missing required variables (not yet configured)
+  for (const name of requiredVariables) {
+    if (!configuredVariableNames.has(name)) {
+      items.push({ kind: "variable", name, data: null, agentRequired: true });
+    }
+  }
 
-  // Variables are always "configured" since they're resolved from CLI --vars at runtime.
-  // We show them for informational purposes.
-  return requiredVariables.map((name) => ({
-    name,
-    configured: false,
-  }));
+  // Configured secrets that are required by this agent
+  for (const secret of secretsList) {
+    if (!requiredSecretSet.has(secret.name)) {
+      continue;
+    }
+    items.push({
+      kind: "secret",
+      name: secret.name,
+      data: secret,
+      agentRequired: !allConnectorEnvVars.has(secret.name),
+    });
+  }
+
+  // Configured variables that are required by this agent
+  for (const variable of variablesList) {
+    if (!requiredVariableSet.has(variable.name)) {
+      continue;
+    }
+    items.push({
+      kind: "variable",
+      name: variable.name,
+      data: variable,
+      agentRequired: true,
+    });
+  }
+
+  return items;
 });
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/signals/cursor-pagination.ts
+++ b/turbo/apps/platform/src/signals/cursor-pagination.ts
@@ -1,0 +1,291 @@
+/**
+ * Factory for cursor-based pagination signals.
+ *
+ * Encapsulates the shared pagination machinery (URL-driven limit/cursor,
+ * cursor history, navigation commands) so that each paginated list only
+ * needs to provide a URL builder for the data fetch.
+ */
+import { state, computed, command, type Computed, type State } from "ccstate";
+import type { LogsListResponse } from "./logs-page/types.ts";
+import { fetch$ } from "./fetch.ts";
+import { searchParams$, updateSearchParams$ } from "./route.ts";
+
+const DEFAULT_LIMIT = 10;
+const VALID_LIMITS = [10, 20, 50, 100] as const;
+
+type GetAccessor = <T>(atom: Computed<T>) => T;
+
+interface CursorPaginationConfig {
+  /**
+   * Build the URLSearchParams for the data fetch.
+   * Receives limit, cursor, and a `get` accessor to read other signals.
+   * Must include limit; cursor is already handled by the caller.
+   */
+  buildFetchParams: (
+    limit: number,
+    cursor: string | null,
+    get: GetAccessor,
+  ) => URLSearchParams | null;
+
+  /**
+   * Extra URL search params to preserve when writing pagination params.
+   * Return entries to merge into the URLSearchParams being written.
+   */
+  preserveUrlParams?: (get: GetAccessor) => Record<string, string>;
+}
+
+interface UrlParamOverrides {
+  cursor?: string | null;
+  limit?: number;
+}
+
+interface PaginationDeps {
+  config: CursorPaginationConfig;
+  limit$: Computed<number>;
+  cursor$: Computed<string | null>;
+  data$: Computed<Promise<LogsListResponse>>;
+  cursorHistory$: State<(string | null)[]>;
+  writeUrlParams$: ReturnType<typeof command<void, [UrlParamOverrides]>>;
+}
+
+function createNavigationCommands(deps: PaginationDeps) {
+  const { config, limit$, cursor$, data$, cursorHistory$, writeUrlParams$ } =
+    deps;
+
+  const goToNextPage$ = command(async ({ get, set }) => {
+    const response = await get(data$);
+    if (!response.pagination.hasMore) {
+      return;
+    }
+
+    const nextCursor = response.pagination.nextCursor;
+    const cursor = get(cursor$);
+    const history = get(cursorHistory$);
+    const currentIdx = Math.max(0, history.indexOf(cursor));
+
+    set(cursorHistory$, (prev) => {
+      const next = [...prev];
+      if (next.length <= currentIdx + 1) {
+        next.push(nextCursor);
+      } else {
+        next[currentIdx + 1] = nextCursor;
+      }
+      return next;
+    });
+
+    set(writeUrlParams$, { cursor: nextCursor });
+  });
+
+  const goToPrevPage$ = command(({ get, set }) => {
+    const cursor = get(cursor$);
+    const history = get(cursorHistory$);
+    const currentIdx = history.indexOf(cursor);
+    if (currentIdx <= 0) {
+      return;
+    }
+
+    const prevCursor = history[currentIdx - 1] ?? null;
+    set(writeUrlParams$, { cursor: prevCursor });
+  });
+
+  const goForwardTwoPages$ = command(async ({ get, set }) => {
+    const response1 = await get(data$);
+    if (!response1.pagination.hasMore) {
+      return;
+    }
+
+    const cursor1 = response1.pagination.nextCursor;
+    if (!cursor1) {
+      return;
+    }
+
+    const currentCursor = get(cursor$);
+    const history = get(cursorHistory$);
+    const idx = Math.max(0, history.indexOf(currentCursor));
+
+    set(cursorHistory$, (prev) => {
+      const next = [...prev];
+      if (next.length <= idx + 1) {
+        next.push(cursor1);
+      } else {
+        next[idx + 1] = cursor1;
+      }
+      return next;
+    });
+
+    // Fetch intermediate page to get second cursor
+    const intermediateParams = config.buildFetchParams(
+      get(limit$),
+      cursor1,
+      get,
+    );
+    if (!intermediateParams) {
+      set(writeUrlParams$, { cursor: cursor1 });
+      return;
+    }
+
+    const fetchFn = get(fetch$);
+    const resp2 = await fetchFn(
+      `/api/platform/logs?${intermediateParams.toString()}`,
+    );
+
+    if (!resp2.ok) {
+      set(writeUrlParams$, { cursor: cursor1 });
+      return;
+    }
+
+    const response2 = (await resp2.json()) as LogsListResponse;
+    if (!response2.pagination.hasMore) {
+      set(writeUrlParams$, { cursor: cursor1 });
+      return;
+    }
+
+    const cursor2 = response2.pagination.nextCursor;
+    set(cursorHistory$, (prev) => {
+      const next = [...prev];
+      if (next.length <= idx + 2) {
+        next.push(cursor2);
+      } else {
+        next[idx + 2] = cursor2;
+      }
+      return next;
+    });
+
+    set(writeUrlParams$, { cursor: cursor2 });
+  });
+
+  const goBackTwoPages$ = command(({ get, set }) => {
+    const cursor = get(cursor$);
+    const history = get(cursorHistory$);
+    const currentIdx = history.indexOf(cursor);
+    if (currentIdx <= 0) {
+      return;
+    }
+
+    const targetIdx = Math.max(0, currentIdx - 2);
+    const targetCursor = history[targetIdx] ?? null;
+    set(writeUrlParams$, { cursor: targetCursor });
+  });
+
+  return {
+    goToNextPage$,
+    goToPrevPage$,
+    goForwardTwoPages$,
+    goBackTwoPages$,
+  };
+}
+
+export function createCursorPagination(config: CursorPaginationConfig) {
+  const limit$ = computed((get) => {
+    const raw = get(searchParams$).get("limit");
+    if (!raw) {
+      return DEFAULT_LIMIT;
+    }
+    const parsed = Number.parseInt(raw, 10);
+    return VALID_LIMITS.includes(parsed as (typeof VALID_LIMITS)[number])
+      ? parsed
+      : DEFAULT_LIMIT;
+  });
+
+  const cursor$ = computed((get) => {
+    return get(searchParams$).get("cursor") ?? null;
+  });
+
+  const data$ = computed(async (get) => {
+    const fetchFn = get(fetch$);
+    const limit = get(limit$);
+    const cursor = get(cursor$);
+
+    const params = config.buildFetchParams(limit, cursor, get);
+    if (!params) {
+      return {
+        data: [],
+        pagination: { hasMore: false, nextCursor: null, totalPages: 1 },
+      } satisfies LogsListResponse;
+    }
+
+    const response = await fetchFn(`/api/platform/logs?${params.toString()}`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch logs: ${response.statusText}`);
+    }
+    return (await response.json()) as LogsListResponse;
+  });
+
+  const cursorHistory$ = state<(string | null)[]>([null]);
+
+  const seedCursorHistory$ = command(({ get, set }) => {
+    const cursor = get(cursor$);
+    if (cursor) {
+      set(cursorHistory$, [null, cursor]);
+    } else {
+      set(cursorHistory$, [null]);
+    }
+  });
+
+  const hasPrev$ = computed((get) => get(cursor$) !== null);
+
+  const currentPage$ = computed((get) => {
+    const cursor = get(cursor$);
+    const history = get(cursorHistory$);
+    const idx = history.indexOf(cursor);
+    return idx === -1 ? 1 : idx + 1;
+  });
+
+  const writeUrlParams$ = command(
+    ({ get, set }, overrides: UrlParamOverrides) => {
+      const params = new URLSearchParams();
+      const limit =
+        overrides.limit !== undefined ? overrides.limit : get(limit$);
+      const cursor =
+        overrides.cursor !== undefined ? overrides.cursor : get(cursor$);
+
+      if (limit !== DEFAULT_LIMIT) {
+        params.set("limit", String(limit));
+      }
+      if (cursor) {
+        params.set("cursor", cursor);
+      }
+
+      if (config.preserveUrlParams) {
+        const extra = config.preserveUrlParams(get);
+        for (const [key, value] of Object.entries(extra)) {
+          if (value) {
+            params.set(key, value);
+          }
+        }
+      }
+
+      set(updateSearchParams$, params);
+    },
+  );
+
+  const nav = createNavigationCommands({
+    config,
+    limit$,
+    cursor$,
+    data$,
+    cursorHistory$,
+    writeUrlParams$,
+  });
+
+  const setRowsPerPage$ = command(({ set }, limit: number) => {
+    set(cursorHistory$, [null]);
+    set(writeUrlParams$, { cursor: null, limit });
+  });
+
+  const resetPaginationState$ = command(({ set }) => {
+    set(cursorHistory$, [null]);
+  });
+
+  return {
+    limit$,
+    cursor$,
+    data$,
+    seedCursorHistory$,
+    hasPrev$,
+    currentPage$,
+    ...nav,
+    setRowsPerPage$,
+    resetPaginationState$,
+  };
+}

--- a/turbo/apps/platform/src/signals/logs-page/logs-signals.ts
+++ b/turbo/apps/platform/src/signals/logs-page/logs-signals.ts
@@ -1,244 +1,66 @@
-import { state, computed, command } from "ccstate";
-import type { LogsListResponse } from "./types.ts";
-import { fetch$ } from "../fetch.ts";
+import { computed, command } from "ccstate";
+import { createCursorPagination } from "../cursor-pagination.ts";
 import { searchParams$, updateSearchParams$ } from "../route.ts";
 
-const DEFAULT_LIMIT = 10;
-const VALID_LIMITS = [10, 20, 50, 100] as const;
-
 // ---------------------------------------------------------------------------
-// URL-derived computeds
+// Search — URL-derived, specific to the logs page
 // ---------------------------------------------------------------------------
-
-export const limit$ = computed((get) => {
-  const raw = get(searchParams$).get("limit");
-  if (!raw) {
-    return DEFAULT_LIMIT;
-  }
-  const parsed = Number.parseInt(raw, 10);
-  return VALID_LIMITS.includes(parsed as (typeof VALID_LIMITS)[number])
-    ? parsed
-    : DEFAULT_LIMIT;
-});
-
-export const cursor$ = computed((get) => {
-  return get(searchParams$).get("cursor") ?? null;
-});
 
 export const search$ = computed((get) => {
   return get(searchParams$).get("search") ?? "";
 });
 
 // Aliases for view backward compatibility
-export const rowsPerPageValue$ = computed((get) => get(limit$));
 export const searchQueryValue$ = computed((get) => get(search$));
 
 // ---------------------------------------------------------------------------
-// Data fetching — single async computed
+// Pagination — shared cursor machinery with search filter
 // ---------------------------------------------------------------------------
 
-export const currentPageLogs$ = computed(async (get) => {
-  const fetchFn = get(fetch$);
-  const limit = get(limit$);
-  const cursor = get(cursor$);
-  const search = get(search$);
-
-  const params = new URLSearchParams({ limit: String(limit) });
-  if (cursor) {
-    params.set("cursor", cursor);
-  }
-  if (search) {
-    params.set("search", search);
-  }
-
-  const response = await fetchFn(`/api/platform/logs?${params.toString()}`);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch logs: ${response.statusText}`);
-  }
-  return (await response.json()) as LogsListResponse;
-});
-
-// ---------------------------------------------------------------------------
-// Cursor history — the only runtime state
-// ---------------------------------------------------------------------------
-
-const cursorHistory$ = state<(string | null)[]>([null]);
-
-export const seedCursorHistory$ = command(({ get, set }) => {
-  const cursor = get(cursor$);
-  if (cursor) {
-    set(cursorHistory$, [null, cursor]);
-  } else {
-    set(cursorHistory$, [null]);
-  }
-});
-
-// ---------------------------------------------------------------------------
-// Derived pagination computeds
-// ---------------------------------------------------------------------------
-
-export const hasPrevPage$ = computed((get) => get(cursor$) !== null);
-
-export const currentPageNumber$ = computed((get) => {
-  const cursor = get(cursor$);
-  const history = get(cursorHistory$);
-  const idx = history.indexOf(cursor);
-  return idx === -1 ? 1 : idx + 1;
-});
-
-// ---------------------------------------------------------------------------
-// Internal command: write URL params
-// ---------------------------------------------------------------------------
-
-interface UrlParamOverrides {
-  cursor?: string | null;
-  limit?: number;
-  search?: string;
-}
-
-const writeUrlParams$ = command(
-  ({ get, set }, overrides: UrlParamOverrides) => {
-    const params = new URLSearchParams();
-    const limit = overrides.limit !== undefined ? overrides.limit : get(limit$);
-    const cursor =
-      overrides.cursor !== undefined ? overrides.cursor : get(cursor$);
-    const search =
-      overrides.search !== undefined ? overrides.search : get(search$);
-
-    if (limit !== DEFAULT_LIMIT) {
-      params.set("limit", String(limit));
-    }
+export const {
+  limit$,
+  cursor$,
+  data$: currentPageLogs$,
+  seedCursorHistory$,
+  hasPrev$: hasPrevPage$,
+  currentPage$: currentPageNumber$,
+  goToNextPage$,
+  goToPrevPage$,
+  goForwardTwoPages$,
+  goBackTwoPages$,
+  setRowsPerPage$,
+  resetPaginationState$,
+} = createCursorPagination({
+  buildFetchParams: (limit, cursor, get) => {
+    const params = new URLSearchParams({ limit: String(limit) });
     if (cursor) {
       params.set("cursor", cursor);
     }
-    if (search) {
-      params.set("search", search);
+    const searchVal = get(search$);
+    if (searchVal) {
+      params.set("search", searchVal);
     }
-
-    set(updateSearchParams$, params);
+    return params;
   },
-);
-
-// ---------------------------------------------------------------------------
-// Navigation commands — URL writers only
-// ---------------------------------------------------------------------------
-
-export const goToNextPage$ = command(async ({ get, set }) => {
-  const response = await get(currentPageLogs$);
-  if (!response.pagination.hasMore) {
-    return;
-  }
-
-  const nextCursor = response.pagination.nextCursor;
-  const cursor = get(cursor$);
-  const history = get(cursorHistory$);
-  const currentIdx = Math.max(0, history.indexOf(cursor));
-
-  set(cursorHistory$, (prev) => {
-    const next = [...prev];
-    if (next.length <= currentIdx + 1) {
-      next.push(nextCursor);
-    } else {
-      next[currentIdx + 1] = nextCursor;
+  preserveUrlParams: (get) => {
+    const searchVal = get(search$);
+    const result: Record<string, string> = {};
+    if (searchVal) {
+      result.search = searchVal;
     }
-    return next;
-  });
-
-  set(writeUrlParams$, { cursor: nextCursor });
+    return result;
+  },
 });
 
-export const goToPrevPage$ = command(({ get, set }) => {
-  const cursor = get(cursor$);
-  const history = get(cursorHistory$);
-  const currentIdx = history.indexOf(cursor);
-  if (currentIdx <= 0) {
-    return;
-  }
+// ---------------------------------------------------------------------------
+// Search command — resets pagination and updates URL
+// ---------------------------------------------------------------------------
 
-  const prevCursor = history[currentIdx - 1] ?? null;
-  set(writeUrlParams$, { cursor: prevCursor });
-});
-
-export const goForwardTwoPages$ = command(async ({ get, set }) => {
-  const response1 = await get(currentPageLogs$);
-  if (!response1.pagination.hasMore) {
-    return;
-  }
-
-  const cursor1 = response1.pagination.nextCursor;
-  if (!cursor1) {
-    return;
-  }
-
-  const currentCursor = get(cursor$);
-  const history = get(cursorHistory$);
-  const idx = Math.max(0, history.indexOf(currentCursor));
-
-  set(cursorHistory$, (prev) => {
-    const next = [...prev];
-    if (next.length <= idx + 1) {
-      next.push(cursor1);
-    } else {
-      next[idx + 1] = cursor1;
-    }
-    return next;
-  });
-
-  // Fetch intermediate page to get second cursor
-  const limit = get(limit$);
-  const search = get(search$);
-  const params = new URLSearchParams({ limit: String(limit) });
-  params.set("cursor", cursor1);
+export const setSearch$ = command(({ set }, search: string) => {
+  set(resetPaginationState$);
+  const params = new URLSearchParams();
   if (search) {
     params.set("search", search);
   }
-  const fetchFn = get(fetch$);
-  const resp2 = await fetchFn(`/api/platform/logs?${params.toString()}`);
-
-  if (!resp2.ok) {
-    set(writeUrlParams$, { cursor: cursor1 });
-    return;
-  }
-
-  const response2 = (await resp2.json()) as LogsListResponse;
-  if (!response2.pagination.hasMore) {
-    set(writeUrlParams$, { cursor: cursor1 });
-    return;
-  }
-
-  const cursor2 = response2.pagination.nextCursor;
-  set(cursorHistory$, (prev) => {
-    const next = [...prev];
-    if (next.length <= idx + 2) {
-      next.push(cursor2);
-    } else {
-      next[idx + 2] = cursor2;
-    }
-    return next;
-  });
-
-  set(writeUrlParams$, { cursor: cursor2 });
-});
-
-export const goBackTwoPages$ = command(({ get, set }) => {
-  const cursor = get(cursor$);
-  const history = get(cursorHistory$);
-  const currentIdx = history.indexOf(cursor);
-  if (currentIdx <= 0) {
-    return;
-  }
-
-  const targetIdx = Math.max(0, currentIdx - 2);
-  const targetCursor = history[targetIdx] ?? null;
-  set(writeUrlParams$, { cursor: targetCursor });
-});
-
-export const setRowsPerPage$ = command(({ set }, limit: number) => {
-  set(cursorHistory$, [null]);
-  set(writeUrlParams$, { cursor: null, limit });
-});
-
-export const setSearch$ = command(({ set }, search: string) => {
-  set(cursorHistory$, [null]);
-  set(writeUrlParams$, { cursor: null, search });
+  set(updateSearchParams$, params);
 });

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-connections-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-connections-page.test.tsx
@@ -73,6 +73,16 @@ function mockSecretsAPI(secrets?: unknown[]) {
   );
 }
 
+function mockVariablesAPI(variables?: unknown[]) {
+  server.use(
+    http.get("/api/variables", () => {
+      return HttpResponse.json({
+        variables: variables ?? [],
+      });
+    }),
+  );
+}
+
 describe("agent connections page", () => {
   it("should redirect to /agents when feature flag is disabled", async () => {
     await setupPage({
@@ -87,6 +97,7 @@ describe("agent connections page", () => {
     mockAgentDetailAPI();
     mockConnectorsAPI();
     mockSecretsAPI();
+    mockVariablesAPI();
 
     await setupPage({
       context,
@@ -109,6 +120,7 @@ describe("agent connections page", () => {
     mockAgentDetailAPI();
     mockConnectorsAPI();
     mockSecretsAPI();
+    mockVariablesAPI();
 
     await setupPage({
       context,
@@ -131,6 +143,7 @@ describe("agent connections page", () => {
     mockAgentDetailAPI();
     mockConnectorsAPI();
     mockSecretsAPI();
+    mockVariablesAPI();
 
     await setupPage({
       context,
@@ -161,6 +174,7 @@ describe("agent connections page", () => {
       },
     ]);
     mockSecretsAPI();
+    mockVariablesAPI();
 
     await setupPage({
       context,
@@ -177,6 +191,7 @@ describe("agent connections page", () => {
     mockAgentDetailAPI();
     mockConnectorsAPI();
     mockSecretsAPI();
+    mockVariablesAPI();
 
     await setupPage({
       context,
@@ -192,10 +207,11 @@ describe("agent connections page", () => {
     expect(connectButtons.length).toBeGreaterThan(0);
   });
 
-  it("should switch to secrets tab and show empty state when no secrets required", async () => {
+  it("should switch to secrets tab and show add row when no secrets required", async () => {
     mockAgentDetailAPI();
     mockConnectorsAPI();
     mockSecretsAPI();
+    mockVariablesAPI();
 
     await setupPage({
       context,
@@ -212,13 +228,11 @@ describe("agent connections page", () => {
     fireEvent.click(screen.getByRole("tab", { name: "Secrets and variables" }));
 
     await vi.waitFor(() => {
-      expect(
-        screen.getByText("No secrets or variables required"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("New secrets and variables")).toBeInTheDocument();
     });
   });
 
-  it("should show required secrets with configured/missing status", async () => {
+  it("should show required secrets with configured and missing rows", async () => {
     mockAgentDetailAPI({
       environment: {
         MY_API_KEY: SECRET_REF_MY_API_KEY,
@@ -236,6 +250,7 @@ describe("agent connections page", () => {
         updatedAt: "2024-01-01T00:00:00Z",
       },
     ]);
+    mockVariablesAPI();
 
     await setupPage({
       context,
@@ -251,19 +266,23 @@ describe("agent connections page", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: "Secrets and variables" }));
 
+    // Configured secret shows with kebab menu
     await vi.waitFor(() => {
       expect(screen.getByText("MY_API_KEY")).toBeInTheDocument();
     });
+    expect(screen.getByLabelText("Secret options")).toBeInTheDocument();
 
-    expect(screen.getByText("Configured")).toBeInTheDocument();
+    // Missing secret shows with "Missing secrets" badge and "Fill" button
     expect(screen.getByText("MY_OTHER_KEY")).toBeInTheDocument();
-    expect(screen.getByText("Missing")).toBeInTheDocument();
+    expect(screen.getByText("Missing secrets")).toBeInTheDocument();
+    expect(screen.getByText("Fill")).toBeInTheDocument();
   });
 
-  it("should show breadcrumb with agents link and agent name connections", async () => {
+  it("should show three-level breadcrumb", async () => {
     mockAgentDetailAPI();
     mockConnectorsAPI();
     mockSecretsAPI();
+    mockVariablesAPI();
 
     await setupPage({
       context,
@@ -277,27 +296,7 @@ describe("agent connections page", () => {
 
     const nav = screen.getByRole("navigation");
     expect(within(nav).getByText("Agents")).toBeInTheDocument();
-    expect(within(nav).getByText("my-agent connections")).toBeInTheDocument();
-  });
-
-  it("should show new connectors row", async () => {
-    mockAgentDetailAPI();
-    mockConnectorsAPI();
-    mockSecretsAPI();
-
-    await setupPage({
-      context,
-      path: "/agents/my-agent/connections",
-      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
-    });
-
-    await vi.waitFor(() => {
-      expect(screen.getByText("New connectors")).toBeInTheDocument();
-    });
-
-    expect(
-      screen.getByText("Add a new connectors and used by your agents"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Add more connectors")).toBeInTheDocument();
+    expect(within(nav).getByText("my-agent")).toBeInTheDocument();
+    expect(within(nav).getByText("Connections")).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-connections-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-connections-page.test.tsx
@@ -1,0 +1,287 @@
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { describe, expect, it, vi } from "vitest";
+import { screen, within, fireEvent } from "@testing-library/react";
+import { pathname$ } from "../../../signals/route.ts";
+import { server } from "../../../mocks/server.ts";
+import { http, HttpResponse } from "msw";
+import { FeatureSwitchKey } from "@vm0/core";
+
+const context = testContext();
+
+/** Compose variable reference strings (built at module scope to satisfy lint rules). */
+const SECRET_REF_MY_API_KEY = `\${{ secrets.MY_API_KEY }}`;
+const SECRET_REF_MY_OTHER_KEY = `\${{ secrets.MY_OTHER_KEY }}`;
+
+function mockAgentDetailAPI(options?: {
+  name?: string;
+  environment?: Record<string, string>;
+}) {
+  const name = options?.name ?? "my-agent";
+  const environment = options?.environment;
+
+  server.use(
+    http.get("/api/agent/composes", ({ request }) => {
+      const url = new URL(request.url);
+      const queryName = url.searchParams.get("name");
+
+      if (queryName !== name) {
+        return new HttpResponse(null, { status: 404 });
+      }
+
+      return HttpResponse.json({
+        id: "compose_1",
+        name,
+        headVersionId: "version_1",
+        content: {
+          version: "1",
+          agents: {
+            [name]: {
+              description: "A test agent",
+              framework: "claude-code",
+              ...(environment ? { environment } : {}),
+            },
+          },
+        },
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      });
+    }),
+    http.get("/api/agent/composes/:id/instructions", () => {
+      return HttpResponse.json({ content: null, filename: null });
+    }),
+  );
+}
+
+function mockConnectorsAPI(connectors?: unknown[]) {
+  server.use(
+    http.get("/api/connectors", () => {
+      return HttpResponse.json({
+        connectors: connectors ?? [],
+      });
+    }),
+  );
+}
+
+function mockSecretsAPI(secrets?: unknown[]) {
+  server.use(
+    http.get("/api/secrets", () => {
+      return HttpResponse.json({
+        secrets: secrets ?? [],
+      });
+    }),
+  );
+}
+
+describe("agent connections page", () => {
+  it("should redirect to /agents when feature flag is disabled", async () => {
+    await setupPage({
+      context,
+      path: "/agents/my-agent/connections",
+    });
+
+    expect(context.store.get(pathname$)).toBe("/agents");
+  });
+
+  it("should render agent header and connections page structure", async () => {
+    mockAgentDetailAPI();
+    mockConnectorsAPI();
+    mockSecretsAPI();
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent/connections",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "my-agent" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Connections of my-agent")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This is the secret list used for your agents in every run",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should show connectors and secrets tabs", async () => {
+    mockAgentDetailAPI();
+    mockConnectorsAPI();
+    mockSecretsAPI();
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent/connections",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("tab", { name: "Connectors" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("tab", { name: "Secrets and variables" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should show connectors tab by default with connector types", async () => {
+    mockAgentDetailAPI();
+    mockConnectorsAPI();
+    mockSecretsAPI();
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent/connections",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Notion")).toBeInTheDocument();
+  });
+
+  it("should show connected status for connected connectors", async () => {
+    mockAgentDetailAPI();
+    mockConnectorsAPI([
+      {
+        id: "conn_1",
+        type: "github",
+        authMethod: "oauth",
+        externalId: "12345",
+        externalUsername: "testuser",
+        externalEmail: "test@example.com",
+        oauthScopes: ["repo"],
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+    mockSecretsAPI();
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent/connections",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Connected as testuser")).toBeInTheDocument();
+    });
+  });
+
+  it("should show Connect button for disconnected connectors", async () => {
+    mockAgentDetailAPI();
+    mockConnectorsAPI();
+    mockSecretsAPI();
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent/connections",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+
+    const connectButtons = screen.getAllByText("Connect");
+    expect(connectButtons.length).toBeGreaterThan(0);
+  });
+
+  it("should switch to secrets tab and show empty state when no secrets required", async () => {
+    mockAgentDetailAPI();
+    mockConnectorsAPI();
+    mockSecretsAPI();
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent/connections",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("tab", { name: "Secrets and variables" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Secrets and variables" }));
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByText("No secrets or variables required"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should show required secrets with configured/missing status", async () => {
+    mockAgentDetailAPI({
+      environment: {
+        MY_API_KEY: SECRET_REF_MY_API_KEY,
+        MY_OTHER_KEY: SECRET_REF_MY_OTHER_KEY,
+      },
+    });
+    mockConnectorsAPI();
+    mockSecretsAPI([
+      {
+        id: "secret_1",
+        name: "MY_API_KEY",
+        description: null,
+        type: "user",
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent/connections",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("tab", { name: "Secrets and variables" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Secrets and variables" }));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("MY_API_KEY")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Configured")).toBeInTheDocument();
+    expect(screen.getByText("MY_OTHER_KEY")).toBeInTheDocument();
+    expect(screen.getByText("Missing")).toBeInTheDocument();
+  });
+
+  it("should show breadcrumb with agents link, agent name, and connections", async () => {
+    mockAgentDetailAPI();
+    mockConnectorsAPI();
+    mockSecretsAPI();
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent/connections",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "my-agent" }),
+      ).toBeInTheDocument();
+    });
+
+    const nav = screen.getByRole("navigation");
+    expect(within(nav).getByText("Agents")).toBeInTheDocument();
+    expect(within(nav).getByText("Connections")).toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-connections-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-connections-page.test.tsx
@@ -83,7 +83,7 @@ describe("agent connections page", () => {
     expect(context.store.get(pathname$)).toBe("/agents");
   });
 
-  it("should render agent header and connections page structure", async () => {
+  it("should render connections page structure", async () => {
     mockAgentDetailAPI();
     mockConnectorsAPI();
     mockSecretsAPI();
@@ -95,12 +95,9 @@ describe("agent connections page", () => {
     });
 
     await vi.waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: "my-agent" }),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Connections of my-agent")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Connections of my-agent")).toBeInTheDocument();
     expect(
       screen.getByText(
         "This is the secret list used for your agents in every run",
@@ -263,7 +260,7 @@ describe("agent connections page", () => {
     expect(screen.getByText("Missing")).toBeInTheDocument();
   });
 
-  it("should show breadcrumb with agents link, agent name, and connections", async () => {
+  it("should show breadcrumb with agents link and agent name connections", async () => {
     mockAgentDetailAPI();
     mockConnectorsAPI();
     mockSecretsAPI();
@@ -275,13 +272,32 @@ describe("agent connections page", () => {
     });
 
     await vi.waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: "my-agent" }),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Connections of my-agent")).toBeInTheDocument();
     });
 
     const nav = screen.getByRole("navigation");
     expect(within(nav).getByText("Agents")).toBeInTheDocument();
-    expect(within(nav).getByText("Connections")).toBeInTheDocument();
+    expect(within(nav).getByText("my-agent connections")).toBeInTheDocument();
+  });
+
+  it("should show new connectors row", async () => {
+    mockAgentDetailAPI();
+    mockConnectorsAPI();
+    mockSecretsAPI();
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent/connections",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("New connectors")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Add a new connectors and used by your agents"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Add more connectors")).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-logs-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-logs-page.test.tsx
@@ -1,0 +1,217 @@
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { describe, expect, it, vi } from "vitest";
+import { screen, within } from "@testing-library/react";
+import { pathname$ } from "../../../signals/route.ts";
+import { server } from "../../../mocks/server.ts";
+import { http, HttpResponse } from "msw";
+import { FeatureSwitchKey } from "@vm0/core";
+
+const context = testContext();
+
+function mockAgentDetailAPI(options?: { name?: string }) {
+  const name = options?.name ?? "my-agent";
+
+  server.use(
+    http.get("/api/agent/composes", ({ request }) => {
+      const url = new URL(request.url);
+      const queryName = url.searchParams.get("name");
+
+      if (queryName !== name) {
+        return new HttpResponse(null, { status: 404 });
+      }
+
+      return HttpResponse.json({
+        id: "compose_1",
+        name,
+        headVersionId: "version_1",
+        content: {
+          version: "1",
+          agents: {
+            [name]: {
+              description: "A test agent",
+              framework: "claude-code",
+            },
+          },
+        },
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      });
+    }),
+    http.get("/api/agent/composes/:id/instructions", () => {
+      return HttpResponse.json({ content: null, filename: null });
+    }),
+  );
+}
+
+function mockLogsAPI(options?: {
+  agentName?: string;
+  data?: unknown[];
+  hasMore?: boolean;
+  totalPages?: number;
+}) {
+  const agentName = options?.agentName ?? "my-agent";
+  const hasMore = options?.hasMore ?? false;
+  const totalPages = options?.totalPages ?? 1;
+  const data = options?.data ?? [
+    {
+      id: "run_1",
+      sessionId: "session_1",
+      agentName,
+      framework: "claude-code",
+      status: "completed",
+      createdAt: "2024-06-15T10:30:00Z",
+    },
+    {
+      id: "run_2",
+      sessionId: null,
+      agentName,
+      framework: "claude-code",
+      status: "running",
+      createdAt: "2024-06-15T09:00:00Z",
+    },
+  ];
+
+  server.use(
+    http.get("/api/platform/logs", ({ request }) => {
+      const url = new URL(request.url);
+      const queryAgent = url.searchParams.get("agent");
+
+      if (queryAgent !== agentName) {
+        return HttpResponse.json({
+          data: [],
+          pagination: { hasMore: false, nextCursor: null, totalPages: 1 },
+        });
+      }
+
+      return HttpResponse.json({
+        data,
+        pagination: {
+          hasMore,
+          nextCursor: hasMore ? "cursor_1" : null,
+          totalPages,
+        },
+      });
+    }),
+  );
+}
+
+describe("agent logs page", () => {
+  it("should redirect to /agents when feature flag is disabled", async () => {
+    await setupPage({
+      context,
+      path: "/agents/my-agent/logs",
+    });
+
+    expect(context.store.get(pathname$)).toBe("/agents");
+  });
+
+  it("should render agent header and logs table", async () => {
+    mockAgentDetailAPI();
+    mockLogsAPI();
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent/logs",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "my-agent" }),
+      ).toBeInTheDocument();
+    });
+
+    // Should show table headers
+    expect(screen.getByText("Run ID")).toBeInTheDocument();
+    expect(screen.getByText("Session ID")).toBeInTheDocument();
+    expect(screen.getByText("Model")).toBeInTheDocument();
+    expect(screen.getByText("Generate time")).toBeInTheDocument();
+
+    // Should show run data
+    expect(screen.getByText("run_1")).toBeInTheDocument();
+    expect(screen.getByText("session_1")).toBeInTheDocument();
+    expect(screen.getByText("run_2")).toBeInTheDocument();
+  });
+
+  it("should show empty state when no logs exist", async () => {
+    mockAgentDetailAPI();
+    mockLogsAPI({ data: [] });
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent/logs",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Nothing here yet")).toBeInTheDocument();
+    });
+  });
+
+  it("should show breadcrumb with agents link, agent name, and logs", async () => {
+    mockAgentDetailAPI();
+    mockLogsAPI();
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent/logs",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "my-agent" }),
+      ).toBeInTheDocument();
+    });
+
+    const nav = screen.getByRole("navigation");
+    expect(within(nav).getByText("Agents")).toBeInTheDocument();
+    expect(within(nav).getByText("Logs")).toBeInTheDocument();
+  });
+
+  it("should show pagination controls", async () => {
+    mockAgentDetailAPI();
+    mockLogsAPI({ hasMore: true, totalPages: 3 });
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent/logs",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Rows per page")).toBeInTheDocument();
+  });
+
+  it("should show dash for null session ID", async () => {
+    mockAgentDetailAPI();
+    mockLogsAPI({
+      data: [
+        {
+          id: "run_1",
+          sessionId: null,
+          agentName: "my-agent",
+          framework: "claude-code",
+          status: "completed",
+          createdAt: "2024-06-15T10:30:00Z",
+        },
+      ],
+    });
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent/logs",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("run_1")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("-")).toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-logs-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-logs-page.test.tsx
@@ -149,7 +149,7 @@ describe("agent logs page", () => {
     });
   });
 
-  it("should show breadcrumb with agents link, agent name, and logs", async () => {
+  it("should show breadcrumb with agents link and agent name logs", async () => {
     mockAgentDetailAPI();
     mockLogsAPI();
 
@@ -167,7 +167,7 @@ describe("agent logs page", () => {
 
     const nav = screen.getByRole("navigation");
     expect(within(nav).getByText("Agents")).toBeInTheDocument();
-    expect(within(nav).getByText("Logs")).toBeInTheDocument();
+    expect(within(nav).getByText("my-agent logs")).toBeInTheDocument();
   });
 
   it("should show pagination controls", async () => {

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-logs-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-logs-page.test.tsx
@@ -106,7 +106,7 @@ describe("agent logs page", () => {
     expect(context.store.get(pathname$)).toBe("/agents");
   });
 
-  it("should render agent header and logs table", async () => {
+  it("should render page header and logs table", async () => {
     mockAgentDetailAPI();
     mockLogsAPI();
 
@@ -149,7 +149,7 @@ describe("agent logs page", () => {
     });
   });
 
-  it("should show breadcrumb with agents link and agent name logs", async () => {
+  it("should show three-level breadcrumb", async () => {
     mockAgentDetailAPI();
     mockLogsAPI();
 
@@ -167,7 +167,8 @@ describe("agent logs page", () => {
 
     const nav = screen.getByRole("navigation");
     expect(within(nav).getByText("Agents")).toBeInTheDocument();
-    expect(within(nav).getByText("my-agent logs")).toBeInTheDocument();
+    expect(within(nav).getByText("my-agent")).toBeInTheDocument();
+    expect(within(nav).getByText("Logs")).toBeInTheDocument();
   });
 
   it("should show pagination controls", async () => {

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-connections-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-connections-page.tsx
@@ -3,19 +3,18 @@ import {
   IconCircleCheck,
   IconLoader,
   IconAlertCircle,
+  IconPlus,
 } from "@tabler/icons-react";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 import { AppShell } from "../layout/app-shell.tsx";
-import { AgentHeader } from "./agent-header.tsx";
 import { ConnectorIcon } from "../settings-page/connector-icons.tsx";
 import { SecretDialog } from "../settings-page/secret-dialog.tsx";
 import {
   agentDetail$,
   agentDetailLoading$,
   agentName$,
-  isOwner$,
 } from "../../signals/agent-detail/agent-detail.ts";
 import {
   agentConnectorStatus$,
@@ -122,6 +121,28 @@ function ConnectorsTab() {
       {connectorStatus.map((item) => (
         <ConnectorRow key={item.type} item={item} />
       ))}
+      <NewConnectorRow />
+    </div>
+  );
+}
+
+function NewConnectorRow() {
+  return (
+    <div className="flex items-center gap-4 border-l border-r border-b border-border bg-card p-4 last:rounded-b-xl">
+      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-dashed border-border">
+        <IconPlus className="h-4 w-4 text-muted-foreground" />
+      </div>
+      <div className="flex flex-1 flex-col gap-1 min-w-0">
+        <div className="text-sm font-medium text-foreground">
+          New connectors
+        </div>
+        <div className="text-sm text-muted-foreground">
+          Add a new connectors and used by your agents
+        </div>
+      </div>
+      <button className="shrink-0 rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-muted transition-colors">
+        Add more connectors
+      </button>
     </div>
   );
 }
@@ -231,7 +252,6 @@ export function AgentConnectionsPage() {
   const agentName = useGet(agentName$);
   const detail = useGet(agentDetail$);
   const loading = useGet(agentDetailLoading$);
-  const isOwner = useGet(isOwner$);
   const activeTab = useGet(connectionsActiveTab$);
   const setActiveTab = useSet(setConnectionsActiveTab$);
 
@@ -239,8 +259,7 @@ export function AgentConnectionsPage() {
     <AppShell
       breadcrumb={[
         { label: "Agents", path: "/agents" },
-        agentName ?? "Loading...",
-        "Connections",
+        `${agentName ?? "Loading..."} connections`,
       ]}
     >
       <div className="flex flex-col gap-[22px] p-8 min-h-full">
@@ -248,7 +267,6 @@ export function AgentConnectionsPage() {
           <AgentConnectionsPageSkeleton />
         ) : detail ? (
           <>
-            <AgentHeader detail={detail} isOwner={isOwner} />
             <div className="flex flex-col gap-1">
               <h2 className="text-lg font-medium text-foreground">
                 Connections of {detail.name}
@@ -280,13 +298,6 @@ export function AgentConnectionsPage() {
 function AgentConnectionsPageSkeleton() {
   return (
     <>
-      <div className="flex items-center gap-3.5">
-        <Skeleton className="h-14 w-14 rounded-xl" />
-        <div className="flex-1 space-y-2">
-          <Skeleton className="h-7 w-48" />
-          <Skeleton className="h-4 w-72" />
-        </div>
-      </div>
       <div className="flex flex-col gap-1">
         <Skeleton className="h-6 w-56" />
         <Skeleton className="h-4 w-80" />

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-connections-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-connections-page.tsx
@@ -38,24 +38,14 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 // Connectors tab
 // ---------------------------------------------------------------------------
 
-function ConnectorRow({
-  item,
-  isFirst,
-  isLast,
-}: {
-  item: AgentConnectorStatus;
-  isFirst: boolean;
-  isLast: boolean;
-}) {
+function ConnectorRow({ item }: { item: AgentConnectorStatus }) {
   const pollingType = useGet(pollingConnectorType$);
   const connect = useSet(connectConnector$);
   const pageSignal = useGet(pageSignal$);
   const isPolling = pollingType === item.type;
 
   return (
-    <div
-      className={`flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 ${isFirst ? "rounded-t-xl" : ""} ${isLast ? "rounded-b-xl border-b" : ""}`}
-    >
+    <div className="flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 first:rounded-t-xl last:rounded-b-xl last:border-b">
       <div className="shrink-0">
         <ConnectorIcon type={item.type} size={28} />
       </div>
@@ -129,13 +119,8 @@ function ConnectorsTab() {
 
   return (
     <div className="flex flex-col">
-      {connectorStatus.map((item, index) => (
-        <ConnectorRow
-          key={item.type}
-          item={item}
-          isFirst={index === 0}
-          isLast={index === connectorStatus.length - 1}
-        />
+      {connectorStatus.map((item) => (
+        <ConnectorRow key={item.type} item={item} />
       ))}
     </div>
   );
@@ -145,21 +130,11 @@ function ConnectorsTab() {
 // Secrets and variables tab
 // ---------------------------------------------------------------------------
 
-function SecretStatusRow({
-  item,
-  isFirst,
-  isLast,
-}: {
-  item: AgentSecretStatus;
-  isFirst: boolean;
-  isLast: boolean;
-}) {
+function SecretStatusRow({ item }: { item: AgentSecretStatus }) {
   const openAddSecret = useSet(openAddSecretDialog$);
 
   return (
-    <div
-      className={`flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 ${isFirst ? "rounded-t-xl" : ""} ${isLast ? "rounded-b-xl border-b" : ""}`}
-    >
+    <div className="flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 first:rounded-t-xl last:rounded-b-xl last:border-b">
       <div className="flex flex-1 flex-col gap-1 min-w-0">
         <div className="text-sm font-medium text-foreground font-mono">
           {item.name}
@@ -188,19 +163,9 @@ function SecretStatusRow({
   );
 }
 
-function VariableStatusRow({
-  item,
-  isFirst,
-  isLast,
-}: {
-  item: AgentVariableStatus;
-  isFirst: boolean;
-  isLast: boolean;
-}) {
+function VariableStatusRow({ item }: { item: AgentVariableStatus }) {
   return (
-    <div
-      className={`flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 ${isFirst ? "rounded-t-xl" : ""} ${isLast ? "rounded-b-xl border-b" : ""}`}
-    >
+    <div className="flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 first:rounded-t-xl last:rounded-b-xl last:border-b">
       <div className="flex flex-1 flex-col gap-1 min-w-0">
         <div className="text-sm font-medium text-foreground font-mono">
           {item.name}
@@ -235,9 +200,7 @@ function SecretsAndVariablesTab() {
     );
   }
 
-  const allItems = [...secretStatus, ...variableStatus];
-
-  if (allItems.length === 0) {
+  if (secretStatus.length === 0 && variableStatus.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center p-8 text-center text-muted-foreground">
         <p className="text-lg">No secrets or variables required</p>
@@ -248,33 +211,14 @@ function SecretsAndVariablesTab() {
     );
   }
 
-  const totalItems = secretStatus.length + variableStatus.length;
-  let rowIndex = 0;
-
   return (
     <div className="flex flex-col">
-      {secretStatus.map((item) => {
-        const currentIndex = rowIndex++;
-        return (
-          <SecretStatusRow
-            key={`secret-${item.name}`}
-            item={item}
-            isFirst={currentIndex === 0}
-            isLast={currentIndex === totalItems - 1}
-          />
-        );
-      })}
-      {variableStatus.map((item) => {
-        const currentIndex = rowIndex++;
-        return (
-          <VariableStatusRow
-            key={`var-${item.name}`}
-            item={item}
-            isFirst={currentIndex === 0}
-            isLast={currentIndex === totalItems - 1}
-          />
-        );
-      })}
+      {secretStatus.map((item) => (
+        <SecretStatusRow key={`secret-${item.name}`} item={item} />
+      ))}
+      {variableStatus.map((item) => (
+        <VariableStatusRow key={`var-${item.name}`} item={item} />
+      ))}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-connections-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-connections-page.tsx
@@ -1,15 +1,295 @@
-import { useGet } from "ccstate-react";
+import { useGet, useLastResolved, useSet } from "ccstate-react";
+import {
+  IconCircleCheck,
+  IconLoader,
+  IconAlertCircle,
+} from "@tabler/icons-react";
+import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
+import { Skeleton } from "@vm0/ui/components/ui/skeleton";
+import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 import { AppShell } from "../layout/app-shell.tsx";
+import { AgentHeader } from "./agent-header.tsx";
+import { ConnectorIcon } from "../settings-page/connector-icons.tsx";
+import { SecretDialog } from "../settings-page/secret-dialog.tsx";
 import {
   agentDetail$,
   agentDetailLoading$,
   agentName$,
+  isOwner$,
 } from "../../signals/agent-detail/agent-detail.ts";
+import {
+  agentConnectorStatus$,
+  agentSecretStatus$,
+  agentVariableStatus$,
+  connectionsActiveTab$,
+  setConnectionsActiveTab$,
+  type AgentConnectorStatus,
+  type AgentSecretStatus,
+  type AgentVariableStatus,
+} from "../../signals/agent-detail/connections.ts";
+import {
+  connectConnector$,
+  pollingConnectorType$,
+} from "../../signals/settings-page/connectors.ts";
+import { openAddSecretDialog$ } from "../../signals/settings-page/secrets.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+
+// ---------------------------------------------------------------------------
+// Connectors tab
+// ---------------------------------------------------------------------------
+
+function ConnectorRow({
+  item,
+  isFirst,
+  isLast,
+}: {
+  item: AgentConnectorStatus;
+  isFirst: boolean;
+  isLast: boolean;
+}) {
+  const pollingType = useGet(pollingConnectorType$);
+  const connect = useSet(connectConnector$);
+  const pageSignal = useGet(pageSignal$);
+  const isPolling = pollingType === item.type;
+
+  return (
+    <div
+      className={`flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 ${isFirst ? "rounded-t-xl" : ""} ${isLast ? "rounded-b-xl border-b" : ""}`}
+    >
+      <div className="shrink-0">
+        <ConnectorIcon type={item.type} size={28} />
+      </div>
+      <div className="flex flex-1 flex-col gap-1 min-w-0">
+        <div className="text-sm font-medium text-foreground">{item.label}</div>
+        <div className="text-sm text-muted-foreground">{item.helpText}</div>
+      </div>
+
+      {/* Status */}
+      <div className="shrink-0">
+        {item.connected && item.externalUsername && (
+          <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
+            <IconCircleCheck className="h-3 w-3 text-green-600" />
+            Connected as {item.externalUsername}
+          </span>
+        )}
+        {item.connected && !item.externalUsername && (
+          <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
+            <IconCircleCheck className="h-3 w-3 text-green-600" />
+            Connected
+          </span>
+        )}
+        {!item.connected && isPolling && (
+          <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
+            <IconLoader className="h-3 w-3 text-yellow-600 animate-spin" />
+            Connecting...
+          </span>
+        )}
+      </div>
+
+      {/* Action */}
+      {!item.connected && (
+        <button
+          onClick={() => connect(item.type, pageSignal)}
+          disabled={isPolling}
+          className="flex items-center shrink-0 rounded-lg border border-border bg-background overflow-hidden hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <span className="px-4 py-2 text-sm font-medium text-foreground">
+            Connect
+          </span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+function ConnectorsTab() {
+  const connectorStatus = useLastResolved(agentConnectorStatus$);
+  const types = (Object.keys(CONNECTOR_TYPES) as ConnectorType[]).filter(
+    (t) => t !== "computer",
+  );
+
+  if (!connectorStatus) {
+    return (
+      <div className="flex flex-col">
+        {types.map((type, i) => (
+          <div
+            key={type}
+            className={`flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 animate-pulse ${i === 0 ? "rounded-t-xl" : ""} ${i === types.length - 1 ? "rounded-b-xl border-b" : ""}`}
+          >
+            <div className="h-7 w-7 rounded bg-muted" />
+            <div className="flex flex-1 flex-col gap-2">
+              <div className="h-4 w-24 rounded bg-muted" />
+              <div className="h-3 w-48 rounded bg-muted" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      {connectorStatus.map((item, index) => (
+        <ConnectorRow
+          key={item.type}
+          item={item}
+          isFirst={index === 0}
+          isLast={index === connectorStatus.length - 1}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Secrets and variables tab
+// ---------------------------------------------------------------------------
+
+function SecretStatusRow({
+  item,
+  isFirst,
+  isLast,
+}: {
+  item: AgentSecretStatus;
+  isFirst: boolean;
+  isLast: boolean;
+}) {
+  const openAddSecret = useSet(openAddSecretDialog$);
+
+  return (
+    <div
+      className={`flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 ${isFirst ? "rounded-t-xl" : ""} ${isLast ? "rounded-b-xl border-b" : ""}`}
+    >
+      <div className="flex flex-1 flex-col gap-1 min-w-0">
+        <div className="text-sm font-medium text-foreground font-mono">
+          {item.name}
+        </div>
+      </div>
+      {item.configured ? (
+        <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
+          <IconCircleCheck className="h-3 w-3 text-green-600" />
+          Configured
+        </span>
+      ) : (
+        <>
+          <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-muted-foreground">
+            <IconAlertCircle className="h-3 w-3 text-yellow-600" />
+            Missing
+          </span>
+          <button
+            onClick={() => openAddSecret(item.name)}
+            className="shrink-0 rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-muted transition-colors"
+          >
+            Add
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+function VariableStatusRow({
+  item,
+  isFirst,
+  isLast,
+}: {
+  item: AgentVariableStatus;
+  isFirst: boolean;
+  isLast: boolean;
+}) {
+  return (
+    <div
+      className={`flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 ${isFirst ? "rounded-t-xl" : ""} ${isLast ? "rounded-b-xl border-b" : ""}`}
+    >
+      <div className="flex flex-1 flex-col gap-1 min-w-0">
+        <div className="text-sm font-medium text-foreground font-mono">
+          {item.name}
+        </div>
+      </div>
+      <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-muted-foreground">
+        Runtime variable
+      </span>
+    </div>
+  );
+}
+
+function SecretsAndVariablesTab() {
+  const secretStatus = useLastResolved(agentSecretStatus$);
+  const variableStatus = useLastResolved(agentVariableStatus$);
+
+  if (!secretStatus || !variableStatus) {
+    return (
+      <div className="flex flex-col">
+        {["s1", "s2", "s3"].map((id, i) => (
+          <div
+            key={id}
+            className={`flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 animate-pulse ${i === 0 ? "rounded-t-xl" : ""} ${i === 2 ? "rounded-b-xl border-b" : ""}`}
+          >
+            <div className="flex flex-1 flex-col gap-2">
+              <div className="h-4 w-32 rounded bg-muted" />
+            </div>
+            <div className="h-5 w-20 rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const allItems = [...secretStatus, ...variableStatus];
+
+  if (allItems.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center p-8 text-center text-muted-foreground">
+        <p className="text-lg">No secrets or variables required</p>
+        <p className="mt-2 text-sm">
+          This agent does not require any secrets or variables.
+        </p>
+      </div>
+    );
+  }
+
+  const totalItems = secretStatus.length + variableStatus.length;
+  let rowIndex = 0;
+
+  return (
+    <div className="flex flex-col">
+      {secretStatus.map((item) => {
+        const currentIndex = rowIndex++;
+        return (
+          <SecretStatusRow
+            key={`secret-${item.name}`}
+            item={item}
+            isFirst={currentIndex === 0}
+            isLast={currentIndex === totalItems - 1}
+          />
+        );
+      })}
+      {variableStatus.map((item) => {
+        const currentIndex = rowIndex++;
+        return (
+          <VariableStatusRow
+            key={`var-${item.name}`}
+            item={item}
+            isFirst={currentIndex === 0}
+            isLast={currentIndex === totalItems - 1}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
 
 export function AgentConnectionsPage() {
   const agentName = useGet(agentName$);
   const detail = useGet(agentDetail$);
   const loading = useGet(agentDetailLoading$);
+  const isOwner = useGet(isOwner$);
+  const activeTab = useGet(connectionsActiveTab$);
+  const setActiveTab = useSet(setConnectionsActiveTab$);
 
   return (
     <AppShell
@@ -19,18 +299,69 @@ export function AgentConnectionsPage() {
         "Connections",
       ]}
     >
-      {loading ? (
-        <div className="p-6 text-muted-foreground">Loading agent...</div>
-      ) : detail ? (
-        <div className="p-6">
-          <h1 className="text-2xl font-bold">{detail.name} — Connections</h1>
-          <p className="text-muted-foreground mt-1">
-            Agent connections page — implementation coming in Phase 5
-          </p>
-        </div>
-      ) : (
-        <div className="p-6 text-muted-foreground">Agent not found</div>
-      )}
+      <div className="flex flex-col gap-[22px] p-8 min-h-full">
+        {loading ? (
+          <AgentConnectionsPageSkeleton />
+        ) : detail ? (
+          <>
+            <AgentHeader detail={detail} isOwner={isOwner} />
+            <div className="flex flex-col gap-1">
+              <h2 className="text-lg font-medium text-foreground">
+                Connections of {detail.name}
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                This is the secret list used for your agents in every run
+              </p>
+            </div>
+            <Tabs value={activeTab} onValueChange={setActiveTab}>
+              <TabsList>
+                <TabsTrigger value="connectors">Connectors</TabsTrigger>
+                <TabsTrigger value="secrets">Secrets and variables</TabsTrigger>
+              </TabsList>
+            </Tabs>
+            {activeTab === "connectors" && <ConnectorsTab />}
+            {activeTab === "secrets" && <SecretsAndVariablesTab />}
+            <SecretDialog />
+          </>
+        ) : (
+          <div className="rounded-lg border border-border bg-card p-8 text-center">
+            <p className="text-sm text-muted-foreground">Agent not found</p>
+          </div>
+        )}
+      </div>
     </AppShell>
+  );
+}
+
+function AgentConnectionsPageSkeleton() {
+  return (
+    <>
+      <div className="flex items-center gap-3.5">
+        <Skeleton className="h-14 w-14 rounded-xl" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-7 w-48" />
+          <Skeleton className="h-4 w-72" />
+        </div>
+      </div>
+      <div className="flex flex-col gap-1">
+        <Skeleton className="h-6 w-56" />
+        <Skeleton className="h-4 w-80" />
+      </div>
+      <Skeleton className="h-9 w-64 rounded-lg" />
+      <div className="flex flex-col">
+        {["c1", "c2"].map((id, i) => (
+          <div
+            key={id}
+            className={`flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 animate-pulse ${i === 0 ? "rounded-t-xl" : ""} ${i === 1 ? "rounded-b-xl border-b" : ""}`}
+          >
+            <div className="h-7 w-7 rounded bg-muted" />
+            <div className="flex flex-1 flex-col gap-2">
+              <div className="h-4 w-24 rounded bg-muted" />
+              <div className="h-3 w-48 rounded bg-muted" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
   );
 }

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-connections-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-connections-page.tsx
@@ -2,15 +2,31 @@ import { useGet, useLastResolved, useSet } from "ccstate-react";
 import {
   IconCircleCheck,
   IconLoader,
-  IconAlertCircle,
   IconPlus,
+  IconDotsVertical,
+  IconChevronDown,
 } from "@tabler/icons-react";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@vm0/ui/components/ui/popover";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorType,
+  type SecretResponse,
+  type VariableResponse,
+} from "@vm0/core";
 import { AppShell } from "../layout/app-shell.tsx";
 import { ConnectorIcon } from "../settings-page/connector-icons.tsx";
 import { SecretDialog } from "../settings-page/secret-dialog.tsx";
+import { VariableDialog } from "../settings-page/variable-dialog.tsx";
+import { DeleteSecretDialog } from "../settings-page/delete-secret-dialog.tsx";
+import { DeleteVariableDialog } from "../settings-page/delete-variable-dialog.tsx";
+import forgotPasswordIcon from "../settings-page/icons/forgot-password.svg";
+import type { MergedItem } from "../../signals/settings-page/secrets-and-variables.ts";
 import {
   agentDetail$,
   agentDetailLoading$,
@@ -18,20 +34,46 @@ import {
 } from "../../signals/agent-detail/agent-detail.ts";
 import {
   agentConnectorStatus$,
-  agentSecretStatus$,
-  agentVariableStatus$,
+  agentMergedItems$,
   connectionsActiveTab$,
   setConnectionsActiveTab$,
   type AgentConnectorStatus,
-  type AgentSecretStatus,
-  type AgentVariableStatus,
 } from "../../signals/agent-detail/connections.ts";
 import {
   connectConnector$,
   pollingConnectorType$,
+  openDisconnectDialog$,
 } from "../../signals/settings-page/connectors.ts";
-import { openAddSecretDialog$ } from "../../signals/settings-page/secrets.ts";
+import { DisconnectConnectorDialog } from "../settings-page/disconnect-connector-dialog.tsx";
+import {
+  openAddSecretDialog$,
+  openEditSecretDialog$,
+  openDeleteSecretDialog$,
+} from "../../signals/settings-page/secrets.ts";
+import {
+  openAddVariableDialog$,
+  openEditVariableDialog$,
+  openDeleteVariableDialog$,
+} from "../../signals/settings-page/variables.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function truncateValue(value: string, maxLength = 60): string {
+  return value.length > maxLength
+    ? value.substring(0, maxLength) + "..."
+    : value;
+}
 
 // ---------------------------------------------------------------------------
 // Connectors tab
@@ -40,6 +82,7 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 function ConnectorRow({ item }: { item: AgentConnectorStatus }) {
   const pollingType = useGet(pollingConnectorType$);
   const connect = useSet(connectConnector$);
+  const openDisconnect = useSet(openDisconnectDialog$);
   const pageSignal = useGet(pageSignal$);
   const isPolling = pollingType === item.type;
 
@@ -76,7 +119,30 @@ function ConnectorRow({ item }: { item: AgentConnectorStatus }) {
       </div>
 
       {/* Action */}
-      {!item.connected && (
+      {item.connected ? (
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              className="icon-button shrink-0"
+              aria-label="Connector options"
+            >
+              <IconDotsVertical
+                size={16}
+                stroke={1.5}
+                className="text-muted-foreground"
+              />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="end" className="flex flex-col gap-1 w-36 p-2">
+            <button
+              onClick={() => openDisconnect(item.type)}
+              className="w-full rounded-md px-3 py-2 text-sm text-left text-destructive hover:bg-accent hover:text-accent-foreground transition-colors"
+            >
+              Disconnect
+            </button>
+          </PopoverContent>
+        </Popover>
+      ) : (
         <button
           onClick={() => connect(item.type, pageSignal)}
           disabled={isPolling}
@@ -121,29 +187,245 @@ function ConnectorsTab() {
       {connectorStatus.map((item) => (
         <ConnectorRow key={item.type} item={item} />
       ))}
-      <NewConnectorRow />
     </div>
   );
 }
 
-function NewConnectorRow() {
+// ---------------------------------------------------------------------------
+// Secrets and variables tab — row components
+// ---------------------------------------------------------------------------
+
+function MissingItemRow({
+  item,
+  isFirst,
+}: {
+  item: MergedItem;
+  isFirst: boolean;
+}) {
+  const openAddSecret = useSet(openAddSecretDialog$);
+  const openAddVariable = useSet(openAddVariableDialog$);
+
+  const badgeLabel =
+    item.kind === "secret" ? "Missing secrets" : "Missing variables";
+
   return (
-    <div className="flex items-center gap-4 border-l border-r border-b border-border bg-card p-4 last:rounded-b-xl">
-      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-dashed border-border">
-        <IconPlus className="h-4 w-4 text-muted-foreground" />
-      </div>
+    <div
+      className={`flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 last:border-b last:rounded-b-xl ${isFirst ? "rounded-t-xl" : ""}`}
+    >
       <div className="flex flex-1 flex-col gap-1 min-w-0">
-        <div className="text-sm font-medium text-foreground">
-          New connectors
-        </div>
-        <div className="text-sm text-muted-foreground">
-          Add a new connectors and used by your agents
+        <div className="text-sm font-medium text-foreground font-mono">
+          {item.name}
         </div>
       </div>
-      <button className="shrink-0 rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-muted transition-colors">
-        Add more connectors
+      <div className="flex items-center gap-1 shrink-0 rounded-md border border-border bg-background px-1.5 py-0.5">
+        <img alt="" src={forgotPasswordIcon} className="size-3" />
+        <span className="text-xs font-medium text-muted-foreground">
+          {badgeLabel}
+        </span>
+      </div>
+      <button
+        onClick={() =>
+          item.kind === "secret"
+            ? openAddSecret(item.name)
+            : openAddVariable(item.name)
+        }
+        className="shrink-0 rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-muted transition-colors"
+      >
+        Fill
       </button>
     </div>
+  );
+}
+
+function SecretRow({
+  secret,
+  agentRequired,
+  isFirst,
+}: {
+  secret: SecretResponse;
+  agentRequired: boolean;
+  isFirst: boolean;
+}) {
+  const openEdit = useSet(openEditSecretDialog$);
+  const openDelete = useSet(openDeleteSecretDialog$);
+
+  return (
+    <div
+      className={`flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 last:border-b last:rounded-b-xl ${isFirst ? "rounded-t-xl" : ""}`}
+    >
+      <div className="flex flex-1 flex-col gap-1 min-w-0">
+        <div className="text-sm font-medium text-foreground font-mono">
+          {secret.name}
+        </div>
+        {secret.description && (
+          <div className="text-sm text-muted-foreground">
+            {secret.description}
+          </div>
+        )}
+      </div>
+      <div className="text-xs text-muted-foreground shrink-0">
+        {formatDate(secret.updatedAt)}
+      </div>
+      <Popover>
+        <PopoverTrigger asChild>
+          <button className="icon-button shrink-0" aria-label="Secret options">
+            <IconDotsVertical
+              size={16}
+              stroke={1.5}
+              className="text-muted-foreground"
+            />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="flex flex-col gap-1 w-36 p-2">
+          <button
+            onClick={() => openEdit(secret)}
+            className="w-full rounded-md px-3 py-2 text-sm text-left hover:bg-accent hover:text-accent-foreground transition-colors"
+          >
+            Edit
+          </button>
+          {!agentRequired && (
+            <button
+              onClick={() => openDelete(secret.name)}
+              className="w-full rounded-md px-3 py-2 text-sm text-left text-destructive hover:bg-accent hover:text-accent-foreground transition-colors"
+            >
+              Delete
+            </button>
+          )}
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+function VariableRow({
+  variable,
+  agentRequired,
+  isFirst,
+}: {
+  variable: VariableResponse;
+  agentRequired: boolean;
+  isFirst: boolean;
+}) {
+  const openEdit = useSet(openEditVariableDialog$);
+  const openDelete = useSet(openDeleteVariableDialog$);
+
+  return (
+    <div
+      className={`flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 last:border-b last:rounded-b-xl ${isFirst ? "rounded-t-xl" : ""}`}
+    >
+      <div className="flex flex-1 flex-col gap-1 min-w-0">
+        <div className="text-sm font-medium text-foreground font-mono">
+          {variable.name}
+        </div>
+        <div className="text-sm text-muted-foreground font-mono truncate">
+          {truncateValue(variable.value)}
+        </div>
+        {variable.description && (
+          <div className="text-xs text-muted-foreground">
+            {variable.description}
+          </div>
+        )}
+      </div>
+      <div className="text-xs text-muted-foreground shrink-0">
+        {formatDate(variable.updatedAt)}
+      </div>
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            className="icon-button shrink-0"
+            aria-label="Variable options"
+          >
+            <IconDotsVertical
+              size={16}
+              stroke={1.5}
+              className="text-muted-foreground"
+            />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="flex flex-col gap-1 w-36 p-2">
+          <button
+            onClick={() => openEdit(variable)}
+            className="w-full rounded-md px-3 py-2 text-sm text-left hover:bg-accent hover:text-accent-foreground transition-colors"
+          >
+            Edit
+          </button>
+          {!agentRequired && (
+            <button
+              onClick={() => openDelete(variable.name)}
+              className="w-full rounded-md px-3 py-2 text-sm text-left text-destructive hover:bg-accent hover:text-accent-foreground transition-colors"
+            >
+              Delete
+            </button>
+          )}
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+function ItemRow({ item, isFirst }: { item: MergedItem; isFirst: boolean }) {
+  if (item.data === null) {
+    return <MissingItemRow item={item} isFirst={isFirst} />;
+  }
+
+  if (item.kind === "secret") {
+    return (
+      <SecretRow
+        secret={item.data}
+        agentRequired={item.agentRequired}
+        isFirst={isFirst}
+      />
+    );
+  }
+
+  return (
+    <VariableRow
+      variable={item.data}
+      agentRequired={item.agentRequired}
+      isFirst={isFirst}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Add dropdown
+// ---------------------------------------------------------------------------
+
+function AddDropdown() {
+  const openAddSecret = useSet(openAddSecretDialog$);
+  const openAddVariable = useSet(openAddVariableDialog$);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button className="flex items-center self-start shrink-0 rounded-md border border-border bg-background overflow-hidden hover:bg-muted transition-colors">
+          <span className="border-r border-border px-4 py-2 text-sm font-medium text-foreground">
+            Add more secrets
+          </span>
+          <span className="pl-2 pr-3 py-2">
+            <IconChevronDown
+              size={16}
+              stroke={1.5}
+              className="text-foreground"
+            />
+          </span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="flex flex-col gap-1 w-44 p-2">
+        <button
+          onClick={() => openAddSecret()}
+          className="w-full rounded-md px-3 py-2 text-sm text-left hover:bg-accent hover:text-accent-foreground transition-colors"
+        >
+          Add secret
+        </button>
+        <button
+          onClick={() => openAddVariable()}
+          className="w-full rounded-md px-3 py-2 text-sm text-left hover:bg-accent hover:text-accent-foreground transition-colors"
+        >
+          Add variable
+        </button>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -151,95 +433,56 @@ function NewConnectorRow() {
 // Secrets and variables tab
 // ---------------------------------------------------------------------------
 
-function SecretStatusRow({ item }: { item: AgentSecretStatus }) {
-  const openAddSecret = useSet(openAddSecretDialog$);
-
-  return (
-    <div className="flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 first:rounded-t-xl last:rounded-b-xl last:border-b">
-      <div className="flex flex-1 flex-col gap-1 min-w-0">
-        <div className="text-sm font-medium text-foreground font-mono">
-          {item.name}
-        </div>
-      </div>
-      {item.configured ? (
-        <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
-          <IconCircleCheck className="h-3 w-3 text-green-600" />
-          Configured
-        </span>
-      ) : (
-        <>
-          <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-muted-foreground">
-            <IconAlertCircle className="h-3 w-3 text-yellow-600" />
-            Missing
-          </span>
-          <button
-            onClick={() => openAddSecret(item.name)}
-            className="shrink-0 rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-muted transition-colors"
-          >
-            Add
-          </button>
-        </>
-      )}
-    </div>
-  );
-}
-
-function VariableStatusRow({ item }: { item: AgentVariableStatus }) {
-  return (
-    <div className="flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 first:rounded-t-xl last:rounded-b-xl last:border-b">
-      <div className="flex flex-1 flex-col gap-1 min-w-0">
-        <div className="text-sm font-medium text-foreground font-mono">
-          {item.name}
-        </div>
-      </div>
-      <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-muted-foreground">
-        Runtime variable
-      </span>
-    </div>
-  );
-}
-
 function SecretsAndVariablesTab() {
-  const secretStatus = useLastResolved(agentSecretStatus$);
-  const variableStatus = useLastResolved(agentVariableStatus$);
+  const items = useLastResolved(agentMergedItems$);
 
-  if (!secretStatus || !variableStatus) {
+  if (!items) {
     return (
       <div className="flex flex-col">
-        {["s1", "s2", "s3"].map((id, i) => (
+        {["sv1", "sv2", "sv3"].map((id, i) => (
           <div
             key={id}
             className={`flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 animate-pulse ${i === 0 ? "rounded-t-xl" : ""} ${i === 2 ? "rounded-b-xl border-b" : ""}`}
           >
             <div className="flex flex-1 flex-col gap-2">
               <div className="h-4 w-32 rounded bg-muted" />
+              <div className="h-3 w-48 rounded bg-muted" />
             </div>
-            <div className="h-5 w-20 rounded bg-muted" />
+            <div className="h-3 w-16 rounded bg-muted" />
           </div>
         ))}
       </div>
     );
   }
 
-  if (secretStatus.length === 0 && variableStatus.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center p-8 text-center text-muted-foreground">
-        <p className="text-lg">No secrets or variables required</p>
-        <p className="mt-2 text-sm">
-          This agent does not require any secrets or variables.
-        </p>
-      </div>
-    );
-  }
-
   return (
     <div className="flex flex-col">
-      {secretStatus.map((item) => (
-        <SecretStatusRow key={`secret-${item.name}`} item={item} />
+      {items.map((item, index) => (
+        <ItemRow
+          key={`${item.kind}-${item.name}`}
+          item={item}
+          isFirst={index === 0}
+        />
       ))}
-      {variableStatus.map((item) => (
-        <VariableStatusRow key={`var-${item.name}`} item={item} />
-      ))}
+
+      <div
+        className={`flex flex-col gap-4 border border-border bg-card p-4 rounded-b-xl sm:flex-row sm:items-center ${items.length === 0 ? "rounded-t-xl" : ""}`}
+      >
+        <div className="flex flex-1 items-center gap-4 min-w-0">
+          <div className="flex shrink-0 items-center justify-center size-[28px]">
+            <IconPlus size={24} stroke={1.5} className="text-foreground" />
+          </div>
+          <div className="flex flex-1 flex-col gap-1 min-w-0">
+            <div className="text-sm font-medium text-foreground">
+              New secrets and variables
+            </div>
+            <div className="text-sm text-muted-foreground">
+              Custom API keys and variables
+            </div>
+          </div>
+        </div>
+        <AddDropdown />
+      </div>
     </div>
   );
 }
@@ -259,7 +502,12 @@ export function AgentConnectionsPage() {
     <AppShell
       breadcrumb={[
         { label: "Agents", path: "/agents" },
-        `${agentName ?? "Loading..."} connections`,
+        {
+          label: agentName ?? "Loading...",
+          path: agentName ? "/agents/:name" : undefined,
+          pathParams: agentName ? { name: agentName } : undefined,
+        },
+        "Connections",
       ]}
     >
       <div className="flex flex-col gap-[22px] p-8 min-h-full">
@@ -284,6 +532,10 @@ export function AgentConnectionsPage() {
             {activeTab === "connectors" && <ConnectorsTab />}
             {activeTab === "secrets" && <SecretsAndVariablesTab />}
             <SecretDialog />
+            <VariableDialog />
+            <DeleteSecretDialog />
+            <DeleteVariableDialog />
+            <DisconnectConnectorDialog />
           </>
         ) : (
           <div className="rounded-lg border border-border bg-card p-8 text-center">

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-logs-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-logs-page.tsx
@@ -1,15 +1,255 @@
-import { useGet } from "ccstate-react";
+import { useGet, useLoadable, useSet } from "ccstate-react";
+import { IconChevronRight } from "@tabler/icons-react";
+import type { MouseEvent } from "react";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from "@vm0/ui";
+import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import { AppShell } from "../layout/app-shell.tsx";
+import { Pagination } from "../components/pagination.tsx";
+import { StatusBadge } from "../logs-page/status-badge.tsx";
 import {
   agentDetail$,
   agentDetailLoading$,
   agentName$,
+  isOwner$,
 } from "../../signals/agent-detail/agent-detail.ts";
+import {
+  currentAgentLogs$,
+  agentLogsHasPrev$,
+  agentLogsCurrentPage$,
+  agentLogsLimit$,
+  goToNextAgentLogsPage$,
+  goToPrevAgentLogsPage$,
+  goForwardTwoAgentLogsPages$,
+  goBackTwoAgentLogsPages$,
+  setAgentLogsRowsPerPage$,
+} from "../../signals/agent-detail/agent-logs.ts";
+import { navigateInReact$ } from "../../signals/route.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import { AgentHeader } from "./agent-header.tsx";
+import type { LogEntry } from "../../signals/logs-page/types.ts";
+
+function formatTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  const options: Intl.DateTimeFormatOptions = {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    timeZoneName: "shortOffset",
+  };
+  return date.toLocaleString("en-US", options);
+}
+
+function AgentLogsTableHeader() {
+  return (
+    <TableHeader className="bg-muted">
+      <TableRow className="hover:bg-transparent">
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[25%] min-w-[120px]">
+          <span className="block truncate whitespace-nowrap">Run ID</span>
+        </TableHead>
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[25%] min-w-[120px]">
+          <span className="block truncate whitespace-nowrap">Session ID</span>
+        </TableHead>
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[15%] min-w-[120px]">
+          <span className="block truncate whitespace-nowrap">Model</span>
+        </TableHead>
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[13%] min-w-[120px]">
+          <span className="block truncate whitespace-nowrap">Status</span>
+        </TableHead>
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[17%] min-w-[120px]">
+          <span className="block truncate whitespace-nowrap">
+            Generate time
+          </span>
+        </TableHead>
+        <TableHead className="h-10 w-[44px] px-2" />
+      </TableRow>
+    </TableHeader>
+  );
+}
+
+function AgentLogsTableSkeleton() {
+  return (
+    <Table>
+      <AgentLogsTableHeader />
+      <TableBody>
+        {Array.from({ length: 8 }, (_, i) => (
+          <TableRow key={`skeleton-${i}`} className="h-[53px]">
+            <TableCell className="px-3 py-2 min-w-[120px]">
+              <Skeleton className="h-4 w-24" />
+            </TableCell>
+            <TableCell className="px-3 py-2 min-w-[120px]">
+              <Skeleton className="h-4 w-28" />
+            </TableCell>
+            <TableCell className="px-3 py-2 min-w-[120px]">
+              <Skeleton className="h-4 w-20" />
+            </TableCell>
+            <TableCell className="px-3 py-2 min-w-[120px]">
+              <Skeleton className="h-6 w-20 rounded-full" />
+            </TableCell>
+            <TableCell className="px-3 py-2 min-w-[120px]">
+              <Skeleton className="h-4 w-32" />
+            </TableCell>
+            <TableCell className="px-2 py-2">
+              <Skeleton className="h-8 w-8 rounded-lg" />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+interface AgentLogsTableRowProps {
+  entry: LogEntry;
+}
+
+function AgentLogsTableRow({ entry }: AgentLogsTableRowProps) {
+  const navigate = useSet(navigateInReact$);
+  const logDetailUrl = `/logs/${entry.id}`;
+
+  const handleRowClick = (event: MouseEvent<HTMLTableRowElement>) => {
+    if (event.metaKey || event.ctrlKey) {
+      window.open(logDetailUrl, "_blank");
+      return;
+    }
+    navigate("/logs/:id", { pathParams: { id: entry.id } });
+  };
+
+  return (
+    <TableRow
+      className="h-[53px] cursor-pointer hover:bg-muted/50"
+      onClick={handleRowClick}
+    >
+      <TableCell className="px-3 py-2 text-sm font-medium w-[25%] min-w-[120px]">
+        <span className="block truncate whitespace-nowrap">{entry.id}</span>
+      </TableCell>
+      <TableCell className="px-3 py-2 text-sm w-[25%] min-w-[120px]">
+        <span className="block truncate whitespace-nowrap">
+          {entry.sessionId ?? "-"}
+        </span>
+      </TableCell>
+      <TableCell className="px-3 py-2 text-sm w-[15%] min-w-[120px]">
+        <span className="block truncate whitespace-nowrap">
+          {entry.framework ?? "-"}
+        </span>
+      </TableCell>
+      <TableCell className="px-3 py-2 w-[13%] min-w-[120px]">
+        <div className="truncate whitespace-nowrap">
+          <StatusBadge status={entry.status} />
+        </div>
+      </TableCell>
+      <TableCell className="px-3 py-2 text-sm w-[17%] min-w-[120px]">
+        <span className="block truncate whitespace-nowrap">
+          {formatTime(entry.createdAt)}
+        </span>
+      </TableCell>
+      <TableCell className="w-[44px] px-2 py-2">
+        <div className="flex size-full items-center justify-end pr-[12px]">
+          <IconChevronRight className="size-4 flex-shrink-0" />
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function AgentLogsTable() {
+  const logsLoadable = useLoadable(currentAgentLogs$);
+
+  if (logsLoadable.state === "loading") {
+    return <AgentLogsTableSkeleton />;
+  }
+
+  if (logsLoadable.state === "hasError") {
+    const errorMessage =
+      logsLoadable.error instanceof Error
+        ? logsLoadable.error.message
+        : "Failed to load logs";
+    return (
+      <Table>
+        <AgentLogsTableHeader />
+        <TableBody>
+          <TableRow>
+            <td colSpan={6} className="p-4 text-center text-destructive">
+              Error: {errorMessage}
+            </td>
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+  }
+
+  if (logsLoadable.data.data.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center p-8 text-center text-muted-foreground">
+        <p className="text-lg">Nothing here yet</p>
+        <p className="mt-2 text-sm">
+          Your agent runs will show up here once they start working their magic.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <Table>
+      <AgentLogsTableHeader />
+      <TableBody>
+        {logsLoadable.data.data.map((entry) => (
+          <AgentLogsTableRow key={entry.id} entry={entry} />
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function AgentLogsPagination() {
+  const logsLoadable = useLoadable(currentAgentLogs$);
+  const hasPrev = useGet(agentLogsHasPrev$);
+  const currentPage = useGet(agentLogsCurrentPage$);
+  const rowsPerPage = useGet(agentLogsLimit$);
+  const goToNext = useSet(goToNextAgentLogsPage$);
+  const goToPrev = useSet(goToPrevAgentLogsPage$);
+  const goForwardTwo = useSet(goForwardTwoAgentLogsPages$);
+  const goBackTwo = useSet(goBackTwoAgentLogsPages$);
+  const setRowsPerPageFn = useSet(setAgentLogsRowsPerPage$);
+
+  const hasNext =
+    logsLoadable.state === "hasData" && logsLoadable.data.pagination.hasMore;
+  const isLoading = logsLoadable.state === "loading";
+  const totalPages =
+    logsLoadable.state === "hasData"
+      ? logsLoadable.data.pagination.totalPages
+      : undefined;
+
+  return (
+    <Pagination
+      currentPage={currentPage}
+      totalPages={totalPages}
+      rowsPerPage={rowsPerPage}
+      hasNext={hasNext}
+      hasPrev={hasPrev}
+      isLoading={isLoading}
+      onNextPage={() => detach(goToNext(), Reason.DomCallback)}
+      onPrevPage={() => goToPrev()}
+      onForwardTwoPages={() => detach(goForwardTwo(), Reason.DomCallback)}
+      onBackTwoPages={() => goBackTwo()}
+      onRowsPerPageChange={(limit) => setRowsPerPageFn(limit)}
+    />
+  );
+}
 
 export function AgentLogsPage() {
   const agentName = useGet(agentName$);
   const detail = useGet(agentDetail$);
   const loading = useGet(agentDetailLoading$);
+  const isOwner = useGet(isOwner$);
 
   return (
     <AppShell
@@ -19,18 +259,40 @@ export function AgentLogsPage() {
         "Logs",
       ]}
     >
-      {loading ? (
-        <div className="p-6 text-muted-foreground">Loading agent...</div>
-      ) : detail ? (
-        <div className="p-6">
-          <h1 className="text-2xl font-bold">{detail.name} — Logs</h1>
-          <p className="text-muted-foreground mt-1">
-            Agent logs page — implementation coming in Phase 5
-          </p>
-        </div>
-      ) : (
-        <div className="p-6 text-muted-foreground">Agent not found</div>
-      )}
+      <div className="flex flex-col gap-[22px] p-8 min-h-full">
+        {loading ? (
+          <AgentLogsPageSkeleton />
+        ) : detail ? (
+          <>
+            <AgentHeader detail={detail} isOwner={isOwner} />
+            <div className="rounded-lg border border-border bg-card overflow-hidden">
+              <AgentLogsTable />
+            </div>
+            <AgentLogsPagination />
+          </>
+        ) : (
+          <div className="rounded-lg border border-border bg-card p-8 text-center">
+            <p className="text-sm text-muted-foreground">Agent not found</p>
+          </div>
+        )}
+      </div>
     </AppShell>
+  );
+}
+
+function AgentLogsPageSkeleton() {
+  return (
+    <>
+      <div className="flex items-center gap-3.5">
+        <Skeleton className="h-14 w-14 rounded-xl" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-7 w-48" />
+          <Skeleton className="h-4 w-72" />
+        </div>
+      </div>
+      <div className="rounded-lg border border-border bg-card overflow-hidden">
+        <AgentLogsTableSkeleton />
+      </div>
+    </>
   );
 }

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-logs-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-logs-page.tsx
@@ -15,7 +15,6 @@ import {
   agentDetail$,
   agentDetailLoading$,
   agentName$,
-  isOwner$,
 } from "../../signals/agent-detail/agent-detail.ts";
 import {
   currentAgentLogs$,
@@ -30,7 +29,8 @@ import {
 } from "../../signals/agent-detail/agent-logs.ts";
 import { navigateInReact$ } from "../../signals/route.ts";
 import { detach, Reason } from "../../signals/utils.ts";
-import { AgentHeader } from "./agent-header.tsx";
+import { AgentAvatar } from "./agent-avatar.tsx";
+import type { AgentDetail } from "../../signals/agent-detail/types.ts";
 import type { LogEntry } from "../../signals/logs-page/types.ts";
 
 function AgentLogsTableHeader() {
@@ -214,13 +214,17 @@ export function AgentLogsPage() {
   const agentName = useGet(agentName$);
   const detail = useGet(agentDetail$);
   const loading = useGet(agentDetailLoading$);
-  const isOwner = useGet(isOwner$);
 
   return (
     <AppShell
       breadcrumb={[
         { label: "Agents", path: "/agents" },
-        `${agentName ?? "Loading..."} logs`,
+        {
+          label: agentName ?? "Loading...",
+          path: agentName ? "/agents/:name" : undefined,
+          pathParams: agentName ? { name: agentName } : undefined,
+        },
+        "Logs",
       ]}
     >
       <div className="flex flex-col gap-[22px] p-8 min-h-full">
@@ -228,7 +232,7 @@ export function AgentLogsPage() {
           <AgentLogsPageSkeleton />
         ) : detail ? (
           <>
-            <AgentHeader detail={detail} isOwner={isOwner} />
+            <AgentLogsHeader detail={detail} />
             <div className="rounded-lg border border-border bg-card overflow-hidden">
               <AgentLogsTable />
             </div>
@@ -241,6 +245,31 @@ export function AgentLogsPage() {
         )}
       </div>
     </AppShell>
+  );
+}
+
+function AgentLogsHeader({ detail }: { detail: AgentDetail }) {
+  const agentKeys = detail.content?.agents
+    ? Object.keys(detail.content.agents)
+    : [];
+  const firstKey = agentKeys[0];
+  const agentDef = firstKey ? detail.content?.agents[firstKey] : null;
+  const description = agentDef?.description;
+
+  return (
+    <div className="flex items-center gap-3.5">
+      <AgentAvatar name={detail.name} size="lg" />
+      <div className="flex-1 min-w-0 flex flex-col gap-1.5">
+        <h1 className="text-2xl leading-8 font-normal text-foreground truncate">
+          {detail.name}
+        </h1>
+        {description && (
+          <p className="text-sm text-muted-foreground truncate">
+            {description}
+          </p>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-logs-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-logs-page.tsx
@@ -1,5 +1,4 @@
 import { useGet, useLoadable, useSet } from "ccstate-react";
-import { IconChevronRight } from "@tabler/icons-react";
 import type { MouseEvent } from "react";
 import {
   Table,
@@ -12,7 +11,6 @@ import {
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import { AppShell } from "../layout/app-shell.tsx";
 import { Pagination } from "../components/pagination.tsx";
-import { StatusBadge } from "../logs-page/status-badge.tsx";
 import {
   agentDetail$,
   agentDetailLoading$,
@@ -35,19 +33,6 @@ import { detach, Reason } from "../../signals/utils.ts";
 import { AgentHeader } from "./agent-header.tsx";
 import type { LogEntry } from "../../signals/logs-page/types.ts";
 
-function formatTime(dateStr: string): string {
-  const date = new Date(dateStr);
-  const options: Intl.DateTimeFormatOptions = {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-    timeZoneName: "shortOffset",
-  };
-  return date.toLocaleString("en-US", options);
-}
-
 function AgentLogsTableHeader() {
   return (
     <TableHeader className="bg-muted">
@@ -58,18 +43,14 @@ function AgentLogsTableHeader() {
         <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[25%] min-w-[120px]">
           <span className="block truncate whitespace-nowrap">Session ID</span>
         </TableHead>
-        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[15%] min-w-[120px]">
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[25%] min-w-[120px]">
           <span className="block truncate whitespace-nowrap">Model</span>
         </TableHead>
-        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[13%] min-w-[120px]">
-          <span className="block truncate whitespace-nowrap">Status</span>
-        </TableHead>
-        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[17%] min-w-[120px]">
+        <TableHead className="h-10 px-3 text-sm font-medium text-foreground w-[25%] min-w-[120px]">
           <span className="block truncate whitespace-nowrap">
             Generate time
           </span>
         </TableHead>
-        <TableHead className="h-10 w-[44px] px-2" />
       </TableRow>
     </TableHeader>
   );
@@ -92,13 +73,7 @@ function AgentLogsTableSkeleton() {
               <Skeleton className="h-4 w-20" />
             </TableCell>
             <TableCell className="px-3 py-2 min-w-[120px]">
-              <Skeleton className="h-6 w-20 rounded-full" />
-            </TableCell>
-            <TableCell className="px-3 py-2 min-w-[120px]">
               <Skeleton className="h-4 w-32" />
-            </TableCell>
-            <TableCell className="px-2 py-2">
-              <Skeleton className="h-8 w-8 rounded-lg" />
             </TableCell>
           </TableRow>
         ))}
@@ -136,25 +111,15 @@ function AgentLogsTableRow({ entry }: AgentLogsTableRowProps) {
           {entry.sessionId ?? "-"}
         </span>
       </TableCell>
-      <TableCell className="px-3 py-2 text-sm w-[15%] min-w-[120px]">
+      <TableCell className="px-3 py-2 text-sm w-[25%] min-w-[120px]">
         <span className="block truncate whitespace-nowrap">
           {entry.framework ?? "-"}
         </span>
       </TableCell>
-      <TableCell className="px-3 py-2 w-[13%] min-w-[120px]">
-        <div className="truncate whitespace-nowrap">
-          <StatusBadge status={entry.status} />
-        </div>
-      </TableCell>
-      <TableCell className="px-3 py-2 text-sm w-[17%] min-w-[120px]">
+      <TableCell className="px-3 py-2 text-sm w-[25%] min-w-[120px]">
         <span className="block truncate whitespace-nowrap">
-          {formatTime(entry.createdAt)}
+          {entry.createdAt}
         </span>
-      </TableCell>
-      <TableCell className="w-[44px] px-2 py-2">
-        <div className="flex size-full items-center justify-end pr-[12px]">
-          <IconChevronRight className="size-4 flex-shrink-0" />
-        </div>
       </TableCell>
     </TableRow>
   );
@@ -177,7 +142,7 @@ function AgentLogsTable() {
         <AgentLogsTableHeader />
         <TableBody>
           <TableRow>
-            <td colSpan={6} className="p-4 text-center text-destructive">
+            <td colSpan={4} className="p-4 text-center text-destructive">
               Error: {errorMessage}
             </td>
           </TableRow>
@@ -255,8 +220,7 @@ export function AgentLogsPage() {
     <AppShell
       breadcrumb={[
         { label: "Agents", path: "/agents" },
-        agentName ?? "Loading...",
-        "Logs",
+        `${agentName ?? "Loading..."} logs`,
       ]}
     >
       <div className="flex flex-col gap-[22px] p-8 min-h-full">

--- a/turbo/apps/platform/src/views/layout/navbar.tsx
+++ b/turbo/apps/platform/src/views/layout/navbar.tsx
@@ -14,6 +14,7 @@ import type { RoutePath } from "../../types/route.ts";
 export interface BreadcrumbItem {
   label: string;
   path?: RoutePath;
+  pathParams?: Record<string, string>;
 }
 
 interface NavbarProps {
@@ -78,7 +79,11 @@ export function Navbar({ breadcrumb }: NavbarProps) {
                 )}
                 {item.path ? (
                   <button
-                    onClick={() => navigate(item.path!)}
+                    onClick={() =>
+                      navigate(item.path!, {
+                        pathParams: item.pathParams,
+                      })
+                    }
                     className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors whitespace-nowrap"
                   >
                     {item.label}

--- a/turbo/apps/platform/src/views/logs-page/__tests__/page.test.tsx
+++ b/turbo/apps/platform/src/views/logs-page/__tests__/page.test.tsx
@@ -13,7 +13,6 @@ import {
   goBackTwoPages$,
   setRowsPerPage$,
   setSearch$,
-  rowsPerPageValue$,
   searchQueryValue$,
   currentPageNumber$,
 } from "../../../signals/logs-page/logs-signals.ts";
@@ -57,11 +56,6 @@ describe("logs page signals", () => {
     it("search$ returns empty string when no search", async () => {
       await setupPage({ context, path: "/logs" });
       expect(context.store.get(search$)).toBe("");
-    });
-
-    it("rowsPerPageValue$ aliases limit$", async () => {
-      await setupPage({ context, path: "/logs?limit=20" });
-      expect(context.store.get(rowsPerPageValue$)).toBe(20);
     });
 
     it("searchQueryValue$ aliases search$", async () => {
@@ -312,10 +306,10 @@ describe("logs page signals", () => {
   describe("setRowsPerPage$", () => {
     it("should write limit to URL", async () => {
       await setupPage({ context, path: "/logs" });
-      expect(context.store.get(rowsPerPageValue$)).toBe(10);
+      expect(context.store.get(limit$)).toBe(10);
 
       context.store.set(setRowsPerPage$, 50);
-      expect(context.store.get(rowsPerPageValue$)).toBe(50);
+      expect(context.store.get(limit$)).toBe(50);
     });
 
     it("should reset cursor when changing rows per page", async () => {

--- a/turbo/apps/platform/src/views/logs-page/logs-pagination.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-pagination.tsx
@@ -7,7 +7,7 @@ import {
   goForwardTwoPages$,
   goBackTwoPages$,
   setRowsPerPage$,
-  rowsPerPageValue$,
+  limit$,
   currentPageNumber$,
 } from "../../signals/logs-page/logs-signals.ts";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -17,7 +17,7 @@ export function LogsPagination() {
   const logsLoadable = useLoadable(currentPageLogs$);
   const hasPrev = useGet(hasPrevPage$);
   const currentPage = useGet(currentPageNumber$);
-  const rowsPerPage = useGet(rowsPerPageValue$);
+  const rowsPerPage = useGet(limit$);
   const goToNext = useSet(goToNextPage$);
   const goToPrev = useSet(goToPrevPage$);
   const goForwardTwo = useSet(goForwardTwoPages$);


### PR DESCRIPTION
## Summary

- Implements Phase 5 of #2972: agent logs page and agent connections page
- **Agent logs page**: cursor-based pagination with agent-filtered log fetching, table with Run ID / Session ID / Model / Status / Generate time columns, loading skeleton, and empty state
- **Agent connections page**: Connectors tab showing connection status with connect buttons, Secrets and Variables tab showing required secret status (configured/missing) with SecretDialog integration

Closes #2978

## Files Changed

**New signals:**
- `signals/agent-detail/agent-logs.ts` — URL-driven pagination signals for agent-filtered logs
- `signals/agent-detail/connections.ts` — Connector/secret/variable status derived from agent compose content

**Updated views:**
- `views/agent-detail-page/agent-logs-page.tsx` — Full implementation replacing placeholder
- `views/agent-detail-page/agent-connections-page.tsx` — Full implementation replacing placeholder

**Updated signals:**
- `signals/agent-detail/agent-logs-page.ts` — Added cursor history seeding

**New tests (15 tests):**
- `__tests__/agent-logs-page.test.tsx` — 6 integration tests (feature flag, table rendering, empty state, breadcrumb, pagination, null handling)
- `__tests__/agent-connections-page.test.tsx` — 9 integration tests (feature flag, page structure, tabs, connectors, connector status, connect button, secrets empty state, secret status, breadcrumb)

## Test plan

- [x] All 391 platform tests pass (including 15 new tests)
- [x] Type check passes
- [x] Lint passes (oxlint + eslint)
- [x] Knip passes (no unused exports)
- [x] Format passes (prettier)
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)