### PR TITLE
feat(email): add threading, mirrored from address, and original subject to trigger response

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
@@ -28,6 +28,9 @@ interface TriggerCallbackPayload {
   userId: string;
   inboundEmailId: string;
   replyToken: string;
+  inboundMessageId?: string;
+  subject?: string;
+  triggerLocalPart?: string;
 }
 
 function createCallbackRequest(
@@ -134,7 +137,7 @@ describe("POST /api/internal/callbacks/email/trigger", () => {
   });
 
   describe("Email Sending", () => {
-    it("should send response email for completed trigger run", async () => {
+    it("should send response email with mirrored from address and original subject", async () => {
       const user = await context.setupUser({ prefix: "trigger-ok" });
       mockClerk({ userId: user.userId });
       const agentName = uniqueId("trigger-agent");
@@ -144,12 +147,16 @@ describe("POST /api/internal/callbacks/email/trigger", () => {
 
       const replyToken = generateReplyToken(crypto.randomUUID());
       const senderEmail = "sender@example.com";
+      const triggerLocalPart = `my-scope+${agentName}`;
       const payload: TriggerCallbackPayload = {
         senderEmail,
         composeId,
         userId: user.userId,
         inboundEmailId: "email-123",
         replyToken,
+        inboundMessageId: "<orig-msg-id@example.com>",
+        subject: "Help me with this",
+        triggerLocalPart,
       };
 
       const { secret } = await createTestCallback({
@@ -174,10 +181,58 @@ describe("POST /api/internal/callbacks/email/trigger", () => {
         to: string;
         subject: string;
         replyTo: string;
+        headers: Record<string, string>;
       };
       expect(sendArgs.to).toBe(senderEmail);
-      expect(sendArgs.subject).toContain("Re:");
+      expect(sendArgs.from).toContain(triggerLocalPart);
+      expect(sendArgs.subject).toBe("Re: Help me with this");
       expect(sendArgs.replyTo).toContain("reply+");
+      expect(sendArgs.headers).toMatchObject({
+        "In-Reply-To": "<orig-msg-id@example.com>",
+        References: "<orig-msg-id@example.com>",
+      });
+    });
+
+    it("should strip existing Re: prefix to prevent duplication", async () => {
+      const user = await context.setupUser({ prefix: "trigger-re" });
+      mockClerk({ userId: user.userId });
+      const agentName = uniqueId("re-agent");
+      const { composeId } = await createTestCompose(agentName);
+      const { runId } = await createTestRun(composeId, "Test prompt");
+      await completeTestRun(user.userId, runId);
+
+      const replyToken = generateReplyToken(crypto.randomUUID());
+      const payload: TriggerCallbackPayload = {
+        senderEmail: "sender@example.com",
+        composeId,
+        userId: user.userId,
+        inboundEmailId: "email-456",
+        replyToken,
+        subject: "Re: Original Topic",
+        triggerLocalPart: agentName,
+      };
+
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/email/trigger",
+        payload: { ...payload },
+      });
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
+      const sendArgs = mockResend.emails.send.mock.calls[0]![0] as {
+        subject: string;
+        from: string;
+      };
+      expect(sendArgs.subject).toBe("Re: Original Topic");
+      expect(sendArgs.from).toContain(agentName);
     });
 
     it("should send error email for failed trigger run", async () => {

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
@@ -70,6 +70,39 @@ function extractAgentSessionId(result: unknown): string | undefined {
   return undefined;
 }
 
+function formatOutput(
+  status: string,
+  rawOutput: string | null | undefined,
+  error: string | undefined,
+): string {
+  if (status !== "completed") {
+    return error ?? "The agent run failed.";
+  }
+  if (!rawOutput) {
+    return "Task completed successfully.";
+  }
+  return rawOutput.length > 2000 ? `${rawOutput.slice(0, 2000)}…` : rawOutput;
+}
+
+function buildThreadingHeaders(
+  inboundMessageId: string | undefined,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (inboundMessageId) {
+    headers["In-Reply-To"] = inboundMessageId;
+    headers["References"] = inboundMessageId;
+  }
+  return headers;
+}
+
+function buildSubject(
+  inboundSubject: string | undefined,
+  composeName: string,
+): string {
+  const cleanSubject = inboundSubject?.replace(/^Re:\s*/i, "") ?? composeName;
+  return `Re: ${cleanSubject}`;
+}
+
 /**
  * Email Trigger Callback Handler
  *
@@ -162,15 +195,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // Get run output and session ID
   const logsUrl = buildLogsUrl(runId);
   const rawOutput = status === "completed" ? await getRunOutput(runId) : null;
-
-  const output =
-    status === "completed"
-      ? rawOutput
-        ? rawOutput.length > 2000
-          ? `${rawOutput.slice(0, 2000)}…`
-          : rawOutput
-        : "Task completed successfully."
-      : (error ?? "The agent run failed.");
+  const output = formatOutput(status, rawOutput, error);
 
   const [run] = await globalThis.services.db
     .select({ result: agentRuns.result })
@@ -185,18 +210,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     ? buildReplyToAddress(replyToken)
     : undefined;
 
-  // Build threading headers from inbound email's Message-ID
-  const headers: Record<string, string> = {};
-  if (payload.inboundMessageId) {
-    headers["In-Reply-To"] = payload.inboundMessageId;
-    headers["References"] = payload.inboundMessageId;
-  }
+  const headers = buildThreadingHeaders(payload.inboundMessageId);
 
   // Send response email
   const { messageId } = await sendEmail({
     from: buildFromAddress(payload.triggerLocalPart ?? compose.name),
     to: senderEmail,
-    subject: `Re: ${payload.subject?.replace(/^Re:\s*/i, "") ?? compose.name}`,
+    subject: buildSubject(payload.subject, compose.name),
     react: AgentReplyEmail({
       agentName: compose.name,
       output,

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
@@ -196,7 +196,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const { messageId } = await sendEmail({
     from: buildFromAddress(payload.triggerLocalPart ?? compose.name),
     to: senderEmail,
-    subject: payload.subject ? `Re: ${payload.subject}` : `Re: ${compose.name}`,
+    subject: `Re: ${payload.subject?.replace(/^Re:\s*/i, "") ?? compose.name}`,
     react: AgentReplyEmail({
       agentName: compose.name,
       output,

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
@@ -26,6 +26,9 @@ interface CallbackPayload {
   userId: string;
   inboundEmailId: string;
   replyToken: string;
+  inboundMessageId?: string;
+  subject?: string;
+  triggerLocalPart?: string;
 }
 
 interface CallbackBody {
@@ -182,17 +185,25 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     ? buildReplyToAddress(replyToken)
     : undefined;
 
+  // Build threading headers from inbound email's Message-ID
+  const headers: Record<string, string> = {};
+  if (payload.inboundMessageId) {
+    headers["In-Reply-To"] = payload.inboundMessageId;
+    headers["References"] = payload.inboundMessageId;
+  }
+
   // Send response email
   const { messageId } = await sendEmail({
-    from: buildFromAddress(compose.name),
+    from: buildFromAddress(payload.triggerLocalPart ?? compose.name),
     to: senderEmail,
-    subject: `Re: ${compose.name}`,
+    subject: payload.subject ? `Re: ${payload.subject}` : `Re: ${compose.name}`,
     react: AgentReplyEmail({
       agentName: compose.name,
       output,
       logsUrl,
     }),
     replyTo: replyToAddress,
+    headers,
   });
 
   // Save email thread session for reply continuity

--- a/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
@@ -320,6 +320,9 @@ describe("POST /api/webhooks/email/inbound", () => {
         userId: user.userId,
         inboundEmailId: "trigger-email-123",
         replyToken: expect.any(String),
+        inboundMessageId: "<default-msg-id@example.com>",
+        subject: "Test Subject",
+        triggerLocalPart: `${scopeSlug}+${agentName}`,
       });
     });
 
@@ -730,6 +733,9 @@ describe("POST /api/webhooks/email/inbound", () => {
         senderEmail,
         userId: user.userId,
         inboundEmailId: "auto-scope-email",
+        inboundMessageId: "<default-msg-id@example.com>",
+        subject: "Auto Scope Test",
+        triggerLocalPart: agentName,
       });
     });
 

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -188,6 +188,7 @@ vi.mock("resend", () => {
             headers: {
               "authentication-results":
                 "mx.resend.com; dkim=pass header.d=example.com; spf=pass smtp.mailfrom=example.com; dmarc=pass header.from=example.com",
+              "message-id": "<default-msg-id@example.com>",
             },
           },
         }),

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -54,7 +54,7 @@ export async function handleInboundEmailTrigger(
   //    - scope+agent@domain (explicit scope)
   //    - agent@domain (scope auto-detected from sender)
   let triggerAddress: { scope: string; agent: string } | null = null;
-  let triggerLocalPart: string | null = null;
+  let triggerLocalPart: string | undefined;
   let userId: string | null = null;
 
   // 1a. Try scope+agent format first

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -54,6 +54,7 @@ export async function handleInboundEmailTrigger(
   //    - scope+agent@domain (explicit scope)
   //    - agent@domain (scope auto-detected from sender)
   let triggerAddress: { scope: string; agent: string } | null = null;
+  let triggerLocalPart: string | null = null;
   let userId: string | null = null;
 
   // 1a. Try scope+agent format first
@@ -61,6 +62,7 @@ export async function handleInboundEmailTrigger(
     const parsed = parseEmailTriggerAddress(addr);
     if (parsed) {
       triggerAddress = parsed;
+      triggerLocalPart = `${parsed.scope}+${parsed.agent}`;
       break;
     }
   }
@@ -81,6 +83,8 @@ export async function handleInboundEmailTrigger(
       log.debug("No trigger address found in recipients", { to });
       return;
     }
+
+    triggerLocalPart = agentName;
 
     // For agent-only format, we need the sender's scope.
     // Look up sender in Clerk first (needed for scope lookup).
@@ -146,7 +150,15 @@ export async function handleInboundEmailTrigger(
   // 5. Fetch full email
   const email = await getReceivedEmail(emailId);
 
-  // 6. Verify sender authenticity via DMARC
+  // 6. Extract inbound Message-ID for threading (case-insensitive lookup)
+  const messageIdKey = Object.keys(email.headers).find(
+    (k) => k.toLowerCase() === "message-id",
+  );
+  const inboundMessageId = messageIdKey
+    ? email.headers[messageIdKey]
+    : undefined;
+
+  // 7. Verify sender authenticity via DMARC
   const verification = verifySenderAuthenticity(email.headers);
   if (!verification.verified) {
     log.warn("Sender authentication failed, ignoring email", {
@@ -157,7 +169,7 @@ export async function handleInboundEmailTrigger(
     return;
   }
 
-  // 7. Build prompt from email content
+  // 8. Build prompt from email content
   const bodyContent = extractEmailBody(email.html, email.text);
 
   // Combine subject + body as prompt
@@ -170,11 +182,11 @@ export async function handleInboundEmailTrigger(
     return;
   }
 
-  // 8. Generate reply token for conversation continuity
+  // 9. Generate reply token for conversation continuity
   const sessionPlaceholderId = crypto.randomUUID();
   const replyToken = generateReplyToken(sessionPlaceholderId);
 
-  // 9. Build callback
+  // 10. Build callback
   const callbacks = [
     {
       url: `${getApiUrl()}/api/internal/callbacks/email/trigger`,
@@ -185,11 +197,14 @@ export async function handleInboundEmailTrigger(
         userId,
         inboundEmailId: emailId,
         replyToken,
+        inboundMessageId,
+        subject,
+        triggerLocalPart,
       },
     },
   ];
 
-  // 10. Create and dispatch run
+  // 11. Create and dispatch run
   const result = await createRun({
     userId,
     agentComposeVersionId: compose.headVersionId,

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -151,12 +151,11 @@ export async function handleInboundEmailTrigger(
   const email = await getReceivedEmail(emailId);
 
   // 6. Extract inbound Message-ID for threading (case-insensitive lookup)
-  const messageIdKey = Object.keys(email.headers).find(
+  const headers = email.headers ?? {};
+  const messageIdKey = Object.keys(headers).find(
     (k) => k.toLowerCase() === "message-id",
   );
-  const inboundMessageId = messageIdKey
-    ? email.headers[messageIdKey]
-    : undefined;
+  const inboundMessageId = messageIdKey ? headers[messageIdKey] : undefined;
 
   // 7. Verify sender authenticity via DMARC
   const verification = verifySenderAuthenticity(email.headers);

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -190,9 +190,11 @@ export function buildReplyToAddress(token: string): string {
 
 /**
  * Build the from address for outbound emails.
+ * The localPart is used as both the display name prefix and the email local part,
+ * so the response mirrors the address the user sent to.
  */
-export function buildFromAddress(agentName: string): string {
-  return `${agentName} from VM0 <agent@${getFromDomain()}>`;
+export function buildFromAddress(localPart: string): string {
+  return `${localPart} from VM0 <${localPart}@${getFromDomain()}>`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `In-Reply-To` and `References` headers to email trigger responses so replies thread correctly in Gmail
- Mirror the from address to match what the user sent to (e.g., `scope+agent@domain` or `agent@domain`)
- Use the original email subject with `Re:` prefix instead of using the agent name

Closes #3226

## Test plan

- [x] Existing trigger tests extended with assertions for `inboundMessageId`, `subject`, `triggerLocalPart`
- [x] Agent-only format test verifies `triggerLocalPart` is just the agent name
- [x] All 3202 tests pass locally
- [x] Type checks, lint, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)