### PR TITLE
chore(e2b): bump vm0-cli template to @vm0/cli@9.41.0

### DIFF
--- a/turbo/scripts/e2b/vm0-cli/template.ts
+++ b/turbo/scripts/e2b/vm0-cli/template.ts
@@ -11,4 +11,4 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "jq", "tzdata"])
-  .npmInstall("@vm0/cli@9.27.0", { g: true });
+  .npmInstall("@vm0/cli@9.41.0", { g: true });


### PR DESCRIPTION
## Summary
- Bump `@vm0/cli` version in E2B `vm0-cli` template from `9.27.0` to `9.41.0`
- This template is used by compose jobs to run `vm0 compose` in E2B sandboxes

## Test plan
- [ ] CI `build-e2b-template` job should trigger and build successfully (since `turbo/scripts/e2b/` changed)
- [ ] Verify compose-from-github workflow works with the updated CLI version

🤖 Generated with [Claude Code](https://claude.com/claude-code)