### PR TITLE
chore: normalize skill names to kebab-case

### DIFF
--- a/.claude/skills/cli-design/SKILL.md
+++ b/.claude/skills/cli-design/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: CLI Design
+name: cli-design
 description: Design patterns and conventions for the vm0 CLI user experience
 context: fork
 ---

--- a/.claude/skills/database-development/SKILL.md
+++ b/.claude/skills/database-development/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Database Development
+name: database-development
 description: Database migrations and Drizzle ORM guidelines for the vm0 project
 ---
 

--- a/.claude/skills/project-principles/SKILL.md
+++ b/.claude/skills/project-principles/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Project Principles
+name: project-principles
 description: Core architectural and code quality principles that guide all development decisions in the vm0 project
 ---
 

--- a/.claude/skills/query-axiom-logs/SKILL.md
+++ b/.claude/skills/query-axiom-logs/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Query Axiom Logs
+name: query-axiom-logs
 description: Query logs from Axiom for debugging (read-only, no ingestion allowed)
 context: fork
 agent: Explore


### PR DESCRIPTION
## Summary
- Standardize all skill `name` fields in SKILL.md frontmatter to use kebab-case format
- Updated 4 skills: `Database Development` → `database-development`, `Project Principles` → `project-principles`, `CLI Design` → `cli-design`, `Query Axiom Logs` → `query-axiom-logs`
- Ensures consistency with the majority of existing skills that already use kebab-case

## Test plan
- [ ] Verify skills are still recognized and invocable via `/skill-name`
- [ ] Confirm no regressions in skill discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)