### PR TITLE
feat(github): implement callback handler for posting agent responses as issue comments

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
@@ -14,6 +14,8 @@ import {
   createTestCallback,
   createTestAgentSession,
   insertTestGitHubInstallation,
+  insertTestGitHubIssueSession,
+  findTestGitHubIssueSession,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import { computeHmacSignature } from "../../../../../../../src/lib/callback/hmac";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
@@ -64,13 +66,30 @@ function createCallbackRequest(
   });
 }
 
+interface CapturedComment {
+  owner: string;
+  repo: string;
+  issueNumber: string;
+  body: string;
+}
+
 /**
  * Set up MSW handlers for GitHub API (installation token + issue comment).
+ * Returns a `capturedComments` array that records every comment POST.
  */
 function setupGitHubApiMocks(installationId: string) {
+  const capturedComments: CapturedComment[] = [];
+
   const commentMock = http.post(
     `https://api.github.com/repos/:owner/:repo/issues/:issueNumber/comments`,
-    () => {
+    async ({ params, request }) => {
+      const { body } = (await request.json()) as { body: string };
+      capturedComments.push({
+        owner: params["owner"] as string,
+        repo: params["repo"] as string,
+        issueNumber: params["issueNumber"] as string,
+        body,
+      });
       return HttpResponse.json({ id: 42 });
     },
   );
@@ -86,7 +105,7 @@ function setupGitHubApiMocks(installationId: string) {
   );
 
   server.use(commentMock, tokenMock);
-  return { commentMock, tokenMock };
+  return { commentMock, tokenMock, capturedComments };
 }
 
 /**
@@ -103,7 +122,7 @@ async function givenGitHubCallbackSetup(overrides?: {
   const { runId } = await createTestRun(composeId, "Test GitHub prompt");
   const installation = await insertTestGitHubInstallation(userId, composeId);
 
-  setupGitHubApiMocks(installation.installationId);
+  const { capturedComments } = setupGitHubApiMocks(installation.installationId);
 
   const payload: CallbackPayload = {
     installationId: installation.id,
@@ -119,7 +138,15 @@ async function givenGitHubCallbackSetup(overrides?: {
     payload: payload as unknown as Record<string, unknown>,
   });
 
-  return { userId, composeId, runId, installation, payload, secret };
+  return {
+    userId,
+    composeId,
+    runId,
+    installation,
+    payload,
+    secret,
+    capturedComments,
+  };
 }
 
 describe("POST /api/internal/callbacks/github/issues", () => {
@@ -245,7 +272,8 @@ describe("POST /api/internal/callbacks/github/issues", () => {
 
   describe("Successful Callback", () => {
     it("should post comment to GitHub issue on completed run", async () => {
-      const { runId, payload, secret } = await givenGitHubCallbackSetup();
+      const { runId, payload, secret, capturedComments } =
+        await givenGitHubCallbackSetup();
 
       const request = createCallbackRequest(
         { runId, status: "completed", payload },
@@ -256,10 +284,19 @@ describe("POST /api/internal/callbacks/github/issues", () => {
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.success).toBe(true);
+
+      // Verify the comment was posted to the correct repo and issue
+      expect(capturedComments).toHaveLength(1);
+      expect(capturedComments[0]!.owner).toBe("test-org");
+      expect(capturedComments[0]!.repo).toBe("test-repo");
+      expect(capturedComments[0]!.issueNumber).toBe("42");
+      // Verify the comment body includes the VM0 attribution footer
+      expect(capturedComments[0]!.body).toContain("Powered by");
     });
 
     it("should post error comment on failed run", async () => {
-      const { runId, payload, secret } = await givenGitHubCallbackSetup();
+      const { runId, payload, secret, capturedComments } =
+        await givenGitHubCallbackSetup();
 
       const request = createCallbackRequest(
         {
@@ -275,6 +312,15 @@ describe("POST /api/internal/callbacks/github/issues", () => {
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.success).toBe(true);
+
+      // Verify the error comment was posted with the error message
+      expect(capturedComments).toHaveLength(1);
+      expect(capturedComments[0]!.body).toContain("Error");
+      expect(capturedComments[0]!.body).toContain("Agent crashed unexpectedly");
+      // Verify the comment targets the correct repo and issue
+      expect(capturedComments[0]!.owner).toBe("test-org");
+      expect(capturedComments[0]!.repo).toBe("test-repo");
+      expect(capturedComments[0]!.issueNumber).toBe("42");
     });
 
     it("should return 404 when GitHub installation is missing", async () => {
@@ -316,7 +362,7 @@ describe("POST /api/internal/callbacks/github/issues", () => {
         await givenGitHubCallbackSetup();
 
       // Create an agent session so findNewSessionId can find it
-      await createTestAgentSession(userId, composeId);
+      const session = await createTestAgentSession(userId, composeId);
 
       const request = createCallbackRequest(
         { runId, status: "completed", payload },
@@ -324,15 +370,38 @@ describe("POST /api/internal/callbacks/github/issues", () => {
       );
       const response = await POST(request);
 
-      // The callback should succeed regardless of session creation
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.success).toBe(true);
+
+      // Verify a github_issue_sessions record was created in the database
+      const issueSession = await findTestGitHubIssueSession(
+        payload.installationId,
+        payload.repo,
+        payload.issueNumber,
+      );
+
+      expect(issueSession).not.toBeNull();
+      expect(issueSession!.agentSessionId).toBe(session.id);
+      expect(issueSession!.userId).toBe(userId);
+      expect(issueSession!.lastCommentId).toBe("42");
     });
 
-    it("should handle existing session on completed run", async () => {
-      const { runId, payload, secret } = await givenGitHubCallbackSetup({
-        existingSessionId: "existing-session-id",
+    it("should update lastCommentId for existing session on completed run", async () => {
+      const { userId, composeId, runId, installation, payload, secret } =
+        await givenGitHubCallbackSetup({
+          existingSessionId: "existing-session-id",
+        });
+
+      // Pre-insert a github_issue_sessions record to simulate an existing session
+      const session = await createTestAgentSession(userId, composeId);
+      await insertTestGitHubIssueSession({
+        userId,
+        installationId: installation.id,
+        repo: payload.repo,
+        issueNumber: payload.issueNumber,
+        agentSessionId: session.id,
+        lastCommentId: "old-comment-id",
       });
 
       const request = createCallbackRequest(
@@ -348,6 +417,16 @@ describe("POST /api/internal/callbacks/github/issues", () => {
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.success).toBe(true);
+
+      // Verify the lastCommentId was updated in the database
+      const issueSession = await findTestGitHubIssueSession(
+        payload.installationId,
+        payload.repo,
+        payload.issueNumber,
+      );
+
+      expect(issueSession).not.toBeNull();
+      expect(issueSession!.lastCommentId).toBe("42");
     });
   });
 });

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../../../../src/mocks/server";
+import { POST } from "../route";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import {
+  createTestRequest,
+  createTestScope,
+  createTestCompose,
+  createTestRun,
+  createTestCallback,
+  createTestAgentSession,
+  insertTestGitHubInstallation,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import { computeHmacSignature } from "../../../../../../../src/lib/callback/hmac";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+const TEST_URL = "http://localhost/api/internal/callbacks/github/issues";
+
+interface CallbackPayload {
+  installationId: string;
+  repo: string;
+  issueNumber: number;
+  composeId: string;
+  existingSessionId?: string;
+}
+
+/**
+ * Create a signed callback request for GitHub issues callback.
+ */
+function createCallbackRequest(
+  body: {
+    runId: string;
+    status: "completed" | "failed";
+    result?: Record<string, unknown>;
+    error?: string;
+    payload: CallbackPayload;
+  },
+  secret: string,
+  options?: { invalidSignature?: boolean; expiredTimestamp?: boolean },
+) {
+  const bodyString = JSON.stringify(body);
+  const timestamp = options?.expiredTimestamp
+    ? Math.floor(Date.now() / 1000) - 600 // 10 minutes ago
+    : Math.floor(Date.now() / 1000);
+
+  const signature = options?.invalidSignature
+    ? "invalid-signature"
+    : computeHmacSignature(bodyString, secret, timestamp);
+
+  return createTestRequest(TEST_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VM0-Signature": signature,
+      "X-VM0-Timestamp": timestamp.toString(),
+    },
+    body: bodyString,
+  });
+}
+
+/**
+ * Set up MSW handlers for GitHub API (installation token + issue comment).
+ */
+function setupGitHubApiMocks(installationId: string) {
+  const commentMock = http.post(
+    `https://api.github.com/repos/:owner/:repo/issues/:issueNumber/comments`,
+    () => {
+      return HttpResponse.json({ id: 42 });
+    },
+  );
+
+  const tokenMock = http.post(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    () => {
+      return HttpResponse.json({
+        token: "ghs_test_token",
+        expires_at: "2099-01-01T00:00:00Z",
+      });
+    },
+  );
+
+  server.use(commentMock, tokenMock);
+  return { commentMock, tokenMock };
+}
+
+/**
+ * Create a full test setup: user, scope, compose, run, GitHub installation, and callback.
+ */
+async function givenGitHubCallbackSetup(overrides?: {
+  existingSessionId?: string;
+}) {
+  const userId = uniqueId("gh-cb-user");
+  mockClerk({ userId });
+  await createTestScope(uniqueId("gh-cb-scope"));
+  const { composeId } = await createTestCompose("gh-callback-agent");
+
+  const { runId } = await createTestRun(composeId, "Test GitHub prompt");
+  const installation = await insertTestGitHubInstallation(userId, composeId);
+
+  setupGitHubApiMocks(installation.installationId);
+
+  const payload: CallbackPayload = {
+    installationId: installation.id,
+    repo: "test-org/test-repo",
+    issueNumber: 42,
+    composeId,
+    existingSessionId: overrides?.existingSessionId,
+  };
+
+  const { secret } = await createTestCallback({
+    runId,
+    url: TEST_URL,
+    payload: payload as unknown as Record<string, unknown>,
+  });
+
+  return { userId, composeId, runId, installation, payload, secret };
+}
+
+describe("POST /api/internal/callbacks/github/issues", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  describe("Signature Verification", () => {
+    it("should reject request with invalid signature", async () => {
+      const { runId, payload, secret } = await givenGitHubCallbackSetup();
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+        { invalidSignature: true },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toContain("signature");
+    });
+
+    it("should reject request with expired timestamp", async () => {
+      const { runId, payload, secret } = await givenGitHubCallbackSetup();
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+        { expiredTimestamp: true },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toContain("expired");
+    });
+
+    it("should reject request for non-existent callback", async () => {
+      const request = createTestRequest(TEST_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-VM0-Signature": "any-signature",
+          "X-VM0-Timestamp": Math.floor(Date.now() / 1000).toString(),
+        },
+        body: JSON.stringify({
+          runId: "00000000-0000-0000-0000-000000000001",
+          status: "completed",
+          payload: {
+            installationId: "inst-123",
+            repo: "org/repo",
+            issueNumber: 1,
+            composeId: "compose-123",
+          },
+        }),
+      });
+      const response = await POST(request);
+
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error).toContain("not found");
+    });
+  });
+
+  describe("Validation", () => {
+    it("should reject request with missing runId", async () => {
+      const request = createTestRequest(TEST_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-VM0-Signature": "any-signature",
+          "X-VM0-Timestamp": Math.floor(Date.now() / 1000).toString(),
+        },
+        body: JSON.stringify({
+          status: "completed",
+          payload: {
+            installationId: "inst-123",
+            repo: "org/repo",
+            issueNumber: 1,
+            composeId: "compose-123",
+          },
+        }),
+      });
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toContain("runId");
+    });
+
+    it("should reject request with invalid payload", async () => {
+      const { runId, secret } = await givenGitHubCallbackSetup();
+
+      // Send request with incomplete payload (missing required fields)
+      const body = JSON.stringify({
+        runId,
+        status: "completed",
+        payload: {
+          installationId: "inst-123",
+          // Missing repo, issueNumber, composeId
+        },
+      });
+      const timestamp = Math.floor(Date.now() / 1000);
+      const signature = computeHmacSignature(body, secret, timestamp);
+
+      const request = createTestRequest(TEST_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-VM0-Signature": signature,
+          "X-VM0-Timestamp": timestamp.toString(),
+        },
+        body,
+      });
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toContain("payload");
+    });
+  });
+
+  describe("Successful Callback", () => {
+    it("should post comment to GitHub issue on completed run", async () => {
+      const { runId, payload, secret } = await givenGitHubCallbackSetup();
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+    });
+
+    it("should post error comment on failed run", async () => {
+      const { runId, payload, secret } = await givenGitHubCallbackSetup();
+
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "failed",
+          error: "Agent crashed unexpectedly",
+          payload,
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+    });
+
+    it("should return 404 when GitHub installation is missing", async () => {
+      const userId = uniqueId("gh-missing-user");
+      mockClerk({ userId });
+      await createTestScope(uniqueId("gh-missing-scope"));
+      const { composeId } = await createTestCompose("gh-missing-agent");
+
+      const { runId } = await createTestRun(composeId, "Test prompt");
+
+      const payload: CallbackPayload = {
+        installationId: "00000000-0000-0000-0000-000000000099",
+        repo: "org/repo",
+        issueNumber: 1,
+        composeId,
+      };
+
+      const { secret } = await createTestCallback({
+        runId,
+        url: TEST_URL,
+        payload: payload as unknown as Record<string, unknown>,
+      });
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error).toContain("GitHub installation not found");
+    });
+  });
+
+  describe("Session Management", () => {
+    it("should create issue session for new issue on completed run", async () => {
+      const { userId, composeId, runId, payload, secret } =
+        await givenGitHubCallbackSetup();
+
+      // Create an agent session so findNewSessionId can find it
+      await createTestAgentSession(userId, composeId);
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      // The callback should succeed regardless of session creation
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+    });
+
+    it("should handle existing session on completed run", async () => {
+      const { runId, payload, secret } = await givenGitHubCallbackSetup({
+        existingSessionId: "existing-session-id",
+      });
+
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "completed",
+          payload: { ...payload, existingSessionId: "existing-session-id" },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
@@ -1,0 +1,280 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, and, gte, desc } from "drizzle-orm";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { verifyCallbackRequest } from "../../../../../../src/lib/callback";
+import { decryptCredentialValue } from "../../../../../../src/lib/crypto/secrets-encryption";
+import { githubInstallations } from "../../../../../../src/db/schema/github-installation";
+import { githubIssueSessions } from "../../../../../../src/db/schema/github-issue-session";
+import { agentSessions } from "../../../../../../src/db/schema/agent-session";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import { agentRunCallbacks } from "../../../../../../src/db/schema/agent-run-callback";
+import { getInstallationAccessToken } from "../../../../../../src/lib/github/github-app";
+import { getRunOutput } from "../../../../../../src/lib/slack/handlers/run-agent";
+import { env } from "../../../../../../src/env";
+import { logger } from "../../../../../../src/lib/logger";
+
+const log = logger("callback:github-issues");
+
+interface CallbackPayload {
+  installationId: string; // GitHub App installation ID (DB primary key)
+  repo: string; // "owner/repo"
+  issueNumber: number;
+  composeId: string;
+  existingSessionId?: string;
+}
+
+interface CallbackBody {
+  runId: string;
+  status: "completed" | "failed";
+  result?: Record<string, unknown>;
+  error?: string;
+  payload: CallbackPayload;
+}
+
+function parsePayload(body: CallbackBody): CallbackPayload | null {
+  if (!body.payload) return null;
+  const p = body.payload;
+  if (
+    typeof p.installationId !== "string" ||
+    typeof p.repo !== "string" ||
+    typeof p.issueNumber !== "number" ||
+    typeof p.composeId !== "string"
+  ) {
+    return null;
+  }
+  return p;
+}
+
+function errorResponse(message: string, status: number): NextResponse {
+  return NextResponse.json({ error: message }, { status });
+}
+
+async function findNewSessionId(
+  userId: string,
+  composeId: string,
+  runCreatedAt: Date,
+): Promise<string | undefined> {
+  const [newSession] = await globalThis.services.db
+    .select({ id: agentSessions.id })
+    .from(agentSessions)
+    .where(
+      and(
+        eq(agentSessions.userId, userId),
+        eq(agentSessions.agentComposeId, composeId),
+        gte(agentSessions.updatedAt, runCreatedAt),
+      ),
+    )
+    .orderBy(desc(agentSessions.updatedAt))
+    .limit(1);
+  return newSession?.id;
+}
+
+/**
+ * Format agent output as a GitHub issue comment with attribution footer.
+ */
+function formatGitHubComment(
+  output: string,
+  status: "completed" | "failed",
+  error?: string,
+): string {
+  const body =
+    status === "completed"
+      ? output || "Task completed successfully."
+      : `**Error:** ${error ?? "Agent execution failed."}`;
+
+  return `${body}\n\n---\n*🤖 Powered by [VM0](https://vm0.com)*`;
+}
+
+/**
+ * Post a comment to a GitHub issue using the installation access token.
+ */
+async function postIssueComment(
+  token: string,
+  repo: string,
+  issueNumber: number,
+  body: string,
+): Promise<string | undefined> {
+  const res = await fetch(
+    `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: JSON.stringify({ body }),
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to post GitHub comment: ${res.status} ${text}`);
+  }
+
+  const data = (await res.json()) as { id: number };
+  return String(data.id);
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  initServices();
+  const { SECRETS_ENCRYPTION_KEY, GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY } =
+    env();
+
+  // Read raw body for signature verification
+  const rawBody = await request.text();
+
+  // Parse body first to get runId for callback lookup
+  let body: CallbackBody;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  const { runId, status, error } = body;
+
+  if (!runId) {
+    return errorResponse("Missing runId", 400);
+  }
+
+  // Query callback record to get the per-callback secret
+  const [callback] = await globalThis.services.db
+    .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
+    .from(agentRunCallbacks)
+    .where(eq(agentRunCallbacks.runId, runId))
+    .limit(1);
+
+  if (!callback) {
+    log.warn("Callback record not found", { runId });
+    return errorResponse("Callback not found", 404);
+  }
+
+  // Decrypt the per-callback secret
+  const callbackSecret = decryptCredentialValue(
+    callback.encryptedSecret,
+    SECRETS_ENCRYPTION_KEY,
+  );
+
+  // Verify signature using the per-callback secret
+  const signature = request.headers.get("X-VM0-Signature");
+  const timestamp = request.headers.get("X-VM0-Timestamp");
+
+  const verification = verifyCallbackRequest(
+    rawBody,
+    callbackSecret,
+    signature,
+    timestamp,
+  );
+
+  if (!verification.valid) {
+    log.warn("Callback signature verification failed", {
+      runId,
+      error: verification.error,
+    });
+    return errorResponse(verification.error ?? "Invalid signature", 401);
+  }
+
+  const payload = parsePayload(body);
+
+  if (!payload) {
+    return errorResponse("Invalid or missing payload", 400);
+  }
+
+  const { installationId, repo, issueNumber, composeId, existingSessionId } =
+    payload;
+
+  log.debug("Processing GitHub issues callback", {
+    runId,
+    status,
+    repo,
+    issueNumber,
+  });
+
+  // Get GitHub installation for access token
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(githubInstallations)
+    .where(eq(githubInstallations.id, installationId))
+    .limit(1);
+
+  if (!installation) {
+    log.error("GitHub installation not found", { installationId });
+    return errorResponse("GitHub installation not found", 404);
+  }
+
+  // Get a fresh installation access token
+  if (!GITHUB_APP_ID || !GITHUB_APP_PRIVATE_KEY) {
+    log.error("GitHub App credentials not configured");
+    return errorResponse("GitHub App not configured", 500);
+  }
+
+  const { token } = await getInstallationAccessToken(
+    GITHUB_APP_ID,
+    GITHUB_APP_PRIVATE_KEY,
+    installation.installationId,
+  );
+
+  // Query Axiom for the agent's output
+  const output = status === "completed" ? await getRunOutput(runId) : undefined;
+
+  // Format and post comment to GitHub issue
+  const commentBody = formatGitHubComment(output ?? "", status, error);
+  const commentId = await postIssueComment(
+    token,
+    repo,
+    issueNumber,
+    commentBody,
+  );
+
+  // Get run to find userId for session lookup
+  const [run] = await globalThis.services.db
+    .select({ userId: agentRuns.userId, createdAt: agentRuns.createdAt })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+
+  // Save issue session mapping
+  if (run) {
+    const newSessionId = !existingSessionId
+      ? await findNewSessionId(run.userId, composeId, run.createdAt)
+      : undefined;
+
+    if (!existingSessionId && newSessionId) {
+      // New issue thread — create mapping
+      await globalThis.services.db
+        .insert(githubIssueSessions)
+        .values({
+          userId: run.userId,
+          installationId,
+          repo,
+          issueNumber,
+          agentSessionId: newSessionId,
+          lastCommentId: commentId,
+        })
+        .onConflictDoNothing();
+    } else if (existingSessionId && status === "completed" && commentId) {
+      // Existing issue thread — update lastCommentId
+      await globalThis.services.db
+        .update(githubIssueSessions)
+        .set({
+          lastCommentId: commentId,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(githubIssueSessions.installationId, installationId),
+            eq(githubIssueSessions.repo, repo),
+            eq(githubIssueSessions.issueNumber, issueNumber),
+          ),
+        );
+    }
+  }
+
+  log.debug("GitHub issues callback processed successfully", {
+    runId,
+    commentId,
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -21,6 +21,7 @@ import { usageDaily } from "../db/schema/usage-daily";
 import { slackComposeRequests } from "../db/schema/slack-compose-request";
 import { slackInstallations } from "../db/schema/slack-installation";
 import { githubInstallations } from "../db/schema/github-installation";
+import { githubIssueSessions } from "../db/schema/github-issue-session";
 import { slackThreadSessions } from "../db/schema/slack-thread-session";
 import { emailThreadSessions } from "../db/schema/email-thread-session";
 import { agentRunCallbacks } from "../db/schema/agent-run-callback";
@@ -2119,4 +2120,57 @@ export async function findTestGitHubInstallationById(id: string) {
     .where(eq(githubInstallations.id, id))
     .limit(1);
   return row;
+}
+
+/**
+ * Insert a GitHub issue session record directly in the database.
+ *
+ * Direct DB insert is required because issue sessions are created by the
+ * callback handler, and we need to pre-populate them for update path tests.
+ */
+export async function insertTestGitHubIssueSession(params: {
+  userId: string;
+  installationId: string;
+  repo: string;
+  issueNumber: number;
+  agentSessionId: string;
+  lastCommentId?: string;
+}): Promise<{ id: string }> {
+  const [row] = await globalThis.services.db
+    .insert(githubIssueSessions)
+    .values({
+      userId: params.userId,
+      installationId: params.installationId,
+      repo: params.repo,
+      issueNumber: params.issueNumber,
+      agentSessionId: params.agentSessionId,
+      lastCommentId: params.lastCommentId,
+    })
+    .returning({ id: githubIssueSessions.id });
+  return row!;
+}
+
+/**
+ * Find a GitHub issue session by installation, repo, and issue number.
+ *
+ * Direct DB read is required because there is no API endpoint to query
+ * issue sessions. Used to verify callback handler creates/updates records.
+ */
+export async function findTestGitHubIssueSession(
+  installationId: string,
+  repo: string,
+  issueNumber: number,
+) {
+  const [row] = await globalThis.services.db
+    .select()
+    .from(githubIssueSessions)
+    .where(
+      and(
+        eq(githubIssueSessions.installationId, installationId),
+        eq(githubIssueSessions.repo, repo),
+        eq(githubIssueSessions.issueNumber, issueNumber),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
 }

--- a/turbo/apps/web/src/db/migrations/meta/0096_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0096_snapshot.json
@@ -62,12 +62,8 @@
           "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_compose_versions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -172,12 +168,8 @@
           "name": "agent_composes_scope_id_scopes_id_fk",
           "tableFrom": "agent_composes",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -282,12 +274,8 @@
           "name": "agent_permissions_agent_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_permissions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "agent_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -297,11 +285,7 @@
         "agent_permissions_compose_type_email_unique": {
           "name": "agent_permissions_compose_type_email_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "agent_compose_id",
-            "grantee_type",
-            "grantee_email"
-          ]
+          "columns": ["agent_compose_id", "grantee_type", "grantee_email"]
         }
       },
       "policies": {},
@@ -421,12 +405,8 @@
           "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_callbacks",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -486,12 +466,8 @@
           "name": "agent_run_events_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -588,12 +564,8 @@
           "name": "agent_run_events_local_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_events_local",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -794,12 +766,8 @@
           "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_compose_versions",
-          "columnsFrom": [
-            "agent_compose_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -807,12 +775,8 @@
           "name": "agent_runs_schedule_id_agent_schedules_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_schedules",
-          "columnsFrom": [
-            "schedule_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1026,12 +990,8 @@
           "name": "agent_schedules_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_schedules",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1039,12 +999,8 @@
           "name": "agent_schedules_last_run_id_agent_runs_id_fk",
           "tableFrom": "agent_schedules",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "last_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["last_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1146,12 +1102,8 @@
           "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "agent_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1159,12 +1111,8 @@
           "name": "agent_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1285,12 +1233,8 @@
           "name": "checkpoints_run_id_agent_runs_id_fk",
           "tableFrom": "checkpoints",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1298,12 +1242,8 @@
           "name": "checkpoints_conversation_id_conversations_id_fk",
           "tableFrom": "checkpoints",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1313,9 +1253,7 @@
         "checkpoints_run_id_unique": {
           "name": "checkpoints_run_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "run_id"
-          ]
+          "columns": ["run_id"]
         }
       },
       "policies": {},
@@ -1378,9 +1316,7 @@
         "cli_tokens_token_unique": {
           "name": "cli_tokens_token_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
+          "columns": ["token"]
         }
       },
       "policies": {},
@@ -1731,12 +1667,8 @@
           "name": "connectors_scope_id_scopes_id_fk",
           "tableFrom": "connectors",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1802,12 +1734,8 @@
           "name": "conversations_run_id_agent_runs_id_fk",
           "tableFrom": "conversations",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1817,9 +1745,7 @@
         "conversations_run_id_unique": {
           "name": "conversations_run_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "run_id"
-          ]
+          "columns": ["run_id"]
         }
       },
       "policies": {},
@@ -1944,12 +1870,8 @@
           "name": "email_reply_requests_run_id_agent_runs_id_fk",
           "tableFrom": "email_reply_requests",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1957,12 +1879,8 @@
           "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
           "tableFrom": "email_reply_requests",
           "tableTo": "email_thread_sessions",
-          "columnsFrom": [
-            "email_thread_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["email_thread_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2066,12 +1984,8 @@
           "name": "email_thread_sessions_compose_id_agent_composes_id_fk",
           "tableFrom": "email_thread_sessions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2079,12 +1993,8 @@
           "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "email_thread_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2157,12 +2067,8 @@
           "name": "github_installations_default_compose_id_agent_composes_id_fk",
           "tableFrom": "github_installations",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "default_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "restrict",
           "onUpdate": "no action"
         }
@@ -2172,9 +2078,7 @@
         "github_installations_installation_id_unique": {
           "name": "github_installations_installation_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "installation_id"
-          ]
+          "columns": ["installation_id"]
         }
       },
       "policies": {},
