### PR TITLE
feat(runner): use service install/drain in ci upgrade test

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -278,25 +278,30 @@ jobs:
           BIN_DIR=$1; JOB_REF=$2; GROUP=$3
           RUNNER_DIR_A="$HOME/.vm0-runner/runners/${JOB_REF}-upgrade-a"
           RUNNER_DIR_B="$HOME/.vm0-runner/runners/${JOB_REF}-upgrade-b"
+          SVC_A="${JOB_REF}-upgrade-a"
+          SVC_B="${JOB_REF}-upgrade-b"
+
+          fail() { echo "FAIL: $1"; exit 1; }
 
           cleanup() {
-            kill $PID_A $PID_B 2>/dev/null || true
-            wait $PID_A $PID_B 2>/dev/null || true
+            echo "--- Cleanup: uninstalling services ---"
+            "$BIN_DIR/runner" service uninstall --name "$SVC_A" 2>/dev/null || true
+            "$BIN_DIR/runner" service uninstall --name "$SVC_B" 2>/dev/null || true
+            echo "--- Cleanup: dumping logs ---"
+            journalctl --unit "vm0-runner-${SVC_A}" --lines 50 --no-pager 2>/dev/null || true
+            journalctl --unit "vm0-runner-${SVC_B}" --lines 50 --no-pager 2>/dev/null || true
           }
           trap cleanup EXIT
 
-          # Kill leftover runners from previous CI runs
-          pkill -f "runner start.*${JOB_REF}-upgrade" 2>/dev/null || true
-          sleep 1
+          # Pre-cleanup: uninstall leftover services from previous CI runs
+          "$BIN_DIR/runner" service uninstall --name "$SVC_A" 2>/dev/null || true
+          "$BIN_DIR/runner" service uninstall --name "$SVC_B" 2>/dev/null || true
 
-          # 1. Start runner A
-          echo "--- Starting runner A ---"
-          USE_MOCK_CLAUDE=true "$BIN_DIR/runner" start \
-            --local --config "$RUNNER_DIR_A/runner.yaml" \
-            > "$RUNNER_DIR_A/local.log" 2>&1 &
-          PID_A=$!
+          # 1. Install runner A
+          echo "--- Installing runner A ---"
+          "$BIN_DIR/runner" service install --name "$SVC_A" \
+            --config "$RUNNER_DIR_A/runner.yaml" --local --env USE_MOCK_CLAUDE=true
           sleep 2
-          kill -0 $PID_A 2>/dev/null || { echo "ERROR: Runner A crashed"; cat "$RUNNER_DIR_A/local.log"; exit 1; }
 
           # 2. Submit job 1 (background, long-running) → only A running
           echo "--- Submit job 1 (only A, long-running) ---"
@@ -304,14 +309,11 @@ jobs:
           SUBMIT1_PID=$!
           sleep 3
 
-          # 3. Start runner B while job 1 still in-flight on A
-          echo "--- Starting runner B ---"
-          USE_MOCK_CLAUDE=true "$BIN_DIR/runner" start \
-            --local --config "$RUNNER_DIR_B/runner.yaml" \
-            > "$RUNNER_DIR_B/local.log" 2>&1 &
-          PID_B=$!
+          # 3. Install runner B while job 1 still in-flight on A
+          echo "--- Installing runner B ---"
+          "$BIN_DIR/runner" service install --name "$SVC_B" \
+            --config "$RUNNER_DIR_B/runner.yaml" --local --env USE_MOCK_CLAUDE=true
           sleep 2
