### PR TITLE
fix(runner): sort gc artifacts by last-used time instead of creation time

### DIFF
--- a/crates/runner/src/cmd/rootfs.rs
+++ b/crates/runner/src/cmd/rootfs.rs
@@ -56,6 +56,7 @@ pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
     if is_build_complete(&rootfs_paths).await? {
         tracing::info!("[OK] rootfs already built: {}", output_dir.display());
         tracing::info!("rootfs hash: {hash}");
+        crate::paths::touch_mtime(output_dir);
         return Ok(hash);
     }
 
@@ -66,6 +67,7 @@ pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
     if is_build_complete(&rootfs_paths).await? {
         tracing::info!("[OK] rootfs already built: {}", output_dir.display());
         tracing::info!("rootfs hash: {hash}");
+        crate::paths::touch_mtime(output_dir);
         return Ok(hash);
     }
 

--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -33,6 +33,7 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<SnapshotConfig> {
 
     if is_snapshot_complete(&output).await? {
         tracing::info!("[OK] snapshot already exists: {}", output_dir.display());
+        crate::paths::touch_mtime(&output_dir);
         return Ok(output.snapshot_config(&snapshot_hash).into());
     }
 
@@ -42,6 +43,7 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<SnapshotConfig> {
     // Re-check after acquiring lock — another process may have completed the build.
     if is_snapshot_complete(&output).await? {
         tracing::info!("[OK] snapshot already exists: {}", output_dir.display());
+        crate::paths::touch_mtime(&output_dir);
         return Ok(output.snapshot_config(&snapshot_hash).into());
     }
 

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -4,6 +4,19 @@ use sha2::{Digest, Sha256};
 
 use crate::error::{RunnerError, RunnerResult};
 
+/// Update a directory's mtime to now, so `runner gc` treats it as recently used.
+pub fn touch_mtime(dir: &Path) {
+    let Ok(f) = std::fs::File::open(dir) else {
+        tracing::debug!("touch_mtime: cannot open {}", dir.display());
+        return;
+    };
+    if let Err(e) =
+        f.set_times(std::fs::FileTimes::new().set_modified(std::time::SystemTime::now()))
+    {
+        tracing::debug!("touch_mtime: set_times failed for {}: {e}", dir.display());
+    }
+}
+
 /// Guest paths (must match rootfs layout).
 pub mod guest {
     pub const STORAGE_MANIFEST: &str = "/tmp/storage-manifest.json";


### PR DESCRIPTION
## Summary
- `runner gc --keep-latest N` was sorting artifacts by file mtime, but rootfs/snapshot files are read-only after creation, so mtime = creation time — a frequently-reused artifact with an old mtime gets evicted before a newer but unused one
- Add `touch_mtime` helper that updates a directory's mtime to now, called on every cache hit (rootfs/snapshot build) and every `runner start`
- Update `dir_stats` in gc to use the root directory mtime as the sole "last used" signal, removing the child-file mtime walk

## Test plan
- [x] `cargo clippy -p runner` passes
- [x] `cargo test -p runner` — all 100 tests pass
- [x] `gc_keep_latest_preserves_newest` test updated to set directory mtimes

🤖 Generated with [Claude Code](https://claude.com/claude-code)