### PR TITLE
refactor(connector): extract provider types and handlers into separate files

### DIFF
--- a/turbo/apps/web/src/lib/connector/provider-registry.ts
+++ b/turbo/apps/web/src/lib/connector/provider-registry.ts
@@ -1,103 +1,16 @@
 import { type ConnectorType } from "@vm0/core";
-import { type Env } from "../../env";
-import {
-  buildGitHubAuthorizationUrl,
-  exchangeGitHubCode,
-  fetchGitHubUserInfo,
-  getGitHubSecretName,
-} from "./providers/github";
-import {
-  buildNotionAuthorizationUrl,
-  exchangeNotionCode,
-  getNotionSecretName,
-} from "./providers/notion";
-import {
-  buildSlackAuthorizationUrl,
-  exchangeSlackCode,
-  fetchSlackUserInfo,
-  getSlackSecretName,
-} from "./providers/slack";
+import { type OAuthTokenResult, type ProviderHandler } from "./provider-types";
+import { githubHandler } from "./providers/github-handler";
+import { notionHandler } from "./providers/notion-handler";
+import { slackHandler } from "./providers/slack-handler";
 
-export interface OAuthTokenResult {
-  accessToken: string;
-  scopes: string[];
-  userInfo: { id: string; username: string | null; email: string | null };
-}
+export type { OAuthTokenResult };
 
-interface ProviderHandler {
-  buildAuthUrl(clientId: string, redirectUri: string, state: string): string;
-  exchangeCode(
-    clientId: string,
-    clientSecret: string,
-    code: string,
-    redirectUri: string,
-  ): Promise<OAuthTokenResult>;
-  getClientId(currentEnv: Env): string | undefined;
-  getClientSecret(currentEnv: Env): string | undefined;
-  getSecretName(): string;
-}
-
-export const PROVIDER_HANDLERS = {
-  github: {
-    buildAuthUrl: buildGitHubAuthorizationUrl,
-    async exchangeCode(clientId, clientSecret, code, redirectUri) {
-      const { accessToken, scopes } = await exchangeGitHubCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      const userInfo = await fetchGitHubUserInfo(accessToken);
-      return { accessToken, scopes, userInfo };
-    },
-    getClientId: (e) => e.GH_OAUTH_CLIENT_ID,
-    getClientSecret: (e) => e.GH_OAUTH_CLIENT_SECRET,
-    getSecretName: getGitHubSecretName,
-  },
-  notion: {
-    buildAuthUrl: buildNotionAuthorizationUrl,
-    async exchangeCode(clientId, clientSecret, code, redirectUri) {
-      const result = await exchangeNotionCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      return {
-        accessToken: result.accessToken,
-        scopes: result.scopes,
-        userInfo: result.userInfo,
-      };
-    },
-    getClientId: (e) => e.NOTION_OAUTH_CLIENT_ID,
-    getClientSecret: (e) => e.NOTION_OAUTH_CLIENT_SECRET,
-    getSecretName: getNotionSecretName,
-  },
-  slack: {
-    buildAuthUrl: buildSlackAuthorizationUrl,
-    async exchangeCode(clientId, clientSecret, code, redirectUri) {
-      const slackResult = await exchangeSlackCode(
-        clientId,
-        clientSecret,
-        code,
-        redirectUri,
-      );
-      const slackUser = await fetchSlackUserInfo(
-        slackResult.userId,
-        slackResult.accessToken,
-      );
-      return {
-        accessToken: slackResult.accessToken,
-        scopes: slackResult.scopes,
-        userInfo: {
-          id: slackUser.id,
-          username: slackUser.username,
-          email: slackUser.email,
-        },
-      };
-    },
-    getClientId: (e) => e.SLACK_CLIENT_ID,
-    getClientSecret: (e) => e.SLACK_CLIENT_SECRET,
-    getSecretName: getSlackSecretName,
-  },
-} as Record<Exclude<ConnectorType, "computer">, ProviderHandler>;
+export const PROVIDER_HANDLERS: Record<
+  Exclude<ConnectorType, "computer">,
+  ProviderHandler
+> = {
+  github: githubHandler,
+  notion: notionHandler,
+  slack: slackHandler,
+};

