### PR TITLE
fix: remove eslint-disable for no-html-link-for-pages in navbar

### DIFF
--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -112,10 +112,9 @@ export default function Navbar() {
                 >
                   {t("contact")}
                 </a>
-                {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-                <a href="/sign-up" className="btn-get-access">
+                <Link href="/sign-up" className="btn-get-access">
                   {t("joinWaitlist")}
-                </a>
+                </Link>
               </>
             )}
             {isSignedIn && (


### PR DESCRIPTION
## What

Remove eslint-disable for @next/next/no-html-link-for-pages in Navbar.tsx.

## Why

Part of #3006 — zero-tolerance policy for lint suppressions.

## How

Replace raw `<a>` tag with Next.js `Link` component for the /sign-up route to enable client-side navigation.

## Verification

- ✅ lint passed
- ✅ 126 test files, 1338 tests passed