### PR TITLE
feat(connectors): filter connector types by configured oauth credentials

### DIFF
--- a/turbo/apps/cli/src/commands/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/list.test.ts
@@ -49,6 +49,7 @@ describe("connector list command", () => {
                 updatedAt: "2025-01-01T00:00:00Z",
               },
             ],
+            configuredTypes: ["github"],
           });
         }),
       );
@@ -67,7 +68,7 @@ describe("connector list command", () => {
     it("should show not-connected status when no connectors", async () => {
       server.use(
         http.get("http://localhost:3000/api/connectors", () => {
-          return HttpResponse.json({ connectors: [] });
+          return HttpResponse.json({ connectors: [], configuredTypes: [] });
         }),
       );
 
@@ -96,6 +97,7 @@ describe("connector list command", () => {
                 updatedAt: "2025-01-01T00:00:00Z",
               },
             ],
+            configuredTypes: ["github"],
           });
         }),
       );

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -54,7 +54,10 @@ export const apiHandlers = [
 
   // GET /api/connectors - listConnectors
   http.get("http://localhost:3000/api/connectors", () => {
-    return HttpResponse.json({ connectors: [] }, { status: 200 });
+    return HttpResponse.json(
+      { connectors: [], configuredTypes: [] },
+      { status: 200 },
+    );
   }),
 
   // GET /api/scope - getScope

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -5,7 +5,14 @@
  */
 
 import { http, HttpResponse } from "msw";
-import type { ConnectorResponse, ConnectorListResponse } from "@vm0/core";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorResponse,
+  type ConnectorListResponse,
+  type ConnectorType,
+} from "@vm0/core";
+
+const ALL_CONNECTOR_TYPES = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
 
 let mockConnectors: ConnectorResponse[] = [];
 
@@ -22,6 +29,7 @@ export const apiConnectorsHandlers = [
   http.get("/api/connectors", () => {
     const response: ConnectorListResponse = {
       connectors: mockConnectors,
+      configuredTypes: ALL_CONNECTOR_TYPES,
     };
     return HttpResponse.json(response);
   }),

--- a/turbo/apps/platform/src/signals/agents-page/__tests__/agents-list.test.ts
+++ b/turbo/apps/platform/src/signals/agents-page/__tests__/agents-list.test.ts
@@ -132,7 +132,7 @@ describe("agents-list signals", () => {
           return HttpResponse.json({ variables: [] });
         }),
         http.get("http://localhost:3000/api/connectors", () => {
-          return HttpResponse.json({ connectors: [] });
+          return HttpResponse.json({ connectors: [], configuredTypes: [] });
         }),
       );
 
@@ -167,7 +167,7 @@ describe("agents-list signals", () => {
           return HttpResponse.json({ variables: [] });
         }),
         http.get("http://localhost:3000/api/connectors", () => {
-          return HttpResponse.json({ connectors: [] });
+          return HttpResponse.json({ connectors: [], configuredTypes: [] });
         }),
       );
 
@@ -215,6 +215,7 @@ describe("agents-list signals", () => {
                 updatedAt: "2024-01-01",
               },
             ],
+            configuredTypes: ["github"],
           });
         }),
       );
@@ -272,7 +273,7 @@ describe("agents-list signals", () => {
           });
         }),
         http.get("http://localhost:3000/api/connectors", () => {
-          return HttpResponse.json({ connectors: [] });
+          return HttpResponse.json({ connectors: [], configuredTypes: [] });
         }),
       );
 

--- a/turbo/apps/platform/src/signals/settings-page/__tests__/connectors.test.ts
+++ b/turbo/apps/platform/src/signals/settings-page/__tests__/connectors.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../connectors";
 import { server } from "../../../mocks/server";
 import { http, HttpResponse } from "msw";
+import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 
 const context = testContext();
 
@@ -30,6 +31,7 @@ describe("allConnectorTypes$", () => {
               updatedAt: new Date().toISOString(),
             },
           ],
+          configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
         });
       }),
     );
@@ -257,7 +259,10 @@ describe("disconnect dialog", () => {
         return new HttpResponse(null, { status: 204 });
       }),
       http.get("/api/connectors", () => {
-        return HttpResponse.json({ connectors: [] });
+        return HttpResponse.json({
+          connectors: [],
+          configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
+        });
       }),
     );
 

