### PR TITLE
feat(runner): replace socket-based local provider with file queue

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -296,7 +296,7 @@ jobs:
 
           # 2. Submit job 1 (background, long-running) → only A running
           echo "--- Submit job 1 (only A, long-running) ---"
-          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 10 && echo job1' &
+          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 30 && echo job1' &
           SUBMIT1_PID=$!
           sleep 3
 
@@ -311,7 +311,7 @@ jobs:
 
           # 4. Submit job 2 (background, long-running) → A and B compete
           echo "--- Submit job 2 (A and B compete, long-running) ---"
-          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 10 && echo job2' &
+          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 30 && echo job2' &
           SUBMIT2_PID=$!
           sleep 3
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -294,7 +294,12 @@ jobs:
           sleep 2
           kill -0 $PID_A 2>/dev/null || { echo "ERROR: Runner A crashed"; cat "$RUNNER_DIR_A/local.log"; exit 1; }
 
-          # 2. Start runner B
+          # 2. Submit job 1 → only A is running
+          echo "--- Submit job 1 (only A) ---"
+          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'echo job1-single-runner'
+          [ $? -eq 0 ] || { echo "ERROR: Job 1 failed"; cat "$RUNNER_DIR_A/local.log"; exit 1; }
+
+          # 3. Start runner B (simulates new version deployment)
           echo "--- Starting runner B ---"
           USE_MOCK_CLAUDE=true "$BIN_DIR/runner" start \
             --local --config "$RUNNER_DIR_B/runner.yaml" \
