### PR TITLE
feat(telegram): add webhook handler and message handlers

### DIFF
--- a/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
@@ -1,0 +1,127 @@
+import { after } from "next/server";
+import { eq } from "drizzle-orm";
+import { initServices } from "../../../../../src/lib/init-services";
+import { telegramInstallations } from "../../../../../src/db/schema/telegram-installation";
+import { verifyTelegramWebhook } from "../../../../../src/lib/telegram/verify";
+import { handleTelegramMention } from "../../../../../src/lib/telegram/handlers/mention";
+import { handleTelegramDirectMessage } from "../../../../../src/lib/telegram/handlers/direct-message";
+import { handleStartCommand } from "../../../../../src/lib/telegram/handlers/start";
+import { storeTelegramMessage } from "../../../../../src/lib/telegram/handlers/shared";
+import { logger } from "../../../../../src/lib/logger";
+
+const log = logger("telegram:webhook");
+
+interface TelegramUpdate {
+  update_id: number;
+  message?: {
+    message_id: number;
+    chat: { id: number; type: string };
+    from?: { id: number; username?: string; is_bot?: boolean };
+    text?: string;
+    entities?: Array<{ type: string; offset: number; length: number }>;
+    reply_to_message?: {
+      message_id: number;
+      from?: { id: number; is_bot?: boolean };
+    };
+  };
+}
+
+/**
+ * Telegram Webhook Endpoint
+ *
+ * POST /api/telegram/webhook/[installationId]
+ *
+ * Routing:
+ * - /start command → handleStartCommand
+ * - Private chat (DM) → handleTelegramDirectMessage
+ * - Bot @mention in group → handleTelegramMention
+ * - Reply to bot message → handleTelegramMention (continuation)
+ * - Other messages → store silently for context
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ installationId: string }> },
+) {
+  const { installationId } = await params;
+
+  initServices();
+
+  // Look up installation for webhook secret
+  const [installation] = await globalThis.services.db
+    .select({
+      id: telegramInstallations.id,
+      webhookSecret: telegramInstallations.webhookSecret,
+      botUsername: telegramInstallations.botUsername,
+    })
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.id, installationId))
+    .limit(1);
+
+  if (!installation) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  // Verify webhook secret
+  if (!verifyTelegramWebhook(request, installation.webhookSecret)) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  // Parse update
+  let update: TelegramUpdate;
+  try {
+    update = (await request.json()) as TelegramUpdate;
+  } catch {
+    return new Response("Bad Request", { status: 400 });
+  }
+
+  const message = update.message;
+  if (!message || !message.text) {
+    // No text message — nothing to process
+    return new Response("OK", { status: 200 });
+  }
+
+  const chatId = String(message.chat.id);
+
+  // Route to appropriate handler
+  after(
+    (async () => {
+      // /start command
+      if (message.text?.startsWith("/start")) {
+        await handleStartCommand({ message }, installationId);
+        return;
+      }
+
+      // Private chat (DM)
+      if (message.chat.type === "private") {
+        await handleTelegramDirectMessage({ message }, installationId);
+        return;
+      }
+
+      // Check for bot @mention in entities
+      const hasBotMention =
+        installation.botUsername &&
+        message.entities?.some(
+          (e) =>
+            e.type === "mention" &&
+            message.text?.slice(e.offset, e.offset + e.length).toLowerCase() ===
+              `@${installation.botUsername?.toLowerCase()}`,
+        );
+
+      // Check if reply to bot's message
+      const isReplyToBot = message.reply_to_message?.from?.is_bot === true;
+
+      if (hasBotMention || isReplyToBot) {
+        await handleTelegramMention({ message }, installationId);
+        return;
+      }
+
+      // Non-matching message — store silently for context
+      await storeTelegramMessage(installationId, chatId, message);
+    })().catch((error) => {
+      log.error("Error handling telegram webhook", { error, installationId });
+    }),
+  );
+
+  // Return 200 immediately
+  return new Response("OK", { status: 200 });
+}

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { testContext } from "../../../../../src/__tests__/test-helpers";
+import { createTelegramInstallation } from "../../../../../src/lib/telegram/__tests__/helpers";
+import { POST } from "../[installationId]/route";
+
+// Mock Next.js after() to execute synchronously
+const afterPromises: Promise<unknown>[] = [];
+vi.mock("next/server", async (importOriginal) => {
+  const original = await importOriginal<typeof import("next/server")>();
+  return {
+    ...original,
+    after: (promise: Promise<unknown>) => {
+      afterPromises.push(promise);
+    },
+  };
+});
+
+async function flushAfterCallbacks() {
+  await Promise.all(afterPromises);
+  afterPromises.length = 0;
+}
+
+testContext();
+
+const WEBHOOK_SECRET = "webhook-secret";
+
+function createWebhookRequest(
+  body: Record<string, unknown>,
+  secret: string = WEBHOOK_SECRET,
+): Request {
+  return new Request("http://localhost/api/telegram/webhook/test", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-telegram-bot-api-secret-token": secret,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/telegram/webhook/[installationId]", () => {
+  let installationId: string;
+
+  beforeEach(async () => {
+    afterPromises.length = 0;
+    installationId = await createTelegramInstallation();
+  });
+
+  it("should return 404 for unknown installation", async () => {
+    const request = createWebhookRequest({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        chat: { id: 123, type: "private" },
+        text: "hi",
+      },
+    });
+    const response = await POST(request, {
+      params: Promise.resolve({
+        installationId: "00000000-0000-0000-0000-000000000000",
+      }),
+    });
+    expect(response.status).toBe(404);
+  });
+
+  it("should return 401 for invalid webhook secret", async () => {
+    const request = createWebhookRequest(
+      {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: 123, type: "private" },
+          text: "hi",
+        },
+      },
+      "wrong-secret",
+    );
+    const response = await POST(request, {
+      params: Promise.resolve({ installationId }),
+    });
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 401 for missing webhook secret header", async () => {
+    const request = new Request("http://localhost/api/telegram/webhook/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: 123, type: "private" },
+          text: "hi",
+        },
+      }),
+    });
+    const response = await POST(request, {
+      params: Promise.resolve({ installationId }),
+    });
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 200 for valid request with no message", async () => {
+    const request = createWebhookRequest({ update_id: 1 });
+    const response = await POST(request, {
+      params: Promise.resolve({ installationId }),
+    });
+    expect(response.status).toBe(200);
+  });
+
+  it("should return 200 for message without text", async () => {
+    const request = createWebhookRequest({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        chat: { id: 123, type: "private" },
+        from: { id: 456, username: "testuser" },
+      },
+    });
+    const response = await POST(request, {
+      params: Promise.resolve({ installationId }),
+    });
+    expect(response.status).toBe(200);
+  });
+
+  it("should return 200 immediately for valid text messages", async () => {
+    const request = createWebhookRequest({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        chat: { id: 123, type: "private" },
+        from: { id: 456, username: "testuser" },
+        text: "hello bot",
+      },
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ installationId }),
+    });
+
+    // Should return 200 immediately (handler runs in after())
+    expect(response.status).toBe(200);
+
+    // after() was called (handler was dispatched)
+    expect(afterPromises.length).toBe(1);
+
+    // Handler errors are caught gracefully (no unhandled rejections)
+    await flushAfterCallbacks();
+  });
+
+  it("should return 200 for /start command", async () => {
+    const request = createWebhookRequest({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        chat: { id: 123, type: "private" },
+        from: { id: 456, username: "testuser" },
+        text: "/start sometoken",
+      },
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ installationId }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(afterPromises.length).toBe(1);
+    await flushAfterCallbacks();
+  });
+
+  it("should return 400 for invalid JSON", async () => {
+    const request = new Request("http://localhost/api/telegram/webhook/test", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-telegram-bot-api-secret-token": WEBHOOK_SECRET,
+      },
+      body: "not json",
+    });
+    const response = await POST(request, {
+      params: Promise.resolve({ installationId }),
+    });
+    expect(response.status).toBe(400);
+  });
+});

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -1,0 +1,160 @@
+import { eq, and } from "drizzle-orm";
+import { telegramInstallations } from "../../../db/schema/telegram-installation";
+import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
+import { decryptCredentialValue } from "../../crypto/secrets-encryption";
+import { env } from "../../../env";
+import { createTelegramClient, sendMessage, sendChatAction } from "../client";
+import { fetchTelegramContext } from "../context";
+import { runAgentForTelegram } from "./run-agent";
+import {
+  lookupTelegramThreadSession,
+  storeTelegramMessage,
+  getWorkspaceAgent,
+  resolveSessionCompose,
+} from "./shared";
+import { logger } from "../../logger";
+
+const log = logger("telegram:dm");
+
+interface TelegramUpdate {
+  message: {
+    message_id: number;
+    chat: { id: number; type: string };
+    from?: { id: number; username?: string; is_bot?: boolean };
+    text?: string;
+  };
+}
+
+/**
+ * Handle a direct message to the bot
+ *
+ * Same flow as mention handler except:
+ * - No mention stripping
+ * - Use rootMessageId = "dm" sentinel for single ongoing DM session
+ */
+export async function handleTelegramDirectMessage(
+  update: TelegramUpdate,
+  installationId: string,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const message = update.message;
+  const chatId = String(message.chat.id);
+  const fromUserId = String(message.from?.id ?? 0);
+
+  // 1. Get installation
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.id, installationId))
+    .limit(1);
+
+  if (!installation) {
+    log.error("Installation not found", { installationId });
+    return;
+  }
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createTelegramClient(botToken);
+
+  // 2. Check user link
+  const [userLink] = await globalThis.services.db
+    .select()
+    .from(telegramUserLinks)
+    .where(
+      and(
+        eq(telegramUserLinks.telegramUserId, fromUserId),
+        eq(telegramUserLinks.installationId, installationId),
+      ),
+    )
+    .limit(1);
+
+  if (!userLink) {
+    await sendMessage(
+      client,
+      chatId,
+      "Please link your account first. Send /start to begin.",
+    );
+    return;
+  }
+
+  // 3. Resolve workspace agent
+  let composeId = installation.defaultComposeId;
+  const defaultAgent = await getWorkspaceAgent(composeId);
+  if (!defaultAgent) {
+    await sendMessage(
+      client,
+      chatId,
+      "The agent is not available. Please contact the admin.",
+    );
+    return;
+  }
+  let agentName = defaultAgent.name;
+
+  // 4. Send typing indicator
+  await sendChatAction(client, chatId, "typing");
+
+  // 5. Store incoming message
+  await storeTelegramMessage(installationId, chatId, message);
+
+  // 6. Use "dm" sentinel as rootMessageId for single ongoing DM session
+  const rootMessageId = "dm";
+
+  // 7. Look up existing session
+  const session = await lookupTelegramThreadSession(
+    chatId,
+    rootMessageId,
+    userLink.id,
+  );
+  const existingSessionId = session.existingSessionId;
+  const lastProcessedMessageId = session.lastProcessedMessageId;
+
+  // 7b. If continuing session, use session's compose
+  if (existingSessionId) {
+    const sessionCompose = await resolveSessionCompose(
+      existingSessionId,
+      userLink.vm0UserId,
+    );
+    if (sessionCompose) {
+      composeId = sessionCompose.composeId;
+      agentName = sessionCompose.agentName;
+    }
+  }
+
+  // 8. Fetch context
+  const { executionContext } = await fetchTelegramContext(
+    installationId,
+    chatId,
+    lastProcessedMessageId,
+  );
+
+  // 9. Dispatch agent run
+  const { status, response } = await runAgentForTelegram({
+    composeId,
+    agentName,
+    sessionId: existingSessionId,
+    prompt: message.text ?? "",
+    threadContext: executionContext,
+    userId: userLink.vm0UserId,
+    callbackContext: {
+      installationId,
+      chatId,
+      messageId: String(message.message_id),
+      userLinkId: userLink.id,
+      agentName,
+      composeId,
+      existingSessionId: existingSessionId ?? null,
+    },
+  });
+
+  if (status === "failed") {
+    log.error("Failed to dispatch agent run", { response });
+    await sendMessage(
+      client,
+      chatId,
+      response ?? "Sorry, an error occurred. Please try again.",
+    );
+  }
+}

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -1,0 +1,213 @@
+import { eq, and } from "drizzle-orm";
+import { telegramInstallations } from "../../../db/schema/telegram-installation";
+import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
+import { decryptCredentialValue } from "../../crypto/secrets-encryption";
+import { env } from "../../../env";
+import { createTelegramClient, sendMessage, sendChatAction } from "../client";
+import { fetchTelegramContext } from "../context";
+import { runAgentForTelegram } from "./run-agent";
+import {
+  lookupTelegramThreadSession,
+  storeTelegramMessage,
+  getWorkspaceAgent,
+  resolveSessionCompose,
+} from "./shared";
+import { logger } from "../../logger";
+
+const log = logger("telegram:mention");
+
+interface TelegramUpdate {
+  message: {
+    message_id: number;
+    chat: { id: number; type: string };
+    from?: { id: number; username?: string; is_bot?: boolean };
+    text?: string;
+    entities?: Array<{ type: string; offset: number; length: number }>;
+    reply_to_message?: { message_id: number; from?: { is_bot?: boolean } };
+  };
+}
+
+/**
+ * Handle a group @mention of the bot
+ *
+ * Flow:
+ * 1. Look up installation → decrypt bot token → create client
+ * 2. Check user link → if not linked, send login prompt
+ * 3. Resolve workspace agent
+ * 4. Send typing indicator
+ * 5. Store incoming message
+ * 6. Strip @botusername from message text
+ * 7. Determine thread anchor (reply-to-bot or new)
+ * 8. Look up existing session
+ * 9. Fetch context
+ * 10. Dispatch agent run
+ */
+export async function handleTelegramMention(
+  update: TelegramUpdate,
+  installationId: string,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const message = update.message;
+  const chatId = String(message.chat.id);
+  const fromUserId = String(message.from?.id ?? 0);
+
+  // 1. Get installation
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.id, installationId))
+    .limit(1);
+
+  if (!installation) {
+    log.error("Installation not found", { installationId });
+    return;
+  }
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createTelegramClient(botToken);
+
+  // 2. Check user link
+  const [userLink] = await globalThis.services.db
+    .select()
+    .from(telegramUserLinks)
+    .where(
+      and(
+        eq(telegramUserLinks.telegramUserId, fromUserId),
+        eq(telegramUserLinks.installationId, installationId),
+      ),
+    )
+    .limit(1);
+
+  if (!userLink) {
+    await sendMessage(
+      client,
+      chatId,
+      "Please link your account first. Send /start to the bot in a direct message.",
+      { replyToMessageId: message.message_id },
+    );
+    return;
+  }
+
+  // 3. Resolve workspace agent
+  let composeId = installation.defaultComposeId;
+  const defaultAgent = await getWorkspaceAgent(composeId);
+  if (!defaultAgent) {
+    await sendMessage(
+      client,
+      chatId,
+      "The agent is not available. Please contact the admin.",
+      { replyToMessageId: message.message_id },
+    );
+    return;
+  }
+  let agentName = defaultAgent.name;
+
+  // 4. Send typing indicator
+  await sendChatAction(client, chatId, "typing");
+
+  // 5. Store incoming message
+  await storeTelegramMessage(installationId, chatId, message);
+
+  // 6. Strip @botusername from message text
+  const messageText = stripBotMention(
+    message.text ?? "",
+    installation.botUsername,
+    message.entities,
+  );
+
+  // 7. Determine thread anchor
+  let rootMessageId: string | undefined;
+  if (
+    message.reply_to_message?.from?.is_bot &&
+    message.reply_to_message.message_id
+  ) {
+    // Replying to bot's message — use that as thread anchor
+    rootMessageId = String(message.reply_to_message.message_id);
+  }
+  // New mention (not replying) — rootMessageId set after bot replies in callback
+
+  // 8. Look up existing session
+  let existingSessionId: string | undefined;
+  let lastProcessedMessageId: string | undefined;
+  if (rootMessageId) {
+    const session = await lookupTelegramThreadSession(
+      chatId,
+      rootMessageId,
+      userLink.id,
+    );
+    existingSessionId = session.existingSessionId;
+    lastProcessedMessageId = session.lastProcessedMessageId;
+  }
+
+  // 8b. If continuing session, use session's compose
+  if (existingSessionId) {
+    const sessionCompose = await resolveSessionCompose(
+      existingSessionId,
+      userLink.vm0UserId,
+    );
+    if (sessionCompose) {
+      composeId = sessionCompose.composeId;
+      agentName = sessionCompose.agentName;
+    }
+  }
+
+  // 9. Fetch context
+  const { executionContext } = await fetchTelegramContext(
+    installationId,
+    chatId,
+    lastProcessedMessageId,
+  );
+
+  // 10. Dispatch agent run
+  const { status, response } = await runAgentForTelegram({
+    composeId,
+    agentName,
+    sessionId: existingSessionId,
+    prompt: messageText,
+    threadContext: executionContext,
+    userId: userLink.vm0UserId,
+    callbackContext: {
+      installationId,
+      chatId,
+      messageId: String(message.message_id),
+      userLinkId: userLink.id,
+      agentName,
+      composeId,
+      existingSessionId: existingSessionId ?? null,
+    },
+  });
+
+  if (status === "failed") {
+    log.error("Failed to dispatch agent run", { response });
+    await sendMessage(
+      client,
+      chatId,
+      response ?? "Sorry, an error occurred. Please try again.",
+      { replyToMessageId: message.message_id },
+    );
+  }
+}
+
+/**
+ * Strip @botusername from message text
+ */
+function stripBotMention(
+  text: string,
+  botUsername: string | null,
+  entities?: Array<{ type: string; offset: number; length: number }>,
+): string {
+  if (!botUsername || !entities) return text;
+
+  // Find mention entities and remove them
+  const mentionText = `@${botUsername}`;
+  return text
+    .replace(new RegExp(`\\s*${escapeRegExp(mentionText)}\\s*`, "gi"), " ")
+    .trim();
+}
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
@@ -1,0 +1,142 @@
+import { eq, desc } from "drizzle-orm";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../db/schema/agent-compose";
+import { createRun } from "../../run";
+import { isConcurrentRunLimit } from "../../errors";
+import { logger } from "../../logger";
+import { generateCallbackSecret, getApiUrl } from "../../callback";
+
+const log = logger("telegram:run-agent");
+
+/**
+ * Telegram-specific context to include in the callback payload
+ */
+export interface TelegramCallbackContext {
+  installationId: string;
+  chatId: string;
+  messageId: string;
+  userLinkId: string;
+  agentName: string;
+  composeId: string;
+  existingSessionId: string | null;
+}
+
+interface RunAgentParams {
+  composeId: string;
+  agentName: string;
+  sessionId: string | undefined;
+  prompt: string;
+  threadContext: string;
+  userId: string;
+  callbackContext: TelegramCallbackContext;
+}
+
+interface RunAgentResult {
+  status: "dispatched" | "failed";
+  response?: string;
+  runId: string | undefined;
+}
+
+/**
+ * Execute an agent run for Telegram
+ *
+ * Creates a run, registers a callback, and returns immediately.
+ * The callback will be invoked when the run completes.
+ */
+export async function runAgentForTelegram(
+  params: RunAgentParams,
+): Promise<RunAgentResult> {
+  const {
+    composeId,
+    agentName,
+    sessionId,
+    prompt,
+    threadContext,
+    userId,
+    callbackContext,
+  } = params;
+
+  try {
+    const [compose] = await globalThis.services.db
+      .select()
+      .from(agentComposes)
+      .where(eq(agentComposes.id, composeId))
+      .limit(1);
+
+    if (!compose) {
+      return {
+        status: "failed",
+        response: "Error: Agent configuration not found.",
+        runId: undefined,
+      };
+    }
+
+    let versionId = compose.headVersionId;
+    if (!versionId) {
+      const [latestVersion] = await globalThis.services.db
+        .select({ id: agentComposeVersions.id })
+        .from(agentComposeVersions)
+        .where(eq(agentComposeVersions.composeId, compose.id))
+        .orderBy(desc(agentComposeVersions.createdAt))
+        .limit(1);
+
+      if (!latestVersion) {
+        return {
+          status: "failed",
+          response: "Error: Agent has no versions configured.",
+          runId: undefined,
+        };
+      }
+      versionId = latestVersion.id;
+    }
+
+    const fullPrompt = threadContext
+      ? `${threadContext}\n\n# User Prompt\n\n${prompt}`
+      : prompt;
+
+    const callbackUrl = `${getApiUrl()}/api/internal/callbacks/telegram`;
+    const callbackSecret = generateCallbackSecret();
+
+    const result = await createRun({
+      userId,
+      agentComposeVersionId: versionId,
+      prompt: fullPrompt,
+      composeId: compose.id,
+      sessionId,
+      agentName,
+      artifactName: "artifact",
+      callbacks: [
+        {
+          url: callbackUrl,
+          secret: callbackSecret,
+          payload: callbackContext,
+        },
+      ],
+    });
+
+    log.debug(`Run ${result.runId} dispatched for Telegram agent ${agentName}`);
+
+    return {
+      status: "dispatched",
+      runId: result.runId,
+    };
+  } catch (error) {
+    if (isConcurrentRunLimit(error)) {
+      return {
+        status: "failed",
+        response:
+          "You have too many concurrent runs. Please wait for existing runs to complete.",
+        runId: undefined,
+      };
+    }
+    log.error("Error running agent for Telegram:", error);
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      status: "failed",
+      response: `Error executing agent: ${message}`,
+      runId: undefined,
+    };
+  }
+}

