### PR TITLE
fix(e2e): add missing experimental_runner config to 03-runner tests

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -37,6 +37,7 @@ jobs:
       migration-changed: ${{ steps.detect-migration.outputs.migration-changed }}
       crates-changed: ${{ steps.detect-crates.outputs.crates-changed }}
       ci-changed: ${{ steps.detect-ci.outputs.ci-changed }}
+      e2e-changed: ${{ steps.detect-e2e.outputs.e2e-changed }}
       cli-e2e-parallel-matrix: ${{ steps.cli-e2e-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
@@ -206,6 +207,25 @@ jobs:
           else
             echo "No CI workflow changes"
             echo "ci-changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Detect E2E test changes
+        id: detect-e2e
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF=$(git merge-base ${{ github.event.pull_request.base.sha }} HEAD)
+          elif [ "${{ github.event_name }}" = "merge_group" ]; then
+            BASE_REF="${{ github.event.merge_group.base_sha }}"
+          else
+            BASE_REF="HEAD^"
+          fi
+
+          if git diff --name-only "$BASE_REF" HEAD | grep -q "^e2e/"; then
+            echo "E2E test changes detected"
+            echo "e2e-changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No E2E test changes"
+            echo "e2e-changed=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Set job-ref
@@ -527,7 +547,8 @@ jobs:
         needs.prepare.outputs.cli-changed == 'true' ||
         needs.prepare.outputs.platform-changed == 'true' ||
         needs.prepare.outputs.crates-changed == 'true' ||
-        needs.prepare.outputs.ci-changed == 'true'
+        needs.prepare.outputs.ci-changed == 'true' ||
+        needs.prepare.outputs.e2e-changed == 'true'
       )
     outputs:
       preview-url: ${{ steps.alias.outputs.url || steps.deploy.outputs.url }}
@@ -1022,7 +1043,8 @@ jobs:
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
         needs.prepare.outputs.crates-changed == 'true' ||
-        needs.prepare.outputs.ci-changed == 'true'
+        needs.prepare.outputs.ci-changed == 'true' ||
+        needs.prepare.outputs.e2e-changed == 'true'
       )
     timeout-minutes: 5
     permissions:
@@ -1097,7 +1119,8 @@ jobs:
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
-        needs.prepare.outputs.ci-changed == 'true'
+        needs.prepare.outputs.ci-changed == 'true' ||
+        needs.prepare.outputs.e2e-changed == 'true'
       )
     strategy:
       fail-fast: false
@@ -1190,7 +1213,8 @@ jobs:
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
         needs.prepare.outputs.crates-changed == 'true' ||
-        needs.prepare.outputs.ci-changed == 'true'
+        needs.prepare.outputs.ci-changed == 'true' ||
+        needs.prepare.outputs.e2e-changed == 'true'
       )
     outputs:
       bin-dir: ${{ steps.host.outputs.bin-dir }}
@@ -1386,7 +1410,8 @@ jobs:
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
         needs.prepare.outputs.crates-changed == 'true' ||
-        needs.prepare.outputs.ci-changed == 'true'
+        needs.prepare.outputs.ci-changed == 'true' ||
+        needs.prepare.outputs.e2e-changed == 'true'
       )
     steps:
       - name: Setup SSH
@@ -1514,7 +1539,8 @@ jobs:
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
         needs.prepare.outputs.crates-changed == 'true' ||
-        needs.prepare.outputs.ci-changed == 'true'
+        needs.prepare.outputs.ci-changed == 'true' ||
+        needs.prepare.outputs.e2e-changed == 'true'
       )
     strategy:
       fail-fast: false

--- a/e2e/tests/03-experimental-runner/t13-vm0-cook.bats
+++ b/e2e/tests/03-experimental-runner/t13-vm0-cook.bats
@@ -34,6 +34,8 @@ agents:
   $AGENT_NAME:
     description: "E2E test agent for cook command"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     image: "vm0/claude-code:dev"
     volumes:
       - ${VOLUME_NAME}:/home/user/data
@@ -107,6 +109,8 @@ agents:
   $AGENT_NAME:
     description: "E2E test agent for env check"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
     environment:
@@ -144,6 +148,8 @@ agents:
   $AGENT_NAME:
     description: "E2E test agent for cook with skills"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
 EOF

--- a/e2e/tests/03-experimental-runner/t13-vm0-cook.bats
+++ b/e2e/tests/03-experimental-runner/t13-vm0-cook.bats
@@ -36,7 +36,6 @@ agents:
     framework: claude-code
     experimental_runner:
       group: ${RUNNER_GROUP}
-    image: "vm0/claude-code:dev"
     volumes:
       - ${VOLUME_NAME}:/home/user/data
     working_dir: /home/user/workspace
