### PR TITLE
fix(cli): use fake timers in usage tests to avoid time-dependent failures

### DIFF
--- a/turbo/apps/cli/src/commands/usage/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/usage/__tests__/index.test.ts
@@ -14,11 +14,13 @@ describe("usage command", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers({ now: new Date("2026-01-19T12:00:00Z") });
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();


### PR DESCRIPTION
## Summary

Usage tests hardcoded `2026-01-15` as `--since` without `--until`, so `endDate` defaults to `Date.now()`. Once the current date exceeds 30 days past Jan 15 (i.e. after Feb 14), the 30-day range validation rejects.

### Failure trace

1. `parseAsync(["node", "cli", "--since", "2026-01-15"])` — test expects success
2. `endDate = new Date()` = 2026-02-14 (today), `startDate` = 2026-01-15
3. Range = 30 days + hours → exceeds `MAX_RANGE_MS` (exactly 30 days)
4. `index.ts:154` calls `process.exit(1)` → mock throws `Error("process.exit called")`
5. Caught by `index.ts:199` catch block → `index.ts:210` calls `process.exit(1)` again
6. Mock throws a second time, no outer catch → `parseAsync` rejects
7. Test does bare `await` (no `rejects.toThrow`) → test fails

### Fix

Pin the clock to `2026-01-19T12:00:00Z` with `vi.useFakeTimers()` so all hardcoded dates stay within the 30-day window regardless of when the test runs.

## Test plan
- [x] `pnpm vitest run apps/cli/src/commands/usage/__tests__/index.test.ts` — 31 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)