### PR TITLE
feat(docs): remove apps field reference from agent anatomy page

### DIFF
--- a/turbo/apps/docs/content/docs/core-concept/agent-anatomy.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/agent-anatomy.mdx
@@ -40,7 +40,7 @@ The Sandbox provides the runtime environment for your agent. It includes:
 - System tools and dependencies
 - Base configuration
 
-VM0 prepares your sandbox with the appropriate runtime environment for your provider. Use the `apps` field to add pre-installed tools like GitHub CLI (e.g., `apps: [github]`).
+VM0 prepares your sandbox with the appropriate runtime environment for your provider. Common tools like GitHub CLI are pre-installed in the base image.
 
 ## Skills & Instructions
 


### PR DESCRIPTION
## Summary

- Remove outdated `apps` field reference from the Agent Anatomy docs page
- The `apps` field was removed in #3461 but this docs page still referenced it

## Changes

Updated `agent-anatomy.mdx` to replace:
> Use the `apps` field to add pre-installed tools like GitHub CLI (e.g., `apps: [github]`).

With:
> Common tools like GitHub CLI are pre-installed in the base image.

## Test plan

- [ ] CI passes
- [ ] Docs site renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)