### PR TITLE
feat(telegram): add message retention cleanup cron job

### DIFF
--- a/turbo/apps/web/app/api/cron/telegram-cleanup/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/telegram-cleanup/__tests__/route.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GET } from "../route";
+import { testContext } from "../../../../../src/__tests__/test-helpers";
+import {
+  createTestTelegramInstallation,
+  insertTestTelegramMessages,
+  countTestTelegramMessages,
+} from "../../../../../src/__tests__/api-test-helpers";
+import { reloadEnv } from "../../../../../src/env";
+
+vi.hoisted(() => {
+  vi.stubEnv("CRON_SECRET", "test-cron-secret");
+});
+
+const context = testContext();
+
+function cronRequest(secret?: string) {
+  return new Request("http://localhost:3000/api/cron/telegram-cleanup", {
+    method: "GET",
+    headers: secret ? { authorization: `Bearer ${secret}` } : {},
+  });
+}
+
+describe("GET /api/cron/telegram-cleanup", () => {
+  beforeEach(() => {
+    context.setupMocks();
+    vi.stubEnv("CRON_SECRET", "test-cron-secret");
+    reloadEnv();
+  });
+
+  it("should return 401 with invalid cron secret", async () => {
+    const response = await GET(cronRequest("wrong-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return zero deleted when no old messages exist", async () => {
+    const response = await GET(cronRequest("test-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.deleted).toBe(0);
+  });
+
+  it("should delete messages older than 30 days", async () => {
+    const installationId = await createTestTelegramInstallation();
+
+    const oldDate = new Date();
+    oldDate.setDate(oldDate.getDate() - 31);
+    await insertTestTelegramMessages(installationId, 3, oldDate);
+
+    const recentDate = new Date();
+    await insertTestTelegramMessages(installationId, 2, recentDate);
+
+    expect(await countTestTelegramMessages(installationId)).toBe(5);
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.deleted).toBe(3);
+    expect(await countTestTelegramMessages(installationId)).toBe(2);
+  });
+
+  it("should not delete messages within retention period", async () => {
+    const installationId = await createTestTelegramInstallation();
+
+    const recentDate = new Date();
+    recentDate.setDate(recentDate.getDate() - 29);
+    await insertTestTelegramMessages(installationId, 5, recentDate);
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.deleted).toBe(0);
+    expect(await countTestTelegramMessages(installationId)).toBe(5);
+  });
+});

--- a/turbo/apps/web/app/api/cron/telegram-cleanup/route.ts
+++ b/turbo/apps/web/app/api/cron/telegram-cleanup/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { initServices } from "../../../../src/lib/init-services";
+import { sql } from "drizzle-orm";
+import { logger } from "../../../../src/lib/logger";
+import { env } from "../../../../src/env";
+
+const log = logger("cron:telegram-cleanup");
+
+// Retention period: 30 days
+const RETENTION_DAYS = 30;
+// Batch size for deletion to avoid long-running transactions
+const BATCH_SIZE = 10000;
+
+export async function GET(request: Request): Promise<Response> {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = env().CRON_SECRET;
+
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json(
+      { error: { message: "Invalid cron secret", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - RETENTION_DAYS);
+
+  log.debug(
+    `Deleting telegram messages older than ${cutoffDate.toISOString()}...`,
+  );
+
+  let totalDeleted = 0;
+
+  // Batch delete to avoid long-running transactions
+  // Uses ctid-based subquery to limit rows per batch
+  let batchDeleted: number;
+  do {
+    const result = await globalThis.services.db.execute(sql`
+      DELETE FROM telegram_messages
+      WHERE ctid IN (
+        SELECT ctid FROM telegram_messages
+        WHERE created_at < ${cutoffDate}
+        LIMIT ${BATCH_SIZE}
+      )
+    `);
+    batchDeleted = Number(result.rowCount ?? 0);
+    totalDeleted += batchDeleted;
+
+    if (batchDeleted > 0) {
+      log.debug(`Deleted batch of ${batchDeleted} messages`);
+    }
+  } while (batchDeleted === BATCH_SIZE);
+
+  log.debug(`Telegram cleanup complete: ${totalDeleted} messages deleted`);
+
+  return NextResponse.json({ deleted: totalDeleted });
+}

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -26,7 +26,9 @@ import { slackThreadSessions } from "../db/schema/slack-thread-session";
 import { emailThreadSessions } from "../db/schema/email-thread-session";
 import { agentRunCallbacks } from "../db/schema/agent-run-callback";
 import { agentSchedules } from "../db/schema/agent-schedule";
-import { and, eq, inArray, like } from "drizzle-orm";
+import { telegramInstallations } from "../db/schema/telegram-installation";
+import { telegramMessages } from "../db/schema/telegram-message";
+import { and, eq, inArray, like, sql } from "drizzle-orm";
 import { generateCallbackSecret } from "../lib/callback/hmac";
 import { initServices } from "../lib/init-services";
 import { encryptSecrets } from "../lib/crypto/secrets-encryption";
@@ -2185,4 +2187,86 @@ export async function findTestGitHubIssueSession(
     )
     .limit(1);
   return row ?? null;
+}
+
+/**
+ * Create a Telegram installation with all required parent records.
+ * Returns the installation ID for use as a foreign key.
+ */
+export async function createTestTelegramInstallation(): Promise<string> {
+  initServices();
+  const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
+
+  const suffix = uniqueId("tg");
+  const adminUserId = uniqueId("test-admin");
+
+  const [scope] = await globalThis.services.db
+    .insert(scopes)
+    .values({
+      slug: uniqueId("scope"),
+      type: "personal",
+      ownerId: adminUserId,
+    })
+    .returning();
+
+  const [compose] = await globalThis.services.db
+    .insert(agentComposes)
+    .values({
+      userId: adminUserId,
+      scopeId: scope!.id,
+      name: uniqueId("compose"),
+    })
+    .returning();
+
+  const [installation] = await globalThis.services.db
+    .insert(telegramInstallations)
+    .values({
+      telegramBotId: suffix,
+      botUsername: `bot_${suffix}`,
+      encryptedBotToken: encryptCredentialValue(
+        "test-bot-token",
+        SECRETS_ENCRYPTION_KEY,
+      ),
+      webhookSecret: uniqueId("secret"),
+      defaultComposeId: compose!.id,
+      adminUserId,
+    })
+    .returning();
+
+  return installation!.id;
+}
+
+/**
+ * Insert test telegram messages with a specific creation date.
+ * Used by cleanup cron tests.
+ */
+export async function insertTestTelegramMessages(
+  installationId: string,
+  count: number,
+  createdAt: Date,
+): Promise<void> {
+  const values = Array.from({ length: count }, (_, i) => ({
+    installationId,
+    chatId: "chat-1",
+    messageId: `${createdAt.getTime()}-${i}`,
+    fromUserId: "user-1",
+    text: `message ${i}`,
+    isBot: false,
+    createdAt,
+  }));
+
+  await globalThis.services.db.insert(telegramMessages).values(values);
+}
+
+/**
+ * Count telegram messages for a specific installation.
+ */
+export async function countTestTelegramMessages(
+  installationId: string,
+): Promise<number> {
+  const result = await globalThis.services.db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(telegramMessages)
+    .where(eq(telegramMessages.installationId, installationId));
+  return result[0]!.count;
 }

--- a/turbo/apps/web/vercel.json
+++ b/turbo/apps/web/vercel.json
@@ -18,6 +18,10 @@
     {
       "path": "/api/cron/aggregate-usage",
       "schedule": "5 0 * * *"
+    },
+    {
+      "path": "/api/cron/telegram-cleanup",
+      "schedule": "0 1 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add daily cron endpoint (`/api/cron/telegram-cleanup`) that deletes `telegram_messages` older than 30 days
- Uses ctid-based batch deletion (10k rows per batch) to avoid long-running transactions and table locks
- Scheduled daily at 1:00 AM UTC via Vercel cron configuration

## Test plan

- [x] Auth check: returns 401 with invalid cron secret
- [x] Empty case: returns `{ deleted: 0 }` when no old messages exist
- [x] Deletion: removes messages older than 30 days while keeping recent ones
- [x] Retention boundary: messages at 29 days are preserved

Closes #3541

🤖 Generated with [Claude Code](https://claude.com/claude-code)