### PR TITLE
feat(platform): add editable agent name and skills multi-select to config dialog

### DIFF
--- a/turbo/apps/platform/src/data/skills.ts
+++ b/turbo/apps/platform/src/data/skills.ts
@@ -193,7 +193,7 @@ function webScrapingSkills(): ComboboxOption[] {
     s("browserbase", "browserbase", "https://cdn.simpleicons.org/googlechrome"),
     s("browserless", "browserless", "https://vm0.ai/skills/browserless.png"),
     s("firecrawl", "firecrawl", "https://vm0.ai/skills/firecrawl.svg"),
-    s("mercury", "mercury", "https://cdn.simpleicons.org/mercury"),
+    s("mercury", "mercury", "https://vm0.ai/skills/mercury.svg"),
     s("scrapeninja", "scrapeninja", "https://vm0.ai/skills/scrapeninja.svg"),
   ];
 }

--- a/turbo/apps/platform/src/data/skills.ts
+++ b/turbo/apps/platform/src/data/skills.ts
@@ -1,0 +1,382 @@
+import type { ComboboxOption } from "@vm0/ui";
+
+const SKILL_URL_PREFIX = "https://github.com/vm0-ai/vm0-skills/tree/main/";
+
+export function skillValueToUrl(value: string): string {
+  return `${SKILL_URL_PREFIX}${value}`;
+}
+
+export function skillUrlToValue(url: string): string {
+  if (url.startsWith(SKILL_URL_PREFIX)) {
+    return url.slice(SKILL_URL_PREFIX.length);
+  }
+  // Fallback: extract last segment from any URL
+  const parts = url.split("/");
+  return parts[parts.length - 1] ?? url;
+}
+
+/**
+ * Static skills data for the multi-select combobox.
+ * Sourced from https://vm0.ai/api/web/skills — maintained manually.
+ *
+ * value = GitHub directory name (used in skill URL)
+ * label = display name
+ * icon  = absolute logo URL
+ */
+// eslint-disable-next-line ccstate/no-package-variable -- static readonly skills data
+export const SKILLS: ComboboxOption[] = [
+  // AI & Media
+  {
+    value: "elevenlabs",
+    label: "elevenlabs",
+    icon: "https://vm0.ai/skills/elevenlabs.svg",
+  },
+  {
+    value: "fal.ai",
+    label: "fal.ai",
+    icon: "https://vm0.ai/skills/fal-image.svg",
+  },
+  {
+    value: "htmlcsstoimage",
+    label: "htmlcsstoimage",
+    icon: "https://vm0.ai/skills/htmlcsstoimage.png",
+  },
+  {
+    value: "openai",
+    label: "openai",
+    icon: "https://upload.wikimedia.org/wikipedia/commons/e/ef/ChatGPT-Logo.svg",
+  },
+  {
+    value: "runway",
+    label: "runway",
+    icon: "https://vm0.ai/skills/runway.svg",
+  },
+  { value: "vm0-agent", label: "vm0-agent", icon: "https://vm0.ai/icon.svg" },
+  { value: "vm0-cli", label: "vm0-cli", icon: "https://vm0.ai/icon.svg" },
+
+  // Analytics
+  { value: "axiom", label: "axiom", icon: "https://vm0.ai/skills/axiom.svg" },
+  {
+    value: "cronlytic",
+    label: "cronlytic",
+    icon: "https://vm0.ai/skills/cronlytic.png",
+  },
+  {
+    value: "plausible",
+    label: "plausible",
+    icon: "https://vm0.ai/skills/plausible.svg",
+  },
+  {
+    value: "reportei",
+    label: "reportei",
+    icon: "https://cdn.simpleicons.org/googleanalytics",
+  },
+  {
+    value: "sentry",
+    label: "sentry",
+    icon: "https://cdn.simpleicons.org/sentry",
+  },
+
+  // Cloud Storage
+  {
+    value: "cloudinary",
+    label: "cloudinary",
+    icon: "https://vm0.ai/skills/cloudinary.svg",
+  },
+  { value: "minio", label: "minio", icon: "https://vm0.ai/skills/minio.svg" },
+  {
+    value: "qdrant",
+    label: "qdrant",
+    icon: "https://vm0.ai/skills/qdrant.svg",
+  },
+  {
+    value: "supabase",
+    label: "supabase",
+    icon: "https://cdn.simpleicons.org/supabase",
+  },
+  {
+    value: "supadata",
+    label: "supadata",
+    icon: "https://cdn.simpleicons.org/supabase",
+  },
+
+  // Communication
+  {
+    value: "agentmail",
+    label: "agentmail",
+    icon: "https://cdn.simpleicons.org/gmail",
+  },
+  {
+    value: "chatwoot",
+    label: "chatwoot",
+    icon: "https://vm0.ai/skills/chatwoot.svg",
+  },
+  {
+    value: "discord",
+    label: "discord",
+    icon: "https://cdn.simpleicons.org/discord",
+  },
+  {
+    value: "discord-webhook",
+    label: "discord-webhook",
+    icon: "https://cdn.simpleicons.org/discord",
+  },
+  { value: "gmail", label: "gmail", icon: "https://cdn.simpleicons.org/gmail" },
+  {
+    value: "intercom",
+    label: "intercom",
+    icon: "https://cdn.simpleicons.org/intercom",
+  },
+  { value: "lark", label: "lark", icon: "https://vm0.ai/skills/lark.png" },
+  {
+    value: "mailsac",
+    label: "mailsac",
+    icon: "https://cdn.simpleicons.org/gmail",
+  },
+  {
+    value: "pushinator",
+    label: "pushinator",
+    icon: "https://cdn.simpleicons.org/pushbullet",
+  },
+  {
+    value: "resend",
+    label: "resend",
+    icon: "https://cdn.simpleicons.org/resend",
+  },
+  { value: "slack", label: "slack", icon: "https://vm0.ai/skills/slack.svg" },
+  {
+    value: "slack-webhook",
+    label: "slack-webhook",
+    icon: "https://vm0.ai/skills/slack.svg",
+  },
+  {
+    value: "zendesk",
+    label: "zendesk",
+    icon: "https://cdn.simpleicons.org/zendesk",
+  },
+  {
+    value: "zeptomail",
+    label: "zeptomail",
+    icon: "https://cdn.simpleicons.org/zoho",
+  },
+
+  // Content
+  {
+    value: "hackernews",
+    label: "hackernews",
+    icon: "https://cdn.simpleicons.org/ycombinator",
+  },
+  { value: "imgur", label: "imgur", icon: "https://vm0.ai/skills/imgur.svg" },
+  {
+    value: "instagram",
+    label: "instagram",
+    icon: "https://vm0.ai/skills/instagram.svg",
+  },
+  {
+    value: "podchaser",
+    label: "podchaser",
+    icon: "https://cdn.simpleicons.org/applepodcasts",
+  },
+  { value: "qiita", label: "qiita", icon: "https://vm0.ai/skills/qiita.svg" },
+  {
+    value: "youtube",
+    label: "youtube",
+    icon: "https://cdn.simpleicons.org/youtube",
+  },
+
+  // Development
+  {
+    value: ".claude",
+    label: "Claude Config",
+    icon: "https://cdn.simpleicons.org/anthropic",
+  },
+  {
+    value: ".claude-plugin",
+    label: "Claude Plugin",
+    icon: "https://cdn.simpleicons.org/anthropic",
+  },
+  {
+    value: "deepseek",
+    label: "deepseek",
+    icon: "https://vm0.ai/skills/deepseek.svg",
+  },
+  {
+    value: "dev.to",
+    label: "dev.to",
+    icon: "https://cdn.simpleicons.org/devdotto",
+  },
+  {
+    value: "github",
+    label: "github",
+    icon: "https://vm0.ai/skills/github.svg",
+  },
+  {
+    value: "github-copilot",
+    label: "github-copilot",
+    icon: "https://vm0.ai/skills/githubcopilot.svg",
+  },
+  {
+    value: "gitlab",
+    label: "gitlab",
+    icon: "https://cdn.simpleicons.org/gitlab",
+  },
+  { value: "vm0", label: "VM0", icon: "https://vm0.ai/icon.svg" },
+  { value: ".vm0", label: "VM0 Config", icon: "https://vm0.ai/icon.svg" },
+
+  // Documents
+  {
+    value: "pdf4me",
+    label: "pdf4me",
+    icon: "https://vm0.ai/skills/pdf4me.svg",
+  },
+  { value: "pdfco", label: "pdfco", icon: "https://vm0.ai/skills/pdfco.svg" },
+  {
+    value: "pdforge",
+    label: "pdforge",
+    icon: "https://vm0.ai/skills/pdforge.svg",
+  },
+  {
+    value: "zapsign",
+    label: "zapsign",
+    icon: "https://vm0.ai/skills/zapsign.svg",
+  },
+
+  // Other
+  {
+    value: "cloudflare-tunnel",
+    label: "cloudflare-tunnel",
+    icon: "https://cdn.simpleicons.org/cloudflare",
+  },
+  {
+    value: "pikvm",
+    label: "pikvm",
+    icon: "https://cdn.simpleicons.org/raspberrypi",
+  },
+  {
+    value: "vm0-computer",
+    label: "vm0-computer",
+    icon: "https://vm0.ai/icon.svg",
+  },
+
+  // Productivity
+  {
+    value: "bitrix",
+    label: "bitrix",
+    icon: "https://vm0.ai/skills/bitrix.svg",
+  },
+  { value: "figma", label: "figma", icon: "https://cdn.simpleicons.org/figma" },
+  {
+    value: "google-sheets",
+    label: "google-sheets",
+    icon: "https://cdn.simpleicons.org/googlesheets",
+  },
+  {
+    value: "instantly",
+    label: "instantly",
+    icon: "https://cdn.simpleicons.org/maildotru",
+  },
+  { value: "jira", label: "jira", icon: "https://cdn.simpleicons.org/jira" },
+  { value: "kommo", label: "kommo", icon: "https://vm0.ai/skills/kommo.webp" },
+  {
+    value: "linear",
+    label: "linear",
+    icon: "https://cdn.simpleicons.org/linear",
+  },
+  {
+    value: "monday",
+    label: "monday",
+    icon: "https://vm0.ai/skills/monday.svg",
+  },
+  {
+    value: "notion",
+    label: "notion",
+    icon: "https://vm0.ai/skills/notion.svg",
+  },
+  {
+    value: "streak",
+    label: "streak",
+    icon: "https://cdn.simpleicons.org/gmail",
+  },
+  {
+    value: "twenty",
+    label: "twenty",
+    icon: "https://cdn.simpleicons.org/airtable",
+  },
+  {
+    value: "workflow-migration",
+    label: "workflow-migration",
+    icon: "https://cdn.simpleicons.org/zapier",
+  },
+
+  // Search
+  {
+    value: "brave-search",
+    label: "brave-search",
+    icon: "https://vm0.ai/skills/brave.svg",
+  },
+  {
+    value: "perplexity",
+    label: "perplexity",
+    icon: "https://vm0.ai/skills/perplexity.svg",
+  },
+  {
+    value: "rss-fetch",
+    label: "rss-fetch",
+    icon: "https://vm0.ai/skills/rss.svg",
+  },
+  {
+    value: "serpapi",
+    label: "serpapi",
+    icon: "https://vm0.ai/skills/serpapi.png",
+  },
+  {
+    value: "tavily",
+    label: "tavily",
+    icon: "https://vm0.ai/skills/tavily.svg",
+  },
+
+  // Utilities
+  {
+    value: "minimax",
+    label: "minimax",
+    icon: "https://vm0.ai/skills/minimax.svg",
+  },
+  {
+    value: "shortio",
+    label: "shortio",
+    icon: "https://cdn.simpleicons.org/bitly",
+  },
+
+  // Web Scraping
+  { value: "apify", label: "apify", icon: "https://vm0.ai/skills/apify.svg" },
+  {
+    value: "bright-data",
+    label: "bright-data",
+    icon: "https://vm0.ai/skills/bright-data.png",
+  },
+  {
+    value: "browserbase",
+    label: "browserbase",
+    icon: "https://cdn.simpleicons.org/googlechrome",
+  },
+  {
+    value: "browserless",
+    label: "browserless",
+    icon: "https://vm0.ai/skills/browserless.png",
+  },
+  {
+    value: "firecrawl",
+    label: "firecrawl",
+    icon: "https://vm0.ai/skills/firecrawl.svg",
+  },
+  {
+    value: "mercury",
+    label: "mercury",
+    icon: "https://cdn.simpleicons.org/mercury",
+  },
+  {
+    value: "scrapeninja",
+    label: "scrapeninja",
+    icon: "https://vm0.ai/skills/scrapeninja.svg",
+  },
+];

