### PR TITLE
fix: use atomic upsert for model-provider and scope to prevent race conditions

### DIFF
--- a/turbo/apps/web/app/api/model-providers/__tests__/list-upsert.test.ts
+++ b/turbo/apps/web/app/api/model-providers/__tests__/list-upsert.test.ts
@@ -211,6 +211,31 @@ describe("PUT /api/model-providers (single-secret)", () => {
     expect(body.provider.selectedModel).toBeNull();
   });
 
+  it("should handle concurrent upsert requests without errors", async () => {
+    // Fire multiple concurrent upsert requests for the same provider type
+    const concurrentRequests = Array.from({ length: 5 }, () =>
+      upsertProvider({
+        type: "claude-code-oauth-token",
+        secret: "concurrent-test-token",
+      }),
+    );
+
+    const responses = await Promise.all(concurrentRequests);
+
+    // All should succeed (either 200 or 201, never 500)
+    for (const response of responses) {
+      expect([200, 201]).toContain(response.status);
+    }
+
+    // Should result in exactly one provider
+    const listResponse = await listProviders();
+    const listBody = await listResponse.json();
+    const oauthProviders = listBody.modelProviders.filter(
+      (p: { type: string }) => p.type === "claude-code-oauth-token",
+    );
+    expect(oauthProviders).toHaveLength(1);
+  });
+
   it("should allow same secret name for user and model-provider types", async () => {
     // Create a user-type secret with the same name
     await createTestSecret("ANTHROPIC_API_KEY", "user-secret-value");

--- a/turbo/apps/web/app/api/scope/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/route.test.ts
@@ -74,6 +74,36 @@ describe("/api/scope", () => {
       expect(data.id).toBeDefined();
     });
 
+    it("should return 400 (not 500) when scope slug already exists", async () => {
+      // First user creates a scope with a slug
+      const userId1 = `dup-slug-user1-${Date.now()}`;
+      const slug = `dup-slug-test-${Date.now()}`;
+
+      mockClerk({ userId: userId1 });
+      const request1 = createTestRequest("http://localhost:3000/api/scope", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug }),
+      });
+      const response1 = await POST(request1);
+      expect(response1.status).toBe(201);
+
+      // Second user tries to create a scope with the same slug
+      // This should return 400 (already exists) not 500 (crash)
+      const userId2 = `dup-slug-user2-${Date.now()}`;
+      mockClerk({ userId: userId2 });
+      const request2 = createTestRequest("http://localhost:3000/api/scope", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug }),
+      });
+      const response2 = await POST(request2);
+      const data = await response2.json();
+
+      expect(response2.status).toBe(400);
+      expect(data.error.message).toContain("already exists");
+    });
+
     it("should reject duplicate scope creation for same user", async () => {
       // Create a user and their first scope
       const userId = `dup-test-user-${Date.now()}`;

--- a/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
@@ -70,14 +70,53 @@ function toModelProviderInfo(params: {
 }
 
 /**
- * Check if user already has a provider for the given framework.
+ * Assign isDefault=true to a provider if no other provider for the same framework
+ * already has isDefault=true. Safe to call after atomic upsert.
  */
-async function hasExistingProviderForFramework(
-  clerkUserId: string,
+async function assignDefaultIfFirst(
+  scopeId: string,
+  providerId: string,
   framework: ModelProviderFramework,
-): Promise<boolean> {
-  const allProviders = await listModelProviders(clerkUserId);
-  return allProviders.some((p) => p.framework === framework);
+): Promise<void> {
+  const allScopeProviders = await globalThis.services.db
+    .select({
+      id: modelProviders.id,
+      type: modelProviders.type,
+      isDefault: modelProviders.isDefault,
+    })
+    .from(modelProviders)
+    .where(eq(modelProviders.scopeId, scopeId));
+
+  const hasDefaultForFramework = allScopeProviders.some(
+    (p) =>
+      p.id !== providerId &&
+      p.isDefault &&
+      getFrameworkForType(p.type as ModelProviderType) === framework,
+  );
+
+  if (!hasDefaultForFramework) {
+    await globalThis.services.db
+      .update(modelProviders)
+      .set({ isDefault: true })
+      .where(eq(modelProviders.id, providerId));
+  }
+}
+
+/**
+ * Get a single model provider by ID within a scope.
+ */
+async function getProviderById(scopeId: string, providerId: string) {
+  const [provider] = await globalThis.services.db
+    .select()
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.scopeId, scopeId),
+        eq(modelProviders.id, providerId),
+      ),
+    )
+    .limit(1);
+  return provider!;
 }
 
 /**
@@ -163,6 +202,8 @@ export async function checkSecretExists(
 
 /**
  * Create or update a model provider (legacy single-secret)
+ * Uses atomic INSERT ... ON CONFLICT DO UPDATE to handle concurrent requests safely.
+ *
  * @param selectedModel For providers with model selection, the chosen model
  *
  * Note: Multi-auth providers (like aws-bedrock) should use upsertMultiAuthModelProvider instead
@@ -202,130 +243,8 @@ export async function upsertModelProvider(
     secretName,
   });
 
-  // Check if model provider already exists
-  const [existingProvider] = await globalThis.services.db
-    .select()
-    .from(modelProviders)
-    .where(
-      and(eq(modelProviders.scopeId, scope.id), eq(modelProviders.type, type)),
-    )
-    .limit(1);
-
-  if (existingProvider) {
-    // Legacy providers should have secretId
-    if (!existingProvider.secretId) {
-      throw badRequest(
-        `Provider "${type}" is missing secret reference. This is an invalid state.`,
-      );
-    }
-
-    // Update existing secret value
-    await globalThis.services.db
-      .update(secrets)
-      .set({ encryptedValue, updatedAt: new Date() })
-      .where(eq(secrets.id, existingProvider.secretId));
-
-    await globalThis.services.db
-      .update(modelProviders)
-      .set({
-        selectedModel: selectedModel ?? null,
-        updatedAt: new Date(),
-      })
-      .where(eq(modelProviders.id, existingProvider.id));
-
-    log.debug("model provider updated", {
-      providerId: existingProvider.id,
-      type,
-      selectedModel,
-    });
-
-    return {
-      provider: toModelProviderInfo({
-        id: existingProvider.id,
-        type,
-        secretName,
-        isDefault: existingProvider.isDefault,
-        selectedModel: selectedModel ?? null,
-        createdAt: existingProvider.createdAt,
-        updatedAt: new Date(),
-      }),
-      created: false,
-    };
-  }
-
-  // Check if model-provider secret already exists with same name
-  // Note: User secrets are independent and don't conflict
-  const [existingSecret] = await globalThis.services.db
-    .select()
-    .from(secrets)
-    .where(
-      and(
-        eq(secrets.scopeId, scope.id),
-        eq(secrets.name, secretName),
-        eq(secrets.type, "model-provider"),
-      ),
-    )
-    .limit(1);
-
-  if (existingSecret) {
-    // Update existing model-provider secret
-    await globalThis.services.db
-      .update(secrets)
-      .set({
-        encryptedValue,
-        updatedAt: new Date(),
-      })
-      .where(eq(secrets.id, existingSecret.id));
-
-    // Check if first for framework (for default assignment)
-    const isFirstForFramework = !(await hasExistingProviderForFramework(
-      clerkUserId,
-      framework,
-    ));
-
-    // Create model provider row
-    const [created] = await globalThis.services.db
-      .insert(modelProviders)
-      .values({
-        scopeId: scope.id,
-        type,
-        secretId: existingSecret.id,
-        isDefault: isFirstForFramework,
-        selectedModel: selectedModel ?? null,
-      })
-      .returning();
-
-    if (!created) {
-      throw new Error("Failed to create model provider");
-    }
-
-    log.debug("model provider created from existing secret", {
-      providerId: created.id,
-      type,
-      selectedModel,
-    });
-
-    return {
-      provider: toModelProviderInfo({
-        id: created.id,
-        type,
-        secretName,
-        isDefault: created.isDefault,
-        selectedModel: created.selectedModel,
-        createdAt: created.createdAt,
-        updatedAt: created.updatedAt,
-      }),
-      created: true,
-    };
-  }
-
-  // Create new model-provider secret and model provider
-  const isFirstForFramework = !(await hasExistingProviderForFramework(
-    clerkUserId,
-    framework,
-  ));
-
-  const [newSecret] = await globalThis.services.db
+  // Atomic secret upsert — handles concurrent requests safely
+  const [upsertedSecret] = await globalThis.services.db
     .insert(secrets)
     .values({
       scopeId: scope.id,
@@ -334,52 +253,73 @@ export async function upsertModelProvider(
       type: "model-provider",
       description: `Model provider secret for ${MODEL_PROVIDER_TYPES[type].label}`,
     })
+    .onConflictDoUpdate({
+      target: [secrets.scopeId, secrets.name, secrets.type],
+      set: { encryptedValue, updatedAt: new Date() },
+    })
     .returning();
 
-  if (!newSecret) {
-    throw new Error("Failed to create secret");
-  }
-
-  const [newProvider] = await globalThis.services.db
+  // Atomic model provider upsert — handles concurrent requests safely
+  const [provider] = await globalThis.services.db
     .insert(modelProviders)
     .values({
       scopeId: scope.id,
       type,
-      secretId: newSecret.id,
-      isDefault: isFirstForFramework,
+      secretId: upsertedSecret!.id,
+      isDefault: false,
       selectedModel: selectedModel ?? null,
+    })
+    .onConflictDoUpdate({
+      target: [modelProviders.scopeId, modelProviders.type],
+      set: {
+        secretId: upsertedSecret!.id,
+        selectedModel: selectedModel ?? null,
+        updatedAt: new Date(),
+      },
     })
     .returning();
 
-  if (!newProvider) {
-    throw new Error("Failed to create model provider");
+  // Determine if the provider was just created (INSERT) or updated (ON CONFLICT)
+  // For INSERT: both timestamps come from schema defaults (identical)
+  // For UPDATE: updatedAt is explicitly set to new Date() (different from createdAt)
+  const wasCreated =
+    provider!.createdAt.getTime() === provider!.updatedAt.getTime();
+
+  // Assign default if this is a new provider and no other default exists for the framework
+  if (wasCreated) {
+    await assignDefaultIfFirst(scope.id, provider!.id, framework);
   }
 
-  log.debug("model provider created", {
-    providerId: newProvider.id,
-    secretId: newSecret.id,
+  // Re-read isDefault since it may have been updated
+  const finalProvider = wasCreated
+    ? await getProviderById(scope.id, provider!.id)
+    : provider!;
+
+  log.debug(wasCreated ? "model provider created" : "model provider updated", {
+    providerId: finalProvider.id,
     type,
     selectedModel,
-    isDefault: newProvider.isDefault,
+    isDefault: finalProvider.isDefault,
   });
 
   return {
     provider: toModelProviderInfo({
-      id: newProvider.id,
+      id: finalProvider.id,
       type,
       secretName,
-      isDefault: newProvider.isDefault,
-      selectedModel: newProvider.selectedModel,
-      createdAt: newProvider.createdAt,
-      updatedAt: newProvider.updatedAt,
+      isDefault: finalProvider.isDefault,
+      selectedModel: finalProvider.selectedModel,
+      createdAt: finalProvider.createdAt,
+      updatedAt: finalProvider.updatedAt,
     }),
-    created: true,
+    created: wasCreated,
   };
 }
 
 /**
- * Upsert a single secret for a multi-auth provider
- * Note: Only looks for model-provider type secrets (user secrets are independent)
+ * Upsert a single secret for a multi-auth provider.
+ * Uses atomic INSERT ... ON CONFLICT DO UPDATE to handle concurrent requests safely.
+ * Note: Only targets model-provider type secrets (user secrets are independent)
  */
 async function upsertMultiAuthSecret(
   scopeId: string,
@@ -390,37 +330,19 @@ async function upsertMultiAuthSecret(
 ): Promise<void> {
   const encryptedValue = encryptCredentialValue(value, encryptionKey);
 
-  // Only look for model-provider secrets (user secrets are independent)
-  const [existingSecret] = await globalThis.services.db
-    .select({ id: secrets.id })
-    .from(secrets)
-    .where(
-      and(
-        eq(secrets.scopeId, scopeId),
-        eq(secrets.name, name),
-        eq(secrets.type, "model-provider"),
-      ),
-    )
-    .limit(1);
-
-  if (existingSecret) {
-    await globalThis.services.db
-      .update(secrets)
-      .set({
-        encryptedValue,
-        description,
-        updatedAt: new Date(),
-      })
-      .where(eq(secrets.id, existingSecret.id));
-  } else {
-    await globalThis.services.db.insert(secrets).values({
+  await globalThis.services.db
+    .insert(secrets)
+    .values({
       scopeId,
       name,
       encryptedValue,
       type: "model-provider",
       description,
+    })
+    .onConflictDoUpdate({
+      target: [secrets.scopeId, secrets.name, secrets.type],
+      set: { encryptedValue, description, updatedAt: new Date() },
     });
-  }
 }
 
 /**
@@ -522,7 +444,7 @@ export async function upsertMultiAuthModelProvider(
     secretNames: Object.keys(secretValues),
   });
 
-  // Check if model provider already exists
+  // Check if model provider already exists (needed for auth method switch cleanup)
   const [existingProvider] = await globalThis.services.db
     .select()
     .from(modelProviders)
@@ -541,7 +463,7 @@ export async function upsertMultiAuthModelProvider(
     );
   }
 
-  // Store/update all secrets
+  // Store/update all secrets atomically
   const secretNames = Object.keys(secretValues);
   const secretDescription = `${MODEL_PROVIDER_TYPES[type].label} secret (${authMethod})`;
 
@@ -555,81 +477,64 @@ export async function upsertMultiAuthModelProvider(
     );
   }
 
-  if (existingProvider) {
-    // Update existing provider
-    await globalThis.services.db
-      .update(modelProviders)
-      .set({
-        authMethod,
-        selectedModel: selectedModel ?? null,
-        updatedAt: new Date(),
-      })
-      .where(eq(modelProviders.id, existingProvider.id));
-
-    log.debug("multi-auth model provider updated", {
-      providerId: existingProvider.id,
-      type,
-      authMethod,
-      selectedModel,
-    });
-
-    return {
-      provider: toModelProviderInfo({
-        id: existingProvider.id,
-        type,
-        authMethod,
-        secretNames,
-        isDefault: existingProvider.isDefault,
-        selectedModel: selectedModel ?? null,
-        createdAt: existingProvider.createdAt,
-        updatedAt: new Date(),
-      }),
-      created: false,
-    };
-  }
-
-  // Check if first for framework (for default assignment)
-  const isFirstForFramework = !(await hasExistingProviderForFramework(
-    clerkUserId,
-    framework,
-  ));
-
-  // Create new provider (no secretId for multi-auth)
-  const [newProvider] = await globalThis.services.db
+  // Atomic model provider upsert — handles concurrent requests safely
+  const [provider] = await globalThis.services.db
     .insert(modelProviders)
     .values({
       scopeId: scope.id,
       type,
       authMethod,
-      isDefault: isFirstForFramework,
+      isDefault: false,
       selectedModel: selectedModel ?? null,
+    })
+    .onConflictDoUpdate({
+      target: [modelProviders.scopeId, modelProviders.type],
+      set: {
+        authMethod,
+        selectedModel: selectedModel ?? null,
+        updatedAt: new Date(),
+      },
     })
     .returning();
 
-  if (!newProvider) {
-    throw new Error("Failed to create model provider");
+  const wasCreated =
+    provider!.createdAt.getTime() === provider!.updatedAt.getTime();
+
+  // Assign default if this is a new provider and no other default exists for the framework
+  if (wasCreated) {
+    await assignDefaultIfFirst(scope.id, provider!.id, framework);
   }
 
-  log.debug("multi-auth model provider created", {
-    providerId: newProvider.id,
-    type,
-    authMethod,
-    selectedModel,
-    isDefault: newProvider.isDefault,
-  });
+  // Re-read isDefault since it may have been updated
+  const finalProvider = wasCreated
+    ? await getProviderById(scope.id, provider!.id)
+    : provider!;
+
+  log.debug(
+    wasCreated
+      ? "multi-auth model provider created"
+      : "multi-auth model provider updated",
+    {
+      providerId: finalProvider.id,
+      type,
+      authMethod,
+      selectedModel,
+      isDefault: finalProvider.isDefault,
+    },
+  );
 
   return {
     provider: toModelProviderInfo({
-      id: newProvider.id,
+      id: finalProvider.id,
       type,
       authMethod,
       secretNames,
-      isDefault: newProvider.isDefault,
-      selectedModel: newProvider.selectedModel,
-      createdAt: newProvider.createdAt,
-      updatedAt: newProvider.updatedAt,
+      isDefault: finalProvider.isDefault,
+      selectedModel: finalProvider.selectedModel,
+      createdAt: finalProvider.createdAt,
+      updatedAt: finalProvider.updatedAt,
     }),
-    created: true,
+    created: wasCreated,
   };
 }
 

--- a/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
@@ -1,4 +1,4 @@
-import { eq, and, inArray } from "drizzle-orm";
+import { eq, and, ne, inArray, sql, notExists } from "drizzle-orm";
 import {
   MODEL_PROVIDER_TYPES,
   getFrameworkForType,
@@ -70,53 +70,53 @@ function toModelProviderInfo(params: {
 }
 
 /**
- * Assign isDefault=true to a provider if no other provider for the same framework
- * already has isDefault=true. Safe to call after atomic upsert.
+ * Get all provider types that belong to a given framework.
+ */
+function getTypesForFramework(framework: ModelProviderFramework): string[] {
+  return Object.keys(MODEL_PROVIDER_TYPES).filter(
+    (t) => getFrameworkForType(t as ModelProviderType) === framework,
+  );
+}
+
+/**
+ * Atomically assign isDefault=true to a provider, but only if no other provider
+ * for the same framework already has isDefault=true.
+ *
+ * Uses a single UPDATE with NOT EXISTS subquery to prevent the race condition
+ * where two concurrent inserts both set isDefault=true.
+ *
+ * @returns true if isDefault was set, false if another default already exists
  */
 async function assignDefaultIfFirst(
   scopeId: string,
   providerId: string,
   framework: ModelProviderFramework,
-): Promise<void> {
-  const allScopeProviders = await globalThis.services.db
-    .select({
-      id: modelProviders.id,
-      type: modelProviders.type,
-      isDefault: modelProviders.isDefault,
-    })
-    .from(modelProviders)
-    .where(eq(modelProviders.scopeId, scopeId));
+): Promise<boolean> {
+  const frameworkTypes = getTypesForFramework(framework);
 
-  const hasDefaultForFramework = allScopeProviders.some(
-    (p) =>
-      p.id !== providerId &&
-      p.isDefault &&
-      getFrameworkForType(p.type as ModelProviderType) === framework,
-  );
-
-  if (!hasDefaultForFramework) {
-    await globalThis.services.db
-      .update(modelProviders)
-      .set({ isDefault: true })
-      .where(eq(modelProviders.id, providerId));
-  }
-}
-
-/**
- * Get a single model provider by ID within a scope.
- */
-async function getProviderById(scopeId: string, providerId: string) {
-  const [provider] = await globalThis.services.db
-    .select()
-    .from(modelProviders)
+  const result = await globalThis.services.db
+    .update(modelProviders)
+    .set({ isDefault: true })
     .where(
       and(
-        eq(modelProviders.scopeId, scopeId),
         eq(modelProviders.id, providerId),
+        notExists(
+          globalThis.services.db
+            .select({ id: sql`1` })
+            .from(modelProviders)
+            .where(
+              and(
+                eq(modelProviders.scopeId, scopeId),
+                eq(modelProviders.isDefault, true),
+                ne(modelProviders.id, providerId),
+                inArray(modelProviders.type, frameworkTypes),
+              ),
+            ),
+        ),
       ),
-    )
-    .limit(1);
-  return provider!;
+    );
+
+  return (result.rowCount ?? 0) > 0;
 }
 
 /**
@@ -243,6 +243,16 @@ export async function upsertModelProvider(
     secretName,
   });
 
+  // Pre-check: does a provider for this type already exist?
+  // Race window is benign — worst case, two concurrent creates both return created:true (cosmetic only)
+  const [existingProvider] = await globalThis.services.db
+    .select({ id: modelProviders.id })
+    .from(modelProviders)
+    .where(
+      and(eq(modelProviders.scopeId, scope.id), eq(modelProviders.type, type)),
+    )
+    .limit(1);
+
   // Atomic secret upsert — handles concurrent requests safely
   const [upsertedSecret] = await globalThis.services.db
     .insert(secrets)
@@ -279,38 +289,36 @@ export async function upsertModelProvider(
     })
     .returning();
 
-  // Determine if the provider was just created (INSERT) or updated (ON CONFLICT)
-  // For INSERT: both timestamps come from schema defaults (identical)
-  // For UPDATE: updatedAt is explicitly set to new Date() (different from createdAt)
-  const wasCreated =
-    provider!.createdAt.getTime() === provider!.updatedAt.getTime();
+  const wasCreated = !existingProvider;
 
   // Assign default if this is a new provider and no other default exists for the framework
   if (wasCreated) {
-    await assignDefaultIfFirst(scope.id, provider!.id, framework);
+    const isDefault = await assignDefaultIfFirst(
+      scope.id,
+      provider!.id,
+      framework,
+    );
+    if (isDefault) {
+      provider!.isDefault = true;
+    }
   }
 
-  // Re-read isDefault since it may have been updated
-  const finalProvider = wasCreated
-    ? await getProviderById(scope.id, provider!.id)
-    : provider!;
-
   log.debug(wasCreated ? "model provider created" : "model provider updated", {
-    providerId: finalProvider.id,
+    providerId: provider!.id,
     type,
     selectedModel,
-    isDefault: finalProvider.isDefault,
+    isDefault: provider!.isDefault,
   });
 
   return {
     provider: toModelProviderInfo({
-      id: finalProvider.id,
+      id: provider!.id,
       type,
       secretName,
-      isDefault: finalProvider.isDefault,
-      selectedModel: finalProvider.selectedModel,
-      createdAt: finalProvider.createdAt,
-      updatedAt: finalProvider.updatedAt,
+      isDefault: provider!.isDefault,
+      selectedModel: provider!.selectedModel,
+      createdAt: provider!.createdAt,
+      updatedAt: provider!.updatedAt,
     }),
     created: wasCreated,
   };
@@ -497,42 +505,43 @@ export async function upsertMultiAuthModelProvider(
     })
     .returning();
 
-  const wasCreated =
-    provider!.createdAt.getTime() === provider!.updatedAt.getTime();
+  const wasCreated = !existingProvider;
 
   // Assign default if this is a new provider and no other default exists for the framework
   if (wasCreated) {
-    await assignDefaultIfFirst(scope.id, provider!.id, framework);
+    const isDefault = await assignDefaultIfFirst(
+      scope.id,
+      provider!.id,
+      framework,
+    );
+    if (isDefault) {
+      provider!.isDefault = true;
+    }
   }
-
-  // Re-read isDefault since it may have been updated
-  const finalProvider = wasCreated
-    ? await getProviderById(scope.id, provider!.id)
-    : provider!;
 
   log.debug(
     wasCreated
       ? "multi-auth model provider created"
       : "multi-auth model provider updated",
     {
-      providerId: finalProvider.id,
+      providerId: provider!.id,
       type,
       authMethod,
       selectedModel,
-      isDefault: finalProvider.isDefault,
+      isDefault: provider!.isDefault,
     },
   );
 
   return {
     provider: toModelProviderInfo({
-      id: finalProvider.id,
+      id: provider!.id,
       type,
       authMethod,
       secretNames,
-      isDefault: finalProvider.isDefault,
-      selectedModel: finalProvider.selectedModel,
-      createdAt: finalProvider.createdAt,
-      updatedAt: finalProvider.updatedAt,
+      isDefault: provider!.isDefault,
+      selectedModel: provider!.selectedModel,
+      createdAt: provider!.createdAt,
+      updatedAt: provider!.updatedAt,
     }),
     created: wasCreated,
   };

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -93,16 +93,11 @@ export async function getScopeById(scopeId: string) {
 }
 
 /**
- * Create a new scope
+ * Create a new scope.
+ * Uses atomic INSERT ... ON CONFLICT DO NOTHING to handle concurrent requests safely.
  */
 async function createScope(slug: string, type: ScopeType, ownerId?: string) {
   validateScopeSlug(slug);
-
-  // Check if slug already exists
-  const existing = await getScopeBySlug(slug);
-  if (existing) {
-    throw badRequest(`Scope "${slug}" already exists`);
-  }
 
   log.debug("creating scope", { slug, type, ownerId });
 
@@ -113,11 +108,16 @@ async function createScope(slug: string, type: ScopeType, ownerId?: string) {
       type,
       ownerId,
     })
+    .onConflictDoNothing({ target: scopes.slug })
     .returning();
 
-  log.debug("scope created", { scopeId: scope!.id, slug });
+  if (!scope) {
+    throw badRequest(`Scope "${slug}" already exists`);
+  }
 
-  return scope!;
+  log.debug("scope created", { scopeId: scope.id, slug });
+
+  return scope;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace non-atomic SELECT-then-INSERT patterns with PostgreSQL `INSERT ... ON CONFLICT DO UPDATE/NOTHING` via Drizzle ORM in model-provider and scope service layers
- Fix flaky CLI E2E tests caused by concurrent bootstrap from parallel jobs (introduced in #3562)
- Add concurrency integration tests to verify atomic behavior

### Changes

| Function | Fix |
|----------|-----|
| `upsertModelProvider()` | Atomic secret + provider upsert via `onConflictDoUpdate` |
| `upsertMultiAuthSecret()` | Atomic secret upsert via `onConflictDoUpdate` |
| `upsertMultiAuthModelProvider()` | Atomic provider upsert via `onConflictDoUpdate` |
| `createScope()` | Atomic scope creation via `onConflictDoNothing` |

Net result: **-40 lines** (204 added, 244 removed) — the code is simpler because the 3-branch flow (existing provider / existing secret / new) is replaced by a 2-step atomic flow.

Closes #3597

## Test plan

- [x] All 68 existing model-provider and scope tests pass
- [x] New concurrency test: 5 concurrent upsert requests all succeed (no 500 errors)
- [x] New scope test: duplicate slug returns 400 (not 500)
- [x] Lint, format, knip all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)