### PR TITLE
fix(slack): preserve scope prefix in agent navigation and selection

### DIFF
--- a/turbo/apps/platform/src/signals/integrations-page/slack-integration.ts
+++ b/turbo/apps/platform/src/signals/integrations-page/slack-integration.ts
@@ -8,7 +8,7 @@ const L = logger("SlackIntegration");
 
 interface SlackIntegrationData {
   workspace: { id: string; name: string | null };
-  agent: { id: string; name: string } | null;
+  agent: { id: string; name: string; scopeSlug: string } | null;
   isAdmin: boolean;
   environment: {
     requiredSecrets: string[];
@@ -124,7 +124,7 @@ export const updateSlackDefaultAgent$ = command(
           ...prev.data,
           agent: prev.data.agent
             ? { ...prev.data.agent, name: agentName }
-            : { id: "", name: agentName },
+            : { id: "", name: agentName, scopeSlug: "" },
         },
       };
     });

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
@@ -20,6 +20,7 @@ import { navigateInReact$ } from "../../signals/route.ts";
 import { openConfigDialog$ } from "../../signals/agent-detail/config-dialog.ts";
 import { openRunDialog$ } from "../../signals/agent-detail/run-dialog.ts";
 import { runButtonState$ } from "../../signals/agent-detail/inline-run.ts";
