### PR TITLE
feat(email): improve reply template with content-first layout

### DIFF
--- a/turbo/apps/web/src/lib/email/templates/agent-reply.tsx
+++ b/turbo/apps/web/src/lib/email/templates/agent-reply.tsx
@@ -6,8 +6,6 @@ import {
   Text,
   Link,
   Hr,
-  Preview,
-  Section,
 } from "@react-email/components";
 
 interface AgentReplyEmailProps {
@@ -24,19 +22,16 @@ export function AgentReplyEmail({
   return (
     <Html>
       <Head />
-      <Preview>Reply from &quot;{agentName}&quot;</Preview>
       <Body style={bodyStyle}>
         <Container style={containerStyle}>
-          <Text style={headingStyle}>Reply from &quot;{agentName}&quot;</Text>
-          <Section style={outputSectionStyle}>
-            <Text style={outputStyle}>{output}</Text>
-          </Section>
+          <Text style={outputStyle}>{output}</Text>
           <Hr style={hrStyle} />
+          <Text style={signatureStyle}>{agentName} from VM0</Text>
           <Text style={footerStyle}>
             <Link href={logsUrl} style={linkStyle}>
               View logs
             </Link>{" "}
-            · Reply to continue the conversation
+            · Reply to continue
           </Text>
         </Container>
       </Body>
@@ -58,19 +53,6 @@ const containerStyle = {
   borderRadius: "8px",
 };
 
-const headingStyle = {
-  fontSize: "18px",
-  fontWeight: "600" as const,
-  color: "#1a1a1a",
-  margin: "0 0 16px",
-};
-
-const outputSectionStyle = {
-  backgroundColor: "#f4f4f5",
-  borderRadius: "6px",
-  padding: "12px 16px",
-};
-
 const outputStyle = {
   fontSize: "14px",
   color: "#374151",
@@ -82,6 +64,13 @@ const outputStyle = {
 const hrStyle = {
   borderColor: "#e5e7eb",
   margin: "20px 0",
+};
+
+const signatureStyle = {
+  fontSize: "13px",
+  fontWeight: "600" as const,
+  color: "#374151",
+  margin: "0 0 4px",
 };
 
 const footerStyle = {

--- a/turbo/apps/web/src/lib/email/templates/schedule-completed.tsx
+++ b/turbo/apps/web/src/lib/email/templates/schedule-completed.tsx
@@ -6,8 +6,6 @@ import {
   Text,
   Link,
   Hr,
-  Preview,
-  Section,
 } from "@react-email/components";
 
 interface ScheduleCompletedEmailProps {
@@ -24,23 +22,16 @@ export function ScheduleCompletedEmail({
   return (
     <Html>
       <Head />
-      <Preview>
-        VM0 - Scheduled run for &quot;{agentName}&quot; completed
-      </Preview>
       <Body style={bodyStyle}>
         <Container style={containerStyle}>
-          <Text style={headingStyle}>
-            VM0 - Scheduled run for &quot;{agentName}&quot; completed
-          </Text>
-          <Section style={outputSectionStyle}>
-            <Text style={outputStyle}>{output}</Text>
-          </Section>
+          <Text style={outputStyle}>{output}</Text>
           <Hr style={hrStyle} />
+          <Text style={signatureStyle}>{agentName} from VM0</Text>
           <Text style={footerStyle}>
             <Link href={logsUrl} style={linkStyle}>
               View logs
             </Link>{" "}
-            · Reply to this email to continue the conversation
+            · Reply to continue
           </Text>
         </Container>
       </Body>
@@ -62,19 +53,6 @@ const containerStyle = {
   borderRadius: "8px",
 };
 
-const headingStyle = {
-  fontSize: "18px",
-  fontWeight: "600" as const,
-  color: "#1a1a1a",
-  margin: "0 0 16px",
-};
-
-const outputSectionStyle = {
-  backgroundColor: "#f4f4f5",
-  borderRadius: "6px",
-  padding: "12px 16px",
-};
-
 const outputStyle = {
   fontSize: "14px",
   color: "#374151",
@@ -86,6 +64,13 @@ const outputStyle = {
 const hrStyle = {
   borderColor: "#e5e7eb",
   margin: "20px 0",
+};
+
+const signatureStyle = {
+  fontSize: "13px",
+  fontWeight: "600" as const,
+  color: "#374151",
+  margin: "0 0 4px",
 };
 
 const footerStyle = {

--- a/turbo/apps/web/src/lib/email/templates/schedule-failed.tsx
+++ b/turbo/apps/web/src/lib/email/templates/schedule-failed.tsx
@@ -6,8 +6,6 @@ import {
   Text,
   Link,
   Hr,
-  Preview,
-  Section,
 } from "@react-email/components";
 
 interface ScheduleFailedEmailProps {
@@ -24,16 +22,11 @@ export function ScheduleFailedEmail({
   return (
     <Html>
       <Head />
-      <Preview>VM0 - Scheduled run for &quot;{agentName}&quot; failed</Preview>
       <Body style={bodyStyle}>
         <Container style={containerStyle}>
-          <Text style={headingStyle}>
-            VM0 - Scheduled run for &quot;{agentName}&quot; failed
-          </Text>
-          <Section style={errorSectionStyle}>
-            <Text style={errorStyle}>{errorMessage}</Text>
-          </Section>
+          <Text style={errorStyle}>{errorMessage}</Text>
           <Hr style={hrStyle} />
+          <Text style={signatureStyle}>{agentName} from VM0</Text>
           <Text style={footerStyle}>
             <Link href={logsUrl} style={linkStyle}>
               View logs
@@ -59,20 +52,6 @@ const containerStyle = {
   borderRadius: "8px",
 };
 
-const headingStyle = {
-  fontSize: "18px",
-  fontWeight: "600" as const,
-  color: "#dc2626",
-  margin: "0 0 16px",
-};
-
-const errorSectionStyle = {
-  backgroundColor: "#fef2f2",
-  borderRadius: "6px",
-  padding: "12px 16px",
-  borderLeft: "3px solid #dc2626",
-};
-
 const errorStyle = {
   fontSize: "14px",
   color: "#991b1b",
@@ -84,6 +63,13 @@ const errorStyle = {
 const hrStyle = {
   borderColor: "#e5e7eb",
   margin: "20px 0",
+};
+
+const signatureStyle = {
+  fontSize: "13px",
+  fontWeight: "600" as const,
+  color: "#374151",
+  margin: "0 0 4px",
 };
 
 const footerStyle = {


### PR DESCRIPTION
## Summary

- Remove redundant "Reply from 'agentName'" heading — agent identity already in From field
- Remove grey output box — content flows naturally on white card
- Add agent name signature line in footer (`{agentName} from VM0`)
- Simplify footer text: "Reply to continue" instead of "Reply to continue the conversation"
- Remove unused `<Preview>` and `<Section>` components
- No robot emoji (per team feedback)

**Before:**
```
Reply from "agent0"

┌─── grey box ───┐
│ [content]      │
└────────────────┘

───
View logs · Reply to continue the conversation
```

**After:**
```
[content starts immediately]

───
agent0 from VM0
View logs · Reply to continue
```

Closes #3260

## Test plan

- [x] TypeScript type check passes (interface unchanged, callers compatible)
- [x] All lint checks pass
- [x] Knip finds no unused exports
- [x] Existing callback tests pass (don't assert template content)
- [ ] Manual verification: send a test email and confirm layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)