### PR TITLE
feat: add intermediate e2e telemetry metrics for cli cold-start diagnosis

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -174,6 +174,7 @@ pub async fn execute_cli(
     }
 
     let mut child = cmd.spawn()?;
+    crate::timing::record_e2e_from_api("api_to_cli_spawn");
 
     let stdout = child
         .stdout

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -134,6 +134,8 @@ async fn execute(
         init_elapsed.as_secs()
     );
 
+    guest_agent::timing::record_e2e_from_api("api_to_init_complete");
+
     // Execution phase
     log_info!(LOG_TAG, "▷ Execution");
     let cli_start = Instant::now();

--- a/turbo/packages/sandbox-scripts/src/scripts/run-agent.ts
+++ b/turbo/packages/sandbox-scripts/src/scripts/run-agent.ts
@@ -284,20 +284,24 @@ async function handleCompletion(
 }
 
 /**
+ * Record an E2E duration from API_START_TIME to now under the given op name.
+ */
+function recordE2eFromApi(opName: string): void {
+  if (!API_START_TIME) return;
+  const apiStartTime = parseInt(API_START_TIME, 10);
+  if (isNaN(apiStartTime)) return;
+  const e2eTime = Date.now() - apiStartTime;
+  recordSandboxOp(opName, e2eTime, true);
+  logInfo(`E2E ${opName}: ${e2eTime}ms`);
+}
+
+/**
  * Main execution logic.
  * Throws exceptions on failure instead of calling process.exit().
  * Returns [exit_code, error_message] tuple on completion.
  */
 async function run(): Promise<[number, string]> {
-  // Record API-to-agent E2E time (if API start timestamp is available)
-  if (API_START_TIME) {
-    const apiStartTime = parseInt(API_START_TIME, 10);
-    if (!isNaN(apiStartTime)) {
-      const e2eTime = Date.now() - apiStartTime;
-      recordSandboxOp("api_to_agent_start", e2eTime, true);
-      logInfo(`E2E time from API to agent start: ${e2eTime}ms`);
-    }
-  }
+  recordE2eFromApi("api_to_agent_start");
 
   // Validate configuration - throws if invalid
   validateConfig();
@@ -363,6 +367,8 @@ async function run(): Promise<[number, string]> {
   recordSandboxOp("init_total", initDurationMs, true);
   logInfo(`✓ Initialization complete (${Math.floor(initDurationMs / 1000)}s)`);
 
+  recordE2eFromApi("api_to_init_complete");
+
   // Lifecycle: Execution
   logInfo("▷ Execution");
   const execStartTime = Date.now();
@@ -394,6 +400,8 @@ async function run(): Promise<[number, string]> {
     const proc = spawn(cmdExe, cmd.slice(1), {
       stdio: ["ignore", "pipe", "pipe"],
     });
+
+    recordE2eFromApi("api_to_cli_spawn");
 
     // Create promise to track process exit - register handlers BEFORE reading streams
     // This prevents race condition where process exits before handlers are registered
@@ -449,13 +457,8 @@ async function run(): Promise<[number, string]> {
           const event = JSON.parse(stripped) as Record<string, unknown>;
 
           // First event is the CLI init (system/init or thread.started)
-          if (eventSequence === 0 && API_START_TIME) {
-            const apiStartTime = parseInt(API_START_TIME, 10);
-            if (!isNaN(apiStartTime)) {
-              const e2eTime = Date.now() - apiStartTime;
-              recordSandboxOp("api_to_cli_init", e2eTime, true);
-              logInfo(`E2E api_to_cli_init: ${e2eTime}ms`);
-            }
+          if (eventSequence === 0) {
+            recordE2eFromApi("api_to_cli_init");
           }
 
           // Valid JSONL - send immediately with sequence number (0-based)


### PR DESCRIPTION
## Summary

- Add `api_to_init_complete` and `api_to_cli_spawn` E2E metrics in both Rust guest-agent and TS run-agent
- Extract `recordE2eFromApi()` helper in TS to eliminate 4x repeated inline `API_START_TIME` parsing logic
- Full E2E breakdown: `api_to_agent_start → api_to_init_complete → api_to_cli_spawn → api_to_cli_init`

Observed ~5.3s gap between `api_to_agent_start` (3087ms) and `api_to_cli_init` (8410ms). These intermediate metrics will pinpoint whether the bottleneck is in agent init, process spawn, or CLI cold start.

Closes #3250

## Test plan

- [ ] Verify new metrics appear in `vm0-sandbox-op-log` Axiom dataset
- [ ] Confirm breakdown narrows down the latency source

🤖 Generated with [Claude Code](https://claude.com/claude-code)