### PR TITLE
feat(runner): copy guest system log to host after job

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -134,8 +134,8 @@ async fn execute_inner(
     // Run job inside sandbox, then destroy regardless of outcome
     let result = run_in_sandbox(sandbox.as_ref(), context, config, telemetry).await;
 
-    // Copy guest system log to host log directory (best-effort).
-    copy_system_log(sandbox.as_ref(), context, &config.log_paths).await;
+    // Copy guest logs to host log directory (best-effort).
+    copy_guest_logs(sandbox.as_ref(), context, &config.log_paths).await;
 
     // Unregister VM from proxy + upload network logs before cleanup timer.
     // Unregister first ensures the addon writes no more log entries.
@@ -305,36 +305,45 @@ fn dmesg_indicates_oom(stdout: &str) -> bool {
         || lower.contains("killed process")
 }
 
-/// Copy the guest system log to the host log directory.
+/// Copy guest log files to the host log directory.
 ///
 /// Best-effort: failures are logged but do not affect job outcome.
-async fn copy_system_log(sandbox: &dyn Sandbox, context: &ExecutionContext, log_paths: &LogPaths) {
-    let guest_path = format!("/tmp/vm0-system-{}.log", context.run_id);
-    let cat_cmd = format!("cat {guest_path}");
-    let result = sandbox
-        .exec(&ExecRequest {
-            cmd: &cat_cmd,
-            timeout: DEFAULT_EXEC_TIMEOUT,
-            env: &[],
-            sudo: false,
-        })
-        .await;
+async fn copy_guest_logs(sandbox: &dyn Sandbox, context: &ExecutionContext, log_paths: &LogPaths) {
+    let run_id = context.run_id;
+    let files = [
+        (
+            format!("/tmp/vm0-system-{run_id}.log"),
+            log_paths.system_log(run_id),
+        ),
+        (
+            format!("/tmp/vm0-metrics-{run_id}.jsonl"),
+            log_paths.metrics_log(run_id),
+        ),
+    ];
 
-    let output = match result {
-        Ok(r) if r.exit_code == 0 => r.stdout,
-        Ok(r) => {
-            info!(run_id = %context.run_id, exit_code = r.exit_code, "system log not found in guest");
-            return;
-        }
-        Err(e) => {
-            warn!(run_id = %context.run_id, error = %e, "failed to read system log from guest");
-            return;
-        }
-    };
+    for (guest_path, host_path) in &files {
+        let cat_cmd = format!("cat {guest_path}");
+        let result = sandbox
+            .exec(&ExecRequest {
+                cmd: &cat_cmd,
+                timeout: DEFAULT_EXEC_TIMEOUT,
+                env: &[],
+                sudo: false,
+            })
+            .await;
 
-    let host_path = log_paths.system_log(context.run_id);
-    if let Err(e) = tokio::fs::write(&host_path, &output).await {
-        warn!(run_id = %context.run_id, error = %e, "failed to write system log to host");
+        let output = match result {
+            Ok(r) if r.exit_code == 0 => r.stdout,
+            Ok(_) => continue,
+            Err(e) => {
+                warn!(run_id = %run_id, error = %e, path = %guest_path, "failed to read guest log");
+                continue;
+            }
+        };
+
+        if let Err(e) = tokio::fs::write(host_path, &output).await {
+            warn!(run_id = %run_id, error = %e, path = %host_path.display(), "failed to write guest log to host");
+        }
     }
 }
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -134,6 +134,9 @@ async fn execute_inner(
     // Run job inside sandbox, then destroy regardless of outcome
     let result = run_in_sandbox(sandbox.as_ref(), context, config, telemetry).await;
 
+    // Copy guest system log to host log directory (best-effort).
+    copy_system_log(sandbox.as_ref(), context, &config.log_paths).await;
+
     // Unregister VM from proxy + upload network logs before cleanup timer.
     // Unregister first ensures the addon writes no more log entries.
     if firewall_enabled {
@@ -300,6 +303,39 @@ fn dmesg_indicates_oom(stdout: &str) -> bool {
         || lower.contains("oom-kill")
         || lower.contains("oom_reaper")
         || lower.contains("killed process")
+}
+
+/// Copy the guest system log to the host log directory.
+///
+/// Best-effort: failures are logged but do not affect job outcome.
+async fn copy_system_log(sandbox: &dyn Sandbox, context: &ExecutionContext, log_paths: &LogPaths) {
+    let guest_path = format!("/tmp/vm0-system-{}.log", context.run_id);
+    let cat_cmd = format!("cat {guest_path}");
+    let result = sandbox
+        .exec(&ExecRequest {
+            cmd: &cat_cmd,
+            timeout: DEFAULT_EXEC_TIMEOUT,
+            env: &[],
+            sudo: false,
+        })
+        .await;
+
+    let output = match result {
+        Ok(r) if r.exit_code == 0 => r.stdout,
+        Ok(r) => {
+            info!(run_id = %context.run_id, exit_code = r.exit_code, "system log not found in guest");
+            return;
+        }
+        Err(e) => {
+            warn!(run_id = %context.run_id, error = %e, "failed to read system log from guest");
+            return;
+        }
+    };
+
+    let host_path = log_paths.system_log(context.run_id);
+    if let Err(e) = tokio::fs::write(&host_path, &output).await {
+        warn!(run_id = %context.run_id, error = %e, "failed to write system log to host");
+    }
 }
 
 /// Sync guest clock to host time after snapshot restore.

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -223,6 +223,10 @@ impl LogPaths {
         self.dir.join(format!("system-{run_id}.log"))
     }
 
+    pub fn metrics_log(&self, run_id: uuid::Uuid) -> PathBuf {
+        self.dir.join(format!("metrics-{run_id}.jsonl"))
+    }
+
     /// Whether `name` matches the `network-{run_id}.jsonl` pattern.
     pub fn is_network_log(name: &str) -> bool {
         name.starts_with("network-") && name.ends_with(".jsonl")

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -219,6 +219,10 @@ impl LogPaths {
         self.dir.join(format!("network-{run_id}.jsonl"))
     }
 
+    pub fn system_log(&self, run_id: uuid::Uuid) -> PathBuf {
+        self.dir.join(format!("system-{run_id}.log"))
+    }
+
     /// Whether `name` matches the `network-{run_id}.jsonl` pattern.
     pub fn is_network_log(name: &str) -> bool {
         name.starts_with("network-") && name.ends_with(".jsonl")


### PR DESCRIPTION
## Summary
- After job finishes (before sandbox destroy), read `/tmp/vm0-system-{run_id}.log` from guest via `exec cat` and write to host `logs/system-{run_id}.log`
- Best-effort: failures are logged but don't affect job outcome
- Makes system logs (including guest-download output from #3328) available on host for debugging

## Test plan
- [ ] Deploy to dev-2, run a job, verify `~/.vm0-runner/logs/system-{run_id}.log` exists on host
- [ ] Verify log contains both download and agent output

🤖 Generated with [Claude Code](https://claude.com/claude-code)