### PR TITLE
fix: unify variable resolution in build-context via caller-provided scope

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -25,7 +25,6 @@ import {
   isBadRequest,
   isNotFound,
 } from "../../../../src/lib/errors";
-import { getVariableValues } from "../../../../src/lib/variable/variable-service";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
 
 const log = logger("api:runs");
@@ -458,17 +457,9 @@ const router = tsr.router(runsMainContract, {
       `Resolved agentComposeVersionId: ${resolved.agentComposeVersionId}`,
     );
 
-    // Resolve scope-specific stored variables (supports org scope via auth header)
-    const isNewRun = !body.checkpointId && !body.sessionId;
-    let resolvedVars = body.vars;
-    if (isNewRun) {
-      const scope = await resolveScope(userId, headers.authorization);
-      if (scope) {
-        const storedVars = await getVariableValues(scope.id);
-        // CLI vars override server-stored vars
-        resolvedVars = { ...storedVars, ...body.vars };
-      }
-    }
+    // Resolve scope for variable/secret resolution (supports org scope via auth header).
+    // The actual variable fetching happens in build-context.ts.
+    const scope = await resolveScope(userId, headers.authorization);
 
     // Delegate run creation, validation, and dispatch to createRun()
     try {
@@ -480,7 +471,7 @@ const router = tsr.router(runsMainContract, {
         checkpointId: body.checkpointId,
         sessionId: body.sessionId,
         conversationId: body.conversationId,
-        vars: resolvedVars,
+        vars: body.vars,
         secrets: body.secrets,
         artifactName: body.artifactName,
         artifactVersion: body.artifactVersion,
@@ -491,6 +482,7 @@ const router = tsr.router(runsMainContract, {
         modelProvider: body.modelProvider,
         checkEnv: body.checkEnv,
         apiStartTime,
+        scopeId: scope?.id,
       });
 
       log.debug(

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -604,19 +604,20 @@ function mergeConnectorSecretsForReferences(
 async function fetchAndMergeVariables(
   userId: string,
   cliVars: Record<string, string> | undefined,
+  scopeId?: string,
 ): Promise<Record<string, string> | undefined> {
-  const userScope = await getUserScopeByClerkId(userId);
-  if (!userScope) {
+  const resolvedScopeId = scopeId ?? (await getUserScopeByClerkId(userId))?.id;
+  if (!resolvedScopeId) {
     return cliVars;
   }
 
-  const storedVars = await getVariableValues(userScope.id);
+  const storedVars = await getVariableValues(resolvedScopeId);
   if (Object.keys(storedVars).length === 0) {
     return cliVars;
   }
 
   log.debug(
-    `Fetched ${Object.keys(storedVars).length} stored variable(s) from scope ${userScope.slug}`,
+    `Fetched ${Object.keys(storedVars).length} stored variable(s) for scope ${resolvedScopeId}`,
   );
 
   // Merge: CLI vars override stored vars
@@ -658,6 +659,9 @@ interface BuildContextParams {
   checkEnv?: boolean;
   // API start time for E2E timing metrics
   apiStartTime?: number;
+  // Caller-resolved scope ID for variable resolution (org-aware).
+  // When provided, used instead of getUserScopeByClerkId fallback.
+  scopeId?: string;
 }
 
 /**
@@ -723,6 +727,7 @@ async function resolveCredentialsAndEnvironment(
   modelProvider: string | undefined,
   runId: string,
   checkEnv: boolean | undefined,
+  scopeId?: string,
 ): Promise<{
   secrets: Record<string, string> | undefined;
   credentials: Record<string, string> | undefined;
@@ -777,7 +782,7 @@ async function resolveCredentialsAndEnvironment(
 
       return { secrets, credentials, modelProviderEnvVars };
     })(),
-    fetchAndMergeVariables(userId, vars),
+    fetchAndMergeVariables(userId, vars, scopeId),
   ]);
 
   const { secrets, credentials } = credentialChainResult;
@@ -921,6 +926,7 @@ export async function buildExecutionContext(
     params.modelProvider,
     params.runId,
     params.checkEnv,
+    params.scopeId,
   );
   secrets = resolvedSecrets;
 

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -606,7 +606,8 @@ async function fetchAndMergeVariables(
   cliVars: Record<string, string> | undefined,
   scopeId?: string,
 ): Promise<Record<string, string> | undefined> {
-  const resolvedScopeId = scopeId ?? (await getUserScopeByClerkId(userId))?.id;
+  const userScope = scopeId ? null : await getUserScopeByClerkId(userId);
+  const resolvedScopeId = scopeId ?? userScope?.id;
   if (!resolvedScopeId) {
     return cliVars;
   }
@@ -617,7 +618,7 @@ async function fetchAndMergeVariables(
   }
 
   log.debug(
-    `Fetched ${Object.keys(storedVars).length} stored variable(s) for scope ${resolvedScopeId}`,
+    `Fetched ${Object.keys(storedVars).length} stored variable(s) from scope ${userScope?.slug ?? resolvedScopeId}`,
   );
 
   // Merge: CLI vars override stored vars

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -305,6 +305,9 @@ export interface CreateRunParams {
   debugNoMockClaude?: boolean;
   checkEnv?: boolean;
   apiStartTime?: number;
+  // Caller-resolved scope ID for variable resolution (org-aware).
+  // When provided, used instead of getUserScopeByClerkId fallback.
+  scopeId?: string;
 }
 
 export interface CreateRunResult {
@@ -385,6 +388,7 @@ async function validateComposeRequirements(
   composeContent: AgentComposeYaml,
   vars?: Record<string, string>,
   checkEnv?: boolean,
+  scopeId?: string,
 ): Promise<void> {
   if (!composeContent?.agents) {
     return;
@@ -394,8 +398,11 @@ async function validateComposeRequirements(
   if (checkEnv) {
     const requiredVars = extractTemplateVars(composeContent);
     if (requiredVars.length > 0) {
-      const scope = await getUserScopeByClerkId(userId);
-      const storedVars = scope ? await getVariableValues(scope.id) : {};
+      const resolvedScopeId =
+        scopeId ?? (await getUserScopeByClerkId(userId))?.id;
+      const storedVars = resolvedScopeId
+        ? await getVariableValues(resolvedScopeId)
+        : {};
       const allVars = { ...storedVars, ...vars };
       const missingVars = requiredVars.filter(
         (varName) => allVars[varName] === undefined,
@@ -515,6 +522,7 @@ export async function createRun(
       composeContent,
       params.vars,
       params.checkEnv,
+      params.scopeId,
     );
   }
 
@@ -580,6 +588,7 @@ export async function createRun(
       modelProvider: params.modelProvider,
       checkEnv: params.checkEnv,
       apiStartTime: params.apiStartTime,
+      scopeId: params.scopeId,
     });
 
     // Step 10: Dispatch to executor


### PR DESCRIPTION
## Summary

- Remove duplicate variable fetching from API route (`runs/route.ts`). Variable resolution is now handled exclusively in `build-context.ts`
- Add optional `scopeId` field to `CreateRunParams` and `BuildContextParams` that flows from the caller through the service layer
- When `scopeId` is provided (e.g., from `resolveScope()` in the API route), it is used directly for variable lookups; otherwise falls back to `getUserScopeByClerkId(userId)`
- Also fix `validateComposeRequirements` to use the same `scopeId`, ensuring consistent scope for both validation and execution

## Test plan

- [x] All 55 existing `route.test.ts` tests pass (including Server-Stored Variables and checkEnv tests)
- [x] All 21 existing `create-run.test.ts` tests pass
- [x] Lint and knip checks pass

Closes #3408

🤖 Generated with [Claude Code](https://claude.com/claude-code)