### PR TITLE
feat(slack): replace thinking reaction with assistant thread status

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/__tests__/route.test.ts
@@ -30,7 +30,6 @@ interface CallbackPayload {
   agentName: string;
   composeId: string;
   existingSessionId?: string;
-  reactionAdded: boolean;
 }
 
 /**
@@ -71,7 +70,7 @@ describe("POST /api/internal/callbacks/slack", () => {
   beforeEach(() => {
     context.setupMocks();
     mockClient.chat.postMessage.mockClear();
-    mockClient.reactions.remove.mockClear();
+    mockClient.assistant.threads.setStatus.mockClear();
   });
 
   describe("Signature Verification", () => {
@@ -96,7 +95,6 @@ describe("POST /api/internal/callbacks/slack", () => {
           userLinkId: userLink.id,
           agentName: "test-agent",
           composeId: binding.composeId,
-          reactionAdded: true,
         },
       });
 
@@ -113,7 +111,6 @@ describe("POST /api/internal/callbacks/slack", () => {
             userLinkId: userLink.id,
             agentName: "test-agent",
             composeId: binding.composeId,
-            reactionAdded: true,
           },
         },
         secret,
@@ -148,7 +145,6 @@ describe("POST /api/internal/callbacks/slack", () => {
           userLinkId: userLink.id,
           agentName: "test-agent",
           composeId: binding.composeId,
-          reactionAdded: true,
         },
       });
 
@@ -165,7 +161,6 @@ describe("POST /api/internal/callbacks/slack", () => {
             userLinkId: userLink.id,
             agentName: "test-agent",
             composeId: binding.composeId,
-            reactionAdded: true,
           },
         },
         secret,
@@ -203,7 +198,6 @@ describe("POST /api/internal/callbacks/slack", () => {
               userLinkId: "link-123",
               agentName: "test-agent",
               composeId: "compose-123",
-              reactionAdded: false,
             },
           }),
         },
@@ -238,7 +232,6 @@ describe("POST /api/internal/callbacks/slack", () => {
               userLinkId: "link-123",
               agentName: "test-agent",
               composeId: "compose-123",
-              reactionAdded: false,
             },
           }),
         },
@@ -275,7 +268,6 @@ describe("POST /api/internal/callbacks/slack", () => {
           userLinkId: userLink.id,
           agentName: "test-agent",
           composeId: binding.composeId,
-          reactionAdded: true,
         },
       });
 
@@ -292,7 +284,6 @@ describe("POST /api/internal/callbacks/slack", () => {
             userLinkId: userLink.id,
             agentName: "test-agent",
             composeId: binding.composeId,
-            reactionAdded: true,
           },
         },
         secret,
@@ -313,8 +304,11 @@ describe("POST /api/internal/callbacks/slack", () => {
       expect(callArgs.channel).toBe(channelId);
       expect(callArgs.thread_ts).toBe("1234567890.000000");
 
-      // And the thinking reaction should be removed
-      expect(mockClient.reactions.remove).toHaveBeenCalledTimes(1);
+      // And the thinking status should be cleared
+      expect(mockClient.assistant.threads.setStatus).toHaveBeenCalledTimes(1);
+      const statusCall = mockClient.assistant.threads.setStatus.mock
+        .calls[0]![0] as { status: string };
+      expect(statusCall.status).toBe("");
     });
 
     it("should post error message on failed run", async () => {
@@ -339,7 +333,6 @@ describe("POST /api/internal/callbacks/slack", () => {
           userLinkId: userLink.id,
           agentName: "test-agent",
           composeId: binding.composeId,
-          reactionAdded: true,
         },
       });
 
@@ -357,7 +350,6 @@ describe("POST /api/internal/callbacks/slack", () => {
             userLinkId: userLink.id,
             agentName: "test-agent",
             composeId: binding.composeId,
-            reactionAdded: true,
           },
         },
         secret,
@@ -374,59 +366,6 @@ describe("POST /api/internal/callbacks/slack", () => {
       };
       expect(callArgs.text).toContain("Error");
       expect(callArgs.text).toContain("Agent crashed unexpectedly");
-    });
-
-    it("should not remove reaction when reactionAdded is false", async () => {
-      // Given a linked Slack user with an agent
-      const { userLink, installation } = await givenLinkedSlackUser();
-      const { binding } = await givenUserHasAgent(userLink, {
-        agentName: "test-agent",
-      });
-
-      // And a run with callback where reactionAdded is false
-      mockClerk({ userId: userLink.vm0UserId });
-      const { runId } = await createTestRun(binding.composeId, "Test prompt");
-      const channelId = `C-noreact-${Date.now()}`;
-      const { secret } = await createTestCallback({
-        runId,
-        url: "http://localhost/api/internal/callbacks/slack",
-        payload: {
-          workspaceId: installation.slackWorkspaceId,
-          channelId,
-          threadTs: "1234567890.000000",
-          messageTs: "1234567890.123456",
-          userLinkId: userLink.id,
-          agentName: "test-agent",
-          composeId: binding.composeId,
-          reactionAdded: false, // No reaction was added
-        },
-      });
-
-      // When the callback is invoked
-      const request = createCallbackRequest(
-        {
-          runId,
-          status: "completed",
-          payload: {
-            workspaceId: installation.slackWorkspaceId,
-            channelId,
-            threadTs: "1234567890.000000",
-            messageTs: "1234567890.123456",
-            userLinkId: userLink.id,
-            agentName: "test-agent",
-            composeId: binding.composeId,
-            reactionAdded: false,
-          },
-        },
-        secret,
-      );
-      const response = await POST(request);
-
-      // Then the request should succeed
-      expect(response.status).toBe(200);
-
-      // And no reaction removal should be attempted
-      expect(mockClient.reactions.remove).not.toHaveBeenCalled();
     });
   });
 
@@ -458,7 +397,6 @@ describe("POST /api/internal/callbacks/slack", () => {
           userLinkId: userLink.id,
           agentName: "test-agent",
           composeId: binding.composeId,
-          reactionAdded: true,
         },
       });
 
@@ -479,7 +417,6 @@ describe("POST /api/internal/callbacks/slack", () => {
             userLinkId: userLink.id,
             agentName: "test-agent",
             composeId: binding.composeId,
-            reactionAdded: true,
           },
         },
         secret,
@@ -519,7 +456,6 @@ describe("POST /api/internal/callbacks/slack", () => {
           agentName: "test-agent",
           composeId: binding.composeId,
           existingSessionId, // Existing session
-          reactionAdded: true,
         },
       });
 
@@ -537,7 +473,6 @@ describe("POST /api/internal/callbacks/slack", () => {
             agentName: "test-agent",
             composeId: binding.composeId,
             existingSessionId,
-            reactionAdded: true,
           },
         },
         secret,
@@ -572,7 +507,6 @@ describe("POST /api/internal/callbacks/slack", () => {
               userLinkId: "link-123",
               agentName: "test-agent",
               composeId: "compose-123",
-              reactionAdded: false,
             },
           }),
         },
@@ -605,7 +539,6 @@ describe("POST /api/internal/callbacks/slack", () => {
           userLinkId: userLink.id,
           agentName: "test-agent",
           composeId: binding.composeId,
-          reactionAdded: true,
         },
       });
 

--- a/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
@@ -11,6 +11,7 @@ import { agentRunCallbacks } from "../../../../../src/db/schema/agent-run-callba
 import {
   createSlackClient,
   postMessage,
+  setThreadStatus,
   buildAgentResponseMessage,
   detectDeepLinks,
 } from "../../../../../src/lib/slack";
@@ -32,7 +33,6 @@ interface CallbackPayload {
   agentName: string;
   composeId: string;
   existingSessionId?: string;
-  reactionAdded: boolean;
 }
 
 interface CallbackBody {
@@ -157,7 +157,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     agentName,
     composeId,
     existingSessionId,
-    reactionAdded,
   } = payload;
 
   log.debug("Processing Slack callback", { runId, status, channelId });
@@ -246,18 +245,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
   }
 
-  // Remove thinking reaction
-  if (reactionAdded) {
-    await client.reactions
-      .remove({
-        channel: channelId,
-        timestamp: messageTs,
-        name: "thought_balloon",
-      })
-      .catch((err) => {
-        // Non-critical: reaction may already be removed or message deleted
-        log.debug("Failed to remove thinking reaction", { runId, error: err });
-      });
+  // Clear assistant thinking status
+  try {
+    await setThreadStatus(client, channelId, threadTs, "");
+  } catch (err) {
+    log.debug("Failed to clear thread status", { runId, error: err });
   }
 
   log.debug("Slack callback processed successfully", { runId });

--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -300,7 +300,7 @@ describe("POST /api/slack/events", () => {
   });
 
   describe("Scenario: Mention bot with single agent", () => {
-    it("should dispatch agent run and add thinking reaction", async () => {
+    it("should dispatch agent run and set thinking status", async () => {
       // Given I am a linked Slack user with one agent
       const { userLink, installation } = await givenLinkedSlackUser();
       await givenUserHasAgent(userLink, {
@@ -320,20 +320,16 @@ describe("POST /api/slack/events", () => {
       await flushAfterCallbacks();
 
       // Then:
-      // 1. Thinking reaction should be added
-      expect(mockClient.reactions.add).toHaveBeenCalledTimes(1);
-      const reactionCall = getCallArgs(mockClient.reactions.add);
-      expect(reactionCall.name).toBe("thought_balloon");
+      // 1. Assistant thinking status should be set
+      expect(mockClient.assistant.threads.setStatus).toHaveBeenCalledTimes(1);
+      const statusCall = getCallArgs(mockClient.assistant.threads.setStatus);
+      expect(statusCall.status).toBe("is thinking...");
 
       // 2. No response message should be posted yet (callback handles that)
-      // The handler returns immediately after dispatching the run
       expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
-
-      // 3. Thinking reaction should NOT be removed yet (callback handles that)
-      expect(mockClient.reactions.remove).not.toHaveBeenCalled();
     });
 
-    it("should post error and remove reaction when dispatch fails", async () => {
+    it("should post error and clear status when dispatch fails", async () => {
       // Given I am a linked Slack user with one agent
       const { userLink, installation } = await givenLinkedSlackUser();
       await givenUserHasAgent(userLink, {
@@ -365,8 +361,11 @@ describe("POST /api/slack/events", () => {
       const text = (call.text as string) ?? "";
       expect(text).toContain("Error");
 
-      // And the thinking reaction should be removed (since callback won't be invoked)
-      expect(mockClient.reactions.remove).toHaveBeenCalledTimes(1);
+      // And the thinking status should be cleared (since callback won't be invoked)
+      expect(mockClient.assistant.threads.setStatus).toHaveBeenCalledTimes(2);
+      const clearCall = mockClient.assistant.threads.setStatus.mock
+        .calls[1]![0] as { status: string };
+      expect(clearCall.status).toBe("");
     });
   });
 
@@ -457,7 +456,7 @@ describe("POST /api/slack/events", () => {
   });
 
   describe("Scenario: DM bot with single agent", () => {
-    it("should dispatch agent run and add thinking reaction", async () => {
+    it("should dispatch agent run and set thinking status", async () => {
       // Given I am a linked Slack user with one agent
       const { userLink, installation } = await givenLinkedSlackUser();
       await givenUserHasAgent(userLink, {
@@ -477,17 +476,16 @@ describe("POST /api/slack/events", () => {
       await flushAfterCallbacks();
 
       // Then:
-      // 1. Thinking reaction should be added
-      expect(mockClient.reactions.add).toHaveBeenCalledTimes(1);
+      // 1. Assistant thinking status should be set
+      expect(mockClient.assistant.threads.setStatus).toHaveBeenCalledTimes(1);
+      const statusCall = getCallArgs(mockClient.assistant.threads.setStatus);
+      expect(statusCall.status).toBe("is thinking...");
 
       // 2. No response message should be posted yet (callback handles that)
       expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
-
-      // 3. Thinking reaction should NOT be removed yet (callback handles that)
-      expect(mockClient.reactions.remove).not.toHaveBeenCalled();
     });
 
-    it("should post error and remove reaction when dispatch fails", async () => {
+    it("should post error and clear status when dispatch fails", async () => {
       // Given I am a linked Slack user with one agent
       const { userLink, installation } = await givenLinkedSlackUser();
       await givenUserHasAgent(userLink, {
@@ -519,8 +517,11 @@ describe("POST /api/slack/events", () => {
       const text = (call.text as string) ?? "";
       expect(text).toContain("Error");
 
-      // And the thinking reaction should be removed
-      expect(mockClient.reactions.remove).toHaveBeenCalledTimes(1);
+      // And the thinking status should be cleared
+      expect(mockClient.assistant.threads.setStatus).toHaveBeenCalledTimes(2);
+      const clearCall = mockClient.assistant.threads.setStatus.mock
+        .calls[1]![0] as { status: string };
+      expect(clearCall.status).toBe("");
     });
   });
 

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -147,6 +147,11 @@ vi.mock("@slack/web-api", () => {
       add: vi.fn().mockResolvedValue({ ok: true }),
       remove: vi.fn().mockResolvedValue({ ok: true }),
     },
+    assistant: {
+      threads: {
+        setStatus: vi.fn().mockResolvedValue({ ok: true }),
+      },
+    },
   };
   return {
     WebClient: vi.fn().mockImplementation(function () {

--- a/turbo/apps/web/src/lib/slack/client.ts
+++ b/turbo/apps/web/src/lib/slack/client.ts
@@ -160,3 +160,29 @@ export async function exchangeOAuthCode(
     authedUserId: result.authed_user?.id ?? "",
   };
 }
+
+/**
+ * Set the assistant thread status indicator.
+ *
+ * Shows a typing-style status below the thread (e.g. "is thinking...").
+ * Pass an empty string to clear the status.
+ *
+ * Requires the `assistant:write` scope and "Agents & AI Apps" enabled.
+ *
+ * @param client - Slack WebClient
+ * @param channel - Channel ID
+ * @param threadTs - Thread timestamp
+ * @param status - Status text (empty string to clear)
+ */
+export async function setThreadStatus(
+  client: WebClient,
+  channel: string,
+  threadTs: string,
+  status: string,
+): Promise<void> {
+  await client.assistant.threads.setStatus({
+    channel_id: channel,
+    thread_ts: threadTs,
+    status,
+  });
+}

