### PR TITLE
fix(ci): add -benchmark suffix to crates.yml runner job ref

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -99,7 +99,7 @@ jobs:
           cd crates
           cargo run -p ably-subscriber --example smoke_test
 
-  runner-metal-test:
+  runner-benchmark:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
@@ -138,7 +138,7 @@ jobs:
         id: host
         env:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
-          JOB_REF: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main' }}
+          JOB_REF: ${{ github.event_name == 'pull_request' && format('pr-{0}-benchmark', github.event.pull_request.number) || 'main-benchmark' }}
         run: |
           NUM_HOSTS=$(echo "$METAL_HOSTS" | tr ',' '\n' | wc -l)
           HASH=$(echo -n "$JOB_REF" | md5sum | cut -c1-8)


### PR DESCRIPTION
## Summary
- Change `runner-metal-test` job's `JOB_REF` from `pr-{N}` to `pr-{N}-benchmark` (and `main` to `main-benchmark`)
- Avoids directory conflicts on metal hosts when both `crates.yml` benchmark and `turbo.yml` E2E pipeline run concurrently for the same PR

Prereq for #3108

## Test plan
- [ ] `crates.yml:runner-metal-test` still passes with the new suffix
- [ ] Directories on metal host use `~/.vm0-runner/bin/pr-{N}-benchmark/` and `~/.vm0-runner/runners/pr-{N}-benchmark/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)