### PR TITLE
feat(telegram): add bot api client library

### DIFF
--- a/turbo/apps/web/src/lib/telegram/__tests__/client.test.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/client.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect } from "vitest";
+import { HttpResponse } from "msw";
+import {
+  callTelegramApi,
+  createTelegramClient,
+  sendMessage,
+  sendChatAction,
+  getMe,
+  setWebhook,
+  deleteWebhook,
+  setMyCommands,
+} from "../client";
+import { server } from "../../../mocks/server";
+import { http } from "../../../__tests__/msw";
+
+const TEST_TOKEN = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11";
+
+describe("createTelegramClient", () => {
+  it("should return a client with the given token", () => {
+    const client = createTelegramClient(TEST_TOKEN);
+    expect(client).toEqual({ token: TEST_TOKEN });
+  });
+});
+
+describe("callTelegramApi", () => {
+  it("should call the Telegram API and return the result", async () => {
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/getMe`,
+      () => {
+        return HttpResponse.json({
+          ok: true,
+          result: {
+            id: 123,
+            is_bot: true,
+            first_name: "TestBot",
+            username: "test_bot",
+          },
+        });
+      },
+    );
+    server.use(handler.handler);
+
+    const result = await callTelegramApi<{ id: number; username: string }>(
+      TEST_TOKEN,
+      "getMe",
+    );
+
+    expect(result).toEqual({
+      id: 123,
+      is_bot: true,
+      first_name: "TestBot",
+      username: "test_bot",
+    });
+    expect(handler.mocked).toHaveBeenCalledTimes(1);
+  });
+
+  it("should send params as JSON body", async () => {
+    let capturedBody: unknown;
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/sendMessage`,
+      async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          ok: true,
+          result: { message_id: 1, chat: { id: 42 }, text: "hello" },
+        });
+      },
+    );
+    server.use(handler.handler);
+
+    await callTelegramApi(TEST_TOKEN, "sendMessage", {
+      chat_id: 42,
+      text: "hello",
+    });
+
+    expect(capturedBody).toEqual({ chat_id: 42, text: "hello" });
+  });
+
+  it("should throw on API error with description", async () => {
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/sendMessage`,
+      () => {
+        return HttpResponse.json(
+          { ok: false, description: "Bad Request: chat not found" },
+          { status: 400 },
+        );
+      },
+    );
+    server.use(handler.handler);
+
+    await expect(
+      callTelegramApi(TEST_TOKEN, "sendMessage", { chat_id: -1 }),
+    ).rejects.toThrow(
+      "Telegram API error (sendMessage): Bad Request: chat not found",
+    );
+  });
+
+  it("should throw on API error with HTTP status when no description", async () => {
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/getMe`,
+      () => {
+        return HttpResponse.json({ ok: false }, { status: 500 });
+      },
+    );
+    server.use(handler.handler);
+
+    await expect(callTelegramApi(TEST_TOKEN, "getMe")).rejects.toThrow(
+      "Telegram API error (getMe): HTTP 500",
+    );
+  });
+
+  it("should retry on 429 rate limit and succeed", async () => {
+    let callCount = 0;
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/sendMessage`,
+      () => {
+        callCount++;
+        if (callCount === 1) {
+          // retry_after must be > 0 to be truthy and trigger retry
+          return HttpResponse.json(
+            {
+              ok: false,
+              description: "Too Many Requests: retry after 1",
+              parameters: { retry_after: 1 },
+            },
+            { status: 429 },
+          );
+        }
+        return HttpResponse.json({
+          ok: true,
+          result: { message_id: 1, chat: { id: 42 }, text: "hello" },
+        });
+      },
+    );
+    server.use(handler.handler);
+
+    const result = await callTelegramApi(TEST_TOKEN, "sendMessage", {
+      chat_id: 42,
+      text: "hello",
+    });
+
+    expect(result).toEqual({ message_id: 1, chat: { id: 42 }, text: "hello" });
+    expect(callCount).toBe(2);
+  });
+});
+
+describe("sendMessage", () => {
+  it("should send a message with HTML parse mode", async () => {
+    let capturedBody: unknown;
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/sendMessage`,
+      async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          ok: true,
+          result: { message_id: 99, chat: { id: 42 }, text: "hello" },
+        });
+      },
+    );
+    server.use(handler.handler);
+
+    const client = createTelegramClient(TEST_TOKEN);
+    const result = await sendMessage(client, 42, "hello");
+
+    expect(result).toEqual({ message_id: 99, chat: { id: 42 }, text: "hello" });
+    expect(capturedBody).toEqual({
+      chat_id: 42,
+      text: "hello",
+      parse_mode: "HTML",
+    });
+  });
+
+  it("should include reply_parameters when replyToMessageId is provided", async () => {
+    let capturedBody: unknown;
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/sendMessage`,
+      async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          ok: true,
+          result: { message_id: 100, chat: { id: 42 } },
+        });
+      },
+    );
+    server.use(handler.handler);
+
+    const client = createTelegramClient(TEST_TOKEN);
+    await sendMessage(client, 42, "reply", { replyToMessageId: 50 });
+
+    expect(capturedBody).toEqual({
+      chat_id: 42,
+      text: "reply",
+      parse_mode: "HTML",
+      reply_parameters: { message_id: 50 },
+    });
+  });
+});
+
+describe("sendChatAction", () => {
+  it("should send a chat action", async () => {
+    let capturedBody: unknown;
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/sendChatAction`,
+      async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({ ok: true, result: true });
+      },
+    );
+    server.use(handler.handler);
+
+    const client = createTelegramClient(TEST_TOKEN);
+    await sendChatAction(client, 42, "typing");
+
+    expect(capturedBody).toEqual({
+      chat_id: 42,
+      action: "typing",
+    });
+  });
+});
+
+describe("getMe", () => {
+  it("should return bot info", async () => {
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/getMe`,
+      () => {
+        return HttpResponse.json({
+          ok: true,
+          result: {
+            id: 123,
+            is_bot: true,
+            first_name: "TestBot",
+            username: "test_bot",
+          },
+        });
+      },
+    );
+    server.use(handler.handler);
+
+    const result = await getMe(TEST_TOKEN);
+
+    expect(result).toEqual({
+      id: 123,
+      is_bot: true,
+      first_name: "TestBot",
+      username: "test_bot",
+    });
+  });
+});
+
+describe("setWebhook", () => {
+  it("should register a webhook with allowed updates", async () => {
+    let capturedBody: unknown;
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/setWebhook`,
+      async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({ ok: true, result: true });
+      },
+    );
+    server.use(handler.handler);
+
+    await setWebhook(TEST_TOKEN, "https://example.com/webhook", "my-secret");
+
+    expect(capturedBody).toEqual({
+      url: "https://example.com/webhook",
+      secret_token: "my-secret",
+      allowed_updates: ["message"],
+    });
+  });
+});
+
+describe("deleteWebhook", () => {
+  it("should delete the webhook", async () => {
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/deleteWebhook`,
+      () => {
+        return HttpResponse.json({ ok: true, result: true });
+      },
+    );
+    server.use(handler.handler);
+
+    await expect(deleteWebhook(TEST_TOKEN)).resolves.toBeUndefined();
+    expect(handler.mocked).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("setMyCommands", () => {
+  it("should register bot commands", async () => {
+    let capturedBody: unknown;
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/setMyCommands`,
+      async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({ ok: true, result: true });
+      },
+    );
+    server.use(handler.handler);
+
+    const commands = [
+      { command: "start", description: "Start the bot" },
+      { command: "help", description: "Show help" },
+    ];
+    await setMyCommands(TEST_TOKEN, commands);
+
+    expect(capturedBody).toEqual({ commands });
+  });
+});

