### PR TITLE
fix(runner): forward mock-claude env var to guest

### DIFF
--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -55,8 +55,6 @@ pub struct ExecutionContext {
     pub cli_agent_type: String,
     #[serde(default)]
     pub experimental_firewall: Option<ExperimentalFirewall>,
-    // TODO: remove allow(dead_code) when mock-claude bypass is implemented
-    #[allow(dead_code)]
     #[serde(default)]
     pub debug_no_mock_claude: Option<bool>,
     #[serde(default)]


### PR DESCRIPTION
## Summary

- Read `USE_MOCK_CLAUDE` from host environment and pass it to guest VM env vars
- Respect `debugNoMockClaude` flag in `ExecutionContext` to suppress the var
- Remove `#[allow(dead_code)]` from the now-used `debug_no_mock_claude` field

Closes #3088

## Test plan

- [x] `build_env_json_with_mock_claude` — verifies env var is forwarded
- [x] `build_env_json_mock_claude_suppressed_by_debug_flag` — verifies suppression
- [x] All 59 runner tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)