@@ -2292,12 +2196,8 @@
           "name": "github_issue_sessions_installation_id_github_installations_id_fk",
           "tableFrom": "github_issue_sessions",
           "tableTo": "github_installations",
-          "columnsFrom": [
-            "installation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2305,12 +2205,8 @@
           "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "github_issue_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2442,12 +2338,8 @@
           "name": "model_providers_scope_id_scopes_id_fk",
           "tableFrom": "model_providers",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2455,12 +2347,8 @@
           "name": "model_providers_secret_id_secrets_id_fk",
           "tableFrom": "model_providers",
           "tableTo": "secrets",
-          "columnsFrom": [
-            "secret_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["secret_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2555,12 +2443,8 @@
           "name": "org_access_tokens_scope_id_scopes_id_fk",
           "tableFrom": "org_access_tokens",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -2570,9 +2454,7 @@
         "org_access_tokens_token_unique": {
           "name": "org_access_tokens_token_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
+          "columns": ["token"]
         }
       },
       "policies": {},
@@ -2659,12 +2541,8 @@
           "name": "runner_job_queue_run_id_agent_runs_id_fk",
           "tableFrom": "runner_job_queue",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2728,12 +2606,8 @@
           "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
           "tableFrom": "sandbox_telemetry",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2869,9 +2743,7 @@
         "scopes_slug_unique": {
           "name": "scopes_slug_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
+          "columns": ["slug"]
         }
       },
       "policies": {},
