### PR TITLE
refactor(guest-init): fork child process for vsock-guest

### DIFF
--- a/crates/guest-init/src/main.rs
+++ b/crates/guest-init/src/main.rs
@@ -3,22 +3,31 @@
 //! Runs as PID 1 inside a Firecracker VM. PID 1 signal handling and zombie
 //! reaping follow the same patterns as [tini](https://github.com/krallin/tini).
 //!
-//! Unlike tini (which forks a single child and supervises it), guest-init runs
-//! vsock-guest directly in the PID 1 process. This is intentional: the VM agent
-//! receives and executes multiple commands over its lifetime, rather than
-//! supervising a single program.
+//! Like tini, guest-init forks a child process (PID 2) to run vsock-guest.
+//! PID 1 then enters a reap loop, waiting for the child to exit while also
+//! reaping orphaned zombie processes.
+//!
+//! This architecture cleanly separates concerns:
+//! - PID 1 only calls `waitpid(-1)`, which reaps any zombie (orphans + the child)
+//! - PID 2 (vsock-guest) calls `waitpid(pid)` for the commands it spawns
+//! - Since PID 2's children are not visible to PID 1's `waitpid(-1)` (they are
+//!   PID 2's children, not PID 1's), there is no ECHILD race condition.
 //!
 //! Startup sequence:
 //! 1. Initialize filesystem (mounts, overlayfs, pivot_root)
 //! 2. Install PID 1 signal handlers (SIGTERM/SIGINT for shutdown, ignore SIGTTIN/SIGTTOU/SIGPIPE)
-//! 3. Start background zombie reaper thread
-//! 4. Run vsock-guest event loop for host-guest communication
+//! 3. Fork child process
+//! 4. Child (PID 2): reset signal handlers to default, run vsock-guest
+//! 5. Parent (PID 1): reap loop until child exits or shutdown signal received
 
 mod init;
 mod pid1;
 
 use std::thread;
 use std::time::Duration;
