### PR TITLE
fix(web): fix drizzle-kit generate partial indexes

### DIFF
--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -73,7 +73,7 @@
     "@typescript-eslint/utils": "^8.55.0",
     "@vm0/eslint-config": "workspace:*",
     "@vm0/typescript-config": "workspace:*",
-    "drizzle-kit": "^0.31.4",
+    "drizzle-kit": "^0.31.9",
     "e2b": "^2.10.3",
     "eslint": "^9.34.0",
     "msw": "^2.7.0",

--- a/turbo/apps/web/src/db/schema/agent-run-callback.ts
+++ b/turbo/apps/web/src/db/schema/agent-run-callback.ts
@@ -8,6 +8,7 @@ import {
   integer,
   index,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { agentRuns } from "./agent-run";
 
 /**
@@ -39,6 +40,6 @@ export const agentRunCallbacks = pgTable(
     index("idx_agent_run_callbacks_run_id").on(table.runId),
     index("idx_agent_run_callbacks_pending")
       .on(table.status)
-      .where("status = 'pending'" as never),
+      .where(sql`status = 'pending'`),
   ],
 );

--- a/turbo/apps/web/src/db/schema/agent-run.ts
+++ b/turbo/apps/web/src/db/schema/agent-run.ts
@@ -8,6 +8,7 @@ import {
   timestamp,
   index,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { agentComposeVersions } from "./agent-compose";
 import { agentSchedules } from "./agent-schedule";
 
@@ -49,10 +50,10 @@ export const agentRuns = pgTable(
     // Partial index for cron cleanup (only running status)
     index("idx_agent_runs_running_heartbeat")
       .on(table.lastHeartbeatAt)
-      .where("status = 'running'" as never),
+      .where(sql`status = 'running'`),
     // Partial index for schedule history (only scheduled runs)
     index("idx_agent_runs_schedule_created")
       .on(table.scheduleId, table.createdAt)
-      .where("schedule_id IS NOT NULL" as never),
+      .where(sql`schedule_id IS NOT NULL`),
   ],
 );

--- a/turbo/apps/web/src/db/schema/agent-schedule.ts
+++ b/turbo/apps/web/src/db/schema/agent-schedule.ts
@@ -9,6 +9,7 @@ import {
   index,
   uniqueIndex,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { agentComposes } from "./agent-compose";
 import { agentRuns } from "./agent-run";
 
@@ -70,6 +71,6 @@ export const agentSchedules = pgTable(
     // Partial index for efficient cron polling: enabled schedules with due next_run_at
     index("idx_agent_schedules_next_run")
       .on(table.nextRunAt)
-      .where("enabled = true" as never),
+      .where(sql`enabled = true`),
   ],
 );

--- a/turbo/apps/web/src/db/schema/runner-job-queue.ts
+++ b/turbo/apps/web/src/db/schema/runner-job-queue.ts
@@ -6,6 +6,7 @@ import {
   jsonb,
   index,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { agentRuns } from "./agent-run";
 
 /**
@@ -38,7 +39,7 @@ export const runnerJobQueue = pgTable(
     // Index for polling unclaimed jobs by group
     index("runner_job_queue_group_unclaimed_idx")
       .on(table.runnerGroup)
-      .where("claimed_at IS NULL" as never),
+      .where(sql`claimed_at IS NULL`),
     // Index for TTL cleanup
     index("runner_job_queue_expires_at_idx").on(table.expiresAt),
   ],

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -521,8 +521,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/typescript-config
       drizzle-kit:
-        specifier: ^0.31.4
-        version: 0.31.4
+        specifier: ^0.31.9
+        version: 0.31.9
       e2b:
         specifier: ^2.10.3
         version: 2.10.3
@@ -5504,8 +5504,8 @@ packages:
     resolution: {integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==}
     engines: {node: '>=12'}
 
-  drizzle-kit@0.31.4:
-    resolution: {integrity: sha512-tCPWVZWZqWVx2XUsVpJRnH9Mx0ClVOf5YUHerZ5so1OKSlqww4zy1R5ksEdGRcO3tM3zj0PYN6V48TbQCL1RfA==}
+  drizzle-kit@0.31.9:
+    resolution: {integrity: sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg==}
     hasBin: true
 
   drizzle-orm@0.44.5:
@@ -13216,7 +13216,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.0.18)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.0.18)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.20.5)(yaml@2.8.1)
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -14134,7 +14134,7 @@ snapshots:
 
   dotenv@17.2.1: {}
 
-  drizzle-kit@0.31.4:
+  drizzle-kit@0.31.9:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
       '@esbuild-kit/esm-loader': 2.6.5


### PR DESCRIPTION
## Summary
- Fixed `TypeError: sql2.toQuery is not a function` when running `drizzle-kit generate`
- Updated 4 schema files to use proper `sql` template string syntax for partial indexes
- Updated drizzle-kit from 0.31.4 to 0.31.9

## Problem
Partial indexes in schema files were using incorrect syntax:
```typescript
.where("claimed_at IS NULL" as never)
```

This caused drizzle-kit to fail when trying to serialize the schema for migration generation.

## Solution
Import `sql` from drizzle-orm and use template strings:
```typescript
import { sql } from "drizzle-orm";

.where(sql\`claimed_at IS NULL\`)
```

## Changed Files
- `src/db/schema/runner-job-queue.ts`
- `src/db/schema/agent-run-callback.ts`
- `src/db/schema/agent-schedule.ts`
- `src/db/schema/agent-run.ts`

## Test Plan
- [x] `drizzle-kit generate` now runs successfully without errors
- [x] All pre-commit hooks pass (prettier, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)