### PR TITLE
feat(storage): auto-create artifact when not found during run

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   createTestCompose,
   createTestVolume,
+  createTestArtifact,
   createTestRequest,
   insertStalePendingRun,
   findTestRunRecord,
@@ -257,6 +258,26 @@ describe("createRun()", () => {
         channel: "C123",
         threadTs: "1234.5678",
       });
+    });
+  });
+
+  describe("Auto-Create Artifact", () => {
+    it("should succeed when artifact does not exist (auto-create)", async () => {
+      const artifactName = uniqueId("new-art");
+      const result = await createRun(baseParams({ artifactName }));
+
+      expect(result.runId).toBeDefined();
+      expect(result.status).toBe("running");
+    });
+
+    it("should succeed when artifact already exists", async () => {
+      const artifactName = uniqueId("existing-art");
+      await createTestArtifact(artifactName);
+
+      const result = await createRun(baseParams({ artifactName }));
+
+      expect(result.runId).toBeDefined();
+      expect(result.status).toBe("running");
     });
   });
 

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -6,7 +6,10 @@ import type {
 } from "../../../types/agent-compose";
 import type { ExecutionContext } from "../types";
 import type { PreparedContext } from "../executors/types";
-import { prepareStorageManifest } from "../../storage/storage-service";
+import {
+  prepareStorageManifest,
+  ensureArtifactExists,
+} from "../../storage/storage-service";
 import type { StorageManifest } from "../../storage/types";
 import { badRequest } from "../../errors";
 import { logger } from "../../logger";
