### PR TITLE
feat(sandbox-scripts): add api_to_cli_init telemetry metric

### DIFF
--- a/turbo/packages/sandbox-scripts/src/scripts/run-agent.ts
+++ b/turbo/packages/sandbox-scripts/src/scripts/run-agent.ts
@@ -448,6 +448,16 @@ async function run(): Promise<[number, string]> {
         try {
           const event = JSON.parse(stripped) as Record<string, unknown>;
 
+          // First event is the CLI init (system/init or thread.started)
+          if (eventSequence === 0 && API_START_TIME) {
+            const apiStartTime = parseInt(API_START_TIME, 10);
+            if (!isNaN(apiStartTime)) {
+              const e2eTime = Date.now() - apiStartTime;
+              recordSandboxOp("api_to_cli_init", e2eTime, true);
+              logInfo(`E2E api_to_cli_init: ${e2eTime}ms`);
+            }
+          }
+
           // Valid JSONL - send immediately with sequence number (0-based)
           await sendEvent(event, eventSequence);
           eventSequence++;


### PR DESCRIPTION
## Summary

- Add `api_to_cli_init` E2E telemetry metric to the TypeScript `run-agent.ts` script
- Records duration from API start time to first CLI event (init), matching the existing Rust guest-agent implementation (#3245)

## Test plan

- [ ] Verify metric is recorded on first CLI event (`eventSequence === 0`)
- [ ] Confirm metric appears in `vm0-sandbox-op-log` Axiom dataset

🤖 Generated with [Claude Code](https://claude.com/claude-code)