### PR TITLE
feat(ci): add runner stress test job

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1677,11 +1677,125 @@ jobs:
             echo "Cron simulator stopped"
           fi
 
+  # Runner stress test: submit concurrent jobs with real Claude to validate queue + stability
+  # Only runs on PRs with the 'needs-runner-pipeline' label (opt-in, costs real API credits)
+  runner-stress-test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+    needs:
+      [
+        prepare,
+        deploy-web,
+        deploy-runner-prepare,
+        deploy-runner-start,
+        cli-e2e-03-runner,
+      ]
+    if: |
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline')
+    timeout-minutes: 30
+    env:
+      STRESS_PROMPT: "Run this exact command: sleep 60 && echo done"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Setup pnpm global directory
+        run: |
+          mkdir -p $HOME/.local/share/pnpm
+          pnpm config set global-bin-dir $HOME/.local/share/pnpm
+          echo "$HOME/.local/share/pnpm" >> $GITHUB_PATH
+
+      - name: Build Sandbox Scripts
+        run: cd turbo && pnpm turbo run build --filter=@vm0/sandbox-scripts
+
+      - name: Build CLI
+        run: cd turbo && pnpm --filter @vm0/cli build
+
+      - name: Setup CLI globally
+        run: cd turbo/apps/cli && pnpm link --global
+
+      - name: Restore test token from cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.vm0
+          key: e2e-token-runner-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            e2e-token-runner-${{ github.run_id }}-
+          fail-on-cache-miss: true
+
+      - name: Bootstrap test account
+        run: |
+          vm0 scope set "e2e-runner" --force
+          vm0 model-provider setup --type "claude-code-oauth-token" --secret "mock-oauth-token-for-e2e"
+        env:
+          VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Start Cron Simulator
+        run: |
+          chmod +x ./e2e/scripts/cron-simulator.sh
+          ./e2e/scripts/cron-simulator.sh "$VM0_API_URL" 60 &
+          echo "CRON_SIMULATOR_PID=$!" >> $GITHUB_ENV
+        env:
+          VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Create stress test agent
+        id: agent
+        run: |
+          AGENT_NAME="stress-test-$(date +%s%3N)-$RANDOM"
+          cat > /tmp/stress-agent.yaml <<EOF
+          version: "1.0"
+          agents:
+            ${AGENT_NAME}:
+              description: "Stress test agent"
+              framework: claude-code
+              experimental_runner:
+                group: vm0/development-${JOB_REF}
+          EOF
+          vm0 compose /tmp/stress-agent.yaml
+          echo "agent-name=${AGENT_NAME}" >> "$GITHUB_OUTPUT"
+        env:
+          VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+
+      - name: Run stress test
+        run: |
+          TOTAL_CAPACITY="${{ needs.deploy-runner-start.outputs.total-capacity }}"
+          JOB_COUNT=$(( TOTAL_CAPACITY * 2 ))
+          echo "Runner capacity: ${TOTAL_CAPACITY}, submitting ${JOB_COUNT} jobs (2x capacity)"
+          chmod +x ./e2e/scripts/stress-test.sh
+          ./e2e/scripts/stress-test.sh \
+            "${{ steps.agent.outputs.agent-name }}" \
+            "$JOB_COUNT" \
+            "$STRESS_PROMPT" \
+            "30" \
+            "$TOTAL_CAPACITY"
+        env:
+          VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
+          USE_MOCK_CLAUDE: "true"
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+
+      - name: Stop Cron Simulator
+        if: always()
+        run: |
+          if [ -n "$CRON_SIMULATOR_PID" ]; then
+            kill "$CRON_SIMULATOR_PID" 2>/dev/null || true
+            echo "Cron simulator stopped"
+          fi
+
   # Stop runner service and clean up after cli-e2e-03-runner completes (or fails/times out)
   # Skip on push to main - runner deployment is only needed for PRs
   cleanup-runner:
     runs-on: ubuntu-latest
-    needs: [prepare, deploy-runner-prepare, deploy-runner-start, cli-e2e-03-runner]
+    needs: [prepare, deploy-runner-prepare, deploy-runner-start, cli-e2e-03-runner, runner-stress-test]
     if: |
       always() &&
       github.event_name != 'push' &&

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1778,8 +1778,6 @@ jobs:
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-          ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
-          USE_MOCK_CLAUDE: "true"
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1677,7 +1677,7 @@ jobs:
             echo "Cron simulator stopped"
           fi
 
