### PR TITLE
fix(ci): use forked release-please-action with cargo-workspace-path support

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,7 +32,7 @@ jobs:
       web_version: ${{ steps.release.outputs['turbo/apps/web--version'] }}
       platform_version: ${{ steps.release.outputs['turbo/apps/platform--version'] }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: seven332/release-please-action@feat/cargo-workspace-path
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -81,7 +81,8 @@
             "alwaysLinkLocal": true
         },
         {
-            "type": "cargo-workspace"
+            "type": "cargo-workspace",
+            "cargoWorkspacePath": "crates"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- Use forked `seven332/release-please-action@feat/cargo-workspace-path` instead of `googleapis/release-please-action@v4`
- Add `cargoWorkspacePath: "crates"` to the cargo-workspace plugin config

The upstream `cargo-workspace` plugin hardcodes `Cargo.toml` at the repo root, but our Rust workspace lives at `crates/Cargo.toml`. Our fork ([seven332/release-please](https://github.com/seven332/release-please/tree/feat/cargo-workspace-path)) adds a `cargoWorkspacePath` option to resolve this.

Upstream issue: https://github.com/googleapis/release-please/issues/2589

Refs: #3173

🤖 Generated with [Claude Code](https://claude.com/claude-code)