### PR TITLE
perf(sandbox-fc): use full cli invocation for snapshot pre-warm

### DIFF
--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -200,7 +200,7 @@ mod tests {
         // Changing this assertion means ALL existing cached snapshots are
         // invalidated.  Only update deliberately.
         assert_eq!(
-            hash, "510a2022ff4b7c42febdc447b81935a622f4fc6a3e8429111b3abbc5b4d3bdf5",
+            hash, "8f1709d611d8120311e2d51dc4d4f630604b93dc0a24757197d20bc86042e826",
             "snapshot hash changed — this invalidates all cached snapshots"
         );
     }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -20,13 +20,17 @@ use crate::sandbox::FirecrackerSandbox;
 /// process group, surviving SIGKILL on timeout as orphans frozen into the
 /// snapshot.
 ///
-/// - `claude --version`: exercises the Bun/JSC runtime startup path so the
-///   OS page cache is warm. The claude binary is a Bun-compiled executable
-///   (not Node.js), so `NODE_COMPILE_CACHE` has no effect.
+/// - `claude --print --verbose --output-format stream-json hi`:
+///   exercises the full CLI initialization path matching the real guest-agent
+///   invocation (module loading, config parsing, API client setup) so all
+///   relevant memory pages are captured in the snapshot. Fails with
+///   "Invalid API key" but still loads the complete module graph. The claude
+///   binary is a Bun-compiled executable (not Node.js), so
+///   `NODE_COMPILE_CACHE` has no effect.
 /// - `codex --help`: lightweight pre-warm for Codex (no `--print` equivalent).
 ///   Also tolerated because codex may not be installed.
 pub const PREWARM_SCRIPT: &str = "\
-    (claude --version >/dev/null 2>&1 || true) && \
+    (claude --print --verbose --output-format stream-json hi 2>/dev/null || true) && \
     (codex --help >/dev/null 2>&1 || true)";
 
 /// SHA-256 fingerprint of all sandbox-fc internal configuration that affects


### PR DESCRIPTION
## Summary
- Change snapshot pre-warm script from `claude --version` to `claude --print --verbose --output-format stream-json hi` to match the real guest-agent invocation path
- Loads the complete module graph (API client, stream-json parser, etc.) into guest memory before snapshot, reducing per-job CLI init time by ~1s
- The command fails with "Invalid API key" but still loads all modules before exiting

## Benchmark (dev-2, EBS gp3, aarch64)

| Pre-warm script | `claude --print` exec_ms |
|---|---|
| `claude --version` (old) | 5,204ms |
| `claude --print --verbose --output-format stream-json hi` (new) | 4,265ms |

## Note
This changes `PREWARM_SCRIPT` which is included in `config_hash`, so existing cached snapshots will be invalidated and rebuilt on next `runner build`.

## Test plan
- [x] Benchmarked on dev-2 with old and new pre-warm scripts
- [x] Verified `claude --print` loads complete module graph before failing on missing API key
- [x] Clippy and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)