### PR TITLE
ci: use tgz archive for vercel deploy to avoid upload rate limit

### DIFF
--- a/.github/actions/vercel-deploy/action.yml
+++ b/.github/actions/vercel-deploy/action.yml
@@ -103,7 +103,7 @@ runs:
 
           # Deploy prebuilt artifacts (no remote build)
           echo "Deploying prebuilt artifacts..."
-          DEPLOY_CMD="vercel deploy --prebuilt --token=${{ inputs.vercel-token }}"
+          DEPLOY_CMD="vercel deploy --prebuilt --archive=tgz --token=${{ inputs.vercel-token }}"
 
           if [ "${{ inputs.environment }}" == "production" ]; then
             DEPLOY_CMD="$DEPLOY_CMD --prod"
@@ -124,7 +124,7 @@ runs:
           fi
         else
           # === Standard mode: remote build on Vercel ===
-          DEPLOY_CMD="vercel deploy --token=${{ inputs.vercel-token }}"
+          DEPLOY_CMD="vercel deploy --archive=tgz --token=${{ inputs.vercel-token }}"
 
           if [ "${{ inputs.environment }}" == "production" ]; then
             DEPLOY_CMD="$DEPLOY_CMD --prod"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -678,7 +678,7 @@ jobs:
       - name: Deploy Web to Vercel
         id: deploy
         run: |
-          DEPLOY_CMD="vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}"
+          DEPLOY_CMD="vercel deploy --prebuilt --archive=tgz --token=${{ secrets.VERCEL_TOKEN }}"
           DEPLOY_CMD="$DEPLOY_CMD --meta branch=${{ github.head_ref || github.ref_name }}"
           DEPLOY_CMD="$DEPLOY_CMD --meta pr=${{ needs.prepare.outputs.job-ref }}"
 


### PR DESCRIPTION
## Summary
- Add `--archive=tgz` to all `vercel deploy` commands (turbo.yml and reusable vercel-deploy action)
- This bundles files into a single tarball upload instead of uploading each file individually, significantly reducing API request count

## Context
Vercel upload API hit the 40000 request limit (`api-upload-paid`), causing all preview deploys to fail with "Too many requests - try again in 7 hours". This affects all PRs.

## Test plan
- [ ] Verify preview deploys succeed on this PR
- [ ] Check that deployment URLs are accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)