### PR TITLE
ci: remove needs-runner-pipeline label requirement

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -37,6 +37,7 @@ jobs:
       docker-platform-changed: ${{ steps.detect-docker.outputs.docker-platform-changed }}
       migration-changed: ${{ steps.detect-migration.outputs.migration-changed }}
       crates-changed: ${{ steps.detect-crates.outputs.crates-changed }}
+      ci-changed: ${{ steps.detect-ci.outputs.ci-changed }}
       cli-e2e-parallel-matrix: ${{ steps.cli-e2e-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
@@ -187,6 +188,25 @@ jobs:
           else
             echo "No crates changes"
             echo "crates-changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Detect CI workflow changes
+        id: detect-ci
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF=$(git merge-base ${{ github.event.pull_request.base.sha }} HEAD)
+          elif [ "${{ github.event_name }}" = "merge_group" ]; then
+            BASE_REF="${{ github.event.merge_group.base_sha }}"
+          else
+            BASE_REF="HEAD^"
+          fi
+
+          if git diff --name-only "$BASE_REF" HEAD | grep -q "^\.github/workflows/"; then
+            echo "CI workflow changes detected"
+            echo "ci-changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No CI workflow changes"
+            echo "ci-changed=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Set job-ref
@@ -507,7 +527,8 @@ jobs:
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
         needs.prepare.outputs.platform-changed == 'true' ||
-        needs.prepare.outputs.crates-changed == 'true'
+        needs.prepare.outputs.crates-changed == 'true' ||
+        needs.prepare.outputs.ci-changed == 'true'
       )
     outputs:
       preview-url: ${{ steps.alias.outputs.url || steps.deploy.outputs.url }}
@@ -824,7 +845,8 @@ jobs:
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
-        needs.prepare.outputs.crates-changed == 'true'
+        needs.prepare.outputs.crates-changed == 'true' ||
+        needs.prepare.outputs.ci-changed == 'true'
       )
     timeout-minutes: 5
     permissions:
@@ -898,7 +920,8 @@ jobs:
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
-        needs.prepare.outputs.cli-changed == 'true'
+        needs.prepare.outputs.cli-changed == 'true' ||
+        needs.prepare.outputs.ci-changed == 'true'
       )
     strategy:
       fail-fast: false
@@ -978,12 +1001,12 @@ jobs:
     needs: [prepare]
     timeout-minutes: 10
     if: |
-      contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&
       github.event_name != 'push' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
-        needs.prepare.outputs.crates-changed == 'true'
+        needs.prepare.outputs.crates-changed == 'true' ||
+        needs.prepare.outputs.ci-changed == 'true'
       )
     outputs:
       host-count: ${{ steps.host.outputs.host-count }}
@@ -1170,12 +1193,12 @@ jobs:
     needs: [prepare, deploy-runner-prepare, deploy-web]
     timeout-minutes: 2
     if: |
-      contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&
       github.event_name != 'push' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
-        needs.prepare.outputs.crates-changed == 'true'
+        needs.prepare.outputs.crates-changed == 'true' ||
+        needs.prepare.outputs.ci-changed == 'true'
       )
     steps:
       - name: Setup SSH
@@ -1288,12 +1311,12 @@ jobs:
     if: |
       always() &&
       (needs.cli-e2e-02-parallel.result == 'success' || needs.cli-e2e-02-parallel.result == 'skipped') &&
-      contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&
       github.event_name != 'push' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
-        needs.prepare.outputs.crates-changed == 'true'
+        needs.prepare.outputs.crates-changed == 'true' ||
+        needs.prepare.outputs.ci-changed == 'true'
       )
     strategy:
       fail-fast: false
@@ -1373,7 +1396,6 @@ jobs:
     needs: [prepare, deploy-runner-prepare, deploy-runner-start, cli-e2e-03-runner]
     if: |
       always() &&
-      contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline') &&
       github.event_name != 'push' &&
       needs.deploy-runner-prepare.outputs.bin-dir != ''
     steps:


### PR DESCRIPTION
## Summary
- Remove `needs-runner-pipeline` label gate from runner pipeline jobs
- Add `ci-changed` detection: `.github/workflows/` file changes now trigger deploy-web, cli-e2e, and runner pipeline jobs
- Runner pipeline now runs automatically on PRs with relevant changes (web/cli/crates/ci) instead of requiring manual labeling

## Test plan
- [ ] This PR itself should trigger the full runner pipeline via `ci-changed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)