### PR TITLE
feat(runner): auto-calculate max_concurrent from host resources

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -11,7 +11,6 @@ env:
   # Sandbox VM parameters for runner build
   RUNNER_VCPU: 2
   RUNNER_MEMORY_MB: 2048
-  RUNNER_MAX_CONCURRENT: 4
 
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (github.event_name == 'merge_group' && format('merge-queue-{0}', github.run_id) || 'staging') }}
@@ -1368,6 +1367,8 @@ jobs:
   deploy-runner-start:
     runs-on: ubuntu-latest
     needs: [prepare, deploy-runner-prepare, deploy-web]
+    outputs:
+      max-concurrent: ${{ steps.start.outputs.max-concurrent }}
     timeout-minutes: 2
     if: |
       github.event_name != 'push' &&
@@ -1388,6 +1389,7 @@ jobs:
 
       # Read METAL_HOSTS from secret directly — GitHub Actions masks secret values in job outputs
       - name: Rebuild config and start runner service on all hosts
+        id: start
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
@@ -1418,7 +1420,6 @@ jobs:
               --runner-dirname ${JOB_REF} \
               --vcpu ${RUNNER_VCPU} \
               --memory-mb ${RUNNER_MEMORY_MB} \
-              --max-concurrent ${RUNNER_MAX_CONCURRENT} \
               --api-url ${PREVIEW_URL} \
               --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
@@ -1469,6 +1470,12 @@ jobs:
           if [ "$FAILED" -ne 0 ]; then
             exit 1
           fi
+
+          # Read auto-detected max_concurrent from first host's status.json
+          FIRST_HOST=$(echo "$METAL_HOSTS" | tr ',' ' ' | awk '{print $1}')
+          MAX_CONCURRENT=$(ssh $SSH_OPTS "${METAL_USER}@${FIRST_HOST}" "jq -r '.max_concurrent' ${RUNNER_DIR}/status.json")
+          echo "max-concurrent=${MAX_CONCURRENT}" >> "$GITHUB_OUTPUT"
+          echo "Runner max_concurrent: ${MAX_CONCURRENT}"
 
   # Run CLI E2E tests - Phase 3: Runner tests (needs runner deployed)
   # Skip on push to main - runner tests are only needed for PRs
@@ -1589,6 +1596,7 @@ jobs:
           BATS_TEST_TIMEOUT=60 RUNNER_GROUP="vm0/development-${JOB_REF}" ./e2e/test/libs/bats/bin/bats -T -j "${PARALLEL}" --no-parallelize-within-files ${{ matrix.files }}
           echo "✅ Chunk ${{ matrix.index }} tests passed"
         env:
+          RUNNER_MAX_CONCURRENT: ${{ needs.deploy-runner-start.outputs.max-concurrent }}
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           USE_MOCK_CLAUDE: "true"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1185,10 +1185,10 @@ jobs:
         needs.prepare.outputs.ci-changed == 'true'
       )
     outputs:
-      host-count: ${{ steps.host.outputs.host-count }}
       bin-dir: ${{ steps.host.outputs.bin-dir }}
       runner-dir: ${{ steps.host.outputs.runner-dir }}
       runner-matrix: ${{ steps.runner-matrix.outputs.matrix }}
+      chunk-count: ${{ steps.runner-matrix.outputs.chunk-count }}
       rootfs-hash: ${{ steps.deploy.outputs.rootfs-hash }}
       snapshot-hash: ${{ steps.deploy.outputs.snapshot-hash }}
     steps:
@@ -1235,15 +1235,16 @@ jobs:
             echo "::error::AWS_METAL_RUNNER_HOSTS is empty"
             exit 1
           fi
-          echo "host-count=${NUM_HOSTS}" >> "$GITHUB_OUTPUT"
           echo "Deploying to ${NUM_HOSTS} metal hosts"
 
       - name: Generate runner E2E test matrix
         id: runner-matrix
         shell: bash
         run: |
