### PR TITLE
docs(runner): add conditional help text for rootfs guest binary args

### DIFF
--- a/crates/runner/src/cmd/rootfs.rs
+++ b/crates/runner/src/cmd/rootfs.rs
@@ -36,13 +36,41 @@ fn bundled_guest(_name: &str) -> Option<&'static [u8]> {
 
 #[derive(Args)]
 pub struct RootfsArgs {
-    #[arg(long)]
+    #[cfg_attr(
+        bundled_guests,
+        arg(long, help = "Path to guest-agent binary [default: bundled]")
+    )]
+    #[cfg_attr(
+        not(bundled_guests),
+        arg(long, help = "Path to guest-agent binary (required)")
+    )]
     guest_agent: Option<PathBuf>,
-    #[arg(long)]
+    #[cfg_attr(
+        bundled_guests,
+        arg(long, help = "Path to guest-download binary [default: bundled]")
+    )]
+    #[cfg_attr(
+        not(bundled_guests),
+        arg(long, help = "Path to guest-download binary (required)")
+    )]
     guest_download: Option<PathBuf>,
-    #[arg(long)]
+    #[cfg_attr(
+        bundled_guests,
+        arg(long, help = "Path to guest-init binary [default: bundled]")
+    )]
+    #[cfg_attr(
+        not(bundled_guests),
+        arg(long, help = "Path to guest-init binary (required)")
+    )]
     guest_init: Option<PathBuf>,
-    #[arg(long)]
+    #[cfg_attr(
+        bundled_guests,
+        arg(long, help = "Path to guest-mock-claude binary [default: bundled]")
+    )]
+    #[cfg_attr(
+        not(bundled_guests),
+        arg(long, help = "Path to guest-mock-claude binary (required)")
+    )]
     guest_mock_claude: Option<PathBuf>,
     /// Compute and print the input hash without building
     #[arg(long)]


### PR DESCRIPTION
## Summary
- Use `#[cfg_attr]` to show different `--help` text for guest binary args depending on compile-time configuration
- `bundled_guests` enabled: `[default: bundled]`
- `bundled_guests` disabled: `(required)`

## Test plan
- [ ] `cargo check -p runner` passes
- [ ] `runner rootfs --help` shows correct help text in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)