### PR TITLE
refactor: consolidate connector feature flags into core package

### DIFF
--- a/turbo/apps/cli/src/commands/connector/list.ts
+++ b/turbo/apps/cli/src/commands/connector/list.ts
@@ -1,6 +1,11 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { CONNECTOR_TYPES } from "@vm0/core";
+import {
+  CONNECTOR_TYPES,
+  CONNECTOR_FEATURE_FLAGS,
+  isFeatureEnabled,
+  type ConnectorType,
+} from "@vm0/core";
 import { listConnectors } from "../../lib/api";
 import { withErrorHandler } from "../../lib/command";
 
@@ -13,9 +18,15 @@ export const listCommand = new Command()
       const result = await listConnectors();
       const connectedMap = new Map(result.connectors.map((c) => [c.type, c]));
 
-      const allTypes = Object.keys(CONNECTOR_TYPES) as Array<
-        keyof typeof CONNECTOR_TYPES
-      >;
+      const allTypesRaw = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+      const allTypes: ConnectorType[] = [];
+      for (const type of allTypesRaw) {
+        const flag = CONNECTOR_FEATURE_FLAGS[type];
+        if (flag && !(await isFeatureEnabled(flag))) {
+          continue;
+        }
+        allTypes.push(type);
+      }
 
       // Calculate column widths
       const typeWidth = Math.max(4, ...allTypes.map((t) => t.length));

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -101,8 +101,8 @@ export const bootstrap$ = command(
     set(setRootSignal$, signal);
 
     set(setupLoggers$);
-    set(setupGlobalMethod$, signal).catch(() => {
-      // Global method setup runs in background, errors are non-fatal
+    const globalMethodDone = set(setupGlobalMethod$, signal).catch(() => {
+      // Global method setup errors are non-fatal
     });
 
     render();
@@ -112,6 +112,8 @@ export const bootstrap$ = command(
 
     await set(setupRoutes$, signal);
     signal.throwIfAborted();
+
+    await globalMethodDone;
   },
 );
 

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -1,6 +1,6 @@
 import { command, computed, state } from "ccstate";
 import { logger } from "../log";
-import { FeatureSwitchKey, isFeatureEnabled } from "@vm0/core";
+import { FeatureSwitchKey, getAllFeatureStates } from "@vm0/core";
 import { localStorageSignals } from "./local-storage";
 import { throwIfAbort } from "../utils";
 import { user$ } from "../auth";
@@ -18,10 +18,7 @@ export const featureSwitch$ = computed(async (get) => {
   const user = await get(user$);
   const userId = user?.id;
 
-  const result: Partial<Record<FeatureSwitchKey, boolean>> = {};
-  for (const key of Object.values(FeatureSwitchKey)) {
-    result[key] = Boolean(await isFeatureEnabled(key, userId));
-  }
+  const result = await getAllFeatureStates(userId);
 
   const override = get(get$);
   if (!override) {

--- a/turbo/apps/platform/src/signals/settings-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/settings-page/connectors.ts
@@ -2,7 +2,7 @@ import { command, computed, state } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   CONNECTOR_TYPES,
-  FeatureSwitchKey,
+  CONNECTOR_FEATURE_FLAGS,
   type ConnectorType,
   type ConnectorResponse,
 } from "@vm0/core";
@@ -31,27 +31,6 @@ export interface ConnectorTypeWithStatus {
   connector: ConnectorResponse | null;
 }
 
-/**
- * Maps connector types that are gated behind a feature flag to their
- * corresponding feature switch key.  Connectors not listed here are
- * always visible.
- */
-const CONNECTOR_FEATURE_FLAGS = Object.freeze<
-  Partial<Record<ConnectorType, FeatureSwitchKey>>
->({
-  computer: FeatureSwitchKey.ComputerConnector,
-  deel: FeatureSwitchKey.DeelConnector,
-  docusign: FeatureSwitchKey.DocuSignConnector,
-  dropbox: FeatureSwitchKey.DropboxConnector,
-  figma: FeatureSwitchKey.FigmaConnector,
-  gmail: FeatureSwitchKey.GmailConnector,
-  "google-sheets": FeatureSwitchKey.GoogleSheetsConnector,
-  "google-docs": FeatureSwitchKey.GoogleDocsConnector,
-  "google-drive": FeatureSwitchKey.GoogleDriveConnector,
-  strava: FeatureSwitchKey.StravaConnector,
-  "garmin-connect": FeatureSwitchKey.GarminConnectConnector,
-});
-
 export const allConnectorTypes$ = computed(async (get) => {
   const { connectors } = await get(connectors$);
   const connectorMap = new Map(connectors.map((c) => [c.type, c]));
@@ -61,13 +40,6 @@ export const allConnectorTypes$ = computed(async (get) => {
     .filter((type) => {
       const flag = CONNECTOR_FEATURE_FLAGS[type];
       if (flag && !features?.[flag]) {
-        return false;
-      }
-      // Filter mercury connector based on feature flag
-      if (
-        type === "mercury" &&
-        !features?.[FeatureSwitchKey.MercuryConnector]
-      ) {
         return false;
       }
       return true;

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -6,6 +6,7 @@
  */
 
 import { FeatureSwitchKey } from "./feature-switch-key";
+import type { ConnectorType } from "./contracts/connectors";
 
 export interface FeatureSwitch {
   readonly maintainer: string;
@@ -19,6 +20,15 @@ async function sha1(input: string): Promise<string> {
   const hashArray = Array.from(new Uint8Array(hashBuffer));
   return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
 }
+
+const STAFF_USER_HASHES: readonly string[] = [
+  "afc25aa601481d794372ed765038148d3a160e2a",
+  "1e7de00267c699185653df499f68e8383013ca08",
+  "b397fa9b0330b421a5113ac88dd2b01ca2067cfe",
+  "d938bb6e49cb8ccfaa962942d69c9ccd1ee239af",
+  "67a65740246389d7fecf7702f8b7d6914ad38dc5",
+  "55651a8b2c85b35ff0629fa3d4718b9476069d0f",
+];
 
 /**
  * Registry of all feature switches
@@ -51,51 +61,84 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ComputerConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
+    enabledUserHashes: STAFF_USER_HASHES,
   },
   [FeatureSwitchKey.DeelConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
+    enabledUserHashes: STAFF_USER_HASHES,
   },
   [FeatureSwitchKey.DocuSignConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
+    enabledUserHashes: STAFF_USER_HASHES,
   },
   [FeatureSwitchKey.DropboxConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
+    enabledUserHashes: STAFF_USER_HASHES,
   },
   [FeatureSwitchKey.FigmaConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
+    enabledUserHashes: STAFF_USER_HASHES,
   },
   [FeatureSwitchKey.GmailConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
+    enabledUserHashes: STAFF_USER_HASHES,
   },
   [FeatureSwitchKey.GoogleSheetsConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
+    enabledUserHashes: STAFF_USER_HASHES,
   },
   [FeatureSwitchKey.GoogleDocsConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
+    enabledUserHashes: STAFF_USER_HASHES,
   },
   [FeatureSwitchKey.GoogleDriveConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
+    enabledUserHashes: STAFF_USER_HASHES,
   },
   [FeatureSwitchKey.MercuryConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
+    enabledUserHashes: STAFF_USER_HASHES,
   },
   [FeatureSwitchKey.StravaConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
+    enabledUserHashes: STAFF_USER_HASHES,
   },
   [FeatureSwitchKey.GarminConnectConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
+    enabledUserHashes: STAFF_USER_HASHES,
   },
+};
+
+/**
+ * Maps connector types to their feature switch keys.
+ * Connectors not listed here are always visible.
+ */
+export const CONNECTOR_FEATURE_FLAGS: Partial<
+  Record<ConnectorType, FeatureSwitchKey>
+> = {
+  computer: FeatureSwitchKey.ComputerConnector,
+  deel: FeatureSwitchKey.DeelConnector,
+  docusign: FeatureSwitchKey.DocuSignConnector,
+  dropbox: FeatureSwitchKey.DropboxConnector,
+  figma: FeatureSwitchKey.FigmaConnector,
+  gmail: FeatureSwitchKey.GmailConnector,
+  "google-sheets": FeatureSwitchKey.GoogleSheetsConnector,
+  "google-docs": FeatureSwitchKey.GoogleDocsConnector,
+  "google-drive": FeatureSwitchKey.GoogleDriveConnector,
+  mercury: FeatureSwitchKey.MercuryConnector,
+  strava: FeatureSwitchKey.StravaConnector,
+  "garmin-connect": FeatureSwitchKey.GarminConnectConnector,
 };
 
 /**

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -14,11 +14,18 @@ export interface FeatureSwitch {
   readonly enabledUserHashes?: readonly string[];
 }
 
+const sha1Cache = new Map<string, string>();
+
 async function sha1(input: string): Promise<string> {
+  const cached = sha1Cache.get(input);
+  if (cached) return cached;
+
   const data = new TextEncoder().encode(input);
   const hashBuffer = await crypto.subtle.digest("SHA-1", data);
   const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+  const hex = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+  sha1Cache.set(input, hex);
+  return hex;
 }
 
 const STAFF_USER_HASHES: readonly string[] = [
@@ -140,6 +147,35 @@ export const CONNECTOR_FEATURE_FLAGS: Partial<
   strava: FeatureSwitchKey.StravaConnector,
   "garmin-connect": FeatureSwitchKey.GarminConnectConnector,
 };
+
+/**
+ * Evaluate all feature switches at once for the given user.
+ *
+ * Computes the user hash once and checks all switches synchronously,
+ * avoiding per-key async overhead.
+ */
+export async function getAllFeatureStates(
+  userId?: string,
+): Promise<Record<FeatureSwitchKey, boolean>> {
+  const userHash =
+    userId &&
+    Object.values(FEATURE_SWITCHES).some((s) => s.enabledUserHashes?.length)
+      ? await sha1(userId)
+      : undefined;
+
+  const result = {} as Record<FeatureSwitchKey, boolean>;
+  for (const key of Object.values(FeatureSwitchKey)) {
+    const fs = FEATURE_SWITCHES[key];
+    if (fs.enabled) {
+      result[key] = true;
+    } else if (userHash && fs.enabledUserHashes?.length) {
+      result[key] = fs.enabledUserHashes.includes(userHash);
+    } else {
+      result[key] = false;
+    }
+  }
+  return result;
+}
 
 /**
  * Check if a feature is enabled for the given user.


### PR DESCRIPTION
## Summary

- Move `CONNECTOR_FEATURE_FLAGS` map from platform connectors signal into `@vm0/core` feature-switch module so it is shared across CLI and platform
- Add `enabledUserHashes` (staff user hashes) to all gated connector feature switches
- Fix mercury connector filtering to use the shared feature flags map instead of a separate hardcoded check
- Update CLI `connector list` command to filter connectors by feature flag using the shared map

## Test plan

- [ ] Verify `pnpm turbo run lint` passes
- [ ] Verify `pnpm check-types` passes
- [ ] Verify `pnpm vitest` passes
- [ ] Verify connector list in CLI only shows connectors the user has access to
- [ ] Verify platform settings page connector list remains unchanged in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)