### PR TITLE
feat(runner): embed guest binaries via build.rs

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -125,11 +125,20 @@ jobs:
           workspaces: crates -> target
           key: aarch64-musl
 
-      - name: Cross-compile runner and guest binaries for ARM64
+      - name: Cross-compile guest binaries for ARM64
         run: |
           cd crates
           cargo build --release --target aarch64-unknown-linux-musl \
-            -p runner -p guest-init -p guest-download -p guest-agent -p guest-mock-claude
+            -p guest-agent -p guest-download -p guest-init -p guest-mock-claude
+
+      - name: Cross-compile runner with embedded guests for ARM64
+        run: |
+          cd crates
+          GUEST_AGENT_PATH=target/aarch64-unknown-linux-musl/release/guest-agent \
+          GUEST_DOWNLOAD_PATH=target/aarch64-unknown-linux-musl/release/guest-download \
+          GUEST_INIT_PATH=target/aarch64-unknown-linux-musl/release/guest-init \
+          GUEST_MOCK_CLAUDE_PATH=target/aarch64-unknown-linux-musl/release/guest-mock-claude \
+          cargo build --release --target aarch64-unknown-linux-musl -p runner
 
       - name: Setup SSH
         env:
@@ -165,12 +174,10 @@ jobs:
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
           TARGET_DIR="crates/target/aarch64-unknown-linux-musl/release"
 
-          # Clean previous run artifacts and upload binaries
-          echo "=== Deploying binaries to ${HOST}:${BIN_DIR} ==="
+          # Clean previous run artifacts and upload runner (guests are embedded)
+          echo "=== Deploying runner to ${HOST}:${BIN_DIR} ==="
           ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} ~/.vm0-runner/runners/${JOB_REF}-bench ~/.vm0-runner/runners/${JOB_REF}-local && mkdir -p ${BIN_DIR}"
-          for bin in runner guest-init guest-download guest-agent guest-mock-claude; do
-            scp $SSH_OPTS "${TARGET_DIR}/${bin}" "${REMOTE}:${BIN_DIR}/"
-          done
+          scp $SSH_OPTS "${TARGET_DIR}/runner" "${REMOTE}:${BIN_DIR}/"
 
           # Clean up old rootfs/snapshots, keep the 2 most recent
           ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner gc --keep-latest 2"
@@ -183,11 +190,7 @@ jobs:
           # Use tee to stream output in real-time while capturing for hash extraction
           echo "=== Running build ==="
           BUILD_LOG=$(mktemp)
-          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner build \
-            --guest-init ${BIN_DIR}/guest-init \
-            --guest-download ${BIN_DIR}/guest-download \
-            --guest-agent ${BIN_DIR}/guest-agent \
-            --guest-mock-claude ${BIN_DIR}/guest-mock-claude" | tee "$BUILD_LOG"
+          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner build" | tee "$BUILD_LOG"
           ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG" | cut -d= -f2)
           SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG" | cut -d= -f2)
           rm -f "$BUILD_LOG"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -434,12 +434,22 @@ jobs:
             text: "*Runner RS* deploying to production servers..."
 
       # Cross-compile Rust binaries for ARM64 (metal runners are ARM64)
-      - name: Build runner and guest binaries for ARM64
+      - name: Cross-compile guest binaries for ARM64
         run: |
           cd crates
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc \
             cargo build --release --target aarch64-unknown-linux-musl \
-            -p runner -p guest-init -p guest-download -p guest-agent -p guest-mock-claude
+            -p guest-agent -p guest-download -p guest-init -p guest-mock-claude
+
+      - name: Cross-compile runner with embedded guests for ARM64
+        run: |
+          cd crates
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc \
+          GUEST_AGENT_PATH=target/aarch64-unknown-linux-musl/release/guest-agent \
+          GUEST_DOWNLOAD_PATH=target/aarch64-unknown-linux-musl/release/guest-download \
+          GUEST_INIT_PATH=target/aarch64-unknown-linux-musl/release/guest-init \
+          GUEST_MOCK_CLAUDE_PATH=target/aarch64-unknown-linux-musl/release/guest-mock-claude \
+            cargo build --release --target aarch64-unknown-linux-musl -p runner
 
       - name: Deploy to production with Ansible
         env:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -989,11 +989,20 @@ jobs:
           workspaces: crates -> target
           key: aarch64-musl
 