@@ -2999,12 +2871,8 @@
           "name": "secrets_scope_id_scopes_id_fk",
           "tableFrom": "secrets",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3080,12 +2948,8 @@
           "name": "slack_compose_requests_compose_job_id_compose_jobs_id_fk",
           "tableFrom": "slack_compose_requests",
           "tableTo": "compose_jobs",
-          "columnsFrom": [
-            "compose_job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3164,12 +3028,8 @@
           "name": "slack_installations_default_compose_id_agent_composes_id_fk",
           "tableFrom": "slack_installations",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "default_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "restrict",
           "onUpdate": "no action"
         }
@@ -3179,9 +3039,7 @@
         "slack_installations_slack_workspace_id_unique": {
           "name": "slack_installations_slack_workspace_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slack_workspace_id"
-          ]
+          "columns": ["slack_workspace_id"]
         }
       },
       "policies": {},
@@ -3293,12 +3151,8 @@
           "name": "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk",
           "tableFrom": "slack_thread_sessions",
           "tableTo": "slack_user_links",
-          "columnsFrom": [
-            "slack_user_link_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["slack_user_link_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3306,12 +3160,8 @@
           "name": "slack_thread_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "slack_thread_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3458,12 +3308,8 @@
           "name": "storage_versions_storage_id_storages_id_fk",
           "tableFrom": "storage_versions",
           "tableTo": "storages",
-          "columnsFrom": [
-            "storage_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3600,12 +3446,8 @@
           "name": "storages_scope_id_scopes_id_fk",
           "tableFrom": "storages",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -3613,12 +3455,8 @@
           "name": "storages_head_version_id_storage_versions_id_fk",
           "tableFrom": "storages",
           "tableTo": "storage_versions",
-          "columnsFrom": [
-            "head_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["head_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -3765,12 +3603,8 @@
           "name": "users_scope_id_scopes_id_fk",
           "tableFrom": "users",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -3874,12 +3708,8 @@
           "name": "variables_scope_id_scopes_id_fk",
           "tableFrom": "variables",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3895,30 +3725,17 @@
     "public.connector_session_status": {
       "name": "connector_session_status",
       "schema": "public",
-      "values": [
-        "pending",
-        "complete",
-        "expired",
-        "error"
-      ]
+      "values": ["pending", "complete", "expired", "error"]
     },
     "public.device_code_status": {
       "name": "device_code_status",
       "schema": "public",
-      "values": [
-        "pending",
-        "authenticated",
-        "expired",
-        "denied"
-      ]
+      "values": ["pending", "authenticated", "expired", "denied"]
     },
     "public.scope_type": {
       "name": "scope_type",
       "schema": "public",
-      "values": [
-        "personal",
-        "organization"
-      ]
+      "values": ["personal", "organization"]
     }
   },
   "schemas": {},

--- a/turbo/apps/web/src/db/migrations/meta/0097_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0097_snapshot.json
@@ -62,12 +62,8 @@
           "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_compose_versions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -172,12 +168,8 @@
           "name": "agent_composes_scope_id_scopes_id_fk",
           "tableFrom": "agent_composes",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -282,12 +274,8 @@
           "name": "agent_permissions_agent_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_permissions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "agent_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -297,11 +285,7 @@
         "agent_permissions_compose_type_email_unique": {
           "name": "agent_permissions_compose_type_email_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "agent_compose_id",
-            "grantee_type",
-            "grantee_email"
-          ]
+          "columns": ["agent_compose_id", "grantee_type", "grantee_email"]
         }
       },
       "policies": {},
