### PR TITLE
fix: resolve double scrollbar on mobile safari in agent detail page

### DIFF
--- a/turbo/apps/platform/src/views/layout/app-shell.tsx
+++ b/turbo/apps/platform/src/views/layout/app-shell.tsx
@@ -33,7 +33,7 @@ export function AppShell({
   const normalizedBreadcrumb = normalizeBreadcrumb(breadcrumb);
 
   return (
-    <div className="flex h-screen">
+    <div className="flex h-dvh">
       <Sidebar />
       <div className="flex flex-1 flex-col min-w-0">
         <Navbar breadcrumb={normalizedBreadcrumb} />


### PR DESCRIPTION
## Summary
- Replace `h-screen` (100vh) with `h-dvh` (100dvh) in the AppShell root layout container
- On Mobile Safari, `100vh` includes the area behind the browser chrome (address bar), making the container taller than the visible viewport
- This caused the body to produce a scrollbar in addition to the `<main>` content area scrollbar, resulting in two overlapping scrollbars
- The `dvh` (dynamic viewport height) unit dynamically adjusts to the actual visible viewport, eliminating the double scrollbar

## Test plan
- [ ] Verify on Mobile Safari that only one scrollbar appears on the agent detail page
- [ ] Verify desktop browsers are unaffected (dvh behaves the same as vh on desktop)
- [ ] Check other pages using AppShell layout for consistent behavior

Closes #3229

🤖 Generated with [Claude Code](https://claude.com/claude-code)