### PR TITLE
refactor(cli): extract git-client boundary module from github-skills

### DIFF
--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -10,17 +10,11 @@ import * as os from "os";
 import * as yaml from "yaml";
 import chalk from "chalk";
 
-// Mock downloadGitHubSkill and downloadGitHubDirectory since they use git commands (external system call)
-// This is the actual external boundary - git sparse-checkout via child_process.exec
-vi.mock("../../../lib/domain/github-skills", async (importOriginal) => {
-  const original =
-    await importOriginal<typeof import("../../../lib/domain/github-skills")>();
-  return {
-    ...original,
-    downloadGitHubSkill: vi.fn(),
-    downloadGitHubDirectory: vi.fn(),
-  };
-});
+// Mock git-client boundary module (external system call: git sparse-checkout via child_process.exec)
+vi.mock("../../../lib/external/git-client", () => ({
+  downloadGitHubSkill: vi.fn(),
+  downloadGitHubDirectory: vi.fn(),
+}));
 
 // Mock child_process.spawn since it's an external system call boundary
 // Used by silentUpgradeAfterCommand to run npm/pnpm install
@@ -35,7 +29,7 @@ vi.mock("child_process", async (importOriginal) => {
 import {
   downloadGitHubSkill,
   downloadGitHubDirectory,
-} from "../../../lib/domain/github-skills";
+} from "../../../lib/external/git-client";
 const mockDownloadGitHubSkill = vi.mocked(downloadGitHubSkill);
 const mockDownloadGitHubDirectory = vi.mocked(downloadGitHubDirectory);
 

--- a/turbo/apps/cli/src/lib/domain/github-skills.ts
+++ b/turbo/apps/cli/src/lib/domain/github-skills.ts
@@ -1,21 +1,21 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import * as os from "node:os";
-import { exec } from "node:child_process";
-import { promisify } from "node:util";
 import { parse as parseYaml } from "yaml";
 import {
   getInstructionsStorageName,
   getSkillStorageName as getCoreSkillStorageName,
   parseGitHubTreeUrl as parseGitHubTreeUrlCore,
-  parseGitHubUrl as parseGitHubUrlCore,
   type ParsedGitHubTreeUrl,
 } from "@vm0/core";
 
-const execAsync = promisify(exec);
-
 // Re-export from @vm0/core for convenience
 export { getInstructionsStorageName };
+
+// Re-export git operations from boundary module for backward compatibility
+export {
+  downloadGitHubSkill,
+  downloadGitHubDirectory,
+} from "../external/git-client";
 
 // Re-export the type with the local name for backwards compatibility
 type ParsedGitHubUrl = ParsedGitHubTreeUrl;
@@ -50,197 +50,6 @@ export function parseGitHubTreeUrl(url: string): ParsedGitHubUrl {
  */
 export function getSkillStorageName(parsed: ParsedGitHubUrl): string {
   return getCoreSkillStorageName(parsed.fullPath);
-}
-
-/**
- * Download a GitHub directory using git sparse-checkout
- *
- * @param parsed - Parsed GitHub URL
- * @param destDir - Destination directory for the downloaded content
- * @returns Path to the downloaded skill directory
- */
-export async function downloadGitHubSkill(
-  parsed: ParsedGitHubUrl,
-  destDir: string,
-): Promise<string> {
-  const repoUrl = `https://github.com/${parsed.owner}/${parsed.repo}.git`;
-  const skillDir = path.join(destDir, parsed.skillName);
-
-  // Create a temporary directory for sparse checkout
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vm0-skill-"));
-
-  try {
-    // Initialize sparse checkout
-    await execAsync(`git init`, { cwd: tempDir });
-    await execAsync(`git remote add origin "${repoUrl}"`, { cwd: tempDir });
-    await execAsync(`git config core.sparseCheckout true`, { cwd: tempDir });
-
-    // Configure sparse checkout to only fetch the skill path
-    const sparseFile = path.join(tempDir, ".git", "info", "sparse-checkout");
-    await fs.writeFile(sparseFile, parsed.path + "\n");
-
-    // Fetch only the required branch
-    await execAsync(`git fetch --depth 1 origin "${parsed.branch}"`, {
-      cwd: tempDir,
-    });
-    await execAsync(`git checkout "${parsed.branch}"`, { cwd: tempDir });
-
-    // Move the skill directory to destination
-    const fetchedPath = path.join(tempDir, parsed.path);
-    await fs.mkdir(path.dirname(skillDir), { recursive: true });
-    await fs.rename(fetchedPath, skillDir);
-
-    return skillDir;
-  } finally {
-    // Clean up temp directory
-    await fs.rm(tempDir, { recursive: true, force: true });
-  }
-}
-
-/**
- * Result of downloading a GitHub directory
- */
-interface GitHubDownloadResult {
-  /** Path to the downloaded directory */
-  dir: string;
-  /** Path to the temp root directory (for cleanup) */
-  tempRoot: string;
-}
-
-/**
- * Get the default branch of a GitHub repository using git ls-remote.
- * This avoids dependency on gh CLI and works with just git installed.
- *
- * @param owner - Repository owner
- * @param repo - Repository name
- * @returns Default branch name
- */
-async function getDefaultBranch(owner: string, repo: string): Promise<string> {
-  const repoUrl = `https://github.com/${owner}/${repo}.git`;
-  try {
-    // git ls-remote --symref outputs:
-    // ref: refs/heads/main    HEAD
-    // a1b2c3d...              HEAD
-    const { stdout } = await execAsync(
-      `git ls-remote --symref "${repoUrl}" HEAD`,
-    );
-
-    // Extract branch name from "ref: refs/heads/main" line
-    const match = stdout.match(/ref: refs\/heads\/([^\s]+)/);
-    if (!match) {
-      throw new Error(
-        `Could not determine default branch for ${owner}/${repo}`,
-      );
-    }
-    return match[1]!;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (
-      message.includes("not found") ||
-      message.includes("Repository not found")
-    ) {
-      throw new Error(`Repository not found: ${owner}/${repo}`);
-    }
-    if (
-      message.includes("Authentication failed") ||
-      message.includes("could not read Username")
-    ) {
-      throw new Error(
-        `Cannot access repository ${owner}/${repo}. Is it private?`,
-      );
-    }
-    throw error;
-  }
-}
-
-/**
- * Download a GitHub directory using git sparse-checkout.
- * Returns paths to both the downloaded directory and the temp root for cleanup.
- *
- * Supports multiple URL formats:
- * - https://github.com/owner/repo (plain repo, uses default branch, downloads root)
- * - https://github.com/owner/repo/tree/branch (root directory with explicit branch)
- * - https://github.com/owner/repo/tree/branch/path (subdirectory)
- *
- * @param url - GitHub URL
- * @returns Object with dir (downloaded path) and tempRoot (for cleanup)
- */
-export async function downloadGitHubDirectory(
-  url: string,
-): Promise<GitHubDownloadResult> {
-  const parsed = parseGitHubUrlCore(url);
-  if (!parsed) {
-    throw new Error(
-      `Invalid GitHub URL: ${url}. Expected format: https://github.com/{owner}/{repo}[/tree/{branch}[/path]]`,
-    );
-  }
-
-  const repoUrl = `https://github.com/${parsed.owner}/${parsed.repo}.git`;
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vm0-github-"));
-
-  try {
-    // Check git is available
-    try {
-      await execAsync("git --version");
-    } catch {
-      throw new Error(
-        "git command not found. Please install git to use GitHub URLs.",
-      );
-    }
-
-    // Resolve branch if not specified
-    const branch =
-      parsed.branch ?? (await getDefaultBranch(parsed.owner, parsed.repo));
-
-    // Initialize sparse checkout
-    await execAsync(`git init`, { cwd: tempDir });
-    await execAsync(`git remote add origin "${repoUrl}"`, { cwd: tempDir });
-    await execAsync(`git config core.sparseCheckout true`, { cwd: tempDir });
-
-    // Configure sparse checkout pattern
-    // For root: use "/*" to get all root-level files
-    // For path: use the path directly
-    const sparsePattern = parsed.path ?? "/*";
-    const sparseFile = path.join(tempDir, ".git", "info", "sparse-checkout");
-    await fs.writeFile(sparseFile, sparsePattern + "\n");
-
-    // Fetch only the required branch with better error handling
-    try {
-      await execAsync(`git fetch --depth 1 origin "${branch}"`, {
-        cwd: tempDir,
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      if (
-        message.includes("Authentication failed") ||
-        message.includes("could not read Username")
-      ) {
-        throw new Error(`Cannot access repository. Is it private? URL: ${url}`);
-      }
-      if (message.includes("couldn't find remote ref")) {
-        throw new Error(`Branch "${branch}" not found in repository: ${url}`);
-      }
-      throw error;
-    }
-
-    await execAsync(`git checkout "${branch}"`, { cwd: tempDir });
-
-    // Return directory path
-    // For root: return tempDir directly
-    // For path: return tempDir/path
-    const downloadedDir = parsed.path
-      ? path.join(tempDir, parsed.path)
-      : tempDir;
-
-    return {
-      dir: downloadedDir,
-      tempRoot: tempDir,
-    };
-  } catch (error) {
-    // Clean up on error
-    await fs.rm(tempDir, { recursive: true, force: true });
-    throw error;
-  }
 }
 
 /**

--- a/turbo/apps/cli/src/lib/external/git-client.ts
+++ b/turbo/apps/cli/src/lib/external/git-client.ts
@@ -1,0 +1,202 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  parseGitHubUrl as parseGitHubUrlCore,
+  type ParsedGitHubTreeUrl,
+} from "@vm0/core";
+
+const execAsync = promisify(exec);
+
+/**
+ * Result of downloading a GitHub directory
+ */
+interface GitHubDownloadResult {
+  /** Path to the downloaded directory */
+  dir: string;
+  /** Path to the temp root directory (for cleanup) */
+  tempRoot: string;
+}
+
+/**
+ * Download a GitHub directory using git sparse-checkout
+ *
+ * @param parsed - Parsed GitHub URL
+ * @param destDir - Destination directory for the downloaded content
+ * @returns Path to the downloaded skill directory
+ */
+export async function downloadGitHubSkill(
+  parsed: ParsedGitHubTreeUrl,
+  destDir: string,
+): Promise<string> {
+  const repoUrl = `https://github.com/${parsed.owner}/${parsed.repo}.git`;
+  const skillDir = path.join(destDir, parsed.skillName);
+
+  // Create a temporary directory for sparse checkout
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vm0-skill-"));
+
+  try {
+    // Initialize sparse checkout
+    await execAsync(`git init`, { cwd: tempDir });
+    await execAsync(`git remote add origin "${repoUrl}"`, { cwd: tempDir });
+    await execAsync(`git config core.sparseCheckout true`, { cwd: tempDir });
+
+    // Configure sparse checkout to only fetch the skill path
+    const sparseFile = path.join(tempDir, ".git", "info", "sparse-checkout");
+    await fs.writeFile(sparseFile, parsed.path + "\n");
+
+    // Fetch only the required branch
+    await execAsync(`git fetch --depth 1 origin "${parsed.branch}"`, {
+      cwd: tempDir,
+    });
+    await execAsync(`git checkout "${parsed.branch}"`, { cwd: tempDir });
+
+    // Move the skill directory to destination
+    const fetchedPath = path.join(tempDir, parsed.path);
+    await fs.mkdir(path.dirname(skillDir), { recursive: true });
+    await fs.rename(fetchedPath, skillDir);
+
+    return skillDir;
+  } finally {
+    // Clean up temp directory
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Get the default branch of a GitHub repository using git ls-remote.
+ * This avoids dependency on gh CLI and works with just git installed.
+ *
+ * @param owner - Repository owner
+ * @param repo - Repository name
+ * @returns Default branch name
+ */
+async function getDefaultBranch(owner: string, repo: string): Promise<string> {
+  const repoUrl = `https://github.com/${owner}/${repo}.git`;
+  try {
+    // git ls-remote --symref outputs:
+    // ref: refs/heads/main    HEAD
+    // a1b2c3d...              HEAD
+    const { stdout } = await execAsync(
+      `git ls-remote --symref "${repoUrl}" HEAD`,
+    );
+
+    // Extract branch name from "ref: refs/heads/main" line
+    const match = stdout.match(/ref: refs\/heads\/([^\s]+)/);
+    if (!match) {
+      throw new Error(
+        `Could not determine default branch for ${owner}/${repo}`,
+      );
+    }
+    return match[1]!;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (
+      message.includes("not found") ||
+      message.includes("Repository not found")
+    ) {
+      throw new Error(`Repository not found: ${owner}/${repo}`);
+    }
+    if (
+      message.includes("Authentication failed") ||
+      message.includes("could not read Username")
+    ) {
+      throw new Error(
+        `Cannot access repository ${owner}/${repo}. Is it private?`,
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Download a GitHub directory using git sparse-checkout.
+ * Returns paths to both the downloaded directory and the temp root for cleanup.
+ *
+ * Supports multiple URL formats:
+ * - https://github.com/owner/repo (plain repo, uses default branch, downloads root)
+ * - https://github.com/owner/repo/tree/branch (root directory with explicit branch)
+ * - https://github.com/owner/repo/tree/branch/path (subdirectory)
+ *
+ * @param url - GitHub URL
+ * @returns Object with dir (downloaded path) and tempRoot (for cleanup)
+ */
+export async function downloadGitHubDirectory(
+  url: string,
+): Promise<GitHubDownloadResult> {
+  const parsed = parseGitHubUrlCore(url);
+  if (!parsed) {
+    throw new Error(
+      `Invalid GitHub URL: ${url}. Expected format: https://github.com/{owner}/{repo}[/tree/{branch}[/path]]`,
+    );
+  }
+
+  const repoUrl = `https://github.com/${parsed.owner}/${parsed.repo}.git`;
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vm0-github-"));
+
+  try {
+    // Check git is available
+    try {
+      await execAsync("git --version");
+    } catch {
+      throw new Error(
+        "git command not found. Please install git to use GitHub URLs.",
+      );
+    }
+
+    // Resolve branch if not specified
+    const branch =
+      parsed.branch ?? (await getDefaultBranch(parsed.owner, parsed.repo));
+
+    // Initialize sparse checkout
+    await execAsync(`git init`, { cwd: tempDir });
+    await execAsync(`git remote add origin "${repoUrl}"`, { cwd: tempDir });
+    await execAsync(`git config core.sparseCheckout true`, { cwd: tempDir });
+
+    // Configure sparse checkout pattern
+    // For root: use "/*" to get all root-level files
+    // For path: use the path directly
+    const sparsePattern = parsed.path ?? "/*";
+    const sparseFile = path.join(tempDir, ".git", "info", "sparse-checkout");
+    await fs.writeFile(sparseFile, sparsePattern + "\n");
+
+    // Fetch only the required branch with better error handling
+    try {
+      await execAsync(`git fetch --depth 1 origin "${branch}"`, {
+        cwd: tempDir,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        message.includes("Authentication failed") ||
+        message.includes("could not read Username")
+      ) {
+        throw new Error(`Cannot access repository. Is it private? URL: ${url}`);
+      }
+      if (message.includes("couldn't find remote ref")) {
+        throw new Error(`Branch "${branch}" not found in repository: ${url}`);
+      }
+      throw error;
+    }
+
+    await execAsync(`git checkout "${branch}"`, { cwd: tempDir });
+
+    // Return directory path
+    // For root: return tempDir directly
+    // For path: return tempDir/path
+    const downloadedDir = parsed.path
+      ? path.join(tempDir, parsed.path)
+      : tempDir;
+
+    return {
+      dir: downloadedDir,
+      tempRoot: tempDir,
+    };
+  } catch (error) {
+    // Clean up on error
+    await fs.rm(tempDir, { recursive: true, force: true });
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

- Extract git CLI operations (`downloadGitHubSkill`, `downloadGitHubDirectory`) from `github-skills.ts` into a dedicated boundary module `lib/external/git-client.ts`
- Simplify `github-skills.ts` to pure domain logic (URL parsing, SKILL.md validation/parsing) with re-exports for backward compatibility
- Update compose test to mock `git-client` (full mock) instead of `github-skills` (partial mock with `importOriginal`)

## Test plan

- [x] All 89 compose tests pass
- [x] Lint, type check, format, knip all pass
- [x] No behavior changes — production code paths are identical

Closes #3007

🤖 Generated with [Claude Code](https://claude.com/claude-code)