### PR TITLE
perf(sandbox-fc): enable v8 compile cache for faster cli cold start

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -13,6 +13,10 @@ use tokio::io::AsyncWriteExt;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
+/// Directory for the Node.js V8 compile cache (NODE_COMPILE_CACHE).
+/// Must match the path exported in `sandbox-fc::factory::PREWARM_SCRIPT`.
+const NODE_COMPILE_CACHE_DIR: &str = "/home/user/.cache/node-compile-cache";
+
 /// Build the CLI command + args based on `CLI_AGENT_TYPE`.
 pub fn build_cli_command() -> Result<Vec<String>, AgentError> {
     let use_mock = env::use_mock_claude();
@@ -168,7 +172,7 @@ pub async fn execute_cli(
         .process_group(0);
 
     // Enable V8 bytecode cache for faster Node.js startup (populated during snapshot creation)
-    cmd.env("NODE_COMPILE_CACHE", "/home/user/.cache/node-compile-cache");
+    cmd.env("NODE_COMPILE_CACHE", NODE_COMPILE_CACHE_DIR);
 
     // Pass CODEX_HOME via Command::env instead of global set_var
     if env::cli_agent_type() == "codex" {

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -167,6 +167,9 @@ pub async fn execute_cli(
         .stderr(Stdio::piped())
         .process_group(0);
 
+    // Enable V8 bytecode cache for faster Node.js startup (populated during snapshot creation)
+    cmd.env("NODE_COMPILE_CACHE", "/home/user/.cache/node-compile-cache");
+
     // Pass CODEX_HOME via Command::env instead of global set_var
     if env::cli_agent_type() == "codex" {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());

--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -200,7 +200,7 @@ mod tests {
         // Changing this assertion means ALL existing cached snapshots are
         // invalidated.  Only update deliberately.
         assert_eq!(
-            hash, "5fc55ca4dcc992836a3ff191ad0b1cac0a494e446abfb3790718788beaa46f7a",
+            hash, "e01bf767daa13f0d80e8da31734b323a3a11129e4e01d761b00ceba2de0b368f",
             "snapshot hash changed — this invalidates all cached snapshots"
         );
     }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -23,6 +23,7 @@ use crate::sandbox::FirecrackerSandbox;
 /// - `NODE_COMPILE_CACHE`: persists V8 bytecode to disk so subsequent runs
 ///   skip parsing/compilation (Node.js 22+). The cache dir survives snapshot
 ///   restore and is reused by the guest-agent when spawning the CLI.
+///   The path must match `NODE_COMPILE_CACHE_DIR` in `guest-agent::cli`.
 /// - `codex --help`: lightweight pre-warm for Codex (no `--print` equivalent).
 pub const PREWARM_SCRIPT: &str = "\
     export NODE_COMPILE_CACHE=/home/user/.cache/node-compile-cache && \

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -19,7 +19,16 @@ use crate::sandbox::FirecrackerSandbox;
 /// Double-wrapping creates nested sessions where inner processes escape the
 /// process group, surviving SIGKILL on timeout as orphans frozen into the
 /// snapshot.
-pub const PREWARM_SCRIPT: &str = "claude --help >/dev/null 2>&1 && codex --help >/dev/null 2>&1";
+///
+/// - `NODE_COMPILE_CACHE`: persists V8 bytecode to disk so subsequent runs
+///   skip parsing/compilation (Node.js 22+). The cache dir survives snapshot
+///   restore and is reused by the guest-agent when spawning the CLI.
+/// - `codex --help`: lightweight pre-warm for Codex (no `--print` equivalent).
+pub const PREWARM_SCRIPT: &str = "\
+    export NODE_COMPILE_CACHE=/home/user/.cache/node-compile-cache && \
+    mkdir -p /home/user/.cache/node-compile-cache && \
+    claude --help >/dev/null 2>&1 && \
+    codex --help >/dev/null 2>&1";
 
 /// SHA-256 fingerprint of all sandbox-fc internal configuration that affects
 /// snapshot output (boot args, guest network, pre-warm script, etc.).


### PR DESCRIPTION
## Summary
- Enable `NODE_COMPILE_CACHE` env var in guest-agent when spawning CLI, so Node.js persists V8 bytecode to disk
- Pre-warm the compile cache during snapshot creation by exporting and `mkdir -p` the cache dir in `PREWARM_SCRIPT`
- Cached bytecode survives snapshot restore, skipping parse/compile on subsequent CLI launches

Closes #3258

## Test plan
- [x] `cargo test -p runner -- snapshot_hash` passes with updated hash
- [x] `cargo clippy -p guest-agent -p sandbox-fc -p runner` clean
- [ ] CI runner-benchmark: verify snapshot builds with new prewarm script

🤖 Generated with [Claude Code](https://claude.com/claude-code)