### PR TITLE
ci: split runner e2e tests into matrix by metal host count

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1023,24 +1023,37 @@ jobs:
         id: runner-matrix
         shell: bash
         run: |
-          # Round-robin distribute test files across metal hosts
+          # Split test files across metal hosts, balanced by test count
           NUM_CHUNKS=${{ steps.host.outputs.host-count }}
-          FILES=(e2e/tests/03-experimental-runner/*.bats)
-          echo "Runner E2E: ${#FILES[@]} files, $NUM_CHUNKS chunks (1 per metal host)"
+
+          # Count tests per file, sort heaviest first
+          mapfile -t SORTED < <(
+            for f in e2e/tests/03-experimental-runner/*.bats; do
+              echo "$(grep -c "^@test" "$f" 2>/dev/null || echo 0) $f"
+            done | sort -rn
+          )
+          echo "Runner E2E: ${#SORTED[@]} files, $NUM_CHUNKS chunks"
+
+          # Greedy bin-packing: assign each file to the lightest chunk
+          declare -a CHUNK_FILES CHUNK_COUNTS
+          for ((i=0; i<NUM_CHUNKS; i++)); do CHUNK_FILES[$i]=""; CHUNK_COUNTS[$i]=0; done
+          for entry in "${SORTED[@]}"; do
+            tests=${entry%% *}; f=${entry#* }
+            min=0
+            for ((i=1; i<NUM_CHUNKS; i++)); do
+              [ ${CHUNK_COUNTS[$i]} -lt ${CHUNK_COUNTS[$min]} ] && min=$i
+            done
+            CHUNK_FILES[$min]="${CHUNK_FILES[$min]:+${CHUNK_FILES[$min]} }$f"
+            CHUNK_COUNTS[$min]=$((CHUNK_COUNTS[$min] + tests))
+          done
 
           CHUNKS="["
           for ((i=0; i<NUM_CHUNKS; i++)); do
-            chunk_files=""
-            for ((j=i; j<${#FILES[@]}; j+=NUM_CHUNKS)); do
-              chunk_files="$chunk_files ${FILES[$j]}"
-            done
             [ $i -gt 0 ] && CHUNKS="$CHUNKS,"
-            CHUNKS="$CHUNKS{\"index\":$((i+1)),\"files\":\"${chunk_files# }\"}"
-            echo "Chunk $((i+1)): $(echo "${chunk_files# }" | wc -w) files"
+            CHUNKS="$CHUNKS{\"index\":$((i+1)),\"files\":\"${CHUNK_FILES[$i]}\"}"
+            echo "Chunk $((i+1)): ${CHUNK_COUNTS[$i]} tests"
           done
-          CHUNKS="$CHUNKS]"
-
-          echo "matrix=$CHUNKS" >> $GITHUB_OUTPUT
+          echo "matrix=${CHUNKS}]" >> $GITHUB_OUTPUT
 
       - name: Deploy binaries and build rootfs/snapshot on all metal hosts
         shell: bash

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1306,7 +1306,7 @@ jobs:
 
       - name: Run Runner E2E Tests (Chunk ${{ matrix.index }})
         run: |
-          PARALLEL=$(( HOST_COUNT * 5 ))
+          PARALLEL=5
           echo "=== Running Runner E2E Tests (Chunk ${{ matrix.index }}, ${PARALLEL} parallel) ==="
           echo "Files: ${{ matrix.files }}"
           BATS_TEST_TIMEOUT=60 RUNNER_GROUP="vm0/development-${JOB_REF}" ./e2e/test/libs/bats/bin/bats -T -j "${PARALLEL}" --no-parallelize-within-files ${{ matrix.files }}
@@ -1318,7 +1318,6 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-          HOST_COUNT: ${{ needs.deploy-runner-prepare.outputs.host-count }}
 
       - name: Stop Cron Simulator
         if: always()

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1023,60 +1023,20 @@ jobs:
         id: runner-matrix
         shell: bash
         run: |
-          # Split runner tests into NUM_HOSTS chunks (one per metal host)
+          # Round-robin distribute test files across metal hosts
           NUM_CHUNKS=${{ steps.host.outputs.host-count }}
-
-          declare -A FILE_TESTS
-          TOTAL_TESTS=0
-          for f in e2e/tests/03-experimental-runner/*.bats; do
-            count=$(grep -c "^@test" "$f" 2>/dev/null || echo 0)
-            FILE_TESTS["$f"]=$count
-            TOTAL_TESTS=$((TOTAL_TESTS + count))
-          done
-
-          mapfile -t SORTED_FILES < <(
-            for f in "${!FILE_TESTS[@]}"; do
-              echo "${FILE_TESTS[$f]} $f"
-            done | sort -rn | cut -d' ' -f2
-          )
-
-          echo "Runner E2E: ${#SORTED_FILES[@]} files, $TOTAL_TESTS tests, $NUM_CHUNKS chunks (1 per metal host)"
-
-          # Greedy load-balancing: assign heaviest file to lightest chunk
-          declare -a CHUNK_FILES
-          declare -a CHUNK_COUNTS
-          for ((i=0; i<NUM_CHUNKS; i++)); do
-            CHUNK_FILES[$i]=""
-            CHUNK_COUNTS[$i]=0
-          done
-
-          for f in "${SORTED_FILES[@]}"; do
-            tests=${FILE_TESTS[$f]}
-            min_chunk=0
-            min_count=${CHUNK_COUNTS[0]}
-            for ((i=1; i<NUM_CHUNKS; i++)); do
-              if [ ${CHUNK_COUNTS[$i]} -lt $min_count ]; then
-                min_chunk=$i
-                min_count=${CHUNK_COUNTS[$i]}
-              fi
-            done
-            if [ -n "${CHUNK_FILES[$min_chunk]}" ]; then
-              CHUNK_FILES[$min_chunk]="${CHUNK_FILES[$min_chunk]} $f"
-            else
-              CHUNK_FILES[$min_chunk]="$f"
-            fi
-            CHUNK_COUNTS[$min_chunk]=$((CHUNK_COUNTS[$min_chunk] + tests))
-          done
+          FILES=(e2e/tests/03-experimental-runner/*.bats)
+          echo "Runner E2E: ${#FILES[@]} files, $NUM_CHUNKS chunks (1 per metal host)"
 
           CHUNKS="["
           for ((i=0; i<NUM_CHUNKS; i++)); do
-            if [ $i -gt 0 ]; then
-              CHUNKS="$CHUNKS,"
-            fi
-            files="${CHUNK_FILES[$i]}"
-            file_count=$(echo "$files" | wc -w)
-            CHUNKS="$CHUNKS{\"index\":$((i+1)),\"files\":\"$files\"}"
-            echo "Chunk $((i+1)): $file_count files, ${CHUNK_COUNTS[$i]} tests"
+            chunk_files=""
+            for ((j=i; j<${#FILES[@]}; j+=NUM_CHUNKS)); do
+              chunk_files="$chunk_files ${FILES[$j]}"
+            done
+            [ $i -gt 0 ] && CHUNKS="$CHUNKS,"
+            CHUNKS="$CHUNKS{\"index\":$((i+1)),\"files\":\"${chunk_files# }\"}"
+            echo "Chunk $((i+1)): $(echo "${chunk_files# }" | wc -w) files"
           done
           CHUNKS="$CHUNKS]"
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -980,6 +980,7 @@ jobs:
       host-count: ${{ steps.host.outputs.host-count }}
       bin-dir: ${{ steps.host.outputs.bin-dir }}
       runner-dir: ${{ steps.host.outputs.runner-dir }}
+      runner-matrix: ${{ steps.runner-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
 
@@ -1017,6 +1018,69 @@ jobs:
           fi
           echo "host-count=${NUM_HOSTS}" >> "$GITHUB_OUTPUT"
           echo "Deploying to ${NUM_HOSTS} metal hosts"
+
+      - name: Generate runner E2E test matrix
+        id: runner-matrix
+        shell: bash
+        run: |
+          # Split runner tests into NUM_HOSTS chunks (one per metal host)
+          NUM_CHUNKS=${{ steps.host.outputs.host-count }}
+
+          declare -A FILE_TESTS
+          TOTAL_TESTS=0
+          for f in e2e/tests/03-experimental-runner/*.bats; do
+            count=$(grep -c "^@test" "$f" 2>/dev/null || echo 0)
+            FILE_TESTS["$f"]=$count
+            TOTAL_TESTS=$((TOTAL_TESTS + count))
+          done
+
+          mapfile -t SORTED_FILES < <(
+            for f in "${!FILE_TESTS[@]}"; do
+              echo "${FILE_TESTS[$f]} $f"
+            done | sort -rn | cut -d' ' -f2
+          )
+
+          echo "Runner E2E: ${#SORTED_FILES[@]} files, $TOTAL_TESTS tests, $NUM_CHUNKS chunks (1 per metal host)"
+
+          # Greedy load-balancing: assign heaviest file to lightest chunk
+          declare -a CHUNK_FILES
+          declare -a CHUNK_COUNTS
+          for ((i=0; i<NUM_CHUNKS; i++)); do
+            CHUNK_FILES[$i]=""
+            CHUNK_COUNTS[$i]=0
+          done
+
+          for f in "${SORTED_FILES[@]}"; do
+            tests=${FILE_TESTS[$f]}
+            min_chunk=0
+            min_count=${CHUNK_COUNTS[0]}
+            for ((i=1; i<NUM_CHUNKS; i++)); do
+              if [ ${CHUNK_COUNTS[$i]} -lt $min_count ]; then
+                min_chunk=$i
+                min_count=${CHUNK_COUNTS[$i]}
+              fi
+            done
+            if [ -n "${CHUNK_FILES[$min_chunk]}" ]; then
+              CHUNK_FILES[$min_chunk]="${CHUNK_FILES[$min_chunk]} $f"
+            else
+              CHUNK_FILES[$min_chunk]="$f"
+            fi
+            CHUNK_COUNTS[$min_chunk]=$((CHUNK_COUNTS[$min_chunk] + tests))
+          done
+
+          CHUNKS="["
+          for ((i=0; i<NUM_CHUNKS; i++)); do
+            if [ $i -gt 0 ]; then
+              CHUNKS="$CHUNKS,"
+            fi
+            files="${CHUNK_FILES[$i]}"
+            file_count=$(echo "$files" | wc -w)
+            CHUNKS="$CHUNKS{\"index\":$((i+1)),\"files\":\"$files\"}"
+            echo "Chunk $((i+1)): $file_count files, ${CHUNK_COUNTS[$i]} tests"
+          done
+          CHUNKS="$CHUNKS]"
+
+          echo "matrix=$CHUNKS" >> $GITHUB_OUTPUT
 
       - name: Deploy binaries and build rootfs/snapshot on all metal hosts
         shell: bash
@@ -1219,6 +1283,10 @@ jobs:
         needs.prepare.outputs.runner-changed == 'true' ||
         needs.prepare.outputs.crates-changed == 'true'
       )
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.deploy-runner-prepare.outputs.runner-matrix) }}
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v6
@@ -1263,12 +1331,13 @@ jobs:
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
-      - name: Run Runner E2E Tests
+      - name: Run Runner E2E Tests (Chunk ${{ matrix.index }})
         run: |
           PARALLEL=$(( HOST_COUNT * 5 ))
-          echo "=== Running Runner E2E Tests (${PARALLEL} parallel across ${HOST_COUNT} hosts) ==="
-          BATS_TEST_TIMEOUT=60 RUNNER_GROUP="vm0/development-${JOB_REF}" ./e2e/test/libs/bats/bin/bats -T -j "${PARALLEL}" --no-parallelize-within-files ./e2e/tests/03-experimental-runner/*.bats
-          echo "✅ Runner tests passed"
+          echo "=== Running Runner E2E Tests (Chunk ${{ matrix.index }}, ${PARALLEL} parallel) ==="
+          echo "Files: ${{ matrix.files }}"
+          BATS_TEST_TIMEOUT=60 RUNNER_GROUP="vm0/development-${JOB_REF}" ./e2e/test/libs/bats/bin/bats -T -j "${PARALLEL}" --no-parallelize-within-files ${{ matrix.files }}
+          echo "✅ Chunk ${{ matrix.index }} tests passed"
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -69,3 +69,4 @@ if (
 }
 // test comment Thu Feb 18 2026 v2
 // test comment Thu Feb 18 2026 v3
+// test comment Thu Feb 18 2026 v4


### PR DESCRIPTION
## Summary

- Split `cli-e2e-03-runner` tests into matrix jobs, one chunk per metal host
- Matrix generated in `deploy-runner-prepare` where host-count is already known
- Uses greedy load-balancing (heaviest-first bin-packing) to distribute test files evenly across chunks
- Each matrix job runs on a separate CI runner for true parallelism
- `cleanup-runner` unchanged — GitHub Actions `needs` on a matrix job waits for all instances

## How it works

1. `deploy-runner-prepare` counts metal hosts from `AWS_METAL_RUNNER_HOSTS` secret
2. New "Generate runner E2E test matrix" step splits 29 test files into N chunks (N = host count)
3. `cli-e2e-03-runner` uses `strategy.matrix.include` to spawn N parallel CI jobs
4. Each job runs its chunk of test files with `bats -j` parallelism

## Test plan

- [ ] Verify matrix generation logs show balanced chunk distribution
- [ ] Verify all matrix jobs run and pass
- [ ] Verify `cleanup-runner` waits for all matrix jobs before executing

🤖 Generated with [Claude Code](https://claude.com/claude-code)