### PR TITLE
feat(sandbox-fc): per-sandbox proxy control with dual-queue netns pool

### DIFF
--- a/crates/runner/src/benchmark.rs
+++ b/crates/runner/src/benchmark.rs
@@ -74,6 +74,7 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
             cpu_count: runner_config.sandbox.vcpu,
             memory_mb: runner_config.sandbox.memory_mb,
         },
+        use_proxy: true,
     };
     let (result, timing) = run_sandbox(&args, &factory, &mitm, sandbox_config, is_snapshot).await;
     let total_ms = total.elapsed().as_millis();

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -72,6 +72,7 @@ async fn execute_inner(
             cpu_count: config.vcpu,
             memory_mb: config.memory_mb,
         },
+        use_proxy: true,
     };
 
     // Create and start sandbox

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -57,7 +57,7 @@ impl std::fmt::Display for SandboxState {
 }
 
 pub struct FirecrackerSandbox {
-    config: SandboxConfig,
+    pub(crate) config: SandboxConfig,
     factory_config: FirecrackerConfig,
     /// Cached `config.id.to_string()`.
     pub(crate) id: String,

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -152,7 +152,7 @@ async fn run_snapshot_workflow(
     netns_pool: &mut NetnsPool,
 ) -> Result<SnapshotConfig, SnapshotError> {
     let network = netns_pool
-        .acquire()
+        .acquire(false)
         .await
         .map_err(|e| SnapshotError::Setup(format!("acquire netns: {e}")))?;
 

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -6,4 +6,5 @@ pub struct ResourceLimits {
 pub struct SandboxConfig {
     pub id: uuid::Uuid,
     pub resources: ResourceLimits,
+    pub use_proxy: bool,
 }


### PR DESCRIPTION
## Summary
- Add `use_proxy: bool` to `SandboxConfig` for per-sandbox proxy control
- Split `NetnsPool` into `plain_queue` and `proxy_queue`, both pre-warmed at startup (`config.size` each)
- `acquire(true)` only touches proxy queue, `acquire(false)` only touches plain queue — no mixing
- Split iptables setup: connectivity-only base rules + separate `add_proxy_redirect_rules` for PREROUTING REDIRECT
- Cleanup unchanged — `delete_iptables_rules_by_comment` catches all rules via comment substring match

Closes #3033

## Test plan
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo test -p sandbox-fc -p runner -p sandbox` — 105 tests pass
- [ ] On dev-2: benchmark with proxy → sandboxes use proxy queue
- [ ] On dev-2: verify plain queue sandboxes bypass mitmproxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)