### PR TITLE
feat(runner): add proxy support to start command

### DIFF
--- a/crates/runner/src/benchmark.rs
+++ b/crates/runner/src/benchmark.rs
@@ -50,6 +50,7 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
         ca_dir: runner_config.ca_dir.clone(),
         addon_path: runner_paths.mitm_addon(),
         registry_path: runner_paths.proxy_registry(),
+        registry_lock_path: runner_paths.proxy_registry_lock(),
         api_url: runner_config.server.as_ref().map(|s| s.url.clone()),
     })
     .await?;

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -13,6 +13,7 @@ const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
 use crate::api::ApiClient;
 use crate::error::RunnerResult;
 use crate::paths::guest;
+use crate::proxy::{self, ProxyRegistryHandle};
 use crate::types::ExecutionContext;
 
 /// Configuration for a single execution.
@@ -21,6 +22,7 @@ pub struct ExecutorConfig {
     pub vcpu: u32,
     pub memory_mb: u32,
     pub is_snapshot: bool,
+    pub registry: ProxyRegistryHandle,
 }
 
 /// Execute a single job inside a Firecracker VM.
@@ -84,8 +86,36 @@ async fn execute_inner(
         return Err(e.into());
     }
 
+    // Register VM in proxy registry (only when firewall is enabled)
+    let source_ip = sandbox.source_ip().to_string();
+    let firewall_enabled = context
+        .experimental_firewall
+        .as_ref()
+        .is_some_and(|fw| fw.enabled);
+
+    if let Some(fw) = &context.experimental_firewall
+        && fw.enabled
+    {
+        let run_id_str = context.run_id.to_string();
+        let registration = proxy::VmRegistration {
+            run_id: &run_id_str,
+            sandbox_token: &context.sandbox_token,
+            firewall_rules: fw.rules.as_deref().unwrap_or(&[]),
+            mitm_enabled: fw.experimental_mitm.unwrap_or(false),
+            seal_secrets_enabled: fw.experimental_seal_secrets.unwrap_or(false),
+        };
+        if let Err(e) = config.registry.register_vm(&source_ip, &registration).await {
+            warn!(run_id = %context.run_id, error = %e, "failed to register VM in proxy");
+        }
+    }
+
     // Run job inside sandbox, then destroy regardless of outcome
     let result = run_in_sandbox(sandbox.as_ref(), context, config).await;
