### PR TITLE
perf(sandbox-fc): pre-warm claude and codex in snapshot

### DIFF
--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -200,7 +200,7 @@ mod tests {
         // Changing this assertion means ALL existing cached snapshots are
         // invalidated.  Only update deliberately.
         assert_eq!(
-            hash, "56c7e2d80112e9bbcaf6de63a8fbe90237f811bb3a144798dc47a633861b2c11",
+            hash, "19a81372c87564c16e4ad4a7edbf0ed71d93e578dcc92f2e0527f4976196d87d",
             "snapshot hash changed — this invalidates all cached snapshots"
         );
     }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -13,7 +13,8 @@ use crate::sandbox::FirecrackerSandbox;
 
 /// Shell command executed during snapshot creation to pre-warm guest caches.
 /// Changing this invalidates all cached snapshots (included in [`config_hash`]).
-pub const PREWARM_SCRIPT: &str = "su - user -c true";
+pub const PREWARM_SCRIPT: &str =
+    "su - user -c 'claude --help >/dev/null 2>&1; codex --help >/dev/null 2>&1; true'";
 
 /// SHA-256 fingerprint of all sandbox-fc internal configuration that affects
 /// snapshot output (boot args, guest network, pre-warm script, etc.).


### PR DESCRIPTION
## Summary
- Expand `PREWARM_SCRIPT` to run `claude --help` and `codex --help` during snapshot creation
- Loads all npm modules and triggers V8 JIT compilation, captured in snapshot memory
- Restored VMs skip CLI cold-start penalty (~500-1000ms → ~20-50ms estimated)

Closes #3231

## Test plan
- [ ] Rebuild snapshot on dev-2, verify prewarm step completes within 5s timeout
- [ ] Measure CLI startup time before/after
- [ ] Compare `memory.bin` size before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)