### PR TITLE
refactor(connector): replace switch statements with provider registry map

### DIFF
--- a/turbo/apps/web/app/api/connectors/[type]/authorize/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/authorize/route.ts
@@ -4,9 +4,7 @@ import { env } from "../../../../../src/env";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getUserIdFromRequest } from "../../../../../src/lib/auth/get-user-id";
 import { getOrigin } from "../../../../../src/lib/request/get-origin";
-import { buildGitHubAuthorizationUrl } from "../../../../../src/lib/connector/providers/github";
-import { buildNotionAuthorizationUrl } from "../../../../../src/lib/connector/providers/notion";
-import { buildSlackAuthorizationUrl } from "../../../../../src/lib/connector/providers/slack";
+import { PROVIDER_HANDLERS } from "../../../../../src/lib/connector/provider-registry";
 
 /**
  * Connector OAuth Authorize Endpoint
@@ -100,44 +98,17 @@ export async function GET(
   // Check for session parameter (CLI device flow)
   const sessionId = url.searchParams.get("session");
 
-  // Build authorization URL directly from provider
+  // Build authorization URL via provider registry
   const currentEnv = env();
-  let authUrl: string;
-  switch (connectorType) {
-    case "github": {
-      const clientId = currentEnv.GH_OAUTH_CLIENT_ID;
-      if (!clientId) {
-        return NextResponse.json(
-          { error: "GitHub OAuth not configured" },
-          { status: 500 },
-        );
-      }
-      authUrl = buildGitHubAuthorizationUrl(clientId, redirectUri, state);
-      break;
-    }
-    case "notion": {
-      const clientId = currentEnv.NOTION_OAUTH_CLIENT_ID;
-      if (!clientId) {
-        return NextResponse.json(
-          { error: "Notion OAuth not configured" },
-          { status: 500 },
-        );
-      }
-      authUrl = buildNotionAuthorizationUrl(clientId, redirectUri, state);
-      break;
-    }
-    case "slack": {
-      const clientId = currentEnv.SLACK_CLIENT_ID;
-      if (!clientId) {
-        return NextResponse.json(
-          { error: "Slack OAuth not configured" },
-          { status: 500 },
-        );
-      }
-      authUrl = buildSlackAuthorizationUrl(clientId, redirectUri, state);
-      break;
-    }
+  const handler = PROVIDER_HANDLERS[connectorType];
+  const clientId = handler.getClientId(currentEnv);
+  if (!clientId) {
+    return NextResponse.json(
+      { error: `${connectorType} OAuth not configured` },
+      { status: 500 },
+    );
   }
+  const authUrl = handler.buildAuthUrl(clientId, redirectUri, state);
 
   // Create redirect response with state cookie
   const response = NextResponse.redirect(authUrl);

--- a/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
@@ -9,14 +9,9 @@ import { connectorSessions } from "../../../../../src/db/schema/connector-sessio
 import { logger } from "../../../../../src/lib/logger";
 import { getOrigin } from "../../../../../src/lib/request/get-origin";
 import {
-  exchangeGitHubCode,
-  fetchGitHubUserInfo,
-} from "../../../../../src/lib/connector/providers/github";
-import { exchangeNotionCode } from "../../../../../src/lib/connector/providers/notion";
-import {
-  exchangeSlackCode,
-  fetchSlackUserInfo,
-} from "../../../../../src/lib/connector/providers/slack";
+  PROVIDER_HANDLERS,
+  type OAuthTokenResult,
+} from "../../../../../src/lib/connector/provider-registry";
 
 const log = logger("api:connectors:callback");
 
@@ -57,91 +52,19 @@ function buildDeleteCookieHeader(name: string): string {
   return `${name}=; Max-Age=0; Path=/`;
 }
 
-interface OAuthTokenResult {
-  accessToken: string;
-  userInfo: { id: string; username: string | null; email: string | null };
-  oauthScopes: string[];
-}
-
 async function exchangeTokenForConnector(
-  connectorType: "github" | "notion" | "slack",
+  connectorType: keyof typeof PROVIDER_HANDLERS,
   code: string,
   redirectUri: string,
 ): Promise<OAuthTokenResult> {
   const currentEnv = env();
-
-  if (connectorType === "github") {
-    const clientId = currentEnv.GH_OAUTH_CLIENT_ID;
-    const clientSecret = currentEnv.GH_OAUTH_CLIENT_SECRET;
-    if (!clientId || !clientSecret) {
-      throw new Error("GitHub OAuth not configured");
-    }
-    const tokenResult = await exchangeGitHubCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    const ghUser = await fetchGitHubUserInfo(tokenResult.accessToken);
-    return {
-      accessToken: tokenResult.accessToken,
-      userInfo: {
-        id: ghUser.id,
-        username: ghUser.username,
-        email: ghUser.email,
-      },
-      oauthScopes: tokenResult.scopes,
-    };
-  }
-
-  if (connectorType === "notion") {
-    const clientId = currentEnv.NOTION_OAUTH_CLIENT_ID;
-    const clientSecret = currentEnv.NOTION_OAUTH_CLIENT_SECRET;
-    if (!clientId || !clientSecret) {
-      throw new Error("Notion OAuth not configured");
-    }
-    const notionResult = await exchangeNotionCode(
-      clientId,
-      clientSecret,
-      code,
-      redirectUri,
-    );
-    return {
-      accessToken: notionResult.accessToken,
-      userInfo: {
-        id: notionResult.userInfo.id,
-        username: notionResult.userInfo.username,
-        email: notionResult.userInfo.email,
-      },
-      oauthScopes: notionResult.scopes,
-    };
-  }
-
-  // slack
-  const clientId = currentEnv.SLACK_CLIENT_ID;
-  const clientSecret = currentEnv.SLACK_CLIENT_SECRET;
+  const handler = PROVIDER_HANDLERS[connectorType];
+  const clientId = handler.getClientId(currentEnv);
+  const clientSecret = handler.getClientSecret(currentEnv);
   if (!clientId || !clientSecret) {
-    throw new Error("Slack OAuth not configured");
+    throw new Error(`${connectorType} OAuth not configured`);
   }
-  const slackResult = await exchangeSlackCode(
-    clientId,
-    clientSecret,
-    code,
-    redirectUri,
-  );
-  const slackUser = await fetchSlackUserInfo(
-    slackResult.userId,
-    slackResult.accessToken,
-  );
-  return {
-    accessToken: slackResult.accessToken,
-    userInfo: {
-      id: slackUser.id,
-      username: slackUser.username,
-      email: slackUser.email,
-    },
-    oauthScopes: slackResult.scopes,
-  };
+  return handler.exchangeCode(clientId, clientSecret, code, redirectUri);
 }
 
 export async function GET(
@@ -223,8 +146,11 @@ export async function GET(
     const redirectUri = `${origin}/api/connectors/${type}/callback`;
 
     // Exchange code for token directly from provider
-    const { accessToken, userInfo, oauthScopes } =
-      await exchangeTokenForConnector(connectorType, code, redirectUri);
+    const {
+      accessToken,
+      userInfo,
+      scopes: oauthScopes,
+    } = await exchangeTokenForConnector(connectorType, code, redirectUri);
 
     log.debug("Storing connector", {
       userId,

--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -10,9 +10,7 @@ import { encryptCredentialValue } from "../crypto";
 import { notFound, badRequest } from "../errors";
 import { logger } from "../logger";
 import { getUserScopeByClerkId } from "../scope/scope-service";
-import { getGitHubSecretName } from "./providers/github";
-import { getNotionSecretName } from "./providers/notion";
-import { getSlackSecretName } from "./providers/slack";
+import { PROVIDER_HANDLERS } from "./provider-registry";
 
 const log = logger("service:connector");
 
@@ -31,16 +29,8 @@ function parseConnectorType(type: string): ConnectorType {
  * Get secret name for a connector type
  */
 function getSecretNameForConnector(type: ConnectorType): string {
-  switch (type) {
-    case "github":
-      return getGitHubSecretName();
-    case "notion":
-      return getNotionSecretName();
-    case "computer":
-      return "COMPUTER_CONNECTOR_AUTHTOKEN";
-    case "slack":
-      return getSlackSecretName();
-  }
+  if (type === "computer") return "COMPUTER_CONNECTOR_AUTHTOKEN";
+  return PROVIDER_HANDLERS[type].getSecretName();
 }
 
 /**

--- a/turbo/apps/web/src/lib/connector/provider-registry.ts
+++ b/turbo/apps/web/src/lib/connector/provider-registry.ts
@@ -1,0 +1,103 @@
+import { type ConnectorType } from "@vm0/core";
+import { type Env } from "../../env";
+import {
+  buildGitHubAuthorizationUrl,
+  exchangeGitHubCode,
+  fetchGitHubUserInfo,
+  getGitHubSecretName,
+} from "./providers/github";
+import {
+  buildNotionAuthorizationUrl,
+  exchangeNotionCode,
+  getNotionSecretName,
+} from "./providers/notion";
+import {
+  buildSlackAuthorizationUrl,
+  exchangeSlackCode,
+  fetchSlackUserInfo,
+  getSlackSecretName,
+} from "./providers/slack";
+
+export interface OAuthTokenResult {
+  accessToken: string;
+  scopes: string[];
+  userInfo: { id: string; username: string | null; email: string | null };
+}
+
+interface ProviderHandler {
+  buildAuthUrl(clientId: string, redirectUri: string, state: string): string;
+  exchangeCode(
+    clientId: string,
+    clientSecret: string,
+    code: string,
+    redirectUri: string,
+  ): Promise<OAuthTokenResult>;
+  getClientId(currentEnv: Env): string | undefined;
+  getClientSecret(currentEnv: Env): string | undefined;
+  getSecretName(): string;
+}
+
+export const PROVIDER_HANDLERS = {
+  github: {
+    buildAuthUrl: buildGitHubAuthorizationUrl,
+    async exchangeCode(clientId, clientSecret, code, redirectUri) {
+      const { accessToken, scopes } = await exchangeGitHubCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      const userInfo = await fetchGitHubUserInfo(accessToken);
+      return { accessToken, scopes, userInfo };
+    },
+    getClientId: (e) => e.GH_OAUTH_CLIENT_ID,
+    getClientSecret: (e) => e.GH_OAUTH_CLIENT_SECRET,
+    getSecretName: getGitHubSecretName,
+  },
+  notion: {
+    buildAuthUrl: buildNotionAuthorizationUrl,
+    async exchangeCode(clientId, clientSecret, code, redirectUri) {
+      const result = await exchangeNotionCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      return {
+        accessToken: result.accessToken,
+        scopes: result.scopes,
+        userInfo: result.userInfo,
+      };
+    },
+    getClientId: (e) => e.NOTION_OAUTH_CLIENT_ID,
+    getClientSecret: (e) => e.NOTION_OAUTH_CLIENT_SECRET,
+    getSecretName: getNotionSecretName,
+  },
+  slack: {
+    buildAuthUrl: buildSlackAuthorizationUrl,
+    async exchangeCode(clientId, clientSecret, code, redirectUri) {
+      const slackResult = await exchangeSlackCode(
+        clientId,
+        clientSecret,
+        code,
+        redirectUri,
+      );
+      const slackUser = await fetchSlackUserInfo(
+        slackResult.userId,
+        slackResult.accessToken,
+      );
+      return {
+        accessToken: slackResult.accessToken,
+        scopes: slackResult.scopes,
+        userInfo: {
+          id: slackUser.id,
+          username: slackUser.username,
+          email: slackUser.email,
+        },
+      };
+    },
+    getClientId: (e) => e.SLACK_CLIENT_ID,
+    getClientSecret: (e) => e.SLACK_CLIENT_SECRET,
+    getSecretName: getSlackSecretName,
+  },
+} as Record<Exclude<ConnectorType, "computer">, ProviderHandler>;


### PR DESCRIPTION
## Summary

- Introduces `PROVIDER_HANDLERS` registry in `provider-registry.ts` mapping each OAuth connector type to a `ProviderHandler` implementation
- Replaces the three switch statements (in `authorize/route.ts`, `callback/route.ts`, `connector-service.ts`) with registry lookups
- Adding a new OAuth provider in Phase 1 no longer requires editing routing code — only adding an entry to the registry and a provider file

## Changes

| File | Change |
|---|---|
| `src/lib/connector/provider-registry.ts` | New file: `PROVIDER_HANDLERS` registry + `OAuthTokenResult` type |
| `app/api/connectors/[type]/authorize/route.ts` | Replace 3-case switch with `handler.buildAuthUrl()` |
| `app/api/connectors/[type]/callback/route.ts` | Replace `exchangeTokenForConnector` body with registry call |
| `src/lib/connector/connector-service.ts` | Replace `getSecretNameForConnector` switch with registry lookup |

## Test plan

- [x] All 60 existing connector tests pass unchanged
- [x] TypeScript check passes
- [x] Lint passes
- [x] Knip passes (no unused exports)

Closes part of #3297 (prerequisite architecture PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)