### PR TITLE
feat(skills): add testing coverage and convention review to pr-review

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -48,7 +48,53 @@ This will:
 - Generate detailed review files in `codereviews/YYYYMMDD/`
 - Check for testing anti-patterns, error handling issues, type safety, etc.
 
-### Step 4: Read Review Results
+### Step 4: Testing Coverage and Convention Review
+
+After `code-quality` completes, perform a dedicated testing review by reading the testing documentation (`docs/testing.md` and relevant guides under `docs/testing/`) and analyzing the PR diff.
+
+#### 4a: Identify Changed Source Files
+
+```bash
+# Get all non-test source files changed in the PR
+gh pr diff "$PR_NUMBER" --name-only | grep -v '\.test\.' | grep -v '__tests__'
+```
+
+#### 4b: Check Test Coverage for Changes
+
+For each changed source file, determine whether corresponding tests exist and cover the changes:
+
+1. **New features (feat commits)** — Must have corresponding integration tests. Missing tests = **P0 Critical**.
+2. **Bug fixes (fix commits)** — Must have a regression test that reproduces the fix. Missing tests = **P0 Critical**.
+3. **Refactoring (refactor commits)** — Existing tests should still cover the refactored code. No new tests required unless behavior changed.
+4. **Docs/chore/ci changes** — No test requirement.
+
+#### 4c: Check Testing Conventions
+
+Review all test files in the PR diff against the project testing standards:
+
+| Rule | Check | Severity |
+|------|-------|----------|
+| Integration tests only | No unit tests for internal functions | P1 |
+| Mock at boundary only | `vi.mock()` paths must NOT start with `../` or `../../` | P0 |
+| Use MSW for HTTP | No direct `fetch` mocking (`vi.stubGlobal("fetch", ...)`) | P0 |
+| Real database | No mocking of `globalThis.services.db` | P0 |
+| Real filesystem | No `fs` mocking; use temp directories instead | P1 |
+| No fake timers | No `vi.useFakeTimers()` / `vi.advanceTimersByTime()` | P1 |
+| Test behavior not mocks | No `expect(mock).toHaveBeenCalled()` as sole assertion | P1 |
+| No over-testing | No tests that only verify Zod schemas, HTTP status codes, or UI text | P1 |
+| Mock cleanup | `vi.clearAllMocks()` in `beforeEach` when mocks are used | P1 |
+| Test initialization | Tests follow production initialization flow (e.g., `setupPage()` for platform) | P1 |
+
+#### 4d: Generate Testing Verdict
+
+Classify the testing status:
+
+- **Adequate** — All new/changed behavior has corresponding tests that follow conventions
+- **Insufficient Coverage** — Missing tests for new features or bug fixes (P0)
+- **Convention Violations** — Tests exist but violate testing standards (severity per table above)
+- **Not Applicable** — Changes are docs/chore/ci only, no tests needed
+
+### Step 5: Read Review Results
 
 After `code-quality` completes, read the generated files:
 
@@ -66,7 +112,9 @@ Extract key findings:
 - Bad smell statistics
 - Action items
 
-### Step 5: Generate PR Comment
+Merge testing review findings from Step 4 into the overall results.
+
+### Step 6: Generate PR Comment
 
 Structure the review findings as a PR comment:
 
@@ -79,25 +127,40 @@ Structure the review findings as a PR comment:
 ### Key Findings
 
 #### Critical Issues (P0)
-<List from code-quality review>
+<List from code-quality review AND testing review>
 
 #### High Priority (P1)
-<List from code-quality review>
+<List from code-quality review AND testing review>
+
+### Testing Review
+
+#### Coverage
+<For each new feature or bug fix, state whether tests exist>
+- feat: <feature description> → <test file or "MISSING">
+- fix: <fix description> → <regression test or "MISSING">
+
+#### Convention Compliance
+<List any violations found in Step 4c, with file:line references>
+
+#### Testing Verdict: <Adequate / Insufficient Coverage / Convention Violations / Not Applicable>
 
 ### Bad Smell Analysis
 <Statistics from code-quality review>
 
 ### Recommendations
-<Action items from code-quality review>
+<Action items from code-quality review AND testing review>
 
 ### Verdict
 <LGTM / Changes Requested / Needs Discussion>
 
+**Note:** If Testing Verdict is "Insufficient Coverage" or has P0 convention violations, the overall Verdict must be "Changes Requested".
+
 ---
 *Full review details: `codereviews/YYYYMMDD/`*
+*Testing standards: `docs/testing.md`*
 ```
 
-### Step 6: Post Comment
+### Step 7: Post Comment
 
 ```bash
 gh pr comment "$PR_NUMBER" --body "$REVIEW_CONTENT"
@@ -117,6 +180,7 @@ Author: <author>
 URL: <url>
 
 Code quality analysis completed.
+Testing review completed.
 Review files: codereviews/YYYYMMDD/
 
 Review posted as comment.
@@ -128,8 +192,10 @@ Comment URL: <comment-url>
 ## Best Practices
 
 1. **Use code-quality for analysis** - Don't duplicate review logic
-2. **Summarize for PR comment** - Keep comment concise, reference files for details
-3. **Be constructive** - Focus on improvements, not criticism
-4. **Prioritize** - Distinguish between blockers and nice-to-haves
+2. **Use testing docs for test review** - Reference `docs/testing.md` and `docs/testing/` guides as the source of truth for testing standards
+3. **Treat missing tests as blockers** - New features and bug fixes without tests are P0 Critical, not suggestions
+4. **Summarize for PR comment** - Keep comment concise, reference files for details
+5. **Be constructive** - Focus on improvements, not criticism
+6. **Prioritize** - Distinguish between blockers and nice-to-haves
 
-Your goal is to leverage the comprehensive code-quality analysis and present it effectively as a PR comment.
+Your goal is to leverage the comprehensive code-quality analysis, enforce testing coverage and conventions, and present findings effectively as a PR comment.


### PR DESCRIPTION
## Summary
- Add a dedicated **Testing Coverage and Convention Review** step (Step 4) to the `pr-review` skill
- Enforce that new features (`feat`) and bug fixes (`fix`) must have corresponding integration/regression tests — missing tests are flagged as **P0 Critical**
- Add a convention compliance checklist (10 rules with severity levels) based on `docs/testing.md` standards
- Add a **Testing Review** section to the PR comment template with Coverage, Convention Compliance, and Testing Verdict
- Missing tests or P0 convention violations now force the overall Verdict to "Changes Requested"

## Test plan
- [ ] Run `/pr-review` on a PR with new features but no tests — verify "Insufficient Coverage" verdict and "Changes Requested" overall verdict
- [ ] Run `/pr-review` on a PR with proper tests — verify "Adequate" verdict
- [ ] Run `/pr-review` on a docs-only PR — verify "Not Applicable" verdict
- [ ] Run `/pr-review` on a PR with convention violations (e.g., `vi.mock("../../...")`) — verify P0 flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)