-      - name: Cross-compile runner and guest binaries for ARM64
+      - name: Cross-compile guest binaries for ARM64
         run: |
           cd crates
           cargo build --release --target aarch64-unknown-linux-musl \
-            -p runner -p guest-init -p guest-download -p guest-agent -p guest-mock-claude
+            -p guest-agent -p guest-download -p guest-init -p guest-mock-claude
+
+      - name: Cross-compile runner with embedded guests for ARM64
+        run: |
+          cd crates
+          GUEST_AGENT_PATH=target/aarch64-unknown-linux-musl/release/guest-agent \
+          GUEST_DOWNLOAD_PATH=target/aarch64-unknown-linux-musl/release/guest-download \
+          GUEST_INIT_PATH=target/aarch64-unknown-linux-musl/release/guest-init \
+          GUEST_MOCK_CLAUDE_PATH=target/aarch64-unknown-linux-musl/release/guest-mock-claude \
+          cargo build --release --target aarch64-unknown-linux-musl -p runner
 
       - name: Setup SSH
         env:
@@ -1076,11 +1085,9 @@ jobs:
             local REMOTE="${METAL_USER}@${HOST}"
             echo "=== Deploying to ${HOST} (runner: ${RUNNER_NAME}) ==="
 
-            # Clean previous run artifacts and upload binaries
+            # Clean previous run artifacts and upload runner (guests are embedded)
             ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} ${RUNNER_DIR} && mkdir -p ${BIN_DIR}"
-            for bin in runner guest-init guest-download guest-agent guest-mock-claude; do
-              scp $SSH_OPTS "${TARGET_DIR}/${bin}" "${REMOTE}:${BIN_DIR}/"
-            done
+            scp $SSH_OPTS "${TARGET_DIR}/runner" "${REMOTE}:${BIN_DIR}/"
 
             # Clean up old rootfs/snapshots, keep the 2 most recent
             ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner gc --keep-latest 2"
@@ -1090,10 +1097,6 @@ jobs:
 
             # Run build to create rootfs + snapshot (outputs hashes to stdout)
             ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner build \
-              --guest-init ${BIN_DIR}/guest-init \
-              --guest-download ${BIN_DIR}/guest-download \
-              --guest-agent ${BIN_DIR}/guest-agent \
-              --guest-mock-claude ${BIN_DIR}/guest-mock-claude \
               --vcpu ${RUNNER_VCPU} \
               --memory-mb ${RUNNER_MEMORY_MB}"
             echo "=== Done deploying to ${HOST} ==="

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -965,7 +965,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
     needs: [prepare]
-    timeout-minutes: 5
+    timeout-minutes: 10
     if: |
       contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&
       github.event_name != 'push' &&

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -75,17 +75,11 @@
         state: directory
         mode: '0755'
 
-    - name: Copy runner and guest binaries
+    - name: Copy runner binary (guest binaries are embedded)
       copy:
-        src: "{{ item }}"
+        src: "{{ playbook_dir }}/../../crates/target/aarch64-unknown-linux-musl/release/runner"
         dest: "{{ bin_dir }}/"
         mode: '0755'
