### PR TITLE
refactor: remove eslint-disable complexity suppressions

### DIFF
--- a/turbo/apps/web/app/[locale]/design-system/DesignSystemClient.tsx
+++ b/turbo/apps/web/app/[locale]/design-system/DesignSystemClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import React, { useState } from "react";
 import { useTheme } from "../../components/ThemeProvider";
 import { Button } from "@vm0/ui/components/ui/button";
 import { Card, CardContent } from "@vm0/ui/components/ui/card";
@@ -60,7 +60,6 @@ type Section =
   | "tokens"
   | "components-button"
   | "components-input"
-  | "components-card"
   | "components-dialog"
   | "components-tooltip"
   | "components-checkbox"
@@ -70,227 +69,213 @@ type Section =
   | "components-copy-button"
   | "components-icons";
 
-// eslint-disable-next-line complexity
+const SECTION_COMPONENTS: Record<Section, React.ComponentType> = {
+  overview: OverviewSection,
+  colors: ColorsSection,
+  typography: TypographySection,
+  tokens: TokensSection,
+  "components-button": ButtonComponentPage,
+  "components-input": InputComponentPage,
+  "components-dialog": DialogComponentPage,
+  "components-tooltip": TooltipComponentPage,
+  "components-checkbox": CheckboxComponentPage,
+  "components-select": SelectComponentPage,
+  "components-popover": PopoverComponentPage,
+  "components-table": TableComponentPage,
+  "components-copy-button": CopyButtonComponentPage,
+  "components-icons": IconsComponentPage,
+};
+
 export default function DesignSystemClient() {
   const [activeSection, setActiveSection] = useState<Section>("overview");
   const [componentsExpanded, setComponentsExpanded] = useState(true);
-  const { theme, toggleTheme } = useTheme();
+
+  const ActiveComponent = SECTION_COMPONENTS[activeSection];
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
-      <header className="sticky top-0 z-50 w-full border-b border-divider bg-background/95 backdrop-blur">
-        <div className="container mx-auto flex h-16 items-center justify-between px-4">
-          <div className="flex items-center gap-3">
-            <svg
-              width="100"
-              height="30"
-              viewBox="0 0 100 30"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M13.3915 0.0627979C13.2455 -0.0209506 13.0657 -0.020839 12.9198 0.0630906L1.0053 6.91543C0.692394 7.09539 0.690093 7.54442 1.00114 7.72755L12.9156 14.7423C13.0636 14.8295 13.2475 14.8296 13.3957 14.7426L25.3445 7.72785C25.6562 7.54485 25.6539 7.09497 25.3404 6.91514L13.3915 0.0627979Z"
-                fill="#ED4E01"
-              />
-              <path
-                d="M0.710495 8.33374L12.6479 15.2595C12.7944 15.3445 12.8846 15.5015 12.8846 15.6715L12.8843 29.5237C12.8843 29.8899 12.4897 30.1187 12.1741 29.9356L0.236691 23.0096C0.0902206 22.9246 -3.46036e-06 22.7676 0 22.5977L0.00028208 8.74568C0.000289537 8.37949 0.394855 8.15064 0.710495 8.33374Z"
-                fill="#ED4E01"
-              />
-              <path
-                d="M24.947 21.6772C24.947 21.9507 24.8017 22.2036 24.5655 22.3415L16.2103 27.219C15.6975 27.5184 15.0533 27.1485 15.0533 26.5547L15.0531 16.7842C15.0531 16.5107 15.1983 16.2578 15.4345 16.1199L23.7897 11.2425C24.3025 10.9431 24.9468 11.313 24.9468 11.9068L24.947 21.6772ZM13.6541 16.3426V29.5279C13.6541 29.8852 14.0308 30.1106 14.3391 29.9444L14.3538 29.9362L25.5769 23.3654C26.25 22.9808 26.3462 22.6924 26.3459 22.1188L26.3459 8.93378C26.3459 8.57084 25.9572 8.344 25.6462 8.52548L14.4231 15.0001C14.0385 15.2885 13.6539 15.577 13.6541 16.3426Z"
-                fill="#ED4E01"
-              />
-              <path
-                d="M25.9616 10.58L15.2113 28.4616L14.2308 27.8817L24.981 10.0001L25.9616 10.58Z"
-                fill="#ED4E01"
-              />
-              <path
-                d="M42.1865 25L34.3459 5H37.4651L43.7887 21.4575L50.1264 5H53.2315L45.3908 25H42.1865Z"
-                fill="currentColor"
-              />
-              <path
-                d="M66.9877 25L59.4023 10.3417V25H56.4957V5H59.6716L67.413 20.0628L75.1686 5H78.3304V25H75.438V10.3417L67.8526 25H66.9877Z"
-                fill="currentColor"
-              />
-              <path
-                d="M99.3459 22.1409C99.3459 22.5314 99.2703 22.9033 99.1191 23.2566C98.9678 23.6007 98.7599 23.9028 98.4952 24.1632C98.2305 24.4235 97.9186 24.6281 97.5594 24.7768C97.2097 24.9256 96.8363 25 96.4393 25H86.2735C85.8765 25 85.4984 24.9256 85.1392 24.7768C84.7894 24.6281 84.4822 24.4235 84.2176 24.1632C83.9529 23.9028 83.745 23.6007 83.5937 23.2566C83.4425 22.9033 83.3669 22.5314 83.3669 22.1409V7.85914C83.3669 7.46862 83.4425 7.10135 83.5937 6.75732C83.745 6.404 83.9529 6.10181 84.2176 5.85077C84.4822 5.59042 84.7894 5.38587 85.1392 5.2371C85.4984 5.07903 85.8765 5 86.2735 5H96.4393C96.8363 5 97.2097 5.07903 97.5594 5.2371C97.9186 5.38587 98.2305 5.59042 98.4952 5.85077C98.7599 6.10181 98.9678 6.404 99.1191 6.75732C99.2703 7.10135 99.3459 7.46862 99.3459 7.85914V22.1409ZM86.2735 7.85914V22.1409H96.4393V7.85914H86.2735Z"
-                fill="currentColor"
-              />
-              <path
-                d="M94.8994 6.79107L97.1494 8.06891L87.8973 23.8325L85.6473 22.5547L94.8994 6.79107Z"
-                fill="currentColor"
-              />
-            </svg>
-            <span className="text-sm text-muted-foreground">Design System</span>
-          </div>
-          <div className="flex items-center gap-3">
-            <TooltipProvider delayDuration={100}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={toggleTheme}
-                    aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
-                  >
-                    {theme === "dark" ? (
-                      <IconSun className="h-5 w-5" />
-                    ) : (
-                      <IconMoon className="h-5 w-5" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p className="text-xs">
-                    {theme === "dark"
-                      ? "Switch to light mode"
-                      : "Switch to dark mode"}
-                  </p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-            <span className="text-sm text-muted-foreground">v1.0</span>
-          </div>
-        </div>
-      </header>
+      <DesignSystemHeader />
 
       <div className="container mx-auto flex gap-8 px-4 pb-8 pt-24">
-        {/* Sidebar Navigation */}
-        <aside className="sticky top-24 h-fit w-64 shrink-0">
-          <nav className="space-y-1">
-            <NavItem
-              active={activeSection === "overview"}
-              onClick={() => setActiveSection("overview")}
-            >
-              Overview
-            </NavItem>
-            <NavItem
-              active={activeSection === "colors"}
-              onClick={() => setActiveSection("colors")}
-            >
-              Colors
-            </NavItem>
-            <NavItem
-              active={activeSection === "typography"}
-              onClick={() => setActiveSection("typography")}
-            >
-              Typography
-            </NavItem>
-
-            {/* Components Section with Submenu */}
-            <div>
-              <button
-                onClick={() => setComponentsExpanded(!componentsExpanded)}
-                className={`flex w-full items-center justify-between rounded-lg px-3 py-2 text-sm font-medium transition-colors hover:bg-muted ${
-                  activeSection.startsWith("components-")
-                    ? "text-primary"
-                    : "text-foreground"
-                }`}
-              >
-                Components
-                <IconChevronRight
-                  className={`h-4 w-4 transition-transform ${componentsExpanded ? "rotate-90" : ""}`}
-                />
-              </button>
-              {componentsExpanded && (
-                <div className="ml-3 mt-1 space-y-1 border-l border-divider pl-3">
-                  <SubNavItem
-                    active={activeSection === "components-button"}
-                    onClick={() => setActiveSection("components-button")}
-                  >
-                    Button
-                  </SubNavItem>
-                  <SubNavItem
-                    active={activeSection === "components-input"}
-                    onClick={() => setActiveSection("components-input")}
-                  >
-                    Input
-                  </SubNavItem>
-                  <SubNavItem
-                    active={activeSection === "components-dialog"}
-                    onClick={() => setActiveSection("components-dialog")}
-                  >
-                    Dialog
-                  </SubNavItem>
-                  <SubNavItem
-                    active={activeSection === "components-tooltip"}
-                    onClick={() => setActiveSection("components-tooltip")}
-                  >
-                    Tooltip
-                  </SubNavItem>
-                  <SubNavItem
-                    active={activeSection === "components-checkbox"}
-                    onClick={() => setActiveSection("components-checkbox")}
-                  >
-                    Checkbox
-                  </SubNavItem>
-                  <SubNavItem
-                    active={activeSection === "components-select"}
-                    onClick={() => setActiveSection("components-select")}
-                  >
-                    Select
-                  </SubNavItem>
-                  <SubNavItem
-                    active={activeSection === "components-popover"}
-                    onClick={() => setActiveSection("components-popover")}
-                  >
-                    Popover
-                  </SubNavItem>
-                  <SubNavItem
-                    active={activeSection === "components-table"}
-                    onClick={() => setActiveSection("components-table")}
-                  >
-                    Table
-                  </SubNavItem>
-                  <SubNavItem
-                    active={activeSection === "components-copy-button"}
-                    onClick={() => setActiveSection("components-copy-button")}
-                  >
-                    Copy Button
-                  </SubNavItem>
-                  <SubNavItem
-                    active={activeSection === "components-icons"}
-                    onClick={() => setActiveSection("components-icons")}
-                  >
-                    Icons
-                  </SubNavItem>
-                </div>
-              )}
-            </div>
-
-            <NavItem
-              active={activeSection === "tokens"}
-              onClick={() => setActiveSection("tokens")}
-            >
-              Design Tokens
-            </NavItem>
-          </nav>
-        </aside>
+        <Sidebar
+          activeSection={activeSection}
+          setActiveSection={setActiveSection}
+          componentsExpanded={componentsExpanded}
+          setComponentsExpanded={setComponentsExpanded}
+        />
 
         {/* Main Content */}
         <main className="flex-1 space-y-12 pb-32 [&_section>div:first-child]:pt-8">
-          {activeSection === "overview" && <OverviewSection />}
-          {activeSection === "colors" && <ColorsSection />}
-          {activeSection === "typography" && <TypographySection />}
-          {activeSection === "tokens" && <TokensSection />}
-
-          {/* Component Pages */}
-          {activeSection === "components-button" && <ButtonComponentPage />}
-          {activeSection === "components-input" && <InputComponentPage />}
-          {activeSection === "components-dialog" && <DialogComponentPage />}
-          {activeSection === "components-tooltip" && <TooltipComponentPage />}
-          {activeSection === "components-checkbox" && <CheckboxComponentPage />}
-          {activeSection === "components-select" && <SelectComponentPage />}
-          {activeSection === "components-popover" && <PopoverComponentPage />}
-          {activeSection === "components-table" && <TableComponentPage />}
-          {activeSection === "components-copy-button" && (
-            <CopyButtonComponentPage />
-          )}
-          {activeSection === "components-icons" && <IconsComponentPage />}
+          <ActiveComponent />
         </main>
       </div>
     </div>
+  );
+}
+
+function DesignSystemHeader() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <header className="sticky top-0 z-50 w-full border-b border-divider bg-background/95 backdrop-blur">
+      <div className="container mx-auto flex h-16 items-center justify-between px-4">
+        <div className="flex items-center gap-3">
+          <svg
+            width="100"
+            height="30"
+            viewBox="0 0 100 30"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M13.3915 0.0627979C13.2455 -0.0209506 13.0657 -0.020839 12.9198 0.0630906L1.0053 6.91543C0.692394 7.09539 0.690093 7.54442 1.00114 7.72755L12.9156 14.7423C13.0636 14.8295 13.2475 14.8296 13.3957 14.7426L25.3445 7.72785C25.6562 7.54485 25.6539 7.09497 25.3404 6.91514L13.3915 0.0627979Z"
+              fill="#ED4E01"
+            />
+            <path
+              d="M0.710495 8.33374L12.6479 15.2595C12.7944 15.3445 12.8846 15.5015 12.8846 15.6715L12.8843 29.5237C12.8843 29.8899 12.4897 30.1187 12.1741 29.9356L0.236691 23.0096C0.0902206 22.9246 -3.46036e-06 22.7676 0 22.5977L0.00028208 8.74568C0.000289537 8.37949 0.394855 8.15064 0.710495 8.33374Z"
+              fill="#ED4E01"
+            />
+            <path
+              d="M24.947 21.6772C24.947 21.9507 24.8017 22.2036 24.5655 22.3415L16.2103 27.219C15.6975 27.5184 15.0533 27.1485 15.0533 26.5547L15.0531 16.7842C15.0531 16.5107 15.1983 16.2578 15.4345 16.1199L23.7897 11.2425C24.3025 10.9431 24.9468 11.313 24.9468 11.9068L24.947 21.6772ZM13.6541 16.3426V29.5279C13.6541 29.8852 14.0308 30.1106 14.3391 29.9444L14.3538 29.9362L25.5769 23.3654C26.25 22.9808 26.3462 22.6924 26.3459 22.1188L26.3459 8.93378C26.3459 8.57084 25.9572 8.344 25.6462 8.52548L14.4231 15.0001C14.0385 15.2885 13.6539 15.577 13.6541 16.3426Z"
+              fill="#ED4E01"
+            />
+            <path
+              d="M25.9616 10.58L15.2113 28.4616L14.2308 27.8817L24.981 10.0001L25.9616 10.58Z"
+              fill="#ED4E01"
+            />
+            <path
+              d="M42.1865 25L34.3459 5H37.4651L43.7887 21.4575L50.1264 5H53.2315L45.3908 25H42.1865Z"
+              fill="currentColor"
+            />
+            <path
+              d="M66.9877 25L59.4023 10.3417V25H56.4957V5H59.6716L67.413 20.0628L75.1686 5H78.3304V25H75.438V10.3417L67.8526 25H66.9877Z"
+              fill="currentColor"
+            />
+            <path
+              d="M99.3459 22.1409C99.3459 22.5314 99.2703 22.9033 99.1191 23.2566C98.9678 23.6007 98.7599 23.9028 98.4952 24.1632C98.2305 24.4235 97.9186 24.6281 97.5594 24.7768C97.2097 24.9256 96.8363 25 96.4393 25H86.2735C85.8765 25 85.4984 24.9256 85.1392 24.7768C84.7894 24.6281 84.4822 24.4235 84.2176 24.1632C83.9529 23.9028 83.745 23.6007 83.5937 23.2566C83.4425 22.9033 83.3669 22.5314 83.3669 22.1409V7.85914C83.3669 7.46862 83.4425 7.10135 83.5937 6.75732C83.745 6.404 83.9529 6.10181 84.2176 5.85077C84.4822 5.59042 84.7894 5.38587 85.1392 5.2371C85.4984 5.07903 85.8765 5 86.2735 5H96.4393C96.8363 5 97.2097 5.07903 97.5594 5.2371C97.9186 5.38587 98.2305 5.59042 98.4952 5.85077C98.7599 6.10181 98.9678 6.404 99.1191 6.75732C99.2703 7.10135 99.3459 7.46862 99.3459 7.85914V22.1409ZM86.2735 7.85914V22.1409H96.4393V7.85914H86.2735Z"
+              fill="currentColor"
+            />
+            <path
+              d="M94.8994 6.79107L97.1494 8.06891L87.8973 23.8325L85.6473 22.5547L94.8994 6.79107Z"
+              fill="currentColor"
+            />
+          </svg>
+          <span className="text-sm text-muted-foreground">Design System</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <TooltipProvider delayDuration={100}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={toggleTheme}
+                  aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+                >
+                  {theme === "dark" ? (
+                    <IconSun className="h-5 w-5" />
+                  ) : (
+                    <IconMoon className="h-5 w-5" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="text-xs">
+                  {theme === "dark"
+                    ? "Switch to light mode"
+                    : "Switch to dark mode"}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <span className="text-sm text-muted-foreground">v1.0</span>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+const TOP_NAV_ITEMS: { section: Section; label: string }[] = [
+  { section: "overview", label: "Overview" },
+  { section: "colors", label: "Colors" },
+  { section: "typography", label: "Typography" },
+];
+
+const COMPONENT_NAV_ITEMS: { section: Section; label: string }[] = [
+  { section: "components-button", label: "Button" },
+  { section: "components-input", label: "Input" },
+  { section: "components-dialog", label: "Dialog" },
+  { section: "components-tooltip", label: "Tooltip" },
+  { section: "components-checkbox", label: "Checkbox" },
+  { section: "components-select", label: "Select" },
+  { section: "components-popover", label: "Popover" },
+  { section: "components-table", label: "Table" },
+  { section: "components-copy-button", label: "Copy Button" },
+  { section: "components-icons", label: "Icons" },
+];
+
+function Sidebar({
+  activeSection,
+  setActiveSection,
+  componentsExpanded,
+  setComponentsExpanded,
+}: {
+  activeSection: Section;
+  setActiveSection: (section: Section) => void;
+  componentsExpanded: boolean;
+  setComponentsExpanded: (expanded: boolean) => void;
+}) {
+  return (
+    <aside className="sticky top-24 h-fit w-64 shrink-0">
+      <nav className="space-y-1">
+        {TOP_NAV_ITEMS.map(({ section, label }) => (
+          <NavItem
+            key={section}
+            active={activeSection === section}
+            onClick={() => setActiveSection(section)}
+          >
+            {label}
+          </NavItem>
+        ))}
+
+        {/* Components Section with Submenu */}
+        <div>
+          <button
+            onClick={() => setComponentsExpanded(!componentsExpanded)}
+            className={`flex w-full items-center justify-between rounded-lg px-3 py-2 text-sm font-medium transition-colors hover:bg-muted ${
+              activeSection.startsWith("components-")
+                ? "text-primary"
+                : "text-foreground"
+            }`}
+          >
+            Components
+            <IconChevronRight
+              className={`h-4 w-4 transition-transform ${componentsExpanded ? "rotate-90" : ""}`}
+            />
+          </button>
+          {componentsExpanded && (
+            <div className="ml-3 mt-1 space-y-1 border-l border-divider pl-3">
+              {COMPONENT_NAV_ITEMS.map(({ section, label }) => (
+                <SubNavItem
+                  key={section}
+                  active={activeSection === section}
+                  onClick={() => setActiveSection(section)}
+                >
+                  {label}
+                </SubNavItem>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <NavItem
+          active={activeSection === "tokens"}
+          onClick={() => setActiveSection("tokens")}
+        >
+          Design Tokens
+        </NavItem>
+      </nav>
+    </aside>
   );
 }
 

--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -18,49 +18,1598 @@ const RUN_TYPED_TEXT = {
   "daily-report": "Generate daily report for the team",
 };
 
+type SelectedAgent = "hackernews" | "tiktok" | "blog" | "daily-report";
+
 interface LandingPageProps {
   claudeCodeVersion?: string;
 }
 
-// eslint-disable-next-line complexity
-export default function LandingPage({ claudeCodeVersion }: LandingPageProps) {
-  const { isSignedIn } = useAuth();
+function HeroSection({ isSignedIn }: { isSignedIn: boolean }) {
+  const [copiedHero, setCopiedHero] = useState(false);
+
+  return (
+    <>
+      {/* Hero Content */}
+      <div className="flex flex-col items-center gap-[40px] mb-16">
+        {/* 3D Rotating Cube */}
+        <div
+          style={{
+            width: "80px",
+            height: "80px",
+            perspective: "500px",
+            margin: "0 auto 24px",
+          }}
+        >
+          <div
+            style={{
+              width: "100%",
+              height: "100%",
+              position: "relative",
+              transformStyle: "preserve-3d",
+              animation: "rotateCube 12s infinite linear",
+            }}
+          >
+            {/* Front */}
+            <div
+              style={{
+                position: "absolute",
+                width: "80px",
+                height: "80px",
+                background:
+                  "linear-gradient(135deg, rgba(237, 78, 1, 0.55), rgba(237, 78, 1, 0.25))",
+                border: "3px solid rgba(237, 78, 1, 0.5)",
+                backdropFilter: "blur(10px)",
+                transform: "translateZ(40px)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                boxShadow: "0 0 30px rgba(237, 78, 1, 0.7)",
+              }}
+            />
+            {/* Back */}
+            <div
+              style={{
+                position: "absolute",
+                width: "80px",
+                height: "80px",
+                background:
+                  "linear-gradient(135deg, rgba(237, 78, 1, 0.5), rgba(237, 78, 1, 0.2))",
+                border: "3px solid rgba(237, 78, 1, 0.4)",
+                backdropFilter: "blur(10px)",
+                transform: "translateZ(-40px) rotateY(180deg)",
+                boxShadow: "0 0 25px rgba(237, 78, 1, 0.6)",
+              }}
+            />
+            {/* Right */}
+            <div
+              style={{
+                position: "absolute",
+                width: "80px",
+                height: "80px",
+                background:
+                  "linear-gradient(135deg, rgba(237, 78, 1, 0.5), rgba(237, 78, 1, 0.2))",
+                border: "3px solid rgba(237, 78, 1, 0.45)",
+                backdropFilter: "blur(10px)",
+                transform: "rotateY(90deg) translateZ(40px)",
+                boxShadow: "0 0 27px rgba(237, 78, 1, 0.65)",
+              }}
+            />
+            {/* Left */}
+            <div
+              style={{
+                position: "absolute",
+                width: "80px",
+                height: "80px",
+                background:
+                  "linear-gradient(135deg, rgba(237, 78, 1, 0.5), rgba(237, 78, 1, 0.2))",
+                border: "3px solid rgba(237, 78, 1, 0.45)",
+                backdropFilter: "blur(10px)",
+                transform: "rotateY(-90deg) translateZ(40px)",
+                boxShadow: "0 0 27px rgba(237, 78, 1, 0.65)",
+              }}
+            />
+            {/* Top */}
+            <div
+              style={{
+                position: "absolute",
+                width: "80px",
+                height: "80px",
+                background:
+                  "linear-gradient(135deg, rgba(237, 78, 1, 0.65), rgba(237, 78, 1, 0.3))",
+                border: "3px solid rgba(237, 78, 1, 0.55)",
+                backdropFilter: "blur(10px)",
+                transform: "rotateX(90deg) translateZ(40px)",
+                boxShadow: "0 0 30px rgba(237, 78, 1, 0.7)",
+              }}
+            />
+            {/* Bottom */}
+            <div
+              style={{
+                position: "absolute",
+                width: "80px",
+                height: "80px",
+                background:
+                  "linear-gradient(135deg, rgba(237, 78, 1, 0.45), rgba(237, 78, 1, 0.2))",
+                border: "3px solid rgba(237, 78, 1, 0.4)",
+                backdropFilter: "blur(10px)",
+                transform: "rotateX(-90deg) translateZ(40px)",
+                boxShadow: "0 0 25px rgba(237, 78, 1, 0.6)",
+              }}
+            />
+          </div>
+        </div>
+        <style>{`
+          @keyframes rotateCube {
+            from {
+              transform: rotateX(45deg) rotateY(0deg);
+            }
+            to {
+              transform: rotateX(45deg) rotateY(360deg);
+            }
+          }
+        `}</style>
+
+        <h1 className="flex flex-col justify-center font-medium text-center text-[36px] leading-[1.4] text-foreground tracking-normal px-4">
+          <span className="block mb-0">
+            Build AI agents with natural language.
+          </span>
+          <span className="block">Run them 24/7 in the cloud.</span>
+        </h1>
+
+        {/* CTA Section - More compact */}
+        <div className="flex flex-col items-center gap-[20px] w-full">
+          {/* Install Command with description */}
+          <div className="flex flex-col items-center gap-[8px] w-full max-w-[566px]">
+            <div className="bg-card border border-[#f5eae1] dark:border-[#2f2f32] border-solid rounded-[12px] px-[16px] sm:px-[24px] py-[12px] w-full flex gap-[12px] sm:gap-[32px] items-center justify-center relative">
+              <code
+                className="flex-1 font-normal leading-[40px] text-[18px] text-foreground whitespace-pre-wrap"
+                style={{
+                  fontFamily:
+                    'var(--font-jetbrains-mono, "JetBrains Mono", monospace)',
+                }}
+              >
+                npm install -g @vm0/cli && vm0 onboard
+              </code>
+              <button
+                onClick={() => {
+                  navigator.clipboard
+                    .writeText("npm install -g @vm0/cli && vm0 onboard")
+                    .catch(() => {});
+                  setCopiedHero(true);
+                  setTimeout(() => setCopiedHero(false), 2000);
+                }}
+                className="h-[40px] w-[40px] flex items-center justify-center transition-colors shrink-0 rounded-[10px] hover:bg-[#f0ebe5] dark:hover:bg-[#292a2e]"
+              >
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="w-[20px] h-[20px]"
+                >
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                </svg>
+              </button>
+              {copiedHero && (
+                <div
+                  className="absolute -top-[50px] right-[0px] bg-[#231f1b] px-[12px] py-[6px] rounded-[6px] text-[14px] whitespace-nowrap"
+                  style={{ color: "#ffffff" }}
+                >
+                  Copied
+                </div>
+              )}
+            </div>
+            <p className="text-sm text-muted-foreground text-center px-4">
+              Throw it in your terminal and vibe
+            </p>
+          </div>
+
+          {/* Divider with OR */}
+          <div className="w-full max-w-[566px] flex items-center gap-4">
+            <div className="flex-1 h-px bg-border" />
+            <span className="text-sm text-muted-foreground">or</span>
+            <div className="flex-1 h-px bg-border" />
+          </div>
+
+          {/* CTA Button */}
+          <div className="w-full max-w-[566px]">
+            {isSignedIn ? (
+              <a
+                href={getPlatformUrl()}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white w-full px-[24px] py-[12px] rounded-[10px] flex items-center justify-center transition-colors"
+              >
+                <span className="font-medium leading-[28px] text-[18px] tracking-normal !text-white">
+                  Get started
+                </span>
+              </a>
+            ) : (
+              <Link
+                href="/sign-up"
+                className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white w-full px-[24px] py-[12px] rounded-[10px] flex items-center justify-center transition-colors"
+              >
+                <span className="font-medium leading-[28px] text-[18px] tracking-normal !text-white">
+                  Get started
+                </span>
+              </Link>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function TerminalHeader({ claudeCodeVersion }: { claudeCodeVersion?: string }) {
+  return (
+    <div className="flex gap-[10px] items-start text-[12px] leading-[16px]">
+      <div className="flex gap-[4px] items-center">
+        <div className="text-black dark:text-white">
+          <p className="m-0"> *</p>
+          <p className="m-0">*</p>
+          <p className="m-0"> *</p>
+        </div>
+        <Image
+          src="/landing/vector-logo.svg"
+          alt="VM0"
+          width="65"
+          height="40"
+          className="w-[65px] h-auto"
+        />
+        <div className="text-black dark:text-white">
+          <p className="m-0">*</p>
+          <p className="m-0"> *</p>
+          <p className="m-0">*</p>
+        </div>
+      </div>
+      <div className="text-[11px]">
+        <p className="m-0">
+          <span className="font-bold">Claude Code</span>
+          {claudeCodeVersion && ` ${claudeCodeVersion}`}
+        </p>
+        <p className="m-0 text-[#827d77]">Opus 4.6 · Claude API</p>
+        <p className="m-0 text-[#827d77]">/Users/ming</p>
+      </div>
+    </div>
+  );
+}
+
+function TerminalAgentOutput({
+  step,
+  typedText,
+  children,
+}: {
+  step: number;
+  typedText: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mt-[10px] text-[12px] leading-[16px] space-y-0 font-light">
+      {step >= 1 && (
+        <p className="m-0 text-secondary-foreground">
+          &gt; {typedText}
+          {step === 1 && <span className="animate-pulse">█</span>}
+        </p>
+      )}
+      {step >= 2 && <p className="m-0">&nbsp;</p>}
+      {children}
+    </div>
+  );
+}
+
+function HackernewsTerminal({ step }: { step: number }) {
+  return (
+    <>
+      {step >= 2 && (
+        <>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              I&apos;ll run the 201-hackernews agent to summarize today&apos;s
+              top stories. This may take a few minutes.
+            </span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 3 && (
+        <>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-[#3b82f6]">Bash</span>
+            <span className="text-secondary-foreground">(</span>
+            <span className="text-[#06b6d4]">
+              vm0 run 201-hackernews &quot;Summarize today&apos;s top
+              stories&quot;
+            </span>
+            <span className="text-secondary-foreground">) timeout: 5m 0s</span>
+          </p>
+          <p className="m-0 text-[#827d77]"> ⎿ ▶ Run started</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Run ID:{" "}
+            <span className="text-[#06b6d4]">
+              882337d4-44f3-4d73-b6a0-3a59c100b70d
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Sandbox:{" "}
+            <span className="text-[#06b6d4]">iucshvzk17eyv7vwvxsah</span>
+          </p>
+          <p className="m-0 text-[#6b7280]"> … +641 lines (ctrl+o to expand)</p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 4 && (
+        <>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-[#22c55e]">
+              Perfect! Your 201-hackernews agent ran successfully! 🎉
+            </span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-secondary-foreground">
+            {" "}
+            <span className="text-foreground font-medium">Results Summary</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            The agent analyzed today&apos;s top 10 HackerNews stories and
+            identified 2 major AI-related articles:
+          </p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 5 && (
+        <>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            <span className="text-foreground font-medium">
+              1. Moltbook
+            </span>{" "}
+            (586 points)
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - A social network built specifically for AI agents
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Agents can post, comment, vote, and build reputation
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Humans can observe, but agents are the primary users
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Represents emerging infrastructure for autonomous agent-to-agent
+            communication
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - 🔗{" "}
+            <span className="text-[#06b6d4]">https://www.moltbook.com/</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 6 && (
+        <>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            <span className="text-foreground font-medium">
+              2. OpenClaw
+            </span>{" "}
+            (289 points)
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Open-source AI agent platform that runs locally
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Full data sovereignty - your data stays on your machine
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Integrates with WhatsApp, Telegram, Discord, Slack, Teams, Twitch,
+            Google Chat
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Went through 3 name changes (Clawd → Moltbot → OpenClaw) due to
+            trademark issues
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Recent focus on security with 34 security commits
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - 🔗{" "}
+            <span className="text-[#06b6d4]">
+              https://openclaw.ai/blog/introducing-openclaw
+            </span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            <span className="text-foreground font-medium">Output File</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            The agent created <span className="text-[#06b6d4]">
+              content.md
+            </span>{" "}
+            with:
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Detailed summaries of both stories
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - A ready-to-post X/Twitter thread format
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            <span className="text-foreground font-medium">Run Details:</span>
+          </p>
+          <p className="m-0 text-[#827d77]"> - Duration: 66.2 seconds</p>
+          <p className="m-0 text-[#827d77]"> - Cost: $0.1850</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Run ID:{" "}
+            <span className="text-[#06b6d4]">
+              882337d4-44f3-4d73-b6a0-3a59c100b70d
+            </span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            You can view the full logs with:
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            <span className="text-[#06b6d4]">
+              vm0 logs 882337d4-44f3-4d73-b6a0-3a59c100b70d
+            </span>
+          </p>
+        </>
+      )}
+    </>
+  );
+}
+
+function TiktokTerminal({ step }: { step: number }) {
+  return (
+    <>
+      {step >= 2 && (
+        <>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              I&apos;ll help you discover TikTok influencers. Let me run the
+              tiktok-influencer agent.
+            </span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 3 && (
+        <>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-[#3b82f6]">Bash</span>
+            <span className="text-secondary-foreground">(</span>
+            <span className="text-[#06b6d4]">vm0 run tiktok-influencer</span>
+            <span className="text-secondary-foreground">) timeout: 8m 0s</span>
+          </p>
+          <p className="m-0 text-[#827d77]"> ⎿ ▶ Run started</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Run ID:{" "}
+            <span className="text-[#06b6d4]">
+              f5a92e18-3d4c-4b89-a1e2-9c7f8b2d4e61
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Sandbox:{" "}
+            <span className="text-[#06b6d4]">xk9dfj2n8pqwer5tyvlmz</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 4 && (
+        <>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Phase 1: Gathering business information...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Search Keyword: <span className="text-foreground">fitness</span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Industry:{" "}
+            <span className="text-foreground">Health & Wellness</span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Notion Database ID:{" "}
+            <span className="text-[#06b6d4]">a8f3e9c...</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Phase 2: Discovering TikTok profiles...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Scraping TikTok for &quot;fitness&quot; creators (this takes 2-3
+            minutes)
+          </p>
+          <p className="m-0 text-[#6b7280]"> … +124 lines (ctrl+o to expand)</p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Phase 3: Storing data in Notion...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            ✓ Added 15 influencers to database
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Phase 4: Analyzing relevance...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Evaluating each influencer based on followers, content, and profile
+            description
+          </p>
+          <p className="m-0 text-[#6b7280]"> … +89 lines (ctrl+o to expand)</p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 5 && (
+        <>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-[#22c55e]">
+              Success! TikTok influencer discovery completed! 🎉
+            </span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-secondary-foreground">
+            {" "}
+            <span className="text-foreground font-medium">Results Summary</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Total Analyzed:{" "}
+            <span className="text-foreground">15 influencers</span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Highly Relevant:{" "}
+            <span className="text-[#22c55e]">8 influencers</span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Data Stored:{" "}
+            <span className="text-[#06b6d4]">Notion Database</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            <span className="text-foreground font-medium">
+              Top Influencer:
+            </span>{" "}
+            @fitnesswithkayla (245K followers)
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Strong fitness content with workout routines, nutrition tips, and
+            motivational posts.
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            <span className="text-foreground font-medium">
+              Output File:
+            </span>{" "}
+            <span className="text-[#06b6d4]">influencer-report.md</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 6 && (
+        <>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            <span className="text-foreground font-medium">Run Details:</span>
+          </p>
+          <p className="m-0 text-[#827d77]"> - Duration: 4m 32s</p>
+          <p className="m-0 text-[#827d77]"> - Cost: $0.4250</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Run ID:{" "}
+            <span className="text-[#06b6d4]">
+              f5a92e18-3d4c-4b89-a1e2-9c7f8b2d4e61
+            </span>
+          </p>
+        </>
+      )}
+    </>
+  );
+}
+
+function BlogTerminal({ step }: { step: number }) {
+  return (
+    <>
+      {step >= 2 && (
+        <>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              I&apos;ll create an SEO-optimized blog article. Let me run the
+              content-farm agent.
+            </span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 3 && (
+        <>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-[#3b82f6]">Bash</span>
+            <span className="text-secondary-foreground">(</span>
+            <span className="text-[#06b6d4]">
+              vm0 run content-farm &quot;AI agents&quot;
+            </span>
+            <span className="text-secondary-foreground">) timeout: 10m 0s</span>
+          </p>
+          <p className="m-0 text-[#827d77]"> ⎿ ▶ Run started</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Run ID:{" "}
+            <span className="text-[#06b6d4]">
+              d8b3f2c9-5e7a-4d91-b2c3-8f9e1a7d5c42
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Sandbox:{" "}
+            <span className="text-[#06b6d4]">nq7wjk3m9rxpvt4ylzbhd</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 4 && (
+        <>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Phase 1: Gathering news from RSS feeds...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Fetching from Hacker News, TechCrunch, Wired, Ars Technica, The
+            Verge
+          </p>
+          <p className="m-0 text-[#827d77]"> ✓ Found 47 recent articles</p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Phase 2: Filtering and selecting articles...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Selected 4 articles matching &quot;AI agents&quot; topic
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Phase 3: Creating SEO title...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]"> Generated 5 title candidates</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Selected:{" "}
+            <span className="text-foreground">
+              &quot;AI Agents in 2025: How Autonomous Systems Are Changing
+              Software Development&quot;
+            </span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Phase 4: Building outline...
+            </span>
+          </p>
+          <p className="m-0 text-[#6b7280]"> … +32 lines (ctrl+o to expand)</p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 5 && (
+        <>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Phase 5: Writing article...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Writing 1,250 word article with conversational tone
+          </p>
+          <p className="m-0 text-[#6b7280]"> … +156 lines (ctrl+o to expand)</p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Phase 6: Generating featured image...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]"> ✓ Image generated and saved</p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Phase 7: Preparing output...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]"> ✓ Saved to output folder</p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Phase 8: Publishing to Dev.to...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            ✓ Article published successfully
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-[#22c55e]">
+              Success! Blog article published! 🎉
+            </span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 6 && (
+        <>
+          <p className="m-0 text-secondary-foreground">
+            {" "}
+            <span className="text-foreground font-medium">Article Details</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Title:{" "}
+            <span className="text-foreground">
+              AI Agents in 2025: How Autonomous Systems Are Changing Software
+              Development
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Word Count: <span className="text-foreground">1,250 words</span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Citations: <span className="text-foreground">4 sources</span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Dev.to URL:{" "}
+            <span className="text-[#06b6d4]">
+              https://dev.to/ai-agents-2025-software-dev
+            </span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            <span className="text-foreground font-medium">Run Details:</span>
+          </p>
+          <p className="m-0 text-[#827d77]"> - Duration: 7m 18s</p>
+          <p className="m-0 text-[#827d77]"> - Cost: $0.7850</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Run ID:{" "}
+            <span className="text-[#06b6d4]">
+              d8b3f2c9-5e7a-4d91-b2c3-8f9e1a7d5c42
+            </span>
+          </p>
+        </>
+      )}
+    </>
+  );
+}
+
+function DailyReportTerminal({ step }: { step: number }) {
+  return (
+    <>
+      {step >= 2 && (
+        <>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              I&apos;ll gather data from multiple sources and generate
+              today&apos;s report.
+            </span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 3 && (
+        <>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-[#3b82f6]">Bash</span>
+            <span className="text-secondary-foreground">(</span>
+            <span className="text-[#06b6d4]">vm0 run daily-data-report</span>
+            <span className="text-secondary-foreground">) timeout: 5m 0s</span>
+          </p>
+          <p className="m-0 text-[#827d77]"> ⎿ ▶ Run started</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Run ID:{" "}
+            <span className="text-[#06b6d4]">
+              a9c2e4f8-1b3d-4c7a-9e2f-5d8b3a7c9e41
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Sandbox:{" "}
+            <span className="text-[#06b6d4]">pk8vmj4n2swqxt6ylazhc</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 4 && (
+        <>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Collecting GitHub repository metrics...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Stars: <span className="text-foreground">2,847</span> (+23
+            yesterday)
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Forks: <span className="text-foreground">156</span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Open Issues: <span className="text-foreground">34</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Fetching Plausible analytics...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Visitors: <span className="text-foreground">1,245</span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Pageviews: <span className="text-foreground">3,892</span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Bounce Rate: <span className="text-foreground">42.3%</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Gathering user registration data...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Total Users: <span className="text-foreground">8,234</span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            New Registrations: <span className="text-foreground">47</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Analyzing code changes...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Commits: <span className="text-foreground">12</span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            Files Changed: <span className="text-foreground">28</span>
+          </p>
+          <p className="m-0 text-[#6b7280]"> … +45 lines (ctrl+o to expand)</p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-secondary-foreground">
+              Checking Notion document updates...
+            </span>
+          </p>
+          <p className="m-0 text-[#827d77]"> ✓ Found 8 page modifications</p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 5 && (
+        <>
+          <p className="m-0">
+            <span className="text-[#22c55e]">⏺</span>{" "}
+            <span className="text-[#22c55e]">
+              Success! Daily report generated! 🎉
+            </span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-secondary-foreground">
+            {" "}
+            <span className="text-foreground font-medium">Report Summary</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Report Date: <span className="text-foreground">2025-01-30</span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Data Sources:{" "}
+            <span className="text-foreground">6 integrated</span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Output File:{" "}
+            <span className="text-[#06b6d4]">daily-report-2025-01-30.md</span>
+          </p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Slack Notification: <span className="text-[#22c55e]">Sent</span>
+          </p>
+          <p className="m-0">&nbsp;</p>
+        </>
+      )}
+      {step >= 6 && (
+        <>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            <span className="text-foreground font-medium">Run Details:</span>
+          </p>
+          <p className="m-0 text-[#827d77]"> - Duration: 2m 45s</p>
+          <p className="m-0 text-[#827d77]"> - Cost: $0.3150</p>
+          <p className="m-0 text-[#827d77]">
+            {" "}
+            - Run ID:{" "}
+            <span className="text-[#06b6d4]">
+              a9c2e4f8-1b3d-4c7a-9e2f-5d8b3a7c9e41
+            </span>
+          </p>
+        </>
+      )}
+    </>
+  );
+}
+
+function RunTerminalContent({
+  selectedAgent,
+  runAnimationStep,
+  runTypedText,
+  claudeCodeVersion,
+}: {
+  selectedAgent: SelectedAgent;
+  runAnimationStep: number;
+  runTypedText: string;
+  claudeCodeVersion?: string;
+}) {
+  const agentTerminals: Record<SelectedAgent, React.ReactNode> = {
+    hackernews: <HackernewsTerminal step={runAnimationStep} />,
+    tiktok: <TiktokTerminal step={runAnimationStep} />,
+    blog: <BlogTerminal step={runAnimationStep} />,
+    "daily-report": <DailyReportTerminal step={runAnimationStep} />,
+  };
+
+  return (
+    <>
+      <TerminalHeader claudeCodeVersion={claudeCodeVersion} />
+      <TerminalAgentOutput step={runAnimationStep} typedText={runTypedText}>
+        {agentTerminals[selectedAgent]}
+      </TerminalAgentOutput>
+    </>
+  );
+}
+
+function RunEditorContent({
+  selectedAgent,
+  activeTab,
+}: {
+  selectedAgent: SelectedAgent;
+  activeTab: "agents" | "yaml";
+}) {
+  if (selectedAgent === "hackernews" && activeTab === "agents") {
+    return (
+      <div
+        className="text-[14px] leading-[20px]"
+        style={{ fontFamily: "var(--font-noto-sans)" }}
+      >
+        <p className="m-0 font-semibold text-[18px] leading-[26px]">
+          Agent Instructions
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0">You are a Hacker News AI content curator.</p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-semibold text-[15px] leading-[22px]">Workflow</p>
+        <ul className="list-disc ml-[20px] m-0">
+          <li className="m-0">Read the top 10 articles on Hacker News</li>
+          <li className="m-0">Identify AI-related content</li>
+          <li className="m-0">Extract key ideas and patterns</li>
+          <li className="m-0">
+            Summarize the findings in an X (Twitter) post format
+          </li>
+          <li className="m-0">Write the output to `content.md`</li>
+        </ul>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-semibold text-[15px] leading-[22px]">
+          Guidelines
+        </p>
+        <ul className="list-disc ml-[20px] m-0">
+          <li className="m-0">Focus on signal over noise</li>
+          <li className="m-0">Keep summaries concise and skimmable</li>
+          <li className="m-0">Use a neutral, non-promotional tone</li>
+        </ul>
+      </div>
+    );
+  }
+
+  if (selectedAgent === "hackernews" && activeTab === "yaml") {
+    return (
+      <div
+        className="text-[13px] leading-[18px] whitespace-pre-wrap break-words"
+        style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+      >
+        <p className="m-0">
+          <span className="text-[#3b82f6]">version</span>
+          <span className="text-[#827d77]">:</span>{" "}
+          <span className="text-[#22c55e]">&quot;1.0&quot;</span>
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0">
+          <span className="text-[#3b82f6]">agents</span>
+          <span className="text-[#827d77]">:</span>
+        </p>
+        <p className="m-0">
+          {"  "}
+          <span className="text-[#3b82f6]">201-hackernews</span>
+          <span className="text-[#827d77]">:</span>
+        </p>
+        <p className="m-0">
+          {"    "}
+          <span className="text-[#3b82f6]">description</span>
+          <span className="text-[#827d77]">:</span>{" "}
+          <span className="text-[#22c55e]">
+            &quot;Daily HackerNews curator that fetches and analyzes top
+            stories&quot;
+          </span>
+        </p>
+        <p className="m-0">
+          {"    "}
+          <span className="text-[#3b82f6]">framework</span>
+          <span className="text-[#827d77]">:</span>{" "}
+          <span className="text-foreground">claude-code</span>
+        </p>
+        <p className="m-0">
+          {"    "}
+          <span className="text-[#3b82f6]">instructions</span>
+          <span className="text-[#827d77]">:</span>{" "}
+          <span className="text-foreground">AGENTS.md</span>
+        </p>
+        <p className="m-0">
+          {"    "}
+          <span className="text-[#3b82f6]">skills</span>
+          <span className="text-[#827d77]">:</span>
+        </p>
+        <p className="m-0">
+          {"      "}
+          <span className="text-[#827d77]">-</span>{" "}
+          <span className="text-[#06b6d4]">
+            https://github.com/vm0-ai/vm0-skills/tree/main/hackernews
+          </span>
+        </p>
+      </div>
+    );
+  }
+
+  if (selectedAgent === "tiktok" && activeTab === "agents") {
+    return (
+      <div
+        className="text-[14px] leading-[20px]"
+        style={{ fontFamily: "var(--font-noto-sans)" }}
+      >
+        <p className="m-0 font-semibold text-[18px] leading-[26px]">
+          TikTok Influencer Discovery Agent
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0">
+          You are a TikTok influencer discovery and analysis expert. You help
+          businesses find the most relevant TikTok influencers for collaboration
+          based on their industry and requirements.
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-semibold text-[15px] leading-[22px]">Workflow</p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-medium text-[14px] leading-[20px]">
+          Phase 1: Gather Business Information
+        </p>
+        <ul className="list-disc ml-[20px] m-0">
+          <li className="m-0">
+            Search Keyword: What type of content/niche to search for
+          </li>
+          <li className="m-0">About Your Business: Brief description</li>
+          <li className="m-0">
+            Industry: The industry the business operates in
+          </li>
+          <li className="m-0">Notion Database ID: To store results</li>
+        </ul>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-medium text-[14px] leading-[20px]">
+          Phase 2: Discover TikTok Influencers
+        </p>
+        <p className="m-0">
+          Search for TikTok profiles matching the keyword. The scraping process
+          takes 2-3 minutes to complete.
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-medium text-[14px] leading-[20px]">
+          Phase 3: Store Raw Data in Notion
+        </p>
+        <p className="m-0">
+          For each influencer discovered, add them to the Notion database. Save
+          the returned page IDs for updating later with analysis.
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-medium text-[14px] leading-[20px]">
+          Phase 4: Analyze Each Influencer
+        </p>
+        <p className="m-0">
+          Evaluate their relevance based on followers (&gt;5,000), content
+          alignment, and profile description. Classify as &quot;Highly
+          Relevant&quot; or &quot;Not Relevant&quot;.
+        </p>
+      </div>
+    );
+  }
+
+  if (selectedAgent === "tiktok" && activeTab === "yaml") {
+    return (
+      <div
+        className="text-[13px] leading-[18px] whitespace-pre-wrap break-words"
+        style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+      >
+        <p className="m-0">
+          <span className="text-[#3b82f6]">version</span>
+          <span className="text-[#827d77]">:</span>{" "}
+          <span className="text-[#22c55e]">&quot;1.0&quot;</span>
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0">
+          <span className="text-[#3b82f6]">agents</span>
+          <span className="text-[#827d77]">:</span>
+        </p>
+        <p className="m-0">
+          {"  "}
+          <span className="text-[#3b82f6]">tiktok-influencer</span>
+          <span className="text-[#827d77]">:</span>
+        </p>
+        <p className="m-0">
+          {"    "}
+          <span className="text-[#3b82f6]">description</span>
+          <span className="text-[#827d77]">:</span>{" "}
+          <span className="text-[#22c55e]">
+            &quot;TikTok influencer discovery and AI-powered analysis agent with
+            Notion integration&quot;
+          </span>
+        </p>
+        <p className="m-0">
+          {"    "}
+          <span className="text-[#3b82f6]">framework</span>
+          <span className="text-[#827d77]">:</span>{" "}
+          <span className="text-foreground">claude-code</span>
+        </p>
+        <p className="m-0">
+          {"    "}
+          <span className="text-[#3b82f6]">instructions</span>
+          <span className="text-[#827d77]">:</span>{" "}
+          <span className="text-foreground">AGENTS.md</span>
+        </p>
+        <p className="m-0">
+          {"    "}
+          <span className="text-[#3b82f6]">skills</span>
+          <span className="text-[#827d77]">:</span>
+        </p>
+        <p className="m-0">
+          {"      "}
+          <span className="text-[#827d77]">-</span>{" "}
+          <span className="text-[#06b6d4]">
+            https://github.com/vm0-ai/vm0-skills/tree/main/bright-data
+          </span>
+        </p>
+        <p className="m-0">
+          {"      "}
+          <span className="text-[#827d77]">-</span>{" "}
+          <span className="text-[#06b6d4]">
+            https://github.com/vm0-ai/vm0-skills/tree/main/notion
+          </span>
+        </p>
+      </div>
+    );
+  }
+
+  if (selectedAgent === "blog" && activeTab === "agents") {
+    return (
+      <div
+        className="text-[14px] leading-[20px]"
+        style={{ fontFamily: "var(--font-noto-sans)" }}
+      >
+        <p className="m-0 font-semibold text-[18px] leading-[26px]">
+          Content Farm Agent
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0">
+          You are a professional content farm agent that automatically generates
+          high-quality, SEO-optimized blog articles from trending news sources.
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-semibold text-[15px] leading-[22px]">Workflow</p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-medium text-[14px] leading-[20px]">
+          Phase 1: Gather News
+        </p>
+        <p className="m-0">
+          Use the rss-fetch skill to collect recent articles from major tech
+          news sources.
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-medium text-[14px] leading-[20px]">
+          Phase 2: Filter and Select
+        </p>
+        <p className="m-0">
+          Review the fetched articles and select the most relevant ones based on
+          the user&apos;s specified topic or keywords. Pick 3-5 articles.
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-medium text-[14px] leading-[20px]">
+          Phase 3: Create SEO Title
+        </p>
+        <p className="m-0">
+          Generate 5 long-tail SEO title candidates, evaluate each for
+          click-through potential, and select the best one.
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-medium text-[14px] leading-[20px]">
+          Phase 4: Build Outline
+        </p>
+        <p className="m-0">
+          Create a structured outline with introduction, 2-3 main sections,
+          conclusion, and references section.
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-medium text-[14px] leading-[20px]">
+          Phase 5: Write the Article
+        </p>
+        <p className="m-0">
+          Write a 1000-1500 word article with conversational tone, short
+          paragraphs, and natural keyword integration.
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-medium text-[14px] leading-[20px]">
+          Phase 6-8: Generate Image, Prepare Output, Publish
+        </p>
+        <p className="m-0">
+          Create featured image, save to output folder, and publish to Dev.to.
+        </p>
+      </div>
+    );
+  }
+
+  if (selectedAgent === "blog" && activeTab === "yaml") {
+    return (
+      <div
+        className="text-[13px] leading-[18px] whitespace-pre-wrap break-words"
+        style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+      >
+        <p className="m-0">
+          <span className="text-[#3b82f6]">version</span>
+          <span className="text-[#827d77]">:</span>{" "}
+          <span className="text-[#22c55e]">&quot;1.0&quot;</span>
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0">
+          <span className="text-[#3b82f6]">agents</span>
+          <span className="text-[#827d77]">:</span>
+        </p>
+        <p className="m-0">
+          {"  "}
+          <span className="text-[#3b82f6]">content-farm</span>
+          <span className="text-[#827d77]">:</span>
+        </p>
+        <p className="m-0">
+          {"    "}
+          <span className="text-[#3b82f6]">description</span>
+          <span className="text-[#827d77]">:</span>{" "}
+          <span className="text-[#22c55e]">
+            &quot;AI-powered blog content generation agent&quot;
+          </span>
+        </p>
+        <p className="m-0">
+          {"    "}
+          <span className="text-[#3b82f6]">framework</span>
+          <span className="text-[#827d77]">:</span>{" "}
+          <span className="text-foreground">claude-code</span>
+        </p>
+        <p className="m-0">
+          {"    "}
+          <span className="text-[#3b82f6]">instructions</span>
+          <span className="text-[#827d77]">:</span>{" "}
+          <span className="text-foreground">AGENTS.md</span>
+        </p>
+        <p className="m-0">
+          {"    "}
+          <span className="text-[#3b82f6]">skills</span>
+          <span className="text-[#827d77]">:</span>
+        </p>
+        <p className="m-0">
+          {"      "}
+          <span className="text-[#827d77]">-</span>{" "}
+          <span className="text-[#06b6d4]">
+            https://github.com/vm0-ai/vm0-skills/tree/main/rss-fetch
+          </span>
+        </p>
+        <p className="m-0">
+          {"      "}
+          <span className="text-[#827d77]">-</span>{" "}
+          <span className="text-[#06b6d4]">
+            https://github.com/vm0-ai/vm0-skills/tree/main/fal.ai
+          </span>
+        </p>
+        <p className="m-0">
+          {"      "}
+          <span className="text-[#827d77]">-</span>{" "}
+          <span className="text-[#06b6d4]">
+            https://github.com/vm0-ai/vm0-skills/tree/main/dev.to
+          </span>
+        </p>
+      </div>
+    );
+  }
+
+  if (selectedAgent === "daily-report" && activeTab === "agents") {
+    return (
+      <div
+        className="text-[14px] leading-[20px]"
+        style={{ fontFamily: "var(--font-noto-sans)" }}
+      >
+        <p className="m-0 font-semibold text-[18px] leading-[26px]">
+          Daily Data Report Agent
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0">
+          This agent generates comprehensive daily reports for the vm0 team
+          across eight sequential phases.
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-semibold text-[15px] leading-[22px]">
+          Key Data Collection Areas
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-medium text-[14px] leading-[20px]">
+          GitHub Repository Metrics
+        </p>
+        <p className="m-0">
+          Stars, forks, watchers, and open issues for vm0-ai/vm0
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-medium text-[14px] leading-[20px]">
+          Website Analytics
+        </p>
+        <p className="m-0">
+          Yesterday&apos;s visitor counts, pageviews, bounce rates, visit
+          duration, and traffic source analysis
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-medium text-[14px] leading-[20px]">
+          User Statistics
+        </p>
+        <p className="m-0">
+          Total users, active users from yesterday, and new user registrations
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-medium text-[14px] leading-[20px]">
+          Code Changes
+        </p>
+        <p className="m-0">
+          Commits, file modifications, and line additions/removals with author
+          attribution
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-medium text-[14px] leading-[20px]">
+          Document Activity
+        </p>
+        <p className="m-0">
+          Notion pages created and edited with change attribution
+        </p>
+        <p className="m-0">&nbsp;</p>
+        <p className="m-0 font-semibold text-[15px] leading-[22px]">Output</p>
+        <p className="m-0">
+          Reports are saved as markdown files and Slack notification sent with
+          key metrics.
+        </p>
+      </div>
+    );
+  }
+
+  // daily-report yaml
+  return (
+    <div
+      className="text-[13px] leading-[18px] whitespace-pre-wrap break-words"
+      style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+    >
+      <p className="m-0">
+        <span className="text-[#3b82f6]">version</span>
+        <span className="text-[#827d77]">:</span>{" "}
+        <span className="text-[#22c55e]">&quot;1.0&quot;</span>
+      </p>
+      <p className="m-0">&nbsp;</p>
+      <p className="m-0">
+        <span className="text-[#3b82f6]">agents</span>
+        <span className="text-[#827d77]">:</span>
+      </p>
+      <p className="m-0">
+        {"  "}
+        <span className="text-[#3b82f6]">daily-data-report</span>
+        <span className="text-[#827d77]">:</span>
+      </p>
+      <p className="m-0">
+        {"    "}
+        <span className="text-[#3b82f6]">description</span>
+        <span className="text-[#827d77]">:</span>{" "}
+        <span className="text-[#22c55e]">
+          &quot;Daily data report agent that gathers GitHub stats, Plausible
+          analytics, code changes, and Notion updates&quot;
+        </span>
+      </p>
+      <p className="m-0">
+        {"    "}
+        <span className="text-[#3b82f6]">framework</span>
+        <span className="text-[#827d77]">:</span>{" "}
+        <span className="text-foreground">claude-code</span>
+      </p>
+      <p className="m-0">
+        {"    "}
+        <span className="text-[#3b82f6]">instructions</span>
+        <span className="text-[#827d77]">:</span>{" "}
+        <span className="text-foreground">AGENTS.md</span>
+      </p>
+      <p className="m-0">
+        {"    "}
+        <span className="text-[#3b82f6]">skills</span>
+        <span className="text-[#827d77]">:</span>
+      </p>
+      <p className="m-0">
+        {"      "}
+        <span className="text-[#827d77]">-</span>{" "}
+        <span className="text-[#06b6d4]">
+          https://github.com/vm0-ai/vm0-skills/tree/main/github
+        </span>
+      </p>
+      <p className="m-0">
+        {"      "}
+        <span className="text-[#827d77]">-</span>{" "}
+        <span className="text-[#06b6d4]">
+          https://github.com/vm0-ai/vm0-skills/tree/main/plausible
+        </span>
+      </p>
+      <p className="m-0">
+        {"      "}
+        <span className="text-[#827d77]">-</span>{" "}
+        <span className="text-[#06b6d4]">
+          https://github.com/vm0-ai/vm0-skills/tree/main/notion
+        </span>
+      </p>
+      <p className="m-0">
+        {"      "}
+        <span className="text-[#827d77]">-</span>{" "}
+        <span className="text-[#06b6d4]">
+          https://github.com/vm0-ai/vm0-skills/tree/main/slack
+        </span>
+      </p>
+      <p className="m-0">
+        {"    "}
+        <span className="text-[#3b82f6]">environment</span>
+        <span className="text-[#827d77]">:</span>
+      </p>
+      <p className="m-0">
+        {"      "}
+        <span className="text-[#3b82f6]">PLAUSIBLE_SITE_ID</span>
+        <span className="text-[#827d77]">:</span>{" "}
+        <span className="text-foreground">$</span>
+        <span className="text-[#827d77]">&#123;&#123;</span>
+        <span className="text-foreground"> vars.PLAUSIBLE_SITE_ID </span>
+        <span className="text-[#827d77]">&#125;&#125;</span>
+      </p>
+      <p className="m-0">
+        {"      "}
+        <span className="text-[#3b82f6]">SLACK_CHANNEL_ID</span>
+        <span className="text-[#827d77]">:</span>{" "}
+        <span className="text-foreground">$</span>
+        <span className="text-[#827d77]">&#123;&#123;</span>
+        <span className="text-foreground"> vars.SLACK_CHANNEL_ID </span>
+        <span className="text-[#827d77]">&#125;&#125;</span>
+      </p>
+    </div>
+  );
+}
+
+function RunSection({ claudeCodeVersion }: { claudeCodeVersion?: string }) {
   const [activeTab, setActiveTab] = useState<"agents" | "yaml">("agents");
-  const [selectedAgent, setSelectedAgent] = useState<
-    "hackernews" | "tiktok" | "blog" | "daily-report"
-  >("hackernews");
-  const [mainTab, setMainTab] = useState<"build" | "run">("run");
-  const [buildAnimationStep, setBuildAnimationStep] = useState(-1);
-  const [typedText, setTypedText] = useState("");
+  const [selectedAgent, setSelectedAgent] =
+    useState<SelectedAgent>("hackernews");
   const [runAnimationStep, setRunAnimationStep] = useState(-1);
   const [runTypedText, setRunTypedText] = useState("");
-
-  const buildSectionRef = useRef<HTMLDivElement>(null);
   const runSectionRef = useRef<HTMLDivElement>(null);
-  const [buildSectionVisible, setBuildSectionVisible] = useState(false);
   const [runSectionVisible, setRunSectionVisible] = useState(false);
-  const [copiedHero, setCopiedHero] = useState(false);
   const [copiedEditor, setCopiedEditor] = useState(false);
-  const [copiedFooter, setCopiedFooter] = useState(false);
-
-  // Intersection Observer for Build section
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry && entry.isIntersecting && !buildSectionVisible) {
-          setBuildSectionVisible(true);
-          setBuildAnimationStep(0);
-        }
-      },
-      { threshold: 0.3 },
-    );
-
-    if (buildSectionRef.current) {
-      observer.observe(buildSectionRef.current);
-    }
-
-    return () => observer.disconnect();
-  }, [buildSectionVisible]);
 
   // Intersection Observer for Run section
   useEffect(() => {
@@ -81,28 +1630,299 @@ export default function LandingPage({ claudeCodeVersion }: LandingPageProps) {
     return () => observer.disconnect();
   }, [runSectionVisible]);
 
-  // Trigger animations when switching tabs
+  // Reset run animation when switching agents
   useEffect(() => {
-    if (mainTab === "build") {
-      setBuildAnimationStep(0);
-      setBuildSectionVisible(true);
-    } else if (mainTab === "run") {
+    if (runSectionVisible) {
       setRunAnimationStep(0);
-      setRunSectionVisible(true);
+      setRunTypedText("");
     }
-  }, [mainTab]);
+  }, [selectedAgent, runSectionVisible]);
 
+  // Run agent animation
   useEffect(() => {
     const timers: NodeJS.Timeout[] = [];
 
-    // Step 0 -> 1: Show loading then start typing
-    if (buildAnimationStep === 0) {
-      const timer = setTimeout(() => setBuildAnimationStep(1), 800);
+    if (runAnimationStep === 0) {
+      const timer = setTimeout(() => setRunAnimationStep(1), 800);
+      timers.push(timer);
+    } else if (runAnimationStep === 1) {
+      const currentText = RUN_TYPED_TEXT[selectedAgent];
+      let currentIndex = 0;
+      const typeInterval = setInterval(() => {
+        if (currentIndex <= currentText.length) {
+          setRunTypedText(currentText.slice(0, currentIndex));
+          currentIndex++;
+        } else {
+          clearInterval(typeInterval);
+          const timer = setTimeout(() => setRunAnimationStep(2), 500);
+          timers.push(timer);
+        }
+      }, 50);
+      timers.push(typeInterval as unknown as NodeJS.Timeout);
+    } else if (runAnimationStep === 2) {
+      const timer = setTimeout(() => setRunAnimationStep(3), 1000);
+      timers.push(timer);
+    } else if (runAnimationStep === 3) {
+      const timer = setTimeout(() => setRunAnimationStep(4), 1500);
+      timers.push(timer);
+    } else if (runAnimationStep === 4) {
+      const timer = setTimeout(() => setRunAnimationStep(5), 2000);
+      timers.push(timer);
+    } else if (runAnimationStep === 5) {
+      const timer = setTimeout(() => setRunAnimationStep(6), 1500);
       timers.push(timer);
     }
 
-    // Step 1: Typewriter effect for user input
-    else if (buildAnimationStep === 1) {
+    return () => timers.forEach(clearTimeout);
+  }, [runAnimationStep, selectedAgent]);
+
+  // Start animation on mount
+  useEffect(() => {
+    setRunAnimationStep(0);
+    setRunSectionVisible(true);
+  }, []);
+
+  return (
+    <div ref={runSectionRef} className="flex flex-col gap-[30px] mb-20">
+      <div className="text-center">
+        <h2 className="text-[36px] font-medium leading-[1.2] text-foreground mb-4">
+          Run an agent
+        </h2>
+        <p className="text-[16px] leading-[1.5] text-foreground">
+          Execute your agents instantly, powered by workflows defined in natural
+          language.
+        </p>
+        <p className="text-[16px] leading-[1.5] text-foreground">
+          Schedule recurring runs or execute on demand, with full visibility and
+          control.
+        </p>
+      </div>
+
+      <div
+        className="rounded-[6px] pt-[20px] pb-[20px] sm:pb-[30px] px-[16px] sm:px-[30px] flex items-center justify-center"
+        style={{
+          backgroundImage:
+            "linear-gradient(137.478deg, #E8A145 0.82464%, #F8732A 45.285%, #933803 99.384%)",
+        }}
+      >
+        <div className="flex flex-col lg:flex-row gap-[16px] sm:gap-[24px] w-full max-w-[1124px] mx-auto">
+          {/* Terminal - Left Side */}
+          <div className="flex-1 bg-white dark:bg-[#19191b] border-[0.5px] border-border rounded-[12px] shadow-[0px_25px_50px_-12px_rgba(0,0,0,0.25)] overflow-hidden h-[422px] flex flex-col">
+            {/* Terminal Header */}
+            <div className="bg-[#f9f4ef] dark:bg-[#292a2e] h-[44px] flex items-center justify-between px-[8px] shadow-[0px_0.5px_0px_0px_#d2d2d2] dark:shadow-[0px_0.5px_0px_0px_#2f2f32]">
+              <div className="flex gap-1.5 w-[39px] items-center">
+                <div className="w-[10px] h-[10px] rounded-full bg-red-500 shrink-0" />
+                <div className="w-[10px] h-[10px] rounded-full bg-yellow-500 shrink-0" />
+                <div className="w-[10px] h-[10px] rounded-full bg-green-500 shrink-0" />
+              </div>
+              <p
+                className="text-[12px] text-center font-medium flex-1"
+                style={{ fontFamily: "var(--font-noto-sans)" }}
+              >
+                <span className="text-[#827d77]">~/work</span>
+                <span className="text-foreground">
+                  {" "}
+                  * VM0 Agent ▸ Claude Code
+                </span>
+              </p>
+              <div className="w-[39px]"></div>
+            </div>
+
+            {/* Terminal Content */}
+            <div
+              className="p-[20px] overflow-y-auto h-[calc(422px-44px)]"
+              style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+            >
+              <RunTerminalContent
+                selectedAgent={selectedAgent}
+                runAnimationStep={runAnimationStep}
+                runTypedText={runTypedText}
+                claudeCodeVersion={claudeCodeVersion}
+              />
+            </div>
+          </div>
+
+          {/* Code Editor - Right Side */}
+          <div className="flex-1 flex flex-col shadow-[0px_25px_50px_0px_rgba(0,0,0,0.25)] h-[422px]">
+            {/* Editor Header with Tabs */}
+            <div className="bg-[#f9f4ef] dark:bg-[#292a2e] border-b border-border h-[44px] flex items-center gap-[6px] px-[12px] py-[6px] rounded-tl-[8px] rounded-tr-[8px] relative">
+              <div className="flex-1 flex gap-[6px] items-center pl-[4px]">
+                <div
+                  onClick={() => setActiveTab("agents")}
+                  className={`flex gap-[6px] items-center px-[6px] py-[4px] rounded-[6px] cursor-pointer transition-all border ${
+                    activeTab === "agents"
+                      ? "bg-[rgba(255,255,255,0.6)] dark:bg-[rgba(25,25,27,0.6)] border-border"
+                      : "border-transparent hover:bg-[rgba(255,255,255,0.3)] dark:hover:bg-[rgba(25,25,27,0.3)] hover:border-border"
+                  }`}
+                >
+                  <IconFile
+                    size={14.4}
+                    stroke={1.2}
+                    className="text-foreground"
+                  />
+                  <p className="text-[14px] font-medium leading-[20px] text-foreground">
+                    AGENTS.MD
+                  </p>
+                </div>
+                <div
+                  onClick={() => setActiveTab("yaml")}
+                  className={`flex gap-[6px] items-center px-[6px] py-[4px] rounded-[6px] cursor-pointer transition-all border ${
+                    activeTab === "yaml"
+                      ? "bg-[rgba(255,255,255,0.6)] dark:bg-[rgba(25,25,27,0.6)] border-border"
+                      : "border-transparent hover:bg-[rgba(255,255,255,0.3)] dark:hover:bg-[rgba(25,25,27,0.3)] hover:border-border"
+                  }`}
+                >
+                  <IconFile
+                    size={14.4}
+                    stroke={1.2}
+                    className="text-foreground"
+                  />
+                  <p className="text-[14px] font-medium leading-[20px] text-foreground">
+                    vm0.yaml
+                  </p>
+                </div>
+              </div>
+              <button
+                onClick={() => {
+                  const content =
+                    activeTab === "agents"
+                      ? `Agent Instructions\n\nYou are a specialized agent for ${selectedAgent}.`
+                      : selectedAgent === "hackernews"
+                        ? `version: "1.0"\n\nagents:\n  201-hackernews:\n    description: "Daily HackerNews curator that fetches and analyzes top stories"\n    framework: claude-code\n    instructions: AGENTS.md\n    skills:\n      - https://github.com/vm0-ai/vm0-skills/tree/main/hackernews`
+                        : `version: "1.0"\n\nagents:\n  ${selectedAgent}:\n    description: "Agent for ${selectedAgent}"\n    framework: claude-code\n    instructions: AGENTS.md`;
+                  navigator.clipboard.writeText(content).catch(() => {});
+                  setCopiedEditor(true);
+                  setTimeout(() => setCopiedEditor(false), 2000);
+                }}
+                className="bg-[#f9f4ef] dark:bg-[#292a2e] hover:bg-[#f0ebe5] dark:hover:bg-[#3a3a3e] rounded-[10px] w-[40px] h-[36px] flex items-center justify-center transition-colors"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                </svg>
+              </button>
+              {copiedEditor && (
+                <div
+                  className="absolute -top-[50px] right-[12px] bg-[#231f1b] px-[12px] py-[6px] rounded-[6px] text-[14px] whitespace-nowrap z-10"
+                  style={{ color: "#ffffff" }}
+                >
+                  Copied
+                </div>
+              )}
+            </div>
+
+            {/* Editor Content */}
+            <div className="bg-white dark:bg-[#19191b] p-[16px] overflow-y-auto rounded-bl-[12px] rounded-br-[12px] h-[calc(422px-44px)]">
+              <RunEditorContent
+                selectedAgent={selectedAgent}
+                activeTab={activeTab}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Sample Agents */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-0 rounded-[8px] mb-[20px]">
+        <AgentCard
+          icon="/landing/ycombinator.svg"
+          title="HackerNews Agent"
+          description="Get Hacker News insights from personal digest."
+          onClick={() => setSelectedAgent("hackernews")}
+          isSelected={selectedAgent === "hackernews"}
+          variant="gradient-left"
+        />
+        <AgentCard
+          icon="/landing/screenshot.png"
+          title="TikTok Influencer Agent"
+          description="Search, filter, and surface TikTok creators for you."
+          onClick={() => setSelectedAgent("tiktok")}
+          isSelected={selectedAgent === "tiktok"}
+          variant="white"
+        />
+        <AgentCard
+          icon={{
+            light: "/landing/notion.svg",
+            dark: "/landing/notion-dark.svg",
+          }}
+          title="Daily report agent"
+          description="Aggregate data from multiple sources and APIs, then summarize in Notion."
+          onClick={() => setSelectedAgent("daily-report")}
+          isSelected={selectedAgent === "daily-report"}
+          variant="white"
+        />
+        <AgentCard
+          icon="/landing/fal-image.svg"
+          title="Blog generator"
+          description="Automate blog generation with multiple APIs."
+          onClick={() => setSelectedAgent("blog")}
+          isSelected={selectedAgent === "blog"}
+          variant="gradient-right"
+        />
+      </div>
+
+      <a
+        href="https://github.com/vm0-ai/vm0-cookbooks/tree/main/examples"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex gap-[8px] items-center justify-center hover:opacity-80 transition-opacity cursor-pointer"
+      >
+        <p
+          className="text-[14px] leading-[20px] text-primary font-normal"
+          style={{ fontFamily: "var(--font-noto-sans)" }}
+        >
+          Show more sample agents
+        </p>
+        <div className="flex items-center justify-center w-[16px] h-[16px] -rotate-90">
+          <IconChevronDown size={16} className="text-primary" />
+        </div>
+      </a>
+    </div>
+  );
+}
+
+function BuildSection({ claudeCodeVersion }: { claudeCodeVersion?: string }) {
+  const [buildAnimationStep, setBuildAnimationStep] = useState(-1);
+  const [typedText, setTypedText] = useState("");
+  const buildSectionRef = useRef<HTMLDivElement>(null);
+  const [buildSectionVisible, setBuildSectionVisible] = useState(false);
+
+  // Intersection Observer for Build section
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry && entry.isIntersecting && !buildSectionVisible) {
+          setBuildSectionVisible(true);
+          setBuildAnimationStep(0);
+        }
+      },
+      { threshold: 0.3 },
+    );
+
+    if (buildSectionRef.current) {
+      observer.observe(buildSectionRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, [buildSectionVisible]);
+
+  // Build animation steps
+  useEffect(() => {
+    const timers: NodeJS.Timeout[] = [];
+
+    if (buildAnimationStep === 0) {
+      const timer = setTimeout(() => setBuildAnimationStep(1), 800);
+      timers.push(timer);
+    } else if (buildAnimationStep === 1) {
       let currentIndex = 0;
       const typeInterval = setInterval(() => {
         if (currentIndex <= TYPED_TEXT.length) {
@@ -110,16 +1930,12 @@ export default function LandingPage({ claudeCodeVersion }: LandingPageProps) {
           currentIndex++;
         } else {
           clearInterval(typeInterval);
-          // Move to next step after typing completes
           const timer = setTimeout(() => setBuildAnimationStep(2), 500);
           timers.push(timer);
         }
       }, 50);
       timers.push(typeInterval as unknown as NodeJS.Timeout);
-    }
-
-    // Progressive reveal of conversation
-    else if (buildAnimationStep === 2) {
+    } else if (buildAnimationStep === 2) {
       const timer = setTimeout(() => setBuildAnimationStep(3), 1000);
       timers.push(timer);
     } else if (buildAnimationStep === 3) {
@@ -142,58 +1958,443 @@ export default function LandingPage({ claudeCodeVersion }: LandingPageProps) {
     return () => timers.forEach(clearTimeout);
   }, [buildAnimationStep]);
 
-  // Reset run animation when switching agents
+  // Start animation on mount
   useEffect(() => {
-    if (runSectionVisible) {
-      setRunAnimationStep(0);
-      setRunTypedText("");
-    }
-  }, [selectedAgent, runSectionVisible]);
+    setBuildAnimationStep(0);
+    setBuildSectionVisible(true);
+  }, []);
 
-  // Run agent animation
-  useEffect(() => {
-    const timers: NodeJS.Timeout[] = [];
+  return (
+    <div ref={buildSectionRef} className="flex flex-col gap-[30px] mb-20">
+      <div className="text-center">
+        <h2 className="text-[36px] font-medium leading-[1.2] text-foreground mb-4">
+          Build an agent
+        </h2>
+        <p className="text-[16px] leading-[1.5] text-foreground">
+          Build your agent with the VM0 builder skill and CLI.
+        </p>
+        <p className="text-[16px] leading-[1.5] text-foreground">
+          Create agents in Claude Code using natural language, on a secure and
+          reliable infrastructure.
+        </p>
+      </div>
 
-    // Step 0 -> 1: Start typing user command
-    if (runAnimationStep === 0) {
-      const timer = setTimeout(() => setRunAnimationStep(1), 800);
-      timers.push(timer);
-    }
+      <div
+        className="rounded-[6px] pt-[20px] pb-[20px] sm:pb-[30px] px-[16px] sm:px-[30px] md:px-[100px] lg:px-[200px] xl:px-[300px]"
+        style={{
+          backgroundImage:
+            "linear-gradient(137.478deg, rgb(183, 200, 210) 0.82464%, rgb(253, 175, 83) 45.285%, rgb(248, 127, 48) 99.384%)",
+        }}
+      >
+        <div className="bg-white dark:bg-[#19191b] border-[0.5px] border-border rounded-[12px] shadow-[0px_25px_50px_-12px_rgba(0,0,0,0.25)] overflow-hidden h-[422px]">
+          {/* Terminal Header */}
+          <div className="bg-[#f9f4ef] dark:bg-[#292a2e] p-[8px] flex items-center justify-between shadow-[0px_0.5px_0px_0px_#d2d2d2] dark:shadow-[0px_0.5px_0px_0px_#2f2f32]">
+            <div className="flex gap-1.5 w-[39px] h-[9px]">
+              <div className="w-2.5 h-2.5 rounded-full bg-red-500" />
+              <div className="w-2.5 h-2.5 rounded-full bg-yellow-500" />
+              <div className="w-2.5 h-2.5 rounded-full bg-green-500" />
+            </div>
+            <p
+              className="text-[12px] text-center font-medium flex-1"
+              style={{ fontFamily: "var(--font-noto-sans)" }}
+            >
+              <span className="text-[#827d77]">~/work</span>
+              <span className="text-foreground">
+                {" "}
+                * VM0 Agent ▸ Claude Code
+              </span>
+            </p>
+            <div className="w-[39px]"></div>
+          </div>
 
-    // Step 1: Typewriter effect for user command
-    else if (runAnimationStep === 1) {
-      const currentText = RUN_TYPED_TEXT[selectedAgent];
-      let currentIndex = 0;
-      const typeInterval = setInterval(() => {
-        if (currentIndex <= currentText.length) {
-          setRunTypedText(currentText.slice(0, currentIndex));
-          currentIndex++;
-        } else {
-          clearInterval(typeInterval);
-          const timer = setTimeout(() => setRunAnimationStep(2), 500);
-          timers.push(timer);
-        }
-      }, 50);
-      timers.push(typeInterval as unknown as NodeJS.Timeout);
-    }
+          {/* Terminal Content */}
+          <div
+            className="p-[20px] overflow-y-auto h-[calc(422px-44px)]"
+            style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+          >
+            <div className="flex gap-[10px] items-start text-[12px] leading-[16px]">
+              <div className="flex gap-[4px] items-center">
+                <div className="text-black dark:text-white">
+                  <p className="m-0"> *</p>
+                  <p className="m-0">*</p>
+                  <p className="m-0"> *</p>
+                </div>
+                <Image
+                  src="/landing/vector-logo.svg"
+                  alt="VM0"
+                  width="65"
+                  height="40"
+                />
+                <div className="text-black dark:text-white">
+                  <p className="m-0">*</p>
+                  <p className="m-0"> *</p>
+                  <p className="m-0">*</p>
+                </div>
+              </div>
+              <div className="text-[11px]">
+                <p className="m-0">
+                  <span className="font-bold">Claude Code</span>
+                  {claudeCodeVersion && ` ${claudeCodeVersion}`}
+                </p>
+                <p className="m-0 text-[#827d77]">Opus 4.6 · Claude API</p>
+                <p className="m-0 text-[#827d77]">/Users/ming</p>
+              </div>
+            </div>
 
-    // Progressive reveal of execution
-    else if (runAnimationStep === 2) {
-      const timer = setTimeout(() => setRunAnimationStep(3), 1000);
-      timers.push(timer);
-    } else if (runAnimationStep === 3) {
-      const timer = setTimeout(() => setRunAnimationStep(4), 1500);
-      timers.push(timer);
-    } else if (runAnimationStep === 4) {
-      const timer = setTimeout(() => setRunAnimationStep(5), 2000);
-      timers.push(timer);
-    } else if (runAnimationStep === 5) {
-      const timer = setTimeout(() => setRunAnimationStep(6), 1500);
-      timers.push(timer);
-    }
+            <div className="mt-[10px] text-[12px] leading-[16px] space-y-0 font-light">
+              {/* Step 0: Loading message */}
+              {buildAnimationStep >= 0 && (
+                <>
+                  <p className="m-0 text-[#827d77]">
+                    &gt; The &quot;vm0-agent&quot; skill is loading
+                  </p>
+                  <p className="m-0">&nbsp;</p>
+                </>
+              )}
 
-    return () => timers.forEach(clearTimeout);
-  }, [runAnimationStep, selectedAgent]);
+              {/* Step 1: User input with typewriter effect */}
+              {buildAnimationStep >= 1 && (
+                <p className="m-0">
+                  <span className="text-[#f59e0b]">●</span>{" "}
+                  <span className="text-black dark:text-white font-medium">
+                    {typedText}
+                  </span>
+                  {buildAnimationStep === 1 && (
+                    <span className="text-black dark:text-white animate-pulse">
+                      {" "}
+                      █
+                    </span>
+                  )}
+                </p>
+              )}
+
+              {buildAnimationStep >= 2 && <p className="m-0">&nbsp;</p>}
+
+              {/* Step 2: First agent response */}
+              {buildAnimationStep >= 2 && (
+                <>
+                  <p className="m-0">
+                    <span className="text-[#22c55e]">⏺</span>{" "}
+                    <span className="text-secondary-foreground">
+                      I&apos;ll help you build a VM0 workflow! Let me understand
+                      what you want to automate.
+                    </span>
+                  </p>
+                  <p className="m-0">&nbsp;</p>
+                </>
+              )}
+
+              {/* Step 3: User answers */}
+              {buildAnimationStep >= 3 && (
+                <>
+                  <p className="m-0">
+                    <span className="text-[#22c55e]">⏺</span>{" "}
+                    <span className="text-secondary-foreground">
+                      User answered Claude&apos;s questions:
+                    </span>
+                  </p>
+                  <p className="m-0 text-[#827d77]">
+                    {" "}
+                    ⎿ · What to aggregate? → Tech news from RSS feeds
+                  </p>
+                  <p className="m-0 text-[#827d77]">
+                    {" "}
+                    · How to process? → Summarize top 5 articles
+                  </p>
+                  <p className="m-0 text-[#827d77]">
+                    {" "}
+                    · Where to send? → Slack #tech-news channel
+                  </p>
+                  <p className="m-0">&nbsp;</p>
+                </>
+              )}
+
+              {/* Step 4: Finding skills */}
+              {buildAnimationStep >= 4 && (
+                <>
+                  <p className="m-0">
+                    <span className="text-[#22c55e]">⏺</span>{" "}
+                    <span className="text-secondary-foreground">
+                      Perfect! Let me find the right skills for your workflow.
+                    </span>
+                  </p>
+                  <p className="m-0">&nbsp;</p>
+                </>
+              )}
+
+              {/* Step 5: Fetch skills */}
+              {buildAnimationStep >= 5 && (
+                <>
+                  <p className="m-0">
+                    <span className="text-[#22c55e]">⏺</span>{" "}
+                    <span className="text-[#3b82f6]">Fetch</span>
+                    <span className="text-secondary-foreground">(</span>
+                    <span className="text-[#06b6d4]">
+                      https://github.com/vm0-ai/vm0-skills
+                    </span>
+                    <span className="text-secondary-foreground">)</span>
+                  </p>
+                  <p className="m-0 text-[#827d77]">
+                    {" "}
+                    ⎿ Received 389KB (200 OK)
+                  </p>
+                  <p className="m-0">&nbsp;</p>
+                </>
+              )}
+
+              {/* Step 6: Write vm0.yaml */}
+              {buildAnimationStep >= 6 && (
+                <>
+                  <p className="m-0">
+                    <span className="text-[#22c55e]">⏺</span>{" "}
+                    <span className="text-[#3b82f6]">Write</span>
+                    <span className="text-secondary-foreground">(</span>
+                    <span className="text-[#06b6d4]">vm0.yaml</span>
+                    <span className="text-secondary-foreground">)</span>
+                  </p>
+                  <p className="m-0 text-[#827d77]">
+                    {" "}
+                    ⎿ Wrote 8 lines to vm0.yaml
+                  </p>
+                  <p className="m-0 text-[#6b7280]"> 1 agents:</p>
+                  <p className="m-0 text-[#6b7280]"> 2 tech-news-digest:</p>
+                  <p className="m-0 text-[#6b7280]">
+                    {" "}
+                    3 framework: claude-code
+                  </p>
+                  <p className="m-0 text-[#6b7280]">
+                    {" "}
+                    4 instructions: AGENTS.md
+                  </p>
+                  <p className="m-0 text-[#6b7280]"> 5 skills:</p>
+                  <p className="m-0 text-[#6b7280]">
+                    {" "}
+                    6 - vm0-skills/rss-fetch
+                  </p>
+                  <p className="m-0 text-[#6b7280]"> 7 - vm0-skills/slack</p>
+                  <p className="m-0 text-[#6b7280]"> … +1 line</p>
+                  <p className="m-0">&nbsp;</p>
+                </>
+              )}
+
+              {/* Step 7: Write AGENTS.md */}
+              {buildAnimationStep >= 7 && (
+                <>
+                  <p className="m-0">
+                    <span className="text-[#22c55e]">⏺</span>{" "}
+                    <span className="text-[#3b82f6]">Write</span>
+                    <span className="text-secondary-foreground">(</span>
+                    <span className="text-[#06b6d4]">AGENTS.md</span>
+                    <span className="text-secondary-foreground">)</span>
+                  </p>
+                  <p className="m-0 text-[#827d77]">
+                    {" "}
+                    ⎿ Wrote 47 lines to AGENTS.md
+                  </p>
+                  <p className="m-0 text-[#6b7280]">
+                    {" "}
+                    1 # Tech News Daily Digest Agent
+                  </p>
+                  <p className="m-0 text-[#6b7280]">
+                    {" "}
+                    2 Fetch TechCrunch RSS, summarize top 5 articles
+                  </p>
+                  <p className="m-0 text-[#6b7280]">
+                    {" "}
+                    … +43 lines (ctrl+o to expand)
+                  </p>
+                  <p className="m-0">&nbsp;</p>
+                </>
+              )}
+
+              {/* Step 8: Final message */}
+              {buildAnimationStep >= 8 && (
+                <>
+                  <p className="m-0">
+                    <span className="text-[#22c55e]">⏺</span>{" "}
+                    <span className="text-secondary-foreground">
+                      Your agent is ready!
+                    </span>
+                  </p>
+                  <p className="m-0">&nbsp;</p>
+                  <p className="m-0">
+                    <span className="text-[#22c55e]">⏺</span>{" "}
+                    <span className="text-secondary-foreground">
+                      Run now or schedule it:
+                    </span>
+                  </p>
+                  <p className="m-0 text-[#827d77]">
+                    {" "}
+                    → Just say: &quot;fetch tech news&quot;
+                  </p>
+                  <p className="m-0 text-[#827d77]">
+                    {" "}
+                    → Or: &quot;run this daily at 9am&quot;
+                  </p>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FinalCtaSection({ isSignedIn }: { isSignedIn: boolean }) {
+  const [copiedFooter, setCopiedFooter] = useState(false);
+
+  return (
+    <section className="w-full max-w-[1440px] py-10">
+      <div className="max-w-[1200px] mx-auto px-[30px]">
+        <div className="bg-white dark:bg-[#19191b] border border-[#f5eae1] dark:border-[#2f2f32] rounded-[12px] p-[24px] sm:p-[40px] md:p-[60px] relative overflow-hidden flex flex-col gap-[24px] sm:gap-[30px]">
+          {/* Decorative circular gradient background */}
+          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[1627px] h-[1627px] pointer-events-none">
+            <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[1400px] h-[1400px] rotate-[79.76deg]">
+              <div
+                className="w-full h-full rounded-full opacity-40"
+                style={{
+                  background:
+                    "radial-gradient(circle, rgba(237, 78, 1, 0.3) 0%, rgba(237, 78, 1, 0) 70%)",
+                }}
+              />
+            </div>
+          </div>
+
+          {/* Grid pattern overlay */}
+          <div className="absolute left-1/2 top-[-429px] -translate-x-1/2 w-[1200px] h-[1120px] overflow-hidden pointer-events-none opacity-[0.06]">
+            {[...Array(20)].map((_, i) => (
+              <div
+                key={`v-${i}`}
+                className="absolute top-0 h-[1600px] w-px bg-[#ed4e01]"
+                style={{ left: `${79 + i * 80}px` }}
+              />
+            ))}
+            {[...Array(20)].map((_, i) => (
+              <div
+                key={`h-${i}`}
+                className="absolute left-0 w-[1600px] h-px bg-[#ed4e01]"
+                style={{ top: `${79 + i * 80}px` }}
+              />
+            ))}
+          </div>
+
+          {/* Content */}
+          <div className="relative z-10 flex flex-col gap-[24px] sm:gap-[30px]">
+            <h2
+              className="text-[36px] font-medium leading-[1.2] dark:!text-[#ffffff]"
+              style={{ fontFamily: "var(--font-noto-sans)" }}
+            >
+              Get started today
+            </h2>
+
+            <div className="bg-white dark:bg-[#19191b] border border-[#f5eae1] dark:border-[#2f2f32] rounded-[12px] p-[16px] sm:p-[24px] flex gap-[12px] sm:gap-[32px] items-center">
+              <div className="flex-1 min-h-px min-w-px overflow-x-auto">
+                <code
+                  className="block text-[18px] leading-[1.6]"
+                  style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+                >
+                  <span className="text-[#0284c7]">
+                    npm install -g @vm0/cli && vm0 onboard
+                  </span>
+                  <br />
+                  <span className="text-[#827d77]">
+                    {" "}
+                    {"//"}One command. Build agents with natural language.
+                  </span>
+                </code>
+              </div>
+              <div className="relative">
+                <button
+                  onClick={() => {
+                    navigator.clipboard
+                      .writeText("npm install -g @vm0/cli && vm0 onboard")
+                      .catch(() => {});
+                    setCopiedFooter(true);
+                    setTimeout(() => setCopiedFooter(false), 2000);
+                  }}
+                  className="rounded-[10px] w-[40px] h-[40px] flex items-center justify-center shrink-0 transition-colors hover:bg-[#f0ebe5] dark:hover:bg-[#292a2e]"
+                >
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="shrink-0"
+                  >
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                  </svg>
+                </button>
+                {copiedFooter && (
+                  <div
+                    className="absolute -top-[40px] left-1/2 -translate-x-1/2 bg-[#231f1b] px-[12px] py-[6px] rounded-[6px] text-[14px] whitespace-nowrap"
+                    style={{ color: "#ffffff" }}
+                  >
+                    Copied
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-[12px] sm:gap-[20px]">
+              {isSignedIn ? (
+                <a
+                  href={getPlatformUrl()}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white px-[24px] py-[12px] rounded-[10px] font-medium text-[18px] leading-[28px] w-full sm:w-[160px] transition-colors flex items-center justify-center"
+                  style={{ fontFamily: "var(--font-noto-sans)" }}
+                >
+                  Get started
+                </a>
+              ) : (
+                <Link
+                  href="/sign-up"
+                  className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white px-[24px] py-[12px] rounded-[10px] font-medium text-[18px] leading-[28px] w-full sm:w-[160px] transition-colors flex items-center justify-center"
+                  style={{ fontFamily: "var(--font-noto-sans)" }}
+                >
+                  Get started
+                </Link>
+              )}
+              <a
+                href="https://github.com/vm0-ai/vm0"
+                target="_blank"
+                rel="noreferrer"
+                className="bg-[rgba(255,255,255,0.6)] dark:bg-[rgba(25,25,27,0.6)] border border-[#ed4e01] dark:border-[#ff6a1f] hover:bg-white dark:hover:bg-[#292a2e] !text-[#ed4e01] dark:!text-[#ff6a1f] px-[24px] py-[12px] rounded-[10px] font-medium text-[18px] leading-[28px] w-full sm:w-[160px] flex items-center justify-center gap-[10px] transition-colors"
+                style={{ fontFamily: "var(--font-noto-sans)" }}
+              >
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="shrink-0"
+                >
+                  <path
+                    d="M8 0.198C3.58 0.198 0 3.78 0 8.198C0 11.7333 2.292 14.7313 5.47 15.788C5.87 15.8633 6.01667 15.616 6.01667 15.4033C6.01667 15.2133 6.01 14.71 6.00667 14.0433C3.78133 14.526 3.312 12.97 3.312 12.97C2.948 12.0467 2.422 11.8 2.422 11.8C1.69733 11.304 2.478 11.314 2.478 11.314C3.28133 11.37 3.70333 12.138 3.70333 12.138C4.41667 13.3613 5.576 13.008 6.03333 12.8033C6.10533 12.286 6.31133 11.9333 6.54 11.7333C4.76333 11.5333 2.896 10.8453 2.896 7.78C2.896 6.90667 3.206 6.19333 3.71933 5.63333C3.62933 5.43133 3.35933 4.618 3.78933 3.516C3.78933 3.516 4.45933 3.30133 5.98933 4.336C6.62933 4.158 7.30933 4.07 7.98933 4.066C8.66933 4.07 9.34933 4.158 9.98933 4.336C11.5093 3.30133 12.1793 3.516 12.1793 3.516C12.6093 4.618 12.3393 5.43133 12.2593 5.63333C12.7693 6.19333 13.0793 6.90667 13.0793 7.78C13.0793 10.8533 11.2093 11.53 9.42933 11.7267C9.70933 11.9667 9.96933 12.4573 9.96933 13.2067C9.96933 14.2773 9.95933 15.1373 9.95933 15.3973C9.95933 15.6073 10.0993 15.8573 10.5093 15.7773C13.71 14.728 16 11.728 16 8.198C16 3.78 12.418 0.198 8 0.198Z"
+                    fill="#ed4e01"
+                    className="dark:fill-[#ff6a1f]"
+                  />
+                </svg>
+                GitHub
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function LandingPage({ claudeCodeVersion }: LandingPageProps) {
+  const { isSignedIn } = useAuth();
+  const [mainTab, setMainTab] = useState<"build" | "run">("run");
 
   return (
     <div className="min-h-screen">
@@ -229,226 +2430,7 @@ export default function LandingPage({ claudeCodeVersion }: LandingPageProps) {
         {/* Hero Section */}
         <section className="w-full max-w-[1440px] pb-0">
           <div className="max-w-[1200px] mx-auto px-[30px]">
-            {/* Hero Content */}
-            <div className="flex flex-col items-center gap-[40px] mb-16">
-              {/* 3D Rotating Cube */}
-              <div
-                style={{
-                  width: "80px",
-                  height: "80px",
-                  perspective: "500px",
-                  margin: "0 auto 24px",
-                }}
-              >
-                <div
-                  style={{
-                    width: "100%",
-                    height: "100%",
-                    position: "relative",
-                    transformStyle: "preserve-3d",
-                    animation: "rotateCube 12s infinite linear",
-                  }}
-                >
-                  {/* Front */}
-                  <div
-                    style={{
-                      position: "absolute",
-                      width: "80px",
-                      height: "80px",
-                      background:
-                        "linear-gradient(135deg, rgba(237, 78, 1, 0.55), rgba(237, 78, 1, 0.25))",
-                      border: "3px solid rgba(237, 78, 1, 0.5)",
-                      backdropFilter: "blur(10px)",
-                      transform: "translateZ(40px)",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      boxShadow: "0 0 30px rgba(237, 78, 1, 0.7)",
-                    }}
-                  />
-                  {/* Back */}
-                  <div
-                    style={{
-                      position: "absolute",
-                      width: "80px",
-                      height: "80px",
-                      background:
-                        "linear-gradient(135deg, rgba(237, 78, 1, 0.5), rgba(237, 78, 1, 0.2))",
-                      border: "3px solid rgba(237, 78, 1, 0.4)",
-                      backdropFilter: "blur(10px)",
-                      transform: "translateZ(-40px) rotateY(180deg)",
-                      boxShadow: "0 0 25px rgba(237, 78, 1, 0.6)",
-                    }}
-                  />
-                  {/* Right */}
-                  <div
-                    style={{
-                      position: "absolute",
-                      width: "80px",
-                      height: "80px",
-                      background:
-                        "linear-gradient(135deg, rgba(237, 78, 1, 0.5), rgba(237, 78, 1, 0.2))",
-                      border: "3px solid rgba(237, 78, 1, 0.45)",
-                      backdropFilter: "blur(10px)",
-                      transform: "rotateY(90deg) translateZ(40px)",
-                      boxShadow: "0 0 27px rgba(237, 78, 1, 0.65)",
-                    }}
-                  />
-                  {/* Left */}
-                  <div
-                    style={{
-                      position: "absolute",
-                      width: "80px",
-                      height: "80px",
-                      background:
-                        "linear-gradient(135deg, rgba(237, 78, 1, 0.5), rgba(237, 78, 1, 0.2))",
-                      border: "3px solid rgba(237, 78, 1, 0.45)",
-                      backdropFilter: "blur(10px)",
-                      transform: "rotateY(-90deg) translateZ(40px)",
-                      boxShadow: "0 0 27px rgba(237, 78, 1, 0.65)",
-                    }}
-                  />
-                  {/* Top */}
-                  <div
-                    style={{
-                      position: "absolute",
-                      width: "80px",
-                      height: "80px",
-                      background:
-                        "linear-gradient(135deg, rgba(237, 78, 1, 0.65), rgba(237, 78, 1, 0.3))",
-                      border: "3px solid rgba(237, 78, 1, 0.55)",
-                      backdropFilter: "blur(10px)",
-                      transform: "rotateX(90deg) translateZ(40px)",
-                      boxShadow: "0 0 30px rgba(237, 78, 1, 0.7)",
-                    }}
-                  />
-                  {/* Bottom */}
-                  <div
-                    style={{
-                      position: "absolute",
-                      width: "80px",
-                      height: "80px",
-                      background:
-                        "linear-gradient(135deg, rgba(237, 78, 1, 0.45), rgba(237, 78, 1, 0.2))",
-                      border: "3px solid rgba(237, 78, 1, 0.4)",
-                      backdropFilter: "blur(10px)",
-                      transform: "rotateX(-90deg) translateZ(40px)",
-                      boxShadow: "0 0 25px rgba(237, 78, 1, 0.6)",
-                    }}
-                  />
-                </div>
-              </div>
-              <style>{`
-                @keyframes rotateCube {
-                  from {
-                    transform: rotateX(45deg) rotateY(0deg);
-                  }
-                  to {
-                    transform: rotateX(45deg) rotateY(360deg);
-                  }
-                }
-              `}</style>
-
-              <h1 className="flex flex-col justify-center font-medium text-center text-[36px] leading-[1.4] text-foreground tracking-normal px-4">
-                <span className="block mb-0">
-                  Build AI agents with natural language.
-                </span>
-                <span className="block">Run them 24/7 in the cloud.</span>
-              </h1>
-
-              {/* CTA Section - More compact */}
-              <div className="flex flex-col items-center gap-[20px] w-full">
-                {/* Install Command with description */}
-                <div className="flex flex-col items-center gap-[8px] w-full max-w-[566px]">
-                  <div className="bg-card border border-[#f5eae1] dark:border-[#2f2f32] border-solid rounded-[12px] px-[16px] sm:px-[24px] py-[12px] w-full flex gap-[12px] sm:gap-[32px] items-center justify-center relative">
-                    <code
-                      className="flex-1 font-normal leading-[40px] text-[18px] text-foreground whitespace-pre-wrap"
-                      style={{
-                        fontFamily:
-                          'var(--font-jetbrains-mono, "JetBrains Mono", monospace)',
-                      }}
-                    >
-                      npm install -g @vm0/cli && vm0 onboard
-                    </code>
-                    <button
-                      onClick={() => {
-                        navigator.clipboard
-                          .writeText("npm install -g @vm0/cli && vm0 onboard")
-                          .catch(() => {});
-                        setCopiedHero(true);
-                        setTimeout(() => setCopiedHero(false), 2000);
-                      }}
-                      className="h-[40px] w-[40px] flex items-center justify-center transition-colors shrink-0 rounded-[10px] hover:bg-[#f0ebe5] dark:hover:bg-[#292a2e]"
-                    >
-                      <svg
-                        width="18"
-                        height="18"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        className="w-[20px] h-[20px]"
-                      >
-                        <rect
-                          x="9"
-                          y="9"
-                          width="13"
-                          height="13"
-                          rx="2"
-                          ry="2"
-                        />
-                        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-                      </svg>
-                    </button>
-                    {copiedHero && (
-                      <div
-                        className="absolute -top-[50px] right-[0px] bg-[#231f1b] px-[12px] py-[6px] rounded-[6px] text-[14px] whitespace-nowrap"
-                        style={{ color: "#ffffff" }}
-                      >
-                        Copied
-                      </div>
-                    )}
-                  </div>
-                  <p className="text-sm text-muted-foreground text-center px-4">
-                    Throw it in your terminal and vibe
-                  </p>
-                </div>
-
-                {/* Divider with OR */}
-                <div className="w-full max-w-[566px] flex items-center gap-4">
-                  <div className="flex-1 h-px bg-border" />
-                  <span className="text-sm text-muted-foreground">or</span>
-                  <div className="flex-1 h-px bg-border" />
-                </div>
-
-                {/* CTA Button */}
-                <div className="w-full max-w-[566px]">
-                  {isSignedIn ? (
-                    <a
-                      href={getPlatformUrl()}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white w-full px-[24px] py-[12px] rounded-[10px] flex items-center justify-center transition-colors"
-                    >
-                      <span className="font-medium leading-[28px] text-[18px] tracking-normal !text-white">
-                        Get started
-                      </span>
-                    </a>
-                  ) : (
-                    <Link
-                      href="/sign-up"
-                      className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white w-full px-[24px] py-[12px] rounded-[10px] flex items-center justify-center transition-colors"
-                    >
-                      <span className="font-medium leading-[28px] text-[18px] tracking-normal !text-white">
-                        Get started
-                      </span>
-                    </Link>
-                  )}
-                </div>
-              </div>
-            </div>
+            <HeroSection isSignedIn={isSignedIn} />
 
             {/* Agent Tabs */}
             <div className="flex gap-[12px] items-center mb-[30px] justify-center">
@@ -474,2177 +2456,12 @@ export default function LandingPage({ claudeCodeVersion }: LandingPageProps) {
               </button>
             </div>
 
-            {/* Run an agent */}
             {mainTab === "run" && (
-              <div
-                ref={runSectionRef}
-                className="flex flex-col gap-[30px] mb-20"
-              >
-                <div className="text-center">
-                  <h2 className="text-[36px] font-medium leading-[1.2] text-foreground mb-4">
-                    Run an agent
-                  </h2>
-                  <p className="text-[16px] leading-[1.5] text-foreground">
-                    Execute your agents instantly, powered by workflows defined
-                    in natural language.
-                  </p>
-                  <p className="text-[16px] leading-[1.5] text-foreground">
-                    Schedule recurring runs or execute on demand, with full
-                    visibility and control.
-                  </p>
-                </div>
-
-                <div
-                  className="rounded-[6px] pt-[20px] pb-[20px] sm:pb-[30px] px-[16px] sm:px-[30px] flex items-center justify-center"
-                  style={{
-                    backgroundImage:
-                      "linear-gradient(137.478deg, #E8A145 0.82464%, #F8732A 45.285%, #933803 99.384%)",
-                  }}
-                >
-                  <div className="flex flex-col lg:flex-row gap-[16px] sm:gap-[24px] w-full max-w-[1124px] mx-auto">
-                    {/* Terminal - Left Side */}
-                    <div className="flex-1 bg-white dark:bg-[#19191b] border-[0.5px] border-border rounded-[12px] shadow-[0px_25px_50px_-12px_rgba(0,0,0,0.25)] overflow-hidden h-[422px] flex flex-col">
-                      {/* Terminal Header */}
-                      <div className="bg-[#f9f4ef] dark:bg-[#292a2e] h-[44px] flex items-center justify-between px-[8px] shadow-[0px_0.5px_0px_0px_#d2d2d2] dark:shadow-[0px_0.5px_0px_0px_#2f2f32]">
-                        <div className="flex gap-1.5 w-[39px] items-center">
-                          <div className="w-[10px] h-[10px] rounded-full bg-red-500 shrink-0" />
-                          <div className="w-[10px] h-[10px] rounded-full bg-yellow-500 shrink-0" />
-                          <div className="w-[10px] h-[10px] rounded-full bg-green-500 shrink-0" />
-                        </div>
-                        <p
-                          className="text-[12px] text-center font-medium flex-1"
-                          style={{ fontFamily: "var(--font-noto-sans)" }}
-                        >
-                          <span className="text-[#827d77]">~/work</span>
-                          <span className="text-foreground">
-                            {" "}
-                            * VM0 Agent ▸ Claude Code
-                          </span>
-                        </p>
-                        <div className="w-[39px]"></div>
-                      </div>
-
-                      {/* Terminal Content */}
-                      <div
-                        className="p-[20px] overflow-y-auto h-[calc(422px-44px)]"
-                        style={{ fontFamily: "var(--font-jetbrains-mono)" }}
-                      >
-                        <div className="flex gap-[10px] items-start text-[12px] leading-[16px]">
-                          <div className="flex gap-[4px] items-center">
-                            <div className="text-black dark:text-white">
-                              <p className="m-0"> *</p>
-                              <p className="m-0">*</p>
-                              <p className="m-0"> *</p>
-                            </div>
-                            <Image
-                              src="/landing/vector-logo.svg"
-                              alt="VM0"
-                              width="65"
-                              height="40"
-                              className="w-[65px] h-auto"
-                            />
-                            <div className="text-black dark:text-white">
-                              <p className="m-0">*</p>
-                              <p className="m-0"> *</p>
-                              <p className="m-0">*</p>
-                            </div>
-                          </div>
-                          <div className="text-[11px]">
-                            <p className="m-0">
-                              <span className="font-bold">Claude Code</span>
-                              {claudeCodeVersion && ` ${claudeCodeVersion}`}
-                            </p>
-                            <p className="m-0 text-[#827d77]">
-                              Opus 4.6 · Claude API
-                            </p>
-                            <p className="m-0 text-[#827d77]">/Users/ming</p>
-                          </div>
-                        </div>
-
-                        {selectedAgent === "hackernews" && (
-                          <div className="mt-[10px] text-[12px] leading-[16px] space-y-0 font-light">
-                            {/* Step 1: User input with typewriter effect */}
-                            {runAnimationStep >= 1 && (
-                              <p className="m-0 text-secondary-foreground">
-                                &gt; {runTypedText}
-                                {runAnimationStep === 1 && (
-                                  <span className="animate-pulse">█</span>
-                                )}
-                              </p>
-                            )}
-
-                            {runAnimationStep >= 2 && (
-                              <p className="m-0">&nbsp;</p>
-                            )}
-
-                            {/* Step 2: Agent response */}
-                            {runAnimationStep >= 2 && (
-                              <>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    I&apos;ll run the 201-hackernews agent to
-                                    summarize today&apos;s top stories. This may
-                                    take a few minutes.
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 3: Bash command and run details */}
-                            {runAnimationStep >= 3 && (
-                              <>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-[#3b82f6]">Bash</span>
-                                  <span className="text-secondary-foreground">
-                                    (
-                                  </span>
-                                  <span className="text-[#06b6d4]">
-                                    vm0 run 201-hackernews &quot;Summarize
-                                    today&apos;s top stories&quot;
-                                  </span>
-                                  <span className="text-secondary-foreground">
-                                    ) timeout: 5m 0s
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  ⎿ ▶ Run started
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Run ID:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    882337d4-44f3-4d73-b6a0-3a59c100b70d
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Sandbox:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    iucshvzk17eyv7vwvxsah
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#6b7280]">
-                                  {" "}
-                                  … +641 lines (ctrl+o to expand)
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 4: Success message and results summary */}
-                            {runAnimationStep >= 4 && (
-                              <>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-[#22c55e]">
-                                    Perfect! Your 201-hackernews agent ran
-                                    successfully! 🎉
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-secondary-foreground">
-                                  {" "}
-                                  <span className="text-foreground font-medium">
-                                    Results Summary
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  The agent analyzed today&apos;s top 10
-                                  HackerNews stories and identified 2 major
-                                  AI-related articles:
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 5: First result (Moltbook) */}
-                            {runAnimationStep >= 5 && (
-                              <>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  <span className="text-foreground font-medium">
-                                    1. Moltbook
-                                  </span>{" "}
-                                  (586 points)
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - A social network built specifically for AI
-                                  agents
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Agents can post, comment, vote, and build
-                                  reputation
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Humans can observe, but agents are the
-                                  primary users
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Represents emerging infrastructure for
-                                  autonomous agent-to-agent communication
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - 🔗{" "}
-                                  <span className="text-[#06b6d4]">
-                                    https://www.moltbook.com/
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 6: Second result and run details */}
-                            {runAnimationStep >= 6 && (
-                              <>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  <span className="text-foreground font-medium">
-                                    2. OpenClaw
-                                  </span>{" "}
-                                  (289 points)
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Open-source AI agent platform that runs
-                                  locally
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Full data sovereignty - your data stays on
-                                  your machine
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Integrates with WhatsApp, Telegram, Discord,
-                                  Slack, Teams, Twitch, Google Chat
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Went through 3 name changes (Clawd → Moltbot
-                                  → OpenClaw) due to trademark issues
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Recent focus on security with 34 security
-                                  commits
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - 🔗{" "}
-                                  <span className="text-[#06b6d4]">
-                                    https://openclaw.ai/blog/introducing-openclaw
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  <span className="text-foreground font-medium">
-                                    Output File
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  The agent created{" "}
-                                  <span className="text-[#06b6d4]">
-                                    content.md
-                                  </span>{" "}
-                                  with:
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Detailed summaries of both stories
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - A ready-to-post X/Twitter thread format
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  <span className="text-foreground font-medium">
-                                    Run Details:
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Duration: 66.2 seconds
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Cost: $0.1850
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Run ID:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    882337d4-44f3-4d73-b6a0-3a59c100b70d
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  You can view the full logs with:
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  <span className="text-[#06b6d4]">
-                                    vm0 logs
-                                    882337d4-44f3-4d73-b6a0-3a59c100b70d
-                                  </span>
-                                </p>
-                              </>
-                            )}
-                          </div>
-                        )}
-
-                        {selectedAgent === "tiktok" && (
-                          <div className="mt-[10px] text-[12px] leading-[16px] space-y-0 font-light">
-                            {/* Step 1: User input with typewriter effect */}
-                            {runAnimationStep >= 1 && (
-                              <p className="m-0 text-secondary-foreground">
-                                &gt; {runTypedText}
-                                {runAnimationStep === 1 && (
-                                  <span className="animate-pulse">█</span>
-                                )}
-                              </p>
-                            )}
-
-                            {runAnimationStep >= 2 && (
-                              <p className="m-0">&nbsp;</p>
-                            )}
-
-                            {/* Step 2: Agent response */}
-                            {runAnimationStep >= 2 && (
-                              <>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    I&apos;ll help you discover TikTok
-                                    influencers. Let me run the
-                                    tiktok-influencer agent.
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 3: Bash command and run start */}
-                            {runAnimationStep >= 3 && (
-                              <>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-[#3b82f6]">Bash</span>
-                                  <span className="text-secondary-foreground">
-                                    (
-                                  </span>
-                                  <span className="text-[#06b6d4]">
-                                    vm0 run tiktok-influencer
-                                  </span>
-                                  <span className="text-secondary-foreground">
-                                    ) timeout: 8m 0s
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  ⎿ ▶ Run started
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Run ID:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    f5a92e18-3d4c-4b89-a1e2-9c7f8b2d4e61
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Sandbox:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    xk9dfj2n8pqwer5tyvlmz
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 4: All phases */}
-                            {runAnimationStep >= 4 && (
-                              <>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Phase 1: Gathering business information...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Search Keyword:{" "}
-                                  <span className="text-foreground">
-                                    fitness
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Industry:{" "}
-                                  <span className="text-foreground">
-                                    Health & Wellness
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Notion Database ID:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    a8f3e9c...
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Phase 2: Discovering TikTok profiles...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Scraping TikTok for &quot;fitness&quot;
-                                  creators (this takes 2-3 minutes)
-                                </p>
-                                <p className="m-0 text-[#6b7280]">
-                                  {" "}
-                                  … +124 lines (ctrl+o to expand)
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Phase 3: Storing data in Notion...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  ✓ Added 15 influencers to database
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Phase 4: Analyzing relevance...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Evaluating each influencer based on followers,
-                                  content, and profile description
-                                </p>
-                                <p className="m-0 text-[#6b7280]">
-                                  {" "}
-                                  … +89 lines (ctrl+o to expand)
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 5: Success and results summary */}
-                            {runAnimationStep >= 5 && (
-                              <>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-[#22c55e]">
-                                    Success! TikTok influencer discovery
-                                    completed! 🎉
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-secondary-foreground">
-                                  {" "}
-                                  <span className="text-foreground font-medium">
-                                    Results Summary
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Total Analyzed:{" "}
-                                  <span className="text-foreground">
-                                    15 influencers
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Highly Relevant:{" "}
-                                  <span className="text-[#22c55e]">
-                                    8 influencers
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Data Stored:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    Notion Database
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  <span className="text-foreground font-medium">
-                                    Top Influencer:
-                                  </span>{" "}
-                                  @fitnesswithkayla (245K followers)
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Strong fitness content with workout routines,
-                                  nutrition tips, and motivational posts.
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  <span className="text-foreground font-medium">
-                                    Output File:
-                                  </span>{" "}
-                                  <span className="text-[#06b6d4]">
-                                    influencer-report.md
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 6: Run details */}
-                            {runAnimationStep >= 6 && (
-                              <>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  <span className="text-foreground font-medium">
-                                    Run Details:
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Duration: 4m 32s
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Cost: $0.4250
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Run ID:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    f5a92e18-3d4c-4b89-a1e2-9c7f8b2d4e61
-                                  </span>
-                                </p>
-                              </>
-                            )}
-                          </div>
-                        )}
-
-                        {selectedAgent === "blog" && (
-                          <div className="mt-[10px] text-[12px] leading-[16px] space-y-0 font-light">
-                            {/* Step 1: User input with typewriter effect */}
-                            {runAnimationStep >= 1 && (
-                              <p className="m-0 text-secondary-foreground">
-                                &gt; {runTypedText}
-                                {runAnimationStep === 1 && (
-                                  <span className="animate-pulse">█</span>
-                                )}
-                              </p>
-                            )}
-
-                            {runAnimationStep >= 2 && (
-                              <p className="m-0">&nbsp;</p>
-                            )}
-
-                            {/* Step 2: Agent response */}
-                            {runAnimationStep >= 2 && (
-                              <>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    I&apos;ll create an SEO-optimized blog
-                                    article. Let me run the content-farm agent.
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 3: Bash command and run start */}
-                            {runAnimationStep >= 3 && (
-                              <>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-[#3b82f6]">Bash</span>
-                                  <span className="text-secondary-foreground">
-                                    (
-                                  </span>
-                                  <span className="text-[#06b6d4]">
-                                    vm0 run content-farm &quot;AI agents&quot;
-                                  </span>
-                                  <span className="text-secondary-foreground">
-                                    ) timeout: 10m 0s
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  ⎿ ▶ Run started
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Run ID:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    d8b3f2c9-5e7a-4d91-b2c3-8f9e1a7d5c42
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Sandbox:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    nq7wjk3m9rxpvt4ylzbhd
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 4: Phases 1-4 */}
-                            {runAnimationStep >= 4 && (
-                              <>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Phase 1: Gathering news from RSS feeds...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Fetching from Hacker News, TechCrunch, Wired,
-                                  Ars Technica, The Verge
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  ✓ Found 47 recent articles
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Phase 2: Filtering and selecting articles...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Selected 4 articles matching &quot;AI
-                                  agents&quot; topic
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Phase 3: Creating SEO title...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Generated 5 title candidates
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Selected:{" "}
-                                  <span className="text-foreground">
-                                    &quot;AI Agents in 2025: How Autonomous
-                                    Systems Are Changing Software
-                                    Development&quot;
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Phase 4: Building outline...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#6b7280]">
-                                  {" "}
-                                  … +32 lines (ctrl+o to expand)
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 5: Phases 5-8 and success */}
-                            {runAnimationStep >= 5 && (
-                              <>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Phase 5: Writing article...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Writing 1,250 word article with conversational
-                                  tone
-                                </p>
-                                <p className="m-0 text-[#6b7280]">
-                                  {" "}
-                                  … +156 lines (ctrl+o to expand)
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Phase 6: Generating featured image...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  ✓ Image generated and saved
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Phase 7: Preparing output...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  ✓ Saved to output folder
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Phase 8: Publishing to Dev.to...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  ✓ Article published successfully
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-[#22c55e]">
-                                    Success! Blog article published! 🎉
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 6: Article details and run details */}
-                            {runAnimationStep >= 6 && (
-                              <>
-                                <p className="m-0 text-secondary-foreground">
-                                  {" "}
-                                  <span className="text-foreground font-medium">
-                                    Article Details
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Title:{" "}
-                                  <span className="text-foreground">
-                                    AI Agents in 2025: How Autonomous Systems
-                                    Are Changing Software Development
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Word Count:{" "}
-                                  <span className="text-foreground">
-                                    1,250 words
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Citations:{" "}
-                                  <span className="text-foreground">
-                                    4 sources
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Dev.to URL:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    https://dev.to/ai-agents-2025-software-dev
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  <span className="text-foreground font-medium">
-                                    Run Details:
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Duration: 7m 18s
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Cost: $0.7850
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Run ID:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    d8b3f2c9-5e7a-4d91-b2c3-8f9e1a7d5c42
-                                  </span>
-                                </p>
-                              </>
-                            )}
-                          </div>
-                        )}
-
-                        {selectedAgent === "daily-report" && (
-                          <div className="mt-[10px] text-[12px] leading-[16px] space-y-0 font-light">
-                            {/* Step 1: User input with typewriter effect */}
-                            {runAnimationStep >= 1 && (
-                              <p className="m-0 text-secondary-foreground">
-                                &gt; {runTypedText}
-                                {runAnimationStep === 1 && (
-                                  <span className="animate-pulse">█</span>
-                                )}
-                              </p>
-                            )}
-
-                            {runAnimationStep >= 2 && (
-                              <p className="m-0">&nbsp;</p>
-                            )}
-
-                            {/* Step 2: Agent response */}
-                            {runAnimationStep >= 2 && (
-                              <>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    I&apos;ll gather data from multiple sources
-                                    and generate today&apos;s report.
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 3: Bash command and run start */}
-                            {runAnimationStep >= 3 && (
-                              <>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-[#3b82f6]">Bash</span>
-                                  <span className="text-secondary-foreground">
-                                    (
-                                  </span>
-                                  <span className="text-[#06b6d4]">
-                                    vm0 run daily-data-report
-                                  </span>
-                                  <span className="text-secondary-foreground">
-                                    ) timeout: 5m 0s
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  ⎿ ▶ Run started
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Run ID:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    a9c2e4f8-1b3d-4c7a-9e2f-5d8b3a7c9e41
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Sandbox:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    pk8vmj4n2swqxt6ylazhc
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 4: All data collection phases */}
-                            {runAnimationStep >= 4 && (
-                              <>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Collecting GitHub repository metrics...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Stars:{" "}
-                                  <span className="text-foreground">
-                                    2,847
-                                  </span>{" "}
-                                  (+23 yesterday)
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Forks:{" "}
-                                  <span className="text-foreground">156</span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Open Issues:{" "}
-                                  <span className="text-foreground">34</span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Fetching Plausible analytics...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Visitors:{" "}
-                                  <span className="text-foreground">1,245</span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Pageviews:{" "}
-                                  <span className="text-foreground">3,892</span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Bounce Rate:{" "}
-                                  <span className="text-foreground">42.3%</span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Gathering user registration data...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Total Users:{" "}
-                                  <span className="text-foreground">8,234</span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  New Registrations:{" "}
-                                  <span className="text-foreground">47</span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Analyzing code changes...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Commits:{" "}
-                                  <span className="text-foreground">12</span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  Files Changed:{" "}
-                                  <span className="text-foreground">28</span>
-                                </p>
-                                <p className="m-0 text-[#6b7280]">
-                                  {" "}
-                                  … +45 lines (ctrl+o to expand)
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-secondary-foreground">
-                                    Checking Notion document updates...
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  ✓ Found 8 page modifications
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 5: Success and report summary */}
-                            {runAnimationStep >= 5 && (
-                              <>
-                                <p className="m-0">
-                                  <span className="text-[#22c55e]">⏺</span>{" "}
-                                  <span className="text-[#22c55e]">
-                                    Success! Daily report generated! 🎉
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-secondary-foreground">
-                                  {" "}
-                                  <span className="text-foreground font-medium">
-                                    Report Summary
-                                  </span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Report Date:{" "}
-                                  <span className="text-foreground">
-                                    2025-01-30
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Data Sources:{" "}
-                                  <span className="text-foreground">
-                                    6 integrated
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Output File:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    daily-report-2025-01-30.md
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Slack Notification:{" "}
-                                  <span className="text-[#22c55e]">Sent</span>
-                                </p>
-                                <p className="m-0">&nbsp;</p>
-                              </>
-                            )}
-
-                            {/* Step 6: Run details */}
-                            {runAnimationStep >= 6 && (
-                              <>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  <span className="text-foreground font-medium">
-                                    Run Details:
-                                  </span>
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Duration: 2m 45s
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Cost: $0.3150
-                                </p>
-                                <p className="m-0 text-[#827d77]">
-                                  {" "}
-                                  - Run ID:{" "}
-                                  <span className="text-[#06b6d4]">
-                                    a9c2e4f8-1b3d-4c7a-9e2f-5d8b3a7c9e41
-                                  </span>
-                                </p>
-                              </>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-
-                    {/* Code Editor - Right Side */}
-                    <div className="flex-1 flex flex-col shadow-[0px_25px_50px_0px_rgba(0,0,0,0.25)] h-[422px]">
-                      {/* Editor Header with Tabs */}
-                      <div className="bg-[#f9f4ef] dark:bg-[#292a2e] border-b border-border h-[44px] flex items-center gap-[6px] px-[12px] py-[6px] rounded-tl-[8px] rounded-tr-[8px] relative">
-                        <div className="flex-1 flex gap-[6px] items-center pl-[4px]">
-                          <div
-                            onClick={() => setActiveTab("agents")}
-                            className={`flex gap-[6px] items-center px-[6px] py-[4px] rounded-[6px] cursor-pointer transition-all border ${
-                              activeTab === "agents"
-                                ? "bg-[rgba(255,255,255,0.6)] dark:bg-[rgba(25,25,27,0.6)] border-border"
-                                : "border-transparent hover:bg-[rgba(255,255,255,0.3)] dark:hover:bg-[rgba(25,25,27,0.3)] hover:border-border"
-                            }`}
-                          >
-                            <IconFile
-                              size={14.4}
-                              stroke={1.2}
-                              className="text-foreground"
-                            />
-                            <p className="text-[14px] font-medium leading-[20px] text-foreground">
-                              AGENTS.MD
-                            </p>
-                          </div>
-                          <div
-                            onClick={() => setActiveTab("yaml")}
-                            className={`flex gap-[6px] items-center px-[6px] py-[4px] rounded-[6px] cursor-pointer transition-all border ${
-                              activeTab === "yaml"
-                                ? "bg-[rgba(255,255,255,0.6)] dark:bg-[rgba(25,25,27,0.6)] border-border"
-                                : "border-transparent hover:bg-[rgba(255,255,255,0.3)] dark:hover:bg-[rgba(25,25,27,0.3)] hover:border-border"
-                            }`}
-                          >
-                            <IconFile
-                              size={14.4}
-                              stroke={1.2}
-                              className="text-foreground"
-                            />
-                            <p className="text-[14px] font-medium leading-[20px] text-foreground">
-                              vm0.yaml
-                            </p>
-                          </div>
-                        </div>
-                        <button
-                          onClick={() => {
-                            const content =
-                              activeTab === "agents"
-                                ? `Agent Instructions\n\nYou are a specialized agent for ${selectedAgent}.`
-                                : selectedAgent === "hackernews"
-                                  ? `version: "1.0"\n\nagents:\n  201-hackernews:\n    description: "Daily HackerNews curator that fetches and analyzes top stories"\n    framework: claude-code\n    instructions: AGENTS.md\n    skills:\n      - https://github.com/vm0-ai/vm0-skills/tree/main/hackernews`
-                                  : `version: "1.0"\n\nagents:\n  ${selectedAgent}:\n    description: "Agent for ${selectedAgent}"\n    framework: claude-code\n    instructions: AGENTS.md`;
-                            navigator.clipboard
-                              .writeText(content)
-                              .catch(() => {});
-                            setCopiedEditor(true);
-                            setTimeout(() => setCopiedEditor(false), 2000);
-                          }}
-                          className="bg-[#f9f4ef] dark:bg-[#292a2e] hover:bg-[#f0ebe5] dark:hover:bg-[#3a3a3e] rounded-[10px] w-[40px] h-[36px] flex items-center justify-center transition-colors"
-                        >
-                          <svg
-                            width="16"
-                            height="16"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          >
-                            <rect
-                              x="9"
-                              y="9"
-                              width="13"
-                              height="13"
-                              rx="2"
-                              ry="2"
-                            />
-                            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-                          </svg>
-                        </button>
-                        {copiedEditor && (
-                          <div
-                            className="absolute -top-[50px] right-[12px] bg-[#231f1b] px-[12px] py-[6px] rounded-[6px] text-[14px] whitespace-nowrap z-10"
-                            style={{ color: "#ffffff" }}
-                          >
-                            Copied
-                          </div>
-                        )}
-                      </div>
-
-                      {/* Editor Content */}
-                      <div className="bg-white dark:bg-[#19191b] p-[16px] overflow-y-auto rounded-bl-[12px] rounded-br-[12px] h-[calc(422px-44px)]">
-                        {selectedAgent === "hackernews" &&
-                          activeTab === "agents" && (
-                            <div
-                              className="text-[14px] leading-[20px]"
-                              style={{ fontFamily: "var(--font-noto-sans)" }}
-                            >
-                              <p className="m-0 font-semibold text-[18px] leading-[26px]">
-                                Agent Instructions
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0">
-                                You are a Hacker News AI content curator.
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0 font-semibold text-[15px] leading-[22px]">
-                                Workflow
-                              </p>
-                              <ul className="list-disc ml-[20px] m-0">
-                                <li className="m-0">
-                                  Read the top 10 articles on Hacker News
-                                </li>
-                                <li className="m-0">
-                                  Identify AI-related content
-                                </li>
-                                <li className="m-0">
-                                  Extract key ideas and patterns
-                                </li>
-                                <li className="m-0">
-                                  Summarize the findings in an X (Twitter) post
-                                  format
-                                </li>
-                                <li className="m-0">
-                                  Write the output to `content.md`
-                                </li>
-                              </ul>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0 font-semibold text-[15px] leading-[22px]">
-                                Guidelines
-                              </p>
-                              <ul className="list-disc ml-[20px] m-0">
-                                <li className="m-0">
-                                  Focus on signal over noise
-                                </li>
-                                <li className="m-0">
-                                  Keep summaries concise and skimmable
-                                </li>
-                                <li className="m-0">
-                                  Use a neutral, non-promotional tone
-                                </li>
-                              </ul>
-                            </div>
-                          )}
-
-                        {selectedAgent === "hackernews" &&
-                          activeTab === "yaml" && (
-                            <div
-                              className="text-[13px] leading-[18px] whitespace-pre-wrap break-words"
-                              style={{
-                                fontFamily: "var(--font-jetbrains-mono)",
-                              }}
-                            >
-                              <p className="m-0">
-                                <span className="text-[#3b82f6]">version</span>
-                                <span className="text-[#827d77]">:</span>{" "}
-                                <span className="text-[#22c55e]">
-                                  &quot;1.0&quot;
-                                </span>
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0">
-                                <span className="text-[#3b82f6]">agents</span>
-                                <span className="text-[#827d77]">:</span>
-                              </p>
-                              <p className="m-0">
-                                {"  "}
-                                <span className="text-[#3b82f6]">
-                                  201-hackernews
-                                </span>
-                                <span className="text-[#827d77]">:</span>
-                              </p>
-                              <p className="m-0">
-                                {"    "}
-                                <span className="text-[#3b82f6]">
-                                  description
-                                </span>
-                                <span className="text-[#827d77]">:</span>{" "}
-                                <span className="text-[#22c55e]">
-                                  &quot;Daily HackerNews curator that fetches
-                                  and analyzes top stories&quot;
-                                </span>
-                              </p>
-                              <p className="m-0">
-                                {"    "}
-                                <span className="text-[#3b82f6]">
-                                  framework
-                                </span>
-                                <span className="text-[#827d77]">:</span>{" "}
-                                <span className="text-foreground">
-                                  claude-code
-                                </span>
-                              </p>
-                              <p className="m-0">
-                                {"    "}
-                                <span className="text-[#3b82f6]">
-                                  instructions
-                                </span>
-                                <span className="text-[#827d77]">:</span>{" "}
-                                <span className="text-foreground">
-                                  AGENTS.md
-                                </span>
-                              </p>
-                              <p className="m-0">
-                                {"    "}
-                                <span className="text-[#3b82f6]">skills</span>
-                                <span className="text-[#827d77]">:</span>
-                              </p>
-                              <p className="m-0">
-                                {"      "}
-                                <span className="text-[#827d77]">-</span>{" "}
-                                <span className="text-[#06b6d4]">
-                                  https://github.com/vm0-ai/vm0-skills/tree/main/hackernews
-                                </span>
-                              </p>
-                            </div>
-                          )}
-
-                        {selectedAgent === "tiktok" &&
-                          activeTab === "agents" && (
-                            <div
-                              className="text-[14px] leading-[20px]"
-                              style={{ fontFamily: "var(--font-noto-sans)" }}
-                            >
-                              <p className="m-0 font-semibold text-[18px] leading-[26px]">
-                                TikTok Influencer Discovery Agent
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0">
-                                You are a TikTok influencer discovery and
-                                analysis expert. You help businesses find the
-                                most relevant TikTok influencers for
-                                collaboration based on their industry and
-                                requirements.
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0 font-semibold text-[15px] leading-[22px]">
-                                Workflow
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0 font-medium text-[14px] leading-[20px]">
-                                Phase 1: Gather Business Information
-                              </p>
-                              <ul className="list-disc ml-[20px] m-0">
-                                <li className="m-0">
-                                  Search Keyword: What type of content/niche to
-                                  search for
-                                </li>
-                                <li className="m-0">
-                                  About Your Business: Brief description
-                                </li>
-                                <li className="m-0">
-                                  Industry: The industry the business operates
-                                  in
-                                </li>
-                                <li className="m-0">
-                                  Notion Database ID: To store results
-                                </li>
-                              </ul>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0 font-medium text-[14px] leading-[20px]">
-                                Phase 2: Discover TikTok Influencers
-                              </p>
-                              <p className="m-0">
-                                Search for TikTok profiles matching the keyword.
-                                The scraping process takes 2-3 minutes to
-                                complete.
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0 font-medium text-[14px] leading-[20px]">
-                                Phase 3: Store Raw Data in Notion
-                              </p>
-                              <p className="m-0">
-                                For each influencer discovered, add them to the
-                                Notion database. Save the returned page IDs for
-                                updating later with analysis.
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0 font-medium text-[14px] leading-[20px]">
-                                Phase 4: Analyze Each Influencer
-                              </p>
-                              <p className="m-0">
-                                Evaluate their relevance based on followers
-                                (&gt;5,000), content alignment, and profile
-                                description. Classify as &quot;Highly
-                                Relevant&quot; or &quot;Not Relevant&quot;.
-                              </p>
-                            </div>
-                          )}
-
-                        {selectedAgent === "tiktok" && activeTab === "yaml" && (
-                          <div
-                            className="text-[13px] leading-[18px] whitespace-pre-wrap break-words"
-                            style={{ fontFamily: "var(--font-jetbrains-mono)" }}
-                          >
-                            <p className="m-0">
-                              <span className="text-[#3b82f6]">version</span>
-                              <span className="text-[#827d77]">:</span>{" "}
-                              <span className="text-[#22c55e]">
-                                &quot;1.0&quot;
-                              </span>
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                            <p className="m-0">
-                              <span className="text-[#3b82f6]">agents</span>
-                              <span className="text-[#827d77]">:</span>
-                            </p>
-                            <p className="m-0">
-                              {"  "}
-                              <span className="text-[#3b82f6]">
-                                tiktok-influencer
-                              </span>
-                              <span className="text-[#827d77]">:</span>
-                            </p>
-                            <p className="m-0">
-                              {"    "}
-                              <span className="text-[#3b82f6]">
-                                description
-                              </span>
-                              <span className="text-[#827d77]">:</span>{" "}
-                              <span className="text-[#22c55e]">
-                                &quot;TikTok influencer discovery and AI-powered
-                                analysis agent with Notion integration&quot;
-                              </span>
-                            </p>
-                            <p className="m-0">
-                              {"    "}
-                              <span className="text-[#3b82f6]">framework</span>
-                              <span className="text-[#827d77]">:</span>{" "}
-                              <span className="text-foreground">
-                                claude-code
-                              </span>
-                            </p>
-                            <p className="m-0">
-                              {"    "}
-                              <span className="text-[#3b82f6]">
-                                instructions
-                              </span>
-                              <span className="text-[#827d77]">:</span>{" "}
-                              <span className="text-foreground">AGENTS.md</span>
-                            </p>
-                            <p className="m-0">
-                              {"    "}
-                              <span className="text-[#3b82f6]">skills</span>
-                              <span className="text-[#827d77]">:</span>
-                            </p>
-                            <p className="m-0">
-                              {"      "}
-                              <span className="text-[#827d77]">-</span>{" "}
-                              <span className="text-[#06b6d4]">
-                                https://github.com/vm0-ai/vm0-skills/tree/main/bright-data
-                              </span>
-                            </p>
-                            <p className="m-0">
-                              {"      "}
-                              <span className="text-[#827d77]">-</span>{" "}
-                              <span className="text-[#06b6d4]">
-                                https://github.com/vm0-ai/vm0-skills/tree/main/notion
-                              </span>
-                            </p>
-                          </div>
-                        )}
-
-                        {selectedAgent === "blog" && activeTab === "agents" && (
-                          <div
-                            className="text-[14px] leading-[20px]"
-                            style={{ fontFamily: "var(--font-noto-sans)" }}
-                          >
-                            <p className="m-0 font-semibold text-[18px] leading-[26px]">
-                              Content Farm Agent
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                            <p className="m-0">
-                              You are a professional content farm agent that
-                              automatically generates high-quality,
-                              SEO-optimized blog articles from trending news
-                              sources.
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                            <p className="m-0 font-semibold text-[15px] leading-[22px]">
-                              Workflow
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                            <p className="m-0 font-medium text-[14px] leading-[20px]">
-                              Phase 1: Gather News
-                            </p>
-                            <p className="m-0">
-                              Use the rss-fetch skill to collect recent articles
-                              from major tech news sources.
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                            <p className="m-0 font-medium text-[14px] leading-[20px]">
-                              Phase 2: Filter and Select
-                            </p>
-                            <p className="m-0">
-                              Review the fetched articles and select the most
-                              relevant ones based on the user&apos;s specified
-                              topic or keywords. Pick 3-5 articles.
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                            <p className="m-0 font-medium text-[14px] leading-[20px]">
-                              Phase 3: Create SEO Title
-                            </p>
-                            <p className="m-0">
-                              Generate 5 long-tail SEO title candidates,
-                              evaluate each for click-through potential, and
-                              select the best one.
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                            <p className="m-0 font-medium text-[14px] leading-[20px]">
-                              Phase 4: Build Outline
-                            </p>
-                            <p className="m-0">
-                              Create a structured outline with introduction, 2-3
-                              main sections, conclusion, and references section.
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                            <p className="m-0 font-medium text-[14px] leading-[20px]">
-                              Phase 5: Write the Article
-                            </p>
-                            <p className="m-0">
-                              Write a 1000-1500 word article with conversational
-                              tone, short paragraphs, and natural keyword
-                              integration.
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                            <p className="m-0 font-medium text-[14px] leading-[20px]">
-                              Phase 6-8: Generate Image, Prepare Output, Publish
-                            </p>
-                            <p className="m-0">
-                              Create featured image, save to output folder, and
-                              publish to Dev.to.
-                            </p>
-                          </div>
-                        )}
-
-                        {selectedAgent === "blog" && activeTab === "yaml" && (
-                          <div
-                            className="text-[13px] leading-[18px] whitespace-pre-wrap break-words"
-                            style={{ fontFamily: "var(--font-jetbrains-mono)" }}
-                          >
-                            <p className="m-0">
-                              <span className="text-[#3b82f6]">version</span>
-                              <span className="text-[#827d77]">:</span>{" "}
-                              <span className="text-[#22c55e]">
-                                &quot;1.0&quot;
-                              </span>
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                            <p className="m-0">
-                              <span className="text-[#3b82f6]">agents</span>
-                              <span className="text-[#827d77]">:</span>
-                            </p>
-                            <p className="m-0">
-                              {"  "}
-                              <span className="text-[#3b82f6]">
-                                content-farm
-                              </span>
-                              <span className="text-[#827d77]">:</span>
-                            </p>
-                            <p className="m-0">
-                              {"    "}
-                              <span className="text-[#3b82f6]">
-                                description
-                              </span>
-                              <span className="text-[#827d77]">:</span>{" "}
-                              <span className="text-[#22c55e]">
-                                &quot;AI-powered blog content generation
-                                agent&quot;
-                              </span>
-                            </p>
-                            <p className="m-0">
-                              {"    "}
-                              <span className="text-[#3b82f6]">framework</span>
-                              <span className="text-[#827d77]">:</span>{" "}
-                              <span className="text-foreground">
-                                claude-code
-                              </span>
-                            </p>
-                            <p className="m-0">
-                              {"    "}
-                              <span className="text-[#3b82f6]">
-                                instructions
-                              </span>
-                              <span className="text-[#827d77]">:</span>{" "}
-                              <span className="text-foreground">AGENTS.md</span>
-                            </p>
-                            <p className="m-0">
-                              {"    "}
-                              <span className="text-[#3b82f6]">skills</span>
-                              <span className="text-[#827d77]">:</span>
-                            </p>
-                            <p className="m-0">
-                              {"      "}
-                              <span className="text-[#827d77]">-</span>{" "}
-                              <span className="text-[#06b6d4]">
-                                https://github.com/vm0-ai/vm0-skills/tree/main/rss-fetch
-                              </span>
-                            </p>
-                            <p className="m-0">
-                              {"      "}
-                              <span className="text-[#827d77]">-</span>{" "}
-                              <span className="text-[#06b6d4]">
-                                https://github.com/vm0-ai/vm0-skills/tree/main/fal.ai
-                              </span>
-                            </p>
-                            <p className="m-0">
-                              {"      "}
-                              <span className="text-[#827d77]">-</span>{" "}
-                              <span className="text-[#06b6d4]">
-                                https://github.com/vm0-ai/vm0-skills/tree/main/dev.to
-                              </span>
-                            </p>
-                          </div>
-                        )}
-
-                        {selectedAgent === "daily-report" &&
-                          activeTab === "agents" && (
-                            <div
-                              className="text-[14px] leading-[20px]"
-                              style={{ fontFamily: "var(--font-noto-sans)" }}
-                            >
-                              <p className="m-0 font-semibold text-[18px] leading-[26px]">
-                                Daily Data Report Agent
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0">
-                                This agent generates comprehensive daily reports
-                                for the vm0 team across eight sequential phases.
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0 font-semibold text-[15px] leading-[22px]">
-                                Key Data Collection Areas
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0 font-medium text-[14px] leading-[20px]">
-                                GitHub Repository Metrics
-                              </p>
-                              <p className="m-0">
-                                Stars, forks, watchers, and open issues for
-                                vm0-ai/vm0
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0 font-medium text-[14px] leading-[20px]">
-                                Website Analytics
-                              </p>
-                              <p className="m-0">
-                                Yesterday&apos;s visitor counts, pageviews,
-                                bounce rates, visit duration, and traffic source
-                                analysis
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0 font-medium text-[14px] leading-[20px]">
-                                User Statistics
-                              </p>
-                              <p className="m-0">
-                                Total users, active users from yesterday, and
-                                new user registrations
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0 font-medium text-[14px] leading-[20px]">
-                                Code Changes
-                              </p>
-                              <p className="m-0">
-                                Commits, file modifications, and line
-                                additions/removals with author attribution
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0 font-medium text-[14px] leading-[20px]">
-                                Document Activity
-                              </p>
-                              <p className="m-0">
-                                Notion pages created and edited with change
-                                attribution
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0 font-semibold text-[15px] leading-[22px]">
-                                Output
-                              </p>
-                              <p className="m-0">
-                                Reports are saved as markdown files and Slack
-                                notification sent with key metrics.
-                              </p>
-                            </div>
-                          )}
-
-                        {selectedAgent === "daily-report" &&
-                          activeTab === "yaml" && (
-                            <div
-                              className="text-[13px] leading-[18px] whitespace-pre-wrap break-words"
-                              style={{
-                                fontFamily: "var(--font-jetbrains-mono)",
-                              }}
-                            >
-                              <p className="m-0">
-                                <span className="text-[#3b82f6]">version</span>
-                                <span className="text-[#827d77]">:</span>{" "}
-                                <span className="text-[#22c55e]">
-                                  &quot;1.0&quot;
-                                </span>
-                              </p>
-                              <p className="m-0">&nbsp;</p>
-                              <p className="m-0">
-                                <span className="text-[#3b82f6]">agents</span>
-                                <span className="text-[#827d77]">:</span>
-                              </p>
-                              <p className="m-0">
-                                {"  "}
-                                <span className="text-[#3b82f6]">
-                                  daily-data-report
-                                </span>
-                                <span className="text-[#827d77]">:</span>
-                              </p>
-                              <p className="m-0">
-                                {"    "}
-                                <span className="text-[#3b82f6]">
-                                  description
-                                </span>
-                                <span className="text-[#827d77]">:</span>{" "}
-                                <span className="text-[#22c55e]">
-                                  &quot;Daily data report agent that gathers
-                                  GitHub stats, Plausible analytics, code
-                                  changes, and Notion updates&quot;
-                                </span>
-                              </p>
-                              <p className="m-0">
-                                {"    "}
-                                <span className="text-[#3b82f6]">
-                                  framework
-                                </span>
-                                <span className="text-[#827d77]">:</span>{" "}
-                                <span className="text-foreground">
-                                  claude-code
-                                </span>
-                              </p>
-                              <p className="m-0">
-                                {"    "}
-                                <span className="text-[#3b82f6]">
-                                  instructions
-                                </span>
-                                <span className="text-[#827d77]">:</span>{" "}
-                                <span className="text-foreground">
-                                  AGENTS.md
-                                </span>
-                              </p>
-                              <p className="m-0">
-                                {"    "}
-                                <span className="text-[#3b82f6]">skills</span>
-                                <span className="text-[#827d77]">:</span>
-                              </p>
-                              <p className="m-0">
-                                {"      "}
-                                <span className="text-[#827d77]">-</span>{" "}
-                                <span className="text-[#06b6d4]">
-                                  https://github.com/vm0-ai/vm0-skills/tree/main/github
-                                </span>
-                              </p>
-                              <p className="m-0">
-                                {"      "}
-                                <span className="text-[#827d77]">-</span>{" "}
-                                <span className="text-[#06b6d4]">
-                                  https://github.com/vm0-ai/vm0-skills/tree/main/plausible
-                                </span>
-                              </p>
-                              <p className="m-0">
-                                {"      "}
-                                <span className="text-[#827d77]">-</span>{" "}
-                                <span className="text-[#06b6d4]">
-                                  https://github.com/vm0-ai/vm0-skills/tree/main/notion
-                                </span>
-                              </p>
-                              <p className="m-0">
-                                {"      "}
-                                <span className="text-[#827d77]">-</span>{" "}
-                                <span className="text-[#06b6d4]">
-                                  https://github.com/vm0-ai/vm0-skills/tree/main/slack
-                                </span>
-                              </p>
-                              <p className="m-0">
-                                {"    "}
-                                <span className="text-[#3b82f6]">
-                                  environment
-                                </span>
-                                <span className="text-[#827d77]">:</span>
-                              </p>
-                              <p className="m-0">
-                                {"      "}
-                                <span className="text-[#3b82f6]">
-                                  PLAUSIBLE_SITE_ID
-                                </span>
-                                <span className="text-[#827d77]">:</span>{" "}
-                                <span className="text-foreground">$</span>
-                                <span className="text-[#827d77]">
-                                  &#123;&#123;
-                                </span>
-                                <span className="text-foreground">
-                                  {" "}
-                                  vars.PLAUSIBLE_SITE_ID{" "}
-                                </span>
-                                <span className="text-[#827d77]">
-                                  &#125;&#125;
-                                </span>
-                              </p>
-                              <p className="m-0">
-                                {"      "}
-                                <span className="text-[#3b82f6]">
-                                  SLACK_CHANNEL_ID
-                                </span>
-                                <span className="text-[#827d77]">:</span>{" "}
-                                <span className="text-foreground">$</span>
-                                <span className="text-[#827d77]">
-                                  &#123;&#123;
-                                </span>
-                                <span className="text-foreground">
-                                  {" "}
-                                  vars.SLACK_CHANNEL_ID{" "}
-                                </span>
-                                <span className="text-[#827d77]">
-                                  &#125;&#125;
-                                </span>
-                              </p>
-                            </div>
-                          )}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Sample Agents */}
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-0 rounded-[8px] mb-[20px]">
-                  <AgentCard
-                    icon="/landing/ycombinator.svg"
-                    title="HackerNews Agent"
-                    description="Get Hacker News insights from personal digest."
-                    onClick={() => setSelectedAgent("hackernews")}
-                    isSelected={selectedAgent === "hackernews"}
-                    variant="gradient-left"
-                  />
-                  <AgentCard
-                    icon="/landing/screenshot.png"
-                    title="TikTok Influencer Agent"
-                    description="Search, filter, and surface TikTok creators for you."
-                    onClick={() => setSelectedAgent("tiktok")}
-                    isSelected={selectedAgent === "tiktok"}
-                    variant="white"
-                  />
-                  <AgentCard
-                    icon={{
-                      light: "/landing/notion.svg",
-                      dark: "/landing/notion-dark.svg",
-                    }}
-                    title="Daily report agent"
-                    description="Aggregate data from multiple sources and APIs, then summarize in Notion."
-                    onClick={() => setSelectedAgent("daily-report")}
-                    isSelected={selectedAgent === "daily-report"}
-                    variant="white"
-                  />
-                  <AgentCard
-                    icon="/landing/fal-image.svg"
-                    title="Blog generator"
-                    description="Automate blog generation with multiple APIs."
-                    onClick={() => setSelectedAgent("blog")}
-                    isSelected={selectedAgent === "blog"}
-                    variant="gradient-right"
-                  />
-                </div>
-
-                <a
-                  href="https://github.com/vm0-ai/vm0-cookbooks/tree/main/examples"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex gap-[8px] items-center justify-center hover:opacity-80 transition-opacity cursor-pointer"
-                >
-                  <p
-                    className="text-[14px] leading-[20px] text-primary font-normal"
-                    style={{ fontFamily: "var(--font-noto-sans)" }}
-                  >
-                    Show more sample agents
-                  </p>
-                  <div className="flex items-center justify-center w-[16px] h-[16px] -rotate-90">
-                    <IconChevronDown size={16} className="text-primary" />
-                  </div>
-                </a>
-              </div>
+              <RunSection claudeCodeVersion={claudeCodeVersion} />
             )}
 
-            {/* Build an agent */}
             {mainTab === "build" && (
-              <div
-                ref={buildSectionRef}
-                className="flex flex-col gap-[30px] mb-20"
-              >
-                <div className="text-center">
-                  <h2 className="text-[36px] font-medium leading-[1.2] text-foreground mb-4">
-                    Build an agent
-                  </h2>
-                  <p className="text-[16px] leading-[1.5] text-foreground">
-                    Build your agent with the VM0 builder skill and CLI.
-                  </p>
-                  <p className="text-[16px] leading-[1.5] text-foreground">
-                    Create agents in Claude Code using natural language, on a
-                    secure and reliable infrastructure.
-                  </p>
-                </div>
-
-                <div
-                  className="rounded-[6px] pt-[20px] pb-[20px] sm:pb-[30px] px-[16px] sm:px-[30px] md:px-[100px] lg:px-[200px] xl:px-[300px]"
-                  style={{
-                    backgroundImage:
-                      "linear-gradient(137.478deg, rgb(183, 200, 210) 0.82464%, rgb(253, 175, 83) 45.285%, rgb(248, 127, 48) 99.384%)",
-                  }}
-                >
-                  <div className="bg-white dark:bg-[#19191b] border-[0.5px] border-border rounded-[12px] shadow-[0px_25px_50px_-12px_rgba(0,0,0,0.25)] overflow-hidden h-[422px]">
-                    {/* Terminal Header */}
-                    <div className="bg-[#f9f4ef] dark:bg-[#292a2e] p-[8px] flex items-center justify-between shadow-[0px_0.5px_0px_0px_#d2d2d2] dark:shadow-[0px_0.5px_0px_0px_#2f2f32]">
-                      <div className="flex gap-1.5 w-[39px] h-[9px]">
-                        <div className="w-2.5 h-2.5 rounded-full bg-red-500" />
-                        <div className="w-2.5 h-2.5 rounded-full bg-yellow-500" />
-                        <div className="w-2.5 h-2.5 rounded-full bg-green-500" />
-                      </div>
-                      <p
-                        className="text-[12px] text-center font-medium flex-1"
-                        style={{ fontFamily: "var(--font-noto-sans)" }}
-                      >
-                        <span className="text-[#827d77]">~/work</span>
-                        <span className="text-foreground">
-                          {" "}
-                          * VM0 Agent ▸ Claude Code
-                        </span>
-                      </p>
-                      <div className="w-[39px]"></div>
-                    </div>
-
-                    {/* Terminal Content */}
-                    <div
-                      className="p-[20px] overflow-y-auto h-[calc(422px-44px)]"
-                      style={{ fontFamily: "var(--font-jetbrains-mono)" }}
-                    >
-                      <div className="flex gap-[10px] items-start text-[12px] leading-[16px]">
-                        <div className="flex gap-[4px] items-center">
-                          <div className="text-black dark:text-white">
-                            <p className="m-0"> *</p>
-                            <p className="m-0">*</p>
-                            <p className="m-0"> *</p>
-                          </div>
-                          <Image
-                            src="/landing/vector-logo.svg"
-                            alt="VM0"
-                            width="65"
-                            height="40"
-                          />
-                          <div className="text-black dark:text-white">
-                            <p className="m-0">*</p>
-                            <p className="m-0"> *</p>
-                            <p className="m-0">*</p>
-                          </div>
-                        </div>
-                        <div className="text-[11px]">
-                          <p className="m-0">
-                            <span className="font-bold">Claude Code</span>
-                            {claudeCodeVersion && ` ${claudeCodeVersion}`}
-                          </p>
-                          <p className="m-0 text-[#827d77]">
-                            Opus 4.6 · Claude API
-                          </p>
-                          <p className="m-0 text-[#827d77]">/Users/ming</p>
-                        </div>
-                      </div>
-
-                      <div className="mt-[10px] text-[12px] leading-[16px] space-y-0 font-light">
-                        {/* Step 0: Loading message */}
-                        {buildAnimationStep >= 0 && (
-                          <>
-                            <p className="m-0 text-[#827d77]">
-                              &gt; The &quot;vm0-agent&quot; skill is loading
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                          </>
-                        )}
-
-                        {/* Step 1: User input with typewriter effect */}
-                        {buildAnimationStep >= 1 && (
-                          <p className="m-0">
-                            <span className="text-[#f59e0b]">●</span>{" "}
-                            <span className="text-black dark:text-white font-medium">
-                              {typedText}
-                            </span>
-                            {buildAnimationStep === 1 && (
-                              <span className="text-black dark:text-white animate-pulse">
-                                {" "}
-                                █
-                              </span>
-                            )}
-                          </p>
-                        )}
-
-                        {buildAnimationStep >= 2 && (
-                          <p className="m-0">&nbsp;</p>
-                        )}
-
-                        {/* Step 2: First agent response */}
-                        {buildAnimationStep >= 2 && (
-                          <>
-                            <p className="m-0">
-                              <span className="text-[#22c55e]">⏺</span>{" "}
-                              <span className="text-secondary-foreground">
-                                I&apos;ll help you build a VM0 workflow! Let me
-                                understand what you want to automate.
-                              </span>
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                          </>
-                        )}
-
-                        {/* Step 3: User answers */}
-                        {buildAnimationStep >= 3 && (
-                          <>
-                            <p className="m-0">
-                              <span className="text-[#22c55e]">⏺</span>{" "}
-                              <span className="text-secondary-foreground">
-                                User answered Claude&apos;s questions:
-                              </span>
-                            </p>
-                            <p className="m-0 text-[#827d77]">
-                              {" "}
-                              ⎿ · What to aggregate? → Tech news from RSS feeds
-                            </p>
-                            <p className="m-0 text-[#827d77]">
-                              {" "}
-                              · How to process? → Summarize top 5 articles
-                            </p>
-                            <p className="m-0 text-[#827d77]">
-                              {" "}
-                              · Where to send? → Slack #tech-news channel
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                          </>
-                        )}
-
-                        {/* Step 4: Finding skills */}
-                        {buildAnimationStep >= 4 && (
-                          <>
-                            <p className="m-0">
-                              <span className="text-[#22c55e]">⏺</span>{" "}
-                              <span className="text-secondary-foreground">
-                                Perfect! Let me find the right skills for your
-                                workflow.
-                              </span>
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                          </>
-                        )}
-
-                        {/* Step 5: Fetch skills */}
-                        {buildAnimationStep >= 5 && (
-                          <>
-                            <p className="m-0">
-                              <span className="text-[#22c55e]">⏺</span>{" "}
-                              <span className="text-[#3b82f6]">Fetch</span>
-                              <span className="text-secondary-foreground">
-                                (
-                              </span>
-                              <span className="text-[#06b6d4]">
-                                https://github.com/vm0-ai/vm0-skills
-                              </span>
-                              <span className="text-secondary-foreground">
-                                )
-                              </span>
-                            </p>
-                            <p className="m-0 text-[#827d77]">
-                              {" "}
-                              ⎿ Received 389KB (200 OK)
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                          </>
-                        )}
-
-                        {/* Step 6: Write vm0.yaml */}
-                        {buildAnimationStep >= 6 && (
-                          <>
-                            <p className="m-0">
-                              <span className="text-[#22c55e]">⏺</span>{" "}
-                              <span className="text-[#3b82f6]">Write</span>
-                              <span className="text-secondary-foreground">
-                                (
-                              </span>
-                              <span className="text-[#06b6d4]">vm0.yaml</span>
-                              <span className="text-secondary-foreground">
-                                )
-                              </span>
-                            </p>
-                            <p className="m-0 text-[#827d77]">
-                              {" "}
-                              ⎿ Wrote 8 lines to vm0.yaml
-                            </p>
-                            <p className="m-0 text-[#6b7280]"> 1 agents:</p>
-                            <p className="m-0 text-[#6b7280]">
-                              {" "}
-                              2 tech-news-digest:
-                            </p>
-                            <p className="m-0 text-[#6b7280]">
-                              {" "}
-                              3 framework: claude-code
-                            </p>
-                            <p className="m-0 text-[#6b7280]">
-                              {" "}
-                              4 instructions: AGENTS.md
-                            </p>
-                            <p className="m-0 text-[#6b7280]"> 5 skills:</p>
-                            <p className="m-0 text-[#6b7280]">
-                              {" "}
-                              6 - vm0-skills/rss-fetch
-                            </p>
-                            <p className="m-0 text-[#6b7280]">
-                              {" "}
-                              7 - vm0-skills/slack
-                            </p>
-                            <p className="m-0 text-[#6b7280]"> … +1 line</p>
-                            <p className="m-0">&nbsp;</p>
-                          </>
-                        )}
-
-                        {/* Step 7: Write AGENTS.md */}
-                        {buildAnimationStep >= 7 && (
-                          <>
-                            <p className="m-0">
-                              <span className="text-[#22c55e]">⏺</span>{" "}
-                              <span className="text-[#3b82f6]">Write</span>
-                              <span className="text-secondary-foreground">
-                                (
-                              </span>
-                              <span className="text-[#06b6d4]">AGENTS.md</span>
-                              <span className="text-secondary-foreground">
-                                )
-                              </span>
-                            </p>
-                            <p className="m-0 text-[#827d77]">
-                              {" "}
-                              ⎿ Wrote 47 lines to AGENTS.md
-                            </p>
-                            <p className="m-0 text-[#6b7280]">
-                              {" "}
-                              1 # Tech News Daily Digest Agent
-                            </p>
-                            <p className="m-0 text-[#6b7280]">
-                              {" "}
-                              2 Fetch TechCrunch RSS, summarize top 5 articles
-                            </p>
-                            <p className="m-0 text-[#6b7280]">
-                              {" "}
-                              … +43 lines (ctrl+o to expand)
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                          </>
-                        )}
-
-                        {/* Step 8: Final message */}
-                        {buildAnimationStep >= 8 && (
-                          <>
-                            <p className="m-0">
-                              <span className="text-[#22c55e]">⏺</span>{" "}
-                              <span className="text-secondary-foreground">
-                                Your agent is ready!
-                              </span>
-                            </p>
-                            <p className="m-0">&nbsp;</p>
-                            <p className="m-0">
-                              <span className="text-[#22c55e]">⏺</span>{" "}
-                              <span className="text-secondary-foreground">
-                                Run now or schedule it:
-                              </span>
-                            </p>
-                            <p className="m-0 text-[#827d77]">
-                              {" "}
-                              → Just say: &quot;fetch tech news&quot;
-                            </p>
-                            <p className="m-0 text-[#827d77]">
-                              {" "}
-                              → Or: &quot;run this daily at 9am&quot;
-                            </p>
-                          </>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
+              <BuildSection claudeCodeVersion={claudeCodeVersion} />
             )}
           </div>
         </section>
@@ -3727,157 +3544,7 @@ export default function LandingPage({ claudeCodeVersion }: LandingPageProps) {
         </section>
 
         {/* Final CTA */}
-        <section className="w-full max-w-[1440px] py-10">
-          <div className="max-w-[1200px] mx-auto px-[30px]">
-            <div className="bg-white dark:bg-[#19191b] border border-[#f5eae1] dark:border-[#2f2f32] rounded-[12px] p-[24px] sm:p-[40px] md:p-[60px] relative overflow-hidden flex flex-col gap-[24px] sm:gap-[30px]">
-              {/* Decorative circular gradient background */}
-              <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[1627px] h-[1627px] pointer-events-none">
-                <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[1400px] h-[1400px] rotate-[79.76deg]">
-                  <div
-                    className="w-full h-full rounded-full opacity-40"
-                    style={{
-                      background:
-                        "radial-gradient(circle, rgba(237, 78, 1, 0.3) 0%, rgba(237, 78, 1, 0) 70%)",
-                    }}
-                  />
-                </div>
-              </div>
-
-              {/* Grid pattern overlay */}
-              <div className="absolute left-1/2 top-[-429px] -translate-x-1/2 w-[1200px] h-[1120px] overflow-hidden pointer-events-none opacity-[0.06]">
-                {[...Array(20)].map((_, i) => (
-                  <div
-                    key={`v-${i}`}
-                    className="absolute top-0 h-[1600px] w-px bg-[#ed4e01]"
-                    style={{ left: `${79 + i * 80}px` }}
-                  />
-                ))}
-                {[...Array(20)].map((_, i) => (
-                  <div
-                    key={`h-${i}`}
-                    className="absolute left-0 w-[1600px] h-px bg-[#ed4e01]"
-                    style={{ top: `${79 + i * 80}px` }}
-                  />
-                ))}
-              </div>
-
-              {/* Content */}
-              <div className="relative z-10 flex flex-col gap-[24px] sm:gap-[30px]">
-                <h2
-                  className="text-[36px] font-medium leading-[1.2] dark:!text-[#ffffff]"
-                  style={{ fontFamily: "var(--font-noto-sans)" }}
-                >
-                  Get started today
-                </h2>
-
-                <div className="bg-white dark:bg-[#19191b] border border-[#f5eae1] dark:border-[#2f2f32] rounded-[12px] p-[16px] sm:p-[24px] flex gap-[12px] sm:gap-[32px] items-center">
-                  <div className="flex-1 min-h-px min-w-px overflow-x-auto">
-                    <code
-                      className="block text-[18px] leading-[1.6]"
-                      style={{ fontFamily: "var(--font-jetbrains-mono)" }}
-                    >
-                      <span className="text-[#0284c7]">
-                        npm install -g @vm0/cli && vm0 onboard
-                      </span>
-                      <br />
-                      <span className="text-[#827d77]">
-                        {" "}
-                        {"//"}One command. Build agents with natural language.
-                      </span>
-                    </code>
-                  </div>
-                  <div className="relative">
-                    <button
-                      onClick={() => {
-                        navigator.clipboard
-                          .writeText("npm install -g @vm0/cli && vm0 onboard")
-                          .catch(() => {});
-                        setCopiedFooter(true);
-                        setTimeout(() => setCopiedFooter(false), 2000);
-                      }}
-                      className="rounded-[10px] w-[40px] h-[40px] flex items-center justify-center shrink-0 transition-colors hover:bg-[#f0ebe5] dark:hover:bg-[#292a2e]"
-                    >
-                      <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        className="shrink-0"
-                      >
-                        <rect
-                          x="9"
-                          y="9"
-                          width="13"
-                          height="13"
-                          rx="2"
-                          ry="2"
-                        />
-                        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-                      </svg>
-                    </button>
-                    {copiedFooter && (
-                      <div
-                        className="absolute -top-[40px] left-1/2 -translate-x-1/2 bg-[#231f1b] px-[12px] py-[6px] rounded-[6px] text-[14px] whitespace-nowrap"
-                        style={{ color: "#ffffff" }}
-                      >
-                        Copied
-                      </div>
-                    )}
-                  </div>
-                </div>
-
-                <div className="flex flex-col sm:flex-row gap-[12px] sm:gap-[20px]">
-                  {isSignedIn ? (
-                    <a
-                      href={getPlatformUrl()}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white px-[24px] py-[12px] rounded-[10px] font-medium text-[18px] leading-[28px] w-full sm:w-[160px] transition-colors flex items-center justify-center"
-                      style={{ fontFamily: "var(--font-noto-sans)" }}
-                    >
-                      Get started
-                    </a>
-                  ) : (
-                    <Link
-                      href="/sign-up"
-                      className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white px-[24px] py-[12px] rounded-[10px] font-medium text-[18px] leading-[28px] w-full sm:w-[160px] transition-colors flex items-center justify-center"
-                      style={{ fontFamily: "var(--font-noto-sans)" }}
-                    >
-                      Get started
-                    </Link>
-                  )}
-                  <a
-                    href="https://github.com/vm0-ai/vm0"
-                    target="_blank"
-                    rel="noreferrer"
-                    className="bg-[rgba(255,255,255,0.6)] dark:bg-[rgba(25,25,27,0.6)] border border-[#ed4e01] dark:border-[#ff6a1f] hover:bg-white dark:hover:bg-[#292a2e] !text-[#ed4e01] dark:!text-[#ff6a1f] px-[24px] py-[12px] rounded-[10px] font-medium text-[18px] leading-[28px] w-full sm:w-[160px] flex items-center justify-center gap-[10px] transition-colors"
-                    style={{ fontFamily: "var(--font-noto-sans)" }}
-                  >
-                    <svg
-                      width="24"
-                      height="24"
-                      viewBox="0 0 16 16"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                      className="shrink-0"
-                    >
-                      <path
-                        d="M8 0.198C3.58 0.198 0 3.78 0 8.198C0 11.7333 2.292 14.7313 5.47 15.788C5.87 15.8633 6.01667 15.616 6.01667 15.4033C6.01667 15.2133 6.01 14.71 6.00667 14.0433C3.78133 14.526 3.312 12.97 3.312 12.97C2.948 12.0467 2.422 11.8 2.422 11.8C1.69733 11.304 2.478 11.314 2.478 11.314C3.28133 11.37 3.70333 12.138 3.70333 12.138C4.41667 13.3613 5.576 13.008 6.03333 12.8033C6.10533 12.286 6.31133 11.9333 6.54 11.7333C4.76333 11.5333 2.896 10.8453 2.896 7.78C2.896 6.90667 3.206 6.19333 3.71933 5.63333C3.62933 5.43133 3.35933 4.618 3.78933 3.516C3.78933 3.516 4.45933 3.30133 5.98933 4.336C6.62933 4.158 7.30933 4.07 7.98933 4.066C8.66933 4.07 9.34933 4.158 9.98933 4.336C11.5093 3.30133 12.1793 3.516 12.1793 3.516C12.6093 4.618 12.3393 5.43133 12.2593 5.63333C12.7693 6.19333 13.0793 6.90667 13.0793 7.78C13.0793 10.8533 11.2093 11.53 9.42933 11.7267C9.70933 11.9667 9.96933 12.4573 9.96933 13.2067C9.96933 14.2773 9.95933 15.1373 9.95933 15.3973C9.95933 15.6073 10.0993 15.8573 10.5093 15.7773C13.71 14.728 16 11.728 16 8.198C16 3.78 12.418 0.198 8 0.198Z"
-                        fill="#ed4e01"
-                        className="dark:fill-[#ff6a1f]"
-                      />
-                    </svg>
-                    GitHub
-                  </a>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
+        <FinalCtaSection isSignedIn={isSignedIn} />
       </main>
 
       <Footer />


### PR DESCRIPTION
## Summary

- Remove 2 `eslint-disable complexity` suppressions from `DesignSystemClient.tsx` and `LandingPage.tsx`
- Extract large monolithic components into smaller, focused sub-components to bring cyclomatic complexity under the ESLint limit (20)
- Remove unused `components-card` variant from the `Section` type in `DesignSystemClient`

### DesignSystemClient.tsx
- Extract `DesignSystemHeader` component (theme toggle, logo)
- Extract `Sidebar` component with data-driven navigation arrays (`TOP_NAV_ITEMS`, `COMPONENT_NAV_ITEMS`)
- Replace 15 conditional section renders with a `SECTION_COMPONENTS` record lookup

### LandingPage.tsx
- Extract `HeroSection` (install command, CTA, 3D cube)
- Extract `RunSection` (run terminal, agent selection, editor panel, animation state/effects)
- Extract `BuildSection` (build terminal, animation state/effects)
- Extract `FinalCtaSection` (footer CTA)
- Extract per-agent terminal components (`HackernewsTerminal`, `TiktokTerminal`, `BlogTerminal`, `DailyReportTerminal`)
- Extract `RunTerminalContent`, `RunEditorContent`, `TerminalHeader`, `TerminalAgentOutput` helpers

## Test plan

- [x] Zero `eslint-disable complexity` comments in the codebase
- [x] Lint passes without suppressions (`pnpm turbo run lint --filter=web`)
- [x] Type checking passes (`pnpm turbo run check-types --filter=web`)
- [x] Knip passes (no unused exports/dependencies)
- [x] Format passes
- [ ] Visual regression: components render identically before and after

Closes #3436

🤖 Generated with [Claude Code](https://claude.com/claude-code)