--- a/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
@@ -58,47 +58,47 @@ export async function runAgentForTelegram(
     callbackContext,
   } = params;
 
-  try {
-    const [compose] = await globalThis.services.db
-      .select()
-      .from(agentComposes)
-      .where(eq(agentComposes.id, composeId))
+  const [compose] = await globalThis.services.db
+    .select()
+    .from(agentComposes)
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+
+  if (!compose) {
+    return {
+      status: "failed",
+      response: "Error: Agent configuration not found.",
+      runId: undefined,
+    };
+  }
+
+  let versionId = compose.headVersionId;
+  if (!versionId) {
+    const [latestVersion] = await globalThis.services.db
+      .select({ id: agentComposeVersions.id })
+      .from(agentComposeVersions)
+      .where(eq(agentComposeVersions.composeId, compose.id))
+      .orderBy(desc(agentComposeVersions.createdAt))
       .limit(1);
 
-    if (!compose) {
+    if (!latestVersion) {
       return {
         status: "failed",
-        response: "Error: Agent configuration not found.",
+        response: "Error: Agent has no versions configured.",
         runId: undefined,
       };
     }
+    versionId = latestVersion.id;
+  }
 
-    let versionId = compose.headVersionId;
-    if (!versionId) {
-      const [latestVersion] = await globalThis.services.db
-        .select({ id: agentComposeVersions.id })
-        .from(agentComposeVersions)
-        .where(eq(agentComposeVersions.composeId, compose.id))
-        .orderBy(desc(agentComposeVersions.createdAt))
-        .limit(1);
+  const fullPrompt = threadContext
+    ? `${threadContext}\n\n# User Prompt\n\n${prompt}`
+    : prompt;
 
-      if (!latestVersion) {
-        return {
-          status: "failed",
-          response: "Error: Agent has no versions configured.",
-          runId: undefined,
-        };
-      }
-      versionId = latestVersion.id;
-    }
+  const callbackUrl = `${getApiUrl()}/api/internal/callbacks/telegram`;
+  const callbackSecret = generateCallbackSecret();
 
-    const fullPrompt = threadContext
-      ? `${threadContext}\n\n# User Prompt\n\n${prompt}`
-      : prompt;
-
-    const callbackUrl = `${getApiUrl()}/api/internal/callbacks/telegram`;
-    const callbackSecret = generateCallbackSecret();
-
+  try {
     const result = await createRun({
       userId,
       agentComposeVersionId: versionId,
@@ -131,12 +131,6 @@ export async function runAgentForTelegram(
         runId: undefined,
       };
     }
-    log.error("Error running agent for Telegram:", error);
-    const message = error instanceof Error ? error.message : "Unknown error";
-    return {
-      status: "failed",
-      response: `Error executing agent: ${message}`,
-      runId: undefined,
-    };
+    throw error;
   }
 }

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -181,20 +181,13 @@ export async function resolveSessionCompose(
   sessionId: string,
   userId: string,
 ): Promise<{ composeId: string; agentName: string } | undefined> {
-  try {
-    const sessionData = await validateAgentSession(sessionId, userId);
-    const agent = await getWorkspaceAgent(sessionData.agentComposeId);
-    if (agent) {
-      return {
-        composeId: sessionData.agentComposeId,
-        agentName: agent.name,
-      };
-    }
-  } catch (error) {
-    log.warn("Failed to resolve session compose, using workspace default", {
-      sessionId,
-      error,
-    });
+  const sessionData = await validateAgentSession(sessionId, userId);
+  const agent = await getWorkspaceAgent(sessionData.agentComposeId);
+  if (agent) {
+    return {
+      composeId: sessionData.agentComposeId,
+      agentName: agent.name,
+    };
   }
   return undefined;
 }

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -1,0 +1,207 @@
+import { eq, and } from "drizzle-orm";
+import { telegramThreadSessions } from "../../../db/schema/telegram-thread-session";
+import { telegramMessages } from "../../../db/schema/telegram-message";
+import { agentComposes } from "../../../db/schema/agent-compose";
+import { getPlatformUrl } from "../../url";
+import {
+  getUserScopeByClerkId,
+  createUserScope,
+  generateDefaultScopeSlug,
+} from "../../scope/scope-service";
+import { validateAgentSession } from "../../run";
+import { ensureArtifactExists } from "../../storage/storage-service";
+import { logger } from "../../logger";
+
+const log = logger("telegram:shared");
+
+interface ThreadSessionLookup {
+  existingSessionId: string | undefined;
+  lastProcessedMessageId: string | undefined;
+}
+
+/**
+ * Look up an existing thread session by chat + rootMessageId + user link.
+ */
+export async function lookupTelegramThreadSession(
+  chatId: string,
+  rootMessageId: string,
+  userLinkId: string,
+): Promise<ThreadSessionLookup> {
+  const [session] = await globalThis.services.db
+    .select({
+      agentSessionId: telegramThreadSessions.agentSessionId,
+      lastProcessedMessageId: telegramThreadSessions.lastProcessedMessageId,
+    })
+    .from(telegramThreadSessions)
+    .where(
+      and(
+        eq(telegramThreadSessions.telegramUserLinkId, userLinkId),
+        eq(telegramThreadSessions.chatId, chatId),
+        eq(telegramThreadSessions.rootMessageId, rootMessageId),
+      ),
+    )
+    .limit(1);
+
+  return {
+    existingSessionId: session?.agentSessionId,
+    lastProcessedMessageId: session?.lastProcessedMessageId ?? undefined,
+  };
+}
+
+/**
+ * Create or update a thread session mapping after agent execution.
+ */
+export async function saveTelegramThreadSession(opts: {
+  userLinkId: string;
+  chatId: string;
+  rootMessageId: string;
+  existingSessionId: string | undefined;
+  newSessionId: string | undefined;
+  messageId: string;
+  runStatus: string;
+}): Promise<void> {
+  const {
+    userLinkId,
+    chatId,
+    rootMessageId,
+    existingSessionId,
+    newSessionId,
+    messageId,
+    runStatus,
+  } = opts;
+
+  if (!existingSessionId && newSessionId) {
+    // New thread — create mapping
+    await globalThis.services.db
+      .insert(telegramThreadSessions)
+      .values({
+        telegramUserLinkId: userLinkId,
+        chatId,
+        rootMessageId,
+        agentSessionId: newSessionId,
+        lastProcessedMessageId: messageId,
+      })
+      .onConflictDoNothing();
+  } else if (
+    existingSessionId &&
+    (runStatus === "completed" || runStatus === "timeout")
+  ) {
+    // Existing thread, successful run — update lastProcessedMessageId
+    await globalThis.services.db
+      .update(telegramThreadSessions)
+      .set({
+        lastProcessedMessageId: messageId,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(telegramThreadSessions.telegramUserLinkId, userLinkId),
+          eq(telegramThreadSessions.chatId, chatId),
+          eq(telegramThreadSessions.rootMessageId, rootMessageId),
+        ),
+      );
+  }
+  // Failed runs — do not update lastProcessedMessageId (allows retry with same context)
+}
+
+/**
+ * Store an incoming Telegram message for context retrieval.
+ */
+export async function storeTelegramMessage(
+  installationId: string,
+  chatId: string,
+  message: {
+    message_id: number;
+    from?: { id: number; username?: string; is_bot?: boolean };
+    text?: string;
+  },
+): Promise<void> {
+  await globalThis.services.db
+    .insert(telegramMessages)
+    .values({
+      installationId,
+      chatId,
+      messageId: String(message.message_id),
+      fromUserId: String(message.from?.id ?? 0),
+      fromUsername: message.from?.username ?? null,
+      text: message.text ?? null,
+      isBot: message.from?.is_bot ?? false,
+    })
+    .onConflictDoNothing();
+}
+
+/**
+ * Build the deep link URL for account linking
+ */
+export function buildLoginUrl(botUsername: string, linkToken: string): string {
+  return `https://t.me/${botUsername}?start=${linkToken}`;
+}
+
+/**
+ * Build the logs URL for a run
+ */
+export function buildLogsUrl(runId: string): string {
+  return `${getPlatformUrl()}/logs/${runId}`;
+}
+
+/**
+ * Ensure scope and artifact storage exist for a user.
+ */
+export async function ensureScopeAndArtifact(vm0UserId: string): Promise<void> {
+  let scope = await getUserScopeByClerkId(vm0UserId);
+  if (!scope) {
+    scope = await createUserScope(
+      vm0UserId,
+      generateDefaultScopeSlug(vm0UserId),
+    );
+    log.info("Auto-created scope for Telegram user", { userId: vm0UserId });
+  }
+
+  try {
+    await ensureArtifactExists(scope.id, vm0UserId, "artifact", scope.slug);
+  } catch (err) {
+    log.error("Failed to ensure artifact exists for Telegram user", {
+      userId: vm0UserId,
+      err,
+    });
+  }
+}
+
+/**
+ * Resolve workspace agent name from composeId
+ */
+export async function getWorkspaceAgent(
+  composeId: string,
+): Promise<{ id: string; name: string } | undefined> {
+  const [compose] = await globalThis.services.db
+    .select({ id: agentComposes.id, name: agentComposes.name })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+  return compose ?? undefined;
+}
+
+/**
+ * Resolve compose info from an existing session.
+ */
+export async function resolveSessionCompose(
+  sessionId: string,
+  userId: string,
+): Promise<{ composeId: string; agentName: string } | undefined> {
+  try {
+    const sessionData = await validateAgentSession(sessionId, userId);
+    const agent = await getWorkspaceAgent(sessionData.agentComposeId);
+    if (agent) {
+      return {
+        composeId: sessionData.agentComposeId,
+        agentName: agent.name,
+      };
+    }
+  } catch (error) {
+    log.warn("Failed to resolve session compose, using workspace default", {
+      sessionId,
+      error,
+    });
+  }
+  return undefined;
+}

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -157,14 +157,7 @@ export async function ensureScopeAndArtifact(vm0UserId: string): Promise<void> {
     log.info("Auto-created scope for Telegram user", { userId: vm0UserId });
   }
 
-  try {
-    await ensureArtifactExists(scope.id, vm0UserId, "artifact", scope.slug);
-  } catch (err) {
-    log.error("Failed to ensure artifact exists for Telegram user", {
-      userId: vm0UserId,
-      err,
-    });
-  }
+  await ensureArtifactExists(scope.id, vm0UserId, "artifact", scope.slug);
 }
 
 /**

--- a/turbo/apps/web/src/lib/telegram/handlers/start.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/start.ts
@@ -1,0 +1,197 @@
+import { eq } from "drizzle-orm";
+import { telegramInstallations } from "../../../db/schema/telegram-installation";
+import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
+import { decryptCredentialValue } from "../../crypto/secrets-encryption";
+import { env } from "../../../env";
+import { createTelegramClient, sendMessage } from "../client";
+import { ensureScopeAndArtifact } from "./shared";
+import { logger } from "../../logger";
+import crypto from "crypto";
+
+const log = logger("telegram:start");
+
+/** Token expiry in seconds (10 minutes) */
+const TOKEN_EXPIRY_SECONDS = 600;
+
+interface TelegramUpdate {
+  message: {
+    message_id: number;
+    chat: { id: number; type: string };
+    from?: { id: number; username?: string; is_bot?: boolean };
+    text?: string;
+  };
+}
+
+interface LinkTokenPayload {
+  vm0UserId: string;
+  installationId: string;
+  exp: number;
+}
+
+/**
+ * Handle /start command
+ *
+ * Flow:
+ * 1. Parse deep link payload from /start {token}
+ * 2. No token → send generic welcome
+ * 3. Token present → validate, create user link, send confirmation
+ */
+export async function handleStartCommand(
+  update: TelegramUpdate,
+  installationId: string,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const message = update.message;
+  const chatId = String(message.chat.id);
+  const fromUserId = String(message.from?.id ?? 0);
+
+  // Get installation for bot token
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.id, installationId))
+    .limit(1);
+
+  if (!installation) {
+    log.error("Installation not found", { installationId });
+    return;
+  }
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createTelegramClient(botToken);
+
+  // Parse /start payload
+  const text = message.text ?? "";
+  const parts = text.split(" ");
+  const token = parts.length > 1 ? parts[1] : undefined;
+
+  if (!token) {
+    // No token — generic welcome
+    await sendMessage(
+      client,
+      chatId,
+      "Welcome! Visit the platform to connect your account and start chatting with the agent.",
+    );
+    return;
+  }
+
+  // Validate token
+  const payload = verifyLinkToken(token, SECRETS_ENCRYPTION_KEY);
+  if (!payload) {
+    await sendMessage(
+      client,
+      chatId,
+      "This link has expired. Please generate a new one from the platform.",
+    );
+    return;
+  }
+
+  if (payload.installationId !== installationId) {
+    await sendMessage(
+      client,
+      chatId,
+      "This link is for a different bot. Please use the correct link.",
+    );
+    return;
+  }
+
+  // Create user link (upsert)
+  await globalThis.services.db
+    .insert(telegramUserLinks)
+    .values({
+      telegramUserId: fromUserId,
+      installationId,
+      vm0UserId: payload.vm0UserId,
+    })
+    .onConflictDoNothing();
+
+  // Auto-grant permission
+  await ensureScopeAndArtifact(payload.vm0UserId);
+
+  await sendMessage(
+    client,
+    chatId,
+    "Account linked! You can now chat with the agent.",
+  );
+
+  log.info("Telegram user linked", {
+    telegramUserId: fromUserId,
+    vm0UserId: payload.vm0UserId,
+    installationId,
+  });
+}
+
+/**
+ * Create a signed link token for account linking.
+ * Uses HMAC-SHA256 with a simple JSON payload + expiry.
+ */
+export function createLinkToken(
+  vm0UserId: string,
+  installationId: string,
+  secretKey: string,
+): string {
+  const payload: LinkTokenPayload = {
+    vm0UserId,
+    installationId,
+    exp: Math.floor(Date.now() / 1000) + TOKEN_EXPIRY_SECONDS,
+  };
+
+  const data = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = crypto
+    .createHmac("sha256", secretKey)
+    .update(data)
+    .digest("base64url");
+
+  return `${data}.${signature}`;
+}
+
+/**
+ * Verify and decode a link token.
+ * Returns null if invalid or expired.
+ */
+export function verifyLinkToken(
+  token: string,
+  secretKey: string,
+): LinkTokenPayload | null {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+
+  const [data, signature] = parts as [string, string];
+
+  const expectedSignature = crypto
+    .createHmac("sha256", secretKey)
+    .update(data)
+    .digest("base64url");
+
+  // Timing-safe comparison
+  try {
+    if (
+      !crypto.timingSafeEqual(
+        Buffer.from(signature),
+        Buffer.from(expectedSignature),
+      )
+    ) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(
+      Buffer.from(data, "base64url").toString(),
+    ) as LinkTokenPayload;
+
+    // Check expiry
+    if (payload.exp < Math.floor(Date.now() / 1000)) {
+      return null;
+    }
+
+    return payload;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Add webhook route at `/api/telegram/webhook/[installationId]` with secret verification and message routing
- Implement 5 handler modules: shared utilities, run-agent adapter, mention handler, DM handler, /start command handler
- Add HMAC-SHA256 link tokens for secure account linking via Telegram `/start` deep link
- Mirror Slack integration patterns (callback-based agent dispatch, thread session management, context deduplication)
- 8 integration tests covering webhook verification, routing, and error handling

## Test plan

- [x] Webhook returns 404 for unknown installation
- [x] Webhook returns 401 for invalid/missing secret
- [x] Webhook returns 200 for valid requests (no message, no text, text messages, /start)
- [x] Webhook returns 400 for invalid JSON
- [x] `after()` dispatches handlers asynchronously
- [x] All lint, type, knip, and format checks pass

Closes #3536

🤖 Generated with [Claude Code](https://claude.com/claude-code)