-      with_fileglob:
-        - "{{ playbook_dir }}/../../crates/target/aarch64-unknown-linux-musl/release/runner"
-        - "{{ playbook_dir }}/../../crates/target/aarch64-unknown-linux-musl/release/guest-init"
-        - "{{ playbook_dir }}/../../crates/target/aarch64-unknown-linux-musl/release/guest-download"
-        - "{{ playbook_dir }}/../../crates/target/aarch64-unknown-linux-musl/release/guest-agent"
-        - "{{ playbook_dir }}/../../crates/target/aarch64-unknown-linux-musl/release/guest-mock-claude"
 
     # ========================================
     # Phase 2: Setup + Build
@@ -103,10 +97,6 @@
     - name: Build rootfs and snapshot
       command: >
         {{ bin_dir }}/runner build
-        --guest-init {{ bin_dir }}/guest-init
-        --guest-download {{ bin_dir }}/guest-download
-        --guest-agent {{ bin_dir }}/guest-agent
-        --guest-mock-claude {{ bin_dir }}/guest-mock-claude
         --vcpu {{ vcpu }}
         --memory-mb {{ memory_mb }}
       register: build_output

--- a/crates/README.md
+++ b/crates/README.md
@@ -64,7 +64,7 @@ cargo build --release
 
 # Cross-compile guest binaries for aarch64 (production target)
 cross build --target aarch64-unknown-linux-musl \
-  -p runner -p guest-init -p guest-download -p guest-agent -p guest-mock-claude \
+  -p runner -p guest-agent -p guest-download -p guest-init -p guest-mock-claude \
   --release
 ```
 

--- a/crates/README.md
+++ b/crates/README.md
@@ -62,10 +62,18 @@ Both HTTP clients in the workspace use `rustls-platform-verifier` to read from t
 cargo build
 cargo build --release
 
-# Cross-compile guest binaries for aarch64 (production target)
+# Cross-compile for aarch64 (production target)
+# Step 1: build guest binaries
 cross build --target aarch64-unknown-linux-musl \
-  -p runner -p guest-agent -p guest-download -p guest-init -p guest-mock-claude \
+  -p guest-agent -p guest-download -p guest-init -p guest-mock-claude \
   --release
+
+# Step 2: build runner with embedded guests
+GUEST_AGENT_PATH=target/aarch64-unknown-linux-musl/release/guest-agent \
+GUEST_DOWNLOAD_PATH=target/aarch64-unknown-linux-musl/release/guest-download \
+GUEST_INIT_PATH=target/aarch64-unknown-linux-musl/release/guest-init \
+GUEST_MOCK_CLAUDE_PATH=target/aarch64-unknown-linux-musl/release/guest-mock-claude \
+cross build --target aarch64-unknown-linux-musl -p runner --release
 ```
 
 ## Testing

