### PR TITLE
refactor: extract shared helpers to reduce duplication in web services

### DIFF
--- a/turbo/apps/web/src/lib/computer-connector/computer-connector-service.ts
+++ b/turbo/apps/web/src/lib/computer-connector/computer-connector-service.ts
@@ -9,10 +9,11 @@ import { eq, and } from "drizzle-orm";
 import type { ComputerConnectorCreateResponse } from "@vm0/core";
 import { connectors } from "../../db/schema/connector";
 import { secrets } from "../../db/schema/secret";
-import { encryptCredentialValue, decryptCredentialValue } from "../crypto";
+import { decryptCredentialValue } from "../crypto";
 import { badRequest, conflict, notFound } from "../errors";
 import { logger } from "../logger";
 import { getUserScopeByClerkId } from "../scope/scope-service";
+import { upsertSecretByScope } from "../secret/secret-service";
 import {
   findOrCreateBotUser,
   createCredential,
@@ -30,46 +31,6 @@ const COMPUTER_SECRETS = [
   "COMPUTER_CONNECTOR_DOMAIN_ID",
   "COMPUTER_CONNECTOR_DOMAIN",
 ] as const;
-
-/**
- * Upsert a single connector secret (type="connector").
- */
-async function upsertSecret(
-  scopeId: string,
-  name: string,
-  value: string,
-): Promise<void> {
-  const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
-  const encryptedValue = encryptCredentialValue(value, encryptionKey);
-  const db = globalThis.services.db;
-
-  const [existing] = await db
-    .select({ id: secrets.id })
-    .from(secrets)
-    .where(
-      and(
-        eq(secrets.scopeId, scopeId),
-        eq(secrets.name, name),
-        eq(secrets.type, "connector"),
-      ),
-    )
-    .limit(1);
-
-  if (existing) {
-    await db
-      .update(secrets)
-      .set({ encryptedValue, updatedAt: new Date() })
-      .where(eq(secrets.id, existing.id));
-  } else {
-    await db.insert(secrets).values({
-      scopeId,
-      name,
-      encryptedValue,
-      type: "connector",
-      description: `Computer connector: ${name}`,
-    });
-  }
-}
 
 /**
  * Create a computer connector with ngrok tunnel credentials.
@@ -197,9 +158,27 @@ export async function createComputerConnector(
 
   // Store secrets (ngrok token is one-time use, returned to client only)
   await Promise.all([
-    upsertSecret(scope.id, "COMPUTER_CONNECTOR_BRIDGE_TOKEN", bridgeToken),
-    upsertSecret(scope.id, "COMPUTER_CONNECTOR_DOMAIN_ID", reservedDomain.id),
-    upsertSecret(scope.id, "COMPUTER_CONNECTOR_DOMAIN", domain),
+    upsertSecretByScope(
+      scope.id,
+      "COMPUTER_CONNECTOR_BRIDGE_TOKEN",
+      bridgeToken,
+      "connector",
+      "Computer connector: COMPUTER_CONNECTOR_BRIDGE_TOKEN",
+    ),
+    upsertSecretByScope(
+      scope.id,
+      "COMPUTER_CONNECTOR_DOMAIN_ID",
+      reservedDomain.id,
+      "connector",
+      "Computer connector: COMPUTER_CONNECTOR_DOMAIN_ID",
+    ),
+    upsertSecretByScope(
+      scope.id,
+      "COMPUTER_CONNECTOR_DOMAIN",
+      domain,
+      "connector",
+      "Computer connector: COMPUTER_CONNECTOR_DOMAIN",
+    ),
   ]);
 
   log.debug("Computer connector created", {

--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -6,10 +6,10 @@ import {
 } from "@vm0/core";
 import { connectors } from "../../db/schema/connector";
 import { secrets } from "../../db/schema/secret";
-import { encryptCredentialValue } from "../crypto";
 import { notFound, badRequest } from "../errors";
 import { logger } from "../logger";
 import { getUserScopeByClerkId } from "../scope/scope-service";
+import { upsertSecretByScope } from "../secret/secret-service";
 import { PROVIDER_HANDLERS } from "./provider-registry";
 
 const log = logger("service:connector");
@@ -142,9 +142,6 @@ export async function upsertOAuthConnector(
   }
 
   const secretName = getSecretNameForConnector(type);
-  const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
-  const encryptedValue = encryptCredentialValue(accessToken, encryptionKey);
-
   const db = globalThis.services.db;
 
   // Check if connector exists
@@ -157,35 +154,13 @@ export async function upsertOAuthConnector(
   const isUpdate = existingConnector.length > 0;
 
   // Upsert secret with type="connector"
-  const existingSecret = await db
-    .select({ id: secrets.id })
-    .from(secrets)
-    .where(
-      and(
-        eq(secrets.scopeId, scope.id),
-        eq(secrets.name, secretName),
-        eq(secrets.type, "connector"),
-      ),
-    )
-    .limit(1);
-
-  if (existingSecret[0]) {
-    await db
-      .update(secrets)
-      .set({
-        encryptedValue,
-        updatedAt: new Date(),
-      })
-      .where(eq(secrets.id, existingSecret[0].id));
-  } else {
-    await db.insert(secrets).values({
-      scopeId: scope.id,
-      name: secretName,
-      encryptedValue,
-      type: "connector",
-      description: `OAuth token for ${type} connector`,
-    });
-  }
+  await upsertSecretByScope(
+    scope.id,
+    secretName,
+    accessToken,
+    "connector",
+    `OAuth token for ${type} connector`,
+  );
 
   // Upsert connector
   let connectorRow: {
@@ -316,34 +291,11 @@ export async function upsertConnectorSecret(
     throw notFound("User scope not found");
   }
 
-  const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
-  const encryptedValue = encryptCredentialValue(secretValue, encryptionKey);
-  const db = globalThis.services.db;
-
-  const existingSecret = await db
-    .select({ id: secrets.id })
-    .from(secrets)
-    .where(
-      and(
-        eq(secrets.scopeId, scope.id),
-        eq(secrets.name, secretName),
-        eq(secrets.type, "connector"),
-      ),
-    )
-    .limit(1);
-
-  if (existingSecret[0]) {
-    await db
-      .update(secrets)
-      .set({ encryptedValue, updatedAt: new Date() })
-      .where(eq(secrets.id, existingSecret[0].id));
-  } else {
-    await db.insert(secrets).values({
-      scopeId: scope.id,
-      name: secretName,
-      encryptedValue,
-      type: "connector",
-      description: `Connector secret: ${secretName}`,
-    });
-  }
+  await upsertSecretByScope(
+    scope.id,
+    secretName,
+    secretValue,
+    "connector",
+    `Connector secret: ${secretName}`,
+  );
 }

--- a/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
@@ -33,6 +33,54 @@ interface ModelProviderInfo {
 }
 
 /**
+ * Build a ModelProviderInfo from raw fields.
+ * Derives framework from type, and secretNames from authMethod when not explicitly provided.
+ */
+function toModelProviderInfo(params: {
+  id: string;
+  type: ModelProviderType;
+  secretName?: string | null;
+  authMethod?: string | null;
+  secretNames?: string[] | null;
+  isDefault: boolean;
+  selectedModel: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}): ModelProviderInfo {
+  const authMethod = params.authMethod ?? null;
+  const secretNames =
+    params.secretNames !== undefined
+      ? params.secretNames
+      : authMethod
+        ? (getSecretNamesForAuthMethod(params.type, authMethod) ?? null)
+        : null;
+
+  return {
+    id: params.id,
+    type: params.type,
+    framework: getFrameworkForType(params.type),
+    secretName: params.secretName ?? null,
+    authMethod,
+    secretNames,
+    isDefault: params.isDefault,
+    selectedModel: params.selectedModel,
+    createdAt: params.createdAt,
+    updatedAt: params.updatedAt,
+  };
+}
+
+/**
+ * Check if user already has a provider for the given framework.
+ */
+async function hasExistingProviderForFramework(
+  clerkUserId: string,
+  framework: ModelProviderFramework,
+): Promise<boolean> {
+  const allProviders = await listModelProviders(clerkUserId);
+  return allProviders.some((p) => p.framework === framework);
+}
+
+/**
  * List all model providers for a user's scope
  */
 export async function listModelProviders(
@@ -60,29 +108,18 @@ export async function listModelProviders(
     .where(eq(modelProviders.scopeId, scope.id))
     .orderBy(modelProviders.type);
 
-  return result.map((row) => {
-    const providerType = row.type as ModelProviderType;
-    const isMultiAuth = hasAuthMethods(providerType);
-
-    // For multi-auth providers, get secret names from config
-    let secretNames: string[] | undefined;
-    if (isMultiAuth && row.authMethod) {
-      secretNames = getSecretNamesForAuthMethod(providerType, row.authMethod);
-    }
-
-    return {
+  return result.map((row) =>
+    toModelProviderInfo({
       id: row.id,
-      type: providerType,
-      framework: getFrameworkForType(providerType),
+      type: row.type as ModelProviderType,
       secretName: row.secretName,
       authMethod: row.authMethod,
-      secretNames: secretNames ?? null,
       isDefault: row.isDefault,
       selectedModel: row.selectedModel,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
-    };
-  });
+    }),
+  );
 }
 
 /**
@@ -203,18 +240,15 @@ export async function upsertModelProvider(
     });
 
     return {
-      provider: {
+      provider: toModelProviderInfo({
         id: existingProvider.id,
         type,
-        framework,
         secretName,
-        authMethod: null, // Legacy single-secret provider
-        secretNames: null,
         isDefault: existingProvider.isDefault,
         selectedModel: selectedModel ?? null,
         createdAt: existingProvider.createdAt,
         updatedAt: new Date(),
-      },
+      }),
       created: false,
     };
   }
@@ -244,10 +278,10 @@ export async function upsertModelProvider(
       .where(eq(secrets.id, existingSecret.id));
 
     // Check if first for framework (for default assignment)
-    const allProviders = await listModelProviders(clerkUserId);
-    const hasProviderForFramework = allProviders.some(
-      (p) => p.framework === framework,
-    );
+    const isFirstForFramework = !(await hasExistingProviderForFramework(
+      clerkUserId,
+      framework,
+    ));
 
     // Create model provider row
     const [created] = await globalThis.services.db
@@ -256,7 +290,7 @@ export async function upsertModelProvider(
         scopeId: scope.id,
         type,
         secretId: existingSecret.id,
-        isDefault: !hasProviderForFramework,
+        isDefault: isFirstForFramework,
         selectedModel: selectedModel ?? null,
       })
       .returning();
@@ -272,28 +306,24 @@ export async function upsertModelProvider(
     });
 
     return {
-      provider: {
+      provider: toModelProviderInfo({
         id: created.id,
         type,
-        framework,
         secretName,
-        authMethod: null, // Legacy single-secret provider
-        secretNames: null,
         isDefault: created.isDefault,
         selectedModel: created.selectedModel,
         createdAt: created.createdAt,
         updatedAt: created.updatedAt,
-      },
+      }),
       created: true,
     };
   }
 
   // Create new model-provider secret and model provider
-  // Check if first for framework
-  const allProviders = await listModelProviders(clerkUserId);
-  const hasProviderForFramework = allProviders.some(
-    (p) => p.framework === framework,
-  );
+  const isFirstForFramework = !(await hasExistingProviderForFramework(
+    clerkUserId,
+    framework,
+  ));
 
   const [newSecret] = await globalThis.services.db
     .insert(secrets)
@@ -316,7 +346,7 @@ export async function upsertModelProvider(
       scopeId: scope.id,
       type,
       secretId: newSecret.id,
-      isDefault: !hasProviderForFramework,
+      isDefault: isFirstForFramework,
       selectedModel: selectedModel ?? null,
     })
     .returning();
@@ -334,18 +364,15 @@ export async function upsertModelProvider(
   });
 
   return {
-    provider: {
+    provider: toModelProviderInfo({
       id: newProvider.id,
       type,
-      framework,
       secretName,
-      authMethod: null, // Legacy single-secret provider
-      secretNames: null,
       isDefault: newProvider.isDefault,
       selectedModel: newProvider.selectedModel,
       createdAt: newProvider.createdAt,
       updatedAt: newProvider.updatedAt,
-    },
+    }),
     created: true,
   };
 }
@@ -547,27 +574,25 @@ export async function upsertMultiAuthModelProvider(
     });
 
     return {
-      provider: {
+      provider: toModelProviderInfo({
         id: existingProvider.id,
         type,
-        framework,
-        secretName: null,
         authMethod,
         secretNames,
         isDefault: existingProvider.isDefault,
         selectedModel: selectedModel ?? null,
         createdAt: existingProvider.createdAt,
         updatedAt: new Date(),
-      },
+      }),
       created: false,
     };
   }
 
   // Check if first for framework (for default assignment)
-  const allProviders = await listModelProviders(clerkUserId);
-  const hasProviderForFramework = allProviders.some(
-    (p) => p.framework === framework,
-  );
+  const isFirstForFramework = !(await hasExistingProviderForFramework(
+    clerkUserId,
+    framework,
+  ));
 
   // Create new provider (no secretId for multi-auth)
   const [newProvider] = await globalThis.services.db
@@ -576,7 +601,7 @@ export async function upsertMultiAuthModelProvider(
       scopeId: scope.id,
       type,
       authMethod,
-      isDefault: !hasProviderForFramework,
+      isDefault: isFirstForFramework,
       selectedModel: selectedModel ?? null,
     })
     .returning();
@@ -594,18 +619,16 @@ export async function upsertMultiAuthModelProvider(
   });
 
   return {
-    provider: {
+    provider: toModelProviderInfo({
       id: newProvider.id,
       type,
-      framework,
-      secretName: null,
       authMethod,
       secretNames,
       isDefault: newProvider.isDefault,
       selectedModel: newProvider.selectedModel,
       createdAt: newProvider.createdAt,
       updatedAt: newProvider.updatedAt,
-    },
+    }),
     created: true,
   };
 }
@@ -743,20 +766,16 @@ export async function setModelProviderDefault(
   }
 
   if (target.isDefault) {
-    return {
+    return toModelProviderInfo({
       id: target.id,
       type,
-      framework,
       secretName,
-      authMethod: target.authMethod ?? null,
-      secretNames: target.authMethod
-        ? (getSecretNamesForAuthMethod(type, target.authMethod) ?? null)
-        : null,
+      authMethod: target.authMethod,
       isDefault: true,
       selectedModel: target.selectedModel,
       createdAt: target.createdAt,
       updatedAt: target.updatedAt,
-    };
+    });
   }
 
   // Get all providers for the same framework to clear their defaults
@@ -790,20 +809,16 @@ export async function setModelProviderDefault(
 
   log.debug("model provider set as default", { type, framework });
 
-  return {
+  return toModelProviderInfo({
     id: target.id,
     type,
-    framework,
     secretName,
-    authMethod: target.authMethod ?? null,
-    secretNames: target.authMethod
-      ? (getSecretNamesForAuthMethod(type, target.authMethod) ?? null)
-      : null,
+    authMethod: target.authMethod,
     isDefault: true,
     selectedModel: target.selectedModel,
     createdAt: target.createdAt,
     updatedAt: new Date(),
-  };
+  });
 }
 
 /**
@@ -819,7 +834,6 @@ export async function updateModelProviderModel(
     throw notFound("Model provider not found");
   }
 
-  const framework = getFrameworkForType(type);
   // For multi-auth providers, secretName will be null in response
   const secretName = getSecretNameForType(type) ?? null;
 
@@ -851,20 +865,16 @@ export async function updateModelProviderModel(
     selectedModel,
   });
 
-  return {
+  return toModelProviderInfo({
     id: provider.id,
     type,
-    framework,
     secretName,
-    authMethod: provider.authMethod ?? null,
-    secretNames: provider.authMethod
-      ? (getSecretNamesForAuthMethod(type, provider.authMethod) ?? null)
-      : null,
+    authMethod: provider.authMethod,
     isDefault: provider.isDefault,
     selectedModel: selectedModel ?? null,
     createdAt: provider.createdAt,
     updatedAt: new Date(),
-  };
+  });
 }
 
 /**
@@ -901,28 +911,14 @@ export async function getDefaultModelProvider(
     return null;
   }
 
-  const providerType = defaultProvider.type as ModelProviderType;
-  const isMultiAuth = hasAuthMethods(providerType);
-
-  // For multi-auth providers, get secret names from config
-  let secretNames: string[] | undefined;
-  if (isMultiAuth && defaultProvider.authMethod) {
-    secretNames = getSecretNamesForAuthMethod(
-      providerType,
-      defaultProvider.authMethod,
-    );
-  }
-
-  return {
+  return toModelProviderInfo({
     id: defaultProvider.id,
-    type: providerType,
-    framework,
+    type: defaultProvider.type as ModelProviderType,
     secretName: defaultProvider.secretName,
-    authMethod: defaultProvider.authMethod ?? null,
-    secretNames: secretNames ?? null,
+    authMethod: defaultProvider.authMethod,
     isDefault: defaultProvider.isDefault,
     selectedModel: defaultProvider.selectedModel,
     createdAt: defaultProvider.createdAt,
     updatedAt: defaultProvider.updatedAt,
-  };
+  });
 }

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -756,6 +756,43 @@ export async function executeDueSchedules(): Promise<{
 }
 
 /**
+ * Advance schedule to next occurrence (cron) or disable (one-time).
+ * Shared by retry-window-expired, failure, and success paths.
+ */
+async function advanceScheduleState(
+  schedule: typeof agentSchedules.$inferSelect,
+  lastRunId?: string,
+): Promise<void> {
+  const now = new Date(Date.now());
+  if (schedule.cronExpression) {
+    const nextRunAt = calculateNextRun(
+      schedule.cronExpression,
+      schedule.timezone,
+    );
+    await globalThis.services.db
+      .update(agentSchedules)
+      .set({
+        ...(lastRunId !== undefined && { lastRunId }),
+        lastRunAt: now,
+        retryStartedAt: null,
+        nextRunAt,
+      })
+      .where(eq(agentSchedules.id, schedule.id));
+  } else {
+    await globalThis.services.db
+      .update(agentSchedules)
+      .set({
+        enabled: false,
+        ...(lastRunId !== undefined && { lastRunId }),
+        lastRunAt: now,
+        retryStartedAt: null,
+        nextRunAt: null,
+      })
+      .where(eq(agentSchedules.id, schedule.id));
+  }
+}
+
+/**
  * Handle concurrency limit failure with retry logic.
  * Returns true if retry was scheduled (don't re-throw), false if should advance to next occurrence.
  */
@@ -812,40 +849,12 @@ async function handleConcurrencyFailure(
     `Schedule ${schedule.name} retry window expired after ${Math.round(windowElapsed / 60000)} min`,
   );
 
-  if (schedule.cronExpression) {
-    // Cron schedule: advance to next occurrence
-    const nextRunAt = calculateNextRun(
-      schedule.cronExpression,
-      schedule.timezone,
-    );
-    await globalThis.services.db
-      .update(agentSchedules)
-      .set({
-        lastRunId: failedRun?.id ?? schedule.lastRunId,
-        lastRunAt: now,
-        retryStartedAt: null,
-        nextRunAt,
-      })
-      .where(eq(agentSchedules.id, schedule.id));
-    log.debug(
-      `Cron schedule ${schedule.name} retry window expired, next run at ${nextRunAt?.toISOString()}`,
-    );
-  } else {
-    // One-time schedule: disable after retry window expires
-    await globalThis.services.db
-      .update(agentSchedules)
-      .set({
-        enabled: false,
-        lastRunId: failedRun?.id ?? schedule.lastRunId,
-        lastRunAt: now,
-        retryStartedAt: null,
-        nextRunAt: null,
-      })
-      .where(eq(agentSchedules.id, schedule.id));
-    log.debug(
-      `One-time schedule ${schedule.name} retry window expired and disabled`,
-    );
-  }
+  await advanceScheduleState(schedule, failedRun?.id ?? schedule.lastRunId);
+  log.debug(
+    schedule.cronExpression
+      ? `Cron schedule ${schedule.name} retry window expired`
+      : `One-time schedule ${schedule.name} retry window expired and disabled`,
+  );
 
   return true; // Already handled, don't re-throw
 }
@@ -945,34 +954,12 @@ async function executeSchedule(
     }
 
     // Any failure (concurrency-expired or other): update schedule state (disable one-time, advance cron)
-    if (schedule.cronExpression) {
-      const nextRunAt = calculateNextRun(
-        schedule.cronExpression,
-        schedule.timezone,
-      );
-      await globalThis.services.db
-        .update(agentSchedules)
-        .set({
-          lastRunAt: new Date(Date.now()),
-          nextRunAt,
-          retryStartedAt: null,
-        })
-        .where(eq(agentSchedules.id, schedule.id));
-      log.debug(
-        `Cron schedule ${schedule.name} failed, next run at ${nextRunAt?.toISOString()}`,
-      );
-    } else {
-      await globalThis.services.db
-        .update(agentSchedules)
-        .set({
-          enabled: false,
-          lastRunAt: new Date(Date.now()),
-          nextRunAt: null,
-          retryStartedAt: null,
-        })
-        .where(eq(agentSchedules.id, schedule.id));
-      log.debug(`One-time schedule ${schedule.name} failed and disabled`);
-    }
+    await advanceScheduleState(schedule);
+    log.debug(
+      schedule.cronExpression
+        ? `Cron schedule ${schedule.name} failed`
+        : `One-time schedule ${schedule.name} failed and disabled`,
+    );
 
     throw error; // Re-throw so executeDueSchedules counts it as skipped
   }