--- a/turbo/apps/web/src/lib/slack/handlers/__tests__/run-agent.test.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/__tests__/run-agent.test.ts
@@ -38,7 +38,6 @@ describe("runAgentForSlack", () => {
       userLinkId: uniqueId("link"),
       agentName: "test-agent",
       composeId,
-      reactionAdded: true,
     };
 
     // When runAgentForSlack is called

--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -108,16 +108,7 @@ export async function handleDirectMessage(
   let agentName = defaultAgent.name;
 
   // 5. Show assistant thinking status
-  try {
-    await setThreadStatus(
-      client,
-      context.channelId,
-      threadTs,
-      "is thinking...",
-    );
-  } catch (err) {
-    log.warn("Failed to set thread status", { error: err });
-  }
+  await setThreadStatus(client, context.channelId, threadTs, "is thinking...");
 
   // Use message text directly (no mention prefix to strip in DMs)
   const messageContent = context.messageText;
@@ -194,11 +185,9 @@ export async function handleDirectMessage(
       { threadTs },
     );
     // Clear thinking status on failure since callback won't be invoked
-    try {
-      await setThreadStatus(client, context.channelId, threadTs, "");
-    } catch {
-      // Non-critical
-    }
+    await setThreadStatus(client, context.channelId, threadTs, "").catch(
+      (err) => log.warn("Failed to clear thread status", { error: err }),
+    );
   }
   // For "dispatched" status, callback will handle response posting and status clearing
 }

