### PR TITLE
fix(e2e): make agent names unique to prevent compose config collisions

### DIFF
--- a/e2e/tests/02-parallel/t05-vm0-artifact-mount.bats
+++ b/e2e/tests/02-parallel/t05-vm0-artifact-mount.bats
@@ -8,8 +8,9 @@
 
 load '../../helpers/setup'
 
-# Unique agent name for this test file to avoid compose conflicts in parallel runs
-AGENT_NAME="e2e-t05"
+setup_file() {
+    export AGENT_NAME="e2e-t05-$(date +%s%3N)-$RANDOM"
+}
 
 setup() {
     # Create unique volume for this test

--- a/e2e/tests/02-parallel/t09-vm0-artifact-empty.bats
+++ b/e2e/tests/02-parallel/t09-vm0-artifact-empty.bats
@@ -11,8 +11,9 @@
 
 load '../../helpers/setup'
 
-# Unique agent name for this test file to avoid compose conflicts in parallel runs
-AGENT_NAME="e2e-t09"
+setup_file() {
+    export AGENT_NAME="e2e-t09-$(date +%s%3N)-$RANDOM"
+}
 
 setup() {
     # Create unique volume for this test

--- a/e2e/tests/02-parallel/t15-vm0-telemetry.bats
+++ b/e2e/tests/02-parallel/t15-vm0-telemetry.bats
@@ -10,8 +10,9 @@
 
 load '../../helpers/setup'
 
-# Unique agent name for this test file to avoid compose conflicts in parallel runs
-AGENT_NAME="e2e-t15"
+setup_file() {
+    export AGENT_NAME="e2e-t15-$(date +%s%3N)-$RANDOM"
+}
 
 setup() {
     # Create unique volume for this test

--- a/e2e/tests/02-parallel/t19-vm0-optional-artifact.bats
+++ b/e2e/tests/02-parallel/t19-vm0-optional-artifact.bats
@@ -11,8 +11,9 @@
 
 load '../../helpers/setup'
 
-# Unique agent name for this test file to avoid compose conflicts in parallel runs
-AGENT_NAME="e2e-t19"
+setup_file() {
+    export AGENT_NAME="e2e-t19-$(date +%s%3N)-$RANDOM"
+}
 
 setup() {
     # Create unique volume for this test

--- a/e2e/tests/02-parallel/t29-vm0-secret.bats
+++ b/e2e/tests/02-parallel/t29-vm0-secret.bats
@@ -98,7 +98,7 @@ teardown() {
     local unique_id="$(date +%s%3N)-$RANDOM"
     local secret_value="secret-${unique_id}"
     local artifact_name="e2e-secret-mask-${unique_id}"
-    local agent_name="e2e-secret-mask-agent"
+    local agent_name="e2e-secret-mask-${unique_id}"
     local test_artifact_dir="$(mktemp -d)"
     local test_config="$(mktemp --suffix=.yaml)"
 
@@ -167,7 +167,7 @@ EOF
     local secret1_value="secret1-${unique_id}"
     local secret2_value="secret2-${unique_id}"
     local artifact_name="e2e-secret-multi-${unique_id}"
-    local agent_name="e2e-secret-multi-agent"
+    local agent_name="e2e-secret-multi-${unique_id}"
     local test_artifact_dir="$(mktemp -d)"
     local test_config="$(mktemp --suffix=.yaml)"
 

--- a/e2e/tests/02-parallel/t30-vm0-realtime-streaming.bats
+++ b/e2e/tests/02-parallel/t30-vm0-realtime-streaming.bats
@@ -10,8 +10,9 @@
 
 load '../../helpers/setup'
 
-# Unique agent name for this test file
-AGENT_NAME="e2e-t30-realtime"
+setup_file() {
+    export AGENT_NAME="e2e-t30-realtime-$(date +%s%3N)-$RANDOM"
+}
 
 setup() {
     # Create unique volume for this test

--- a/e2e/tests/02-parallel/t31-vm0-variable.bats
+++ b/e2e/tests/02-parallel/t31-vm0-variable.bats
@@ -101,7 +101,7 @@ teardown() {
     local unique_id="$(date +%s%3N)-$RANDOM"
     local var_value="var-value-${unique_id}"
     local artifact_name="e2e-var-expand-${unique_id}"
-    local agent_name="e2e-var-expand-agent"
+    local agent_name="e2e-var-expand-${unique_id}"
     local test_artifact_dir="$(mktemp -d)"
     local test_config="$(mktemp --suffix=.yaml)"
 
@@ -171,7 +171,7 @@ EOF
     local server_value="server-value-${unique_id}"
     local cli_value="cli-value-${unique_id}"
     local artifact_name="e2e-var-override-${unique_id}"
-    local agent_name="e2e-var-override-agent"
+    local agent_name="e2e-var-override-${unique_id}"
     local test_artifact_dir="$(mktemp -d)"
     local test_config="$(mktemp --suffix=.yaml)"
 

--- a/e2e/tests/03-experimental-runner/t05-vm0-artifact-mount.bats
+++ b/e2e/tests/03-experimental-runner/t05-vm0-artifact-mount.bats
@@ -8,8 +8,9 @@
 
 load '../../helpers/setup'
 
-# Unique agent name for this test file to avoid compose conflicts in parallel runs
-AGENT_NAME="e2e-t05"
+setup_file() {
+    export AGENT_NAME="e2e-t05-$(date +%s%3N)-$RANDOM"
+}
 
 setup() {
     # Create unique volume for this test

--- a/e2e/tests/03-experimental-runner/t09-vm0-artifact-empty.bats
+++ b/e2e/tests/03-experimental-runner/t09-vm0-artifact-empty.bats
@@ -11,8 +11,9 @@
 
 load '../../helpers/setup'
 
-# Unique agent name for this test file to avoid compose conflicts in parallel runs
-AGENT_NAME="e2e-t09"
+setup_file() {
+    export AGENT_NAME="e2e-t09-$(date +%s%3N)-$RANDOM"
+}
 
 setup() {
     # Create unique volume for this test

--- a/e2e/tests/03-experimental-runner/t15-vm0-telemetry.bats
+++ b/e2e/tests/03-experimental-runner/t15-vm0-telemetry.bats
@@ -10,8 +10,9 @@
 
 load '../../helpers/setup'
 
-# Unique agent name for this test file to avoid compose conflicts in parallel runs
-AGENT_NAME="e2e-t15"
+setup_file() {
+    export AGENT_NAME="e2e-t15-$(date +%s%3N)-$RANDOM"
+}
 
 setup() {
     # Create unique volume for this test

--- a/e2e/tests/03-experimental-runner/t19-vm0-optional-artifact.bats
+++ b/e2e/tests/03-experimental-runner/t19-vm0-optional-artifact.bats
@@ -11,8 +11,9 @@
 
 load '../../helpers/setup'
 
-# Unique agent name for this test file to avoid compose conflicts in parallel runs
-AGENT_NAME="e2e-t19"
+setup_file() {
+    export AGENT_NAME="e2e-t19-$(date +%s%3N)-$RANDOM"
+}
 
 setup() {
     # Create unique volume for this test

--- a/e2e/tests/03-experimental-runner/t29-vm0-secret.bats
+++ b/e2e/tests/03-experimental-runner/t29-vm0-secret.bats
@@ -98,7 +98,7 @@ teardown() {
     local unique_id="$(date +%s%3N)-$RANDOM"
     local secret_value="secret-${unique_id}"
     local artifact_name="e2e-secret-mask-${unique_id}"
-    local agent_name="e2e-secret-mask-agent"
+    local agent_name="e2e-secret-mask-${unique_id}"
     local test_artifact_dir="$(mktemp -d)"
     local test_config="$(mktemp --suffix=.yaml)"
 
@@ -168,7 +168,7 @@ EOF
     local secret1_value="secret1-${unique_id}"
     local secret2_value="secret2-${unique_id}"
     local artifact_name="e2e-secret-multi-${unique_id}"
-    local agent_name="e2e-secret-multi-agent"
+    local agent_name="e2e-secret-multi-${unique_id}"
     local test_artifact_dir="$(mktemp -d)"
     local test_config="$(mktemp --suffix=.yaml)"
 

--- a/e2e/tests/03-experimental-runner/t30-vm0-realtime-streaming.bats
+++ b/e2e/tests/03-experimental-runner/t30-vm0-realtime-streaming.bats
@@ -10,8 +10,9 @@
 
 load '../../helpers/setup'
 
-# Unique agent name for this test file
-AGENT_NAME="e2e-t30-realtime"
+setup_file() {
+    export AGENT_NAME="e2e-t30-realtime-$(date +%s%3N)-$RANDOM"
+}
 
 setup() {
     # Create unique volume for this test

--- a/e2e/tests/03-experimental-runner/t31-vm0-variable.bats
+++ b/e2e/tests/03-experimental-runner/t31-vm0-variable.bats
@@ -101,7 +101,7 @@ teardown() {
     local unique_id="$(date +%s%3N)-$RANDOM"
     local var_value="var-value-${unique_id}"
     local artifact_name="e2e-var-expand-${unique_id}"
-    local agent_name="e2e-var-expand-agent"
+    local agent_name="e2e-var-expand-${unique_id}"
     local test_artifact_dir="$(mktemp -d)"
     local test_config="$(mktemp --suffix=.yaml)"
 
@@ -172,7 +172,7 @@ EOF
     local server_value="server-value-${unique_id}"
     local cli_value="cli-value-${unique_id}"
     local artifact_name="e2e-var-override-${unique_id}"
-    local agent_name="e2e-var-override-agent"
+    local agent_name="e2e-var-override-${unique_id}"
     local test_artifact_dir="$(mktemp -d)"
     local test_config="$(mktemp --suffix=.yaml)"
 

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -70,3 +70,4 @@ if (
 // test comment Thu Feb 18 2026 v2
 // test comment Thu Feb 18 2026 v3
 // test comment Thu Feb 18 2026 v4
+// test comment Thu Feb 18 2026 v5


### PR DESCRIPTION
## Summary
- Hardcoded agent names in E2E tests caused flaky failures when parallel tests or concurrent CI runs overwrote each other's compose configs (compose is keyed by `(scopeId, name)`)
- Add timestamp/random suffixes to all 7 affected test files in both `02-parallel` and `03-experimental-runner`
- Files changed: t05, t09, t15, t19, t29, t30-realtime, t31

## Root cause
Variable/secret expansion happens at **run time**, not compose time. When two parallel tests use the same agent name, the second `vm0 compose` overwrites the first's config, so the first test's `vm0 run` picks up the wrong values.

## Test plan
- [ ] CI e2e-02 parallel tests pass
- [ ] CI e2e-03 runner tests pass (if `needs-runner-pipeline` label added)

Closes #3144

🤖 Generated with [Claude Code](https://claude.com/claude-code)