### PR TITLE
feat(runner): gc stale network log files older than 7 days

### DIFF
--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -253,7 +253,7 @@ async fn gc_network_logs(home: &HomePaths, dry_run: bool) -> RunnerResult<(u64, 
         let Some(name) = name.to_str() else { continue };
 
         // Only target network log files, not runner logs.
-        if !name.starts_with("network-") || !name.ends_with(".jsonl") {
+        if !crate::paths::LogPaths::is_network_log(name) {
             continue;
         }
 

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -593,9 +593,7 @@ mod tests {
     }
 
     fn test_home(root: &Path) -> HomePaths {
-        HomePaths {
-            root: root.to_path_buf(),
-        }
+        HomePaths::with_root(root.to_path_buf())
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -659,6 +659,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gc_network_logs_keeps_at_boundary() {
+        use std::fs::FileTimes;
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let logs_dir = home.logs_dir();
+        std::fs::create_dir_all(&logs_dir).unwrap();
+
+        // File just under 7 days old — should be kept (age <= MAX_AGE).
+        // Subtract 1 second less than max age to avoid race between set_times and check.
+        let boundary = logs_dir.join("network-11111111-1111-1111-1111-111111111111.jsonl");
+        std::fs::write(&boundary, r#"{"timestamp":"2026-02-11T00:00:00"}"#).unwrap();
+        let boundary_time = SystemTime::now() - NETWORK_LOG_MAX_AGE + Duration::from_secs(1);
+        std::fs::File::open(&boundary)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(boundary_time))
+            .unwrap();
+
+        let (removed, _) = gc_network_logs(&home, false).await.unwrap();
+        assert_eq!(removed, 0);
+        assert!(boundary.exists(), "file at max age should be kept");
+    }
+
+    #[tokio::test]
     async fn gc_network_logs_dry_run() {
         use std::fs::FileTimes;
         use std::time::Duration;

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -1,6 +1,6 @@
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use clap::Args;
 use nix::fcntl::{Flock, FlockArg};
@@ -8,6 +8,9 @@ use tracing::info;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
+
+/// Network log files older than this are eligible for GC.
+const NETWORK_LOG_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 3600);
 
 #[derive(Args)]
 pub struct GcArgs {
@@ -41,9 +44,10 @@ pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
     .await?;
 
     let locks_removed = gc_orphaned_locks(&home, args.dry_run).await?;
+    let (net_logs_removed, net_logs_freed) = gc_network_logs(&home, args.dry_run).await?;
 
-    let total = rootfs_freed + snapshot_freed;
-    if total == 0 && locks_removed == 0 {
+    let total = rootfs_freed + snapshot_freed + net_logs_freed;
+    if total == 0 && locks_removed == 0 && net_logs_removed == 0 {
         info!("nothing to clean up");
     } else if args.dry_run {
         info!("total: {} would be freed", human_bytes(total));
@@ -221,6 +225,75 @@ async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> RunnerResult<u64>
     }
 
     Ok(removed)
+}
+
+/// Delete stale network log files (older than [`NETWORK_LOG_MAX_AGE`]).
+///
+/// Network log files (`network-{run_id}.jsonl`) accumulate when upload fails or
+/// the runner crashes before cleanup. Returns `(files_removed, bytes_freed)`.
+async fn gc_network_logs(home: &HomePaths, dry_run: bool) -> RunnerResult<(u64, u64)> {
+    let logs_dir = home.logs_dir();
+    let mut entries = match tokio::fs::read_dir(&logs_dir).await {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok((0, 0)),
+        Err(e) => {
+            return Err(RunnerError::Internal(format!(
+                "read {}: {e}",
+                logs_dir.display()
+            )));
+        }
+    };
+
+    let now = SystemTime::now();
+    let mut removed = 0u64;
+    let mut freed = 0u64;
+
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+
+        // Only target network log files, not runner logs.
+        if !name.starts_with("network-") || !name.ends_with(".jsonl") {
+            continue;
+        }
+
+        let Ok(meta) = entry.metadata().await else {
+            continue;
+        };
+
+        let age = meta
+            .modified()
+            .ok()
+            .and_then(|mtime| now.duration_since(mtime).ok())
+            .unwrap_or_default();
+
+        if age <= NETWORK_LOG_MAX_AGE {
+            continue;
+        }
+
+        let size = meta.blocks() * 512;
+        if dry_run {
+            info!(
+                "[dry-run] would delete network log {name} ({})",
+                human_bytes(size)
+            );
+        } else {
+            match tokio::fs::remove_file(entry.path()).await {
+                Ok(()) => {
+                    info!("deleted network log {name} ({})", human_bytes(size));
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    tracing::debug!("cannot remove {}: {e}", entry.path().display());
+                    continue;
+                }
+            }
+        }
+        removed += 1;
+        freed += size;
+    }
+
+    Ok((removed, freed))
 }
 
 /// Compute total disk usage (st_blocks * 512) and last-used time for a directory.
@@ -517,5 +590,96 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(freed, 0);
+    }
+
+    fn test_home(root: &Path) -> HomePaths {
+        HomePaths {
+            root: root.to_path_buf(),
+        }
+    }
+
+    #[tokio::test]
+    async fn gc_network_logs_deletes_stale() {
+        use std::fs::FileTimes;
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let logs_dir = home.logs_dir();
+        std::fs::create_dir_all(&logs_dir).unwrap();
+
+        let old_file = logs_dir.join("network-550e8400-e29b-41d4-a716-446655440000.jsonl");
+        std::fs::write(&old_file, r#"{"timestamp":"2026-01-01T00:00:00"}"#).unwrap();
+        let old_time = SystemTime::now() - Duration::from_secs(8 * 24 * 3600);
+        std::fs::File::open(&old_file)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(old_time))
+            .unwrap();
+
+        let (removed, _freed) = gc_network_logs(&home, false).await.unwrap();
+        assert_eq!(removed, 1);
+        assert!(!old_file.exists());
+    }
+
+    #[tokio::test]
+    async fn gc_network_logs_keeps_recent() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let logs_dir = home.logs_dir();
+        std::fs::create_dir_all(&logs_dir).unwrap();
+
+        let recent = logs_dir.join("network-aabbccdd-1234-5678-9abc-def012345678.jsonl");
+        std::fs::write(&recent, r#"{"timestamp":"2026-02-18T00:00:00"}"#).unwrap();
+
+        let (removed, _) = gc_network_logs(&home, false).await.unwrap();
+        assert_eq!(removed, 0);
+        assert!(recent.exists());
+    }
+
+    #[tokio::test]
+    async fn gc_network_logs_ignores_runner_logs() {
+        use std::fs::FileTimes;
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let logs_dir = home.logs_dir();
+        std::fs::create_dir_all(&logs_dir).unwrap();
+
+        // Old runner log file — must NOT be deleted.
+        let runner_log = logs_dir.join("runner-default.2026-02-10.log");
+        std::fs::write(&runner_log, "log content").unwrap();
+        let old_time = SystemTime::now() - Duration::from_secs(30 * 24 * 3600);
+        std::fs::File::open(&runner_log)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(old_time))
+            .unwrap();
+
+        let (removed, _) = gc_network_logs(&home, false).await.unwrap();
+        assert_eq!(removed, 0);
+        assert!(runner_log.exists());
+    }
+
+    #[tokio::test]
+    async fn gc_network_logs_dry_run() {
+        use std::fs::FileTimes;
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let logs_dir = home.logs_dir();
+        std::fs::create_dir_all(&logs_dir).unwrap();
+
+        let old_file = logs_dir.join("network-00000000-0000-0000-0000-000000000001.jsonl");
+        std::fs::write(&old_file, r#"{"timestamp":"2026-01-01T00:00:00"}"#).unwrap();
+        let old_time = SystemTime::now() - Duration::from_secs(8 * 24 * 3600);
+        std::fs::File::open(&old_file)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(old_time))
+            .unwrap();
+
+        let (removed, _) = gc_network_logs(&home, true).await.unwrap();
+        assert_eq!(removed, 1);
+        assert!(old_file.exists(), "dry-run should not delete");
     }
 }

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -209,6 +209,11 @@ impl LogPaths {
     pub fn network_log(&self, run_id: uuid::Uuid) -> PathBuf {
         self.dir.join(format!("network-{run_id}.jsonl"))
     }
+
+    /// Whether `name` matches the `network-{run_id}.jsonl` pattern.
+    pub fn is_network_log(name: &str) -> bool {
+        name.starts_with("network-") && name.ends_with(".jsonl")
+    }
 }
 
 #[cfg(test)]

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -53,7 +53,7 @@ impl RunnerPaths {
 
 /// Paths rooted at ~/.vm0-runner/.
 pub struct HomePaths {
-    pub(crate) root: PathBuf,
+    root: PathBuf,
 }
 
 impl HomePaths {
@@ -63,6 +63,11 @@ impl HomePaths {
         Ok(Self {
             root: PathBuf::from(home).join(".vm0-runner"),
         })
+    }
+
+    #[cfg(test)]
+    pub fn with_root(root: PathBuf) -> Self {
+        Self { root }
     }
 
     pub fn bin_dir(&self) -> PathBuf {
@@ -221,9 +226,7 @@ mod tests {
     use super::*;
 
     fn home(root: &Path) -> HomePaths {
-        HomePaths {
-            root: root.to_path_buf(),
-        }
+        HomePaths::with_root(root.to_path_buf())
     }
 
     #[test]

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -53,7 +53,7 @@ impl RunnerPaths {
 
 /// Paths rooted at ~/.vm0-runner/.
 pub struct HomePaths {
-    root: PathBuf,
+    pub(crate) root: PathBuf,
 }
 
 impl HomePaths {


### PR DESCRIPTION
## Summary

- Add `gc_network_logs()` to `runner gc` that deletes `network-*.jsonl` files older than 7 days
- Network log files accumulate when upload fails or runner crashes before cleanup
- Only targets `network-*.jsonl` files, leaves runner log files untouched
- Supports `--dry-run` flag consistent with existing GC behavior

Closes #3136

## Test plan

- [x] Test: stale files (>7 days) are deleted
- [x] Test: recent files are preserved
- [x] Test: runner log files are not touched
- [x] Test: dry-run mode reports but does not delete
- [x] All 104 runner tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)