### PR TITLE
ci: run e2e-03-runner after e2e-02-parallel completes

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1255,11 +1255,14 @@ jobs:
       [
         prepare,
         cli-e2e-01-serial,
+        cli-e2e-02-parallel,
         deploy-web,
         deploy-runner-prepare,
         deploy-runner-start,
       ]
     if: |
+      always() &&
+      (needs.cli-e2e-02-parallel.result == 'success' || needs.cli-e2e-02-parallel.result == 'skipped') &&
       contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&
       github.event_name != 'push' &&
       needs.prepare.outputs.job-ref != '' && (

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -74,3 +74,4 @@ if (
 // test comment Thu Feb 18 2026 v6
 // test comment Thu Feb 18 2026 v7
 // test comment Thu Feb 18 2026 v8
+// test comment Thu Feb 19 2026 v9


### PR DESCRIPTION
## Summary
- Make `cli-e2e-03-runner` wait for `cli-e2e-02-parallel` to complete before starting
- Prevents shared user-level state races (e.g., `vm0 preference --timezone` is global)
- Uses `always()` with result check so 03 still runs when 02 is skipped (no label)

## Test plan
- [ ] CI passes with `needs-runner-pipeline` label (both 02 and 03 run sequentially)
- [ ] CI passes without label (02 runs, 03 is skipped as usual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)