### PR TITLE
feat(runner): add execution telemetry for sandbox operations

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -152,7 +152,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     factory.startup().await?;
     let factory = Arc::new(factory);
 
-    let api = ApiClient::new(config.api_url.clone(), config.token.clone())?;
+    let http = crate::http::HttpClient::new(config.api_url.clone())?;
+    let api = ApiClient::new(http.clone(), config.token.clone());
     let semaphore = Arc::new(Semaphore::new(config.max_concurrent));
     let mut jobs = JoinSet::new();
 
@@ -163,6 +164,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         memory_mb: config.memory_mb,
         is_snapshot,
         registry: config.registry.clone(),
+        http,
     });
 
     config.status.write_initial().await;

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -45,7 +45,7 @@ pub async fn execute_job(
     // Record api_to_vm_start: elapsed time from the API-side timestamp to now.
     // api_start_time is milliseconds since Unix epoch (Date.now() in TS).
     if let Some(api_start_ms) = context.api_start_time {
-        let now_ms = epoch_millis();
+        let now_ms = chrono::Utc::now().timestamp_millis() as f64;
         let elapsed_ms = (now_ms - api_start_ms).max(0.0);
         telemetry.record(
             "api_to_vm_start",
@@ -150,12 +150,21 @@ async fn execute_inner(
     }
 
     // Best-effort stop
-    if let Err(e) = sandbox.stop().await {
-        warn!(sandbox_id = %sandbox_id, error = %e, "sandbox stop failed");
-    }
+    let stop_err = match sandbox.stop().await {
+        Ok(()) => None,
+        Err(e) => {
+            warn!(sandbox_id = %sandbox_id, error = %e, "sandbox stop failed");
+            Some(e.to_string())
+        }
+    };
     factory.destroy(sandbox).await;
 
-    telemetry.record("cleanup", t.elapsed(), true, None);
+    telemetry.record(
+        "cleanup",
+        t.elapsed(),
+        stop_err.is_none(),
+        stop_err.as_deref(),
+    );
 
     result
 }
@@ -346,15 +355,6 @@ async fn restore_session(
         .await?;
     info!(run_id = %context.run_id, path = %session_path, "restored session history");
     Ok(())
-}
-
-/// Current wall-clock time as milliseconds since Unix epoch.
-fn epoch_millis() -> f64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs_f64()
-        * 1000.0
 }
 
 /// Build the environment variables JSON, matching the TS `buildEnvironmentVariables`.

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use sandbox::{ExecRequest, Sandbox, SandboxConfig, SandboxFactory};
 use tracing::{error, info, warn};
@@ -12,8 +12,10 @@ const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
 
 use crate::api::ApiClient;
 use crate::error::RunnerResult;
+use crate::http::HttpClient;
 use crate::paths::guest;
 use crate::proxy::{self, ProxyRegistryHandle};
+use crate::telemetry::JobTelemetry;
 use crate::types::ExecutionContext;
 
 /// Configuration for a single execution.
@@ -23,6 +25,7 @@ pub struct ExecutorConfig {
     pub memory_mb: u32,
     pub is_snapshot: bool,
     pub registry: ProxyRegistryHandle,
+    pub http: HttpClient,
 }
 
 /// Execute a single job inside a Firecracker VM.
@@ -36,8 +39,23 @@ pub async fn execute_job(
     config: &ExecutorConfig,
 ) {
     let run_id = context.run_id;
+    let mut telemetry =
+        JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
 
-    let (exit_code, err) = match execute_inner(factory, &context, config).await {
+    // Record api_to_vm_start: elapsed time from the API-side timestamp to now.
+    // api_start_time is milliseconds since Unix epoch (Date.now() in TS).
+    if let Some(api_start_ms) = context.api_start_time {
+        let now_ms = epoch_millis();
+        let elapsed_ms = (now_ms - api_start_ms).max(0.0);
+        telemetry.record(
+            "api_to_vm_start",
+            Duration::from_millis(elapsed_ms as u64),
+            true,
+            None,
+        );
+    }
+
+    let (exit_code, err) = match execute_inner(factory, &context, config, &mut telemetry).await {
         Ok((code, stderr)) => (code, stderr),
         Err(e) => {
             error!(run_id = %run_id, error = %e, "job execution failed");
@@ -60,12 +78,15 @@ pub async fn execute_job(
             error!(run_id = %run_id, error = %e, "failed to report completion after retry");
         }
     }
+
+    telemetry.flush().await;
 }
 
 async fn execute_inner(
     factory: &dyn SandboxFactory,
     context: &ExecutionContext,
     config: &ExecutorConfig,
+    telemetry: &mut JobTelemetry,
 ) -> RunnerResult<(i32, Option<String>)> {
     let sandbox_id = Uuid::new_v4();
     let sandbox_config = SandboxConfig {
@@ -79,12 +100,21 @@ async fn execute_inner(
 
     // Create and start sandbox
     info!(run_id = %context.run_id, sandbox_id = %sandbox_id, "creating sandbox");
-    let mut sandbox = factory.create(sandbox_config).await?;
+    let t = Instant::now();
+    let mut sandbox = match factory.create(sandbox_config).await {
+        Ok(s) => s,
+        Err(e) => {
+            telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
+            return Err(e.into());
+        }
+    };
 
     if let Err(e) = sandbox.start().await {
+        telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
         factory.destroy(sandbox).await;
         return Err(e.into());
     }
+    telemetry.record("vm_create", t.elapsed(), true, None);
 
     // Register VM in proxy registry (only when firewall is enabled)
     let source_ip = sandbox.source_ip().to_string();
@@ -110,9 +140,11 @@ async fn execute_inner(
     }
 
     // Run job inside sandbox, then destroy regardless of outcome
-    let result = run_in_sandbox(sandbox.as_ref(), context, config).await;
+    let result = run_in_sandbox(sandbox.as_ref(), context, config, telemetry).await;
 
-    // Unregister VM from proxy registry
+    // Cleanup: unregister + stop + destroy
+    let t = Instant::now();
+
     if firewall_enabled && let Err(e) = config.registry.unregister_vm(&source_ip).await {
         warn!(run_id = %context.run_id, error = %e, "failed to unregister VM from proxy");
     }
@@ -123,6 +155,8 @@ async fn execute_inner(
     }
     factory.destroy(sandbox).await;
 
+    telemetry.record("cleanup", t.elapsed(), true, None);
+
     result
 }
 
@@ -130,6 +164,7 @@ async fn run_in_sandbox(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     config: &ExecutorConfig,
+    telemetry: &mut JobTelemetry,
 ) -> RunnerResult<(i32, Option<String>)> {
     // 1. Fix guest clock after snapshot restore (must happen before HTTPS calls)
     if config.is_snapshot {
@@ -138,12 +173,30 @@ async fn run_in_sandbox(
 
     // 2. Download storages
     if let Some(manifest) = &context.storage_manifest {
-        download_storages(sandbox, context, manifest).await?;
+        let t = Instant::now();
+        let result = download_storages(sandbox, context, manifest).await;
+        let err = result.as_ref().err().map(|e| e.to_string());
+        telemetry.record(
+            "storage_download",
+            t.elapsed(),
+            result.is_ok(),
+            err.as_deref(),
+        );
+        result?;
     }
 
     // 3. Restore session history
     if let Some(session) = &context.resume_session {
-        restore_session(sandbox, context, session).await?;
+        let t = Instant::now();
+        let result = restore_session(sandbox, context, session).await;
+        let err = result.as_ref().err().map(|e| e.to_string());
+        telemetry.record(
+            "session_restore",
+            t.elapsed(),
+            result.is_ok(),
+            err.as_deref(),
+        );
+        result?;
     }
 
     // 4. Build env vars (passed directly via vsock protocol)
@@ -163,6 +216,7 @@ async fn run_in_sandbox(
 
     // JOB_TIMEOUT is used for both spawn_watch (guest-side kill) and wait_exit
     // (host-side watchdog) so neither side outlives the other.
+    let t = Instant::now();
     let handle = sandbox
         .spawn_watch(&ExecRequest {
             cmd: &agent_cmd,
@@ -170,10 +224,23 @@ async fn run_in_sandbox(
             env: &env_refs,
             sudo: false,
         })
-        .await?;
+        .await;
+
+    let handle = match handle {
+        Ok(h) => h,
+        Err(e) => {
+            telemetry.record("agent_execute", t.elapsed(), false, Some(&e.to_string()));
+            return Err(e.into());
+        }
+    };
 
     // 6. Wait for exit
-    let exit = sandbox.wait_exit(handle, JOB_TIMEOUT).await?;
+    let result = sandbox.wait_exit(handle, JOB_TIMEOUT).await;
+    let success = result.as_ref().is_ok_and(|exit| exit.exit_code == 0);
+    let err = result.as_ref().err().map(|e| e.to_string());
+    telemetry.record("agent_execute", t.elapsed(), success, err.as_deref());
+    let exit = result?;
+
     let stderr = String::from_utf8_lossy(&exit.stderr).to_string();
 
     info!(
@@ -279,6 +346,15 @@ async fn restore_session(
         .await?;
     info!(run_id = %context.run_id, path = %session_path, "restored session history");
     Ok(())
+}
+
+/// Current wall-clock time as milliseconds since Unix epoch.
+fn epoch_millis() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+        * 1000.0
 }
 
 /// Build the environment variables JSON, matching the TS `buildEnvironmentVariables`.

--- a/crates/runner/src/http.rs
+++ b/crates/runner/src/http.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::Client;
+use tracing::info;
+
+use crate::error::{RunnerError, RunnerResult};
+
+/// Default timeout for API requests (covers large claim payloads).
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Shared HTTP client for the vm0 API. Owns the connection pool, base URL,
+/// and Vercel bypass header. Clone is a cheap Arc refcount bump.
+#[derive(Clone)]
+pub struct HttpClient {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    client: Client,
+    api_url: String,
+    vercel_bypass: Option<String>,
+}
+
+impl HttpClient {
+    pub fn new(api_url: String) -> RunnerResult<Self> {
+        let client = Client::builder()
+            .timeout(DEFAULT_TIMEOUT)
+            .build()
+            .map_err(|e| RunnerError::Internal(format!("http client: {e}")))?;
+
+        let vercel_bypass = std::env::var("VERCEL_AUTOMATION_BYPASS_SECRET").ok();
+
+        info!(
+            api_url = %api_url,
+            vercel_bypass = vercel_bypass.is_some(),
+            "http client initialized"
+        );
+
+        Ok(Self {
+            inner: Arc::new(Inner {
+                client,
+                api_url,
+                vercel_bypass,
+            }),
+        })
+    }
+
+    /// Build an authenticated request with bearer token and Vercel bypass.
+    ///
+    /// `path` is appended to the base URL (e.g. `/api/runners/poll`).
+    pub fn request(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        token: &str,
+    ) -> reqwest::RequestBuilder {
+        let url = format!("{}{path}", self.inner.api_url);
+        let mut req = self.inner.client.request(method, url).bearer_auth(token);
+
+        if let Some(bypass) = &self.inner.vercel_bypass {
+            req = req.header("x-vercel-protection-bypass", bypass);
+        }
+
+        req
+    }
+}

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -4,10 +4,12 @@ mod config;
 mod deps;
 mod error;
 mod executor;
+mod http;
 mod lock;
 mod paths;
 mod proxy;
 mod status;
+mod telemetry;
 mod types;
 
 use std::fmt;

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -1,0 +1,208 @@
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use serde::Serialize;
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::http::HttpClient;
+
+/// How long before we auto-flush pending ops (matching TS: 30s).
+const FLUSH_THRESHOLD: Duration = Duration::from_secs(30);
+
+/// Timeout for telemetry HTTP requests (shorter than default API timeout).
+const TELEMETRY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Per-job telemetry collector. Buffers sandbox operations and flushes them
+/// periodically (auto on 30 s threshold) and at job end.
+///
+/// Owns its state — passed as `&mut` through the call chain, no `Mutex` needed.
+pub struct JobTelemetry {
+    http: HttpClient,
+    run_id: Uuid,
+    sandbox_token: String,
+    pending_ops: Vec<SandboxOp>,
+    oldest_pending: Option<Instant>,
+}
+
+#[derive(Serialize, Clone)]
+struct SandboxOp {
+    ts: String,
+    action_type: String,
+    duration_ms: u64,
+    success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TelemetryPayload {
+    run_id: String,
+    sandbox_operations: Vec<SandboxOp>,
+}
+
+impl JobTelemetry {
+    /// Create a new per-job telemetry collector.
+    pub fn new(http: HttpClient, run_id: Uuid, sandbox_token: String) -> Self {
+        Self {
+            http,
+            run_id,
+            sandbox_token,
+            pending_ops: Vec::new(),
+            oldest_pending: None,
+        }
+    }
+
+    /// Record a timed operation. Auto-flushes (fire-and-forget) if the oldest
+    /// pending op exceeds the 30 s threshold.
+    pub fn record(
+        &mut self,
+        action_type: &str,
+        duration: Duration,
+        success: bool,
+        error: Option<&str>,
+    ) {
+        self.pending_ops.push(SandboxOp {
+            ts: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            action_type: action_type.to_string(),
+            duration_ms: duration.as_millis() as u64,
+            success,
+            error: error.map(String::from),
+        });
+        if self.oldest_pending.is_none() {
+            self.oldest_pending = Some(Instant::now());
+        }
+
+        if let Some(oldest) = self.oldest_pending
+            && oldest.elapsed() >= FLUSH_THRESHOLD
+        {
+            self.fire_and_forget_flush();
+        }
+    }
+
+    /// Final flush — awaits the HTTP request. Consumes self so callers can't
+    /// accidentally record after flushing.
+    pub async fn flush(mut self) {
+        if self.pending_ops.is_empty() {
+            return;
+        }
+        let ops = std::mem::take(&mut self.pending_ops);
+        send_telemetry(&self.http, self.run_id, &self.sandbox_token, ops).await;
+    }
+
+    /// Spawn a fire-and-forget flush for auto-threshold flushes.
+    fn fire_and_forget_flush(&mut self) {
+        let ops = std::mem::take(&mut self.pending_ops);
+        self.oldest_pending = None;
+
+        let http = self.http.clone();
+        let run_id = self.run_id;
+        let sandbox_token = self.sandbox_token.clone();
+
+        tokio::spawn(async move {
+            send_telemetry(&http, run_id, &sandbox_token, ops).await;
+        });
+    }
+}
+
+async fn send_telemetry(http: &HttpClient, run_id: Uuid, sandbox_token: &str, ops: Vec<SandboxOp>) {
+    if ops.is_empty() {
+        return;
+    }
+
+    let payload = TelemetryPayload {
+        run_id: run_id.to_string(),
+        sandbox_operations: ops,
+    };
+
+    let req = http
+        .request(
+            reqwest::Method::POST,
+            "/api/webhooks/agent/telemetry",
+            sandbox_token,
+        )
+        .timeout(TELEMETRY_TIMEOUT)
+        .json(&payload);
+
+    match req.send().await {
+        Ok(resp) if !resp.status().is_success() => {
+            warn!(run_id = %run_id, status = %resp.status(), "telemetry flush rejected");
+        }
+        Err(e) => {
+            warn!(run_id = %run_id, error = %e, "telemetry flush failed");
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sandbox_op_serializes_correctly() {
+        let op = SandboxOp {
+            ts: "2026-01-15T10:00:00+00:00".to_string(),
+            action_type: "vm_create".to_string(),
+            duration_ms: 1500,
+            success: true,
+            error: None,
+        };
+        let json = serde_json::to_value(&op).unwrap();
+        assert_eq!(json["ts"], "2026-01-15T10:00:00+00:00");
+        assert_eq!(json["action_type"], "vm_create");
+        assert_eq!(json["duration_ms"], 1500);
+        assert_eq!(json["success"], true);
+        assert!(json.get("error").is_none()); // omitted when None
+    }
+
+    #[test]
+    fn telemetry_payload_uses_camel_case() {
+        let payload = TelemetryPayload {
+            run_id: "abc-123".to_string(),
+            sandbox_operations: vec![SandboxOp {
+                ts: "2026-01-15T10:00:00+00:00".to_string(),
+                action_type: "test".to_string(),
+                duration_ms: 100,
+                success: true,
+                error: None,
+            }],
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert!(json.get("runId").is_some());
+        assert!(json.get("sandboxOperations").is_some());
+    }
+
+    #[test]
+    fn new_creates_empty_telemetry() {
+        let http = HttpClient::new("http://localhost".to_string()).unwrap();
+        let telemetry = JobTelemetry::new(http, Uuid::nil(), "tok".to_string());
+        assert!(telemetry.pending_ops.is_empty());
+        assert!(telemetry.oldest_pending.is_none());
+    }
+
+    #[test]
+    fn record_buffers_ops() {
+        let http = HttpClient::new("http://localhost".to_string()).unwrap();
+        let mut telemetry = JobTelemetry::new(http, Uuid::nil(), "tok".to_string());
+
+        telemetry.record("vm_create", Duration::from_millis(500), true, None);
+        telemetry.record(
+            "agent_execute",
+            Duration::from_secs(10),
+            false,
+            Some("timeout"),
+        );
+
+        assert_eq!(telemetry.pending_ops.len(), 2);
+        assert_eq!(telemetry.pending_ops[0].action_type, "vm_create");
+        assert_eq!(telemetry.pending_ops[0].duration_ms, 500);
+        assert!(telemetry.pending_ops[0].success);
+        assert!(telemetry.pending_ops[0].error.is_none());
+        assert_eq!(telemetry.pending_ops[1].action_type, "agent_execute");
+        assert!(!telemetry.pending_ops[1].success);
+        assert_eq!(telemetry.pending_ops[1].error.as_deref(), Some("timeout"));
+        assert!(telemetry.oldest_pending.is_some());
+    }
+}


### PR DESCRIPTION
## Summary

- Add per-job telemetry that sends sandbox operation timings to `POST /api/webhooks/agent/telemetry`, matching the TS runner's format and making Rust runners visible in the Axiom performance dashboard
- Extract shared `HttpClient` (`Arc<Inner>`) used by both `ApiClient` and telemetry — single connection pool, single Vercel bypass env read
- `JobTelemetry` collector: buffered ops with 30s auto-flush (fire-and-forget `tokio::spawn`) and final awaited flush on job completion

### Metrics collected

| action_type | What's timed |
|---|---|
| `api_to_vm_start` | API `apiStartTime` → runner starts processing |
| `vm_create` | `factory.create()` + `sandbox.start()` |
| `storage_download` | `download_storages()` |
| `session_restore` | `restore_session()` |
| `agent_execute` | `spawn_watch()` + `wait_exit()` |
| `cleanup` | proxy unregister + `sandbox.stop()` + `factory.destroy()` |

### Payload format (matches TS exactly)

```json
POST /api/webhooks/agent/telemetry
Authorization: Bearer {sandbox_token}

{
  "runId": "...",
  "sandboxOperations": [
    {
      "ts": "2026-02-15T10:30:00.123Z",
      "action_type": "vm_create",
      "duration_ms": 1500,
      "success": true
    }
  ]
}
```

Failed operations include an `error` field with the error message.

## Test plan

- [x] `cargo clippy -p runner --tests` passes
- [x] `cargo test -p runner` — 47 tests pass
- [ ] E2E: deploy to dev-2, run a job, verify telemetry appears in Axiom

Closes #3064

🤖 Generated with [Claude Code](https://claude.com/claude-code)