### PR TITLE
chore(ci): switch release-please-action to vm0 branch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,7 +32,7 @@ jobs:
       web_version: ${{ steps.release.outputs['turbo/apps/web--version'] }}
       platform_version: ${{ steps.release.outputs['turbo/apps/platform--version'] }}
     steps:
-      - uses: seven332/release-please-action@feat/cargo-workspace-path
+      - uses: seven332/release-please-action@vm0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Switch `release-please-action` from `@feat/cargo-workspace-path` to `@vm0` branch
- The `vm0` branch on `seven332/release-please` combines both fixes:
  - `cargoWorkspacePath` support for non-root `Cargo.toml`
  - Merge plugin fix: propagate `version` field when merging candidates (fixes cli not appearing in release PR)

## Test plan
- [ ] CI passes
- [ ] After merge, release-please creates release PR including both Rust crates and Node packages (cli)

🤖 Generated with [Claude Code](https://claude.com/claude-code)