@@ -983,36 +970,11 @@ async function executeSchedule(
     .set({ lastRunId: runId })
     .where(eq(agentSchedules.id, schedule.id));
 
-  // Calculate next run time for success path
-  let nextRunAt: Date | null = null;
-  if (schedule.cronExpression) {
-    nextRunAt = calculateNextRun(schedule.cronExpression, schedule.timezone);
-  } else {
-    // One-time schedule: disable after successful execution
-    await globalThis.services.db
-      .update(agentSchedules)
-      .set({
-        enabled: false,
-        lastRunAt: new Date(Date.now()),
-        nextRunAt: null,
-        retryStartedAt: null,
-      })
-      .where(eq(agentSchedules.id, schedule.id));
-    log.debug(`One-time schedule ${schedule.name} executed and disabled`);
-    return;
-  }
-
-  // Update schedule with next run time
-  await globalThis.services.db
-    .update(agentSchedules)
-    .set({
-      lastRunAt: new Date(Date.now()),
-      nextRunAt,
-      retryStartedAt: null,
-    })
-    .where(eq(agentSchedules.id, schedule.id));
-
+  // Advance schedule to next occurrence (cron) or disable (one-time)
+  await advanceScheduleState(schedule);
   log.debug(
-    `Schedule ${schedule.name} executed, next run at ${nextRunAt?.toISOString()}`,
+    schedule.cronExpression
+      ? `Schedule ${schedule.name} executed`
+      : `One-time schedule ${schedule.name} executed and disabled`,
   );
 }

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -849,7 +849,10 @@ async function handleConcurrencyFailure(
     `Schedule ${schedule.name} retry window expired after ${Math.round(windowElapsed / 60000)} min`,
   );
 
