### PR TITLE
perf(platform): parallelize bootstrap setup operations

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -101,19 +101,15 @@ export const bootstrap$ = command(
     set(setRootSignal$, signal);
 
     set(setupLoggers$);
-    const globalMethodDone = set(setupGlobalMethod$, signal).catch(() => {
-      // Global method setup errors are non-fatal
-    });
 
     render();
 
-    await set(setupClerk$, signal);
+    await Promise.all([
+      set(setupGlobalMethod$, signal),
+      set(setupClerk$, signal),
+      set(setupRoutes$, signal),
+    ]);
     signal.throwIfAborted();
-
-    await set(setupRoutes$, signal);
-    signal.throwIfAborted();
-
-    await globalMethodDone;
   },
 );
 


### PR DESCRIPTION
## Summary
- Refactors the platform bootstrap sequence to run `setupGlobalMethod$`, `setupClerk$`, and `setupRoutes$` concurrently via `Promise.all` instead of sequentially
- Removes the special non-fatal error handling for `setupGlobalMethod$` since errors should propagate naturally
- Consolidates multiple `signal.throwIfAborted()` calls into a single check after all parallel operations complete

## Test plan
- [ ] Verify the platform boots correctly in development
- [ ] Confirm routes initialize properly after the change
- [ ] Confirm Clerk authentication setup works as expected
- [ ] Verify global method setup completes without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)