### PR TITLE
refactor(sandbox-fc): add sock_base() to runtime paths

### DIFF
--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -99,15 +99,10 @@ fn resolve_control_socket(input: &str) -> RunnerResult<PathBuf> {
         return Err(RunnerError::Config("run_id must not be empty".into()));
     }
 
-    // sock_dir("x") → /run/vm0/sock/x, parent → /run/vm0/sock
-    // Can't use sock_dir("") because join("") is a no-op in Rust.
     let runtime = RuntimePaths::new();
-    let sock_parent = runtime.sock_dir("_");
-    let sock_parent = sock_parent
-        .parent()
-        .ok_or_else(|| RunnerError::Config("unable to determine socket base directory".into()))?;
+    let sock_parent = runtime.sock_base();
 
-    let entries = std::fs::read_dir(sock_parent).map_err(|e| {
+    let entries = std::fs::read_dir(&sock_parent).map_err(|e| {
         RunnerError::Config(format!(
             "cannot read {}: {e} (is a sandbox running?)",
             sock_parent.display()

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -22,9 +22,14 @@ impl RuntimePaths {
         }
     }
 
+    /// Socket base directory: `/run/vm0/sock/`.
+    pub fn sock_base(&self) -> PathBuf {
+        self.base_dir.join("sock")
+    }
+
     /// Socket directory: `/run/vm0/sock/<id>/`.
     pub fn sock_dir(&self, id: &str) -> PathBuf {
-        self.base_dir.join("sock").join(id)
+        self.sock_base().join(id)
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `sock_base()` method to `RuntimePaths` that returns `/run/vm0/sock/`
- Replace `sock_dir("_").parent()` hack in `exec.rs` with the new method
- `sock_dir()` now internally calls `sock_base().join(id)`

## Test plan

- [x] `cargo clippy -p sandbox-fc -p runner` — no warnings
- [x] `cargo test -p sandbox-fc -p runner` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)