### PR TITLE
feat(email): auto-detect scope from sender for agent-only addresses

### DIFF
--- a/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
@@ -572,4 +572,104 @@ describe("POST /api/webhooks/email/inbound", () => {
       expect(runs).toHaveLength(0);
     });
   });
+
+  describe("Email Trigger (agent@domain, auto-detect scope)", () => {
+    it("should dispatch agent run for agent-only email (auto-detect scope)", async () => {
+      const user = await context.setupUser({ prefix: "auto-scope" });
+      const agentName = uniqueId("auto-agent");
+      await createTestCompose(agentName);
+
+      const senderEmail = "sender@example.com";
+      mockClerk({ userId: user.userId, email: senderEmail });
+
+      // Send to agentname@domain (no scope, no plus sign)
+      const payload = JSON.stringify({
+        type: "email.received",
+        data: {
+          email_id: "auto-scope-email",
+          to: [`${agentName}@vm7.bot`],
+          from: senderEmail,
+          subject: "Auto Scope Test",
+          created_at: new Date().toISOString(),
+        },
+      });
+
+      const request = createWebhookRequest(payload);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      // Verify: agent run was created
+      const runs = await findTestRunsByUserAndPrompt(
+        user.userId,
+        "Auto Scope Test\n\nHello from email",
+      );
+      expect(runs).toHaveLength(1);
+
+      // Verify: trigger callback was registered
+      const callbacks = await findTestCallbacksByRunId(runs[0]!.id);
+      const triggerCallback = callbacks.find((c) =>
+        c.url.includes("/callbacks/email/trigger"),
+      );
+      expect(triggerCallback).toBeDefined();
+      expect(triggerCallback!.payload).toMatchObject({
+        senderEmail,
+        userId: user.userId,
+        inboundEmailId: "auto-scope-email",
+      });
+    });
+
+    it("should ignore agent-only email from unregistered sender", async () => {
+      mockResend.emails.receiving.get.mockClear();
+      mockClerk({ userId: "some-user-id", email: "registered@example.com" });
+
+      const payload = JSON.stringify({
+        type: "email.received",
+        data: {
+          email_id: "unreg-auto-email",
+          to: ["someagent@vm7.bot"],
+          from: "unregistered@example.com",
+          subject: "Test",
+          created_at: new Date().toISOString(),
+        },
+      });
+
+      const request = createWebhookRequest(payload);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
+    });
+
+    it("should ignore agent-only email when sender has no scope", async () => {
+      mockResend.emails.receiving.get.mockClear();
+
+      // Mock Clerk to return a userId that has no scope in the database
+      const senderEmail = "noscopeuser@example.com";
+      mockClerk({ userId: "no-scope-user-id", email: senderEmail });
+
+      const payload = JSON.stringify({
+        type: "email.received",
+        data: {
+          email_id: "no-scope-email",
+          to: ["someagent@vm7.bot"],
+          from: senderEmail,
+          subject: "Test",
+          created_at: new Date().toISOString(),
+        },
+      });
+
+      const request = createWebhookRequest(payload);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      // No email fetch should have happened (early return after scope lookup failed)
+      expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
@@ -671,5 +671,81 @@ describe("POST /api/webhooks/email/inbound", () => {
       // No email fetch should have happened (early return after scope lookup failed)
       expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
     });
+
+    it("should ignore agent-only email for non-existent agent", async () => {
+      mockResend.emails.receiving.get.mockClear();
+
+      const user = await context.setupUser({ prefix: "no-agent" });
+      const senderEmail = "sender@example.com";
+      mockClerk({ userId: user.userId, email: senderEmail });
+
+      // Send to an agent that doesn't exist in the sender's scope
+      const payload = JSON.stringify({
+        type: "email.received",
+        data: {
+          email_id: "no-agent-auto-email",
+          to: ["nonexistent@vm7.bot"],
+          from: senderEmail,
+          subject: "Test",
+          created_at: new Date().toISOString(),
+        },
+      });
+
+      const request = createWebhookRequest(payload);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
+    });
+
+    it("should reject agent-only email when DMARC fails", async () => {
+      const user = await context.setupUser({ prefix: "auto-dmarc" });
+      const agentName = uniqueId("auto-dmarc-agent");
+      await createTestCompose(agentName);
+
+      const senderEmail = "spoofed@example.com";
+      mockClerk({ userId: user.userId, email: senderEmail });
+
+      // Override Resend mock to return dmarc=fail
+      mockResend.emails.receiving.get.mockResolvedValueOnce({
+        data: {
+          from: senderEmail,
+          to: [`${agentName}@vm7.bot`],
+          subject: "Spoofed auto-scope",
+          text: "I am pretending to be someone else",
+          html: "<p>I am pretending to be someone else</p>",
+          headers: {
+            "authentication-results":
+              "mx.resend.com; dkim=fail; spf=fail; dmarc=fail",
+          },
+        },
+      } as never);
+
+      const payload = JSON.stringify({
+        type: "email.received",
+        data: {
+          email_id: "auto-dmarc-fail-email",
+          to: [`${agentName}@vm7.bot`],
+          from: senderEmail,
+          subject: "Spoofed auto-scope",
+          created_at: new Date().toISOString(),
+        },
+      });
+
+      const request = createWebhookRequest(payload);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      // No run should have been created
+      const runs = await findTestRunsByUserAndPrompt(
+        user.userId,
+        "Spoofed auto-scope\n\nI am pretending to be someone else",
+      );
+      expect(runs).toHaveLength(0);
+    });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/email/inbound/route.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/route.ts
@@ -19,7 +19,8 @@ const log = logger("webhook:email:inbound");
  * Receives inbound email events from Resend via Svix.
  * Routes to appropriate handler based on email address type:
  * - reply+{token}@domain → handleInboundEmailReply (continue conversation)
- * - {scope}+{agent}@domain → handleInboundEmailTrigger (new agent run)
+ * - {scope}+{agent}@domain → handleInboundEmailTrigger (new agent run, explicit scope)
+ * - {agent}@domain → handleInboundEmailTrigger (new agent run, scope from sender)
  *
  * Verifies the webhook signature and dispatches handling in the background.
  * Returns 200 immediately to acknowledge receipt.

--- a/turbo/apps/web/src/lib/email/handlers/__tests__/shared.test.ts
+++ b/turbo/apps/web/src/lib/email/handlers/__tests__/shared.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { parseEmailTriggerAddress, isReplyAddress } from "../shared";
+import {
+  parseEmailTriggerAddress,
+  parseAgentOnlyAddress,
+  isReplyAddress,
+} from "../shared";
 
 describe("parseEmailTriggerAddress", () => {
   it("should parse valid scope+agent address", () => {
@@ -55,6 +59,40 @@ describe("parseEmailTriggerAddress", () => {
   it("should return null for empty string", () => {
     const result = parseEmailTriggerAddress("");
     expect(result).toBeNull();
+  });
+});
+
+describe("parseAgentOnlyAddress", () => {
+  it("should parse valid agent-only address", () => {
+    expect(parseAgentOnlyAddress("my-agent@vm0.bot")).toBe("my-agent");
+  });
+
+  it("should normalize to lowercase", () => {
+    expect(parseAgentOnlyAddress("MY-AGENT@vm0.bot")).toBe("my-agent");
+  });
+
+  it("should handle agent with numbers", () => {
+    expect(parseAgentOnlyAddress("agent123@vm0.bot")).toBe("agent123");
+  });
+
+  it("should return null for scope+agent format", () => {
+    expect(parseAgentOnlyAddress("scope+agent@vm0.bot")).toBeNull();
+  });
+
+  it("should return null for reply address", () => {
+    expect(parseAgentOnlyAddress("reply+token@vm0.bot")).toBeNull();
+  });
+
+  it("should return null for empty local part", () => {
+    expect(parseAgentOnlyAddress("@vm0.bot")).toBeNull();
+  });
+
+  it("should return null for agent starting with hyphen", () => {
+    expect(parseAgentOnlyAddress("-agent@vm0.bot")).toBeNull();
+  });
+
+  it("should return null for empty string", () => {
+    expect(parseAgentOnlyAddress("")).toBeNull();
   });
 });
 

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -3,12 +3,14 @@ import { stripQuotedReply } from "../quote-strip";
 import { verifySenderAuthenticity } from "../sender-auth";
 import {
   parseEmailTriggerAddress,
+  parseAgentOnlyAddress,
   resolveAgentByAddress,
   generateReplyToken,
 } from "./shared";
 import { createRun } from "../../run";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getUserIdByEmail } from "../../auth/get-user-id-by-email";
+import { getUserScopeByClerkId } from "../../scope/scope-service";
 import { canAccessCompose } from "../../agent/permission-service";
 import { getUserEmail } from "../../auth/get-user-email";
 import { logger } from "../../logger";
@@ -28,10 +30,12 @@ interface InboundEmailEvent {
 
 /**
  * Handle an inbound email that triggers an agent run.
- * This is for direct emails to scope+agent@domain addresses.
+ * Supports two address formats:
+ * - scope+agent@domain (explicit scope)
+ * - agent@domain (scope auto-detected from sender's personal scope)
  *
  * Flow:
- * 1. Parse scope+agent from recipient address
+ * 1. Parse trigger address from recipients (scope+agent or agent-only)
  * 2. Look up sender email in Clerk to get user ID
  * 3. Resolve agent by scope slug + agent name
  * 4. Check if user has permission to access the agent
@@ -46,8 +50,13 @@ export async function handleInboundEmailTrigger(
   const { email_id: emailId, to, from: senderEmail, subject } = event.data;
 
   // 1. Find trigger address in recipients
+  //    Supports two formats:
+  //    - scope+agent@domain (explicit scope)
+  //    - agent@domain (scope auto-detected from sender)
   let triggerAddress: { scope: string; agent: string } | null = null;
+  let userId: string | null = null;
 
+  // 1a. Try scope+agent format first
   for (const addr of to) {
     const parsed = parseEmailTriggerAddress(addr);
     if (parsed) {
@@ -56,9 +65,38 @@ export async function handleInboundEmailTrigger(
     }
   }
 
+  // 1b. If no scope+agent match, try agent-only format
   if (!triggerAddress) {
-    log.debug("No trigger address found in recipients", { to });
-    return;
+    let agentName: string | null = null;
+
+    for (const addr of to) {
+      const parsed = parseAgentOnlyAddress(addr);
+      if (parsed) {
+        agentName = parsed;
+        break;
+      }
+    }
+
+    if (!agentName) {
+      log.debug("No trigger address found in recipients", { to });
+      return;
+    }
+
+    // For agent-only format, we need the sender's scope.
+    // Look up sender in Clerk first (needed for scope lookup).
+    userId = await getUserIdByEmail(senderEmail);
+    if (!userId) {
+      log.debug("Sender email not registered", { from: senderEmail });
+      return;
+    }
+
+    const userScope = await getUserScopeByClerkId(userId);
+    if (!userScope) {
+      log.debug("Sender has no scope", { from: senderEmail, userId });
+      return;
+    }
+
+    triggerAddress = { scope: userScope.slug, agent: agentName };
   }
 
   log.debug("Processing email trigger", {
@@ -67,11 +105,13 @@ export async function handleInboundEmailTrigger(
     from: senderEmail,
   });
 
-  // 2. Look up sender in Clerk
-  const userId = await getUserIdByEmail(senderEmail);
+  // 2. Look up sender in Clerk (skip if already done for agent-only format)
   if (!userId) {
-    log.debug("Sender email not registered", { from: senderEmail });
-    return;
+    userId = await getUserIdByEmail(senderEmail);
+    if (!userId) {
+      log.debug("Sender email not registered", { from: senderEmail });
+      return;
+    }
   }
 
   // 3. Resolve agent

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -44,6 +44,26 @@ export function parseEmailTriggerAddress(
 }
 
 /**
+ * Parse an agent-only email address in the format: agent@domain
+ * Returns the agent name if the address is a simple local-part (no plus sign),
+ * or null if the address contains a plus sign or doesn't match.
+ *
+ * Examples:
+ * - "my-agent@vm0.bot" → "my-agent"
+ * - "scope+agent@vm0.bot" → null (has plus sign, use parseEmailTriggerAddress)
+ * - "reply+token@vm0.bot" → null (has plus sign)
+ * - "@vm0.bot" → null (empty local part)
+ */
+export function parseAgentOnlyAddress(toAddress: string): string | null {
+  if (toAddress.includes("+")) return null;
+
+  const match = toAddress.match(/^([a-z0-9][a-z0-9-]*)@/i);
+  if (!match?.[1]) return null;
+
+  return match[1].toLowerCase();
+}
+
+/**
  * Check if an email address is a reply address (reply+token@domain)
  */
 export function isReplyAddress(toAddress: string): boolean {


### PR DESCRIPTION
## Summary

Closes #3195

- Support `agent@domain` email format in addition to existing `scope+agent@domain`
- When no scope is specified in the address, automatically resolve the sender's personal scope
- Add `parseAgentOnlyAddress()` parser for the new format
- Add else-branch in trigger handler: try agent-only parsing when scope+agent fails, then look up sender's scope via `getUserScopeByClerkId()`

## Changes

| File | Change |
|------|--------|
| `shared.ts` | Add `parseAgentOnlyAddress()` function |
| `inbound-trigger.ts` | Add agent-only branch with scope lookup |
| `shared.test.ts` | Add 8 parser test cases |
| `route.test.ts` | Add 3 integration tests (happy path, unregistered sender, no scope) |
| `route.ts` | Update docstring |

## Design decisions

- **Only sender's personal scope** — no shared scope search, no system scope fallback
- **Backward compatible** — existing `scope+agent@domain` format works unchanged
- **Silent failures** — consistent with existing error handling (no response email on failure)
- **Clerk lookup reuse** — `userId` is hoisted to avoid duplicate Clerk calls

## Test plan

- [x] Parser tests: valid agent-only, lowercase normalization, numbers, rejects `+` addresses, rejects empty/invalid
- [x] Integration: happy path dispatches agent run with auto-detected scope
- [x] Integration: unregistered sender silently dropped
- [x] Integration: registered sender without scope silently dropped
- [x] Existing scope+agent tests still pass (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)