### PR TITLE
refactor(platform): simplify session creation to two-branch model

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
+  createTestRunDirect,
   createTestSandboxToken,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
@@ -19,6 +20,7 @@ const context = testContext();
 describe("POST /api/webhooks/agent/checkpoints", () => {
   let user: UserContext;
   let testComposeId: string;
+  let testVersionId: string;
   let testRunId: string;
   let testToken: string;
 
@@ -27,8 +29,11 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
     user = await context.setupUser();
 
     // Create compose for test runs
-    const { composeId } = await createTestCompose(uniqueId("checkpoint"));
+    const { composeId, versionId } = await createTestCompose(
+      uniqueId("checkpoint"),
+    );
     testComposeId = composeId;
+    testVersionId = versionId;
 
     // Create a running run
     const { runId } = await createTestRun(testComposeId, "Test prompt");
@@ -322,6 +327,137 @@ describe("POST /api/webhooks/agent/checkpoints", () => {
       expect(data.agentSessionId).toBeDefined();
       expect(data.conversationId).toBeDefined();
       expect(data.artifact).toEqual(artifactSnapshot);
+    });
+  });
+
+  describe("Session independence", () => {
+    it("should create independent sessions for separate artifact runs", async () => {
+      const artifactSnapshot = {
+        artifactName: "my-app",
+        artifactVersion: "v1",
+      };
+
+      // Create two runs directly in DB (bypasses API auth complexity)
+      const run1 = await createTestRunDirect(user.userId, testVersionId, {
+        prompt: "Run 1",
+      });
+      const run2 = await createTestRunDirect(user.userId, testVersionId, {
+        prompt: "Run 2",
+      });
+
+      const token1 = await createTestSandboxToken(user.userId, run1.id);
+      const token2 = await createTestSandboxToken(user.userId, run2.id);
+
+      const request1 = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token1}`,
+          },
+          body: JSON.stringify({
+            runId: run1.id,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "session-run-1",
+            cliAgentSessionHistory: '{"type":"test"}',
+            artifactSnapshot,
+          }),
+        },
+      );
+
+      const response1 = await POST(request1);
+      expect(response1.status).toBe(200);
+      const data1 = await response1.json();
+
+      const request2 = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token2}`,
+          },
+          body: JSON.stringify({
+            runId: run2.id,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "session-run-2",
+            cliAgentSessionHistory: '{"type":"test"}',
+            artifactSnapshot,
+          }),
+        },
+      );
+
+      const response2 = await POST(request2);
+      expect(response2.status).toBe(200);
+      const data2 = await response2.json();
+
+      // Each run should get its own independent session
+      expect(data1.agentSessionId).not.toBe(data2.agentSessionId);
+    });
+
+    it("should reuse session when continuedFromSessionId is set", async () => {
+      // Create a session via first run's checkpoint
+      const request1 = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "session-original",
+            cliAgentSessionHistory: '{"type":"test"}',
+          }),
+        },
+      );
+
+      const response1 = await POST(request1);
+      expect(response1.status).toBe(200);
+      const data1 = await response1.json();
+      const originalSessionId = data1.agentSessionId;
+
+      // Create a continue run with continuedFromSessionId
+      const continueRun = await createTestRunDirect(
+        user.userId,
+        testVersionId,
+        {
+          prompt: "Continue prompt",
+          continuedFromSessionId: originalSessionId,
+        },
+      );
+
+      const continueToken = await createTestSandboxToken(
+        user.userId,
+        continueRun.id,
+      );
+
+      const request2 = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${continueToken}`,
+          },
+          body: JSON.stringify({
+            runId: continueRun.id,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "session-continued",
+            cliAgentSessionHistory: '{"type":"test-continued"}',
+          }),
+        },
+      );
+
+      const response2 = await POST(request2);
+      expect(response2.status).toBe(200);
+      const data2 = await response2.json();
+
+      // Continue run should reuse the same session
+      expect(data2.agentSessionId).toBe(originalSessionId);
     });
   });
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -469,6 +469,33 @@ async function createTestComposeVersion(
 
 /**
  * Create a run record directly in the database.
+ * Use this when you need a run without going through the API route
+ * (e.g., for webhook tests where Clerk auth is disabled).
+ */
+export async function createTestRunDirect(
+  userId: string,
+  versionId: string,
+  options?: {
+    status?: string;
+    prompt?: string;
+    continuedFromSessionId?: string;
+  },
+): Promise<{ id: string }> {
+  const [run] = await globalThis.services.db
+    .insert(agentRuns)
+    .values({
+      userId,
+      agentComposeVersionId: versionId,
+      status: options?.status ?? "running",
+      prompt: options?.prompt ?? "test prompt",
+      continuedFromSessionId: options?.continuedFromSessionId,
+    })
+    .returning({ id: agentRuns.id });
+  return run!;
+}
+
+/**
+ * Create a run record directly in the database.
  * Internal helper for createTestSessionWithConversation.
  */
 async function createTestRunRecord(

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -495,26 +495,6 @@ export async function createTestRunDirect(
 }
 
 /**
- * Create a run record directly in the database.
- * Internal helper for createTestSessionWithConversation.
- */
-async function createTestRunRecord(
-  userId: string,
-  versionId: string,
-): Promise<{ id: string }> {
-  const [run] = await globalThis.services.db
-    .insert(agentRuns)
-    .values({
-      userId,
-      agentComposeVersionId: versionId,
-      status: "completed",
-      prompt: "test prompt",
-    })
-    .returning({ id: agentRuns.id });
-  return run!;
-}
-
-/**
  * Create a conversation record for a run.
  * Internal helper for createTestSessionWithConversation.
  */
@@ -543,7 +523,9 @@ export async function createTestSessionWithConversation(
   // Create compose version
   const versionId = await createTestComposeVersion(agentComposeId, userId);
   // Create run
-  const run = await createTestRunRecord(userId, versionId);
+  const run = await createTestRunDirect(userId, versionId, {
+    status: "completed",
+  });
   // Create conversation
   const conversation = await createTestConversation(run.id);
   // Create session with conversation

--- a/turbo/apps/web/src/lib/agent-session/agent-session-service.ts
+++ b/turbo/apps/web/src/lib/agent-session/agent-session-service.ts
@@ -55,59 +55,6 @@ export async function getAgentSessionWithConversation(
 }
 
 /**
- * Find existing session or create a new one
- * Used when checkpoint is created to ensure session exists
- * Note: artifactName is optional - sessions without artifact use (userId, composeId) as key
- */
-export async function findOrCreateAgentSession(
-  userId: string,
-  agentComposeId: string,
-  artifactName?: string,
-  conversationId?: string,
-): Promise<{ session: AgentSessionData; created: boolean }> {
-  // Build query conditions - handle null artifactName for sessions without artifact
-  // For sessions with artifact: match (userId, composeId, artifactName)
-  // For sessions without artifact: match (userId, composeId, artifactName IS NULL)
-  const conditions = artifactName
-    ? and(
-        eq(agentSessions.userId, userId),
-        eq(agentSessions.agentComposeId, agentComposeId),
-        eq(agentSessions.artifactName, artifactName),
-      )
-    : and(
-        eq(agentSessions.userId, userId),
-        eq(agentSessions.agentComposeId, agentComposeId),
-        isNull(agentSessions.artifactName),
-      );
-
-  // Find existing session with same compose and artifact
-  const [existing] = await globalThis.services.db
-    .select()
-    .from(agentSessions)
-    .where(conditions)
-    .limit(1);
-
-  if (existing) {
-    // Update conversation reference if provided
-    if (conversationId) {
-      const updated = await updateAgentSession(existing.id, conversationId);
-      return { session: updated, created: false };
-    }
-    return { session: mapToAgentSessionData(existing), created: false };
-  }
-
-  // Create new session
-  const session = await createAgentSession({
-    userId,
-    agentComposeId,
-    artifactName,
-    conversationId,
-  });
-
-  return { session, created: true };
-}
-
-/**
  * Create a new agent session
  */
 export async function createAgentSession(

--- a/turbo/apps/web/src/lib/agent-session/index.ts
+++ b/turbo/apps/web/src/lib/agent-session/index.ts
@@ -1,6 +1,5 @@
 export {
   getAgentSessionWithConversation,
-  findOrCreateAgentSession,
   createAgentSession,
   updateAgentSession,
   listAgentSessions,

--- a/turbo/apps/web/src/lib/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/checkpoint/checkpoint-service.ts
@@ -4,11 +4,7 @@ import { agentComposeVersions } from "../../db/schema/agent-compose";
 import { conversations } from "../../db/schema/conversation";
 import { checkpoints } from "../../db/schema/checkpoint";
 import { notFound } from "../errors";
-import {
-  findOrCreateAgentSession,
-  createAgentSession,
-  updateAgentSession,
-} from "../agent-session";
+import { createAgentSession, updateAgentSession } from "../agent-session";
 import { storeSessionHistory } from "../session-history";
 import { logger } from "../logger";
 import type {
@@ -186,9 +182,7 @@ export async function createCheckpoint(
 
   // Resolve agent session
   // For session continuations, update the existing session's conversation reference.
-  // For new chat runs (no artifact, no session), create a new session to support
-  // multiple chat sessions per agent.
-  // For artifact sessions, use find-or-create to maintain 1:1 mapping.
+  // For new runs, always create a new session (with artifact name if present).
   const artifactSnapshot = request.artifactSnapshot as
     | ArtifactSnapshot
     | undefined;
@@ -198,27 +192,19 @@ export async function createCheckpoint(
 
   let agentSession;
   if (run.continuedFromSessionId) {
-    // Session continuation: update existing session's conversation reference
+    // Continue: update existing session's conversation reference
     agentSession = await updateAgentSession(
       run.continuedFromSessionId,
       conversation.id,
     );
-  } else if (!artifactSnapshot?.artifactName) {
-    // New chat (no artifact, no session): always create a new session
+  } else {
+    // New run: always create a new session (with artifact name if present)
     agentSession = await createAgentSession({
       userId: run.userId,
       agentComposeId: version.composeId,
+      artifactName: artifactSnapshot?.artifactName,
       conversationId: conversation.id,
     });
-  } else {
-    // Artifact session: find-or-create maintains 1:1 mapping
-    const { session } = await findOrCreateAgentSession(
-      run.userId,
-      version.composeId,
-      artifactSnapshot.artifactName,
-      conversation.id,
-    );
-    agentSession = session;
   }
 
   log.debug(`Agent session updated/created: ${agentSession.id}`);


### PR DESCRIPTION
## Summary
- Remove `findOrCreateAgentSession` function and collapse the three-branch session creation logic in `checkpoint-service.ts` to two branches: continue (update existing session) and new run (always create new session with optional artifact name)
- The find-or-create pattern for artifact sessions provided no value since new runs never loaded conversation history from found sessions and artifact file loading is independent of sessions
- Add two integration tests verifying session independence for artifact runs and session reuse for continued runs

## Test plan
- [x] All 11 checkpoint route tests pass (9 existing + 2 new)
- [x] TypeScript type checking passes
- [x] Lint passes (no violations)
- [x] Knip passes (no unused exports/dependencies)
- [x] Prettier formatting passes
- [ ] CI pipeline passes

Closes #3559

🤖 Generated with [Claude Code](https://claude.com/claude-code)