### PR TITLE
fix(web): use next/link for sign-up to prevent locale prefix 404

### DIFF
--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Image from "next/image";
+import NextLink from "next/link";
 import { Link } from "../../navigation";
 import { useTranslations } from "next-intl";
 import { useTheme } from "./ThemeProvider";
@@ -112,9 +113,9 @@ export default function Navbar() {
                 >
                   {t("contact")}
                 </a>
-                <Link href="/sign-up" className="btn-get-access">
+                <NextLink href="/sign-up" className="btn-get-access">
                   {t("joinWaitlist")}
-                </Link>
+                </NextLink>
               </>
             )}
             {isSignedIn && (


### PR DESCRIPTION
## Summary

- Fix sign-up link in Navbar redirecting to 404 after sign-in
- The next-intl `Link` component was adding a locale prefix (`/en/sign-up`) to the sign-up URL, but `/sign-up` skips i18n and has no localized route
- Switch to `next/link` (aliased as `NextLink`) which doesn't add locale prefixes, matching the approach in `LandingPage.tsx`

Closes #3390

## Test plan

- [ ] Visit a localized landing page (e.g. `/en/pricing`)
- [ ] Click the sign-up button in the navbar
- [ ] Verify it navigates to `/sign-up` (not `/en/sign-up`)
- [ ] Complete sign-in and verify redirect to dashboard (not 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)