### PR TITLE
fix: align deep-plan test strategy with project testing standards

### DIFF
--- a/.claude/commands/deep-plan.md
+++ b/.claude/commands/deep-plan.md
@@ -87,7 +87,7 @@ Apply these thinking approaches during planning:
 2. **Structure the document:**
    - Chosen approach summary
    - Task breakdown with details
-   - Test strategy (unit tests and e2e tests)
+   - Test strategy (integration tests and e2e tests)
    - Dependency graph (if complex)
    - Risk assessment
    - Definition of done


### PR DESCRIPTION
replace "unit tests" with "integration tests" in the deep-plan skill
documentation to match the project's testing philosophy of writing
integration tests instead of unit tests

Co-authored-by: Claude <noreply@anthropic.com>

https://claude.ai/code/session_014We7bQ68ajJ9K2DZ1ABUdP