### PR TITLE
fix(platform): resolve empty logs page for scoped agents

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/v1-runs.ts
+++ b/turbo/apps/platform/src/mocks/handlers/v1-runs.ts
@@ -67,6 +67,7 @@ export const platformLogsHandlers = [
         id: log.id,
         sessionId: log.sessionId,
         agentName: log.agentName,
+        scopeSlug: null,
         framework: log.framework,
         status: log.status,
         createdAt: log.createdAt,

--- a/turbo/apps/platform/src/signals/agent-detail/agent-logs.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-logs.ts
@@ -18,15 +18,24 @@ export const {
   setRowsPerPage$: setAgentLogsRowsPerPage$,
 } = createCursorPagination({
   buildFetchParams: (limit, cursor, get) => {
-    const agentName = get(agentName$);
-    if (!agentName) {
+    const rawName = get(agentName$);
+    if (!rawName) {
       return null;
     }
 
+    // Split scoped name (e.g., "e7h4n/agent0") into name and scope
+    const slashIndex = rawName.indexOf("/");
+    const isOwner = slashIndex === -1;
+    const name = isOwner ? rawName : rawName.slice(slashIndex + 1);
+    const scope = isOwner ? undefined : rawName.slice(0, slashIndex);
+
     const params = new URLSearchParams({
       limit: String(limit),
-      agent: agentName,
+      name,
     });
+    if (scope) {
+      params.set("scope", scope);
+    }
     if (cursor) {
       params.set("cursor", cursor);
     }

--- a/turbo/apps/platform/src/signals/logs-page/types.ts
+++ b/turbo/apps/platform/src/signals/logs-page/types.ts
@@ -14,6 +14,7 @@ export interface LogEntry {
   id: string;
   sessionId: string | null;
   agentName: string;
+  scopeSlug: string | null;
   framework: string | null;
   status: LogStatus;
   createdAt: string;

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-logs-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-logs-page.test.tsx
@@ -73,9 +73,9 @@ function mockLogsAPI(options?: {
   server.use(
     http.get("/api/platform/logs", ({ request }) => {
       const url = new URL(request.url);
-      const queryAgent = url.searchParams.get("agent");
+      const queryName = url.searchParams.get("name");
 
-      if (queryAgent !== agentName) {
+      if (queryName !== agentName) {
         return HttpResponse.json({
           data: [],
           pagination: { hasMore: false, nextCursor: null, totalPages: 1 },

--- a/turbo/apps/platform/src/views/logs-page/logs-table-row.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-table-row.tsx
@@ -51,7 +51,9 @@ export function LogsTableRow({ entry }: LogsTableRowProps) {
       </TableCell>
       <TableCell className="px-3 py-2 text-sm w-[15%] min-w-[120px]">
         <span className="block truncate whitespace-nowrap">
-          {entry.agentName}
+          {entry.scopeSlug
+            ? `${entry.scopeSlug}/${entry.agentName}`
+            : entry.agentName}
         </span>
       </TableCell>
       <TableCell className="px-3 py-2 text-sm w-[12%] min-w-[120px]">

--- a/turbo/apps/web/app/api/platform/logs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/platform/logs/__tests__/route.test.ts
@@ -277,6 +277,66 @@ describe("GET /api/platform/logs", () => {
     expect(returnedIds).not.toContain(otherRunId);
   });
 
+  describe("name and scope filter", () => {
+    let agentName: string;
+
+    beforeEach(async () => {
+      agentName = `scope-agent-${randomUUID().slice(0, 8)}`;
+      const { composeId } = await createTestCompose(agentName);
+
+      const { runId } = await createTestRun(composeId, "Scoped prompt");
+      await completeTestRun(user.userId, runId);
+    });
+
+    it("should filter by name param", async () => {
+      const request = createTestRequest(
+        `http://localhost:3000/api/platform/logs?name=${agentName}`,
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data).toHaveLength(1);
+      expect(data.data[0].agentName).toBe(agentName);
+    });
+
+    it("should return empty when name matches but scope does not", async () => {
+      const request = createTestRequest(
+        `http://localhost:3000/api/platform/logs?name=${agentName}&scope=nonexistent-scope`,
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data).toEqual([]);
+    });
+
+    it("should include scopeSlug in response", async () => {
+      const request = createTestRequest(
+        `http://localhost:3000/api/platform/logs?name=${agentName}`,
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data).toHaveLength(1);
+      expect(data.data[0].scopeSlug).toBeDefined();
+      expect(typeof data.data[0].scopeSlug).toBe("string");
+    });
+
+    it("name param should take precedence over agent param", async () => {
+      const request = createTestRequest(
+        `http://localhost:3000/api/platform/logs?name=${agentName}&agent=nonexistent`,
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data).toHaveLength(1);
+      expect(data.data[0].agentName).toBe(agentName);
+    });
+  });
+
   it("should return 400 for invalid limit", async () => {
     const request = createTestRequest(
       "http://localhost:3000/api/platform/logs?limit=0",

--- a/turbo/apps/web/app/api/platform/logs/route.ts
+++ b/turbo/apps/web/app/api/platform/logs/route.ts
@@ -15,13 +15,115 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
+import { scopes } from "../../../../src/db/schema/scope";
 import { conversations } from "../../../../src/db/schema/conversation";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
-import { eq, and, desc, lt, or, ilike, count } from "drizzle-orm";
+import { eq, and, desc, lt, or, ilike, count, type SQL } from "drizzle-orm";
 
 // Minimal type for extracting framework from compose content
 interface AgentComposeContent {
   agents: Record<string, { framework: string }>;
+}
+
+interface LogsQuery {
+  name?: string;
+  scope?: string;
+  agent?: string;
+  search?: string;
+  cursor?: string;
+  limit?: number;
+}
+
+/**
+ * Build agent name/scope filter conditions from query params.
+ * name+scope take precedence over legacy agent param, which takes precedence over search.
+ */
+function buildAgentFilterConditions(query: LogsQuery): SQL[] {
+  const conditions: SQL[] = [];
+
+  if (query.name) {
+    conditions.push(eq(agentComposes.name, query.name));
+    if (query.scope) {
+      conditions.push(eq(scopes.slug, query.scope));
+    }
+  } else if (query.agent) {
+    conditions.push(eq(agentComposes.name, query.agent));
+  } else if (query.search) {
+    conditions.push(ilike(agentComposes.name, `%${query.search}%`));
+  }
+
+  return conditions;
+}
+
+/**
+ * Build cursor pagination condition from cursor string.
+ * Cursor format: "createdAt|id" (ISO timestamp|uuid)
+ */
+function buildCursorCondition(cursor: string): SQL | null {
+  const separatorIndex = cursor.lastIndexOf("|");
+  if (separatorIndex <= 0) return null;
+
+  const cursorTime = cursor.slice(0, separatorIndex);
+  const cursorId = cursor.slice(separatorIndex + 1);
+  const cursorDate = new Date(cursorTime);
+
+  return or(
+    lt(agentRuns.createdAt, cursorDate),
+    and(eq(agentRuns.createdAt, cursorDate), lt(agentRuns.id, cursorId)),
+  )!;
+}
+
+/**
+ * Get total count of matching runs for pagination.
+ */
+async function getTotalCount(
+  userId: string,
+  query: LogsQuery,
+): Promise<number> {
+  const conditions: SQL[] = [eq(agentRuns.userId, userId)];
+  conditions.push(...buildAgentFilterConditions(query));
+
+  const needsComposeJoin = !!(query.name || query.agent || query.search);
+
+  let countQuery;
+  if (needsComposeJoin) {
+    let q = globalThis.services.db
+      .select({ count: count() })
+      .from(agentRuns)
+      .leftJoin(
+        agentComposeVersions,
+        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+      )
+      .leftJoin(
+        agentComposes,
+        eq(agentComposeVersions.composeId, agentComposes.id),
+      );
+
+    if (query.scope) {
+      q = q.leftJoin(scopes, eq(agentComposes.scopeId, scopes.id)) as typeof q;
+    }
+
+    countQuery = q.where(and(...conditions));
+  } else {
+    countQuery = globalThis.services.db
+      .select({ count: count() })
+      .from(agentRuns)
+      .where(and(...conditions));
+  }
+
+  const [result] = await countQuery;
+  return result?.count ?? 0;
+}
+
+/**
+ * Extract framework string from compose content.
+ */
+function extractFramework(composeContent: unknown): string | null {
+  const content = composeContent as AgentComposeContent | null;
+  const agentNames = content?.agents ? Object.keys(content.agents) : [];
+  const firstAgent =
+    agentNames.length > 0 ? content?.agents[agentNames[0]!] : null;
+  return firstAgent?.framework ?? null;
 }
 
 const router = tsr.router(platformLogsListContract, {
@@ -40,36 +142,17 @@ const router = tsr.router(platformLogsListContract, {
 
     const limit = query.limit ?? 20;
 
-    // Build base conditions - filter by user
-    const conditions = [eq(agentRuns.userId, userId)];
+    // Build conditions
+    const conditions: SQL[] = [eq(agentRuns.userId, userId)];
 
-    // Handle cursor-based pagination
-    // Cursor format: "createdAt|id" (ISO timestamp|uuid)
     if (query.cursor) {
-      const separatorIndex = query.cursor.lastIndexOf("|");
-      if (separatorIndex > 0) {
-        const cursorTime = query.cursor.slice(0, separatorIndex);
-        const cursorId = query.cursor.slice(separatorIndex + 1);
-        const cursorDate = new Date(cursorTime);
-        // Get records older than cursor, or same time but smaller id
-        conditions.push(
-          or(
-            lt(agentRuns.createdAt, cursorDate),
-            and(
-              eq(agentRuns.createdAt, cursorDate),
-              lt(agentRuns.id, cursorId),
-            ),
-          )!,
-        );
+      const cursorCondition = buildCursorCondition(query.cursor);
+      if (cursorCondition) {
+        conditions.push(cursorCondition);
       }
     }
 
-    // Agent name filter: exact match takes precedence over fuzzy search
-    if (query.agent) {
-      conditions.push(eq(agentComposes.name, query.agent));
-    } else if (query.search) {
-      conditions.push(ilike(agentComposes.name, `%${query.search}%`));
-    }
+    conditions.push(...buildAgentFilterConditions(query));
 
     const runs = await globalThis.services.db
       .select({
@@ -77,6 +160,7 @@ const router = tsr.router(platformLogsListContract, {
         status: agentRuns.status,
         createdAt: agentRuns.createdAt,
         composeName: agentComposes.name,
+        scopeSlug: scopes.slug,
         sessionId: conversations.cliAgentSessionId,
         composeContent: agentComposeVersions.content,
       })
@@ -89,41 +173,13 @@ const router = tsr.router(platformLogsListContract, {
         agentComposes,
         eq(agentComposeVersions.composeId, agentComposes.id),
       )
+      .leftJoin(scopes, eq(agentComposes.scopeId, scopes.id))
       .leftJoin(conversations, eq(agentRuns.id, conversations.runId))
       .where(and(...conditions))
       .orderBy(desc(agentRuns.createdAt), desc(agentRuns.id))
       .limit(limit + 1);
 
-    // Get total count for pagination
-    const countConditions = [eq(agentRuns.userId, userId)];
-    if (query.agent) {
-      countConditions.push(eq(agentComposes.name, query.agent));
-    } else if (query.search) {
-      countConditions.push(ilike(agentComposes.name, `%${query.search}%`));
-    }
-
-    let countQuery = globalThis.services.db
-      .select({ count: count() })
-      .from(agentRuns)
-      .where(and(...countConditions));
-
-    if (query.agent || query.search) {
-      countQuery = globalThis.services.db
-        .select({ count: count() })
-        .from(agentRuns)
-        .leftJoin(
-          agentComposeVersions,
-          eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-        )
-        .leftJoin(
-          agentComposes,
-          eq(agentComposeVersions.composeId, agentComposes.id),
-        )
-        .where(and(...countConditions));
-    }
-
-    const [countResult] = await countQuery;
-    const totalCount = countResult?.count ?? 0;
+    const totalCount = await getTotalCount(userId, query);
     const totalPages = Math.max(1, Math.ceil(totalCount / limit));
 
     // Determine pagination info
@@ -140,27 +196,19 @@ const router = tsr.router(platformLogsListContract, {
     return {
       status: 200 as const,
       body: {
-        data: data.map((run) => {
-          // Extract framework from compose content (first agent definition)
-          const content = run.composeContent as AgentComposeContent | null;
-          const agentNames = content?.agents ? Object.keys(content.agents) : [];
-          const firstAgent =
-            agentNames.length > 0 ? content?.agents[agentNames[0]!] : null;
-          const framework = firstAgent?.framework ?? null;
-
-          return {
-            id: run.id,
-            sessionId: run.sessionId ?? null,
-            agentName: run.composeName ?? "unknown",
-            framework,
-            status: run.status as PlatformLogStatus,
-            createdAt: run.createdAt.toISOString(),
-          };
-        }),
+        data: data.map((run) => ({
+          id: run.id,
+          sessionId: run.sessionId ?? null,
+          agentName: run.composeName ?? "unknown",
+          scopeSlug: run.scopeSlug ?? null,
+          framework: extractFramework(run.composeContent),
+          status: run.status as PlatformLogStatus,
+          createdAt: run.createdAt.toISOString(),
+        })),
         pagination: {
-          hasMore: hasMore,
-          nextCursor: nextCursor,
-          totalPages: totalPages,
+          hasMore,
+          nextCursor,
+          totalPages,
         },
       },
     };

--- a/turbo/packages/core/src/contracts/platform.ts
+++ b/turbo/packages/core/src/contracts/platform.ts
@@ -33,6 +33,7 @@ const platformLogEntrySchema = z.object({
   id: z.string().uuid(),
   sessionId: z.string().nullable(),
   agentName: z.string(),
+  scopeSlug: z.string().nullable(),
   framework: z.string().nullable(),
   status: platformLogStatusSchema,
   createdAt: z.string(),
@@ -82,6 +83,8 @@ export const platformLogsListContract = c.router({
     query: listQuerySchema.extend({
       search: z.string().optional(),
       agent: z.string().optional(),
+      name: z.string().optional(),
+      scope: z.string().optional(),
     }),
     responses: {
       200: platformLogsListResponseSchema,


### PR DESCRIPTION
## Summary

- **Fixes the logs page showing empty results for agents with scope prefix** (e.g., `e7h4n/agent0`) by properly splitting the scoped name into `name` and `scope` parameters
- **Adds `scopeSlug` to the logs API response** so the frontend can display scope prefix in the agent column
- **Refactors the logs API route handler** to reduce cyclomatic complexity below the lint threshold

## Changes

### API (`/api/platform/logs`)
- Added `name` and `scope` query parameters (backward compatible — legacy `agent` param still works)
- Joined `scopes` table to include `scopeSlug` in response
- Extracted helper functions to reduce handler complexity

### Signal layer (`agent-logs.ts`)
- Splits scoped agent name (`scope/name`) into separate `name` and `scope` params before API call
- Uses same pattern as `agent-detail.ts`

### Frontend (`logs-table-row.tsx`)
- Displays `scope/agentName` format when scope is present

### Contract (`platform.ts`)
- Added `name`, `scope` to query schema
- Added `scopeSlug` to log entry schema

## Test plan

- [x] All 18 existing + new integration tests pass
- [x] Type check passes (core, web, platform)
- [x] Lint passes with no errors
- [x] Knip clean — no unused exports or dependencies
- [ ] Verify scoped agent logs display correctly in browser
- [ ] Verify non-scoped agents continue to work as before

Closes #3306

🤖 Generated with [Claude Code](https://claude.com/claude-code)