### PR TITLE
feat(web): update connector oauth scopes and add deel pkce support

### DIFF
--- a/turbo/apps/platform/src/views/settings-page/icons/strava.svg
+++ b/turbo/apps/platform/src/views/settings-page/icons/strava.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Strava</title><path fill="#FC4C02" d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.598h4.172L10.463 0l-7 13.828h4.169"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><path d="M41.03 47.852l-5.572-10.976h-8.172L41.03 64l13.736-27.124h-8.18" fill="#f9b797"/><path d="M27.898 21.944l7.564 14.928h11.124L27.898 0 9.234 36.876H20.35" fill="#f05222"/></svg>

--- a/turbo/apps/web/app/api/connectors/[type]/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/callback/__tests__/route.test.ts
@@ -38,8 +38,8 @@ const STRAVA_ATHLETE_URL = "https://www.strava.com/api/v3/athlete";
 const GARMIN_TOKEN_URL =
   "https://diauth.garmin.com/di-oauth2-service/oauth/token";
 const GARMIN_USER_ID_URL = "https://apis.garmin.com/wellness-api/rest/user/id";
-const DEEL_TOKEN_URL = "https://app.deel.com/oauth/token";
-const DEEL_LEGAL_ENTITIES_URL = "https://api.deel.com/rest/v2/legal-entities";
+const DEEL_TOKEN_URL = "https://app.deel.com/oauth2/tokens";
+const DEEL_PEOPLE_ME_URL = "https://api.letsdeel.com/rest/v2/people/me";
 const MERCURY_TOKEN_URL = "https://oauth2.mercury.com/oauth2/token";
 const MERCURY_ACCOUNTS_URL = "https://api.mercury.com/api/v1/accounts";
 
@@ -490,20 +490,19 @@ function createDeelOAuthMock(options: {
         token_type: "Bearer",
       });
     }),
-    userInfo: http.get(DEEL_LEGAL_ENTITIES_URL, () => {
+    userInfo: http.get(DEEL_PEOPLE_ME_URL, () => {
       if (options.userError) {
         return HttpResponse.json({ error: "unauthorized" }, { status: 401 });
       }
       return HttpResponse.json({
-        data: [
-          {
-            id: options.entityId ?? "deel-entity-123",
-            legal_name:
-              options.legalName !== undefined
-                ? options.legalName
-                : "Deel Test Org",
-          },
-        ],
+        data: {
+          id: options.entityId ?? "deel-entity-123",
+          full_name:
+            options.legalName !== undefined
+              ? options.legalName
+              : "Deel Test Org",
+          emails: [{ type: "work", value: "test@deel.com" }],
+        },
       });
     }),
   });