--- a/turbo/apps/platform/src/data/skills.ts
+++ b/turbo/apps/platform/src/data/skills.ts
@@ -1,3 +1,4 @@
+import { computed } from "ccstate";
 import type { ComboboxOption } from "@vm0/ui";
 
 const SKILL_URL_PREFIX = "https://github.com/vm0-ai/vm0-skills/tree/main/";
@@ -10,9 +11,7 @@ export function skillUrlToValue(url: string): string {
   if (url.startsWith(SKILL_URL_PREFIX)) {
     return url.slice(SKILL_URL_PREFIX.length);
   }
-  // Fallback: extract last segment from any URL
-  const parts = url.split("/");
-  return parts[parts.length - 1] ?? url;
+  return url;
 }
 
 /**
@@ -23,360 +22,193 @@ export function skillUrlToValue(url: string): string {
  * label = display name
  * icon  = absolute logo URL
  */
-// eslint-disable-next-line ccstate/no-package-variable -- static readonly skills data
-export const SKILLS: ComboboxOption[] = [
-  // AI & Media
-  {
-    value: "elevenlabs",
-    label: "elevenlabs",
-    icon: "https://vm0.ai/skills/elevenlabs.svg",
-  },
-  {
-    value: "fal.ai",
-    label: "fal.ai",
-    icon: "https://vm0.ai/skills/fal-image.svg",
-  },
-  {
-    value: "htmlcsstoimage",
-    label: "htmlcsstoimage",
-    icon: "https://vm0.ai/skills/htmlcsstoimage.png",
-  },
-  {
-    value: "openai",
-    label: "openai",
-    icon: "https://upload.wikimedia.org/wikipedia/commons/e/ef/ChatGPT-Logo.svg",
-  },
-  {
-    value: "runway",
-    label: "runway",
-    icon: "https://vm0.ai/skills/runway.svg",
-  },
-  { value: "vm0-agent", label: "vm0-agent", icon: "https://vm0.ai/icon.svg" },
-  { value: "vm0-cli", label: "vm0-cli", icon: "https://vm0.ai/icon.svg" },
 
-  // Analytics
-  { value: "axiom", label: "axiom", icon: "https://vm0.ai/skills/axiom.svg" },
-  {
-    value: "cronlytic",
-    label: "cronlytic",
-    icon: "https://vm0.ai/skills/cronlytic.png",
-  },
-  {
-    value: "plausible",
-    label: "plausible",
-    icon: "https://vm0.ai/skills/plausible.svg",
-  },
-  {
-    value: "reportei",
-    label: "reportei",
-    icon: "https://cdn.simpleicons.org/googleanalytics",
-  },
-  {
-    value: "sentry",
-    label: "sentry",
-    icon: "https://cdn.simpleicons.org/sentry",
-  },
+function s(value: string, label: string, icon: string): ComboboxOption {
+  return { value, label, icon };
+}
 
-  // Cloud Storage
-  {
-    value: "cloudinary",
-    label: "cloudinary",
-    icon: "https://vm0.ai/skills/cloudinary.svg",
-  },
-  { value: "minio", label: "minio", icon: "https://vm0.ai/skills/minio.svg" },
-  {
-    value: "qdrant",
-    label: "qdrant",
-    icon: "https://vm0.ai/skills/qdrant.svg",
-  },
-  {
-    value: "supabase",
-    label: "supabase",
-    icon: "https://cdn.simpleicons.org/supabase",
-  },
-  {
-    value: "supadata",
-    label: "supadata",
-    icon: "https://cdn.simpleicons.org/supabase",
-  },
+function aiMediaSkills(): ComboboxOption[] {
+  return [
+    s("elevenlabs", "elevenlabs", "https://vm0.ai/skills/elevenlabs.svg"),
+    s("fal.ai", "fal.ai", "https://vm0.ai/skills/fal-image.svg"),
+    s(
+      "htmlcsstoimage",
+      "htmlcsstoimage",
+      "https://vm0.ai/skills/htmlcsstoimage.png",
+    ),
+    s(
+      "openai",
+      "openai",
+      "https://upload.wikimedia.org/wikipedia/commons/e/ef/ChatGPT-Logo.svg",
+    ),
+    s("runway", "runway", "https://vm0.ai/skills/runway.svg"),
+    s("vm0-agent", "vm0-agent", "https://vm0.ai/icon.svg"),
+    s("vm0-cli", "vm0-cli", "https://vm0.ai/icon.svg"),
+  ];
+}
 
-  // Communication
-  {
-    value: "agentmail",
-    label: "agentmail",
-    icon: "https://cdn.simpleicons.org/gmail",
-  },
-  {
-    value: "chatwoot",
-    label: "chatwoot",
-    icon: "https://vm0.ai/skills/chatwoot.svg",
-  },
-  {
-    value: "discord",
-    label: "discord",
-    icon: "https://cdn.simpleicons.org/discord",
-  },
-  {
-    value: "discord-webhook",
-    label: "discord-webhook",
-    icon: "https://cdn.simpleicons.org/discord",
-  },
-  { value: "gmail", label: "gmail", icon: "https://cdn.simpleicons.org/gmail" },
-  {
-    value: "intercom",
-    label: "intercom",
-    icon: "https://cdn.simpleicons.org/intercom",
-  },
-  { value: "lark", label: "lark", icon: "https://vm0.ai/skills/lark.png" },
-  {
-    value: "mailsac",
-    label: "mailsac",
-    icon: "https://cdn.simpleicons.org/gmail",
-  },
-  {
-    value: "pushinator",
-    label: "pushinator",
-    icon: "https://cdn.simpleicons.org/pushbullet",
-  },
-  {
-    value: "resend",
-    label: "resend",
-    icon: "https://cdn.simpleicons.org/resend",
-  },
-  { value: "slack", label: "slack", icon: "https://vm0.ai/skills/slack.svg" },
-  {
-    value: "slack-webhook",
-    label: "slack-webhook",
-    icon: "https://vm0.ai/skills/slack.svg",
-  },
-  {
-    value: "zendesk",
-    label: "zendesk",
-    icon: "https://cdn.simpleicons.org/zendesk",
-  },
-  {
-    value: "zeptomail",
-    label: "zeptomail",
-    icon: "https://cdn.simpleicons.org/zoho",
-  },
+function analyticsSkills(): ComboboxOption[] {
+  return [
+    s("axiom", "axiom", "https://vm0.ai/skills/axiom.svg"),
+    s("cronlytic", "cronlytic", "https://vm0.ai/skills/cronlytic.png"),
+    s("plausible", "plausible", "https://vm0.ai/skills/plausible.svg"),
+    s("reportei", "reportei", "https://cdn.simpleicons.org/googleanalytics"),
+    s("sentry", "sentry", "https://cdn.simpleicons.org/sentry"),
+  ];
+}
 
-  // Content
-  {
-    value: "hackernews",
-    label: "hackernews",
-    icon: "https://cdn.simpleicons.org/ycombinator",
-  },
-  { value: "imgur", label: "imgur", icon: "https://vm0.ai/skills/imgur.svg" },
-  {
-    value: "instagram",
-    label: "instagram",
-    icon: "https://vm0.ai/skills/instagram.svg",
-  },
-  {
-    value: "podchaser",
-    label: "podchaser",
-    icon: "https://cdn.simpleicons.org/applepodcasts",
-  },
-  { value: "qiita", label: "qiita", icon: "https://vm0.ai/skills/qiita.svg" },
-  {
-    value: "youtube",
-    label: "youtube",
-    icon: "https://cdn.simpleicons.org/youtube",
-  },
+function cloudStorageSkills(): ComboboxOption[] {
+  return [
+    s("cloudinary", "cloudinary", "https://vm0.ai/skills/cloudinary.svg"),
+    s("minio", "minio", "https://vm0.ai/skills/minio.svg"),
+    s("qdrant", "qdrant", "https://vm0.ai/skills/qdrant.svg"),
+    s("supabase", "supabase", "https://cdn.simpleicons.org/supabase"),
+    s("supadata", "supadata", "https://cdn.simpleicons.org/supabase"),
+  ];
+}
 
-  // Development
-  {
-    value: ".claude",
-    label: "Claude Config",
-    icon: "https://cdn.simpleicons.org/anthropic",
-  },
-  {
-    value: ".claude-plugin",
-    label: "Claude Plugin",
-    icon: "https://cdn.simpleicons.org/anthropic",
-  },
-  {
-    value: "deepseek",
-    label: "deepseek",
-    icon: "https://vm0.ai/skills/deepseek.svg",
-  },
-  {
-    value: "dev.to",
-    label: "dev.to",
-    icon: "https://cdn.simpleicons.org/devdotto",
-  },
-  {
-    value: "github",
-    label: "github",
-    icon: "https://vm0.ai/skills/github.svg",
-  },
-  {
-    value: "github-copilot",
-    label: "github-copilot",
-    icon: "https://vm0.ai/skills/githubcopilot.svg",
-  },
-  {
-    value: "gitlab",
-    label: "gitlab",
-    icon: "https://cdn.simpleicons.org/gitlab",
-  },
-  { value: "vm0", label: "VM0", icon: "https://vm0.ai/icon.svg" },
-  { value: ".vm0", label: "VM0 Config", icon: "https://vm0.ai/icon.svg" },
+function communicationSkills(): ComboboxOption[] {
+  return [
+    s("agentmail", "agentmail", "https://cdn.simpleicons.org/gmail"),
+    s("chatwoot", "chatwoot", "https://vm0.ai/skills/chatwoot.svg"),
+    s("discord", "discord", "https://cdn.simpleicons.org/discord"),
+    s(
+      "discord-webhook",
+      "discord-webhook",
+      "https://cdn.simpleicons.org/discord",
+    ),
+    s("gmail", "gmail", "https://cdn.simpleicons.org/gmail"),
+    s("intercom", "intercom", "https://cdn.simpleicons.org/intercom"),
+    s("lark", "lark", "https://vm0.ai/skills/lark.png"),
+    s("mailsac", "mailsac", "https://cdn.simpleicons.org/gmail"),
+    s("pushinator", "pushinator", "https://cdn.simpleicons.org/pushbullet"),
+    s("resend", "resend", "https://cdn.simpleicons.org/resend"),
+    s("slack", "slack", "https://vm0.ai/skills/slack.svg"),
+    s("slack-webhook", "slack-webhook", "https://vm0.ai/skills/slack.svg"),
+    s("zendesk", "zendesk", "https://cdn.simpleicons.org/zendesk"),
+    s("zeptomail", "zeptomail", "https://cdn.simpleicons.org/zoho"),
+  ];
+}
 
-  // Documents
-  {
-    value: "pdf4me",
-    label: "pdf4me",
-    icon: "https://vm0.ai/skills/pdf4me.svg",
-  },
-  { value: "pdfco", label: "pdfco", icon: "https://vm0.ai/skills/pdfco.svg" },
-  {
-    value: "pdforge",
-    label: "pdforge",
-    icon: "https://vm0.ai/skills/pdforge.svg",
-  },
-  {
-    value: "zapsign",
-    label: "zapsign",
-    icon: "https://vm0.ai/skills/zapsign.svg",
-  },
+function contentSkills(): ComboboxOption[] {
+  return [
+    s("hackernews", "hackernews", "https://cdn.simpleicons.org/ycombinator"),
+    s("imgur", "imgur", "https://vm0.ai/skills/imgur.svg"),
+    s("instagram", "instagram", "https://vm0.ai/skills/instagram.svg"),
+    s("podchaser", "podchaser", "https://cdn.simpleicons.org/applepodcasts"),
+    s("qiita", "qiita", "https://vm0.ai/skills/qiita.svg"),
+    s("youtube", "youtube", "https://cdn.simpleicons.org/youtube"),
+  ];
+}
 
-  // Other
-  {
-    value: "cloudflare-tunnel",
-    label: "cloudflare-tunnel",
-    icon: "https://cdn.simpleicons.org/cloudflare",
-  },
-  {
-    value: "pikvm",
-    label: "pikvm",
-    icon: "https://cdn.simpleicons.org/raspberrypi",
-  },
-  {
-    value: "vm0-computer",
-    label: "vm0-computer",
-    icon: "https://vm0.ai/icon.svg",
-  },
+function developmentSkills(): ComboboxOption[] {
+  return [
+    s(".claude", "Claude Config", "https://cdn.simpleicons.org/anthropic"),
+    s(
+      ".claude-plugin",
+      "Claude Plugin",
+      "https://cdn.simpleicons.org/anthropic",
+    ),
+    s("deepseek", "deepseek", "https://vm0.ai/skills/deepseek.svg"),
+    s("dev.to", "dev.to", "https://cdn.simpleicons.org/devdotto"),
+    s("github", "github", "https://vm0.ai/skills/github.svg"),
+    s(
+      "github-copilot",
+      "github-copilot",
+      "https://vm0.ai/skills/githubcopilot.svg",
+    ),
+    s("gitlab", "gitlab", "https://cdn.simpleicons.org/gitlab"),
+    s("vm0", "VM0", "https://vm0.ai/icon.svg"),
+    s(".vm0", "VM0 Config", "https://vm0.ai/icon.svg"),
+  ];
+}
 
-  // Productivity
-  {
-    value: "bitrix",
-    label: "bitrix",
-    icon: "https://vm0.ai/skills/bitrix.svg",
-  },
-  { value: "figma", label: "figma", icon: "https://cdn.simpleicons.org/figma" },
-  {
-    value: "google-sheets",
-    label: "google-sheets",
-    icon: "https://cdn.simpleicons.org/googlesheets",
-  },
-  {
-    value: "instantly",
-    label: "instantly",
-    icon: "https://cdn.simpleicons.org/maildotru",
-  },
-  { value: "jira", label: "jira", icon: "https://cdn.simpleicons.org/jira" },
-  { value: "kommo", label: "kommo", icon: "https://vm0.ai/skills/kommo.webp" },
-  {
-    value: "linear",
-    label: "linear",
-    icon: "https://cdn.simpleicons.org/linear",
-  },
-  {
-    value: "monday",
-    label: "monday",
-    icon: "https://vm0.ai/skills/monday.svg",
-  },
-  {
-    value: "notion",
-    label: "notion",
-    icon: "https://vm0.ai/skills/notion.svg",
-  },
-  {
-    value: "streak",
-    label: "streak",
-    icon: "https://cdn.simpleicons.org/gmail",
-  },
-  {
-    value: "twenty",
-    label: "twenty",
-    icon: "https://cdn.simpleicons.org/airtable",
-  },
-  {
-    value: "workflow-migration",
-    label: "workflow-migration",
-    icon: "https://cdn.simpleicons.org/zapier",
-  },
+function documentSkills(): ComboboxOption[] {
+  return [
+    s("pdf4me", "pdf4me", "https://vm0.ai/skills/pdf4me.svg"),
+    s("pdfco", "pdfco", "https://vm0.ai/skills/pdfco.svg"),
+    s("pdforge", "pdforge", "https://vm0.ai/skills/pdforge.svg"),
+    s("zapsign", "zapsign", "https://vm0.ai/skills/zapsign.svg"),
+  ];
+}
 
-  // Search
-  {
-    value: "brave-search",
-    label: "brave-search",
-    icon: "https://vm0.ai/skills/brave.svg",
-  },
-  {
-    value: "perplexity",
-    label: "perplexity",
-    icon: "https://vm0.ai/skills/perplexity.svg",
-  },
-  {
-    value: "rss-fetch",
-    label: "rss-fetch",
-    icon: "https://vm0.ai/skills/rss.svg",
-  },
-  {
-    value: "serpapi",
-    label: "serpapi",
-    icon: "https://vm0.ai/skills/serpapi.png",
-  },
-  {
-    value: "tavily",
-    label: "tavily",
-    icon: "https://vm0.ai/skills/tavily.svg",
-  },
+function otherSkills(): ComboboxOption[] {
+  return [
+    s(
+      "cloudflare-tunnel",
+      "cloudflare-tunnel",
+      "https://cdn.simpleicons.org/cloudflare",
+    ),
+    s("pikvm", "pikvm", "https://cdn.simpleicons.org/raspberrypi"),
+    s("vm0-computer", "vm0-computer", "https://vm0.ai/icon.svg"),
+  ];
+}
 
-  // Utilities
-  {
-    value: "minimax",
-    label: "minimax",
-    icon: "https://vm0.ai/skills/minimax.svg",
-  },
-  {
-    value: "shortio",
-    label: "shortio",
-    icon: "https://cdn.simpleicons.org/bitly",
-  },
+function productivitySkills(): ComboboxOption[] {
+  return [
+    s("bitrix", "bitrix", "https://vm0.ai/skills/bitrix.svg"),
+    s("figma", "figma", "https://cdn.simpleicons.org/figma"),
+    s(
+      "google-sheets",
+      "google-sheets",
+      "https://cdn.simpleicons.org/googlesheets",
+    ),
+    s("instantly", "instantly", "https://cdn.simpleicons.org/maildotru"),
+    s("jira", "jira", "https://cdn.simpleicons.org/jira"),
+    s("kommo", "kommo", "https://vm0.ai/skills/kommo.webp"),
+    s("linear", "linear", "https://cdn.simpleicons.org/linear"),
+    s("monday", "monday", "https://vm0.ai/skills/monday.svg"),
+    s("notion", "notion", "https://vm0.ai/skills/notion.svg"),
+    s("streak", "streak", "https://cdn.simpleicons.org/gmail"),
+    s("twenty", "twenty", "https://cdn.simpleicons.org/airtable"),
+    s(
+      "workflow-migration",
+      "workflow-migration",
+      "https://cdn.simpleicons.org/zapier",
+    ),
+  ];
+}
 
-  // Web Scraping
-  { value: "apify", label: "apify", icon: "https://vm0.ai/skills/apify.svg" },
-  {
-    value: "bright-data",
-    label: "bright-data",
-    icon: "https://vm0.ai/skills/bright-data.png",
-  },
-  {
-    value: "browserbase",
-    label: "browserbase",
-    icon: "https://cdn.simpleicons.org/googlechrome",
-  },
-  {
-    value: "browserless",
-    label: "browserless",
-    icon: "https://vm0.ai/skills/browserless.png",
-  },
-  {
-    value: "firecrawl",
-    label: "firecrawl",
-    icon: "https://vm0.ai/skills/firecrawl.svg",
-  },
-  {
-    value: "mercury",
-    label: "mercury",
-    icon: "https://cdn.simpleicons.org/mercury",
-  },
-  {
-    value: "scrapeninja",
-    label: "scrapeninja",
-    icon: "https://vm0.ai/skills/scrapeninja.svg",
-  },
-];
+function searchSkills(): ComboboxOption[] {
+  return [
+    s("brave-search", "brave-search", "https://vm0.ai/skills/brave.svg"),
+    s("perplexity", "perplexity", "https://vm0.ai/skills/perplexity.svg"),
+    s("rss-fetch", "rss-fetch", "https://vm0.ai/skills/rss.svg"),
+    s("serpapi", "serpapi", "https://vm0.ai/skills/serpapi.png"),
+    s("tavily", "tavily", "https://vm0.ai/skills/tavily.svg"),
+  ];
+}
+
+function utilitySkills(): ComboboxOption[] {
+  return [
+    s("minimax", "minimax", "https://vm0.ai/skills/minimax.svg"),
+    s("shortio", "shortio", "https://cdn.simpleicons.org/bitly"),
+  ];
+}
+
+function webScrapingSkills(): ComboboxOption[] {
+  return [
+    s("apify", "apify", "https://vm0.ai/skills/apify.svg"),
+    s("bright-data", "bright-data", "https://vm0.ai/skills/bright-data.png"),
+    s("browserbase", "browserbase", "https://cdn.simpleicons.org/googlechrome"),
+    s("browserless", "browserless", "https://vm0.ai/skills/browserless.png"),
+    s("firecrawl", "firecrawl", "https://vm0.ai/skills/firecrawl.svg"),
+    s("mercury", "mercury", "https://cdn.simpleicons.org/mercury"),
+    s("scrapeninja", "scrapeninja", "https://vm0.ai/skills/scrapeninja.svg"),
+  ];
+}
+
+export const skills$ = computed((): ComboboxOption[] => [
+  ...aiMediaSkills(),
+  ...analyticsSkills(),
+  ...cloudStorageSkills(),
+  ...communicationSkills(),
+  ...contentSkills(),
+  ...developmentSkills(),
+  ...documentSkills(),
+  ...otherSkills(),
+  ...productivitySkills(),
+  ...searchSkills(),
+  ...utilitySkills(),
+  ...webScrapingSkills(),
+]);