+
+    // Unregister VM from proxy registry
+    if firewall_enabled && let Err(e) = config.registry.unregister_vm(&source_ip).await {
+        warn!(run_id = %context.run_id, error = %e, "failed to unregister VM from proxy");
+    }
 
     // Best-effort stop
     if let Err(e) = sandbox.stop().await {
@@ -355,7 +385,10 @@ mod tests {
         ExecutionContext {
             run_id: Uuid::nil(),
             prompt: "test prompt".into(),
+            agent_compose_version_id: None,
             vars: None,
+            secret_names: None,
+            checkpoint_id: None,
             sandbox_token: "tok".into(),
             working_dir: "/workspace".into(),
             storage_manifest: None,
@@ -363,6 +396,8 @@ mod tests {
             resume_session: None,
             secret_values: None,
             cli_agent_type: String::new(),
+            experimental_firewall: None,
+            debug_no_mock_claude: None,
             api_start_time: None,
             user_timezone: None,
         }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -545,4 +545,55 @@ mod tests {
         // User environment TZ takes precedence
         assert_eq!(env.get("TZ").unwrap(), "America/New_York");
     }
+
+    /// Verify ExecutionContext deserializes from JSON matching the TS schema,
+    /// including the snake_case `experimentalFirewall` inner fields.
+    #[test]
+    fn deserialize_execution_context_with_firewall() {
+        let json = r#"{
+            "runId": "00000000-0000-0000-0000-000000000001",
+            "prompt": "hello",
+            "agentComposeVersionId": null,
+            "vars": null,
+            "secretNames": null,
+            "checkpointId": null,
+            "sandboxToken": "tok",
+            "workingDir": "/workspace",
+            "storageManifest": null,
+            "environment": null,
+            "resumeSession": null,
+            "secretValues": null,
+            "cliAgentType": "claude-code",
+            "experimentalFirewall": {
+                "enabled": true,
+                "rules": [
+                    {"domain": "*.example.com", "action": "ALLOW"},
+                    {"final": "DENY"}
+                ],
+                "experimental_mitm": true,
+                "experimental_seal_secrets": false
+            },
+            "debugNoMockClaude": true,
+            "apiStartTime": 1700000000.5,
+            "userTimezone": "Asia/Shanghai"
+        }"#;
+
+        let ctx: ExecutionContext = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            ctx.run_id.to_string(),
+            "00000000-0000-0000-0000-000000000001"
+        );
+        assert_eq!(ctx.prompt, "hello");
+        assert_eq!(ctx.cli_agent_type, "claude-code");
+
+        let fw = ctx.experimental_firewall.as_ref().unwrap();
+        assert!(fw.enabled);
+        let rules = fw.rules.as_ref().unwrap();
+        assert_eq!(rules.len(), 2);
+        assert_eq!(fw.experimental_mitm, Some(true));
+        assert_eq!(fw.experimental_seal_secrets, Some(false));
+
+        assert_eq!(ctx.api_start_time, Some(1700000000.5));
+        assert_eq!(ctx.user_timezone.as_deref(), Some("Asia/Shanghai"));
+    }
 }

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -30,6 +30,10 @@ impl RunnerPaths {
     pub fn proxy_registry(&self) -> PathBuf {
         self.base_dir.join("proxy-registry.json")
     }
+
+    pub fn proxy_registry_lock(&self) -> PathBuf {
+        self.base_dir.join("proxy-registry.json.lock")
+    }
 }
 
 /// Paths rooted at ~/.vm0-runner/.

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -81,6 +81,8 @@ pub struct ProxyConfig {
     pub addon_path: PathBuf,
     /// Path where the proxy registry JSON will be written.
     pub registry_path: PathBuf,
+    /// Lock file path for coordinating concurrent registry access.
+    pub registry_lock_path: PathBuf,
     /// VM0 API URL passed to the addon (optional).
     pub api_url: Option<String>,
 }
@@ -181,48 +183,31 @@ impl MitmProxy {
         self.port
     }
 
-    /// Register a VM in the proxy registry so the addon can identify its traffic.
+    /// Create a cloneable handle for registry operations (register/unregister VMs).
     ///
-    /// Note: the read-modify-write is not concurrent-safe. Current usage is
-    /// single-sandbox (benchmark). If reused for multi-sandbox, add file locking.
+    /// The handle is `Clone + Send + Sync` and uses file locking for concurrent
+    /// access, making it safe to share across executor tasks.
+    pub fn registry_handle(&self) -> ProxyRegistryHandle {
+        ProxyRegistryHandle {
+            registry_path: self.config.registry_path.clone(),
+            lock_path: self.config.registry_lock_path.clone(),
+        }
+    }
+
+    /// Register a VM in the proxy registry so the addon can identify its traffic.
     pub async fn register_vm(
         &self,
         source_ip: &str,
         registration: &VmRegistration<'_>,
     ) -> RunnerResult<()> {
-        let mut registry = read_registry(&self.config.registry_path).await?;
-        let now = chrono::Utc::now().timestamp_millis();
-        registry.vms.insert(
-            source_ip.to_string(),
-            VmEntry {
-                run_id: registration.run_id.to_string(),
-                sandbox_token: registration.sandbox_token.to_string(),
-                registered_at: now,
-                firewall_rules: registration.firewall_rules.to_vec(),
-                mitm_enabled: registration.mitm_enabled,
-                seal_secrets_enabled: registration.seal_secrets_enabled,
-            },
-        );
-        registry.updated_at = now;
-        write_registry(&self.config.registry_path, &registry).await?;
-        info!(
-            source_ip,
-            run_id = registration.run_id,
-            "registered VM in proxy registry"
-        );
-        Ok(())
+        self.registry_handle()
+            .register_vm(source_ip, registration)
+            .await
     }
 
     /// Unregister a VM from the proxy registry.
