### PR TITLE
feat(github): add GitHub integration configuration UI

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -23,6 +23,7 @@ import { setupLoggers$ } from "./bootstrap/loggers.ts";
 import { setupPlaygroundPage$ } from "./playground-page/playground-page.ts";
 import { setupEnvironmentVariablesSetupPage$ } from "./environment-variables-setup/setup-page.ts";
 import { setupSlackSettingsPage$ } from "./integrations-page/slack-settings-page.ts";
+import { setupGitHubSettingsPage$ } from "./integrations-page/github-settings-page.ts";
 import { setupProviderSetupPage$ } from "./provider-setup/provider-setup-page.ts";
 import { setupSlackConnectPage$ } from "./slack-connect/slack-connect-page.ts";
 import { setupSlackConnectSuccessPage$ } from "./slack-connect/slack-connect-success-page.ts";
@@ -69,6 +70,10 @@ const ROUTE_CONFIG = [
   {
     path: "/settings/slack",
     setup: setupScopeRequiredPageWrapper(setupSlackSettingsPage$),
+  },
+  {
+    path: "/settings/github",
+    setup: setupScopeRequiredPageWrapper(setupGitHubSettingsPage$),
   },
   {
     path: "/environment-variables-setup",

--- a/turbo/apps/platform/src/signals/integrations-page/github-integration.ts
+++ b/turbo/apps/platform/src/signals/integrations-page/github-integration.ts
@@ -1,22 +1,41 @@
 import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { fetch$ } from "../fetch.ts";
 import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
 
 const L = logger("GitHubIntegration");
 
+interface GitHubIntegrationData {
+  installation: { id: string; installationId: string };
+  agent: { id: string; name: string; scopeSlug: string } | null;
+  environment: {
+    requiredSecrets: string[];
+    requiredVars: string[];
+    missingSecrets: string[];
+    missingVars: string[];
+  };
+}
+
 interface GitHubIntegrationState {
+  data: GitHubIntegrationData | null;
   loading: boolean;
+  error: string | null;
   notLinked: boolean;
   installUrl: string | null;
 }
 
 const githubIntegrationState$ = state<GitHubIntegrationState>({
+  data: null,
   loading: false,
+  error: null,
   notLinked: false,
   installUrl: null,
 });
 
+export const githubIntegrationData$ = computed(
+  (get) => get(githubIntegrationState$).data,
+);
 export const githubIntegrationLoading$ = computed(
   (get) => get(githubIntegrationState$).loading,
 );
@@ -31,6 +50,7 @@ export const fetchGitHubIntegration$ = command(async ({ get, set }) => {
   set(githubIntegrationState$, (prev) => ({
     ...prev,
     loading: true,
+    error: null,
   }));
 
   try {
@@ -42,7 +62,9 @@ export const fetchGitHubIntegration$ = command(async ({ get, set }) => {
         installUrl?: string | null;
       };
       set(githubIntegrationState$, {
+        data: null,
         loading: false,
+        error: null,
         notLinked: true,
         installUrl: body.installUrl ?? null,
       });
@@ -55,9 +77,11 @@ export const fetchGitHubIntegration$ = command(async ({ get, set }) => {
       );
     }
 
-    await response.json();
+    const data = (await response.json()) as GitHubIntegrationData;
     set(githubIntegrationState$, {
+      data,
       loading: false,
+      error: null,
       notLinked: false,
       installUrl: null,
     });
@@ -67,6 +91,86 @@ export const fetchGitHubIntegration$ = command(async ({ get, set }) => {
     set(githubIntegrationState$, (prev) => ({
       ...prev,
       loading: false,
+      error: error instanceof Error ? error.message : "Unknown error",
     }));
   }
+});
+
+const githubDisconnectDialogState$ = state(false);
+
+export const githubDisconnectDialogOpen$ = computed((get) =>
+  get(githubDisconnectDialogState$),
+);
+
+export const openGithubDisconnectDialog$ = command(({ set }) => {
+  set(githubDisconnectDialogState$, true);
+});
+
+export const closeGithubDisconnectDialog$ = command(({ set }) => {
+  set(githubDisconnectDialogState$, false);
+});
+
+export const updateGithubDefaultAgent$ = command(
+  async ({ get, set }, agentName: string) => {
+    // Optimistically update agent name so the UI doesn't flash a loading state
+    set(githubIntegrationState$, (prev) => {
+      if (!prev.data) {
+        return prev;
+      }
+      return {
+        ...prev,
+        data: {
+          ...prev.data,
+          agent: prev.data.agent
+            ? { ...prev.data.agent, name: agentName }
+            : { id: "", name: agentName, scopeSlug: "" },
+        },
+      };
+    });
+
+    const fetchFn = get(fetch$);
+    const response = await fetchFn("/api/integrations/github", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agentName }),
+    });
+
+    if (!response.ok) {
+      toast.error("Failed to update default agent");
+      // Re-fetch to revert optimistic update
+      await set(fetchGitHubIntegration$);
+      return;
+    }
+
+    toast.success(`Default agent updated to ${agentName}`);
+
+    // Silently refresh to pick up updated environment status without loading spinner
+    try {
+      const refreshResponse = await fetchFn("/api/integrations/github");
+      if (refreshResponse.ok) {
+        const data = (await refreshResponse.json()) as GitHubIntegrationData;
+        set(githubIntegrationState$, (prev) => ({
+          ...prev,
+          data,
+        }));
+      }
+    } catch (error) {
+      throwIfAbort(error);
+      L.error("Failed to refresh after agent update:", error);
+    }
+  },
+);
+
+export const disconnectGithub$ = command(async ({ get, set }) => {
+  const fetchFn = get(fetch$);
+  const response = await fetchFn("/api/integrations/github", {
+    method: "DELETE",
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to disconnect GitHub");
+  }
+
+  // Re-fetch to get the updated state with install URL
+  await set(fetchGitHubIntegration$);
 });

--- a/turbo/apps/platform/src/signals/integrations-page/github-settings-page.ts
+++ b/turbo/apps/platform/src/signals/integrations-page/github-settings-page.ts
@@ -1,0 +1,14 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { updatePage$ } from "../react-router";
+import { GitHubSettingsPage } from "../../views/integrations-page/github-settings-page";
+import { fetchGitHubIntegration$ } from "./github-integration.ts";
+import { fetchAgentsList$ } from "../agents-page/agents-list.ts";
+
+/**
+ * Setup the GitHub settings detail page.
+ */
+export const setupGitHubSettingsPage$ = command(async ({ set }) => {
+  set(updatePage$, createElement(GitHubSettingsPage));
+  await Promise.all([set(fetchGitHubIntegration$), set(fetchAgentsList$)]);
+});

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -4,6 +4,7 @@ export type RoutePath =
   | "/logs/:id"
   | "/settings"
   | "/settings/slack"
+  | "/settings/github"
   | "/agents"
   | "/agents/:name"
   | "/agents/:name/logs"

--- a/turbo/apps/platform/src/views/integrations-page/github-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/github-settings-page.tsx
@@ -1,0 +1,308 @@
+import { useGet, useSet } from "ccstate-react";
+import { IconAlertTriangle } from "@tabler/icons-react";
+import {
+  CONNECTOR_TYPES,
+  getConnectorProvidedSecretNames,
+  type ConnectorType,
+} from "@vm0/core";
+import { Button } from "@vm0/ui/components/ui/button";
+import { Skeleton } from "@vm0/ui/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vm0/ui/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui/components/ui/dialog";
+import { detach, Reason } from "../../signals/utils.ts";
+import {
+  githubIntegrationData$,
+  githubIntegrationLoading$,
+  disconnectGithub$,
+  updateGithubDefaultAgent$,
+  githubDisconnectDialogOpen$,
+  openGithubDisconnectDialog$,
+  closeGithubDisconnectDialog$,
+} from "../../signals/integrations-page/github-integration.ts";
+import { agentsList$ } from "../../signals/agents-page/agents-list.ts";
+import { navigateInReact$ } from "../../signals/route.ts";
+import { AppShell } from "../layout/app-shell.tsx";
+import { Link } from "../router/link.tsx";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getAllConnectorEnvVars(): Set<string> {
+  return getConnectorProvidedSecretNames(
+    Object.keys(CONNECTOR_TYPES) as ConnectorType[],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Missing env banner
+// ---------------------------------------------------------------------------
+
+function MissingEnvBanner({
+  agentName,
+  missingSecrets,
+  missingVars,
+}: {
+  agentName: string | undefined;
+  missingSecrets: string[];
+  missingVars: string[];
+}) {
+  const envVars = getAllConnectorEnvVars();
+
+  const hasMissingConnectors = missingSecrets.some((s) => envVars.has(s));
+  const hasMissingSecretsOrVars =
+    missingSecrets.some((s) => !envVars.has(s)) || missingVars.length > 0;
+
+  if (!hasMissingConnectors && !hasMissingSecretsOrVars) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-amber-500 bg-amber-50 px-4 py-3 dark:border-amber-700 dark:bg-amber-950/30">
+      <IconAlertTriangle
+        size={20}
+        className="shrink-0 text-amber-500"
+        stroke={1.5}
+      />
+      <p className="text-sm">
+        {"Looks like this agent is missing some "}
+        {hasMissingConnectors &&
+          (agentName ? (
+            <Link
+              pathname="/agents/:name/connections"
+              options={{
+                pathParams: { name: agentName },
+                searchParams: new URLSearchParams({ tab: "connectors" }),
+              }}
+              className="font-medium text-amber-600 hover:underline dark:text-amber-500"
+            >
+              connectors
+            </Link>
+          ) : (
+            <span className="font-medium text-amber-600 dark:text-amber-500">
+              connectors
+            </span>
+          ))}
+        {hasMissingConnectors && hasMissingSecretsOrVars && ", "}
+        {hasMissingSecretsOrVars &&
+          (agentName ? (
+            <Link
+              pathname="/agents/:name/connections"
+              options={{
+                pathParams: { name: agentName },
+                searchParams: new URLSearchParams({ tab: "secrets" }),
+              }}
+              className="font-medium text-amber-600 hover:underline dark:text-amber-500"
+            >
+              secrets or variables
+            </Link>
+          ) : (
+            <span className="font-medium text-amber-600 dark:text-amber-500">
+              secrets or variables
+            </span>
+          ))}
+        {". Add them now so it can run without stopping."}
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
+export function GitHubSettingsPage() {
+  const data = useGet(githubIntegrationData$);
+  const loading = useGet(githubIntegrationLoading$);
+  const agents = useGet(agentsList$);
+  const navigate = useSet(navigateInReact$);
+  const disconnect = useSet(disconnectGithub$);
+  const updateAgent = useSet(updateGithubDefaultAgent$);
+  const confirmOpen = useGet(githubDisconnectDialogOpen$);
+  const openConfirm = useSet(openGithubDisconnectDialog$);
+  const closeConfirm = useSet(closeGithubDisconnectDialog$);
+
+  // Construct scoped agent name that matches the format used in agentsList$
+  // (shared agents use "scope/name", owned agents use just "name").
+  const scopedAgentName = (() => {
+    if (!data?.agent) {
+      return undefined;
+    }
+    const fullName = `${data.agent.scopeSlug}/${data.agent.name}`;
+    // If the scoped name exists in agents list, use it (shared agent)
+    if (agents.some((a) => a.name === fullName)) {
+      return fullName;
+    }
+    // Otherwise use bare name (owned agent)
+    return data.agent.name;
+  })();
+
+  // Ensure the current agent appears in the dropdown even if
+  // it isn't in the user's own agents list (e.g. shared by another user).
+  const agentOptions = (() => {
+    if (!scopedAgentName) {
+      return agents;
+    }
+    const hasCurrentAgent = agents.some((a) => a.name === scopedAgentName);
+    if (hasCurrentAgent) {
+      return agents;
+    }
+    return [
+      { name: scopedAgentName, headVersionId: null, updatedAt: "" },
+      ...agents,
+    ];
+  })();
+
+  const handleDisconnect = () => {
+    detach(
+      (async () => {
+        await disconnect();
+        closeConfirm();
+        navigate("/settings", {
+          searchParams: new URLSearchParams({ tab: "integrations" }),
+        });
+      })(),
+      Reason.DomCallback,
+    );
+  };
+
+  const handleAgentChange = (agentName: string) => {
+    detach(updateAgent(agentName), Reason.DomCallback);
+  };
+
+  const breadcrumb = [
+    { label: "Settings", path: "/settings" as const },
+    "GitHub Issues",
+  ];
+
+  return (
+    <AppShell
+      breadcrumb={breadcrumb}
+      title="GitHub Issues"
+      subtitle="Configure your GitHub integration settings."
+    >
+      <div className="flex flex-col gap-6 px-6 pb-8">
+        {loading ? (
+          <div className="flex flex-col gap-6">
+            <Skeleton className="h-24 w-full rounded-xl" />
+            <Skeleton className="h-14 w-full rounded-lg" />
+            <Skeleton className="h-20 w-full rounded-xl" />
+          </div>
+        ) : (
+          <>
+            {/* Default agent section */}
+            <div className="flex flex-col gap-4">
+              <h3 className="text-base font-medium">Default agent</h3>
+              <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-4 sm:flex-row sm:items-center">
+                <div className="flex flex-1 flex-col gap-1">
+                  <p className="text-sm font-medium">
+                    Default agent for GitHub issues
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {
+                      "If you want to manage your agent's model provider, secrets, or connectors, go to "
+                    }
+                    <Link
+                      pathname="/settings"
+                      options={{
+                        searchParams: new URLSearchParams({ tab: "providers" }),
+                      }}
+                      className="text-primary hover:underline"
+                    >
+                      Settings
+                    </Link>
+                    .
+                  </p>
+                </div>
+                <Select
+                  value={scopedAgentName ?? ""}
+                  onValueChange={handleAgentChange}
+                >
+                  <SelectTrigger className="w-full sm:w-[280px] sm:shrink-0">
+                    <SelectValue placeholder="Select an agent" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {agentOptions.map((agent) => (
+                      <SelectItem key={agent.name} value={agent.name}>
+                        {agent.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <MissingEnvBanner
+              agentName={scopedAgentName}
+              missingSecrets={data?.environment.missingSecrets ?? []}
+              missingVars={data?.environment.missingVars ?? []}
+            />
+
+            {/* Disconnect section */}
+            <div className="flex flex-col gap-4">
+              <h3 className="text-base font-medium">Disconnect GitHub</h3>
+              <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-4 sm:flex-row sm:items-center">
+                <div className="flex flex-1 flex-col gap-1">
+                  <p className="text-sm font-medium">
+                    Disconnect GitHub integration
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    Your GitHub App installation will be removed and agents will
+                    no longer respond to GitHub issues.
+                  </p>
+                </div>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => openConfirm()}
+                >
+                  Disconnect
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      <Dialog
+        open={confirmOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeConfirm();
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Disconnect GitHub</DialogTitle>
+            <DialogDescription>
+              This will remove your GitHub App installation and delete all
+              associated issue sessions. You can reconnect at any time.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => closeConfirm()}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDisconnect}>
+              Disconnect
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </AppShell>
+  );
+}

--- a/turbo/apps/platform/src/views/integrations-page/integrations-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/integrations-page.tsx
@@ -98,8 +98,8 @@ export function GitHubIntegrationCard() {
             </Button>
           ) : null
         ) : (
-          <Button variant="outline" size="sm" disabled>
-            Installed
+          <Button variant="outline" size="sm" asChild>
+            <Link pathname="/settings/github">Settings</Link>
           </Button>
         )}
       </div>

--- a/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { GET, DELETE } from "../route";
+import { GET, DELETE, PATCH } from "../route";
 import {
   createTestRequest,
   createTestScope,
   createTestCompose,
   insertTestGitHubInstallation,
   findTestGitHubInstallationById,
+  findTestComposeWithScope,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -70,6 +71,29 @@ describe("/api/integrations/github", () => {
       expect(data.agent).toBeDefined();
       expect(data.agent.name).toBe("gh-agent");
     });
+
+    it("should return environment data in response", async () => {
+      const userId = uniqueId("gh-user");
+      mockClerk({ userId });
+      await createTestScope(uniqueId("gh-scope"));
+      const { composeId } = await createTestCompose("gh-agent");
+
+      await insertTestGitHubInstallation(userId, composeId);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/github",
+        { headers: { Authorization: "Bearer test-token" } },
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.environment).toBeDefined();
+      expect(data.environment.requiredSecrets).toBeDefined();
+      expect(data.environment.requiredVars).toBeDefined();
+      expect(data.environment.missingSecrets).toBeDefined();
+      expect(data.environment.missingVars).toBeDefined();
+    });
   });
 
   describe("DELETE /api/integrations/github", () => {
@@ -129,6 +153,184 @@ describe("/api/integrations/github", () => {
       // Verify installation was deleted
       const row = await findTestGitHubInstallationById(installation.id);
       expect(row).toBeUndefined();
+    });
+  });
+
+  describe("PATCH /api/integrations/github", () => {
+    it("should return 401 when not authenticated", async () => {
+      mockClerk({ userId: null });
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/github",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agentName: "test-agent" }),
+        },
+      );
+      const response = await PATCH(request);
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should return 400 when agentName is missing", async () => {
+      const userId = uniqueId("gh-user");
+      mockClerk({ userId });
+      await createTestScope(uniqueId("gh-scope"));
+      const { composeId } = await createTestCompose("gh-agent");
+      await insertTestGitHubInstallation(userId, composeId);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/github",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: "Bearer test-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({}),
+        },
+      );
+      const response = await PATCH(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.code).toBe("BAD_REQUEST");
+    });
+
+    it("should return 404 when no installation exists", async () => {
+      const userId = uniqueId("gh-user");
+      mockClerk({ userId });
+      await createTestScope(uniqueId("gh-scope"));
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/github",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: "Bearer test-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ agentName: "some-agent" }),
+        },
+      );
+      const response = await PATCH(request);
+
+      expect(response.status).toBe(404);
+    });
+
+    it("should return 404 when agent does not exist", async () => {
+      const userId = uniqueId("gh-user");
+      mockClerk({ userId });
+      await createTestScope(uniqueId("gh-scope"));
+      const { composeId } = await createTestCompose("gh-agent");
+      await insertTestGitHubInstallation(userId, composeId);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/github",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: "Bearer test-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ agentName: "nonexistent-agent" }),
+        },
+      );
+      const response = await PATCH(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
+
+    it("should update default agent successfully", async () => {
+      const userId = uniqueId("gh-user");
+      mockClerk({ userId });
+      await createTestScope(uniqueId("gh-scope"));
+      const { composeId } = await createTestCompose("gh-agent");
+      await insertTestGitHubInstallation(userId, composeId);
+
+      // Create a new agent to switch to
+      await createTestCompose("new-agent");
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/github",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: "Bearer test-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ agentName: "new-agent" }),
+        },
+      );
+      const response = await PATCH(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.ok).toBe(true);
+
+      // Verify the agent was updated by fetching the integration
+      const getResponse = await GET(
+        createTestRequest("http://localhost:3000/api/integrations/github", {
+          headers: { Authorization: "Bearer test-token" },
+        }),
+      );
+      const getData = await getResponse.json();
+
+      expect(getData.agent.name).toBe("new-agent");
+    });
+
+    it("should update default agent with scoped name", async () => {
+      const userId = uniqueId("gh-user");
+      mockClerk({ userId });
+      await createTestScope(uniqueId("gh-scope"));
+      const { composeId } = await createTestCompose("gh-agent");
+      await insertTestGitHubInstallation(userId, composeId);
+
+      // Create a compose in a different scope (simulating a shared agent)
+      const otherUserId = uniqueId("other-user");
+      mockClerk({ userId: otherUserId });
+      await createTestScope(uniqueId("other-scope"));
+      const { composeId: otherComposeId } =
+        await createTestCompose("shared-agent");
+
+      // Switch back to original user
+      mockClerk({ userId });
+
+      // Look up the other scope's slug for the scoped name
+      const otherCompose = await findTestComposeWithScope(otherComposeId);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/github",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: "Bearer test-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            agentName: `${otherCompose!.scopeSlug}/${otherCompose!.composeName}`,
+          }),
+        },
+      );
+      const response = await PATCH(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.ok).toBe(true);
+
+      // Verify the agent was updated
+      const getResponse = await GET(
+        createTestRequest("http://localhost:3000/api/integrations/github", {
+          headers: { Authorization: "Bearer test-token" },
+        }),
+      );
+      const getData = await getResponse.json();
+
+      expect(getData.agent.name).toBe(otherCompose!.composeName);
+      expect(getData.agent.scopeSlug).toBe(otherCompose!.scopeSlug);
     });
   });
 });

