### PR TITLE
fix(runner): add exclusive lock on base_dir to prevent silent data corruption

### DIFF
--- a/crates/runner/src/lock.rs
+++ b/crates/runner/src/lock.rs
@@ -1,28 +1,52 @@
-use std::path::PathBuf;
+use std::fs::File;
+use std::path::{Path, PathBuf};
 
 use nix::fcntl::{Flock, FlockArg};
 
 use crate::error::{RunnerError, RunnerResult};
 
+/// Open (or create) the lock file, creating parent directories as needed.
+fn open_lock_file(path: &Path) -> RunnerResult<File> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            RunnerError::Internal(format!("create lock dir {}: {e}", parent.display()))
+        })?;
+    }
+    File::options()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(|e| RunnerError::Internal(format!("open lock {}: {e}", path.display())))
+}
+
 /// Acquire an exclusive flock on the given path, blocking until available.
 ///
 /// The returned guard holds the lock until dropped.
-pub async fn acquire(path: PathBuf) -> RunnerResult<Flock<std::fs::File>> {
+pub async fn acquire(path: PathBuf) -> RunnerResult<Flock<File>> {
     tokio::task::spawn_blocking(move || {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| {
-                RunnerError::Internal(format!("create lock dir {}: {e}", parent.display()))
-            })?;
-        }
-        let file = std::fs::File::options()
-            .create(true)
-            .truncate(false)
-            .read(true)
-            .write(true)
-            .open(&path)
-            .map_err(|e| RunnerError::Internal(format!("open lock {}: {e}", path.display())))?;
+        let file = open_lock_file(&path)?;
         Flock::lock(file, FlockArg::LockExclusive)
             .map_err(|(_file, e)| RunnerError::Internal(format!("flock {}: {e}", path.display())))
+    })
+    .await
+    .map_err(|e| RunnerError::Internal(format!("lock task: {e}")))?
+}
+
+/// Try to acquire an exclusive flock, returning an error immediately if held by another process.
+///
+/// The returned guard holds the lock until dropped.
+pub async fn try_acquire(path: PathBuf) -> RunnerResult<Flock<File>> {
+    tokio::task::spawn_blocking(move || {
+        let file = open_lock_file(&path)?;
+        Flock::lock(file, FlockArg::LockExclusiveNonblock).map_err(|(_, e)| {
+            if e == nix::errno::Errno::EWOULDBLOCK {
+                RunnerError::Config("lock is already held by another process".into())
+            } else {
+                RunnerError::Internal(format!("flock {}: {e}", path.display()))
+            }
+        })
     })
     .await
     .map_err(|e| RunnerError::Internal(format!("lock task: {e}")))?
@@ -83,6 +107,26 @@ mod tests {
         let path = dir.path().join("a").join("b").join("test.lock");
 
         let guard = acquire(path.clone()).await.unwrap();
+        assert!(path.exists());
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn try_acquire_fails_when_held() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+
+        let _guard = acquire(path.clone()).await.unwrap();
+        let err = try_acquire(path).await.unwrap_err();
+        assert!(err.to_string().contains("already held by another process"));
+    }
+
+    #[tokio::test]
+    async fn try_acquire_succeeds_when_free() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+
+        let guard = try_acquire(path.clone()).await.unwrap();
         assert!(path.exists());
         drop(guard);
     }

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use sha2::{Digest, Sha256};
+
 use crate::error::{RunnerError, RunnerResult};
 
 /// Guest paths (must match rootfs layout).
@@ -93,6 +95,11 @@ impl HomePaths {
 
     pub fn locks_dir(&self) -> PathBuf {
         self.root.join("locks")
+    }
+
+    pub fn base_dir_lock(&self, base_dir: &Path) -> PathBuf {
+        let hash = Sha256::digest(base_dir.as_os_str().as_encoded_bytes());
+        self.locks_dir().join(format!("base-dir-{hash:x}.lock"))
     }
 
     pub fn rootfs_lock(&self, hash: &str) -> PathBuf {


### PR DESCRIPTION
## Summary

- Add nonblocking exclusive flock on base_dir at runner startup — second runner using the same directory fails fast with a clear error instead of silently corrupting shared state (`status.json`, `proxy-registry.json`, overlay dirs, mitmproxy ports)
- Lock file stored in `~/.vm0-runner/locks/base-dir-{sha256}.lock`, consistent with existing `rootfs_lock`/`snapshot_lock` pattern
- Base dir path is canonicalized before hashing so equivalent paths (symlinks, `..`) produce the same lock

## Test plan

- [x] `cargo clippy -p runner --tests` — zero warnings
- [x] `cargo test -p runner` — 81 tests pass (2 new: `try_acquire_fails_when_held`, `try_acquire_succeeds_when_free`)
- [ ] E2E: start two runners with same `base_dir` — second should exit immediately with "cannot lock base_dir" error

Closes #3125

🤖 Generated with [Claude Code](https://claude.com/claude-code)