@@ -208,6 +211,16 @@ export async function prepareForExecution(
 
   if (!composeInfo) {
     throw badRequest("Agent compose not found");
+  }
+
+  // Auto-create artifact if it doesn't exist yet
+  if (context.artifactName) {
+    await ensureArtifactExists(
+      runnerScope.id,
+      context.userId || "",
+      context.artifactName,
+      runnerScope.slug,
+    );
   }
 
   // Prepare storage manifest with dual scopes

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -189,7 +189,8 @@ export async function prepareForExecution(
   );
 
   // Resolve runner's scope for artifact access
-  const runnerScope = await getUserScopeByClerkId(context.userId || "");
+  const userId = context.userId || "";
+  const runnerScope = await getUserScopeByClerkId(userId);
   if (!runnerScope) {
     throw badRequest("Runner scope not found");
   }
@@ -217,7 +218,7 @@ export async function prepareForExecution(
   if (context.artifactName) {
     await ensureArtifactExists(
       runnerScope.id,
-      context.userId || "",
+      userId,
       context.artifactName,
       runnerScope.slug,
     );

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -1,4 +1,4 @@
-import { eq, and, isNull } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { createSlackClient } from "../client";
 import {
   fetchThreadContext,
@@ -8,7 +8,6 @@ import {
 } from "../context";
 import { slackThreadSessions } from "../../../db/schema/slack-thread-session";
 import { agentComposes } from "../../../db/schema/agent-compose";
-import { storages, storageVersions } from "../../../db/schema/storage";
 import { getPlatformUrl } from "../../url";
 import {
   getUserScopeByClerkId,
@@ -16,9 +15,7 @@ import {
   generateDefaultScopeSlug,
 } from "../../scope/scope-service";
 import { validateAgentSession } from "../../run";
-import { computeContentHashFromHashes } from "../../storage/content-hash";
-import { putS3Object } from "../../s3/s3-client";
-import { env } from "../../../env";
+import { ensureArtifactExists } from "../../storage/storage-service";
 import { logger } from "../../logger";
 
 const log = logger("slack:shared");
@@ -232,115 +229,7 @@ export async function ensureScopeAndArtifact(vm0UserId: string): Promise<void> {
     log.info("Auto-created scope for Slack user", { userId: vm0UserId });
   }
 
-  // Find or create storage record
-  let [storage] = await globalThis.services.db
-    .select()
-    .from(storages)
-    .where(
-      and(
-        eq(storages.scopeId, scope.id),
-        eq(storages.name, "artifact"),
-        eq(storages.type, "artifact"),
-      ),
-    )
-    .limit(1);
-
-  if (!storage) {
-    const [newStorage] = await globalThis.services.db
-      .insert(storages)
-      .values({
-        scopeId: scope.id,
-        name: "artifact",
-        type: "artifact",
-        userId: vm0UserId,
-        s3Prefix: `${scope.slug}/artifact/artifact`,
-        size: 0,
-        fileCount: 0,
-      })
-      .onConflictDoNothing()
-      .returning();
-
-    if (!newStorage) {
-      // Race condition: another request created it. Re-fetch.
-      const [existing] = await globalThis.services.db
-        .select()
-        .from(storages)
-        .where(
-          and(
-            eq(storages.scopeId, scope.id),
-            eq(storages.name, "artifact"),
-            eq(storages.type, "artifact"),
-          ),
-        )
-        .limit(1);
-      storage = existing;
-    } else {
-      storage = newStorage;
-    }
-    log.info("Auto-created artifact storage", { userId: vm0UserId });
-  }
-
-  if (!storage) return;
-
-  // If HEAD version already exists, nothing more to do
-  if (storage.headVersionId) return;
-
-  // Create initial empty version synchronously — this only runs during the
-  // link flow (server action) so there is no Slack timeout constraint.
-  const storageId = storage.id;
-  const scopeSlug = scope.slug;
-  try {
-    const versionId = computeContentHashFromHashes(storageId, []);
-    const s3Key = `${scopeSlug}/artifact/artifact/${versionId}`;
-    const manifestKey = `${s3Key}/manifest.json`;
-    const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
-
-    await putS3Object(
-      bucketName,
-      manifestKey,
-      JSON.stringify({ files: [] }),
-      "application/json",
-    );
-
-    await globalThis.services.db.transaction(async (tx) => {
-      await tx
-        .insert(storageVersions)
-        .values({
-          id: versionId,
-          storageId,
-          s3Key,
-          size: 0,
-          fileCount: 0,
-          message: "Initial empty artifact (auto-created via Slack)",
-          createdBy: "user",
-        })
-        .onConflictDoNothing();
-
-      await tx
-        .update(storages)
-        .set({
-          headVersionId: versionId,
-          size: 0,
-          fileCount: 0,
-          updatedAt: new Date(),
-        })
-        .where(eq(storages.id, storageId));
-    });
-
-    log.info("Auto-created initial artifact version", {
-      userId: vm0UserId,
-      versionId,
-    });
-  } catch (err) {
-    log.error("Failed to create initial artifact version", { err });
-    // Clean up the headless storage so the next call can retry
-    await globalThis.services.db
-      .delete(storages)
-      .where(and(eq(storages.id, storageId), isNull(storages.headVersionId)))
-      .catch((cleanupErr) => {
-        log.error("Failed to clean up headless storage", { cleanupErr });
-      });
-  }
+  await ensureArtifactExists(scope.id, vm0UserId, "artifact", scope.slug);
 }
 
 /**

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -229,7 +229,16 @@ export async function ensureScopeAndArtifact(vm0UserId: string): Promise<void> {
     log.info("Auto-created scope for Slack user", { userId: vm0UserId });
   }
 
-  await ensureArtifactExists(scope.id, vm0UserId, "artifact", scope.slug);
+  // Preserve original Slack behavior: log but don't throw on artifact creation failure.
+  // Slack callers (server actions, OAuth callback) don't have error handling for this.
+  try {
+    await ensureArtifactExists(scope.id, vm0UserId, "artifact", scope.slug);
+  } catch (err) {
+    log.error("Failed to ensure artifact exists for Slack user", {
+      userId: vm0UserId,
+      err,
+    });
+  }
 }
 
 /**

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -1,5 +1,9 @@
 import { resolveVolumes } from "./storage-resolver";
-import { generatePresignedUrl, listS3Objects } from "../s3/s3-client";
+import {
+  generatePresignedUrl,
+  listS3Objects,
+  putS3Object,
+} from "../s3/s3-client";
 import { logger } from "../logger";
 import { badRequest } from "../errors";
 import type {
@@ -9,11 +13,139 @@ import type {
   ManifestArtifact,
 } from "./types";
 import { storages, storageVersions } from "../../db/schema/storage";
-import { eq, and } from "drizzle-orm";
+import { eq, and, isNull } from "drizzle-orm";
 import { env } from "../../env";
 import { resolveVersionByPrefix, isResolutionError } from "./version-resolver";
+import { computeContentHashFromHashes } from "./content-hash";
 
 const log = logger("storage");
+
+/**
+ * Ensure an artifact storage exists with at least one version.
+ * If the storage record doesn't exist, creates it.
+ * If it exists but has no HEAD version, creates an empty initial version.
+ * If it already has a HEAD version, this is a no-op.
+ *
+ * @param scopeId - Scope ID for storage access
+ * @param userId - User ID for storage record ownership
+ * @param artifactName - Artifact storage name
+ * @param scopeSlug - Scope slug for S3 prefix construction
+ */
+export async function ensureArtifactExists(
+  scopeId: string,
+  userId: string,
+  artifactName: string,
+  scopeSlug: string,
+): Promise<void> {
+  // Find or create storage record
+  let [storage] = await globalThis.services.db
+    .select()
+    .from(storages)
+    .where(
+      and(
+        eq(storages.scopeId, scopeId),
+        eq(storages.name, artifactName),
+        eq(storages.type, "artifact"),
+      ),
+    )
+    .limit(1);
+
+  if (!storage) {
+    const [newStorage] = await globalThis.services.db
+      .insert(storages)
+      .values({
+        scopeId,
+        name: artifactName,
+        type: "artifact",
+        userId,
+        s3Prefix: `${scopeSlug}/artifact/${artifactName}`,
+        size: 0,
+        fileCount: 0,
+      })
+      .onConflictDoNothing()
+      .returning();
+
+    if (!newStorage) {
+      // Race condition: another request created it. Re-fetch.
+      const [existing] = await globalThis.services.db
+        .select()
+        .from(storages)
+        .where(
+          and(
+            eq(storages.scopeId, scopeId),
+            eq(storages.name, artifactName),
+            eq(storages.type, "artifact"),
+          ),
+        )
+        .limit(1);
+      storage = existing;
+    } else {
+      storage = newStorage;
+    }
+    log.info("Auto-created artifact storage", { artifactName, scopeId });
+  }
+
+  if (!storage) return;
+
+  // If HEAD version already exists, nothing more to do
+  if (storage.headVersionId) return;
+
+  // Create initial empty version
+  const storageId = storage.id;
+  try {
+    const versionId = computeContentHashFromHashes(storageId, []);
+    const s3Key = `${scopeSlug}/artifact/${artifactName}/${versionId}`;
+    const manifestKey = `${s3Key}/manifest.json`;
+    const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
+
+    await putS3Object(
+      bucketName,
+      manifestKey,
+      JSON.stringify({ files: [] }),
+      "application/json",
+    );
+
+    await globalThis.services.db.transaction(async (tx) => {
+      await tx
+        .insert(storageVersions)
+        .values({
+          id: versionId,
+          storageId,
+          s3Key,
+          size: 0,
+          fileCount: 0,
+          message: "Initial empty artifact (auto-created)",
+          createdBy: "user",
+        })
+        .onConflictDoNothing();
+
+      await tx
+        .update(storages)
+        .set({
+          headVersionId: versionId,
+          size: 0,
+          fileCount: 0,
+          updatedAt: new Date(),
+        })
+        .where(eq(storages.id, storageId));
+    });
+
+    log.info("Auto-created initial artifact version", {
+      artifactName,
+      versionId,
+    });
+  } catch (err) {
+    log.error("Failed to create initial artifact version", { err });
+    // Clean up the headless storage so the next call can retry
+    await globalThis.services.db
+      .delete(storages)
+      .where(and(eq(storages.id, storageId), isNull(storages.headVersionId)))
+      .catch((cleanupErr) => {
+        log.error("Failed to clean up headless storage", { cleanupErr });
+      });
+    throw err;
+  }
+}
 
 /**
  * Resolve version ID from version string

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -85,7 +85,11 @@ export async function ensureArtifactExists(
     log.info("Auto-created artifact storage", { artifactName, scopeId });
   }
 
-  if (!storage) return;
+  if (!storage) {
+    throw new Error(
+      `Failed to create or fetch artifact storage "${artifactName}"`,
+    );
+  }
 
   // If HEAD version already exists, nothing more to do
   if (storage.headVersionId) return;

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -98,7 +98,7 @@ export async function ensureArtifactExists(
   const storageId = storage.id;
   try {
     const versionId = computeContentHashFromHashes(storageId, []);
-    const s3Key = `${scopeSlug}/artifact/${artifactName}/${versionId}`;
+    const s3Key = `${storage.s3Prefix}/${versionId}`;
     const manifestKey = `${s3Key}/manifest.json`;
     const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
 


### PR DESCRIPTION
## Summary

- Add shared `ensureArtifactExists()` function that auto-creates artifact storage + empty initial version when `--artifact-name` references a non-existent artifact
- Call it from `prepareForExecution()` before resolving the storage manifest, so `resolveVersion()` succeeds normally
- Refactor Slack's `ensureScopeAndArtifact()` to use the shared function, removing ~100 lines of duplicate artifact creation logic

Closes #3413

## Test plan

- [x] New integration test: run with non-existent artifact name succeeds (auto-created)
- [x] New integration test: run with existing artifact name still succeeds (no-op)
- [x] All 2992 existing tests pass (zero regressions)
- [x] Type check, lint, knip, format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)