### PR TITLE
test: sync t32-timezone and t33-optional-volume to runner e2e tests

### DIFF
--- a/e2e/tests/03-experimental-runner/t32-vm0-timezone.bats
+++ b/e2e/tests/03-experimental-runner/t32-vm0-timezone.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+
+# E2E tests for vm0 preference --timezone and TZ injection into sandbox
+#
+# These tests verify:
+# 1. The vm0 preference command can set user timezone preference
+# 2. The TZ environment variable is correctly injected into sandbox
+#
+# Test Structure:
+# - setup_file: Creates shared agent and volume ONCE for all tests
+# - teardown_file: Cleans up after all tests
+# - Each @test: Uses shared agent to verify timezone functionality
+
+load '../../helpers/setup'
+
+setup_file() {
+    local UNIQUE_ID="$(date +%s%3N)-$RANDOM"
+    local AGENT_NAME="timezone-e2e-${UNIQUE_ID}"
+    local VOLUME_NAME="tz-vol-${UNIQUE_ID}"
+    local TEST_DIR="$(mktemp -d)"
+
+    # Save state to persist across tests
+    echo "$UNIQUE_ID" > "$BATS_FILE_TMPDIR/unique_id"
+    echo "$AGENT_NAME" > "$BATS_FILE_TMPDIR/agent_name"
+    echo "$VOLUME_NAME" > "$BATS_FILE_TMPDIR/volume_name"
+    echo "$TEST_DIR" > "$BATS_FILE_TMPDIR/test_dir"
+
+    # Create volume for the agent
+    mkdir -p "$TEST_DIR/$VOLUME_NAME"
+    cd "$TEST_DIR/$VOLUME_NAME"
+    cat > CLAUDE.md << 'VOLEOF'
+Test volume for timezone E2E tests.
+VOLEOF
+    $CLI_COMMAND volume init --name "$VOLUME_NAME" >/dev/null
+    $CLI_COMMAND volume push >/dev/null
+    cd "$TEST_DIR"
+
+    # Create agent config
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  ${AGENT_NAME}:
+    description: "E2E timezone test agent"
+    framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
+    working_dir: /home/user/workspace
+    volumes:
+      - claude-files:/home/user/.claude
+
+volumes:
+  claude-files:
+    name: ${VOLUME_NAME}
+    version: latest
+EOF
+
+    $CLI_COMMAND compose vm0.yaml
+}
+
+teardown_file() {
+    local TEST_DIR=$(cat "$BATS_FILE_TMPDIR/test_dir" 2>/dev/null || true)
+
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
+}
+
+setup() {
+    # Load state from files
+    UNIQUE_ID=$(cat "$BATS_FILE_TMPDIR/unique_id")
+    AGENT_NAME=$(cat "$BATS_FILE_TMPDIR/agent_name")
+    VOLUME_NAME=$(cat "$BATS_FILE_TMPDIR/volume_name")
+    TEST_DIR=$(cat "$BATS_FILE_TMPDIR/test_dir")
+    cd "$TEST_DIR"
+}
+
+# ============================================================
+# vm0 preference --timezone command tests
+# ============================================================
+
+@test "vm0 preference --timezone sets user preference" {
+    run $CLI_COMMAND preference --timezone "Asia/Shanghai"
+    assert_success
+    assert_output --partial "Timezone set to"
+    assert_output --partial "Asia/Shanghai"
+}
+
+@test "vm0 preference shows current preferences" {
+    # Set a timezone first
+    $CLI_COMMAND preference --timezone "America/New_York" >/dev/null
+
+    run $CLI_COMMAND preference
+    assert_success
+    assert_output --partial "America/New_York"
+}
+
+@test "vm0 preference --timezone rejects invalid timezone" {
+    run $CLI_COMMAND preference --timezone "Invalid/Timezone"
+    assert_failure
+    assert_output --partial "Invalid timezone"
+}
+
+# ============================================================
+# TZ environment variable injection tests
+# ============================================================
+
+@test "sandbox receives TZ environment variable from user preference" {
+    # Set timezone preference
+    $CLI_COMMAND preference --timezone "Asia/Tokyo" >/dev/null
+
+    # Run agent and check TZ environment variable
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --verbose \
+        "echo TZ=\$TZ"
+    assert_success
+    assert_output --partial "TZ=Asia/Tokyo"
+}
+
+@test "explicit TZ in environment overrides user preference" {
+    # Set user timezone preference
+    $CLI_COMMAND preference --timezone "Asia/Shanghai" >/dev/null
+
+    # Create agent config with explicit TZ in environment
+    local OVERRIDE_AGENT_NAME="tz-override-${UNIQUE_ID}"
+    cat > "$TEST_DIR/vm0-tz-override.yaml" <<EOF
+version: "1.0"
+
+agents:
+  ${OVERRIDE_AGENT_NAME}:
+    description: "Agent with explicit TZ"
+    framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
+    working_dir: /home/user/workspace
+    environment:
+      TZ: "Europe/London"
+    volumes:
+      - claude-files:/home/user/.claude
+
+volumes:
+  claude-files:
+    name: ${VOLUME_NAME}
+    version: latest
+EOF
+
+    $CLI_COMMAND compose "$TEST_DIR/vm0-tz-override.yaml" >/dev/null
+
+    # Run agent - explicit TZ should take precedence
+    run $CLI_COMMAND run "$OVERRIDE_AGENT_NAME" \
+        --verbose \
+        "echo TZ=\$TZ"
+    assert_success
+    assert_output --partial "TZ=Europe/London"
+}

