### PR TITLE
feat(connectors): add token refresh for linear connector during run context build

### DIFF
--- a/turbo/apps/web/src/lib/connector/providers/linear.ts
+++ b/turbo/apps/web/src/lib/connector/providers/linear.ts
@@ -19,6 +19,11 @@ interface LinearTokenResult {
   userInfo: LinearUserInfo;
 }
 
+interface LinearRefreshResult {
+  accessToken: string;
+  refreshToken: string | null;
+}
+
 /**
  * Build Linear OAuth authorization URL.
  */
@@ -104,6 +109,60 @@ export async function exchangeLinearCode(
     expiresIn: data.expires_in,
     scopes: data.scope ? data.scope.split(",") : [],
     userInfo,
+  };
+}
+
+/**
+ * Refresh a Linear access token using the refresh token.
+ * Returns new access token and new refresh token (both must be stored).
+ */
+export async function refreshLinearToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+): Promise<LinearRefreshResult> {
+  const oauthConfig = getConnectorOAuthConfig("linear");
+  if (!oauthConfig) {
+    throw new Error("Linear OAuth config not found");
+  }
+
+  const response = await fetch(oauthConfig.tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Linear token refresh failed: ${response.status}`);
+  }
+
+  const data = z
+    .object({
+      access_token: z.string().optional(),
+      refresh_token: z.string().nullable().optional(),
+      error: z.string().optional(),
+      error_description: z.string().optional(),
+    })
+    .parse(await response.json());
+
+  if (data.error) {
+    throw new Error(data.error_description ?? data.error);
+  }
+
+  if (!data.access_token) {
+    throw new Error("No access token in Linear refresh response");
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? null,
   };
 }
 

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -33,6 +33,7 @@ import { getVariableValues } from "../variable/variable-service";
 import { getDefaultModelProvider } from "../model-provider/model-provider-service";
 import { connectors } from "../../db/schema/connector";
 import { refreshNotionToken } from "../connector/providers/notion";
+import { refreshLinearToken } from "../connector/providers/linear";
 import { upsertConnectorSecret } from "../connector/connector-service";
 
 const log = logger("run:build-context");
@@ -376,6 +377,71 @@ async function refreshNotionAccessToken(
 }
 
 /**
+ * Refresh Linear access token using the stored refresh token.
+ * Updates both LINEAR_ACCESS_TOKEN and LINEAR_REFRESH_TOKEN in the database
+ * and returns the new access token for immediate use.
+ *
+ * Returns null if refresh token is unavailable or refresh fails
+ * (caller should fall back to using the existing access token).
+ */
+async function refreshLinearAccessToken(
+  userId: string,
+  connectorSecrets: Record<string, string>,
+): Promise<string | null> {
+  const currentRefreshToken = connectorSecrets["LINEAR_REFRESH_TOKEN"];
+  if (!currentRefreshToken) {
+    log.debug("No Linear refresh token available, skipping token refresh");
+    return null;
+  }
+
+  const env = globalThis.services.env;
+  const clientId = env.LINEAR_OAUTH_CLIENT_ID;
+  const clientSecret = env.LINEAR_OAUTH_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    log.debug(
+      "Linear OAuth credentials not configured, skipping token refresh",
+    );
+    return null;
+  }
+
+  try {
+    const result = await refreshLinearToken(
+      clientId,
+      clientSecret,
+      currentRefreshToken,
+    );
+
+    // Persist new tokens to database
+    await upsertConnectorSecret(
+      userId,
+      "LINEAR_ACCESS_TOKEN",
+      result.accessToken,
+    );
+    if (result.refreshToken) {
+      await upsertConnectorSecret(
+        userId,
+        "LINEAR_REFRESH_TOKEN",
+        result.refreshToken,
+      );
+    }
+
+    // Update in-memory secrets map so subsequent mapping uses fresh token
+    connectorSecrets["LINEAR_ACCESS_TOKEN"] = result.accessToken;
+    if (result.refreshToken) {
+      connectorSecrets["LINEAR_REFRESH_TOKEN"] = result.refreshToken;
+    }
+
+    log.debug("Linear access token refreshed successfully");
+    return result.accessToken;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    log.warn(`Linear token refresh failed: ${message}`);
+    return null;
+  }
+}
+
+/**
  * Result of connector credential resolution
  */
 interface ConnectorCredentialResult {
@@ -426,9 +492,11 @@ async function resolveConnectorCredentials(
       continue;
     }
 
-    // Refresh Notion token before resolving environment mapping
+    // Refresh tokens before resolving environment mapping
     if (connectorType.data === "notion") {
       await refreshNotionAccessToken(userId, connectorSecrets);
+    } else if (connectorType.data === "linear") {
+      await refreshLinearAccessToken(userId, connectorSecrets);
     }
 
     const mapping = getConnectorEnvironmentMapping(connectorType.data);


### PR DESCRIPTION
## Summary
- Add `refreshLinearToken` function to the Linear connector provider for refreshing OAuth access tokens using stored refresh tokens
- Add `refreshLinearAccessToken` to `build-context.ts` that persists refreshed tokens to the database and updates the in-memory secrets map
- Integrate Linear token refresh into the connector credential resolution flow, following the same pattern already established for Notion

## Test plan
- [ ] Verify Linear connector works with a fresh access token after the previous one expires
- [ ] Verify the refresh token rotation is persisted correctly (both `LINEAR_ACCESS_TOKEN` and `LINEAR_REFRESH_TOKEN` are updated in the database)
- [ ] Verify that if no refresh token is available, the flow gracefully falls back to the existing access token
- [ ] Verify that if Linear OAuth credentials are not configured, the refresh is skipped without error
- [ ] Verify that Notion token refresh continues to work as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)