### PR TITLE
perf(guest-agent): disable non-essential cli network traffic on startup

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -167,6 +167,13 @@ pub async fn execute_cli(
         .stderr(Stdio::piped())
         .process_group(0);
 
+    // Disable non-essential network traffic during CLI startup to reduce
+    // latency. Claude CLI makes synchronous requests to statsig, Datadog,
+    // Segment, GCS (update check), and GitHub on startup — these add ~2s
+    // of idle waiting in the guest network environment.
+    cmd.env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
+    cmd.env("DISABLE_TELEMETRY", "1");
+
     // Pass CODEX_HOME via Command::env instead of global set_var
     if env::cli_agent_type() == "codex" {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());


### PR DESCRIPTION
## Summary

- Set `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` and `DISABLE_TELEMETRY=1` on the spawned Claude CLI process to skip non-essential network requests during startup
- Claude CLI makes synchronous requests to statsig, Datadog, Segment, GCS (update check), and GitHub on startup — these add idle waiting time in the guest network environment

## Benchmark

Tested on dev-2 with `claude --print --verbose --output-format stream-json hi` (warm cache, 3 runs):

| Run | Without | With | Delta |
|-----|---------|------|-------|
| 1 | 4.055s | 3.428s | -627ms |
| 2 | 4.034s | 3.430s | -604ms |
| 3 | 4.148s | 3.848s | -300ms |
| **Avg** | **4.08s** | **3.57s** | **-510ms (~12.5%)** |

## Test plan

- [x] `cargo clippy -p guest-agent` passes
- [x] Benchmarked on dev-2 with A/B comparison (3 rounds)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)