-  # Runner stress test: submit concurrent jobs with real Claude to validate queue + stability
+  # Runner stress test: submit concurrent jobs with mock Claude to validate queue + stability
   # Only runs on PRs with the 'stress-test' label (opt-in)
   runner-stress-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1746,7 +1746,7 @@ jobs:
       - name: Create stress test agent
         id: agent
         run: |
-          AGENT_NAME="stress-test-$(date +%s%3N)-$RANDOM"
+          AGENT_NAME="stress-test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           cat > /tmp/stress-agent.yaml <<EOF
           version: "1.0"
           agents:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1696,7 +1696,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline')
     timeout-minutes: 30
     env:
-      STRESS_PROMPT: "Run this exact command: sleep 60 && echo done"
+      STRESS_PROMPT: "sleep 10 && echo done"
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1678,7 +1678,7 @@ jobs:
           fi
 
   # Runner stress test: submit concurrent jobs with real Claude to validate queue + stability
-  # Only runs on PRs with the 'needs-runner-pipeline' label (opt-in, costs real API credits)
+  # Only runs on PRs with the 'stress-test' label (opt-in)
   runner-stress-test:
     runs-on: ubuntu-latest
     container:
@@ -1693,7 +1693,7 @@ jobs:
       ]
     if: |
       github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.labels.*.name, 'needs-runner-pipeline')
+      contains(github.event.pull_request.labels.*.name, 'stress-test')
     timeout-minutes: 30
     env:
       STRESS_PROMPT: "sleep 10 && echo done"

