### PR TITLE
fix(runner): deterministic active_run_ids order in status.json

### DIFF
--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
@@ -45,7 +45,7 @@ pub struct StatusTracker {
 
 struct MutableState {
     mode: RunnerMode,
-    active_run_ids: HashSet<Uuid>,
+    active_run_ids: BTreeSet<Uuid>,
 }
 
 impl StatusTracker {
@@ -56,7 +56,7 @@ impl StatusTracker {
             path,
             state: Mutex::new(MutableState {
                 mode: RunnerMode::Running,
-                active_run_ids: HashSet::new(),
+                active_run_ids: BTreeSet::new(),
             }),
         }
     }


### PR DESCRIPTION
## Summary
- Replace `HashSet<Uuid>` with `BTreeSet<Uuid>` in `StatusTracker` for deterministic `active_run_ids` serialization order in `status.json`
- `HashSet` iteration order is non-deterministic, causing the JSON output to vary between writes even when the set contents are unchanged
- `BTreeSet` maintains sorted order with negligible overhead for this small collection (concurrent sandbox count)

## Test plan
- [x] All 6 existing `status` tests pass (`cargo test -p runner -- status`)
- [x] cargo clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)