### PR TITLE
refactor(runner): use .test tld for fake api url and skip doctor check

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -249,7 +249,7 @@ jobs:
             --name ${JOB_REF}-bench \
             --group vm0/development-${JOB_REF} \
             --runner-dirname ${JOB_REF}-bench \
-            --api-url https://localhost \
+            --api-url https://not-a-real-server.test \
             --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
           echo "=== Running benchmark ==="
@@ -290,7 +290,7 @@ jobs:
             --name ${JOB_REF}-exec \
             --group vm0/exec-${JOB_REF} \
             --runner-dirname ${JOB_REF}-exec \
-            --api-url https://localhost \
+            --api-url https://not-a-real-server.test \
             --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
           echo "=== Running exec test ==="
@@ -391,7 +391,7 @@ jobs:
               --name ${JOB_REF}-${SUFFIX} \
               --group ${GROUP} \
               --runner-dirname ${JOB_REF}-${SUFFIX} \
-              --api-url https://localhost \
+              --api-url https://not-a-real-server.test \
               --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
           done
 

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -307,10 +307,14 @@ async fn read_status(base_dir: &Path) -> Option<StatusInfo> {
 // API connectivity check
 // ---------------------------------------------------------------------------
 
-/// Returns `None` if no server configured, `Some(true)` if reachable,
-/// `Some(false)` if unreachable.
+/// Returns `None` if no server configured or URL uses `.test` TLD (RFC 2606),
+/// `Some(true)` if reachable, `Some(false)` if unreachable.
 async fn check_api(config: &RunnerConfig) -> Option<bool> {
     let server = config.server.as_ref()?;
+    // Skip connectivity check for .test domains (reserved per RFC 2606, used in CI)
+    if server.url.contains(".test") {
+        return None;
+    }
     let client = reqeast::builder()
         .timeout(Duration::from_secs(5))
         .build()


### PR DESCRIPTION
## Summary
- Replace `https://localhost` with `https://not-a-real-server.test` in `crates.yml` CI tests (benchmark, exec, upgrade-local) to make the fake URL self-documenting
- Skip API connectivity check in `runner doctor` for `.test` domains (reserved per RFC 2606) to eliminate false "API unreachable" warnings

## Test plan
- [ ] `cargo check -p runner` passes
- [ ] `cargo clippy -p runner` passes
- [ ] Runner benchmark/exec/upgrade-local CI tests still pass with new URL

Closes #3544

🤖 Generated with [Claude Code](https://claude.com/claude-code)