### PR TITLE
fix(platform): rename integration connect buttons to install

### DIFF
--- a/turbo/apps/platform/src/views/integrations-page/__tests__/slack-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/__tests__/slack-settings-page.test.tsx
@@ -203,7 +203,7 @@ describe("settings integrations tab", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows Connect link when user is not linked to Slack", async () => {
+  it("shows Install link when user is not linked to Slack", async () => {
     server.use(
       http.get("/api/integrations/slack", () => {
         return HttpResponse.json(
@@ -221,7 +221,7 @@ describe("settings integrations tab", () => {
     // Should show the Slack card
     expect(screen.getByText("VM0 in Slack")).toBeInTheDocument();
 
-    // Should show Connect link (not Settings button within the card)
-    expect(screen.getByText("Connect")).toBeInTheDocument();
+    // Should show Install link (not Settings button within the card)
+    expect(screen.getByText("Install")).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/integrations-page/integrations-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/integrations-page.tsx
@@ -54,7 +54,7 @@ export function SlackIntegrationCard() {
           installUrl ? (
             <Button variant="outline" size="sm" asChild>
               <a href={installUrl} target="_blank" rel="noopener noreferrer">
-                Connect
+                Install
               </a>
             </Button>
           ) : null
@@ -93,13 +93,13 @@ export function GitHubIntegrationCard() {
           installUrl ? (
             <Button variant="outline" size="sm" asChild>
               <a href={installUrl} target="_blank" rel="noopener noreferrer">
-                Connect
+                Install
               </a>
             </Button>
           ) : null
         ) : (
           <Button variant="outline" size="sm" disabled>
-            Connected
+            Installed
           </Button>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Rename "Connect" to "Install" and "Connected" to "Installed" on integration cards (Slack + GitHub)
- Update corresponding test assertions

## Test plan

- [x] Slack settings page tests pass (8 tests)
- [x] Lint, type check, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)