### PR TITLE
fix(runner): prevent vm process leak on executor task panic

### DIFF
--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [dependencies]
 async-trait.workspace = true
 libc.workspace = true
-nix = { workspace = true, features = ["user", "inotify", "fs"] }
+nix = { workspace = true, features = ["user", "inotify", "fs", "signal"] }
 sandbox.workspace = true
 serde_json.workspace = true
 sha2.workspace = true


### PR DESCRIPTION
## Summary

- Add `process_group(0)` + `kill_on_drop(true)` to both Firecracker spawn sites so all child processes share a single PGID
- Implement `Drop` for `FirecrackerSandbox` that calls `killpg(SIGKILL)` on the process group, ensuring the entire process tree is killed even on task panic
- Wrap `execute_job` in nested `tokio::spawn` so status tracking and semaphore permit are always cleaned up even on panic
- Adjust `factory.destroy()` to clone lightweight handles before dropping sandbox (required by Drop ownership rules)

Closes #3078

## Test plan

- [x] `cargo clippy -p sandbox-fc --tests` passes
- [x] `cargo clippy -p runner --tests` passes
- [x] `cargo test -p sandbox-fc` — 70 tests pass
- [x] `cargo test -p runner` — 52 tests pass
- [ ] E2E: deploy to dev-2, run a job, verify clean shutdown
- [ ] E2E: simulate panic scenario, verify no orphan firecracker processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)