--- a/crates/runner/build.rs
+++ b/crates/runner/build.rs
@@ -1,7 +1,17 @@
+use std::path::PathBuf;
 use std::process;
 
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(bundled_guests)");
+
+    // Build scripts run with cwd=CARGO_MANIFEST_DIR (crates/runner/), but
+    // GUEST_*_PATH values are relative to the workspace root (crates/).
+    // Resolve relative paths against the workspace root so canonicalize works.
+    let workspace_root: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+
     let guests = [
         ("GUEST_AGENT_PATH", "BUNDLED_GUEST_AGENT"),
         ("GUEST_DOWNLOAD_PATH", "BUNDLED_GUEST_DOWNLOAD"),
@@ -36,10 +46,18 @@ fn main() {
     if paths.len() == guests.len() {
         println!("cargo:rustc-cfg=bundled_guests");
         for ((_, bundled_key), (_, raw_path)) in guests.iter().zip(paths.iter()) {
-            let abs = match std::fs::canonicalize(raw_path) {
+            let resolved = if std::path::Path::new(raw_path).is_relative() {
+                workspace_root.join(raw_path)
+            } else {
+                PathBuf::from(raw_path)
+            };
+            let abs = match std::fs::canonicalize(&resolved) {
                 Ok(p) => p,
                 Err(e) => {
-                    eprintln!("cargo:warning={raw_path}: {e}");
+                    eprintln!(
+                        "cargo:warning={raw_path} (resolved to {}): {e}",
+                        resolved.display()
+                    );
                     process::exit(1);
                 }
             };

--- a/crates/runner/build.rs
+++ b/crates/runner/build.rs
@@ -1,0 +1,54 @@
+use std::process;
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(bundled_guests)");
+    let guests = [
+        ("GUEST_AGENT_PATH", "BUNDLED_GUEST_AGENT"),
+        ("GUEST_DOWNLOAD_PATH", "BUNDLED_GUEST_DOWNLOAD"),
+        ("GUEST_INIT_PATH", "BUNDLED_GUEST_INIT"),
+        ("GUEST_MOCK_CLAUDE_PATH", "BUNDLED_GUEST_MOCK_CLAUDE"),
+    ];
+
+    // Always rebuild when any of these env vars change.
+    for (env_var, _) in &guests {
+        println!("cargo:rerun-if-env-changed={env_var}");
+    }
+
+    // All-or-nothing: either all GUEST_*_PATH vars are set, or none.
+    let paths: Vec<_> = guests
+        .iter()
+        .filter_map(|(env_var, _)| std::env::var(env_var).ok().map(|v| (*env_var, v)))
+        .collect();
+
+    if !paths.is_empty() && paths.len() != guests.len() {
+        let set: Vec<_> = paths.iter().map(|(k, _)| *k).collect();
+        let missing: Vec<_> = guests
+            .iter()
+            .filter(|(k, _)| !set.contains(k))
+            .map(|(k, _)| *k)
+            .collect();
+        eprintln!(
+            "cargo:warning=partial GUEST_*_PATH env vars: set={set:?}, missing={missing:?} — must set all or none"
+        );
+        process::exit(1);
+    }
+
+    if paths.len() == guests.len() {
+        println!("cargo:rustc-cfg=bundled_guests");
+        for ((_, bundled_key), (_, raw_path)) in guests.iter().zip(paths.iter()) {
+            let abs = match std::fs::canonicalize(raw_path) {
+                Ok(p) => p,
+                Err(e) => {
+                    eprintln!("cargo:warning={raw_path}: {e}");
+                    process::exit(1);
+                }
+            };
+            let Some(abs_str) = abs.to_str() else {
+                eprintln!("cargo:warning=non-UTF-8 path: {}", abs.display());
+                process::exit(1);
+            };
+            println!("cargo:rustc-env={bundled_key}={abs_str}");
+            println!("cargo:rerun-if-changed={abs_str}");
+        }
+    }
+}

--- a/crates/runner/build.rs
+++ b/crates/runner/build.rs
@@ -1,5 +1,7 @@
+// Build scripts are compile-time only — panic/expect/unwrap are appropriate for fatal errors.
+#![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+
 use std::path::PathBuf;
-use std::process;
 
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(bundled_guests)");
@@ -9,8 +11,8 @@ fn main() {
     // Resolve relative paths against the workspace root so canonicalize works.
     let workspace_root: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("."));
+        .expect("CARGO_MANIFEST_DIR should have a parent")
+        .to_path_buf();
 
     let guests = [
         ("GUEST_AGENT_PATH", "BUNDLED_GUEST_AGENT"),
@@ -37,10 +39,9 @@ fn main() {
             .filter(|(k, _)| !set.contains(k))
             .map(|(k, _)| *k)
             .collect();
-        eprintln!(
-            "cargo:warning=partial GUEST_*_PATH env vars: set={set:?}, missing={missing:?} — must set all or none"
+        panic!(
+            "partial GUEST_*_PATH env vars: set={set:?}, missing={missing:?} — must set all or none"
         );
-        process::exit(1);
     }
 
     if paths.len() == guests.len() {
@@ -51,20 +52,11 @@ fn main() {
             } else {
                 PathBuf::from(raw_path)
             };
-            let abs = match std::fs::canonicalize(&resolved) {
-                Ok(p) => p,
-                Err(e) => {
-                    eprintln!(
-                        "cargo:warning={raw_path} (resolved to {}): {e}",
-                        resolved.display()
-                    );
-                    process::exit(1);
-                }
-            };
-            let Some(abs_str) = abs.to_str() else {
-                eprintln!("cargo:warning=non-UTF-8 path: {}", abs.display());
-                process::exit(1);
-            };
+            let abs = std::fs::canonicalize(&resolved)
+                .unwrap_or_else(|e| panic!("{raw_path} (resolved to {}): {e}", resolved.display()));
+            let abs_str = abs
+                .to_str()
+                .unwrap_or_else(|| panic!("non-UTF-8 path: {}", abs.display()));
             println!("cargo:rustc-env={bundled_key}={abs_str}");
             println!("cargo:rerun-if-changed={abs_str}");
         }

--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -9,9 +9,9 @@
 #   bash build-rootfs.sh \
 #     --output-dir /path/to/output \
 #     --work-dir /path/to/workdir \
-#     --guest-init /path/to/guest-init \
-#     --guest-download /path/to/guest-download \
 #     --guest-agent /path/to/guest-agent \
+#     --guest-download /path/to/guest-download \
+#     --guest-init /path/to/guest-init \
 #     --guest-mock-claude /path/to/guest-mock-claude
 
 set -euo pipefail
@@ -22,24 +22,24 @@ set -euo pipefail
 
 OUTPUT_DIR=""
 WORK_DIR=""
-GUEST_INIT=""
-GUEST_DOWNLOAD=""
 GUEST_AGENT=""
+GUEST_DOWNLOAD=""
+GUEST_INIT=""
 GUEST_MOCK_CLAUDE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --output-dir)       OUTPUT_DIR="$2";       shift 2 ;;
     --work-dir)   WORK_DIR="$2";   shift 2 ;;
-    --guest-init)       GUEST_INIT="$2";       shift 2 ;;
-    --guest-download)   GUEST_DOWNLOAD="$2";   shift 2 ;;
     --guest-agent)      GUEST_AGENT="$2";      shift 2 ;;
+    --guest-download)   GUEST_DOWNLOAD="$2";   shift 2 ;;
+    --guest-init)       GUEST_INIT="$2";       shift 2 ;;
     --guest-mock-claude) GUEST_MOCK_CLAUDE="$2"; shift 2 ;;
     *) echo "error: unknown argument: $1" >&2; exit 1 ;;
   esac
 done
 
