### PR TITLE
perf(rootfs): install claude code as standalone binary for faster cold-start

### DIFF
--- a/crates/runner/scripts/rootfs.Dockerfile
+++ b/crates/runner/scripts/rootfs.Dockerfile
@@ -46,8 +46,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-# Install Claude Code CLI globally (matching e2b template)
-RUN npm install -g @anthropic-ai/claude-code@2.1.12
+# Install Claude Code CLI as a standalone binary (SEA = Single Executable Application).
+# The SEA binary bundles Node.js + V8 + application code, eliminating module resolution
+# overhead at startup and significantly reducing CLI cold-start time compared to npm.
+ARG CLAUDE_CODE_VERSION=2.1.12
+RUN ARCH=$(dpkg --print-architecture) \
+    && case "$ARCH" in amd64) PLATFORM="linux-x64" ;; arm64) PLATFORM="linux-arm64" ;; *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; esac \
+    && GCS_BUCKET="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases" \
+    && curl -fsSL "${GCS_BUCKET}/${CLAUDE_CODE_VERSION}/${PLATFORM}/claude" -o /usr/local/bin/claude \
+    && CHECKSUM=$(curl -fsSL "${GCS_BUCKET}/${CLAUDE_CODE_VERSION}/manifest.json" \
+       | jq -r ".platforms[\"$PLATFORM\"].checksum") \
+    && echo "${CHECKSUM}  /usr/local/bin/claude" | sha256sum -c - \
+    && chmod +x /usr/local/bin/claude
 
 # Install Codex CLI globally (matching e2b template)
 # See: turbo/scripts/e2b/vm0-codex/template.ts


### PR DESCRIPTION
## Summary

- Replace `npm install -g @anthropic-ai/claude-code@2.1.12` with direct download of the SEA (Single Executable Application) binary from GCS
- The standalone binary bundles Node.js + V8 + application code into a single executable, eliminating module resolution overhead at startup
- This targets the ~4s `api_to_cli_spawn → api_to_cli_init` gap, which is dominated by Node.js module loading in the npm-installed version
- Version pinned via `ARG CLAUDE_CODE_VERSION` with SHA256 checksum verification from the release manifest

## Test plan

- [ ] Verify rootfs builds successfully on both amd64 and arm64
- [ ] Confirm `claude --version` works inside the VM
- [ ] Compare `api_to_cli_init - api_to_cli_spawn` metrics before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)