+import { agentName$ } from "../../signals/agent-detail/agent-detail.ts";
 import {
   agentSchedule$,
   openScheduleDialog$,
@@ -40,6 +41,7 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
   const isBusy = buttonState !== "idle";
   const schedule = useGet(agentSchedule$);
   const openSchedule = useSet(openScheduleDialog$);
+  const agentName = useGet(agentName$);
 
   // Extract description from the first agent definition
   const agentKeys = detail.content?.agents
@@ -144,8 +146,9 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
                 size="icon"
                 className="h-9 w-9"
                 onClick={() =>
+                  agentName &&
                   navigate("/agents/:name/connections", {
-                    pathParams: { name: detail.name },
+                    pathParams: { name: agentName },
                   })
                 }
               >
@@ -162,8 +165,9 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
                 size="icon"
                 className="h-9 w-9"
                 onClick={() =>
+                  agentName &&
                   navigate("/agents/:name/logs", {
-                    pathParams: { name: detail.name },
+                    pathParams: { name: agentName },
                   })
                 }
               >

--- a/turbo/apps/platform/src/views/integrations-page/slack-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/slack-settings-page.tsx
@@ -208,18 +208,33 @@ export function SlackSettingsPage() {
   const openConfirm = useSet(openSlackDisconnectDialog$);
   const closeConfirm = useSet(closeSlackDisconnectDialog$);
 
+  // Construct scoped agent name that matches the format used in agentsList$
+  // (shared agents use "scope/name", owned agents use just "name").
+  const scopedAgentName = (() => {
+    if (!data?.agent) {
+      return undefined;
+    }
+    const fullName = `${data.agent.scopeSlug}/${data.agent.name}`;
+    // If the scoped name exists in agents list, use it (shared agent)
+    if (agents.some((a) => a.name === fullName)) {
+      return fullName;
+    }
+    // Otherwise use bare name (owned agent)
+    return data.agent.name;
+  })();
+
   // Ensure the current workspace agent appears in the dropdown even if
   // it isn't in the user's own agents list (e.g. shared by another user).
   const agentOptions = (() => {
-    if (!data?.agent) {
+    if (!scopedAgentName) {
       return agents;
     }
-    const hasCurrentAgent = agents.some((a) => a.name === data.agent?.name);
+    const hasCurrentAgent = agents.some((a) => a.name === scopedAgentName);
     if (hasCurrentAgent) {
       return agents;
     }
     return [
-      { name: data.agent.name, headVersionId: null, updatedAt: "" },
+      { name: scopedAgentName, headVersionId: null, updatedAt: "" },
       ...agents,
     ];
   })();
@@ -264,13 +279,13 @@ export function SlackSettingsPage() {
           <>
             <DefaultAgentSection
               isAdmin={data?.isAdmin ?? false}
-              agentName={data?.agent?.name}
+              agentName={scopedAgentName}
               agentOptions={agentOptions}
               onAgentChange={handleAgentChange}
             />
 
             <MissingEnvBanner
-              agentName={data?.agent?.name}
+              agentName={scopedAgentName}
               missingSecrets={data?.environment.missingSecrets ?? []}
               missingVars={data?.environment.missingVars ?? []}
             />

--- a/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
@@ -12,10 +12,12 @@ import {
 } from "../../../../../src/__tests__/slack/api-helpers";
 import {
   createTestCompose,
+  createTestScope,
   findTestAgentPermissions,
   findTestComposeWithScope,
   insertTestAgentPermission,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { uniqueId } from "../../../../../src/__tests__/test-helpers";
 import { reloadEnv } from "../../../../../src/env";
 
 const context = testContext();
@@ -55,7 +57,7 @@ describe("/api/integrations/slack", () => {
       expect(data.installUrl).toContain(user.userId);
     });
 
-    it("returns workspace info for linked user", async () => {
+    it("returns workspace info for linked user including scopeSlug", async () => {
       const { userLink, installation } = await givenLinkedSlackUser();
 
       // Restore Clerk mock for the linked user
@@ -72,6 +74,8 @@ describe("/api/integrations/slack", () => {
       expect(data.workspace.name).toBe(installation.slackWorkspaceName);
       expect(data.agent).toBeDefined();
       expect(data.agent.name).toBeDefined();
+      expect(data.agent.scopeSlug).toBeDefined();
+      expect(typeof data.agent.scopeSlug).toBe("string");
       expect(data.environment).toBeDefined();
       expect(data.environment.requiredSecrets).toBeDefined();
       expect(data.environment.requiredVars).toBeDefined();
@@ -350,6 +354,69 @@ describe("/api/integrations/slack", () => {
         MOCK_USER_EMAIL,
       );
       expect(oldPermissions).toHaveLength(1);
+    });
+
+    it("updates the default agent with scoped name (scope/agentName)", async () => {
+      const { userLink } = await givenLinkedSlackUser({ isAdmin: true });
+
+      // Create a compose in a different scope (simulating a shared agent)
+      const otherUserId = uniqueId("other-user");
+      mockClerk({ userId: otherUserId });
+      const otherScope = await createTestScope(uniqueId("other-scope"));
+      const { composeId: otherComposeId } =
+        await createTestCompose("shared-agent");
+
+      // Switch back to admin user
+      mockClerk({ userId: userLink.vm0UserId });
+
+      // Look up the other scope's slug for the scoped name
+      const otherCompose = await findTestComposeWithScope(otherComposeId);
+
+      const request = new Request(
+        "http://localhost:3000/api/integrations/slack",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentName: `${otherCompose!.scopeSlug}/${otherCompose!.composeName}`,
+          }),
+        },
+      );
+      const response = await PATCH(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.ok).toBe(true);
+
+      // Verify the agent was updated by fetching the integration
+      const getResponse = await GET(
+        new Request("http://localhost:3000/api/integrations/slack"),
+      );
+      const getData = await getResponse.json();
+
+      expect(getData.agent.name).toBe(otherCompose!.composeName);
+      expect(getData.agent.scopeSlug).toBe(otherCompose!.scopeSlug);
+    });
+
+    it("returns 400 when scoped name has invalid scope slug", async () => {
+      const { userLink } = await givenLinkedSlackUser({ isAdmin: true });
+      mockClerk({ userId: userLink.vm0UserId });
+
+      const request = new Request(
+        "http://localhost:3000/api/integrations/slack",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentName: "nonexistent-scope/some-agent",
+          }),
+        },
+      );
+      const response = await PATCH(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.code).toBe("BAD_REQUEST");
     });
 
     it("handles duplicate permissions gracefully", async () => {

--- a/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
@@ -362,7 +362,7 @@ describe("/api/integrations/slack", () => {
       // Create a compose in a different scope (simulating a shared agent)
       const otherUserId = uniqueId("other-user");
       mockClerk({ userId: otherUserId });
-      const otherScope = await createTestScope(uniqueId("other-scope"));
+      await createTestScope(uniqueId("other-scope"));
       const { composeId: otherComposeId } =
         await createTestCompose("shared-agent");
 

--- a/turbo/apps/web/app/api/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/route.ts
@@ -14,6 +14,7 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
+import { scopes } from "../../../../src/db/schema/scope";
 import { listSecrets } from "../../../../src/lib/secret/secret-service";
 import { listVariables } from "../../../../src/lib/variable/variable-service";
 import { listConnectors } from "../../../../src/lib/connector/connector-service";
@@ -26,7 +27,10 @@ import {
 import { decryptCredentialValue } from "../../../../src/lib/crypto/secrets-encryption";
 import { removePermission } from "../../../../src/lib/agent/permission-service";
 import { getUserEmail } from "../../../../src/lib/auth/get-user-email";
-import { getUserScopeByClerkId } from "../../../../src/lib/scope/scope-service";
+import {
+  getScopeBySlug,
+  getUserScopeByClerkId,
+} from "../../../../src/lib/scope/scope-service";
 import { syncWorkspaceAgentPermissions } from "../../../../src/lib/slack/permission-sync";
 
 /**
@@ -85,14 +89,16 @@ export async function GET(request: Request) {
     );
   }
 
-  // Get workspace agent
+  // Get workspace agent with scope info for navigation
   const [compose] = await db
     .select({
       id: agentComposes.id,
       name: agentComposes.name,
       headVersionId: agentComposes.headVersionId,
+      scopeSlug: scopes.slug,
     })
     .from(agentComposes)
+    .innerJoin(scopes, eq(scopes.id, agentComposes.scopeId))
     .where(eq(agentComposes.id, installation.defaultComposeId))
     .limit(1);
 
@@ -149,7 +155,9 @@ export async function GET(request: Request) {
       id: installation.slackWorkspaceId,
       name: installation.slackWorkspaceName,
     },
-    agent: compose ? { id: compose.id, name: compose.name } : null,
+    agent: compose
+      ? { id: compose.id, name: compose.name, scopeSlug: compose.scopeSlug }
+      : null,
     isAdmin,
     environment: {
       requiredSecrets,
@@ -300,23 +308,33 @@ export async function PATCH(request: Request) {
     );
   }
 
-  // Resolve user's scope to find the agent compose
-  const userScope = await getUserScopeByClerkId(userId);
-  if (!userScope) {
+  // Parse scope/agentName format (shared agents use "scopeSlug/agentName")
+  const slashIndex = body.agentName.indexOf("/");
+  const agentName =
+    slashIndex === -1 ? body.agentName : body.agentName.slice(slashIndex + 1);
+  const scopeSlug =
+    slashIndex === -1 ? null : body.agentName.slice(0, slashIndex);
+
+  // Resolve target scope
+  const targetScope = scopeSlug
+    ? await getScopeBySlug(scopeSlug)
+    : await getUserScopeByClerkId(userId);
+
+  if (!targetScope) {
     return NextResponse.json(
-      { error: { message: "User scope not found", code: "BAD_REQUEST" } },
+      { error: { message: "Scope not found", code: "BAD_REQUEST" } },
       { status: 400 },
     );
   }
 
-  // Find agent compose by name in user's scope
+  // Find agent compose by name in target scope
   const [compose] = await db
     .select({ id: agentComposes.id })
     .from(agentComposes)
     .where(
       and(
-        eq(agentComposes.scopeId, userScope.id),
-        eq(agentComposes.name, body.agentName),
+        eq(agentComposes.scopeId, targetScope.id),
+        eq(agentComposes.name, agentName),
       ),
     )
     .limit(1);


### PR DESCRIPTION
## Summary
- Fix agent detail header buttons (connections/logs) losing scope prefix when navigating for shared agents, causing blank pages on refresh
- Add `scopeSlug` to Slack integration API GET response so the frontend can construct scoped navigation URLs
- Update Slack API PATCH handler to parse `scope/agentName` format so switching to shared agents works correctly
- Fix Slack settings page dropdown and banner to use scoped agent names matching the `agentsList$` format

## Test plan
- [ ] Open a shared agent detail page → click connections/logs buttons → verify URL preserves scope prefix and page loads correctly on refresh
- [ ] Open Slack settings → switch default agent to a shared agent → verify the PATCH succeeds and dropdown shows the correct name
- [ ] Verify the missing env banner links navigate to the correct scoped connections page

🤖 Generated with [Claude Code](https://claude.com/claude-code)