### PR TITLE
ci(runner): reduce max concurrent from 8 to 4

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -11,7 +11,7 @@ env:
   # Sandbox VM parameters for runner build
   RUNNER_VCPU: 2
   RUNNER_MEMORY_MB: 2048
-  RUNNER_MAX_CONCURRENT: 8
+  RUNNER_MAX_CONCURRENT: 4
 
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (github.event_name == 'merge_group' && format('merge-queue-{0}', github.run_id) || 'staging') }}


### PR DESCRIPTION
## Summary
- Reduce `RUNNER_MAX_CONCURRENT` from 8 to 4 in CI workflow

## Test plan
- CI passes with the new concurrency limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)