### PR TITLE
fix(slack): sync agent permissions when admin switches workspace agent

### DIFF
--- a/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
@@ -2,11 +2,21 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { WebClient } from "@slack/web-api";
 import { GET, DELETE, PATCH } from "../route";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
-import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import {
+  mockClerk,
+  MOCK_USER_EMAIL,
+} from "../../../../../src/__tests__/clerk-mock";
 import {
   givenLinkedSlackUser,
   givenUserHasAgent,
 } from "../../../../../src/__tests__/slack/api-helpers";
+import {
+  createTestCompose,
+  findTestAgentPermissions,
+  findTestComposeWithScope,
+  insertTestAgentPermission,
+} from "../../../../../src/__tests__/api-test-helpers";
+import { reloadEnv } from "../../../../../src/env";
 
 const context = testContext();
 
@@ -248,6 +258,136 @@ describe("/api/integrations/slack", () => {
       const getData = await getResponse.json();
 
       expect(getData.agent.name).toBe(compose.name);
+    });
+
+    it("grants permissions on new agent and revokes old agent permissions", async () => {
+      const { userLink, installation } = await givenLinkedSlackUser({
+        isAdmin: true,
+      });
+
+      // Create new agent WITHOUT updating the installation's defaultComposeId
+      mockClerk({ userId: userLink.vm0UserId });
+      const { composeId: newComposeId } = await createTestCompose("new-agent");
+
+      // Verify initial state: user has permission on old (default) agent
+      const oldPermissions = await findTestAgentPermissions(
+        installation.defaultComposeId,
+        MOCK_USER_EMAIL,
+      );
+      expect(oldPermissions).toHaveLength(1);
+
+      // Switch agent via PATCH
+      const request = new Request(
+        "http://localhost:3000/api/integrations/slack",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agentName: "new-agent" }),
+        },
+      );
+      const response = await PATCH(request);
+      expect(response.status).toBe(200);
+
+      // Verify: permission on new agent exists
+      const newPermissions = await findTestAgentPermissions(
+        newComposeId,
+        MOCK_USER_EMAIL,
+      );
+      expect(newPermissions).toHaveLength(1);
+
+      // Verify: permission on old agent is revoked
+      const revokedPermissions = await findTestAgentPermissions(
+        installation.defaultComposeId,
+        MOCK_USER_EMAIL,
+      );
+      expect(revokedPermissions).toHaveLength(0);
+    });
+
+    it("skips revocation when old agent is SLACK_DEFAULT_AGENT", async () => {
+      const { userLink, installation } = await givenLinkedSlackUser({
+        isAdmin: true,
+      });
+
+      mockClerk({ userId: userLink.vm0UserId });
+
+      // Find the scope slug and name used for the default agent
+      const defaultCompose = await findTestComposeWithScope(
+        installation.defaultComposeId,
+      );
+
+      // Set SLACK_DEFAULT_AGENT to match the current default agent
+      vi.stubEnv(
+        "SLACK_DEFAULT_AGENT",
+        `${defaultCompose!.scopeSlug}/${defaultCompose!.composeName}`,
+      );
+      reloadEnv();
+
+      // Create new agent WITHOUT updating installation's defaultComposeId
+      const { composeId: newComposeId } =
+        await createTestCompose("replacement-agent");
+
+      const request = new Request(
+        "http://localhost:3000/api/integrations/slack",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agentName: "replacement-agent" }),
+        },
+      );
+      const response = await PATCH(request);
+      expect(response.status).toBe(200);
+
+      // Verify: permission on new agent exists
+      const newPermissions = await findTestAgentPermissions(
+        newComposeId,
+        MOCK_USER_EMAIL,
+      );
+      expect(newPermissions).toHaveLength(1);
+
+      // Verify: permission on old (default) agent is NOT revoked
+      const oldPermissions = await findTestAgentPermissions(
+        installation.defaultComposeId,
+        MOCK_USER_EMAIL,
+      );
+      expect(oldPermissions).toHaveLength(1);
+    });
+
+    it("handles duplicate permissions gracefully", async () => {
+      const { userLink } = await givenLinkedSlackUser({ isAdmin: true });
+
+      // Create new agent WITHOUT updating installation's defaultComposeId
+      mockClerk({ userId: userLink.vm0UserId });
+      const { composeId: newComposeId } =
+        await createTestCompose("shared-agent");
+
+      // Pre-grant permission (simulates CLI share)
+      await insertTestAgentPermission(
+        newComposeId,
+        MOCK_USER_EMAIL,
+        "cli-user",
+      );
+
+      // Switch to agent that already has permission — should not error
+      const request = new Request(
+        "http://localhost:3000/api/integrations/slack",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agentName: "shared-agent" }),
+        },
+      );
+      const response = await PATCH(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.ok).toBe(true);
+
+      // Permission should still exist (not duplicated)
+      const permissions = await findTestAgentPermissions(
+        newComposeId,
+        MOCK_USER_EMAIL,
+      );
+      expect(permissions).toHaveLength(1);
     });
   });
 });

