### PR TITLE
fix(ci): unify runner doctor retry to 5 attempts × 5s everywhere

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1403,9 +1403,9 @@ jobs:
               --env USE_MOCK_CLAUDE=true"
 
             # Health check — wait for the runner to initialize (mitmdump, status.json).
-            # Retry up to 5 times with 2s intervals to handle slow cold starts.
+            # Retry up to 5 times with 5s intervals to handle slow cold starts.
             for attempt in 1 2 3 4 5; do
-              sleep 2
+              sleep 5
               if ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner doctor"; then
                 break
               fi
@@ -1533,7 +1533,16 @@ jobs:
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
           for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
             echo "Checking runner on ${HOST}..."
-            if ! ssh $SSH_OPTS "${METAL_USER}@${HOST}" "test -x ${BIN_DIR}/runner && ${BIN_DIR}/runner doctor"; then
+            HEALTHY=false
+            for attempt in 1 2 3 4 5; do
+              if ssh $SSH_OPTS "${METAL_USER}@${HOST}" "test -x ${BIN_DIR}/runner && ${BIN_DIR}/runner doctor"; then
+                HEALTHY=true
+                break
+              fi
+              echo "runner doctor attempt $attempt failed on ${HOST}, retrying in 5s..."
+              sleep 5
+            done
+            if [ "$HEALTHY" != "true" ]; then
               echo ""
               echo "::error::Runner not healthy on ${HOST}. This typically happens when 'Re-run failed jobs' is used after the cleanup step has already run. Use 'Re-run all jobs' to redeploy the runner first."
               exit 1

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -93,7 +93,7 @@
     - name: Verify runner health
       command: "{{ bin_dir }}/runner doctor"
       retries: 5
-      delay: 10
+      delay: 5
       register: health
       until: health.rc == 0
 
@@ -123,3 +123,7 @@
     # ========================================
     - name: Verify runner health after cleanup
       command: "{{ bin_dir }}/runner doctor"
+      retries: 5
+      delay: 5
+      register: health_final
+      until: health_final.rc == 0


### PR DESCRIPTION
## Summary
- Unified all `runner doctor` health checks to consistent 5 attempts × 5s retry
- `deploy-runner-start`: 5×2s → 5×5s
- `cli-e2e-03-runner` verify: added 5×5s retry (previously no retry)
- Ansible Phase 4: 5×10s → 5×5s
- Ansible Phase 6: added 5×5s retry (previously no retry)

Prevents transient `NO PROCESS` warnings (e.g. VM process exited but runner hasn't cleaned up yet) from causing false CI failures.

## Test plan
- [ ] CI runner E2E tests pass without false failures from transient doctor warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)