### PR TITLE
refactor(runner): unify signal handling for graceful shutdown

### DIFF
--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -12,7 +12,6 @@ use uuid::Uuid;
 pub enum RunnerMode {
     Running,
     Draining,
-    Stopping,
     Stopped,
 }
 


### PR DESCRIPTION
## Summary

- Remove `RunnerMode::Stopping` — SIGTERM/SIGINT/SIGUSR1 all trigger `Draining`
- Shutdown drain loop now maintains mitmproxy so active jobs can use the proxy during graceful shutdown
- Signal handler simplified from loop+select to single select (all signals equivalent)

Follows industry convention: SIGTERM = graceful shutdown (wait for current work). Force-kill timeout is controlled by the caller (systemd `TimeoutStopSec` → SIGKILL), not the process itself.

Closes #3096

## Test plan

- [x] `cargo clippy -p runner --tests` passes
- [x] `cargo test -p runner` — 65 tests pass
- [ ] E2E on metal: send SIGTERM/SIGUSR1 to running runner, verify jobs complete and mitmproxy stays alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)