### PR TITLE
feat(platform): support cmd+click to open in new tab for all navigation

### DIFF
--- a/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
@@ -16,7 +16,6 @@ import {
   IconEdit,
 } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
-import { navigateInReact$ } from "../../signals/route.ts";
 import { openConfigDialog$ } from "../../signals/agent-detail/config-dialog.ts";
 import { openRunDialog$ } from "../../signals/agent-detail/run-dialog.ts";
 import { runButtonState$ } from "../../signals/agent-detail/inline-run.ts";
@@ -28,6 +27,7 @@ import {
 } from "../../signals/agent-detail/schedule.ts";
 import { AgentAvatar } from "./agent-avatar.tsx";
 import type { AgentDetail } from "../../signals/agent-detail/types.ts";
+import { Link } from "../router/link.tsx";
 
 interface AgentHeaderProps {
   detail: AgentDetail;
@@ -35,7 +35,6 @@ interface AgentHeaderProps {
 }
 
 export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
-  const navigate = useSet(navigateInReact$);
   const openConfig = useSet(openConfigDialog$);
   const openRun = useSet(openRunDialog$);
   const buttonState = useGet(runButtonState$);
@@ -151,43 +150,47 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
             </Tooltip>
           )}
 
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-9 w-9"
-                onClick={() =>
-                  agentName &&
-                  navigate("/agents/:name/connections", {
-                    pathParams: { name: agentName },
-                  })
-                }
-              >
-                <IconPlug size={18} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Connections</TooltipContent>
-          </Tooltip>
+          {agentName && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="h-9 w-9"
+                  asChild
+                >
+                  <Link
+                    pathname="/agents/:name/connections"
+                    options={{ pathParams: { name: agentName } }}
+                  >
+                    <IconPlug size={18} />
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Connections</TooltipContent>
+            </Tooltip>
+          )}
 
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-9 w-9"
-                onClick={() =>
-                  agentName &&
-                  navigate("/agents/:name/logs", {
-                    pathParams: { name: agentName },
-                  })
-                }
-              >
-                <IconList size={18} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Logs</TooltipContent>
-          </Tooltip>
+          {agentName && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="h-9 w-9"
+                  asChild
+                >
+                  <Link
+                    pathname="/agents/:name/logs"
+                    options={{ pathParams: { name: agentName } }}
+                  >
+                    <IconList size={18} />
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Logs</TooltipContent>
+            </Tooltip>
+          )}
         </TooltipProvider>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-logs-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-logs-page.tsx
@@ -1,5 +1,4 @@
 import { useGet, useLoadable, useSet } from "ccstate-react";
