### PR TITLE
perf(ci): deploy runner to all metal hosts in parallel

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -977,7 +977,6 @@ jobs:
         needs.prepare.outputs.crates-changed == 'true'
       )
     outputs:
-      runner-hosts: ${{ steps.host.outputs.hosts }}
       host-count: ${{ steps.host.outputs.host-count }}
       bin-dir: ${{ steps.host.outputs.bin-dir }}
       runner-dir: ${{ steps.host.outputs.runner-dir }}
@@ -1009,7 +1008,6 @@ jobs:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
         run: |
-          echo "hosts=${METAL_HOSTS}" >> "$GITHUB_OUTPUT"
           echo "bin-dir=~/.vm0-runner/bin/${JOB_REF}" >> "$GITHUB_OUTPUT"
           echo "runner-dir=~/.vm0-runner/runners/${JOB_REF}" >> "$GITHUB_OUTPUT"
           NUM_HOSTS=$(echo "$METAL_HOSTS" | tr ',' '\n' | grep -c .)
@@ -1025,7 +1023,7 @@ jobs:
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-          METAL_HOSTS: ${{ steps.host.outputs.hosts }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           BIN_DIR: ${{ steps.host.outputs.bin-dir }}
           RUNNER_DIR: ${{ steps.host.outputs.runner-dir }}
@@ -1117,7 +1115,7 @@ jobs:
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-          METAL_HOSTS: ${{ needs.deploy-runner-prepare.outputs.runner-hosts }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
           RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
@@ -1274,12 +1272,12 @@ jobs:
       always() &&
       contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&
       github.event_name != 'push' &&
-      needs.deploy-runner-prepare.outputs.runner-hosts != ''
+      needs.deploy-runner-prepare.outputs.bin-dir != ''
     steps:
       - name: Cleanup runner on all metal hosts
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
-          METAL_HOSTS: ${{ needs.deploy-runner-prepare.outputs.runner-hosts }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
           RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1111,6 +1111,7 @@ jobs:
           echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
           chmod 600 "$HOME/.ssh/runner.pem"
 
+      # Read METAL_HOSTS from secret directly — GitHub Actions masks secret values in job outputs
       - name: Rebuild config and start runner service on all hosts
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
@@ -1274,6 +1275,7 @@ jobs:
       github.event_name != 'push' &&
       needs.deploy-runner-prepare.outputs.bin-dir != ''
     steps:
+      # Read METAL_HOSTS from secret directly — GitHub Actions masks secret values in job outputs
       - name: Cleanup runner on all metal hosts
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1012,7 +1012,11 @@ jobs:
           echo "hosts=${METAL_HOSTS}" >> "$GITHUB_OUTPUT"
           echo "bin-dir=~/.vm0-runner/bin/${JOB_REF}" >> "$GITHUB_OUTPUT"
           echo "runner-dir=~/.vm0-runner/runners/${JOB_REF}" >> "$GITHUB_OUTPUT"
-          NUM_HOSTS=$(echo "$METAL_HOSTS" | tr ',' '\n' | wc -l)
+          NUM_HOSTS=$(echo "$METAL_HOSTS" | tr ',' '\n' | grep -c .)
+          if [ "$NUM_HOSTS" -lt 1 ]; then
+            echo "::error::AWS_METAL_RUNNER_HOSTS is empty"
+            exit 1
+          fi
           echo "host-count=${NUM_HOSTS}" >> "$GITHUB_OUTPUT"
           echo "Deploying to ${NUM_HOSTS} metal hosts"
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -958,7 +958,7 @@ jobs:
             echo "Cron simulator stopped"
           fi
 
-  # Deploy runner prepare: cross-compile, deploy to metal host, build rootfs/snapshot with mock URL
+  # Deploy runner prepare: cross-compile, deploy to all metal hosts, build rootfs/snapshot with mock URL
   # Runs in parallel with deploy-web since rootfs/snapshot don't need the preview URL
   # Skip on push to main - runner deployment is only needed for PRs
   deploy-runner-prepare:
@@ -977,7 +977,8 @@ jobs:
         needs.prepare.outputs.crates-changed == 'true'
       )
     outputs:
-      runner-host: ${{ steps.host.outputs.host }}
+      runner-hosts: ${{ steps.host.outputs.hosts }}
+      host-count: ${{ steps.host.outputs.host-count }}
       bin-dir: ${{ steps.host.outputs.bin-dir }}
       runner-dir: ${{ steps.host.outputs.runner-dir }}
     steps:
@@ -1002,62 +1003,80 @@ jobs:
           echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
           chmod 600 "$HOME/.ssh/runner.pem"
 
-      - name: Select metal host
+      - name: Resolve metal hosts
         id: host
         env:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
         run: |
-          NUM_HOSTS=$(echo "$METAL_HOSTS" | tr ',' '\n' | wc -l)
-          HASH=$(echo -n "$JOB_REF" | md5sum | cut -c1-8)
-          HOST_INDEX=$(( 0x$HASH % NUM_HOSTS ))
-          HOST=$(echo "$METAL_HOSTS" | tr ',' '\n' | sed -n "$((HOST_INDEX + 1))p")
-          echo "host=${HOST}" >> "$GITHUB_OUTPUT"
+          echo "hosts=${METAL_HOSTS}" >> "$GITHUB_OUTPUT"
           echo "bin-dir=~/.vm0-runner/bin/${JOB_REF}" >> "$GITHUB_OUTPUT"
           echo "runner-dir=~/.vm0-runner/runners/${JOB_REF}" >> "$GITHUB_OUTPUT"
-          echo "Selected metal host: ${HOST} (index ${HOST_INDEX}/${NUM_HOSTS})"
+          NUM_HOSTS=$(echo "$METAL_HOSTS" | tr ',' '\n' | wc -l)
+          echo "host-count=${NUM_HOSTS}" >> "$GITHUB_OUTPUT"
+          echo "Deploying to ${NUM_HOSTS} metal hosts"
 
-      - name: Deploy binaries and build rootfs/snapshot on metal host
+      - name: Deploy binaries and build rootfs/snapshot on all metal hosts
+        shell: bash
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-          HOST: ${{ steps.host.outputs.host }}
+          METAL_HOSTS: ${{ steps.host.outputs.hosts }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           BIN_DIR: ${{ steps.host.outputs.bin-dir }}
           RUNNER_DIR: ${{ steps.host.outputs.runner-dir }}
         run: |
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
-          REMOTE="${METAL_USER}@${HOST}"
           TARGET_DIR="crates/target/aarch64-unknown-linux-musl/release"
 
-          # Clean previous run artifacts and upload binaries
-          echo "=== Deploying binaries to ${HOST}:${BIN_DIR} ==="
-          ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} ${RUNNER_DIR} && mkdir -p ${BIN_DIR}"
-          for bin in runner guest-init guest-download guest-agent guest-mock-claude; do
-            scp $SSH_OPTS "${TARGET_DIR}/${bin}" "${REMOTE}:${BIN_DIR}/"
+          deploy_to_host() {
+            local HOST=$1
+            local REMOTE="${METAL_USER}@${HOST}"
+            echo "=== Deploying to ${HOST} ==="
+
+            # Clean previous run artifacts and upload binaries
+            ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} ${RUNNER_DIR} && mkdir -p ${BIN_DIR}"
+            for bin in runner guest-init guest-download guest-agent guest-mock-claude; do
+              scp $SSH_OPTS "${TARGET_DIR}/${bin}" "${REMOTE}:${BIN_DIR}/"
+            done
+
+            # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
+            ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner setup"
+
+            # Run build with mock URL to trigger rootfs+snapshot construction and caching
+            # --api-url does not affect rootfs/snapshot hash, only runner.yaml config
+            ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner build \
+              --name ${JOB_REF} \
+              --group vm0/development-${JOB_REF} \
+              --runner-dirname ${JOB_REF} \
+              --guest-init ${BIN_DIR}/guest-init \
+              --guest-download ${BIN_DIR}/guest-download \
+              --guest-agent ${BIN_DIR}/guest-agent \
+              --guest-mock-claude ${BIN_DIR}/guest-mock-claude \
+              --api-url http://localhost \
+              --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
+
+            # Clean up old rootfs/snapshots, keep the 3 most recent
+            ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner gc --keep-latest 3"
+            echo "=== Done deploying to ${HOST} ==="
+          }
+
+          PIDS=()
+          for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
+            deploy_to_host "$HOST" &
+            PIDS+=($!)
           done
 
-          # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
-          echo "=== Running setup ==="
-          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner setup"
-
-          # Run build with mock URL to trigger rootfs+snapshot construction and caching
-          # --api-url does not affect rootfs/snapshot hash, only runner.yaml config
-          echo "=== Running build (mock URL for caching) ==="
-          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner build \
-            --name ${JOB_REF} \
-            --group vm0/development-${JOB_REF} \
-            --runner-dirname ${JOB_REF} \
-            --guest-init ${BIN_DIR}/guest-init \
-            --guest-download ${BIN_DIR}/guest-download \
-            --guest-agent ${BIN_DIR}/guest-agent \
-            --guest-mock-claude ${BIN_DIR}/guest-mock-claude \
-            --api-url http://localhost \
-            --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
-
-          # Clean up old rootfs/snapshots, keep the 3 most recent
-          echo "=== Running gc ==="
-          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner gc --keep-latest 3"
+          FAILED=0
+          for PID in "${PIDS[@]}"; do
+            if ! wait "$PID"; then
+              FAILED=1
+            fi
+          done
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::One or more host deployments failed"
+            exit 1
+          fi
 
   # Deploy runner start: rebuild config with real preview URL and start service
   # Waits for both deploy-runner-prepare (binaries + rootfs/snapshot) and deploy-web (preview URL)
@@ -1084,11 +1103,11 @@ jobs:
           echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
           chmod 600 "$HOME/.ssh/runner.pem"
 
-      - name: Rebuild config and start runner service
+      - name: Rebuild config and start runner service on all hosts
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-          HOST: ${{ needs.deploy-runner-prepare.outputs.runner-host }}
+          METAL_HOSTS: ${{ needs.deploy-runner-prepare.outputs.runner-hosts }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
           RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
@@ -1096,28 +1115,49 @@ jobs:
           VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
-          REMOTE="${METAL_USER}@${HOST}"
 
-          # Re-run build with real preview URL (cache hit, only rewrites runner.yaml)
-          echo "=== Running build (real URL, cache hit) ==="
-          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner build \
-            --name ${JOB_REF} \
-            --group vm0/development-${JOB_REF} \
-            --runner-dirname ${JOB_REF} \
-            --guest-init ${BIN_DIR}/guest-init \
-            --guest-download ${BIN_DIR}/guest-download \
-            --guest-agent ${BIN_DIR}/guest-agent \
-            --guest-mock-claude ${BIN_DIR}/guest-mock-claude \
-            --api-url ${PREVIEW_URL} \
-            --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
+          start_on_host() {
+            local HOST=$1
+            local REMOTE="${METAL_USER}@${HOST}"
+            echo "=== Starting runner on ${HOST} ==="
 
-          # Start as systemd transient service
-          echo "=== Starting runner service ==="
-          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner service start \
-            --name ${JOB_REF} \
-            --config ${RUNNER_DIR}/runner.yaml \
-            --env VERCEL_AUTOMATION_BYPASS_SECRET=${VERCEL_BYPASS} \
-            --env USE_MOCK_CLAUDE=true"
+            # Re-run build with real preview URL (cache hit, only rewrites runner.yaml)
+            ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner build \
+              --name ${JOB_REF} \
+              --group vm0/development-${JOB_REF} \
+              --runner-dirname ${JOB_REF} \
+              --guest-init ${BIN_DIR}/guest-init \
+              --guest-download ${BIN_DIR}/guest-download \
+              --guest-agent ${BIN_DIR}/guest-agent \
+              --guest-mock-claude ${BIN_DIR}/guest-mock-claude \
+              --api-url ${PREVIEW_URL} \
+              --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
+
+            # Start as systemd transient service
+            ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner service start \
+              --name ${JOB_REF} \
+              --config ${RUNNER_DIR}/runner.yaml \
+              --env VERCEL_AUTOMATION_BYPASS_SECRET=${VERCEL_BYPASS} \
+              --env USE_MOCK_CLAUDE=true"
+            echo "=== Runner started on ${HOST} ==="
+          }
+
+          PIDS=()
+          for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
+            start_on_host "$HOST" &
+            PIDS+=($!)
+          done
+
+          FAILED=0
+          for PID in "${PIDS[@]}"; do
+            if ! wait "$PID"; then
+              FAILED=1
+            fi
+          done
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::One or more runner starts failed"
+            exit 1
+          fi
 
   # Run CLI E2E tests - Phase 3: Runner tests (needs runner deployed)
   # Skip on push to main - runner tests are only needed for PRs
@@ -1130,6 +1170,7 @@ jobs:
         prepare,
         cli-e2e-01-serial,
         deploy-web,
+        deploy-runner-prepare,
         deploy-runner-start,
       ]
     if: |
@@ -1187,8 +1228,9 @@ jobs:
 
       - name: Run Runner E2E Tests
         run: |
-          echo "=== Running Runner E2E Tests (4 parallel) ==="
-          BATS_TEST_TIMEOUT=60 RUNNER_GROUP="vm0/development-${JOB_REF}" ./e2e/test/libs/bats/bin/bats -T -j 4 --no-parallelize-within-files ./e2e/tests/03-experimental-runner/*.bats
+          PARALLEL=$(( HOST_COUNT * 4 ))
+          echo "=== Running Runner E2E Tests (${PARALLEL} parallel across ${HOST_COUNT} hosts) ==="
+          BATS_TEST_TIMEOUT=60 RUNNER_GROUP="vm0/development-${JOB_REF}" ./e2e/test/libs/bats/bin/bats -T -j "${PARALLEL}" --no-parallelize-within-files ./e2e/tests/03-experimental-runner/*.bats
           echo "✅ Runner tests passed"
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
@@ -1197,6 +1239,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+          HOST_COUNT: ${{ needs.deploy-runner-prepare.outputs.host-count }}
 
       - name: Stop Cron Simulator
         if: always()
@@ -1215,12 +1258,12 @@ jobs:
       always() &&
       contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&
       github.event_name != 'push' &&
-      needs.deploy-runner-prepare.outputs.runner-host != ''
+      needs.deploy-runner-prepare.outputs.runner-hosts != ''
     steps:
-      - name: Cleanup runner on metal host
+      - name: Cleanup runner on all metal hosts
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
-          HOST: ${{ needs.deploy-runner-prepare.outputs.runner-host }}
+          METAL_HOSTS: ${{ needs.deploy-runner-prepare.outputs.runner-hosts }}
           BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
           RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
@@ -1230,11 +1273,16 @@ jobs:
           echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
           chmod 600 "$HOME/.ssh/runner.pem"
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
-          REMOTE="${METAL_USER}@${HOST}"
 
-          echo "Cleaning up ${JOB_REF} on ${HOST}"
-          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner service stop --name ${JOB_REF}" || true
-          ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} ${RUNNER_DIR}" || true
+          for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
+            (
+              REMOTE="${METAL_USER}@${HOST}"
+              echo "Cleaning up ${JOB_REF} on ${HOST}"
+              ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner service stop --name ${JOB_REF}" || true
+              ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} ${RUNNER_DIR}" || true
+            ) &
+          done
+          wait
 
   # Build E2B templates (development account)
   # Uses repository-level E2B_API_KEY secret

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1065,20 +1065,26 @@ jobs:
             echo "=== Done deploying to ${HOST} ==="
           }
 
+          LOG_DIR=$(mktemp -d)
+          HOSTS=()
           PIDS=()
           for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
-            deploy_to_host "$HOST" &
+            deploy_to_host "$HOST" > "${LOG_DIR}/${HOST}.log" 2>&1 &
             PIDS+=($!)
+            HOSTS+=("$HOST")
           done
 
           FAILED=0
-          for PID in "${PIDS[@]}"; do
-            if ! wait "$PID"; then
+          for i in "${!PIDS[@]}"; do
+            if ! wait "${PIDS[$i]}"; then
               FAILED=1
+              echo "::error::Deployment failed on ${HOSTS[$i]}"
             fi
+            echo "=== ${HOSTS[$i]} ==="
+            cat "${LOG_DIR}/${HOSTS[$i]}.log"
           done
+          rm -rf "$LOG_DIR"
           if [ "$FAILED" -ne 0 ]; then
-            echo "::error::One or more host deployments failed"
             exit 1
           fi
 
@@ -1146,20 +1152,26 @@ jobs:
             echo "=== Runner started on ${HOST} ==="
           }
 
+          LOG_DIR=$(mktemp -d)
+          HOSTS=()
           PIDS=()
           for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
-            start_on_host "$HOST" &
+            start_on_host "$HOST" > "${LOG_DIR}/${HOST}.log" 2>&1 &
             PIDS+=($!)
+            HOSTS+=("$HOST")
           done
 
           FAILED=0
-          for PID in "${PIDS[@]}"; do
-            if ! wait "$PID"; then
+          for i in "${!PIDS[@]}"; do
+            if ! wait "${PIDS[$i]}"; then
               FAILED=1
+              echo "::error::Runner start failed on ${HOSTS[$i]}"
             fi
+            echo "=== ${HOSTS[$i]} ==="
+            cat "${LOG_DIR}/${HOSTS[$i]}.log"
           done
+          rm -rf "$LOG_DIR"
           if [ "$FAILED" -ne 0 ]; then
-            echo "::error::One or more runner starts failed"
             exit 1
           fi
 

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -68,4 +68,4 @@ if (
   program.parse();
 }
 // test comment Thu Feb  5 10:39:10 AM UTC 2026
-// test comment Thu Feb  5 10:39:48 AM UTC 2026
+// test comment Thu Feb 18 2026


### PR DESCRIPTION
## Summary

- **deploy-runner-prepare**: Remove hash-based single host selection. Deploy binaries and build rootfs/snapshot on all `AWS_METAL_RUNNER_HOSTS` concurrently using bash background processes (`&` + `wait`).
- **deploy-runner-start**: Start runner service on all hosts concurrently.
- **cleanup-runner**: Clean up all hosts concurrently.
- **cli-e2e-03-runner**: Scale bats parallelism to `host_count * 4` (4 per metal host).

All runners register to the same group `vm0/development-${JOB_REF}`, so the API distributes test jobs across all available runners automatically.

Closes #3133

## Test plan

- [ ] CI passes with `needs-runner-pipeline` label
- [ ] `deploy-runner-prepare` deploys to all hosts in parallel
- [ ] `cli-e2e-03-runner` runs with increased parallelism
- [ ] `cleanup-runner` cleans up all hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)