### PR TITLE
fix(email): correct In-Reply-To and References headers for proper threading

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/email/reply/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/reply/__tests__/route.test.ts
@@ -26,6 +26,8 @@ const mockResend = vi.mocked(new Resend(""), true);
 interface ReplyCallbackPayload {
   emailThreadSessionId: string;
   inboundEmailId: string;
+  inboundMessageId?: string;
+  inboundReferences?: string;
 }
 
 function createCallbackRequest(
@@ -129,6 +131,9 @@ describe("POST /api/internal/callbacks/email/reply", () => {
       const payload: ReplyCallbackPayload = {
         emailThreadSessionId: emailSession.id,
         inboundEmailId: "inbound-email-456",
+        inboundMessageId: "<user-reply@mail.example.com>",
+        inboundReferences:
+          "<orig-user-msg@mail.example.com> <original-msg-id@vm7.bot>",
       };
 
       const { secret } = await createTestCallback({
@@ -158,7 +163,12 @@ describe("POST /api/internal/callbacks/email/reply", () => {
       };
       expect(sendArgs.to).toBe("test@example.com");
       expect(sendArgs.replyTo).toContain("reply+");
-      expect(sendArgs.headers["In-Reply-To"]).toBe("<original-msg-id@vm7.bot>");
+      expect(sendArgs.headers["In-Reply-To"]).toBe(
+        "<user-reply@mail.example.com>",
+      );
+      expect(sendArgs.headers["References"]).toBe(
+        "<orig-user-msg@mail.example.com> <original-msg-id@vm7.bot> <user-reply@mail.example.com>",
+      );
 
       // Verify thread session was updated with new messageId
       const updatedSession = await findTestEmailThreadSession(replyToken);
@@ -166,6 +176,56 @@ describe("POST /api/internal/callbacks/email/reply", () => {
       expect(updatedSession!.lastEmailMessageId).toBe(
         "<mock-message-id@vm7.bot>",
       );
+    });
+
+    it("should fall back to session.lastEmailMessageId when inbound headers are missing", async () => {
+      const user = await context.setupUser({ prefix: "reply-fallback" });
+      mockClerk({ userId: user.userId });
+      const { composeId } = await createTestCompose(uniqueId("reply-agent"));
+      const agentSession = await createTestAgentSession(user.userId, composeId);
+      const replyToken = generateReplyToken(agentSession.id);
+      const emailSession = await createTestEmailThreadSession({
+        userId: user.userId,
+        composeId,
+        agentSessionId: agentSession.id,
+        replyToToken: replyToken,
+        lastEmailMessageId: "<bot-prev@vm7.bot>",
+      });
+
+      const { runId } = await createTestRun(composeId, "Email reply task");
+      await completeTestRun(user.userId, runId);
+
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        { eventData: { result: "Fallback output" } },
+      ]);
+
+      // Payload without inbound threading headers (backwards compatibility)
+      const payload: ReplyCallbackPayload = {
+        emailThreadSessionId: emailSession.id,
+        inboundEmailId: "inbound-email-fallback",
+      };
+
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/email/reply",
+        payload: { ...payload },
+      });
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
+      const sendArgs = mockResend.emails.send.mock.calls[0]![0] as {
+        headers: Record<string, string>;
+      };
+      // Falls back to session.lastEmailMessageId for both headers
+      expect(sendArgs.headers["In-Reply-To"]).toBe("<bot-prev@vm7.bot>");
+      expect(sendArgs.headers["References"]).toBe("<bot-prev@vm7.bot>");
     });
 
     it("should send error reply email on failed run", async () => {

--- a/turbo/apps/web/app/api/internal/callbacks/email/reply/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/reply/__tests__/route.test.ts
@@ -228,6 +228,111 @@ describe("POST /api/internal/callbacks/email/reply", () => {
       expect(sendArgs.headers["References"]).toBe("<bot-prev@vm7.bot>");
     });
 
+    it("should use session.lastEmailMessageId in References when inboundMessageId is present but inboundReferences is missing", async () => {
+      const user = await context.setupUser({ prefix: "reply-partial" });
+      mockClerk({ userId: user.userId });
+      const { composeId } = await createTestCompose(uniqueId("reply-agent"));
+      const agentSession = await createTestAgentSession(user.userId, composeId);
+      const replyToken = generateReplyToken(agentSession.id);
+      const emailSession = await createTestEmailThreadSession({
+        userId: user.userId,
+        composeId,
+        agentSessionId: agentSession.id,
+        replyToToken: replyToken,
+        lastEmailMessageId: "<bot-prev@vm7.bot>",
+      });
+
+      const { runId } = await createTestRun(composeId, "Email reply task");
+      await completeTestRun(user.userId, runId);
+
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        { eventData: { result: "Partial headers output" } },
+      ]);
+
+      // Payload with inboundMessageId but no inboundReferences
+      const payload: ReplyCallbackPayload = {
+        emailThreadSessionId: emailSession.id,
+        inboundEmailId: "inbound-email-partial",
+        inboundMessageId: "<user-reply@mail.example.com>",
+      };
+
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/email/reply",
+        payload: { ...payload },
+      });
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
+      const sendArgs = mockResend.emails.send.mock.calls[0]![0] as {
+        headers: Record<string, string>;
+      };
+      // In-Reply-To uses inbound Message-ID
+      expect(sendArgs.headers["In-Reply-To"]).toBe(
+        "<user-reply@mail.example.com>",
+      );
+      // References falls back to session.lastEmailMessageId + inbound Message-ID
+      expect(sendArgs.headers["References"]).toBe(
+        "<bot-prev@vm7.bot> <user-reply@mail.example.com>",
+      );
+    });
+
+    it("should omit threading headers when both inbound and session message IDs are absent", async () => {
+      const user = await context.setupUser({ prefix: "reply-no-ids" });
+      mockClerk({ userId: user.userId });
+      const { composeId } = await createTestCompose(uniqueId("reply-agent"));
+      const agentSession = await createTestAgentSession(user.userId, composeId);
+      const replyToken = generateReplyToken(agentSession.id);
+      const emailSession = await createTestEmailThreadSession({
+        userId: user.userId,
+        composeId,
+        agentSessionId: agentSession.id,
+        replyToToken: replyToken,
+      });
+
+      const { runId } = await createTestRun(composeId, "Email reply task");
+      await completeTestRun(user.userId, runId);
+
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        { eventData: { result: "No threading output" } },
+      ]);
+
+      // Payload without any threading info, session also has no lastEmailMessageId
+      const payload: ReplyCallbackPayload = {
+        emailThreadSessionId: emailSession.id,
+        inboundEmailId: "inbound-email-no-ids",
+      };
+
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/email/reply",
+        payload: { ...payload },
+      });
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
+      const sendArgs = mockResend.emails.send.mock.calls[0]![0] as {
+        headers: Record<string, string>;
+      };
+      // No threading headers should be set
+      expect(sendArgs.headers["In-Reply-To"]).toBeUndefined();
+      expect(sendArgs.headers["References"]).toBeUndefined();
+    });
+
     it("should send error reply email on failed run", async () => {
       const user = await context.setupUser({ prefix: "reply-fail" });
       mockClerk({ userId: user.userId });

--- a/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
@@ -25,6 +25,8 @@ const log = logger("callback:email:reply");
 interface CallbackPayload {
   emailThreadSessionId: string;
   inboundEmailId: string;
+  inboundMessageId?: string;
+  inboundReferences?: string;
 }
 
 interface CallbackBody {
@@ -190,9 +192,27 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const replyToAddress = buildReplyToAddress(session.replyToToken);
   const headers: Record<string, string> = {};
 
-  if (session.lastEmailMessageId) {
-    headers["In-Reply-To"] = session.lastEmailMessageId;
-    headers["References"] = session.lastEmailMessageId;
+  // In-Reply-To: the inbound message we are replying to (RFC 2822)
+  // Falls back to session.lastEmailMessageId for backwards compatibility
+  const replyToMessageId =
+    payload.inboundMessageId ?? session.lastEmailMessageId;
+  if (replyToMessageId) {
+    headers["In-Reply-To"] = replyToMessageId;
+  }
+
+  // References: inbound References chain + inbound Message-ID (RFC 2822)
+  // Falls back to session.lastEmailMessageId if no inbound data
+  const referencesParts: string[] = [];
+  if (payload.inboundReferences) {
+    referencesParts.push(payload.inboundReferences);
+  } else if (session.lastEmailMessageId) {
+    referencesParts.push(session.lastEmailMessageId);
+  }
+  if (payload.inboundMessageId) {
+    referencesParts.push(payload.inboundMessageId);
+  }
+  if (referencesParts.length > 0) {
+    headers["References"] = referencesParts.join(" ");
   }
 
   const { messageId } = await sendEmail({

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
@@ -29,6 +29,7 @@ interface TriggerCallbackPayload {
   inboundEmailId: string;
   replyToken: string;
   inboundMessageId?: string;
+  inboundReferences?: string;
   subject?: string;
   triggerLocalPart?: string;
 }

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
@@ -27,6 +27,7 @@ interface CallbackPayload {
   inboundEmailId: string;
   replyToken: string;
   inboundMessageId?: string;
+  inboundReferences?: string;
   subject?: string;
   triggerLocalPart?: string;
 }
@@ -86,11 +87,17 @@ function formatOutput(
 
 function buildThreadingHeaders(
   inboundMessageId: string | undefined,
+  inboundReferences: string | undefined,
 ): Record<string, string> {
   const headers: Record<string, string> = {};
   if (inboundMessageId) {
     headers["In-Reply-To"] = inboundMessageId;
-    headers["References"] = inboundMessageId;
+    const referencesParts: string[] = [];
+    if (inboundReferences) {
+      referencesParts.push(inboundReferences);
+    }
+    referencesParts.push(inboundMessageId);
+    headers["References"] = referencesParts.join(" ");
   }
   return headers;
 }
@@ -210,7 +217,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     ? buildReplyToAddress(replyToken)
     : undefined;
 
-  const headers = buildThreadingHeaders(payload.inboundMessageId);
+  const headers = buildThreadingHeaders(
+    payload.inboundMessageId,
+    payload.inboundReferences,
+  );
 
   // Send response email
   const { messageId } = await sendEmail({

--- a/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
@@ -148,6 +148,7 @@ describe("POST /api/webhooks/email/inbound", () => {
     expect(emailReplyCallback!.payload).toEqual({
       emailThreadSessionId: expect.any(String),
       inboundEmailId: "inbound-email-123",
+      inboundMessageId: "<default-msg-id@example.com>",
     });
   });
 

--- a/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
@@ -60,14 +60,25 @@ export async function handleInboundEmailReply(
   // 4. Fetch full email body from Resend
   const email = await getReceivedEmail(emailId);
 
-  // 5. Extract email body (prefer HTML, fallback to text, strip quotes)
+  // 5. Extract inbound Message-ID and References for threading (case-insensitive lookup)
+  const headers = email.headers ?? {};
+  const messageIdKey = Object.keys(headers).find(
+    (k) => k.toLowerCase() === "message-id",
+  );
+  const inboundMessageId = messageIdKey ? headers[messageIdKey] : undefined;
+  const referencesKey = Object.keys(headers).find(
+    (k) => k.toLowerCase() === "references",
+  );
+  const inboundReferences = referencesKey ? headers[referencesKey] : undefined;
+
+  // 6. Extract email body (prefer HTML, fallback to text, strip quotes)
   const replyContent = extractEmailBody(email.html, email.text);
   if (!replyContent.trim()) {
     log.debug("Empty reply content after stripping", { emailId });
     return;
   }
 
-  // 6. Get compose to find agent name and version
+  // 7. Get compose to find agent name and version
   const [compose] = await globalThis.services.db
     .select({
       name: agentComposes.name,
@@ -84,7 +95,7 @@ export async function handleInboundEmailReply(
     return;
   }
 
-  // 7. Build callbacks for email reply notification
+  // 8. Build callbacks for email reply notification
   const callbacks = [
     {
       url: `${getApiUrl()}/api/internal/callbacks/email/reply`,
@@ -92,11 +103,13 @@ export async function handleInboundEmailReply(
       payload: {
         emailThreadSessionId: session.id,
         inboundEmailId: emailId,
+        inboundMessageId,
+        inboundReferences,
       },
     },
   ];
 
-  // 8. Create and dispatch run via unified pipeline
+  // 9. Create and dispatch run via unified pipeline
   const result = await createRun({
     userId: session.userId,
     agentComposeVersionId: compose.headVersionId ?? "",

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -156,6 +156,10 @@ export async function handleInboundEmailTrigger(
     (k) => k.toLowerCase() === "message-id",
   );
   const inboundMessageId = messageIdKey ? headers[messageIdKey] : undefined;
+  const referencesKey = Object.keys(headers).find(
+    (k) => k.toLowerCase() === "references",
+  );
+  const inboundReferences = referencesKey ? headers[referencesKey] : undefined;
 
   // 7. Verify sender authenticity via DMARC
   const verification = verifySenderAuthenticity(email.headers);
@@ -197,6 +201,7 @@ export async function handleInboundEmailTrigger(
         inboundEmailId: emailId,
         replyToken,
         inboundMessageId,
+        inboundReferences,
         subject,
         triggerLocalPart,
       },


### PR DESCRIPTION
Extract inbound Message-ID and References headers in the reply handler
(mirroring the trigger handler) and pass them through callback payloads.
Reply callback now uses the inbound Message-ID for In-Reply-To instead of
the bot's previous outbound ID, and builds References by forwarding the
inbound References chain per RFC 2822. Includes backwards-compatible
fallback to session.lastEmailMessageId for in-flight callbacks.

Closes #3234

https://claude.ai/code/session_011BUnQBoWViwE7dozRgue2r