@@ -421,12 +405,8 @@
           "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_callbacks",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -486,12 +466,8 @@
           "name": "agent_run_events_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -588,12 +564,8 @@
           "name": "agent_run_events_local_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_events_local",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -800,12 +772,8 @@
           "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_compose_versions",
-          "columnsFrom": [
-            "agent_compose_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -813,12 +781,8 @@
           "name": "agent_runs_schedule_id_agent_schedules_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_schedules",
-          "columnsFrom": [
-            "schedule_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1032,12 +996,8 @@
           "name": "agent_schedules_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_schedules",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1045,12 +1005,8 @@
           "name": "agent_schedules_last_run_id_agent_runs_id_fk",
           "tableFrom": "agent_schedules",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "last_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["last_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1152,12 +1108,8 @@
           "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "agent_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1165,12 +1117,8 @@
           "name": "agent_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1291,12 +1239,8 @@
           "name": "checkpoints_run_id_agent_runs_id_fk",
           "tableFrom": "checkpoints",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1304,12 +1248,8 @@
           "name": "checkpoints_conversation_id_conversations_id_fk",
           "tableFrom": "checkpoints",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1319,9 +1259,7 @@
         "checkpoints_run_id_unique": {
           "name": "checkpoints_run_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "run_id"
-          ]
+          "columns": ["run_id"]
         }
       },
       "policies": {},
