### PR TITLE
refactor: simplify computer connector secrets storage

### DIFF
--- a/turbo/apps/web/app/api/connectors/computer/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/connectors/computer/__tests__/route.test.ts
@@ -246,9 +246,10 @@ describe("DELETE /api/connectors/computer - Delete", () => {
 
     expect(response.status).toBe(204);
 
-    // Verify ngrok credential and endpoint were deleted
+    // Verify ngrok resources were deleted
     expect(ngrokCalls.deleteCredential).toEqual(["cr_test_456"]);
     expect(ngrokCalls.deleteEndpoint).toEqual(["ep_test_789"]);
+    expect(ngrokCalls.deleteReservedDomain).toEqual(["rd_test_abc"]);
 
     // Verify GET returns 404
     const getResponse = await GET(createTestRequest(BASE_URL));


### PR DESCRIPTION
## Summary
- Reduces stored secrets from 4 to 2 by storing only essential data
- Moves domain ID from `oauthScopes` field to proper secret storage
- Improves deletion logic to retrieve domain ID from secrets
- Fixes test to properly verify run failure with captured run ID

## Changes
- Store only `COMPUTER_CONNECTOR_BRIDGE_TOKEN` and `COMPUTER_CONNECTOR_DOMAIN_ID` as secrets
- Remove unnecessary `COMPUTER_CONNECTOR_NGROK_TOKEN`, `COMPUTER_CONNECTOR_ENDPOINT`, and `COMPUTER_CONNECTOR_DOMAIN` from persistent storage
- Move reserved domain ID from connector's `oauthScopes` field to secrets table
- Import `decryptCredentialValue` to retrieve domain ID during deletion
- Fix test to capture and verify the run ID when sandbox creation fails

## Test plan
- [ ] Unit tests pass
- [ ] Integration tests for computer connector creation pass
- [ ] Integration tests for computer connector deletion pass
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)