### PR TITLE
fix(ably-subscriber): align protocol handling with ably-js sdk

### DIFF
--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -271,9 +271,12 @@ impl ConnState {
         Instant::now() + renew_in
     }
 
+    /// RTN15h: resume is allowed when elapsed time since disconnect is less
+    /// than `connection_state_ttl + max_idle_interval` and we have a key.
     fn can_resume(&self) -> bool {
         if let Some(disconnected_at) = self.disconnected_at {
-            disconnected_at.elapsed() < self.connection_state_ttl && self.connection_key.is_some()
+            disconnected_at.elapsed() < self.connection_state_ttl + self.max_idle_interval
+                && self.connection_key.is_some()
         } else {
             false
         }
@@ -463,8 +466,9 @@ enum LoopAction {
 
 /// Mirrors ably-js `isRetriable()` from `connectionerrors.ts`.
 ///
-/// An error is retriable when it has no status code, is a server error (5xx),
-/// or carries a well-known connection error code even at 4xx.
+/// An error is retriable when it has no status code, no error code, is a
+/// server error (5xx), or carries a well-known connection error code even
+/// at 4xx.
 fn is_retriable(err: &crate::protocol::ErrorInfo) -> bool {
     const CONNECTION_ERROR_CODES: &[i32] = &[
         80003, // DISCONNECTED
@@ -474,6 +478,9 @@ fn is_retriable(err: &crate::protocol::ErrorInfo) -> bool {
         50002, // UNKNOWN_CONNECTION_ERR
         50001, // UNKNOWN_CHANNEL_ERR
     ];
+    if err.code == 0 {
+        return true;
+    }
     match err.status_code {
         None => true,
         Some(sc) if sc >= 500 => true,
@@ -585,18 +592,10 @@ async fn handle_message(p: &mut EventLoopState, msg: ProtocolMessage) -> LoopAct
             }
         }
         action::DISCONNECTED => {
-            if let Some(ref err) = msg.error
-                && !is_retriable(err)
-            {
-                let _ = p
-                    .event_tx
-                    .send(Event::Error {
-                        code: err.code,
-                        message: err.message.clone(),
-                    })
-                    .await;
-                return LoopAction::Stop;
-            }
+            // ably-js always reconnects on mid-session DISCONNECTED regardless
+            // of retriability. The server may send DISCONNECTED with a non-
+            // retriable error (e.g. 429 rate limit) but still expect the client
+            // to reconnect after backoff. Only connection-level ERROR is fatal.
             let reason = msg.error.map(|e| e.message);
             let _ = p.event_tx.send(Event::Disconnected { reason }).await;
             return LoopAction::Reconnect;
@@ -1059,6 +1058,16 @@ mod tests {
             message: String::new(),
         };
         assert!(!is_retriable(&err));
+    }
+
+    #[test]
+    fn is_retriable_zero_code() {
+        let err = crate::protocol::ErrorInfo {
+            code: 0,
+            status_code: Some(400),
+            message: String::new(),
+        };
+        assert!(is_retriable(&err));
     }
 
     #[test]

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -954,13 +954,17 @@ async fn close_subscription() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 13: non-retriable DISCONNECTED → Event::Error (not reconnect)
+// Test 13: non-retriable DISCONNECTED still triggers reconnect
 // ---------------------------------------------------------------------------
 
+/// ably-js always reconnects on mid-session DISCONNECTED regardless of
+/// retriability — the server may send 429 or 401 but still expect the
+/// client to backoff-and-retry. Only connection-level ERROR is fatal.
 #[tokio::test]
-async fn non_retriable_disconnected_emits_error() {
+async fn non_retriable_disconnected_triggers_reconnect() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
     mock_token_endpoint(&http, "testKey.testId");
 
     let ws_port = ws.port;
@@ -982,26 +986,63 @@ async fn non_retriable_disconnected_emits_error() {
         ))
         .await
         .unwrap();
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        // Give client time to process and reconnect
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        drop(conn);
+
+        // Client should reconnect (fresh connect with new token)
+        let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
+        send_message(
+            &mut conn2,
+            "ch",
+            "after-non-retriable-disconnect",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_secs(5)).await;
     });
 
-    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+    let mut timing = TimingConfig::default();
+    timing.initial_retry_interval = Duration::from_millis(10);
+    timing.max_retry_interval = Duration::from_millis(50);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
 
     assert!(matches!(sub.next().await.unwrap(), Event::Connected));
 
+    // Should get Disconnected (not Error)
     let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
         .await
-        .expect("timed out")
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    // Should reconnect
+    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
+        .await
+        .expect("timed out waiting for Connected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected, got {event:?}"
+    );
+
+    // Message after reconnect proves subscription is alive
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message")
         .unwrap();
     match event {
-        Event::Error { code, .. } => assert_eq!(code, 40142),
-        other => panic!("expected Error, got {other:?}"),
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("after-non-retriable-disconnect"))
+        }
+        other => panic!("expected Message, got {other:?}"),
     }
-
-    // Stream should end (loop stopped)
-    assert!(sub.next().await.is_none());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Align `can_resume()` resume window with RTN15h spec: `connection_state_ttl + max_idle_interval` (was missing `max_idle_interval`, giving up 15s early)
- Mid-session DISCONNECTED always triggers reconnect regardless of retriability, matching ably-js behavior (was fatally stopping on non-retriable DISCONNECTED like 429 rate limit)
- `is_retriable()` treats `code == 0` as retriable, matching ably-js `!err.code` check

Found via systematic comparison of ably-subscriber against ably-js SDK (`connectionmanager.ts`, `connectionerrors.ts`, `realtimechannel.ts`).

Closes #3274

## Test plan
- [x] Updated `non_retriable_disconnected_emits_error` → `non_retriable_disconnected_triggers_reconnect` (verifies reconnect instead of fatal stop)
- [x] New unit test `is_retriable_zero_code` for `code == 0` edge case
- [x] All 38 unit tests + 29 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)