### PR TITLE
fix(schedule): reject schedule creation for organization-scoped agents

### DIFF
--- a/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
   listTestSchedules,
   createTestSecret,
   createTestVariable,
+  createScopedCompose,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -192,7 +193,7 @@ describe("POST /api/agent/schedules - Deploy Schedule", () => {
       const data = await response.json();
 
       // BadRequestError from service is mapped to 409 in route
-      expect(response.status).toBe(409);
+      expect(response.status).toBe(400);
       expect(data.error.message).toContain("timezone");
     });
 
@@ -343,6 +344,34 @@ describe("POST /api/agent/schedules - Deploy Schedule", () => {
       expect(response.status).toBe(404);
       expect(data.error.code).toBe("NOT_FOUND");
     });
+
+    it("should reject schedule for organization-scoped compose", async () => {
+      const { composeId } = await createScopedCompose(
+        user.userId,
+        "organization",
+      );
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/schedules",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            composeId,
+            name: "org-schedule",
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+            prompt: "Test org rejection",
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain("organization-scoped");
+    });
   });
 
   describe("Schedule Limit", () => {
@@ -372,7 +401,7 @@ describe("POST /api/agent/schedules - Deploy Schedule", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      expect(response.status).toBe(409);
+      expect(response.status).toBe(400);
       expect(data.error.message).toContain("already has a schedule");
     });
   });
@@ -533,7 +562,7 @@ describe("POST /api/agent/schedules - Platform Configuration Validation", () => 
     const response = await POST(request);
     const data = await response.json();
 
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(400);
     expect(data.error.message).toContain("Missing required configuration");
     expect(data.error.message).toContain("MISSING_SECRET");
   });
@@ -608,7 +637,7 @@ describe("POST /api/agent/schedules - Platform Configuration Validation", () => 
     const response = await POST(request);
     const data = await response.json();
 
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(400);
     expect(data.error.message).toContain("Missing required configuration");
     expect(data.error.message).toContain("MISSING_VAR");
   });

--- a/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
@@ -192,7 +192,6 @@ describe("POST /api/agent/schedules - Deploy Schedule", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      // BadRequestError from service is mapped to 409 in route
       expect(response.status).toBe(400);
       expect(data.error.message).toContain("timezone");
     });

--- a/turbo/apps/web/app/api/agent/schedules/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/route.ts
@@ -85,9 +85,9 @@ const router = tsr.router(schedulesMainContract, {
       }
       if (isBadRequest(error)) {
         return {
-          status: 409 as const,
+          status: 400 as const,
           body: {
-            error: { message: error.message, code: "SCHEDULE_LIMIT_REACHED" },
+            error: { message: error.message, code: "BAD_REQUEST" },
           },
         };
       }

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -73,7 +73,7 @@ import {
   agentComposeVersions,
 } from "../db/schema/agent-compose";
 import { agentPermissions } from "../db/schema/agent-permission";
-import { scopes } from "../db/schema/scope";
+import { scopes, type ScopeType } from "../db/schema/scope";
 import { conversations } from "../db/schema/conversation";
 import { uniqueId } from "./test-helpers";
 
@@ -1995,4 +1995,37 @@ export async function createTestRunnerJob(
   });
 
   return { runId: run!.id };
+}
+
+/**
+ * Create a compose under a specific scope type for testing.
+ * Useful for testing scope-based restrictions (e.g., org scope rejection).
+ *
+ * @param userId - The user ID to own the compose
+ * @param scopeType - The scope type ("personal", "organization", "system")
+ * @returns The created compose and scope IDs
+ */
+export async function createScopedCompose(
+  userId: string,
+  scopeType: ScopeType,
+): Promise<{ composeId: string; scopeId: string }> {
+  const [scope] = await globalThis.services.db
+    .insert(scopes)
+    .values({
+      slug: uniqueId(`test-${scopeType}`),
+      type: scopeType,
+      ownerId: userId,
+    })
+    .returning();
+
+  const [compose] = await globalThis.services.db
+    .insert(agentComposes)
+    .values({
+      userId,
+      scopeId: scope!.id,
+      name: uniqueId(`${scopeType}-agent`),
+    })
+    .returning();
+
+  return { composeId: compose!.id, scopeId: scope!.id };
 }

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -7,7 +7,7 @@ import {
   agentComposeVersions,
 } from "../../db/schema/agent-compose";
 import { agentRuns } from "../../db/schema/agent-run";
-import { scopes } from "../../db/schema/scope";
+import { scopes, type ScopeType } from "../../db/schema/scope";
 import { decryptSecretsMap } from "../crypto";
 import {
   notFound,
@@ -209,6 +209,7 @@ async function verifyComposeOwnership(
 ): Promise<{
   compose: typeof agentComposes.$inferSelect;
   scopeSlug: string;
+  scopeType: ScopeType;
 }> {
   const [compose] = await globalThis.services.db
     .select()
@@ -222,7 +223,7 @@ async function verifyComposeOwnership(
     throw notFound("Agent compose not found or not owned by user");
   }
 
-  // Get scope slug for response
+  // Get scope slug and type for response
   const [scope] = await globalThis.services.db
     .select()
     .from(scopes)
@@ -232,6 +233,7 @@ async function verifyComposeOwnership(
   return {
     compose,
     scopeSlug: scope?.slug ?? "default",
+    scopeType: scope?.type ?? "personal",
   };
 }
 
@@ -304,10 +306,17 @@ export async function deploySchedule(
   );
 
   // Verify user owns the compose
-  const { compose, scopeSlug } = await verifyComposeOwnership(
+  const { compose, scopeSlug, scopeType } = await verifyComposeOwnership(
     userId,
     request.composeId,
   );
+
+  // Reject organization-scoped agents (schedules resolve secrets from personal scope)
+  if (scopeType === "organization") {
+    throw badRequest(
+      "Schedules are not supported for organization-scoped agents",
+    );
+  }
 
   // Validate timezone
   if (!isValidTimezone(request.timezone)) {

--- a/turbo/packages/core/src/contracts/schedules.ts
+++ b/turbo/packages/core/src/contracts/schedules.ts
@@ -154,7 +154,6 @@ export const schedulesMainContract = c.router({
       400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
-      409: apiErrorSchema, // Schedule limit reached
     },
     summary: "Deploy schedule (create or update)",
   },


### PR DESCRIPTION
## Summary

- Add a guard in `deploySchedule()` to reject schedule creation when the compose belongs to an organization scope
- Fix route handler error mapping: `badRequest` errors now return `400 BAD_REQUEST` instead of `409 SCHEDULE_LIMIT_REACHED`
- Add `createScopedCompose()` test helper for creating composes under specific scope types

Closes #3414

## Test plan

- [x] All 22 existing schedule deploy tests pass (4 assertions updated from 409→400)
- [x] New test: reject schedule for organization-scoped compose
- [x] Lint passes (0 errors)
- [x] Knip passes (no unused exports)
- [x] Format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)