### PR TITLE
fix(sandbox-fc): remove double su wrapper from prewarm script

### DIFF
--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -200,7 +200,7 @@ mod tests {
         // Changing this assertion means ALL existing cached snapshots are
         // invalidated.  Only update deliberately.
         assert_eq!(
-            hash, "19a81372c87564c16e4ad4a7edbf0ed71d93e578dcc92f2e0527f4976196d87d",
+            hash, "10d4c607d58a34e4f3ccbeabe7ffef50648dc8b1fa14ce4280012af89cff9b87",
             "snapshot hash changed — this invalidates all cached snapshots"
         );
     }

--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -200,7 +200,7 @@ mod tests {
         // Changing this assertion means ALL existing cached snapshots are
         // invalidated.  Only update deliberately.
         assert_eq!(
-            hash, "10d4c607d58a34e4f3ccbeabe7ffef50648dc8b1fa14ce4280012af89cff9b87",
+            hash, "5fc55ca4dcc992836a3ff191ad0b1cac0a494e446abfb3790718788beaa46f7a",
             "snapshot hash changed — this invalidates all cached snapshots"
         );
     }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -19,8 +19,7 @@ use crate::sandbox::FirecrackerSandbox;
 /// Double-wrapping creates nested sessions where inner processes escape the
 /// process group, surviving SIGKILL on timeout as orphans frozen into the
 /// snapshot.
-pub const PREWARM_SCRIPT: &str =
-    "claude --help >/dev/null 2>&1; codex --help >/dev/null 2>&1; true";
+pub const PREWARM_SCRIPT: &str = "claude --help >/dev/null 2>&1 && codex --help >/dev/null 2>&1";
 
 /// SHA-256 fingerprint of all sandbox-fc internal configuration that affects
 /// snapshot output (boot args, guest network, pre-warm script, etc.).

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -13,8 +13,14 @@ use crate::sandbox::FirecrackerSandbox;
 
 /// Shell command executed during snapshot creation to pre-warm guest caches.
 /// Changing this invalidates all cached snapshots (included in [`config_hash`]).
+///
+/// **Note:** Do NOT wrap this in `su - user -c '...'` — the vsock-guest exec
+/// handler already wraps commands with `su - user -c` in release builds.
+/// Double-wrapping creates nested sessions where inner processes escape the
+/// process group, surviving SIGKILL on timeout as orphans frozen into the
+/// snapshot.
 pub const PREWARM_SCRIPT: &str =
-    "su - user -c 'claude --help >/dev/null 2>&1; codex --help >/dev/null 2>&1; true'";
+    "claude --help >/dev/null 2>&1; codex --help >/dev/null 2>&1; true";
 
 /// SHA-256 fingerprint of all sandbox-fc internal configuration that affects
 /// snapshot output (boot args, guest network, pre-warm script, etc.).

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -283,15 +283,22 @@ async fn run_with_firecracker(
 
     info!("guest connected");
 
-    // 9.5. Pre-warm PAM/nsswitch caches so post-restore `su` calls are fast.
-    //      The snapshot captures memory state, so caches populated here persist.
-    match guest
-        .exec(crate::factory::PREWARM_SCRIPT, 5000, &[], false)
+    // 9.5. Pre-warm caches (PAM/nsswitch, CLI modules) so post-restore calls
+    //      are fast. The snapshot captures memory + overlay state, so caches
+    //      populated here persist across restores.
+    let prewarm_result = guest
+        .exec(crate::factory::PREWARM_SCRIPT, 30_000, &[], false)
         .await
-    {
-        Ok(result) => info!(exit_code = result.exit_code, "pre-warm: su cache"),
-        Err(e) => tracing::warn!(error = %e, "pre-warm: su cache failed (non-fatal)"),
+        .map_err(|e| SnapshotError::Setup(format!("pre-warm exec: {e}")))?;
+    if prewarm_result.exit_code != 0 {
+        let stderr = String::from_utf8_lossy(&prewarm_result.stderr);
+        return Err(SnapshotError::Setup(format!(
+            "pre-warm failed (exit code {}): {}",
+            prewarm_result.exit_code,
+            stderr.trim(),
+        )));
     }
+    info!("pre-warm complete");
 
     // 10. Pause VM.
     client.pause().await?;


### PR DESCRIPTION
## Summary

- Remove redundant `su - user -c` wrapper from `PREWARM_SCRIPT` — vsock-guest's `build_exec_command` already wraps commands with `su - user -c` in release builds. Double-wrapping created nested login sessions where inner processes escaped the process group, surviving SIGKILL on timeout as orphans frozen into the snapshot.
- Increase prewarm exec timeout from 5s to 30s (one-time build operation, not latency-sensitive)
- Fail snapshot creation on prewarm failure instead of silently continuing with a potentially broken snapshot

## Test plan

- [x] `cargo test -p runner -- snapshot` passes (hash updated)
- [x] `cargo clippy -p sandbox-fc -p runner` clean
- [ ] CI runner-benchmark passes with new snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)