### PR TITLE
fix(email): validate sender authenticity via DMARC for email triggers

### DIFF
--- a/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
@@ -374,5 +374,202 @@ describe("POST /api/webhooks/email/inbound", () => {
       // Resend should not have been called (early return after agent lookup failed)
       expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
     });
+
+    it("should reject trigger email when DMARC fails", async () => {
+      const user = await context.setupUser({ prefix: "dmarc-fail" });
+      const suffix = user.userId.slice("dmarc-fail-".length);
+      const scopeSlug = `scope-${suffix}`;
+      const agentName = uniqueId("dmarc-agent");
+      await createTestCompose(agentName);
+
+      const senderEmail = "spoofed@example.com";
+      mockClerk({ userId: user.userId, email: senderEmail });
+
+      // Override Resend mock to return dmarc=fail
+      mockResend.emails.receiving.get.mockResolvedValueOnce({
+        data: {
+          from: senderEmail,
+          to: [`${scopeSlug}+${agentName}@vm7.bot`],
+          subject: "Spoofed email",
+          text: "I am pretending to be someone else",
+          html: "<p>I am pretending to be someone else</p>",
+          headers: {
+            "authentication-results":
+              "mx.resend.com; dkim=fail header.d=example.com; spf=fail smtp.mailfrom=attacker.com; dmarc=fail header.from=example.com",
+          },
+        },
+      } as never);
+
+      const payload = JSON.stringify({
+        type: "email.received",
+        data: {
+          email_id: "dmarc-fail-email",
+          to: [`${scopeSlug}+${agentName}@vm7.bot`],
+          from: senderEmail,
+          subject: "Spoofed email",
+          created_at: new Date().toISOString(),
+        },
+      });
+
+      const request = createWebhookRequest(payload);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      // No run should have been created
+      const runs = await findTestRunsByUserAndPrompt(
+        user.userId,
+        "Spoofed email\n\nI am pretending to be someone else",
+      );
+      expect(runs).toHaveLength(0);
+    });
+
+    it("should reject trigger email when DMARC is none even if DKIM passes", async () => {
+      const user = await context.setupUser({ prefix: "dkim-pass" });
+      const suffix = user.userId.slice("dkim-pass-".length);
+      const scopeSlug = `scope-${suffix}`;
+      const agentName = uniqueId("dkim-agent");
+      await createTestCompose(agentName);
+
+      const senderEmail = "user@nodmarc.com";
+      mockClerk({ userId: user.userId, email: senderEmail });
+
+      // Override Resend mock: dmarc=none but dkim=pass — still rejected
+      mockResend.emails.receiving.get.mockResolvedValueOnce({
+        data: {
+          from: senderEmail,
+          to: [`${scopeSlug}+${agentName}@vm7.bot`],
+          subject: "DKIM Only",
+          text: "My domain has no DMARC but DKIM is valid",
+          html: "<p>My domain has no DMARC but DKIM is valid</p>",
+          headers: {
+            "authentication-results":
+              "mx.resend.com; dkim=pass header.d=nodmarc.com; spf=fail smtp.mailfrom=nodmarc.com; dmarc=none header.from=nodmarc.com",
+          },
+        },
+      } as never);
+
+      const payload = JSON.stringify({
+        type: "email.received",
+        data: {
+          email_id: "dkim-pass-email",
+          to: [`${scopeSlug}+${agentName}@vm7.bot`],
+          from: senderEmail,
+          subject: "DKIM Only",
+          created_at: new Date().toISOString(),
+        },
+      });
+
+      const request = createWebhookRequest(payload);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      // No run should have been created — DMARC-only policy rejects dmarc=none
+      const runs = await findTestRunsByUserAndPrompt(
+        user.userId,
+        "DKIM Only\n\nMy domain has no DMARC but DKIM is valid",
+      );
+      expect(runs).toHaveLength(0);
+    });
+
+    it("should reject trigger email when authentication-results header is missing", async () => {
+      const user = await context.setupUser({ prefix: "no-auth" });
+      const suffix = user.userId.slice("no-auth-".length);
+      const scopeSlug = `scope-${suffix}`;
+      const agentName = uniqueId("noauth-agent");
+      await createTestCompose(agentName);
+
+      const senderEmail = "user@example.com";
+      mockClerk({ userId: user.userId, email: senderEmail });
+
+      // Override Resend mock: no authentication-results header
+      mockResend.emails.receiving.get.mockResolvedValueOnce({
+        data: {
+          from: senderEmail,
+          to: [`${scopeSlug}+${agentName}@vm7.bot`],
+          subject: "No Auth Headers",
+          text: "Email without authentication results",
+          html: "<p>Email without authentication results</p>",
+          headers: {},
+        },
+      } as never);
+
+      const payload = JSON.stringify({
+        type: "email.received",
+        data: {
+          email_id: "no-auth-email",
+          to: [`${scopeSlug}+${agentName}@vm7.bot`],
+          from: senderEmail,
+          subject: "No Auth Headers",
+          created_at: new Date().toISOString(),
+        },
+      });
+
+      const request = createWebhookRequest(payload);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      // No run should have been created
+      const runs = await findTestRunsByUserAndPrompt(
+        user.userId,
+        "No Auth Headers\n\nEmail without authentication results",
+      );
+      expect(runs).toHaveLength(0);
+    });
+
+    it("should reject trigger email when all authentication methods fail", async () => {
+      const user = await context.setupUser({ prefix: "all-fail" });
+      const suffix = user.userId.slice("all-fail-".length);
+      const scopeSlug = `scope-${suffix}`;
+      const agentName = uniqueId("allfail-agent");
+      await createTestCompose(agentName);
+
+      const senderEmail = "user@misconfigured.com";
+      mockClerk({ userId: user.userId, email: senderEmail });
+
+      // Override Resend mock: all authentication methods fail
+      mockResend.emails.receiving.get.mockResolvedValueOnce({
+        data: {
+          from: senderEmail,
+          to: [`${scopeSlug}+${agentName}@vm7.bot`],
+          subject: "All Fail",
+          text: "Everything failed",
+          html: "<p>Everything failed</p>",
+          headers: {
+            "authentication-results":
+              "mx.resend.com; dkim=fail; spf=fail; dmarc=fail",
+          },
+        },
+      } as never);
+
+      const payload = JSON.stringify({
+        type: "email.received",
+        data: {
+          email_id: "all-fail-email",
+          to: [`${scopeSlug}+${agentName}@vm7.bot`],
+          from: senderEmail,
+          subject: "All Fail",
+          created_at: new Date().toISOString(),
+        },
+      });
+
+      const request = createWebhookRequest(payload);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      // No run should have been created
+      const runs = await findTestRunsByUserAndPrompt(
+        user.userId,
+        "All Fail\n\nEverything failed",
+      );
+      expect(runs).toHaveLength(0);
+    });
   });
 });

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -185,6 +185,10 @@ vi.mock("resend", () => {
             subject: "Re: test",
             text: "Hello from email",
             html: "<p>Hello from email</p>",
+            headers: {
+              "authentication-results":
+                "mx.resend.com; dkim=pass header.d=example.com; spf=pass smtp.mailfrom=example.com; dmarc=pass header.from=example.com",
+            },
           },
         }),
       },

