### PR TITLE
fix(ci): use curl instead of gh cli for release upload

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -456,11 +456,35 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
         run: |
-          cp crates/target/aarch64-unknown-linux-musl/release/runner \
-             "runner-v${VERSION}-aarch64-linux"
-          gh release upload "runner-rs-v${VERSION}" \
-            "runner-v${VERSION}-aarch64-linux" \
-            --clobber
+          TAG="runner-rs-v${VERSION}"
+          ASSET_NAME="runner-v${VERSION}-aarch64-linux"
+          ASSET_PATH="crates/target/aarch64-unknown-linux-musl/release/runner"
+
+          # Get the release ID from the tag
+          RELEASE_ID=$(curl -sfL \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+
+          # Delete existing asset with the same name (--clobber equivalent)
+          EXISTING=$(curl -sfL \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets" \
+            | python3 -c "import sys,json; assets=json.load(sys.stdin); [print(a['id']) for a in assets if a['name']=='${ASSET_NAME}']") || true
+          for aid in $EXISTING; do
+            curl -sfL -X DELETE \
+              -H "Authorization: token ${GH_TOKEN}" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${aid}"
+          done
+
+          # Upload binary
+          curl -sfL \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Content-Type: application/octet-stream" \
+            --data-binary "@${ASSET_PATH}" \
+            "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${ASSET_NAME}"
 
       - name: Deploy to production with Ansible
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -472,7 +472,7 @@ jobs:
             -H "Authorization: token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets" \
-            | jq -r ".[] | select(.name==\"${ASSET_NAME}\") | .id") || true
+            | jq -r --arg name "${ASSET_NAME}" '.[] | select(.name==$name) | .id') || true
           for aid in $EXISTING; do
             curl -sfL -X DELETE \
               -H "Authorization: token ${GH_TOKEN}" \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -465,14 +465,14 @@ jobs:
             -H "Authorization: token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
-            | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+            | jq -r '.id')
 
           # Delete existing asset with the same name (--clobber equivalent)
           EXISTING=$(curl -sfL \
             -H "Authorization: token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets" \
-            | python3 -c "import sys,json; assets=json.load(sys.stdin); [print(a['id']) for a in assets if a['name']=='${ASSET_NAME}']") || true
+            | jq -r ".[] | select(.name==\"${ASSET_NAME}\") | .id") || true
           for aid in $EXISTING; do
             curl -sfL -X DELETE \
               -H "Authorization: token ${GH_TOKEN}" \


### PR DESCRIPTION
## Summary
- Replace `gh release upload` with `curl` + GitHub API in `deploy-runner-production` job
- The Rust toolchain container (`ghcr.io/vm0-ai/vm0-toolchain-rust`) doesn't have `gh` CLI installed
- Uses GitHub Releases API directly: get release ID by tag, delete existing asset if present, upload binary

Fixes the `gh: not found` error from #3320.

## Test plan
- [ ] Next runner-rs release should successfully upload the binary to GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)