### PR TITLE
feat(connectors): add token refresh for all oauth connectors

### DIFF
--- a/turbo/apps/web/src/lib/connector/providers/deel.ts
+++ b/turbo/apps/web/src/lib/connector/providers/deel.ts
@@ -17,6 +17,11 @@ interface DeelTokenResult {
   userInfo: DeelUserInfo;
 }
 
+interface DeelRefreshResult {
+  accessToken: string;
+  refreshToken: string | null;
+}
+
 /**
  * Derive a PKCE code_verifier deterministically from the OAuth state.
  */
@@ -75,6 +80,64 @@ export async function buildDeelAuthorizationUrl(
   });
 
   return `${oauthConfig.authorizationUrl}?${params.toString()}`;
+}
+
+/**
+ * Refresh a Deel access token using the refresh token.
+ * Deel uses Basic Auth for token requests. PKCE is not required for refresh.
+ * Returns new access token and new refresh token (both must be stored).
+ */
+export async function refreshDeelToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+): Promise<DeelRefreshResult> {
+  const oauthConfig = getConnectorOAuthConfig("deel");
+  if (!oauthConfig) {
+    throw new Error("Deel OAuth config not found");
+  }
+
+  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
+    "base64",
+  );
+
+  const response = await fetch(oauthConfig.tokenUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Deel token refresh failed: ${response.status}`);
+  }
+
+  const data = z
+    .object({
+      access_token: z.string().optional(),
+      refresh_token: z.string().nullable().optional(),
+      error: z.string().optional(),
+      error_description: z.string().optional(),
+    })
+    .parse(await response.json());
+
+  if (data.error) {
+    throw new Error(data.error_description ?? data.error);
+  }
+
+  if (!data.access_token) {
+    throw new Error("No access token in Deel refresh response");
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? null,
+  };
 }
 
 /**

--- a/turbo/apps/web/src/lib/connector/providers/docusign.ts
+++ b/turbo/apps/web/src/lib/connector/providers/docusign.ts
@@ -17,6 +17,11 @@ interface DocuSignTokenResult {
   userInfo: DocuSignUserInfo;
 }
 
+interface DocuSignRefreshResult {
+  accessToken: string;
+  refreshToken: string | null;
+}
+
 /**
  * Build DocuSign OAuth authorization URL.
  * Requests offline access to obtain a refresh token.
@@ -105,6 +110,64 @@ export async function exchangeDocuSignCode(
     expiresIn: data.expires_in,
     scopes: data.scope ? data.scope.split(" ") : [],
     userInfo,
+  };
+}
+
+/**
+ * Refresh a DocuSign access token using the refresh token.
+ * DocuSign uses Basic Auth for token requests.
+ * Returns new access token and new refresh token (both must be stored).
+ */
+export async function refreshDocuSignToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+): Promise<DocuSignRefreshResult> {
+  const oauthConfig = getConnectorOAuthConfig("docusign");
+  if (!oauthConfig) {
+    throw new Error("DocuSign OAuth config not found");
+  }
+
+  const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
+    "base64",
+  );
+
+  const response = await fetch(oauthConfig.tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization: `Basic ${basicAuth}`,
+    },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`DocuSign token refresh failed: ${response.status}`);
+  }
+
+  const data = z
+    .object({
+      access_token: z.string().optional(),
+      refresh_token: z.string().nullable().optional(),
+      error: z.string().optional(),
+      error_description: z.string().optional(),
+    })
+    .parse(await response.json());
+
+  if (data.error) {
+    throw new Error(data.error_description ?? data.error);
+  }
+
+  if (!data.access_token) {
+    throw new Error("No access token in DocuSign refresh response");
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? null,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/dropbox.ts
+++ b/turbo/apps/web/src/lib/connector/providers/dropbox.ts
@@ -18,6 +18,11 @@ interface DropboxTokenResult {
   userInfo: DropboxUserInfo;
 }
 
+interface DropboxRefreshResult {
+  accessToken: string;
+  refreshToken: string | null;
+}
+
 /**
  * Build Dropbox OAuth authorization URL.
  * Requests offline access to obtain a refresh token.
@@ -103,6 +108,60 @@ export async function exchangeDropboxCode(
     expiresIn: data.expires_in,
     scopes: data.scope ? data.scope.split(" ") : [],
     userInfo,
+  };
+}
+
+/**
+ * Refresh a Dropbox access token using the refresh token.
+ * Returns new access token (Dropbox does not rotate refresh tokens).
+ */
+export async function refreshDropboxToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+): Promise<DropboxRefreshResult> {
+  const oauthConfig = getConnectorOAuthConfig("dropbox");
+  if (!oauthConfig) {
+    throw new Error("Dropbox OAuth config not found");
+  }
+
+  const response = await fetch(oauthConfig.tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Dropbox token refresh failed: ${response.status}`);
+  }
+
+  const data = z
+    .object({
+      access_token: z.string().optional(),
+      refresh_token: z.string().nullable().optional(),
+      error: z.string().optional(),
+      error_description: z.string().optional(),
+    })
+    .parse(await response.json());
+
+  if (data.error) {
+    throw new Error(data.error_description ?? data.error);
+  }
+
+  if (!data.access_token) {
+    throw new Error("No access token in Dropbox refresh response");
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? null,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/figma.ts
+++ b/turbo/apps/web/src/lib/connector/providers/figma.ts
@@ -17,6 +17,11 @@ interface FigmaTokenResult {
   userInfo: FigmaUserInfo;
 }
 
+interface FigmaRefreshResult {
+  accessToken: string;
+  refreshToken: string | null;
+}
+
 /**
  * Build Figma OAuth authorization URL.
  */
@@ -103,6 +108,64 @@ export async function exchangeFigmaCode(
     expiresIn: data.expires_in,
     scopes: ["file_content:read"],
     userInfo,
+  };
+}
+
+/**
+ * Refresh a Figma access token using the refresh token.
+ * Figma uses Basic Auth for token requests.
+ * Returns new access token and new refresh token (both must be stored).
+ */
+export async function refreshFigmaToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+): Promise<FigmaRefreshResult> {
+  const oauthConfig = getConnectorOAuthConfig("figma");
+  if (!oauthConfig) {
+    throw new Error("Figma OAuth config not found");
+  }
+
+  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
+    "base64",
+  );
+
+  const response = await fetch(oauthConfig.tokenUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Figma token refresh failed: ${response.status}`);
+  }
+
+  const data = z
+    .object({
+      access_token: z.string().optional(),
+      refresh_token: z.string().nullable().optional(),
+      error: z.string().optional(),
+      error_description: z.string().optional(),
+    })
+    .parse(await response.json());
+
+  if (data.error) {
+    throw new Error(data.error_description ?? data.error);
+  }
+
+  if (!data.access_token) {
+    throw new Error("No access token in Figma refresh response");
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? null,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/garmin-connect.ts
+++ b/turbo/apps/web/src/lib/connector/providers/garmin-connect.ts
@@ -17,6 +17,11 @@ interface GarminConnectTokenResult {
   userInfo: GarminConnectUserInfo;
 }
 
+interface GarminConnectRefreshResult {
+  accessToken: string;
+  refreshToken: string | null;
+}
+
 /**
  * Derive a PKCE code_verifier deterministically from the OAuth state.
  * Uses the state as seed material for a reproducible verifier.
@@ -139,6 +144,61 @@ export async function exchangeGarminConnectCode(
     expiresIn: data.expires_in,
     scopes: [],
     userInfo,
+  };
+}
+
+/**
+ * Refresh a Garmin Connect access token using the refresh token.
+ * PKCE is not required for refresh — only client credentials and refresh token.
+ * Garmin rotates refresh tokens — both must be stored.
+ */
+export async function refreshGarminConnectToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+): Promise<GarminConnectRefreshResult> {
+  const oauthConfig = getConnectorOAuthConfig("garmin-connect");
+  if (!oauthConfig) {
+    throw new Error("Garmin Connect OAuth config not found");
+  }
+
+  const response = await fetch(oauthConfig.tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Garmin Connect token refresh failed: ${response.status}`);
+  }
+
+  const data = z
+    .object({
+      access_token: z.string().optional(),
+      refresh_token: z.string().nullable().optional(),
+      error: z.string().optional(),
+      error_description: z.string().optional(),
+    })
+    .parse(await response.json());
+
+  if (data.error) {
+    throw new Error(data.error_description ?? data.error);
+  }
+
+  if (!data.access_token) {
+    throw new Error("No access token in Garmin Connect refresh response");
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? null,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/google-oauth.ts
+++ b/turbo/apps/web/src/lib/connector/providers/google-oauth.ts
@@ -17,6 +17,11 @@ interface GoogleTokenResult {
   userInfo: GoogleUserInfo;
 }
 
+interface GoogleRefreshResult {
+  accessToken: string;
+  refreshToken: string | null;
+}
+
 /**
  * Build Google OAuth authorization URL for any Google connector.
  * Requests offline access to obtain a refresh token.
@@ -108,6 +113,64 @@ export async function exchangeGoogleOAuthCode(
     expiresIn: data.expires_in,
     scopes: data.scope ? data.scope.split(" ") : [],
     userInfo,
+  };
+}
+
+/**
+ * Refresh a Google access token using the refresh token.
+ * Works for any Google connector (Gmail, Sheets, Docs, Drive).
+ * Returns new access token (Google does not rotate refresh tokens).
+ */
+export async function refreshGoogleToken(
+  connectorType: ConnectorType,
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+): Promise<GoogleRefreshResult> {
+  const oauthConfig = getConnectorOAuthConfig(connectorType);
+  if (!oauthConfig) {
+    throw new Error(`${connectorType} OAuth config not found`);
+  }
+
+  const response = await fetch(oauthConfig.tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `${connectorType} token refresh failed: ${response.status}`,
+    );
+  }
+
+  const data = z
+    .object({
+      access_token: z.string().optional(),
+      refresh_token: z.string().nullable().optional(),
+      error: z.string().optional(),
+      error_description: z.string().optional(),
+    })
+    .parse(await response.json());
+
+  if (data.error) {
+    throw new Error(data.error_description ?? data.error);
+  }
+
+  if (!data.access_token) {
+    throw new Error(`No access token in ${connectorType} refresh response`);
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? null,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/mercury.ts
+++ b/turbo/apps/web/src/lib/connector/providers/mercury.ts
@@ -17,6 +17,11 @@ interface MercuryTokenResult {
   userInfo: MercuryUserInfo;
 }
 
+interface MercuryRefreshResult {
+  accessToken: string;
+  refreshToken: string | null;
+}
+
 /**
  * Build Mercury OAuth authorization URL.
  * Requests offline_access scope to obtain a refresh token.
@@ -101,6 +106,60 @@ export async function exchangeMercuryCode(
     expiresIn: data.expires_in,
     scopes: data.scope ? data.scope.split(" ") : [],
     userInfo,
+  };
+}
+
+/**
+ * Refresh a Mercury access token using the refresh token.
+ * Returns new access token and new refresh token (both must be stored).
+ */
+export async function refreshMercuryToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+): Promise<MercuryRefreshResult> {
+  const oauthConfig = getConnectorOAuthConfig("mercury");
+  if (!oauthConfig) {
+    throw new Error("Mercury OAuth config not found");
+  }
+
+  const response = await fetch(oauthConfig.tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Mercury token refresh failed: ${response.status}`);
+  }
+
+  const data = z
+    .object({
+      access_token: z.string().optional(),
+      refresh_token: z.string().nullable().optional(),
+      error: z.string().optional(),
+      error_description: z.string().optional(),
+    })
+    .parse(await response.json());
+
+  if (data.error) {
+    throw new Error(data.error_description ?? data.error);
+  }
+
+  if (!data.access_token) {
+    throw new Error("No access token in Mercury refresh response");
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? null,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/strava.ts
+++ b/turbo/apps/web/src/lib/connector/providers/strava.ts
@@ -17,6 +17,11 @@ interface StravaTokenResult {
   userInfo: StravaUserInfo;
 }
 
+interface StravaRefreshResult {
+  accessToken: string;
+  refreshToken: string | null;
+}
+
 /**
  * Build Strava OAuth authorization URL.
  * Requests offline access via approval_prompt=force to obtain a refresh token.
@@ -119,6 +124,60 @@ export async function exchangeStravaCode(
     expiresIn: data.expires_in,
     scopes: [],
     userInfo,
+  };
+}
+
+/**
+ * Refresh a Strava access token using the refresh token.
+ * Strava rotates refresh tokens — both must be stored.
+ */
+export async function refreshStravaToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+): Promise<StravaRefreshResult> {
+  const oauthConfig = getConnectorOAuthConfig("strava");
+  if (!oauthConfig) {
+    throw new Error("Strava OAuth config not found");
+  }
+
+  const response = await fetch(oauthConfig.tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Strava token refresh failed: ${response.status}`);
+  }
+
+  const data = z
+    .object({
+      access_token: z.string().optional(),
+      refresh_token: z.string().nullable().optional(),
+      error: z.string().optional(),
+      error_description: z.string().optional(),
+    })
+    .parse(await response.json());
+
+  if (data.error) {
+    throw new Error(data.error_description ?? data.error);
+  }
+
+  if (!data.access_token) {
+    throw new Error("No access token in Strava refresh response");
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? null,
   };
 }
 

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -34,6 +34,14 @@ import { getDefaultModelProvider } from "../model-provider/model-provider-servic
 import { connectors } from "../../db/schema/connector";
 import { refreshNotionToken } from "../connector/providers/notion";
 import { refreshLinearToken } from "../connector/providers/linear";
