### PR TITLE
perf(sandbox-fc): prefetch snapshot memory.bin on factory startup

### DIFF
--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -1,4 +1,8 @@
+use std::fs::File;
+use std::path::Path;
+
 use async_trait::async_trait;
+use nix::fcntl::{PosixFadviseAdvice, posix_fadvise};
 use sandbox::{Sandbox, SandboxConfig, SandboxError, SandboxFactory};
 use sha2::{Digest, Sha256};
 use tracing::{info, warn};
@@ -298,8 +302,8 @@ impl SandboxFactory for FirecrackerFactory {
 /// memory accesses trigger host-side demand paging (~1.6s overhead).
 /// `posix_fadvise(WILLNEED)` is non-blocking — the kernel reads pages
 /// asynchronously in the background.
-fn prefetch_memory(path: &std::path::Path) {
-    let file = match std::fs::File::open(path) {
+fn prefetch_memory(path: &Path) {
+    let file = match File::open(path) {
         Ok(f) => f,
         Err(e) => {
             warn!(error = %e, path = %path.display(), "memory prefetch: open failed");
@@ -319,12 +323,7 @@ fn prefetch_memory(path: &std::path::Path) {
             return;
         }
     };
-    match nix::fcntl::posix_fadvise(
-        &file,
-        0,
-        len,
-        nix::fcntl::PosixFadviseAdvice::POSIX_FADV_WILLNEED,
-    ) {
+    match posix_fadvise(&file, 0, len, PosixFadviseAdvice::POSIX_FADV_WILLNEED) {
         Ok(()) => info!(bytes = len, path = %path.display(), "memory prefetch initiated"),
         Err(e) => warn!(error = %e, "memory prefetch: posix_fadvise failed"),
     }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -153,6 +153,10 @@ impl SandboxFactory for FirecrackerFactory {
         self.netns_pool = Some(tokio::sync::Mutex::new(netns_pool));
         self.overlay_pool = Some(tokio::sync::Mutex::new(overlay_pool));
 
+        if let Some(snapshot) = &self.config.snapshot {
+            prefetch_memory(&snapshot.memory_path);
+        }
+
         let mode = if self.config.snapshot.is_some() {
             "snapshot"
         } else {
@@ -285,5 +289,43 @@ impl SandboxFactory for FirecrackerFactory {
         }
 
         info!("factory shutdown complete");
+    }
+}
+
+/// Hint the kernel to prefetch the snapshot memory file into page cache.
+///
+/// Firecracker mmaps this file on snapshot load; without prefetching, guest
+/// memory accesses trigger host-side demand paging (~1.6s overhead).
+/// `posix_fadvise(WILLNEED)` is non-blocking — the kernel reads pages
+/// asynchronously in the background.
+fn prefetch_memory(path: &std::path::Path) {
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(e) => {
+            warn!(error = %e, path = %path.display(), "memory prefetch: open failed");
+            return;
+        }
+    };
+    let len: i64 = match file.metadata() {
+        Ok(m) => match m.len().try_into() {
+            Ok(n) => n,
+            Err(_) => {
+                warn!(path = %path.display(), "memory prefetch: file too large");
+                return;
+            }
+        },
+        Err(e) => {
+            warn!(error = %e, "memory prefetch: metadata failed");
+            return;
+        }
+    };
+    match nix::fcntl::posix_fadvise(
+        &file,
+        0,
+        len,
+        nix::fcntl::PosixFadviseAdvice::POSIX_FADV_WILLNEED,
+    ) {
+        Ok(()) => info!(bytes = len, path = %path.display(), "memory prefetch initiated"),
+        Err(e) => warn!(error = %e, "memory prefetch: posix_fadvise failed"),
     }
 }


### PR DESCRIPTION
## Summary

- Add `posix_fadvise(WILLNEED)` call during factory startup to prefetch the 2GB `memory.bin` snapshot file into the host page cache
- Eliminates ~1.6s demand-paging overhead on cold VM starts — since `memory.bin` is shared (not copied per-VM), one prefetch benefits all subsequent VMs
- Non-blocking: kernel reads pages asynchronously in the background, overlapping with first sandbox creation

## Test plan

- [x] `cargo clippy -p sandbox-fc --all-targets` — clean
- [x] `cargo test -p sandbox-fc` — 73 tests pass
- [ ] Deploy to dev-2 and benchmark with host cache dropped:
  ```
  echo 3 | sudo tee /proc/sys/vm/drop_caches
  runner benchmark -c config.yaml "claude --version"
  ```
  Expect Run1 to drop from ~4.5s to ~2.9s (matching host-cache-warm baseline)

Closes #3342

🤖 Generated with [Claude Code](https://claude.com/claude-code)