--- a/turbo/apps/platform/src/signals/agent-detail/config-dialog.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/config-dialog.ts
@@ -4,7 +4,9 @@ import { stringify, parse } from "yaml";
 import { fetch$ } from "../fetch.ts";
 import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
+import { navigateInReact$ } from "../route.ts";
 import { agentDetail$, fetchAgentDetail$ } from "./agent-detail.ts";
+import { skillValueToUrl } from "../../data/skills.ts";
 import type { AgentDetail } from "./types.ts";
 
 const L = logger("ConfigDialog");
@@ -143,6 +145,67 @@ export const updateComposeField$ = command(
 );
 
 // ---------------------------------------------------------------------------
+// Update agent name — restructures the agents dictionary key
+// ---------------------------------------------------------------------------
+
+export const updateAgentName$ = command(({ get, set }, newName: string) => {
+  const compose = get(internalEditableCompose$);
+  if (!compose) {
+    return;
+  }
+
+  const agentKeys = Object.keys(compose.agents);
+  const firstKey = agentKeys[0];
+  if (!firstKey || newName === firstKey) {
+    return;
+  }
+
+  const agentDef = compose.agents[firstKey];
+  if (!agentDef) {
+    return;
+  }
+
+  const updated: ComposeContent = {
+    ...compose,
+    agents: { [newName]: agentDef },
+  };
+
+  set(internalEditableCompose$, updated);
+  set(internalYamlText$, stringify(updated));
+  set(internalYamlError$, null);
+});
+
+// ---------------------------------------------------------------------------
+// Update skills — converts values to GitHub URLs
+// ---------------------------------------------------------------------------
+
+export const updateSkills$ = command(({ get, set }, skillValues: string[]) => {
+  const compose = get(internalEditableCompose$);
+  if (!compose) {
+    return;
+  }
+
+  const agentKeys = Object.keys(compose.agents);
+  const firstKey = agentKeys[0];
+  if (!firstKey) {
+    return;
+  }
+
+  const updated = structuredClone(compose);
+  const agent = updated.agents[firstKey];
+  if (!agent) {
+    return;
+  }
+
+  agent.skills =
+    skillValues.length > 0 ? skillValues.map(skillValueToUrl) : undefined;
+
+  set(internalEditableCompose$, updated);
+  set(internalYamlText$, stringify(updated));
+  set(internalYamlError$, null);
+});
+
+// ---------------------------------------------------------------------------
 // Update from YAML tab — parse YAML and update compose
 // ---------------------------------------------------------------------------
 
