### PR TITLE
feat(slack): add context preamble for better tone matching

### DIFF
--- a/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
@@ -337,6 +337,36 @@ describe("Feature: Format Context For Agent", () => {
     });
   });
 
+  describe("Scenario: Include context preamble with interpretation guidelines", () => {
+    it("should include preamble between header and messages for thread context", () => {
+      const messages = [{ user: "U123", text: "Hello", ts: "1234567890.001" }];
+
+      const result = formatContextForAgent(messages);
+
+      expect(result).toContain("Match the tone of the conversation");
+      expect(result).toContain(
+        "Only provide technical analysis when explicitly asked",
+      );
+      expect(result).toContain(
+        "Keep responses proportional to the message length",
+      );
+    });
+
+    it("should include preamble for channel context", () => {
+      const messages = [{ user: "U123", text: "Hello", ts: "1234567890.001" }];
+
+      const result = formatContextForAgent(messages, undefined, "channel");
+
+      expect(result).toContain("Match the tone of the conversation");
+    });
+
+    it("should not include preamble for empty messages", () => {
+      const result = formatContextForAgent([]);
+
+      expect(result).toBe("");
+    });
+  });
+
   describe("Scenario: Relative index calculation", () => {
     it("should calculate relative index from the end of messages", () => {
       const messages = [
@@ -820,6 +850,32 @@ describe("Feature: Format Context With Image Upload", () => {
       expect(result).toContain("[file]: img2.png");
       // Both should have presigned URLs
       expect((result.match(/Image URL:/g) || []).length).toBe(2);
+    });
+  });
+
+  describe("Scenario: Include context preamble in image context", () => {
+    it("should include preamble between header and messages", async () => {
+      const messages = [
+        {
+          user: "U123",
+          text: "Hello",
+          ts: "1234567890.001",
+        },
+      ];
+
+      const result = await formatContextForAgentWithImages(
+        messages,
+        "xoxb-test-token",
+        "test-session-123",
+      );
+
+      expect(result).toContain("Match the tone of the conversation");
+      expect(result).toContain(
+        "Only provide technical analysis when explicitly asked",
+      );
+      expect(result).toContain(
+        "Keep responses proportional to the message length",
+      );
     });
   });
 

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -343,6 +343,13 @@ function formatMessageWithMetadata(
   return parts.join("\n");
 }
 
+const CONTEXT_PREAMBLE = [
+  "The messages below are from a Slack conversation. When responding:",
+  "- Match the tone of the conversation — casual messages deserve casual replies.",
+  "- Only provide technical analysis when explicitly asked a technical question.",
+  "- Keep responses proportional to the message length and complexity.",
+].join("\n");
+
 /**
  * Format messages into context for agent prompt (sync version, metadata only)
  *
@@ -393,7 +400,7 @@ export function formatContextForAgent(
       ? "# Slack Thread Context"
       : "# Recent Channel Messages";
 
-  const result = `${header}\n\n${formattedMessages.join("\n\n")}\n\n---`;
+  const result = `${header}\n\n${CONTEXT_PREAMBLE}\n\n${formattedMessages.join("\n\n")}\n\n---`;
   log.debug("Formatted messages for context", {
     messageCount: formattedMessages.length,
     contextType,
@@ -464,7 +471,7 @@ export async function formatContextForAgentWithImages(
       ? "# Slack Thread Context"
       : "# Recent Channel Messages";
 
-  const result = `${header}\n\n${formattedMessages.join("\n\n")}\n\n---`;
+  const result = `${header}\n\n${CONTEXT_PREAMBLE}\n\n${formattedMessages.join("\n\n")}\n\n---`;
   log.debug("Formatted messages for context with images", {
     messageCount: formattedMessages.length,
     contextType,


### PR DESCRIPTION
## Summary
- Add interpretation guidelines to Slack thread/channel context so agents match the conversational tone
- Prevents agents from defaulting to technical analysis when users send casual messages (e.g. vacation photos, emoji reactions)
- Applies to both `formatContextForAgent` (routing) and `formatContextForAgentWithImages` (execution)

Closes #3257

## Test plan
- [ ] Existing context tests pass (31 tests, verified locally)
- [ ] Send a casual message (e.g. emoji, short comment) to an agent in Slack → agent responds casually, not with a technical deep-dive
- [ ] Send a technical question → agent still responds with full technical detail
- [ ] Verify context format includes preamble between header and messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)