### PR TITLE
fix(sandbox-fc): use deterministic mac on tap devices for snapshot arp stability

### DIFF
--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -200,7 +200,7 @@ mod tests {
         // Changing this assertion means ALL existing cached snapshots are
         // invalidated.  Only update deliberately.
         assert_eq!(
-            hash, "e01bf767daa13f0d80e8da31734b323a3a11129e4e01d761b00ceba2de0b368f",
+            hash, "e9f86f41ad2dcf9373a6642e94879247db36f5d3facd4552230da03c455e1850",
             "snapshot hash changed — this invalidates all cached snapshots"
         );
     }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -49,6 +49,8 @@ pub fn config_hash() -> String {
     hasher.update(GUEST_NETWORK.guest_mac.as_bytes());
     hasher.update(b"tap_name:");
     hasher.update(GUEST_NETWORK.tap_name.as_bytes());
+    hasher.update(b"tap_mac:");
+    hasher.update(GUEST_NETWORK.tap_mac.as_bytes());
     hasher.update(b"prewarm:");
     hasher.update(PREWARM_SCRIPT.as_bytes());
     format!("{:x}", hasher.finalize())

--- a/crates/sandbox-fc/src/network/guest.rs
+++ b/crates/sandbox-fc/src/network/guest.rs
@@ -5,6 +5,11 @@
 pub struct GuestNetwork {
     /// TAP device name inside namespace (must match Firecracker config).
     pub tap_name: &'static str,
+    /// Fixed MAC for the TAP device (host-side, locally administered).
+    ///
+    /// Must be deterministic so that guest ARP cache entries baked into a
+    /// snapshot remain valid after restore in a different network namespace.
+    pub tap_mac: &'static str,
     /// Guest MAC address (locally administered, fixed for all VMs).
     pub guest_mac: &'static str,
     /// Guest IP inside the VM.
@@ -19,6 +24,7 @@ pub struct GuestNetwork {
 
 pub const GUEST_NETWORK: GuestNetwork = GuestNetwork {
     tap_name: "vm0-tap",
+    tap_mac: "02:00:00:00:00:02",
     guest_mac: "02:00:00:00:00:01",
     guest_ip: "192.168.241.2",
     gateway_ip: "192.168.241.1",

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -178,11 +178,17 @@ async fn sudo_iptables(args: &[&str]) -> Result<()> {
 async fn create_netns_with_tap(
     ns_name: &str,
     tap_name: &str,
+    tap_mac: &str,
     gateway_ip_with_prefix: &str,
 ) -> Result<()> {
     sudo_ip(&["netns", "add", ns_name]).await?;
     sudo_ip(&[
         "netns", "exec", ns_name, "ip", "tuntap", "add", tap_name, "mode", "tap",
+    ])
+    .await?;
+    // Set a fixed MAC so guest ARP cache from snapshots stays valid after restore.
+    sudo_ip(&[
+        "netns", "exec", ns_name, "ip", "link", "set", tap_name, "address", tap_mac,
     ])
     .await?;
     sudo_ip(&[
@@ -845,7 +851,7 @@ async fn create_namespace_inner(
     default_iface: &str,
 ) -> Result<()> {
     let gw_with_prefix = format!("{}/{}", sn.gateway_ip, sn.prefix_len);
-    create_netns_with_tap(name, sn.tap_name, &gw_with_prefix).await?;
+    create_netns_with_tap(name, sn.tap_name, sn.tap_mac, &gw_with_prefix).await?;
     setup_veth_pair(name, host_device, host_ip, peer_ip).await?;
     setup_namespace_routing(name, host_ip, sn.gateway_ip, sn.prefix_len).await?;
     setup_host_iptables(name, host_device, peer_ip, default_iface).await?;


### PR DESCRIPTION
## Summary

- Set a fixed locally-administered MAC (`02:00:00:00:00:02`) on every TAP device during netns creation, instead of relying on the kernel's random assignment
- Add `tap_mac` to `config_hash` so future MAC changes invalidate cached snapshots
- **Root cause:** TAP devices get random MACs from the kernel. When the guest makes network calls during prewarm, ARP entries referencing the TAP MAC are frozen into the snapshot. On restore in a different netns with a different random MAC, all outbound frames are dropped — breaking networking entirely (curl exit code 28)

## Test plan

- [x] `cargo clippy -p sandbox-fc -p runner` passes
- [x] `cargo test -p sandbox-fc` — 73 tests pass
- [x] `cargo test -p runner snapshot_hash` — hash updated
- [ ] CI runner-benchmark on dev-2

Closes #3268

🤖 Generated with [Claude Code](https://claude.com/claude-code)