@@ -1384,9 +1322,7 @@
         "cli_tokens_token_unique": {
           "name": "cli_tokens_token_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
+          "columns": ["token"]
         }
       },
       "policies": {},
@@ -1737,12 +1673,8 @@
           "name": "connectors_scope_id_scopes_id_fk",
           "tableFrom": "connectors",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1808,12 +1740,8 @@
           "name": "conversations_run_id_agent_runs_id_fk",
           "tableFrom": "conversations",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1823,9 +1751,7 @@
         "conversations_run_id_unique": {
           "name": "conversations_run_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "run_id"
-          ]
+          "columns": ["run_id"]
         }
       },
       "policies": {},
@@ -1950,12 +1876,8 @@
           "name": "email_reply_requests_run_id_agent_runs_id_fk",
           "tableFrom": "email_reply_requests",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1963,12 +1885,8 @@
           "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
           "tableFrom": "email_reply_requests",
           "tableTo": "email_thread_sessions",
-          "columnsFrom": [
-            "email_thread_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["email_thread_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2072,12 +1990,8 @@
           "name": "email_thread_sessions_compose_id_agent_composes_id_fk",
           "tableFrom": "email_thread_sessions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2085,12 +1999,8 @@
           "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "email_thread_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2163,12 +2073,8 @@
           "name": "github_installations_default_compose_id_agent_composes_id_fk",
           "tableFrom": "github_installations",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "default_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "restrict",
           "onUpdate": "no action"
         }
