### PR TITLE
feat(runner): inject agent name and scope env vars into sandbox runtime

### DIFF
--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
@@ -1,14 +1,20 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { POST } from "../route";
 import { randomUUID } from "crypto";
+import { eq } from "drizzle-orm";
 import {
   createTestRequest,
   createTestCliToken,
+  createTestCompose,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
+import { agentRuns } from "../../../../../../../src/db/schema/agent-run";
+import { runnerJobQueue } from "../../../../../../../src/db/schema/runner-job-queue";
+import { scopes } from "../../../../../../../src/db/schema/scope";
+import { encryptSecrets } from "../../../../../../../src/lib/crypto/secrets-encryption";
 
 const context = testContext();
 
@@ -226,6 +232,140 @@ describe("POST /api/runners/jobs/:id/claim", () => {
         expect(response.status).toBe(401);
         expect(data.error.message).toContain("Not authenticated");
       });
+    });
+  });
+
+  describe("Claim flow - Agent metadata", () => {
+    it("should return agentName and agentScopeSlug in claim response", async () => {
+      // Look up user's scope slug
+      const [scope] = await globalThis.services.db
+        .select({ slug: scopes.slug })
+        .from(scopes)
+        .where(eq(scopes.id, user.scopeId))
+        .limit(1);
+
+      // Create compose (links to user's scope)
+      const { versionId } = await createTestCompose("test-agent");
+
+      // Create run record
+      const [run] = await globalThis.services.db
+        .insert(agentRuns)
+        .values({
+          userId: user.userId,
+          agentComposeVersionId: versionId,
+          status: "pending",
+          prompt: "test prompt",
+        })
+        .returning({ id: agentRuns.id });
+
+      // Queue runner job with agent metadata in stored context
+      const runnerGroup = `${scope!.slug}/default`;
+      const encryptedSecrets = encryptSecrets(
+        null,
+        globalThis.services.env.SECRETS_ENCRYPTION_KEY,
+      );
+
+      await globalThis.services.db.insert(runnerJobQueue).values({
+        runId: run!.id,
+        runnerGroup,
+        executionContext: {
+          workingDir: "/home/user",
+          storageManifest: null,
+          environment: null,
+          resumeSession: null,
+          encryptedSecrets,
+          cliAgentType: "claude",
+          agentName: "test-agent",
+          agentScopeSlug: scope!.slug,
+        },
+        expiresAt: new Date(Date.now() + 2 * 60 * 60 * 1000),
+      });
+
+      // Claim the job
+      const token = await createTestCliToken(user.userId);
+      const request = createTestRequest(
+        `http://localhost:3000/api/runners/jobs/${run!.id}/claim`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({}),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.agentName).toBe("test-agent");
+      expect(data.agentScopeSlug).toBe(scope!.slug);
+    });
+
+    it("should omit agentName and agentScopeSlug when not set in stored context", async () => {
+      // Look up user's scope slug
+      const [scope] = await globalThis.services.db
+        .select({ slug: scopes.slug })
+        .from(scopes)
+        .where(eq(scopes.id, user.scopeId))
+        .limit(1);
+
+      // Create compose
+      const { versionId } = await createTestCompose("test-agent-no-meta");
+
+      // Create run record
+      const [run] = await globalThis.services.db
+        .insert(agentRuns)
+        .values({
+          userId: user.userId,
+          agentComposeVersionId: versionId,
+          status: "pending",
+          prompt: "test prompt",
+        })
+        .returning({ id: agentRuns.id });
+
+      // Queue runner job WITHOUT agent metadata
+      const runnerGroup = `${scope!.slug}/default`;
+      const encryptedSecrets = encryptSecrets(
+        null,
+        globalThis.services.env.SECRETS_ENCRYPTION_KEY,
+      );
+
+      await globalThis.services.db.insert(runnerJobQueue).values({
+        runId: run!.id,
+        runnerGroup,
+        executionContext: {
+          workingDir: "/home/user",
+          storageManifest: null,
+          environment: null,
+          resumeSession: null,
+          encryptedSecrets,
+          cliAgentType: "claude",
+        },
+        expiresAt: new Date(Date.now() + 2 * 60 * 60 * 1000),
+      });
+
+      // Claim the job
+      const token = await createTestCliToken(user.userId);
+      const request = createTestRequest(
+        `http://localhost:3000/api/runners/jobs/${run!.id}/claim`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({}),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.agentName).toBeUndefined();
+      expect(data.agentScopeSlug).toBeUndefined();
     });
   });
 });

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
@@ -1,20 +1,17 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { POST } from "../route";
 import { randomUUID } from "crypto";
