### PR TITLE
refactor(runner): move build lock files from /var/lock to ~/.vm0-runner/locks

### DIFF
--- a/crates/runner/src/cmd/rootfs.rs
+++ b/crates/runner/src/cmd/rootfs.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use sha2::{Digest, Sha256};
 
 use crate::error::{RunnerError, RunnerResult};
-use crate::paths::{HomePaths, LockPaths, RootfsPaths};
+use crate::paths::{HomePaths, RootfsPaths};
 
 const BUILD_SCRIPT: &str = include_str!("../../scripts/build-rootfs.sh");
 const VERIFY_SCRIPT: &str = include_str!("../../scripts/verify-rootfs.sh");
@@ -60,8 +60,7 @@ pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
     }
 
     // Acquire exclusive lock to prevent concurrent builds with the same hash.
-    let locks = LockPaths::new();
-    let _lock = crate::lock::acquire(locks.rootfs(&hash)).await?;
+    let _lock = crate::lock::acquire(paths.rootfs_lock(&hash)).await?;
 
     // Re-check after acquiring lock — another process may have completed the build.
     if is_build_complete(&rootfs_paths).await? {

--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -6,7 +6,7 @@ use sandbox_fc::SnapshotOutputPaths;
 use crate::config::{DEFAULT_MEMORY_MB, DEFAULT_VCPU, SnapshotConfig};
 use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
 use crate::error::{RunnerError, RunnerResult};
-use crate::paths::{HomePaths, LockPaths, RootfsPaths};
+use crate::paths::{HomePaths, RootfsPaths};
 
 #[derive(Args, Clone)]
 pub struct SnapshotArgs {
@@ -37,8 +37,7 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<SnapshotConfig> {
     }
 
     // Acquire exclusive lock to prevent concurrent builds with the same hash.
-    let locks = LockPaths::new();
-    let _lock = crate::lock::acquire(locks.snapshot(&snapshot_hash)).await?;
+    let _lock = crate::lock::acquire(paths.snapshot_lock(&snapshot_hash)).await?;
 
     // Re-check after acquiring lock — another process may have completed the build.
     if is_snapshot_complete(&output).await? {

--- a/crates/runner/src/lock.rs
+++ b/crates/runner/src/lock.rs
@@ -78,8 +78,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn acquire_creates_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a").join("b").join("test.lock");
+
+        let guard = acquire(path.clone()).await.unwrap();
+        assert!(path.exists());
+        drop(guard);
+    }
+
+    #[tokio::test]
     async fn invalid_path_returns_error() {
-        let path = PathBuf::from("/nonexistent/dir/test.lock");
+        // /dev/null is a file, so create_dir_all cannot create a child directory
+        // inside it — this fails even as root.
+        let path = PathBuf::from("/dev/null/impossible/test.lock");
         let result = acquire(path).await;
         assert!(result.is_err());
     }

--- a/crates/runner/src/lock.rs
+++ b/crates/runner/src/lock.rs
@@ -9,6 +9,11 @@ use crate::error::{RunnerError, RunnerResult};
 /// The returned guard holds the lock until dropped.
 pub async fn acquire(path: PathBuf) -> RunnerResult<Flock<std::fs::File>> {
     tokio::task::spawn_blocking(move || {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                RunnerError::Internal(format!("create lock dir {}: {e}", parent.display()))
+            })?;
+        }
         let file = std::fs::File::options()
             .create(true)
             .truncate(false)

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -90,34 +90,17 @@ impl HomePaths {
     pub fn runners_dir(&self) -> PathBuf {
         self.root.join("runners")
     }
-}
 
-/// Lock file paths under `/var/lock` for coordinating concurrent builds.
-///
-/// `/var/lock` is FHS-standard (mode 1777), same as the netns pool locks.
-pub struct LockPaths {
-    base_dir: PathBuf,
-}
-
-impl Default for LockPaths {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl LockPaths {
-    pub fn new() -> Self {
-        Self {
-            base_dir: PathBuf::from("/var/lock"),
-        }
+    pub fn locks_dir(&self) -> PathBuf {
+        self.root.join("locks")
     }
 
-    pub fn rootfs(&self, hash: &str) -> PathBuf {
-        self.base_dir.join(format!("vm0-rootfs-{hash}.lock"))
+    pub fn rootfs_lock(&self, hash: &str) -> PathBuf {
+        self.locks_dir().join(format!("rootfs-{hash}.lock"))
     }
 
-    pub fn snapshot(&self, hash: &str) -> PathBuf {
-        self.base_dir.join(format!("vm0-snapshot-{hash}.lock"))
+    pub fn snapshot_lock(&self, hash: &str) -> PathBuf {
+        self.locks_dir().join(format!("snapshot-{hash}.lock"))
     }
 }
 


### PR DESCRIPTION
## Summary

- Move rootfs/snapshot build lock files from `/var/lock` to `~/.vm0-runner/locks/` — these locks protect per-user artifacts under `~/.vm0-runner/`, not system-level resources
- Delete `LockPaths` struct from runner, add `locks_dir()`/`rootfs_lock()`/`snapshot_lock()` methods to `HomePaths`
- Have `lock::acquire` auto-create parent directories so callers don't need to ensure lock dir existence

The system-level netns pool locks in `sandbox-fc` remain at `/var/lock` where they belong (they coordinate network namespace allocation across all processes on the machine).

## Test plan

- [x] `cargo clippy -p runner --tests` — zero warnings
- [x] `cargo test -p runner` — all 56 tests pass
- [ ] Verify on dev-2: `runner build` creates locks under `~/.vm0-runner/locks/` instead of `/var/lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)