-import type { MouseEvent } from "react";
 import {
   Table,
   TableHeader,
@@ -27,8 +26,8 @@ import {
   goBackTwoAgentLogsPages$,
   setAgentLogsRowsPerPage$,
 } from "../../signals/agent-detail/agent-logs.ts";
-import { navigateInReact$ } from "../../signals/route.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import { useNavigationHandler } from "../router/link.tsx";
 import { AgentAvatar } from "./agent-avatar.tsx";
 import type { AgentDetail } from "../../signals/agent-detail/types.ts";
 import type { LogEntry } from "../../signals/logs-page/types.ts";
@@ -100,18 +99,11 @@ interface AgentLogsTableRowProps {
 }
 
 function AgentLogsTableRow({ entry }: AgentLogsTableRowProps) {
-  const navigate = useSet(navigateInReact$);
   const agentName = useGet(agentName$);
-
-  const handleRowClick = (event: MouseEvent<HTMLTableRowElement>) => {
-    if (event.metaKey || event.ctrlKey) {
-      window.open(`/agents/${agentName}/logs/${entry.id}`, "_blank");
-      return;
-    }
-    navigate("/agents/:name/logs/:id", {
-      pathParams: { name: agentName ?? "", id: entry.id },
-    });
-  };
+  const { onClick: handleRowClick } = useNavigationHandler(
+    "/agents/:name/logs/:id",
+    { pathParams: { name: agentName ?? "", id: entry.id } },
+  );
 
   return (
     <TableRow

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -15,7 +15,7 @@ import {
 } from "@vm0/ui/components/ui/table";
 import { AppShell } from "../layout/app-shell.tsx";
 import { AgentsListSkeleton } from "./agents-list-skeleton.tsx";
-import { useGet, useLastResolved, useResolved, useSet } from "ccstate-react";
+import { useGet, useLastResolved, useResolved } from "ccstate-react";
 import {
   agentsList$,
   agentsLoading$,
@@ -25,7 +25,7 @@ import {
   getAgentScheduleStatus,
 } from "../../signals/agents-page/agents-list.ts";
 import { defaultModelProvider$ } from "../../signals/external/model-providers.ts";
-import { navigateInReact$ } from "../../signals/route.ts";
+import { useNavigationHandler } from "../router/link.tsx";
 import { getUILabel } from "../settings-page/provider-ui-config.ts";
 import { Bed, Settings, Clock, AlertTriangle } from "lucide-react";
 import type { ComposeListItem } from "@vm0/core";
@@ -147,12 +147,9 @@ function AgentRow({
   missingCount: number;
   modelProviderLabel: string;
 }) {
-  const navigate = useSet(navigateInReact$);
-
-  const handleRowClick = () =>
-    navigate("/agents/:name", {
-      pathParams: { name: agent.name },
-    });
+  const { onClick: handleRowClick } = useNavigationHandler("/agents/:name", {
+    pathParams: { name: agent.name },
+  });
 
   return (
     <TableRow className="h-[53px]">

--- a/turbo/apps/platform/src/views/integrations-page/__tests__/slack-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/__tests__/slack-settings-page.test.tsx
@@ -100,7 +100,7 @@ describe("slack settings page", () => {
 
     // Should show a link to secrets or variables settings
     expect(
-      screen.getByRole("button", { name: /secrets or variables/i }),
+      screen.getByRole("link", { name: /secrets or variables/i }),
     ).toBeInTheDocument();
   });
 
@@ -193,13 +193,13 @@ describe("settings integrations tab", () => {
     expect(screen.getByText("VM0 in Slack")).toBeInTheDocument();
     expect(screen.getByText("Use your VM0 agent in Slack")).toBeInTheDocument();
 
-    // Should show a Settings button inside the Slack card (not the nav "Settings")
+    // Should show a Settings link inside the Slack card (not the nav "Settings")
     // The Slack card now uses rounded-xl instead of rounded-lg
     const slackCard = screen
       .getByText("Use your VM0 agent in Slack")
       .closest("div.rounded-xl") as HTMLElement;
     expect(
-      within(slackCard).getByRole("button", { name: /settings/i }),
+      within(slackCard).getByRole("link", { name: /settings/i }),
     ).toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/integrations-page/integrations-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/integrations-page.tsx
@@ -1,4 +1,4 @@
-import { useGet, useSet } from "ccstate-react";
+import { useGet } from "ccstate-react";
 import { Button } from "@vm0/ui/components/ui/button";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import {
@@ -6,13 +6,12 @@ import {
   slackIntegrationNotLinked$,
   slackInstallUrl$,
 } from "../../signals/integrations-page/slack-integration.ts";
-import { navigateInReact$ } from "../../signals/route.ts";
+import { Link } from "../router/link.tsx";
 
 export function SlackIntegrationCard() {
   const loading = useGet(slackIntegrationLoading$);
   const notLinked = useGet(slackIntegrationNotLinked$);
   const installUrl = useGet(slackInstallUrl$);
-  const navigate = useSet(navigateInReact$);
 
   if (loading) {
     return (
@@ -50,12 +49,8 @@ export function SlackIntegrationCard() {
             </Button>
           ) : null
         ) : (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => navigate("/settings/slack")}
-          >
-            Settings
+          <Button variant="outline" size="sm" asChild>
+            <Link pathname="/settings/slack">Settings</Link>
           </Button>
         )}
       </div>

--- a/turbo/apps/platform/src/views/integrations-page/slack-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/slack-settings-page.tsx
@@ -35,6 +35,7 @@ import {
 import { agentsList$ } from "../../signals/agents-page/agents-list.ts";
 import { navigateInReact$ } from "../../signals/route.ts";
 import { AppShell } from "../layout/app-shell.tsx";
+import { Link } from "../router/link.tsx";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -59,7 +60,6 @@ function MissingEnvBanner({
   missingSecrets: string[];
   missingVars: string[];
 }) {
-  const navigate = useSet(navigateInReact$);
   const envVars = getAllConnectorEnvVars();
 
   const hasMissingConnectors = missingSecrets.some((s) => envVars.has(s));
@@ -70,15 +70,6 @@ function MissingEnvBanner({
     return null;
   }
 
-  const navigateToConnections = (tab: "connectors" | "secrets") => {
-    if (agentName) {
-      navigate("/agents/:name/connections", {
-        pathParams: { name: agentName },
-        searchParams: new URLSearchParams({ tab }),
-      });
-    }
-  };
-
   return (
     <div className="flex items-center gap-3 rounded-lg border border-amber-500 bg-amber-50 px-4 py-3 dark:border-amber-700 dark:bg-amber-950/30">
       <IconAlertTriangle
@@ -88,23 +79,41 @@ function MissingEnvBanner({
       />
       <p className="text-sm">
         {"Looks like this agent is missing some "}
-        {hasMissingConnectors && (
-          <button
-            className="font-medium text-amber-600 hover:underline dark:text-amber-500"
-            onClick={() => navigateToConnections("connectors")}
-          >
-            connectors
-          </button>
-        )}
+        {hasMissingConnectors &&
+          (agentName ? (
+            <Link
+              pathname="/agents/:name/connections"
+              options={{
+                pathParams: { name: agentName },
+                searchParams: new URLSearchParams({ tab: "connectors" }),
+              }}
+              className="font-medium text-amber-600 hover:underline dark:text-amber-500"
+            >
+              connectors
+            </Link>
+          ) : (
+            <span className="font-medium text-amber-600 dark:text-amber-500">
+              connectors
+            </span>
+          ))}
         {hasMissingConnectors && hasMissingSecretsOrVars && ", "}
-        {hasMissingSecretsOrVars && (
-          <button
-            className="font-medium text-amber-600 hover:underline dark:text-amber-500"
-            onClick={() => navigateToConnections("secrets")}
-          >
-            secrets or variables
-          </button>
-        )}
+        {hasMissingSecretsOrVars &&
+          (agentName ? (
+            <Link
+              pathname="/agents/:name/connections"
+              options={{
+                pathParams: { name: agentName },
+                searchParams: new URLSearchParams({ tab: "secrets" }),
+              }}
+              className="font-medium text-amber-600 hover:underline dark:text-amber-500"
+            >
+              secrets or variables
+            </Link>
+          ) : (
+            <span className="font-medium text-amber-600 dark:text-amber-500">
+              secrets or variables
+            </span>
+          ))}
         {". Add them now so it can run without stopping."}
       </p>
     </div>
@@ -126,8 +135,6 @@ function DefaultAgentSection({
   agentOptions: { name: string }[];
   onAgentChange: (name: string) => void;
 }) {
-  const navigate = useSet(navigateInReact$);
-
   return (
     <div className="flex flex-col gap-4">
       <h3 className="text-base font-medium">Default agent</h3>
@@ -142,18 +149,15 @@ function DefaultAgentSection({
                 {
                   "If you want to manage your agent's model provider, secrets, or connectors, go to "
                 }
-                <button
+                <Link
+                  pathname="/settings"
+                  options={{
+                    searchParams: new URLSearchParams({ tab: "providers" }),
+                  }}
                   className="text-primary hover:underline"
-                  onClick={() =>
-                    navigate("/settings", {
-                      searchParams: new URLSearchParams({
-                        tab: "providers",
-                      }),
-                    })
-                  }
                 >
                   Settings
-                </button>
+                </Link>
                 .
               </p>
             </>
@@ -244,6 +248,7 @@ export function SlackSettingsPage() {
       (async () => {
         await disconnect();
         closeConfirm();
+        // Programmatic post-action redirect — not a user-clickable link
         navigate("/settings", {
           searchParams: new URLSearchParams({ tab: "integrations" }),
         });

--- a/turbo/apps/platform/src/views/layout/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/layout/__tests__/sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { testContext } from "../../../signals/__tests__/test-helpers";
 import { setupPage } from "../../../__tests__/page-helper";
 import { screen } from "@testing-library/react";
@@ -12,8 +12,9 @@ describe("sidebar", () => {
       path: "/",
     });
 
-    const spyOpen = vi.spyOn(window, "open").mockImplementation(() => null);
-    screen.getByText("Documentation").click();
-    expect(spyOpen).toHaveBeenCalledWith("https://docs.vm0.ai", "_blank");
+    const link = screen.getByText("Documentation").closest("a") as HTMLElement;
+    expect(link).toHaveAttribute("href", "https://docs.vm0.ai");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
 });

--- a/turbo/apps/platform/src/views/layout/nav-link.tsx
+++ b/turbo/apps/platform/src/views/layout/nav-link.tsx
@@ -1,4 +1,3 @@
-import { useSet } from "ccstate-react";
 import {
   IconRobot,
   IconCircleDotFilled,
@@ -26,7 +25,7 @@ import {
   TooltipTrigger,
 } from "@vm0/ui/components/ui/tooltip";
 import type { NavIconName, NavItem } from "../../types/navigation.ts";
-import { navigateInReact$ } from "../../signals/route.ts";
+import { Link } from "../router/link.tsx";
 
 function getIconComponent(name: NavIconName): Icon {
   const map: Record<NavIconName, Icon> = {
@@ -58,45 +57,51 @@ interface NavLinkProps {
 }
 
 export function NavLink({ item, isActive, collapsed }: NavLinkProps) {
-  const navigate = useSet(navigateInReact$);
   const IconComponent = getIconComponent(item.icon);
 
-  const handleClick = () => {
-    if (item.path) {
-      // Clear search params to ensure navigation goes to base route with clean state
-      navigate(item.path, { searchParams: new URLSearchParams() });
-    } else if (item.url) {
-      if (item.newTab) {
-        window.open(item.url, "_blank");
-      } else {
-        window.location.href = item.url;
-      }
-    }
-  };
+  const className = `flex w-full items-center h-8 p-2 rounded-lg text-sm leading-5 transition-colors ${
+    collapsed ? "justify-center" : "gap-2"
+  } ${
+    isActive
+      ? "bg-sidebar-active text-sidebar-primary font-medium"
+      : "text-sidebar-foreground hover:bg-sidebar-accent"
+  }`;
 
-  const button = (
-    <button
-      onClick={handleClick}
-      className={`flex w-full items-center h-8 p-2 rounded-lg text-sm leading-5 transition-colors ${
-        collapsed ? "justify-center" : "gap-2"
-      } ${
-        isActive
-          ? "bg-sidebar-active text-sidebar-primary font-medium"
-          : "text-sidebar-foreground hover:bg-sidebar-accent"
-      }`}
-    >
+  const content = (
+    <>
       {IconComponent && (
         <IconComponent size={16} stroke={1.5} className="shrink-0" />
       )}
       {!collapsed && <span className="truncate">{item.label}</span>}
-    </button>
+    </>
+  );
+
+  // Internal path → use Link for SPA navigation with cmd+click support
+  const element = item.path ? (
+    <Link
+      pathname={item.path}
+      options={{ searchParams: new URLSearchParams() }}
+      className={className}
+    >
+      {content}
+    </Link>
+  ) : (
+    // External URL → native <a> tag
+    <a
+      href={item.url}
+      target={item.newTab ? "_blank" : undefined}
+      rel={item.newTab ? "noopener noreferrer" : undefined}
+      className={className}
+    >
+      {content}
+    </a>
   );
 
   if (collapsed) {
     return (
       <TooltipProvider delayDuration={100}>
         <Tooltip>
-          <TooltipTrigger asChild>{button}</TooltipTrigger>
+          <TooltipTrigger asChild>{element}</TooltipTrigger>
           <TooltipContent side="right">
             <p className="text-xs">{item.label}</p>
           </TooltipContent>
@@ -105,5 +110,5 @@ export function NavLink({ item, isActive, collapsed }: NavLinkProps) {
     );
   }
 
-  return button;
+  return element;
 }

--- a/turbo/apps/platform/src/views/layout/navbar.tsx
+++ b/turbo/apps/platform/src/views/layout/navbar.tsx
@@ -7,9 +7,9 @@ import {
   TooltipTrigger,
 } from "@vm0/ui/components/ui/tooltip";
 import { ThemeToggle } from "../components/theme-toggle.tsx";
-import { navigateInReact$ } from "../../signals/route.ts";
 import { toggleSidebar$, toggleMobileSidebar$ } from "../../signals/sidebar.ts";
 import type { RoutePath } from "../../types/route.ts";
+import { Link } from "../router/link.tsx";
 
 export interface BreadcrumbItem {
   label: string;
@@ -22,7 +22,6 @@ interface NavbarProps {
 }
 
 export function Navbar({ breadcrumb }: NavbarProps) {
-  const navigate = useSet(navigateInReact$);
   const toggleSidebar = useSet(toggleSidebar$);
   const toggleMobileSidebar = useSet(toggleMobileSidebar$);
 
@@ -78,16 +77,13 @@ export function Navbar({ breadcrumb }: NavbarProps) {
                   <span className="text-muted-foreground/50 shrink-0">/</span>
                 )}
                 {item.path ? (
-                  <button
-                    onClick={() =>
-                      navigate(item.path!, {
-                        pathParams: item.pathParams,
-                      })
-                    }
+                  <Link
+                    pathname={item.path}
+                    options={{ pathParams: item.pathParams }}
                     className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors whitespace-nowrap"
                   >
                     {item.label}
-                  </button>
+                  </Link>
                 ) : (
                   <TooltipProvider delayDuration={300}>
                     <Tooltip>

--- a/turbo/apps/platform/src/views/logs-page/logs-table-row.tsx
+++ b/turbo/apps/platform/src/views/logs-page/logs-table-row.tsx
@@ -1,10 +1,8 @@
-import { useSet } from "ccstate-react";
 import { IconChevronRight } from "@tabler/icons-react";
-import type { MouseEvent } from "react";
-import { navigateInReact$ } from "../../signals/route.ts";
 import { TableRow, TableCell } from "@vm0/ui";
 import { StatusBadge } from "./status-badge.tsx";
 import type { LogEntry } from "../../signals/logs-page/types.ts";
+import { useNavigationHandler } from "../router/link.tsx";
 
 function formatTime(dateStr: string): string {
   const date = new Date(dateStr);
@@ -24,17 +22,9 @@ interface LogsTableRowProps {
 }
 
 export function LogsTableRow({ entry }: LogsTableRowProps) {
-  const navigate = useSet(navigateInReact$);
-  const logDetailUrl = `/logs/${entry.id}`;
-
-  const handleRowClick = (event: MouseEvent<HTMLTableRowElement>) => {
-    // Open in new tab if Cmd (Mac) or Ctrl (Windows/Linux) is pressed
-    if (event.metaKey || event.ctrlKey) {
-      window.open(logDetailUrl, "_blank");
-      return;
-    }
-    navigate("/logs/:id", { pathParams: { id: entry.id } });
-  };
+  const { onClick: handleRowClick } = useNavigationHandler("/logs/:id", {
+    pathParams: { id: entry.id },
+  });
 
   return (
     <TableRow

--- a/turbo/apps/platform/src/views/router/link.tsx
+++ b/turbo/apps/platform/src/views/router/link.tsx
@@ -1,32 +1,86 @@
 import { useSet } from "ccstate-react";
-import type { PropsWithChildren } from "react";
+import type { MouseEvent, Ref } from "react";
 import { generateRouterPath, navigateInReact$ } from "../../signals/route.ts";
 
-interface LinkProps extends PropsWithChildren {
-  pathname: Parameters<typeof generateRouterPath>[0];
-  options?: {
-    pathParams?: Parameters<typeof generateRouterPath>[1];
-    searchParams?: URLSearchParams;
-  };
-  target?: "_blank" | "_self";
+type PathName = Parameters<typeof generateRouterPath>[0];
+type PathParams = Parameters<typeof generateRouterPath>[1];
+
+interface NavigationOptions {
+  pathParams?: PathParams;
+  searchParams?: URLSearchParams;
 }
 
-export function Link({ pathname, options, children, target }: LinkProps) {
+function buildHref(path: string, searchParams?: URLSearchParams): string {
+  const search = searchParams?.toString();
+  return search ? `${path}?${search}` : path;
+}
+
+function isNewTabClick(e: MouseEvent): boolean {
+  return e.metaKey || e.ctrlKey || e.shiftKey;
+}
+
+// ---------------------------------------------------------------------------
+// Link component
+// ---------------------------------------------------------------------------
+
+interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  pathname: PathName;
+  options?: NavigationOptions;
+  ref?: Ref<HTMLAnchorElement>;
+}
+
+export function Link({
+  pathname,
+  options,
+  children,
+  onClick,
+  ref,
+  ...rest
+}: LinkProps) {
   const navigate = useSet(navigateInReact$);
   const path = generateRouterPath(pathname, options?.pathParams);
+  const href = buildHref(path, options?.searchParams);
 
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(e);
+    if (e.defaultPrevented) {
+      return;
+    }
     e.preventDefault();
-    if (e.shiftKey || e.metaKey || target === "_blank") {
-      window.open(`${window.location.origin}${path}`, "_blank");
+
+    if (isNewTabClick(e)) {
+      window.open(`${window.location.origin}${href}`, "_blank");
     } else {
       navigate(pathname, options);
     }
   };
 
   return (
-    <a href={path} onClick={handleClick}>
+    <a ref={ref} href={href} onClick={handleClick} {...rest}>
       {children}
     </a>
   );
+}
+
+// ---------------------------------------------------------------------------
+// useNavigationHandler hook (for table rows where <a> is invalid)
+// ---------------------------------------------------------------------------
+
+export function useNavigationHandler(
+  pathname: PathName,
+  options?: NavigationOptions,
+): { href: string; onClick: (e: MouseEvent) => void } {
+  const navigate = useSet(navigateInReact$);
+  const path = generateRouterPath(pathname, options?.pathParams);
+  const href = buildHref(path, options?.searchParams);
+
+  const onClick = (e: MouseEvent) => {
+    if (isNewTabClick(e)) {
+      window.open(`${window.location.origin}${href}`, "_blank");
+    } else {
+      navigate(pathname, options);
+    }
+  };
+
+  return { href, onClick };
 }


### PR DESCRIPTION
## Summary
- Enhanced the `Link` component (`views/router/link.tsx`) with React 19 ref prop support, cmd/ctrl+click new-tab detection, and searchParams in href generation
- Added `useNavigationHandler` hook for table row click handlers where wrapping in `<a>` is semantically invalid
- Converted all internal navigation points from `<button onClick>` / `window.open` patterns to semantic `<a href>` elements via `Link` component and `useNavigationHandler` hook

### Files changed (11)
| File | Change |
|------|--------|
| `views/router/link.tsx` | Enhanced Link + new `useNavigationHandler` hook |
| `views/layout/nav-link.tsx` | Sidebar: `<button>` → `<Link>` for internal, `<a>` for external |
| `views/layout/navbar.tsx` | Breadcrumbs: clickable items → `<Link>` |
| `views/agent-detail-page/agent-header.tsx` | Connections/Logs buttons → `<Button asChild><Link>` |
| `views/integrations-page/integrations-page.tsx` | Settings button → `<Button asChild><Link>` |
| `views/integrations-page/slack-settings-page.tsx` | Inline text links → `<Link>` |
| `views/agents-page/agents-page.tsx` | Table row clicks → `useNavigationHandler` |
| `views/logs-page/logs-table-row.tsx` | Table row clicks → `useNavigationHandler` |
| `views/agent-detail-page/agent-logs-page.tsx` | Table row clicks → `useNavigationHandler` |
| `views/layout/__tests__/sidebar.test.tsx` | Updated for `<a>` element assertions |
| `views/integrations-page/__tests__/slack-settings-page.test.tsx` | Updated role assertions (button → link) |

## Test plan
- [x] All 418 platform tests pass
- [x] Lint passes (0 errors)
- [x] Type check passes
- [x] Knip clean (no unused exports)
- [ ] Manual: verify cmd+click opens new tab on sidebar links, breadcrumbs, agent header buttons, table rows
- [ ] Manual: verify normal click still does SPA navigation
- [ ] Manual: verify right-click shows browser context menu with correct URL

Closes #3471

🤖 Generated with [Claude Code](https://claude.com/claude-code)