### PR TITLE
feat(cli): detect field typos in vm0.yaml agent definitions

### DIFF
--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -354,6 +354,172 @@ describe("compose command", () => {
     });
   });
 
+  describe("field typo detection", () => {
+    it("should detect plural typo 'environments' and suggest 'environment'", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "config.yaml"),
+        `version: "1.0"\nagents:\n  test-agent:\n    framework: anthropic\n    environments:\n      MY_VAR: foo`,
+      );
+
+      await expect(async () => {
+        await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Did you mean "environment"'),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should detect singular typo 'volume' and suggest 'volumes'", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "config.yaml"),
+        `version: "1.0"\nagents:\n  test-agent:\n    framework: anthropic\n    volume:\n      - data:/data`,
+      );
+
+      await expect(async () => {
+        await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Did you mean "volumes"'),
+      );
+    });
+
+    it("should detect singular typo 'skill' and suggest 'skills'", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "config.yaml"),
+        `version: "1.0"\nagents:\n  test-agent:\n    framework: anthropic\n    skill:\n      - https://github.com/org/repo/tree/main/path`,
+      );
+
+      await expect(async () => {
+        await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Did you mean "skills"'),
+      );
+    });
+
+    it("should detect misspelling 'framwork' and suggest 'framework'", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "config.yaml"),
+        `version: "1.0"\nagents:\n  test-agent:\n    framwork: anthropic`,
+      );
+
+      await expect(async () => {
+        await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Did you mean "framework"'),
+      );
+    });
+
+    it("should detect abbreviation 'env' and suggest 'environment'", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "config.yaml"),
+        `version: "1.0"\nagents:\n  test-agent:\n    framework: anthropic\n    env:\n      MY_VAR: foo`,
+      );
+
+      await expect(async () => {
+        await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Did you mean "environment"'),
+      );
+    });
+
+    it("should detect abbreviation 'desc' and suggest 'description'", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "config.yaml"),
+        `version: "1.0"\nagents:\n  test-agent:\n    framework: anthropic\n    desc: my agent`,
+      );
+
+      await expect(async () => {
+        await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Did you mean "description"'),
+      );
+    });
+
+    it("should allow unknown fields that do not resemble known fields", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "config.yaml"),
+        `version: "1.0"\nagents:\n  test-agent:\n    framework: claude-code\n    foobar: something`,
+      );
+      server.use(
+        http.post("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json({
+            composeId: "cmp-123",
+            name: "test-agent",
+            versionId:
+              "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6",
+            action: "created",
+          });
+        }),
+        http.get("http://localhost:3000/api/scope", () => {
+          return HttpResponse.json(scopeResponse);
+        }),
+      );
+
+      await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
+
+      // Should not have exited with error
+      expect(mockConsoleError).not.toHaveBeenCalledWith(
+        expect.stringContaining("Did you mean"),
+      );
+    });
+
+    it("should report multiple typos at once", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "config.yaml"),
+        `version: "1.0"\nagents:\n  test-agent:\n    framework: anthropic\n    environments:\n      MY_VAR: foo\n    skill:\n      - https://github.com/org/repo/tree/main/path`,
+      );
+
+      await expect(async () => {
+        await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Did you mean "environment"'),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Did you mean "skills"'),
+      );
+    });
+
+    it("should not flag valid 'environment' field as typo", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "config.yaml"),
+        `version: "1.0"\nagents:\n  test-agent:\n    framework: claude-code\n    environment:\n      MY_VAR: foo`,
+      );
+      server.use(
+        http.post("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json({
+            composeId: "cmp-123",
+            name: "test-agent",
+            versionId:
+              "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6",
+            action: "created",
+          });
+        }),
+        http.get("http://localhost:3000/api/scope", () => {
+          return HttpResponse.json(scopeResponse);
+        }),
+      );
+
+      await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
+
+      expect(mockConsoleError).not.toHaveBeenCalledWith(
+        expect.stringContaining("Did you mean"),
+      );
+    });
+  });
+
   describe("API interaction", () => {
     beforeEach(async () => {
       await fs.writeFile(

--- a/turbo/apps/cli/src/lib/domain/yaml-validator.ts
+++ b/turbo/apps/cli/src/lib/domain/yaml-validator.ts
@@ -300,10 +300,12 @@ function findSimilarField(
 }
 
 /**
- * Checks for unknown fields in agent definitions that look like typos.
- * Returns an error message listing all detected typos, or null if none found.
+ * Extracts agent entries from raw config, with type guards.
+ * Returns null if config structure is invalid for agent inspection.
  */
-function checkForFieldTypos(config: unknown): string | null {
+function extractAgentEntries(
+  config: unknown,
+): Record<string, Record<string, unknown>> | null {
   if (!config || typeof config !== "object") return null;
   const cfg = config as Record<string, unknown>;
   const agents = cfg.agents as
@@ -311,6 +313,16 @@ function checkForFieldTypos(config: unknown): string | null {
     | undefined;
   if (!agents || typeof agents !== "object" || Array.isArray(agents))
     return null;
+  return agents;
+}
+
+/**
+ * Checks for unknown fields in agent definitions that look like typos.
+ * Returns an error message listing all detected typos, or null if none found.
+ */
+function checkForFieldTypos(config: unknown): string | null {
+  const agents = extractAgentEntries(config);
+  if (!agents) return null;
 
   const errors: string[] = [];
 
@@ -336,13 +348,8 @@ function checkForFieldTypos(config: unknown): string | null {
  * Checks for deprecated 'provider' field and returns migration error message
  */
 function checkForDeprecatedProvider(config: unknown): string | null {
-  if (!config || typeof config !== "object") return null;
-  const cfg = config as Record<string, unknown>;
-  const agents = cfg.agents as
-    | Record<string, Record<string, unknown>>
-    | undefined;
-  if (!agents || typeof agents !== "object" || Array.isArray(agents))
-    return null;
+  const agents = extractAgentEntries(config);
+  if (!agents) return null;
 
   for (const agent of Object.values(agents)) {
     if (agent && typeof agent === "object" && !Array.isArray(agent)) {

--- a/turbo/apps/cli/src/lib/domain/yaml-validator.ts
+++ b/turbo/apps/cli/src/lib/domain/yaml-validator.ts
@@ -228,22 +228,10 @@ export function validateAgentName(name: string): boolean {
 }
 
 /**
- * Known fields in agent definition schema.
+ * Known fields in agent definition schema, derived from the Zod schema shape.
  * Used for typo detection against unknown fields in YAML config.
  */
-const KNOWN_AGENT_FIELDS = [
-  "description",
-  "framework",
-  "apps",
-  "volumes",
-  "environment",
-  "instructions",
-  "skills",
-  "experimental_runner",
-  "experimental_firewall",
-  "image",
-  "working_dir",
-];
+const KNOWN_AGENT_FIELDS = Object.keys(agentDefinitionSchema.shape);
 
 /**
  * Computes Levenshtein edit distance between two strings.

--- a/turbo/apps/cli/src/lib/domain/yaml-validator.ts
+++ b/turbo/apps/cli/src/lib/domain/yaml-validator.ts
@@ -228,6 +228,123 @@ export function validateAgentName(name: string): boolean {
 }
 
 /**
+ * Known fields in agent definition schema.
+ * Used for typo detection against unknown fields in YAML config.
+ */
+const KNOWN_AGENT_FIELDS = [
+  "description",
+  "framework",
+  "apps",
+  "volumes",
+  "environment",
+  "instructions",
+  "skills",
+  "experimental_runner",
+  "experimental_firewall",
+  "image",
+  "working_dir",
+];
+
+/**
+ * Computes Levenshtein edit distance between two strings.
+ * Uses single-row DP optimization for O(min(m,n)) space.
+ */
+function levenshteinDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  // Ensure a is the shorter string for space optimization
+  if (a.length > b.length) [a, b] = [b, a];
+
+  const row = Array.from({ length: a.length + 1 }, (_, i) => i);
+
+  for (let j = 1; j <= b.length; j++) {
+    let prev = j - 1;
+    row[0] = j;
+    for (let i = 1; i <= a.length; i++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      const current = Math.min(
+        row[i]! + 1, // deletion
+        row[i - 1]! + 1, // insertion
+        prev + cost, // substitution
+      );
+      prev = row[i]!;
+      row[i] = current;
+    }
+  }
+
+  return row[a.length]!;
+}
+
+/**
+ * Finds the most similar known field for an unknown field name.
+ * Uses two strategies:
+ * 1. Levenshtein distance ≤ 2 for close typos (e.g., "environments" → "environment")
+ * 2. Prefix containment for abbreviations (e.g., "env" → "environment")
+ *
+ * Returns the best matching field name, or null if no match found.
+ */
+function findSimilarField(
+  unknown: string,
+  knownFields: string[],
+): string | null {
+  let bestMatch: string | null = null;
+  let bestDistance = Infinity;
+
+  for (const known of knownFields) {
+    if (unknown === known) continue;
+
+    // Check 1: Levenshtein distance ≤ 2
+    const distance = levenshteinDistance(unknown, known);
+    if (distance <= 2 && distance < bestDistance) {
+      bestDistance = distance;
+      bestMatch = known;
+    }
+
+    // Check 2: Prefix containment (unknown is a prefix of known, min 3 chars)
+    if (unknown.length >= 3 && known.startsWith(unknown) && !bestMatch) {
+      bestMatch = known;
+    }
+  }
+
+  return bestMatch;
+}
+
+/**
+ * Checks for unknown fields in agent definitions that look like typos.
+ * Returns an error message listing all detected typos, or null if none found.
+ */
+function checkForFieldTypos(config: unknown): string | null {
+  if (!config || typeof config !== "object") return null;
+  const cfg = config as Record<string, unknown>;
+  const agents = cfg.agents as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  if (!agents || typeof agents !== "object" || Array.isArray(agents))
+    return null;
+
+  const errors: string[] = [];
+
+  for (const [agentName, agent] of Object.entries(agents)) {
+    if (!agent || typeof agent !== "object" || Array.isArray(agent)) continue;
+
+    for (const field of Object.keys(agent)) {
+      if (KNOWN_AGENT_FIELDS.includes(field)) continue;
+
+      const suggestion = findSimilarField(field, KNOWN_AGENT_FIELDS);
+      if (suggestion) {
+        errors.push(
+          `Unknown field "${field}" in agent "${agentName}". Did you mean "${suggestion}"?`,
+        );
+      }
+    }
+  }
+
+  return errors.length > 0 ? errors.join("\n") : null;
+}
+
+/**
  * Checks for deprecated 'provider' field and returns migration error message
  */
 function checkForDeprecatedProvider(config: unknown): string | null {
@@ -261,6 +378,12 @@ export function validateAgentCompose(config: unknown): {
   const deprecationError = checkForDeprecatedProvider(config);
   if (deprecationError) {
     return { valid: false, error: deprecationError };
+  }
+
+  // Pre-check: Detect likely typos in agent definition fields
+  const typoError = checkForFieldTypos(config);
+  if (typoError) {
+    return { valid: false, error: typoError };
   }
 
   // Pre-check: Better error for array agents (common mistake)


### PR DESCRIPTION
## Summary

- Add typo detection for unknown fields in agent definitions that closely resemble known fields
- Uses a hybrid approach: Levenshtein distance (≤2) for close typos + prefix containment for abbreviations
- Catches common mistakes: `environments` → `environment`, `env` → `environment`, `volume` → `volumes`, `framwork` → `framework`, etc.
- Unknown fields that don't resemble any known field are silently ignored (forward compatibility)

## How it works

A new pre-check runs before Zod validation (which strips unknown keys) on the raw YAML config:

1. For each agent definition, collect fields not in the known list
2. For each unknown field, check similarity against known fields:
   - **Levenshtein distance ≤ 2**: catches `environments`/`environment`, `framwork`/`framework`
   - **Prefix match (min 3 chars)**: catches `env`/`environment`, `desc`/`description`
3. If matches found, report error with "Did you mean X?" suggestion and exit

## Test plan

- [x] Detects plural typos (`environments` → `environment`)
- [x] Detects singular typos (`volume` → `volumes`, `skill` → `skills`)
- [x] Detects misspellings (`framwork` → `framework`)
- [x] Detects abbreviations (`env` → `environment`, `desc` → `description`)
- [x] Allows truly unknown fields (`foobar` passes through)
- [x] Reports multiple typos at once
- [x] Does not flag valid known fields
- [x] All 840 CLI tests pass

Closes #3291

🤖 Generated with [Claude Code](https://claude.com/claude-code)