### PR TITLE
fix(guest-agent): skip api calls in local provider mode

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -94,3 +94,10 @@ pub fn artifact_mount_path() -> &'static str {
 pub fn artifact_volume_name() -> &'static str {
     &ARTIFACT_VOLUME_NAME
 }
+/// Whether a backend API is available (token set).
+///
+/// When false (e.g. local-provider test mode), heartbeat / events / checkpoint
+/// are skipped because there is no API server to call.
+pub fn has_api() -> bool {
+    !API_TOKEN.is_empty()
+}

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -26,6 +26,11 @@ pub async fn send_event(
     // Extract session ID from init event (must happen before masking)
     extract_session_id(event);
 
+    // No API token → local/test mode; skip posting events.
+    if !env::has_api() {
+        return Ok(());
+    }
+
     // Add sequence number
     if let Some(obj) = event.as_object_mut() {
         obj.insert("sequenceNumber".to_string(), json!(seq));

--- a/crates/guest-agent/src/heartbeat.rs
+++ b/crates/guest-agent/src/heartbeat.rs
@@ -23,6 +23,12 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 /// The caller should race this against CLI execution so that a network
 /// failure terminates the run early.
 pub async fn heartbeat_loop(shutdown: CancellationToken) -> Result<(), AgentError> {
+    // No API token → local/test mode; heartbeat has no server to reach.
+    if !env::has_api() {
+        shutdown.cancelled().await;
+        return Ok(());
+    }
+
     let mut interval =
         tokio::time::interval(Duration::from_secs(constants::HEARTBEAT_INTERVAL_SECS));
     let mut is_first = true;

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -193,8 +193,8 @@ async fn execute(
         log_info!(LOG_TAG, "✗ Execution failed ({}s)", cli_elapsed.as_secs());
     }
 
-    // Checkpoint on success
-    if cli_exit_code == 0 && exit_code == 0 {
+    // Checkpoint on success (skip when no API — local/test mode)
+    if cli_exit_code == 0 && exit_code == 0 && env::has_api() {
         log_info!(LOG_TAG, "{} completed successfully", env::cli_agent_type());
 
         log_info!(LOG_TAG, "▷ Checkpoint");
@@ -217,6 +217,8 @@ async fn execute(
                 exit_code = 1;
             }
         }
+    } else if cli_exit_code == 0 && exit_code == 0 {
+        log_info!(LOG_TAG, "{} completed successfully", env::cli_agent_type());
     } else if cli_exit_code != 0 {
         log_info!(
             LOG_TAG,

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -123,6 +123,11 @@ async fn upload_telemetry(masker: &SecretMasker) -> Result<(), AgentError> {
 
 /// Background loop uploading telemetry every `TELEMETRY_INTERVAL_SECS`.
 pub async fn telemetry_loop(shutdown: CancellationToken, masker: Arc<SecretMasker>) {
+    if !env::has_api() {
+        shutdown.cancelled().await;
+        return;
+    }
+
     let mut interval =
         tokio::time::interval(Duration::from_secs(constants::TELEMETRY_INTERVAL_SECS));
     loop {
@@ -137,6 +142,9 @@ pub async fn telemetry_loop(shutdown: CancellationToken, masker: Arc<SecretMaske
 
 /// Final telemetry upload before agent completion.
 pub async fn final_upload(masker: &SecretMasker) -> Result<(), AgentError> {
+    if !env::has_api() {
+        return Ok(());
+    }
     log_info!(LOG_TAG, "Performing final telemetry upload...");
     upload_telemetry(masker).await
 }


### PR DESCRIPTION
## Summary

- When `VM0_API_TOKEN` is empty (local provider jobs via `runner submit`), guest-agent now skips all API calls
- Fixes `runner-start-local` CI test failure where heartbeat POST to unreachable `https://localhost` killed the agent (exit code 1)

### Changes

- `env.rs`: add `has_api()` — returns false when sandbox token is empty
- `heartbeat.rs`: wait for shutdown instead of sending heartbeats when no API
- `events.rs`: skip event POST when no API (session ID extraction still runs)
- `telemetry.rs`: skip upload loop and final upload when no API
- `main.rs`: skip checkpoint creation when no API

## Root cause

Local provider sets `sandbox_token: String::new()` → `VM0_API_TOKEN=""` in VM. The heartbeat loop's first POST to `https://localhost` fails immediately, returning `Err` which races against CLI execution in `tokio::select!` and kills the mock-claude process. Even without the heartbeat kill, event send failures would set the `event_error_flag`, and checkpoint would also fail — all causing exit code 1.

## Test plan

- [x] `cargo clippy -p guest-agent --all-targets` passes
- [x] `cargo test -p guest-agent --all-targets` — all 34 tests pass
- [ ] CI `runner-start-local` job should now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)