### PR TITLE
feat(runner): add ably realtime subscription to start command

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1486,6 +1486,7 @@ dependencies = [
 name = "runner"
 version = "0.1.0"
 dependencies = [
+ "ably-subscriber",
  "base64",
  "chrono",
  "clap",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -21,6 +21,7 @@ edition = "2024"
 
 [workspace.dependencies]
 # Internal crates
+ably-subscriber = { path = "ably-subscriber" }
 guest-common = { path = "guest-common" }
 sandbox = { path = "sandbox" }
 sandbox-fc = { path = "sandbox-fc" }

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
+ably-subscriber = { workspace = true }
 sandbox = { workspace = true }
 sandbox-fc = { workspace = true }
 


### PR DESCRIPTION
## Summary

- Subscribe to Ably channel `runner-group:{group}` for push-based job notifications
- Adaptive poll fallback: 30s when Ably connected, 5s when disconnected
- Ably connection failure is non-fatal — runner degrades to poll-only mode automatically
- Add `realtime_token()` to `ApiClient` for token exchange via `POST /api/runners/realtime/token`
- Extract `claim_and_spawn` helper shared by both Ably and poll paths

Closes #3046

## Test plan

- [x] `cargo clippy -p runner` passes
- [x] `cargo test -p runner` passes (43 tests, 5 new for `parse_job_run_id`)
- [ ] E2E on dev-2: verify Ably connected log, job notification → immediate claim
- [ ] E2E on dev-2: verify poll-only mode when Ably credentials missing
- [ ] E2E on dev-2: verify SIGTERM cleanly disconnects Ably

🤖 Generated with [Claude Code](https://claude.com/claude-code)