### PR TITLE
chore(ci): reduce gc keep-latest from 3 to 2

### DIFF
--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -168,7 +168,7 @@
       ignore_errors: true
 
     - name: Garbage collect old artifacts
-      command: "{{ bin_dir }}/runner gc --keep-latest 3"
+      command: "{{ bin_dir }}/runner gc --keep-latest 2"
 
     # ========================================
     # Phase 6: Final health check


### PR DESCRIPTION
## Summary

- Reduce `runner gc --keep-latest` from 3 to 2 in deploy playbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)