--- a/turbo/apps/web/app/api/integrations/slack/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/link/route.ts
@@ -19,6 +19,7 @@ import { addPermission } from "../../../../../src/lib/agent/permission-service";
 import { getUserScopeByClerkId } from "../../../../../src/lib/scope/scope-service";
 import { agentComposes } from "../../../../../src/db/schema/agent-compose";
 import { logger } from "../../../../../src/lib/logger";
+import { syncWorkspaceAgentPermissions } from "../../../../../src/lib/slack/permission-sync";
 
 const log = logger("api:slack:link");
 
@@ -222,10 +223,19 @@ export async function POST(request: Request) {
     agentId !== installation.defaultComposeId &&
     slackUserId === installation.adminSlackUserId
   ) {
+    const oldComposeId = installation.defaultComposeId;
     await globalThis.services.db
       .update(slackInstallations)
       .set({ defaultComposeId: agentId, updatedAt: new Date() })
       .where(eq(slackInstallations.id, installation.id));
+
+    // Sync permissions for all linked workspace users
+    await syncWorkspaceAgentPermissions(
+      oldComposeId,
+      agentId,
+      workspaceId,
+      installation.adminSlackUserId,
+    );
   }
 
   if (existingLink) {

--- a/turbo/apps/web/app/api/integrations/slack/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/link/route.ts
@@ -224,18 +224,22 @@ export async function POST(request: Request) {
     slackUserId === installation.adminSlackUserId
   ) {
     const oldComposeId = installation.defaultComposeId;
-    await globalThis.services.db
-      .update(slackInstallations)
-      .set({ defaultComposeId: agentId, updatedAt: new Date() })
-      .where(eq(slackInstallations.id, installation.id));
 
-    // Sync permissions for all linked workspace users
-    await syncWorkspaceAgentPermissions(
-      oldComposeId,
-      agentId,
-      workspaceId,
-      installation.adminSlackUserId,
-    );
+    // Update installation + sync permissions atomically
+    await globalThis.services.db.transaction(async (tx) => {
+      await tx
+        .update(slackInstallations)
+        .set({ defaultComposeId: agentId, updatedAt: new Date() })
+        .where(eq(slackInstallations.id, installation.id));
+
+      await syncWorkspaceAgentPermissions(
+        oldComposeId,
+        agentId,
+        workspaceId,
+        installation.adminSlackUserId,
+        tx,
+      );
+    });
   }
 
   if (existingLink) {

--- a/turbo/apps/web/app/api/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/route.ts
@@ -330,19 +330,21 @@ export async function PATCH(request: Request) {
 
   const oldComposeId = installation.defaultComposeId;
 
-  // Update the installation's default compose
-  await db
-    .update(slackInstallations)
-    .set({ defaultComposeId: compose.id, updatedAt: new Date() })
-    .where(eq(slackInstallations.id, installation.id));
+  // Update installation + sync permissions atomically
+  await db.transaction(async (tx) => {
+    await tx
+      .update(slackInstallations)
+      .set({ defaultComposeId: compose.id, updatedAt: new Date() })
+      .where(eq(slackInstallations.id, installation.id));
 
-  // Sync permissions for all linked workspace users
-  await syncWorkspaceAgentPermissions(
-    oldComposeId,
-    compose.id,
-    installation.slackWorkspaceId,
-    installation.adminSlackUserId,
-  );
+    await syncWorkspaceAgentPermissions(
+      oldComposeId,
+      compose.id,
+      installation.slackWorkspaceId,
+      installation.adminSlackUserId,
+      tx,
+    );
+  });
 
   return NextResponse.json({ ok: true });
 }

--- a/turbo/apps/web/app/api/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/route.ts
@@ -27,6 +27,7 @@ import { decryptCredentialValue } from "../../../../src/lib/crypto/secrets-encry
 import { removePermission } from "../../../../src/lib/agent/permission-service";
 import { getUserEmail } from "../../../../src/lib/auth/get-user-email";
 import { getUserScopeByClerkId } from "../../../../src/lib/scope/scope-service";
+import { syncWorkspaceAgentPermissions } from "../../../../src/lib/slack/permission-sync";
 
 /**
  * GET /api/integrations/slack
@@ -327,11 +328,21 @@ export async function PATCH(request: Request) {
     );
   }
 
+  const oldComposeId = installation.defaultComposeId;
+
   // Update the installation's default compose
   await db
     .update(slackInstallations)
     .set({ defaultComposeId: compose.id, updatedAt: new Date() })
     .where(eq(slackInstallations.id, installation.id));
+
+  // Sync permissions for all linked workspace users
+  await syncWorkspaceAgentPermissions(
+    oldComposeId,
+    compose.id,
+    installation.slackWorkspaceId,
+    installation.adminSlackUserId,
+  );
 
   return NextResponse.json({ ok: true });
 }

--- a/turbo/apps/web/src/lib/slack/permission-sync.ts
+++ b/turbo/apps/web/src/lib/slack/permission-sync.ts
@@ -4,6 +4,7 @@ import { agentPermissions } from "../../db/schema/agent-permission";
 import { getUserEmail } from "../auth/get-user-email";
 import { resolveDefaultAgentComposeId } from "./index";
 import { logger } from "../logger";
+import type { Database } from "../../types/global";
 
 const log = logger("slack:permission-sync");
 
@@ -14,18 +15,22 @@ const log = logger("slack:permission-sync");
  * - Revokes email permissions on the old agent (unless it's the SLACK_DEFAULT_AGENT)
  * - Grants email permissions on the new agent
  * - All permission changes are wrapped in a single DB transaction
+ *
+ * An optional `dbOverride` parameter allows callers to pass a transaction
+ * so that the installation update and permission sync are atomic.
  */
 export async function syncWorkspaceAgentPermissions(
   oldComposeId: string,
   newComposeId: string,
   slackWorkspaceId: string,
   adminSlackUserId: string,
+  dbOverride?: Database,
 ): Promise<void> {
   if (oldComposeId === newComposeId) {
     return;
   }
 
-  const db = globalThis.services.db;
+  const db = dbOverride ?? globalThis.services.db;
 
   // 1. Query all linked users in the workspace
   const linkedUsers = await db
@@ -40,7 +45,15 @@ export async function syncWorkspaceAgentPermissions(
   // 2. Resolve emails in parallel
   const emails = (
     await Promise.all(
-      linkedUsers.map((u) => getUserEmail(u.vm0UserId).catch(() => null)),
+      linkedUsers.map((u) =>
+        getUserEmail(u.vm0UserId).catch((err) => {
+          log.warn("Failed to resolve user email for permission sync", {
+            userId: u.vm0UserId,
+            err,
+          });
+          return null;
+        }),
+      ),
     )
   ).filter((e): e is string => !!e);
 

--- a/turbo/apps/web/src/lib/slack/permission-sync.ts
+++ b/turbo/apps/web/src/lib/slack/permission-sync.ts
@@ -14,10 +14,10 @@ const log = logger("slack:permission-sync");
  *
  * - Revokes email permissions on the old agent (unless it's the SLACK_DEFAULT_AGENT)
  * - Grants email permissions on the new agent
- * - All permission changes are wrapped in a single DB transaction
  *
- * An optional `dbOverride` parameter allows callers to pass a transaction
- * so that the installation update and permission sync are atomic.
+ * When `dbOverride` is provided (a caller's transaction), permission writes
+ * execute directly on it — no nested transaction / savepoint is created.
+ * When omitted, a new transaction is opened for the permission writes.
  */
 export async function syncWorkspaceAgentPermissions(
   oldComposeId: string,
@@ -44,17 +44,7 @@ export async function syncWorkspaceAgentPermissions(
 
   // 2. Resolve emails in parallel
   const emails = (
-    await Promise.all(
-      linkedUsers.map((u) =>
-        getUserEmail(u.vm0UserId).catch((err) => {
-          log.warn("Failed to resolve user email for permission sync", {
-            userId: u.vm0UserId,
-            err,
-          });
-          return null;
-        }),
-      ),
-    )
+    await Promise.all(linkedUsers.map((u) => getUserEmail(u.vm0UserId)))
   ).filter((e): e is string => !!e);
 
   if (emails.length === 0) {
@@ -65,9 +55,10 @@ export async function syncWorkspaceAgentPermissions(
   const defaultComposeId = await resolveDefaultAgentComposeId();
   const skipRevoke = oldComposeId === defaultComposeId;
 
-  // 4. Batch permission changes in a single transaction
-  await db.transaction(async (tx) => {
-    // Revoke old agent permissions (unless it's the default)
+  // 4. Batch permission changes
+  // When dbOverride is provided (caller's transaction), use it directly
+  // to avoid nested savepoints. Otherwise, open a new transaction.
+  const execute = async (tx: Database) => {
     if (!skipRevoke) {
       await tx
         .delete(agentPermissions)
@@ -80,7 +71,6 @@ export async function syncWorkspaceAgentPermissions(
         );
     }
 
-    // Grant new agent permissions
     await tx
       .insert(agentPermissions)
       .values(
@@ -92,7 +82,13 @@ export async function syncWorkspaceAgentPermissions(
         })),
       )
       .onConflictDoNothing();
-  });
+  };
+
+  if (dbOverride) {
+    await execute(dbOverride);
+  } else {
+    await db.transaction(async (tx) => execute(tx));
+  }
 
   log.info("Synced workspace agent permissions", {
     slackWorkspaceId,

--- a/turbo/apps/web/src/lib/slack/permission-sync.ts
+++ b/turbo/apps/web/src/lib/slack/permission-sync.ts
@@ -1,0 +1,91 @@
+import { eq, and, inArray } from "drizzle-orm";
+import { slackUserLinks } from "../../db/schema/slack-user-link";
+import { agentPermissions } from "../../db/schema/agent-permission";
+import { getUserEmail } from "../auth/get-user-email";
+import { resolveDefaultAgentComposeId } from "./index";
+import { logger } from "../logger";
+
+const log = logger("slack:permission-sync");
+
+/**
+ * Sync agent permissions for all linked users in a Slack workspace
+ * when the workspace default agent is switched.
+ *
+ * - Revokes email permissions on the old agent (unless it's the SLACK_DEFAULT_AGENT)
+ * - Grants email permissions on the new agent
+ * - All permission changes are wrapped in a single DB transaction
+ */
+export async function syncWorkspaceAgentPermissions(
+  oldComposeId: string,
+  newComposeId: string,
+  slackWorkspaceId: string,
+  adminSlackUserId: string,
+): Promise<void> {
+  if (oldComposeId === newComposeId) {
+    return;
+  }
+
+  const db = globalThis.services.db;
+
+  // 1. Query all linked users in the workspace
+  const linkedUsers = await db
+    .select({ vm0UserId: slackUserLinks.vm0UserId })
+    .from(slackUserLinks)
+    .where(eq(slackUserLinks.slackWorkspaceId, slackWorkspaceId));
+
+  if (linkedUsers.length === 0) {
+    return;
+  }
+
+  // 2. Resolve emails in parallel
+  const emails = (
+    await Promise.all(
+      linkedUsers.map((u) => getUserEmail(u.vm0UserId).catch(() => null)),
+    )
+  ).filter((e): e is string => !!e);
+
+  if (emails.length === 0) {
+    return;
+  }
+
+  // 3. Determine if old agent is the SLACK_DEFAULT_AGENT (skip revocation)
+  const defaultComposeId = await resolveDefaultAgentComposeId();
+  const skipRevoke = oldComposeId === defaultComposeId;
+
+  // 4. Batch permission changes in a single transaction
+  await db.transaction(async (tx) => {
+    // Revoke old agent permissions (unless it's the default)
+    if (!skipRevoke) {
+      await tx
+        .delete(agentPermissions)
+        .where(
+          and(
+            eq(agentPermissions.agentComposeId, oldComposeId),
+            eq(agentPermissions.granteeType, "email"),
+            inArray(agentPermissions.granteeEmail, emails),
+          ),
+        );
+    }
+
+    // Grant new agent permissions
+    await tx
+      .insert(agentPermissions)
+      .values(
+        emails.map((email) => ({
+          agentComposeId: newComposeId,
+          granteeType: "email" as const,
+          granteeEmail: email,
+          grantedBy: adminSlackUserId,
+        })),
+      )
+      .onConflictDoNothing();
+  });
+
+  log.info("Synced workspace agent permissions", {
+    slackWorkspaceId,
+    oldComposeId,
+    newComposeId,
+    skipRevoke,
+    userCount: emails.length,
+  });
+}


### PR DESCRIPTION
## Summary

- When a Slack workspace admin switches the default agent (via PATCH `/api/integrations/slack` or POST `/api/integrations/slack/link`), batch-sync email permissions for **all linked workspace users**: grant on the new agent, revoke on the old agent
- Skip revocation when the old agent is the `SLACK_DEFAULT_AGENT` (platform default)
- All permission changes run inside a single DB transaction for consistency

## Changes

| File | Description |
|------|-------------|
| `src/lib/slack/permission-sync.ts` | **New** — `syncWorkspaceAgentPermissions()` service function |
| `app/api/integrations/slack/route.ts` | Call sync in PATCH handler after updating `defaultComposeId` |
| `app/api/integrations/slack/link/route.ts` | Call sync in POST handler when admin selects a different agent |
| `app/api/integrations/slack/__tests__/route.test.ts` | 3 new test cases (grant+revoke, default skip, duplicate handling) |
| `src/__tests__/api-test-helpers.ts` | New helpers: `findTestAgentPermissions`, `insertTestAgentPermission`, `findTestComposeWithScope` |

## Test plan

- [x] Permission grant on new agent + revoke on old agent
- [x] Skip revocation when old agent is SLACK_DEFAULT_AGENT
- [x] Handle duplicate permissions gracefully (ON CONFLICT DO NOTHING)
- [x] All 15 existing + new tests pass
- [x] Lint, type check, knip, prettier all pass

Closes #3022

🤖 Generated with [Claude Code](https://claude.com/claude-code)