--- a/e2e/tests/03-experimental-runner/t33-vm0-optional-volume.bats
+++ b/e2e/tests/03-experimental-runner/t33-vm0-optional-volume.bats
@@ -1,0 +1,180 @@
+#!/usr/bin/env bats
+
+# Test VM0 optional volume functionality
+# This test verifies that volumes marked as optional: true can be missing at runtime
+# without causing run failures.
+
+load '../../helpers/setup'
+
+setup_file() {
+    # Unique agent name for this test file
+    export AGENT_NAME="e2e-t33-$(date +%s%3N)-$RANDOM"
+    # Create shared test directory for this file
+    export TEST_DIR="$(mktemp -d)"
+    export TEST_CONFIG="$TEST_DIR/vm0.yaml"
+
+    # Create a claude-files volume that exists (required for claude-code framework)
+    export CLAUDE_VOLUME_NAME="e2e-vol-t33-claude-$(date +%s%3N)-$RANDOM"
+    mkdir -p "$TEST_DIR/$CLAUDE_VOLUME_NAME"
+    cd "$TEST_DIR/$CLAUDE_VOLUME_NAME"
+    cat > CLAUDE.md << 'VOLEOF'
+This is a test file for the volume.
+VOLEOF
+    $CLI_COMMAND volume init --name "$CLAUDE_VOLUME_NAME" >/dev/null
+    $CLI_COMMAND volume push >/dev/null
+    cd - >/dev/null
+
+    # Unique name for the optional volume that will NOT exist
+    export OPTIONAL_VOLUME_NAME="e2e-vol-t33-optional-nonexistent-$(date +%s%3N)-$RANDOM"
+}
+
+teardown_file() {
+    # Clean up shared test directory
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
+}
+
+setup() {
+    # Per-test setup
+    export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
+    export ARTIFACT_NAME="e2e-art-optional-${UNIQUE_ID}"
+}
+
+@test "t33-1: compose succeeds with optional volume that does not exist" {
+    # Create config with optional volume that doesn't exist
+    cat > "$TEST_CONFIG" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_NAME}:
+    description: "Test agent with optional volume"
+    framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
+    volumes:
+      - optional-data:/home/user/optional-data
+      - claude-files:/home/user/.config/claude
+volumes:
+  optional-data:
+    name: $OPTIONAL_VOLUME_NAME
+    version: latest
+    optional: true
+  claude-files:
+    name: $CLAUDE_VOLUME_NAME
+    version: latest
+EOF
+
+    run $CLI_COMMAND compose "$TEST_CONFIG"
+    assert_success
+    assert_output --partial "$AGENT_NAME"
+}
+
+@test "t33-2: run succeeds when optional volume does not exist (skip silently)" {
+    # Ensure config is created with optional volume
+    cat > "$TEST_CONFIG" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_NAME}:
+    description: "Test agent with optional volume"
+    framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
+    volumes:
+      - optional-data:/home/user/optional-data
+      - claude-files:/home/user/.config/claude
+volumes:
+  optional-data:
+    name: $OPTIONAL_VOLUME_NAME
+    version: latest
+    optional: true
+  claude-files:
+    name: $CLAUDE_VOLUME_NAME
+    version: latest
+EOF
+
+    # Compose the agent
+    $CLI_COMMAND compose "$TEST_CONFIG" >/dev/null
+
+    # Create artifact (required for run)
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME" >/dev/null
+    echo "test" > marker.txt
+    run $CLI_COMMAND artifact push
+    assert_success
+    cd - >/dev/null
+
+    # Run agent - should succeed even though optional volume doesn't exist
+    # The optional volume mount point should simply not exist
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        --verbose \
+        "ls -la /home/user/optional-data 2>&1 || echo 'OPTIONAL_DIR_NOT_MOUNTED'"
+
+    assert_success
+    # The optional directory should not be mounted (volume doesn't exist)
+    assert_output --partial "OPTIONAL_DIR_NOT_MOUNTED"
+}
+
+@test "t33-3: run succeeds with mixed volumes (required exists, optional missing)" {
+    # Create a required volume that DOES exist
+    export REQUIRED_VOLUME_NAME="e2e-vol-t33-required-$(date +%s%3N)-$RANDOM"
+    mkdir -p "$TEST_DIR/$REQUIRED_VOLUME_NAME"
+    cd "$TEST_DIR/$REQUIRED_VOLUME_NAME"
+    echo "required-data-content" > required.txt
+    $CLI_COMMAND volume init --name "$REQUIRED_VOLUME_NAME" >/dev/null
+    $CLI_COMMAND volume push >/dev/null
+    cd - >/dev/null
+
+    # Create config with both required and optional volumes
+    cat > "$TEST_CONFIG" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_NAME}-mixed:
+    description: "Test agent with mixed volumes"
+    framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
+    volumes:
+      - required-data:/home/user/required-data
+      - optional-data:/home/user/optional-data
+      - claude-files:/home/user/.config/claude
+volumes:
+  required-data:
+    name: $REQUIRED_VOLUME_NAME
+    version: latest
+  optional-data:
+    name: $OPTIONAL_VOLUME_NAME
+    version: latest
+    optional: true
+  claude-files:
+    name: $CLAUDE_VOLUME_NAME
+    version: latest
+EOF
+
+    # Compose the agent
+    run $CLI_COMMAND compose "$TEST_CONFIG"
+    assert_success
+
+    # Create artifact
+    export ARTIFACT_NAME_MIXED="e2e-art-mixed-${UNIQUE_ID}"
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME_MIXED"
+    cd "$TEST_DIR/$ARTIFACT_NAME_MIXED"
+    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME_MIXED" >/dev/null
+    echo "test" > marker.txt
+    run $CLI_COMMAND artifact push
+    assert_success
+    cd - >/dev/null
+
+    # Run agent - should succeed with required volume mounted, optional skipped
+    run $CLI_COMMAND run "${AGENT_NAME}-mixed" \
+        --artifact-name "$ARTIFACT_NAME_MIXED" \
+        --verbose \
+        "cat /home/user/required-data/required.txt && (ls /home/user/optional-data 2>&1 || echo 'OPTIONAL_NOT_MOUNTED')"
+
+    assert_success
+    # Required volume should be mounted and readable
+    assert_output --partial "required-data-content"
+    # Optional volume should not be mounted
+    assert_output --partial "OPTIONAL_NOT_MOUNTED"
+}

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -72,3 +72,4 @@ if (
 // test comment Thu Feb 18 2026 v4
 // test comment Thu Feb 18 2026 v5
 // test comment Thu Feb 18 2026 v6
+// test comment Thu Feb 18 2026 v7


### PR DESCRIPTION
## Summary
- Copy `t32-vm0-timezone.bats` and `t33-vm0-optional-volume.bats` from `02-parallel` to `03-experimental-runner`
- Replace `image: "vm0/claude-code:dev"` with `experimental_runner: group: ${RUNNER_GROUP}` to match the runner test pattern
- After this change, all tests in `02-parallel` are present in `03-experimental-runner` (plus runner-specific `t40`/`t41` firewall tests)

## Test plan
- [ ] CI passes — new tests are included in runner e2e matrix via existing glob pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)