### PR TITLE
fix(runner): walk ppid chain for orphan detection

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -27,7 +27,6 @@ struct RunnerReport {
     pid: u32,
     config_path: PathBuf,
     subcommand: String,
-    config: Option<RunnerConfig>,
     service_type: ServiceType,
     status: Option<StatusInfo>,
     api_ok: Option<bool>,
@@ -169,7 +168,6 @@ async fn build_runner_report(
         pid: runner.pid,
         config_path: runner.config_path.clone(),
         subcommand: runner.subcommand.clone(),
-        config,
         service_type,
         status,
         api_ok,
@@ -389,44 +387,18 @@ async fn detect_global_orphans(
 ) -> Vec<String> {
     let mut warnings = Vec::new();
 
-    // Collect all runner PIDs and base_dirs
     let runner_pids: Vec<u32> = reports.iter().map(|r| r.pid).collect();
-    let runner_base_dirs: Vec<PathBuf> = reports
-        .iter()
-        .filter_map(|r| r.config.as_ref().map(|c| c.base_dir.clone()))
-        .collect();
 
     // Orphan firecracker processes
     for fc in fc_procs {
-        if is_reparented(fc.ppid, &runner_pids) {
-            // ppid known but not a runner → true orphan
+        if process::is_orphan(fc.pid, &runner_pids).await {
             warnings.push(format!(
                 "orphan firecracker PID {} (run {}, ppid={})",
                 fc.pid,
                 fc.run_id,
                 fc.ppid.map_or("?".into(), |p| p.to_string()),
             ));
-        } else if fc.ppid.is_none() {
-            // ppid unknown → fallback to base_dir check
-            match &fc.base_dir {
-                Some(bd) if !runner_base_dirs.contains(bd) => {
-                    warnings.push(format!(
-                        "orphan firecracker PID {} (run {}, base_dir {})",
-                        fc.pid,
-                        fc.run_id,
-                        bd.display()
-                    ));
-                }
-                None => {
-                    warnings.push(format!(
-                        "firecracker PID {} (run {}): cannot determine owner",
-                        fc.pid, fc.run_id
-                    ));
-                }
-                _ => {}
-            }
         }
-        // else: ppid matches a runner → not orphan, skip
     }
 
     // Orphan mitmproxy processes.
@@ -441,38 +413,20 @@ async fn detect_global_orphans(
         if claimed_ports.contains(&mitm.port) {
             continue;
         }
-        if is_reparented(mitm.ppid, &runner_pids) {
+        if process::is_orphan(mitm.pid, &runner_pids).await {
             warnings.push(format!(
                 "orphan mitmdump PID {} (port {}, ppid={})",
                 mitm.pid,
                 mitm.port,
                 mitm.ppid.map_or("?".into(), |p| p.to_string()),
             ));
-        } else if mitm.ppid.is_none() {
-            warnings.push(format!(
-                "orphan mitmdump PID {} (port {})",
-                mitm.pid, mitm.port
-            ));
         }
-        // else: ppid matches a runner → not orphan, skip
     }
 
     // Orphan network namespaces
     warnings.extend(detect_orphan_namespaces().await);
 
     warnings
-}
-
-/// A child process is "reparented" if its ppid is not any known runner PID.
-///
-/// This happens when the parent runner crashes — the kernel reparents the child
-/// to PID 1 (init/systemd). We also treat ppid=None (unreadable) as not
-/// reparented to avoid false positives.
-fn is_reparented(ppid: Option<u32>, runner_pids: &[u32]) -> bool {
-    match ppid {
-        Some(p) => !runner_pids.contains(&p),
-        None => false, // can't read ppid → don't flag
-    }
 }
 
 /// List `vm0-ns-*` namespaces and check if their pool locks are held.
@@ -823,7 +777,6 @@ mod tests {
             pid: 1,
             config_path: PathBuf::from("/data/active.yaml"),
             subcommand: "start".into(),
-            config: None,
             service_type: ServiceType::Installed("vm0-runner-active".into()),
             status: None,
             api_ok: None,
@@ -834,31 +787,5 @@ mod tests {
         let stopped = find_stopped_services(&installed, &reports);
         assert_eq!(stopped.len(), 1);
         assert_eq!(stopped.first().unwrap().unit_name, "vm0-runner-stopped");
-    }
-
-    #[test]
-    fn is_reparented_ppid_1() {
-        let runner_pids = vec![100, 200];
-        assert!(is_reparented(Some(1), &runner_pids));
-    }
-
-    #[test]
-    fn is_reparented_ppid_matches_runner() {
-        let runner_pids = vec![100, 200];
-        assert!(!is_reparented(Some(100), &runner_pids));
-    }
-
-    #[test]
-    fn is_reparented_ppid_unknown() {
-        let runner_pids = vec![100];
-        // Can't read ppid → don't flag as orphan
-        assert!(!is_reparented(None, &runner_pids));
-    }
-
-    #[test]
-    fn is_reparented_ppid_other_process() {
-        let runner_pids = vec![100];
-        // ppid is some other process, not a runner
-        assert!(is_reparented(Some(999), &runner_pids));
     }
 }

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -253,6 +253,38 @@ pub async fn discover_all() -> DiscoveredProcesses {
 }
 
 // ---------------------------------------------------------------------------
+// Orphan detection
+// ---------------------------------------------------------------------------
+
+/// Walk the ppid chain from `pid` upward to determine if it's an orphan.
+///
+/// Firecracker is not a direct child of the runner — the spawn chain is
+/// `runner → sudo → ip netns exec → sudo -u → firecracker`, so checking
+/// only the immediate ppid is insufficient. This function walks up the
+/// process tree until it either finds a runner PID (not orphan) or reaches
+/// PID 1 / init (orphan).
+///
+/// Returns `false` (not orphan) when the ppid chain cannot be read, to
+/// avoid false positives.
+pub async fn is_orphan(pid: u32, runner_pids: &[u32]) -> bool {
+    let mut current = pid;
+    // Max depth prevents infinite loops from circular pid references.
+    for _ in 0..16 {
+        let Some(ppid) = read_ppid(current).await else {
+            return false; // can't read → don't flag
+        };
+        if runner_pids.contains(&ppid) {
+            return false;
+        }
+        if ppid <= 1 {
+            return true; // reached init → orphaned
+        }
+        current = ppid;
+    }
+    false // max depth reached → don't flag
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Firecracker is spawned via `runner → sudo → ip netns exec → sudo -u → firecracker`, so the immediate ppid never matches the runner PID
- The old `is_reparented(ppid)` check would flag **all** sandboxes as orphans, causing `runner doctor` to report false positives
- Replace with `is_orphan(pid)` that walks up the process tree (max 16 levels) until it finds a runner ancestor (not orphan) or reaches PID 1 (orphan)
- Clean up now-unused `config` field and `runner_base_dirs` from `RunnerReport` in doctor.rs

## Test plan

- [x] `cargo clippy -p runner` passes
- [x] `cargo test -p runner` — 134 tests pass
- [ ] Deploy to dev-2 and verify `runner doctor` no longer reports false orphans

🤖 Generated with [Claude Code](https://claude.com/claude-code)