-for var in OUTPUT_DIR WORK_DIR GUEST_INIT GUEST_DOWNLOAD GUEST_AGENT GUEST_MOCK_CLAUDE; do
+for var in OUTPUT_DIR WORK_DIR GUEST_AGENT GUEST_DOWNLOAD GUEST_INIT GUEST_MOCK_CLAUDE; do
   if [[ -z "${!var}" ]]; then
     echo "error: --$(echo "$var" | tr '_' '-' | tr '[:upper:]' '[:lower:]') is required" >&2
     exit 1

--- a/crates/runner/src/cmd/rootfs.rs
+++ b/crates/runner/src/cmd/rootfs.rs
@@ -10,47 +10,105 @@ const BUILD_SCRIPT: &str = include_str!("../../scripts/build-rootfs.sh");
 const VERIFY_SCRIPT: &str = include_str!("../../scripts/verify-rootfs.sh");
 const EMBEDDED_DOCKERFILE: &str = include_str!("../../scripts/rootfs.Dockerfile");
 
+#[cfg(bundled_guests)]
+mod embedded {
+    pub const GUEST_INIT: &[u8] = include_bytes!(env!("BUNDLED_GUEST_INIT"));
+    pub const GUEST_DOWNLOAD: &[u8] = include_bytes!(env!("BUNDLED_GUEST_DOWNLOAD"));
+    pub const GUEST_AGENT: &[u8] = include_bytes!(env!("BUNDLED_GUEST_AGENT"));
+    pub const GUEST_MOCK_CLAUDE: &[u8] = include_bytes!(env!("BUNDLED_GUEST_MOCK_CLAUDE"));
+}
+
+#[cfg(bundled_guests)]
+fn bundled_guest(name: &str) -> Option<&'static [u8]> {
+    match name {
+        "guest-agent" => Some(embedded::GUEST_AGENT),
+        "guest-download" => Some(embedded::GUEST_DOWNLOAD),
+        "guest-init" => Some(embedded::GUEST_INIT),
+        "guest-mock-claude" => Some(embedded::GUEST_MOCK_CLAUDE),
+        _ => None,
+    }
+}
+
+#[cfg(not(bundled_guests))]
+fn bundled_guest(_name: &str) -> Option<&'static [u8]> {
+    None
+}
+
 #[derive(Args)]
 pub struct RootfsArgs {
     #[arg(long)]
-    guest_init: PathBuf,
+    guest_agent: Option<PathBuf>,
     #[arg(long)]
-    guest_download: PathBuf,
+    guest_download: Option<PathBuf>,
     #[arg(long)]
-    guest_agent: PathBuf,
+    guest_init: Option<PathBuf>,
     #[arg(long)]
-    guest_mock_claude: PathBuf,
+    guest_mock_claude: Option<PathBuf>,
     /// Compute and print the input hash without building
     #[arg(long)]
     pub dry_run: bool,
 }
 