@@ -111,7 +110,6 @@ agents:
     framework: claude-code
     experimental_runner:
       group: ${RUNNER_GROUP}
-    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
     environment:
       API_KEY: \${{ vars.E2E_TEST_VAR }}

--- a/e2e/tests/03-experimental-runner/t19-vm0-optional-artifact.bats
+++ b/e2e/tests/03-experimental-runner/t19-vm0-optional-artifact.bats
@@ -27,7 +27,8 @@ agents:
   ${AGENT_NAME}:
     description: "E2E test agent for optional artifact testing"
     framework: claude-code
-    image: "vm0/claude-code:dev"
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace

--- a/e2e/tests/03-experimental-runner/t20-vm0-schedule.bats
+++ b/e2e/tests/03-experimental-runner/t20-vm0-schedule.bats
@@ -34,7 +34,6 @@ agents:
     framework: claude-code
     experimental_runner:
       group: ${RUNNER_GROUP}
-    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -171,7 +170,6 @@ agents:
     framework: claude-code
     experimental_runner:
       group: ${RUNNER_GROUP}
-    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -256,7 +254,6 @@ agents:
     framework: claude-code
     experimental_runner:
       group: ${RUNNER_GROUP}
-    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
     environment:
       SCHEDULE_TEST_API_KEY: "\${{ secrets.${SECRET_NAME} }}"

--- a/e2e/tests/03-experimental-runner/t20-vm0-schedule.bats
+++ b/e2e/tests/03-experimental-runner/t20-vm0-schedule.bats
@@ -32,6 +32,8 @@ agents:
   ${AGENT_NAME}:
     description: "E2E schedule test agent"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
@@ -167,6 +169,8 @@ agents:
   ${LOOP_AGENT_NAME}:
     description: "E2E loop schedule test agent"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
@@ -250,6 +254,8 @@ agents:
   ${CONFIG_AGENT_NAME}:
     description: "Test agent with configuration requirements"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
     environment:

--- a/e2e/tests/03-experimental-runner/t24-vm0-skill-frontmatter.bats
+++ b/e2e/tests/03-experimental-runner/t24-vm0-skill-frontmatter.bats
@@ -48,6 +48,8 @@ agents:
   $AGENT_NAME:
     description: "Test agent with --yes flag"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
 EOF
@@ -67,6 +69,8 @@ agents:
   $AGENT_NAME_2:
     description: "Test agent with -y short flag"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
 EOF
@@ -86,6 +90,8 @@ agents:
   $AGENT_NAME:
     description: "Test agent in non-TTY"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
 EOF
 
     echo "# Step 2: Compose with --yes flag and piped input (non-TTY)"
@@ -109,6 +115,8 @@ agents:
   $AGENT_NAME:
     description: "Test agent with skill and environment"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
     environment:
@@ -133,6 +141,8 @@ agents:
   $AGENT_NAME:
     description: "Test agent with skill"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
 EOF
@@ -162,6 +172,8 @@ agents:
   $AGENT_NAME:
     description: "Test agent with skill upload"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
 EOF
@@ -186,6 +198,8 @@ agents:
   $AGENT_NAME:
     description: "Test agent with multiple skills"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
       - https://github.com/vm0-ai/vm0-skills/tree/main/axiom

--- a/e2e/tests/03-experimental-runner/t26-vm0-agent-list-status.bats
+++ b/e2e/tests/03-experimental-runner/t26-vm0-agent-list-status.bats
@@ -43,7 +43,6 @@ agents:
     framework: claude-code
     experimental_runner:
       group: ${RUNNER_GROUP}
-    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -71,7 +70,6 @@ agents:
     framework: claude-code
     experimental_runner:
       group: ${RUNNER_GROUP}
-    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -101,7 +99,6 @@ agents:
     framework: claude-code
     experimental_runner:
       group: ${RUNNER_GROUP}
-    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -129,7 +126,6 @@ agents:
     framework: claude-code
     experimental_runner:
       group: ${RUNNER_GROUP}
-    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -156,7 +152,6 @@ agents:
     framework: claude-code
     experimental_runner:
       group: ${RUNNER_GROUP}
-    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 
@@ -182,7 +177,6 @@ agents:
     framework: claude-code
     experimental_runner:
       group: ${RUNNER_GROUP}
-    image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
 

--- a/e2e/tests/03-experimental-runner/t26-vm0-agent-list-status.bats
+++ b/e2e/tests/03-experimental-runner/t26-vm0-agent-list-status.bats
@@ -41,6 +41,8 @@ agents:
   $AGENT_NAME:
     description: "Test agent for list command"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
@@ -67,6 +69,8 @@ agents:
   $AGENT_NAME:
     description: "Test agent for version format"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
