### PR TITLE
feat(runner): add version flag to cli

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -36,7 +36,7 @@ impl FormatTime for Elapsed {
 }
 
 #[derive(Parser)]
-#[command(name = "runner")]
+#[command(name = "runner", version)]
 struct Cli {
     #[command(subcommand)]
     command: Command,


### PR DESCRIPTION
## Summary
- Add `--version` / `-V` flag to the runner CLI via clap's `#[command(version)]`
- Version is automatically derived from `Cargo.toml` (`runner 0.1.0`)

## Test plan
- [x] `cargo run -p runner -- --version` outputs `runner 0.1.0`
- [x] `cargo clippy -p runner --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)