### PR TITLE
feat(runner): add firewall rules and seal secrets to proxy registry

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -176,11 +176,11 @@ jobs:
             --api-url https://localhost \
             --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
-          # Run benchmark (boot VM from snapshot, exec command, verify output)
+          # Run benchmark (boot VM from snapshot, exec command, verify network)
           echo "=== Running benchmark ==="
           ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner benchmark \
             --config ${RUNNER_DIR}/runner.yaml \
-            'echo hello-from-vm'"
+            'curl -sf --max-time 10 https://httpbin.org/get'"
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -180,7 +180,7 @@ jobs:
           echo "=== Running benchmark ==="
           ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner benchmark \
             --config ${RUNNER_DIR}/runner.yaml \
-            'curl -sk --max-time 10 -o /dev/null -w \"http_code=%{http_code}\\n\" https://httpbin.org/get'"
+            'curl -sf --max-time 10 https://httpbin.org/get'"
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -180,7 +180,7 @@ jobs:
           echo "=== Running benchmark ==="
           ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner benchmark \
             --config ${RUNNER_DIR}/runner.yaml \
-            'curl -sf --max-time 10 https://httpbin.org/get'"
+            'curl -sk --max-time 10 -o /dev/null -w \"http_code=%{http_code}\\n\" https://httpbin.org/get'"
 
       - name: Cleanup
         if: always()

