### PR TITLE
chore(ci): improve runner deployment cleanup and slack labels

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -431,7 +431,7 @@ jobs:
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            text: "*Runner* deploying to production servers..."
+            text: "*Runner RS* deploying to production servers..."
 
       # Cross-compile Rust binaries for ARM64 (metal runners are ARM64)
       - name: Build runner and guest binaries for ARM64
@@ -472,7 +472,7 @@ jobs:
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
             ts: "${{ steps.slack-start.outputs.ts }}"
-            text: "*Runner* deploying to production servers...\n:white_check_mark: Deployed successfully"
+            text: "*Runner RS* deploying to production servers...\n:white_check_mark: Deployed successfully"
 
       - name: Notify Slack - Failure
         if: ${{ failure() && steps.slack-start.outputs.ts }}
@@ -483,7 +483,7 @@ jobs:
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
             ts: "${{ steps.slack-start.outputs.ts }}"
-            text: "*Runner* deploying to production servers...\n:x: Deploy failed"
+            text: "*Runner RS* deploying to production servers...\n:x: Deploy failed"
 
   # Build E2B templates to production account
   # Uses production environment E2B_API_KEY secret

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -43,6 +43,29 @@
       command: pm2 kill
       ignore_errors: true
 
+    # Kill orphan firecracker/mitmproxy processes whose parent is PID 1
+    # (reparented to init after their runner crashed). This avoids killing
+    # processes that belong to the currently active runner.
+    - name: Find orphan firecracker processes
+      shell: pgrep -x firecracker | xargs -I{} sh -c 'test "$(ps -o ppid= -p {})" -eq 1 && echo {}'
+      register: orphan_fc
+      changed_when: false
+      failed_when: false
+
+    - name: Kill orphan firecracker processes
+      command: kill {{ orphan_fc.stdout_lines | join(' ') }}
+      when: orphan_fc.stdout_lines | length > 0
+
+    - name: Find orphan mitmproxy processes
+      shell: pgrep -x mitmdump | xargs -I{} sh -c 'test "$(ps -o ppid= -p {})" -eq 1 && echo {}'
+      register: orphan_mitm
+      changed_when: false
+      failed_when: false
+
+    - name: Kill orphan mitmproxy processes
+      command: kill {{ orphan_mitm.stdout_lines | join(' ') }}
+      when: orphan_mitm.stdout_lines | length > 0
+
     # ========================================
     # Phase 1: Deploy binaries
     # ========================================
@@ -147,25 +170,8 @@
     - name: Garbage collect old artifacts
       command: "{{ bin_dir }}/runner gc --keep-latest 3"
 
-    # Kill orphan firecracker/mitmproxy processes left behind by crashed
-    # runners or the legacy TS runner. Run after drain so we don't hit
-    # processes that belong to the still-active old runner.
-    - name: Find orphan firecracker processes
-      command: pgrep -x firecracker
-      register: orphan_fc
-      changed_when: false
-      failed_when: false
-
-    - name: Kill orphan firecracker processes
-      command: kill {{ orphan_fc.stdout_lines | join(' ') }}
-      when: orphan_fc.stdout_lines | length > 0
-
-    - name: Find orphan mitmproxy processes
-      command: pgrep -x mitmdump
-      register: orphan_mitm
-      changed_when: false
-      failed_when: false
-
-    - name: Kill orphan mitmproxy processes
-      command: kill {{ orphan_mitm.stdout_lines | join(' ') }}
-      when: orphan_mitm.stdout_lines | length > 0
+    # ========================================
+    # Phase 6: Final health check
+    # ========================================
+    - name: Verify runner health after cleanup
+      command: "{{ bin_dir }}/runner doctor"


### PR DESCRIPTION
## Summary

- Move orphan process cleanup from Phase 5 to Phase 0 (before deploy), filtering by PPID=1 to only kill truly orphaned `firecracker`/`mitmdump` processes — safe even while the current runner is active
- Add Phase 6 final `runner doctor` health check after drain + gc
- Rename Slack deploy notifications from "Runner" to "Runner RS"

Supersedes #3203.

## Test plan

- [x] Verified `pgrep -x firecracker` and `pgrep -x mitmdump` match actual binary names on dev-1
- [x] PPID=1 filter confirmed to only match orphaned processes (not children of active runners)
- [ ] Deploy to a dev machine and verify playbook runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)