+import { refreshGoogleToken } from "../connector/providers/google-oauth";
+import { refreshDropboxToken } from "../connector/providers/dropbox";
+import { refreshStravaToken } from "../connector/providers/strava";
+import { refreshDocuSignToken } from "../connector/providers/docusign";
+import { refreshFigmaToken } from "../connector/providers/figma";
+import { refreshMercuryToken } from "../connector/providers/mercury";
+import { refreshDeelToken } from "../connector/providers/deel";
+import { refreshGarminConnectToken } from "../connector/providers/garmin-connect";
 import { upsertConnectorSecret } from "../connector/connector-service";
 
 const log = logger("run:build-context");
@@ -312,101 +320,174 @@ async function resolveModelProviderCredential(
 }
 
 /**
- * Refresh Notion access token using the stored refresh token.
- * Updates both NOTION_ACCESS_TOKEN and NOTION_REFRESH_TOKEN in the database
- * and returns the new access token for immediate use.
- *
- * Returns null if refresh token is unavailable or refresh fails
- * (caller should fall back to using the existing access token).
+ * Configuration for connector token refresh.
+ * Maps connector type to its refresh function, secret names, and OAuth env var names.
  */
-async function refreshNotionAccessToken(
-  userId: string,
-  connectorSecrets: Record<string, string>,
-): Promise<string | null> {
-  const currentRefreshToken = connectorSecrets["NOTION_REFRESH_TOKEN"];
-  if (!currentRefreshToken) {
-    log.debug("No Notion refresh token available, skipping token refresh");
-    return null;
-  }
-
-  const env = globalThis.services.env;
-  const clientId = env.NOTION_OAUTH_CLIENT_ID;
-  const clientSecret = env.NOTION_OAUTH_CLIENT_SECRET;
-
-  if (!clientId || !clientSecret) {
-    log.debug(
-      "Notion OAuth credentials not configured, skipping token refresh",
-    );
-    return null;
-  }
-
-  try {
-    const result = await refreshNotionToken(
-      clientId,
-      clientSecret,
-      currentRefreshToken,
-    );
-
-    // Persist new tokens to database
-    await upsertConnectorSecret(
-      userId,
-      "NOTION_ACCESS_TOKEN",
-      result.accessToken,
-    );
-    if (result.refreshToken) {
-      await upsertConnectorSecret(
-        userId,
-        "NOTION_REFRESH_TOKEN",
-        result.refreshToken,
-      );
-    }
-
-    // Update in-memory secrets map so subsequent mapping uses fresh token
-    connectorSecrets["NOTION_ACCESS_TOKEN"] = result.accessToken;
-    if (result.refreshToken) {
-      connectorSecrets["NOTION_REFRESH_TOKEN"] = result.refreshToken;
-    }
-
-    log.debug("Notion access token refreshed successfully");
-    return result.accessToken;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    log.warn(`Notion token refresh failed: ${message}`);
-    return null;
-  }
+interface ConnectorRefreshConfig {
+  label: string;
+  accessTokenSecret: string;
+  refreshTokenSecret: string;
+  getClientId: (env: typeof globalThis.services.env) => string | undefined;
+  getClientSecret: (env: typeof globalThis.services.env) => string | undefined;
+  refresh: (
+    clientId: string,
+    clientSecret: string,
+    refreshToken: string,
+  ) => Promise<{ accessToken: string; refreshToken: string | null }>;
 }
 
+const CONNECTOR_REFRESH_CONFIGS: Partial<
+  Record<string, ConnectorRefreshConfig>
+> = {
+  notion: {
+    label: "Notion",
+    accessTokenSecret: "NOTION_ACCESS_TOKEN",
+    refreshTokenSecret: "NOTION_REFRESH_TOKEN",
+    getClientId: (env) => env.NOTION_OAUTH_CLIENT_ID,
+    getClientSecret: (env) => env.NOTION_OAUTH_CLIENT_SECRET,
+    refresh: refreshNotionToken,
+  },
+  linear: {
+    label: "Linear",
+    accessTokenSecret: "LINEAR_ACCESS_TOKEN",
+    refreshTokenSecret: "LINEAR_REFRESH_TOKEN",
+    getClientId: (env) => env.LINEAR_OAUTH_CLIENT_ID,
+    getClientSecret: (env) => env.LINEAR_OAUTH_CLIENT_SECRET,
+    refresh: refreshLinearToken,
+  },
+  gmail: {
+    label: "Gmail",
+    accessTokenSecret: "GMAIL_ACCESS_TOKEN",
+    refreshTokenSecret: "GMAIL_REFRESH_TOKEN",
+    getClientId: (env) => env.GOOGLE_OAUTH_CLIENT_ID,
+    getClientSecret: (env) => env.GOOGLE_OAUTH_CLIENT_SECRET,
+    refresh: (clientId, clientSecret, refreshToken) =>
+      refreshGoogleToken("gmail", clientId, clientSecret, refreshToken),
+  },
+  "google-sheets": {
+    label: "Google Sheets",
+    accessTokenSecret: "GOOGLE_SHEETS_ACCESS_TOKEN",
+    refreshTokenSecret: "GOOGLE_SHEETS_REFRESH_TOKEN",
+    getClientId: (env) => env.GOOGLE_OAUTH_CLIENT_ID,
+    getClientSecret: (env) => env.GOOGLE_OAUTH_CLIENT_SECRET,
+    refresh: (clientId, clientSecret, refreshToken) =>
+      refreshGoogleToken("google-sheets", clientId, clientSecret, refreshToken),
+  },
+  "google-docs": {
+    label: "Google Docs",
+    accessTokenSecret: "GOOGLE_DOCS_ACCESS_TOKEN",
+    refreshTokenSecret: "GOOGLE_DOCS_REFRESH_TOKEN",
+    getClientId: (env) => env.GOOGLE_OAUTH_CLIENT_ID,
+    getClientSecret: (env) => env.GOOGLE_OAUTH_CLIENT_SECRET,
+    refresh: (clientId, clientSecret, refreshToken) =>
+      refreshGoogleToken("google-docs", clientId, clientSecret, refreshToken),
+  },
+  "google-drive": {
+    label: "Google Drive",
+    accessTokenSecret: "GOOGLE_DRIVE_ACCESS_TOKEN",
+    refreshTokenSecret: "GOOGLE_DRIVE_REFRESH_TOKEN",
+    getClientId: (env) => env.GOOGLE_OAUTH_CLIENT_ID,
+    getClientSecret: (env) => env.GOOGLE_OAUTH_CLIENT_SECRET,
+    refresh: (clientId, clientSecret, refreshToken) =>
+      refreshGoogleToken("google-drive", clientId, clientSecret, refreshToken),
+  },
+  dropbox: {
+    label: "Dropbox",
+    accessTokenSecret: "DROPBOX_ACCESS_TOKEN",
+    refreshTokenSecret: "DROPBOX_REFRESH_TOKEN",
+    getClientId: (env) => env.DROPBOX_OAUTH_CLIENT_ID,
+    getClientSecret: (env) => env.DROPBOX_OAUTH_CLIENT_SECRET,
+    refresh: refreshDropboxToken,
+  },
+  strava: {
+    label: "Strava",
+    accessTokenSecret: "STRAVA_ACCESS_TOKEN",
+    refreshTokenSecret: "STRAVA_REFRESH_TOKEN",
+    getClientId: (env) => env.STRAVA_OAUTH_CLIENT_ID,
+    getClientSecret: (env) => env.STRAVA_OAUTH_CLIENT_SECRET,
+    refresh: refreshStravaToken,
+  },
+  docusign: {
+    label: "DocuSign",
+    accessTokenSecret: "DOCUSIGN_ACCESS_TOKEN",
+    refreshTokenSecret: "DOCUSIGN_REFRESH_TOKEN",
+    getClientId: (env) => env.DOCUSIGN_OAUTH_CLIENT_ID,
+    getClientSecret: (env) => env.DOCUSIGN_OAUTH_CLIENT_SECRET,
+    refresh: refreshDocuSignToken,
+  },
+  figma: {
+    label: "Figma",
+    accessTokenSecret: "FIGMA_ACCESS_TOKEN",
+    refreshTokenSecret: "FIGMA_REFRESH_TOKEN",
+    getClientId: (env) => env.FIGMA_OAUTH_CLIENT_ID,
+    getClientSecret: (env) => env.FIGMA_OAUTH_CLIENT_SECRET,
+    refresh: refreshFigmaToken,
+  },
+  mercury: {
+    label: "Mercury",
+    accessTokenSecret: "MERCURY_ACCESS_TOKEN",
+    refreshTokenSecret: "MERCURY_REFRESH_TOKEN",
+    getClientId: (env) => env.MERCURY_OAUTH_CLIENT_ID,
+    getClientSecret: (env) => env.MERCURY_OAUTH_CLIENT_SECRET,
+    refresh: refreshMercuryToken,
+  },
+  deel: {
+    label: "Deel",
+    accessTokenSecret: "DEEL_ACCESS_TOKEN",
+    refreshTokenSecret: "DEEL_REFRESH_TOKEN",
+    getClientId: (env) => env.DEEL_OAUTH_CLIENT_ID,
+    getClientSecret: (env) => env.DEEL_OAUTH_CLIENT_SECRET,
+    refresh: refreshDeelToken,
+  },
+  "garmin-connect": {
+    label: "Garmin Connect",
+    accessTokenSecret: "GARMIN_CONNECT_ACCESS_TOKEN",
+    refreshTokenSecret: "GARMIN_CONNECT_REFRESH_TOKEN",
+    getClientId: (env) => env.GARMIN_CONNECT_OAUTH_CLIENT_ID,
+    getClientSecret: (env) => env.GARMIN_CONNECT_OAUTH_CLIENT_SECRET,
+    refresh: refreshGarminConnectToken,
+  },
+};
+
 /**
- * Refresh Linear access token using the stored refresh token.
- * Updates both LINEAR_ACCESS_TOKEN and LINEAR_REFRESH_TOKEN in the database
- * and returns the new access token for immediate use.
+ * Generic connector access token refresh.
+ * Looks up the connector's refresh config, calls the provider-specific refresh
+ * function, persists new tokens, and updates the in-memory secrets map.
  *
- * Returns null if refresh token is unavailable or refresh fails
- * (caller should fall back to using the existing access token).
+ * Returns null if refresh token is unavailable, OAuth credentials are missing,
+ * or the refresh fails (caller should fall back to the existing access token).
  */
-async function refreshLinearAccessToken(
+async function refreshConnectorAccessToken(
+  connectorType: string,
   userId: string,
   connectorSecrets: Record<string, string>,
 ): Promise<string | null> {
-  const currentRefreshToken = connectorSecrets["LINEAR_REFRESH_TOKEN"];
+  const config = CONNECTOR_REFRESH_CONFIGS[connectorType];
+  if (!config) {
+    return null;
+  }
+
+  const currentRefreshToken = connectorSecrets[config.refreshTokenSecret];
   if (!currentRefreshToken) {
-    log.debug("No Linear refresh token available, skipping token refresh");
+    log.debug(
+      `No ${config.label} refresh token available, skipping token refresh`,
+    );
     return null;
   }
 
   const env = globalThis.services.env;
-  const clientId = env.LINEAR_OAUTH_CLIENT_ID;
-  const clientSecret = env.LINEAR_OAUTH_CLIENT_SECRET;
+  const clientId = config.getClientId(env);
+  const clientSecret = config.getClientSecret(env);
 
   if (!clientId || !clientSecret) {
     log.debug(
-      "Linear OAuth credentials not configured, skipping token refresh",
+      `${config.label} OAuth credentials not configured, skipping token refresh`,
     );
     return null;
   }
 
   try {
-    const result = await refreshLinearToken(
+    const result = await config.refresh(
       clientId,
       clientSecret,
       currentRefreshToken,
@@ -415,28 +496,28 @@ async function refreshLinearAccessToken(
     // Persist new tokens to database
     await upsertConnectorSecret(
       userId,
-      "LINEAR_ACCESS_TOKEN",
+      config.accessTokenSecret,
       result.accessToken,
     );
     if (result.refreshToken) {
       await upsertConnectorSecret(
         userId,
-        "LINEAR_REFRESH_TOKEN",
+        config.refreshTokenSecret,
         result.refreshToken,
       );
     }
 
     // Update in-memory secrets map so subsequent mapping uses fresh token
-    connectorSecrets["LINEAR_ACCESS_TOKEN"] = result.accessToken;
+    connectorSecrets[config.accessTokenSecret] = result.accessToken;
     if (result.refreshToken) {
-      connectorSecrets["LINEAR_REFRESH_TOKEN"] = result.refreshToken;
+      connectorSecrets[config.refreshTokenSecret] = result.refreshToken;
     }
 
-    log.debug("Linear access token refreshed successfully");
+    log.debug(`${config.label} access token refreshed successfully`);
     return result.accessToken;
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
-    log.warn(`Linear token refresh failed: ${message}`);
+    log.warn(`${config.label} token refresh failed: ${message}`);
     return null;
   }
 }
@@ -492,11 +573,13 @@ async function resolveConnectorCredentials(
       continue;
     }
 
-    // Refresh tokens before resolving environment mapping
-    if (connectorType.data === "notion") {
-      await refreshNotionAccessToken(userId, connectorSecrets);
-    } else if (connectorType.data === "linear") {
-      await refreshLinearAccessToken(userId, connectorSecrets);
+    // Refresh access token before resolving environment mapping
+    if (connectorType.data in CONNECTOR_REFRESH_CONFIGS) {
+      await refreshConnectorAccessToken(
+        connectorType.data,
+        userId,
+        connectorSecrets,
+      );
     }
 
     const mapping = getConnectorEnvironmentMapping(connectorType.data);


### PR DESCRIPTION
## Summary

- Add `refresh*Token()` functions to all remaining OAuth connector providers: Deel, DocuSign, Dropbox, Figma, Garmin Connect, Google OAuth (Gmail, Sheets, Docs, Drive), Mercury, and Strava
- Refactor `build-context.ts` to replace per-connector refresh functions (`refreshNotionAccessToken`, `refreshLinearAccessToken`) with a generic config-driven `refreshConnectorAccessToken()` backed by a `CONNECTOR_REFRESH_CONFIGS` map
- All OAuth connectors now automatically refresh expired access tokens before run context resolution

## Test plan

- [ ] Verify build passes (`pnpm turbo run build`)
- [ ] Verify existing tests pass (`pnpm vitest`)
- [ ] Verify token refresh works for connectors that rotate refresh tokens (Strava, Garmin Connect, Deel, Figma, DocuSign, Mercury)
- [ ] Verify token refresh works for connectors that do not rotate refresh tokens (Google, Dropbox)
- [ ] Verify fallback behavior when refresh token is missing or OAuth credentials are not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)