### PR TITLE
test(e2e): add playwright sign-in flow test

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -769,6 +769,14 @@ jobs:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
+      - name: Verify sign-in flow
+        run: cd e2e && npx playwright test sign-in.spec.ts
+        env:
+          VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
+          CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
   # Run API E2E tests (lightweight, fast)
   api-e2e-test:
     runs-on: ubuntu-latest

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,8 @@
+import { clerkSetup } from "@clerk/testing/playwright";
+import * as dotenv from "dotenv";
+
+dotenv.config({ path: ".env.local" });
+
+export default async function globalSetup() {
+  await clerkSetup();
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,12 +8,15 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "auth": "tsx cli-auth-automation.ts"
+    "auth": "tsx cli-auth-automation.ts",
+    "sign-in": "npx playwright test sign-in.spec.ts"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@clerk/testing": "^1.14.3",
+    "@playwright/test": "^1.58.2",
     "@types/node": "^25.3.3",
     "dotenv": "^17.3.1",
     "playwright": "^1.58.2"

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: "*.spec.ts",
+  globalSetup: "./global-setup.ts",
+  workers: 1,
+  timeout: 60_000,
+  use: {
+    baseURL: process.env.VM0_API_URL ?? "http://localhost:3000",
+  },
+});

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@clerk/testing':
+        specifier: ^1.14.3
+        version: 1.14.3(@playwright/test@1.58.2)(react@19.2.4)
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@types/node':
         specifier: ^25.3.3
         version: 25.3.3
@@ -23,6 +29,38 @@ importers:
         version: 4.21.0
 
 packages:
