### PR TITLE
feat(platform): add schedule summary tooltip to agent header

### DIFF
--- a/turbo/apps/platform/src/signals/agent-detail/schedule.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/schedule.ts
@@ -42,6 +42,65 @@ interface ScheduleResponse {
 const internalAgentSchedule$ = state<ScheduleResponse | null>(null);
 export const agentSchedule$ = computed((get) => get(internalAgentSchedule$));
 
+/** Human-readable summary of the current schedule for tooltip display. */
+export const agentScheduleSummary$ = computed((get) => {
+  const schedule = get(internalAgentSchedule$);
+  if (!schedule) {
+    return null;
+  }
+
+  const parts: string[] = [];
+
+  if (schedule.cronExpression) {
+    parts.push(describeCron(schedule.cronExpression));
+  }
+
+  if (schedule.timezone) {
+    parts.push(schedule.timezone);
+  }
+
+  if (schedule.nextRunAt) {
+    const next = new Date(schedule.nextRunAt);
+    parts.push(
+      `Next: ${next.toLocaleString("en-US", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}`,
+    );
+  }
+
+  return parts.join("\n");
+});
+
+function describeCron(cron: string): string {
+  const dayNames: Record<string, string> = {
+    "0": "Sunday",
+    "1": "Monday",
+    "2": "Tuesday",
+    "3": "Wednesday",
+    "4": "Thursday",
+    "5": "Friday",
+    "6": "Saturday",
+    "7": "Sunday",
+  };
+  const parsed = parseCronExpression(cron);
+  const hh = parsed.hour.padStart(2, "0");
+  const mm = parsed.minute.padStart(2, "0");
+  const time = `${hh}:${mm}`;
+
+  switch (parsed.timeOption) {
+    case "every-weekday": {
+      return `Weekdays at ${time}`;
+    }
+    case "every-day": {
+      return `Daily at ${time}`;
+    }
+    case "every-week": {
+      return `${dayNames[parsed.dayOfWeek] ?? `Day ${parsed.dayOfWeek}`}s at ${time}`;
+    }
+    case "every-month": {
+      return `Monthly on day ${parsed.dayOfMonth} at ${time}`;
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Fetch agent schedule
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
@@ -22,6 +22,7 @@ import { openRunDialog$ } from "../../signals/agent-detail/run-dialog.ts";
 import { runButtonState$ } from "../../signals/agent-detail/inline-run.ts";
 import {
   agentSchedule$,
+  agentScheduleSummary$,
   openScheduleDialog$,
 } from "../../signals/agent-detail/schedule.ts";
 import { AgentAvatar } from "./agent-avatar.tsx";
@@ -39,6 +40,7 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
   const buttonState = useGet(runButtonState$);
   const isBusy = buttonState !== "idle";
   const schedule = useGet(agentSchedule$);
+  const scheduleSummary = useGet(agentScheduleSummary$);
   const openSchedule = useSet(openScheduleDialog$);
 
   // Extract description from the first agent definition
@@ -50,8 +52,8 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
   const description = agentDef?.description;
 
   return (
-    <div className="sticky top-0 z-10 flex items-center gap-3.5 bg-background -mx-8 px-8 -mt-8 pt-8 pb-[22px]">
-      <AgentAvatar name={detail.name} size="lg" />
+    <div className="sticky top-0 z-10 flex flex-wrap items-center gap-3.5 bg-background -mx-8 px-8 -mt-8 pt-8 pb-[22px]">
+      <AgentAvatar name={detail.name} size="lg" className="shrink-0" />
       <div className="flex-1 min-w-0 flex flex-col gap-1.5">
         <div className="flex items-center gap-2.5">
           <h1 className="text-2xl leading-8 font-normal text-foreground truncate">
@@ -73,22 +75,32 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
       <div className="flex items-center gap-2 shrink-0">
         <TooltipProvider delayDuration={100}>
           {schedule && (
-            <div className="inline-flex h-9 shrink-0 items-center rounded-md border border-border bg-sidebar">
-              <div className="flex items-center gap-1 pl-2.5 pr-2 py-0.5">
-                <IconClockHour3 size={12} className="shrink-0 text-sky-700" />
-                <span className="text-xs font-medium leading-4 text-secondary-foreground">
-                  Scheduled
-                </span>
-              </div>
-              <button
-                type="button"
-                onClick={() => openSchedule()}
-                aria-label="Edit schedule"
-                className="flex h-9 w-9 items-center justify-center border-l border-border text-secondary-foreground hover:bg-accent rounded-r-md cursor-pointer"
-              >
-                <IconEdit size={16} />
-              </button>
-            </div>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="inline-flex h-9 shrink-0 items-center rounded-md border border-border bg-sidebar">
+                  <div className="flex items-center gap-1 pl-2.5 pr-2 py-0.5">
+                    <IconClockHour3
+                      size={12}
+                      className="shrink-0 text-sky-700"
+                    />
+                    <span className="text-xs font-medium leading-4 text-secondary-foreground max-sm:hidden">
+                      Scheduled
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => openSchedule()}
+                    aria-label="Edit schedule"
+                    className="flex h-9 w-9 items-center justify-center border-l border-border text-secondary-foreground hover:bg-accent rounded-r-md cursor-pointer"
+                  >
+                    <IconEdit size={16} />
+                  </button>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent className="whitespace-pre-line">
+                {scheduleSummary ?? "Scheduled"}
+              </TooltipContent>
+            </Tooltip>
           )}
 
           <Tooltip>

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-logs-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-logs-page.tsx
@@ -82,6 +82,19 @@ function AgentLogsTableSkeleton() {
   );
 }
 
+function formatTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  const options: Intl.DateTimeFormatOptions = {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    timeZoneName: "shortOffset",
+  };
+  return date.toLocaleString("en-US", options);
+}
+
 interface AgentLogsTableRowProps {
   entry: LogEntry;
 }
@@ -118,7 +131,7 @@ function AgentLogsTableRow({ entry }: AgentLogsTableRowProps) {
       </TableCell>
       <TableCell className="px-3 py-2 text-sm w-[25%] min-w-[120px]">
         <span className="block truncate whitespace-nowrap">
-          {entry.createdAt}
+          {formatTime(entry.createdAt)}
         </span>
       </TableCell>
     </TableRow>


### PR DESCRIPTION
## Summary
- Add a human-readable schedule summary tooltip to the "Scheduled" badge in the agent header, showing cron description (e.g. "Daily at 09:00"), timezone, and next run time
- Add `agentScheduleSummary$` computed signal and `describeCron` helper that translates cron expressions into readable text
- Improve header responsiveness: hide "Scheduled" label on small screens, add `flex-wrap` and `shrink-0` for better wrapping

## Test plan
- [ ] Verify the schedule tooltip displays correct cron description for each time option (daily, weekdays, weekly, monthly)
- [ ] Verify timezone and next run time appear in the tooltip when available
- [ ] Verify the "Scheduled" label hides on small viewports while the icon and edit button remain visible
- [ ] Verify header layout wraps cleanly on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)