-    ///
-    /// Note: same concurrency caveat as [`Self::register_vm`].
     pub async fn unregister_vm(&self, source_ip: &str) -> RunnerResult<()> {
-        let mut registry = read_registry(&self.config.registry_path).await?;
-        registry.vms.remove(source_ip);
-        registry.updated_at = chrono::Utc::now().timestamp_millis();
-        write_registry(&self.config.registry_path, &registry).await?;
-        info!(source_ip, "unregistered VM from proxy registry");
-        Ok(())
+        self.registry_handle().unregister_vm(source_ip).await
     }
 
     /// Gracefully stop mitmdump (SIGTERM → timeout → SIGKILL).
@@ -327,6 +312,61 @@ async fn write_registry(path: &std::path::Path, value: &ProxyRegistry) -> Runner
     tokio::fs::write(path, content)
         .await
         .map_err(|e| RunnerError::Internal(format!("write registry: {e}")))
+}
+
+/// Lightweight, cloneable handle for proxy registry operations.
+///
+/// Uses file locking (`flock`) to ensure concurrent register/unregister calls
+/// from multiple executor tasks don't corrupt the registry JSON.
+#[derive(Clone)]
+pub struct ProxyRegistryHandle {
+    registry_path: PathBuf,
+    lock_path: PathBuf,
+}
+
+impl ProxyRegistryHandle {
+    /// Register a VM in the proxy registry.
+    pub async fn register_vm(
+        &self,
+        source_ip: &str,
+        registration: &VmRegistration<'_>,
+    ) -> RunnerResult<()> {
+        let _guard = crate::lock::acquire(self.lock_path.clone()).await?;
+
+        let mut registry = read_registry(&self.registry_path).await?;
+        let now = chrono::Utc::now().timestamp_millis();
+        registry.vms.insert(
+            source_ip.to_string(),
+            VmEntry {
+                run_id: registration.run_id.to_string(),
+                sandbox_token: registration.sandbox_token.to_string(),
+                registered_at: now,
+                firewall_rules: registration.firewall_rules.to_vec(),
+                mitm_enabled: registration.mitm_enabled,
+                seal_secrets_enabled: registration.seal_secrets_enabled,
+            },
+        );
+        registry.updated_at = now;
+        write_registry(&self.registry_path, &registry).await?;
+        info!(
+            source_ip,
+            run_id = registration.run_id,
+            "registered VM in proxy registry"
+        );
+        Ok(())
+    }
+
+    /// Unregister a VM from the proxy registry.
+    pub async fn unregister_vm(&self, source_ip: &str) -> RunnerResult<()> {
+        let _guard = crate::lock::acquire(self.lock_path.clone()).await?;
+
+        let mut registry = read_registry(&self.registry_path).await?;
+        registry.vms.remove(source_ip);
+        registry.updated_at = chrono::Utc::now().timestamp_millis();
+        write_registry(&self.registry_path, &registry).await?;
+        info!(source_ip, "unregistered VM from proxy registry");
+        Ok(())
+    }
 }
 
 /// Send SIGTERM to a child process.
