### PR TITLE
perf(sandbox-fc): pre-warm real claude execution path instead of --help

### DIFF
--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -200,7 +200,7 @@ mod tests {
         // Changing this assertion means ALL existing cached snapshots are
         // invalidated.  Only update deliberately.
         assert_eq!(
-            hash, "e9f86f41ad2dcf9373a6642e94879247db36f5d3facd4552230da03c455e1850",
+            hash, "e94d098ac4f692c56dc65e5e8eaee9a6000d5c6846ef5cbe256cff3f33f82e15",
             "snapshot hash changed — this invalidates all cached snapshots"
         );
     }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -24,12 +24,18 @@ use crate::sandbox::FirecrackerSandbox;
 ///   skip parsing/compilation (Node.js 22+). The cache dir survives snapshot
 ///   restore and is reused by the guest-agent when spawning the CLI.
 ///   The path must match `NODE_COMPILE_CACHE_DIR` in `guest-agent::cli`.
+/// - `claude --print ...`: pre-warms the real execution path (Sentry, API
+///   clients, stream-json output) rather than just `--help` which takes a
+///   lightweight short-circuit path. Failure is tolerated (`|| true`) because
+///   there is no API key during snapshot creation — the goal is to populate
+///   the V8 compile cache, not to complete the API call.
 /// - `codex --help`: lightweight pre-warm for Codex (no `--print` equivalent).
+///   Also tolerated because codex may not be installed.
 pub const PREWARM_SCRIPT: &str = "\
     export NODE_COMPILE_CACHE=/home/user/.cache/node-compile-cache && \
     mkdir -p /home/user/.cache/node-compile-cache && \
-    claude --help >/dev/null 2>&1 && \
-    codex --help >/dev/null 2>&1";
+    (claude --print --verbose --output-format stream-json --dangerously-skip-permissions hi >/dev/null 2>&1 || true) && \
+    (codex --help >/dev/null 2>&1 || true)";
 
 /// SHA-256 fingerprint of all sandbox-fc internal configuration that affects
 /// snapshot output (boot args, guest network, pre-warm script, etc.).


### PR DESCRIPTION
## Summary
- Use `claude --print` with stream-json output during snapshot prewarm instead of `--help`
- Exercises the real execution path (Sentry init, API clients, output formatting) to populate more V8 compile cache entries
- `--help` takes a lightweight short-circuit path that skips most startup code
- Failure is tolerated (`|| true`) because there is no API key during snapshot creation

Previously blocked by stale ARP cache after snapshot restore (random TAP MACs), which was fixed in #3269.

Closes #3258

## Test plan
- [x] `cargo test -p runner -- snapshot` passes with updated hash
- [x] `cargo clippy -p sandbox-fc -p runner` clean
- [ ] CI runner-benchmark: verify snapshot builds with new prewarm script

🤖 Generated with [Claude Code](https://claude.com/claude-code)