### PR TITLE
feat(platform): add schedule management dialog and enhanced cron options

### DIFF
--- a/turbo/apps/platform/src/signals/agent-detail/agent-detail-page.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-detail-page.ts
@@ -8,11 +8,12 @@ import {
   initInstructionsViewMode$,
 } from "./agent-detail.ts";
 import { initInlineRunFromUrl$ } from "./inline-run.ts";
+import { fetchAgentSchedule$ } from "./schedule.ts";
 
 export const setupAgentDetailPage$ = command(async ({ set }) => {
   set(updatePage$, createElement(AgentDetailPage));
   set(initInstructionsViewMode$);
   set(initInlineRunFromUrl$);
   await set(fetchAgentDetail$);
-  await set(fetchAgentInstructions$);
+  await Promise.all([set(fetchAgentInstructions$), set(fetchAgentSchedule$)]);
 });

--- a/turbo/apps/platform/src/signals/agent-detail/cron.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/cron.ts
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------------
+// Shared cron expression utilities
+// ---------------------------------------------------------------------------
+
+export type ScheduleTimeOption =
+  | "every-weekday"
+  | "every-day"
+  | "every-week"
+  | "every-month";
+
+export function buildCronExpression(opts: {
+  timeOption: ScheduleTimeOption;
+  hour: string;
+  minute?: string;
+  dayOfWeek?: string;
+  dayOfMonth?: string;
+}): string {
+  const h = Number.parseInt(opts.hour, 10);
+  const m = opts.minute !== undefined ? Number.parseInt(opts.minute, 10) : 0;
+  switch (opts.timeOption) {
+    case "every-weekday": {
+      return `${String(m)} ${String(h)} * * 1-5`;
+    }
+    case "every-day": {
+      return `${String(m)} ${String(h)} * * *`;
+    }
+    case "every-week": {
+      const dow = opts.dayOfWeek ?? "1";
+      return `${String(m)} ${String(h)} * * ${dow}`;
+    }
+    case "every-month": {
+      const dom = opts.dayOfMonth ?? "1";
+      return `${String(m)} ${String(h)} ${dom} * *`;
+    }
+  }
+}

--- a/turbo/apps/platform/src/signals/agent-detail/run-dialog.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/run-dialog.ts
@@ -31,12 +31,13 @@ export const setRunDialogPrompt$ = command(({ set }, value: string) => {
 });
 
 // Time option: "now" or a schedule preset
-type TimeOption =
-  | "now"
+export type ScheduleTimeOption =
   | "every-weekday"
   | "every-day"
   | "every-week"
   | "every-month";
+
+type TimeOption = "now" | ScheduleTimeOption;
 
 const internalTimeOption$ = state<TimeOption>("now");
 export const runDialogTimeOption$ = computed((get) => get(internalTimeOption$));
@@ -65,6 +66,30 @@ export const setRunDialogFrequency$ = command(({ set }, value: string) => {
   set(internalFrequency$, value);
 });
 
+// Minute of hour for schedule options
+const internalMinute$ = state("0");
+export const runDialogMinute$ = computed((get) => get(internalMinute$));
+
+export const setRunDialogMinute$ = command(({ set }, value: string) => {
+  set(internalMinute$, value);
+});
+
+// Day of week for "every-week" (cron: 0=Sun, 1=Mon, ..., 6=Sat)
+const internalDayOfWeek$ = state("1");
+export const runDialogDayOfWeek$ = computed((get) => get(internalDayOfWeek$));
+
+export const setRunDialogDayOfWeek$ = command(({ set }, value: string) => {
+  set(internalDayOfWeek$, value);
+});
+
+// Day of month for "every-month" (1-31)
+const internalDayOfMonth$ = state("1");
+export const runDialogDayOfMonth$ = computed((get) => get(internalDayOfMonth$));
+
+export const setRunDialogDayOfMonth$ = command(({ set }, value: string) => {
+  set(internalDayOfMonth$, value);
+});
+
 // ---------------------------------------------------------------------------
 // Saving state
 // ---------------------------------------------------------------------------
@@ -87,6 +112,9 @@ export const openRunDialog$ = command(({ set }) => {
   set(internalPrompt$, "");
   set(internalTimeOption$, "now");
   set(internalFrequency$, "9");
+  set(internalMinute$, "0");
+  set(internalDayOfWeek$, "1");
+  set(internalDayOfMonth$, "1");
   set(internalSaveError$, null);
   set(internalOpen$, true);
 });
