### PR TITLE
fix(ci): remove skip-github-release from internal crates

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,60 +19,47 @@
             "release-type": "node"
         },
         "crates/ably-subscriber": {
-            "release-type": "rust",
-            "skip-github-release": true
+            "release-type": "rust"
         },
         "crates/guest-agent": {
-            "release-type": "rust",
-            "skip-github-release": true
+            "release-type": "rust"
         },
         "crates/guest-common": {
-            "release-type": "rust",
-            "skip-github-release": true
+            "release-type": "rust"
         },
         "crates/guest-download": {
-            "release-type": "rust",
-            "skip-github-release": true
+            "release-type": "rust"
         },
         "crates/guest-init": {
-            "release-type": "rust",
-            "skip-github-release": true
+            "release-type": "rust"
         },
         "crates/guest-mock-claude": {
-            "release-type": "rust",
-            "skip-github-release": true
+            "release-type": "rust"
         },
         "crates/reqeast": {
-            "release-type": "rust",
-            "skip-github-release": true
+            "release-type": "rust"
         },
         "crates/runner": {
             "release-type": "rust",
             "component": "runner-rs"
         },
         "crates/sandbox": {
-            "release-type": "rust",
-            "skip-github-release": true
+            "release-type": "rust"
         },
         "crates/sandbox-fc": {
-            "release-type": "rust",
-            "skip-github-release": true
+            "release-type": "rust"
         },
         "crates/vsock-guest": {
-            "release-type": "rust",
-            "skip-github-release": true
+            "release-type": "rust"
         },
         "crates/vsock-host": {
-            "release-type": "rust",
-            "skip-github-release": true
+            "release-type": "rust"
         },
         "crates/vsock-proto": {
-            "release-type": "rust",
-            "skip-github-release": true
+            "release-type": "rust"
         },
         "crates/vsock-test": {
-            "release-type": "rust",
-            "skip-github-release": true
+            "release-type": "rust"
         }
     },
     "plugins": [


### PR DESCRIPTION
## Summary

- Remove `skip-github-release: true` from all internal Rust crates in `release-please-config.json`

## Problem

`skip-github-release: true` prevents git tag creation. Without tags, release-please cannot determine the "since" commit for changelog generation, causing it to re-accumulate **all historical commits** on every release. The cargo-workspace plugin then cascades unnecessary patch bumps to `runner-rs` even when no Rust code has changed.

Evidence: `ably-subscriber` had the exact same 4 changelog entries (#2790, #2913, #2938, #2824) across 4 consecutive releases (PR #3162, #3193, #3202, #3204), bumping from 0.2.0 → 0.3.0 → 0.4.0 → 0.5.0 with identical content each time.

## Fix

Remove the flag so internal crates get git tags on release. This breaks the accumulation cycle while preserving the cargo-workspace dependency cascade for real changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)