### PR TITLE
refactor(docs): exclude .source from tsconfig instead of using @ts-nocheck

### DIFF
--- a/turbo/apps/docs/tsconfig.json
+++ b/turbo/apps/docs/tsconfig.json
@@ -26,5 +26,5 @@
     ]
   },
   "include": ["**/*.ts", "**/*.tsx", "next-env.d.ts", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", ".source"]
 }


### PR DESCRIPTION
## Summary

- Excludes the auto-generated `.source` directory from TypeScript compilation in the docs app `tsconfig.json`
- The `.source` directory is generated by `fumadocs-mdx` (on `postinstall`) and is already gitignored — it should not be type-checked as a compilation root
- This eliminates the need for `@ts-nocheck` in generated files while keeping type checking and builds fully functional

## Context

The `.source/index.ts` file (and other generated files like `server.ts`, `browser.ts`, `dynamic.ts`) use `@ts-nocheck` because they import MDX files with query parameters (`?collection=docs&hash=...`) that TypeScript can't resolve natively. Rather than suppressing type checking inside the file, we exclude the entire directory from the TypeScript compilation roots. The `paths` alias (`@/.source` → `.source/server.ts`) still resolves correctly since `exclude` only controls compilation roots, not import resolution.

Closes #3437

## Test plan

- [x] `tsc --noEmit` passes (docs app type checking)
- [x] `pnpm build` succeeds (docs app build)
- [x] `pnpm turbo run lint --filter=docs` passes
- [x] `pnpm knip` passes
- [x] Zero `@ts-nocheck` / `@ts-ignore` / `@ts-expect-error` in tracked codebase (`git grep` confirms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)