### PR TITLE
refactor(runner): extract config generation into standalone `runner config` command

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -172,16 +172,24 @@ jobs:
           echo "=== Running setup ==="
           ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner setup"
 
-          # Run build (rootfs via Docker + snapshot via Firecracker, generates runner.yaml)
+          # Run build (rootfs via Docker + snapshot via Firecracker)
           echo "=== Running build ==="
-          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner build \
-            --name ${JOB_REF} \
-            --group vm0/development-${JOB_REF} \
-            --runner-dirname ${JOB_REF} \
+          BUILD_OUTPUT=$(ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner build \
             --guest-init ${BIN_DIR}/guest-init \
             --guest-download ${BIN_DIR}/guest-download \
             --guest-agent ${BIN_DIR}/guest-agent \
-            --guest-mock-claude ${BIN_DIR}/guest-mock-claude \
+            --guest-mock-claude ${BIN_DIR}/guest-mock-claude")
+          ROOTFS_HASH=$(echo "$BUILD_OUTPUT" | grep '^rootfs_hash=' | cut -d= -f2)
+          SNAPSHOT_HASH=$(echo "$BUILD_OUTPUT" | grep '^snapshot_hash=' | cut -d= -f2)
+
+          # Generate runner.yaml config
+          echo "=== Generating config ==="
+          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner config \
+            --rootfs-hash ${ROOTFS_HASH} \
+            --snapshot-hash ${SNAPSHOT_HASH} \
+            --name ${JOB_REF} \
+            --group vm0/development-${JOB_REF} \
+            --runner-dirname ${JOB_REF} \
             --api-url https://localhost \
             --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -987,6 +987,8 @@ jobs:
       bin-dir: ${{ steps.host.outputs.bin-dir }}
       runner-dir: ${{ steps.host.outputs.runner-dir }}
       runner-matrix: ${{ steps.runner-matrix.outputs.matrix }}
+      rootfs-hash: ${{ steps.deploy.outputs.rootfs-hash }}
+      snapshot-hash: ${{ steps.deploy.outputs.snapshot-hash }}
     steps:
       - uses: actions/checkout@v6
 
@@ -1062,6 +1064,7 @@ jobs:
           echo "matrix=${CHUNKS}]" >> $GITHUB_OUTPUT
 
       - name: Deploy binaries and build rootfs/snapshot on all metal hosts
+        id: deploy
         shell: bash
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
@@ -1090,21 +1093,14 @@ jobs:
             # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
             ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner setup"
 
-            # Run build with mock URL to trigger rootfs+snapshot construction and caching
-            # --api-url does not affect rootfs/snapshot hash, only runner.yaml config
+            # Run build to create rootfs + snapshot (outputs hashes to stdout)
             ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner build \
-              --name ${RUNNER_NAME} \
-              --group vm0/development-${JOB_REF} \
-              --runner-dirname ${JOB_REF} \
               --guest-init ${BIN_DIR}/guest-init \
               --guest-download ${BIN_DIR}/guest-download \
               --guest-agent ${BIN_DIR}/guest-agent \
               --guest-mock-claude ${BIN_DIR}/guest-mock-claude \
               --vcpu ${RUNNER_VCPU} \
-              --memory-mb ${RUNNER_MEMORY_MB} \
-              --max-concurrent ${RUNNER_MAX_CONCURRENT} \
-              --api-url http://localhost \
-              --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
+              --memory-mb ${RUNNER_MEMORY_MB}"
 
             # Clean up old rootfs/snapshots, keep the 3 most recent
             ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner gc --keep-latest 3"
@@ -1131,14 +1127,21 @@ jobs:
             echo "=== ${HOSTS[$i]} ==="
             cat "${LOG_DIR}/${HOSTS[$i]}.log"
           done
-          rm -rf "$LOG_DIR"
           if [ "$FAILED" -ne 0 ]; then
+            rm -rf "$LOG_DIR"
             exit 1
           fi
 
-  # Deploy runner start: rebuild config with real preview URL and start service
+          # Extract build hashes from any host's log (all hosts produce identical hashes)
+          FIRST_LOG=$(ls ${LOG_DIR}/*.log | head -1)
+          ROOTFS_HASH=$(grep '^rootfs_hash=' "$FIRST_LOG" | cut -d= -f2)
+          SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$FIRST_LOG" | cut -d= -f2)
+          rm -rf "$LOG_DIR"
+          echo "rootfs-hash=${ROOTFS_HASH}" >> "$GITHUB_OUTPUT"
+          echo "snapshot-hash=${SNAPSHOT_HASH}" >> "$GITHUB_OUTPUT"
+
+  # Deploy runner start: generate config with real preview URL and start service
   # Waits for both deploy-runner-prepare (binaries + rootfs/snapshot) and deploy-web (preview URL)
-  # The second `runner build` is a cache hit — only rewrites runner.yaml (~100ms)
   deploy-runner-start:
     runs-on: ubuntu-latest
     needs: [prepare, deploy-runner-prepare, deploy-web]
@@ -1170,6 +1173,8 @@ jobs:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
           RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
+          ROOTFS_HASH: ${{ needs.deploy-runner-prepare.outputs.rootfs-hash }}
+          SNAPSHOT_HASH: ${{ needs.deploy-runner-prepare.outputs.snapshot-hash }}
           PREVIEW_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
@@ -1182,15 +1187,13 @@ jobs:
             local REMOTE="${METAL_USER}@${HOST}"
             echo "=== Starting runner ${RUNNER_NAME} on ${HOST} ==="
 
-            # Re-run build with real preview URL (cache hit, only rewrites runner.yaml)
-            ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner build \
+            # Generate runner.yaml with real preview URL (no build needed, uses cached hashes)
+            ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner config \
+              --rootfs-hash ${ROOTFS_HASH} \
+              --snapshot-hash ${SNAPSHOT_HASH} \
               --name ${RUNNER_NAME} \
               --group vm0/development-${JOB_REF} \
               --runner-dirname ${JOB_REF} \
-              --guest-init ${BIN_DIR}/guest-init \
-              --guest-download ${BIN_DIR}/guest-download \
-              --guest-agent ${BIN_DIR}/guest-agent \
-              --guest-mock-claude ${BIN_DIR}/guest-mock-claude \
               --vcpu ${RUNNER_VCPU} \
               --memory-mb ${RUNNER_MEMORY_MB} \
               --max-concurrent ${RUNNER_MAX_CONCURRENT} \

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -2,26 +2,11 @@ use clap::Args;
 
 use super::rootfs::RootfsArgs;
 use super::snapshot::SnapshotArgs;
-use crate::config::{
-    self, DEFAULT_MAX_CONCURRENT, DEFAULT_MEMORY_MB, DEFAULT_VCPU, FirecrackerConfig, RunnerConfig,
-    SandboxConfig, ServerConfig,
-};
-use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
+use crate::config::{DEFAULT_MEMORY_MB, DEFAULT_VCPU};
 use crate::error::RunnerResult;
-use crate::paths::{HomePaths, RootfsPaths};
 
 #[derive(Args)]
 pub struct BuildArgs {
-    /// Runner logical name
-    #[arg(long)]
-    name: String,
-    /// Runner group in scope/name format (e.g. "acme/production")
-    #[arg(long)]
-    group: String,
-    /// Runner directory name (under ~/.vm0-runner/runners/)
-    #[arg(long)]
-    runner_dirname: String,
-
     #[command(flatten)]
     rootfs: RootfsArgs,
     /// Number of vCPUs for the snapshot VM
@@ -30,58 +15,19 @@ pub struct BuildArgs {
     /// Memory size in MiB for the snapshot VM
     #[arg(long, default_value_t = DEFAULT_MEMORY_MB)]
     memory_mb: u32,
-
-    /// Maximum concurrent job executions
-    #[arg(long, default_value_t = DEFAULT_MAX_CONCURRENT)]
-    max_concurrent: usize,
-
-    /// vm0 API URL
-    #[arg(long, env = "VM0_API_URL")]
-    api_url: String,
-    /// Runner authentication token
-    #[arg(long, env = "VM0_RUNNER_TOKEN")]
-    token: String,
 }
 
 pub async fn run_build(args: BuildArgs) -> RunnerResult<()> {
     let rootfs_hash = super::rootfs::run_rootfs(args.rootfs).await?;
-    let snapshot_paths = super::snapshot::run_snapshot(SnapshotArgs {
+    let (snapshot_hash, _snapshot_config) = super::snapshot::run_snapshot(SnapshotArgs {
         rootfs_hash: rootfs_hash.clone(),
         vcpu: args.vcpu,
         memory_mb: args.memory_mb,
     })
     .await?;
 
-    // Generate runner.yaml
-    let paths = HomePaths::new()?;
-    let rootfs_paths = RootfsPaths::new(&paths, &rootfs_hash);
-    let runner_dir = paths.runners_dir().join(&args.runner_dirname);
-
-    let runner_config = RunnerConfig {
-        name: args.name,
-        group: args.group,
-        base_dir: runner_dir.clone(),
-        ca_dir: rootfs_paths.dir().to_path_buf(),
-        firecracker: FirecrackerConfig {
-            binary: paths.firecracker_bin(FIRECRACKER_VERSION),
-            kernel: paths.kernel_bin(FIRECRACKER_VERSION, KERNEL_VERSION),
-            rootfs: rootfs_paths.rootfs(),
-            snapshot: Some(snapshot_paths),
-        },
-        sandbox: SandboxConfig {
-            vcpu: args.vcpu,
-            memory_mb: args.memory_mb,
-            max_concurrent: args.max_concurrent,
-        },
-        server: Some(ServerConfig {
-            url: args.api_url,
-            token: args.token,
-        }),
-    };
-
-    config::generate(&runner_config).await?;
-    let config_path = runner_dir.join("runner.yaml");
-    tracing::info!("config written to {}", config_path.display());
+    println!("rootfs_hash={rootfs_hash}");
+    println!("snapshot_hash={snapshot_hash}");
 
     Ok(())
 }

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -1,0 +1,86 @@
+use clap::Args;
+
+use sandbox_fc::SnapshotOutputPaths;
+
+use crate::config::{
+    self, DEFAULT_MAX_CONCURRENT, DEFAULT_MEMORY_MB, DEFAULT_VCPU, FirecrackerConfig, RunnerConfig,
+    SandboxConfig, ServerConfig,
+};
+use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
+use crate::error::RunnerResult;
+use crate::paths::{HomePaths, RootfsPaths};
+
+#[derive(Args)]
+pub struct ConfigArgs {
+    /// SHA-256 hash of the rootfs inputs (output of `runner build` or `runner rootfs`).
+    #[arg(long)]
+    rootfs_hash: String,
+    /// SHA-256 hash of the snapshot inputs (output of `runner build` or `runner snapshot`).
+    #[arg(long)]
+    snapshot_hash: String,
+
+    /// Runner logical name
+    #[arg(long)]
+    name: String,
+    /// Runner group in scope/name format (e.g. "acme/production")
+    #[arg(long)]
+    group: String,
+    /// Runner directory name (under ~/.vm0-runner/runners/)
+    #[arg(long)]
+    runner_dirname: String,
+
+    /// Number of vCPUs for sandbox VMs
+    #[arg(long, default_value_t = DEFAULT_VCPU)]
+    vcpu: u32,
+    /// Memory size in MiB for sandbox VMs
+    #[arg(long, default_value_t = DEFAULT_MEMORY_MB)]
+    memory_mb: u32,
+    /// Maximum concurrent job executions
+    #[arg(long, default_value_t = DEFAULT_MAX_CONCURRENT)]
+    max_concurrent: usize,
+
+    /// vm0 API URL
+    #[arg(long, env = "VM0_API_URL")]
+    api_url: String,
+    /// Runner authentication token
+    #[arg(long, env = "VM0_RUNNER_TOKEN")]
+    token: String,
+}
+
+pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
+    let paths = HomePaths::new()?;
+    let rootfs_paths = RootfsPaths::new(&paths, &args.rootfs_hash);
+
+    let snapshot_output = SnapshotOutputPaths::new(paths.snapshots_dir().join(&args.snapshot_hash));
+    let snapshot_config = snapshot_output.snapshot_config(&args.snapshot_hash).into();
+
+    let runner_dir = paths.runners_dir().join(&args.runner_dirname);
+
+    let runner_config = RunnerConfig {
+        name: args.name,
+        group: args.group,
+        base_dir: runner_dir.clone(),
+        ca_dir: rootfs_paths.dir().to_path_buf(),
+        firecracker: FirecrackerConfig {
+            binary: paths.firecracker_bin(FIRECRACKER_VERSION),
+            kernel: paths.kernel_bin(FIRECRACKER_VERSION, KERNEL_VERSION),
+            rootfs: rootfs_paths.rootfs(),
+            snapshot: Some(snapshot_config),
+        },
+        sandbox: SandboxConfig {
+            vcpu: args.vcpu,
+            memory_mb: args.memory_mb,
+            max_concurrent: args.max_concurrent,
+        },
+        server: Some(ServerConfig {
+            url: args.api_url,
+            token: args.token,
+        }),
+    };
+
+    config::generate(&runner_config).await?;
+    let config_path = runner_dir.join("runner.yaml");
+    tracing::info!("config written to {}", config_path.display());
+
+    Ok(())
+}

--- a/crates/runner/src/cmd/mod.rs
+++ b/crates/runner/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 mod benchmark;
 mod build;
+mod config;
 mod doctor;
 mod gc;
 mod kill;
@@ -12,6 +13,7 @@ mod submit;
 
 pub use benchmark::{BenchmarkArgs, run_benchmark};
 pub use build::{BuildArgs, run_build};
+pub use config::{ConfigArgs, run_config};
 pub use doctor::{DoctorArgs, run_doctor};
 pub use gc::{GcArgs, run_gc};
 pub use kill::{KillArgs, run_kill};

--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -22,7 +22,7 @@ pub struct SnapshotArgs {
 }
 
 /// Create a snapshot and return the complete snapshot path information.
-pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<SnapshotConfig> {
+pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<(String, SnapshotConfig)> {
     let paths = HomePaths::new()?;
 
     let snapshot_hash = compute_snapshot_hash(&args);
@@ -34,7 +34,8 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<SnapshotConfig> {
     if is_snapshot_complete(&output).await? {
         tracing::info!("[OK] snapshot already exists: {}", output_dir.display());
         crate::paths::touch_mtime(&output_dir);
-        return Ok(output.snapshot_config(&snapshot_hash).into());
+        let config = output.snapshot_config(&snapshot_hash).into();
+        return Ok((snapshot_hash, config));
     }
 
     // Acquire exclusive lock to prevent concurrent builds with the same hash.
@@ -44,7 +45,8 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<SnapshotConfig> {
     if is_snapshot_complete(&output).await? {
         tracing::info!("[OK] snapshot already exists: {}", output_dir.display());
         crate::paths::touch_mtime(&output_dir);
-        return Ok(output.snapshot_config(&snapshot_hash).into());
+        let config = output.snapshot_config(&snapshot_hash).into();
+        return Ok((snapshot_hash, config));
     }
 
     // Clean up any partial output from a previous failed attempt.
@@ -96,7 +98,7 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<SnapshotConfig> {
         "snapshot creation complete"
     );
 
-    Ok(sc.into())
+    Ok((snapshot_hash, sc.into()))
 }
 
 /// Check whether all expected snapshot outputs exist in the directory.

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -54,6 +54,8 @@ enum Command {
     Rootfs(cmd::RootfsArgs),
     /// Create a Firecracker VM snapshot for fast sandbox boot
     Snapshot(cmd::SnapshotArgs),
+    /// Generate runner.yaml from pre-built rootfs and snapshot hashes
+    Config(cmd::ConfigArgs),
     /// Run a single bash command in a VM for benchmarking
     Benchmark(cmd::BenchmarkArgs),
     /// Start the runner and poll for jobs (must run setup + build first)
@@ -191,6 +193,7 @@ async fn main() -> ExitCode {
         Command::Build(args) => cmd::run_build(args).await.map(|()| ExitCode::SUCCESS),
         Command::Rootfs(args) => cmd::run_rootfs(args).await.map(|_| ExitCode::SUCCESS),
         Command::Snapshot(args) => cmd::run_snapshot(args).await.map(|_| ExitCode::SUCCESS),
+        Command::Config(args) => cmd::run_config(args).await.map(|()| ExitCode::SUCCESS),
         Command::Benchmark(args) => cmd::run_benchmark(args).await,
         Command::Kill(args) => cmd::run_kill(args).await,
         Command::Start(args) => cmd::run_start(*args).await.map(|()| ExitCode::SUCCESS),

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -76,3 +76,4 @@ if (
 // test comment Thu Feb 18 2026 v8
 // test comment Thu Feb 19 2026 v9
 // test comment Thu Feb 19 2026 v10
+// test comment Thu Feb 19 2026 v11


### PR DESCRIPTION
## Summary

- **`runner build`** now only builds rootfs + snapshot and outputs `rootfs_hash=...` / `snapshot_hash=...` to stdout (breaking change: removes `--name`, `--group`, `--runner-dirname`, `--api-url`, `--token`, `--max-concurrent` flags)
- **`runner config`** is a new subcommand that takes `--rootfs-hash` and `--snapshot-hash` plus deployment params to generate `runner.yaml`
- **`run_snapshot`** returns `(String, SnapshotConfig)` so callers can access the snapshot hash
- **CI workflows** updated: `deploy-runner-start` now uses `runner config` instead of re-running the entire build pipeline just to rewrite one YAML file

## Test plan

- [x] `cargo clippy -p runner` passes
- [x] `cargo test -p runner` — 154 tests pass
- [ ] CI pipeline validates workflow changes on PR with `needs-runner-pipeline` label

Closes #3159

🤖 Generated with [Claude Code](https://claude.com/claude-code)