-impl RootfsArgs {
-    /// Returns (source_path, rootfs_dest) pairs sorted by name for deterministic hashing.
-    fn guest_bins(&self) -> [(&Path, &str); 4] {
-        [
-            (self.guest_agent.as_path(), "/usr/local/bin/guest-agent"),
-            (
-                self.guest_download.as_path(),
-                "/usr/local/bin/guest-download",
-            ),
-            (self.guest_init.as_path(), "/sbin/guest-init"),
-            (
-                self.guest_mock_claude.as_path(),
-                "/usr/local/bin/guest-mock-claude",
-            ),
-        ]
+/// Resolve a guest binary path: CLI arg takes priority, then bundled binary
+/// written to a temp file, otherwise error.
+async fn resolve_guest(
+    cli_path: Option<PathBuf>,
+    name: &str,
+    tmp_dir: &Path,
+) -> RunnerResult<PathBuf> {
+    if let Some(p) = cli_path {
+        return Ok(p);
     }
+    if let Some(bytes) = bundled_guest(name) {
+        let dest = tmp_dir.join(name);
+        tokio::fs::write(&dest, bytes)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("write bundled {name}: {e}")))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            tokio::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755))
+                .await
+                .map_err(|e| RunnerError::Internal(format!("chmod {name}: {e}")))?;
+        }
+        return Ok(dest);
+    }
+    Err(RunnerError::Internal(format!(
+        "missing --{} and no bundled binary available",
+        name
+    )))
 }
 
 /// Build rootfs and return the content hash of the inputs.
 pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
     let dry_run = args.dry_run;
-    let guest_bins = args.guest_bins();
+
+    // Create temp dir for any bundled guest binaries that need extracting.
+    let tmp_dir =
+        tempfile::tempdir().map_err(|e| RunnerError::Internal(format!("create temp dir: {e}")))?;
+
+    // Resolve all guest binary paths (CLI arg → bundled → error).
+    let guest_agent = resolve_guest(args.guest_agent, "guest-agent", tmp_dir.path()).await?;
+    let guest_download =
+        resolve_guest(args.guest_download, "guest-download", tmp_dir.path()).await?;
+    let guest_init = resolve_guest(args.guest_init, "guest-init", tmp_dir.path()).await?;
+    let guest_mock_claude =
+        resolve_guest(args.guest_mock_claude, "guest-mock-claude", tmp_dir.path()).await?;
+
+    // Sorted by dest name for deterministic hashing.
+    let bins: [(&Path, &str); 4] = [
+        (guest_agent.as_path(), "/usr/local/bin/guest-agent"),
+        (guest_download.as_path(), "/usr/local/bin/guest-download"),
+        (guest_init.as_path(), "/sbin/guest-init"),
+        (
+            guest_mock_claude.as_path(),
+            "/usr/local/bin/guest-mock-claude",
+        ),
+    ];
 
     // Compute input hash: script + dockerfile + guest binaries.
     // The build script content is included so any logic change invalidates cache.