--- a/turbo/apps/web/src/lib/email/client.ts
+++ b/turbo/apps/web/src/lib/email/client.ts
@@ -77,25 +77,11 @@ export async function getReceivedEmail(emailId: string): Promise<{
   subject: string;
   text: string;
   html: string;
+  headers: Record<string, string>;
 }> {
   const resend = getResendClient();
 
-  // Workaround: Resend SDK v4 has `emails.receiving.get()` at runtime but
-  // does not expose it in its TypeScript types. Track as tech debt.
-  const emails = resend.emails as unknown as Record<string, unknown>;
-  const receiving = emails?.receiving as
-    | {
-        get: (id: string) => Promise<{
-          data: Record<string, unknown> | null;
-          error: { message: string } | null;
-        }>;
-      }
-    | undefined;
-  if (!receiving?.get) {
-    throw new Error("Resend SDK does not support emails.receiving.get");
-  }
-
-  const { data, error } = await receiving.get(emailId);
+  const { data, error } = await resend.emails.receiving.get(emailId);
 
   if (error || !data) {
     throw new Error(
@@ -104,10 +90,11 @@ export async function getReceivedEmail(emailId: string): Promise<{
   }
 
   return {
-    from: String(data.from ?? ""),
-    to: Array.isArray(data.to) ? data.to.map(String) : [String(data.to ?? "")],
-    subject: String(data.subject ?? ""),
-    text: String(data.text ?? ""),
-    html: String(data.html ?? ""),
+    from: data.from,
+    to: data.to,
+    subject: data.subject,
+    text: data.text ?? "",
+    html: data.html ?? "",
+    headers: data.headers,
   };
 }

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -1,5 +1,6 @@
 import { getReceivedEmail } from "../client";
 import { stripQuotedReply } from "../quote-strip";
+import { verifySenderAuthenticity } from "../sender-auth";
 import {
   parseEmailTriggerAddress,
   resolveAgentByAddress,
@@ -34,7 +35,8 @@ interface InboundEmailEvent {
  * 2. Look up sender email in Clerk to get user ID
  * 3. Resolve agent by scope slug + agent name
  * 4. Check if user has permission to access the agent
- * 5. Create agent run with callback for response delivery
+ * 5. Fetch full email and verify sender via DMARC
+ * 6. Create agent run with callback for response delivery
  *
  * All failures are silent (no response email) to prevent information leakage.
  */
@@ -101,8 +103,21 @@ export async function handleInboundEmailTrigger(
     return;
   }
 
-  // 5. Fetch full email and build prompt
+  // 5. Fetch full email
   const email = await getReceivedEmail(emailId);
+
+  // 6. Verify sender authenticity via DMARC
+  const verification = verifySenderAuthenticity(email.headers);
+  if (!verification.verified) {
+    log.warn("Sender authentication failed, ignoring email", {
+      from: senderEmail,
+      reason: verification.reason,
+      emailId,
+    });
+    return;
+  }
+
+  // 7. Build prompt from email content
   const bodyContent = stripQuotedReply(email.text);
 
   // Combine subject + body as prompt
@@ -115,11 +130,11 @@ export async function handleInboundEmailTrigger(
     return;
   }
 
-  // 6. Generate reply token for conversation continuity
+  // 8. Generate reply token for conversation continuity
   const sessionPlaceholderId = crypto.randomUUID();
   const replyToken = generateReplyToken(sessionPlaceholderId);
 
-  // 7. Build callback
+  // 9. Build callback
   const callbacks = [
     {
       url: `${getApiUrl()}/api/internal/callbacks/email/trigger`,
@@ -134,7 +149,7 @@ export async function handleInboundEmailTrigger(
     },
   ];
 
-  // 8. Create and dispatch run
+  // 10. Create and dispatch run
   const result = await createRun({
     userId,
     agentComposeVersionId: compose.headVersionId,

--- a/turbo/apps/web/src/lib/email/sender-auth.ts
+++ b/turbo/apps/web/src/lib/email/sender-auth.ts
@@ -1,0 +1,124 @@
+/**
+ * Email sender authentication via DMARC verification.
+ *
+ * Parses the Authentication-Results header (RFC 8601) from the upstream MTA
+ * and enforces a DMARC-only policy: only dmarc=pass is accepted.
+ *
+ * Why DMARC-only:
+ * - SPF validates envelope sender (MAIL FROM), not the From header.
+ * - DKIM without DMARC doesn't enforce alignment with the From domain.
+ * - DMARC is the only mechanism that guarantees From header alignment.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type AuthResult =
+  | "pass"
+  | "fail"
+  | "softfail"
+  | "neutral"
+  | "none"
+  | "temperror"
+  | "permerror"
+  | "policy"
+  | null;
+
+interface AuthenticationResults {
+  dmarc: AuthResult;
+  dkim: AuthResult;
+  spf: AuthResult;
+}
+
+interface SenderVerification {
+  verified: boolean;
+  reason: string;
+  details: AuthenticationResults;
+}
+
+// ============================================================================
+// Parser
+// ============================================================================
+
+const AUTH_RESULT_VALUES = [
+  "pass",
+  "fail",
+  "softfail",
+  "neutral",
+  "none",
+  "temperror",
+  "permerror",
+  "policy",
+] as const;
+
+type AuthResultValue = (typeof AUTH_RESULT_VALUES)[number];
+
+function isAuthResultValue(value: string): value is AuthResultValue {
+  return (AUTH_RESULT_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * Parse an Authentication-Results header value into structured results.
+ *
+ * Extracts dmarc=, dkim=, spf= results from the header string.
+ * Case-insensitive matching per RFC 8601.
+ */
+function parseAuthenticationResults(
+  headerValue: string,
+): AuthenticationResults {
+  const lower = headerValue.toLowerCase();
+
+  function extractResult(method: string): AuthResult {
+    const regex = new RegExp(`${method}\\s*=\\s*(\\w+)`);
+    const match = lower.match(regex);
+    if (!match?.[1]) return null;
+    return isAuthResultValue(match[1]) ? match[1] : null;
+  }
+
+  return {
+    dmarc: extractResult("dmarc"),
+    dkim: extractResult("dkim"),
+    spf: extractResult("spf"),
+  };
+}
+
+// ============================================================================
+// Decision Function
+// ============================================================================
+
+/**
+ * Verify sender authenticity based on Authentication-Results header.
+ *
+ * DMARC-only policy: only dmarc=pass is accepted, everything else is rejected.
+ */
+export function verifySenderAuthenticity(
+  headers: Record<string, string>,
+): SenderVerification {
+  // Case-insensitive header lookup
+  const headerKey = Object.keys(headers).find(
+    (k) => k.toLowerCase() === "authentication-results",
+  );
+
+  if (!headerKey) {
+    return {
+      verified: false,
+      reason: "no authentication-results header found",
+      details: { dmarc: null, dkim: null, spf: null },
+    };
+  }
+
+  const details = parseAuthenticationResults(headers[headerKey]!);
+
+  // Only DMARC pass is accepted
+  if (details.dmarc === "pass") {
+    return { verified: true, reason: "dmarc=pass", details };
+  }
+
+  // Everything else is rejected
+  return {
+    verified: false,
+    reason: `dmarc=${details.dmarc ?? "missing"}`,
+    details,
+  };
+}


### PR DESCRIPTION
## Summary

- Add DMARC-only sender verification to the email trigger flow to prevent From header spoofing attacks
- Clean up Resend SDK workaround (v4 → v6 typed API) and expose `headers` from received emails
- Create `sender-auth.ts` module with Authentication-Results header parser and DMARC-only decision function

## Security Fix

The email trigger flow (`scope+agent@vm0.bot`) previously trusted the `From` header at face value. An attacker could send a spoofed email with a forged `From` address matching a registered user, triggering agent runs under the victim's identity.

**Policy**: Only `dmarc=pass` is accepted. All other results (including `dmarc=none` with SPF/DKIM pass) are rejected. SPF alone doesn't verify the From header, and DKIM without DMARC doesn't enforce alignment.

## Changes

| File | Change |
|------|--------|
| `src/lib/email/client.ts` | Clean up SDK workaround, add `headers` to return type |
| `src/lib/email/sender-auth.ts` | NEW: Authentication-Results parser + DMARC-only verification |
| `src/lib/email/handlers/inbound-trigger.ts` | Add verification gate before run creation |
| `src/__tests__/setup.ts` | Add `headers` with `dmarc=pass` to default Resend mock |
| `app/api/webhooks/email/inbound/__tests__/route.test.ts` | Add 4 sender verification integration tests |

## Test plan

- [x] Existing trigger happy path passes (default mock has `dmarc=pass`)
- [x] `dmarc=fail` → email rejected, no run created
- [x] `dmarc=none` + `dkim=pass` → email rejected (DMARC-only policy)
- [x] Missing `authentication-results` header → email rejected
- [x] All authentication methods fail → email rejected
- [x] Reply flow unaffected (doesn't use sender verification)
- [x] All 41 email-related tests pass

Closes #3194

🤖 Generated with [Claude Code](https://claude.com/claude-code)