-import { eq } from "drizzle-orm";
 import {
   createTestRequest,
   createTestCliToken,
   createTestCompose,
+  createTestRunnerJob,
+  findTestComposeWithScope,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
-import { agentRuns } from "../../../../../../../src/db/schema/agent-run";
-import { runnerJobQueue } from "../../../../../../../src/db/schema/runner-job-queue";
-import { scopes } from "../../../../../../../src/db/schema/scope";
-import { encryptSecrets } from "../../../../../../../src/lib/crypto/secrets-encryption";
 
 const context = testContext();
 
@@ -237,54 +234,26 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
   describe("Claim flow - Agent metadata", () => {
     it("should return agentName and agentScopeSlug in claim response", async () => {
-      // Look up user's scope slug
-      const [scope] = await globalThis.services.db
-        .select({ slug: scopes.slug })
-        .from(scopes)
-        .where(eq(scopes.id, user.scopeId))
-        .limit(1);
+      // Create compose and look up scope slug
+      const { composeId, versionId } = await createTestCompose("test-agent");
+      const composeInfo = await findTestComposeWithScope(composeId);
+      const scopeSlug = composeInfo!.scopeSlug;
 
-      // Create compose (links to user's scope)
-      const { versionId } = await createTestCompose("test-agent");
-
-      // Create run record
-      const [run] = await globalThis.services.db
-        .insert(agentRuns)
-        .values({
-          userId: user.userId,
-          agentComposeVersionId: versionId,
-          status: "pending",
-          prompt: "test prompt",
-        })
-        .returning({ id: agentRuns.id });
-
-      // Queue runner job with agent metadata in stored context
-      const runnerGroup = `${scope!.slug}/default`;
-      const encryptedSecrets = encryptSecrets(
-        null,
-        globalThis.services.env.SECRETS_ENCRYPTION_KEY,
-      );
-
-      await globalThis.services.db.insert(runnerJobQueue).values({
-        runId: run!.id,
-        runnerGroup,
-        executionContext: {
-          workingDir: "/home/user",
-          storageManifest: null,
-          environment: null,
-          resumeSession: null,
-          encryptedSecrets,
-          cliAgentType: "claude",
+      // Create runner job with agent metadata in stored context
+      const { runId } = await createTestRunnerJob(
+        user.userId,
+        versionId,
+        `${scopeSlug}/default`,
+        {
           agentName: "test-agent",
-          agentScopeSlug: scope!.slug,
+          agentScopeSlug: scopeSlug,
         },
-        expiresAt: new Date(Date.now() + 2 * 60 * 60 * 1000),
-      });
+      );
 
       // Claim the job
       const token = await createTestCliToken(user.userId);
       const request = createTestRequest(
-        `http://localhost:3000/api/runners/jobs/${run!.id}/claim`,
+        `http://localhost:3000/api/runners/jobs/${runId}/claim`,
         {
           method: "POST",
           headers: {
@@ -300,56 +269,27 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
       const data = await response.json();
       expect(data.agentName).toBe("test-agent");
-      expect(data.agentScopeSlug).toBe(scope!.slug);
+      expect(data.agentScopeSlug).toBe(scopeSlug);
     });
 
     it("should omit agentName and agentScopeSlug when not set in stored context", async () => {
-      // Look up user's scope slug
-      const [scope] = await globalThis.services.db
-        .select({ slug: scopes.slug })
-        .from(scopes)
-        .where(eq(scopes.id, user.scopeId))
-        .limit(1);
+      // Create compose and look up scope slug
+      const { composeId, versionId } =
+        await createTestCompose("test-agent-no-meta");
+      const composeInfo = await findTestComposeWithScope(composeId);
+      const scopeSlug = composeInfo!.scopeSlug;
 
-      // Create compose
-      const { versionId } = await createTestCompose("test-agent-no-meta");
-
-      // Create run record
-      const [run] = await globalThis.services.db
-        .insert(agentRuns)
-        .values({
-          userId: user.userId,
-          agentComposeVersionId: versionId,
-          status: "pending",
-          prompt: "test prompt",
-        })
-        .returning({ id: agentRuns.id });
-
-      // Queue runner job WITHOUT agent metadata
-      const runnerGroup = `${scope!.slug}/default`;
-      const encryptedSecrets = encryptSecrets(
-        null,
-        globalThis.services.env.SECRETS_ENCRYPTION_KEY,
+      // Create runner job WITHOUT agent metadata
+      const { runId } = await createTestRunnerJob(
+        user.userId,
+        versionId,
+        `${scopeSlug}/default`,
       );
-
-      await globalThis.services.db.insert(runnerJobQueue).values({
-        runId: run!.id,
-        runnerGroup,
-        executionContext: {
-          workingDir: "/home/user",
-          storageManifest: null,
-          environment: null,
-          resumeSession: null,
-          encryptedSecrets,
-          cliAgentType: "claude",
-        },
-        expiresAt: new Date(Date.now() + 2 * 60 * 60 * 1000),
-      });
 
       // Claim the job
       const token = await createTestCliToken(user.userId);
       const request = createTestRequest(
-        `http://localhost:3000/api/runners/jobs/${run!.id}/claim`,
+        `http://localhost:3000/api/runners/jobs/${runId}/claim`,
         {
           method: "POST",
           headers: {

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -196,6 +196,8 @@ const router = tsr.router(runnersJobClaimContract, {
         debugNoMockClaude: storedContext.debugNoMockClaude,
         apiStartTime: storedContext.apiStartTime,
         userTimezone: storedContext.userTimezone,
+        agentName: storedContext.agentName,
+        agentScopeSlug: storedContext.agentScopeSlug,
       },
     };
   },

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -14,6 +14,7 @@ import {
 import { cliTokens } from "../db/schema/cli-tokens";
 import { deviceCodes } from "../db/schema/device-codes";
 import { agentRuns } from "../db/schema/agent-run";
+import { runnerJobQueue } from "../db/schema/runner-job-queue";
 import { composeJobs } from "../db/schema/compose-job";
 import { storages, storageVersions } from "../db/schema/storage";
 import { usageDaily } from "../db/schema/usage-daily";
@@ -24,6 +25,8 @@ import { emailThreadSessions } from "../db/schema/email-thread-session";
 import { agentRunCallbacks } from "../db/schema/agent-run-callback";
 import { and, eq, like } from "drizzle-orm";
 import { generateCallbackSecret } from "../lib/callback/hmac";
+import { encryptSecrets } from "../lib/crypto/secrets-encryption";
+import type { StoredExecutionContext } from "@vm0/core";
 
 // Route handlers - imported here so callers don't need to pass them
 import { POST as createComposeRoute } from "../../app/api/agent/composes/route";
@@ -1942,4 +1945,54 @@ export async function findTestComposeWithScope(composeId: string) {
     .where(eq(agentComposes.id, composeId))
     .limit(1);
   return row;
+}
+
+/**
+ * Create a runner job queue entry with an associated agent run.
+ *
+ * @param userId - The user who owns the run
+ * @param versionId - The agent compose version ID
+ * @param runnerGroup - The runner group (e.g., "scope-slug/default")
+ * @param contextOverrides - Optional overrides for the stored execution context
+ * @returns The created run ID
+ */
+export async function createTestRunnerJob(
+  userId: string,
+  versionId: string,
+  runnerGroup: string,
+  contextOverrides?: Partial<StoredExecutionContext>,
+): Promise<{ runId: string }> {
+  const [run] = await globalThis.services.db
+    .insert(agentRuns)
+    .values({
+      userId,
+      agentComposeVersionId: versionId,
+      status: "pending",
+      prompt: "test prompt",
+    })
+    .returning({ id: agentRuns.id });
+
+  const encryptedSecrets = encryptSecrets(
+    null,
+    globalThis.services.env.SECRETS_ENCRYPTION_KEY,
+  );
+
+  const storedContext: StoredExecutionContext = {
+    workingDir: "/home/user",
+    storageManifest: null,
+    environment: null,
+    resumeSession: null,
+    encryptedSecrets,
+    cliAgentType: "claude",
+    ...contextOverrides,
+  };
+
+  await globalThis.services.db.insert(runnerJobQueue).values({
+    runId: run!.id,
+    runnerGroup,
+    executionContext: storedContext,
+    expiresAt: new Date(Date.now() + 2 * 60 * 60 * 1000),
+  });
+
+  return { runId: run!.id };
 }

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -255,7 +255,7 @@ function buildPreparedContext(
   runnerGroup: string | null,
   storageManifest: StorageManifest,
   experimentalFirewall: CoreExperimentalFirewall | null,
-  agentScopeSlug: string,
+  agentScopeSlug: string | null,
 ): PreparedContext {
   return {
     // Identity

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -15,6 +15,7 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../db/schema/agent-compose";
+import { scopes } from "../../../db/schema/scope";
 import type { ExperimentalFirewall as CoreExperimentalFirewall } from "@vm0/core";
 import { extractCliAgentType } from "../utils";
 
@@ -190,14 +191,18 @@ export async function prepareForExecution(
     throw badRequest("Runner scope not found");
   }
 
-  // Resolve owner's scope from compose for volume access
+  // Resolve owner's scope from compose for volume access and agent metadata
   const [composeInfo] = await globalThis.services.db
-    .select({ scopeId: agentComposes.scopeId })
+    .select({
+      scopeId: agentComposes.scopeId,
+      scopeSlug: scopes.slug,
+    })
     .from(agentComposeVersions)
     .innerJoin(
       agentComposes,
       eq(agentComposeVersions.composeId, agentComposes.id),
     )
+    .innerJoin(scopes, eq(agentComposes.scopeId, scopes.id))
     .where(eq(agentComposeVersions.id, context.agentComposeVersionId))
     .limit(1);
 
@@ -232,6 +237,7 @@ export async function prepareForExecution(
     runnerGroup,
     storageManifest,
     experimentalFirewall,
+    composeInfo.scopeSlug,
   );
 
   log.debug(`PreparedContext built for run ${context.runId}`);
@@ -249,6 +255,7 @@ function buildPreparedContext(
   runnerGroup: string | null,
   storageManifest: StorageManifest,
   experimentalFirewall: CoreExperimentalFirewall | null,
+  agentScopeSlug: string,
 ): PreparedContext {
   return {
     // Identity
@@ -287,6 +294,7 @@ function buildPreparedContext(
 
     // Metadata
     agentName: context.agentName || null,
+    agentScopeSlug,
     resumedFromCheckpointId: context.resumedFromCheckpointId || null,
     continuedFromSessionId: context.continuedFromSessionId || null,
 

--- a/turbo/apps/web/src/lib/run/executors/docker-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/docker-executor.ts
@@ -247,6 +247,15 @@ async function buildSandboxEnvVars(
     CLI_AGENT_TYPE: context.cliAgentType,
   };
 
+  // Inject agent metadata
+  if (context.agentName) {
+    sandboxEnvVars.VM0_AGENT_NAME = context.agentName;
+  }
+
+  if (context.agentScopeSlug) {
+    sandboxEnvVars.VM0_AGENT_SCOPE = context.agentScopeSlug;
+  }
+
   if (context.resumeSession?.sessionId) {
     sandboxEnvVars.VM0_RESUME_SESSION_ID = context.resumeSession.sessionId;
   }

--- a/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
@@ -263,6 +263,15 @@ function buildSandboxEnvVars(
     CLI_AGENT_TYPE: context.cliAgentType,
   };
 
+  // Inject agent metadata
+  if (context.agentName) {
+    sandboxEnvVars.VM0_AGENT_NAME = context.agentName;
+  }
+
+  if (context.agentScopeSlug) {
+    sandboxEnvVars.VM0_AGENT_SCOPE = context.agentScopeSlug;
+  }
+
   // Add Vercel protection bypass if available
   const vercelBypassSecret = env().VERCEL_AUTOMATION_BYPASS_SECRET;
   if (vercelBypassSecret) {

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -62,6 +62,8 @@ export async function executeRunnerJob(
     debugNoMockClaude: context.debugNoMockClaude || undefined,
     apiStartTime: context.apiStartTime ?? undefined,
     userTimezone: context.userTimezone ?? undefined,
+    agentName: context.agentName ?? undefined,
+    agentScopeSlug: context.agentScopeSlug ?? undefined,
   };
 
   // Insert into runner job queue

--- a/turbo/apps/web/src/lib/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/run/executors/types.ts
@@ -47,6 +47,7 @@ export interface PreparedContext {
 
   // Metadata for vm0_start event
   agentName: string | null;
+  agentScopeSlug: string | null;
   resumedFromCheckpointId: string | null;
   continuedFromSessionId: string | null;
 

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -132,6 +132,9 @@ export const storedExecutionContextSchema = z.object({
   apiStartTime: z.number().optional(),
   // User's timezone preference (IANA format, e.g., "Asia/Shanghai")
   userTimezone: z.string().optional(),
+  // Agent metadata for VM0_AGENT_NAME and VM0_AGENT_SCOPE env vars
+  agentName: z.string().optional(),
+  agentScopeSlug: z.string().optional(),
 });
 
 /**
@@ -160,6 +163,9 @@ export const executionContextSchema = z.object({
   apiStartTime: z.number().optional(),
   // User's timezone preference (IANA format, e.g., "Asia/Shanghai")
   userTimezone: z.string().optional(),
+  // Agent metadata
+  agentName: z.string().optional(),
+  agentScopeSlug: z.string().optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Inject `VM0_AGENT_NAME` and `VM0_AGENT_SCOPE` environment variables into the agent runtime sandbox
- Thread agent owner's scope slug from DB through `PreparedContext` to all three execution paths (Docker, E2B, Runner)
- Add agent metadata fields to `StoredExecutionContext` schema and runner claim response for runner parity

## Motivation

Agents currently have no way to know their own name or scope at runtime, forcing hardcoded identifiers in operations like self-update. These new environment variables enable generic, reusable self-aware agent capabilities.

## Changes

| File | Change |
|------|--------|
| `executors/types.ts` | Add `agentScopeSlug` field to `PreparedContext` |
| `context/execution-preparer.ts` | Extend DB query to join `scopes` table, thread slug through |
| `executors/docker-executor.ts` | Inject `VM0_AGENT_NAME` and `VM0_AGENT_SCOPE` in `buildSandboxEnvVars()` |
| `executors/e2b-executor.ts` | Same injection as Docker executor |
| `executors/runner-executor.ts` | Store `agentName` and `agentScopeSlug` in `StoredExecutionContext` |
| `@vm0/core runners.ts` | Add optional fields to `storedExecutionContextSchema` and `executionContextSchema` |
| `runners/jobs/[id]/claim/route.ts` | Return agent metadata in claim response |

## Test plan

- [x] TypeScript type check passes (`web`, `@vm0/core`)
- [x] Lint passes (oxlint + eslint)
- [x] Format passes (prettier)
- [x] Knip passes (no unused exports)
- [x] Existing executor tests pass (15/15)
- [x] Core package tests pass (223/223)
- [ ] CI pipeline passes

Closes #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)