@@ -456,6 +496,89 @@ mod tests {
         assert!(matches!(rules[1].action, Some(FirewallAction::Deny)));
         assert!(matches!(rules[2].terminal, Some(FirewallAction::Deny)));
         assert!(rules[2].action.is_none());
+    }
+
+    #[tokio::test]
+    async fn registry_handle_register_and_unregister() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        let lock_path = dir.path().join("proxy-registry.json.lock");
+        let empty = ProxyRegistry {
+            vms: HashMap::new(),
+            updated_at: 0,
+        };
+        write_registry(&registry_path, &empty).await.unwrap();
+
+        let handle = ProxyRegistryHandle {
+            registry_path: registry_path.clone(),
+            lock_path,
+        };
+
+        // Register via handle.
+        let registration = VmRegistration {
+            run_id: "run-1",
+            sandbox_token: "tok-1",
+            firewall_rules: &[],
+            mitm_enabled: true,
+            seal_secrets_enabled: false,
+        };
+        handle
+            .register_vm("10.200.0.2", &registration)
+            .await
+            .unwrap();
+
+        let loaded = read_registry(&registry_path).await.unwrap();
+        let vm = loaded.vms.get("10.200.0.2").unwrap();
+        assert_eq!(vm.run_id, "run-1");
+        assert!(vm.mitm_enabled);
+
+        // Unregister via handle.
+        handle.unregister_vm("10.200.0.2").await.unwrap();
+
+        let loaded = read_registry(&registry_path).await.unwrap();
+        assert!(!loaded.vms.contains_key("10.200.0.2"));
+    }
+
+    #[tokio::test]
+    async fn registry_handle_concurrent_access() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        let lock_path = dir.path().join("proxy-registry.json.lock");
+        let empty = ProxyRegistry {
+            vms: HashMap::new(),
+            updated_at: 0,
+        };
+        write_registry(&registry_path, &empty).await.unwrap();
+
+        let handle = ProxyRegistryHandle {
+            registry_path: registry_path.clone(),
+            lock_path,
+        };
+
+        // Spawn 10 concurrent register tasks.
+        let mut tasks = tokio::task::JoinSet::new();
+        for i in 0..10 {
+            let h = handle.clone();
+            let ip = format!("10.200.0.{}", i + 2);
+            let run_id_owned = format!("run-{i}");
+            tasks.spawn(async move {
+                let registration = VmRegistration {
+                    run_id: &run_id_owned,
+                    sandbox_token: "",
+                    firewall_rules: &[],
+                    mitm_enabled: false,
+                    seal_secrets_enabled: false,
+                };
+                h.register_vm(&ip, &registration).await.unwrap();
+            });
+        }
+        while let Some(result) = tasks.join_next().await {
+            result.unwrap();
+        }
+
+        // All 10 VMs should be registered (no lost updates).
+        let loaded = read_registry(&registry_path).await.unwrap();
+        assert_eq!(loaded.vms.len(), 10);
     }
 
     #[tokio::test]

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -305,13 +305,19 @@ async fn read_registry(path: &std::path::Path) -> RunnerResult<ProxyRegistry> {
         .map_err(|e| RunnerError::Internal(format!("parse registry: {e}")))
 }
 