@@ -99,23 +127,29 @@ export const closeRunDialog$ = command(({ set }) => {
 // Cron expression mapping
 // ---------------------------------------------------------------------------
 
-function buildCronExpression(timeOption: TimeOption, hour: string): string {
-  const h = Number.parseInt(hour, 10);
-  switch (timeOption) {
+export function buildCronExpression(opts: {
+  timeOption: ScheduleTimeOption;
+  hour: string;
+  minute?: string;
+  dayOfWeek?: string;
+  dayOfMonth?: string;
+}): string {
+  const h = Number.parseInt(opts.hour, 10);
+  const m = opts.minute !== undefined ? Number.parseInt(opts.minute, 10) : 0;
+  switch (opts.timeOption) {
     case "every-weekday": {
-      return `0 ${String(h)} * * 1-5`;
+      return `${String(m)} ${String(h)} * * 1-5`;
     }
     case "every-day": {
-      return `0 ${String(h)} * * *`;
+      return `${String(m)} ${String(h)} * * *`;
     }
     case "every-week": {
-      return `0 ${String(h)} * * 1`;
+      const dow = opts.dayOfWeek ?? "1";
+      return `${String(m)} ${String(h)} * * ${dow}`;
     }
     case "every-month": {
-      return `0 ${String(h)} 1 * *`;
-    }
-    default: {
-      return "";
+      const dom = opts.dayOfMonth ?? "1";
+      return `${String(m)} ${String(h)} ${dom} * *`;
     }
   }
 }
@@ -129,6 +163,9 @@ export const submitRunDialog$ = command(async ({ get, set }) => {
   const prompt = get(internalPrompt$);
   const timeOption = get(internalTimeOption$);
   const frequency = get(internalFrequency$);
+  const minute = get(internalMinute$);
+  const dayOfWeek = get(internalDayOfWeek$);
+  const dayOfMonth = get(internalDayOfMonth$);
 
   if (!detail || !prompt.trim()) {
     return;
@@ -181,7 +218,13 @@ export const submitRunDialog$ = command(async ({ get, set }) => {
     }
 
     // Schedule creation
-    const cronExpression = buildCronExpression(timeOption, frequency);
+    const cronExpression = buildCronExpression({
+      timeOption,
+      hour: frequency,
+      minute,
+      dayOfWeek,
+      dayOfMonth,
+    });
     const timezone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
 
     const response = await fetchFn("/api/agent/schedules", {
@@ -205,8 +248,26 @@ export const submitRunDialog$ = command(async ({ get, set }) => {
       );
     }
 
+    // Enable the schedule (backend creates with enabled=false)
+    const enableResponse = await fetchFn(
+      `/api/agent/schedules/default/enable`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ composeId: detail.id }),
+      },
+    );
+
+    if (!enableResponse.ok) {
+      L.warn("Failed to enable schedule:", enableResponse.statusText);
+    }
+
     set(internalOpen$, false);
     toast.success("Schedule created");
+
+    // Refresh the schedule badge in the header
+    const { fetchAgentSchedule$ } = await import("./schedule.ts");
+    await set(fetchAgentSchedule$);
   } catch (error) {
     throwIfAbort(error);
     L.error("Failed to submit run dialog:", error);

--- a/turbo/apps/platform/src/signals/agent-detail/run-dialog.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/run-dialog.ts
@@ -9,6 +9,8 @@ import {
   prepareNewRun$,
   cancelPendingRun$,
 } from "./inline-run.ts";
+import { fetchAgentSchedule$ } from "./schedule.ts";
+import { type ScheduleTimeOption, buildCronExpression } from "./cron.ts";
 
 const L = logger("RunDialog");
 
@@ -29,13 +31,6 @@ export const runDialogPrompt$ = computed((get) => get(internalPrompt$));
 export const setRunDialogPrompt$ = command(({ set }, value: string) => {
   set(internalPrompt$, value);
 });
-
-// Time option: "now" or a schedule preset
-export type ScheduleTimeOption =
-  | "every-weekday"
-  | "every-day"
-  | "every-week"
-  | "every-month";
 
 type TimeOption = "now" | ScheduleTimeOption;
 
@@ -122,37 +117,6 @@ export const openRunDialog$ = command(({ set }) => {
 export const closeRunDialog$ = command(({ set }) => {
   set(internalOpen$, false);
 });
-
-// ---------------------------------------------------------------------------
-// Cron expression mapping
-// ---------------------------------------------------------------------------
-
-export function buildCronExpression(opts: {
-  timeOption: ScheduleTimeOption;
-  hour: string;
-  minute?: string;
-  dayOfWeek?: string;
-  dayOfMonth?: string;
-}): string {
-  const h = Number.parseInt(opts.hour, 10);
-  const m = opts.minute !== undefined ? Number.parseInt(opts.minute, 10) : 0;
-  switch (opts.timeOption) {
-    case "every-weekday": {
-      return `${String(m)} ${String(h)} * * 1-5`;
-    }
-    case "every-day": {
-      return `${String(m)} ${String(h)} * * *`;
-    }
-    case "every-week": {
-      const dow = opts.dayOfWeek ?? "1";
-      return `${String(m)} ${String(h)} * * ${dow}`;
-    }
-    case "every-month": {
-      const dom = opts.dayOfMonth ?? "1";
-      return `${String(m)} ${String(h)} ${dom} * *`;
-    }
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Submit — immediate run or schedule creation
@@ -266,7 +230,6 @@ export const submitRunDialog$ = command(async ({ get, set }) => {
     toast.success("Schedule created");
 
     // Refresh the schedule badge in the header
-    const { fetchAgentSchedule$ } = await import("./schedule.ts");
     await set(fetchAgentSchedule$);
   } catch (error) {
     throwIfAbort(error);

--- a/turbo/apps/platform/src/signals/agent-detail/schedule.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/schedule.ts
@@ -1,0 +1,370 @@
+import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { fetch$ } from "../fetch.ts";
+import { throwIfAbort } from "../utils.ts";
+import { logger } from "../log.ts";
+import { agentDetail$ } from "./agent-detail.ts";
+import { buildCronExpression, type ScheduleTimeOption } from "./run-dialog.ts";
+
+const L = logger("Schedule");
+
+// ---------------------------------------------------------------------------
+// Schedule response type (matches API schema)
+// ---------------------------------------------------------------------------
+
+interface ScheduleResponse {
+  id: string;
+  composeId: string;
+  composeName: string;
+  scopeSlug: string;
+  name: string;
+  cronExpression: string | null;
+  atTime: string | null;
+  timezone: string;
+  prompt: string;
+  vars: Record<string, string> | null;
+  secretNames: string[] | null;
+  artifactName: string | null;
+  artifactVersion: string | null;
+  volumeVersions: Record<string, string> | null;
+  enabled: boolean;
+  nextRunAt: string | null;
+  lastRunAt: string | null;
+  retryStartedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Agent schedule state
+// ---------------------------------------------------------------------------
+
+const internalAgentSchedule$ = state<ScheduleResponse | null>(null);
+export const agentSchedule$ = computed((get) => get(internalAgentSchedule$));
+
+// ---------------------------------------------------------------------------
+// Fetch agent schedule
+// ---------------------------------------------------------------------------
+
+export const fetchAgentSchedule$ = command(async ({ get, set }) => {
+  const detail = get(agentDetail$);
+  if (!detail) {
+    return;
+  }
+
+  try {
+    const fetchFn = get(fetch$);
+    const response = await fetchFn("/api/agent/schedules");
+
+    if (!response.ok) {
+      set(internalAgentSchedule$, null);
+      return;
+    }
+
+    const data = (await response.json()) as {
+      schedules: ScheduleResponse[];
+    };
+
+    // Find the first enabled schedule for this agent (match by composeId for reliability)
+    const match = data.schedules.find(
+      (s) => s.composeId === detail.id && s.enabled,
+    );
+
+    set(internalAgentSchedule$, match ?? null);
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to fetch agent schedule:", error);
+    set(internalAgentSchedule$, null);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Delete agent schedule
+// ---------------------------------------------------------------------------
+
+const deleteAgentSchedule$ = command(async ({ get, set }) => {
+  const schedule = get(internalAgentSchedule$);
+  const detail = get(agentDetail$);
+  if (!schedule || !detail) {
+    return;
+  }
+
+  const fetchFn = get(fetch$);
+  const response = await fetchFn(
+    `/api/agent/schedules/${encodeURIComponent(schedule.name)}?composeId=${encodeURIComponent(detail.id)}`,
+    { method: "DELETE" },
+  );
+
+  if (!response.ok && response.status !== 204) {
+    const errorData = (await response.json().catch(() => null)) as {
+      message?: string;
+    } | null;
+    throw new Error(
+      errorData?.message ?? `Delete failed: ${response.statusText}`,
+    );
+  }
+
+  set(internalAgentSchedule$, null);
+});
+
+// ---------------------------------------------------------------------------
+// Cron parsing helper
+// ---------------------------------------------------------------------------
+
+function parseCronExpression(cron: string): {
+  minute: string;
+  hour: string;
+  timeOption: ScheduleTimeOption;
+  dayOfWeek: string;
+  dayOfMonth: string;
+} {
+  const parts = cron.split(" ");
+  const minute = parts[0] ?? "0";
+  const hour = parts[1] ?? "9";
+  const dayOfMonth = parts[2] ?? "*";
+  const dayOfWeek = parts[4] ?? "*";
+
+  let timeOption: ScheduleTimeOption = "every-day";
+
+  if (dayOfMonth !== "*") {
+    timeOption = "every-month";
+  } else if (dayOfWeek === "1-5") {
+    timeOption = "every-weekday";
+  } else if (dayOfWeek !== "*") {
+    timeOption = "every-week";
+  } else {
+    timeOption = "every-day";
+  }
+
+  return {
+    minute,
+    hour,
+    timeOption,
+    dayOfWeek: dayOfWeek === "*" || dayOfWeek === "1-5" ? "1" : dayOfWeek,
+    dayOfMonth: dayOfMonth === "*" ? "1" : dayOfMonth,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Schedule edit dialog state
+// ---------------------------------------------------------------------------
+
+const internalDialogOpen$ = state(false);
+export const scheduleDialogOpen$ = computed((get) => get(internalDialogOpen$));
+
+const internalDialogPrompt$ = state("");
+export const scheduleDialogPrompt$ = computed((get) =>
+  get(internalDialogPrompt$),
+);
+
+export const setScheduleDialogPrompt$ = command(({ set }, value: string) => {
+  set(internalDialogPrompt$, value);
+});
+
+const internalDialogTimeOption$ = state<ScheduleTimeOption>("every-day");
+export const scheduleDialogTimeOption$ = computed((get) =>
+  get(internalDialogTimeOption$),
+);
+
+export const setScheduleDialogTimeOption$ = command(
+  ({ set }, value: string) => {
+    if (isScheduleTimeOption(value)) {
+      set(internalDialogTimeOption$, value);
+    }
+  },
+);
+
+function isScheduleTimeOption(v: string): v is ScheduleTimeOption {
+  return (
+    v === "every-weekday" ||
+    v === "every-day" ||
+    v === "every-week" ||
+    v === "every-month"
+  );
+}
+
+const internalDialogHour$ = state("9");
+export const scheduleDialogHour$ = computed((get) => get(internalDialogHour$));
+
+export const setScheduleDialogHour$ = command(({ set }, value: string) => {
+  set(internalDialogHour$, value);
+});
+
+const internalDialogMinute$ = state("0");
+export const scheduleDialogMinute$ = computed((get) =>
+  get(internalDialogMinute$),
+);
+
+export const setScheduleDialogMinute$ = command(({ set }, value: string) => {
+  set(internalDialogMinute$, value);
+});
+
+const internalDialogDayOfWeek$ = state("1");
+export const scheduleDialogDayOfWeek$ = computed((get) =>
+  get(internalDialogDayOfWeek$),
+);
+
+export const setScheduleDialogDayOfWeek$ = command(({ set }, value: string) => {
+  set(internalDialogDayOfWeek$, value);
+});
+
+const internalDialogDayOfMonth$ = state("1");
+export const scheduleDialogDayOfMonth$ = computed((get) =>
+  get(internalDialogDayOfMonth$),
+);
+
+export const setScheduleDialogDayOfMonth$ = command(
+  ({ set }, value: string) => {
+    set(internalDialogDayOfMonth$, value);
+  },
+);
+
+const internalDialogSaving$ = state(false);
+export const scheduleDialogSaving$ = computed((get) =>
+  get(internalDialogSaving$),
+);
+
+const internalDialogSaveError$ = state<string | null>(null);
+export const scheduleDialogSaveError$ = computed((get) =>
+  get(internalDialogSaveError$),
+);
+
+// ---------------------------------------------------------------------------
+// Open / close schedule dialog
+// ---------------------------------------------------------------------------
+
+export const openScheduleDialog$ = command(({ get, set }) => {
+  const schedule = get(internalAgentSchedule$);
+  if (!schedule) {
+    return;
+  }
+
+  set(internalDialogPrompt$, schedule.prompt);
+  set(internalDialogSaveError$, null);
+
+  if (schedule.cronExpression) {
+    const parsed = parseCronExpression(schedule.cronExpression);
+    set(internalDialogTimeOption$, parsed.timeOption);
+    set(internalDialogHour$, parsed.hour);
+    set(internalDialogMinute$, parsed.minute);
+    set(internalDialogDayOfWeek$, parsed.dayOfWeek);
+    set(internalDialogDayOfMonth$, parsed.dayOfMonth);
+  } else {
+    set(internalDialogTimeOption$, "every-day");
+    set(internalDialogHour$, "9");
+    set(internalDialogMinute$, "0");
+    set(internalDialogDayOfWeek$, "1");
+    set(internalDialogDayOfMonth$, "1");
+  }
+
+  set(internalDialogOpen$, true);
+});
+
+export const closeScheduleDialog$ = command(({ set }) => {
+  set(internalDialogOpen$, false);
+});
+
+// ---------------------------------------------------------------------------
+// Submit schedule edit
+// ---------------------------------------------------------------------------
+
+export const submitScheduleDialog$ = command(async ({ get, set }) => {
+  const detail = get(agentDetail$);
+  const prompt = get(internalDialogPrompt$);
+  const timeOption = get(internalDialogTimeOption$);
+  const hour = get(internalDialogHour$);
+  const minute = get(internalDialogMinute$);
+  const dayOfWeek = get(internalDialogDayOfWeek$);
+  const dayOfMonth = get(internalDialogDayOfMonth$);
+
+  if (!detail || !prompt.trim()) {
+    return;
+  }
+
+  set(internalDialogSaving$, true);
+  set(internalDialogSaveError$, null);
+
+  try {
+    const fetchFn = get(fetch$);
+    const cronExpression = buildCronExpression({
+      timeOption,
+      hour,
+      minute,
+      dayOfWeek,
+      dayOfMonth,
+    });
+    const timezone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+    const response = await fetchFn("/api/agent/schedules", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        composeId: detail.id,
+        name: "default",
+        cronExpression,
+        timezone,
+        prompt: prompt.trim(),
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => null)) as {
+        message?: string;
+      } | null;
+      throw new Error(
+        errorData?.message ?? `Save failed: ${response.statusText}`,
+      );
+    }
+
+    // Enable the schedule (backend creates/updates with enabled=false)
+    const enableResponse = await fetchFn(
+      `/api/agent/schedules/default/enable`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ composeId: detail.id }),
+      },
+    );
+
+    if (!enableResponse.ok) {
+      L.warn("Failed to enable schedule:", enableResponse.statusText);
+    }
+
+    set(internalDialogOpen$, false);
+    toast.success("Schedule updated");
+    await set(fetchAgentSchedule$);
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to update schedule:", error);
+    set(
+      internalDialogSaveError$,
+      error instanceof Error ? error.message : "Failed to save",
+    );
+  } finally {
+    set(internalDialogSaving$, false);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Delete schedule from dialog
+// ---------------------------------------------------------------------------
+
+export const deleteScheduleFromDialog$ = command(async ({ set }) => {
+  set(internalDialogSaving$, true);
+  set(internalDialogSaveError$, null);
+
+  try {
+    await set(deleteAgentSchedule$);
+    set(internalDialogOpen$, false);
+    toast.success("Schedule deleted");
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to delete schedule:", error);
+    set(
+      internalDialogSaveError$,
+      error instanceof Error ? error.message : "Failed to delete",
+    );
+  } finally {
+    set(internalDialogSaving$, false);
+  }
+});

--- a/turbo/apps/platform/src/signals/agent-detail/schedule.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/schedule.ts
@@ -4,7 +4,7 @@ import { fetch$ } from "../fetch.ts";
 import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
 import { agentDetail$ } from "./agent-detail.ts";
-import { buildCronExpression, type ScheduleTimeOption } from "./run-dialog.ts";
+import { buildCronExpression, type ScheduleTimeOption } from "./cron.ts";
 
 const L = logger("Schedule");
 

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/run-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/run-dialog.test.tsx
@@ -56,6 +56,12 @@ function mockAgentDetailAPI() {
         createdAt: "2024-01-01T00:00:00Z",
       });
     }),
+    http.get("/api/agent/schedules", () => {
+      return HttpResponse.json({ schedules: [] });
+    }),
+    http.post("/api/agent/schedules/:name/enable", () => {
+      return new HttpResponse(null, { status: 200 });
+    }),
   );
 }
 

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/schedule-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/schedule-dialog.test.tsx
@@ -1,0 +1,248 @@
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { describe, expect, it, vi } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { server } from "../../../mocks/server.ts";
+import { http, HttpResponse } from "msw";
+import { FeatureSwitchKey } from "@vm0/core";
+
+const context = testContext();
+
+function makeSchedule(overrides?: Record<string, unknown>) {
+  return {
+    id: "schedule_1",
+    composeId: "compose_1",
+    composeName: "my-agent",
+    scopeSlug: "test-user",
+    name: "default",
+    cronExpression: "30 14 * * 1-5",
+    atTime: null,
+    timezone: "UTC",
+    prompt: "Daily standup summary",
+    vars: null,
+    secretNames: null,
+    artifactName: null,
+    artifactVersion: null,
+    volumeVersions: null,
+    enabled: true,
+    nextRunAt: null,
+    lastRunAt: null,
+    retryStartedAt: null,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function mockAgentDetailAPI(
+  opts: { withSchedule?: boolean } = { withSchedule: true },
+) {
+  server.use(
+    http.get("/api/agent/composes", ({ request }) => {
+      const url = new URL(request.url);
+      const name = url.searchParams.get("name");
+
+      if (name !== "my-agent") {
+        return new HttpResponse(null, { status: 404 });
+      }
+
+      return HttpResponse.json({
+        id: "compose_1",
+        name: "my-agent",
+        headVersionId: "version_1",
+        content: {
+          version: "1",
+          agents: {
+            "my-agent": {
+              description: "A test agent",
+              framework: "claude-code",
+            },
+          },
+        },
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      });
+    }),
+    http.get("/api/agent/composes/:id/instructions", () => {
+      return HttpResponse.json({
+        content: "# Instructions",
+        filename: "instructions.md",
+      });
+    }),
+    http.get("/api/agent/schedules", () => {
+      return HttpResponse.json({
+        schedules: opts.withSchedule ? [makeSchedule()] : [],
+      });
+    }),
+    http.post("/api/agent/schedules/:name/enable", () => {
+      return new HttpResponse(null, { status: 200 });
+    }),
+  );
+}
+
+describe("schedule dialog", () => {
+  it("should show Scheduled badge when agent has active schedule", async () => {
+    mockAgentDetailAPI({ withSchedule: true });
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Scheduled")).toBeInTheDocument();
+    });
+  });
+
+  it("should not show Scheduled badge when no schedule exists", async () => {
+    mockAgentDetailAPI({ withSchedule: false });
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "my-agent" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Scheduled")).not.toBeInTheDocument();
+  });
+
+  it("should open edit dialog when clicking schedule badge edit button", async () => {
+    mockAgentDetailAPI({ withSchedule: true });
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Scheduled")).toBeInTheDocument();
+    });
+
+    // Click the edit button next to the Scheduled badge
+    const editButtons = screen.getAllByRole("button");
+    const editButton = editButtons.find((btn) =>
+      btn.closest(".inline-flex")?.textContent?.includes("Scheduled"),
+    );
+    expect(editButton).toBeDefined();
+    fireEvent.click(editButton!);
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Edit this schedule" }),
+      ).toBeInTheDocument();
+    });
+
+    // Prompt should be pre-filled
+    const textarea = screen.getByDisplayValue("Daily standup summary");
+    expect(textarea).toBeInTheDocument();
+  });
+
+  it("should update schedule on save", async () => {
+    mockAgentDetailAPI({ withSchedule: true });
+
+    let capturedBody: unknown = null;
+    server.use(
+      http.post("/api/agent/schedules", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(makeSchedule(), { status: 201 });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Scheduled")).toBeInTheDocument();
+    });
+
+    // Open schedule dialog
+    const editButtons = screen.getAllByRole("button");
+    const editButton = editButtons.find((btn) =>
+      btn.closest(".inline-flex")?.textContent?.includes("Scheduled"),
+    );
+    fireEvent.click(editButton!);
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Edit this schedule" }),
+      ).toBeInTheDocument();
+    });
+
+    // Modify prompt
+    const textarea = screen.getByDisplayValue("Daily standup summary");
+    fireEvent.change(textarea, {
+      target: { value: "Updated standup summary" },
+    });
+
+    // Click save
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await vi.waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: "Edit this schedule" }),
+      ).not.toBeInTheDocument();
+    });
+
+    const body = capturedBody as Record<string, unknown>;
+    expect(body.composeId).toBe("compose_1");
+    expect(body.prompt).toBe("Updated standup summary");
+  });
+
+  it("should delete schedule and hide badge", async () => {
+    mockAgentDetailAPI({ withSchedule: true });
+
+    server.use(
+      http.delete("/api/agent/schedules/:name", () => {
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Scheduled")).toBeInTheDocument();
+    });
+
+    // Open schedule dialog
+    const editButtons = screen.getAllByRole("button");
+    const editButton = editButtons.find((btn) =>
+      btn.closest(".inline-flex")?.textContent?.includes("Scheduled"),
+    );
+    fireEvent.click(editButton!);
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Edit this schedule" }),
+      ).toBeInTheDocument();
+    });
+
+    // Click destructive (delete) button
+    fireEvent.click(screen.getByRole("button", { name: "Destructive" }));
+
+    // Dialog should close and badge should disappear
+    await vi.waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: "Edit this schedule" }),
+      ).not.toBeInTheDocument();
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("Scheduled")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/schedule-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/schedule-dialog.test.tsx
@@ -127,12 +127,7 @@ describe("schedule dialog", () => {
     });
 
     // Click the edit button next to the Scheduled badge