--- a/turbo/apps/platform/src/signals/settings-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/settings-page/connectors.ts
@@ -53,12 +53,16 @@ const CONNECTOR_FEATURE_FLAGS = Object.freeze<
 });
 
 export const allConnectorTypes$ = computed(async (get) => {
-  const { connectors } = await get(connectors$);
+  const { connectors, configuredTypes } = await get(connectors$);
   const connectorMap = new Map(connectors.map((c) => [c.type, c]));
   const features = await get(featureSwitch$);
+  const configuredSet = new Set(configuredTypes);
 
   return (Object.keys(CONNECTOR_TYPES) as ConnectorType[])
     .filter((type) => {
+      if (!configuredSet.has(type)) {
+        return false;
+      }
       const flag = CONNECTOR_FEATURE_FLAGS[type];
       if (flag && !features?.[flag]) {
         return false;

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-connections-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-connections-page.test.tsx
@@ -58,6 +58,24 @@ function mockConnectorsAPI(connectors?: unknown[]) {
     http.get("/api/connectors", () => {
       return HttpResponse.json({
         connectors: connectors ?? [],
+        configuredTypes: [
+          "github",
+          "gmail",
+          "google-sheets",
+          "google-docs",
+          "google-drive",
+          "notion",
+          "computer",
+          "slack",
+          "deel",
+          "docusign",
+          "dropbox",
+          "linear",
+          "figma",
+          "mercury",
+          "strava",
+          "garmin-connect",
+        ],
       });
     }),
   );

--- a/turbo/apps/platform/src/views/agents-page/__tests__/agents-page.test.tsx
+++ b/turbo/apps/platform/src/views/agents-page/__tests__/agents-page.test.tsx
@@ -98,7 +98,7 @@ describe("agents page", () => {
         return HttpResponse.json({ variables: [] });
       }),
       http.get("/api/connectors", () => {
-        return HttpResponse.json({ connectors: [] });
+        return HttpResponse.json({ connectors: [], configuredTypes: [] });
       }),
     );
 
@@ -148,7 +148,7 @@ describe("agents page", () => {
         return HttpResponse.json({ variables: [] });
       }),
       http.get("/api/connectors", () => {
-        return HttpResponse.json({ connectors: [] });
+        return HttpResponse.json({ connectors: [], configuredTypes: [] });
       }),
     );
 
@@ -215,7 +215,7 @@ describe("agents page", () => {
         });
       }),
       http.get("/api/connectors", () => {
-        return HttpResponse.json({ connectors: [] });
+        return HttpResponse.json({ connectors: [], configuredTypes: [] });
       }),
     );
 

--- a/turbo/apps/web/app/api/connectors/route.ts
+++ b/turbo/apps/web/app/api/connectors/route.ts
@@ -3,6 +3,7 @@ import { connectorsMainContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../src/lib/init-services";
 import { getUserId } from "../../../src/lib/auth/get-user-id";
 import { listConnectors } from "../../../src/lib/connector/connector-service";
+import { getConfiguredConnectorTypes } from "../../../src/lib/connector/provider-registry";
 
 const router = tsr.router(connectorsMainContract, {
   /**
@@ -17,11 +18,15 @@ const router = tsr.router(connectorsMainContract, {
     }
 
     const connectorList = await listConnectors(userId);
+    const configuredTypes = getConfiguredConnectorTypes(
+      globalThis.services.env,
+    );
 
     return {
       status: 200 as const,
       body: {
         connectors: connectorList,
+        configuredTypes,
       },
     };
   },

--- a/turbo/apps/web/src/lib/connector/provider-registry.ts
+++ b/turbo/apps/web/src/lib/connector/provider-registry.ts
@@ -1,4 +1,5 @@
 import { type ConnectorType } from "@vm0/core";
+import { type Env } from "../../env";
 import { type OAuthTokenResult, type ProviderHandler } from "./provider-types";
 import { deelHandler } from "./providers/deel-handler";
 import { docusignHandler } from "./providers/docusign-handler";
@@ -38,3 +39,27 @@ export const PROVIDER_HANDLERS: Record<
   slack: slackHandler,
   strava: stravaHandler,
 };
+
+/**
+ * Returns connector types whose OAuth credentials (or equivalent) are
+ * configured in the current environment.
+ */
+export function getConfiguredConnectorTypes(currentEnv: Env): ConnectorType[] {
+  const configured: ConnectorType[] = [];
+
+  for (const [type, handler] of Object.entries(PROVIDER_HANDLERS)) {
+    if (
+      handler.getClientId(currentEnv) &&
+      handler.getClientSecret(currentEnv)
+    ) {
+      configured.push(type as ConnectorType);
+    }
+  }
+
+  // computer connector: no OAuth — uses ngrok credentials instead
+  if (currentEnv.NGROK_API_KEY && currentEnv.NGROK_COMPUTER_CONNECTOR_DOMAIN) {
+    configured.push("computer");
+  }
+
+  return configured;
+}

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -725,6 +725,7 @@ export type ConnectorResponse = z.infer<typeof connectorResponseSchema>;
  */
 export const connectorListResponseSchema = z.object({
   connectors: z.array(connectorResponseSchema),
+  configuredTypes: z.array(connectorTypeSchema),
 });
 
 export type ConnectorListResponse = z.infer<typeof connectorListResponseSchema>;


### PR DESCRIPTION
## Summary
- Add `configuredTypes` field to the `/api/connectors` list response that returns only connector types whose OAuth credentials (client ID + secret) are present in the environment
- Add `getConfiguredConnectorTypes()` function in provider-registry that inspects each provider handler's credentials, plus special handling for the computer connector (ngrok-based)
- Filter the platform UI connector list using `configuredTypes` so users only see connectors they can actually use
- Update `connectorListResponseSchema` contract in `@vm0/core` to include the new field
- Update all related test mocks to include `configuredTypes` in API responses

## Test plan
- [ ] Verify existing connector list tests pass with updated mock responses
- [ ] Verify connectors settings page only displays connector types that are configured in the environment
- [ ] Verify agent connections page shows the correct set of connectors
- [ ] Confirm the API response includes `configuredTypes` matching the environment configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)