-/// Write the proxy registry JSON file.
+/// Write the proxy registry JSON file atomically (write tmp + rename).
+///
+/// This ensures the Python mitm-addon never reads a partially-written file.
 async fn write_registry(path: &std::path::Path, value: &ProxyRegistry) -> RunnerResult<()> {
     let content = serde_json::to_string(value)
         .map_err(|e| RunnerError::Internal(format!("serialize registry: {e}")))?;
-    tokio::fs::write(path, content)
+    let tmp = path.with_extension("json.tmp");
+    tokio::fs::write(&tmp, content)
         .await
-        .map_err(|e| RunnerError::Internal(format!("write registry: {e}")))
+        .map_err(|e| RunnerError::Internal(format!("write registry tmp: {e}")))?;
+    tokio::fs::rename(&tmp, path)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("rename registry: {e}")))
 }
 
 /// Lightweight, cloneable handle for proxy registry operations.

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -532,11 +532,32 @@ mod tests {
         assert_eq!(vm.run_id, "run-1");
         assert!(vm.mitm_enabled);
 
+        // Re-register same IP overwrites the entry.
+        let registration2 = VmRegistration {
+            run_id: "run-2",
+            sandbox_token: "tok-2",
+            firewall_rules: &[],
+            mitm_enabled: false,
+            seal_secrets_enabled: true,
+        };
+        handle
+            .register_vm("10.200.0.2", &registration2)
+            .await
+            .unwrap();
+        let loaded = read_registry(&registry_path).await.unwrap();
+        let vm = loaded.vms.get("10.200.0.2").unwrap();
+        assert_eq!(vm.run_id, "run-2");
+        assert!(!vm.mitm_enabled);
+        assert!(vm.seal_secrets_enabled);
+
         // Unregister via handle.
         handle.unregister_vm("10.200.0.2").await.unwrap();
 
         let loaded = read_registry(&registry_path).await.unwrap();
         assert!(!loaded.vms.contains_key("10.200.0.2"));
+
+        // Unregister non-existent IP is a no-op.
+        handle.unregister_vm("10.200.0.99").await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -28,14 +28,17 @@ pub struct Job {
 pub struct ExecutionContext {
     pub run_id: Uuid,
     pub prompt: String,
+    // TODO: remove allow(dead_code) when consumed by compose pipeline
     #[allow(dead_code)]
     #[serde(default)]
     pub agent_compose_version_id: Option<String>,
     #[serde(default)]
     pub vars: Option<HashMap<String, String>>,
+    // TODO: remove allow(dead_code) when secret injection is implemented
     #[allow(dead_code)]
     #[serde(default)]
     pub secret_names: Option<Vec<String>>,
+    // TODO: remove allow(dead_code) when checkpoint resume is implemented
     #[allow(dead_code)]
     #[serde(default)]
     pub checkpoint_id: Option<Uuid>,
@@ -52,6 +55,7 @@ pub struct ExecutionContext {
     pub cli_agent_type: String,
     #[serde(default)]
     pub experimental_firewall: Option<ExperimentalFirewall>,
+    // TODO: remove allow(dead_code) when mock-claude bypass is implemented
     #[allow(dead_code)]
     #[serde(default)]
     pub debug_no_mock_claude: Option<bool>,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -28,8 +28,17 @@ pub struct Job {
 pub struct ExecutionContext {
     pub run_id: Uuid,
     pub prompt: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub agent_compose_version_id: Option<String>,
     #[serde(default)]
     pub vars: Option<HashMap<String, String>>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub secret_names: Option<Vec<String>>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub checkpoint_id: Option<Uuid>,
     pub sandbox_token: String,
     pub working_dir: String,
     #[serde(default)]
@@ -42,10 +51,28 @@ pub struct ExecutionContext {
     pub secret_values: Option<Vec<String>>,
     pub cli_agent_type: String,
     #[serde(default)]
+    pub experimental_firewall: Option<ExperimentalFirewall>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub debug_no_mock_claude: Option<bool>,
+    #[serde(default)]
     pub api_start_time: Option<f64>,
-    /// User's timezone preference (IANA format, e.g., "Asia/Shanghai")
     #[serde(default)]
     pub user_timezone: Option<String>,
+}
+
+/// Firewall and proxy configuration attached to each execution.
+///
+/// Field names use snake_case in JSON (matching the TS zod schema).
+#[derive(Debug, Deserialize)]
+pub struct ExperimentalFirewall {
+    pub enabled: bool,
+    #[serde(default)]
+    pub rules: Option<Vec<crate::proxy::FirewallRule>>,
+    #[serde(default)]
+    pub experimental_mitm: Option<bool>,
+    #[serde(default)]
+    pub experimental_seal_secrets: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
## Summary

- Wire `MitmProxy` lifecycle into `runner start`: init before factory so `proxy_port` flows into netns pool, stop after all jobs drain
- Extract `ProxyRegistryHandle` (`Clone+Send+Sync`) from `MitmProxy` with `flock`-based concurrent safety for multi-executor access
- Align `ExecutionContext` with TS `executionContextSchema` exactly (add `experimentalFirewall`, `agentComposeVersionId`, `secretNames`, `checkpointId`, `debugNoMockClaude`)
- Register/unregister VMs in proxy registry when `experimentalFirewall.enabled == true`
- Centralize proxy registry lock path in `RunnerPaths`

## Test plan

- [x] 37 runner tests pass (including 2 new: `registry_handle_register_and_unregister`, `registry_handle_concurrent_access`)
- [x] `cargo clippy -p runner -- -D warnings` clean
- [ ] CI check job passes
- [ ] CI runner-metal-test passes
- [ ] Manual verification on dev-2: proxy starts/stops, register/unregister logs appear

Closes #3042

🤖 Generated with [Claude Code](https://claude.com/claude-code)