### PR TITLE
fix(api): use framework-based filename lookup in instructions api

### DIFF
--- a/turbo/apps/cli/src/lib/storage/system-storage.ts
+++ b/turbo/apps/cli/src/lib/storage/system-storage.ts
@@ -11,7 +11,7 @@ import {
   type SkillFrontmatter,
 } from "../domain/github-skills";
 import { directUpload } from "./direct-upload";
-import { getValidatedFramework } from "@vm0/core";
+import { getInstructionsFilename } from "@vm0/core";
 
 interface StorageUploadResult {
   name: string;
@@ -25,25 +25,6 @@ interface StorageUploadResult {
 export interface SkillUploadResult extends StorageUploadResult {
   skillName: string;
   frontmatter: SkillFrontmatter;
-}
-
-/**
- * Get the canonical instructions filename for a framework
- *
- * Each framework expects instructions at a specific filename:
- * - claude-code: CLAUDE.md (read from ~/.claude/)
- * - codex: AGENTS.md (read from ~/.codex/)
- *
- * @param framework - The framework name (e.g., "claude-code", "codex")
- * @returns The canonical filename for instructions
- * @throws Error if framework is defined but not supported
- */
-function getInstructionsFilename(framework?: string): string {
-  const validatedFramework = getValidatedFramework(framework);
-  if (validatedFramework === "codex") {
-    return "AGENTS.md";
-  }
-  return "CLAUDE.md";
 }
 
 /**

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
@@ -257,6 +257,49 @@ describe("GET /api/agent/composes/:id/instructions", () => {
     expect(data.filename).toBe("AGENTS.md");
   });
 
+  it("should use AGENTS.md canonical filename for codex framework", async () => {
+    const agentName = "codex-agent";
+    const instructionsContent = "# Codex Instructions\n";
+
+    const { composeId } = await createTestCompose(agentName, {
+      overrides: { instructions: "AGENTS.md", framework: "codex" },
+    });
+
+    const storageName = getInstructionsStorageName(agentName);
+    await createTestVolume(storageName);
+
+    // Manifest contains AGENTS.md — the canonical filename for codex framework
+    context.mocks.s3.downloadManifest.mockResolvedValueOnce({
+      version: "a".repeat(64),
+      createdAt: new Date().toISOString(),
+      totalSize: instructionsContent.length,
+      fileCount: 1,
+      files: [
+        {
+          path: "AGENTS.md",
+          hash: "f".repeat(64),
+          size: instructionsContent.length,
+        },
+      ],
+    });
+
+    context.mocks.s3.downloadS3Buffer.mockResolvedValueOnce(
+      buildTarGz("AGENTS.md", instructionsContent),
+    );
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/composes/${composeId}/instructions`,
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: composeId }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.content).toBe(instructionsContent);
+    expect(data.filename).toBe("AGENTS.md");
+  });
+
   it("should normalize ./ prefix when matching instructions file in manifest", async () => {
     const agentName = "normalize-prefix-agent";
     const instructionsContent = "# Normalized content\n";

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
@@ -101,7 +101,7 @@ describe("GET /api/agent/composes/:id/instructions", () => {
     const agentName = "instructions-test-agent";
     const instructionsContent = "# My Agent\n\nDo the thing.\n";
 
-    // Create compose with instructions field
+    // Create compose with instructions field (framework defaults to claude-code)
     const { composeId } = await createTestCompose(agentName, {
       overrides: { instructions: "AGENTS.md" },
     });
@@ -110,7 +110,8 @@ describe("GET /api/agent/composes/:id/instructions", () => {
     const storageName = getInstructionsStorageName(agentName);
     await createTestVolume(storageName);
 
-    // Mock manifest to describe the file in the archive
+    // Mock manifest with CLAUDE.md — the canonical filename for claude-code framework.
+    // CLI uploads instructions with the framework-canonical name, not the user's filename.
     context.mocks.s3.downloadManifest.mockResolvedValueOnce({
       version: "a".repeat(64),
       createdAt: new Date().toISOString(),
@@ -118,16 +119,15 @@ describe("GET /api/agent/composes/:id/instructions", () => {
       fileCount: 1,
       files: [
         {
-          path: "AGENTS.md",
+          path: "CLAUDE.md",
           hash: "b".repeat(64),
           size: instructionsContent.length,
         },
       ],
     });
 
-    // Mock downloadS3Buffer to return a gzipped tar archive containing the instructions
     context.mocks.s3.downloadS3Buffer.mockResolvedValueOnce(
-      buildTarGz("AGENTS.md", instructionsContent),
+      buildTarGz("CLAUDE.md", instructionsContent),
     );
 
     const request = createTestRequest(
@@ -140,6 +140,7 @@ describe("GET /api/agent/composes/:id/instructions", () => {
 
     expect(response.status).toBe(200);
     expect(data.content).toBe(instructionsContent);
+    // filename in response is from compose YAML (what frontend displays)
     expect(data.filename).toBe("AGENTS.md");
   });
 
@@ -167,12 +168,11 @@ describe("GET /api/agent/composes/:id/instructions", () => {
       createdAt: new Date().toISOString(),
       totalSize: 50,
       fileCount: 1,
-      files: [{ path: "AGENTS.md", hash: "c".repeat(64), size: 50 }],
+      files: [{ path: "CLAUDE.md", hash: "c".repeat(64), size: 50 }],
     });
 
-    // Mock downloadS3Buffer to return a gzipped tar archive
     context.mocks.s3.downloadS3Buffer.mockResolvedValueOnce(
-      buildTarGz("AGENTS.md", "# Shared Instructions"),
+      buildTarGz("CLAUDE.md", "# Shared Instructions"),
     );
 
     const request = createTestRequest(
@@ -210,10 +210,13 @@ describe("GET /api/agent/composes/:id/instructions", () => {
     expect(data.error.code).toBe("NOT_FOUND");
   });
 
-  it("should fall back to CLAUDE.md when configured filename not found in manifest", async () => {
-    const agentName = "fallback-agent";
-    const claudeContent = "# Legacy CLAUDE.md content\n";
+  it("should find instructions by framework canonical filename regardless of compose YAML filename", async () => {
+    const agentName = "framework-lookup-agent";
+    const claudeContent = "# Instructions via framework lookup\n";
 
+    // Compose YAML says "AGENTS.md" but framework is claude-code,
+    // so CLI uploaded as "CLAUDE.md". The API should derive the canonical
+    // filename from the framework and find it in the manifest.
     const { composeId } = await createTestCompose(agentName, {
       overrides: { instructions: "AGENTS.md" },
     });
@@ -221,7 +224,7 @@ describe("GET /api/agent/composes/:id/instructions", () => {
     const storageName = getInstructionsStorageName(agentName);
     await createTestVolume(storageName);
 
-    // Manifest only contains CLAUDE.md, not AGENTS.md
+    // Manifest contains CLAUDE.md (canonical for claude-code framework)
     context.mocks.s3.downloadManifest.mockResolvedValueOnce({
       version: "a".repeat(64),
       createdAt: new Date().toISOString(),
@@ -250,6 +253,7 @@ describe("GET /api/agent/composes/:id/instructions", () => {
 
     expect(response.status).toBe(200);
     expect(data.content).toBe(claudeContent);
+    // filename in response is still from compose YAML (what the frontend displays)
     expect(data.filename).toBe("AGENTS.md");
   });
 
@@ -264,7 +268,8 @@ describe("GET /api/agent/composes/:id/instructions", () => {
     const storageName = getInstructionsStorageName(agentName);
     await createTestVolume(storageName);
 
-    // Manifest file has ./ prefix but config says "AGENTS.md" without prefix
+    // Manifest file has ./ prefix (e.g., ./CLAUDE.md) — should still match
+    // the canonical filename CLAUDE.md after normalization
     context.mocks.s3.downloadManifest.mockResolvedValueOnce({
       version: "a".repeat(64),
       createdAt: new Date().toISOString(),
@@ -272,7 +277,7 @@ describe("GET /api/agent/composes/:id/instructions", () => {
       fileCount: 1,
       files: [
         {
-          path: "./AGENTS.md",
+          path: "./CLAUDE.md",
           hash: "e".repeat(64),
           size: instructionsContent.length,
         },
@@ -280,7 +285,7 @@ describe("GET /api/agent/composes/:id/instructions", () => {
     });
 
     context.mocks.s3.downloadS3Buffer.mockResolvedValueOnce(
-      buildTarGz("./AGENTS.md", instructionsContent),
+      buildTarGz("./CLAUDE.md", instructionsContent),
     );
 
     const request = createTestRequest(
@@ -517,10 +522,10 @@ describe("PUT /api/agent/composes/:id/instructions", () => {
     );
     const manifestBody = JSON.parse(manifestCall![2] as string);
 
-    // Mock GET to return what was PUT
+    // Mock GET to return what was PUT (PUT now stores with canonical filename CLAUDE.md)
     context.mocks.s3.downloadManifest.mockResolvedValueOnce(manifestBody);
     context.mocks.s3.downloadS3Buffer.mockResolvedValueOnce(
-      buildTarGz("AGENTS.md", newContent),
+      buildTarGz("CLAUDE.md", newContent),
     );
 
     // GET the instructions back

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -29,7 +29,7 @@ import {
 } from "../../../../../../src/lib/s3/s3-client";
 import type { S3StorageManifest } from "../../../../../../src/lib/s3/types";
 import { env } from "../../../../../../src/env";
-import { getInstructionsStorageName } from "@vm0/core";
+import { getInstructionsStorageName, getInstructionsFilename } from "@vm0/core";
 import type { AgentComposeYaml } from "../../../../../../src/types/agent-compose";
 import {
   hashFileContent,
@@ -140,14 +140,15 @@ export async function GET(
   // Download manifest to find the actual filename in storage
   const manifest = await downloadManifest(bucket, version.s3Key);
 
-  // Find the instructions file in manifest, normalizing ./ prefix.
-  // Temporary fallback: if the configured filename isn't found, try CLAUDE.md
-  // (some volumes were created with CLAUDE.md before the rename to AGENTS.md).
+  // Derive the canonical filename from the agent's framework.
+  // CLI uploads instructions with a framework-canonical name (e.g., CLAUDE.md
+  // for claude-code, AGENTS.md for codex). Use the same mapping to look up
+  // the file in the manifest, ensuring the read path matches the write path.
+  const canonicalFilename = getInstructionsFilename(agentDef?.framework);
   const normalize = (p: string) => (p.startsWith("./") ? p.slice(2) : p);
-  const instructionFile =
-    manifest.files.find(
-      (f) => normalize(f.path) === normalize(instructionsFilename),
-    ) ?? manifest.files.find((f) => normalize(f.path) === "CLAUDE.md");
+  const instructionFile = manifest.files.find(
+    (f) => normalize(f.path) === normalize(canonicalFilename),
+  );
 
   if (!instructionFile) {
     return NextResponse.json({ content: null, filename: instructionsFilename });
@@ -325,12 +326,16 @@ export async function PUT(
     );
   }
 
+  // Use the framework-canonical filename so the archive matches what CLI uploads
+  // and what the GET endpoint expects (symmetric read/write contract).
+  const canonicalFilename = getInstructionsFilename(agentDef?.framework);
+
   // Compute content hash and version ID
   const contentBuffer = Buffer.from(body.content, "utf-8");
   const contentHash = hashFileContent(contentBuffer);
   const files = [
     {
-      path: instructionsFilename,
+      path: canonicalFilename,
       hash: contentHash,
       size: contentBuffer.length,
     },
@@ -349,7 +354,7 @@ export async function PUT(
     files,
   };
 
-  const tarBuffer = createSingleFileTar(instructionsFilename, contentBuffer);
+  const tarBuffer = createSingleFileTar(canonicalFilename, contentBuffer);
   const archiveBuffer = gzipSync(tarBuffer);
 
   // Upload to S3 before the DB transaction. If the DB transaction fails,

--- a/turbo/packages/core/src/__tests__/frameworks.spec.ts
+++ b/turbo/packages/core/src/__tests__/frameworks.spec.ts
@@ -5,6 +5,7 @@ import {
   assertSupportedFramework,
   getValidatedFramework,
   getFrameworkDisplayName,
+  getInstructionsFilename,
 } from "../frameworks";
 
 describe("frameworks", () => {
@@ -106,6 +107,26 @@ describe("frameworks", () => {
 
     it("throws for unknown framework", () => {
       expect(() => getFrameworkDisplayName("unknown")).toThrow(
+        'Unsupported framework "unknown"',
+      );
+    });
+  });
+
+  describe("getInstructionsFilename", () => {
+    it('returns "CLAUDE.md" for claude-code', () => {
+      expect(getInstructionsFilename("claude-code")).toBe("CLAUDE.md");
+    });
+
+    it('returns "AGENTS.md" for codex', () => {
+      expect(getInstructionsFilename("codex")).toBe("AGENTS.md");
+    });
+
+    it('returns "CLAUDE.md" for undefined (defaults to claude-code)', () => {
+      expect(getInstructionsFilename(undefined)).toBe("CLAUDE.md");
+    });
+
+    it("throws for unknown framework", () => {
+      expect(() => getInstructionsFilename("unknown")).toThrow(
         'Unsupported framework "unknown"',
       );
     });

--- a/turbo/packages/core/src/frameworks.ts
+++ b/turbo/packages/core/src/frameworks.ts
@@ -79,3 +79,29 @@ export function getFrameworkDisplayName(framework: string): string {
   assertSupportedFramework(framework);
   return FRAMEWORK_DISPLAY_NAMES[framework];
 }
+
+/**
+ * Canonical instructions filename for each framework.
+ */
+const FRAMEWORK_INSTRUCTIONS_FILENAMES: Record<SupportedFramework, string> = {
+  "claude-code": "CLAUDE.md",
+  codex: "AGENTS.md",
+};
+
+/**
+ * Get the canonical instructions filename for a framework
+ *
+ * Each framework expects instructions at a specific filename:
+ * - claude-code: CLAUDE.md (read from ~/.claude/)
+ * - codex: AGENTS.md (read from ~/.codex/)
+ *
+ * Used by CLI (upload) and web API (read) to ensure a symmetric contract.
+ *
+ * @param framework - The framework name (undefined defaults to claude-code)
+ * @returns The canonical filename for instructions
+ * @throws Error if framework is defined but not supported
+ */
+export function getInstructionsFilename(framework?: string): string {
+  const validated = getValidatedFramework(framework);
+  return FRAMEWORK_INSTRUCTIONS_FILENAMES[validated];
+}


### PR DESCRIPTION
## Summary

- Fix instructions API filename mismatch by deriving canonical filename from the agent's framework instead of using compose YAML's user-specified filename
- Move `getInstructionsFilename` from CLI private function to `@vm0/core` shared package, establishing a symmetric contract between upload (CLI) and read (API)
- Update both GET and PUT endpoints to use framework-based filename, eliminating the temporary CLAUDE.md fallback

## Test plan

- [ ] `@vm0/core` framework tests pass (4 new tests for `getInstructionsFilename`)
- [ ] Instructions route tests pass (17/17, updated to reflect framework-based lookup)
- [ ] Lint, knip pass cleanly
- [ ] Round-trip test (PUT then GET) confirms symmetric behavior

Closes #3009

🤖 Generated with [Claude Code](https://claude.com/claude-code)