--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -1,16 +1,33 @@
 import { NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
+import {
+  extractVariableReferences,
+  groupVariablesBySource,
+  getConnectorProvidedSecretNames,
+} from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { env } from "../../../../src/env";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
 import { githubInstallations } from "../../../../src/db/schema/github-installation";
-import { agentComposes } from "../../../../src/db/schema/agent-compose";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../src/db/schema/agent-compose";
 import { scopes } from "../../../../src/db/schema/scope";
+import { listSecrets } from "../../../../src/lib/secret/secret-service";
+import { listVariables } from "../../../../src/lib/variable/variable-service";
+import { listConnectors } from "../../../../src/lib/connector/connector-service";
+import type { AgentComposeYaml } from "../../../../src/types/agent-compose";
+import {
+  getScopeBySlug,
+  getUserScopeByClerkId,
+} from "../../../../src/lib/scope/scope-service";
 
 /**
  * GET /api/integrations/github
  *
- * Returns GitHub App installation info for the authenticated user.
+ * Returns GitHub App installation info for the authenticated user,
+ * including current agent and environment variable status.
  * If no installation exists, returns 404 with an install URL.
  */
 export async function GET(request: Request) {
@@ -52,17 +69,64 @@ export async function GET(request: Request) {
     );
   }
 
-  // Get default agent info
+  // Get default agent info with headVersionId for environment extraction
   const [compose] = await db
     .select({
       id: agentComposes.id,
       name: agentComposes.name,
+      headVersionId: agentComposes.headVersionId,
       scopeSlug: scopes.slug,
     })
     .from(agentComposes)
     .innerJoin(scopes, eq(scopes.id, agentComposes.scopeId))
     .where(eq(agentComposes.id, installation.defaultComposeId))
     .limit(1);
+
+  // Extract required secrets/vars from agent compose
+  let requiredSecrets: string[] = [];
+  let requiredVars: string[] = [];
+
+  if (compose?.headVersionId) {
+    const [version] = await db
+      .select({ content: agentComposeVersions.content })
+      .from(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, compose.headVersionId))
+      .limit(1);
+
+    if (version) {
+      const content = version.content as AgentComposeYaml;
+      const refs = extractVariableReferences(content);
+      const grouped = groupVariablesBySource(refs);
+      requiredSecrets = [
+        ...grouped.secrets.map((s) => s.name),
+        ...grouped.credentials.map((s) => s.name),
+      ];
+      requiredVars = grouped.vars.map((v) => v.name);
+    }
+  }
+
+  // Get user's existing secrets, vars, connectors
+  const [userSecrets, userVars, userConnectors] = await Promise.all([
+    listSecrets(userId),
+    listVariables(userId),
+    listConnectors(userId),
+  ]);
+
+  const connectorProvided = getConnectorProvidedSecretNames(
+    userConnectors.map((c) => c.type),
+  );
+  const existingSecretNames = new Set([
+    ...userSecrets.map((s) => s.name),
+    ...connectorProvided,
+  ]);
+  const existingVarNames = new Set(userVars.map((v) => v.name));
+
+  const missingSecrets = requiredSecrets.filter(
+    (name) => !existingSecretNames.has(name),
+  );
+  const missingVars = requiredVars.filter(
+    (name) => !existingVarNames.has(name),
+  );
 
   return NextResponse.json({
     installation: {
@@ -72,6 +136,12 @@ export async function GET(request: Request) {
     agent: compose
       ? { id: compose.id, name: compose.name, scopeSlug: compose.scopeSlug }
       : null,
+    environment: {
+      requiredSecrets,
+      requiredVars,
+      missingSecrets,
+      missingVars,
+    },
   });
 }
 
@@ -113,6 +183,96 @@ export async function DELETE(request: Request) {
   // Delete installation (cascades to github_issue_sessions)
   await db
     .delete(githubInstallations)
+    .where(eq(githubInstallations.id, installation.id));
+
+  return NextResponse.json({ ok: true });
+}
+
+/**
+ * PATCH /api/integrations/github
+ *
+ * Updates the default agent for the authenticated user's GitHub installation.
+ * Body: { agentName: string }
+ */
+export async function PATCH(request: Request) {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const userId = await getUserId(authHeader ?? undefined);
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const body = (await request.json()) as { agentName?: string };
+  if (!body.agentName) {
+    return NextResponse.json(
+      { error: { message: "agentName is required", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+
+  const db = globalThis.services.db;
+
+  // Find user's GitHub App installation
+  const [installation] = await db
+    .select({ id: githubInstallations.id })
+    .from(githubInstallations)
+    .where(eq(githubInstallations.userId, userId))
+    .limit(1);
+
+  if (!installation) {
+    return NextResponse.json(
+      { error: { message: "No GitHub installation found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  // Parse scope/agentName format (shared agents use "scopeSlug/agentName")
+  const slashIndex = body.agentName.indexOf("/");
+  const agentName =
+    slashIndex === -1 ? body.agentName : body.agentName.slice(slashIndex + 1);
+  const scopeSlug =
+    slashIndex === -1 ? null : body.agentName.slice(0, slashIndex);
+
+  // Resolve target scope
+  const targetScope = scopeSlug
+    ? await getScopeBySlug(scopeSlug)
+    : await getUserScopeByClerkId(userId);
+
+  if (!targetScope) {
+    return NextResponse.json(
+      { error: { message: "Scope not found", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+
+  // Find agent compose by name in target scope
+  const [compose] = await db
+    .select({ id: agentComposes.id })
+    .from(agentComposes)
+    .where(
+      and(
+        eq(agentComposes.scopeId, targetScope.id),
+        eq(agentComposes.name, agentName),
+      ),
+    )
+    .limit(1);
+
+  if (!compose) {
+    return NextResponse.json(
+      { error: { message: "Agent not found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  // Update installation's default agent
+  await db
+    .update(githubInstallations)
+    .set({ defaultComposeId: compose.id, updatedAt: new Date() })
     .where(eq(githubInstallations.id, installation.id));
 
   return NextResponse.json({ ok: true });

--- a/turbo/apps/web/src/db/migrations/meta/0096_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0096_snapshot.json
@@ -62,12 +62,8 @@
           "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_compose_versions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -172,12 +168,8 @@
           "name": "agent_composes_scope_id_scopes_id_fk",
           "tableFrom": "agent_composes",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -282,12 +274,8 @@
           "name": "agent_permissions_agent_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_permissions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "agent_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -297,11 +285,7 @@
         "agent_permissions_compose_type_email_unique": {
           "name": "agent_permissions_compose_type_email_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "agent_compose_id",
-            "grantee_type",
-            "grantee_email"
-          ]
+          "columns": ["agent_compose_id", "grantee_type", "grantee_email"]
         }
       },
       "policies": {},
@@ -421,12 +405,8 @@
           "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_callbacks",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -486,12 +466,8 @@
           "name": "agent_run_events_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -588,12 +564,8 @@
           "name": "agent_run_events_local_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_events_local",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -794,12 +766,8 @@
           "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_compose_versions",
-          "columnsFrom": [
-            "agent_compose_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -807,12 +775,8 @@
           "name": "agent_runs_schedule_id_agent_schedules_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_schedules",
-          "columnsFrom": [
-            "schedule_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1026,12 +990,8 @@
           "name": "agent_schedules_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_schedules",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1039,12 +999,8 @@
           "name": "agent_schedules_last_run_id_agent_runs_id_fk",
           "tableFrom": "agent_schedules",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "last_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["last_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1146,12 +1102,8 @@
           "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "agent_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1159,12 +1111,8 @@
           "name": "agent_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1285,12 +1233,8 @@
           "name": "checkpoints_run_id_agent_runs_id_fk",
           "tableFrom": "checkpoints",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1298,12 +1242,8 @@
           "name": "checkpoints_conversation_id_conversations_id_fk",
           "tableFrom": "checkpoints",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1313,9 +1253,7 @@
         "checkpoints_run_id_unique": {
           "name": "checkpoints_run_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "run_id"
-          ]
+          "columns": ["run_id"]
         }
       },
       "policies": {},
@@ -1378,9 +1316,7 @@
         "cli_tokens_token_unique": {
           "name": "cli_tokens_token_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
+          "columns": ["token"]
         }
       },
       "policies": {},
@@ -1731,12 +1667,8 @@
           "name": "connectors_scope_id_scopes_id_fk",
           "tableFrom": "connectors",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1802,12 +1734,8 @@
           "name": "conversations_run_id_agent_runs_id_fk",
           "tableFrom": "conversations",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1817,9 +1745,7 @@
         "conversations_run_id_unique": {
           "name": "conversations_run_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "run_id"
-          ]
+          "columns": ["run_id"]
         }
       },
       "policies": {},
@@ -1944,12 +1870,8 @@
           "name": "email_reply_requests_run_id_agent_runs_id_fk",
           "tableFrom": "email_reply_requests",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1957,12 +1879,8 @@
           "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
           "tableFrom": "email_reply_requests",
           "tableTo": "email_thread_sessions",
-          "columnsFrom": [
-            "email_thread_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["email_thread_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2066,12 +1984,8 @@
           "name": "email_thread_sessions_compose_id_agent_composes_id_fk",
           "tableFrom": "email_thread_sessions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2079,12 +1993,8 @@
           "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "email_thread_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2157,12 +2067,8 @@
           "name": "github_installations_default_compose_id_agent_composes_id_fk",
           "tableFrom": "github_installations",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "default_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "restrict",
           "onUpdate": "no action"
         }
@@ -2172,9 +2078,7 @@
         "github_installations_installation_id_unique": {
           "name": "github_installations_installation_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "installation_id"
-          ]
+          "columns": ["installation_id"]
         }
       },
       "policies": {},
@@ -2292,12 +2196,8 @@
           "name": "github_issue_sessions_installation_id_github_installations_id_fk",
           "tableFrom": "github_issue_sessions",
           "tableTo": "github_installations",
-          "columnsFrom": [
-            "installation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2305,12 +2205,8 @@
           "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "github_issue_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2442,12 +2338,8 @@
           "name": "model_providers_scope_id_scopes_id_fk",
           "tableFrom": "model_providers",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2455,12 +2347,8 @@
           "name": "model_providers_secret_id_secrets_id_fk",
           "tableFrom": "model_providers",
           "tableTo": "secrets",
-          "columnsFrom": [
-            "secret_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["secret_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2555,12 +2443,8 @@
           "name": "org_access_tokens_scope_id_scopes_id_fk",
           "tableFrom": "org_access_tokens",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -2570,9 +2454,7 @@
         "org_access_tokens_token_unique": {
           "name": "org_access_tokens_token_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
+          "columns": ["token"]
         }
       },
       "policies": {},
@@ -2659,12 +2541,8 @@
           "name": "runner_job_queue_run_id_agent_runs_id_fk",
           "tableFrom": "runner_job_queue",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2728,12 +2606,8 @@
           "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
           "tableFrom": "sandbox_telemetry",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2869,9 +2743,7 @@
         "scopes_slug_unique": {
           "name": "scopes_slug_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
+          "columns": ["slug"]
         }
       },
       "policies": {},
@@ -2999,12 +2871,8 @@
           "name": "secrets_scope_id_scopes_id_fk",
           "tableFrom": "secrets",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3080,12 +2948,8 @@
           "name": "slack_compose_requests_compose_job_id_compose_jobs_id_fk",
           "tableFrom": "slack_compose_requests",
           "tableTo": "compose_jobs",
-          "columnsFrom": [
-            "compose_job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3164,12 +3028,8 @@
           "name": "slack_installations_default_compose_id_agent_composes_id_fk",
           "tableFrom": "slack_installations",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "default_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "restrict",
           "onUpdate": "no action"
         }
@@ -3179,9 +3039,7 @@
         "slack_installations_slack_workspace_id_unique": {
           "name": "slack_installations_slack_workspace_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slack_workspace_id"
-          ]
+          "columns": ["slack_workspace_id"]
         }
       },
       "policies": {},
@@ -3293,12 +3151,8 @@
           "name": "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk",
           "tableFrom": "slack_thread_sessions",
           "tableTo": "slack_user_links",
-          "columnsFrom": [
-            "slack_user_link_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["slack_user_link_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3306,12 +3160,8 @@
           "name": "slack_thread_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "slack_thread_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3458,12 +3308,8 @@
           "name": "storage_versions_storage_id_storages_id_fk",
           "tableFrom": "storage_versions",
           "tableTo": "storages",
-          "columnsFrom": [
-            "storage_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3600,12 +3446,8 @@
           "name": "storages_scope_id_scopes_id_fk",
           "tableFrom": "storages",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -3613,12 +3455,8 @@
           "name": "storages_head_version_id_storage_versions_id_fk",
           "tableFrom": "storages",
           "tableTo": "storage_versions",
-          "columnsFrom": [
-            "head_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["head_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -3765,12 +3603,8 @@
           "name": "users_scope_id_scopes_id_fk",
           "tableFrom": "users",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -3874,12 +3708,8 @@
           "name": "variables_scope_id_scopes_id_fk",
           "tableFrom": "variables",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3895,30 +3725,17 @@
     "public.connector_session_status": {
       "name": "connector_session_status",
       "schema": "public",
-      "values": [
-        "pending",
-        "complete",
-        "expired",
-        "error"
-      ]
+      "values": ["pending", "complete", "expired", "error"]
     },
     "public.device_code_status": {
       "name": "device_code_status",
       "schema": "public",
-      "values": [
-        "pending",
-        "authenticated",
-        "expired",
-        "denied"
-      ]
+      "values": ["pending", "authenticated", "expired", "denied"]
     },
     "public.scope_type": {
       "name": "scope_type",
       "schema": "public",
-      "values": [
-        "personal",
-        "organization"
-      ]
+      "values": ["personal", "organization"]
     }
   },
   "schemas": {},

--- a/turbo/apps/web/src/db/migrations/meta/0097_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0097_snapshot.json
@@ -62,12 +62,8 @@
           "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_compose_versions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -172,12 +168,8 @@
           "name": "agent_composes_scope_id_scopes_id_fk",
           "tableFrom": "agent_composes",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -282,12 +274,8 @@
           "name": "agent_permissions_agent_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_permissions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "agent_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -297,11 +285,7 @@
         "agent_permissions_compose_type_email_unique": {
           "name": "agent_permissions_compose_type_email_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "agent_compose_id",
-            "grantee_type",
-            "grantee_email"
-          ]
+          "columns": ["agent_compose_id", "grantee_type", "grantee_email"]
         }
       },
       "policies": {},
@@ -421,12 +405,8 @@
           "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_callbacks",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -486,12 +466,8 @@
           "name": "agent_run_events_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -588,12 +564,8 @@
           "name": "agent_run_events_local_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_events_local",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -800,12 +772,8 @@
           "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_compose_versions",
-          "columnsFrom": [
-            "agent_compose_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -813,12 +781,8 @@
           "name": "agent_runs_schedule_id_agent_schedules_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_schedules",
-          "columnsFrom": [
-            "schedule_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1032,12 +996,8 @@
           "name": "agent_schedules_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_schedules",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1045,12 +1005,8 @@
           "name": "agent_schedules_last_run_id_agent_runs_id_fk",
           "tableFrom": "agent_schedules",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "last_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["last_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1152,12 +1108,8 @@
           "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "agent_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1165,12 +1117,8 @@
           "name": "agent_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1291,12 +1239,8 @@
           "name": "checkpoints_run_id_agent_runs_id_fk",
           "tableFrom": "checkpoints",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1304,12 +1248,8 @@
           "name": "checkpoints_conversation_id_conversations_id_fk",
           "tableFrom": "checkpoints",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1319,9 +1259,7 @@
         "checkpoints_run_id_unique": {
           "name": "checkpoints_run_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "run_id"
-          ]
+          "columns": ["run_id"]
         }
       },
       "policies": {},
@@ -1384,9 +1322,7 @@
         "cli_tokens_token_unique": {
           "name": "cli_tokens_token_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
+          "columns": ["token"]
         }
       },
       "policies": {},
@@ -1737,12 +1673,8 @@
           "name": "connectors_scope_id_scopes_id_fk",
           "tableFrom": "connectors",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1808,12 +1740,8 @@
           "name": "conversations_run_id_agent_runs_id_fk",
           "tableFrom": "conversations",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1823,9 +1751,7 @@
         "conversations_run_id_unique": {
           "name": "conversations_run_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "run_id"
-          ]
+          "columns": ["run_id"]
         }
       },
       "policies": {},
@@ -1950,12 +1876,8 @@
           "name": "email_reply_requests_run_id_agent_runs_id_fk",
           "tableFrom": "email_reply_requests",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1963,12 +1885,8 @@
           "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
           "tableFrom": "email_reply_requests",
           "tableTo": "email_thread_sessions",
-          "columnsFrom": [
-            "email_thread_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["email_thread_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2072,12 +1990,8 @@
           "name": "email_thread_sessions_compose_id_agent_composes_id_fk",
           "tableFrom": "email_thread_sessions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2085,12 +1999,8 @@
           "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "email_thread_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2163,12 +2073,8 @@
           "name": "github_installations_default_compose_id_agent_composes_id_fk",
           "tableFrom": "github_installations",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "default_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "restrict",
           "onUpdate": "no action"
         }
@@ -2178,9 +2084,7 @@
         "github_installations_installation_id_unique": {
           "name": "github_installations_installation_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "installation_id"
-          ]
+          "columns": ["installation_id"]
         }
       },
       "policies": {},
@@ -2298,12 +2202,8 @@
           "name": "github_issue_sessions_installation_id_github_installations_id_fk",
           "tableFrom": "github_issue_sessions",
           "tableTo": "github_installations",
-          "columnsFrom": [
-            "installation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2311,12 +2211,8 @@
           "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "github_issue_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2448,12 +2344,8 @@
           "name": "model_providers_scope_id_scopes_id_fk",
           "tableFrom": "model_providers",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2461,12 +2353,8 @@
           "name": "model_providers_secret_id_secrets_id_fk",
           "tableFrom": "model_providers",
           "tableTo": "secrets",
-          "columnsFrom": [
-            "secret_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["secret_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2561,12 +2449,8 @@
           "name": "org_access_tokens_scope_id_scopes_id_fk",
           "tableFrom": "org_access_tokens",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -2576,9 +2460,7 @@
         "org_access_tokens_token_unique": {
           "name": "org_access_tokens_token_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
+          "columns": ["token"]
         }
       },
       "policies": {},
@@ -2665,12 +2547,8 @@
           "name": "runner_job_queue_run_id_agent_runs_id_fk",
           "tableFrom": "runner_job_queue",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2734,12 +2612,8 @@
           "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
           "tableFrom": "sandbox_telemetry",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2875,9 +2749,7 @@
         "scopes_slug_unique": {
           "name": "scopes_slug_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
+          "columns": ["slug"]
         }
       },
       "policies": {},
@@ -3005,12 +2877,8 @@
           "name": "secrets_scope_id_scopes_id_fk",
           "tableFrom": "secrets",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3086,12 +2954,8 @@
           "name": "slack_compose_requests_compose_job_id_compose_jobs_id_fk",
           "tableFrom": "slack_compose_requests",
           "tableTo": "compose_jobs",
-          "columnsFrom": [
-            "compose_job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3170,12 +3034,8 @@
           "name": "slack_installations_default_compose_id_agent_composes_id_fk",
           "tableFrom": "slack_installations",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "default_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "restrict",
           "onUpdate": "no action"
         }
@@ -3185,9 +3045,7 @@
         "slack_installations_slack_workspace_id_unique": {
           "name": "slack_installations_slack_workspace_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slack_workspace_id"
-          ]
+          "columns": ["slack_workspace_id"]
         }
       },
       "policies": {},
@@ -3299,12 +3157,8 @@
           "name": "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk",
           "tableFrom": "slack_thread_sessions",
           "tableTo": "slack_user_links",
-          "columnsFrom": [
-            "slack_user_link_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["slack_user_link_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3312,12 +3166,8 @@
           "name": "slack_thread_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "slack_thread_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3464,12 +3314,8 @@
           "name": "storage_versions_storage_id_storages_id_fk",
           "tableFrom": "storage_versions",
           "tableTo": "storages",
-          "columnsFrom": [
-            "storage_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3606,12 +3452,8 @@
           "name": "storages_scope_id_scopes_id_fk",
           "tableFrom": "storages",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -3619,12 +3461,8 @@
           "name": "storages_head_version_id_storage_versions_id_fk",
           "tableFrom": "storages",
           "tableTo": "storage_versions",
-          "columnsFrom": [
-            "head_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["head_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -3771,12 +3609,8 @@
           "name": "users_scope_id_scopes_id_fk",
           "tableFrom": "users",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -3880,12 +3714,8 @@
           "name": "variables_scope_id_scopes_id_fk",
           "tableFrom": "variables",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3901,30 +3731,17 @@
     "public.connector_session_status": {
       "name": "connector_session_status",
       "schema": "public",
-      "values": [
-        "pending",
-        "complete",
-        "expired",
-        "error"
-      ]
+      "values": ["pending", "complete", "expired", "error"]
     },
     "public.device_code_status": {
       "name": "device_code_status",
       "schema": "public",
-      "values": [
-        "pending",
-        "authenticated",
-        "expired",
-        "denied"
-      ]
+      "values": ["pending", "authenticated", "expired", "denied"]
     },
     "public.scope_type": {
       "name": "scope_type",
       "schema": "public",
-      "values": [
-        "personal",
-        "organization"
-      ]
+      "values": ["personal", "organization"]
     }
   },
   "schemas": {},


### PR DESCRIPTION
## Summary

- Add `PATCH /api/integrations/github` endpoint to update default agent selection
- Enhance `GET /api/integrations/github` response with environment data (required/missing secrets and variables)
- Create `/settings/github` settings page with default agent selector, missing environment banner, and disconnect flow
- Expand GitHub integration signal state with full data management, optimistic updates, and disconnect dialog
- Update GitHub integration card to link to settings page instead of showing disabled "Installed" button
- Add `/settings/github` route path

Closes #3443

## Test plan

- [x] Integration tests for PATCH endpoint (401, 400, 404, success, scoped agent name)
- [x] Integration test for enhanced GET response (environment data)
- [x] Existing GET and DELETE tests still pass
- [x] Full test suite passes (272/273 - 1 pre-existing flaky test in Slack)
- [x] Lint passes with 0 errors
- [x] Knip finds no unused exports
- [ ] Manual: Navigate to Settings > Integrations, click Settings on GitHub card
- [ ] Manual: Change default agent via dropdown, verify toast and persistence
- [ ] Manual: Disconnect GitHub, verify redirect to integrations tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)