### PR TITLE
fix(platform): use existing schedule name when editing and fix error parsing

### DIFF
--- a/turbo/apps/platform/src/signals/agent-detail/schedule.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/schedule.ts
@@ -156,10 +156,10 @@ const deleteAgentSchedule$ = command(async ({ get, set }) => {
 
   if (!response.ok && response.status !== 204) {
     const errorData = (await response.json().catch(() => null)) as {
-      message?: string;
+      error?: { message?: string };
     } | null;
     throw new Error(
-      errorData?.message ?? `Delete failed: ${response.statusText}`,
+      errorData?.error?.message ?? `Delete failed: ${response.statusText}`,
     );
   }
 

--- a/turbo/apps/platform/src/signals/agent-detail/schedule.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/schedule.ts
@@ -354,12 +354,16 @@ export const submitScheduleDialog$ = command(async ({ get, set }) => {
     });
     const timezone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
 
+    // Use existing schedule name if editing, otherwise default to "default"
+    const existingSchedule = get(internalAgentSchedule$);
+    const scheduleName = existingSchedule?.name ?? "default";
+
     const response = await fetchFn("/api/agent/schedules", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         composeId: detail.id,
-        name: "default",
+        name: scheduleName,
         cronExpression,
         timezone,
         prompt: prompt.trim(),
@@ -368,16 +372,16 @@ export const submitScheduleDialog$ = command(async ({ get, set }) => {
 
     if (!response.ok) {
       const errorData = (await response.json().catch(() => null)) as {
-        message?: string;
+        error?: { message?: string };
       } | null;
       throw new Error(
-        errorData?.message ?? `Save failed: ${response.statusText}`,
+        errorData?.error?.message ?? `Save failed: ${response.statusText}`,
       );
     }
 
     // Enable the schedule (backend creates/updates with enabled=false)
     const enableResponse = await fetchFn(
-      `/api/agent/schedules/default/enable`,
+      `/api/agent/schedules/${encodeURIComponent(scheduleName)}/enable`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- Fix schedule dialog to use the existing schedule's name when editing, instead of always hardcoding "default"
- Fix error response parsing to match the actual API shape (`{ error: { message } }` instead of `{ message }`)
- Use the correct schedule name in the enable endpoint URL instead of hardcoded `/api/agent/schedules/default/enable`

## Test plan
- [ ] Edit an existing schedule with a non-default name and verify it saves correctly
- [ ] Trigger a save error and verify the error message is displayed properly
- [ ] Create a new schedule and verify it still defaults to "default" name

🤖 Generated with [Claude Code](https://claude.com/claude-code)