### PR TITLE
fix(runner): add path validation and ci hash guards

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -181,6 +181,10 @@ jobs:
             --guest-mock-claude ${BIN_DIR}/guest-mock-claude")
           ROOTFS_HASH=$(echo "$BUILD_OUTPUT" | grep '^rootfs_hash=' | cut -d= -f2)
           SNAPSHOT_HASH=$(echo "$BUILD_OUTPUT" | grep '^snapshot_hash=' | cut -d= -f2)
+          if [ -z "$ROOTFS_HASH" ] || [ -z "$SNAPSHOT_HASH" ]; then
+            echo "ERROR: Failed to extract build hashes"
+            exit 1
+          fi
 
           # Generate runner.yaml config
           echo "=== Generating config ==="

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1137,6 +1137,10 @@ jobs:
           ROOTFS_HASH=$(grep '^rootfs_hash=' "$FIRST_LOG" | cut -d= -f2)
           SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$FIRST_LOG" | cut -d= -f2)
           rm -rf "$LOG_DIR"
+          if [ -z "$ROOTFS_HASH" ] || [ -z "$SNAPSHOT_HASH" ]; then
+            echo "::error::Failed to extract build hashes from log"
+            exit 1
+          fi
           echo "rootfs-hash=${ROOTFS_HASH}" >> "$GITHUB_OUTPUT"
           echo "snapshot-hash=${SNAPSHOT_HASH}" >> "$GITHUB_OUTPUT"
 

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -7,7 +7,7 @@ use crate::config::{
     SandboxConfig, ServerConfig,
 };
 use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
-use crate::error::RunnerResult;
+use crate::error::{RunnerError, RunnerResult};
 use crate::paths::{HomePaths, RootfsPaths};
 
 #[derive(Args)]
@@ -51,7 +51,29 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
     let paths = HomePaths::new()?;
     let rootfs_paths = RootfsPaths::new(&paths, &args.rootfs_hash);
 
-    let snapshot_output = SnapshotOutputPaths::new(paths.snapshots_dir().join(&args.snapshot_hash));
+    // Fail fast if referenced artifacts don't exist.
+    let rootfs_dir = rootfs_paths.dir();
+    if !tokio::fs::try_exists(rootfs_dir)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("check rootfs dir: {e}")))?
+    {
+        return Err(RunnerError::Config(format!(
+            "rootfs not found for hash {}; run `build` or `rootfs` first",
+            args.rootfs_hash
+        )));
+    }
+    let snapshot_dir = paths.snapshots_dir().join(&args.snapshot_hash);
+    if !tokio::fs::try_exists(&snapshot_dir)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("check snapshot dir: {e}")))?
+    {
+        return Err(RunnerError::Config(format!(
+            "snapshot not found for hash {}; run `build` or `snapshot` first",
+            args.snapshot_hash
+        )));
+    }
+
+    let snapshot_output = SnapshotOutputPaths::new(snapshot_dir);
     let snapshot_config = snapshot_output.snapshot_config(&args.snapshot_hash).into();
 
     let runner_dir = paths.runners_dir().join(&args.runner_dirname);

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -76,4 +76,3 @@ if (
 // test comment Thu Feb 18 2026 v8
 // test comment Thu Feb 19 2026 v9
 // test comment Thu Feb 19 2026 v10
-// test comment Thu Feb 19 2026 v11


### PR DESCRIPTION
## Summary

Follow-up to #3160 — the merge queue picked up the pre-amend commit, missing three fixes:

- `runner config` now validates rootfs/snapshot dirs exist before generating config (fail-fast on stale hashes)
- CI workflows guard against empty hash extraction with explicit error messages
- Remove stale test comment from `index.ts`

## Test plan

- [x] `cargo clippy -p runner` passes
- [x] `cargo test -p runner` — 154 tests pass
- [ ] CI validates workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)