### PR TITLE
fix: redirect to platform after sign-up and handle locale-prefixed auth paths

### DIFF
--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -9,6 +9,7 @@ import {
 import { ClerkProvider } from "@clerk/nextjs";
 import { getClerkPublishableKey } from "../src/lib/clerk-config";
 import { hasClerkAuth } from "../src/env";
+import { getPlatformUrl } from "../src/lib/url";
 import { ThemeProvider } from "./components/ThemeProvider";
 import "./globals.css";
 import "./landing.css";
@@ -265,6 +266,8 @@ export default function RootLayout({
       publishableKey={getClerkPublishableKey()}
       signInUrl="/sign-in"
       signUpUrl="/sign-up"
+      afterSignInUrl={getPlatformUrl()}
+      afterSignUpUrl={getPlatformUrl()}
     >
       {content}
     </ClerkProvider>

--- a/turbo/apps/web/middleware.clerk.ts
+++ b/turbo/apps/web/middleware.clerk.ts
@@ -7,6 +7,7 @@ import { NextRequest } from "next/server";
 import {
   runLayers,
   corsLayer,
+  authRedirectLayer,
   i18nLayer,
   MiddlewareLayer,
   isProtectedSkipRoute,
@@ -76,5 +77,10 @@ const clerkAuthLayer: MiddlewareLayer = async (ctx) => {
 export default clerkMiddleware(async (auth, request: NextRequest) => {
   _clerkAuth = auth;
 
-  return runLayers(request, [corsLayer, clerkAuthLayer, i18nLayer]);
+  return runLayers(request, [
+    corsLayer,
+    authRedirectLayer,
+    clerkAuthLayer,
+    i18nLayer,
+  ]);
 });

--- a/turbo/apps/web/middleware.layers.ts
+++ b/turbo/apps/web/middleware.layers.ts
@@ -111,6 +111,23 @@ export async function runLayers(
 // Shared layers (used by both Clerk and local middleware)
 // ---------------------------------------------------------------------------
 
+/**
+ * Redirect locale-prefixed auth paths (e.g. /en/sign-up) to the root auth
+ * pages (/sign-up). Auth pages live outside the [locale] route tree, so
+ * /:locale/sign-up would 404 without this redirect.
+ */
+const LOCALE_AUTH_RE = /^\/(\w{2})\/(sign-in|sign-up)(\/.*)?$/;
+
+export const authRedirectLayer: MiddlewareLayer = (ctx) => {
+  const match = ctx.request.nextUrl.pathname.match(LOCALE_AUTH_RE);
+  if (match && locales.includes(match[1] as (typeof locales)[number])) {
+    const target = new URL(ctx.request.nextUrl);
+    target.pathname = `/${match[2]}${match[3] ?? ""}`;
+    return NextResponse.redirect(target, 308);
+  }
+  return null;
+};
+
 /** Handle CORS for API routes. Always short-circuits for "api" routes. */
 export const corsLayer: MiddlewareLayer = (ctx) => {
   if (ctx.routeKind === "api") {

--- a/turbo/apps/web/middleware.local.ts
+++ b/turbo/apps/web/middleware.local.ts
@@ -2,12 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   runLayers,
   corsLayer,
+  authRedirectLayer,
   i18nLayer,
   MiddlewareLayer,
 } from "./middleware.layers";
 
 /** Redirect auth pages to home since self-hosted mode has no login flow. */
-const authRedirectLayer: MiddlewareLayer = (ctx) => {
+const localAuthRedirectLayer: MiddlewareLayer = (ctx) => {
   const { pathname } = ctx.request.nextUrl;
   if (pathname.startsWith("/sign-in") || pathname.startsWith("/sign-up")) {
     return NextResponse.redirect(new URL("/", ctx.request.url));
@@ -23,5 +24,10 @@ const authRedirectLayer: MiddlewareLayer = (ctx) => {
  * Auth pages redirect to home.
  */
 export default async function localMiddleware(request: NextRequest) {
-  return runLayers(request, [authRedirectLayer, corsLayer, i18nLayer]);
+  return runLayers(request, [
+    authRedirectLayer,
+    localAuthRedirectLayer,
+    corsLayer,
+    i18nLayer,
+  ]);
 }


### PR DESCRIPTION
## Summary

- Add `afterSignInUrl` and `afterSignUpUrl` to `ClerkProvider` pointing to the platform URL, so users land on the dashboard after authentication instead of a 404 page
- Add `authRedirectLayer` middleware that redirects locale-prefixed auth paths (e.g. `/en/sign-up` → `/sign-up`), since auth pages live outside the `[locale]` route tree

## Root Cause

The sign-up page exists only at `/sign-up` (root level), not under `/[locale]/sign-up`. When a user completed authentication, Clerk's default redirect could lead to `/en/sign-up`, which:
1. Wasn't excluded by the middleware matcher (only bare `sign-up` prefix was excluded)
2. Wasn't in `SKIP_I18N_PREFIXES` (only `/sign-up` was listed)
3. Wasn't a Clerk public route (only `/sign-up(.*)` was matched)
4. Had no corresponding route → **404**

## Test plan

- [ ] Sign up via the landing page sign-up button → should redirect to platform dashboard
- [ ] Sign in via the landing page → should redirect to platform dashboard
- [ ] Navigate directly to `/en/sign-up` → should redirect to `/sign-up`
- [ ] Navigate to `/de/sign-in` → should redirect to `/sign-in`
- [ ] Existing landing page, blog, and locale routes continue to work normally

Closes #3390

🤖 Generated with [Claude Code](https://claude.com/claude-code)