+
+  '@clerk/backend@2.33.0':
+    resolution: {integrity: sha512-sVR214TlJ5vsRprDE9EiZpqeNq/YVhCQLtAZ19ugjNf1C9xMX28JoMyodI/dU5FLBelmgSyjBAjodPULjIeF+w==}
+    engines: {node: '>=18.17.0'}
+
+  '@clerk/shared@3.47.2':
+    resolution: {integrity: sha512-dwUT27DKq3Gr9vn9lAfc/LSe79P1rKIib8/mTWA7ZEzY7XX2Yq5UnDMCMznYrI8oVLdJrCT4ypFXRgnH306Oew==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@clerk/testing@1.14.3':
+    resolution: {integrity: sha512-2yOLWq5RnfN9/c5jnMmGxi55BDEtU1WnFMa7wBnAGSimLICaE2MZ4nhejgLT5SEjwL7LJpp+8GVeqW8ywR9JEQ==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      '@playwright/test': ^1
+      cypress: ^13 || ^14
+    peerDependenciesMeta:
+      '@playwright/test':
+        optional: true
+      cypress:
+        optional: true
+
+  '@clerk/types@4.101.20':
+    resolution: {integrity: sha512-MHvr1tGL5lwxD6zdzzixkHICbbZz/S1LChONKR52Qeu0yRGChZomPknsgqBMG9J3yNeyhaj0SWa5phQgQUk0lg==}
+    engines: {node: '>=18.17.0'}
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -180,8 +218,27 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@types/node@25.3.3':
     resolution: {integrity: sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==}
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  dotenv@17.2.2:
+    resolution: {integrity: sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==}
+    engines: {node: '>=12'}
 
   dotenv@17.3.1:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
@@ -191,6 +248,9 @@ packages:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -205,6 +265,13 @@ packages:
   get-tsconfig@4.13.1:
     resolution: {integrity: sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==}
 
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
+
   playwright-core@1.58.2:
     resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
     engines: {node: '>=18'}
@@ -215,8 +282,26 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  swr@2.3.4:
+    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -226,7 +311,52 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
 snapshots:
+
+  '@clerk/backend@2.33.0(react@19.2.4)':
+    dependencies:
+      '@clerk/shared': 3.47.2(react@19.2.4)
+      '@clerk/types': 4.101.20(react@19.2.4)
+      standardwebhooks: 1.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@clerk/shared@3.47.2(react@19.2.4)':
+    dependencies:
+      csstype: 3.1.3
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.10.0
+      swr: 2.3.4(react@19.2.4)
+    optionalDependencies:
+      react: 19.2.4
+
+  '@clerk/testing@1.14.3(@playwright/test@1.58.2)(react@19.2.4)':
+    dependencies:
+      '@clerk/backend': 2.33.0(react@19.2.4)
+      '@clerk/shared': 3.47.2(react@19.2.4)
+      '@clerk/types': 4.101.20(react@19.2.4)
+      dotenv: 17.2.2
+    optionalDependencies:
+      '@playwright/test': 1.58.2
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@clerk/types@4.101.20(react@19.2.4)':
+    dependencies:
+      '@clerk/shared': 3.47.2(react@19.2.4)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
@@ -306,9 +436,21 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
+
+  '@stablelib/base64@1.0.1': {}
+
   '@types/node@25.3.3':
     dependencies:
       undici-types: 7.18.2
+
+  csstype@3.1.3: {}
+
+  dequal@2.0.3: {}
+
+  dotenv@17.2.2: {}
 
   dotenv@17.3.1: {}
 
@@ -341,6 +483,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
 
+  fast-sha256@1.3.0: {}
+
   fsevents@2.3.2:
     optional: true
 
@@ -351,6 +495,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  glob-to-regexp@0.4.1: {}
+
+  js-cookie@3.0.5: {}
+
   playwright-core@1.58.2: {}
 
   playwright@1.58.2:
@@ -359,7 +507,24 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  react@19.2.4: {}
+
   resolve-pkg-maps@1.0.0: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
+  std-env@3.10.0: {}
+
+  swr@2.3.4(react@19.2.4):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:
@@ -369,3 +534,7 @@ snapshots:
       fsevents: 2.3.3
 
   undici-types@7.18.2: {}
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4

--- a/e2e/sign-in.spec.ts
+++ b/e2e/sign-in.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+
+const TEST_EMAIL = "e2e+clerk_test@vm0.ai";
+const TEST_OTP = "424242";
+
+test("sign-up flow and post-auth landing page", async ({ page, baseURL }) => {
+  await setupClerkTestingToken({ page });
+
+  // Handle Vercel protection bypass if needed
+  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (bypassSecret) {
+    await page.goto(
+      `${baseURL}?x-vercel-set-bypass-cookie=samesitenone&x-vercel-protection-bypass=${bypassSecret}`
+    );
+  }
+
+  // Navigate to landing page
+  await page.goto("/");
+  await page.waitForLoadState("domcontentloaded");
+
+  // Click the sign-up button in the navbar.
+  // This verifies the link goes to /sign-up (not /en/sign-up which would 404).
+  const signUpLink = page.locator("a.btn-get-access[href='/sign-up']");
+  await signUpLink.waitFor({ state: "visible", timeout: 10_000 });
+  await signUpLink.click();
+
+  // Verify we landed on /sign-up (not a locale-prefixed path)
+  await page.waitForURL("**/sign-up**");
+  expect(new URL(page.url()).pathname).toBe("/sign-up");
+
+  // The sign-up page renders Clerk's <SignUp> component.
+  // Since the test account already exists, click "Sign in" to switch to sign-in flow.
+  const signInLink = page.locator('a:has-text("Sign in")');
+  await signInLink.waitFor({ state: "visible", timeout: 10_000 });
+  await signInLink.click();
+  await page.waitForURL("**/sign-in**");
+
+  // Complete Clerk sign-in via UI
+  const emailInput = page.locator('input[name="identifier"]');
+  await emailInput.waitFor({ state: "visible", timeout: 10_000 });
+  await emailInput.fill(TEST_EMAIL);
+
+  await page.locator(".cl-formButtonPrimary").click();
+
+  // Switch to email code method
+  const useAnotherMethod = page.locator(
+    'a:has-text("Use another method"), button:has-text("Use another method")'
+  );
+  await useAnotherMethod.waitFor({ state: "visible", timeout: 10_000 });
+  await useAnotherMethod.click();
+
+  const emailCodeOption = page.locator('button:has-text("Email code")');
+  await emailCodeOption.waitFor({ state: "visible", timeout: 10_000 });
+  await emailCodeOption.click();
+
+  // Enter OTP
+  const otpInput = page.locator('input[data-input-otp="true"]');
+  await otpInput.waitFor({ state: "attached", timeout: 10_000 });
+  await page.waitForTimeout(2_000);
+  await otpInput.focus();
+  await page.keyboard.type(TEST_OTP);
+
+  // Wait for redirect away from /sign-in back to landing page
+  await page.waitForURL(
+    (url) =>
+      !url.pathname.includes("/sign-in") &&
+      !url.pathname.includes("/sign-up"),
+    { timeout: 15_000 }
+  );
+  expect(page.url()).not.toContain("/404");
+
+  // Verify post-auth state: "Platform" button visible in navbar
+  const platformButton = page.locator("a.btn-get-access:has-text('Platform')");
+  await platformButton.waitFor({ state: "visible", timeout: 10_000 });
+
+  // Verify Platform button opens new tab to platform URL
+  const [newPage] = await Promise.all([
+    page.context().waitForEvent("page"),
+    platformButton.click(),
+  ]);
+  await newPage.waitForLoadState("domcontentloaded");
+  expect(newPage.url()).toContain("platform");
+  await newPage.close();
+
+  // Sign out (cleanup) — target the desktop nav button specifically
+  const signOutButton = page.locator('button.btn-try-demo:has-text("Sign out")');
+  await signOutButton.waitFor({ state: "visible", timeout: 10_000 });
+  await signOutButton.click();
+
+  // Verify we're signed out: sign-up button reappears
+  await signUpLink.waitFor({ state: "visible", timeout: 10_000 });
+});

--- a/turbo/apps/web/src/env.ts
+++ b/turbo/apps/web/src/env.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 /**
  * Whether Clerk authentication is configured.
  *
+ *
  * Derived from the presence of NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY.
  * When false, the app falls back to single-user local auth.
  *


### PR DESCRIPTION
## Summary

- Add Playwright E2E test that verifies the full sign-up → sign-in → post-auth landing page flow
- Catches locale prefix regressions (e.g. `/en/sign-up` → 404, as in #3390)
- Test clicks navbar sign-up link, verifies URL is `/sign-up`, completes Clerk OTP sign-in, asserts Platform button and sign-out work
- Runs in the existing `e2e-auth` CI job after the device flow test

## Test plan

- [x] `VM0_API_URL=http://localhost:3000 pnpm sign-in` passes locally
- [ ] `e2e-auth` job passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)