### PR TITLE
refactor(connectors): move token refresh into provider handler interface

### DIFF
--- a/turbo/apps/web/src/lib/connector/provider-types.ts
+++ b/turbo/apps/web/src/lib/connector/provider-types.ts
@@ -25,4 +25,9 @@ export interface ProviderHandler {
   getClientSecret(currentEnv: Env): string | undefined;
   getSecretName(): string;
   getRefreshSecretName?(): string;
+  refreshToken?(
+    clientId: string,
+    clientSecret: string,
+    refreshToken: string,
+  ): Promise<{ accessToken: string; refreshToken: string | null }>;
 }

--- a/turbo/apps/web/src/lib/connector/providers/deel-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/deel-handler.ts
@@ -3,6 +3,7 @@ import {
   buildDeelAuthorizationUrl,
   exchangeDeelCode,
   getDeelSecretName,
+  refreshDeelToken,
 } from "./deel";
 
 export const deelHandler: ProviderHandler = {
@@ -34,4 +35,5 @@ export const deelHandler: ProviderHandler = {
   getClientSecret: (e) => e.DEEL_OAUTH_CLIENT_SECRET,
   getSecretName: getDeelSecretName,
   getRefreshSecretName: () => "DEEL_REFRESH_TOKEN",
+  refreshToken: refreshDeelToken,
 };

--- a/turbo/apps/web/src/lib/connector/providers/docusign-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/docusign-handler.ts
@@ -3,6 +3,7 @@ import {
   buildDocuSignAuthorizationUrl,
   exchangeDocuSignCode,
   getDocuSignSecretName,
+  refreshDocuSignToken,
 } from "./docusign";
 
 export const docusignHandler: ProviderHandler = {
@@ -30,4 +31,5 @@ export const docusignHandler: ProviderHandler = {
   getClientSecret: (e) => e.DOCUSIGN_OAUTH_CLIENT_SECRET,
   getSecretName: getDocuSignSecretName,
   getRefreshSecretName: () => "DOCUSIGN_REFRESH_TOKEN",
+  refreshToken: refreshDocuSignToken,
 };

--- a/turbo/apps/web/src/lib/connector/providers/dropbox-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/dropbox-handler.ts
@@ -3,6 +3,7 @@ import {
   buildDropboxAuthorizationUrl,
   exchangeDropboxCode,
   getDropboxSecretName,
+  refreshDropboxToken,
 } from "./dropbox";
 
 export const dropboxHandler: ProviderHandler = {
@@ -30,4 +31,5 @@ export const dropboxHandler: ProviderHandler = {
   getClientSecret: (e) => e.DROPBOX_OAUTH_CLIENT_SECRET,
   getSecretName: getDropboxSecretName,
   getRefreshSecretName: () => "DROPBOX_REFRESH_TOKEN",
+  refreshToken: refreshDropboxToken,
 };

--- a/turbo/apps/web/src/lib/connector/providers/figma-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/figma-handler.ts
@@ -3,6 +3,7 @@ import {
   buildFigmaAuthorizationUrl,
   exchangeFigmaCode,
   getFigmaSecretName,
+  refreshFigmaToken,
 } from "./figma";
 
 export const figmaHandler: ProviderHandler = {
@@ -30,4 +31,5 @@ export const figmaHandler: ProviderHandler = {
   getClientSecret: (e) => e.FIGMA_OAUTH_CLIENT_SECRET,
   getSecretName: getFigmaSecretName,
   getRefreshSecretName: () => "FIGMA_REFRESH_TOKEN",
+  refreshToken: refreshFigmaToken,
 };

--- a/turbo/apps/web/src/lib/connector/providers/garmin-connect-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/garmin-connect-handler.ts
@@ -3,6 +3,7 @@ import {
   buildGarminConnectAuthorizationUrl,
   exchangeGarminConnectCode,
   getGarminConnectSecretName,
+  refreshGarminConnectToken,
 } from "./garmin-connect";
 
 export const garminConnectHandler: ProviderHandler = {
@@ -35,4 +36,5 @@ export const garminConnectHandler: ProviderHandler = {
   getClientSecret: (e) => e.GARMIN_CONNECT_OAUTH_CLIENT_SECRET,
   getSecretName: getGarminConnectSecretName,
   getRefreshSecretName: () => "GARMIN_CONNECT_REFRESH_TOKEN",
+  refreshToken: refreshGarminConnectToken,
 };

--- a/turbo/apps/web/src/lib/connector/providers/gmail-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/gmail-handler.ts
@@ -4,6 +4,7 @@ import {
   exchangeGmailCode,
   getGmailSecretName,
 } from "./gmail";
+import { refreshGoogleToken } from "./google-oauth";
 
 export const gmailHandler: ProviderHandler = {
   buildAuthUrl: buildGmailAuthorizationUrl,
@@ -30,4 +31,6 @@ export const gmailHandler: ProviderHandler = {
   getClientSecret: (e) => e.GOOGLE_OAUTH_CLIENT_SECRET,
   getSecretName: getGmailSecretName,
   getRefreshSecretName: () => "GMAIL_REFRESH_TOKEN",
+  refreshToken: (clientId, clientSecret, refreshToken) =>
+    refreshGoogleToken("gmail", clientId, clientSecret, refreshToken),
 };

--- a/turbo/apps/web/src/lib/connector/providers/google-docs-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/google-docs-handler.ts
@@ -2,6 +2,7 @@ import { type ProviderHandler } from "../provider-types";
 import {
   buildGoogleAuthorizationUrl,
   exchangeGoogleOAuthCode,
+  refreshGoogleToken,
 } from "./google-oauth";
 
 export const googleDocsHandler: ProviderHandler = {
@@ -31,4 +32,6 @@ export const googleDocsHandler: ProviderHandler = {
   getClientSecret: (e) => e.GOOGLE_OAUTH_CLIENT_SECRET,
   getSecretName: () => "GOOGLE_DOCS_ACCESS_TOKEN",
   getRefreshSecretName: () => "GOOGLE_DOCS_REFRESH_TOKEN",
+  refreshToken: (clientId, clientSecret, refreshToken) =>
+    refreshGoogleToken("google-docs", clientId, clientSecret, refreshToken),
 };

--- a/turbo/apps/web/src/lib/connector/providers/google-drive-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/google-drive-handler.ts
@@ -2,6 +2,7 @@ import { type ProviderHandler } from "../provider-types";
 import {
   buildGoogleAuthorizationUrl,
   exchangeGoogleOAuthCode,
+  refreshGoogleToken,
 } from "./google-oauth";
 
 export const googleDriveHandler: ProviderHandler = {
@@ -31,4 +32,6 @@ export const googleDriveHandler: ProviderHandler = {
   getClientSecret: (e) => e.GOOGLE_OAUTH_CLIENT_SECRET,
   getSecretName: () => "GOOGLE_DRIVE_ACCESS_TOKEN",
   getRefreshSecretName: () => "GOOGLE_DRIVE_REFRESH_TOKEN",
+  refreshToken: (clientId, clientSecret, refreshToken) =>
+    refreshGoogleToken("google-drive", clientId, clientSecret, refreshToken),
 };

--- a/turbo/apps/web/src/lib/connector/providers/google-sheets-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/google-sheets-handler.ts
@@ -2,6 +2,7 @@ import { type ProviderHandler } from "../provider-types";
 import {
   buildGoogleAuthorizationUrl,
   exchangeGoogleOAuthCode,
+  refreshGoogleToken,
 } from "./google-oauth";
 
 export const googleSheetsHandler: ProviderHandler = {
@@ -31,4 +32,6 @@ export const googleSheetsHandler: ProviderHandler = {
   getClientSecret: (e) => e.GOOGLE_OAUTH_CLIENT_SECRET,
   getSecretName: () => "GOOGLE_SHEETS_ACCESS_TOKEN",
   getRefreshSecretName: () => "GOOGLE_SHEETS_REFRESH_TOKEN",
+  refreshToken: (clientId, clientSecret, refreshToken) =>
+    refreshGoogleToken("google-sheets", clientId, clientSecret, refreshToken),
 };

--- a/turbo/apps/web/src/lib/connector/providers/linear-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/linear-handler.ts
@@ -3,6 +3,7 @@ import {
   buildLinearAuthorizationUrl,
   exchangeLinearCode,
   getLinearSecretName,
+  refreshLinearToken,
 } from "./linear";
 
 export const linearHandler: ProviderHandler = {
@@ -30,4 +31,5 @@ export const linearHandler: ProviderHandler = {
   getClientSecret: (e) => e.LINEAR_OAUTH_CLIENT_SECRET,
   getSecretName: getLinearSecretName,
   getRefreshSecretName: () => "LINEAR_REFRESH_TOKEN",
+  refreshToken: refreshLinearToken,
 };

--- a/turbo/apps/web/src/lib/connector/providers/mercury-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/mercury-handler.ts
@@ -3,6 +3,7 @@ import {
   buildMercuryAuthorizationUrl,
   exchangeMercuryCode,
   getMercurySecretName,
+  refreshMercuryToken,
 } from "./mercury";
 
 export const mercuryHandler: ProviderHandler = {
@@ -30,4 +31,5 @@ export const mercuryHandler: ProviderHandler = {
   getClientSecret: (e) => e.MERCURY_OAUTH_CLIENT_SECRET,
   getSecretName: getMercurySecretName,
   getRefreshSecretName: () => "MERCURY_REFRESH_TOKEN",
+  refreshToken: refreshMercuryToken,
 };

--- a/turbo/apps/web/src/lib/connector/providers/notion-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/notion-handler.ts
@@ -3,6 +3,7 @@ import {
   buildNotionAuthorizationUrl,
   exchangeNotionCode,
   getNotionSecretName,
+  refreshNotionToken,
 } from "./notion";
 
 export const notionHandler: ProviderHandler = {
@@ -26,4 +27,5 @@ export const notionHandler: ProviderHandler = {
   getClientSecret: (e) => e.NOTION_OAUTH_CLIENT_SECRET,
   getSecretName: getNotionSecretName,
   getRefreshSecretName: () => "NOTION_REFRESH_TOKEN",
+  refreshToken: refreshNotionToken,
 };

--- a/turbo/apps/web/src/lib/connector/providers/strava-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/strava-handler.ts
@@ -3,6 +3,7 @@ import {
   buildStravaAuthorizationUrl,
   exchangeStravaCode,
   getStravaSecretName,
+  refreshStravaToken,
 } from "./strava";
 
 export const stravaHandler: ProviderHandler = {
@@ -25,4 +26,5 @@ export const stravaHandler: ProviderHandler = {
   getClientSecret: (e) => e.STRAVA_OAUTH_CLIENT_SECRET,
   getSecretName: getStravaSecretName,
   getRefreshSecretName: () => "STRAVA_REFRESH_TOKEN",
+  refreshToken: refreshStravaToken,
 };

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -32,16 +32,7 @@ import { getSecretValue, getSecretValues } from "../secret/secret-service";
 import { getVariableValues } from "../variable/variable-service";
 import { getDefaultModelProvider } from "../model-provider/model-provider-service";
 import { connectors } from "../../db/schema/connector";
-import { refreshNotionToken } from "../connector/providers/notion";
-import { refreshLinearToken } from "../connector/providers/linear";
-import { refreshGoogleToken } from "../connector/providers/google-oauth";
-import { refreshDropboxToken } from "../connector/providers/dropbox";
-import { refreshStravaToken } from "../connector/providers/strava";
-import { refreshDocuSignToken } from "../connector/providers/docusign";
-import { refreshFigmaToken } from "../connector/providers/figma";
-import { refreshMercuryToken } from "../connector/providers/mercury";
-import { refreshDeelToken } from "../connector/providers/deel";
-import { refreshGarminConnectToken } from "../connector/providers/garmin-connect";
+import { PROVIDER_HANDLERS } from "../connector/provider-registry";
 import { upsertConnectorSecret } from "../connector/connector-service";
 
 const log = logger("run:build-context");
@@ -320,139 +311,9 @@ async function resolveModelProviderCredential(
 }
 
 /**
- * Configuration for connector token refresh.
- * Maps connector type to its refresh function, secret names, and OAuth env var names.
- */
-interface ConnectorRefreshConfig {
-  label: string;
-  accessTokenSecret: string;
-  refreshTokenSecret: string;
-  getClientId: (env: typeof globalThis.services.env) => string | undefined;
-  getClientSecret: (env: typeof globalThis.services.env) => string | undefined;
-  refresh: (
-    clientId: string,
-    clientSecret: string,
-    refreshToken: string,
-  ) => Promise<{ accessToken: string; refreshToken: string | null }>;
-}
-
-const CONNECTOR_REFRESH_CONFIGS: Partial<
-  Record<string, ConnectorRefreshConfig>
-> = {
-  notion: {
-    label: "Notion",
-    accessTokenSecret: "NOTION_ACCESS_TOKEN",
-    refreshTokenSecret: "NOTION_REFRESH_TOKEN",
-    getClientId: (env) => env.NOTION_OAUTH_CLIENT_ID,
-    getClientSecret: (env) => env.NOTION_OAUTH_CLIENT_SECRET,
-    refresh: refreshNotionToken,
-  },
-  linear: {
-    label: "Linear",
-    accessTokenSecret: "LINEAR_ACCESS_TOKEN",
-    refreshTokenSecret: "LINEAR_REFRESH_TOKEN",
-    getClientId: (env) => env.LINEAR_OAUTH_CLIENT_ID,
-    getClientSecret: (env) => env.LINEAR_OAUTH_CLIENT_SECRET,
-    refresh: refreshLinearToken,
-  },
-  gmail: {
-    label: "Gmail",
-    accessTokenSecret: "GMAIL_ACCESS_TOKEN",
-    refreshTokenSecret: "GMAIL_REFRESH_TOKEN",
-    getClientId: (env) => env.GOOGLE_OAUTH_CLIENT_ID,
-    getClientSecret: (env) => env.GOOGLE_OAUTH_CLIENT_SECRET,
-    refresh: (clientId, clientSecret, refreshToken) =>
-      refreshGoogleToken("gmail", clientId, clientSecret, refreshToken),
-  },
-  "google-sheets": {
-    label: "Google Sheets",
-    accessTokenSecret: "GOOGLE_SHEETS_ACCESS_TOKEN",
-    refreshTokenSecret: "GOOGLE_SHEETS_REFRESH_TOKEN",
-    getClientId: (env) => env.GOOGLE_OAUTH_CLIENT_ID,
-    getClientSecret: (env) => env.GOOGLE_OAUTH_CLIENT_SECRET,
-    refresh: (clientId, clientSecret, refreshToken) =>
-      refreshGoogleToken("google-sheets", clientId, clientSecret, refreshToken),
-  },
-  "google-docs": {
-    label: "Google Docs",
-    accessTokenSecret: "GOOGLE_DOCS_ACCESS_TOKEN",
-    refreshTokenSecret: "GOOGLE_DOCS_REFRESH_TOKEN",
-    getClientId: (env) => env.GOOGLE_OAUTH_CLIENT_ID,
-    getClientSecret: (env) => env.GOOGLE_OAUTH_CLIENT_SECRET,
-    refresh: (clientId, clientSecret, refreshToken) =>
-      refreshGoogleToken("google-docs", clientId, clientSecret, refreshToken),
-  },
-  "google-drive": {
-    label: "Google Drive",
-    accessTokenSecret: "GOOGLE_DRIVE_ACCESS_TOKEN",
-    refreshTokenSecret: "GOOGLE_DRIVE_REFRESH_TOKEN",
-    getClientId: (env) => env.GOOGLE_OAUTH_CLIENT_ID,
-    getClientSecret: (env) => env.GOOGLE_OAUTH_CLIENT_SECRET,
-    refresh: (clientId, clientSecret, refreshToken) =>
-      refreshGoogleToken("google-drive", clientId, clientSecret, refreshToken),
-  },
-  dropbox: {
-    label: "Dropbox",
-    accessTokenSecret: "DROPBOX_ACCESS_TOKEN",
-    refreshTokenSecret: "DROPBOX_REFRESH_TOKEN",
-    getClientId: (env) => env.DROPBOX_OAUTH_CLIENT_ID,
-    getClientSecret: (env) => env.DROPBOX_OAUTH_CLIENT_SECRET,
-    refresh: refreshDropboxToken,
-  },
-  strava: {
-    label: "Strava",
-    accessTokenSecret: "STRAVA_ACCESS_TOKEN",
-    refreshTokenSecret: "STRAVA_REFRESH_TOKEN",
-    getClientId: (env) => env.STRAVA_OAUTH_CLIENT_ID,
-    getClientSecret: (env) => env.STRAVA_OAUTH_CLIENT_SECRET,
-    refresh: refreshStravaToken,
-  },
-  docusign: {
-    label: "DocuSign",
-    accessTokenSecret: "DOCUSIGN_ACCESS_TOKEN",
-    refreshTokenSecret: "DOCUSIGN_REFRESH_TOKEN",
-    getClientId: (env) => env.DOCUSIGN_OAUTH_CLIENT_ID,
-    getClientSecret: (env) => env.DOCUSIGN_OAUTH_CLIENT_SECRET,
-    refresh: refreshDocuSignToken,
-  },
-  figma: {
-    label: "Figma",
-    accessTokenSecret: "FIGMA_ACCESS_TOKEN",
-    refreshTokenSecret: "FIGMA_REFRESH_TOKEN",
-    getClientId: (env) => env.FIGMA_OAUTH_CLIENT_ID,
-    getClientSecret: (env) => env.FIGMA_OAUTH_CLIENT_SECRET,
-    refresh: refreshFigmaToken,
-  },
-  mercury: {
-    label: "Mercury",
-    accessTokenSecret: "MERCURY_ACCESS_TOKEN",
-    refreshTokenSecret: "MERCURY_REFRESH_TOKEN",
-    getClientId: (env) => env.MERCURY_OAUTH_CLIENT_ID,
-    getClientSecret: (env) => env.MERCURY_OAUTH_CLIENT_SECRET,
-    refresh: refreshMercuryToken,
-  },
-  deel: {
-    label: "Deel",
-    accessTokenSecret: "DEEL_ACCESS_TOKEN",
-    refreshTokenSecret: "DEEL_REFRESH_TOKEN",
-    getClientId: (env) => env.DEEL_OAUTH_CLIENT_ID,
-    getClientSecret: (env) => env.DEEL_OAUTH_CLIENT_SECRET,
-    refresh: refreshDeelToken,
-  },
-  "garmin-connect": {
-    label: "Garmin Connect",
-    accessTokenSecret: "GARMIN_CONNECT_ACCESS_TOKEN",
-    refreshTokenSecret: "GARMIN_CONNECT_REFRESH_TOKEN",
-    getClientId: (env) => env.GARMIN_CONNECT_OAUTH_CLIENT_ID,
-    getClientSecret: (env) => env.GARMIN_CONNECT_OAUTH_CLIENT_SECRET,
-    refresh: refreshGarminConnectToken,
-  },
-};
-
-/**
  * Generic connector access token refresh.
- * Looks up the connector's refresh config, calls the provider-specific refresh
- * function, persists new tokens, and updates the in-memory secrets map.
+ * Looks up the connector's handler from PROVIDER_HANDLERS, calls its refreshToken
+ * method, persists new tokens, and updates the in-memory secrets map.
  *
  * Returns null if refresh token is unavailable, OAuth credentials are missing,
  * or the refresh fails (caller should fall back to the existing access token).
@@ -462,62 +323,60 @@ async function refreshConnectorAccessToken(
   userId: string,
   connectorSecrets: Record<string, string>,
 ): Promise<string | null> {
-  const config = CONNECTOR_REFRESH_CONFIGS[connectorType];
-  if (!config) {
+  const handler =
+    PROVIDER_HANDLERS[connectorType as keyof typeof PROVIDER_HANDLERS];
+  if (!handler?.refreshToken || !handler.getRefreshSecretName) {
     return null;
   }
 
-  const currentRefreshToken = connectorSecrets[config.refreshTokenSecret];
+  const refreshTokenSecret = handler.getRefreshSecretName();
+  const currentRefreshToken = connectorSecrets[refreshTokenSecret];
   if (!currentRefreshToken) {
-    log.debug(
-      `No ${config.label} refresh token available, skipping token refresh`,
-    );
+    log.debug(`No ${connectorType} refresh token available, skipping`);
     return null;
   }
 
   const env = globalThis.services.env;
-  const clientId = config.getClientId(env);
-  const clientSecret = config.getClientSecret(env);
+  const clientId = handler.getClientId(env);
+  const clientSecret = handler.getClientSecret(env);
 
   if (!clientId || !clientSecret) {
     log.debug(
-      `${config.label} OAuth credentials not configured, skipping token refresh`,
+      `${connectorType} OAuth credentials not configured, skipping token refresh`,
     );
     return null;
   }
 
+  const accessTokenSecret = handler.getSecretName();
+
   try {
-    const result = await config.refresh(
+    const result = await handler.refreshToken(
       clientId,
       clientSecret,
       currentRefreshToken,
     );
 
     // Persist new tokens to database
-    await upsertConnectorSecret(
-      userId,
-      config.accessTokenSecret,
-      result.accessToken,
-    );
+    await upsertConnectorSecret(userId, accessTokenSecret, result.accessToken);
     if (result.refreshToken) {
       await upsertConnectorSecret(
         userId,
-        config.refreshTokenSecret,
+        refreshTokenSecret,
         result.refreshToken,
       );
     }
 
     // Update in-memory secrets map so subsequent mapping uses fresh token
-    connectorSecrets[config.accessTokenSecret] = result.accessToken;
+    connectorSecrets[accessTokenSecret] = result.accessToken;
     if (result.refreshToken) {
-      connectorSecrets[config.refreshTokenSecret] = result.refreshToken;
+      connectorSecrets[refreshTokenSecret] = result.refreshToken;
     }
 
-    log.debug(`${config.label} access token refreshed successfully`);
+    log.debug(`${connectorType} access token refreshed successfully`);
     return result.accessToken;
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
-    log.warn(`${config.label} token refresh failed: ${message}`);
+    log.warn(`${connectorType} token refresh failed: ${message}`);
     return null;
   }
 }
@@ -574,7 +433,9 @@ async function resolveConnectorCredentials(
     }
 
     // Refresh access token before resolving environment mapping
-    if (connectorType.data in CONNECTOR_REFRESH_CONFIGS) {
+    const handler =
+      PROVIDER_HANDLERS[connectorType.data as keyof typeof PROVIDER_HANDLERS];
+    if (handler?.refreshToken) {
       await refreshConnectorAccessToken(
         connectorType.data,
         userId,


### PR DESCRIPTION
## Summary
- Adds an optional `refreshToken` method to the `ProviderHandler` interface, co-locating token refresh logic with each connector's handler
- Wires up `refreshToken` on all 14 OAuth connector handlers (Notion, Linear, Gmail, Google Docs/Drive/Sheets, Dropbox, Strava, DocuSign, Figma, Mercury, Deel, Garmin Connect)
- Removes the duplicated `CONNECTOR_REFRESH_CONFIGS` map (~130 lines) from `build-context.ts`, replacing it with direct lookups into `PROVIDER_HANDLERS`

## Test plan
- [ ] Verify `pnpm check-types` passes (type safety of new interface method)
- [ ] Verify `pnpm turbo run lint` passes
- [ ] Verify `pnpm vitest` passes (existing build-context tests)
- [ ] Verify token refresh behavior is unchanged for connectors with refresh tokens (Notion, Linear, Google, Dropbox, Strava, DocuSign, Figma, Mercury, Deel, Garmin Connect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)