@@ -2178,9 +2084,7 @@
         "github_installations_installation_id_unique": {
           "name": "github_installations_installation_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "installation_id"
-          ]
+          "columns": ["installation_id"]
         }
       },
       "policies": {},
@@ -2298,12 +2202,8 @@
           "name": "github_issue_sessions_installation_id_github_installations_id_fk",
           "tableFrom": "github_issue_sessions",
           "tableTo": "github_installations",
-          "columnsFrom": [
-            "installation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2311,12 +2211,8 @@
           "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "github_issue_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2448,12 +2344,8 @@
           "name": "model_providers_scope_id_scopes_id_fk",
           "tableFrom": "model_providers",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2461,12 +2353,8 @@
           "name": "model_providers_secret_id_secrets_id_fk",
           "tableFrom": "model_providers",
           "tableTo": "secrets",
-          "columnsFrom": [
-            "secret_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["secret_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2561,12 +2449,8 @@
           "name": "org_access_tokens_scope_id_scopes_id_fk",
           "tableFrom": "org_access_tokens",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -2576,9 +2460,7 @@
         "org_access_tokens_token_unique": {
           "name": "org_access_tokens_token_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
+          "columns": ["token"]
         }
       },
       "policies": {},
@@ -2665,12 +2547,8 @@
           "name": "runner_job_queue_run_id_agent_runs_id_fk",
           "tableFrom": "runner_job_queue",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2734,12 +2612,8 @@
           "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
           "tableFrom": "sandbox_telemetry",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2875,9 +2749,7 @@
         "scopes_slug_unique": {
           "name": "scopes_slug_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
+          "columns": ["slug"]
         }
       },
       "policies": {},
