### PR TITLE
fix: remove eslint-disable for no-explicit-any in global types

### DIFF
--- a/turbo/apps/web/src/types/global.d.ts
+++ b/turbo/apps/web/src/types/global.d.ts
@@ -1,12 +1,13 @@
 import type { Pool } from "pg";
-import type { PgDatabase } from "drizzle-orm/pg-core";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import type { NeonDatabase } from "drizzle-orm/neon-serverless";
 import type { schema } from "../db/db";
 import type { Env } from "../env";
 
-// Use PgDatabase with any query result type to support both
-// node-postgres (local) and neon-serverless (Vercel serverless) modes
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Database = PgDatabase<any, typeof schema>;
+// Support both node-postgres (local) and neon-serverless (Vercel serverless) modes
+export type Database =
+  | NodePgDatabase<typeof schema>
+  | NeonDatabase<typeof schema>;
 
 export type Services = {
   env: Env;


### PR DESCRIPTION
## What

Remove `eslint-disable-next-line @typescript-eslint/no-explicit-any` from `global.d.ts`.

## Why

Part of #3006 — zero-tolerance policy for lint suppressions.

## How

- Replace `PgDatabase<any, typeof schema>` with explicit union type `NodePgDatabase<typeof schema> | NeonDatabase<typeof schema>`
- This accurately represents the two supported database driver modes (node-postgres for local dev, neon-serverless for Vercel)
- No behavioral change — the union type matches exactly what `init-services.ts` already produces

## Verification

- ✅ `pnpm --filter web lint` — 0 errors
- ✅ `pnpm --filter web test` — 126 files, 1338 tests passed
