### PR TITLE
feat(guest-agent): add api_to_cli_init telemetry metric

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -216,6 +216,10 @@ pub async fn execute_cli(
                         }
 
                         if let Ok(mut event) = serde_json::from_str::<serde_json::Value>(stripped) {
+                            // First event is the CLI init (system/init or thread.started)
+                            if seq == 0 {
+                                crate::timing::record_e2e_from_api("api_to_cli_init");
+                            }
                             // Print result to stdout if applicable
                             if event.get("type").and_then(|v| v.as_str()) == Some("result")
                                 && let Some(result) = event.get("result").and_then(|v| v.as_str())

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -13,4 +13,5 @@ pub mod masker;
 pub mod metrics;
 pub mod paths;
 pub mod telemetry;
+pub mod timing;
 mod urls;

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -14,7 +14,7 @@ use guest_agent::telemetry;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
@@ -29,18 +29,7 @@ async fn main() {
 /// Cleanup (final telemetry + complete API) is guaranteed to run.
 async fn run() -> i32 {
     // Record API-to-agent E2E time (as early as possible)
-    let api_start = env::api_start_time();
-    if !api_start.is_empty()
-        && let Ok(api_ms) = api_start.parse::<u64>()
-    {
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::SystemTime::UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0);
-        let e2e = now_ms.saturating_sub(api_ms);
-        record_sandbox_op("api_to_agent_start", Duration::from_millis(e2e), true, None);
-        log_info!(LOG_TAG, "E2E time from API to agent start: {e2e}ms");
-    }
+    guest_agent::timing::record_e2e_from_api("api_to_agent_start");
 
     // Validate required env vars
     if env::working_dir().is_empty() {

--- a/crates/guest-agent/src/timing.rs
+++ b/crates/guest-agent/src/timing.rs
@@ -1,0 +1,23 @@
+//! E2E timing helpers — measure durations from API start time.
+
+use crate::env;
+use guest_common::log_info;
+use guest_common::telemetry::record_sandbox_op;
+
+const LOG_TAG: &str = "sandbox:guest-agent";
+
+/// Record an E2E duration from `VM0_API_START_TIME` to now under `op_name`.
+pub fn record_e2e_from_api(op_name: &str) {
+    let api_start = env::api_start_time();
+    if !api_start.is_empty()
+        && let Ok(api_ms) = api_start.parse::<u64>()
+    {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let e2e = now_ms.saturating_sub(api_ms);
+        record_sandbox_op(op_name, std::time::Duration::from_millis(e2e), true, None);
+        log_info!(LOG_TAG, "E2E {op_name}: {e2e}ms");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `api_to_cli_init` sandbox op: measures E2E time from API run creation to CLI emitting its first init event
- Extract shared E2E timing logic from `main.rs` into new `timing` module
- Complements existing `api_to_agent_start` metric to give visibility into CLI cold-start overhead

Closes #3244

## Test plan
- [x] `cargo check -p guest-agent` passes
- [ ] Deploy to dev-2, verify `api_to_cli_init` appears in telemetry sandbox ops
- [ ] Compare `api_to_cli_init` vs `api_to_agent_start` to measure CLI cold-start delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)