### PR TITLE
ci: add ansible provision playbook for metal host dependencies

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -174,6 +174,19 @@ jobs:
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
           TARGET_DIR="crates/target/aarch64-unknown-linux-musl/release"
 
+          # Provision system dependencies (idempotent)
+          echo "=== Provisioning system dependencies ==="
+          apt-get update && apt-get install -y python3 python3-pip
+          pip3 install ansible
+          cd ansible
+          ansible-playbook \
+            -i "${HOST}," \
+            playbooks/provision-metal.yml \
+            --private-key $HOME/.ssh/runner.pem \
+            -e "ansible_user=${METAL_USER}" \
+            -v
+          cd ..
+
           # Clean previous run artifacts and upload runner (guests are embedded)
           echo "=== Deploying runner to ${HOST}:${BIN_DIR} ==="
           ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} ~/.vm0-runner/runners/${JOB_REF}-bench ~/.vm0-runner/runners/${JOB_REF}-local && mkdir -p ${BIN_DIR}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -593,6 +593,12 @@ jobs:
           cd ansible
           ansible-playbook \
             -i "${AWS_METAL_RUNNER_HOSTS}," \
+            playbooks/provision-metal.yml \
+            --private-key ~/.ssh/prod-runner.pem \
+            -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
+            -v
+          ansible-playbook \
+            -i "${AWS_METAL_RUNNER_HOSTS}," \
             playbooks/deploy-runner.yml \
             --private-key ~/.ssh/prod-runner.pem \
             -e "ansible_user=${AWS_METAL_RUNNER_USER}" \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1089,6 +1089,19 @@ jobs:
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
           TARGET_DIR="crates/target/aarch64-unknown-linux-musl/release"
 
+          # Provision system dependencies on all hosts (idempotent)
+          echo "=== Provisioning system dependencies ==="
+          apt-get update && apt-get install -y python3 python3-pip
+          pip3 install ansible
+          cd ansible
+          ansible-playbook \
+            -i "${METAL_HOSTS}," \
+            playbooks/provision-metal.yml \
+            --private-key $HOME/.ssh/runner.pem \
+            -e "ansible_user=${METAL_USER}" \
+            -v
+          cd ..
+
           deploy_to_host() {
             local HOST=$1
             local HOST_INDEX=$2

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -87,13 +87,6 @@
     - name: Download dependencies (Firecracker, kernel, mitmproxy)
       command: "{{ bin_dir }}/runner setup"
 
-    - name: Ensure kvm group membership
-      user:
-        name: "{{ ansible_user }}"
-        groups: kvm
-        append: true
-      become: true
-
     - name: Build rootfs and snapshot
       command: >
         {{ bin_dir }}/runner build

--- a/ansible/playbooks/provision-metal.yml
+++ b/ansible/playbooks/provision-metal.yml
@@ -1,0 +1,52 @@
+# Provision Metal Host Dependencies
+#
+# Idempotent playbook that installs all system-level dependencies required by
+# the VM0 runner on bare-metal hosts. Safe to run repeatedly — all tasks use
+# idempotent operations (apt state=present, group append, chmod).
+#
+# Usage:
+#   ansible-playbook -i "host1,host2," playbooks/provision-metal.yml \
+#     -e "ansible_user=ubuntu"
+
+- name: Provision metal host dependencies
+  hosts: all
+
+  tasks:
+    - name: Install system packages
+      apt:
+        name:
+          - squashfs-tools
+          - e2fsprogs
+          - openssl
+          - iproute2
+          - iptables
+          - procps
+        state: present
+        update_cache: true
+      become: true
+
+    - name: Check if Docker is installed
+      command: docker --version
+      register: docker_check
+      changed_when: false
+      failed_when: false
+
+    - name: Install Docker
+      shell: curl -fsSL https://get.docker.com | sh
+      when: docker_check.rc != 0
+      become: true
+
+    - name: Add user to docker and kvm groups
+      user:
+        name: "{{ ansible_user }}"
+        groups:
+          - docker
+          - kvm
+        append: true
+      become: true
+
+    - name: Ensure /dev/kvm is accessible
+      file:
+        path: /dev/kvm
+        mode: '0666'
+      become: true


### PR DESCRIPTION
## Summary

- Add `ansible/playbooks/provision-metal.yml` — idempotent playbook that installs all system-level dependencies on metal hosts (Docker, squashfs-tools, e2fsprogs, openssl, iproute2, iptables, procps, kvm/docker groups, /dev/kvm permissions)
- Remove duplicate "Ensure kvm group membership" task from `deploy-runner.yml` (now handled by provision playbook)
- Run provision playbook before deploy in all three CI workflows: `release-please.yml`, `crates.yml`, `turbo.yml`

## Context

PR #3310 removed the old TS runner which included `install-firecracker.sh` for system-level setup. The new Rust runner's `runner setup` only downloads Firecracker/kernel/mitmdump but doesn't install system packages or configure device permissions. Fresh/re-provisioned hosts fail because dependencies are missing.

## Test plan

- [ ] Verify provision playbook is idempotent (all tasks use apt `state=present`, group `append`, chmod)
- [ ] Verify all three CI workflows run provision before deploy
- [ ] Verify `/dev/kvm` is accessible without sudo after provision
- [ ] Verify no duplicate kvm tasks between playbooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)