### PR TITLE
feat(slack): add streaming response effect for agent callbacks

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/__tests__/route.test.ts
@@ -71,6 +71,7 @@ describe("POST /api/internal/callbacks/slack", () => {
   beforeEach(() => {
     context.setupMocks();
     mockClient.chat.postMessage.mockClear();
+    mockClient.chat.update.mockClear();
     mockClient.reactions.remove.mockClear();
   });
 
@@ -253,7 +254,7 @@ describe("POST /api/internal/callbacks/slack", () => {
   });
 
   describe("Successful Callback", () => {
-    it("should post response message to Slack on completed run", async () => {
+    it("should stream response to Slack on completed run", async () => {
       // Given a linked Slack user with an agent
       const { userLink, installation } = await givenLinkedSlackUser();
       const { binding } = await givenUserHasAgent(userLink, {
@@ -304,20 +305,29 @@ describe("POST /api/internal/callbacks/slack", () => {
       const data = await response.json();
       expect(data.success).toBe(true);
 
-      // And a message should be posted to Slack
+      // And an initial streaming message should be posted
       expect(mockClient.chat.postMessage).toHaveBeenCalledTimes(1);
-      const callArgs = mockClient.chat.postMessage.mock.calls[0]![0] as {
+      const postArgs = mockClient.chat.postMessage.mock.calls[0]![0] as {
         channel: string;
         thread_ts: string;
+        text: string;
       };
-      expect(callArgs.channel).toBe(channelId);
-      expect(callArgs.thread_ts).toBe("1234567890.000000");
+      expect(postArgs.channel).toBe(channelId);
+      expect(postArgs.thread_ts).toBe("1234567890.000000");
+      expect(postArgs.text).toContain("is responding");
+
+      // And the message should be finalized via chat.update with blocks
+      expect(mockClient.chat.update).toHaveBeenCalled();
+      const lastUpdate = mockClient.chat.update.mock.calls.at(-1)?.[0] as {
+        blocks: unknown;
+      };
+      expect(lastUpdate).toHaveProperty("blocks");
 
       // And the thinking reaction should be removed
       expect(mockClient.reactions.remove).toHaveBeenCalledTimes(1);
     });
 
-    it("should post error message on failed run", async () => {
+    it("should post error message directly on failed run without streaming", async () => {
       // Given a linked Slack user with an agent
       const { userLink, installation } = await givenLinkedSlackUser();
       const { binding } = await givenUserHasAgent(userLink, {
@@ -367,13 +377,79 @@ describe("POST /api/internal/callbacks/slack", () => {
       // Then the request should succeed
       expect(response.status).toBe(200);
 
-      // And an error message should be posted
+      // And an error message should be posted directly (not streamed)
       expect(mockClient.chat.postMessage).toHaveBeenCalledTimes(1);
       const callArgs = mockClient.chat.postMessage.mock.calls[0]![0] as {
         text: string;
+        blocks: unknown;
       };
       expect(callArgs.text).toContain("Error");
       expect(callArgs.text).toContain("Agent crashed unexpectedly");
+      expect(callArgs).toHaveProperty("blocks");
+
+      // And no streaming updates should have been made
+      expect(mockClient.chat.update).not.toHaveBeenCalled();
+    });
+
+    it("should fall back to postMessage when streaming fails", async () => {
+      // Given a linked Slack user with an agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { binding } = await givenUserHasAgent(userLink, {
+        agentName: "test-agent",
+      });
+
+      // And a run with a registered callback
+      mockClerk({ userId: userLink.vm0UserId });
+      const { runId } = await createTestRun(binding.composeId, "Test prompt");
+      const channelId = `C-fallback-${Date.now()}`;
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/slack",
+        payload: {
+          workspaceId: installation.slackWorkspaceId,
+          channelId,
+          threadTs: "1234567890.000000",
+          messageTs: "1234567890.123456",
+          userLinkId: userLink.id,
+          agentName: "test-agent",
+          composeId: binding.composeId,
+          reactionAdded: true,
+        },
+      });
+
+      // And chat.update will fail (simulating rate limit or API error)
+      mockClient.chat.update.mockRejectedValue(new Error("rate_limited"));
+
+      // When the callback is invoked with completed status
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "completed",
+          payload: {
+            workspaceId: installation.slackWorkspaceId,
+            channelId,
+            threadTs: "1234567890.000000",
+            messageTs: "1234567890.123456",
+            userLinkId: userLink.id,
+            agentName: "test-agent",
+            composeId: binding.composeId,
+            reactionAdded: true,
+          },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      // Then the request should still succeed
+      expect(response.status).toBe(200);
+
+      // And a fallback postMessage with blocks should have been sent
+      // (first call is streaming initial, second is fallback with full content)
+      expect(mockClient.chat.postMessage).toHaveBeenCalledTimes(2);
+      const fallbackArgs = mockClient.chat.postMessage.mock.calls[1]![0] as {
+        blocks: unknown;
+      };
+      expect(fallbackArgs).toHaveProperty("blocks");
     });
 
     it("should not remove reaction when reactionAdded is false", async () => {

--- a/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
@@ -8,9 +8,12 @@ import { slackThreadSessions } from "../../../../../src/db/schema/slack-thread-s
 import { agentSessions } from "../../../../../src/db/schema/agent-session";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import { agentRunCallbacks } from "../../../../../src/db/schema/agent-run-callback";
+import type { WebClient } from "@slack/web-api";
+import type { Block, KnownBlock } from "@slack/web-api";
 import {
   createSlackClient,
   postMessage,
+  streamResponse,
   buildAgentResponseMessage,
   detectDeepLinks,
 } from "../../../../../src/lib/slack";
@@ -82,6 +85,46 @@ async function findNewSessionId(
     .orderBy(desc(agentSessions.updatedAt))
     .limit(1);
   return newSession?.id;
+}
+
+/**
+ * Post the agent response to Slack.
+ * Completed runs are streamed progressively; failed runs are posted directly.
+ */
+async function postResponseToSlack(
+  client: WebClient,
+  channelId: string,
+  threadTs: string,
+  responseText: string,
+  blocks: (Block | KnownBlock)[],
+  status: "completed" | "failed",
+  agentName: string,
+  runId: string,
+): Promise<void> {
+  if (status === "completed") {
+    try {
+      await streamResponse(client, channelId, responseText, {
+        threadTs,
+        blocks,
+        typingIndicator: `_${agentName} is responding..._`,
+      });
+    } catch (streamError) {
+      log.warn("Streaming failed, falling back to postMessage", {
+        runId,
+        error: streamError,
+      });
+      await postMessage(client, channelId, responseText, {
+        threadTs,
+        blocks,
+      });
+    }
+    return;
+  }
+
+  await postMessage(client, channelId, responseText, {
+    threadTs,
+    blocks,
+  });
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -191,17 +234,24 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const logsUrl = buildLogsUrl(runId);
   const deepLinks = detectDeepLinks(responseText, getPlatformUrl());
+  const blocks = buildAgentResponseMessage(
+    responseText,
+    agentName,
+    logsUrl,
+    deepLinks,
+  );
 
   // Post response to Slack
-  await postMessage(client, channelId, responseText, {
+  await postResponseToSlack(
+    client,
+    channelId,
     threadTs,
-    blocks: buildAgentResponseMessage(
-      responseText,
-      agentName,
-      logsUrl,
-      deepLinks,
-    ),
-  });
+    responseText,
+    blocks,
+    status,
+    agentName,
+    runId,
+  );
 
   // Get run to find userId for session lookup
   const [run] = await globalThis.services.db

--- a/turbo/apps/web/src/lib/slack/client.ts
+++ b/turbo/apps/web/src/lib/slack/client.ts
@@ -1,6 +1,11 @@
 import { WebClient, type WebAPICallResult } from "@slack/web-api";
 import type { Block, KnownBlock, View } from "@slack/web-api";
 
+const STREAM_CHUNK_SIZE = 200;
+const STREAM_THROTTLE_MS = 1000;
+const STREAM_MAX_PREVIEW_LENGTH = 4000;
+const STREAM_MAX_UPDATES = 30;
+
 /**
  * Check if an error is a Slack invalid_auth error
  * This happens when the bot token is revoked, expired, or invalid
@@ -159,4 +164,91 @@ export async function exchangeOAuthCode(
     teamName: result.team.name ?? "",
     authedUserId: result.authed_user?.id ?? "",
   };
+}
+
+/**
+ * Stream a response to Slack using progressive message updates.
+ *
+ * Posts an initial typing indicator, then progressively reveals content
+ * via chat.update calls, and finalizes with full Block Kit formatting.
+ * Falls back to a single postMessage if streaming fails.
+ *
+ * @param client - Slack WebClient
+ * @param channel - Channel ID
+ * @param text - Full response text
+ * @param options - Thread timestamp, final blocks, and optional typing indicator
+ */
+export async function streamResponse(
+  client: WebClient,
+  channel: string,
+  text: string,
+  options: {
+    threadTs: string;
+    blocks: (Block | KnownBlock)[];
+    typingIndicator?: string;
+  },
+): Promise<{ ts: string | undefined; channel: string | undefined }> {
+  const initial = await client.chat.postMessage({
+    channel,
+    thread_ts: options.threadTs,
+    text: options.typingIndicator ?? "...",
+  });
+
+  const messageTs = initial.ts;
+  if (!messageTs) {
+    return { ts: initial.ts, channel: initial.channel };
+  }
+
+  const previewText = text.slice(0, STREAM_MAX_PREVIEW_LENGTH);
+  const chunks = splitIntoChunks(previewText, STREAM_CHUNK_SIZE);
+  let accumulated = "";
+  let updateCount = 0;
+
+  for (const chunk of chunks) {
+    if (updateCount >= STREAM_MAX_UPDATES) {
+      break;
+    }
+    accumulated += chunk;
+    await client.chat.update({
+      channel,
+      ts: messageTs,
+      text: accumulated,
+    });
+    updateCount++;
+    await sleep(STREAM_THROTTLE_MS);
+  }
+
+  await client.chat.update({
+    channel,
+    ts: messageTs,
+    text,
+    blocks: options.blocks,
+  });
+
+  return { ts: messageTs, channel: initial.channel };
+}
+
+function splitIntoChunks(text: string, chunkSize: number): string[] {
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= chunkSize) {
+      chunks.push(remaining);
+      break;
+    }
+    let splitAt = remaining.lastIndexOf("\n", chunkSize);
+    if (splitAt === -1 || splitAt < chunkSize / 2) {
+      splitAt = remaining.lastIndexOf(" ", chunkSize);
+    }
+    if (splitAt === -1 || splitAt < chunkSize / 2) {
+      splitAt = chunkSize;
+    }
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt);
+  }
+  return chunks;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/turbo/apps/web/src/lib/slack/index.ts
+++ b/turbo/apps/web/src/lib/slack/index.ts
@@ -72,6 +72,7 @@ export { verifySlackSignature, getSlackSignatureHeaders } from "./verify";
 export {
   createSlackClient,
   postMessage,
+  streamResponse,
   openModal,
   updateModal,
   publishAppHome,


### PR DESCRIPTION
## Summary

- Add progressive streaming response effect for Agent0 Slack callbacks using `postMessage` + `chat.update` pattern
- Completed runs stream content progressively (typing indicator → chunked updates → final Block Kit message)
- Failed runs post error messages directly without streaming
- Automatic fallback to single `postMessage` if streaming encounters an error (e.g., rate limiting)

## Changes

- **`client.ts`**: Add `streamResponse()` function with chunking (200 chars), throttling (1/sec), and configurable limits
- **`index.ts`**: Export `streamResponse` from slack module
- **`route.ts`**: Extract `postResponseToSlack()` helper; use streaming for completed runs, direct post for errors
- **`route.test.ts`**: Update tests for streaming behavior, add streaming fallback test

## Design Decisions

- **Draft stream approach** (not native Slack Streaming API) — avoids requiring `assistant:write` scope which would force all existing installations to re-authorize
- **Post-completion streaming** — simulates the streaming effect by chunking the final output, since the callback model fires once at completion
- **Error isolation** — streaming failures are caught and fall back gracefully to the original `postMessage` behavior

## Test plan

- [x] Completed runs trigger streaming (initial postMessage + chat.update chunks + final update with blocks)
- [x] Failed runs post error messages directly (no streaming, no chat.update calls)
- [x] Streaming fallback works when chat.update fails (falls back to postMessage with blocks)
- [x] All existing tests pass (signature verification, thread sessions, reaction removal)
- [ ] Manual test: verify streaming effect in Slack thread conversations
- [ ] Manual test: verify thinking animation displays correctly during generation

Closes #3239

🤖 Generated with [Claude Code](https://claude.com/claude-code)