### PR TITLE
fix(platform): add bg-card to agent instructions container

### DIFF
--- a/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-instructions.tsx
@@ -39,7 +39,7 @@ export function AgentInstructions({
 
   if (loading) {
     return (
-      <div className="rounded-lg border border-border p-4">
+      <div className="rounded-lg border border-border bg-card p-4">
         <Skeleton className="h-5 w-40 mb-6" />
         <Skeleton className="h-64 w-full" />
       </div>
@@ -48,7 +48,7 @@ export function AgentInstructions({
 
   if (!instructions?.content && !isOwner) {
     return (
-      <div className="rounded-lg border border-border p-4">
+      <div className="rounded-lg border border-border bg-card p-4">
         <h2 className="text-base font-medium text-foreground">
           Agent instructions
         </h2>
@@ -60,7 +60,7 @@ export function AgentInstructions({
   }
 
   return (
-    <div className="rounded-lg border border-border p-4">
+    <div className="rounded-lg border border-border bg-card p-4">
       <div className="flex items-center justify-between gap-4">
         <h2 className="text-base font-medium text-foreground">
           Agent instructions


### PR DESCRIPTION
## Summary
- Add `bg-card` background color to the agent instructions container on the agent detail page
- Applied to all three states: loading skeleton, empty state, and main instructions view

## Test plan
- [ ] Verify agent detail page instructions section has card background color
- [ ] Check loading state, empty state, and content state all show correct background

🤖 Generated with [Claude Code](https://claude.com/claude-code)