--- a/e2e/scripts/stress-test.sh
+++ b/e2e/scripts/stress-test.sh
@@ -60,8 +60,6 @@ run_job() {
   # Save results
   echo "$status" > "${WORK_DIR}/job-${index}.status"
   echo "$duration" > "${WORK_DIR}/job-${index}.duration"
-  echo "$job_start" > "${WORK_DIR}/job-${index}.start"
-  echo "$job_end" > "${WORK_DIR}/job-${index}.end"
   echo "$output" > "${WORK_DIR}/job-${index}.output"
 
   echo "[${index}/${JOB_COUNT}] ${status} (${duration}s)"

--- a/e2e/scripts/stress-test.sh
+++ b/e2e/scripts/stress-test.sh
@@ -4,7 +4,6 @@
 #
 # Prerequisites:
 #   - VM0_API_URL: Vercel preview URL (set in ~/.vm0/config.json via test token)
-#   - ANTHROPIC_API_KEY: Real API key for Claude
 #   - Agent already created via `vm0 compose`
 #
 # Usage: ./stress-test.sh <agent_name> <job_count> <prompt> <timeout_minutes> <total_capacity>
@@ -16,11 +15,6 @@ JOB_COUNT="${2:?Error: job_count is required}"
 PROMPT="${3:?Error: prompt is required}"
 TIMEOUT_MINUTES="${4:?Error: timeout_minutes is required}"
 TOTAL_CAPACITY="${5:?Error: total_capacity is required}"
-
-if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
-  echo "Error: ANTHROPIC_API_KEY environment variable is required"
-  exit 1
-fi
 
 TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
 START_TIME=$(date +%s)
@@ -47,9 +41,7 @@ run_job() {
 
   # vm0 run blocks until completion, captures output and exit code
   local output exit_code=0
-  output=$(timeout "${TIMEOUT_SECONDS}" vm0 run "$AGENT_NAME" "$PROMPT" \
-    --secrets "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \
-    --debug-no-mock-claude 2>&1) || exit_code=$?
+  output=$(timeout "${TIMEOUT_SECONDS}" vm0 run "$AGENT_NAME" "$PROMPT" 2>&1) || exit_code=$?
 
   local job_end
   job_end=$(date +%s)

--- a/e2e/scripts/stress-test.sh
+++ b/e2e/scripts/stress-test.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# Runner stress test driver
+# Submits N concurrent jobs via `vm0 run`, waits for all to complete, and reports metrics.
+#
+# Prerequisites:
+#   - VM0_API_URL: Vercel preview URL (set in ~/.vm0/config.json via test token)
+#   - ANTHROPIC_API_KEY: Real API key for Claude
+#   - Agent already created via `vm0 compose`
+#
+# Usage: ./stress-test.sh <agent_name> <job_count> <prompt> <timeout_minutes> <total_capacity>
+
+set -euo pipefail
+
+AGENT_NAME="${1:?Error: agent_name is required}"
+JOB_COUNT="${2:?Error: job_count is required}"
+PROMPT="${3:?Error: prompt is required}"
+TIMEOUT_MINUTES="${4:?Error: timeout_minutes is required}"
+TOTAL_CAPACITY="${5:?Error: total_capacity is required}"
+
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  echo "Error: ANTHROPIC_API_KEY environment variable is required"
+  exit 1
+fi
+
+TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
+START_TIME=$(date +%s)
+
+# Temporary directory for job tracking
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "=== Runner Stress Test ==="
+echo "  Agent:    ${AGENT_NAME}"
+echo "  Jobs:     ${JOB_COUNT}"
+echo "  Prompt:   ${PROMPT}"
+echo "  Timeout:  ${TIMEOUT_MINUTES}m"
+echo "  Capacity: ${TOTAL_CAPACITY}"
+echo ""
+
+# --- Run jobs ---
+echo "=== Launching ${JOB_COUNT} concurrent vm0 run commands ==="
+
+run_job() {
+  local index=$1
+  local job_start
+  job_start=$(date +%s)
+
+  # vm0 run blocks until completion, captures output and exit code
+  local output exit_code=0
+  output=$(timeout "${TIMEOUT_SECONDS}" vm0 run "$AGENT_NAME" "$PROMPT" \
+    --secrets "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \
+    --debug-no-mock-claude 2>&1) || exit_code=$?
+
+  local job_end
+  job_end=$(date +%s)
+  local duration=$((job_end - job_start))
+
+  # Determine status from exit code
+  local status
+  if [[ "$exit_code" -eq 0 ]]; then
+    status="completed"
+  elif [[ "$exit_code" -eq 124 ]]; then
+    status="timed_out"
+  else
+    status="failed"
+  fi
+
+  # Save results
+  echo "$status" > "${WORK_DIR}/job-${index}.status"
+  echo "$duration" > "${WORK_DIR}/job-${index}.duration"
+  echo "$job_start" > "${WORK_DIR}/job-${index}.start"
+  echo "$job_end" > "${WORK_DIR}/job-${index}.end"
+  echo "$output" > "${WORK_DIR}/job-${index}.output"
+
+  echo "[${index}/${JOB_COUNT}] ${status} (${duration}s)"
+}
+
+PIDS=()
+for i in $(seq 1 "$JOB_COUNT"); do
+  run_job "$i" &
+  PIDS+=($!)
+done
+
+echo "All ${JOB_COUNT} jobs launched, waiting for completion..."
+echo ""
+
+# Wait for all jobs
+for pid in "${PIDS[@]}"; do
+  wait "$pid" || true
+done
+
+# --- Collect results ---
+echo ""
+echo "=== Generating report ==="
+
+TOTAL_DURATION=$(( $(date +%s) - START_TIME ))
+COMPLETED=0
+FAILED=0
+TIMED_OUT=0
+DURATIONS=()
+
+for i in $(seq 1 "$JOB_COUNT"); do
+  status=$(cat "${WORK_DIR}/job-${i}.status" 2>/dev/null || echo "unknown")
+  case "$status" in
+    completed) COMPLETED=$((COMPLETED + 1)) ;;
+    failed) FAILED=$((FAILED + 1)) ;;
+    timed_out) TIMED_OUT=$((TIMED_OUT + 1)) ;;
+  esac
+
+  if [[ -f "${WORK_DIR}/job-${i}.duration" ]]; then
+    DURATIONS+=("$(cat "${WORK_DIR}/job-${i}.duration")")
+  fi
+done
+
+# Helper: compute stats from an array of numbers
+compute_stats() {
+  local -n arr=$1
+  local count=${#arr[@]}
+  if [[ "$count" -eq 0 ]]; then
+    echo "n/a|n/a|n/a|n/a"
+    return
+  fi
+
+  IFS=$'\n' sorted=($(sort -n <<< "${arr[*]}")); unset IFS
+
+  local sum=0
+  for v in "${sorted[@]}"; do
+    sum=$((sum + v))
+  done
+  local avg=$((sum / count))
+  local min=${sorted[0]}
+  local max=${sorted[$((count - 1))]}
+  local p50_idx=$(( (count - 1) / 2 ))
+  local p50=${sorted[$p50_idx]}
+
+  echo "${avg}|${min}|${max}|${p50}"
+}
+
+DUR_STATS=$(compute_stats DURATIONS)
+IFS='|' read -r D_AVG D_MIN D_MAX D_P50 <<< "$DUR_STATS"
+
+# Print failed job outputs for debugging
+if [[ "$FAILED" -gt 0 ]] || [[ "$TIMED_OUT" -gt 0 ]]; then
+  echo ""
+  echo "=== Failed/Timed-out job outputs ==="
+  for i in $(seq 1 "$JOB_COUNT"); do
+    status=$(cat "${WORK_DIR}/job-${i}.status" 2>/dev/null || echo "unknown")
+    if [[ "$status" == "failed" ]] || [[ "$status" == "timed_out" ]]; then
+      echo "--- Job ${i} (${status}) ---"
+      tail -20 "${WORK_DIR}/job-${i}.output" 2>/dev/null || true
+      echo ""
+    fi
+  done
+fi
+
+# Write GitHub Actions step summary
+cat >> "$GITHUB_STEP_SUMMARY" << EOF
+## Runner Stress Test Results
+
+### Summary
+| Metric | Value |
+|--------|-------|
+| Jobs | ${JOB_COUNT} |
+| Completed | ${COMPLETED} |
+| Failed | ${FAILED} |
+| Timed Out | ${TIMED_OUT} |
+| Total Wall Time | ${TOTAL_DURATION}s |
+| Runner Capacity | ${TOTAL_CAPACITY} |
+
+### Per-Job Duration (end-to-end, including queue time)
+| Stat | Value |
+|------|-------|
+| Avg | ${D_AVG}s |
+| Min | ${D_MIN}s |
+| Max | ${D_MAX}s |
+| p50 | ${D_P50}s |
+
+### Configuration
+- Agent: \`${AGENT_NAME}\`
+- Prompt: \`${PROMPT}\`
+- Runner capacity: ${TOTAL_CAPACITY}
+- Timeout: ${TIMEOUT_MINUTES}m
+EOF
+
+echo ""
+echo "=== Stress Test Complete ==="
+echo "  Jobs:      ${JOB_COUNT}"
+echo "  Completed: ${COMPLETED}"
+echo "  Failed:    ${FAILED}"
+echo "  Timed Out: ${TIMED_OUT}"
+echo "  Wall Time: ${TOTAL_DURATION}s"
+echo "  Per-job:   avg=${D_AVG}s min=${D_MIN}s max=${D_MAX}s p50=${D_P50}s"
+echo ""
+
+if [[ "$FAILED" -gt 0 ]] || [[ "$TIMED_OUT" -gt 0 ]]; then
+  echo "::error::Stress test had failures: ${FAILED} failed, ${TIMED_OUT} timed out"
+  exit 1
+fi
+
+echo "All jobs completed successfully"


### PR DESCRIPTION
## Summary
- Add `runner-stress-test` job to turbo.yml, gated behind `needs-runner-pipeline` PR label
- Submits `2x runner capacity` concurrent jobs with real Claude (`--debug-no-mock-claude`) to validate queue behavior and runner stability under load
- Runs after `cli-e2e-03-runner` completes, reusing the same test account
- New `e2e/scripts/stress-test.sh` driver: launches parallel `vm0 run` commands, collects per-job timing, writes metrics to GitHub Actions step summary

## Test plan
- [ ] Add `needs-runner-pipeline` label to a PR with runner-related changes
- [ ] Verify stress test job appears and runs after runner E2E tests
- [ ] Check GitHub Actions summary for metrics table (completed/failed/timed out counts, duration stats)
- [ ] Confirm jobs exceeding capacity show queuing behavior (~2 rounds of execution)
- [ ] Verify cleanup-runner still works when stress test is skipped (no label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)