### PR TITLE
feat(platform): forward logger errors to sentry

### DIFF
--- a/turbo/apps/platform/src/main.ts
+++ b/turbo/apps/platform/src/main.ts
@@ -1,13 +1,28 @@
 // Initialize Sentry before anything else (side-effect import)
-import "./lib/sentry.ts";
+import { Sentry } from "./lib/sentry.ts";
 import "./polyfill.ts";
 import { createRoot } from "react-dom/client";
 import { appStore, AppStoreProvider } from "./signals/app-store.ts";
 import { bootstrap$ } from "./signals/bootstrap.ts";
+import { setLogErrorHandler } from "./signals/log.ts";
 import { initSidebar$ } from "./signals/sidebar.ts";
 import { initTheme$ } from "./signals/theme.ts";
 import { detach, Reason } from "./signals/utils.ts";
 import { setupRouter } from "./views/main.tsx";
+
+setLogErrorHandler((loggerName, args) => {
+  const error = args.find((a): a is Error => a instanceof Error);
+  if (error) {
+    Sentry.captureException(error, {
+      tags: { logger: loggerName },
+    });
+  } else {
+    Sentry.captureMessage(args.map(String).join(" "), {
+      level: "error",
+      tags: { logger: loggerName },
+    });
+  }
+});
 
 async function main(rootEl: HTMLDivElement, signal: AbortSignal) {
   // Initialize theme and sidebar before bootstrap

--- a/turbo/apps/platform/src/signals/__tests__/log.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/log.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  logger,
+  Level,
+  setLogErrorHandler,
+  resetLoggerForTest,
+} from "../log.ts";
+
+describe("setLogErrorHandler", () => {
+  beforeEach(() => {
+    resetLoggerForTest();
+  });
+
+  it("should invoke handler on error()", () => {
+    const handler = vi.fn();
+    setLogErrorHandler(handler);
+
+    const log = logger("test-error");
+    log.error("something went wrong");
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith("test-error", [
+      "something went wrong",
+    ]);
+  });
+
+  it("should invoke handler on fatal()", () => {
+    const handler = vi.fn();
+    setLogErrorHandler(handler);
+
+    const log = logger("test-fatal");
+    log.fatal("critical failure");
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith("test-fatal", ["critical failure"]);
+  });
+
+  it("should invoke handler with Error objects", () => {
+    const handler = vi.fn();
+    setLogErrorHandler(handler);
+
+    const err = new Error("boom");
+    const log = logger("test-err-obj");
+    log.error(err);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith("test-err-obj", [err]);
+  });
+
+  it("should invoke handler with multiple args", () => {
+    const handler = vi.fn();
+    setLogErrorHandler(handler);
+
+    const err = new Error("boom");
+    const log = logger("test-multi");
+    log.error("context", err, 42);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith("test-multi", ["context", err, 42]);
+  });
+
+  it("should not invoke handler for debug level", () => {
+    const handler = vi.fn();
+    setLogErrorHandler(handler);
+
+    const log = logger("test-debug");
+    log.level = Level.Debug;
+    log.debug("debug message");
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("should not invoke handler for info level", () => {
+    const handler = vi.fn();
+    setLogErrorHandler(handler);
+
+    const log = logger("test-info");
+    log.info("info message");
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("should not invoke handler for warn level", () => {
+    const handler = vi.fn();
+    setLogErrorHandler(handler);
+
+    const log = logger("test-warn");
+    log.warn("warn message");
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("should not invoke handler for trace level", () => {
+    const handler = vi.fn();
+    setLogErrorHandler(handler);
+
+    const log = logger("test-trace");
+    log.level = Level.Debug;
+    log.trace("trace message");
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("should not throw when no handler is set", () => {
+    const log = logger("test-no-handler");
+    expect(() => log.error("no handler")).not.toThrow();
+  });
+
+  it("should pass a copy of args to the handler", () => {
+    const handler = vi.fn();
+    setLogErrorHandler(handler);
+
+    const log = logger("test-copy");
+    log.error("msg");
+
+    const passedArgs = handler.mock.calls[0]![1] as unknown[];
+    expect(passedArgs).toStrictEqual(["msg"]);
+  });
+
+  it("should clear handler on resetLoggerForTest", () => {
+    const handler = vi.fn();
+    setLogErrorHandler(handler);
+
+    resetLoggerForTest();
+
+    const log = logger("test-reset");
+    log.error("after reset");
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/platform/src/signals/log.ts
+++ b/turbo/apps/platform/src/signals/log.ts
@@ -61,7 +61,7 @@ type ErrorHandler = (loggerName: string, args: unknown[]) => void;
 
 class LoggerRegistry {
   private store: Partial<Record<string, ConsoleLogger>> = {};
-  errorHandler: ErrorHandler | null = null;
+  private errorHandler: ErrorHandler | null = null;
 
   get(name: string): ConsoleLogger | undefined {
     return this.store[name];
@@ -71,6 +71,14 @@ class LoggerRegistry {
     this.store[name] = instance;
   }
 
+  setErrorHandler(handler: ErrorHandler): void {
+    this.errorHandler = handler;
+  }
+
+  getErrorHandler(): ErrorHandler | null {
+    return this.errorHandler;
+  }
+
   reset(): void {
     for (const key of Object.keys(this.store)) {
       const inst = this.store[key];
@@ -78,6 +86,7 @@ class LoggerRegistry {
         inst.level = Level.Info;
       }
     }
+    this.errorHandler = null;
   }
 
   getAll(): Partial<Record<string, ConsoleLogger>> {
@@ -88,7 +97,7 @@ class LoggerRegistry {
 const loggerRegistry = new LoggerRegistry();
 
 export function setLogErrorHandler(handler: ErrorHandler): void {
-  loggerRegistry.errorHandler = handler;
+  loggerRegistry.setErrorHandler(handler);
 }
 
 /**
@@ -208,11 +217,9 @@ export function logger(name: string): ConsoleLogger {
         return;
       }
 
-      if (
-        (level === Level.Error || level === Level.Fatal) &&
-        loggerRegistry.errorHandler
-      ) {
-        loggerRegistry.errorHandler(name, [...args]);
+      const errorHandler = loggerRegistry.getErrorHandler();
+      if ((level === Level.Error || level === Level.Fatal) && errorHandler) {
+        errorHandler(name, [...args]);
       }
 
       if (autoAppendName) {

--- a/turbo/apps/platform/src/signals/log.ts
+++ b/turbo/apps/platform/src/signals/log.ts
@@ -57,8 +57,11 @@ export enum Level {
   Fatal = "fatal",
 }
 
+type ErrorHandler = (loggerName: string, args: unknown[]) => void;
+
 class LoggerRegistry {
   private store: Partial<Record<string, ConsoleLogger>> = {};
+  errorHandler: ErrorHandler | null = null;
 
   get(name: string): ConsoleLogger | undefined {
     return this.store[name];
@@ -83,6 +86,10 @@ class LoggerRegistry {
 }
 
 const loggerRegistry = new LoggerRegistry();
+
+export function setLogErrorHandler(handler: ErrorHandler): void {
+  loggerRegistry.errorHandler = handler;
+}
 
 /**
  * Create a logger instance with the given name.
@@ -199,6 +206,13 @@ export function logger(name: string): ConsoleLogger {
     return function (...args: ARGS) {
       if (!loggerInstance.shouldLog(level)) {
         return;
+      }
+
+      if (
+        (level === Level.Error || level === Level.Fatal) &&
+        loggerRegistry.errorHandler
+      ) {
+        loggerRegistry.errorHandler(name, [...args]);
       }
 
       if (autoAppendName) {


### PR DESCRIPTION
## Summary

- Add a pluggable `ErrorHandler` type and `setLogErrorHandler` function to the logger registry
- Wire up Sentry in `main.ts` so that all `error()` and `fatal()` log calls are automatically reported
- Errors with `Error` instances use `Sentry.captureException`; plain message logs use `Sentry.captureMessage` with the logger name as a tag

## Test plan

- [ ] Verify that calling `logger("foo").error(new Error("test"))` sends an exception to Sentry with `logger: foo` tag
- [ ] Verify that calling `logger("foo").error("message")` sends a message-level event to Sentry
- [ ] Verify that `debug`, `info`, `warn`, and `trace` log levels do NOT trigger the error handler
- [ ] Confirm no regressions in existing logger behavior (filtering, prefixing, level gating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)