### PR TITLE
feat(web): add per-user cloud endpoint with traffic policy for computer connector

### DIFF
--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -39,6 +39,10 @@ GH_OAUTH_CLIENT_SECRET=op://Development/vm0-env-local/gh_oauth_client_secret
 NOTION_OAUTH_CLIENT_ID=op://Development/vm0-env-local/notion_oauth_client_id
 NOTION_OAUTH_CLIENT_SECRET=op://Development/vm0-env-local/notion_oauth_client_secret
 
+# Optional: ngrok (Computer Connector)
+NGROK_API_KEY=op://Development/vm0-env-local/NGROK_API_KEY
+NGROK_COMPUTER_CONNECTOR_DOMAIN=computer.vm7.io
+
 # Required: Platform UI URL (for settings page links in error messages)
 NEXT_PUBLIC_PLATFORM_URL=op://Development/vm0-env-local/next_public_platform_url
 

--- a/turbo/apps/web/src/lib/computer-connector/computer-connector-service.ts
+++ b/turbo/apps/web/src/lib/computer-connector/computer-connector-service.ts
@@ -133,7 +133,7 @@ export async function createComputerConnector(
           {
             type: "forward-internal",
             config: {
-              url: `https://$\{conn.server_name.split('.${domain}')[0].replaceAll('-', '.', 1)}.internal`,
+              url: `https://$\{conn.server_name.split('.${domain}')[0]}.internal`,
               on_error: "continue",
             },
           },

--- a/turbo/apps/web/src/lib/computer-connector/computer-connector-service.ts
+++ b/turbo/apps/web/src/lib/computer-connector/computer-connector-service.ts
@@ -17,6 +17,8 @@ import {
   findOrCreateBotUser,
   createCredential,
   deleteCredential,
+  createCloudEndpoint,
+  deleteCloudEndpoint,
 } from "./ngrok-client";
 
 const log = logger("service:computer-connector");
@@ -117,6 +119,40 @@ export async function createComputerConnector(
 
   const bridgeToken = randomUUID();
 
+  // Create Cloud Endpoint with traffic policy
+  const trafficPolicy = JSON.stringify({
+    on_http_request: [
+      {
+        expressions: [
+          `!('x-vm0-token' in req.headers) || req.headers['x-vm0-token'][0] != '${bridgeToken}'`,
+        ],
+        actions: [{ type: "deny", config: { status_code: 403 } }],
+      },
+      {
+        actions: [
+          {
+            type: "forward-internal",
+            config: {
+              url: `https://$\{conn.server_name.split('.${domain}')[0].replaceAll('-', '.', 1)}.internal`,
+              on_error: "continue",
+            },
+          },
+          {
+            type: "custom-response",
+            config: { status_code: 502, body: "Agent offline" },
+          },
+        ],
+      },
+    ],
+  });
+
+  const endpointUrl = `https://*.${endpointPrefix}.${domain}`;
+  const cloudEndpoint = await createCloudEndpoint(
+    apiKey,
+    endpointUrl,
+    trafficPolicy,
+  );
+
   // Create connector row
   const db = globalThis.services.db;
   const [connectorRow] = await db
@@ -127,6 +163,7 @@ export async function createComputerConnector(
       authMethod: "api",
       externalId: botUser.id,
       externalUsername: credential.id,
+      externalEmail: cloudEndpoint.id,
     })
     .returning();
 
@@ -173,6 +210,7 @@ export async function deleteComputerConnector(
     .select({
       id: connectors.id,
       externalUsername: connectors.externalUsername,
+      externalEmail: connectors.externalEmail,
     })
     .from(connectors)
     .where(
@@ -188,6 +226,11 @@ export async function deleteComputerConnector(
   const apiKey = globalThis.services.env.NGROK_API_KEY;
   if (apiKey && connector.externalUsername) {
     await deleteCredential(apiKey, connector.externalUsername);
+  }
+
+  // Delete Cloud Endpoint
+  if (apiKey && connector.externalEmail) {
+    await deleteCloudEndpoint(apiKey, connector.externalEmail);
   }
 
   // Delete connector row

--- a/turbo/apps/web/src/lib/computer-connector/ngrok-client.ts
+++ b/turbo/apps/web/src/lib/computer-connector/ngrok-client.ts
@@ -25,6 +25,11 @@ interface NgrokCredential {
   token: string;
 }
 
+interface NgrokEndpoint {
+  id: string;
+  url: string;
+}
+
 /**
  * Make an authenticated request to the ngrok API.
  */
@@ -136,6 +141,33 @@ export async function deleteCredential(
   credentialId: string,
 ): Promise<void> {
   await ngrokFetch(apiKey, `/credentials/${credentialId}`, {
+    method: "DELETE",
+  });
+}
+
+/**
+ * Create a Cloud Endpoint with a traffic policy.
+ */
+export async function createCloudEndpoint(
+  apiKey: string,
+  url: string,
+  trafficPolicy: string,
+): Promise<NgrokEndpoint> {
+  const response = await ngrokFetch(apiKey, "/endpoints", {
+    method: "POST",
+    body: JSON.stringify({ url, type: "cloud", traffic_policy: trafficPolicy }),
+  });
+  return (await response.json()) as NgrokEndpoint;
+}
+
+/**
+ * Delete a Cloud Endpoint.
+ */
+export async function deleteCloudEndpoint(
+  apiKey: string,
+  endpointId: string,
+): Promise<void> {
+  await ngrokFetch(apiKey, `/endpoints/${endpointId}`, {
     method: "DELETE",
   });
 }


### PR DESCRIPTION
## Summary
- Add `createCloudEndpoint` / `deleteCloudEndpoint` to ngrok client for Cloud Endpoint lifecycle management
- Create per-user Cloud Endpoint with traffic policy during connector provisioning, including `x-vm0-token` bridge token verification and `forward-internal` routing to user's internal endpoint
- Clean up Cloud Endpoint on connector deletion (ID stored in `externalEmail` field)
- Add MSW mocks and assertions for endpoint API in integration tests

## Test plan
- [x] `pnpm vitest run apps/web/app/api/connectors/computer` — all 11 tests pass
- [x] `pnpm turbo run lint --filter=web` — no lint errors
- [x] Type check — no errors in changed files
- [ ] Manual spike: recreate connector, verify tunnel + curl Cloud Endpoint connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)