### PR TITLE
feat(platform): add agent log detail as nested sub-route

### DIFF
--- a/turbo/apps/platform/src/signals/agent-detail/agent-log-detail-page.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-log-detail-page.ts
@@ -1,0 +1,20 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { AgentLogDetailPage } from "../../views/agent-detail-page/agent-log-detail-page.tsx";
+import { updatePage$ } from "../react-router.ts";
+import { detach, Reason } from "../utils.ts";
+import { fetchAgentDetail$ } from "./agent-detail.ts";
+import { setLogDetailSearchTerm$ } from "../logs-page/log-detail-state.ts";
+import { setupEventPolling$ } from "../logs-page/log-detail-signals.ts";
+
+export const setupAgentLogDetailPage$ = command(
+  ({ set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(AgentLogDetailPage));
+
+    detach(set(fetchAgentDetail$), Reason.Daemon);
+
+    set(setLogDetailSearchTerm$, "");
+
+    detach(set(setupEventPolling$, signal), Reason.Daemon);
+  },
+);

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -14,6 +14,7 @@ import { setupSettingsPage$ } from "./settings-page/settings-page.ts";
 import { setupAgentsPage$ } from "./agents-page/agents-page.ts";
 import { setupAgentDetailPage$ } from "./agent-detail/agent-detail-page.ts";
 import { setupAgentLogsPage$ } from "./agent-detail/agent-logs-page.ts";
+import { setupAgentLogDetailPage$ } from "./agent-detail/agent-log-detail-page.ts";
 import { setupAgentConnectionsPage$ } from "./agent-detail/agent-connections-page.ts";
 import { hasScope$ } from "./scope.ts";
 import { logger } from "./log.ts";
@@ -44,6 +45,10 @@ const ROUTE_CONFIG = [
   {
     path: "/settings",
     setup: setupScopeRequiredPageWrapper(setupSettingsPage$),
+  },
+  {
+    path: "/agents/:name/logs/:id",
+    setup: setupScopeRequiredPageWrapper(setupAgentLogDetailPage$),
   },
   {
     path: "/agents/:name/logs",

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -7,6 +7,7 @@ export type RoutePath =
   | "/agents"
   | "/agents/:name"
   | "/agents/:name/logs"
+  | "/agents/:name/logs/:id"
   | "/agents/:name/connections"
   | "/environment-variables-setup"
   | "/provider-setup"

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-log-detail-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-log-detail-page.tsx
@@ -1,0 +1,41 @@
+import { useGet } from "ccstate-react";
+import { AppShell } from "../layout/app-shell.tsx";
+import { agentName$ } from "../../signals/agent-detail/agent-detail.ts";
+import { currentLogId$ } from "../../signals/logs-page/log-detail-state.ts";
+import { LogDetailContent } from "../logs-page/log-detail/components/log-detail-content.tsx";
+import { SecretDialog } from "../settings-page/secret-dialog.tsx";
+
+export function AgentLogDetailPage() {
+  const agentName = useGet(agentName$);
+  const logId = useGet(currentLogId$);
+
+  return (
+    <AppShell
+      breadcrumb={[
+        { label: "Agents", path: "/agents" },
+        {
+          label: agentName ?? "Loading...",
+          path: agentName ? "/agents/:name" : undefined,
+          pathParams: agentName ? { name: agentName } : undefined,
+        },
+        {
+          label: "Logs",
+          path: agentName ? "/agents/:name/logs" : undefined,
+          pathParams: agentName ? { name: agentName } : undefined,
+        },
+        { label: logId ? `Run ID - ${logId}` : "Detail" },
+      ]}
+    >
+      <div className="h-full flex flex-col">
+        {logId ? (
+          <LogDetailContent />
+        ) : (
+          <div className="p-8 text-center text-muted-foreground">
+            Can&apos;t find that run
+          </div>
+        )}
+      </div>
+      <SecretDialog />
+    </AppShell>
+  );
+}

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-logs-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-logs-page.tsx
@@ -101,14 +101,16 @@ interface AgentLogsTableRowProps {
 
 function AgentLogsTableRow({ entry }: AgentLogsTableRowProps) {
   const navigate = useSet(navigateInReact$);
-  const logDetailUrl = `/logs/${entry.id}`;
+  const agentName = useGet(agentName$);
 
   const handleRowClick = (event: MouseEvent<HTMLTableRowElement>) => {
     if (event.metaKey || event.ctrlKey) {
-      window.open(logDetailUrl, "_blank");
+      window.open(`/agents/${agentName}/logs/${entry.id}`, "_blank");
       return;
     }
-    navigate("/logs/:id", { pathParams: { id: entry.id } });
+    navigate("/agents/:name/logs/:id", {
+      pathParams: { name: agentName ?? "", id: entry.id },
+    });
   };
 
   return (


### PR DESCRIPTION
## Summary
- Add `/agents/:name/logs/:id` nested route so clicking a log entry from the agent logs page stays within agent context
- Breadcrumbs show `Agents > {agentName} > Logs > Run ID - {id}` with proper navigation back to agent logs
- Reuses existing `LogDetailContent` component — no UI duplication

## Test plan
- [ ] Navigate to `/agents/:name/logs`, click a log row → URL becomes `/agents/:name/logs/:id`
- [ ] Breadcrumbs show: Agents > agent-name > Logs > Run ID - xxx
- [ ] Clicking "Logs" breadcrumb returns to `/agents/:name/logs`
- [ ] Cmd/Ctrl+click opens log detail in new tab at `/agents/:name/logs/:id`
- [ ] Log detail content (events, search, artifacts) works identically to `/logs/:id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)