@@ -3005,12 +2877,8 @@
           "name": "secrets_scope_id_scopes_id_fk",
           "tableFrom": "secrets",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3086,12 +2954,8 @@
           "name": "slack_compose_requests_compose_job_id_compose_jobs_id_fk",
           "tableFrom": "slack_compose_requests",
           "tableTo": "compose_jobs",
-          "columnsFrom": [
-            "compose_job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3170,12 +3034,8 @@
           "name": "slack_installations_default_compose_id_agent_composes_id_fk",
           "tableFrom": "slack_installations",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "default_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "restrict",
           "onUpdate": "no action"
         }
@@ -3185,9 +3045,7 @@
         "slack_installations_slack_workspace_id_unique": {
           "name": "slack_installations_slack_workspace_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slack_workspace_id"
-          ]
+          "columns": ["slack_workspace_id"]
         }
       },
       "policies": {},
@@ -3299,12 +3157,8 @@
           "name": "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk",
           "tableFrom": "slack_thread_sessions",
           "tableTo": "slack_user_links",
-          "columnsFrom": [
-            "slack_user_link_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["slack_user_link_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3312,12 +3166,8 @@
           "name": "slack_thread_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "slack_thread_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3464,12 +3314,8 @@
           "name": "storage_versions_storage_id_storages_id_fk",
           "tableFrom": "storage_versions",
           "tableTo": "storages",
-          "columnsFrom": [
-            "storage_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3606,12 +3452,8 @@
           "name": "storages_scope_id_scopes_id_fk",
           "tableFrom": "storages",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -3619,12 +3461,8 @@
           "name": "storages_head_version_id_storage_versions_id_fk",
           "tableFrom": "storages",
           "tableTo": "storage_versions",
-          "columnsFrom": [
-            "head_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["head_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -3771,12 +3609,8 @@
           "name": "users_scope_id_scopes_id_fk",
           "tableFrom": "users",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -3880,12 +3714,8 @@
           "name": "variables_scope_id_scopes_id_fk",
           "tableFrom": "variables",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3901,30 +3731,17 @@
     "public.connector_session_status": {
       "name": "connector_session_status",
       "schema": "public",
-      "values": [
-        "pending",
-        "complete",
-        "expired",
-        "error"
-      ]
+      "values": ["pending", "complete", "expired", "error"]
     },
     "public.device_code_status": {
       "name": "device_code_status",
       "schema": "public",
-      "values": [
-        "pending",
-        "authenticated",
-        "expired",
-        "denied"
-      ]
+      "values": ["pending", "authenticated", "expired", "denied"]
     },
     "public.scope_type": {
       "name": "scope_type",
       "schema": "public",
-      "values": [
-        "personal",
-        "organization"
-      ]
+      "values": ["personal", "organization"]
     }
   },
   "schemas": {},


### PR DESCRIPTION
## Summary

- Implements `POST /api/internal/callbacks/github/issues` endpoint that receives agent run completion notifications and posts responses back to GitHub as issue comments
- Follows the same callback pattern as the existing Slack integration (signature verification, Axiom output fetching, session management)
- Creates/updates `github_issue_sessions` for multi-turn conversation continuity

## Key Implementation Details

- **Signature verification**: Per-callback HMAC secret (same as Slack/Email callbacks)
- **GitHub API**: Gets fresh installation access token via GitHub App JWT, posts comment via REST API
- **Session management**: Creates session mapping for new issues, updates `lastCommentId` for existing sessions
- **Error handling**: Handles missing installations, GitHub API failures, and empty agent output gracefully
- **Attribution footer**: Comments include VM0 attribution footer

## Test plan

- [x] Signature verification: invalid signature rejected (401)
- [x] Signature verification: expired timestamp rejected (401)
- [x] Signature verification: non-existent callback rejected (404)
- [x] Validation: missing runId rejected (400)
- [x] Validation: invalid payload rejected (400)
- [x] Success: completed run posts comment to GitHub
- [x] Success: failed run posts error comment to GitHub
- [x] Error: missing GitHub installation returns 404
- [x] Session: new issue session created on completion
- [x] Session: existing session handled on completion

Closes #3442

🤖 Generated with [Claude Code](https://claude.com/claude-code)