--- a/crates/runner/src/benchmark.rs
+++ b/crates/runner/src/benchmark.rs
@@ -154,7 +154,14 @@ async fn run_sandbox(
 
     let source_ip = sandbox.source_ip().to_string();
     let run_id = sandbox.id().to_string();
-    if let Err(e) = mitm.register_vm(&source_ip, &run_id).await {
+    let registration = proxy::VmRegistration {
+        run_id: &run_id,
+        sandbox_token: "",
+        firewall_rules: &[],
+        mitm_enabled: true,
+        seal_secrets_enabled: false,
+    };
+    if let Err(e) = mitm.register_vm(&source_ip, &registration).await {
         warn!(error = %e, "failed to register VM in proxy");
     }
 

--- a/crates/runner/src/benchmark.rs
+++ b/crates/runner/src/benchmark.rs
@@ -158,6 +158,7 @@ async fn run_sandbox(
         run_id: &run_id,
         sandbox_token: "",
         firewall_rules: &[],
+        // mitm rewrites requests to the API proxy endpoint; benchmark doesn't need that.
         mitm_enabled: false,
         seal_secrets_enabled: false,
     };

--- a/crates/runner/src/benchmark.rs
+++ b/crates/runner/src/benchmark.rs
@@ -58,9 +58,8 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     info!(proxy_ms, port = mitm.port(), "proxy ready");
 
     // 3. Factory init (with proxy port)
-    let fc_config = runner_config.firecracker_config();
-    // TODO: re-enable once proxy networking is verified
-    // fc_config.proxy_port = Some(mitm.port());
+    let mut fc_config = runner_config.firecracker_config();
+    fc_config.proxy_port = Some(mitm.port());
 
     let t = Instant::now();
     let mut factory = FirecrackerFactory::new(fc_config).await?;

--- a/crates/runner/src/benchmark.rs
+++ b/crates/runner/src/benchmark.rs
@@ -58,8 +58,9 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     info!(proxy_ms, port = mitm.port(), "proxy ready");
 
     // 3. Factory init (with proxy port)
-    let mut fc_config = runner_config.firecracker_config();
-    fc_config.proxy_port = Some(mitm.port());
+    let fc_config = runner_config.firecracker_config();
+    // TODO: re-enable once proxy networking is verified
+    // fc_config.proxy_port = Some(mitm.port());
 
     let t = Instant::now();
     let mut factory = FirecrackerFactory::new(fc_config).await?;

--- a/crates/runner/src/benchmark.rs
+++ b/crates/runner/src/benchmark.rs
@@ -158,7 +158,7 @@ async fn run_sandbox(
         run_id: &run_id,
         sandbox_token: "",
         firewall_rules: &[],
-        mitm_enabled: true,
+        mitm_enabled: false,
         seal_secrets_enabled: false,
     };
     if let Err(e) = mitm.register_vm(&source_ip, &registration).await {

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -65,7 +65,7 @@ pub struct VmRegistration<'a> {
 const MITM_ADDON: &str = include_str!("../scripts/mitm-addon.py");
 
 /// Timeout for waiting for mitmdump to become ready after spawn.
-const READY_TIMEOUT: Duration = Duration::from_secs(5);
+const READY_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Timeout for graceful shutdown before SIGKILL.
 const STOP_TIMEOUT: Duration = Duration::from_secs(3);
@@ -168,7 +168,7 @@ impl MitmProxy {
         }
 
         // Wait for process to be alive (poll liveness).
-        wait_for_ready(&mut child, READY_TIMEOUT).await?;
+        wait_for_ready(&mut child, self.port, READY_TIMEOUT).await?;
 
         self.child = Some(child);
         info!(port = self.port, "mitmdump started");
@@ -258,12 +258,18 @@ impl Drop for MitmProxy {
     }
 }
 
-/// Wait for the mitmdump process to be alive and not immediately exit.
-async fn wait_for_ready(child: &mut tokio::process::Child, timeout: Duration) -> RunnerResult<()> {
+/// Wait for mitmdump to start listening on `port` (TCP connect probe).
+async fn wait_for_ready(
+    child: &mut tokio::process::Child,
+    port: u16,
+    timeout: Duration,
+) -> RunnerResult<()> {
     let poll_interval = Duration::from_millis(200);
     let start = std::time::Instant::now();
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
 
     while start.elapsed() < timeout {
+        // Check if process died.
         match child.try_wait() {
             Ok(Some(status)) => {
                 return Err(RunnerError::Internal(format!(
@@ -273,22 +279,24 @@ async fn wait_for_ready(child: &mut tokio::process::Child, timeout: Duration) ->
                         .map_or("unknown".to_string(), |c| c.to_string()),
                 )));
             }
-            Ok(None) => {
-                // Still running — after first successful check, consider ready.
-                if start.elapsed() >= poll_interval {
-                    return Ok(());
-                }
-            }
+            Ok(None) => {}
             Err(e) => {
                 return Err(RunnerError::Internal(format!(
                     "mitmdump process check: {e}"
                 )));
             }
         }
+        // Probe TCP port.
+        if tokio::net::TcpStream::connect(addr).await.is_ok() {
+            return Ok(());
+        }
         tokio::time::sleep(poll_interval).await;
     }
 
-    Ok(())
+    Err(RunnerError::Internal(format!(
+        "mitmdump did not start listening on port {port} within {}s",
+        timeout.as_secs()
+    )))
 }
 
 /// Find an available TCP port by binding to port 0.

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -32,7 +32,7 @@ struct VmEntry {
 /// - Domain rule: `{ "domain": "*.example.com", "action": "ALLOW" }`
 /// - IP rule: `{ "ip": "10.0.0.0/8", "action": "DENY" }`
 /// - Terminal rule: `{ "final": "DENY" }`
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FirewallRule {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub domain: Option<String>,
@@ -44,7 +44,7 @@ pub struct FirewallRule {
     pub action: Option<FirewallAction>,
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FirewallAction {
     #[serde(rename = "ALLOW")]
     Allow,
@@ -53,6 +53,7 @@ pub enum FirewallAction {
 }
 
 /// Parameters for registering a VM in the proxy registry.
+#[derive(Debug)]
 pub struct VmRegistration<'a> {
     pub run_id: &'a str,
     pub sandbox_token: &'a str,

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -21,7 +21,44 @@ struct VmEntry {
     run_id: String,
     sandbox_token: String,
     registered_at: i64,
+    firewall_rules: Vec<FirewallRule>,
     mitm_enabled: bool,
+    seal_secrets_enabled: bool,
+}
+
+/// Firewall rule for network filtering (first-match-wins).
+///
+/// Variants:
+/// - Domain rule: `{ "domain": "*.example.com", "action": "ALLOW" }`
+/// - IP rule: `{ "ip": "10.0.0.0/8", "action": "DENY" }`
+/// - Terminal rule: `{ "final": "DENY" }`
+#[derive(Clone, Serialize, Deserialize)]
+pub struct FirewallRule {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip: Option<String>,
+    #[serde(rename = "final", skip_serializing_if = "Option::is_none")]
+    pub terminal: Option<FirewallAction>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<FirewallAction>,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+pub enum FirewallAction {
+    #[serde(rename = "ALLOW")]
+    Allow,
+    #[serde(rename = "DENY")]
+    Deny,
+}
+
+/// Parameters for registering a VM in the proxy registry.
+pub struct VmRegistration<'a> {
+    pub run_id: &'a str,
+    pub sandbox_token: &'a str,
+    pub firewall_rules: &'a [FirewallRule],
+    pub mitm_enabled: bool,
+    pub seal_secrets_enabled: bool,
 }
 
 /// Embedded mitmproxy addon script (compiled into the binary).
@@ -147,21 +184,31 @@ impl MitmProxy {
     ///
     /// Note: the read-modify-write is not concurrent-safe. Current usage is
     /// single-sandbox (benchmark). If reused for multi-sandbox, add file locking.
-    pub async fn register_vm(&self, source_ip: &str, run_id: &str) -> RunnerResult<()> {
+    pub async fn register_vm(
+        &self,
+        source_ip: &str,
+        registration: &VmRegistration<'_>,
+    ) -> RunnerResult<()> {
         let mut registry = read_registry(&self.config.registry_path).await?;
         let now = chrono::Utc::now().timestamp_millis();
         registry.vms.insert(
             source_ip.to_string(),
             VmEntry {
-                run_id: run_id.to_string(),
-                sandbox_token: String::new(),
+                run_id: registration.run_id.to_string(),
+                sandbox_token: registration.sandbox_token.to_string(),
                 registered_at: now,
-                mitm_enabled: true,
+                firewall_rules: registration.firewall_rules.to_vec(),
+                mitm_enabled: registration.mitm_enabled,
+                seal_secrets_enabled: registration.seal_secrets_enabled,
             },
         );
         registry.updated_at = now;
         write_registry(&self.config.registry_path, &registry).await?;
-        info!(source_ip, run_id, "registered VM in proxy registry");
+        info!(
+            source_ip,
+            run_id = registration.run_id,
+            "registered VM in proxy registry"
+        );
         Ok(())
     }
 
@@ -319,7 +366,9 @@ mod tests {
                 run_id: "test-run".to_string(),
                 sandbox_token: String::new(),
                 registered_at: 1000,
+                firewall_rules: Vec::new(),
                 mitm_enabled: true,
+                seal_secrets_enabled: false,
             },
         );
         write_registry(&registry_path, &registry).await.unwrap();
@@ -341,5 +390,111 @@ mod tests {
             !loaded.vms.contains_key("10.200.0.2"),
             "VM should be removed from registry"
         );
+    }
+
+    #[test]
+    fn firewall_rule_serializes_to_ts_format() {
+        let rules = vec![
+            FirewallRule {
+                domain: Some("*.example.com".to_string()),
+                ip: None,
+                terminal: None,
+                action: Some(FirewallAction::Allow),
+            },
+            FirewallRule {
+                domain: None,
+                ip: Some("10.0.0.0/8".to_string()),
+                terminal: None,
+                action: Some(FirewallAction::Deny),
+            },
+            FirewallRule {
+                domain: None,
+                ip: None,
+                terminal: Some(FirewallAction::Deny),
+                action: None,
+            },
+        ];
+        let json = serde_json::to_value(&rules).unwrap();
+        let arr = json.as_array().unwrap();
+
+        // Domain rule
+        assert_eq!(arr[0]["domain"], "*.example.com");
+        assert_eq!(arr[0]["action"], "ALLOW");
+        assert!(arr[0].get("ip").is_none());
+        assert!(arr[0].get("final").is_none());
+
+        // IP rule
+        assert_eq!(arr[1]["ip"], "10.0.0.0/8");
+        assert_eq!(arr[1]["action"], "DENY");
+
+        // Terminal rule (field name is "final" in JSON)
+        assert_eq!(arr[2]["final"], "DENY");
+        assert!(arr[2].get("action").is_none());
+    }
+
+    #[test]
+    fn firewall_rule_round_trip() {
+        let json = r#"[
+            {"domain": "example.com", "action": "ALLOW"},
+            {"ip": "192.168.0.0/16", "action": "DENY"},
+            {"final": "DENY"}
+        ]"#;
+        let rules: Vec<FirewallRule> = serde_json::from_str(json).unwrap();
+        assert_eq!(rules.len(), 3);
+        assert_eq!(rules[0].domain.as_deref(), Some("example.com"));
+        assert!(matches!(rules[0].action, Some(FirewallAction::Allow)));
+        assert_eq!(rules[1].ip.as_deref(), Some("192.168.0.0/16"));
+        assert!(matches!(rules[1].action, Some(FirewallAction::Deny)));
+        assert!(matches!(rules[2].terminal, Some(FirewallAction::Deny)));
+        assert!(rules[2].action.is_none());
+    }
+
+    #[tokio::test]
+    async fn registry_with_firewall_rules() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+
+        let mut registry = ProxyRegistry {
+            vms: HashMap::new(),
+            updated_at: 0,
+        };
+        registry.vms.insert(
+            "10.200.0.2".to_string(),
+            VmEntry {
+                run_id: "run-1".to_string(),
+                sandbox_token: "tok".to_string(),
+                registered_at: 1000,
+                firewall_rules: vec![
+                    FirewallRule {
+                        domain: Some("*.allowed.com".to_string()),
+                        ip: None,
+                        terminal: None,
+                        action: Some(FirewallAction::Allow),
+                    },
+                    FirewallRule {
+                        domain: None,
+                        ip: None,
+                        terminal: Some(FirewallAction::Deny),
+                        action: None,
+                    },
+                ],
+                mitm_enabled: true,
+                seal_secrets_enabled: true,
+            },
+        );
+        write_registry(&registry_path, &registry).await.unwrap();
+
+        let loaded = read_registry(&registry_path).await.unwrap();
+        let vm = loaded.vms.get("10.200.0.2").unwrap();
+        assert_eq!(vm.firewall_rules.len(), 2);
+        assert!(vm.seal_secrets_enabled);
+
+        // Verify JSON field names match TS/Python format.
+        let raw = tokio::fs::read_to_string(&registry_path).await.unwrap();
+        let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let vm_json = &value["vms"]["10.200.0.2"];
+        assert!(vm_json["firewallRules"].is_array());
+        assert_eq!(vm_json["sealSecretsEnabled"], true);
+        assert_eq!(vm_json["mitmEnabled"], true);
     }
 }


### PR DESCRIPTION
## Summary
- Add `FirewallRule` / `FirewallAction` types matching TS and Python contracts (domain, IP/CIDR, terminal rules with first-match-wins semantics)
- Add `VmRegistration` parameter struct for `register_vm`, replacing loose `&str` args
- Add `seal_secrets_enabled` field to `VmEntry`
- Change CI benchmark command from `echo` to `curl` for network connectivity verification

## Test plan
- [x] Firewall rule serialization matches TS/Python JSON format (`"final"`, `"ALLOW"/"DENY"`, `camelCase`)
- [x] Firewall rule JSON round-trip deserialization
- [x] Registry read/write with firewall rules and seal secrets
- [x] All 35 runner tests pass
- [ ] CI metal test verifies VM network connectivity via curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)