-          kill -0 $PID_B 2>/dev/null || { echo "ERROR: Runner B crashed"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
 
           # 4. Submit job 2 (background, long-running) → A and B compete
           echo "--- Submit job 2 (A and B compete, long-running) ---"
@@ -321,28 +323,27 @@ jobs:
 
           # 5. Drain A while jobs may be in-flight
           echo "--- Draining runner A ---"
-          kill -USR1 $PID_A 2>/dev/null
+          "$BIN_DIR/runner" service drain --name "$SVC_A"
 
           # 6. Verify both jobs complete despite drain
           echo "--- Waiting for job 1 ---"
-          wait $SUBMIT1_PID
-          [ $? -eq 0 ] || { echo "ERROR: Job 1 failed"; cat "$RUNNER_DIR_A/local.log"; exit 1; }
+          wait $SUBMIT1_PID || fail "Job 1 failed"
           echo "--- Waiting for job 2 ---"
-          wait $SUBMIT2_PID
-          [ $? -eq 0 ] || { echo "ERROR: Job 2 failed"; cat "$RUNNER_DIR_A/local.log"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
+          wait $SUBMIT2_PID || fail "Job 2 failed"
 
-          # 7. Wait for A to exit
-          wait $PID_A 2>/dev/null || true
+          # 7. Uninstall A (systemctl stop blocks until drain finishes)
+          echo "--- Uninstalling runner A ---"
+          "$BIN_DIR/runner" service uninstall --name "$SVC_A"
 
           # 8. Submit job 3 → only B is left
           echo "--- Submit job 3 (only B) ---"
-          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'echo job3'
-          [ $? -eq 0 ] || { echo "ERROR: Job 3 failed"; cat "$RUNNER_DIR_B/local.log"; exit 1; }
+          "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'echo job3' || fail "Job 3 failed"
 
-          # 9. Drain B
+          # 9. Drain and uninstall B
           echo "--- Draining runner B ---"
-          kill -USR1 $PID_B 2>/dev/null
-          wait $PID_B 2>/dev/null || true
+          "$BIN_DIR/runner" service drain --name "$SVC_B"
+          echo "--- Uninstalling runner B ---"
+          "$BIN_DIR/runner" service uninstall --name "$SVC_B"
           trap - EXIT
 
           echo "=== Upgrade test passed ==="
@@ -371,4 +372,6 @@ jobs:
           REMOTE="${METAL_USER}@${HOST}"
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
           echo "Cleaning up ${JOB_REF} on ${HOST}"
+          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner service uninstall --name ${JOB_REF}-upgrade-a" 2>/dev/null || true
+          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner service uninstall --name ${JOB_REF}-upgrade-b" 2>/dev/null || true
           ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} ~/.vm0-runner/runners/${JOB_REF}-bench ~/.vm0-runner/runners/${JOB_REF}-upgrade-a ~/.vm0-runner/runners/${JOB_REF}-upgrade-b ~/.vm0-runner/groups/vm0/upgrade-${JOB_REF}" || true

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -304,25 +304,21 @@ jobs:
           echo "--- Installing runner A ---"
           "$BIN_DIR/runner" service install --name "$SVC_A" \
             --config "$RUNNER_DIR_A/runner.yaml" --local --env USE_MOCK_CLAUDE=true
-          sleep 2  # wait for systemd to start the service and the runner to initialize
 
           # 2. Submit job 1 (background, long-running) → only A running
           echo "--- Submit job 1 (only A, long-running) ---"
           "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 12 && echo job1' &
           SUBMIT1_PID=$!
-          sleep 3
 
           # 3. Install runner B while job 1 still in-flight on A
           echo "--- Installing runner B ---"
           "$BIN_DIR/runner" service install --name "$SVC_B" \
             --config "$RUNNER_DIR_B/runner.yaml" --local --env USE_MOCK_CLAUDE=true
-          sleep 2  # wait for systemd to start the service and the runner to initialize
 
           # 4. Submit job 2 (background, long-running) → A and B compete
           echo "--- Submit job 2 (A and B compete, long-running) ---"
           "$BIN_DIR/runner" submit --group "$GROUP" --prompt 'sleep 12 && echo job2' &
           SUBMIT2_PID=$!
-          sleep 3
 
           # 5. Drain A while jobs may be in-flight
           echo "--- Draining runner A ---"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -281,15 +281,18 @@ jobs:
           SVC_A="${JOB_REF}-upgrade-a"
           SVC_B="${JOB_REF}-upgrade-b"
 
-          fail() { echo "FAIL: $1"; exit 1; }
+          FAILED=0
+          fail() { FAILED=1; echo "FAIL: $1"; exit 1; }
 
           cleanup() {
             echo "--- Cleanup: uninstalling services ---"
             "$BIN_DIR/runner" service uninstall --name "$SVC_A" 2>/dev/null || true
             "$BIN_DIR/runner" service uninstall --name "$SVC_B" 2>/dev/null || true
-            echo "--- Cleanup: dumping logs ---"
-            journalctl --unit "vm0-runner-${SVC_A}" --lines 50 --no-pager 2>/dev/null || true
-            journalctl --unit "vm0-runner-${SVC_B}" --lines 50 --no-pager 2>/dev/null || true
+            if [ "$FAILED" -ne 0 ]; then
+              echo "--- Cleanup: dumping logs (test failed) ---"
+              journalctl --unit "vm0-runner-${SVC_A}" --lines 50 --no-pager 2>/dev/null || true
+              journalctl --unit "vm0-runner-${SVC_B}" --lines 50 --no-pager 2>/dev/null || true
+            fi
           }
           trap cleanup EXIT
 
@@ -301,7 +304,7 @@ jobs:
           echo "--- Installing runner A ---"
           "$BIN_DIR/runner" service install --name "$SVC_A" \
             --config "$RUNNER_DIR_A/runner.yaml" --local --env USE_MOCK_CLAUDE=true
-          sleep 2
+          sleep 2  # wait for systemd to start the service and the runner to initialize
 
           # 2. Submit job 1 (background, long-running) → only A running
           echo "--- Submit job 1 (only A, long-running) ---"
@@ -313,7 +316,7 @@ jobs:
           echo "--- Installing runner B ---"
           "$BIN_DIR/runner" service install --name "$SVC_B" \
             --config "$RUNNER_DIR_B/runner.yaml" --local --env USE_MOCK_CLAUDE=true
-          sleep 2
+          sleep 2  # wait for systemd to start the service and the runner to initialize
 
           # 4. Submit job 2 (background, long-running) → A and B compete
           echo "--- Submit job 2 (A and B compete, long-running) ---"

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -40,6 +40,9 @@ struct ServiceStartArgs {
     /// Environment variables to pass to the service (KEY=VALUE)
     #[arg(long, value_name = "KEY=VALUE")]
     env: Vec<String>,
+    /// Use local file queue provider instead of API
+    #[arg(long)]
+    local: bool,
 }
 
 #[derive(Args)]
@@ -53,6 +56,9 @@ struct ServiceInstallArgs {
     /// Environment variables to pass to the service (KEY=VALUE)
     #[arg(long, value_name = "KEY=VALUE")]
     env: Vec<String>,
+    /// Use local file queue provider instead of API
+    #[arg(long)]
+    local: bool,
 }
 
 #[derive(Args)]
@@ -143,11 +149,13 @@ fn generate_unit_file(
     config_path: &Path,
     user: &str,
     env_vars: &[String],
+    local: bool,
 ) -> String {
     let mut env_lines = String::new();
     for entry in env_vars {
         env_lines.push_str(&format!("Environment=\"{entry}\"\n"));
     }
+    let local_flag = if local { " --local" } else { "" };
     format!(
         "\
 [Unit]
@@ -157,7 +165,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=\"{exe}\" start --config \"{config}\"
+ExecStart=\"{exe}\" start --config \"{config}\"{local_flag}
 Restart=on-failure
 RestartSec=5
 MemoryMax=2G
@@ -310,6 +318,9 @@ async fn start(args: ServiceStartArgs) -> RunnerResult<()> {
     cmd.arg(&exe_path)
         .args(["start", "--config"])
         .arg(&config_path);
+    if args.local {
+        cmd.arg("--local");
+    }
 
     let status = cmd
         .status()
@@ -351,7 +362,8 @@ async fn install(args: ServiceInstallArgs) -> RunnerResult<()> {
         .ok_or_else(|| RunnerError::Internal(format!("no user found for uid {uid}")))?
         .name;
 
-    let unit_content = generate_unit_file(&unit, &exe_path, &config_path, &user, &args.env);
+    let unit_content =
+        generate_unit_file(&unit, &exe_path, &config_path, &user, &args.env, args.local);
     let upath = unit_file_path(&unit);
 
     write_unit_file(&upath, &unit_content).await?;
@@ -496,10 +508,11 @@ mod tests {
             Path::new("/home/ubuntu/runner.yaml"),
             "ubuntu",
             &[],
+            false,
         );
         assert!(content.contains("Description=VM0 Runner (vm0-runner-v0.1.0)"));
         assert!(content.contains(
-            "ExecStart=\"/home/ubuntu/.vm0-runner/bin/v0.1.0/vm0-runner\" start --config \"/home/ubuntu/runner.yaml\""
+            "ExecStart=\"/home/ubuntu/.vm0-runner/bin/v0.1.0/vm0-runner\" start --config \"/home/ubuntu/runner.yaml\"\n"
         ));
         assert!(content.contains("User=ubuntu"));
         assert!(content.contains("SyslogIdentifier=vm0-runner-v0.1.0"));
@@ -509,6 +522,7 @@ mod tests {
         assert!(content.contains("[Install]"));
         assert!(content.contains("WantedBy=multi-user.target"));
         assert!(!content.contains("Environment="));
+        assert!(!content.contains("--local"));
     }
 
     #[test]
@@ -524,6 +538,7 @@ mod tests {
             Path::new("/home/ubuntu/runner.yaml"),
             "ubuntu",
             &env,
+            false,
         );
         assert!(content.contains("Environment=\"VERCEL_AUTOMATION_BYPASS_SECRET=xxx\""));
         assert!(content.contains("Environment=\"USE_MOCK_CLAUDE=true\""));
@@ -539,11 +554,27 @@ mod tests {
             Path::new("/opt/my config/runner.yaml"),
             "deploy-user",
             &[],
+            false,
         );
         assert!(content.contains(
             "ExecStart=\"/opt/my runner/vm0-runner\" start --config \"/opt/my config/runner.yaml\""
         ));
         assert!(content.contains("User=deploy-user"));
+    }
+
+    #[test]
+    fn test_generate_unit_file_local_flag() {
+        let content = generate_unit_file(
+            "vm0-runner-v0.1.0",
+            Path::new("/usr/bin/runner"),
+            Path::new("/etc/runner.yaml"),
+            "ubuntu",
+            &[],
+            true,
+        );
+        assert!(content.contains(
+            "ExecStart=\"/usr/bin/runner\" start --config \"/etc/runner.yaml\" --local\n"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `--local` flag to `runner service install` and `runner service start` so the spawned runner uses the local file queue provider
- Rewrite `runner-upgrade-local` CI job to use `service install --local` / `service drain` / `service uninstall` instead of manual `start &` with PID tracking
- Add `service uninstall` to `runner-cleanup` job as safety net before `rm -rf`

This tests the actual systemd service lifecycle used in production and eliminates stale-process cleanup problems (systemd owns the lifecycle).

## Test plan
- [x] `cargo clippy -p runner --all-targets` — clean
- [x] `cargo test -p runner` — 156 tests pass
- [ ] CI `runner-upgrade-local` job passes on metal host

🤖 Generated with [Claude Code](https://claude.com/claude-code)