--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -3,7 +3,7 @@ import { slackInstallations } from "../../../db/schema/slack-installation";
 import { slackUserLinks } from "../../../db/schema/slack-user-link";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
-import { createSlackClient, postMessage } from "../client";
+import { createSlackClient, postMessage, setThreadStatus } from "../client";
 import { buildLoginPromptMessage } from "../blocks";
 import { runAgentForSlack } from "./run-agent";
 import {
@@ -107,15 +107,17 @@ export async function handleDirectMessage(
   }
   let agentName = defaultAgent.name;
 
-  // 5. Add thinking reaction
-  const reactionAdded = await client.reactions
-    .add({
-      channel: context.channelId,
-      timestamp: context.messageTs,
-      name: "thought_balloon",
-    })
-    .then(() => true)
-    .catch(() => false);
+  // 5. Show assistant thinking status
+  try {
+    await setThreadStatus(
+      client,
+      context.channelId,
+      threadTs,
+      "is thinking...",
+    );
+  } catch (err) {
+    log.warn("Failed to set thread status", { error: err });
+  }
 
   // Use message text directly (no mention prefix to strip in DMs)
   const messageContent = context.messageText;
@@ -179,7 +181,6 @@ export async function handleDirectMessage(
       agentName,
       composeId,
       existingSessionId,
-      reactionAdded,
     },
   });
 