--- a/turbo/apps/web/src/lib/telegram/__tests__/client.test.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/client.test.ts
@@ -120,8 +120,8 @@ describe("callTelegramApi", () => {
           return HttpResponse.json(
             {
               ok: false,
-              description: "Too Many Requests: retry after 1",
-              parameters: { retry_after: 1 },
+              description: "Too Many Requests: retry after 0.001",
+              parameters: { retry_after: 0.001 },
             },
             { status: 429 },
           );
@@ -141,6 +141,30 @@ describe("callTelegramApi", () => {
 
     expect(result).toEqual({ message_id: 1, chat: { id: 42 }, text: "hello" });
     expect(callCount).toBe(2);
+  });
+
+  it("should throw after max retries on persistent 429", async () => {
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/sendMessage`,
+      () => {
+        return HttpResponse.json(
+          {
+            ok: false,
+            description: "Too Many Requests: retry after 0.001",
+            parameters: { retry_after: 0.001 },
+          },
+          { status: 429 },
+        );
+      },
+    );
+    server.use(handler.handler);
+
+    await expect(
+      callTelegramApi(TEST_TOKEN, "sendMessage", { chat_id: 42 }),
+    ).rejects.toThrow("Telegram API error (sendMessage): Too Many Requests");
+
+    // Should have been called 4 times (1 initial + 3 retries)
+    expect(handler.mocked).toHaveBeenCalledTimes(4);
   });
 });
 

--- a/turbo/apps/web/src/lib/telegram/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/context.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { formatContextForAgent, fetchTelegramContext } from "../context";
+import { uniqueId } from "../../../__tests__/test-helpers";
+import { createTelegramInstallation, insertTelegramMessage } from "./helpers";
+
+describe("formatContextForAgent", () => {
+  it("should return empty string for empty messages", () => {
+    expect(formatContextForAgent([])).toBe("");
+  });
+
+  it("should format messages with username", () => {
+    const messages = [
+      {
+        fromUsername: "alice",
+        fromUserId: "111",
+        text: "Hello",
+        isBot: false,
+        messageId: "1",
+      },
+    ];
+
+    const result = formatContextForAgent(messages);
+
+    expect(result).toContain("# Telegram Chat Context");
+    expect(result).toContain("[alice]: Hello");
+  });
+
+  it("should fall back to user ID when username is null", () => {
+    const messages = [
+      {
+        fromUsername: null,
+        fromUserId: "222",
+        text: "Hi there",
+        isBot: false,
+        messageId: "2",
+      },
+    ];
+
+    const result = formatContextForAgent(messages);
+
+    expect(result).toContain("[user:222]: Hi there");
+  });
+
+  it("should label bot messages as BOT", () => {
+    const messages = [
+      {
+        fromUsername: "my_bot",
+        fromUserId: "333",
+        text: "I am a bot",
+        isBot: true,
+        messageId: "3",
+      },
+    ];
+
+    const result = formatContextForAgent(messages);
+
+    expect(result).toContain("[BOT]: I am a bot");
+  });
+
+  it("should filter out messages with null text", () => {
+    const messages = [
+      {
+        fromUsername: "alice",
+        fromUserId: "111",
+        text: null,
+        isBot: false,
+        messageId: "1",
+      },
+      {
+        fromUsername: "bob",
+        fromUserId: "222",
+        text: "Visible",
+        isBot: false,
+        messageId: "2",
+      },
+    ];
+
+    const result = formatContextForAgent(messages);
+
+    expect(result).not.toContain("[alice]");
+    expect(result).toContain("[bob]: Visible");
+  });
+
+  it("should include context preamble", () => {
+    const messages = [
+      {
+        fromUsername: "alice",
+        fromUserId: "111",
+        text: "Hello",
+        isBot: false,
+        messageId: "1",
+      },
+    ];
+
+    const result = formatContextForAgent(messages);
+
+    expect(result).toContain("Match the tone of the conversation");
+    expect(result).toContain(
+      "Only provide technical analysis when explicitly asked",
+    );
+    expect(result).toContain(
+      "Keep responses proportional to the message length",
+    );
+  });
+
+  it("should format multiple messages in order", () => {
+    const messages = [
+      {
+        fromUsername: "alice",
+        fromUserId: "111",
+        text: "First",
+        isBot: false,
+        messageId: "1",
+      },
+      {
+        fromUsername: null,
+        fromUserId: "222",
+        text: "Second",
+        isBot: false,
+        messageId: "2",
+      },
+      {
+        fromUsername: "bot",
+        fromUserId: "333",
+        text: "Third",
+        isBot: true,
+        messageId: "3",
+      },
+    ];
+
+    const result = formatContextForAgent(messages);
+
+    const lines = result.split("\n");
+    const aliceLine = lines.findIndex((l) => l.includes("[alice]: First"));
+    const userLine = lines.findIndex((l) => l.includes("[user:222]: Second"));
+    const botLine = lines.findIndex((l) => l.includes("[BOT]: Third"));
+
+    expect(aliceLine).toBeLessThan(userLine);
+    expect(userLine).toBeLessThan(botLine);
+  });
+});
+
+describe("fetchTelegramContext", () => {
+  let installationId: string;
+
+  beforeEach(async () => {
+    installationId = await createTelegramInstallation();
+  });
+
+  it("should return empty context when no messages exist", async () => {
+    const result = await fetchTelegramContext(installationId, "chat-1");
+
+    expect(result.routingContext).toBe("");
+    expect(result.executionContext).toBe("");
+  });
+
+  it("should return messages in chronological order", async () => {
+    const chatId = uniqueId("chat");
+
+    await insertTelegramMessage({
+      installationId,
+      chatId,
+      messageId: "1",
+      fromUserId: "111",
+      fromUsername: "alice",
+      text: "First message",
+      createdAt: new Date("2025-01-01T00:00:01Z"),
+    });
+    await insertTelegramMessage({
+      installationId,
+      chatId,
+      messageId: "2",
+      fromUserId: "222",
+      fromUsername: "bob",
+      text: "Second message",
+      createdAt: new Date("2025-01-01T00:00:02Z"),
+    });
+
+    const result = await fetchTelegramContext(installationId, chatId);
+
+    expect(result.routingContext).toContain("[alice]: First message");
+    expect(result.routingContext).toContain("[bob]: Second message");
+
+    const firstIdx = result.routingContext.indexOf("[alice]: First message");
+    const secondIdx = result.routingContext.indexOf("[bob]: Second message");
+    expect(firstIdx).toBeLessThan(secondIdx);
+  });
+
+  it("should split routing and execution context by lastProcessedMessageId", async () => {
+    const chatId = uniqueId("chat");
+
+    await insertTelegramMessage({
+      installationId,
+      chatId,
+      messageId: "10",
+      fromUserId: "111",
+      fromUsername: "alice",
+      text: "Old message",
+      createdAt: new Date("2025-01-01T00:00:01Z"),
+    });
+    await insertTelegramMessage({
+      installationId,
+      chatId,
+      messageId: "20",
+      fromUserId: "222",
+      fromUsername: "bob",
+      text: "New message",
+      createdAt: new Date("2025-01-01T00:00:02Z"),
+    });
+
+    const result = await fetchTelegramContext(installationId, chatId, "10");
+
+    // Routing context includes all messages
+    expect(result.routingContext).toContain("[alice]: Old message");
+    expect(result.routingContext).toContain("[bob]: New message");
+
+    // Execution context only includes messages after ID 10
+    expect(result.executionContext).not.toContain("[alice]: Old message");
+    expect(result.executionContext).toContain("[bob]: New message");
+  });
+
+  it("should return empty execution context when no new messages after lastProcessedMessageId", async () => {
+    const chatId = uniqueId("chat");
+
+    await insertTelegramMessage({
+      installationId,
+      chatId,
+      messageId: "5",
+      fromUserId: "111",
+      fromUsername: "alice",
+      text: "Only message",
+      createdAt: new Date("2025-01-01T00:00:01Z"),
+    });
+
+    const result = await fetchTelegramContext(installationId, chatId, "5");
+
+    expect(result.routingContext).toContain("[alice]: Only message");
+    expect(result.executionContext).toBe("");
+  });
+
+  it("should only return messages for the specified chat", async () => {
+    const chatA = uniqueId("chatA");
+    const chatB = uniqueId("chatB");
+
+    await insertTelegramMessage({
+      installationId,
+      chatId: chatA,
+      messageId: "1",
+      fromUserId: "111",
+      fromUsername: "alice",
+      text: "Chat A message",
+    });
+    await insertTelegramMessage({
+      installationId,
+      chatId: chatB,
+      messageId: "2",
+      fromUserId: "222",
+      fromUsername: "bob",
+      text: "Chat B message",
+    });
+
+    const result = await fetchTelegramContext(installationId, chatA);
+
+    expect(result.routingContext).toContain("[alice]: Chat A message");
+    expect(result.routingContext).not.toContain("[bob]: Chat B message");
+  });
+
+  it("should include bot messages in context", async () => {
+    const chatId = uniqueId("chat");
+
+    await insertTelegramMessage({
+      installationId,
+      chatId,
+      messageId: "1",
+      fromUserId: "111",
+      fromUsername: "alice",
+      text: "User message",
+      createdAt: new Date("2025-01-01T00:00:01Z"),
+    });
+    await insertTelegramMessage({
+      installationId,
+      chatId,
+      messageId: "2",
+      fromUserId: "999",
+      fromUsername: "test_bot",
+      text: "Bot reply",
+      isBot: true,
+      createdAt: new Date("2025-01-01T00:00:02Z"),
+    });
+
+    const result = await fetchTelegramContext(installationId, chatId);
+
+    expect(result.routingContext).toContain("[alice]: User message");
+    expect(result.routingContext).toContain("[BOT]: Bot reply");
+  });
+});

--- a/turbo/apps/web/src/lib/telegram/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/context.test.ts
@@ -164,7 +164,7 @@ describe("fetchTelegramContext", () => {
       fromUserId: "111",
       fromUsername: "alice",
       text: "First message",
-      createdAt: new Date("2025-01-01T00:00:01Z"),
+      createdAt: new Date(Date.now() - 60_000),
     });
     await insertTelegramMessage({
       installationId,
@@ -173,7 +173,7 @@ describe("fetchTelegramContext", () => {
       fromUserId: "222",
       fromUsername: "bob",
       text: "Second message",
-      createdAt: new Date("2025-01-01T00:00:02Z"),
+      createdAt: new Date(Date.now() - 30_000),
     });
 
     const result = await fetchTelegramContext(installationId, chatId);
@@ -196,7 +196,7 @@ describe("fetchTelegramContext", () => {
       fromUserId: "111",
       fromUsername: "alice",
       text: "Old message",
-      createdAt: new Date("2025-01-01T00:00:01Z"),
+      createdAt: new Date(Date.now() - 60_000),
     });
     await insertTelegramMessage({
       installationId,
@@ -205,7 +205,7 @@ describe("fetchTelegramContext", () => {
       fromUserId: "222",
       fromUsername: "bob",
       text: "New message",
-      createdAt: new Date("2025-01-01T00:00:02Z"),
+      createdAt: new Date(Date.now() - 30_000),
     });
 
     const result = await fetchTelegramContext(installationId, chatId, "10");
@@ -229,7 +229,7 @@ describe("fetchTelegramContext", () => {
       fromUserId: "111",
       fromUsername: "alice",
       text: "Only message",
-      createdAt: new Date("2025-01-01T00:00:01Z"),
+      createdAt: new Date(Date.now() - 60_000),
     });
 
     const result = await fetchTelegramContext(installationId, chatId, "5");
@@ -275,7 +275,7 @@ describe("fetchTelegramContext", () => {
       fromUserId: "111",
       fromUsername: "alice",
       text: "User message",
-      createdAt: new Date("2025-01-01T00:00:01Z"),
+      createdAt: new Date(Date.now() - 60_000),
     });
     await insertTelegramMessage({
       installationId,
@@ -285,7 +285,7 @@ describe("fetchTelegramContext", () => {
       fromUsername: "test_bot",
       text: "Bot reply",
       isBot: true,
-      createdAt: new Date("2025-01-01T00:00:02Z"),
+      createdAt: new Date(Date.now() - 30_000),
     });
 
     const result = await fetchTelegramContext(installationId, chatId);

--- a/turbo/apps/web/src/lib/telegram/__tests__/format.test.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/format.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { escapeHtml, markdownToTelegramHtml, splitMessage } from "../format";
+
+describe("escapeHtml", () => {
+  it("should escape &, <, >", () => {
+    expect(escapeHtml("a < b > c & d")).toBe("a &lt; b &gt; c &amp; d");
+  });
+
+  it("should leave normal text unchanged", () => {
+    expect(escapeHtml("hello world")).toBe("hello world");
+  });
+});
+
+describe("markdownToTelegramHtml", () => {
+  it("should convert bold", () => {
+    expect(markdownToTelegramHtml("**bold**")).toBe("<b>bold</b>");
+  });
+
+  it("should convert italic", () => {
+    expect(markdownToTelegramHtml("*italic*")).toBe("<i>italic</i>");
+  });
+
+  it("should convert inline code", () => {
+    expect(markdownToTelegramHtml("`code`")).toBe("<code>code</code>");
+  });
+
+  it("should convert code blocks", () => {
+    expect(markdownToTelegramHtml("```js\nconsole.log(1)\n```")).toBe(
+      "<pre>console.log(1)\n</pre>",
+    );
+  });
+
+  it("should convert links", () => {
+    expect(markdownToTelegramHtml("[click](https://example.com)")).toBe(
+      '<a href="https://example.com">click</a>',
+    );
+  });
+
+  it("should handle mixed formatting", () => {
+    const input = "Hello **bold** and *italic* with `code`";
+    const expected =
+      "Hello <b>bold</b> and <i>italic</i> with <code>code</code>";
+    expect(markdownToTelegramHtml(input)).toBe(expected);
+  });
+
+  it("should escape HTML entities in plain text", () => {
+    expect(markdownToTelegramHtml("a < b & c > d")).toBe(
+      "a &lt; b &amp; c &gt; d",
+    );
+  });
+
+  it("should escape HTML entities inside formatted text", () => {
+    expect(markdownToTelegramHtml("**a < b**")).toBe("<b>a &lt; b</b>");
+  });
+});
+
+describe("splitMessage", () => {
+  it("should return single chunk for short messages", () => {
+    expect(splitMessage("hello")).toEqual(["hello"]);
+  });
+
+  it("should split at paragraph boundaries", () => {
+    const maxLen = 20;
+    const text = "first paragraph\n\nsecond paragraph";
+    const chunks = splitMessage(text, maxLen);
+    expect(chunks).toEqual(["first paragraph", "second paragraph"]);
+  });
+
+  it("should split at line boundaries when no paragraph break", () => {
+    const maxLen = 15;
+    const text = "line one\nline two\nline three";
+    const chunks = splitMessage(text, maxLen);
+    expect(chunks[0]).toBe("line one");
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+
+  it("should hard-cut when no boundaries available", () => {
+    const maxLen = 10;
+    const text = "a".repeat(25);
+    const chunks = splitMessage(text, maxLen);
+    expect(chunks).toEqual(["a".repeat(10), "a".repeat(10), "a".repeat(5)]);
+  });
+
+  it("should not break code blocks mid-block", () => {
+    const maxLen = 30;
+    const text = "intro text\n\n```\ncode line 1\ncode line 2\n```";
+    const chunks = splitMessage(text, maxLen);
+    // The code block should be in a single chunk
+    const codeChunk = chunks.find((c) => c.includes("```"));
+    expect(codeChunk).toBeDefined();
+    const backtickCount = (codeChunk!.match(/```/g) ?? []).length;
+    expect(backtickCount % 2).toBe(0);
+  });
+
+  it("should respect default max length of 4096", () => {
+    const text = "x".repeat(8000);
+    const chunks = splitMessage(text);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(4096);
+    }
+  });
+});

--- a/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
@@ -1,0 +1,79 @@
+import { initServices } from "../../init-services";
+import { telegramInstallations } from "../../../db/schema/telegram-installation";
+import { telegramMessages } from "../../../db/schema/telegram-message";
+import { agentComposes } from "../../../db/schema/agent-compose";
+import { scopes } from "../../../db/schema/scope";
+import { uniqueId } from "../../../__tests__/test-helpers";
+
+/**
+ * Create a telegram installation with all required foreign key dependencies.
+ * Returns the installation ID for use in tests.
+ */
+export async function createTelegramInstallation(): Promise<string> {
+  initServices();
+
+  const suffix = uniqueId("tg");
+
+  const [scope] = await globalThis.services.db
+    .insert(scopes)
+    .values({
+      slug: suffix,
+      type: "personal",
+      ownerId: uniqueId("test-admin"),
+    })
+    .returning();
+
+  const [compose] = await globalThis.services.db
+    .insert(agentComposes)
+    .values({
+      userId: uniqueId("test-user"),
+      scopeId: scope!.id,
+      name: uniqueId("test-compose"),
+    })
+    .returning();
+
+  const [installation] = await globalThis.services.db
+    .insert(telegramInstallations)
+    .values({
+      telegramBotId: uniqueId("bot"),
+      botUsername: "test_bot",
+      encryptedBotToken: "encrypted-token",
+      webhookSecret: "webhook-secret",
+      defaultComposeId: compose!.id,
+      adminUserId: uniqueId("admin"),
+    })
+    .returning();
+
+  return installation!.id;
+}
+
+interface InsertMessageOptions {
+  installationId: string;
+  chatId: string;
+  messageId: string;
+  fromUserId: string;
+  fromUsername?: string;
+  text?: string;
+  isBot?: boolean;
+  createdAt?: Date;
+}
+
+/**
+ * Insert a telegram message into the database for testing.
+ */
+export async function insertTelegramMessage(
+  options: InsertMessageOptions,
+): Promise<void> {
+  initServices();
+
+  await globalThis.services.db.insert(telegramMessages).values({
+    installationId: options.installationId,
+    chatId: options.chatId,
+    messageId: options.messageId,
+    fromUserId: options.fromUserId,
+    fromUsername: options.fromUsername ?? null,
+    text: options.text ?? null,
+    isBot: options.isBot ?? false,
+    createdAt: options.createdAt ?? new Date(),
+  });
+}

--- a/turbo/apps/web/src/lib/telegram/__tests__/verify.test.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/verify.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { verifyTelegramWebhook } from "../verify";
+
+function makeRequest(headers: Record<string, string>): Request {
+  return new Request("https://example.com/webhook", { headers });
+}
+
+describe("verifyTelegramWebhook", () => {
+  const secret = "test-webhook-secret-token-abc123";
+
+  it("should return true for valid secret", () => {
+    const request = makeRequest({
+      "x-telegram-bot-api-secret-token": secret,
+    });
+
+    expect(verifyTelegramWebhook(request, secret)).toBe(true);
+  });
+
+  it("should return false for invalid secret", () => {
+    const request = makeRequest({
+      "x-telegram-bot-api-secret-token": "wrong-secret",
+    });
+
+    expect(verifyTelegramWebhook(request, secret)).toBe(false);
+  });
+
+  it("should return false for missing header", () => {
+    const request = makeRequest({});
+
+    expect(verifyTelegramWebhook(request, secret)).toBe(false);
+  });
+
+  it("should use timing-safe comparison (different length secrets)", () => {
+    const request = makeRequest({
+      "x-telegram-bot-api-secret-token": "short",
+    });
+
+    // Should not throw, should return false
+    expect(verifyTelegramWebhook(request, secret)).toBe(false);
+  });
+});

--- a/turbo/apps/web/src/lib/telegram/client.ts
+++ b/turbo/apps/web/src/lib/telegram/client.ts
@@ -3,6 +3,7 @@ import { logger } from "../logger";
 const log = logger("telegram:client");
 
 const TELEGRAM_API_BASE = "https://api.telegram.org/bot";
+const MAX_RETRIES = 3;
 
 interface TelegramApiResponse<T> {
   ok: boolean;
@@ -49,6 +50,7 @@ export async function callTelegramApi<T>(
   token: string,
   method: string,
   params?: Record<string, unknown>,
+  _retryCount = 0,
 ): Promise<T> {
   const url = `${TELEGRAM_API_BASE}${token}/${method}`;
 
@@ -61,11 +63,19 @@ export async function callTelegramApi<T>(
   const data = (await response.json()) as TelegramApiResponse<T>;
 
   if (!response.ok || !data.ok) {
-    if (response.status === 429 && data.parameters?.retry_after) {
+    if (
+      response.status === 429 &&
+      data.parameters?.retry_after &&
+      _retryCount < MAX_RETRIES
+    ) {
       const retryAfter = data.parameters.retry_after;
-      log.warn("Rate limited by Telegram, retrying", { method, retryAfter });
+      log.warn("Rate limited by Telegram, retrying", {
+        method,
+        retryAfter,
+        attempt: _retryCount + 1,
+      });
       await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
-      return callTelegramApi<T>(token, method, params);
+      return callTelegramApi<T>(token, method, params, _retryCount + 1);
     }
 
     throw new Error(

--- a/turbo/apps/web/src/lib/telegram/client.ts
+++ b/turbo/apps/web/src/lib/telegram/client.ts
@@ -1,0 +1,149 @@
+import { logger } from "../logger";
+
+const log = logger("telegram:client");
+
+const TELEGRAM_API_BASE = "https://api.telegram.org/bot";
+
+interface TelegramApiResponse<T> {
+  ok: boolean;
+  result: T;
+  description?: string;
+  parameters?: {
+    retry_after?: number;
+  };
+}
+
+export interface TelegramBotInfo {
+  id: number;
+  is_bot: boolean;
+  first_name: string;
+  username: string;
+}
+
+export interface TelegramSentMessage {
+  message_id: number;
+  chat: { id: number };
+  text?: string;
+}
+
+export interface TelegramClient {
+  token: string;
+}
+
+/**
+ * Create a Telegram Bot API client
+ */
+export function createTelegramClient(token: string): TelegramClient {
+  return { token };
+}
+
+/**
+ * Call the Telegram Bot API
+ *
+ * @param token - Bot token
+ * @param method - API method name
+ * @param params - Method parameters
+ * @returns API response result
+ */
+export async function callTelegramApi<T>(
+  token: string,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<T> {
+  const url = `${TELEGRAM_API_BASE}${token}/${method}`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: params ? JSON.stringify(params) : undefined,
+  });
+
+  const data = (await response.json()) as TelegramApiResponse<T>;
+
+  if (!response.ok || !data.ok) {
+    if (response.status === 429 && data.parameters?.retry_after) {
+      const retryAfter = data.parameters.retry_after;
+      log.warn("Rate limited by Telegram, retrying", { method, retryAfter });
+      await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
+      return callTelegramApi<T>(token, method, params);
+    }
+
+    throw new Error(
+      `Telegram API error (${method}): ${data.description ?? `HTTP ${response.status}`}`,
+    );
+  }
+
+  return data.result;
+}
+
+/**
+ * Send a text message
+ */
+export async function sendMessage(
+  client: TelegramClient,
+  chatId: string | number,
+  text: string,
+  options?: { replyToMessageId?: number },
+): Promise<TelegramSentMessage> {
+  return callTelegramApi<TelegramSentMessage>(client.token, "sendMessage", {
+    chat_id: chatId,
+    text,
+    parse_mode: "HTML",
+    ...(options?.replyToMessageId && {
+      reply_parameters: { message_id: options.replyToMessageId },
+    }),
+  });
+}
+
+/**
+ * Send a chat action (e.g. typing indicator)
+ */
+export async function sendChatAction(
+  client: TelegramClient,
+  chatId: string | number,
+  action: string,
+): Promise<void> {
+  await callTelegramApi<boolean>(client.token, "sendChatAction", {
+    chat_id: chatId,
+    action,
+  });
+}
+
+/**
+ * Verify bot token and get bot info
+ */
+export async function getMe(token: string): Promise<TelegramBotInfo> {
+  return callTelegramApi<TelegramBotInfo>(token, "getMe");
+}
+
+/**
+ * Register a webhook URL with Telegram
+ */
+export async function setWebhook(
+  token: string,
+  url: string,
+  secretToken: string,
+): Promise<void> {
+  await callTelegramApi<boolean>(token, "setWebhook", {
+    url,
+    secret_token: secretToken,
+    allowed_updates: ["message"],
+  });
+}
+
+/**
+ * Remove webhook
+ */
+export async function deleteWebhook(token: string): Promise<void> {
+  await callTelegramApi<boolean>(token, "deleteWebhook");
+}
+
+/**
+ * Register bot commands
+ */
+export async function setMyCommands(
+  token: string,
+  commands: Array<{ command: string; description: string }>,
+): Promise<void> {
+  await callTelegramApi<boolean>(token, "setMyCommands", { commands });
+}

--- a/turbo/apps/web/src/lib/telegram/context.ts
+++ b/turbo/apps/web/src/lib/telegram/context.ts
@@ -1,0 +1,102 @@
+import { eq, and, desc } from "drizzle-orm";
+import { telegramMessages } from "../../db/schema/telegram-message";
+import { logger } from "../logger";
+
+const log = logger("telegram:context");
+
+/** Maximum number of recent messages to fetch for context */
+const MAX_CONTEXT_MESSAGES = 50;
+
+const CONTEXT_PREAMBLE = [
+  "The messages below are from a Telegram conversation. When responding:",
+  "- Match the tone of the conversation — casual messages deserve casual replies.",
+  "- Only provide technical analysis when explicitly asked a technical question.",
+  "- Keep responses proportional to the message length and complexity.",
+].join("\n");
+
+interface TelegramContextMessage {
+  fromUsername: string | null;
+  fromUserId: string;
+  text: string | null;
+  isBot: boolean;
+  messageId: string;
+}
+
+/**
+ * Fetch recent Telegram messages for a chat and build context strings.
+ *
+ * @param installationId - Telegram installation ID
+ * @param chatId - Telegram chat ID
+ * @param lastProcessedMessageId - Only include messages after this ID for execution context
+ * @returns routingContext (all recent text) and executionContext (only new messages)
+ */
+export async function fetchTelegramContext(
+  installationId: string,
+  chatId: string,
+  lastProcessedMessageId?: string,
+): Promise<{ routingContext: string; executionContext: string }> {
+  const messages = await globalThis.services.db
+    .select({
+      fromUsername: telegramMessages.fromUsername,
+      fromUserId: telegramMessages.fromUserId,
+      text: telegramMessages.text,
+      isBot: telegramMessages.isBot,
+      messageId: telegramMessages.messageId,
+    })
+    .from(telegramMessages)
+    .where(
+      and(
+        eq(telegramMessages.installationId, installationId),
+        eq(telegramMessages.chatId, chatId),
+      ),
+    )
+    .orderBy(desc(telegramMessages.createdAt))
+    .limit(MAX_CONTEXT_MESSAGES);
+
+  // Reverse to chronological order (oldest first)
+  const chronological = messages.reverse();
+
+  log.debug("Fetched telegram context messages", {
+    chatId,
+    count: chronological.length,
+  });
+
+  const routingContext = formatContextForAgent(chronological);
+
+  // For execution context, only include messages after lastProcessedMessageId
+  const executionMessages = lastProcessedMessageId
+    ? chronological.filter(
+        (m) => Number(m.messageId) > Number(lastProcessedMessageId),
+      )
+    : chronological;
+
+  const executionContext =
+    executionMessages.length > 0
+      ? formatContextForAgent(executionMessages)
+      : "";
+
+  return { routingContext, executionContext };
+}
+
+/**
+ * Format message array into agent-readable text
+ */
+export function formatContextForAgent(
+  messages: TelegramContextMessage[],
+): string {
+  if (messages.length === 0) {
+    return "";
+  }
+
+  const formatted = messages
+    .filter((m) => m.text)
+    .map((m) => {
+      const sender = m.isBot
+        ? "BOT"
+        : (m.fromUsername ?? `user:${m.fromUserId}`);
+      return `[${sender}]: ${m.text}`;
+    })
+    .join("\n");
+
+  return `# Telegram Chat Context\n\n${CONTEXT_PREAMBLE}\n\n${formatted}`;
+}

--- a/turbo/apps/web/src/lib/telegram/format.ts
+++ b/turbo/apps/web/src/lib/telegram/format.ts
@@ -1,0 +1,157 @@
+/** Maximum message length allowed by Telegram */
+const MAX_MESSAGE_LENGTH = 4096;
+
+/**
+ * Escape HTML special characters for Telegram HTML parse mode
+ */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Convert standard Markdown to Telegram-supported HTML subset.
+ *
+ * Supported conversions:
+ * - `**bold**` → `<b>bold</b>`
+ * - `*italic*` → `<i>italic</i>`
+ * - `` `code` `` → `<code>code</code>`
+ * - ` ```lang\nblock\n``` ` → `<pre>block</pre>`
+ * - `[text](url)` → `<a href="url">text</a>`
+ */
+export function markdownToTelegramHtml(markdown: string): string {
+  let result = "";
+  let remaining = markdown;
+
+  while (remaining.length > 0) {
+    // Fenced code blocks: ```lang?\n...\n```
+    const codeBlockMatch = remaining.match(/^```[^\n]*\n([\s\S]*?)```/);
+    if (codeBlockMatch) {
+      const content = codeBlockMatch[1] as string;
+      result += `<pre>${escapeHtml(content)}</pre>`;
+      remaining = remaining.slice(codeBlockMatch[0].length);
+      continue;
+    }
+
+    // Inline code: `code`
+    const inlineCodeMatch = remaining.match(/^`([^`]+)`/);
+    if (inlineCodeMatch) {
+      const content = inlineCodeMatch[1] as string;
+      result += `<code>${escapeHtml(content)}</code>`;
+      remaining = remaining.slice(inlineCodeMatch[0].length);
+      continue;
+    }
+
+    // Links: [text](url)
+    const linkMatch = remaining.match(/^\[([^\]]+)\]\(([^)]+)\)/);
+    if (linkMatch) {
+      const linkText = linkMatch[1] as string;
+      const linkUrl = linkMatch[2] as string;
+      result += `<a href="${escapeHtml(linkUrl)}">${escapeHtml(linkText)}</a>`;
+      remaining = remaining.slice(linkMatch[0].length);
+      continue;
+    }
+
+    // Bold: **text**
+    const boldMatch = remaining.match(/^\*\*(.+?)\*\*/);
+    if (boldMatch) {
+      const content = boldMatch[1] as string;
+      result += `<b>${escapeHtml(content)}</b>`;
+      remaining = remaining.slice(boldMatch[0].length);
+      continue;
+    }
+
+    // Italic: *text* (but not **)
+    const italicMatch = remaining.match(/^\*([^*]+)\*/);
+    if (italicMatch) {
+      const content = italicMatch[1] as string;
+      result += `<i>${escapeHtml(content)}</i>`;
+      remaining = remaining.slice(italicMatch[0].length);
+      continue;
+    }
+
+    // Escape HTML entities in plain text, one char at a time
+    const char = remaining[0] as string;
+    result += escapeHtml(char);
+    remaining = remaining.slice(1);
+  }
+
+  return result;
+}
+
+/**
+ * Split a message into chunks that fit within Telegram's message length limit.
+ *
+ * Splitting priority:
+ * 1. Paragraph boundaries (`\n\n`)
+ * 2. Line boundaries (`\n`)
+ * 3. Hard cut at maxLength
+ *
+ * Never breaks code blocks mid-block.
+ */
+export function splitMessage(
+  text: string,
+  maxLength: number = MAX_MESSAGE_LENGTH,
+): string[] {
+  if (text.length <= maxLength) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLength) {
+      chunks.push(remaining);
+      break;
+    }
+
+    const window = remaining.slice(0, maxLength);
+
+    // Check if we're inside a code block — don't split mid-block
+    const codeBlockOpens = (window.match(/```/g) ?? []).length;
+    if (codeBlockOpens % 2 !== 0) {
+      // Odd number of ``` means we'd split inside a code block
+      const lastOpenIndex = window.lastIndexOf("```");
+      if (lastOpenIndex > 0) {
+        // Split before the code block starts
+        chunks.push(remaining.slice(0, lastOpenIndex).trimEnd());
+        remaining = remaining.slice(lastOpenIndex);
+        continue;
+      }
+      // Code block starts at position 0 and exceeds maxLength —
+      // find the closing ``` and include the whole block
+      const closingIndex = remaining.indexOf("```", 3);
+      if (closingIndex !== -1) {
+        const endIndex = closingIndex + 3;
+        chunks.push(remaining.slice(0, endIndex));
+        remaining = remaining.slice(endIndex).replace(/^\n/, "");
+        continue;
+      }
+    }
+
+    // Try to split at paragraph boundary
+    const lastParagraph = window.lastIndexOf("\n\n");
+    if (lastParagraph > maxLength / 4) {
+      chunks.push(remaining.slice(0, lastParagraph).trimEnd());
+      remaining = remaining.slice(lastParagraph + 2);
+      continue;
+    }
+
+    // Try to split at line boundary
+    const lastNewline = window.lastIndexOf("\n");
+    if (lastNewline > maxLength / 4) {
+      chunks.push(remaining.slice(0, lastNewline).trimEnd());
+      remaining = remaining.slice(lastNewline + 1);
+      continue;
+    }
+
+    // Hard cut
+    chunks.push(remaining.slice(0, maxLength));
+    remaining = remaining.slice(maxLength);
+  }
+
+  return chunks;
+}

--- a/turbo/apps/web/src/lib/telegram/verify.ts
+++ b/turbo/apps/web/src/lib/telegram/verify.ts
@@ -1,0 +1,30 @@
+import crypto from "crypto";
+
+/**
+ * Verify Telegram webhook request using the secret token header.
+ * Uses timing-safe comparison to prevent timing attacks.
+ *
+ * @param request - Incoming request
+ * @param expectedSecret - The webhook secret set during setWebhook
+ * @returns true if the secret token matches
+ */
+export function verifyTelegramWebhook(
+  request: Request,
+  expectedSecret: string,
+): boolean {
+  const token = request.headers.get("x-telegram-bot-api-secret-token");
+
+  if (!token) {
+    return false;
+  }
+
+  try {
+    return crypto.timingSafeEqual(
+      Buffer.from(token),
+      Buffer.from(expectedSecret),
+    );
+  } catch {
+    // Buffers have different lengths
+    return false;
+  }
+}

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -113,6 +113,7 @@
     "apps/cli/src/lib/utils/paginate.ts",
     "apps/cli/src/commands/cook/cook.ts",
     "apps/web/src/lib/slack/**",
+    "apps/web/src/lib/telegram/**",
     "apps/web/src/lib/auth/sandbox-token.ts",
     "scripts/rebuild-snapshots.ts",
     "scripts/rebuild-snapshots-from-db.ts"


### PR DESCRIPTION
## Summary

- Add Telegram Bot API client library (`client.ts`) — thin HTTP wrapper using native `fetch` with rate limit (HTTP 429) retry handling
- Add webhook secret verification (`verify.ts`) — timing-safe comparison of `X-Telegram-Bot-Api-Secret-Token` header
- Add message formatter (`format.ts`) — Markdown to Telegram HTML conversion and smart message splitting (respects code blocks, paragraph/line boundaries, 4096 char limit)
- Add context builder (`context.ts`) — fetches recent chat messages from DB and formats as agent-readable context with routing/execution separation
- Add knip ignore for `apps/web/src/lib/telegram/**` (same pattern as Slack)

## Test plan

- [x] 4 verify tests: valid secret, invalid secret, missing header, timing-safe with different lengths
- [x] 16 format tests: HTML escaping, bold/italic/code/link/code-block conversion, mixed formatting, message splitting (paragraph/line/hard-cut/code-block preservation)
- [x] All 20 tests passing
- [x] Lint, format, knip, type-check passing

Closes #3535

🤖 Generated with [Claude Code](https://claude.com/claude-code)