### PR TITLE
fix(runner): clean up request_start_times on flow error in mitm-addon

### DIFF
--- a/crates/runner/scripts/mitm-addon.py
+++ b/crates/runner/scripts/mitm-addon.py
@@ -498,5 +498,13 @@ def response(flow: http.HTTPFlow) -> None:
         )
 
 
+def error(flow: http.HTTPFlow) -> None:
+    """
+    Clean up request_start_times on flow error (timeout, connection reset, etc.)
+    to prevent unbounded dict growth over the runner's lifetime.
+    """
+    request_start_times.pop(flow.id, None)
+
+
 # mitmproxy addon registration
-addons = [tls_clienthello, request, response]
+addons = [tls_clienthello, request, response, error]


### PR DESCRIPTION
## Summary

- Add `error()` handler to `mitm-addon.py` that cleans up `request_start_times[flow.id]` when a flow fails without a response (timeout, connection reset, TLS failure)
- Prevents unbounded dict growth over the runner's lifetime

## Test plan

- [x] 52 existing tests pass
- [x] Clippy clean

Closes #3073

🤖 Generated with [Claude Code](https://claude.com/claude-code)