### PR TITLE
perf(ci): increase runner e2e parallelism to 5 per host

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1243,7 +1243,7 @@ jobs:
 
       - name: Run Runner E2E Tests
         run: |
-          PARALLEL=$(( HOST_COUNT * 4 ))
+          PARALLEL=$(( HOST_COUNT * 5 ))
           echo "=== Running Runner E2E Tests (${PARALLEL} parallel across ${HOST_COUNT} hosts) ==="
           BATS_TEST_TIMEOUT=60 RUNNER_GROUP="vm0/development-${JOB_REF}" ./e2e/test/libs/bats/bin/bats -T -j "${PARALLEL}" --no-parallelize-within-files ./e2e/tests/03-experimental-runner/*.bats
           echo "✅ Runner tests passed"

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -67,5 +67,4 @@ if (
 ) {
   program.parse();
 }
-// test comment Thu Feb  5 10:39:10 AM UTC 2026
-// test comment Thu Feb 18 2026
+// test comment Thu Feb 18 2026 v2


### PR DESCRIPTION
## Summary

- Increase bats test parallelism from `HOST_COUNT * 4` to `HOST_COUNT * 5`
- Each metal host has `max_concurrent: 4` sandbox slots, but the 5th test can queue while one finishes, reducing idle time between batches

## Test plan

- [ ] `cli-e2e-03-runner` completes faster than 4m47s (baseline with `* 4`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)