@@ -192,16 +193,12 @@ export async function handleDirectMessage(
       response ?? "Sorry, an error occurred. Please try again.",
       { threadTs },
     );
-    // Remove reaction on failure since callback won't be invoked
-    if (reactionAdded) {
-      await client.reactions
-        .remove({
-          channel: context.channelId,
-          timestamp: context.messageTs,
-          name: "thought_balloon",
-        })
-        .catch(() => {});
+    // Clear thinking status on failure since callback won't be invoked
+    try {
+      await setThreadStatus(client, context.channelId, threadTs, "");
+    } catch {
+      // Non-critical
     }
   }
-  // For "dispatched" status, callback will handle response posting and reaction removal
+  // For "dispatched" status, callback will handle response posting and status clearing
 }

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -35,7 +35,7 @@ interface MentionContext {
  * 2. Check if user is linked
  * 3. If not linked, post link message
  * 4. Resolve workspace agent name
- * 5. Add thinking reaction
+ * 5. Set assistant thinking status
  * 6. Look up existing thread session
  * 7. Fetch conversation context
  * 8. Dispatch agent run with callback
@@ -114,16 +114,7 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
   let agentName = defaultAgent.name;
 
   // 5. Show assistant thinking status
-  try {
-    await setThreadStatus(
-      client,
-      context.channelId,
-      threadTs,
-      "is thinking...",
-    );
-  } catch (err) {
-    log.warn("Failed to set thread status", { error: err });
-  }
+  await setThreadStatus(client, context.channelId, threadTs, "is thinking...");
 
   // Extract message content (remove bot mention)
   const messageContent = extractMessageContent(context.messageText, botUserId);
@@ -200,11 +191,9 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       { threadTs },
     );
     // Clear thinking status on failure since callback won't be invoked