@@ -303,30 +308,24 @@ jobs:
           sleep 2
           kill -0 $PID_B 2>/dev/null || { echo "ERROR: Runner B crashed"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
 
-          # 3. Competition: both A and B race to claim one job
-          echo "--- Submit job 1 (A and B compete) ---"
-          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'echo job1-competition'
-          [ $? -eq 0 ] || { echo "ERROR: Job 1 failed"; cat "$RUNNER_DIR_A/local.log"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
-          echo "--- Job 1 completed (one runner won the claim) ---"
-
-          # 4. Submit long-running job (background) for drain test
-          echo "--- Submit job 2 (background, long-running) ---"
+          # 4. Submit job 2 (background, long-running) → A and B compete
+          echo "--- Submit job 2 (A and B compete, long-running) ---"
           "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 10 && echo job2-in-flight' &
           SUBMIT2_PID=$!
 
-          # Give runner time to claim and start executing
+          # Give winner time to claim and start executing
           sleep 3
 
-          # 5. Drain A while job 2 may be in-flight
+          # 5. Drain A while job 2 is in-flight
           echo "--- Draining runner A ---"
           kill -USR1 $PID_A 2>/dev/null
 
-          # 6. Verify job 2 completes successfully despite drain
+          # 6. Verify job 2 completes despite drain
           echo "--- Waiting for job 2 to complete ---"
           wait $SUBMIT2_PID
           JOB2_RC=$?
-          [ $JOB2_RC -eq 0 ] || { echo "ERROR: Job 2 failed (exit $JOB2_RC) — drain killed in-flight job"; cat "$RUNNER_DIR_A/local.log"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
-          echo "--- Job 2 completed successfully after drain ---"
+          [ $JOB2_RC -eq 0 ] || { echo "ERROR: Job 2 failed (exit $JOB2_RC)"; cat "$RUNNER_DIR_A/local.log"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
+          echo "--- Job 2 completed successfully ---"
 
           # 7. Wait for A to exit
           wait $PID_A 2>/dev/null || true

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -296,7 +296,7 @@ jobs:
 
           # 2. Submit job 1 (background, long-running) → only A running
           echo "--- Submit job 1 (only A, long-running) ---"
-          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 30 && echo job1' &
+          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 12 && echo job1' &
           SUBMIT1_PID=$!
           sleep 3
 
@@ -311,7 +311,7 @@ jobs:
 
           # 4. Submit job 2 (background, long-running) → A and B compete
           echo "--- Submit job 2 (A and B compete, long-running) ---"
-          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 30 && echo job2' &
+          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 12 && echo job2' &
           SUBMIT2_PID=$!
           sleep 3
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -234,7 +234,7 @@ jobs:
             --config ${RUNNER_DIR}/runner.yaml \
             'curl -sf --max-time 10 https://httpbin.org/get'"
 
-  runner-start-local:
+  runner-upgrade-local:
     runs-on: ubuntu-latest
     needs: [runner-build]
     timeout-minutes: 5
@@ -247,7 +247,7 @@ jobs:
           echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
           chmod 600 "$HOME/.ssh/runner.pem"
 
-      - name: Run local provider test
+      - name: Run upgrade test
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
@@ -259,59 +259,89 @@ jobs:
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
           REMOTE="${METAL_USER}@${HOST}"
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
-          RUNNER_DIR="~/.vm0-runner/runners/${JOB_REF}-local"
+          GROUP="vm0/upgrade-${JOB_REF}"
 
-          echo "=== Generating config ==="
-          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner config \
-            --rootfs-hash ${ROOTFS_HASH} \
-            --snapshot-hash ${SNAPSHOT_HASH} \
-            --name ${JOB_REF}-local \
-            --group vm0/development-${JOB_REF} \
-            --runner-dirname ${JOB_REF}-local \
-            --api-url https://localhost \
-            --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
-
-          echo "=== Running local provider test ==="
-          ssh $SSH_OPTS $REMOTE bash -s -- "${BIN_DIR}" "${RUNNER_DIR}" <<'REMOTE_SCRIPT'
-          BIN_DIR=$1; RUNNER_DIR=$2
-
-          USE_MOCK_CLAUDE=true "$BIN_DIR/runner" start \
-            --local --config "$RUNNER_DIR/runner.yaml" \
-            > "$RUNNER_DIR/local.log" 2>&1 &
-          RUNNER_PID=$!
-
-          # Wait for socket, bail early if runner crashes
-          for i in $(seq 1 30); do
-            [ -S "$RUNNER_DIR/jobs.sock" ] && break
-            kill -0 $RUNNER_PID 2>/dev/null || { echo "ERROR: Runner exited early"; cat "$RUNNER_DIR/local.log"; exit 1; }
-            sleep 1
+          echo "=== Generating configs for runner A and B ==="
+          for SUFFIX in upgrade-a upgrade-b; do
+            ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner config \
+              --rootfs-hash ${ROOTFS_HASH} \
+              --snapshot-hash ${SNAPSHOT_HASH} \
+              --name ${JOB_REF}-${SUFFIX} \
+              --group ${GROUP} \
+              --runner-dirname ${JOB_REF}-${SUFFIX} \
+              --api-url https://localhost \
+              --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
           done
-          if [ ! -S "$RUNNER_DIR/jobs.sock" ]; then
-            echo "ERROR: Local socket did not appear within 30s"
-            cat "$RUNNER_DIR/local.log"
-            kill $RUNNER_PID 2>/dev/null || true
-            exit 1
-          fi
 
-          # Submit a job and verify it completes
-          "$BIN_DIR/runner" submit \
-            --socket "$RUNNER_DIR/jobs.sock" \
-            --prompt 'echo hello from local provider test'
-          RC=$?
-          if [ $RC -ne 0 ]; then
-            echo "ERROR: Job submission failed (exit $RC)"
-            cat "$RUNNER_DIR/local.log"
-          fi
+          echo "=== Running upgrade test ==="
+          ssh $SSH_OPTS $REMOTE bash -s -- "${BIN_DIR}" "${JOB_REF}" "${GROUP}" <<'REMOTE_SCRIPT'
+          BIN_DIR=$1; JOB_REF=$2; GROUP=$3
+          RUNNER_DIR_A="$HOME/.vm0-runner/runners/${JOB_REF}-upgrade-a"
+          RUNNER_DIR_B="$HOME/.vm0-runner/runners/${JOB_REF}-upgrade-b"
 
-          # Drain and wait for graceful shutdown
-          kill -USR1 $RUNNER_PID 2>/dev/null
-          wait $RUNNER_PID 2>/dev/null || true
-          exit $RC
+          cleanup() {
+            kill $PID_A $PID_B 2>/dev/null || true
+            wait $PID_A $PID_B 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          # 1. Start runner A
+          echo "--- Starting runner A ---"
+          USE_MOCK_CLAUDE=true "$BIN_DIR/runner" start \
+            --local --config "$RUNNER_DIR_A/runner.yaml" \
+            > "$RUNNER_DIR_A/local.log" 2>&1 &
+          PID_A=$!
+          sleep 2
+          kill -0 $PID_A 2>/dev/null || { echo "ERROR: Runner A crashed"; cat "$RUNNER_DIR_A/local.log"; exit 1; }
+
+          # 2. Submit a job (background — blocks until result file appears)
+          echo "--- Submit job 1 (background) ---"
+          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 10 && echo job1-in-flight' &
+          SUBMIT1_PID=$!
+
+          # Give A time to claim and start executing the job
+          sleep 3
+
+          # 3. Start runner B (simulates new version deployment)
+          echo "--- Starting runner B ---"
+          USE_MOCK_CLAUDE=true "$BIN_DIR/runner" start \
+            --local --config "$RUNNER_DIR_B/runner.yaml" \
+            > "$RUNNER_DIR_B/local.log" 2>&1 &
+          PID_B=$!
+          sleep 2
+          kill -0 $PID_B 2>/dev/null || { echo "ERROR: Runner B crashed"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
+
+          # 4. Drain A while job 1 is still in flight
+          echo "--- Draining runner A (job 1 still running) ---"
+          kill -USR1 $PID_A 2>/dev/null
+
+          # 5. Verify job 1 completes successfully despite A being drained
+          echo "--- Waiting for job 1 to complete on A ---"
+          wait $SUBMIT1_PID
+          JOB1_RC=$?
+          [ $JOB1_RC -eq 0 ] || { echo "ERROR: Job 1 failed (exit $JOB1_RC) — drain killed in-flight job"; cat "$RUNNER_DIR_A/local.log"; exit 1; }
+          echo "--- Job 1 completed successfully after drain ---"
+
+          # 6. Wait for A to exit
+          wait $PID_A 2>/dev/null || true
+
+          # 7. Submit job 2 → only B is left
+          echo "--- Submit job 2 (only B) ---"
+          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'echo job2-after-upgrade'
+          [ $? -eq 0 ] || { echo "ERROR: Job 2 failed"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
+
+          # 8. Drain B
+          echo "--- Draining runner B ---"
+          kill -USR1 $PID_B 2>/dev/null
+          wait $PID_B 2>/dev/null || true
+          trap - EXIT
+
+          echo "=== Upgrade test passed ==="
           REMOTE_SCRIPT
 
   runner-cleanup:
     runs-on: ubuntu-latest
-    needs: [runner-build, runner-benchmark, runner-start-local]
+    needs: [runner-build, runner-benchmark, runner-upgrade-local]
     if: ${{ always() && needs.runner-build.result != 'skipped' }}
     steps:
       - name: Setup SSH
@@ -332,4 +362,4 @@ jobs:
           REMOTE="${METAL_USER}@${HOST}"
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
           echo "Cleaning up ${JOB_REF} on ${HOST}"
-          ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} ~/.vm0-runner/runners/${JOB_REF}-bench ~/.vm0-runner/runners/${JOB_REF}-local" || true
+          ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} ~/.vm0-runner/runners/${JOB_REF}-bench ~/.vm0-runner/runners/${JOB_REF}-upgrade-a ~/.vm0-runner/runners/${JOB_REF}-upgrade-b ~/.vm0-runner/groups/vm0/upgrade-${JOB_REF}" || true

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -285,6 +285,10 @@ jobs:
           }
           trap cleanup EXIT
 
+          # Kill leftover runners from previous CI runs
+          pkill -f "runner start.*${JOB_REF}-upgrade" 2>/dev/null || true
+          sleep 1
+
           # 1. Start runner A
           echo "--- Starting runner A ---"
           USE_MOCK_CLAUDE=true "$BIN_DIR/runner" start \

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -294,15 +294,7 @@ jobs:
           sleep 2
           kill -0 $PID_A 2>/dev/null || { echo "ERROR: Runner A crashed"; cat "$RUNNER_DIR_A/local.log"; exit 1; }
 
-          # 2. Submit a job (background — blocks until result file appears)
-          echo "--- Submit job 1 (background) ---"
-          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 10 && echo job1-in-flight' &
-          SUBMIT1_PID=$!
-
-          # Give A time to claim and start executing the job
-          sleep 3
-
-          # 3. Start runner B (simulates new version deployment)
+          # 2. Start runner B
           echo "--- Starting runner B ---"
           USE_MOCK_CLAUDE=true "$BIN_DIR/runner" start \
             --local --config "$RUNNER_DIR_B/runner.yaml" \
@@ -311,26 +303,40 @@ jobs:
           sleep 2
           kill -0 $PID_B 2>/dev/null || { echo "ERROR: Runner B crashed"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
 
-          # 4. Drain A while job 1 is still in flight
-          echo "--- Draining runner A (job 1 still running) ---"
+          # 3. Competition: both A and B race to claim one job
+          echo "--- Submit job 1 (A and B compete) ---"
+          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'echo job1-competition'
+          [ $? -eq 0 ] || { echo "ERROR: Job 1 failed"; cat "$RUNNER_DIR_A/local.log"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
+          echo "--- Job 1 completed (one runner won the claim) ---"
+
+          # 4. Submit long-running job (background) for drain test
+          echo "--- Submit job 2 (background, long-running) ---"
+          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 10 && echo job2-in-flight' &
+          SUBMIT2_PID=$!
+
+          # Give runner time to claim and start executing
+          sleep 3
+
+          # 5. Drain A while job 2 may be in-flight
+          echo "--- Draining runner A ---"
           kill -USR1 $PID_A 2>/dev/null
 
-          # 5. Verify job 1 completes successfully despite A being drained
-          echo "--- Waiting for job 1 to complete on A ---"
-          wait $SUBMIT1_PID
-          JOB1_RC=$?
-          [ $JOB1_RC -eq 0 ] || { echo "ERROR: Job 1 failed (exit $JOB1_RC) — drain killed in-flight job"; cat "$RUNNER_DIR_A/local.log"; exit 1; }
-          echo "--- Job 1 completed successfully after drain ---"
+          # 6. Verify job 2 completes successfully despite drain
+          echo "--- Waiting for job 2 to complete ---"
+          wait $SUBMIT2_PID
+          JOB2_RC=$?
+          [ $JOB2_RC -eq 0 ] || { echo "ERROR: Job 2 failed (exit $JOB2_RC) — drain killed in-flight job"; cat "$RUNNER_DIR_A/local.log"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
+          echo "--- Job 2 completed successfully after drain ---"
 
-          # 6. Wait for A to exit
+          # 7. Wait for A to exit
           wait $PID_A 2>/dev/null || true
 
-          # 7. Submit job 2 → only B is left
-          echo "--- Submit job 2 (only B) ---"
-          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'echo job2-after-upgrade'
-          [ $? -eq 0 ] || { echo "ERROR: Job 2 failed"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
+          # 8. Submit job 3 → only B is left
+          echo "--- Submit job 3 (only B) ---"
+          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'echo job3-after-upgrade'
+          [ $? -eq 0 ] || { echo "ERROR: Job 3 failed"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
 
-          # 8. Drain B
+          # 9. Drain B
           echo "--- Draining runner B ---"
           kill -USR1 $PID_B 2>/dev/null
           wait $PID_B 2>/dev/null || true

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -294,12 +294,13 @@ jobs:
           sleep 2
           kill -0 $PID_A 2>/dev/null || { echo "ERROR: Runner A crashed"; cat "$RUNNER_DIR_A/local.log"; exit 1; }
 
-          # 2. Submit job 1 → only A is running
-          echo "--- Submit job 1 (only A) ---"
-          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'echo job1-single-runner'
-          [ $? -eq 0 ] || { echo "ERROR: Job 1 failed"; cat "$RUNNER_DIR_A/local.log"; exit 1; }
+          # 2. Submit job 1 (background, long-running) → only A running
+          echo "--- Submit job 1 (only A, long-running) ---"
+          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 10 && echo job1' &
+          SUBMIT1_PID=$!
+          sleep 3
 
-          # 3. Start runner B (simulates new version deployment)
+          # 3. Start runner B while job 1 still in-flight on A
           echo "--- Starting runner B ---"
           USE_MOCK_CLAUDE=true "$BIN_DIR/runner" start \
             --local --config "$RUNNER_DIR_B/runner.yaml" \
@@ -310,29 +311,28 @@ jobs:
 
           # 4. Submit job 2 (background, long-running) → A and B compete
           echo "--- Submit job 2 (A and B compete, long-running) ---"
-          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 10 && echo job2-in-flight' &
+          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 10 && echo job2' &
           SUBMIT2_PID=$!
-
-          # Give winner time to claim and start executing
           sleep 3
 
-          # 5. Drain A while job 2 is in-flight
+          # 5. Drain A while jobs may be in-flight
           echo "--- Draining runner A ---"
           kill -USR1 $PID_A 2>/dev/null
 
-          # 6. Verify job 2 completes despite drain
-          echo "--- Waiting for job 2 to complete ---"
+          # 6. Verify both jobs complete despite drain
+          echo "--- Waiting for job 1 ---"
+          wait $SUBMIT1_PID
+          [ $? -eq 0 ] || { echo "ERROR: Job 1 failed"; cat "$RUNNER_DIR_A/local.log"; exit 1; }
+          echo "--- Waiting for job 2 ---"
           wait $SUBMIT2_PID
-          JOB2_RC=$?
-          [ $JOB2_RC -eq 0 ] || { echo "ERROR: Job 2 failed (exit $JOB2_RC)"; cat "$RUNNER_DIR_A/local.log"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
-          echo "--- Job 2 completed successfully ---"
+          [ $? -eq 0 ] || { echo "ERROR: Job 2 failed"; cat "$RUNNER_DIR_A/local.log"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
 
           # 7. Wait for A to exit
           wait $PID_A 2>/dev/null || true
 
           # 8. Submit job 3 → only B is left
           echo "--- Submit job 3 (only B) ---"
-          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'echo job3-after-upgrade'
+          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'echo job3'
           [ $? -eq 0 ] || { echo "ERROR: Job 3 failed"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
 
           # 9. Drain B

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -165,7 +165,11 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
     let cancel = CancellationToken::new();
     let http = crate::http::HttpClient::new(server.url.clone())?;
     let (provider, group_name): (Arc<dyn JobProvider>, String) = if args.local {
-        let provider = LocalProvider::new(paths.jobs_sock(), cancel.clone()).await?;
+        let group_dir = home.groups_dir().join(&group);
+        std::fs::create_dir_all(&group_dir).map_err(|e| {
+            RunnerError::Config(format!("create group dir {}: {e}", group_dir.display()))
+        })?;
+        let provider = LocalProvider::new(group_dir, cancel.clone());
         (provider, group)
     } else {
         let group_name = group.clone();

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -39,7 +39,7 @@ pub struct StartArgs {
     /// Runner authentication token (overrides config)
     #[arg(long, env = "VM0_RUNNER_TOKEN")]
     token: Option<String>,
-    /// Use local Unix socket provider instead of API (for testing)
+    /// Use local file queue provider instead of API (for testing)
     #[arg(long)]
     local: bool,
 }

--- a/crates/runner/src/cmd/submit.rs
+++ b/crates/runner/src/cmd/submit.rs
@@ -1,20 +1,26 @@
-//! `runner submit` — send a job to a locally running runner over Unix socket.
+//! `runner submit` — submit a job to locally running runners via file queue.
+//!
+//! Writes a `{job_id}.job` file into the group directory and polls for a
+//! `{job_id}.result` file written by the runner that claimed the job.
 
-use std::path::PathBuf;
 use std::process::ExitCode;
+use std::time::Duration;
 
 use clap::Args;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::UnixStream;
+use uuid::Uuid;
 
 use crate::error::{RunnerError, RunnerResult};
+use crate::paths::HomePaths;
 use crate::provider::{JobRequest, JobResponse};
+
+/// Poll interval for checking the result file.
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 #[derive(Args)]
 pub struct SubmitArgs {
-    /// Path to the Unix socket
+    /// Runner group name (writes job to ~/.vm0-runner/groups/{group}/)
     #[arg(long)]
-    socket: PathBuf,
+    group: String,
     /// Job prompt
     #[arg(long)]
     prompt: String,
@@ -24,14 +30,22 @@ pub struct SubmitArgs {
     /// Agent type
     #[arg(long, default_value = "claude-code")]
     cli_agent_type: String,
+    /// Timeout in seconds waiting for a runner to complete the job
+    #[arg(long, default_value_t = 300)]
+    timeout: u64,
 }
 
 pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
-    let mut stream = UnixStream::connect(&args.socket).await.map_err(|e| {
-        RunnerError::Config(format!("connect to socket {}: {e}", args.socket.display()))
+    let home = HomePaths::new()?;
+    let group_dir = home.groups_dir().join(&args.group);
+
+    std::fs::create_dir_all(&group_dir).map_err(|e| {
+        RunnerError::Config(format!("create group dir {}: {e}", group_dir.display()))
     })?;
 
+    let job_id = Uuid::new_v4();
     let request = JobRequest {
+        job_id,
         prompt: args.prompt,
         working_dir: args.working_dir,
         cli_agent_type: args.cli_agent_type,
@@ -43,27 +57,45 @@ pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
     let json = serde_json::to_vec(&request)
         .map_err(|e| RunnerError::Internal(format!("serialize request: {e}")))?;
 
-    stream
-        .write_all(&json)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("write to socket: {e}")))?;
-    stream
-        .shutdown()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("shutdown write: {e}")))?;
+    // Write atomically: tmp file then rename.
+    let tmp_path = group_dir.join(format!("{job_id}.job.tmp"));
+    let job_path = group_dir.join(format!("{job_id}.job"));
+    std::fs::write(&tmp_path, &json)
+        .map_err(|e| RunnerError::Internal(format!("write job file: {e}")))?;
+    std::fs::rename(&tmp_path, &job_path)
+        .map_err(|e| RunnerError::Internal(format!("rename job file: {e}")))?;
 
-    // Read response until EOF
-    let mut buf = Vec::new();
-    stream
-        .read_to_end(&mut buf)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("read response: {e}")))?;
+    // Poll for result.
+    let result_path = group_dir.join(format!("{job_id}.result"));
+    let timeout = Duration::from_secs(args.timeout);
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    let buf = loop {
+        if result_path.exists() {
+            match std::fs::read(&result_path) {
+                Ok(b) if !b.is_empty() => break b,
+                _ => {}
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            // Clean up queue files on timeout.
+            let _ = std::fs::remove_file(&job_path);
+            let _ = std::fs::remove_file(group_dir.join(format!("{job_id}.claim")));
+            return Err(RunnerError::Internal(format!(
+                "timeout waiting for result after {timeout:?}"
+            )));
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
 
     let response: JobResponse = serde_json::from_slice(&buf)
-        .map_err(|e| RunnerError::Internal(format!("parse response: {e}")))?;
+        .map_err(|e| RunnerError::Internal(format!("parse result: {e}")))?;
 
-    // Write response as JSON to stdout for machine-parseable output.
-    // The buf is already valid JSON from the server, write it directly.
+    // Clean up queue files.
+    let _ = std::fs::remove_file(&job_path);
+    let _ = std::fs::remove_file(&result_path);
+    let _ = std::fs::remove_file(group_dir.join(format!("{job_id}.claim")));
+
     use std::io::Write;
     std::io::stdout().write_all(&buf).ok();
     std::io::stdout().write_all(b"\n").ok();

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -49,10 +49,6 @@ impl RunnerPaths {
     pub fn proxy_registry_lock(&self) -> PathBuf {
         self.base_dir.join("proxy-registry.json.lock")
     }
-
-    pub fn jobs_sock(&self) -> PathBuf {
-        self.base_dir.join("jobs.sock")
-    }
 }
 
 /// Paths rooted at ~/.vm0-runner/.
@@ -113,6 +109,10 @@ impl HomePaths {
 
     pub fn runners_dir(&self) -> PathBuf {
         self.root.join("runners")
+    }
+
+    pub fn groups_dir(&self) -> PathBuf {
+        self.root.join("groups")
     }
 
     pub fn locks_dir(&self) -> PathBuf {

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -1,17 +1,15 @@
-//! [`JobProvider`] backed by a local Unix domain socket.
+//! [`JobProvider`] backed by a file queue in a shared group directory.
 //!
-//! Each client connection represents a single job: the client sends a JSON
-//! [`JobRequest`], shuts down its write end (EOF), and waits for a JSON
-//! [`JobResponse`] containing the execution result.
+//! `submit` writes a `{job_id}.job` file. Runners poll the directory for new
+//! `.job` files and race to claim them via `{job_id}.claim` (O_EXCL). The
+//! winning runner executes the job and writes a `{job_id}.result` file that
+//! `submit` polls for.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::UnixListener;
-use tokio::net::unix::OwnedWriteHalf;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 use uuid::Uuid;
@@ -19,14 +17,13 @@ use uuid::Uuid;
 use super::JobProvider;
 use crate::types::ExecutionContext;
 
-/// Max request size (64 KB).
-const MAX_REQUEST_SIZE: u64 = 64 * 1024;
-/// Timeout for reading job request from client.
-const READ_TIMEOUT: Duration = Duration::from_secs(5);
+/// Poll interval for discovering new job files.
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-/// Job request sent by the client over the Unix socket.
+/// Job request written by `submit` as a `{job_id}.job` file.
 #[derive(serde::Deserialize, serde::Serialize)]
 pub(crate) struct JobRequest {
+    pub(crate) job_id: Uuid,
     pub(crate) prompt: String,
     pub(crate) working_dir: String,
     pub(crate) cli_agent_type: String,
@@ -38,7 +35,7 @@ pub(crate) struct JobRequest {
     pub(crate) user_timezone: Option<String>,
 }
 
-/// Job response written back to the client.
+/// Job response written by the runner as a `{job_id}.result` file.
 #[derive(serde::Deserialize, serde::Serialize)]
 pub(crate) struct JobResponse {
     pub(crate) run_id: Uuid,
@@ -46,344 +43,281 @@ pub(crate) struct JobResponse {
     pub(crate) error: Option<String>,
 }
 
-/// [`JobProvider`] that accepts jobs over a local Unix domain socket.
+/// [`JobProvider`] backed by a file queue in a shared group directory.
 ///
-/// Each incoming connection is treated as a single job request. The client
-/// writes a JSON-encoded [`JobRequest`], shuts down its write end (EOF),
-/// and waits for a JSON-encoded [`JobResponse`].
-/// Lock ordering: always acquire `state` before `streams`.
-/// `discover()` holds `state` for its entire loop and briefly locks `streams`
-/// to insert write halves. `claim()` only locks `state`. `complete()` only
-/// locks `streams`. Never acquire `state` while holding `streams`.
+/// - `discover()` polls `{group_dir}/*.job` for files without a `.claim`.
+/// - `claim()` atomically creates `{job_id}.claim` via `O_EXCL`.
+/// - `complete()` writes `{job_id}.result`.
 pub struct LocalProvider {
-    state: tokio::sync::Mutex<LocalState>,
-    streams: tokio::sync::Mutex<HashMap<Uuid, OwnedWriteHalf>>,
+    group_dir: PathBuf,
     cancel: CancellationToken,
-    sock_path: PathBuf,
-}
-
-struct LocalState {
-    listener: UnixListener,
-    pending: HashMap<Uuid, ExecutionContext>,
 }
 
 impl LocalProvider {
-    /// Create a new local provider listening on the given Unix socket path.
-    ///
-    /// Removes any stale socket file before binding.
-    pub async fn new(
-        sock_path: PathBuf,
-        cancel: CancellationToken,
-    ) -> crate::error::RunnerResult<Arc<Self>> {
-        // Remove stale socket file (ignore not-found)
-        let _ = std::fs::remove_file(&sock_path);
+    /// Create a new file-queue provider for the given group directory.
+    pub fn new(group_dir: PathBuf, cancel: CancellationToken) -> Arc<Self> {
+        info!(path = %group_dir.display(), "local provider watching");
+        Arc::new(Self { group_dir, cancel })
+    }
 
-        let listener = UnixListener::bind(&sock_path).map_err(|e| {
-            crate::error::RunnerError::Config(format!(
-                "bind local socket {}: {e}",
-                sock_path.display()
-            ))
-        })?;
-
-        info!(path = %sock_path.display(), "local provider listening");
-
-        Ok(Arc::new(Self {
-            state: tokio::sync::Mutex::new(LocalState {
-                listener,
-                pending: HashMap::new(),
-            }),
-            streams: tokio::sync::Mutex::new(HashMap::new()),
-            cancel,
-            sock_path,
-        }))
+    /// Find the first `.job` file that has no corresponding `.claim` file.
+    fn find_unclaimed_job(&self) -> Option<Uuid> {
+        let entries = match std::fs::read_dir(&self.group_dir) {
+            Ok(e) => e,
+            Err(e) => {
+                warn!(path = %self.group_dir.display(), error = %e, "local: cannot read group dir");
+                return None;
+            }
+        };
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("job") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let Ok(job_id) = stem.parse::<Uuid>() else {
+                continue;
+            };
+            let claim_path = self.group_dir.join(format!("{job_id}.claim"));
+            if !claim_path.exists() {
+                return Some(job_id);
+            }
+        }
+        None
     }
 }
 
 #[async_trait::async_trait]
 impl JobProvider for LocalProvider {
     async fn discover(&self) -> Option<Uuid> {
-        let mut state = self.state.lock().await;
         loop {
             if self.cancel.is_cancelled() {
                 return None;
             }
-
-            let stream = tokio::select! {
+            if let Some(job_id) = self.find_unclaimed_job() {
+                info!(run_id = %job_id, "local: job discovered");
+                return Some(job_id);
+            }
+            tokio::select! {
                 () = self.cancel.cancelled() => return None,
-                result = state.listener.accept() => {
-                    match result {
-                        Ok((stream, _addr)) => stream,
-                        Err(e) => {
-                            warn!(error = %e, "local: accept failed");
-                            continue;
-                        }
-                    }
-                }
-            };
-
-            // Read request with timeout + size limit.
-            // Client must send JSON then shut down its write end (EOF).
-            let (read_half, write_half) = stream.into_split();
-            let read_result = tokio::time::timeout(READ_TIMEOUT, async {
-                let mut buf = Vec::with_capacity(4096);
-                read_half
-                    .take(MAX_REQUEST_SIZE)
-                    .read_to_end(&mut buf)
-                    .await
-                    .map(|_| buf)
-            })
-            .await;
-
-            let buf = match read_result {
-                Ok(Ok(buf)) => buf,
-                Ok(Err(e)) => {
-                    warn!(error = %e, "local: read failed");
-                    continue;
-                }
-                Err(_) => {
-                    warn!("local: read timed out");
-                    continue;
-                }
-            };
-
-            let req: JobRequest = match serde_json::from_slice(&buf) {
-                Ok(r) => r,
-                Err(e) => {
-                    warn!(error = %e, "local: invalid request JSON");
-                    continue;
-                }
-            };
-
-            let run_id = Uuid::new_v4();
-            let context = ExecutionContext {
-                run_id,
-                prompt: req.prompt,
-                agent_compose_version_id: None,
-                vars: req.vars,
-                secret_names: None,
-                checkpoint_id: None,
-                sandbox_token: String::new(),
-                working_dir: req.working_dir,
-                storage_manifest: None,
-                environment: req.environment,
-                resume_session: None,
-                secret_values: None,
-                cli_agent_type: req.cli_agent_type,
-                experimental_firewall: None,
-                debug_no_mock_claude: None,
-                api_start_time: None,
-                user_timezone: req.user_timezone,
-            };
-
-            info!(run_id = %run_id, "local: job received");
-            state.pending.insert(run_id, context);
-            self.streams.lock().await.insert(run_id, write_half);
-            return Some(run_id);
+                () = tokio::time::sleep(POLL_INTERVAL) => {}
+            }
         }
     }
 
     async fn claim(&self, run_id: Uuid) -> Option<ExecutionContext> {
-        self.state.lock().await.pending.remove(&run_id)
+        // Atomic claim via O_EXCL — only the first runner to create the file wins.
+        let claim_file = self.group_dir.join(format!("{run_id}.claim"));
+        if std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&claim_file)
+            .is_err()
+        {
+            return None;
+        }
+
+        // Read the job request.
+        let job_file = self.group_dir.join(format!("{run_id}.job"));
+        let buf = match std::fs::read(&job_file) {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(run_id = %run_id, error = %e, "local: failed to read job file");
+                return None;
+            }
+        };
+        let req: JobRequest = match serde_json::from_slice(&buf) {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(run_id = %run_id, error = %e, "local: invalid job JSON");
+                return None;
+            }
+        };
+
+        info!(run_id = %run_id, "local: job claimed");
+        Some(ExecutionContext {
+            run_id,
+            prompt: req.prompt,
+            agent_compose_version_id: None,
+            vars: req.vars,
+            secret_names: None,
+            checkpoint_id: None,
+            sandbox_token: String::new(),
+            working_dir: req.working_dir,
+            storage_manifest: None,
+            environment: req.environment,
+            resume_session: None,
+            secret_values: None,
+            cli_agent_type: req.cli_agent_type,
+            experimental_firewall: None,
+            debug_no_mock_claude: None,
+            api_start_time: None,
+            user_timezone: req.user_timezone,
+        })
     }
 
     async fn complete(&self, run_id: Uuid, exit_code: i32, error: Option<&str>) {
-        let write_half = self.streams.lock().await.remove(&run_id);
-        let Some(mut writer) = write_half else {
-            warn!(run_id = %run_id, "local: no stream for completion");
-            return;
-        };
-
         let response = JobResponse {
             run_id,
             exit_code,
             error: error.map(String::from),
         };
-
         let json = match serde_json::to_vec(&response) {
             Ok(j) => j,
             Err(e) => {
-                warn!(run_id = %run_id, error = %e, "local: failed to serialize response");
+                warn!(run_id = %run_id, error = %e, "local: failed to serialize result");
                 return;
             }
         };
 
-        if let Err(e) = writer.write_all(&json).await {
-            warn!(run_id = %run_id, error = %e, "local: write response failed");
+        // Atomic write: tmp then rename, so submit never reads a partial file.
+        let tmp_file = self.group_dir.join(format!("{run_id}.result.tmp"));
+        let result_file = self.group_dir.join(format!("{run_id}.result"));
+        if let Err(e) = std::fs::write(&tmp_file, &json) {
+            warn!(run_id = %run_id, error = %e, "local: failed to write result file");
             return;
         }
-        if let Err(e) = writer.shutdown().await {
-            warn!(run_id = %run_id, error = %e, "local: shutdown write failed");
+        if let Err(e) = std::fs::rename(&tmp_file, &result_file) {
+            warn!(run_id = %run_id, error = %e, "local: failed to rename result file");
         }
     }
 
-    /// # Ordering requirement
-    ///
-    /// `discover()` holds the state Mutex for its entire loop.
-    /// Callers must cancel the `CancellationToken` *before* calling
-    /// `shutdown()` so that `discover()` observes the cancellation,
-    /// returns `None`, and releases the lock.
-    async fn shutdown(&self) {
-        let _ = std::fs::remove_file(&self.sock_path);
-    }
+    async fn shutdown(&self) {}
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::UnixStream;
+    /// Write a job file into the group directory.
+    fn write_job(dir: &std::path::Path, job_id: Uuid, prompt: &str) {
+        let req = JobRequest {
+            job_id,
+            prompt: prompt.into(),
+            working_dir: "/workspace".into(),
+            cli_agent_type: "claude-code".into(),
+            vars: None,
+            environment: None,
+            user_timezone: None,
+        };
+        let json = serde_json::to_vec(&req).unwrap();
+        std::fs::write(dir.join(format!("{job_id}.job")), &json).unwrap();
+    }
 
-    #[tokio::test]
-    async fn local_provider_discover_claim_complete() {
-        let dir = tempfile::tempdir().unwrap();
-        let sock_path = dir.path().join("test.sock");
-        let cancel = CancellationToken::new();
-        let provider = LocalProvider::new(sock_path.clone(), cancel).await.unwrap();
-
-        // Client connects and sends request
-        let client = tokio::spawn({
-            let sock_path = sock_path.clone();
-            async move {
-                let mut stream = UnixStream::connect(&sock_path).await.unwrap();
-                let req = serde_json::json!({
-                    "prompt": "hello world",
-                    "working_dir": "/tmp/test",
-                    "cli_agent_type": "test-agent"
-                });
-                stream
-                    .write_all(serde_json::to_string(&req).unwrap().as_bytes())
-                    .await
-                    .unwrap();
-                stream.shutdown().await.unwrap();
-
-                // Read response
-                let mut buf = Vec::new();
-                stream.read_to_end(&mut buf).await.unwrap();
-                serde_json::from_slice::<JobResponse>(&buf).unwrap()
-            }
-        });
-
-        // Provider discovers and claims
-        let run_id = provider.discover().await.unwrap();
-        let ctx = provider.claim(run_id).await.unwrap();
-        assert_eq!(ctx.run_id, run_id);
-        assert_eq!(ctx.prompt, "hello world");
-        assert_eq!(ctx.working_dir, "/tmp/test");
-        assert_eq!(ctx.cli_agent_type, "test-agent");
-
-        // Complete the job
-        provider.complete(run_id, 0, None).await;
-
-        // Verify client received response
-        let response = client.await.unwrap();
-        assert_eq!(response.run_id, run_id);
-        assert_eq!(response.exit_code, 0);
-        assert!(response.error.is_none());
+    /// Read a result file from the group directory.
+    fn read_result(dir: &std::path::Path, job_id: Uuid) -> JobResponse {
+        let path = dir.join(format!("{job_id}.result"));
+        let buf = std::fs::read(path).unwrap();
+        serde_json::from_slice(&buf).unwrap()
     }
 
     #[tokio::test]
-    async fn local_provider_shutdown_returns_none() {
+    async fn discover_claim_complete() {
         let dir = tempfile::tempdir().unwrap();
-        let sock_path = dir.path().join("test.sock");
         let cancel = CancellationToken::new();
-        let provider = LocalProvider::new(sock_path, cancel.clone()).await.unwrap();
+        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel);
+
+        let job_id = Uuid::new_v4();
+        write_job(dir.path(), job_id, "hello world");
+
+        let run_id = provider.discover().await.unwrap();
+        assert_eq!(run_id, job_id);
+
+        let ctx = provider.claim(run_id).await.unwrap();
+        assert_eq!(ctx.run_id, run_id);
+        assert_eq!(ctx.prompt, "hello world");
+
+        provider.complete(run_id, 0, None).await;
+
+        let resp = read_result(dir.path(), job_id);
+        assert_eq!(resp.exit_code, 0);
+        assert!(resp.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn shutdown_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel.clone());
 
         cancel.cancel();
         assert!(provider.discover().await.is_none());
     }
 
     #[tokio::test]
-    async fn local_provider_invalid_json_continues() {
+    async fn skips_already_claimed_jobs() {
         let dir = tempfile::tempdir().unwrap();
-        let sock_path = dir.path().join("test.sock");
         let cancel = CancellationToken::new();
-        let provider = LocalProvider::new(sock_path.clone(), cancel).await.unwrap();
+        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel);
 
-        // First client sends garbage
-        let sock = sock_path.clone();
-        tokio::spawn(async move {
-            let mut stream = UnixStream::connect(&sock).await.unwrap();
-            stream.write_all(b"not json at all").await.unwrap();
-            stream.shutdown().await.unwrap();
-        });
-
-        // Second client sends valid request (delayed to ensure ordering)
-        let sock = sock_path.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            let mut stream = UnixStream::connect(&sock).await.unwrap();
-            let req = serde_json::json!({"prompt": "valid", "working_dir": "/workspace", "cli_agent_type": "claude-code"});
-            stream
-                .write_all(serde_json::to_string(&req).unwrap().as_bytes())
-                .await
-                .unwrap();
-            stream.shutdown().await.unwrap();
-        });
+        // Write two jobs, pre-claim the first
+        let job1 = Uuid::new_v4();
+        let job2 = Uuid::new_v4();
+        write_job(dir.path(), job1, "claimed");
+        write_job(dir.path(), job2, "available");
+        std::fs::write(dir.path().join(format!("{job1}.claim")), b"").unwrap();
 
         let run_id = provider.discover().await.unwrap();
-        let ctx = provider.claim(run_id).await.unwrap();
-        assert_eq!(ctx.prompt, "valid");
+        assert_eq!(run_id, job2);
     }
 
     #[tokio::test]
-    async fn local_provider_concurrent_jobs() {
+    async fn concurrent_jobs() {
         let dir = tempfile::tempdir().unwrap();
-        let sock_path = dir.path().join("test.sock");
         let cancel = CancellationToken::new();
-        let provider = LocalProvider::new(sock_path.clone(), cancel).await.unwrap();
+        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel);
 
-        // Client 1
-        let sock = sock_path.clone();
-        let client1 = tokio::spawn(async move {
-            let mut stream = UnixStream::connect(&sock).await.unwrap();
-            let req = serde_json::json!({"prompt": "job1", "working_dir": "/workspace", "cli_agent_type": "claude-code"});
-            stream
-                .write_all(serde_json::to_string(&req).unwrap().as_bytes())
-                .await
-                .unwrap();
-            stream.shutdown().await.unwrap();
-            let mut buf = Vec::new();
-            stream.read_to_end(&mut buf).await.unwrap();
-            serde_json::from_slice::<JobResponse>(&buf).unwrap()
-        });
+        let job1 = Uuid::new_v4();
+        let job2 = Uuid::new_v4();
+        write_job(dir.path(), job1, "job1");
 
-        // Discover + claim job 1
         let run_id1 = provider.discover().await.unwrap();
         let ctx1 = provider.claim(run_id1).await.unwrap();
         assert_eq!(ctx1.prompt, "job1");
 
-        // Client 2
-        let sock = sock_path.clone();
-        let client2 = tokio::spawn(async move {
-            let mut stream = UnixStream::connect(&sock).await.unwrap();
-            let req = serde_json::json!({"prompt": "job2", "working_dir": "/workspace", "cli_agent_type": "claude-code"});
-            stream
-                .write_all(serde_json::to_string(&req).unwrap().as_bytes())
-                .await
-                .unwrap();
-            stream.shutdown().await.unwrap();
-            let mut buf = Vec::new();
-            stream.read_to_end(&mut buf).await.unwrap();
-            serde_json::from_slice::<JobResponse>(&buf).unwrap()
-        });
+        write_job(dir.path(), job2, "job2");
 
-        // Discover + claim job 2
         let run_id2 = provider.discover().await.unwrap();
         let ctx2 = provider.claim(run_id2).await.unwrap();
         assert_eq!(ctx2.prompt, "job2");
         assert_ne!(run_id1, run_id2);
 
-        // Complete both
         provider.complete(run_id1, 0, None).await;
         provider.complete(run_id2, 1, Some("test error")).await;
 
-        let resp1 = client1.await.unwrap();
+        let resp1 = read_result(dir.path(), job1);
         assert_eq!(resp1.exit_code, 0);
         assert!(resp1.error.is_none());
 
-        let resp2 = client2.await.unwrap();
+        let resp2 = read_result(dir.path(), job2);
         assert_eq!(resp2.exit_code, 1);
         assert_eq!(resp2.error.as_deref(), Some("test error"));
+    }
+
+    #[tokio::test]
+    async fn group_claim_only_one_winner() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+
+        let provider_a = LocalProvider::new(dir.path().to_path_buf(), cancel.clone());
+        let provider_b = LocalProvider::new(dir.path().to_path_buf(), cancel);
+
+        let job_id = Uuid::new_v4();
+        write_job(dir.path(), job_id, "shared");
+
+        let id_a = provider_a.discover().await.unwrap();
+        let id_b = provider_b.discover().await.unwrap();
+        assert_eq!(id_a, job_id);
+        assert_eq!(id_b, job_id);
+
+        let claim_a = provider_a.claim(id_a).await;
+        let claim_b = provider_b.claim(id_b).await;
+
+        assert!(
+            claim_a.is_some() ^ claim_b.is_some(),
+            "exactly one runner should win the claim"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Replace Unix socket local provider with file queue for multi-runner upgrade testing
- File queue protocol: `.job` → `.claim` (O_EXCL) → `.result` (atomic rename)
- `submit --group <name>` resolves to `~/.vm0-runner/groups/{group}/`
- CI: new `runner-upgrade-local` job tests drain-during-execution (SIGUSR1 while job in-flight)

## Test plan

- [x] `cargo clippy -p runner --all-targets` clean
- [x] `cargo test -p runner` — 155 tests pass
- [ ] CI `runner-upgrade-local` job passes on metal host

Closes #3165

🤖 Generated with [Claude Code](https://claude.com/claude-code)