@@ -95,6 +99,8 @@ agents:
   $AGENT_NAME:
     description: "Test agent for status command"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
@@ -121,6 +127,8 @@ agents:
   $AGENT_NAME:
     description: "Test agent for version specifier"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
@@ -146,6 +154,8 @@ agents:
   $AGENT_NAME:
     description: "Test agent for latest tag"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
@@ -170,6 +180,8 @@ agents:
   $AGENT_NAME:
     description: "Test agent for no-sources flag"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     image: "vm0/claude-code:dev"
     working_dir: /home/user/workspace
 EOF
@@ -196,6 +208,8 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     environment:
       API_KEY: "${{ secrets.MY_API_KEY }}"
       AUTH_TOKEN: "${{ secrets.AUTH_TOKEN }}"
@@ -223,6 +237,8 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     environment:
       DEBUG_MODE: "${{ vars.DEBUG }}"
       LOG_LEVEL: "${{ vars.LOG_LEVEL }}"
@@ -250,6 +266,8 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     environment:
       DATABASE_URL: "${{ credentials.DB_URL }}"
 EOF
@@ -275,6 +293,8 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     environment:
       API_KEY: "${{ secrets.API_KEY }}"
       DEBUG: "${{ vars.DEBUG }}"
@@ -312,6 +332,8 @@ agents:
   $AGENT_NAME:
     description: "Test agent for delete command"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
 EOF
 
     echo "# Step 2: Run vm0 compose to create the agent"
@@ -343,6 +365,8 @@ agents:
   $AGENT_NAME:
     description: "Test agent for rm alias"
     framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
 EOF
 
     echo "# Step 2: Run vm0 compose to create the agent"

--- a/e2e/tests/03-experimental-runner/t26-vm0-agent-list-status.bats
+++ b/e2e/tests/03-experimental-runner/t26-vm0-agent-list-status.bats
@@ -209,7 +209,7 @@ agents:
       AUTH_TOKEN: "${{ secrets.AUTH_TOKEN }}"
 EOF
     # Replace $AGENT_NAME in the file
-    sed -i "s/\$AGENT_NAME/$AGENT_NAME/g" "$TEST_DIR/vm0.yaml"
+    sed -i "s|\$AGENT_NAME|$AGENT_NAME|g; s|\${RUNNER_GROUP}|$RUNNER_GROUP|g" "$TEST_DIR/vm0.yaml"
 
     echo "# Step 2: Run vm0 compose"
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml" --yes
@@ -238,7 +238,7 @@ agents:
       LOG_LEVEL: "${{ vars.LOG_LEVEL }}"
 EOF
     # Replace $AGENT_NAME in the file
-    sed -i "s/\$AGENT_NAME/$AGENT_NAME/g" "$TEST_DIR/vm0.yaml"
+    sed -i "s|\$AGENT_NAME|$AGENT_NAME|g; s|\${RUNNER_GROUP}|$RUNNER_GROUP|g" "$TEST_DIR/vm0.yaml"
 
     echo "# Step 2: Run vm0 compose"
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
@@ -266,7 +266,7 @@ agents:
       DATABASE_URL: "${{ credentials.DB_URL }}"
 EOF
     # Replace $AGENT_NAME in the file
-    sed -i "s/\$AGENT_NAME/$AGENT_NAME/g" "$TEST_DIR/vm0.yaml"
+    sed -i "s|\$AGENT_NAME|$AGENT_NAME|g; s|\${RUNNER_GROUP}|$RUNNER_GROUP|g" "$TEST_DIR/vm0.yaml"
 
     echo "# Step 2: Run vm0 compose"
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
@@ -296,7 +296,7 @@ agents:
       STATIC_VALUE: "hardcoded"
 EOF
     # Replace $AGENT_NAME in the file
-    sed -i "s/\$AGENT_NAME/$AGENT_NAME/g" "$TEST_DIR/vm0.yaml"
+    sed -i "s|\$AGENT_NAME|$AGENT_NAME|g; s|\${RUNNER_GROUP}|$RUNNER_GROUP|g" "$TEST_DIR/vm0.yaml"
 
     echo "# Step 2: Run vm0 compose"
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml" --yes


### PR DESCRIPTION
## Summary
- Several tests in `e2e/tests/03-experimental-runner/` were missing `experimental_runner.group` config in their agent compose YAML
- This caused them to run on E2B instead of the runner, leading to flaky failures like `[storage_download] 2: [unknown] terminated`
- Added `experimental_runner.group: ${RUNNER_GROUP}` to all agent configs in t13, t19, t20, t24, t26

## Test plan
- [ ] CI passes with `needs-runner-pipeline` label
- [ ] Verify t19 no longer hits E2B storage_download failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)