### PR TITLE
refactor(platform): rename disconnect to uninstall in settings

### DIFF
--- a/turbo/apps/platform/src/views/integrations-page/__tests__/slack-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/__tests__/slack-settings-page.test.tsx
@@ -36,12 +36,12 @@ describe("slack settings page", () => {
     expect(screen.getByText("/vm0 disconnect")).toBeInTheDocument();
     expect(screen.getByText("/vm0 settings")).toBeInTheDocument();
 
-    // Disconnect section (heading + button)
+    // Uninstall section (heading + button)
     expect(
-      screen.getByRole("heading", { name: "Disconnect with Slack" }),
+      screen.getByRole("heading", { name: "Uninstall Slack" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /disconnect/i }),
+      screen.getByRole("button", { name: /uninstall/i }),
     ).toBeInTheDocument();
   });
 
@@ -104,28 +104,28 @@ describe("slack settings page", () => {
     ).toBeInTheDocument();
   });
 
-  it("opens disconnect confirmation dialog", async () => {
+  it("opens uninstall confirmation dialog", async () => {
     await setupPage({ context, path: "/settings/slack" });
 
-    // Click the disconnect button
-    const disconnectButton = screen.getByRole("button", {
-      name: /disconnect/i,
+    // Click the uninstall button
+    const uninstallButton = screen.getByRole("button", {
+      name: /uninstall/i,
     });
-    await user.click(disconnectButton);
+    await user.click(uninstallButton);
 
     // Confirm dialog should appear
     const dialog = await screen.findByRole("dialog");
-    expect(within(dialog).getByText("Disconnect Slack")).toBeInTheDocument();
+    expect(within(dialog).getByText("Uninstall Slack")).toBeInTheDocument();
     expect(
       within(dialog).getByText(/remove your Slack account connection/),
     ).toBeInTheDocument();
 
-    // Should have Cancel and Disconnect buttons
+    // Should have Cancel and Uninstall buttons
     expect(
       within(dialog).getByRole("button", { name: /cancel/i }),
     ).toBeInTheDocument();
     expect(
-      within(dialog).getByRole("button", { name: /disconnect/i }),
+      within(dialog).getByRole("button", { name: /uninstall/i }),
     ).toBeInTheDocument();
   });
 
@@ -163,14 +163,14 @@ describe("slack settings page", () => {
     expect(screen.getByText("shared-agent")).toBeInTheDocument();
   });
 
-  it("closes disconnect dialog on cancel", async () => {
+  it("closes uninstall dialog on cancel", async () => {
     await setupPage({ context, path: "/settings/slack" });
 
     // Open the dialog
-    const disconnectButton = screen.getByRole("button", {
-      name: /disconnect/i,
+    const uninstallButton = screen.getByRole("button", {
+      name: /uninstall/i,
     });
-    await user.click(disconnectButton);
+    await user.click(uninstallButton);
 
     const dialog = await screen.findByRole("dialog");
     const cancelButton = within(dialog).getByRole("button", {

--- a/turbo/apps/platform/src/views/integrations-page/slack-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/slack-settings-page.tsx
@@ -141,26 +141,9 @@ function DefaultAgentSection({
       <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-4 sm:flex-row sm:items-center">
         <div className="flex flex-1 flex-col gap-1">
           {isAdmin ? (
-            <>
-              <p className="text-sm font-medium">
-                Default agent you would like to use in Slack
-              </p>
-              <p className="text-sm text-muted-foreground">
-                {
-                  "If you want to manage your agent's model provider, secrets, or connectors, go to "
-                }
-                <Link
-                  pathname="/settings"
-                  options={{
-                    searchParams: new URLSearchParams({ tab: "providers" }),
-                  }}
-                  className="text-primary hover:underline"
-                >
-                  Settings
-                </Link>
-                .
-              </p>
-            </>
+            <p className="text-sm font-medium">
+              Default agent you would like to use in Slack
+            </p>
           ) : (
             <>
               <p className="text-sm font-medium">
@@ -331,14 +314,14 @@ export function SlackSettingsPage() {
               </div>
             </div>
 
-            {/* Disconnect section */}
+            {/* Uninstall section */}
             <div className="flex flex-col gap-4">
-              <h3 className="text-base font-medium">Disconnect with Slack</h3>
+              <h3 className="text-base font-medium">Uninstall Slack</h3>
               <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-4 sm:flex-row sm:items-center">
                 <div className="flex flex-1 flex-col gap-1">
-                  <p className="text-sm font-medium">Disconnect with Slack</p>
+                  <p className="text-sm font-medium">Uninstall Slack</p>
                   <p className="text-sm text-muted-foreground">
-                    Your VM0 agent will be removed and disconnect with your
+                    Your VM0 agent will be removed and uninstalled from your
                     Slack workspace.
                   </p>
                 </div>
@@ -347,7 +330,7 @@ export function SlackSettingsPage() {
                   size="sm"
                   onClick={() => openConfirm()}
                 >
-                  Disconnect
+                  Uninstall
                 </Button>
               </div>
             </div>
@@ -365,10 +348,10 @@ export function SlackSettingsPage() {
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Disconnect Slack</DialogTitle>
+            <DialogTitle>Uninstall Slack</DialogTitle>
             <DialogDescription>
               This will remove your Slack account connection and revoke agent
-              access. You can reconnect at any time.
+              access. You can reinstall at any time.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -376,7 +359,7 @@ export function SlackSettingsPage() {
               Cancel
             </Button>
             <Button variant="destructive" onClick={handleDisconnect}>
-              Disconnect
+              Uninstall
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/turbo/apps/platform/src/views/settings-page/__tests__/connectors.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/connectors.test.tsx
@@ -58,7 +58,7 @@ describe("connectors tab", () => {
     // "Not connected" status has been removed from the UI
   });
 
-  it("can disconnect a connector via kebab menu", async () => {
+  it("can uninstall a connector via kebab menu", async () => {
     setMockConnectors([makeConnector("github")]);
 
     let deletedType: string | null = null;
@@ -77,18 +77,18 @@ describe("connectors tab", () => {
     });
     await user.click(optionsButton);
 
-    // Click Disconnect
-    const disconnectButton = await screen.findByText("Disconnect");
-    await user.click(disconnectButton);
+    // Click Uninstall
+    const uninstallButton = await screen.findByText("Uninstall");
+    await user.click(uninstallButton);
 
     // Confirm in dialog
     const dialog = await screen.findByRole("dialog");
     expect(
-      within(dialog).getByText(/are you sure you want to disconnect github/i),
+      within(dialog).getByText(/are you sure you want to uninstall github/i),
     ).toBeInTheDocument();
 
     const confirmButton = within(dialog).getByRole("button", {
-      name: /^disconnect$/i,
+      name: /^uninstall$/i,
     });
     await user.click(confirmButton);
 

--- a/turbo/apps/platform/src/views/settings-page/connector-list.tsx
+++ b/turbo/apps/platform/src/views/settings-page/connector-list.tsx
@@ -91,7 +91,7 @@ function ConnectorRow({
               onClick={() => openDisconnect(item.type)}
               className="w-full rounded-md px-3 py-2 text-sm text-left text-destructive hover:bg-accent hover:text-accent-foreground transition-colors"
             >
-              Disconnect
+              Uninstall
             </button>
           </PopoverContent>
         </Popover>

--- a/turbo/apps/platform/src/views/settings-page/disconnect-connector-dialog.tsx
+++ b/turbo/apps/platform/src/views/settings-page/disconnect-connector-dialog.tsx
@@ -38,13 +38,13 @@ export function DisconnectConnectorDialog() {
       <DialogContent className="max-w-2xl gap-6">
         <DialogHeader>
           <DialogTitle className="font-normal leading-7">
-            Are you sure you want to disconnect {connectorLabel}?
+            Are you sure you want to uninstall {connectorLabel}?
           </DialogTitle>
         </DialogHeader>
         <p className="text-sm text-secondary-foreground">
           This will remove the connection and its stored credentials. Your
           agents will no longer have access to {connectorLabel}. You can always
-          reconnect later.
+          reinstall later.
         </p>
         <DialogFooter>
           <Button
@@ -59,7 +59,7 @@ export function DisconnectConnectorDialog() {
             onClick={handleDisconnect}
             disabled={isLoading}
           >
-            {isLoading ? "Disconnecting..." : "Disconnect"}
+            {isLoading ? "Uninstalling..." : "Uninstall"}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary
- Rename "Disconnect" to "Uninstall" across Slack settings and connector settings UI
- Update confirmation dialogs to use "Uninstall" / "Uninstalling..." / "reinstall" wording
- Remove unused Settings link paragraph from the Slack default agent section for admins
- Update all corresponding test assertions to match new labels

## Test plan
- [ ] Verify Slack settings page shows "Uninstall Slack" heading and button
- [ ] Verify uninstall confirmation dialog uses updated wording
- [ ] Verify connector kebab menu shows "Uninstall" instead of "Disconnect"
- [ ] Verify connector disconnect dialog uses updated wording
- [ ] Run existing tests: `pnpm vitest apps/platform/src/views/integrations-page/__tests__/slack-settings-page.test.tsx apps/platform/src/views/settings-page/__tests__/connectors.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)