### PR TITLE
refactor(web): convert feature-switch to server module

### DIFF
--- a/turbo/apps/web/src/lib/__tests__/feature-switch.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/feature-switch.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { useFeature, FeatureSwitchKey } from "../feature-switch";
+import { isFeatureEnabled, FeatureSwitchKey } from "../feature-switch";
 
 describe("feature-switch", () => {
-  describe("useFeature", () => {
+  describe("isFeatureEnabled", () => {
     it("returns a Promise", () => {
-      const result = useFeature(FeatureSwitchKey.Pricing);
+      const result = isFeatureEnabled(FeatureSwitchKey.Pricing);
       expect(result).toBeInstanceOf(Promise);
     });
 
     it("resolves to false for Pricing", async () => {
-      const result = await useFeature(FeatureSwitchKey.Pricing);
+      const result = await isFeatureEnabled(FeatureSwitchKey.Pricing);
       expect(result).toBe(false);
     });
   });

--- a/turbo/apps/web/src/lib/feature-switch.ts
+++ b/turbo/apps/web/src/lib/feature-switch.ts
@@ -1,15 +1,1 @@
-"use client";
-
-import { FeatureSwitchKey, isFeatureEnabled } from "@vm0/core";
-
-export { FeatureSwitchKey } from "@vm0/core";
-
-/**
- * React hook to check if a feature is enabled
- *
- * @param key - The feature switch key to check
- * @returns A Promise that resolves to the enabled state
- */
-export function useFeature(key: FeatureSwitchKey): Promise<boolean> {
-  return isFeatureEnabled(key);
-}
+export { FeatureSwitchKey, isFeatureEnabled } from "@vm0/core";


### PR DESCRIPTION
## Summary
- Removed `"use client"` directive from `feature-switch.ts` since the module uses no React hooks or browser APIs
- Replaced the `useFeature` wrapper function with direct re-exports of `isFeatureEnabled` and `FeatureSwitchKey` from `@vm0/core`
- Updated tests to use `isFeatureEnabled` instead of the removed `useFeature`

Closes #3463

## Test plan
- [x] Existing feature-switch tests pass with updated imports
- [x] Knip reports no unused exports
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)