--- a/turbo/apps/web/src/lib/connector/provider-types.ts
+++ b/turbo/apps/web/src/lib/connector/provider-types.ts
@@ -1,0 +1,20 @@
+import { type Env } from "../../env";
+
+export interface OAuthTokenResult {
+  accessToken: string;
+  scopes: string[];
+  userInfo: { id: string; username: string | null; email: string | null };
+}
+
+export interface ProviderHandler {
+  buildAuthUrl(clientId: string, redirectUri: string, state: string): string;
+  exchangeCode(
+    clientId: string,
+    clientSecret: string,
+    code: string,
+    redirectUri: string,
+  ): Promise<OAuthTokenResult>;
+  getClientId(currentEnv: Env): string | undefined;
+  getClientSecret(currentEnv: Env): string | undefined;
+  getSecretName(): string;
+}

--- a/turbo/apps/web/src/lib/connector/providers/github-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/github-handler.ts
@@ -1,0 +1,24 @@
+import { type ProviderHandler } from "../provider-types";
+import {
+  buildGitHubAuthorizationUrl,
+  exchangeGitHubCode,
+  fetchGitHubUserInfo,
+  getGitHubSecretName,
+} from "./github";
+
+export const githubHandler: ProviderHandler = {
+  buildAuthUrl: buildGitHubAuthorizationUrl,
+  async exchangeCode(clientId, clientSecret, code, redirectUri) {
+    const { accessToken, scopes } = await exchangeGitHubCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    const userInfo = await fetchGitHubUserInfo(accessToken);
+    return { accessToken, scopes, userInfo };
+  },
+  getClientId: (e) => e.GH_OAUTH_CLIENT_ID,
+  getClientSecret: (e) => e.GH_OAUTH_CLIENT_SECRET,
+  getSecretName: getGitHubSecretName,
+};

--- a/turbo/apps/web/src/lib/connector/providers/notion-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/notion-handler.ts
@@ -1,0 +1,26 @@
+import { type ProviderHandler } from "../provider-types";
+import {
+  buildNotionAuthorizationUrl,
+  exchangeNotionCode,
+  getNotionSecretName,
+} from "./notion";
+
+export const notionHandler: ProviderHandler = {
+  buildAuthUrl: buildNotionAuthorizationUrl,
+  async exchangeCode(clientId, clientSecret, code, redirectUri) {
+    const result = await exchangeNotionCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    return {
+      accessToken: result.accessToken,
+      scopes: result.scopes,
+      userInfo: result.userInfo,
+    };
+  },
+  getClientId: (e) => e.NOTION_OAUTH_CLIENT_ID,
+  getClientSecret: (e) => e.NOTION_OAUTH_CLIENT_SECRET,
+  getSecretName: getNotionSecretName,
+};

--- a/turbo/apps/web/src/lib/connector/providers/slack-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/slack-handler.ts
@@ -1,0 +1,35 @@
+import { type ProviderHandler } from "../provider-types";
+import {
+  buildSlackAuthorizationUrl,
+  exchangeSlackCode,
+  fetchSlackUserInfo,
+  getSlackSecretName,
+} from "./slack";
+
+export const slackHandler: ProviderHandler = {
+  buildAuthUrl: buildSlackAuthorizationUrl,
+  async exchangeCode(clientId, clientSecret, code, redirectUri) {
+    const slackResult = await exchangeSlackCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+    const slackUser = await fetchSlackUserInfo(
+      slackResult.userId,
+      slackResult.accessToken,
+    );
+    return {
+      accessToken: slackResult.accessToken,
+      scopes: slackResult.scopes,
+      userInfo: {
+        id: slackUser.id,
+        username: slackUser.username,
+        email: slackUser.email,
+      },
+    };
+  },
+  getClientId: (e) => e.SLACK_CLIENT_ID,
+  getClientSecret: (e) => e.SLACK_CLIENT_SECRET,
+  getSecretName: getSlackSecretName,
+};


### PR DESCRIPTION
## Summary

- Extracts `OAuthTokenResult` and `ProviderHandler` interfaces into a new `provider-types.ts` file
- Moves each provider's handler object (GitHub, Notion, Slack) into dedicated handler files (`github-handler.ts`, `notion-handler.ts`, `slack-handler.ts`)
- Slims down `provider-registry.ts` to only contain the `PROVIDER_HANDLERS` map, delegating implementation details to individual handler files

## Test plan
- [ ] Verify existing OAuth connector flows work for GitHub, Notion, and Slack
- [ ] Confirm TypeScript type checking passes (`pnpm check-types`)
- [ ] Confirm lint passes (`pnpm turbo run lint`)