-    let hash = compute_input_hash(&guest_bins).await?;
+    let hash = compute_input_hash(&bins).await?;
     tracing::info!("rootfs input hash: {hash}");
     // Machine-readable output — do not change format without updating consumers
     println!("rootfs_hash={hash}");
@@ -103,10 +161,10 @@ pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
     let script_path = work_dir.path().join("build-rootfs.sh");
     let output_dir_str = output_dir.to_string_lossy();
     let work_dir_str = work_dir.path().to_string_lossy();
-    let guest_init_str = args.guest_init.to_string_lossy();
-    let guest_download_str = args.guest_download.to_string_lossy();
-    let guest_agent_str = args.guest_agent.to_string_lossy();
-    let guest_mock_claude_str = args.guest_mock_claude.to_string_lossy();
+    let guest_agent_str = guest_agent.to_string_lossy();
+    let guest_download_str = guest_download.to_string_lossy();
+    let guest_init_str = guest_init.to_string_lossy();
+    let guest_mock_claude_str = guest_mock_claude.to_string_lossy();
 
     let status = tokio::process::Command::new("bash")
         .arg(&script_path)
@@ -115,12 +173,12 @@ pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
             &output_dir_str,
             "--work-dir",
             &work_dir_str,
-            "--guest-init",
-            &guest_init_str,
-            "--guest-download",
-            &guest_download_str,
             "--guest-agent",
             &guest_agent_str,
+            "--guest-download",
+            &guest_download_str,
+            "--guest-init",
+            &guest_init_str,
             "--guest-mock-claude",
             &guest_mock_claude_str,
         ])

--- a/crates/runner/src/cmd/rootfs.rs
+++ b/crates/runner/src/cmd/rootfs.rs
@@ -84,6 +84,7 @@ pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
     let dry_run = args.dry_run;
 
     // Create temp dir for any bundled guest binaries that need extracting.
+    // IMPORTANT: tmp_dir must outlive build script execution — dropping it deletes extracted guests.
     let tmp_dir =
         tempfile::tempdir().map_err(|e| RunnerError::Internal(format!("create temp dir: {e}")))?;
 


### PR DESCRIPTION
## Summary

- Embed 4 guest binaries (`guest-agent`, `guest-download`, `guest-init`, `guest-mock-claude`) into the runner at compile time via `include_bytes!()`, making it a single self-contained binary
- Add `build.rs` that checks `GUEST_*_PATH` env vars (all-or-nothing validation) and emits `bundled_guests` cfg
- Make `RootfsArgs` guest fields optional with fallback resolution: CLI arg → embedded binary (extracted to tmpdir + chmod 755) → error
- Split CI cross-compile into two steps: guests first, then runner with `GUEST_*_PATH` env vars
- Simplify all deploy steps (crates.yml, turbo.yml, ansible) to only copy/use the single runner binary
- Unify guest binary ordering to alphabetical across all files

Closes #3317

## Test plan

- [ ] `cargo check -p runner` passes (dev build, no embedding)
- [ ] `cargo clippy -p runner --all-targets` passes with no warnings
- [ ] `runner build --help` shows guest args as optional
- [ ] CI crates workflow builds runner with embedded guests and deploys successfully
- [ ] CI turbo workflow deploys single runner binary to metal hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)