### PR TITLE
chore(crates): upgrade cargo resolver from 2 to 3

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "ably-subscriber",
     "guest-agent",


### PR DESCRIPTION
## Summary
- Upgrade workspace resolver from `"2"` to `"3"` to match edition 2024 default
- Resolver 3 provides better feature isolation for proc-macro and build-script dependencies, preventing feature leakage into normal dependencies
- Virtual workspaces require an explicit `resolver` field (cannot be omitted)

## Test plan
- [x] `cargo clippy --all-targets` passes
- [x] `cargo test --workspace` passes (all 369 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)