### PR TITLE
ci(crates): add cargo compilation cache

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -70,6 +70,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates -> target
+
       - name: Check formatting
         run: |
           cd crates
@@ -110,6 +114,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates -> target
+          key: aarch64-musl
 
       - name: Cross-compile runner and guest binaries for ARM64
         run: |


### PR DESCRIPTION
## Summary
- Add `Swatinem/rust-cache@v2` to `check` and `runner-metal-test` jobs in `crates.yml`
- Uses separate cache keys for native x86_64 (`check`) and cross-compiled aarch64-musl (`runner-metal-test`)
- Caches `target/` directory and Cargo registry to speed up subsequent CI runs

## Test plan
- [ ] First CI run completes successfully (cold cache miss, generates cache)
- [ ] Subsequent CI run restores cache and shows reduced compilation time

🤖 Generated with [Claude Code](https://claude.com/claude-code)