-  await advanceScheduleState(schedule, failedRun?.id ?? schedule.lastRunId);
+  await advanceScheduleState(
+    schedule,
+    failedRun?.id ?? schedule.lastRunId ?? undefined,
+  );
   log.debug(
     schedule.cronExpression
       ? `Cron schedule ${schedule.name} retry window expired`

--- a/turbo/apps/web/src/lib/secret/secret-service.ts
+++ b/turbo/apps/web/src/lib/secret/secret-service.ts
@@ -178,6 +178,48 @@ export async function getSecretValues(
 }
 
 /**
+ * Upsert a secret by scope ID, name, and type.
+ * Used internally by connector services for managing connector/model-provider secrets.
+ */
+export async function upsertSecretByScope(
+  scopeId: string,
+  name: string,
+  value: string,
+  type: SecretType,
+  description: string,
+): Promise<void> {
+  const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
+  const encryptedValue = encryptCredentialValue(value, encryptionKey);
+
+  const [existing] = await globalThis.services.db
+    .select({ id: secrets.id })
+    .from(secrets)
+    .where(
+      and(
+        eq(secrets.scopeId, scopeId),
+        eq(secrets.name, name),
+        eq(secrets.type, type),
+      ),
+    )
+    .limit(1);
+
+  if (existing) {
+    await globalThis.services.db
+      .update(secrets)
+      .set({ encryptedValue, updatedAt: new Date() })
+      .where(eq(secrets.id, existing.id));
+  } else {
+    await globalThis.services.db.insert(secrets).values({
+      scopeId,
+      name,
+      encryptedValue,
+      type,
+      description,
+    });
+  }
+}
+
+/**
  * Create or update a secret (upsert)
  */
 export async function setSecret(


### PR DESCRIPTION
## Summary
- **schedule-service**: Extract `advanceScheduleState()` helper to replace 3 duplicated cron-vs-one-time branching blocks in `handleConcurrencyFailure()` and `executeSchedule()`
- **model-provider-service**: Extract `toModelProviderInfo()` to replace 10 manual `ModelProviderInfo` object constructions, and `hasExistingProviderForFramework()` to replace 3 repeated check-if-first-for-framework patterns
- **secret-service + connector services**: Extract shared `upsertSecretByScope()` to replace 3 duplicated encrypt+upsert-by-scope blocks across `connector-service.ts` and `computer-connector-service.ts`

Net reduction: **69 lines** (225 added, 294 removed) across 5 files. Pure internal refactor — no API or behavior changes.

## Test plan
- [x] TypeScript type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Code formatting verified (`pnpm format`)
- [x] Knip finds no unused exports/dependencies (`pnpm knip`)
- [x] Test failures identical to main branch (pre-existing DB infrastructure issue)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)