### PR TITLE
feat(runner): add --dry-run flag to rootfs, snapshot, and build commands

### DIFF
--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -18,16 +18,15 @@ pub struct BuildArgs {
 }
 
 pub async fn run_build(args: BuildArgs) -> RunnerResult<()> {
+    let dry_run = args.rootfs.dry_run;
     let rootfs_hash = super::rootfs::run_rootfs(args.rootfs).await?;
-    let (snapshot_hash, _snapshot_config) = super::snapshot::run_snapshot(SnapshotArgs {
-        rootfs_hash: rootfs_hash.clone(),
+    super::snapshot::run_snapshot(SnapshotArgs {
+        rootfs_hash,
         vcpu: args.vcpu,
         memory_mb: args.memory_mb,
+        dry_run,
     })
     .await?;
-
-    println!("rootfs_hash={rootfs_hash}");
-    println!("snapshot_hash={snapshot_hash}");
 
     Ok(())
 }

--- a/crates/runner/src/cmd/rootfs.rs
+++ b/crates/runner/src/cmd/rootfs.rs
@@ -20,6 +20,9 @@ pub struct RootfsArgs {
     guest_agent: PathBuf,
     #[arg(long)]
     guest_mock_claude: PathBuf,
+    /// Compute and print the input hash without building
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 impl RootfsArgs {
@@ -42,14 +45,20 @@ impl RootfsArgs {
 
 /// Build rootfs and return the content hash of the inputs.
 pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
+    let dry_run = args.dry_run;
     let guest_bins = args.guest_bins();
-    let paths = HomePaths::new()?;
 
     // Compute input hash: script + dockerfile + guest binaries.
     // The build script content is included so any logic change invalidates cache.
     let hash = compute_input_hash(&guest_bins).await?;
     tracing::info!("rootfs input hash: {hash}");
+    println!("rootfs_hash={hash}");
 
+    if dry_run {
+        return Ok(hash);
+    }
+
+    let paths = HomePaths::new()?;
     let rootfs_paths = RootfsPaths::new(&paths, &hash);
     let output_dir = rootfs_paths.dir();
 

--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -19,15 +19,22 @@ pub struct SnapshotArgs {
     /// Memory size in MiB for the snapshot VM.
     #[arg(long, default_value_t = DEFAULT_MEMORY_MB)]
     pub memory_mb: u32,
+    /// Compute and print the snapshot hash without building
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 /// Create a snapshot and return the complete snapshot path information.
-pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<(String, SnapshotConfig)> {
-    let paths = HomePaths::new()?;
-
+pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<(String, Option<SnapshotConfig>)> {
     let snapshot_hash = compute_snapshot_hash(&args);
     tracing::info!("snapshot hash: {snapshot_hash}");
+    println!("snapshot_hash={snapshot_hash}");
 
+    if args.dry_run {
+        return Ok((snapshot_hash, None));
+    }
+
+    let paths = HomePaths::new()?;
     let output_dir = paths.snapshots_dir().join(&snapshot_hash);
     let output = SnapshotOutputPaths::new(output_dir.clone());
 
@@ -35,7 +42,7 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<(String, SnapshotC
         tracing::info!("[OK] snapshot already exists: {}", output_dir.display());
         crate::paths::touch_mtime(&output_dir);
         let config = output.snapshot_config(&snapshot_hash).into();
-        return Ok((snapshot_hash, config));
+        return Ok((snapshot_hash, Some(config)));
     }
 
     // Acquire exclusive lock to prevent concurrent builds with the same hash.
@@ -46,7 +53,7 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<(String, SnapshotC
         tracing::info!("[OK] snapshot already exists: {}", output_dir.display());
         crate::paths::touch_mtime(&output_dir);
         let config = output.snapshot_config(&snapshot_hash).into();
-        return Ok((snapshot_hash, config));
+        return Ok((snapshot_hash, Some(config)));
     }
 
     // Clean up any partial output from a previous failed attempt.
@@ -98,7 +105,7 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<(String, SnapshotC
         "snapshot creation complete"
     );
 
-    Ok((snapshot_hash, sc.into()))
+    Ok((snapshot_hash, Some(sc.into())))
 }
 
 /// Check whether all expected snapshot outputs exist in the directory.
@@ -185,6 +192,7 @@ mod tests {
             rootfs_hash: "abc123".into(),
             vcpu: 2,
             memory_mb: 2048,
+            dry_run: false,
         };
         let hash = compute_snapshot_hash(&args);
 
@@ -202,6 +210,7 @@ mod tests {
             rootfs_hash: "abc123".into(),
             vcpu: 2,
             memory_mb: 2048,
+            dry_run: false,
         };
         let different_rootfs = SnapshotArgs {
             rootfs_hash: "def456".into(),
@@ -215,10 +224,16 @@ mod tests {
             memory_mb: 4096,
             ..base.clone()
         };
+        let different_dry_run = SnapshotArgs {
+            dry_run: true,
+            ..base.clone()
+        };
 
         let base_hash = compute_snapshot_hash(&base);
         assert_ne!(base_hash, compute_snapshot_hash(&different_rootfs));
         assert_ne!(base_hash, compute_snapshot_hash(&different_vcpu));
         assert_ne!(base_hash, compute_snapshot_hash(&different_memory));
+        // dry_run is not a build input — it must not change the hash.
+        assert_eq!(base_hash, compute_snapshot_hash(&different_dry_run));
     }
 }


### PR DESCRIPTION
## Summary

- Add `--dry-run` flag to `runner rootfs`, `runner snapshot`, and `runner build` commands
- When set, computes and prints the input hash (`key=value` format) without performing the actual build
- Each subcommand always prints its own hash to stdout; `run_build` is a pure orchestrator with no printing logic
- `run_snapshot` return type changed to `Option<SnapshotConfig>` (returns `None` in dry-run)
- CI `grep '^rootfs_hash=' | cut -d= -f2` parsing is fully compatible

## Test plan

- [x] `cargo clippy -p runner --all-targets` passes
- [x] `cargo test -p runner` — 156 tests pass (including snapshot hash stability + dry_run-doesn't-affect-hash assertion)
- [ ] Manual: `runner rootfs --dry-run --guest-init ... --guest-download ... --guest-agent ... --guest-mock-claude ...` outputs `rootfs_hash=<hash>` and returns immediately
- [ ] Manual: `runner build --dry-run ...` outputs both hashes without building

Closes #3168

🤖 Generated with [Claude Code](https://claude.com/claude-code)