### PR TITLE
feat(connector): add gmail connector feature flag

### DIFF
--- a/turbo/apps/platform/src/signals/settings-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/settings-page/connectors.ts
@@ -60,6 +60,10 @@ export const allConnectorTypes$ = computed(async (get) => {
       if (type === "figma" && !features?.[FeatureSwitchKey.FigmaConnector]) {
         return false;
       }
+      // Filter gmail connector based on feature flag
+      if (type === "gmail" && !features?.[FeatureSwitchKey.GmailConnector]) {
+        return false;
+      }
       return true;
     })
     .map((type) => {

--- a/turbo/apps/platform/src/views/settings-page/__tests__/connectors.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/connectors.test.tsx
@@ -34,7 +34,11 @@ describe("connectors tab", () => {
     await setupPage({
       context,
       path: "/settings?tab=connectors",
-      featureSwitches: { linearConnector: true, dropboxConnector: true },
+      featureSwitches: {
+        linearConnector: true,
+        dropboxConnector: true,
+        gmailConnector: true,
+      },
     });
 
     expect(screen.getByText("Dropbox")).toBeInTheDocument();

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -14,4 +14,5 @@ export enum FeatureSwitchKey {
   LinearConnector = "linearConnector",
   DropboxConnector = "dropboxConnector",
   FigmaConnector = "figmaConnector",
+  GmailConnector = "gmailConnector",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -56,6 +56,10 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     enabled: false,
   },
+  [FeatureSwitchKey.GmailConnector]: {
+    maintainer: "ethan@vm0.ai",
+    enabled: false,
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary
- Add `GmailConnector` entry to the `FeatureSwitchKey` enum
- Register the Gmail connector feature switch (disabled by default, maintained by ethan@vm0.ai)
- Filter the Gmail connector in the settings page connector list based on the feature flag

## Test plan
- [ ] Verify Gmail connector does not appear in the settings page when the feature flag is disabled
- [ ] Verify Gmail connector appears in the settings page when the feature flag is enabled
- [ ] Verify no regression for other connectors (Figma, Linear, Dropbox, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)