--- a/turbo/apps/web/app/api/cron/cleanup-compose-jobs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-compose-jobs/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import { testContext } from "../../../../../src/__tests__/test-helpers";
 import {
   createTestComposeJob,
   findTestComposeJob,
+  deleteStaleTestComposeJobs,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { reloadEnv } from "../../../../../src/env";
 
@@ -21,10 +22,15 @@ function cronRequest(secret?: string) {
 }
 
 describe("GET /api/cron/cleanup-compose-jobs", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     context.setupMocks();
     vi.stubEnv("CRON_SECRET", "test-cron-secret");
     reloadEnv();
+
+    // Clean up stale compose jobs from other tests to ensure isolation.
+    // The cron route queries all pending/running jobs globally, so leftover
+    // data from other test suites would cause incorrect counts.
+    await deleteStaleTestComposeJobs();
   });
 
   it("should return 401 with invalid cron secret", async () => {

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -23,8 +23,9 @@ import { slackInstallations } from "../db/schema/slack-installation";
 import { slackThreadSessions } from "../db/schema/slack-thread-session";
 import { emailThreadSessions } from "../db/schema/email-thread-session";
 import { agentRunCallbacks } from "../db/schema/agent-run-callback";
-import { and, eq, like } from "drizzle-orm";
+import { and, eq, inArray, like } from "drizzle-orm";
 import { generateCallbackSecret } from "../lib/callback/hmac";
+import { initServices } from "../lib/init-services";
 import { encryptSecrets } from "../lib/crypto/secrets-encryption";
 import type { StoredExecutionContext } from "@vm0/core";
 
@@ -1526,6 +1527,18 @@ export async function findTestComposeJob(
     .from(composeJobs)
     .where(eq(composeJobs.id, jobId));
   return row;
+}
+
+/**
+ * Delete all pending and running compose jobs.
+ * Used by cleanup cron tests to ensure test isolation, since the cron
+ * route queries all jobs globally regardless of user.
+ */
+export async function deleteStaleTestComposeJobs(): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .delete(composeJobs)
+    .where(inArray(composeJobs.status, ["pending", "running"]));
 }
 
 /**

--- a/turbo/apps/web/src/lib/connector/providers/deel-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/deel-handler.ts
@@ -7,12 +7,16 @@ import {
 
 export const deelHandler: ProviderHandler = {
   buildAuthUrl: buildDeelAuthorizationUrl,
-  async exchangeCode(clientId, clientSecret, code, redirectUri) {
+  async exchangeCode(clientId, clientSecret, code, redirectUri, state) {
+    if (!state) {
+      throw new Error("Deel PKCE requires state for code_verifier derivation");
+    }
     const result = await exchangeDeelCode(
       clientId,
       clientSecret,
       code,
       redirectUri,
+      state,
     );
     return {
       accessToken: result.accessToken,

--- a/turbo/apps/web/src/lib/connector/providers/deel.ts
+++ b/turbo/apps/web/src/lib/connector/providers/deel.ts
@@ -1,7 +1,7 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
 
-const DEEL_LEGAL_ENTITIES_URL = "https://api.deel.com/rest/v2/legal-entities";
+const DEEL_PEOPLE_ME_URL = "https://api.letsdeel.com/rest/v2/people/me";
 
 interface DeelUserInfo {
   id: string;
@@ -18,51 +18,94 @@ interface DeelTokenResult {
 }
 
 /**
- * Build Deel OAuth authorization URL.
+ * Derive a PKCE code_verifier deterministically from the OAuth state.
  */
-export function buildDeelAuthorizationUrl(
+async function deriveCodeVerifier(state: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(state + ":deel-pkce-verifier");
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return base64UrlEncode(new Uint8Array(hash));
+}
+
+/**
+ * Compute the PKCE code_challenge from a code_verifier using S256.
+ */
+async function computeCodeChallenge(codeVerifier: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(codeVerifier);
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return base64UrlEncode(new Uint8Array(hash));
+}
+
+/**
+ * Base64url encode a byte array (RFC 7636).
+ */
+function base64UrlEncode(bytes: Uint8Array): string {
+  const binString = Array.from(bytes, (b) => String.fromCharCode(b)).join("");
+  return btoa(binString)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Build Deel OAuth authorization URL with PKCE code_challenge.
+ */
+export async function buildDeelAuthorizationUrl(
   clientId: string,
   redirectUri: string,
   state: string,
-): string {
+): Promise<string> {
   const oauthConfig = getConnectorOAuthConfig("deel");
   if (!oauthConfig) {
     throw new Error("Deel OAuth config not found");
   }
 
+  const codeVerifier = await deriveCodeVerifier(state);
+  const codeChallenge = await computeCodeChallenge(codeVerifier);
+
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
+    scope: oauthConfig.scopes.join(" "),
     state,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
   });
 
   return `${oauthConfig.authorizationUrl}?${params.toString()}`;
 }
 
 /**
- * Exchange authorization code for access token and user info.
+ * Exchange authorization code for access token and user info with PKCE code_verifier.
  */
 export async function exchangeDeelCode(
   clientId: string,
   clientSecret: string,
   code: string,
   redirectUri: string,
+  state: string,
 ): Promise<DeelTokenResult> {
   const oauthConfig = getConnectorOAuthConfig("deel");
   if (!oauthConfig) {
     throw new Error("Deel OAuth config not found");
   }
 
+  const codeVerifier = await deriveCodeVerifier(state);
+  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
+    "base64",
+  );
+
   const response = await fetch(oauthConfig.tokenUrl, {
     method: "POST",
     headers: {
+      Authorization: `Basic ${credentials}`,
       "Content-Type": "application/x-www-form-urlencoded",
     },
     body: new URLSearchParams({
-      client_id: clientId,
-      client_secret: clientSecret,
       code,
+      code_verifier: codeVerifier,
       redirect_uri: redirectUri,
       grant_type: "authorization_code",
     }),
@@ -91,7 +134,7 @@ export async function exchangeDeelCode(
     throw new Error("No access token in Deel response");
   }
 
-  const userInfo = await fetchDeelUserInfo(data.access_token);
+  const userInfo = await fetchDeelUserInfo(clientId, data.access_token);
 
   return {
     accessToken: data.access_token,
@@ -103,15 +146,18 @@ export async function exchangeDeelCode(
 }
 
 /**
- * Fetch Deel user info using the legal-entities endpoint.
- * Deel does not expose a /me endpoint, so we use legal-entities
- * as a lightweight way to identify the connected organization.
+ * Fetch the current Deel user's personal profile via /rest/v2/people/me.
+ * Requires the people:read scope.
  */
-async function fetchDeelUserInfo(accessToken: string): Promise<DeelUserInfo> {
-  const response = await fetch(DEEL_LEGAL_ENTITIES_URL, {
+async function fetchDeelUserInfo(
+  clientId: string,
+  accessToken: string,
+): Promise<DeelUserInfo> {
+  const response = await fetch(DEEL_PEOPLE_ME_URL, {
     method: "GET",
     headers: {
       Authorization: `Bearer ${accessToken}`,
+      "x-client-id": clientId,
       Accept: "application/json",
     },
   });
@@ -123,22 +169,37 @@ async function fetchDeelUserInfo(accessToken: string): Promise<DeelUserInfo> {
   const data = z
     .object({
       data: z
-        .array(
-          z.object({
-            id: z.string().optional(),
-            legal_name: z.string().nullable().optional(),
-          }),
-        )
+        .object({
+          id: z.string().optional(),
+          full_name: z.string().nullable().optional(),
+          first_name: z.string().nullable().optional(),
+          last_name: z.string().nullable().optional(),
+          emails: z
+            .array(
+              z.object({
+                type: z.string().optional(),
+                value: z.string().nullable().optional(),
+              }),
+            )
+            .optional(),
+        })
+        .passthrough()
         .optional(),
     })
+    .passthrough()
     .parse(await response.json());
 
-  const entity = data.data?.[0];
+  const person = data.data;
+  const name =
+    person?.full_name ??
+    [person?.first_name, person?.last_name].filter(Boolean).join(" ") ??
+    null;
+  const email = person?.emails?.[0]?.value ?? null;
 
   return {
-    id: entity?.id ?? "",
-    username: entity?.legal_name ?? null,
-    email: null,
+    id: person?.id ?? "",
+    username: name || null,
+    email,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/figma.ts
+++ b/turbo/apps/web/src/lib/connector/providers/figma.ts
@@ -101,7 +101,7 @@ export async function exchangeFigmaCode(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in,
-    scopes: ["files:read"],
+    scopes: ["file_content:read"],
     userInfo,
   };
 }

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -402,9 +402,18 @@ export const CONNECTOR_TYPES = {
       DEEL_TOKEN: "$secrets.DEEL_ACCESS_TOKEN",
     } as Record<string, string>,
     oauth: {
-      authorizationUrl: "https://app.deel.com/oauth/authorize",
-      tokenUrl: "https://app.deel.com/oauth/token",
-      scopes: [],
+      authorizationUrl: "https://app.deel.com/oauth2/authorize",
+      tokenUrl: "https://app.deel.com/oauth2/tokens",
+      scopes: [
+        "contracts:read",
+        "people:read",
+        "organizations:read",
+        "payslips:read",
+        "time-off:read",
+        "time-off:write",
+        "invoice-adjustments:read",
+        "invoice-adjustments:write",
+      ],
     } as ConnectorOAuthConfig,
   },
   figma: {
@@ -433,7 +442,17 @@ export const CONNECTOR_TYPES = {
     oauth: {
       authorizationUrl: "https://www.figma.com/oauth",
       tokenUrl: "https://api.figma.com/v1/oauth/token",
-      scopes: ["files:read"],
+      scopes: [
+        "current_user:read",
+        "file_content:read",
+        "file_metadata:read",
+        "file_versions:read",
+        "projects:read",
+        "file_comments:read",
+        "file_comments:write",
+        "library_assets:read",
+        "library_content:read",
+      ],
     } as ConnectorOAuthConfig,
   },
   mercury: {
@@ -493,7 +512,12 @@ export const CONNECTOR_TYPES = {
     oauth: {
       authorizationUrl: "https://www.strava.com/oauth/authorize",
       tokenUrl: "https://www.strava.com/oauth/token",
-      scopes: ["read", "activity:read_all"],
+      scopes: [
+        "read",
+        "profile:read_all",
+        "activity:read_all",
+        "activity:write",
+      ],
     } as ConnectorOAuthConfig,
   },
   "garmin-connect": {


### PR DESCRIPTION
## Summary

- **Deel connector**: Add PKCE (S256) flow for OAuth, switch authorization/token URLs to the correct `/oauth2/` endpoints, use Basic auth for token exchange, and replace the legal-entities endpoint with `/rest/v2/people/me` for user info retrieval
- **Figma connector**: Fix scope from `files:read` to `file_content:read` and expand scopes to include metadata, versions, projects, comments, and library access
- **Strava connector**: Expand OAuth scopes to include `profile:read_all` and `activity:write`, and update the SVG icon
- **Connector config**: Update OAuth URLs and scope definitions in `CONNECTOR_TYPES` for Deel, Figma, and Strava

## Test plan

- [ ] Verify Deel OAuth flow completes successfully with PKCE challenge/verifier
- [ ] Verify Deel user info is correctly fetched from `/rest/v2/people/me`
- [ ] Verify Figma OAuth flow works with updated scopes
- [ ] Verify Strava OAuth flow works with expanded scopes
- [ ] Confirm the Strava icon renders correctly in the settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)