### PR TITLE
ci: bump runner max concurrent from 4 to 8

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -11,7 +11,7 @@ env:
   # Sandbox VM parameters for runner build
   RUNNER_VCPU: 2
   RUNNER_MEMORY_MB: 2048
-  RUNNER_MAX_CONCURRENT: 4
+  RUNNER_MAX_CONCURRENT: 8
 
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (github.event_name == 'merge_group' && format('merge-queue-{0}', github.run_id) || 'staging') }}


### PR DESCRIPTION
## Summary
- Increase `RUNNER_MAX_CONCURRENT` from 4 to 8 to allow more concurrent sandbox VMs during CI E2E tests

## Test plan
- [ ] Verify CI E2E tests pass with the higher concurrency limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)