### PR TITLE
feat(runner): auto-restart mitmproxy on crash

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -45,7 +45,7 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     let t = Instant::now();
     let home = HomePaths::new()?;
     let runner_paths = RunnerPaths::new(runner_config.base_dir.clone());
-    let mut mitm = proxy::MitmProxy::new(proxy::ProxyConfig {
+    let (mut mitm, _crash_rx) = proxy::MitmProxy::new(proxy::ProxyConfig {
         mitmdump_bin: home.mitmdump_bin(MITMPROXY_VERSION),
         ca_dir: runner_config.ca_dir.clone(),
         addon_path: runner_paths.mitm_addon(),

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -45,6 +45,7 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     let t = Instant::now();
     let home = HomePaths::new()?;
     let runner_paths = RunnerPaths::new(runner_config.base_dir.clone());
+    // Benchmark runs a single short-lived sandbox; crash recovery is not needed.
     let (mut mitm, _crash_rx) = proxy::MitmProxy::new(proxy::ProxyConfig {
         mitmdump_bin: home.mitmdump_bin(MITMPROXY_VERSION),
         ca_dir: runner_config.ca_dir.clone(),

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -841,4 +841,111 @@ mod tests {
         let msg = make_message(Some("job"), serde_json::json!({ "other": "data" }));
         assert!(parse_job_run_id(&msg).is_none());
     }
+
+    /// Create a MitmProxy for testing (does not start mitmdump).
+    async fn test_mitm() -> (
+        proxy::MitmProxy,
+        tokio::sync::mpsc::Receiver<()>,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let (mitm, rx) = proxy::MitmProxy::new(proxy::ProxyConfig {
+            mitmdump_bin: PathBuf::from("true"),
+            ca_dir: dir.path().to_path_buf(),
+            addon_path: dir.path().join("addon.py"),
+            registry_path: dir.path().join("registry.json"),
+            registry_lock_path: dir.path().join("registry.lock"),
+            api_url: None,
+        })
+        .await
+        .unwrap();
+        (mitm, rx, dir)
+    }
+
+    #[tokio::test]
+    async fn mitm_restart_success_resets_backoff() {
+        let (mut mitm, _rx, _dir) = test_mitm().await;
+        let mut restart_at = Some(Instant::now());
+        let mut backoff = Duration::from_secs(16);
+        let mut failures = 5u32;
+
+        let child = tokio::process::Command::new("true")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+
+        handle_mitm_restart_result(
+            Ok(child),
+            &mut mitm,
+            &mut restart_at,
+            &mut backoff,
+            &mut failures,
+        );
+
+        assert_eq!(backoff, MITM_BACKOFF_INITIAL);
+        assert_eq!(failures, 0);
+    }
+
+    #[tokio::test]
+    async fn mitm_restart_failure_schedules_retry_with_backoff() {
+        let (mut mitm, _rx, _dir) = test_mitm().await;
+        let mut restart_at = None;
+        let mut backoff = MITM_BACKOFF_INITIAL;
+        let mut failures = 0u32;
+
+        handle_mitm_restart_result(
+            Err("spawn failed".into()),
+            &mut mitm,
+            &mut restart_at,
+            &mut backoff,
+            &mut failures,
+        );
+
+        assert_eq!(failures, 1);
+        assert!(restart_at.is_some());
+        assert_eq!(backoff, MITM_BACKOFF_INITIAL * 2);
+    }
+
+    #[tokio::test]
+    async fn mitm_restart_backoff_caps_at_max() {
+        let (mut mitm, _rx, _dir) = test_mitm().await;
+        let mut restart_at = None;
+        let mut backoff = MITM_BACKOFF_MAX;
+        let mut failures = 10u32;
+
+        handle_mitm_restart_result(
+            Err("spawn failed".into()),
+            &mut mitm,
+            &mut restart_at,
+            &mut backoff,
+            &mut failures,
+        );
+
+        assert_eq!(backoff, MITM_BACKOFF_MAX);
+        assert!(restart_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn mitm_restart_circuit_breaker_stops_retrying() {
+        let (mut mitm, _rx, _dir) = test_mitm().await;
+        let mut restart_at = None;
+        let mut backoff = MITM_BACKOFF_MAX;
+        let mut failures = MITM_MAX_CONSECUTIVE_FAILURES - 1;
+
+        handle_mitm_restart_result(
+            Err("binary missing".into()),
+            &mut mitm,
+            &mut restart_at,
+            &mut backoff,
+            &mut failures,
+        );
+
+        assert_eq!(failures, MITM_MAX_CONSECUTIVE_FAILURES);
+        assert!(
+            restart_at.is_none(),
+            "circuit breaker should prevent further retries"
+        );
+    }
 }

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -26,6 +26,10 @@ const POLL_FAST: Duration = Duration::from_secs(5);
 const ABLY_BACKOFF_INITIAL: Duration = Duration::from_secs(5);
 /// Maximum backoff between Ably reconnection attempts.
 const ABLY_BACKOFF_MAX: Duration = Duration::from_secs(60);
+/// Initial backoff before retrying mitmproxy after a crash.
+const MITM_BACKOFF_INITIAL: Duration = Duration::from_secs(1);
+/// Maximum backoff between mitmproxy restart attempts.
+const MITM_BACKOFF_MAX: Duration = Duration::from_secs(30);
 
 #[derive(Args)]
 pub struct StartArgs {
@@ -90,7 +94,7 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
 
     // Start proxy before factory so proxy_port is available for netns pool.
     let paths = RunnerPaths::new(runner_config.base_dir.clone());
-    let mut mitm = proxy::MitmProxy::new(proxy::ProxyConfig {
+    let (mut mitm, mitm_crash_rx) = proxy::MitmProxy::new(proxy::ProxyConfig {
         mitmdump_bin: home.mitmdump_bin(deps::MITMPROXY_VERSION),
         ca_dir: runner_config.ca_dir.clone(),
         addon_path: paths.mitm_addon(),
@@ -137,16 +141,11 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         status,
         registry: registry_handle,
         log_paths,
+        mitm,
+        mitm_crash_rx,
     };
 
-    let result = run(config).await;
-
-    // Stop proxy after all jobs have drained and factory is shut down.
-    if let Err(e) = mitm.stop().await {
-        warn!(error = %e, "proxy stop failed");
-    }
-
-    result
+    run(config).await
 }
 
 struct RunConfig {
@@ -161,12 +160,16 @@ struct RunConfig {
     status: Arc<StatusTracker>,
     registry: ProxyRegistryHandle,
     log_paths: crate::paths::LogPaths,
+    mitm: proxy::MitmProxy,
+    mitm_crash_rx: tokio::sync::mpsc::Receiver<()>,
 }
 
 type AblyReconnectHandle =
     tokio::task::JoinHandle<Result<ably_subscriber::Subscription, ably_subscriber::Error>>;
 
-async fn run(config: RunConfig) -> RunnerResult<()> {
+type MitmRestartHandle = tokio::task::JoinHandle<RunnerResult<tokio::process::Child>>;
+
+async fn run(mut config: RunConfig) -> RunnerResult<()> {
     let mut factory = FirecrackerFactory::new(config.fc_config.clone()).await?;
     factory.startup().await?;
     let factory = Arc::new(factory);
@@ -219,6 +222,14 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let mut ably_connected = ably.is_some();
 
     // -----------------------------------------------------------------------
+    // Mitmproxy crash-restart state (same shape as Ably)
+    // -----------------------------------------------------------------------
+    let mut mitm_restart_at: Option<Instant> = None;
+    let mut mitm_restarting: Option<MitmRestartHandle> = None;
+    let mut mitm_backoff = MITM_BACKOFF_INITIAL;
+    let mut mitm_consecutive_failures: u32 = 0;
+
+    // -----------------------------------------------------------------------
     // Signal handling
     // -----------------------------------------------------------------------
     let (mode_tx, mut mode_rx) = tokio::sync::watch::channel(RunnerMode::Running);
@@ -264,11 +275,21 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         match mode {
             RunnerMode::Stopping | RunnerMode::Stopped => break,
             RunnerMode::Draining => {
-                // Don't accept new jobs, wait for running ones to complete
+                // Don't accept new jobs, wait for running ones to complete.
+                // Still restart mitmproxy — running jobs need the proxy.
                 if jobs.is_empty() {
                     info!("all jobs drained");
                     break;
                 }
+
+                // Spawn background restart task when timer fires
+                maybe_spawn_mitm_restart(
+                    &mut config.mitm,
+                    &mut mitm_restart_at,
+                    &mut mitm_restarting,
+                )
+                .await;
+
                 tokio::select! {
                     _ = mode_rx.changed() => {}
                     result = jobs.join_next() => {
@@ -276,6 +297,18 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                             error!(error = %e, "job task panicked");
                         }
                     }
+                    _ = config.mitm_crash_rx.recv() => {
+                        warn!("mitmproxy exited unexpectedly, scheduling restart");
+                        mitm_restart_at = Some(Instant::now() + mitm_backoff);
+                    }
+                    result = recv_mitm_restart(&mut mitm_restarting) => {
+                        handle_mitm_restart_result(
+                            result, &mut config.mitm,
+                            &mut mitm_restart_at, &mut mitm_backoff,
+                            &mut mitm_consecutive_failures,
+                        );
+                    }
+                    _ = sleep_until_mitm_restart(&mitm_restart_at) => {}
                 }
                 continue;
             }
@@ -293,6 +326,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             ably_reconnecting = Some(tokio::spawn(ably_subscriber::subscribe(ably_config)));
         }
 
+        // Spawn background restart task when timer fires
+        maybe_spawn_mitm_restart(&mut config.mitm, &mut mitm_restart_at, &mut mitm_restarting)
+            .await;
+
         // If all permits are taken, wait for a job to finish or mode change
         if semaphore.available_permits() == 0 {
             tokio::select! {
@@ -302,6 +339,18 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         error!(error = %e, "job task panicked");
                     }
                 }
+                _ = config.mitm_crash_rx.recv() => {
+                    warn!("mitmproxy exited unexpectedly, scheduling restart");
+                    mitm_restart_at = Some(Instant::now() + mitm_backoff);
+                }
+                result = recv_mitm_restart(&mut mitm_restarting) => {
+                    handle_mitm_restart_result(
+                        result, &mut config.mitm,
+                        &mut mitm_restart_at, &mut mitm_backoff,
+                        &mut mitm_consecutive_failures,
+                    );
+                }
+                _ = sleep_until_mitm_restart(&mitm_restart_at) => {}
             }
             continue;
         }
@@ -409,6 +458,21 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     }
                 }
             }
+            // Mitmproxy crash detection
+            _ = config.mitm_crash_rx.recv() => {
+                warn!("mitmproxy exited unexpectedly, scheduling restart");
+                mitm_restart_at = Some(Instant::now() + mitm_backoff);
+            }
+            // Mitmproxy restart result (background task)
+            result = recv_mitm_restart(&mut mitm_restarting) => {
+                handle_mitm_restart_result(
+                    result, &mut config.mitm,
+                    &mut mitm_restart_at, &mut mitm_backoff,
+                    &mut mitm_consecutive_failures,
+                );
+            }
+            // Mitmproxy restart timer
+            _ = sleep_until_mitm_restart(&mitm_restart_at) => {}
             // Mode changes (signals)
             _ = mode_rx.changed() => {}
         }
@@ -420,6 +484,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // Close Ably subscription and cancel any in-flight reconnection
     drop(ably);
     if let Some(h) = ably_reconnecting {
+        h.abort();
+    }
+    if let Some(h) = mitm_restarting {
         h.abort();
     }
 
@@ -438,6 +505,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let mut factory = Arc::try_unwrap(factory)
         .map_err(|_| RunnerError::Internal("factory still referenced at shutdown".into()))?;
     factory.shutdown().await;
+
+    // Stop proxy after all jobs have drained and factory is shut down.
+    if let Err(e) = config.mitm.stop().await {
+        warn!(error = %e, "proxy stop failed");
+    }
 
     config.status.set_mode(RunnerMode::Stopped).await;
     info!("runner stopped");
@@ -577,6 +649,96 @@ async fn recv_reconnect(
             Ok(Err(e)) => Err(e.to_string()),
             Err(e) => Err(format!("reconnect task panicked: {e}")),
         },
+        None => std::future::pending().await,
+    }
+}
+
+/// Spawn a background mitm restart task when the backoff timer fires
+/// and no restart is already in flight.
+async fn maybe_spawn_mitm_restart(
+    mitm: &mut proxy::MitmProxy,
+    restart_at: &mut Option<Instant>,
+    restarting: &mut Option<MitmRestartHandle>,
+) {
+    if restarting.is_some() {
+        return;
+    }
+    let Some(at) = *restart_at else { return };
+    if Instant::now() < at {
+        return;
+    }
+    *restart_at = None;
+    let params = mitm.begin_restart().await;
+    *restarting = Some(tokio::spawn(params.spawn()));
+}
+
+/// Handle the result of a background mitm restart task.
+fn handle_mitm_restart_result(
+    result: Result<tokio::process::Child, String>,
+    mitm: &mut proxy::MitmProxy,
+    restart_at: &mut Option<Instant>,
+    backoff: &mut Duration,
+    consecutive_failures: &mut u32,
+) {
+    match result {
+        Ok(child) => {
+            if *consecutive_failures > 0 {
+                info!(
+                    attempts = *consecutive_failures,
+                    "mitmproxy restarted after failures"
+                );
+            } else {
+                info!("mitmproxy restarted");
+            }
+            mitm.complete_restart(child);
+            *backoff = MITM_BACKOFF_INITIAL;
+            *consecutive_failures = 0;
+        }
+        Err(e) => {
+            *consecutive_failures += 1;
+            let next_secs = backoff.as_secs();
+            if *consecutive_failures >= 5 {
+                error!(
+                    error = %e,
+                    failures = *consecutive_failures,
+                    next_attempt_secs = next_secs,
+                    "mitmproxy restart failing persistently"
+                );
+            } else {
+                warn!(
+                    error = %e,
+                    next_attempt_secs = next_secs,
+                    "mitmproxy restart failed"
+                );
+            }
+            *restart_at = Some(Instant::now() + *backoff);
+            *backoff = (*backoff * 2).min(MITM_BACKOFF_MAX);
+        }
+    }
+}
+
+/// Await a background mitm restart task, or pend forever if none is running.
+async fn recv_mitm_restart(
+    handle: &mut Option<MitmRestartHandle>,
+) -> Result<tokio::process::Child, String> {
+    match handle {
+        Some(h) => {
+            let result = match h.await {
+                Ok(Ok(child)) => Ok(child),
+                Ok(Err(e)) => Err(e.to_string()),
+                Err(e) => Err(format!("restart task panicked: {e}")),
+            };
+            *handle = None;
+            result
+        }
+        None => std::future::pending().await,
+    }
+}
+
+/// Sleep until the mitm restart timer fires, or pend forever if no restart is scheduled.
+async fn sleep_until_mitm_restart(restart_at: &Option<Instant>) {
+    match restart_at {
+        Some(at) => tokio::time::sleep_until(tokio::time::Instant::from_std(*at)).await,
         None => std::future::pending().await,
     }
 }

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -30,6 +30,8 @@ const ABLY_BACKOFF_MAX: Duration = Duration::from_secs(60);
 const MITM_BACKOFF_INITIAL: Duration = Duration::from_secs(1);
 /// Maximum backoff between mitmproxy restart attempts.
 const MITM_BACKOFF_MAX: Duration = Duration::from_secs(30);
+/// Stop retrying mitmproxy after this many consecutive failures.
+const MITM_MAX_CONSECUTIVE_FAILURES: u32 = 20;
 
 #[derive(Args)]
 pub struct StartArgs {
@@ -285,6 +287,7 @@ async fn run(mut config: RunConfig) -> RunnerResult<()> {
                 // Spawn background restart task when timer fires
                 maybe_spawn_mitm_restart(
                     &mut config.mitm,
+                    &mut config.mitm_crash_rx,
                     &mut mitm_restart_at,
                     &mut mitm_restarting,
                 )
@@ -327,8 +330,13 @@ async fn run(mut config: RunConfig) -> RunnerResult<()> {
         }
 
         // Spawn background restart task when timer fires
-        maybe_spawn_mitm_restart(&mut config.mitm, &mut mitm_restart_at, &mut mitm_restarting)
-            .await;
+        maybe_spawn_mitm_restart(
+            &mut config.mitm,
+            &mut config.mitm_crash_rx,
+            &mut mitm_restart_at,
+            &mut mitm_restarting,
+        )
+        .await;
 
         // If all permits are taken, wait for a job to finish or mode change
         if semaphore.available_permits() == 0 {
@@ -427,7 +435,6 @@ async fn run(mut config: RunConfig) -> RunnerResult<()> {
             }
             // Ably reconnection result (background task)
             result = recv_reconnect(&mut ably_reconnecting) => {
-                ably_reconnecting = None;
                 match result {
                     Ok(sub) => {
                         if ably_consecutive_failures > 0 {
@@ -644,11 +651,15 @@ async fn recv_reconnect(
     handle: &mut Option<AblyReconnectHandle>,
 ) -> Result<ably_subscriber::Subscription, String> {
     match handle {
-        Some(h) => match h.await {
-            Ok(Ok(sub)) => Ok(sub),
-            Ok(Err(e)) => Err(e.to_string()),
-            Err(e) => Err(format!("reconnect task panicked: {e}")),
-        },
+        Some(h) => {
+            let result = match h.await {
+                Ok(Ok(sub)) => Ok(sub),
+                Ok(Err(e)) => Err(e.to_string()),
+                Err(e) => Err(format!("reconnect task panicked: {e}")),
+            };
+            *handle = None;
+            result
+        }
         None => std::future::pending().await,
     }
 }
@@ -657,6 +668,7 @@ async fn recv_reconnect(
 /// and no restart is already in flight.
 async fn maybe_spawn_mitm_restart(
     mitm: &mut proxy::MitmProxy,
+    crash_rx: &mut tokio::sync::mpsc::Receiver<()>,
     restart_at: &mut Option<Instant>,
     restarting: &mut Option<MitmRestartHandle>,
 ) {
@@ -668,6 +680,9 @@ async fn maybe_spawn_mitm_restart(
         return;
     }
     *restart_at = None;
+    // Drain any stale crash notifications from the previous process to prevent
+    // a spurious restart cycle after this one completes.
+    while crash_rx.try_recv().is_ok() {}
     let params = mitm.begin_restart().await;
     *restarting = Some(tokio::spawn(params.spawn()));
 }
@@ -696,6 +711,15 @@ fn handle_mitm_restart_result(
         }
         Err(e) => {
             *consecutive_failures += 1;
+            if *consecutive_failures >= MITM_MAX_CONSECUTIVE_FAILURES {
+                error!(
+                    error = %e,
+                    failures = *consecutive_failures,
+                    "mitmproxy restart abandoned after too many failures"
+                );
+                // Don't schedule another restart — circuit breaker tripped.
+                return;
+            }
             let next_secs = backoff.as_secs();
             if *consecutive_failures >= 5 {
                 error!(

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -184,7 +184,7 @@ impl MitmProxy {
     /// The caller should spawn the mitmdump process (potentially in a
     /// background task) and then call [`complete_restart`] with the result.
     pub async fn begin_restart(&mut self) -> MitmRestartParams {
-        self.stopping.store(false, Ordering::Relaxed);
+        self.stopping.store(false, Ordering::Release);
         // Kill old child if somehow still running.
         if let Some(ref mut child) = self.child {
             let _ = child.kill().await;
@@ -205,7 +205,7 @@ impl MitmProxy {
 
     /// Gracefully stop mitmdump (SIGTERM → timeout → SIGKILL).
     pub async fn stop(&mut self) -> RunnerResult<()> {
-        self.stopping.store(true, Ordering::Relaxed);
+        self.stopping.store(true, Ordering::Release);
         let Some(ref mut child) = self.child else {
             return Ok(());
         };
@@ -231,7 +231,7 @@ impl MitmProxy {
 
 impl Drop for MitmProxy {
     fn drop(&mut self) {
-        self.stopping.store(true, Ordering::Relaxed);
+        self.stopping.store(true, Ordering::Release);
         // Best-effort kill if still running.
         if let Some(ref mut child) = self.child {
             let _ = child.start_kill();
@@ -242,7 +242,7 @@ impl Drop for MitmProxy {
 /// Parameters needed to spawn a mitmdump process, returned by
 /// [`MitmProxy::begin_restart`]. All fields are owned/cloned so the spawn
 /// can happen in a background task without borrowing `MitmProxy`.
-pub struct MitmRestartParams {
+pub(crate) struct MitmRestartParams {
     config: ProxyConfig,
     port: u16,
     crash_tx: mpsc::Sender<()>,
@@ -251,7 +251,7 @@ pub struct MitmRestartParams {
 
 impl MitmRestartParams {
     /// Spawn mitmdump using these parameters. Suitable for `tokio::spawn`.
-    pub async fn spawn(self) -> RunnerResult<tokio::process::Child> {
+    pub(crate) async fn spawn(self) -> RunnerResult<tokio::process::Child> {
         spawn_mitmdump(&self.config, self.port, &self.crash_tx, &self.stopping).await
     }
 }
@@ -259,7 +259,7 @@ impl MitmRestartParams {
 /// Spawn a mitmdump process, wire up stdout/stderr monitors, and wait for
 /// it to become ready. This is a free function so it can run in a
 /// `tokio::spawn` without borrowing `MitmProxy`.
-pub async fn spawn_mitmdump(
+pub(crate) async fn spawn_mitmdump(
     config: &ProxyConfig,
     port: u16,
     crash_tx: &mpsc::Sender<()>,
@@ -306,7 +306,7 @@ pub async fn spawn_mitmdump(
                 }
             }
             // Pipe closed — process exited.
-            if !stopping.load(Ordering::Relaxed) {
+            if !stopping.load(Ordering::Acquire) {
                 let _ = crash_tx.send(()).await;
             }
         });

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncBufReadExt;
+use tokio::sync::mpsc;
 use tracing::{info, warn};
 
 use crate::error::{RunnerError, RunnerResult};
@@ -74,6 +77,7 @@ const READY_TIMEOUT: Duration = Duration::from_secs(10);
 const STOP_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Configuration for starting the proxy.
+#[derive(Clone)]
 pub struct ProxyConfig {
     /// Path to the mitmdump binary.
     pub mitmdump_bin: PathBuf,
@@ -94,11 +98,18 @@ pub struct MitmProxy {
     port: u16,
     config: ProxyConfig,
     child: Option<tokio::process::Child>,
+    /// Sender used by the stdout monitor task to signal unexpected exit.
+    crash_tx: mpsc::Sender<()>,
+    /// Set to `true` during graceful `stop()` / `Drop` to suppress crash notifications.
+    stopping: Arc<AtomicBool>,
 }
 
 impl MitmProxy {
     /// Prepare the proxy: allocate a port, write addon script and empty registry.
-    pub async fn new(config: ProxyConfig) -> RunnerResult<Self> {
+    ///
+    /// Returns `(proxy, crash_rx)`. The caller should select on `crash_rx` to
+    /// detect unexpected mitmdump exits and trigger a restart.
+    pub async fn new(config: ProxyConfig) -> RunnerResult<(Self, mpsc::Receiver<()>)> {
         let port = find_available_port()?;
 
         // Write addon script.
@@ -113,68 +124,23 @@ impl MitmProxy {
         };
         write_registry(&config.registry_path, &empty_registry).await?;
 
-        Ok(Self {
-            port,
-            config,
-            child: None,
-        })
+        let (crash_tx, crash_rx) = mpsc::channel(1);
+
+        Ok((
+            Self {
+                port,
+                config,
+                child: None,
+                crash_tx,
+                stopping: Arc::new(AtomicBool::new(false)),
+            },
+            crash_rx,
+        ))
     }
 
     /// Spawn the mitmdump process.
     pub async fn start(&mut self) -> RunnerResult<()> {
-        let mut cmd = tokio::process::Command::new(&self.config.mitmdump_bin);
-        cmd.arg("--mode")
-            .arg("transparent")
-            .arg("--listen-port")
-            .arg(self.port.to_string())
-            .arg("--set")
-            .arg(format!("confdir={}", self.config.ca_dir.display()))
-            .arg("--set")
-            .arg(format!(
-                "vm0_proxy_registry_path={}",
-                self.config.registry_path.display()
-            ))
-            .arg("--scripts")
-            .arg(&self.config.addon_path)
-            .arg("--quiet");
-        if let Some(url) = &self.config.api_url {
-            cmd.arg("--set").arg(format!("vm0_api_url={url}"));
-        }
-        cmd.stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped());
-
-        info!(port = self.port, bin = %self.config.mitmdump_bin.display(), "starting mitmdump");
-
-        let mut child = cmd
-            .spawn()
-            .map_err(|e| RunnerError::Internal(format!("spawn mitmdump: {e}")))?;
-
-        // Stream stdout/stderr to tracing.
-        if let Some(stdout) = child.stdout.take() {
-            tokio::spawn(async move {
-                let mut lines = tokio::io::BufReader::new(stdout).lines();
-                while let Ok(Some(line)) = lines.next_line().await {
-                    if !line.is_empty() {
-                        info!(target: "mitmdump", "{line}");
-                    }
-                }
-            });
-        }
-        if let Some(stderr) = child.stderr.take() {
-            tokio::spawn(async move {
-                let mut lines = tokio::io::BufReader::new(stderr).lines();
-                while let Ok(Some(line)) = lines.next_line().await {
-                    if !line.is_empty() {
-                        warn!(target: "mitmdump", "stderr: {line}");
-                    }
-                }
-            });
-        }
-
-        // Wait for process to be alive (poll liveness).
-        wait_for_ready(&mut child, self.port, READY_TIMEOUT).await?;
-
+        let child = spawn_mitmdump(&self.config, self.port, &self.crash_tx, &self.stopping).await?;
         self.child = Some(child);
         info!(port = self.port, "mitmdump started");
         Ok(())
@@ -212,8 +178,34 @@ impl MitmProxy {
         self.registry_handle().unregister_vm(source_ip).await
     }
 
+    /// Prepare for restart: reset `stopping`, kill any lingering child, and
+    /// return the parameters needed for [`spawn_mitmdump`].
+    ///
+    /// The caller should spawn the mitmdump process (potentially in a
+    /// background task) and then call [`complete_restart`] with the result.
+    pub async fn begin_restart(&mut self) -> MitmRestartParams {
+        self.stopping.store(false, Ordering::Relaxed);
+        // Kill old child if somehow still running.
+        if let Some(ref mut child) = self.child {
+            let _ = child.kill().await;
+            self.child = None;
+        }
+        MitmRestartParams {
+            config: self.config.clone(),
+            port: self.port,
+            crash_tx: self.crash_tx.clone(),
+            stopping: Arc::clone(&self.stopping),
+        }
+    }
+
+    /// Finish a restart by storing the newly spawned child process.
+    pub fn complete_restart(&mut self, child: tokio::process::Child) {
+        self.child = Some(child);
+    }
+
     /// Gracefully stop mitmdump (SIGTERM → timeout → SIGKILL).
     pub async fn stop(&mut self) -> RunnerResult<()> {
+        self.stopping.store(true, Ordering::Relaxed);
         let Some(ref mut child) = self.child else {
             return Ok(());
         };
@@ -239,11 +231,101 @@ impl MitmProxy {
 
 impl Drop for MitmProxy {
     fn drop(&mut self) {
+        self.stopping.store(true, Ordering::Relaxed);
         // Best-effort kill if still running.
         if let Some(ref mut child) = self.child {
             let _ = child.start_kill();
         }
     }
+}
+
+/// Parameters needed to spawn a mitmdump process, returned by
+/// [`MitmProxy::begin_restart`]. All fields are owned/cloned so the spawn
+/// can happen in a background task without borrowing `MitmProxy`.
+pub struct MitmRestartParams {
+    config: ProxyConfig,
+    port: u16,
+    crash_tx: mpsc::Sender<()>,
+    stopping: Arc<AtomicBool>,
+}
+
+impl MitmRestartParams {
+    /// Spawn mitmdump using these parameters. Suitable for `tokio::spawn`.
+    pub async fn spawn(self) -> RunnerResult<tokio::process::Child> {
+        spawn_mitmdump(&self.config, self.port, &self.crash_tx, &self.stopping).await
+    }
+}
+
+/// Spawn a mitmdump process, wire up stdout/stderr monitors, and wait for
+/// it to become ready. This is a free function so it can run in a
+/// `tokio::spawn` without borrowing `MitmProxy`.
+pub async fn spawn_mitmdump(
+    config: &ProxyConfig,
+    port: u16,
+    crash_tx: &mpsc::Sender<()>,
+    stopping: &Arc<AtomicBool>,
+) -> RunnerResult<tokio::process::Child> {
+    let mut cmd = tokio::process::Command::new(&config.mitmdump_bin);
+    cmd.arg("--mode")
+        .arg("transparent")
+        .arg("--listen-port")
+        .arg(port.to_string())
+        .arg("--set")
+        .arg(format!("confdir={}", config.ca_dir.display()))
+        .arg("--set")
+        .arg(format!(
+            "vm0_proxy_registry_path={}",
+            config.registry_path.display()
+        ))
+        .arg("--scripts")
+        .arg(&config.addon_path)
+        .arg("--quiet");
+    if let Some(url) = &config.api_url {
+        cmd.arg("--set").arg(format!("vm0_api_url={url}"));
+    }
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    info!(port, bin = %config.mitmdump_bin.display(), "starting mitmdump");
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| RunnerError::Internal(format!("spawn mitmdump: {e}")))?;
+
+    // Stream stdout to tracing; when the pipe closes (process exited),
+    // send a crash notification unless we're in a graceful stop.
+    if let Some(stdout) = child.stdout.take() {
+        let crash_tx = crash_tx.clone();
+        let stopping = Arc::clone(stopping);
+        tokio::spawn(async move {
+            let mut lines = tokio::io::BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if !line.is_empty() {
+                    info!(target: "mitmdump", "{line}");
+                }
+            }
+            // Pipe closed — process exited.
+            if !stopping.load(Ordering::Relaxed) {
+                let _ = crash_tx.send(()).await;
+            }
+        });
+    }
+    if let Some(stderr) = child.stderr.take() {
+        tokio::spawn(async move {
+            let mut lines = tokio::io::BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if !line.is_empty() {
+                    warn!(target: "mitmdump", "stderr: {line}");
+                }
+            }
+        });
+    }
+
+    // Wait for process to be alive (poll liveness).
+    wait_for_ready(&mut child, port, READY_TIMEOUT).await?;
+
+    Ok(child)
 }
 
 /// Wait for mitmdump to start listening on `port` (TCP connect probe).


### PR DESCRIPTION
## Summary

- Detect mitmproxy (mitmdump) process exit via stdout pipe close and automatically restart it on the same port with exponential backoff (1s → 30s)
- Integrate crash detection into all three main-loop `select!` branches (Running, Draining, semaphore-full) following the existing Ably reconnection pattern
- Non-blocking restart: `begin_restart()` synchronously kills the old process, then `spawn()` runs in a background task to avoid blocking the main loop during `wait_for_ready`

Closes #3082

## Test plan

- [ ] Verify existing `MitmProxy` tests pass (`cargo test -p runner`)
- [ ] Verify clippy clean (`cargo clippy -p runner --tests`)
- [ ] E2E: kill mitmdump process while a VM is running, confirm runner logs restart and VM traffic recovers
- [ ] E2E: verify graceful `stop()` does NOT trigger crash notification
- [ ] E2E: verify rapid repeated crashes trigger exponential backoff in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)