### PR TITLE
refactor(platform): extract shared markdown preview component

### DIFF
--- a/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
@@ -1,7 +1,7 @@
 import { useGet, useSet } from "ccstate-react";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
-import MarkdownPreview from "@uiw/react-markdown-preview";
+import { Markdown } from "../components/markdown.tsx";
 import {
   instructionsViewMode$,
   setInstructionsViewMode$,
@@ -63,15 +63,7 @@ export function AgentInstructions({
           </pre>
         ) : (
           <div className="px-1">
-            <MarkdownPreview
-              source={instructions.content}
-              className="!bg-transparent !text-foreground text-sm"
-              style={{
-                backgroundColor: "transparent",
-                fontSize: "0.875rem",
-                lineHeight: "1.5",
-              }}
-            />
+            <Markdown source={instructions.content} />
           </div>
         )}
       </div>

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -1,0 +1,19 @@
+import MarkdownPreview, {
+  type MarkdownPreviewProps,
+} from "@uiw/react-markdown-preview";
+
+export function Markdown({ className, style, ...rest }: MarkdownPreviewProps) {
+  return (
+    <MarkdownPreview
+      className={`!bg-transparent !text-foreground text-sm ${className ?? ""}`}
+      style={{
+        backgroundColor: "transparent",
+        fontSize: "0.875rem",
+        lineHeight: "1.5",
+        fontFamily: "var(--font-family-sans)",
+        ...style,
+      }}
+      {...rest}
+    />
+  );
+}

--- a/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/event-card.tsx
@@ -5,7 +5,7 @@ import {
   IconRobot,
   IconTerminal,
 } from "@tabler/icons-react";
-import MarkdownPreview from "@uiw/react-markdown-preview";
+import { Markdown } from "../../components/markdown.tsx";
 import { Popover, PopoverContent, PopoverTrigger } from "@vm0/ui";
 
 // Type definitions for EventData
@@ -261,16 +261,7 @@ export function ResultEventContent({ eventData }: { eventData: EventData }) {
       {/* Result text */}
       {result && (
         <div className="pt-1">
-          <MarkdownPreview
-            source={result}
-            className="!bg-transparent !text-foreground text-sm"
-            style={{
-              backgroundColor: "transparent",
-              fontSize: "0.875rem",
-              lineHeight: "1.5",
-              fontFamily: "var(--font-family-sans)",
-            }}
-          />
+          <Markdown source={result} />
         </div>
       )}
     </div>

--- a/turbo/apps/platform/src/views/logs-page/components/grouped-message-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/grouped-message-card.tsx
@@ -1,5 +1,5 @@
 import { IconCheck, IconCircleDashed, IconLoader } from "@tabler/icons-react";
-import MarkdownPreview from "@uiw/react-markdown-preview";
+import { Markdown } from "../../components/markdown.tsx";
 import type { GroupedMessage, ToolOperation } from "../log-detail/utils.ts";
 import { ToolSummary } from "./tool-summary.tsx";
 import {
@@ -22,18 +22,7 @@ interface GroupedMessageCardProps {
 const MESSAGE_SPACING = "py-2";
 
 function MarkdownContent({ text }: { text: string }) {
-  return (
-    <MarkdownPreview
-      source={text}
-      className="!bg-transparent !text-foreground text-sm"
-      style={{
-        backgroundColor: "transparent",
-        fontSize: "0.875rem",
-        lineHeight: "1.5",
-        fontFamily: "var(--font-family-sans)",
-      }}
-    />
-  );
+  return <Markdown source={text} />;
 }
 
 function CollapsibleText({ text }: { text: string }) {

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/agent-events-card.tsx
@@ -1,6 +1,6 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import { IconSearch, IconLoader2 } from "@tabler/icons-react";
-import MarkdownPreview from "@uiw/react-markdown-preview";
+import { Markdown } from "../../../components/markdown.tsx";
 import { Input } from "@vm0/ui";
 import { StatusDot } from "../../components/status-dot.tsx";
 import {
@@ -258,16 +258,7 @@ function PromptCard({
         </summary>
         <div className="absolute left-[2px] top-[2.25rem] bottom-0 w-[1px] bg-border/70 group-open:block hidden" />
         <div className="ml-[18px] mt-2">
-          <MarkdownPreview
-            source={prompt}
-            className="!bg-transparent !text-foreground text-sm"
-            style={{
-              backgroundColor: "transparent",
-              fontSize: "0.875rem",
-              lineHeight: "1.5",
-              fontFamily: "var(--font-family-sans)",
-            }}
-          />
+          <Markdown source={prompt} />
         </div>
       </details>
     </div>


### PR DESCRIPTION
## Summary
- Created a shared `<Markdown>` component in `views/components/markdown.tsx` that wraps `@uiw/react-markdown-preview` with common theme styles (transparent background, foreground color, font size, line height, sans font family)
- Replaced all 4 direct usages of `MarkdownPreview` with the shared component, eliminating duplicated style props
- Callers can still pass additional `className` or `style` overrides

Closes #3018

## Test plan
- [x] Lint passes (`pnpm turbo run lint --filter=@vm0/platform`)
- [x] Type check passes (`pnpm turbo run check-types --filter=@vm0/platform`)
- [x] Knip finds no issues
- [x] All pre-commit hooks pass
- [ ] Visual inspection: rendered markdown looks identical in agent instructions page (markdown/preview toggle)
- [ ] Visual inspection: rendered markdown looks identical in log detail event cards
- [ ] Visual inspection: rendered markdown looks identical in grouped message cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)