### PR TITLE
fix(guest-agent): detect cli process exit to prevent hanging on orphaned pipes

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -198,9 +198,29 @@ pub async fn execute_cli(
     // Open agent log file
     let mut log_file = tokio::fs::File::create(paths::agent_log_file()).await?;
 
-    // Stream stdout JSONL, racing against heartbeat
+    // Stream stdout JSONL, racing against heartbeat and process exit.
+    //
+    // We must race `child.wait()` alongside the stdout reader because the
+    // CLI may spawn child processes that inherit the stdout pipe fd.  If
+    // the CLI main process is killed (e.g. OOM) while children survive,
+    // the pipe stays open and `reader.next_line()` blocks forever.
+    //
+    // When `child.wait()` fires we do NOT break — we keep processing events
+    // so buffered lines (including the final `result` event) are not lost.
+    // Instead we arm a 5-second drain deadline; if the pipe is still open
+    // after that we kill the process group and exit.
     let mut reader = tokio::io::BufReader::new(stdout).lines();
     let mut seq = 0u32;
+
+    // Capture the process group ID before wait() reaps the child, since
+    // child.id() returns None after the process has been reaped.
+    let pgid = child.id().map(|pid| pid as i32);
+
+    let mut cli_status: Option<std::process::ExitStatus> = None;
+    // Drain deadline: armed when the CLI process exits, fires after 5s.
+    let drain_deadline = tokio::time::sleep(std::time::Duration::from_secs(0));
+    tokio::pin!(drain_deadline);
+    let mut drain_active = false;
 
     let event_result: Result<(), AgentError> = loop {
         tokio::select! {
@@ -233,16 +253,43 @@ pub async fn execute_cli(
                             seq += 1;
                         }
                     }
-                    Ok(None) => break Ok(()), // EOF
+                    Ok(None) => break Ok(()), // EOF — pipe closed normally
                     Err(e) => break Err(AgentError::Io(e)),
                 }
+            }
+            status = child.wait(), if cli_status.is_none() => {
+                // CLI main process exited.  Arm a drain deadline but keep
+                // the loop running so remaining buffered events are processed.
+                match status {
+                    Ok(s) => {
+                        cli_status = Some(s);
+                        drain_active = true;
+                        drain_deadline.as_mut().reset(
+                            tokio::time::Instant::now() + std::time::Duration::from_secs(5),
+                        );
+                    }
+                    Err(e) => break Err(AgentError::Io(e)),
+                }
+            }
+            () = &mut drain_deadline, if drain_active => {
+                // Stdout is still open 5s after the CLI process exited —
+                // orphaned child processes are holding the pipe.  Kill
+                // the entire process group so we don't hang forever.
+                log_warn!(
+                    LOG_TAG,
+                    "CLI process exited but stdout still open after 5s, killing process group"
+                );
+                if let Some(pid) = pgid {
+                    unsafe { libc::kill(-pid, libc::SIGKILL); }
+                }
+                break Ok(());
             }
             hb_result = &mut heartbeat_handle => {
                 match hb_result {
                     Ok(Err(e)) => {
                         // Heartbeat failed — kill process group
-                        if let Some(pid) = child.id() {
-                            unsafe { libc::kill(-(pid as i32), libc::SIGTERM); }
+                        if let Some(pid) = pgid {
+                            unsafe { libc::kill(-pid, libc::SIGTERM); }
                         }
                         break Err(e);
                     }
@@ -258,7 +305,10 @@ pub async fn execute_cli(
         }
     };
 
-    let status = child.wait().await?;
+    let status = match cli_status {
+        Some(s) => s,
+        None => child.wait().await?,
+    };
     let exit_code = match status.code() {
         Some(code) => code,
         None => {

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -262,6 +262,7 @@ pub async fn execute_cli(
                 // the loop running so remaining buffered events are processed.
                 match status {
                     Ok(s) => {
+                        log_info!(LOG_TAG, "CLI process exited (status: {s}), draining stdout");
                         cli_status = Some(s);
                         drain_active = true;
                         drain_deadline.as_mut().reset(
@@ -312,14 +313,18 @@ pub async fn execute_cli(
     let exit_code = match status.code() {
         Some(code) => code,
         None => {
+            let mut code = 1;
             #[cfg(unix)]
             {
                 use std::os::unix::process::ExitStatusExt;
                 if let Some(sig) = status.signal() {
                     log_warn!(LOG_TAG, "Process killed by signal {sig}");
+                    // Map signal to 128+signal (same convention as bash/vsock-guest)
+                    // so the runner can detect OOM kills (SIGKILL=9 → exit 137).
+                    code = 128 + sig;
                 }
             }
-            1
+            code
         }
     };
 


### PR DESCRIPTION
## Summary

- Race `child.wait()` in the `select!` loop alongside stdout reader and heartbeat
- When the CLI main process exits (e.g. OOM kill) but child processes keep the stdout pipe open, the agent now detects the exit immediately, kills the process group, and proceeds with cleanup
- Fixes a production hang where the guest-agent blocked forever on `reader.next_line()` after the CLI was killed

## Root cause

Observed on prod-2: a job hung for 20+ minutes with the VM at 0% CPU and no network activity. The CLI process was killed (likely OOM with 1024 MiB VM memory) but orphaned child processes inherited the stdout pipe fd, keeping it open. The `select!` loop only raced stdout and heartbeat — it never noticed the main process was gone.

## Test plan

- [x] `cargo clippy -p guest-agent` passes
- [ ] CI passes
- [ ] Deploy to dev-2 and verify with `kill -9` on claude process during execution — agent should detect exit and clean up

🤖 Generated with [Claude Code](https://claude.com/claude-code)