-          # Split test files across metal hosts, balanced by test count
-          NUM_CHUNKS=${{ steps.host.outputs.host-count }}
+          # Split test files into fixed chunks for parallel bats execution
+          NUM_FILES=$(ls e2e/tests/03-experimental-runner/*.bats 2>/dev/null | wc -l)
+          NUM_CHUNKS=4
+          [ "$NUM_CHUNKS" -gt "$NUM_FILES" ] && NUM_CHUNKS=$NUM_FILES
 
           # Count tests per file, sort heaviest first
           mapfile -t SORTED < <(
@@ -1273,6 +1274,7 @@ jobs:
             echo "Chunk $((i+1)): ${CHUNK_COUNTS[$i]} tests"
           done
           echo "matrix=${CHUNKS}]" >> $GITHUB_OUTPUT
+          echo "chunk-count=${NUM_CHUNKS}" >> $GITHUB_OUTPUT
 
       - name: Deploy binaries and build rootfs/snapshot on all metal hosts
         id: deploy
@@ -1368,7 +1370,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prepare, deploy-runner-prepare, deploy-web]
     outputs:
-      max-concurrent: ${{ steps.start.outputs.max-concurrent }}
+      total-capacity: ${{ steps.start.outputs.total-capacity }}
     timeout-minutes: 2
     if: |
       github.event_name != 'push' &&
@@ -1471,11 +1473,15 @@ jobs:
             exit 1
           fi
 
-          # Read auto-detected max_concurrent from first host's status.json
-          FIRST_HOST=$(echo "$METAL_HOSTS" | tr ',' ' ' | awk '{print $1}')
-          MAX_CONCURRENT=$(ssh $SSH_OPTS "${METAL_USER}@${FIRST_HOST}" "grep -o '\"max_concurrent\": [0-9]*' ${RUNNER_DIR}/status.json | grep -o '[0-9]*'")
-          echo "max-concurrent=${MAX_CONCURRENT}" >> "$GITHUB_OUTPUT"
-          echo "Runner max_concurrent: ${MAX_CONCURRENT}"
+          # Sum auto-detected max_concurrent from all hosts' status.json
+          TOTAL=0
+          for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
+            MC=$(ssh $SSH_OPTS "${METAL_USER}@${HOST}" "grep -o '\"max_concurrent\": [0-9]*' ${RUNNER_DIR}/status.json | grep -o '[0-9]*'")
+            echo "Host ${HOST}: max_concurrent=${MC}"
+            TOTAL=$((TOTAL + MC))
+          done
+          echo "total-capacity=${TOTAL}" >> "$GITHUB_OUTPUT"
+          echo "Total capacity across all hosts: ${TOTAL}"
 
   # Run CLI E2E tests - Phase 3: Runner tests (needs runner deployed)
   # Skip on push to main - runner tests are only needed for PRs
@@ -1590,13 +1596,15 @@ jobs:
 
       - name: Run Runner E2E Tests (Chunk ${{ matrix.index }})
         run: |
-          PARALLEL=${RUNNER_MAX_CONCURRENT}
-          echo "=== Running Runner E2E Tests (Chunk ${{ matrix.index }}, ${PARALLEL} parallel) ==="
+          PARALLEL=$(( RUNNER_TOTAL_CAPACITY / RUNNER_CHUNK_COUNT ))
+          [ "$PARALLEL" -lt 1 ] && PARALLEL=1
+          echo "=== Running Runner E2E Tests (Chunk ${{ matrix.index }}, ${PARALLEL} parallel, total capacity ${RUNNER_TOTAL_CAPACITY}) ==="
           echo "Files: ${{ matrix.files }}"
           BATS_TEST_TIMEOUT=60 RUNNER_GROUP="vm0/development-${JOB_REF}" ./e2e/test/libs/bats/bin/bats -T -j "${PARALLEL}" --no-parallelize-within-files ${{ matrix.files }}
           echo "✅ Chunk ${{ matrix.index }} tests passed"
         env:
-          RUNNER_MAX_CONCURRENT: ${{ needs.deploy-runner-start.outputs.max-concurrent }}
+          RUNNER_TOTAL_CAPACITY: ${{ needs.deploy-runner-start.outputs.total-capacity }}
+          RUNNER_CHUNK_COUNT: ${{ needs.deploy-runner-prepare.outputs.chunk-count }}
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           USE_MOCK_CLAUDE: "true"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1473,7 +1473,7 @@ jobs:
 
           # Read auto-detected max_concurrent from first host's status.json
           FIRST_HOST=$(echo "$METAL_HOSTS" | tr ',' ' ' | awk '{print $1}')
-          MAX_CONCURRENT=$(ssh $SSH_OPTS "${METAL_USER}@${FIRST_HOST}" "jq -r '.max_concurrent' ${RUNNER_DIR}/status.json")
+          MAX_CONCURRENT=$(ssh $SSH_OPTS "${METAL_USER}@${FIRST_HOST}" "grep -o '\"max_concurrent\": [0-9]*' ${RUNNER_DIR}/status.json | grep -o '[0-9]*'")
           echo "max-concurrent=${MAX_CONCURRENT}" >> "$GITHUB_OUTPUT"
           echo "Runner max_concurrent: ${MAX_CONCURRENT}"
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1476,7 +1476,11 @@ jobs:
           # Sum auto-detected max_concurrent from all hosts' status.json
           TOTAL=0
           for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
-            MC=$(ssh $SSH_OPTS "${METAL_USER}@${HOST}" "grep -o '\"max_concurrent\": [0-9]*' ${RUNNER_DIR}/status.json | grep -o '[0-9]*'")
+            MC=$(ssh $SSH_OPTS "${METAL_USER}@${HOST}" "grep -o '\"max_concurrent\": [0-9]*' ${RUNNER_DIR}/status.json | grep -o '[0-9]*'") || true
+            if [ -z "$MC" ] || ! [[ "$MC" =~ ^[0-9]+$ ]]; then
+              echo "::error::Failed to read max_concurrent from ${HOST}"
+              exit 1
+            fi
             echo "Host ${HOST}: max_concurrent=${MC}"
             TOTAL=$((TOTAL + MC))
           done
@@ -1596,6 +1600,10 @@ jobs:
 
       - name: Run Runner E2E Tests (Chunk ${{ matrix.index }})
         run: |
+          if [ -z "$RUNNER_CHUNK_COUNT" ] || [ "$RUNNER_CHUNK_COUNT" -eq 0 ]; then
+            echo "::error::RUNNER_CHUNK_COUNT is empty or zero"
+            exit 1
+          fi
           PARALLEL=$(( RUNNER_TOTAL_CAPACITY / RUNNER_CHUNK_COUNT ))
           [ "$PARALLEL" -lt 1 ] && PARALLEL=1
           echo "=== Running Runner E2E Tests (Chunk ${{ matrix.index }}, ${PARALLEL} parallel, total capacity ${RUNNER_TOTAL_CAPACITY}) ==="

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -24,8 +24,7 @@
     runner_name: "v{{ runner_version }}"
     runner_group: vm0/production
     vcpu: 2
-    memory_mb: 1024
-    max_concurrent: 8
+    memory_mb: 2048
     home_dir: "{{ ansible_facts['env']['HOME'] }}"
     bin_dir: "{{ home_dir }}/.vm0-runner/bin/{{ runner_name }}"
     runner_dir: "{{ home_dir }}/.vm0-runner/runners/{{ runner_name }}"
@@ -77,7 +76,6 @@
         --runner-dirname {{ runner_name }}
         --vcpu {{ vcpu }}
         --memory-mb {{ memory_mb }}
-        --max-concurrent {{ max_concurrent }}
         --api-url {{ api_url }}
         --token vm0_official_{{ official_runner_secret }}
 

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -35,7 +35,7 @@ pub struct ConfigArgs {
     /// Memory size in MiB for sandbox VMs
     #[arg(long, default_value_t = DEFAULT_MEMORY_MB)]
     memory_mb: u32,
-    /// Maximum concurrent job executions
+    /// Maximum concurrent VMs (0 = auto-detect from host CPU/memory)
     #[arg(long, default_value_t = DEFAULT_MAX_CONCURRENT)]
     max_concurrent: usize,
 

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -164,13 +164,10 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         memory_mb,
     } = sandbox;
     let max_concurrent = if max_concurrent == 0 {
-        let host_cpus = crate::host::cpu_count();
+        let host_cpus = crate::host::cpu_count()?;
         let host_memory_mb = crate::host::memory_mb()?;
-        let computed = std::cmp::min(
-            host_cpus / vcpu as usize,
-            host_memory_mb / memory_mb as usize,
-        )
-        .max(1);
+        let computed =
+            crate::host::compute_max_concurrent(host_cpus, host_memory_mb, vcpu, memory_mb);
         info!(
             host_cpus,
             host_memory_mb, vcpu, memory_mb, computed, "auto-detected max_concurrent"

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -163,7 +163,23 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         vcpu,
         memory_mb,
     } = sandbox;
-    let mut status = StatusTracker::new(paths.status());
+    let max_concurrent = if max_concurrent == 0 {
+        let host_cpus = crate::host::cpu_count();
+        let host_memory_mb = crate::host::memory_mb()?;
+        let computed = std::cmp::min(
+            host_cpus / vcpu as usize,
+            host_memory_mb / memory_mb as usize,
+        )
+        .max(1);
+        info!(
+            host_cpus,
+            host_memory_mb, vcpu, memory_mb, computed, "auto-detected max_concurrent"
+        );
+        computed
+    } else {
+        max_concurrent
+    };
+    let mut status = StatusTracker::new(paths.status(), max_concurrent);
     status.set_proxy_port(mitm.port()).await;
     let status = Arc::new(status);
 

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -179,6 +179,7 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
     } else {
         max_concurrent
     };
+    fc_config.concurrency = max_concurrent;
     let mut status = StatusTracker::new(paths.status(), max_concurrent);
     status.set_proxy_port(mitm.port()).await;
     let status = Arc::new(status);

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -307,6 +307,88 @@ firecracker:
     }
 
     #[tokio::test]
+    async fn load_rejects_zero_vcpu() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        let rootfs = dir.path().join("rootfs.squashfs");
+        for f in [&fc, &kernel, &rootfs] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+
+        let yaml = format!(
+            r#"
+name: test
+group: test/group
+base_dir: {base_dir}
+ca_dir: {ca_dir}
+firecracker:
+  binary: {fc}
+  kernel: {kernel}
+  rootfs: {rootfs}
+sandbox:
+  vcpu: 0
+  memory_mb: 2048
+"#,
+            base_dir = dir.path().display(),
+            ca_dir = dir.path().display(),
+            fc = fc.display(),
+            kernel = kernel.display(),
+            rootfs = rootfs.display(),
+        );
+
+        let config_path = dir.path().join("runner.yaml");
+        tokio::fs::write(&config_path, &yaml).await.unwrap();
+
+        let err = load(&config_path).await.unwrap_err();
+        assert!(
+            err.to_string().contains("non-zero"),
+            "expected non-zero error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_rejects_zero_memory_mb() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        let rootfs = dir.path().join("rootfs.squashfs");
+        for f in [&fc, &kernel, &rootfs] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+
+        let yaml = format!(
+            r#"
+name: test
+group: test/group
+base_dir: {base_dir}
+ca_dir: {ca_dir}
+firecracker:
+  binary: {fc}
+  kernel: {kernel}
+  rootfs: {rootfs}
+sandbox:
+  vcpu: 2
+  memory_mb: 0
+"#,
+            base_dir = dir.path().display(),
+            ca_dir = dir.path().display(),
+            fc = fc.display(),
+            kernel = kernel.display(),
+            rootfs = rootfs.display(),
+        );
+
+        let config_path = dir.path().join("runner.yaml");
+        tokio::fs::write(&config_path, &yaml).await.unwrap();
+
+        let err = load(&config_path).await.unwrap_err();
+        assert!(
+            err.to_string().contains("non-zero"),
+            "expected non-zero error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
     async fn load_with_snapshot() {
         let dir = tempfile::tempdir().unwrap();
         let fc = dir.path().join("firecracker");

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -6,7 +6,8 @@ use crate::error::{RunnerError, RunnerResult};
 
 pub(crate) const DEFAULT_VCPU: u32 = 2;
 pub(crate) const DEFAULT_MEMORY_MB: u32 = 2048;
-pub(crate) const DEFAULT_MAX_CONCURRENT: usize = 4;
+/// 0 means auto-detect from host CPU and memory at startup.
+pub(crate) const DEFAULT_MAX_CONCURRENT: usize = 0;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct RunnerConfig {

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -87,6 +87,11 @@ pub async fn load(path: &Path) -> RunnerResult<RunnerConfig> {
         config.resolve_relative_paths(config_dir);
     }
     validate_paths(&config).await?;
+    if config.sandbox.vcpu == 0 || config.sandbox.memory_mb == 0 {
+        return Err(RunnerError::Config(
+            "sandbox.vcpu and sandbox.memory_mb must be non-zero".into(),
+        ));
+    }
     Ok(config)
 }
 

--- a/crates/runner/src/host.rs
+++ b/crates/runner/src/host.rs
@@ -1,10 +1,10 @@
 use crate::error::{RunnerError, RunnerResult};
 
 /// Return the number of logical CPUs available to this process.
-pub fn cpu_count() -> usize {
+pub fn cpu_count() -> RunnerResult<usize> {
     std::thread::available_parallelism()
         .map(|n| n.get())
-        .unwrap_or(1)
+        .map_err(|e| RunnerError::Internal(format!("detect CPU count: {e}")))
 }
 
 /// Read total physical memory in MiB from `/proc/meminfo`.
@@ -27,13 +27,31 @@ pub fn memory_mb() -> RunnerResult<usize> {
     ))
 }
 
+/// Compute how many sandboxes can run concurrently given host resources and
+/// per-sandbox requirements.
+///
+/// Uses integer division because we need whole sandboxes — a host with 5 CPUs
+/// and vcpu=2 can run 2 sandboxes, not 2.5.
+pub fn compute_max_concurrent(
+    host_cpus: usize,
+    host_memory_mb: usize,
+    vcpu: u32,
+    memory_mb: u32,
+) -> usize {
+    std::cmp::min(
+        host_cpus / vcpu as usize,
+        host_memory_mb / memory_mb as usize,
+    )
+    .max(1)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn cpu_count_is_positive() {
-        assert!(cpu_count() > 0);
+        assert!(cpu_count().unwrap() > 0);
     }
 
     #[test]
@@ -42,5 +60,29 @@ mod tests {
         if std::path::Path::new("/proc/meminfo").exists() {
             assert!(memory_mb().unwrap() > 0);
         }
+    }
+
+    #[test]
+    fn compute_max_concurrent_cpu_limited() {
+        // 8 CPUs, 32 GB, 2 vcpu, 4 GB per VM → min(4, 8) = 4
+        assert_eq!(compute_max_concurrent(8, 32768, 2, 4096), 4);
+    }
+
+    #[test]
+    fn compute_max_concurrent_memory_limited() {
+        // 16 CPUs, 8 GB, 2 vcpu, 4 GB per VM → min(8, 2) = 2
+        assert_eq!(compute_max_concurrent(16, 8192, 2, 4096), 2);
+    }
+
+    #[test]
+    fn compute_max_concurrent_minimum_one() {
+        // 1 CPU, 1 GB, 2 vcpu, 4 GB → min(0, 0) → max(1) = 1
+        assert_eq!(compute_max_concurrent(1, 1024, 2, 4096), 1);
+    }
+
+    #[test]
+    fn compute_max_concurrent_exact_fit() {
+        // 4 CPUs, 8 GB, 2 vcpu, 2 GB → min(2, 4) = 2
+        assert_eq!(compute_max_concurrent(4, 8192, 2, 2048), 2);
     }
 }

--- a/crates/runner/src/host.rs
+++ b/crates/runner/src/host.rs
@@ -1,0 +1,46 @@
+use crate::error::{RunnerError, RunnerResult};
+
+/// Return the number of logical CPUs available to this process.
+pub fn cpu_count() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+}
+
+/// Read total physical memory in MiB from `/proc/meminfo`.
+pub fn memory_mb() -> RunnerResult<usize> {
+    let content = std::fs::read_to_string("/proc/meminfo")
+        .map_err(|e| RunnerError::Internal(format!("read /proc/meminfo: {e}")))?;
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            let kb: usize = rest
+                .trim()
+                .trim_end_matches("kB")
+                .trim()
+                .parse()
+                .map_err(|e| RunnerError::Internal(format!("parse MemTotal: {e}")))?;
+            return Ok(kb / 1024);
+        }
+    }
+    Err(RunnerError::Internal(
+        "MemTotal not found in /proc/meminfo".into(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cpu_count_is_positive() {
+        assert!(cpu_count() > 0);
+    }
+
+    #[test]
+    fn memory_mb_is_positive() {
+        // Only works on Linux with /proc
+        if std::path::Path::new("/proc/meminfo").exists() {
+            assert!(memory_mb().unwrap() > 0);
+        }
+    }
+}

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod deps;
 mod error;
 mod executor;
+mod host;
 mod http;
 mod lock;
 mod network_logs;

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -18,6 +18,7 @@ pub enum RunnerMode {
 #[derive(Debug, Serialize)]
 struct RunnerStatus {
     mode: RunnerMode,
+    max_concurrent: usize,
     active_runs: usize,
     active_run_ids: Vec<Uuid>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -38,6 +39,7 @@ fn serialize_iso<S: serde::Serializer>(dt: &DateTime<Utc>, s: S) -> Result<S::Ok
 /// Share via `Arc<StatusTracker>` — immutable fields live outside the mutex.
 pub struct StatusTracker {
     started_at: DateTime<Utc>,
+    max_concurrent: usize,
     proxy_port: Option<u16>,
     path: PathBuf,
     state: Mutex<MutableState>,
@@ -49,9 +51,10 @@ struct MutableState {
 }
 
 impl StatusTracker {
-    pub fn new(path: PathBuf) -> Self {
+    pub fn new(path: PathBuf, max_concurrent: usize) -> Self {
         Self {
             started_at: Utc::now(),
+            max_concurrent,
             proxy_port: None,
             path,
             state: Mutex::new(MutableState {
@@ -95,6 +98,7 @@ impl StatusTracker {
     async fn write_status(&self, state: &MutableState) {
         let status = RunnerStatus {
             mode: state.mode,
+            max_concurrent: self.max_concurrent,
             active_runs: state.active_run_ids.len(),
             active_run_ids: state.active_run_ids.iter().copied().collect(),
             proxy_port: self.proxy_port,
@@ -134,12 +138,13 @@ mod tests {
     async fn write_initial_creates_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("status.json");
-        let tracker = StatusTracker::new(path.clone());
+        let tracker = StatusTracker::new(path.clone(), 4);
 
         tracker.write_initial().await;
 
         let status = read_status(&path);
         assert_eq!(status["mode"], "running");
+        assert_eq!(status["max_concurrent"], 4);
         assert_eq!(status["active_runs"], 0);
         assert!(status["active_run_ids"].as_array().unwrap().is_empty());
         assert!(status["started_at"].as_str().is_some());
@@ -150,7 +155,7 @@ mod tests {
     async fn set_mode_updates_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("status.json");
-        let tracker = StatusTracker::new(path.clone());
+        let tracker = StatusTracker::new(path.clone(), 4);
 
         tracker.write_initial().await;
         tracker.set_mode(RunnerMode::Draining).await;
@@ -163,7 +168,7 @@ mod tests {
     async fn add_and_remove_run() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("status.json");
-        let tracker = StatusTracker::new(path.clone());
+        let tracker = StatusTracker::new(path.clone(), 4);
 
         let id1 = Uuid::new_v4();
         let id2 = Uuid::new_v4();
@@ -195,7 +200,7 @@ mod tests {
     async fn proxy_port_in_status() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("status.json");
-        let mut tracker = StatusTracker::new(path.clone());
+        let mut tracker = StatusTracker::new(path.clone(), 4);
         tracker.set_proxy_port(8080).await;
 
         let status = read_status(&path);
@@ -206,7 +211,7 @@ mod tests {
     async fn proxy_port_absent_when_not_set() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("status.json");
-        let tracker = StatusTracker::new(path.clone());
+        let tracker = StatusTracker::new(path.clone(), 4);
 
         tracker.write_initial().await;
 
@@ -218,7 +223,7 @@ mod tests {
     async fn timestamps_are_iso8601() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("status.json");
-        let tracker = StatusTracker::new(path.clone());
+        let tracker = StatusTracker::new(path.clone(), 4);
 
         tracker.write_initial().await;
 


### PR DESCRIPTION
## Summary
- Auto-detect `max_concurrent` from host CPU and memory using `min(cpus / vcpu, memory_mb / vm_memory_mb)`
- Use sentinel value `0` (new default) to mean "auto-detect at startup"
- Add `max_concurrent` field to `status.json` so CI can read the computed value
- Remove hardcoded `RUNNER_MAX_CONCURRENT` from CI workflow and Ansible playbook
- Fix Ansible `memory_mb` from 1024 to 2048

## Test plan
- [x] `cargo test -p runner` — 166 passed
- [x] `cargo clippy -p runner` — clean
- [ ] CI runner E2E tests pass with auto-detected concurrency
- [ ] Verify `status.json` contains `max_concurrent` field on metal host

Closes #3525

🤖 Generated with [Claude Code](https://claude.com/claude-code)