### PR TITLE
feat(cli): add vm0 upgrade command

### DIFF
--- a/turbo/apps/cli/src/commands/upgrade/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/upgrade/__tests__/index.test.ts
@@ -63,9 +63,9 @@ describe("upgrade command", () => {
       .map((call) => call[0])
       .filter((log): log is string => typeof log === "string");
 
-    expect(allLogs.some((log) => log.includes("Upgraded to 99.0.0"))).toBe(
-      true,
-    );
+    expect(
+      allLogs.some((log) => log.includes("Upgraded from 0.0.0-test to 99.0.0")),
+    ).toBe(true);
   });
 
   it("should upgrade via pnpm when installed with pnpm", async () => {

--- a/turbo/apps/cli/src/commands/upgrade/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/upgrade/__tests__/index.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for upgrade command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): npm registry via MSW, child_process.spawn
+ * - Real (internal): All CLI code including update-checker logic
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { createMockChildProcess } from "../../../mocks/spawn-helpers";
+
+// Mock child_process for package manager commands (external tools)
+vi.mock("child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+import { spawn } from "child_process";
+import { upgradeCommand } from "..";
+
+describe("upgrade command", () => {
+  const originalArgv = process.argv;
+
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: npm package manager
+    process.argv = ["/usr/bin/node", "/usr/local/bin/vm0"];
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+  });
+
+  it("should upgrade via npm when new version is available", async () => {
+    server.use(
+      http.get("https://registry.npmjs.org/*/latest", () => {
+        return HttpResponse.json({ version: "99.0.0" });
+      }),
+    );
+    vi.mocked(spawn).mockImplementation(
+      () => createMockChildProcess(0) as never,
+    );
+
+    await upgradeCommand.parseAsync(["node", "cli"]);
+
+    expect(spawn).toHaveBeenCalledWith(
+      "npm",
+      ["install", "-g", "@vm0/cli@latest"],
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+
+    const allLogs = mockConsoleLog.mock.calls
+      .map((call) => call[0])
+      .filter((log): log is string => typeof log === "string");
+
+    expect(allLogs.some((log) => log.includes("Upgraded to 99.0.0"))).toBe(
+      true,
+    );
+  });
+
+  it("should upgrade via pnpm when installed with pnpm", async () => {
+    process.argv = [
+      "/usr/bin/node",
+      "/home/user/.local/share/pnpm/global/5/node_modules/.bin/vm0",
+    ];
+
+    server.use(
+      http.get("https://registry.npmjs.org/*/latest", () => {
+        return HttpResponse.json({ version: "99.0.0" });
+      }),
+    );
+    vi.mocked(spawn).mockImplementation(
+      () => createMockChildProcess(0) as never,
+    );
+
+    await upgradeCommand.parseAsync(["node", "cli"]);
+
+    expect(spawn).toHaveBeenCalledWith(
+      "pnpm",
+      ["add", "-g", "@vm0/cli@latest"],
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+  });
+
+  it("should report already up to date when on latest version", async () => {
+    server.use(
+      http.get("https://registry.npmjs.org/*/latest", () => {
+        return HttpResponse.json({ version: "0.0.0-test" });
+      }),
+    );
+
+    await upgradeCommand.parseAsync(["node", "cli"]);
+
+    expect(spawn).not.toHaveBeenCalled();
+
+    const allLogs = mockConsoleLog.mock.calls
+      .map((call) => call[0])
+      .filter((log): log is string => typeof log === "string");
+
+    expect(allLogs.some((log) => log.includes("Already up to date"))).toBe(
+      true,
+    );
+  });
+
+  it("should exit with error when version check fails", async () => {
+    server.use(
+      http.get("https://registry.npmjs.org/*/latest", () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    await expect(async () => {
+      await upgradeCommand.parseAsync(["node", "cli"]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(spawn).not.toHaveBeenCalled();
+
+    const allErrors = mockConsoleError.mock.calls
+      .map((call) => call[0])
+      .filter((log): log is string => typeof log === "string");
+
+    expect(
+      allErrors.some((log) => log.includes("Could not check for updates")),
+    ).toBe(true);
+  });
+
+  it("should show manual instructions for bun", async () => {
+    process.argv = ["/usr/bin/node", "/home/user/.bun/bin/vm0"];
+
+    server.use(
+      http.get("https://registry.npmjs.org/*/latest", () => {
+        return HttpResponse.json({ version: "99.0.0" });
+      }),
+    );
+
+    await upgradeCommand.parseAsync(["node", "cli"]);
+
+    expect(spawn).not.toHaveBeenCalled();
+
+    const allLogs = mockConsoleLog.mock.calls
+      .map((call) => call[0])
+      .filter((log): log is string => typeof log === "string");
+
+    expect(allLogs.some((log) => log.includes("not supported for bun"))).toBe(
+      true,
+    );
+    expect(
+      allLogs.some((log) => log.includes("bun add -g @vm0/cli@latest")),
+    ).toBe(true);
+  });
+
+  it("should show manual instructions for yarn", async () => {
+    process.argv = ["/usr/bin/node", "/home/user/.yarn/bin/vm0"];
+
+    server.use(
+      http.get("https://registry.npmjs.org/*/latest", () => {
+        return HttpResponse.json({ version: "99.0.0" });
+      }),
+    );
+
+    await upgradeCommand.parseAsync(["node", "cli"]);
+
+    expect(spawn).not.toHaveBeenCalled();
+
+    const allLogs = mockConsoleLog.mock.calls
+      .map((call) => call[0])
+      .filter((log): log is string => typeof log === "string");
+
+    expect(allLogs.some((log) => log.includes("not supported for yarn"))).toBe(
+      true,
+    );
+    expect(
+      allLogs.some((log) => log.includes("yarn global add @vm0/cli@latest")),
+    ).toBe(true);
+  });
+
+  it("should show manual instructions for unknown package manager", async () => {
+    process.argv = ["/usr/bin/node", "/some/random/path/vm0"];
+
+    server.use(
+      http.get("https://registry.npmjs.org/*/latest", () => {
+        return HttpResponse.json({ version: "99.0.0" });
+      }),
+    );
+
+    await upgradeCommand.parseAsync(["node", "cli"]);
+
+    expect(spawn).not.toHaveBeenCalled();
+
+    const allLogs = mockConsoleLog.mock.calls
+      .map((call) => call[0])
+      .filter((log): log is string => typeof log === "string");
+
+    expect(
+      allLogs.some((log) =>
+        log.includes("Could not detect your package manager"),
+      ),
+    ).toBe(true);
+    expect(
+      allLogs.some((log) => log.includes("npm install -g @vm0/cli@latest")),
+    ).toBe(true);
+  });
+
+  it("should show error when upgrade fails", async () => {
+    server.use(
+      http.get("https://registry.npmjs.org/*/latest", () => {
+        return HttpResponse.json({ version: "99.0.0" });
+      }),
+    );
+    vi.mocked(spawn).mockImplementation(
+      () => createMockChildProcess(1) as never,
+    );
+
+    await expect(async () => {
+      await upgradeCommand.parseAsync(["node", "cli"]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+
+    const allErrors = mockConsoleError.mock.calls
+      .map((call) => call[0])
+      .filter((log): log is string => typeof log === "string");
+
+    expect(allErrors.some((log) => log.includes("Upgrade failed"))).toBe(true);
+    expect(
+      allErrors.some((log) => log.includes("npm install -g @vm0/cli@latest")),
+    ).toBe(true);
+  });
+});

--- a/turbo/apps/cli/src/commands/upgrade/index.ts
+++ b/turbo/apps/cli/src/commands/upgrade/index.ts
@@ -32,7 +32,7 @@ export const upgradeCommand = new Command()
 
     console.log(
       chalk.yellow(
-        `Current version: ${__CLI_VERSION__} → Latest version: ${latestVersion}`,
+        `Current version: ${__CLI_VERSION__} -> Latest version: ${latestVersion}`,
       ),
     );
     console.log();

--- a/turbo/apps/cli/src/commands/upgrade/index.ts
+++ b/turbo/apps/cli/src/commands/upgrade/index.ts
@@ -1,0 +1,70 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import {
+  detectPackageManager,
+  getLatestVersion,
+  getManualUpgradeCommand,
+  isAutoUpgradeSupported,
+  performUpgrade,
+} from "../../lib/utils/update-checker";
+
+declare const __CLI_VERSION__: string;
+
+export const upgradeCommand = new Command()
+  .name("upgrade")
+  .description("Upgrade vm0 CLI to the latest version")
+  .action(async () => {
+    console.log("Checking for updates...");
+
+    const latestVersion = await getLatestVersion();
+
+    if (latestVersion === null) {
+      console.error(
+        chalk.yellow("⚠ Could not check for updates. Please try again later."),
+      );
+      process.exit(1);
+    }
+
+    if (latestVersion === __CLI_VERSION__) {
+      console.log(chalk.green(`✓ Already up to date (${__CLI_VERSION__})`));
+      return;
+    }
+
+    console.log(
+      chalk.yellow(
+        `Current version: ${__CLI_VERSION__} → Latest version: ${latestVersion}`,
+      ),
+    );
+    console.log();
+
+    const packageManager = detectPackageManager();
+
+    if (!isAutoUpgradeSupported(packageManager)) {
+      if (packageManager === "unknown") {
+        console.log(
+          chalk.yellow(
+            "Could not detect your package manager for auto-upgrade.",
+          ),
+        );
+      } else {
+        console.log(
+          chalk.yellow(`Auto-upgrade is not supported for ${packageManager}.`),
+        );
+      }
+      console.log(chalk.yellow("Please upgrade manually:"));
+      console.log(chalk.cyan(`  ${getManualUpgradeCommand(packageManager)}`));
+      return;
+    }
+
+    console.log(`Upgrading via ${packageManager}...`);
+    const success = await performUpgrade(packageManager);
+
+    if (success) {
+      console.log(chalk.green(`✓ Upgraded to ${latestVersion}`));
+      return;
+    }
+
+    console.error(chalk.red("✗ Upgrade failed. Please run manually:"));
+    console.error(chalk.cyan(`  ${getManualUpgradeCommand(packageManager)}`));
+    process.exit(1);
+  });

--- a/turbo/apps/cli/src/commands/upgrade/index.ts
+++ b/turbo/apps/cli/src/commands/upgrade/index.ts
@@ -60,7 +60,9 @@ export const upgradeCommand = new Command()
     const success = await performUpgrade(packageManager);
 
     if (success) {
-      console.log(chalk.green(`✓ Upgraded to ${latestVersion}`));
+      console.log(
+        chalk.green(`✓ Upgraded from ${__CLI_VERSION__} to ${latestVersion}`),
+      );
       return;
     }
 

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -24,6 +24,7 @@ import { setupClaudeCommand } from "./commands/setup-claude";
 import { dashboardCommand } from "./commands/dashboard";
 import { devToolCommand } from "./commands/dev-tool";
 import { preferenceCommand } from "./commands/preference";
+import { upgradeCommand } from "./commands/upgrade";
 
 const program = new Command();
 
@@ -56,6 +57,7 @@ program.addCommand(onboardCommand);
 program.addCommand(setupClaudeCommand);
 program.addCommand(dashboardCommand);
 program.addCommand(preferenceCommand);
+program.addCommand(upgradeCommand);
 program.addCommand(devToolCommand, { hidden: true });
 
 export { program };

--- a/turbo/apps/cli/src/lib/utils/update-checker.ts
+++ b/turbo/apps/cli/src/lib/utils/update-checker.ts
@@ -66,14 +66,16 @@ export function detectPackageManager(): PackageManager {
 /**
  * Check if the package manager supports auto-upgrade
  */
-function isAutoUpgradeSupported(pm: PackageManager): pm is "npm" | "pnpm" {
+export function isAutoUpgradeSupported(
+  pm: PackageManager,
+): pm is "npm" | "pnpm" {
   return pm === "npm" || pm === "pnpm";
 }
 
 /**
  * Get the manual upgrade command for a package manager
  */
-function getManualUpgradeCommand(pm: PackageManager): string {
+export function getManualUpgradeCommand(pm: PackageManager): string {
   switch (pm) {
     case "bun":
       return `bun add -g ${PACKAGE_NAME}@latest`;
@@ -110,7 +112,7 @@ function buildRerunCommand(prompt: string | undefined): string {
  * Fetch the latest version of the package from npm registry
  * Returns null if the request fails or times out
  */
-async function getLatestVersion(): Promise<string | null> {
+export async function getLatestVersion(): Promise<string | null> {
   try {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
@@ -138,7 +140,9 @@ async function getLatestVersion(): Promise<string | null> {
  * - pnpm: pnpm add -g @vm0/cli@latest
  * Returns true on success, false on failure
  */
-function performUpgrade(packageManager: "npm" | "pnpm"): Promise<boolean> {
+export function performUpgrade(
+  packageManager: "npm" | "pnpm",
+): Promise<boolean> {
   return new Promise((resolve) => {
     const isWindows = process.platform === "win32";
     const command = isWindows ? `${packageManager}.cmd` : packageManager;


### PR DESCRIPTION
## Summary

- Add a new `vm0 upgrade` command that allows users to manually upgrade the CLI to the latest version
- Export internal upgrade utilities from `update-checker.ts` for reuse by the new command
- The command detects the user's package manager and executes the appropriate upgrade command (npm/pnpm), or shows manual instructions for unsupported package managers (bun/yarn/unknown)

Closes #3242

## Test plan

- [x] Integration tests covering all 8 upgrade scenarios (npm upgrade, pnpm upgrade, already up to date, version check failure, bun/yarn/unknown manual instructions, upgrade failure)
- [ ] Verify `vm0 upgrade` appears in `vm0 --help` output
- [ ] Verify existing auto-upgrade tests still pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)