### PR TITLE
feat(github): add webhook endpoint for issue events

### DIFF
--- a/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
@@ -1,0 +1,535 @@
+import crypto from "crypto";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { testContext } from "../../../../../src/__tests__/test-helpers";
+import { givenGitHubInstallation } from "../../../../../src/__tests__/github/api-helpers";
+import { POST } from "../route";
+import * as runModule from "../../../../../src/lib/run";
+import { reloadEnv } from "../../../../../src/env";
+
+// Mock Next.js after() to capture callbacks for controlled execution
+const afterPromises: Promise<unknown>[] = [];
+vi.mock("next/server", async (importOriginal) => {
+  const original = await importOriginal<typeof import("next/server")>();
+  return {
+    ...original,
+    after: (promise: Promise<unknown>) => {
+      afterPromises.push(promise);
+    },
+  };
+});
+
+const context = testContext();
+
+const TEST_WEBHOOK_SECRET = "test-github-webhook-secret";
+const TEST_APP_SLUG = "vm0-bot";
+
+/** Wait for all after() callbacks to complete */
+async function flushAfterCallbacks() {
+  await Promise.all(afterPromises);
+  afterPromises.length = 0;
+}
+
+/** Sign a payload with HMAC-SHA256 matching GitHub's format */
+function signPayload(body: string, secret: string): string {
+  const hmac = crypto.createHmac("sha256", secret);
+  return `sha256=${hmac.update(body).digest("hex")}`;
+}
+
+/** Create a signed GitHub webhook request */
+function createGitHubWebhookRequest(
+  event: string,
+  payload: Record<string, unknown>,
+  options?: { invalidSignature?: boolean; missingHeaders?: boolean },
+): Request {
+  const body = JSON.stringify(payload);
+  const signature = options?.invalidSignature
+    ? "sha256=invalid"
+    : signPayload(body, TEST_WEBHOOK_SECRET);
+  const deliveryId = crypto.randomUUID();
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (!options?.missingHeaders) {
+    headers["x-hub-signature-256"] = signature;
+    headers["x-github-event"] = event;
+    headers["x-github-delivery"] = deliveryId;
+  }
+
+  return new Request("http://localhost/api/webhooks/github", {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+interface IssuesPayloadOverrides {
+  action?: string;
+  labels?: Array<{ id: number; name: string }>;
+  label?: { id: number; name: string };
+  installationId?: number;
+  repo?: string;
+  issueBody?: string | null;
+}
+
+/** Build a GitHub issues event payload */
+function buildIssuesPayload(overrides?: IssuesPayloadOverrides) {
+  return {
+    action: overrides?.action ?? "opened",
+    issue: {
+      number: 42,
+      title: "Test Issue",
+      body:
+        overrides?.issueBody !== undefined
+          ? overrides.issueBody
+          : "This is a test issue body",
+      labels: overrides?.labels ?? [{ id: 1, name: "vm0-agent" }],
+      user: { id: 100, login: "testuser", type: "User" },
+    },
+    ...(overrides?.label && { label: overrides.label }),
+    repository: { full_name: overrides?.repo ?? "owner/repo" },
+    installation: { id: overrides?.installationId ?? 12345 },
+    sender: { id: 100, login: "testuser", type: "User" },
+  };
+}
+
+interface CommentPayloadOverrides {
+  action?: string;
+  labels?: Array<{ id: number; name: string }>;
+  commentBody?: string;
+  commentId?: number;
+  installationId?: number;
+  repo?: string;
+  senderType?: string;
+  senderLogin?: string;
+}
+
+/** Build a GitHub issue_comment event payload */
+function buildIssueCommentPayload(overrides?: CommentPayloadOverrides) {
+  const senderLogin = overrides?.senderLogin ?? "testuser";
+  const senderType = overrides?.senderType ?? "User";
+
+  return {
+    action: overrides?.action ?? "created",
+    issue: {
+      number: 42,
+      title: "Test Issue",
+      body: "This is a test issue body",
+      labels: overrides?.labels ?? [{ id: 1, name: "vm0-agent" }],
+      user: { id: 100, login: "testuser", type: "User" },
+    },
+    comment: {
+      id: overrides?.commentId ?? 999,
+      body: overrides?.commentBody ?? "Please help with this",
+      user: { id: 100, login: senderLogin, type: senderType },
+    },
+    repository: { full_name: overrides?.repo ?? "owner/repo" },
+    installation: { id: overrides?.installationId ?? 12345 },
+    sender: { id: 100, login: senderLogin, type: senderType },
+  };
+}
+
+describe("POST /api/webhooks/github", () => {
+  let createRunSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    afterPromises.length = 0;
+    context.setupMocks();
+
+    // Stub GitHub App env vars
+    vi.stubEnv("GITHUB_APP_WEBHOOK_SECRET", TEST_WEBHOOK_SECRET);
+    vi.stubEnv("GITHUB_APP_SLUG", TEST_APP_SLUG);
+
+    // Reload env after stubbing
+    reloadEnv();
+
+    // Mock createRun to prevent actual sandbox dispatch
+    createRunSpy = vi.spyOn(runModule, "createRun").mockResolvedValue({
+      runId: "test-run-id",
+      status: "running",
+      createdAt: new Date(),
+    });
+  });
+
+  describe("Signature Verification", () => {
+    it("should reject request with missing headers", async () => {
+      const request = createGitHubWebhookRequest(
+        "issues",
+        buildIssuesPayload(),
+        { missingHeaders: true },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toContain("Missing");
+    });
+
+    it("should reject request with invalid signature", async () => {
+      const request = createGitHubWebhookRequest(
+        "issues",
+        buildIssuesPayload(),
+        { invalidSignature: true },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toContain("Invalid signature");
+    });
+
+    it("should accept request with valid signature", async () => {
+      const request = createGitHubWebhookRequest("ping", { zen: "test" });
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("Ping Event", () => {
+    it("should respond with pong", async () => {
+      const request = createGitHubWebhookRequest("ping", {
+        zen: "Anything added dilutes everything else.",
+      });
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.message).toBe("pong");
+    });
+  });
+
+  describe("Issues Event", () => {
+    it("should trigger agent for opened issue with vm0-agent label", async () => {
+      // Given a GitHub installation exists
+      const { ghInstallationId } = await givenGitHubInstallation();
+
+      // When a webhook arrives for an opened issue with the vm0-agent label
+      const request = createGitHubWebhookRequest(
+        "issues",
+        buildIssuesPayload({
+          action: "opened",
+          labels: [{ id: 1, name: "vm0-agent" }],
+          installationId: ghInstallationId,
+        }),
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await flushAfterCallbacks();
+
+      // Then createRun should have been called
+      expect(createRunSpy).toHaveBeenCalledTimes(1);
+      const callArgs = createRunSpy.mock.calls[0]![0] as {
+        prompt: string;
+        callbacks: Array<{ payload: { issueNumber: number } }>;
+      };
+      expect(callArgs.prompt).toContain("Test Issue");
+      expect(callArgs.prompt).toContain("test issue body");
+      expect(callArgs.callbacks[0]!.payload.issueNumber).toBe(42);
+    });
+
+    it("should trigger agent when vm0-agent label is added", async () => {
+      const { ghInstallationId } = await givenGitHubInstallation();
+
+      const request = createGitHubWebhookRequest(
+        "issues",
+        buildIssuesPayload({
+          action: "labeled",
+          labels: [{ id: 1, name: "vm0-agent" }],
+          label: { id: 1, name: "vm0-agent" },
+          installationId: ghInstallationId,
+        }),
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await flushAfterCallbacks();
+
+      expect(createRunSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("should NOT trigger agent for opened issue without vm0-agent label", async () => {
+      const { ghInstallationId } = await givenGitHubInstallation();
+
+      const request = createGitHubWebhookRequest(
+        "issues",
+        buildIssuesPayload({
+          action: "opened",
+          labels: [{ id: 2, name: "bug" }],
+          installationId: ghInstallationId,
+        }),
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await flushAfterCallbacks();
+
+      expect(createRunSpy).not.toHaveBeenCalled();
+    });
+
+    it("should NOT trigger agent when a non-vm0-agent label is added", async () => {
+      const { ghInstallationId } = await givenGitHubInstallation();
+
+      const request = createGitHubWebhookRequest(
+        "issues",
+        buildIssuesPayload({
+          action: "labeled",
+          labels: [
+            { id: 1, name: "vm0-agent" },
+            { id: 2, name: "enhancement" },
+          ],
+          label: { id: 2, name: "enhancement" },
+          installationId: ghInstallationId,
+        }),
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await flushAfterCallbacks();
+
+      expect(createRunSpy).not.toHaveBeenCalled();
+    });
+
+    it("should ignore closed/edited/other issue actions", async () => {
+      const { ghInstallationId } = await givenGitHubInstallation();
+
+      for (const action of ["closed", "edited", "reopened", "deleted"]) {
+        createRunSpy.mockClear();
+
+        const request = createGitHubWebhookRequest(
+          "issues",
+          buildIssuesPayload({
+            action,
+            labels: [{ id: 1, name: "vm0-agent" }],
+            installationId: ghInstallationId,
+          }),
+        );
+        const response = await POST(request);
+        expect(response.status).toBe(200);
+
+        await flushAfterCallbacks();
+
+        expect(createRunSpy).not.toHaveBeenCalled();
+      }
+    });
+
+    it("should handle issue with null body", async () => {
+      const { ghInstallationId } = await givenGitHubInstallation();
+
+      const request = createGitHubWebhookRequest(
+        "issues",
+        buildIssuesPayload({
+          action: "opened",
+          labels: [{ id: 1, name: "vm0-agent" }],
+          installationId: ghInstallationId,
+          issueBody: null,
+        }),
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await flushAfterCallbacks();
+
+      expect(createRunSpy).toHaveBeenCalledTimes(1);
+      const callArgs = createRunSpy.mock.calls[0]![0] as { prompt: string };
+      expect(callArgs.prompt).toContain("No description provided");
+    });
+  });
+
+  describe("Issue Comment Event", () => {
+    it("should trigger agent for comment on issue with vm0-agent label", async () => {
+      const { ghInstallationId } = await givenGitHubInstallation();
+
+      const request = createGitHubWebhookRequest(
+        "issue_comment",
+        buildIssueCommentPayload({
+          labels: [{ id: 1, name: "vm0-agent" }],
+          commentBody: "Can you help me fix this?",
+          installationId: ghInstallationId,
+        }),
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await flushAfterCallbacks();
+
+      expect(createRunSpy).toHaveBeenCalledTimes(1);
+      const callArgs = createRunSpy.mock.calls[0]![0] as { prompt: string };
+      expect(callArgs.prompt).toContain("Can you help me fix this?");
+      expect(callArgs.prompt).toContain("Test Issue");
+    });
+
+    it("should trigger agent for comment mentioning @bot", async () => {
+      const { ghInstallationId } = await givenGitHubInstallation();
+
+      const request = createGitHubWebhookRequest(
+        "issue_comment",
+        buildIssueCommentPayload({
+          labels: [], // No vm0-agent label
+          commentBody: `@${TEST_APP_SLUG}[bot] please review this`,
+          installationId: ghInstallationId,
+        }),
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await flushAfterCallbacks();
+
+      expect(createRunSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("should NOT trigger for comment without label or mention", async () => {
+      const { ghInstallationId } = await givenGitHubInstallation();
+
+      const request = createGitHubWebhookRequest(
+        "issue_comment",
+        buildIssueCommentPayload({
+          labels: [{ id: 2, name: "bug" }],
+          commentBody: "Just a regular comment",
+          installationId: ghInstallationId,
+        }),
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await flushAfterCallbacks();
+
+      expect(createRunSpy).not.toHaveBeenCalled();
+    });
+
+    it("should prevent self-triggering from bot comments", async () => {
+      const { ghInstallationId } = await givenGitHubInstallation();
+
+      const request = createGitHubWebhookRequest(
+        "issue_comment",
+        buildIssueCommentPayload({
+          labels: [{ id: 1, name: "vm0-agent" }],
+          commentBody: "Here is the analysis...",
+          senderType: "Bot",
+          senderLogin: `${TEST_APP_SLUG}[bot]`,
+          installationId: ghInstallationId,
+        }),
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await flushAfterCallbacks();
+
+      expect(createRunSpy).not.toHaveBeenCalled();
+    });
+
+    it("should ignore non-created comment actions", async () => {
+      const { ghInstallationId } = await givenGitHubInstallation();
+
+      for (const action of ["edited", "deleted"]) {
+        createRunSpy.mockClear();
+
+        const request = createGitHubWebhookRequest(
+          "issue_comment",
+          buildIssueCommentPayload({
+            action,
+            labels: [{ id: 1, name: "vm0-agent" }],
+            installationId: ghInstallationId,
+          }),
+        );
+        const response = await POST(request);
+        expect(response.status).toBe(200);
+
+        await flushAfterCallbacks();
+
+        expect(createRunSpy).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe("Installation Not Found", () => {
+    it("should handle gracefully when installation does not exist", async () => {
+      // Use an installation ID that doesn't exist in the database
+      const request = createGitHubWebhookRequest(
+        "issues",
+        buildIssuesPayload({
+          installationId: 99999,
+          labels: [{ id: 1, name: "vm0-agent" }],
+        }),
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await flushAfterCallbacks();
+
+      // Should not crash, just log and return
+      expect(createRunSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Unknown Events", () => {
+    it("should acknowledge unknown event types with 200", async () => {
+      const request = createGitHubWebhookRequest("push", {
+        ref: "refs/heads/main",
+      });
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("Unconfigured GitHub App", () => {
+    it("should return 503 when webhook secret is not configured", async () => {
+      // Remove the webhook secret
+      vi.stubEnv("GITHUB_APP_WEBHOOK_SECRET", "");
+      reloadEnv();
+
+      const request = createGitHubWebhookRequest(
+        "issues",
+        buildIssuesPayload(),
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(503);
+      const data = await response.json();
+      expect(data.error).toContain("not configured");
+    });
+  });
+
+  describe("Session Continuity", () => {
+    it("should include callback context with session info", async () => {
+      const { ghInstallationId } = await givenGitHubInstallation();
+
+      const request = createGitHubWebhookRequest(
+        "issue_comment",
+        buildIssueCommentPayload({
+          labels: [{ id: 1, name: "vm0-agent" }],
+          commentBody: "Follow-up question",
+          installationId: ghInstallationId,
+        }),
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await flushAfterCallbacks();
+
+      expect(createRunSpy).toHaveBeenCalledTimes(1);
+      const callArgs = createRunSpy.mock.calls[0]![0] as {
+        callbacks: Array<{
+          url: string;
+          secret: string;
+          payload: {
+            repo: string;
+            issueNumber: number;
+            installationId: string;
+          };
+        }>;
+      };
+
+      // Callback should include GitHub-specific context
+      expect(callArgs.callbacks).toHaveLength(1);
+      expect(callArgs.callbacks[0]!.url).toContain(
+        "/api/internal/callbacks/github",
+      );
+      expect(callArgs.callbacks[0]!.payload.repo).toBe("owner/repo");
+      expect(callArgs.callbacks[0]!.payload.issueNumber).toBe(42);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
@@ -6,6 +6,13 @@ import { POST } from "../route";
 import * as runModule from "../../../../../src/lib/run";
 import { reloadEnv } from "../../../../../src/env";
 
+// Note: createRun is spied on (rather than exercised with real DB + executor)
+// because this test file focuses on the webhook routing layer: signature
+// verification, event routing, trigger conditions, and callback context
+// construction.  Real createRun integration is covered by its own dedicated
+// tests in src/lib/run/__tests__/create-run.test.ts.  The same boundary is
+// used in the Slack webhook tests (slack/handlers/__tests__/run-agent.test.ts).
+
 // Mock Next.js after() to capture callbacks for controlled execution
 const afterPromises: Promise<unknown>[] = [];
 vi.mock("next/server", async (importOriginal) => {
@@ -445,7 +452,7 @@ describe("POST /api/webhooks/github", () => {
   });
 
   describe("Installation Not Found", () => {
-    it("should handle gracefully when installation does not exist", async () => {
+    it("should handle missing installation without crashing", async () => {
       // Use an installation ID that doesn't exist in the database
       const request = createGitHubWebhookRequest(
         "issues",
@@ -457,9 +464,9 @@ describe("POST /api/webhooks/github", () => {
       const response = await POST(request);
       expect(response.status).toBe(200);
 
+      // The error thrown in dispatchAgentRun is caught by the .catch() in route.ts
       await flushAfterCallbacks();
 
-      // Should not crash, just log and return
       expect(createRunSpy).not.toHaveBeenCalled();
     });
   });

--- a/turbo/apps/web/app/api/webhooks/github/route.ts
+++ b/turbo/apps/web/app/api/webhooks/github/route.ts
@@ -8,10 +8,8 @@ import {
 import {
   handleIssuesEvent,
   handleIssueCommentEvent,
-} from "../../../../src/lib/github/handlers/issue-event";
-import type {
-  GitHubIssuesEvent,
-  GitHubIssueCommentEvent,
+  gitHubIssuesEventSchema,
+  gitHubIssueCommentEventSchema,
 } from "../../../../src/lib/github/handlers/issue-event";
 import { logger } from "../../../../src/lib/logger";
 
@@ -80,13 +78,19 @@ export async function POST(request: Request) {
 
   // Route to event-specific handlers
   if (headers.event === "issues") {
+    const parsed = gitHubIssuesEventSchema.safeParse(payload);
+    if (!parsed.success) {
+      log.error("Invalid issues event payload", { error: parsed.error });
+      return NextResponse.json(
+        { error: "Invalid payload structure" },
+        { status: 400 },
+      );
+    }
+
     initServices();
 
     after(
-      handleIssuesEvent(
-        payload as unknown as GitHubIssuesEvent,
-        GITHUB_APP_SLUG,
-      ).catch((error) => {
+      handleIssuesEvent(parsed.data, GITHUB_APP_SLUG).catch((error) => {
         log.error("Error handling issues event", { error });
       }),
     );
@@ -95,13 +99,21 @@ export async function POST(request: Request) {
   }
 
   if (headers.event === "issue_comment") {
+    const parsed = gitHubIssueCommentEventSchema.safeParse(payload);
+    if (!parsed.success) {
+      log.error("Invalid issue_comment event payload", {
+        error: parsed.error,
+      });
+      return NextResponse.json(
+        { error: "Invalid payload structure" },
+        { status: 400 },
+      );
+    }
+
     initServices();
 
     after(
-      handleIssueCommentEvent(
-        payload as unknown as GitHubIssueCommentEvent,
-        GITHUB_APP_SLUG,
-      ).catch((error) => {
+      handleIssueCommentEvent(parsed.data, GITHUB_APP_SLUG).catch((error) => {
         log.error("Error handling issue_comment event", { error });
       }),
     );

--- a/turbo/apps/web/app/api/webhooks/github/route.ts
+++ b/turbo/apps/web/app/api/webhooks/github/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse, after } from "next/server";
+import { initServices } from "../../../../src/lib/init-services";
+import { env } from "../../../../src/env";
+import {
+  verifyGitHubWebhookSignature,
+  getGitHubWebhookHeaders,
+} from "../../../../src/lib/github/verify-webhook";
+import {
+  handleIssuesEvent,
+  handleIssueCommentEvent,
+} from "../../../../src/lib/github/handlers/issue-event";
+import type {
+  GitHubIssuesEvent,
+  GitHubIssueCommentEvent,
+} from "../../../../src/lib/github/handlers/issue-event";
+import { logger } from "../../../../src/lib/logger";
+
+const log = logger("webhook:github");
+
+/**
+ * GitHub Webhook Endpoint
+ *
+ * POST /api/webhooks/github
+ *
+ * Handles incoming events from the GitHub App:
+ * - issues (opened, labeled) — trigger agent on new/labeled issues
+ * - issue_comment (created) — trigger agent on new comments
+ *
+ * Important: Must respond within GitHub's 10-second timeout.
+ * Uses Next.js after() to process events in the background.
+ */
+export async function POST(request: Request) {
+  const { GITHUB_APP_WEBHOOK_SECRET, GITHUB_APP_SLUG } = env();
+
+  if (!GITHUB_APP_WEBHOOK_SECRET) {
+    return NextResponse.json(
+      { error: "GitHub App integration is not configured" },
+      { status: 503 },
+    );
+  }
+
+  // Extract and validate headers
+  const headers = getGitHubWebhookHeaders(request.headers);
+  if (!headers) {
+    return NextResponse.json(
+      { error: "Missing GitHub webhook headers" },
+      { status: 401 },
+    );
+  }
+
+  // Get raw body for signature verification
+  const body = await request.text();
+
+  // Verify webhook signature
+  const isValid = verifyGitHubWebhookSignature(
+    GITHUB_APP_WEBHOOK_SECRET,
+    headers.signature,
+    body,
+  );
+
+  if (!isValid) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  // Parse the payload
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(body) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON payload" },
+      { status: 400 },
+    );
+  }
+
+  // Handle ping event (sent when webhook is first configured)
+  if (headers.event === "ping") {
+    return NextResponse.json({ message: "pong" });
+  }
+
+  // Route to event-specific handlers
+  if (headers.event === "issues") {
+    initServices();
+
+    after(
+      handleIssuesEvent(
+        payload as unknown as GitHubIssuesEvent,
+        GITHUB_APP_SLUG,
+      ).catch((error) => {
+        log.error("Error handling issues event", { error });
+      }),
+    );
+
+    return new Response("OK", { status: 200 });
+  }
+
+  if (headers.event === "issue_comment") {
+    initServices();
+
+    after(
+      handleIssueCommentEvent(
+        payload as unknown as GitHubIssueCommentEvent,
+        GITHUB_APP_SLUG,
+      ).catch((error) => {
+        log.error("Error handling issue_comment event", { error });
+      }),
+    );
+
+    return new Response("OK", { status: 200 });
+  }
+
+  // Unknown event type — acknowledge but don't process
+  log.debug("Ignoring unhandled GitHub event", { event: headers.event });
+  return new Response("OK", { status: 200 });
+}

--- a/turbo/apps/web/src/__tests__/github/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/github/api-helpers.ts
@@ -1,0 +1,118 @@
+/**
+ * API-based GitHub Test Helpers
+ *
+ * These helpers create GitHub test fixtures for webhook handler tests.
+ * Direct DB operations are used because GitHub App installations are created
+ * via a GitHub OAuth callback that requires real GitHub API interaction.
+ */
+import crypto from "crypto";
+import { eq } from "drizzle-orm";
+import { uniqueId } from "../test-helpers";
+import { initServices } from "../../lib/init-services";
+import { env } from "../../env";
+import { encryptCredentialValue } from "../../lib/crypto/secrets-encryption";
+import { scopes } from "../../db/schema/scope";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../db/schema/agent-compose";
+import { githubInstallations } from "../../db/schema/github-installation";
+
+interface GitHubInstallationResult {
+  installation: {
+    id: string;
+    userId: string;
+    installationId: string;
+    defaultComposeId: string;
+  };
+  ghInstallationId: number;
+  compose: { id: string; name: string };
+  versionId: string;
+  userId: string;
+}
+
+/**
+ * Given a GitHub App installation exists in the database.
+ *
+ * Creates all prerequisite records (scope, compose, version, installation)
+ * needed for webhook handler tests.
+ */
+export async function givenGitHubInstallation(
+  installationId?: number,
+): Promise<GitHubInstallationResult> {
+  const ghInstallationId =
+    installationId ?? Math.floor(Math.random() * 1_000_000_000);
+
+  initServices();
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  const userId = uniqueId("gh-user");
+  const scopeSlug = uniqueId("scope");
+
+  // Create scope
+  const [scope] = await globalThis.services.db
+    .insert(scopes)
+    .values({ slug: scopeSlug, type: "personal", ownerId: userId })
+    .returning();
+
+  // Create compose
+  const [compose] = await globalThis.services.db
+    .insert(agentComposes)
+    .values({
+      userId,
+      scopeId: scope!.id,
+      name: uniqueId("gh-agent"),
+    })
+    .returning();
+
+  // Create compose version (content-addressed: id is SHA-256 hash)
+  const versionContent = {
+    agents: { default: { model: "claude-sonnet-4-20250514" } },
+  };
+  const versionId = crypto
+    .createHash("sha256")
+    .update(JSON.stringify(versionContent) + compose!.id)
+    .digest("hex");
+
+  await globalThis.services.db.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId: compose!.id,
+    content: versionContent,
+    createdBy: userId,
+  });
+
+  // Update compose headVersionId
+  await globalThis.services.db
+    .update(agentComposes)
+    .set({ headVersionId: versionId })
+    .where(eq(agentComposes.id, compose!.id));
+
+  // Create installation
+  const encryptedToken = encryptCredentialValue(
+    "ghs_test_token",
+    SECRETS_ENCRYPTION_KEY,
+  );
+
+  const [installation] = await globalThis.services.db
+    .insert(githubInstallations)
+    .values({
+      userId,
+      installationId: String(ghInstallationId),
+      encryptedAccessToken: encryptedToken,
+      defaultComposeId: compose!.id,
+    })
+    .returning();
+
+  return {
+    installation: {
+      id: installation!.id,
+      userId: installation!.userId,
+      installationId: installation!.installationId,
+      defaultComposeId: installation!.defaultComposeId,
+    },
+    ghInstallationId,
+    compose: { id: compose!.id, name: compose!.name },
+    versionId,
+    userId,
+  };
+}

--- a/turbo/apps/web/src/lib/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/issue-event.ts
@@ -1,0 +1,381 @@
+import { eq, and, desc } from "drizzle-orm";
+import { githubInstallations } from "../../../db/schema/github-installation";
+import { githubIssueSessions } from "../../../db/schema/github-issue-session";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../db/schema/agent-compose";
+import { createRun } from "../../run";
+import { isConcurrentRunLimit } from "../../errors";
+import { generateCallbackSecret, getApiUrl } from "../../callback";
+import { logger } from "../../logger";
+
+const log = logger("github:issue-event");
+
+const VM0_AGENT_LABEL = "vm0-agent";
+
+// ─── GitHub Webhook Payload Types ──────────────────────────────────
+
+interface GitHubUser {
+  id: number;
+  login: string;
+  type: string; // "User" | "Bot" | "Organization"
+}
+
+interface GitHubLabel {
+  id: number;
+  name: string;
+}
+
+interface GitHubIssue {
+  number: number;
+  title: string;
+  body: string | null;
+  labels: GitHubLabel[];
+  user: GitHubUser;
+}
+
+interface GitHubComment {
+  id: number;
+  body: string;
+  user: GitHubUser;
+}
+
+interface GitHubRepository {
+  full_name: string; // "owner/repo"
+}
+
+interface GitHubInstallation {
+  id: number;
+}
+
+export interface GitHubIssuesEvent {
+  action: string;
+  issue: GitHubIssue;
+  label?: GitHubLabel;
+  repository: GitHubRepository;
+  installation: GitHubInstallation;
+  sender: GitHubUser;
+}
+
+export interface GitHubIssueCommentEvent {
+  action: string;
+  issue: GitHubIssue;
+  comment: GitHubComment;
+  repository: GitHubRepository;
+  installation: GitHubInstallation;
+  sender: GitHubUser;
+}
+
+// ─── Callback Context ──────────────────────────────────────────────
+
+interface GitHubCallbackContext {
+  installationId: string;
+  repo: string;
+  issueNumber: number;
+  userId: string;
+  agentName: string;
+  composeId: string;
+  existingSessionId?: string;
+}
+
+// ─── Event Handlers ────────────────────────────────────────────────
+
+/**
+ * Handle `issues` events (opened, labeled).
+ *
+ * Triggers agent when:
+ * - issues.opened with vm0-agent label
+ * - issues.labeled with vm0-agent label
+ */
+export async function handleIssuesEvent(
+  payload: GitHubIssuesEvent,
+  appSlug: string | undefined,
+): Promise<void> {
+  const { action, issue, label, repository, installation } = payload;
+
+  // Only handle opened and labeled actions
+  if (action !== "opened" && action !== "labeled") {
+    log.debug("Ignoring issues event", { action });
+    return;
+  }
+
+  // For "labeled" action, only trigger when the vm0-agent label is added
+  if (action === "labeled" && label?.name !== VM0_AGENT_LABEL) {
+    log.debug("Ignoring label that is not vm0-agent", { label: label?.name });
+    return;
+  }
+
+  // For "opened" action, check if issue has the vm0-agent label
+  if (action === "opened") {
+    const hasLabel = issue.labels.some((l) => l.name === VM0_AGENT_LABEL);
+    if (!hasLabel) {
+      log.debug("Ignoring opened issue without vm0-agent label");
+      return;
+    }
+  }
+
+  // Build prompt from issue content
+  const prompt = buildIssuePrompt(issue);
+
+  await dispatchAgentRun({
+    ghInstallationId: String(installation.id),
+    repo: repository.full_name,
+    issueNumber: issue.number,
+    prompt,
+    appSlug,
+  });
+}
+
+/**
+ * Handle `issue_comment` events (created).
+ *
+ * Triggers agent when:
+ * - Issue has vm0-agent label, OR
+ * - Comment mentions @{app-slug}[bot]
+ *
+ * Skips if:
+ * - Comment is from a bot (prevents self-triggering)
+ */
+export async function handleIssueCommentEvent(
+  payload: GitHubIssueCommentEvent,
+  appSlug: string | undefined,
+): Promise<void> {
+  const { action, issue, comment, repository, installation, sender } = payload;
+
+  if (action !== "created") {
+    log.debug("Ignoring issue_comment event", { action });
+    return;
+  }
+
+  // Prevent self-triggering: ignore comments from bots
+  if (sender.type === "Bot") {
+    log.debug("Ignoring comment from bot", { sender: sender.login });
+    return;
+  }
+
+  // Check trigger conditions
+  const hasLabel = issue.labels.some((l) => l.name === VM0_AGENT_LABEL);
+  const botMention = appSlug ? `@${appSlug}[bot]` : null;
+  const hasMention = botMention ? comment.body.includes(botMention) : false;
+
+  if (!hasLabel && !hasMention) {
+    log.debug("Ignoring comment: no vm0-agent label and no bot mention");
+    return;
+  }
+
+  // Build prompt with comment as the user message and issue as context
+  const prompt = buildCommentPrompt(issue, comment);
+
+  await dispatchAgentRun({
+    ghInstallationId: String(installation.id),
+    repo: repository.full_name,
+    issueNumber: issue.number,
+    prompt,
+    commentId: String(comment.id),
+    appSlug,
+  });
+}
+
+// ─── Internal Helpers ──────────────────────────────────────────────
+
+interface DispatchParams {
+  ghInstallationId: string;
+  repo: string;
+  issueNumber: number;
+  prompt: string;
+  commentId?: string;
+  appSlug: string | undefined;
+}
+
+/**
+ * Core dispatch logic shared by issue and comment handlers.
+ *
+ * 1. Resolve installation from GitHub installation ID
+ * 2. Get agent compose and latest version
+ * 3. Look up existing session for multi-turn
+ * 4. Create agent run with callback
+ * 5. Update/create issue session mapping
+ */
+async function dispatchAgentRun(params: DispatchParams): Promise<void> {
+  const { ghInstallationId, repo, issueNumber, prompt, commentId } = params;
+
+  // 1. Resolve installation
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(githubInstallations)
+    .where(eq(githubInstallations.installationId, ghInstallationId))
+    .limit(1);
+
+  if (!installation) {
+    log.error("GitHub installation not found", {
+      installationId: ghInstallationId,
+    });
+    return;
+  }
+
+  // 2. Resolve agent compose and version
+  const [compose] = await globalThis.services.db
+    .select()
+    .from(agentComposes)
+    .where(eq(agentComposes.id, installation.defaultComposeId))
+    .limit(1);
+
+  if (!compose) {
+    log.error("Agent compose not found", {
+      composeId: installation.defaultComposeId,
+    });
+    return;
+  }
+
+  let versionId = compose.headVersionId;
+  if (!versionId) {
+    const [latestVersion] = await globalThis.services.db
+      .select({ id: agentComposeVersions.id })
+      .from(agentComposeVersions)
+      .where(eq(agentComposeVersions.composeId, compose.id))
+      .orderBy(desc(agentComposeVersions.createdAt))
+      .limit(1);
+
+    if (!latestVersion) {
+      log.error("Agent compose has no versions", { composeId: compose.id });
+      return;
+    }
+    versionId = latestVersion.id;
+  }
+
+  // 3. Look up existing session for multi-turn
+  let existingSessionId: string | undefined;
+  const [existingSession] = await globalThis.services.db
+    .select({
+      agentSessionId: githubIssueSessions.agentSessionId,
+      lastCommentId: githubIssueSessions.lastCommentId,
+    })
+    .from(githubIssueSessions)
+    .where(
+      and(
+        eq(githubIssueSessions.installationId, installation.id),
+        eq(githubIssueSessions.repo, repo),
+        eq(githubIssueSessions.issueNumber, issueNumber),
+      ),
+    )
+    .limit(1);
+
+  if (existingSession) {
+    existingSessionId = existingSession.agentSessionId;
+
+    // Deduplicate: skip if we already processed this comment
+    if (commentId && existingSession.lastCommentId === commentId) {
+      log.debug("Skipping duplicate comment", { commentId });
+      return;
+    }
+  }
+
+  // 4. Create agent run with callback
+  const callbackUrl = `${getApiUrl()}/api/internal/callbacks/github`;
+  const callbackSecret = generateCallbackSecret();
+  const callbackContext: GitHubCallbackContext = {
+    installationId: installation.id,
+    repo,
+    issueNumber,
+    userId: installation.userId,
+    agentName: compose.name,
+    composeId: compose.id,
+    existingSessionId,
+  };
+
+  try {
+    const result = await createRun({
+      userId: installation.userId,
+      agentComposeVersionId: versionId,
+      prompt,
+      composeId: compose.id,
+      sessionId: existingSessionId,
+      agentName: compose.name,
+      artifactName: "artifact",
+      callbacks: [
+        {
+          url: callbackUrl,
+          secret: callbackSecret,
+          payload: callbackContext,
+        },
+      ],
+    });
+
+    log.info("Agent run dispatched for GitHub issue", {
+      runId: result.runId,
+      repo,
+      issueNumber,
+    });
+
+    // 5. Update or create issue session mapping
+    if (existingSession) {
+      // Update lastCommentId for deduplication
+      if (commentId) {
+        await globalThis.services.db
+          .update(githubIssueSessions)
+          .set({
+            lastCommentId: commentId,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(githubIssueSessions.installationId, installation.id),
+              eq(githubIssueSessions.repo, repo),
+              eq(githubIssueSessions.issueNumber, issueNumber),
+            ),
+          );
+      }
+    }
+    // Note: New session mapping will be created by the callback handler
+    // once the run completes and we have the agentSessionId from the result
+  } catch (error) {
+    if (isConcurrentRunLimit(error)) {
+      log.warn("Concurrent run limit reached for GitHub issue", {
+        repo,
+        issueNumber,
+      });
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Build a prompt from an issue (for opened/labeled events).
+ */
+function buildIssuePrompt(issue: GitHubIssue): string {
+  const parts: string[] = [
+    `# GitHub Issue #${issue.number}: ${issue.title}`,
+    "",
+  ];
+
+  if (issue.body) {
+    parts.push(issue.body);
+  } else {
+    parts.push("(No description provided)");
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Build a prompt from a comment, with issue context.
+ */
+function buildCommentPrompt(
+  issue: GitHubIssue,
+  comment: GitHubComment,
+): string {
+  const parts: string[] = [
+    `# GitHub Issue #${issue.number}: ${issue.title}`,
+    "",
+  ];
+
+  if (issue.body) {
+    parts.push("## Issue Description", "", issue.body, "");
+  }
+
+  parts.push("## New Comment", "", `**@${comment.user.login}:**`, comment.body);
+
+  return parts.join("\n");
+}

--- a/turbo/apps/web/src/lib/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/issue-event.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { eq, and, desc } from "drizzle-orm";
 import { githubInstallations } from "../../../db/schema/github-installation";
 import { githubIssueSessions } from "../../../db/schema/github-issue-session";
@@ -14,58 +15,65 @@ const log = logger("github:issue-event");
 
 const VM0_AGENT_LABEL = "vm0-agent";
 
+// ─── GitHub Webhook Payload Schemas ────────────────────────────────
+
+const gitHubUserSchema = z.object({
+  id: z.number(),
+  login: z.string(),
+  type: z.string(),
+});
+
+const gitHubLabelSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+});
+
+const gitHubIssueSchema = z.object({
+  number: z.number(),
+  title: z.string(),
+  body: z.string().nullable(),
+  labels: z.array(gitHubLabelSchema),
+  user: gitHubUserSchema,
+});
+
+const gitHubCommentSchema = z.object({
+  id: z.number(),
+  body: z.string(),
+  user: gitHubUserSchema,
+});
+
+const gitHubRepositorySchema = z.object({
+  full_name: z.string(),
+});
+
+const gitHubInstallationSchema = z.object({
+  id: z.number(),
+});
+
+export const gitHubIssuesEventSchema = z.object({
+  action: z.string(),
+  issue: gitHubIssueSchema,
+  label: gitHubLabelSchema.optional(),
+  repository: gitHubRepositorySchema,
+  installation: gitHubInstallationSchema,
+  sender: gitHubUserSchema,
+});
+
+export const gitHubIssueCommentEventSchema = z.object({
+  action: z.string(),
+  issue: gitHubIssueSchema,
+  comment: gitHubCommentSchema,
+  repository: gitHubRepositorySchema,
+  installation: gitHubInstallationSchema,
+  sender: gitHubUserSchema,
+});
+
 // ─── GitHub Webhook Payload Types ──────────────────────────────────
 
-interface GitHubUser {
-  id: number;
-  login: string;
-  type: string; // "User" | "Bot" | "Organization"
-}
-
-interface GitHubLabel {
-  id: number;
-  name: string;
-}
-
-interface GitHubIssue {
-  number: number;
-  title: string;
-  body: string | null;
-  labels: GitHubLabel[];
-  user: GitHubUser;
-}
-
-interface GitHubComment {
-  id: number;
-  body: string;
-  user: GitHubUser;
-}
-
-interface GitHubRepository {
-  full_name: string; // "owner/repo"
-}
-
-interface GitHubInstallation {
-  id: number;
-}
-
-export interface GitHubIssuesEvent {
-  action: string;
-  issue: GitHubIssue;
-  label?: GitHubLabel;
-  repository: GitHubRepository;
-  installation: GitHubInstallation;
-  sender: GitHubUser;
-}
-
-export interface GitHubIssueCommentEvent {
-  action: string;
-  issue: GitHubIssue;
-  comment: GitHubComment;
-  repository: GitHubRepository;
-  installation: GitHubInstallation;
-  sender: GitHubUser;
-}
+type GitHubIssuesEvent = z.infer<typeof gitHubIssuesEventSchema>;
+type GitHubIssueCommentEvent = z.infer<typeof gitHubIssueCommentEventSchema>;
+type GitHubIssue = z.infer<typeof gitHubIssueSchema>;
+type GitHubComment = z.infer<typeof gitHubCommentSchema>;
 
 // ─── Callback Context ──────────────────────────────────────────────
 
@@ -208,10 +216,9 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
     .limit(1);
 
   if (!installation) {
-    log.error("GitHub installation not found", {
-      installationId: ghInstallationId,
-    });
-    return;
+    throw new Error(
+      `GitHub installation not found: installationId=${ghInstallationId}`,
+    );
   }
 
   // 2. Resolve agent compose and version
@@ -222,10 +229,9 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
     .limit(1);
 
   if (!compose) {
-    log.error("Agent compose not found", {
-      composeId: installation.defaultComposeId,
-    });
-    return;
+    throw new Error(
+      `Agent compose not found: composeId=${installation.defaultComposeId}`,
+    );
   }
 
   let versionId = compose.headVersionId;
@@ -238,8 +244,7 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
       .limit(1);
 
     if (!latestVersion) {
-      log.error("Agent compose has no versions", { composeId: compose.id });
-      return;
+      throw new Error(`Agent compose has no versions: composeId=${compose.id}`);
     }
     versionId = latestVersion.id;
   }

--- a/turbo/apps/web/src/lib/github/verify-webhook.ts
+++ b/turbo/apps/web/src/lib/github/verify-webhook.ts
@@ -1,0 +1,49 @@
+import crypto from "crypto";
+
+/**
+ * Verify GitHub webhook signature using HMAC-SHA256.
+ *
+ * GitHub sends X-Hub-Signature-256 in the format: sha256=<hex-digest>
+ * The payload is signed with the webhook secret configured in the GitHub App.
+ *
+ * @see https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+ */
+export function verifyGitHubWebhookSignature(
+  secret: string,
+  signature: string,
+  body: string,
+): boolean {
+  const hmac = crypto.createHmac("sha256", secret);
+  const expectedSignature = `sha256=${hmac.update(body).digest("hex")}`;
+
+  try {
+    return crypto.timingSafeEqual(
+      Buffer.from(signature),
+      Buffer.from(expectedSignature),
+    );
+  } catch {
+    // Buffers have different lengths
+    return false;
+  }
+}
+
+/**
+ * Extract GitHub webhook headers from a request.
+ *
+ * @returns Signature and event type headers, or null if required headers are missing
+ */
+export function getGitHubWebhookHeaders(headers: Headers): {
+  signature: string;
+  event: string;
+  deliveryId: string;
+} | null {
+  const signature = headers.get("x-hub-signature-256");
+  const event = headers.get("x-github-event");
+  const deliveryId = headers.get("x-github-delivery");
+
+  if (!signature || !event || !deliveryId) {
+    return null;
+  }
+
+  return { signature, event, deliveryId };
+}


### PR DESCRIPTION
## Summary
- Implement `POST /api/webhooks/github` to handle incoming GitHub App webhooks for issue-driven agent runs
- Support `issues` (opened/labeled) and `issue_comment` (created) events with `vm0-agent` label detection, `@bot` mention triggers, and bot self-triggering prevention
- Add HMAC-SHA256 webhook signature verification, multi-turn session support via `github_issue_sessions`, and agent run dispatch with callback context

## Test plan
- [x] 19 integration tests covering signature verification, event routing, trigger conditions, self-triggering prevention, installation lookup, session continuity, and error handling
- [x] All 3076 tests pass across full test suite
- [x] Lint, type-check, format, and knip all clean

Closes #3441

🤖 Generated with [Claude Code](https://claude.com/claude-code)