### PR TITLE
fix(vsock-guest): handle ECHILD race with PID 1 zombie reaper

### DIFF
--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -5,6 +5,7 @@
 // Perf: Added snapshot support for fast VM boot from pre-warmed state (issue #1600)
 // CI: Sync 02-parallel E2E tests into 03-experimental-runner (issue #2830)
 // Fix: Only treat 404 as non-fatal for artifact downloads (issue #2899)
+// Fix: Handle ECHILD race between vsock-guest and PID 1 zombie reaper (issue #3118)
 import { program } from "commander";
 import { startCommand } from "./commands/start.js";
 import { doctorCommand } from "./commands/doctor.js";


### PR DESCRIPTION
## Summary

- Replace `child.wait_with_output()` with a custom `collect_output()` that reads stdout/stderr pipes first, then calls `child.wait()` with ECHILD handling
- When PID 1's zombie reaper harvests a child before our `waitpid(pid)` call, stdout/stderr are preserved (previously lost entirely)
- Affects both `wait_with_timeout` (exec with timeout) and `handle_spawn_watch` (background process monitoring)

## Root Cause

`guest-init` runs as PID 1 and calls `vsock_guest::run()` directly in the same process. A background thread reaps zombies via `waitpid(-1, WNOHANG)` every 100ms. All children spawned by vsock-guest (exec, spawn_watch, write_file) are direct children of PID 1.

Rust's `wait_with_output()` internally reads stdout/stderr pipes to EOF, then calls `waitpid(pid)`. Between pipe EOF and `waitpid(pid)`, the reaper can steal the zombie, causing ECHILD.

The fix splits `wait_with_output()` into explicit pipe reads + `child.wait()`, handling ECHILD gracefully with exit code 255 (status unknown but output preserved).

## Test plan

- [ ] `cargo clippy -p vsock-guest --tests` passes
- [ ] `cargo test -p vsock-guest` passes
- [ ] CI crates workflow passes
- [ ] E2E: re-run turbo.yml runner pipeline to verify test #124 no longer fails with "Failed to wait: No child process"

Fixes the ECHILD error observed in PR #3117 CLI E2E test #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)