-    const editButtons = screen.getAllByRole("button");
-    const editButton = editButtons.find((btn) =>
-      btn.closest(".inline-flex")?.textContent?.includes("Scheduled"),
-    );
-    expect(editButton).toBeDefined();
-    fireEvent.click(editButton!);
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
 
     await vi.waitFor(() => {
       expect(
@@ -167,11 +162,7 @@ describe("schedule dialog", () => {
     });
 
     // Open schedule dialog
-    const editButtons = screen.getAllByRole("button");
-    const editButton = editButtons.find((btn) =>
-      btn.closest(".inline-flex")?.textContent?.includes("Scheduled"),
-    );
-    fireEvent.click(editButton!);
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
 
     await vi.waitFor(() => {
       expect(
@@ -219,11 +210,7 @@ describe("schedule dialog", () => {
     });
 
     // Open schedule dialog
-    const editButtons = screen.getAllByRole("button");
-    const editButton = editButtons.find((btn) =>
-      btn.closest(".inline-flex")?.textContent?.includes("Scheduled"),
-    );
-    fireEvent.click(editButton!);
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
 
     await vi.waitFor(() => {
       expect(
@@ -231,8 +218,8 @@ describe("schedule dialog", () => {
       ).toBeInTheDocument();
     });
 
-    // Click destructive (delete) button
-    fireEvent.click(screen.getByRole("button", { name: "Destructive" }));
+    // Click delete button
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
 
     // Dialog should close and badge should disappear
     await vi.waitFor(() => {

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-detail-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-detail-page.tsx
@@ -20,6 +20,7 @@ import { AgentInstructions } from "./agent-instructions.tsx";
 import { InlineRunPanel } from "./inline-run-panel.tsx";
 import { ConfigDialog } from "./config-dialog/config-dialog.tsx";
 import { RunDialog } from "./run-dialog/run-dialog.tsx";
+import { ScheduleDialog } from "./schedule-dialog.tsx";
 
 export function AgentDetailPage() {
   const agentName = useGet(agentName$);
@@ -73,6 +74,7 @@ export function AgentDetailPage() {
             )}
             <ConfigDialog />
             <RunDialog />
+            <ScheduleDialog />
           </>
         ) : (
           <div className="rounded-lg border border-border bg-card p-8 text-center">

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
@@ -12,12 +12,18 @@ import {
   IconList,
   IconLink,
   IconLoader2,
+  IconClockHour3,
+  IconEdit,
 } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
 import { navigateInReact$ } from "../../signals/route.ts";
 import { openConfigDialog$ } from "../../signals/agent-detail/config-dialog.ts";
 import { openRunDialog$ } from "../../signals/agent-detail/run-dialog.ts";
 import { runButtonState$ } from "../../signals/agent-detail/inline-run.ts";
+import {
+  agentSchedule$,
+  openScheduleDialog$,
+} from "../../signals/agent-detail/schedule.ts";
 import { AgentAvatar } from "./agent-avatar.tsx";
 import type { AgentDetail } from "../../signals/agent-detail/types.ts";
 
@@ -32,6 +38,8 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
   const openRun = useSet(openRunDialog$);
   const buttonState = useGet(runButtonState$);
   const isBusy = buttonState !== "idle";
+  const schedule = useGet(agentSchedule$);
+  const openSchedule = useSet(openScheduleDialog$);
 
   // Extract description from the first agent definition
   const agentKeys = detail.content?.agents
@@ -64,6 +72,24 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
       </div>
       <div className="flex items-center gap-2 shrink-0">
         <TooltipProvider delayDuration={100}>
+          {schedule && (
+            <div className="inline-flex h-9 shrink-0 items-center rounded-md border border-border bg-sidebar">
+              <div className="flex items-center gap-1 pl-2.5 pr-2 py-0.5">
+                <IconClockHour3 size={12} className="shrink-0 text-sky-700" />
+                <span className="text-xs font-medium leading-4 text-secondary-foreground">
+                  Scheduled
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={() => openSchedule()}
+                className="flex h-9 w-9 items-center justify-center border-l border-border text-secondary-foreground hover:bg-accent rounded-r-md cursor-pointer"
+              >
+                <IconEdit size={16} />
+              </button>
+            </div>
+          )}
+
           <Tooltip>
             <TooltipTrigger asChild>
               <Button

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
@@ -83,6 +83,7 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
               <button
                 type="button"
                 onClick={() => openSchedule()}
+                aria-label="Edit schedule"
                 className="flex h-9 w-9 items-center justify-center border-l border-border text-secondary-foreground hover:bg-accent rounded-r-md cursor-pointer"
               >
                 <IconEdit size={16} />

--- a/turbo/apps/platform/src/views/agent-detail-page/run-dialog/run-dialog.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/run-dialog/run-dialog.tsx
@@ -176,7 +176,7 @@ export function RunDialog() {
           {isSchedule && (
             <div className="flex flex-col gap-3">
               <label className="text-sm font-medium text-foreground px-1">
-                Frequence
+                Frequency
               </label>
               <div className="flex items-center gap-2">
                 <IconClock

--- a/turbo/apps/platform/src/views/agent-detail-page/run-dialog/run-dialog.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/run-dialog/run-dialog.tsx
@@ -25,39 +25,70 @@ import {
   setRunDialogTimeOption$,
   runDialogFrequency$,
   setRunDialogFrequency$,
+  runDialogMinute$,
+  setRunDialogMinute$,
+  runDialogDayOfWeek$,
+  setRunDialogDayOfWeek$,
+  runDialogDayOfMonth$,
+  setRunDialogDayOfMonth$,
   runDialogSaving$,
   runDialogSaveError$,
   submitRunDialog$,
 } from "../../../signals/agent-detail/run-dialog.ts";
+import { agentSchedule$ } from "../../../signals/agent-detail/schedule.ts";
 import { detach, Reason } from "../../../signals/utils.ts";
 
-function buildHourOptions() {
-  return Array.from({ length: 16 }, (_, i) => {
-    const hour = i + 6; // 6:00 am to 9:00 pm
-    const period = hour >= 12 ? "pm" : "am";
-    const displayHour = hour > 12 ? hour - 12 : hour;
-    return {
-      value: String(hour),
-      label: `${String(displayHour)}:00 ${period}`,
-    };
-  });
-}
+// ---------------------------------------------------------------------------
+// RunDialog
+// ---------------------------------------------------------------------------
 
 export function RunDialog() {
   const open = useGet(runDialogOpen$);
   const prompt = useGet(runDialogPrompt$);
   const timeOption = useGet(runDialogTimeOption$);
   const frequency = useGet(runDialogFrequency$);
+  const minute = useGet(runDialogMinute$);
+  const dayOfWeek = useGet(runDialogDayOfWeek$);
+  const dayOfMonth = useGet(runDialogDayOfMonth$);
   const saving = useGet(runDialogSaving$);
   const saveError = useGet(runDialogSaveError$);
   const close = useSet(closeRunDialog$);
   const setPrompt = useSet(setRunDialogPrompt$);
   const setTimeOption = useSet(setRunDialogTimeOption$);
   const setFrequency = useSet(setRunDialogFrequency$);
+  const setMinute = useSet(setRunDialogMinute$);
+  const setDayOfWeek = useSet(setRunDialogDayOfWeek$);
+  const setDayOfMonth = useSet(setRunDialogDayOfMonth$);
   const submit = useSet(submitRunDialog$);
+  const schedule = useGet(agentSchedule$);
 
-  const isSchedule = timeOption !== "now";
-  const hourOptions = buildHourOptions();
+  const weekdays = [
+    { value: "1", label: "Monday" },
+    { value: "2", label: "Tuesday" },
+    { value: "3", label: "Wednesday" },
+    { value: "4", label: "Thursday" },
+    { value: "5", label: "Friday" },
+    { value: "6", label: "Saturday" },
+    { value: "0", label: "Sunday" },
+  ];
+
+  const hours = Array.from({ length: 24 }, (_, i) => ({
+    value: String(i),
+    label: String(i).padStart(2, "0"),
+  }));
+
+  const minutes = Array.from({ length: 60 }, (_, i) => ({
+    value: String(i),
+    label: String(i).padStart(2, "0"),
+  }));
+
+  const dayOfMonthOptions = Array.from({ length: 31 }, (_, i) => ({
+    value: String(i + 1),
+    label: String(i + 1),
+  }));
+
+  const hasSchedule = schedule !== null;
+  const isSchedule = !hasSchedule && timeOption !== "now";
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && close()}>
@@ -69,55 +100,115 @@ export function RunDialog() {
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex flex-col gap-5">
-          <div className="flex flex-col gap-2">
-            <label className="text-sm font-medium text-foreground">
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-3">
+            <label className="text-sm font-medium text-foreground px-1">
               Prompt
             </label>
             <textarea
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
               placeholder="Describe your task in natural language."
-              className="w-full min-h-[120px] rounded-lg border border-border bg-input p-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-y"
+              className="w-full h-[100px] rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-y"
             />
           </div>
 
-          <div className="flex flex-col gap-2">
-            <label className="text-sm font-medium text-foreground">Time</label>
-            <Select value={timeOption} onValueChange={setTimeOption}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="now">Now</SelectItem>
-                <SelectItem value="every-weekday">Every weekday</SelectItem>
-                <SelectItem value="every-day">Every day</SelectItem>
-                <SelectItem value="every-week">Every week</SelectItem>
-                <SelectItem value="every-month">Every month</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          {isSchedule && (
-            <div className="flex flex-col gap-2">
-              <label className="text-sm font-medium text-foreground">
-                Frequency
+          {!hasSchedule && (
+            <div className="flex flex-col gap-3">
+              <label className="text-sm font-medium text-foreground px-1">
+                Time
               </label>
-              <Select value={frequency} onValueChange={setFrequency}>
+              <Select value={timeOption} onValueChange={setTimeOption}>
                 <SelectTrigger>
-                  <div className="flex items-center gap-2">
-                    <IconClock size={16} className="text-muted-foreground" />
-                    <SelectValue />
-                  </div>
+                  <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {hourOptions.map((opt) => (
-                    <SelectItem key={opt.value} value={opt.value}>
-                      {opt.label}
+                  <SelectItem value="now">Now</SelectItem>
+                  <SelectItem value="every-weekday">Every weekday</SelectItem>
+                  <SelectItem value="every-day">Every day</SelectItem>
+                  <SelectItem value="every-week">Every week</SelectItem>
+                  <SelectItem value="every-month">Every month</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {isSchedule && timeOption === "every-week" && (
+            <div className="flex flex-col gap-3">
+              <label className="text-sm font-medium text-foreground px-1">
+                Day of week
+              </label>
+              <Select value={dayOfWeek} onValueChange={setDayOfWeek}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {weekdays.map((d) => (
+                    <SelectItem key={d.value} value={d.value}>
+                      {d.label}
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
+            </div>
+          )}
+
+          {isSchedule && timeOption === "every-month" && (
+            <div className="flex flex-col gap-3">
+              <label className="text-sm font-medium text-foreground px-1">
+                Day of month
+              </label>
+              <Select value={dayOfMonth} onValueChange={setDayOfMonth}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {dayOfMonthOptions.map((d) => (
+                    <SelectItem key={d.value} value={d.value}>
+                      {d.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {isSchedule && (
+            <div className="flex flex-col gap-3">
+              <label className="text-sm font-medium text-foreground px-1">
+                Frequence
+              </label>
+              <div className="flex items-center gap-2">
+                <IconClock
+                  size={16}
+                  className="text-muted-foreground shrink-0"
+                />
+                <Select value={frequency} onValueChange={setFrequency}>
+                  <SelectTrigger className="w-[80px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {hours.map((o) => (
+                      <SelectItem key={o.value} value={o.value}>
+                        {o.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <span className="text-sm text-muted-foreground">:</span>
+                <Select value={minute} onValueChange={setMinute}>
+                  <SelectTrigger className="w-[80px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {minutes.map((o) => (
+                      <SelectItem key={o.value} value={o.value}>
+                        {o.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
             </div>
           )}
         </div>

--- a/turbo/apps/platform/src/views/agent-detail-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/schedule-dialog.tsx
@@ -205,7 +205,7 @@ export function ScheduleDialog() {
             onClick={() => detach(deleteSchedule(), Reason.DomCallback)}
             disabled={saving}
           >
-            Destructive
+            Delete
           </Button>
           <div className="flex gap-2">
             <Button variant="outline" onClick={close} disabled={saving}>

--- a/turbo/apps/platform/src/views/agent-detail-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/schedule-dialog.tsx
@@ -164,7 +164,7 @@ export function ScheduleDialog() {
 
           <div className="flex flex-col gap-3">
             <label className="text-sm font-medium text-foreground px-1">
-              Frequence
+              Frequency
             </label>
             <div className="flex items-center gap-2">
               <IconClock size={16} className="text-muted-foreground shrink-0" />

--- a/turbo/apps/platform/src/views/agent-detail-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/schedule-dialog.tsx
@@ -1,0 +1,225 @@
+import { useGet, useSet } from "ccstate-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui/components/ui/dialog";
+import { Button } from "@vm0/ui/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vm0/ui/components/ui/select";
+import { IconClock } from "@tabler/icons-react";
+import {
+  scheduleDialogOpen$,
+  closeScheduleDialog$,
+  scheduleDialogPrompt$,
+  setScheduleDialogPrompt$,
+  scheduleDialogTimeOption$,
+  setScheduleDialogTimeOption$,
+  scheduleDialogHour$,
+  setScheduleDialogHour$,
+  scheduleDialogMinute$,
+  setScheduleDialogMinute$,
+  scheduleDialogDayOfWeek$,
+  setScheduleDialogDayOfWeek$,
+  scheduleDialogDayOfMonth$,
+  setScheduleDialogDayOfMonth$,
+  scheduleDialogSaving$,
+  scheduleDialogSaveError$,
+  submitScheduleDialog$,
+  deleteScheduleFromDialog$,
+} from "../../signals/agent-detail/schedule.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+
+// ---------------------------------------------------------------------------
+// ScheduleDialog
+// ---------------------------------------------------------------------------
+
+export function ScheduleDialog() {
+  const weekdays = [
+    { value: "1", label: "Monday" },
+    { value: "2", label: "Tuesday" },
+    { value: "3", label: "Wednesday" },
+    { value: "4", label: "Thursday" },
+    { value: "5", label: "Friday" },
+    { value: "6", label: "Saturday" },
+    { value: "0", label: "Sunday" },
+  ];
+
+  const hours = Array.from({ length: 24 }, (_, i) => ({
+    value: String(i),
+    label: String(i).padStart(2, "0"),
+  }));
+
+  const minutes = Array.from({ length: 60 }, (_, i) => ({
+    value: String(i),
+    label: String(i).padStart(2, "0"),
+  }));
+  const open = useGet(scheduleDialogOpen$);
+  const prompt = useGet(scheduleDialogPrompt$);
+  const timeOption = useGet(scheduleDialogTimeOption$);
+  const hour = useGet(scheduleDialogHour$);
+  const minute = useGet(scheduleDialogMinute$);
+  const dayOfWeek = useGet(scheduleDialogDayOfWeek$);
+  const dayOfMonth = useGet(scheduleDialogDayOfMonth$);
+  const saving = useGet(scheduleDialogSaving$);
+  const saveError = useGet(scheduleDialogSaveError$);
+  const close = useSet(closeScheduleDialog$);
+  const setPrompt = useSet(setScheduleDialogPrompt$);
+  const setTimeOption = useSet(setScheduleDialogTimeOption$);
+  const setHour = useSet(setScheduleDialogHour$);
+  const setMinute = useSet(setScheduleDialogMinute$);
+  const setDayOfWeek = useSet(setScheduleDialogDayOfWeek$);
+  const setDayOfMonth = useSet(setScheduleDialogDayOfMonth$);
+  const submit = useSet(submitScheduleDialog$);
+  const deleteSchedule = useSet(deleteScheduleFromDialog$);
+
+  const dayOfMonthOptions = Array.from({ length: 31 }, (_, i) => ({
+    value: String(i + 1),
+    label: String(i + 1),
+  }));
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && close()}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit this schedule</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-3">
+            <label className="text-sm font-medium text-foreground px-1">
+              Prompt
+            </label>
+            <textarea
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Describe your task in natural language."
+              className="w-full h-[100px] rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-y"
+            />
+          </div>
+
+          <div className="flex flex-col gap-3">
+            <label className="text-sm font-medium text-foreground px-1">
+              Time
+            </label>
+            <Select value={timeOption} onValueChange={setTimeOption}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="every-weekday">Every weekday</SelectItem>
+                <SelectItem value="every-day">Every day</SelectItem>
+                <SelectItem value="every-week">Every week</SelectItem>
+                <SelectItem value="every-month">Every month</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {timeOption === "every-week" && (
+            <div className="flex flex-col gap-3">
+              <label className="text-sm font-medium text-foreground px-1">
+                Day of week
+              </label>
+              <Select value={dayOfWeek} onValueChange={setDayOfWeek}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {weekdays.map((d) => (
+                    <SelectItem key={d.value} value={d.value}>
+                      {d.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {timeOption === "every-month" && (
+            <div className="flex flex-col gap-3">
+              <label className="text-sm font-medium text-foreground px-1">
+                Day of month
+              </label>
+              <Select value={dayOfMonth} onValueChange={setDayOfMonth}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {dayOfMonthOptions.map((d) => (
+                    <SelectItem key={d.value} value={d.value}>
+                      {d.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <div className="flex flex-col gap-3">
+            <label className="text-sm font-medium text-foreground px-1">
+              Frequence
+            </label>
+            <div className="flex items-center gap-2">
+              <IconClock size={16} className="text-muted-foreground shrink-0" />
+              <Select value={hour} onValueChange={setHour}>
+                <SelectTrigger className="w-[80px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {hours.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <span className="text-sm text-muted-foreground">:</span>
+              <Select value={minute} onValueChange={setMinute}>
+                <SelectTrigger className="w-[80px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {minutes.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </div>
+
+        {saveError && <p className="text-sm text-destructive">{saveError}</p>}
+
+        <DialogFooter className="flex !justify-between">
+          <Button
+            variant="destructive"
+            onClick={() => detach(deleteSchedule(), Reason.DomCallback)}
+            disabled={saving}
+          >
+            Destructive
+          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={close} disabled={saving}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => detach(submit(), Reason.DomCallback)}
+              disabled={saving || !prompt.trim()}
+            >
+              {saving ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a new `ScheduleDialog` component for editing/deleting existing agent schedules, with full cron configuration (time option, hour, minute, day of week, day of month)
- Enhance the `RunDialog` with minute-level precision, day-of-week, and day-of-month selectors for schedule creation, and auto-enable schedules after creation
- Add a "Scheduled" badge in the agent header that shows when an active schedule exists, with an edit button to open the schedule dialog
- Add new `schedule.ts` signal module for fetching, parsing, and managing agent schedule state

## Test plan
- [x] Existing `run-dialog.test.tsx` tests pass with new mock endpoints for schedule API
- [ ] Verify schedule badge appears in agent header when an enabled schedule exists
- [ ] Verify clicking the edit button on the schedule badge opens the schedule dialog with pre-populated values
- [ ] Verify creating a schedule from the run dialog enables it and refreshes the badge
- [ ] Verify editing a schedule updates cron expression correctly
- [ ] Verify deleting a schedule removes the badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)