+
+/// Number of 100ms iterations to wait after SIGTERM before escalating to SIGKILL (= 1 second).
+const SHUTDOWN_GRACE_ITERATIONS: u32 = 10;
 
 fn main() {
     eprintln!("[guest-init] Starting...");
@@ -29,30 +38,82 @@ fn main() {
         std::process::exit(1);
     }
 
-    // Step 2: Setup PID 1 signal handlers
+    // Step 2: Setup PID 1 signal handlers (before fork — child inherits SIG_IGN)
     pid1::setup_signal_handlers();
     eprintln!("[guest-init] PID 1 signal handlers installed");
 
-    // Step 3: Start background thread for zombie reaping
-    // This runs continuously while vsock-guest handles messages
-    thread::spawn(|| {
-        loop {
-            pid1::reap_zombies();
-
-            // Check for shutdown signal
-            if pid1::shutdown_requested() {
-                eprintln!("[guest-init] Shutdown requested");
-                std::process::exit(0);
-            }
-
-            thread::sleep(Duration::from_millis(100));
-        }
-    });
-
-    // Step 4: Run vsock-guest (this is the main event loop)
-    // The guest agent connects to host via vsock and handles commands
-    if let Err(e) = vsock_guest::run(None) {
-        vsock_guest::log("ERROR", &format!("Fatal: {}", e));
+    // Step 3: Fork child process for vsock-guest
+    // SAFETY: fork() is called before any threads are spawned, so it is safe.
+    // The child will run vsock-guest; the parent stays as PID 1 reaper.
+    let child_pid = unsafe { libc::fork() };
+    if child_pid < 0 {
+        eprintln!("[guest-init] FATAL: fork() failed");
         std::process::exit(1);
+    }
+
+    if child_pid == 0 {
+        // Step 4: Child (PID 2) — reset signal handlers and run vsock-guest
+        // Reset SIGTERM/SIGINT to default so vsock-guest can be killed normally.
+        // SIG_IGN for SIGTTIN/SIGTTOU/SIGPIPE survives fork, which is fine.
+        // SAFETY: SIG_DFL is a valid handler constant.
+        unsafe {
+            libc::signal(libc::SIGTERM, libc::SIG_DFL);
+            libc::signal(libc::SIGINT, libc::SIG_DFL);
+        }
+
+        let code = match vsock_guest::run(None) {
+            Ok(()) => 0,
+            Err(e) => {
+                vsock_guest::log("ERROR", &format!("Fatal: {e}"));
+                1
+            }
+        };
+
+        // SAFETY: _exit() is the correct way to terminate a forked child.
+        // Using std::process::exit() would run atexit handlers and flush
+        // shared stdio buffers, potentially corrupting parent output.
+        unsafe {
+            libc::_exit(code);
+        }
+    }
+
+    // === Parent process (PID 1) ===
+    eprintln!("[guest-init] vsock-guest forked as pid={child_pid}");
+
+    // Step 5: Reap loop — wait for child to exit while reaping orphans
+    loop {
+        if let Some(exit_code) = pid1::reap_zombies(child_pid) {
+            eprintln!("[guest-init] vsock-guest exited with code {exit_code}");
+            std::process::exit(exit_code);
+        }
+
+        if pid1::shutdown_requested() {
+            eprintln!("[guest-init] Shutdown requested, sending SIGTERM to vsock-guest");
+            // SAFETY: child_pid is a valid PID from fork().
+            unsafe {
+                libc::kill(child_pid, libc::SIGTERM);
+            }
+            // Wait up to 1s for graceful exit, then escalate to SIGKILL
+            for _ in 0..SHUTDOWN_GRACE_ITERATIONS {
+                thread::sleep(Duration::from_millis(100));
+                if let Some(exit_code) = pid1::reap_zombies(child_pid) {
+                    eprintln!(
+                        "[guest-init] vsock-guest exited with code {exit_code} after SIGTERM"
+                    );
+                    std::process::exit(exit_code);
+                }
+            }
+            eprintln!("[guest-init] vsock-guest did not exit after SIGTERM, sending SIGKILL");
+            // SAFETY: child_pid is a valid PID from fork().
+            unsafe {
+                libc::kill(child_pid, libc::SIGKILL);
+            }
+            // Block until the child is reaped. SIGKILL is unconditional
+            // (except for uninterruptible sleep), so this won't hang.
+            let exit_code = pid1::wait_blocking(child_pid);
+            std::process::exit(exit_code);
+        }
+
+        thread::sleep(Duration::from_millis(100));
     }
 }

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -6,12 +6,11 @@
 //!
 //! Protocol encoding/decoding is handled by the `vsock-proto` crate.
 
-use std::collections::HashMap;
 use std::io::{self, Read, Write};
 use std::os::unix::net::UnixStream;
-use std::process::{Child, Command, ExitStatus, Stdio};
+use std::process::{Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
@@ -163,146 +162,9 @@ pub fn log(level: &str, msg: &str) {
     eprintln!("[vsock-guest] [{level}] {msg}");
 }
 
-/// Exit statuses stored by the PID 1 zombie reaper.
-///
-/// When `guest-init`'s reaper calls `waitpid(-1)` and harvests a child that
-/// `collect_output` is about to wait on, the reaper stores `(pid, exit_code)`
-/// here. On `ECHILD`, `collect_output` recovers the correct exit status
-/// instead of using a fallback.
-static REAPED_STATUSES: LazyLock<Mutex<HashMap<u32, i32>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-/// Store a reaped child's exit status for later recovery.
-///
-/// Called by `guest-init`'s `reap_zombies` after `waitpid(-1)` returns a PID.
-/// The raw `wstatus` is decoded into a standard exit code (exit status for
-/// normal exit, 128+signal for signal death).
-pub fn store_reaped_status(pid: u32, wstatus: i32) {
-    let exit_code = if libc::WIFEXITED(wstatus) {
-        libc::WEXITSTATUS(wstatus)
-    } else if libc::WIFSIGNALED(wstatus) {
-        128 + libc::WTERMSIG(wstatus)
-    } else {
-        1
-    };
-    let mut map = REAPED_STATUSES.lock().unwrap_or_else(|e| e.into_inner());
-    map.insert(pid, exit_code);
-}
-
-/// Collect stdout/stderr from a child process and wait for it to exit.
-///
-/// Unlike [`Child::wait_with_output`], this handles `ECHILD` gracefully.
-/// When running inside guest-init (PID 1), the zombie reaper thread calls
-/// `waitpid(-1, WNOHANG)` every 100ms. If the child exits between our pipe
-/// reads completing and our `waitpid(pid)` call, the reaper may harvest the
-/// zombie first, causing our wait to fail with `ECHILD`.
-///
-/// By reading the pipes before calling `wait()`, we preserve stdout/stderr
-/// even in the ECHILD case. The exit code is recovered from [`REAPED_STATUSES`]
-/// (populated by `guest-init`'s reaper), falling back to 255 if not found.
-fn collect_output(mut child: Child) -> (i32, Vec<u8>, Vec<u8>) {
-    let pid = child.id();
-
-    // Close stdin so the child won't block waiting for input.
-    // This matches wait_with_output()'s behavior.
-    drop(child.stdin.take());
-
-    // Take pipe handles BEFORE waiting. Rust's wait_with_output() does this
-    // internally, but we need to split the operation so we can handle ECHILD
-    // on the wait() call separately.
-    let stdout_pipe = child.stdout.take();
-    let stderr_pipe = child.stderr.take();
-
-    // Read pipes in background threads (mirrors Rust's internal approach).
-    // EOF on the pipes means the child (and any descendants sharing the fd)
-    // have closed their end — the child has exited or is about to.
-    let stdout_thread = stdout_pipe.map(|mut pipe| {
-        thread::spawn(move || {
-            let mut buf = Vec::new();
-            if let Err(e) = pipe.read_to_end(&mut buf) {
-                log("WARN", &format!("stdout pipe read error: {e}"));
-            }
-            buf
-        })
-    });
-    let stderr_thread = stderr_pipe.map(|mut pipe| {
-        thread::spawn(move || {
-            let mut buf = Vec::new();
-            if let Err(e) = pipe.read_to_end(&mut buf) {
-                log("WARN", &format!("stderr pipe read error: {e}"));
-            }
-            buf
-        })
-    });
-
-    let stdout = match stdout_thread {
-        Some(t) => match t.join() {
-            Ok(buf) => buf,
-            Err(_) => {
-                log("WARN", "stdout reader thread panicked");
-                Vec::new()
-            }
-        },
-        None => Vec::new(),
-    };
-    let stderr = match stderr_thread {
-        Some(t) => match t.join() {
-            Ok(buf) => buf,
-            Err(_) => {
-                log("WARN", "stderr reader thread panicked");
-                Vec::new()
-            }
-        },
-        None => Vec::new(),
-    };
-
-    // Now wait for the child. The pipes are closed so the child has exited;
-    // this should return immediately unless the reaper beat us to it.
-    let exit_code = match child.wait() {
-        Ok(status) => extract_exit_code(status),
-        Err(e) if e.raw_os_error() == Some(libc::ECHILD) => {
-            // Child was already reaped by PID 1's zombie reaper.
-            // Try to recover the exit code from the shared map.
-            // Note: there is a theoretical micro-window where the reaper has
-            // called waitpid(-1) (removing the zombie) but hasn't yet called
-            // store_reaped_status(). In that case the lookup misses and we
-            // fall back to 255 — same as the pre-recovery behavior.
-            let recovered = REAPED_STATUSES
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .remove(&pid);
-            if let Some(code) = recovered {
-                log(
-                    "INFO",
-                    &format!(
-                        "child pid={pid} reaped by zombie reaper (ECHILD), \
-                         recovered exit code {code}"
-                    ),
-                );
-                code
-            } else {
-                log(
-                    "WARN",
-                    &format!(
-                        "child pid={pid} reaped by zombie reaper (ECHILD), \
-                         exit status not recoverable, using 255"
-                    ),
-                );
-                255
-            }
-        }
-        Err(e) => {
-            log("ERROR", &format!("failed to wait for child pid={pid}: {e}"));
-            1
-        }
-    };
-
-    (exit_code, stdout, stderr)
-}
-
 /// Run a child process with timeout. Returns (exit_code, stdout, stderr).
 /// Returns exit code 124 on timeout (same as bash timeout command).
-fn wait_with_timeout(child: Child, timeout_ms: u32) -> (i32, Vec<u8>, Vec<u8>) {
+fn wait_with_timeout(child: std::process::Child, timeout_ms: u32) -> (i32, Vec<u8>, Vec<u8>) {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc;
@@ -332,16 +194,26 @@ fn wait_with_timeout(child: Child, timeout_ms: u32) -> (i32, Vec<u8>, Vec<u8>) {
         }
     });
 
-    let (exit_code, stdout, stderr) = collect_output(child);
+    // Wait for the process to complete
+    let output = child.wait_with_output();
 
     // Signal that process completed (killer thread will exit)
     let _ = tx.send(());
 
-    if killed_by_timeout.load(Ordering::SeqCst) {
-        return (EXIT_CODE_TIMEOUT, stdout, b"Timeout".to_vec());
+    match output {
+        Ok(output) => {
+            // Check if process was killed by OUR timeout (not external SIGKILL)
+            if killed_by_timeout.load(Ordering::SeqCst) {
+                return (EXIT_CODE_TIMEOUT, output.stdout, b"Timeout".to_vec());
+            }
+            (
+                extract_exit_code(output.status),
+                output.stdout,
+                output.stderr,
+            )
+        }
+        Err(e) => (1, Vec::new(), format!("Failed to wait: {}", e).into_bytes()),
     }
-
-    (exit_code, stdout, stderr)
 }
 
 /// Handle exec message
@@ -529,7 +401,15 @@ fn handle_spawn_watch(
                 let result = if timeout_ms > 0 {
                     wait_with_timeout(child, timeout_ms)
                 } else {
-                    collect_output(child)
+                    // No timeout - wait indefinitely
+                    match child.wait_with_output() {
+                        Ok(output) => (
+                            extract_exit_code(output.status),
+                            output.stdout,
+                            output.stderr,
+                        ),
+                        Err(e) => (1, Vec::new(), format!("Failed to wait: {}", e).into_bytes()),
+                    }
                 };
 
                 log(
@@ -861,44 +741,5 @@ mod tests {
     fn prepend_env_with_special_chars() {
         let result = prepend_env("cmd", &[("KEY", "it's a \"test\"")]);
         assert_eq!(result, "export KEY='it'\\''s a \"test\"'; cmd");
-    }
-
-    #[test]
-    fn store_reaped_status_normal_exit() {
-        // wstatus for exit(42): WIFEXITED=true, WEXITSTATUS=42
-        // On Linux, normal exit wstatus = exit_code << 8
-        let wstatus = 42 << 8;
-        store_reaped_status(9999, wstatus);
-        let code = REAPED_STATUSES.lock().unwrap().remove(&9999);
-        assert_eq!(code, Some(42));
-    }
-
-    #[test]
-    fn store_reaped_status_signal_death() {
-        // wstatus for killed by SIGKILL(9): WIFSIGNALED=true, WTERMSIG=9
-        // On Linux, signal death wstatus = signal_number
-        let wstatus = 9;
-        store_reaped_status(9998, wstatus);
-        let code = REAPED_STATUSES.lock().unwrap().remove(&9998);
-        assert_eq!(code, Some(128 + 9));
-    }
-
-    #[test]
-    fn store_reaped_status_zero_exit() {
-        // wstatus for exit(0): exit_code << 8 = 0
-        let wstatus = 0;
-        store_reaped_status(9997, wstatus);
-        let code = REAPED_STATUSES.lock().unwrap().remove(&9997);
-        assert_eq!(code, Some(0));
-    }
-
-    #[test]
-    fn store_reaped_status_stopped() {
-        // wstatus = 0x7f is a stopped process (WIFSTOPPED).
-        // Neither WIFEXITED nor WIFSIGNALED, so the else branch returns 1.
-        let wstatus = 0x7f;
-        store_reaped_status(9996, wstatus);
-        let code = REAPED_STATUSES.lock().unwrap().remove(&9996);
-        assert_eq!(code, Some(1));
     }
 }

--- a/turbo/apps/runner/src/index.ts
+++ b/turbo/apps/runner/src/index.ts
@@ -1,5 +1,4 @@
 // Deployment: Buildkit cache retry mechanism (issue #1328)
-// CI: Refactored E2E tests with setup_file() - parallel tests use 45s timeout (issue #1555)
 // Perf: Replaced Python vsock-guest with Rust for 16x faster VM startup (issue #1668)
 // Ops: File logging for Rust runner with daily rotation (issue #3099)
 // Perf: Added snapshot support for fast VM boot from pre-warmed state (issue #1600)


### PR DESCRIPTION
## Summary

- Fork vsock-guest into a child process (PID 2) instead of running it directly in PID 1
- PID 1's `waitpid(-1)` only sees its own children (PID 2 + orphans), while PID 2's `waitpid(pid)` operates on its own children — no overlap, no ECHILD race
- Removes `REAPED_STATUSES`, `store_reaped_status()`, `collect_output()`, and 4 associated tests from vsock-guest, reverting to simple `wait_with_output()` calls
- Net reduction of ~100 lines of code

## Architecture

```
Before: PID 1 runs vsock-guest directly
  PID 1 (guest-init + vsock-guest)
    ├── waitpid(-1, WNOHANG) in reaper thread  ← RACES with ↓
    └── waitpid(pid) in vsock-guest             ← ECHILD if reaper wins

After: PID 1 forks PID 2 for vsock-guest
  PID 1 (guest-init reaper)
    └── waitpid(-1, WNOHANG) — only sees PID 2 + orphans
  PID 2 (vsock-guest)
    └── waitpid(pid) — only sees its own children (invisible to PID 1)
```

## Test plan

- [x] `cargo clippy -p vsock-guest -p guest-init --tests` passes
- [x] `cargo test -p vsock-guest -p guest-init` passes
- [ ] Cross-compile and E2E test on dev-2 metal machine
- [ ] CLI E2E test #124 (verifies exit code correctness)

Closes #3121

🤖 Generated with [Claude Code](https://claude.com/claude-code)