### PR TITLE
fix(guest-agent): only set claude-specific env vars for claude-code cli

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -172,12 +172,14 @@ pub async fn execute_cli(
         let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
         cmd.env("CODEX_HOME", format!("{home}/.codex"));
     } else {
-        // Disable non-essential network traffic during Claude CLI startup to
-        // reduce latency. Claude CLI makes synchronous requests to statsig,
-        // Datadog, Segment, GCS (update check), and GitHub on startup — these
-        // add ~2s of idle waiting in the guest network environment.
+        // Suppress Claude CLI features that are unnecessary or harmful in a
+        // sandbox: startup network calls (statsig, Datadog, Segment, GCS
+        // update check, GitHub) add ~2s latency, telemetry has no receiver,
+        // and the CLI version is baked into the rootfs image.
         cmd.env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
         cmd.env("DISABLE_TELEMETRY", "1");
+        cmd.env("DISABLE_AUTOUPDATER", "1");
+        cmd.env("DISABLE_INSTALLATION_CHECKS", "1");
     }
 
     let mut child = cmd.spawn()?;

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -167,17 +167,17 @@ pub async fn execute_cli(
         .stderr(Stdio::piped())
         .process_group(0);
 
-    // Disable non-essential network traffic during CLI startup to reduce
-    // latency. Claude CLI makes synchronous requests to statsig, Datadog,
-    // Segment, GCS (update check), and GitHub on startup — these add ~2s
-    // of idle waiting in the guest network environment.
-    cmd.env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
-    cmd.env("DISABLE_TELEMETRY", "1");
-
-    // Pass CODEX_HOME via Command::env instead of global set_var
     if env::cli_agent_type() == "codex" {
+        // Pass CODEX_HOME via Command::env instead of global set_var
         let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
         cmd.env("CODEX_HOME", format!("{home}/.codex"));
+    } else {
+        // Disable non-essential network traffic during Claude CLI startup to
+        // reduce latency. Claude CLI makes synchronous requests to statsig,
+        // Datadog, Segment, GCS (update check), and GitHub on startup — these
+        // add ~2s of idle waiting in the guest network environment.
+        cmd.env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
+        cmd.env("DISABLE_TELEMETRY", "1");
     }
 
     let mut child = cmd.spawn()?;


### PR DESCRIPTION
## Summary
- Move `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` and `DISABLE_TELEMETRY` env vars into the `else` branch so they are only set when running Claude Code, not Codex
- These env vars are Claude CLI-specific and have no effect on Codex

## Test plan
- [ ] CI passes (build, clippy, fmt)
- [ ] Claude Code runs still get the telemetry-disable env vars
- [ ] Codex runs no longer receive irrelevant env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)