### PR TITLE
fix: hide connect button while polling

### DIFF
--- a/turbo/apps/platform/src/views/settings-page/connector-list.tsx
+++ b/turbo/apps/platform/src/views/settings-page/connector-list.tsx
@@ -96,17 +96,18 @@ function ConnectorRow({
           </PopoverContent>
         </Popover>
       ) : (
-        <button
-          onClick={() =>
-            detach(connect(item.type, pageSignal), Reason.DomCallback)
-          }
-          disabled={isPolling}
-          className="flex items-center shrink-0 rounded-lg border border-border bg-background overflow-hidden hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          <span className="px-4 py-2 text-sm font-medium text-foreground">
-            Connect
-          </span>
-        </button>
+        !isPolling && (
+          <button
+            onClick={() =>
+              detach(connect(item.type, pageSignal), Reason.DomCallback)
+            }
+            className="flex items-center shrink-0 rounded-lg border border-border bg-background overflow-hidden hover:bg-muted transition-colors"
+          >
+            <span className="px-4 py-2 text-sm font-medium text-foreground">
+              Connect
+            </span>
+          </button>
+        )
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
Hides the "Connect" button while a connector is in polling state to prevent duplicate connection attempts.

## Changes
- Modified connector-list.tsx to conditionally render the Connect button only when not polling
- Removed disabled state styling in favor of hiding the button entirely

## Test plan
- [ ] Verify Connect button is hidden during polling
- [ ] Verify Connect button reappears after polling completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)