### PR TITLE
chore: link runner and guest-* versions in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -70,6 +70,17 @@
         {
             "type": "cargo-workspace",
             "cargoWorkspacePath": "crates"
+        },
+        {
+            "type": "linked-versions",
+            "groupName": "runner-guest",
+            "components": [
+                "runner-rs",
+                "guest-agent",
+                "guest-download",
+                "guest-init",
+                "guest-mock-claude"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Summary

- Add `linked-versions` plugin to `release-please-config.json` grouping `runner-rs`, `guest-agent`, `guest-download`, `guest-init`, `guest-mock-claude`
- When any guest binary is updated, runner also gets a version bump, ensuring it is redeployed with the new binaries

Closes #3246

## Test plan

- [ ] Verify release-please config is valid JSON
- [ ] Confirm next release-please run picks up the linked-versions group

🤖 Generated with [Claude Code](https://claude.com/claude-code)