### PR TITLE
chore(ci): disable runner doctor health checks in e2e pipeline

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1440,19 +1440,20 @@ jobs:
               --env VERCEL_AUTOMATION_BYPASS_SECRET=${VERCEL_BYPASS} \
               --env USE_MOCK_CLAUDE=true"
 
-            # Health check — wait for the runner to initialize (mitmdump, status.json).
-            # Retry up to 5 times with 5s intervals to handle slow cold starts.
-            for attempt in 1 2 3 4 5; do
-              sleep 5
-              if ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner doctor"; then
-                break
-              fi
-              if [ "$attempt" -eq 5 ]; then
-                echo "runner doctor failed after 5 attempts"
-                exit 1
-              fi
-              echo "runner doctor attempt $attempt failed, retrying..."
-            done
+            # Health check — temporarily disabled while runner doctor is being reworked.
+            # TODO: re-enable once runner doctor is stable
+            # for attempt in 1 2 3 4 5; do
+            #   sleep 5
+            #   if ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner doctor"; then
+            #     break
+            #   fi
+            #   if [ "$attempt" -eq 5 ]; then
+            #     echo "runner doctor failed after 5 attempts"
+            #     exit 1
+            #   fi
+            #   echo "runner doctor attempt $attempt failed, retrying..."
+            # done
+            sleep 10  # wait for runner to initialize
             echo "=== Runner started on ${HOST} ==="
           }
 
@@ -1580,31 +1581,33 @@ jobs:
           echo "$SSH_KEY" > "$HOME/.ssh/runner.pem"
           chmod 600 "$HOME/.ssh/runner.pem"
 
-      - name: Verify runners are deployed
-        env:
-          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
-          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
-          BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
-        run: |
-          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
-          for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
-            echo "Checking runner on ${HOST}..."
-            HEALTHY=false
-            for attempt in 1 2 3 4 5; do
-              if ssh $SSH_OPTS "${METAL_USER}@${HOST}" "test -x ${BIN_DIR}/runner && ${BIN_DIR}/runner doctor"; then
-                HEALTHY=true
-                break
-              fi
-              echo "runner doctor attempt $attempt failed on ${HOST}, retrying in 5s..."
-              sleep 5
-            done
-            if [ "$HEALTHY" != "true" ]; then
-              echo ""
-              echo "::error::Runner not healthy on ${HOST}. This typically happens when 'Re-run failed jobs' is used after the cleanup step has already run. Use 'Re-run all jobs' to redeploy the runner first."
-              exit 1
-            fi
-          done
-          echo "All runners healthy"
+      # Verify runners are deployed — temporarily disabled while runner doctor is being reworked.
+      # TODO: re-enable once runner doctor is stable
+      # - name: Verify runners are deployed
+      #   env:
+      #     METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+      #     METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+      #     BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
+      #   run: |
+      #     SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
+      #     for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
+      #       echo "Checking runner on ${HOST}..."
+      #       HEALTHY=false
+      #       for attempt in 1 2 3 4 5; do
+      #         if ssh $SSH_OPTS "${METAL_USER}@${HOST}" "test -x ${BIN_DIR}/runner && ${BIN_DIR}/runner doctor"; then
+      #           HEALTHY=true
+      #           break
+      #         fi
+      #         echo "runner doctor attempt $attempt failed on ${HOST}, retrying in 5s..."
+      #         sleep 5
+      #       done
+      #       if [ "$HEALTHY" != "true" ]; then
+      #         echo ""
+      #         echo "::error::Runner not healthy on ${HOST}. This typically happens when 'Re-run failed jobs' is used after the cleanup step has already run. Use 'Re-run all jobs' to redeploy the runner first."
+      #         exit 1
+      #       fi
+      #     done
+      #     echo "All runners healthy"
 
       - name: Run Runner E2E Tests (Chunk ${{ matrix.index }})
         run: |


### PR DESCRIPTION
## Summary
- Temporarily disable `runner doctor` health checks in CI E2E pipeline (`deploy-runner-start` and `cli-e2e-03-runner` jobs)
- Replace startup health check with a simple `sleep 10` wait
- Production deployment checks (ansible) are preserved

## Test plan
- [ ] CI E2E pipeline passes without runner doctor gating
- [ ] Production ansible playbook still has health checks intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)