-    try {
-      await setThreadStatus(client, context.channelId, threadTs, "");
-    } catch {
-      // Non-critical
-    }
+    await setThreadStatus(client, context.channelId, threadTs, "").catch(
+      (err) => log.warn("Failed to clear thread status", { error: err }),
+    );
   }
   // For "dispatched" status, callback will handle response posting and status clearing
 }

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -3,7 +3,7 @@ import { slackInstallations } from "../../../db/schema/slack-installation";
 import { slackUserLinks } from "../../../db/schema/slack-user-link";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
-import { createSlackClient, postMessage } from "../client";
+import { createSlackClient, postMessage, setThreadStatus } from "../client";
 import { buildLoginPromptMessage } from "../blocks";
 import { extractMessageContent } from "../context";
 import { runAgentForSlack } from "./run-agent";
@@ -113,15 +113,17 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
   }
   let agentName = defaultAgent.name;
 
-  // 5. Add thinking reaction (emoji only, no message)
-  const reactionAdded = await client.reactions
-    .add({
-      channel: context.channelId,
-      timestamp: context.messageTs,
-      name: "thought_balloon",
-    })
-    .then(() => true)
-    .catch(() => false);
+  // 5. Show assistant thinking status
+  try {
+    await setThreadStatus(
+      client,
+      context.channelId,
+      threadTs,
+      "is thinking...",
+    );
+  } catch (err) {
+    log.warn("Failed to set thread status", { error: err });
+  }
 
   // Extract message content (remove bot mention)
   const messageContent = extractMessageContent(context.messageText, botUserId);
@@ -185,7 +187,6 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       agentName,
       composeId,
       existingSessionId,
-      reactionAdded,
     },
   });
 
@@ -198,16 +199,12 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
       response ?? "Sorry, an error occurred. Please try again.",
       { threadTs },
     );
-    // Remove reaction on failure since callback won't be invoked
-    if (reactionAdded) {
-      await client.reactions
-        .remove({
-          channel: context.channelId,
-          timestamp: context.messageTs,
-          name: "thought_balloon",
-        })
-        .catch(() => {});
+    // Clear thinking status on failure since callback won't be invoked
+    try {
+      await setThreadStatus(client, context.channelId, threadTs, "");
+    } catch {
+      // Non-critical
     }
   }
-  // For "dispatched" status, callback will handle response posting and reaction removal
+  // For "dispatched" status, callback will handle response posting and status clearing
 }

--- a/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
@@ -23,7 +23,6 @@ export interface SlackCallbackContext {
   agentName: string;
   composeId: string;
   existingSessionId?: string;
-  reactionAdded: boolean;
 }
 
 interface RunAgentParams {

--- a/turbo/apps/web/src/lib/slack/index.ts
+++ b/turbo/apps/web/src/lib/slack/index.ts
@@ -72,6 +72,7 @@ export { verifySlackSignature, getSlackSignatureHeaders } from "./verify";
 export {
   createSlackClient,
   postMessage,
+  setThreadStatus,
   openModal,
   updateModal,
   publishAppHome,


### PR DESCRIPTION
## Summary
- Replace the `thought_balloon` emoji reaction with Slack's native `assistant.threads.setStatus` API to show a "is thinking..." typing-style indicator in threads
- Add a new `setThreadStatus` helper in the Slack client module for setting/clearing assistant thread status
- Remove the `reactionAdded` flag from callback payloads since thread status is now set/cleared unconditionally
- Update all tests to verify the new status-based behavior instead of reaction add/remove

## Test plan
- [ ] Verify existing integration tests pass with the updated mock (`assistant.threads.setStatus`)
- [ ] Verify the callback route clears status with empty string on completion
- [ ] Verify mention and DM handlers set "is thinking..." status before dispatching
- [ ] Verify error paths clear the thinking status when dispatch fails
- [ ] Manual test: trigger a Slack agent run and confirm the native typing indicator appears instead of the emoji reaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)