### PR TITLE
fix(api): include clerk error details in org creation failure logs

### DIFF
--- a/turbo/apps/web/app/api/org/route.ts
+++ b/turbo/apps/web/app/api/org/route.ts
@@ -52,7 +52,16 @@ const router = tsr.router(orgContract, {
       }
       const message =
         error instanceof Error ? error.message : "Internal server error";
-      log.error("Failed to create organization", { error: message });
+      const err = error as Record<string, unknown>;
+      if ("clerkError" in err) {
+        log.error("Failed to create organization (Clerk API)", {
+          status: err.status,
+          errors: err.errors,
+          clerkTraceId: err.clerkTraceId,
+        });
+      } else {
+        log.error("Failed to create organization", { error: message });
+      }
       return {
         status: 500 as const,
         body: {

--- a/turbo/apps/web/app/api/org/route.ts
+++ b/turbo/apps/web/app/api/org/route.ts
@@ -4,6 +4,7 @@ import { initServices } from "../../../src/lib/init-services";
 import { getUserId } from "../../../src/lib/auth/get-user-id";
 import { createOrganization } from "../../../src/lib/org/org-service";
 import { isBadRequest } from "../../../src/lib/errors";
+import { isClerkAPIResponseError } from "@clerk/nextjs/errors";
 import { logger } from "../../../src/lib/logger";
 
 const log = logger("api:org");
@@ -52,12 +53,11 @@ const router = tsr.router(orgContract, {
       }
       const message =
         error instanceof Error ? error.message : "Internal server error";
-      const err = error as Record<string, unknown>;
-      if ("clerkError" in err) {
+      if (isClerkAPIResponseError(error)) {
         log.error("Failed to create organization (Clerk API)", {
-          status: err.status,
-          errors: err.errors,
-          clerkTraceId: err.clerkTraceId,
+          status: error.status,
+          errors: error.errors,
+          clerkTraceId: error.clerkTraceId,
         });
       } else {
         log.error("Failed to create organization", { error: message });


### PR DESCRIPTION
## Summary

- When Clerk's `createOrganization` API returns an error, the catch block now logs the full Clerk error details (`status`, `errors` array with code/message, `clerkTraceId`) instead of just the generic error message
- This was discovered when a `403 Forbidden` error only showed `{ error: 'Forbidden' }` in logs, making it impossible to determine the root cause (`organization_slugs_disabled`) without adding temporary debug logging

## Test plan

- [ ] Verify build passes
- [ ] Confirm normal org creation still works (no log changes for success path)
- [ ] Simulate a Clerk API error and verify detailed error info appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)