### PR TITLE
feat(docs): remove remaining public api v1 references

### DIFF
--- a/turbo/apps/docs/content/docs/index.mdx
+++ b/turbo/apps/docs/content/docs/index.mdx
@@ -200,37 +200,3 @@ Welcome to VM0 documentation. Get started with building AI agents.
   />
 </Cards>
 
-### API Reference
-
-<Cards>
-  <Card
-    title="Overview"
-    href="/docs/reference/api"
-    description="API introduction, authentication, errors, and pagination"
-  />
-  <Card
-    title="Agents"
-    href="/docs/reference/api/agents"
-    description="Agent management endpoints"
-  />
-  <Card
-    title="Artifacts"
-    href="/docs/reference/api/artifacts"
-    description="Output storage management endpoints"
-  />
-  <Card
-    title="Runs"
-    href="/docs/reference/api/runs"
-    description="Agent execution and monitoring endpoints"
-  />
-  <Card
-    title="Tokens"
-    href="/docs/reference/api/tokens"
-    description="API token management endpoints"
-  />
-  <Card
-    title="Volumes"
-    href="/docs/reference/api/volumes"
-    description="Input storage management endpoints"
-  />
-</Cards>

--- a/turbo/apps/docs/content/docs/usage/run-agent.mdx
+++ b/turbo/apps/docs/content/docs/usage/run-agent.mdx
@@ -131,7 +131,7 @@ vm0 run resume 61cddb1f-b83a-4b89-8785-97df099fe61f "try different approach"
 
 <Accordion title="How do I list all my previous runs?">
 
-You can list your runs using the CLI or the web dashboard:
+You can list your runs using the CLI:
 
 1. **List recent runs** with the CLI:
    ```bash

--- a/turbo/apps/docs/content/docs/usage/run-agent.mdx
+++ b/turbo/apps/docs/content/docs/usage/run-agent.mdx
@@ -131,17 +131,16 @@ vm0 run resume 61cddb1f-b83a-4b89-8785-97df099fe61f "try different approach"
 
 <Accordion title="How do I list all my previous runs?">
 
-Currently, there's no dedicated CLI command to list runs. However, you can:
+You can list your runs using the CLI or the web dashboard:
 
-1. **Check your artifacts** to see what agents have produced:
+1. **List recent runs** with the CLI:
    ```bash
-   vm0 artifact list
+   vm0 run list
    ```
 
-2. **Use the API** to query runs:
+2. **Check your artifacts** to see what agents have produced:
    ```bash
-   curl -H "Authorization: Bearer $VM0_TOKEN" \
-     https://api.vm0.ai/v1/runs
+   vm0 artifact list
    ```
 
 3. **View in the web dashboard** at [vm0.ai](https://vm0.ai)
@@ -160,13 +159,6 @@ The Run ID will be displayed immediately. You can then check the logs later:
 
 ```bash
 vm0 logs 11007483-20b2-42b1-8f2a-b42a10186810
-```
-
-Or use the API to check the run status:
-
-```bash
-curl -H "Authorization: Bearer $VM0_TOKEN" \
-  https://api.vm0.ai/v1/runs/11007483-20b2-42b1-8f2a-b42a10186810
 ```
 
 </Accordion>

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -470,7 +470,7 @@ async function markRunFailed(
  * Unified run creation pipeline
  *
  * Validates, creates, and dispatches a run in a single call.
- * All callers (API Route, Public API, Schedule, Slack) should use this.
+ * All callers (API Route, Schedule, Slack) should use this.
  *
  * Pipeline:
  * 1. Check concurrent run limit

--- a/turbo/apps/web/src/lib/s3/s3-client.ts
+++ b/turbo/apps/web/src/lib/s3/s3-client.ts
@@ -37,7 +37,7 @@ function getS3Client(): S3Client {
 
 /**
  * Get S3 client for generating presigned URLs consumed by external clients
- * (CLI, browsers, public API). Uses S3_PUBLIC_ENDPOINT so the resulting URLs
+ * (CLI, browsers). Uses S3_PUBLIC_ENDPOINT so the resulting URLs
  * are reachable from outside the Docker network. Falls back to the internal
  * endpoint when S3_PUBLIC_ENDPOINT is not set (e.g. SaaS / R2).
  */


### PR DESCRIPTION
## Summary

- Remove dead API Reference card links (6 cards) from docs homepage (`index.mdx`)
- Replace V1 API curl examples in FAQ with `vm0 run list` CLI alternative (`run-agent.mdx`)
- Update stale code comments referencing "Public API" as a caller (`run-service.ts`, `s3-client.ts`)

This PR uses `feat(docs):` prefix to trigger docs release-please, which will also remove the old API V1 pages (deleted in #3393 but not yet deployed) from the live docs site.

Closes #3468

## Test plan

- [x] `pnpm format` — no changes needed
- [x] `pnpm turbo run lint` — 0 errors
- [x] `pnpm knip` — no issues found
- [ ] Verify docs homepage no longer shows API Reference section after deployment
- [ ] Verify FAQ curl examples are replaced with CLI commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)