### PR TITLE
ci(runner): upload binary to github release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -451,6 +451,17 @@ jobs:
           GUEST_MOCK_CLAUDE_PATH=target/aarch64-unknown-linux-musl/release/guest-mock-claude \
             cargo build --release --target aarch64-unknown-linux-musl -p runner
 
+      - name: Upload runner binary to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
+        run: |
+          cp crates/target/aarch64-unknown-linux-musl/release/runner \
+             "runner-v${VERSION}-aarch64-linux"
+          gh release upload "runner-rs-v${VERSION}" \
+            "runner-v${VERSION}-aarch64-linux" \
+            --clobber
+
       - name: Deploy to production with Ansible
         env:
           AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -411,7 +411,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
     permissions:
-      contents: read
+      contents: write
     environment: production
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add a step to `release-please.yml` that uploads the compiled runner binary to the GitHub Release
- Binary is named `runner-v{VERSION}-aarch64-linux` and uploaded with `gh release upload --clobber`
- Runs after cross-compilation, before Ansible deploy

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Next runner-rs release should have the binary attached to the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)