@@ -200,10 +263,23 @@ export const saveConfigDialog$ = command(async ({ get, set }) => {
       );
     }
 
-    // Refresh agent detail and close dialog
-    await set(fetchAgentDetail$);
-    set(internalOpen$, false);
-    toast.success("Agent configuration saved");
+    // Check if name changed
+    const newAgentKey = Object.keys(compose.agents)[0];
+    const nameChanged = newAgentKey && newAgentKey !== detail.name;
+
+    if (nameChanged) {
+      // Navigate to new agent URL
+      set(internalOpen$, false);
+      toast.success("Agent configuration saved");
+      set(navigateInReact$, "/agents/:name", {
+        pathParams: { name: newAgentKey },
+      });
+    } else {
+      // Refresh agent detail and close dialog
+      await set(fetchAgentDetail$);
+      set(internalOpen$, false);
+      toast.success("Agent configuration saved");
+    }
   } catch (error) {
     throwIfAbort(error);
     const message = error instanceof Error ? error.message : "Failed to save";

--- a/turbo/apps/platform/src/signals/agent-detail/config-dialog.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/config-dialog.ts
@@ -74,6 +74,23 @@ export const configDialogSaveError$ = computed((get) =>
 );
 
 // ---------------------------------------------------------------------------
+// Validation — checks if the current compose state is valid for saving
+// ---------------------------------------------------------------------------
+
+export const configDialogValid$ = computed((get) => {
+  const compose = get(internalEditableCompose$);
+  if (!compose) {
+    return true;
+  }
+  const agentKeys = Object.keys(compose.agents);
+  const firstKey = agentKeys[0];
+  if (!firstKey) {
+    return true;
+  }
+  return /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/.test(firstKey);
+});
+
+// ---------------------------------------------------------------------------
 // Open dialog — initialises editable state from current agent detail
 // ---------------------------------------------------------------------------
 

--- a/turbo/apps/platform/src/signals/agent-detail/config-dialog.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/config-dialog.ts
@@ -84,8 +84,8 @@ export const configDialogValid$ = computed((get) => {
   }
   const agentKeys = Object.keys(compose.agents);
   const firstKey = agentKeys[0];
-  if (!firstKey) {
-    return true;
+  if (firstKey === undefined || firstKey === "") {
+    return false;
   }
   return /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/.test(firstKey);
 });
@@ -130,7 +130,7 @@ export const updateComposeField$ = command(
 
     const agentKeys = Object.keys(compose.agents);
     const firstKey = agentKeys[0];
-    if (!firstKey) {
+    if (firstKey === undefined) {
       return;
     }
 
@@ -173,7 +173,7 @@ export const updateAgentName$ = command(({ get, set }, newName: string) => {
 
   const agentKeys = Object.keys(compose.agents);
   const firstKey = agentKeys[0];
-  if (!firstKey || newName === firstKey) {
+  if (firstKey === undefined || newName === firstKey) {
     return;
   }
 
@@ -204,7 +204,7 @@ export const updateSkills$ = command(({ get, set }, skillValues: string[]) => {
 
   const agentKeys = Object.keys(compose.agents);
   const firstKey = agentKeys[0];
-  if (!firstKey) {
+  if (firstKey === undefined) {
     return;
   }
 
@@ -265,10 +265,15 @@ export const saveConfigDialog$ = command(async ({ get, set }) => {
 
   try {
     const fetchFn = get(fetch$);
+    const newAgentKey = Object.keys(compose.agents)[0];
+    const nameChanged = newAgentKey && newAgentKey !== detail.name;
     const response = await fetchFn("/api/agent/composes", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content: compose }),
+      body: JSON.stringify({
+        content: compose,
+        ...(nameChanged ? { previousName: detail.name } : {}),
+      }),
     });
 
     if (!response.ok) {
@@ -279,10 +284,6 @@ export const saveConfigDialog$ = command(async ({ get, set }) => {
         errorData?.message ?? `Save failed: ${response.statusText}`,
       );
     }
-
-    // Check if name changed
-    const newAgentKey = Object.keys(compose.agents)[0];
-    const nameChanged = newAgentKey && newAgentKey !== detail.name;
 
     if (nameChanged) {
       // Navigate to new agent URL

--- a/turbo/apps/platform/src/signals/agent-detail/config-dialog.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/config-dialog.ts
@@ -7,6 +7,7 @@ import { logger } from "../log.ts";
 import { navigateInReact$ } from "../route.ts";
 import { agentDetail$, fetchAgentDetail$ } from "./agent-detail.ts";
 import { skillValueToUrl } from "../../data/skills.ts";
+import { AGENT_NAME_REGEX } from "@vm0/core";
 import type { AgentDetail } from "./types.ts";
 
 const L = logger("ConfigDialog");
@@ -87,7 +88,7 @@ export const configDialogValid$ = computed((get) => {
   if (firstKey === undefined || firstKey === "") {
     return false;
   }
-  return /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/.test(firstKey);
+  return AGENT_NAME_REGEX.test(firstKey);
 });
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/config-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/config-dialog.test.tsx
@@ -299,6 +299,84 @@ describe("config dialog", () => {
     });
   });
 
+  it("should allow editing agent name and sync to YAML", async () => {
+    mockAgentDetailAPI();
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "my-agent" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(findSettingsIconButton());
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Your agent configs" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Forms" }));
+
+    await vi.waitFor(() => {
+      expect(screen.getByDisplayValue("my-agent")).toBeInTheDocument();
+    });
+
+    const nameInput = screen.getByDisplayValue("my-agent");
+    fireEvent.change(nameInput, { target: { value: "new-agent" } });
+
+    // Switch to YAML tab and verify name change is reflected
+    fireEvent.click(screen.getByRole("tab", { name: "vm0.yaml" }));
+
+    await vi.waitFor(() => {
+      const textarea = document.querySelector("textarea");
+      expect(textarea?.value).toContain("new-agent");
+    });
+  });
+
+  it("should show validation error for invalid agent name", async () => {
+    mockAgentDetailAPI();
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "my-agent" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(findSettingsIconButton());
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Your agent configs" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Forms" }));
+
+    await vi.waitFor(() => {
+      expect(screen.getByDisplayValue("my-agent")).toBeInTheDocument();
+    });
+
+    const nameInput = screen.getByDisplayValue("my-agent");
+    fireEvent.change(nameInput, { target: { value: "-invalid" } });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/Must be 3-64 chars/)).toBeInTheDocument();
+    });
+  });
+
   it("should close dialog without saving on Cancel", async () => {
     mockAgentDetailAPI();
 

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/config-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/config-dialog.test.tsx
@@ -375,6 +375,66 @@ describe("config dialog", () => {
     await vi.waitFor(() => {
       expect(screen.getByText(/Must be 3-64 chars/)).toBeInTheDocument();
     });
+
+    // Save button should be disabled when name is invalid
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("should show selected skills and allow removing them", async () => {
+    mockAgentDetailAPI({
+      skills: [
+        "https://github.com/vm0-ai/vm0-skills/tree/main/hackernews",
+        "https://github.com/vm0-ai/vm0-skills/tree/main/github",
+      ],
+    });
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      featureSwitches: { [FeatureSwitchKey.AgentDetailPage]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "my-agent" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(findSettingsIconButton());
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Your agent configs" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Forms" }));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("hackernews")).toBeInTheDocument();
+    });
+
+    // Remove hackernews skill via the remove button
+    const removeButton = screen.getByRole("button", {
+      name: "Remove hackernews",
+    });
+    fireEvent.click(removeButton);
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("hackernews")).not.toBeInTheDocument();
+    });
+
+    // github should still be there
+    expect(screen.getByText("github")).toBeInTheDocument();
+
+    // Verify YAML tab reflects the removal
+    fireEvent.click(screen.getByRole("tab", { name: "vm0.yaml" }));
+
+    await vi.waitFor(() => {
+      const textarea = document.querySelector("textarea");
+      expect(textarea?.value).not.toContain("hackernews");
+      expect(textarea?.value).toContain("github");
+    });
   });
 
   it("should close dialog without saving on Cancel", async () => {

--- a/turbo/apps/platform/src/views/agent-detail-page/config-dialog/config-dialog.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/config-dialog/config-dialog.tsx
@@ -16,6 +16,7 @@ import {
   setConfigActiveTab$,
   configDialogSaving$,
   configDialogSaveError$,
+  configDialogValid$,
   saveConfigDialog$,
 } from "../../../signals/agent-detail/config-dialog.ts";
 import { detach, Reason } from "../../../signals/utils.ts";
@@ -26,6 +27,7 @@ export function ConfigDialog() {
   const open = useGet(configDialogOpen$);
   const activeTab = useGet(configActiveTab$);
   const saving = useGet(configDialogSaving$);
+  const valid = useGet(configDialogValid$);
   const saveError = useGet(configDialogSaveError$);
   const close = useSet(closeConfigDialog$);
   const setTab = useSet(setConfigActiveTab$);
@@ -58,7 +60,7 @@ export function ConfigDialog() {
           </Button>
           <Button
             onClick={() => detach(save(), Reason.DomCallback)}
-            disabled={saving}
+            disabled={saving || !valid}
           >
             {saving ? "Saving..." : "Save"}
           </Button>

--- a/turbo/apps/platform/src/views/agent-detail-page/config-dialog/forms-tab.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/config-dialog/forms-tab.tsx
@@ -1,19 +1,29 @@
 import { useGet, useSet } from "ccstate-react";
 import { Input } from "@vm0/ui/components/ui/input";
+import { MultiSelectCombobox } from "@vm0/ui/components/ui/multi-select-combobox";
 import {
   editableCompose$,
   updateComposeField$,
+  updateAgentName$,
+  updateSkills$,
 } from "../../../signals/agent-detail/config-dialog.ts";
+import { SKILLS, skillUrlToValue } from "../../../data/skills.ts";
 
-function extractSkillName(url: string): string {
-  // https://github.com/vm0-ai/vm0-skills/tree/main/hackernews → hackernews
-  const parts = url.split("/");
-  return parts[parts.length - 1] ?? url;
+function validateAgentName(name: string): string | null {
+  if (!name) {
+    return null;
+  }
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/.test(name)) {
+    return "Must be 3-64 chars, letters/numbers/hyphens, start and end with letter or number";
+  }
+  return null;
 }
 
 export function FormsTab() {
   const compose = useGet(editableCompose$);
   const updateField = useSet(updateComposeField$);
+  const updateName = useSet(updateAgentName$);
+  const updateSkillValues = useSet(updateSkills$);
 
   if (!compose) {
     return null;
@@ -30,13 +40,21 @@ export function FormsTab() {
     return null;
   }
 
+  const nameError = validateAgentName(firstKey);
+  const selectedSkills = agent.skills?.map(skillUrlToValue) ?? [];
+
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-2">
         <label className="text-sm font-medium text-foreground">
           Agent name
         </label>
-        <Input value={firstKey} readOnly className="bg-muted" />
+        <Input
+          value={firstKey}
+          onChange={(e) => updateName(e.target.value)}
+          placeholder="my-agent"
+        />
+        {nameError && <p className="text-xs text-destructive">{nameError}</p>}
       </div>
 
       <div className="flex flex-col gap-2">
@@ -50,21 +68,16 @@ export function FormsTab() {
         />
       </div>
 
-      {agent.skills && agent.skills.length > 0 && (
-        <div className="flex flex-col gap-2">
-          <label className="text-sm font-medium text-foreground">Skills</label>
-          <div className="flex flex-wrap gap-1.5">
-            {agent.skills.map((skill) => (
-              <span
-                key={skill}
-                className="inline-flex items-center rounded-md border border-border bg-muted px-2 py-0.5 text-xs font-medium text-foreground"
-              >
-                {extractSkillName(skill)}
-              </span>
-            ))}
-          </div>
-        </div>
-      )}
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium text-foreground">Skills</label>
+        <MultiSelectCombobox
+          options={SKILLS}
+          selected={selectedSkills}
+          onChange={updateSkillValues}
+          placeholder="Select skills..."
+          searchPlaceholder="Search skills..."
+        />
+      </div>
 
       <div className="flex flex-col gap-2">
         <label className="text-sm font-medium text-foreground">Framework</label>

--- a/turbo/apps/platform/src/views/agent-detail-page/config-dialog/forms-tab.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/config-dialog/forms-tab.tsx
@@ -11,7 +11,7 @@ import { skills$, skillUrlToValue } from "../../../data/skills.ts";
 
 function validateAgentName(name: string): string | null {
   if (!name) {
-    return null;
+    return "Agent name is required";
   }
   if (!/^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/.test(name)) {
     return "Must be 3-64 chars, letters/numbers/hyphens, start and end with letter or number";
@@ -32,7 +32,7 @@ export function FormsTab() {
 
   const agentKeys = Object.keys(compose.agents);
   const firstKey = agentKeys[0];
-  if (!firstKey) {
+  if (firstKey === undefined) {
     return null;
   }
 

--- a/turbo/apps/platform/src/views/agent-detail-page/config-dialog/forms-tab.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/config-dialog/forms-tab.tsx
@@ -7,7 +7,7 @@ import {
   updateAgentName$,
   updateSkills$,
 } from "../../../signals/agent-detail/config-dialog.ts";
-import { SKILLS, skillUrlToValue } from "../../../data/skills.ts";
+import { skills$, skillUrlToValue } from "../../../data/skills.ts";
 
 function validateAgentName(name: string): string | null {
   if (!name) {
@@ -21,6 +21,7 @@ function validateAgentName(name: string): string | null {
 
 export function FormsTab() {
   const compose = useGet(editableCompose$);
+  const skills = useGet(skills$);
   const updateField = useSet(updateComposeField$);
   const updateName = useSet(updateAgentName$);
   const updateSkillValues = useSet(updateSkills$);
@@ -71,7 +72,7 @@ export function FormsTab() {
       <div className="flex flex-col gap-2">
         <label className="text-sm font-medium text-foreground">Skills</label>
         <MultiSelectCombobox
-          options={SKILLS}
+          options={skills}
           selected={selectedSkills}
           onChange={updateSkillValues}
           placeholder="Select skills..."

--- a/turbo/apps/platform/src/views/agent-detail-page/config-dialog/forms-tab.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/config-dialog/forms-tab.tsx
@@ -45,6 +45,15 @@ export function FormsTab() {
   const nameError = validateAgentName(firstKey);
   const selectedSkills = agent.skills?.map(skillUrlToValue) ?? [];
 
+  // Include custom/unrecognized skill URLs as extra options so they aren't
+  // silently dropped from the selection when editing.
+  const knownValues = new Set(skills.map((s) => s.value));
+  const extraOptions = selectedSkills
+    .filter((v) => !knownValues.has(v))
+    .map((v) => ({ value: v, label: v }));
+  const allOptions =
+    extraOptions.length > 0 ? [...skills, ...extraOptions] : skills;
+
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-2">
@@ -73,7 +82,7 @@ export function FormsTab() {
       <div className="flex flex-col gap-2">
         <label className="text-sm font-medium text-foreground">Skills</label>
         <MultiSelectCombobox
-          options={skills}
+          options={allOptions}
           selected={selectedSkills}
           onChange={updateSkillValues}
           placeholder="Select skills..."

--- a/turbo/apps/platform/src/views/agent-detail-page/config-dialog/forms-tab.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/config-dialog/forms-tab.tsx
@@ -8,12 +8,13 @@ import {
   updateSkills$,
 } from "../../../signals/agent-detail/config-dialog.ts";
 import { skills$, skillUrlToValue } from "../../../data/skills.ts";
+import { AGENT_NAME_REGEX } from "@vm0/core";
 
 function validateAgentName(name: string): string | null {
   if (!name) {
     return "Agent name is required";
   }
-  if (!/^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/.test(name)) {
+  if (!AGENT_NAME_REGEX.test(name)) {
     return "Must be 3-64 chars, letters/numbers/hyphens, start and end with letter or number";
   }
   return null;

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
@@ -75,7 +75,10 @@ describe("GET /api/agent/composes/:id/instructions", () => {
 
     expect(response.status).toBe(200);
     expect(data.content).toBeNull();
-    expect(data.filename).toBeNull();
+    // Even without an explicit instructions field, the framework-canonical
+    // filename is returned (CLAUDE.md for claude-code) because the CLI may
+    // upload instructions without setting the field in the YAML.
+    expect(data.filename).toBe("CLAUDE.md");
   });
 
   it("should return null content when instructions volume does not exist", async () => {

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -100,11 +100,11 @@ export async function GET(
   const agentKeys = Object.keys(content.agents);
   const firstKey = agentKeys[0];
   const agentDef = firstKey ? content.agents[firstKey] : null;
-  const instructionsFilename = agentDef?.instructions;
-
-  if (!instructionsFilename) {
-    return NextResponse.json({ content: null, filename: null });
-  }
+  // Use the explicit instructions filename from YAML, or fall back to the
+  // framework-canonical name (e.g. CLAUDE.md for claude-code).  The CLI may
+  // upload instructions without setting the `instructions` field in the YAML.
+  const instructionsFilename =
+    agentDef?.instructions ?? getInstructionsFilename(agentDef?.framework);
 
   // Look up the instructions storage volume
   const storageName = getInstructionsStorageName(result.name);

--- a/turbo/apps/web/app/api/agent/composes/__tests__/storage-migration.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/storage-migration.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "../route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestVolume,
+  findTestStorageByName,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
+import { getInstructionsStorageName } from "@vm0/core";
+
+vi.hoisted(() => {
+  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
+});
+
+const context = testContext();
+
+describe("Storage Volume Migration on Agent Rename", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("should rename instructions volume when agent is renamed", async () => {
+    const oldName = `old-agent-${Date.now()}`;
+    const newName = `new-agent-${Date.now()}`;
+
+    // Create the original agent compose
+    await createTestCompose(oldName);
+
+    // Create the instructions volume for the old agent
+    const oldStorageName = getInstructionsStorageName(oldName);
+    await createTestVolume(oldStorageName);
+
+    // Rename the agent by posting with previousName
+    const config = {
+      version: "1.0",
+      agents: {
+        [newName]: { framework: "claude-code" },
+      },
+    };
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/composes",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: config, previousName: oldName }),
+      },
+    );
+
+    const response = await POST(request);
+    // 201 because the new agent name creates a new compose entry
+    expect(response.status).toBe(201);
+
+    // Old storage name should no longer exist
+    const newStorageName = getInstructionsStorageName(newName);
+
+    const oldStorage = await findTestStorageByName(
+      user.scopeId,
+      oldStorageName,
+    );
+    expect(oldStorage).toBeUndefined();
+
+    // New storage name should exist
+    const newStorage = await findTestStorageByName(
+      user.scopeId,
+      newStorageName,
+    );
+    expect(newStorage).toBeDefined();
+  });
+
+  it("should delete conflicting storage before renaming", async () => {
+    const oldName = `conflict-old-${Date.now()}`;
+    const newName = `conflict-new-${Date.now()}`;
+
+    // Create old agent + volume
+    await createTestCompose(oldName);
+    const oldStorageName = getInstructionsStorageName(oldName);
+    await createTestVolume(oldStorageName);
+
+    // Create a conflicting volume with the new name (e.g. from a previously deleted agent)
+    const newStorageName = getInstructionsStorageName(newName);
+    await createTestVolume(newStorageName);
+
+    // Remember the old storage's ID — after rename it should have the new name
+    const oldStorageBefore = await findTestStorageByName(
+      user.scopeId,
+      oldStorageName,
+    );
+    expect(oldStorageBefore).toBeDefined();
+    const oldStorageId = oldStorageBefore!.id;
+
+    // Rename
+    const config = {
+      version: "1.0",
+      agents: {
+        [newName]: { framework: "claude-code" },
+      },
+    };
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/composes",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: config, previousName: oldName }),
+      },
+    );
+
+    const response = await POST(request);
+    // 201 because the new agent name creates a new compose entry
+    expect(response.status).toBe(201);
+
+    // The renamed storage should have the old storage's ID
+    const renamedStorage = await findTestStorageByName(
+      user.scopeId,
+      newStorageName,
+    );
+    expect(renamedStorage).toBeDefined();
+    expect(renamedStorage!.id).toBe(oldStorageId);
+
+    // Old name should no longer exist
+    const oldStorageAfter = await findTestStorageByName(
+      user.scopeId,
+      oldStorageName,
+    );
+    expect(oldStorageAfter).toBeUndefined();
+  });
+
+  it("should not migrate when previousName equals new name", async () => {
+    const agentName = `same-name-agent-${Date.now()}`;
+
+    // Create agent + volume
+    await createTestCompose(agentName);
+    const storageName = getInstructionsStorageName(agentName);
+    await createTestVolume(storageName);
+
+    const storageBefore = await findTestStorageByName(
+      user.scopeId,
+      storageName,
+    );
+    expect(storageBefore).toBeDefined();
+
+    // "Rename" with same name — should be a no-op for storage
+    const config = {
+      version: "1.0",
+      agents: {
+        [agentName]: {
+          framework: "claude-code",
+          description: "updated",
+        },
+      },
+    };
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/composes",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: config, previousName: agentName }),
+      },
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    // Storage should still exist with the same name and ID
+    const storageAfter = await findTestStorageByName(user.scopeId, storageName);
+    expect(storageAfter).toBeDefined();
+    expect(storageAfter!.id).toBe(storageBefore!.id);
+  });
+
+  it("should handle rename when no instructions volume exists", async () => {
+    const oldName = `no-volume-old-${Date.now()}`;
+    const newName = `no-volume-new-${Date.now()}`;
+
+    // Create old agent but no instructions volume
+    await createTestCompose(oldName);
+
+    // Rename
+    const config = {
+      version: "1.0",
+      agents: {
+        [newName]: { framework: "claude-code" },
+      },
+    };
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/composes",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: config, previousName: oldName }),
+      },
+    );
+
+    const response = await POST(request);
+    // 201 because the new agent name creates a new compose entry
+    expect(response.status).toBe(201);
+
+    const data = await response.json();
+    expect(data.name).toBe(newName);
+  });
+});

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -17,6 +17,7 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
+import { storages } from "../../../../src/db/schema/storage";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
 import { eq, and } from "drizzle-orm";
 import { computeComposeVersionId } from "../../../../src/lib/agent-compose/content-hash";
@@ -26,6 +27,7 @@ import {
 } from "../../../../src/lib/scope/scope-service";
 import { getUserEmail } from "../../../../src/lib/auth/get-user-email";
 import { canAccessCompose } from "../../../../src/lib/agent/permission-service";
+import { getInstructionsStorageName } from "@vm0/core";
 import type { AgentComposeYaml } from "../../../../src/types/agent-compose";
 
 const router = tsr.router(composesMainContract, {
@@ -155,7 +157,7 @@ const router = tsr.router(composesMainContract, {
       };
     }
 
-    const { content } = body;
+    const { content, previousName } = body;
 
     // Validate agents is not array (Zod validates it's an object, but not that it's not an array)
     if (Array.isArray(content.agents)) {
@@ -350,6 +352,47 @@ const router = tsr.router(composesMainContract, {
         updatedAt: new Date(),
       })
       .where(eq(agentComposes.id, composeId));
+
+    // When renaming, migrate the instructions storage volume to the new name.
+    // If the target name already exists (e.g. from a previous agent), delete it
+    // first to avoid unique constraint violations, then rename the old one.
+    if (previousName && previousName.toLowerCase() !== normalizedAgentName) {
+      const oldStorageName = getInstructionsStorageName(
+        previousName.toLowerCase(),
+      );
+      const newStorageName = getInstructionsStorageName(normalizedAgentName);
+
+      // Check if old storage exists before attempting rename
+      const [oldStorage] = await globalThis.services.db
+        .select({ id: storages.id })
+        .from(storages)
+        .where(
+          and(
+            eq(storages.scopeId, userScope.id),
+            eq(storages.name, oldStorageName),
+            eq(storages.type, "volume"),
+          ),
+        )
+        .limit(1);
+
+      if (oldStorage) {
+        // Remove any existing storage with the new name to avoid conflicts
+        await globalThis.services.db
+          .delete(storages)
+          .where(
+            and(
+              eq(storages.scopeId, userScope.id),
+              eq(storages.name, newStorageName),
+              eq(storages.type, "volume"),
+            ),
+          );
+
+        await globalThis.services.db
+          .update(storages)
+          .set({ name: newStorageName, updatedAt: new Date() })
+          .where(eq(storages.id, oldStorage.id));
+      }
+    }
 
     const updatedAt = new Date().toISOString();
 

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../../src/lib/ts-rest-handler";
 import {
   composesMainContract,
+  AGENT_NAME_REGEX,
   SUPPORTED_FRAMEWORKS,
   isSupportedFramework,
 } from "@vm0/core";
@@ -214,8 +215,7 @@ const router = tsr.router(composesMainContract, {
     }
 
     // Validate name format: 3-64 chars, alphanumeric and hyphens, start/end with alphanumeric
-    const nameRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/;
-    if (!nameRegex.test(agentName)) {
+    if (!AGENT_NAME_REGEX.test(agentName)) {
       return {
         status: 400 as const,
         body: {
@@ -376,21 +376,23 @@ const router = tsr.router(composesMainContract, {
         .limit(1);
 
       if (oldStorage) {
-        // Remove any existing storage with the new name to avoid conflicts
-        await globalThis.services.db
-          .delete(storages)
-          .where(
-            and(
-              eq(storages.scopeId, userScope.id),
-              eq(storages.name, newStorageName),
-              eq(storages.type, "volume"),
-            ),
-          );
+        // Delete conflicting storage + rename in a single transaction
+        await globalThis.services.db.transaction(async (tx) => {
+          await tx
+            .delete(storages)
+            .where(
+              and(
+                eq(storages.scopeId, userScope.id),
+                eq(storages.name, newStorageName),
+                eq(storages.type, "volume"),
+              ),
+            );
 
-        await globalThis.services.db
-          .update(storages)
-          .set({ name: newStorageName, updatedAt: new Date() })
-          .where(eq(storages.id, oldStorage.id));
+          await tx
+            .update(storages)
+            .set({ name: newStorageName, updatedAt: new Date() })
+            .where(eq(storages.id, oldStorage.id));
+        });
       }
     }
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -1588,6 +1588,28 @@ export async function findTestArtifactStorage(scopeId: string) {
   return { storage, version: version ?? null };
 }
 
+/**
+ * Find a storage volume by scope and name.
+ * Returns the storage id and name, or undefined if not found.
+ */
+export async function findTestStorageByName(
+  scopeId: string,
+  name: string,
+): Promise<{ id: string; name: string } | undefined> {
+  const [result] = await globalThis.services.db
+    .select({ id: storages.id, name: storages.name })
+    .from(storages)
+    .where(
+      and(
+        eq(storages.scopeId, scopeId),
+        eq(storages.name, name),
+        eq(storages.type, "volume"),
+      ),
+    )
+    .limit(1);
+  return result;
+}
+
 export async function findTestSlackComposeRequest(composeJobId: string) {
   const [row] = await globalThis.services.db
     .select()

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -238,6 +238,8 @@ export const composesMainContract = c.router({
     headers: authHeadersSchema,
     body: z.object({
       content: agentComposeContentSchema,
+      /** When renaming an agent, pass the previous name so the server can migrate storage volumes. */
+      previousName: agentNameSchema.optional(),
     }),
     responses: {
       200: createComposeResponseSchema,

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -19,6 +19,11 @@ const composeVersionQuerySchema = z
   );
 
 /**
+ * Agent name regex: 3-64 chars, letters/numbers/hyphens, start and end with alphanumeric.
+ */
+export const AGENT_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/;
+
+/**
  * Agent name validation schema
  * - Must be 3-64 characters
  * - Letters, numbers, and hyphens only
@@ -29,7 +34,7 @@ const agentNameSchema = z
   .min(3, "Agent name must be at least 3 characters")
   .max(64, "Agent name must be 64 characters or less")
   .regex(
-    /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/,
+    AGENT_NAME_REGEX,
     "Agent name must start and end with letter or number, and contain only letters, numbers, and hyphens",
   );
 

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -28,6 +28,7 @@ export {
   type ComposesByIdContract,
   type ComposesVersionsContract,
   type ComposesListContract,
+  AGENT_NAME_REGEX,
   agentNameSchema,
   volumeConfigSchema,
   agentDefinitionSchema,

--- a/turbo/packages/ui/src/components/ui/multi-select-combobox.tsx
+++ b/turbo/packages/ui/src/components/ui/multi-select-combobox.tsx
@@ -68,7 +68,7 @@ export function MultiSelectCombobox({
     }
   }
 
-  function remove(value: string, e: React.MouseEvent) {
+  function remove(value: string, e: React.SyntheticEvent) {
     e.stopPropagation();
     onChange(selected.filter((v) => v !== value));
   }

--- a/turbo/packages/ui/src/components/ui/multi-select-combobox.tsx
+++ b/turbo/packages/ui/src/components/ui/multi-select-combobox.tsx
@@ -8,8 +8,8 @@ import {
   IconSearch,
 } from "@tabler/icons-react";
 
-import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 import { cn } from "../../lib/utils";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 
 export interface ComboboxOption {
   value: string;
@@ -37,6 +37,20 @@ export function MultiSelectCombobox({
   const [open, setOpen] = React.useState(false);
   const [search, setSearch] = React.useState("");
   const searchInputRef = React.useRef<HTMLInputElement>(null);
+
+  // Radix Dialog's react-remove-scroll adds a non-passive wheel listener on
+  // document that calls preventDefault() for events outside the Dialog DOM.
+  // Popover portal content is outside the Dialog DOM, so scroll gets blocked.
+  // Native stopPropagation prevents the event from reaching that listener.
+  const scrollContainerRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node) return;
+      const stop = (e: Event) => e.stopPropagation();
+      node.addEventListener("wheel", stop);
+      node.addEventListener("touchmove", stop);
+    },
+    [],
+  );
 
   const filtered = React.useMemo(() => {
     if (!search) return options;
@@ -70,12 +84,12 @@ export function MultiSelectCombobox({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <button
-          type="button"
+        <div
           role="combobox"
           aria-expanded={open}
+          tabIndex={0}
           className={cn(
-            "flex min-h-9 w-full items-center gap-1.5 rounded-lg border border-border bg-input px-3 py-1.5 text-sm text-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10",
+            "flex min-h-9 w-full cursor-pointer items-center gap-1.5 rounded-lg border border-border bg-input px-3 py-1.5 text-sm text-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10",
             className,
           )}
         >
@@ -90,14 +104,21 @@ export function MultiSelectCombobox({
                     <OptionIcon src={opt.icon} alt={opt.label} size={14} />
                   )}
                   {opt.label}
-                  <button
-                    type="button"
+                  <span
+                    role="button"
+                    tabIndex={0}
                     className="ml-0.5 rounded-sm text-muted-foreground hover:text-foreground"
                     onClick={(e) => remove(opt.value, e)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        remove(opt.value, e as unknown as React.MouseEvent);
+                      }
+                    }}
                     aria-label={`Remove ${opt.label}`}
                   >
                     <IconX size={12} />
-                  </button>
+                  </span>
                 </span>
               ))
             ) : (
@@ -108,7 +129,7 @@ export function MultiSelectCombobox({
             size={16}
             className="shrink-0 text-muted-foreground"
           />
-        </button>
+        </div>
       </PopoverTrigger>
       <PopoverContent
         className="w-[var(--radix-popover-trigger-width)] p-0"
@@ -116,6 +137,10 @@ export function MultiSelectCombobox({
         onOpenAutoFocus={(e) => {
           e.preventDefault();
           searchInputRef.current?.focus();
+        }}
+        onCloseAutoFocus={(e) => {
+          e.preventDefault();
+          setSearch("");
         }}
       >
         <div className="flex items-center gap-2 border-b border-border px-3 py-2">
@@ -129,7 +154,7 @@ export function MultiSelectCombobox({
             className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
           />
         </div>
-        <div className="max-h-60 overflow-y-auto p-1">
+        <div ref={scrollContainerRef} className="max-h-60 overflow-y-auto p-1">
           {filtered.length === 0 ? (
             <p className="py-4 text-center text-sm text-muted-foreground">
               No results found

--- a/turbo/packages/ui/src/components/ui/multi-select-combobox.tsx
+++ b/turbo/packages/ui/src/components/ui/multi-select-combobox.tsx
@@ -63,7 +63,7 @@ export function MultiSelectCombobox({
     () =>
       selected
         .map((v) => options.find((o) => o.value === v))
-        .filter(Boolean) as ComboboxOption[],
+        .filter((o): o is ComboboxOption => o !== undefined),
     [selected, options],
   );
 

--- a/turbo/packages/ui/src/components/ui/multi-select-combobox.tsx
+++ b/turbo/packages/ui/src/components/ui/multi-select-combobox.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import * as React from "react";
+import {
+  IconChevronDown,
+  IconCheck,
+  IconX,
+  IconSearch,
+} from "@tabler/icons-react";
+
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+import { cn } from "../../lib/utils";
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+  icon?: string;
+}
+
+export interface MultiSelectComboboxProps {
+  options: ComboboxOption[];
+  selected: string[];
+  onChange: (selected: string[]) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  className?: string;
+}
+
+export function MultiSelectCombobox({
+  options,
+  selected,
+  onChange,
+  placeholder = "Select...",
+  searchPlaceholder = "Search...",
+  className,
+}: MultiSelectComboboxProps) {
+  const [open, setOpen] = React.useState(false);
+  const [search, setSearch] = React.useState("");
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
+
+  const filtered = React.useMemo(() => {
+    if (!search) return options;
+    const lower = search.toLowerCase();
+    return options.filter((o) => o.label.toLowerCase().includes(lower));
+  }, [options, search]);
+
+  const selectedSet = React.useMemo(() => new Set(selected), [selected]);
+
+  function toggle(value: string) {
+    if (selectedSet.has(value)) {
+      onChange(selected.filter((v) => v !== value));
+    } else {
+      onChange([...selected, value]);
+    }
+  }
+
+  function remove(value: string, e: React.MouseEvent) {
+    e.stopPropagation();
+    onChange(selected.filter((v) => v !== value));
+  }
+
+  const selectedOptions = React.useMemo(
+    () =>
+      selected
+        .map((v) => options.find((o) => o.value === v))
+        .filter(Boolean) as ComboboxOption[],
+    [selected, options],
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          role="combobox"
+          aria-expanded={open}
+          className={cn(
+            "flex min-h-9 w-full items-center gap-1.5 rounded-lg border border-border bg-input px-3 py-1.5 text-sm text-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10",
+            className,
+          )}
+        >
+          <div className="flex flex-1 flex-wrap items-center gap-1">
+            {selectedOptions.length > 0 ? (
+              selectedOptions.map((opt) => (
+                <span
+                  key={opt.value}
+                  className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-1.5 py-0.5 text-xs font-medium"
+                >
+                  {opt.icon && (
+                    <OptionIcon src={opt.icon} alt={opt.label} size={14} />
+                  )}
+                  {opt.label}
+                  <button
+                    type="button"
+                    className="ml-0.5 rounded-sm text-muted-foreground hover:text-foreground"
+                    onClick={(e) => remove(opt.value, e)}
+                    aria-label={`Remove ${opt.label}`}
+                  >
+                    <IconX size={12} />
+                  </button>
+                </span>
+              ))
+            ) : (
+              <span className="text-muted-foreground">{placeholder}</span>
+            )}
+          </div>
+          <IconChevronDown
+            size={16}
+            className="shrink-0 text-muted-foreground"
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          searchInputRef.current?.focus();
+        }}
+      >
+        <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+          <IconSearch size={14} className="shrink-0 text-muted-foreground" />
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={searchPlaceholder}
+            className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
+          />
+        </div>
+        <div className="max-h-60 overflow-y-auto p-1">
+          {filtered.length === 0 ? (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              No results found
+            </p>
+          ) : (
+            filtered.map((opt) => {
+              const isSelected = selectedSet.has(opt.value);
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  className="flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground"
+                  onClick={() => toggle(opt.value)}
+                >
+                  {opt.icon && (
+                    <OptionIcon src={opt.icon} alt={opt.label} size={16} />
+                  )}
+                  <span className="flex-1 text-left">{opt.label}</span>
+                  {isSelected && (
+                    <IconCheck size={16} className="shrink-0 text-primary" />
+                  )}
+                </button>
+              );
+            })
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function OptionIcon({
+  src,
+  alt,
+  size,
+}: {
+  src: string;
+  alt: string;
+  size: number;
+}) {
+  const [error, setError] = React.useState(false);
+
+  if (error) return null;
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      width={size}
+      height={size}
+      className="shrink-0 object-contain"
+      onError={() => setError(true)}
+    />
+  );
+}

--- a/turbo/packages/ui/src/components/ui/multi-select-combobox.tsx
+++ b/turbo/packages/ui/src/components/ui/multi-select-combobox.tsx
@@ -112,7 +112,7 @@ export function MultiSelectCombobox({
                     onKeyDown={(e) => {
                       if (e.key === "Enter" || e.key === " ") {
                         e.preventDefault();
-                        remove(opt.value, e as unknown as React.MouseEvent);
+                        remove(opt.value, e);
                       }
                     }}
                     aria-label={`Remove ${opt.label}`}

--- a/turbo/packages/ui/src/index.ts
+++ b/turbo/packages/ui/src/index.ts
@@ -4,6 +4,7 @@ export * from "./components/ui/card";
 export * from "./components/ui/checkbox";
 export * from "./components/ui/copy-button";
 export * from "./components/ui/input";
+export * from "./components/ui/multi-select-combobox";
 export * from "./components/ui/dialog";
 export * from "./components/ui/popover";
 export * from "./components/ui/select";


### PR DESCRIPTION
## Summary
- Add editable agent name input with real-time validation (3-64 chars, alphanumeric + hyphens) in config dialog Forms tab
- Create reusable `MultiSelectCombobox` component in `@vm0/ui` with search filtering, icon support, and tag-based selection
- Add static skills data (79 entries) with icons for the skills dropdown
- Handle agent rename: after save, navigate to new agent URL if name changed
- Add `updateAgentName$` and `updateSkills$` state commands with bidirectional YAML sync

## Test plan
- [x] Existing 7 config dialog tests still pass
- [x] New test: editing agent name syncs to YAML tab
- [x] New test: invalid agent name shows validation error
- [x] All quality checks pass (lint, type-check, format, knip)

Closes #3213

🤖 Generated with [Claude Code](https://claude.com/claude-code)